### PR TITLE
Added comments for each entry of gBattlescriptsForBallThrow

### DIFF
--- a/data/battle_scripts_2.s
+++ b/data/battle_scripts_2.s
@@ -13,34 +13,34 @@
 
 	.align 2
 gBattlescriptsForBallThrow:: @ 82DBD08
-	.4byte BattleScript_BallThrow
-	.4byte BattleScript_BallThrow
-	.4byte BattleScript_BallThrow
-	.4byte BattleScript_BallThrow
-	.4byte BattleScript_BallThrow
-	.4byte BattleScript_SafariBallThrow
-	.4byte BattleScript_BallThrow
-	.4byte BattleScript_BallThrow
-	.4byte BattleScript_BallThrow
-	.4byte BattleScript_BallThrow
-	.4byte BattleScript_BallThrow
-	.4byte BattleScript_BallThrow
-	.4byte BattleScript_BallThrow
-	.4byte BattleScript_BallThrow
-	.4byte BattleScript_BallThrow
-	.4byte BattleScript_BallThrow
-	.4byte BattleScript_BallThrow
-	.4byte BattleScript_BallThrow
-	.4byte BattleScript_BallThrow
-	.4byte BattleScript_BallThrow
-	.4byte BattleScript_BallThrow
-	.4byte BattleScript_BallThrow
-	.4byte BattleScript_BallThrow
-	.4byte BattleScript_BallThrow
-	.4byte BattleScript_BallThrow
-	.4byte BattleScript_BallThrow
-	.4byte BattleScript_BallThrow
-	.4byte BattleScript_BallThrow
+	.4byte BattleScript_BallThrow        @ ITEM_NONE
+	.4byte BattleScript_BallThrow        @ ITEM_MASTER_BALL
+	.4byte BattleScript_BallThrow        @ ITEM_ULTRA_BALL
+	.4byte BattleScript_BallThrow        @ ITEM_GREAT_BALL
+	.4byte BattleScript_BallThrow        @ ITEM_POKE_BALL
+	.4byte BattleScript_SafariBallThrow  @ ITEM_SAFARI_BALL
+	.4byte BattleScript_BallThrow        @ ITEM_NET_BALL
+	.4byte BattleScript_BallThrow        @ ITEM_DIVE_BALL
+	.4byte BattleScript_BallThrow        @ ITEM_NEST_BALL
+	.4byte BattleScript_BallThrow        @ ITEM_REPEAT_BALL
+	.4byte BattleScript_BallThrow        @ ITEM_TIMER_BALL
+	.4byte BattleScript_BallThrow        @ ITEM_LUXURY_BALL
+	.4byte BattleScript_BallThrow        @ ITEM_DUSK_BALL
+	.4byte BattleScript_BallThrow        @ ITEM_HEAL_BALL
+	.4byte BattleScript_BallThrow        @ ITEM_QUICK_BALL
+	.4byte BattleScript_BallThrow        @ ITEM_CHERISH_BALL
+	.4byte BattleScript_BallThrow        @ ITEM_FAST_BALL
+	.4byte BattleScript_BallThrow        @ ITEM_LEVEL_BALL
+	.4byte BattleScript_BallThrow        @ ITEM_LURE_BALL
+	.4byte BattleScript_BallThrow        @ ITEM_HEAVY_BALL
+	.4byte BattleScript_BallThrow        @ ITEM_LOVE_BALL
+	.4byte BattleScript_BallThrow        @ ITEM_FRIEND_BALL
+	.4byte BattleScript_BallThrow        @ ITEM_MOON_BALL
+	.4byte BattleScript_BallThrow        @ ITEM_SPORT_BALL
+	.4byte BattleScript_BallThrow        @ ITEM_PARK_BALL
+	.4byte BattleScript_BallThrow        @ ITEM_DREAM_BALL
+	.4byte BattleScript_BallThrow        @ ITEM_BEAST_BALL
+	.4byte BattleScript_BallThrow        @ ITEM_PREMIER_BALL
 
 	.align 2
 gBattlescriptsForUsingItem:: @ 82DBD3C


### PR DESCRIPTION
## Description
In an attempt to match the structure of upstream, I reintroduced the comments that point out the Poké Balls affected by each BallThrow battlescript in `gBattlescriptsForBallThrow`. 

## **Discord contact info**
Lunos#4026

As usual, if there's anything wrong please let me know.