### PR TITLE
Removed duplicate inclusion of battle_config.h

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -19,7 +19,6 @@
 #include "berry.h"
 #include "pokedex.h"
 #include "mail.h"
-#include "constants/battle_config.h"
 #include "field_weather.h"
 #include "constants/abilities.h"
 #include "constants/battle_anim.h"


### PR DESCRIPTION
## Description
I think the title is self-explanatory, but the header file that is `include/constants/battle_config.h` is included twice unnecessarily.

## **Discord contact info**
Lunos#4026

As usual, if there's anything wrong please let me know.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->