### PR TITLE
More Battle Config options

### DIFF
--- a/include/constants/battle_config.h
+++ b/include/constants/battle_config.h
@@ -80,6 +80,8 @@
 #define B_PSYWAVE_DMG               GEN_6 // Psywave's damage formula. See Cmd_psywavedamageeffect.
 
 // Move settings
+#define B_UPDATED_MOVE_VALUES       GEN_7 // Power, Accuracy and Power of moves vary between generations.
+
 #define B_FELL_STINGER_STAT_RAISE   GEN_6 // In Gen7+, it raises Atk by 3 stages instead of 2 if it causes the target to faint.
 #define B_SOUND_SUBSTITUTE          GEN_6 // In Gen6+, sound moves bypass Substitute.
 #define B_TOXIC_NEVER_MISS          GEN_6 // In Gen6+, if Toxic is used by a Poison type, it will never miss.

--- a/include/constants/battle_config.h
+++ b/include/constants/battle_config.h
@@ -1,61 +1,69 @@
 #ifndef GUARD_CONSTANTS_BATTLE_CONFIG_H
 #define GUARD_CONSTANTS_BATTLE_CONFIG_H
 
-// Species with peculiar battle effects. Remove them if they're properly placed in constant/species.h
-#define SPECIES_DIALGA 0
-#define SPECIES_PALKIA 0
-#define SPECIES_GIRATINA 0
-#define SPECIES_CHERRIM 0
-#define SPECIES_ARCEUS 0
-#define SPECIES_SILVALLY 0
-#define SPECIES_GENESECT 0
-#define SPECIES_AEGISLASH 0
-#define SPECIES_AEGISLASH_BLADE 10000
-#define SPECIES_MIMIKYU 0
-#define SPECIES_MIMIKYU_BUSTED 10001
-#define SPECIES_DARMANITAN 0
-#define SPECIES_DARMANITAN_ZEN 10002
-#define SPECIES_MINIOR_CORE 0
-#define SPECIES_MINIOR 10003
-#define SPECIES_WISHIWASHI 0
-#define SPECIES_WISHIWASHI_SCHOOL 10004
-#define SPECIES_ZYGARDE 0 // 50%
-#define SPECIES_ZYGARDE_10 10005 // 10 %
-#define SPECIES_ZYGARDE_COMPLETE 10006 // 100 %
+#define BATTLE_ENGINE
 
-// Items with peculiar battle effects. Remove them if they're properly placed in constant/items.h
-#define ITEM_GRISEOUS_ORB 0
-#define ITEM_OCCA_BERRY 204
-#define ITEM_PASSHO_BERRY 205
-#define ITEM_WACAN_BERRY 206
-#define ITEM_RINDO_BERRY 207
-#define ITEM_YACHE_BERRY 208
-#define ITEM_CHOPLE_BERRY 177
-#define ITEM_KEBIA_BERRY 178
-#define ITEM_SHUCA_BERRY 179
-#define ITEM_COBA_BERRY 180
-#define ITEM_PAYAPA_BERRY 181
-#define ITEM_TANGA_BERRY 182
-#define ITEM_CHARTI_BERRY 183
-#define ITEM_KASIB_BERRY 184
-#define ITEM_HABAN_BERRY 185
-#define ITEM_COLBUR_BERRY 186
-#define ITEM_BABIRI_BERRY 187
-#define ITEM_CHILAN_BERRY 188
-#define ITEM_ROSELI_BERRY 189
-#define ITEM_MICLE_BERRY 197
-#define ITEM_CUSTAP_BERRY 199
-#define ITEM_JABOCA_BERRY 200
-#define ITEM_ROWAP_BERRY 201
-#define ITEM_KEE_BERRY 202
-#define ITEM_MARANGA_BERRY 203
+// Species with peculiar battle effects.
+#ifndef POKEMON_EXPANSION
+    #define SPECIES_DIALGA            0
+    #define SPECIES_PALKIA            0
+    #define SPECIES_GIRATINA          0
+    #define SPECIES_CHERRIM           0
+    #define SPECIES_ARCEUS            0
+    #define SPECIES_SILVALLY          0
+    #define SPECIES_GENESECT          0
+    #define SPECIES_AEGISLASH         0
+    #define SPECIES_AEGISLASH_BLADE   10000
+    #define SPECIES_MIMIKYU           0
+    #define SPECIES_MIMIKYU_BUSTED    10001
+    #define SPECIES_DARMANITAN        0
+    #define SPECIES_DARMANITAN_ZEN    10002
+    #define SPECIES_MINIOR_CORE       0
+    #define SPECIES_MINIOR            10003
+    #define SPECIES_WISHIWASHI        0
+    #define SPECIES_WISHIWASHI_SCHOOL 10004
+    #define SPECIES_ZYGARDE           0     // 50%
+    #define SPECIES_ZYGARDE_10        10005 // 10 %
+    #define SPECIES_ZYGARDE_COMPLETE  10006 // 100 %
+#endif
 
-#define GEN_3 0
-#define GEN_4 1
-#define GEN_5 2
-#define GEN_6 3
-#define GEN_7 4
-#define GEN_8 5
+// Items with peculiar battle effects.
+#ifndef ITEM_EXPANSION
+    #define ITEM_CHOPLE_BERRY   177
+    #define ITEM_KEBIA_BERRY    178
+    #define ITEM_SHUCA_BERRY    179
+    #define ITEM_COBA_BERRY     180
+    #define ITEM_PAYAPA_BERRY   181
+    #define ITEM_TANGA_BERRY    182
+    #define ITEM_CHARTI_BERRY   183
+    #define ITEM_KASIB_BERRY    184
+    #define ITEM_HABAN_BERRY    185
+    #define ITEM_COLBUR_BERRY   186
+    #define ITEM_BABIRI_BERRY   187
+    #define ITEM_CHILAN_BERRY   188
+    #define ITEM_ROSELI_BERRY   189
+    #define ITEM_MICLE_BERRY    197
+    #define ITEM_CUSTAP_BERRY   199
+    #define ITEM_JABOCA_BERRY   200
+    #define ITEM_ROWAP_BERRY    201
+    #define ITEM_KEE_BERRY      202
+    #define ITEM_MARANGA_BERRY  203
+    #define ITEM_OCCA_BERRY     204
+    #define ITEM_PASSHO_BERRY   205
+    #define ITEM_WACAN_BERRY    206
+    #define ITEM_RINDO_BERRY    207
+    #define ITEM_YACHE_BERRY    208
+    #define ITEM_GRISEOUS_ORB   369
+#endif
+
+#ifndef GEN_3
+    #define GEN_3 0
+    #define GEN_4 1
+    #define GEN_5 2
+    #define GEN_6 3
+    #define GEN_7 4
+    #define GEN_8 5
+#endif
 
 // Calculation settings
 #define B_CRIT_CHANCE               GEN_6 // Chances of a critical hit landing. See CalcCritChanceStage.
@@ -107,20 +115,20 @@
 #define B_POWDER_GRASS              GEN_6 // In Gen6+, Grass type Pokémon are immune to powder and spore moves.
 
 // Animation Settings
-#define NEW_SWORD_PARTICLE              TRUE    // update swords dance particle
-#define NEW_LEECH_SEED_PARTICLE         TRUE    //update leech seed's animation particle
-#define NEW_HORN_ATTACK_PARTICLE        TRUE    //update horn attack's horn
-#define NEW_LEAF_PARTICLE               TRUE    // update leaf particle
-#define NEW_EMBER_PARTICLES             TRUE    //updates ember fire particle
-#define NEW_MEAN_LOOK_PARTICLE          TRUE    //update mean look eye
-#define NEW_TEETH_PARTICLE              TRUE    //update bite/crunch teeth particle
-#define NEW_HANDS_FEET_PARTICLE         TRUE    //update chop/kick/punch particles
-#define NEW_SPIKES_PARTICLE             TRUE    //update spikes particle
-#define NEW_FLY_BUBBLE_PARTICLE         TRUE    //update fly 'bubble' particle
-#define NEW_CURSE_NAIL_PARTICLE         TRUE    //updates curse nail
-#define NEW_BATON_PASS_BALL_PARTICLE    TRUE    //update baton pass pokeball sprite
-#define NEW_MORNING_SUN_STAR_PARTICLE   TRUE    //updates morning sun star particles
-#define NEW_IMPACT_PALETTE              TRUE    //updates the basic 'hit' particle
-#define NEW_SURF_PARTICLE_PALETTE       TRUE    //updates the surf wave palette
+#define B_NEW_SWORD_PARTICLE            TRUE    // update swords dance particle
+#define B_NEW_LEECH_SEED_PARTICLE       TRUE    //update leech seed's animation particle
+#define B_NEW_HORN_ATTACK_PARTICLE      TRUE    //update horn attack's horn
+#define B_NEW_LEAF_PARTICLE             TRUE    // update leaf particle
+#define B_NEW_EMBER_PARTICLES           TRUE    //updates ember fire particle
+#define B_NEW_MEAN_LOOK_PARTICLE        TRUE    //update mean look eye
+#define B_NEW_TEETH_PARTICLE            TRUE    //update bite/crunch teeth particle
+#define B_NEW_HANDS_FEET_PARTICLE       TRUE    //update chop/kick/punch particles
+#define B_NEW_SPIKES_PARTICLE           TRUE    //update spikes particle
+#define B_NEW_FLY_BUBBLE_PARTICLE       TRUE    //update fly 'bubble' particle
+#define B_NEW_CURSE_NAIL_PARTICLE       TRUE    //updates curse nail
+#define B_NEW_BATON_PASS_BALL_PARTICLE  TRUE    //update baton pass pokeball sprite
+#define B_NEW_MORNING_SUN_STAR_PARTICLE TRUE    //updates morning sun star particles
+#define B_NEW_IMPACT_PALETTE            TRUE    //updates the basic 'hit' particle
+#define B_NEW_SURF_PARTICLE_PALETTE     TRUE    //updates the surf wave palette
 
 #endif // GUARD_CONSTANTS_BATTLE_CONFIG_H

--- a/include/constants/battle_config.h
+++ b/include/constants/battle_config.h
@@ -93,7 +93,6 @@
 #define B_SPEED_BUFFING_RAPID_SPIN  GEN_8 // In Gen8, Rapid Spin raises the user's Speed by 1 stage.
 
 // Ability settings
-#define B_ABILITY_POP_UP            GEN_6 // In Gen5+, the Pokémon abilities are displayed in a pop-up, when they activate in battle.
 #define B_ABILITY_WEATHER           GEN_6 // In Gen5+, weather caused by abilities lasts the same amount of turns as induced from a move. Before, they lasted till the battle's end or weather change by a move.
 #define B_GALE_WINGS                GEN_6 // In Gen7+ requires full HP to trigger.
 #define B_STANCE_CHANGE_FAIL        GEN_7 // In Gen7+, Aegislash's form change does not happen, if the Pokémon cannot use a move, because of confusion, paralysis, etc. In gen6, the form change occurs despite not being able to move.
@@ -107,13 +106,16 @@
 #define B_BERRIES_INSTANT           GEN_6 // In Gen4+, most berries activate on battle start/switch-in if applicable. In gen3, they only activate either at the move end or turn end.
 
 // Flag settings. Replace the 0s with defined flags to be able to toggle the following features using those flags.
-#define B_FLAG_INVERSE_BATTLE       0 // If the flag is set, the battle's type effectiveness are inversed. For example, fire is super effective against water.
-#define B_FLAG_FORCE_DOUBLE_WILD    0 // If the flag is set, all wild battles will be double battles.
+#define B_FLAG_INVERSE_BATTLE       0     // If the flag is set, the battle's type effectiveness are inversed. For example, fire is super effective against water.
+#define B_FLAG_FORCE_DOUBLE_WILD    0     // If the flag is set, all land and surfing wild battles will be double battles.
+
+// Interface settings
+#define B_ABILITY_POP_UP            TRUE  // In Gen5+, the Pokémon abilities are displayed in a pop-up, when they activate in battle.
+#define B_FAST_INTRO                TRUE  // If set to TRUE, battle intro texts print at the same time as animation of a Pokémon, as opposing to waiting for the animation to end.
+#define B_SHOW_TARGETS              TRUE  // If set to TRUE, all available targets, for moves hitting 2 or 3 Pokémon, will be shown before selecting a move.
 
 // Other
 #define B_DOUBLE_WILD_CHANCE        0     // % chance of encountering two Pokémon in a Wild Encounter.
-#define B_FAST_INTRO                TRUE  // If set to TRUE, battle intro texts print at the same time as animation of a Pokémon, as opposing to waiting for the animation to end.
-#define B_SHOW_TARGETS              TRUE  // If set to TRUE, all available targets, for moves hitting 2 or 3 Pokémon, will be shown before selecting a move.
 #define B_SLEEP_TURNS               GEN_6 // In Gen5+, sleep lasts for 1-3 turns instead of 2-5 turns.
 #define B_PARALYZE_ELECTRIC         GEN_6 // In Gen6+, Electric type Pokémon can't be paralyzed.
 #define B_POWDER_GRASS              GEN_6 // In Gen6+, Grass type Pokémon are immune to powder and spore moves.

--- a/include/constants/battle_config.h
+++ b/include/constants/battle_config.h
@@ -106,8 +106,12 @@
 #define B_HP_BERRIES                GEN_6 // In Gen4+, berries which restore hp activate immediately after hp drops to half. In gen3, the effect occurs at the end of the turn.
 #define B_BERRIES_INSTANT           GEN_6 // In Gen4+, most berries activate on battle start/switch-in if applicable. In gen3, they only activate either at the move end or turn end.
 
+// Flag settings. Replace the 0s with defined flags to be able to toggle the following features using those flags.
+#define B_FLAG_INVERSE_BATTLE       0 // If the flag is set, the battle's type effectiveness are inversed. For example, fire is super effective against water.
+#define B_FLAG_FORCE_DOUBLE_WILD    0 // If the flag is set, all wild battles will be double battles.
+
 // Other
-#define B_FLAG_INVERSE_BATTLE       0     // If this flag is set, the battle's type effectiveness are inversed. For example, fire is super effective against water. 0 disables the feature.
+#define B_DOUBLE_WILD_CHANCE        0     // % chance of encountering two Pokémon in a Wild Encounter.
 #define B_FAST_INTRO                TRUE  // If set to TRUE, battle intro texts print at the same time as animation of a Pokémon, as opposing to waiting for the animation to end.
 #define B_SHOW_TARGETS              TRUE  // If set to TRUE, all available targets, for moves hitting 2 or 3 Pokémon, will be shown before selecting a move.
 #define B_SLEEP_TURNS               GEN_6 // In Gen5+, sleep lasts for 1-3 turns instead of 2-5 turns.

--- a/include/constants/battle_config.h
+++ b/include/constants/battle_config.h
@@ -80,8 +80,7 @@
 #define B_PSYWAVE_DMG               GEN_6 // Psywave's damage formula. See Cmd_psywavedamageeffect.
 
 // Move settings
-#define B_UPDATED_MOVE_VALUES       GEN_7 // Power, Accuracy and Power of moves vary between generations.
-
+#define B_UPDATED_MOVE_DATA         GEN_7 // Move data varies between generations.
 #define B_FELL_STINGER_STAT_RAISE   GEN_6 // In Gen7+, it raises Atk by 3 stages instead of 2 if it causes the target to faint.
 #define B_SOUND_SUBSTITUTE          GEN_6 // In Gen6+, sound moves bypass Substitute.
 #define B_TOXIC_NEVER_MISS          GEN_6 // In Gen6+, if Toxic is used by a Poison type, it will never miss.

--- a/include/constants/battle_config.h
+++ b/include/constants/battle_config.h
@@ -79,19 +79,22 @@
 #define B_RECOIL_IF_MISS_DMG        GEN_6 // In Gen5+, Jump Kick and Hi Jump Kick will always do half of the user's max HP when missing.
 #define B_PSYWAVE_DMG               GEN_6 // Psywave's damage formula. See Cmd_psywavedamageeffect.
 
-// Move settings
-#define B_UPDATED_MOVE_DATA         GEN_7 // Move data varies between generations.
+// Move data settings
+#define B_UPDATED_MOVE_DATA         GEN_7 // Updates move data in gBattleMoves, including Power, Accuracy, PP, stat changes, targets, chances of secondary effects, etc.
 #define B_FELL_STINGER_STAT_RAISE   GEN_6 // In Gen7+, it raises Atk by 3 stages instead of 2 if it causes the target to faint.
+#define B_KINGS_SHIELD_LOWER_ATK    GEN_6 // In Gen7+, it lowers Atk by 1 stage instead of 2 of oponents that hit it.
+#define B_SPEED_BUFFING_RAPID_SPIN  GEN_8 // In Gen8, Rapid Spin raises the user's Speed by 1 stage.
+#define B_WATER_SHURIKEN_SPLIT      GEN_8 // In Gen7, Water Shuriken was changed from Physical to Special.
+
+// Other move settings
 #define B_SOUND_SUBSTITUTE          GEN_6 // In Gen6+, sound moves bypass Substitute.
 #define B_TOXIC_NEVER_MISS          GEN_6 // In Gen6+, if Toxic is used by a Poison type, it will never miss.
 #define B_PAYBACK_SWITCH_BOOST      GEN_6 // In Gen5+, if the opponent switches out, Payback's damage will no longer be doubled.
-#define B_KINGS_SHIELD_LOWER_ATK    GEN_6 // In Gen7+, it lowers Atk by 1 stage instead of 2 of oponents that hit it.
 #define B_BINDING_TURNS             GEN_6 // In Gen5+, binding moves last for 4-5 turns instead of 2-5 turns. (With Grip Claw, 7 and 5 turns respectively.)
 #define B_UPROAR_TURNS              GEN_6 // In Gen5+, Uproar lasts for 3 turns instead of 2-5 turns.
 #define B_DISABLE_TURNS             GEN_6 // Disable's turns. See Cmd_disablelastusedattack.
 #define B_INCINERATE_GEMS           GEN_6 // In Gen6+, Incinerate can destroy Gems.
 #define B_MINIMIZE_DMG_ACC          GEN_6 // In Gen6+, moves that causes double damage to minimized Pokémon will also skip accuracy checks.
-#define B_SPEED_BUFFING_RAPID_SPIN  GEN_8 // In Gen8, Rapid Spin raises the user's Speed by 1 stage.
 
 // Ability settings
 #define B_ABILITY_WEATHER           GEN_6 // In Gen5+, weather caused by abilities lasts the same amount of turns as induced from a move. Before, they lasted till the battle's end or weather change by a move.

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -204,6 +204,7 @@ struct BaseStats
             u8 noFlip : 1;
 };
 
+#include "constants/battle_config.h"
 struct BattleMove
 {
     u16 effect;

--- a/include/wild_encounter.h
+++ b/include/wild_encounter.h
@@ -40,5 +40,6 @@ void FishingWildEncounter(u8 rod);
 u16 GetLocalWildMon(bool8 *isWaterMon);
 u16 GetLocalWaterMon(void);
 bool8 UpdateRepelCounter(void);
+bool8 TryDoDoubleWildBattle(void);
 
 #endif // GUARD_WILD_ENCOUNTER_H

--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -2956,7 +2956,7 @@ void CreateAbilityPopUp(u8 battlerId, u32 ability, bool32 isDoubleBattle)
     const s16 (*coords)[2];
     u8 spriteId1, spriteId2, battlerPosition, taskId;
 
-    if (B_ABILITY_POP_UP < GEN_5)
+    if (!B_ABILITY_POP_UP)
         return;
 
     if (!gBattleStruct->activeAbilityPopUps)

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -4828,14 +4828,14 @@ static void Cmd_moveend(void)
                     BattleScriptPushCursor();
                     if (gBattleTypeFlags & BATTLE_TYPE_TRAINER || GetBattlerSide(i) == B_SIDE_PLAYER)
                     {
-                        if (B_ABILITY_POP_UP >= GEN_6)
+                        if (B_ABILITY_POP_UP)
                             gBattlescriptCurrInstr = BattleScript_EmergencyExit;
                         else
                             gBattlescriptCurrInstr = BattleScript_EmergencyExitNoPopUp;
                     }
                     else
                     {
-                        if (B_ABILITY_POP_UP >= GEN_6)
+                        if (B_ABILITY_POP_UP)
                             gBattlescriptCurrInstr = BattleScript_EmergencyExitWild;
                         else
                             gBattlescriptCurrInstr = BattleScript_EmergencyExitWildNoPopUp;

--- a/src/data/battle_moves.h
+++ b/src/data/battle_moves.h
@@ -198,7 +198,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SWORDS_DANCE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .pp = 20,
         #else
             .pp = 30,
@@ -258,7 +258,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_WHIRLWIND] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .accuracy = 0,
         #else
             .accuracy = 100,
@@ -276,7 +276,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FLY] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_4
+        #if B_UPDATED_MOVE_DATA >= GEN_4
             .power = 90,
         #else
             .power = 70,
@@ -294,7 +294,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_BIND] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_5
+        #if B_UPDATED_MOVE_DATA >= GEN_5
             .accuracy = 85,
         #else
             .accuracy = 75,
@@ -326,10 +326,10 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_VINE_WHIP] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 45,
             .pp = 25,
-        #elif B_UPDATED_MOVE_VALUES >= GEN_4
+        #elif B_UPDATED_MOVE_DATA >= GEN_4
             .power = 35,
             .pp = 15,
         #else
@@ -390,10 +390,10 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_JUMP_KICK] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_5
+        #if B_UPDATED_MOVE_DATA >= GEN_5
             .power = 100,
             .pp = 10,
-        #elif B_UPDATED_MOVE_VALUES == GEN_4
+        #elif B_UPDATED_MOVE_DATA == GEN_4
             .power = 85,
             .pp = 25,
         #else
@@ -496,10 +496,10 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_TACKLE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_7
+        #if B_UPDATED_MOVE_DATA >= GEN_7
             .power = 40,
             .accuracy = 100,
-        #elif B_UPDATED_MOVE_VALUES >= GEN_5
+        #elif B_UPDATED_MOVE_DATA >= GEN_5
             .power = 50,
             .accuracy = 100,
         #else
@@ -532,7 +532,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_WRAP] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_5
+        #if B_UPDATED_MOVE_DATA >= GEN_5
             .accuracy = 90,
         #else
             .accuracy = 85,
@@ -564,7 +564,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_THRASH] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_5
+        #if B_UPDATED_MOVE_DATA >= GEN_5
             .power = 120,
             .pp = 10,
         #else
@@ -639,7 +639,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_PIN_MISSILE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 25,
             .accuracy = 95,
         #else
@@ -700,7 +700,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_ROAR] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .accuracy = 0,
         #else
             .accuracy = 100,
@@ -760,9 +760,9 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_DISABLE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_5
+        #if B_UPDATED_MOVE_DATA >= GEN_5
             .accuracy = 100,
-        #elif B_UPDATED_MOVE_VALUES == GEN_4
+        #elif B_UPDATED_MOVE_DATA == GEN_4
             .accuracy = 80,
         #else
             .accuracy = 55,
@@ -808,7 +808,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FLAMETHROWER] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 90,
         #else
             .power = 95,
@@ -854,7 +854,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_HYDRO_PUMP] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 110,
         #else
             .power = 120,
@@ -872,7 +872,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SURF] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 90,
         #else
             .power = 95,
@@ -890,7 +890,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_ICE_BEAM] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 90,
         #else
             .power = 95,
@@ -908,7 +908,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_BLIZZARD] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 110,
         #else
             .power = 120,
@@ -1010,7 +1010,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SUBMISSION] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .pp = 20,
         #else
             .pp = 25,
@@ -1084,7 +1084,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_ABSORB] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_4
+        #if B_UPDATED_MOVE_DATA >= GEN_4
             .pp = 25,
         #else
             .pp = 20,
@@ -1102,7 +1102,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_MEGA_DRAIN] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_4
+        #if B_UPDATED_MOVE_DATA >= GEN_4
             .pp = 15,
         #else
             .pp = 10,
@@ -1134,7 +1134,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_GROWTH] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .pp = 20,
         #else
             .pp = 40,
@@ -1222,10 +1222,10 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_PETAL_DANCE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_5
+        #if B_UPDATED_MOVE_DATA >= GEN_5
             .power = 120,
             .pp = 10,
-        #elif B_UPDATED_MOVE_VALUES == GEN_4
+        #elif B_UPDATED_MOVE_DATA == GEN_4
             .power = 90,
             .pp = 20,
         #else
@@ -1272,7 +1272,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FIRE_SPIN] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_5
+        #if B_UPDATED_MOVE_DATA >= GEN_5
             .power = 35,
             .accuracy = 85,
         #else
@@ -1305,7 +1305,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_THUNDERBOLT] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 90,
         #else
             .power = 95,
@@ -1323,7 +1323,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_THUNDER_WAVE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_7
+        #if B_UPDATED_MOVE_DATA >= GEN_7
             .accuracy = 90,
         #else
             .accuracy = 100,
@@ -1341,7 +1341,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_THUNDER] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 110,
         #else
             .power = 120,
@@ -1401,7 +1401,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_DIG] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_4
+        #if B_UPDATED_MOVE_DATA >= GEN_4
             .power = 80,
         #else
             .power = 60,
@@ -1419,7 +1419,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_TOXIC] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_5
+        #if B_UPDATED_MOVE_DATA >= GEN_5
             .accuracy = 90,
         #else
             .accuracy = 85,
@@ -1605,7 +1605,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_RECOVER] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_4
+        #if B_UPDATED_MOVE_DATA >= GEN_4
             .pp = 10,
         #else
             .pp = 20,
@@ -1637,7 +1637,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_MINIMIZE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .pp = 10,
         #else
             .pp = 20,
@@ -1711,7 +1711,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_BARRIER] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .pp = 20,
         #else
             .pp = 30,
@@ -1785,7 +1785,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_BIDE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_4
+        #if B_UPDATED_MOVE_DATA >= GEN_4
             .accuracy = 0,
             .priority = 1,
         #else
@@ -1860,7 +1860,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_LICK] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 30,
         #else
             .power = 20,
@@ -1878,7 +1878,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SMOG] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 30,
         #else
             .power = 20,
@@ -1924,7 +1924,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FIRE_BLAST] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 120,
         #else
             .power = 110,
@@ -1956,7 +1956,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_CLAMP] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_5
+        #if B_UPDATED_MOVE_DATA >= GEN_5
             .accuracy = 85,
             .pp = 15,
         #else
@@ -1989,7 +1989,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SKULL_BASH] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 130,
             .pp = 10,
         #else
@@ -2078,10 +2078,10 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_HI_JUMP_KICK] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_5
+        #if B_UPDATED_MOVE_DATA >= GEN_5
             .power = 130,
             .pp = 10,
-        #elif B_UPDATED_MOVE_VALUES == GEN_4
+        #elif B_UPDATED_MOVE_DATA == GEN_4
             .power = 100,
             .pp = 20,
         #else
@@ -2100,9 +2100,9 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_GLARE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .accuracy = 100,
-        #elif B_UPDATED_MOVE_VALUES == GEN_5
+        #elif B_UPDATED_MOVE_DATA == GEN_5
             .accuracy = 90,
         #else
             .accuracy = 75,
@@ -2134,9 +2134,9 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_POISON_GAS] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .accuracy = 90,
-        #elif B_UPDATED_MOVE_VALUES == GEN_5
+        #elif B_UPDATED_MOVE_DATA == GEN_5
             .accuracy = 80,
         #else
             .accuracy = 55,
@@ -2168,7 +2168,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_LEECH_LIFE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_7
+        #if B_UPDATED_MOVE_DATA >= GEN_7
             .power = 80,
             .pp = 10,
         #else
@@ -2230,7 +2230,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_BUBBLE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 40,
         #else
             .power = 20,
@@ -2276,7 +2276,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FLASH] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_4
+        #if B_UPDATED_MOVE_DATA >= GEN_4
             .accuracy = 100,
         #else
             .accuracy = 70,
@@ -2294,7 +2294,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_PSYWAVE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .accuracy = 100,
         #else
             .accuracy = 80,
@@ -2326,7 +2326,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_ACID_ARMOR] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .pp = 20,
         #else
             .pp = 40,
@@ -2344,10 +2344,10 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_CRABHAMMER] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 100,
             .accuracy = 90,
-        #elif B_UPDATED_MOVE_VALUES == GEN_5
+        #elif B_UPDATED_MOVE_DATA == GEN_5
             .power = 90,
             .accuracy = 90,
         #else
@@ -2534,7 +2534,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_STRUGGLE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_4
+        #if B_UPDATED_MOVE_DATA >= GEN_4
             .accuracy = 0,
         #else
             .accuracy = 100,
@@ -2580,7 +2580,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_THIEF] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 60,
             .pp = 25,
         #else
@@ -2613,7 +2613,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_MIND_READER] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_4
+        #if B_UPDATED_MOVE_DATA >= GEN_4
             .accuracy = 0,
         #else
             .accuracy = 100,
@@ -2631,7 +2631,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_NIGHTMARE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_4
+        #if B_UPDATED_MOVE_DATA >= GEN_4
             .accuracy = 100,
         #else
             .accuracy = 0,
@@ -2663,7 +2663,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SNORE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 50,
         #else
             .power = 40,
@@ -2737,7 +2737,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_COTTON_SPORE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_5
+        #if B_UPDATED_MOVE_DATA >= GEN_5
             .accuracy = 100,
         #else
             .accuracy = 85,
@@ -2825,7 +2825,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SCARY_FACE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_5
+        #if B_UPDATED_MOVE_DATA >= GEN_5
             .accuracy = 100,
         #else
             .accuracy = 90,
@@ -2941,7 +2941,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_ZAP_CANNON] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_4
+        #if B_UPDATED_MOVE_DATA >= GEN_4
             .power = 120,
         #else
             .power = 100,
@@ -2959,7 +2959,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FORESIGHT] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_4
+        #if B_UPDATED_MOVE_DATA >= GEN_4
             .accuracy = 0,
         #else
             .accuracy = 100,
@@ -3033,7 +3033,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_BONE_RUSH] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_5
+        #if B_UPDATED_MOVE_DATA >= GEN_5
             .accuracy = 90,
         #else
             .accuracy = 80,
@@ -3051,7 +3051,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_LOCK_ON] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_4
+        #if B_UPDATED_MOVE_DATA >= GEN_4
             .accuracy = 100,
         #else
             .accuracy = 0,
@@ -3069,10 +3069,10 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_OUTRAGE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_5
+        #if B_UPDATED_MOVE_DATA >= GEN_5
             .power = 120,
             .pp = 10,
-        #elif B_UPDATED_MOVE_VALUES == GEN_4
+        #elif B_UPDATED_MOVE_DATA == GEN_4
             .power = 120,
             .pp = 15,
         #else
@@ -3105,10 +3105,10 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_GIGA_DRAIN] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_5
+        #if B_UPDATED_MOVE_DATA >= GEN_5
             .power = 75,
             .pp = 10,
-        #elif B_UPDATED_MOVE_VALUES == GEN_4
+        #elif B_UPDATED_MOVE_DATA == GEN_4
             .power = 60,
             .pp = 10,
         #else
@@ -3183,7 +3183,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SWAGGER] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_7
+        #if B_UPDATED_MOVE_DATA >= GEN_7
             .accuracy = 85,
         #else
             .accuracy = 90,
@@ -3229,9 +3229,9 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FURY_CUTTER] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 40,
-        #elif B_UPDATED_MOVE_VALUES == GEN_5
+        #elif B_UPDATED_MOVE_DATA == GEN_5
             .power = 20,
         #else
             .power = 10,
@@ -3501,7 +3501,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_RAPID_SPIN] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_4
+        #if B_UPDATED_MOVE_DATA >= GEN_4
             .power = 50,
         #else
             .power = 20,
@@ -3771,11 +3771,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FUTURE_SIGHT] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 120,
             .accuracy = 100,
             .pp = 10,
-        #elif B_UPDATED_MOVE_VALUES == GEN_5
+        #elif B_UPDATED_MOVE_DATA == GEN_5
             .power = 100,
             .accuracy = 100,
             .pp = 10,
@@ -3795,7 +3795,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_ROCK_SMASH] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_4
+        #if B_UPDATED_MOVE_DATA >= GEN_4
             .power = 40,
         #else
             .power = 20,
@@ -3813,7 +3813,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_WHIRLPOOL] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_5
+        #if B_UPDATED_MOVE_DATA >= GEN_5
             .power = 35,
             .accuracy = 85,
         #else
@@ -3864,7 +3864,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_UPROAR] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_5
+        #if B_UPDATED_MOVE_DATA >= GEN_5
             .power = 90,
         #else
             .power = 50,
@@ -3882,7 +3882,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_STOCKPILE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_4
+        #if B_UPDATED_MOVE_DATA >= GEN_4
             .pp = 20,
         #else
             .pp = 10,
@@ -3900,7 +3900,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SPIT_UP] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_4
+        #if B_UPDATED_MOVE_DATA >= GEN_4
             .power = 1,
         #else
             .power = 100,
@@ -3932,7 +3932,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_HEAT_WAVE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 95,
         #else
             .power = 100,
@@ -3992,7 +3992,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_WILL_O_WISP] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .accuracy = 85,
         #else
             .accuracy = 75,
@@ -4052,7 +4052,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SMELLING_SALT] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 70,
         #else
             .power = 60,
@@ -4295,7 +4295,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_KNOCK_OFF] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 65,
         #else
             .power = 20,
@@ -4425,7 +4425,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_DIVE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_4
+        #if B_UPDATED_MOVE_DATA >= GEN_4
             .power = 80,
         #else
             .power = 60,
@@ -4681,7 +4681,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_METEOR_MASH] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 90,
             .accuracy = 90,
         #else
@@ -4756,7 +4756,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_AIR_CUTTER] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 60,
         #else
             .power = 55,
@@ -4774,7 +4774,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_OVERHEAT] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 130,
         #else
             .power = 140,
@@ -4792,7 +4792,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_ODOR_SLEUTH] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_4
+        #if B_UPDATED_MOVE_DATA >= GEN_4
             .accuracy = 0,
         #else
             .accuracy = 100,
@@ -4810,7 +4810,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_ROCK_TOMB] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 60,
             .accuracy = 95,
             .pp = 15,
@@ -4942,7 +4942,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_EXTRASENSORY] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .pp = 20,
         #else
             .pp = 30,
@@ -4974,7 +4974,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SAND_TOMB] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_5
+        #if B_UPDATED_MOVE_DATA >= GEN_5
             .power = 35,
             .accuracy = 85,
         #else
@@ -5007,7 +5007,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_MUDDY_WATER] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 90,
         #else
             .power = 95,
@@ -5025,7 +5025,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_BULLET_SEED] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_5
+        #if B_UPDATED_MOVE_DATA >= GEN_5
             .power = 25,
         #else
             .power = 10,
@@ -5057,7 +5057,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_ICICLE_SPEAR] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_5
+        #if B_UPDATED_MOVE_DATA >= GEN_5
             .power = 25,
         #else
             .power = 10,
@@ -5202,10 +5202,10 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_COVET] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 60,
             .pp = 25,
-        #elif B_UPDATED_MOVE_VALUES == GEN_5
+        #elif B_UPDATED_MOVE_DATA == GEN_5
             .power = 60,
             .pp = 40,
         #else
@@ -5281,7 +5281,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_LEAF_BLADE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_4
+        #if B_UPDATED_MOVE_DATA >= GEN_4
             .power = 90,
         #else
             .power = 70,
@@ -5313,7 +5313,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_ROCK_BLAST] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_5
+        #if B_UPDATED_MOVE_DATA >= GEN_5
             .accuracy = 90,
         #else
             .accuracy = 80,
@@ -5359,7 +5359,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_DOOM_DESIRE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_5
+        #if B_UPDATED_MOVE_DATA >= GEN_5
             .power = 140,
             .accuracy = 100,
         #else
@@ -5434,7 +5434,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_WAKE_UP_SLAP] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 70,
         #else
             .power = 60,
@@ -5523,7 +5523,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FEINT] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_5
+        #if B_UPDATED_MOVE_DATA >= GEN_5
             .power = 30,
         #else
             .power = 50,
@@ -5555,7 +5555,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_TAILWIND] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .pp = 15,
         #else
             .pp = 30,
@@ -5643,7 +5643,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_ASSURANCE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 60,
         #else
             .power = 50,
@@ -5689,7 +5689,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_PSYCHO_SHIFT] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .accuracy = 100,
         #else
             .accuracy = 90,
@@ -5861,7 +5861,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_LAST_RESORT] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_5
+        #if B_UPDATED_MOVE_DATA >= GEN_5
             .power = 140,
         #else
             .power = 130,
@@ -5893,7 +5893,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SUCKER_PUNCH] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_7
+        #if B_UPDATED_MOVE_DATA >= GEN_7
             .power = 70,
         #else
             .power = 80,
@@ -5996,7 +5996,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_AURA_SPHERE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 80,
         #else
             .power = 90,
@@ -6098,7 +6098,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_AIR_SLASH] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .pp = 15,
         #else
             .pp = 20,
@@ -6144,7 +6144,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_DRAGON_PULSE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 85,
         #else
             .power = 90,
@@ -6176,7 +6176,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_POWER_GEM] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 80,
         #else
             .power = 70,
@@ -6194,7 +6194,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_DRAIN_PUNCH] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_5
+        #if B_UPDATED_MOVE_DATA >= GEN_5
             .power = 75,
             .pp = 10,
         #else
@@ -6241,7 +6241,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_ENERGY_BALL] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 90,
         #else
             .power = 80,
@@ -6556,7 +6556,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_DRACO_METEOR] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 130,
         #else
             .power = 140,
@@ -6602,7 +6602,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_LEAF_STORM] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 130,
         #else
             .power = 140,
@@ -6662,7 +6662,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_GUNK_SHOT] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .accuracy = 80,
         #else
             .accuracy = 70,
@@ -6764,7 +6764,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_CHATTER] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 65,
         #else
             .power = 60,
@@ -6978,10 +6978,10 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_MAGMA_STORM] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 100,
             .accuracy = 75,
-        #elif B_UPDATED_MOVE_VALUES == GEN_5
+        #elif B_UPDATED_MOVE_DATA == GEN_5
             .power = 120,
             .accuracy = 75,
         #else
@@ -7000,7 +7000,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_DARK_VOID] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_7
+        #if B_UPDATED_MOVE_DATA >= GEN_7
             .accuracy = 50,
         #else
             .accuracy = 80,
@@ -7229,7 +7229,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_STORM_THROW] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 60,
         #else
             .power = 40,
@@ -7303,7 +7303,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SYNCHRONOISE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 120,
             .pp = 10,
         #else
@@ -7378,7 +7378,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_LOW_SWEEP] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 65,
         #else
             .power = 60,
@@ -7607,7 +7607,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_HEX] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 65,
         #else
             .power = 50,
@@ -7667,7 +7667,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_INCINERATE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 60,
         #else
             .power = 30,
@@ -7783,7 +7783,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_WATER_PLEDGE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 80,
         #else
             .power = 50,
@@ -7801,7 +7801,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FIRE_PLEDGE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 80,
         #else
             .power = 50,
@@ -7819,7 +7819,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_GRASS_PLEDGE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 80,
         #else
             .power = 50,
@@ -7851,7 +7851,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_STRUGGLE_BUG] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 50,
         #else
             .power = 30,
@@ -7883,7 +7883,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FROST_BREATH] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 60,
         #else
             .power = 40,
@@ -8013,7 +8013,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SACRED_SWORD] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .pp = 15,
         #else
             .pp = 20,
@@ -8143,7 +8143,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_HURRICANE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 110,
         #else
             .power = 120,
@@ -8203,7 +8203,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_TECHNO_BLAST] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_6
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 120,
         #else
             .power = 85,
@@ -8405,7 +8405,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FLYING_PRESS] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_7
+        #if B_UPDATED_MOVE_DATA >= GEN_7
             .power = 100,
         #else
             .power = 80,
@@ -8481,7 +8481,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FELL_STINGER] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_7
+        #if B_UPDATED_MOVE_DATA >= GEN_7
             .power = 50,
         #else
             .power = 30,
@@ -8557,7 +8557,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_PARABOLIC_CHARGE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_7
+        #if B_UPDATED_MOVE_DATA >= GEN_7
             .power = 65,
         #else
             .power = 50,
@@ -8646,7 +8646,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_TOPSY_TURVY] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_7
+        #if B_UPDATED_MOVE_DATA >= GEN_7
             .accuracy = 0,
         #else
             .accuracy = 100,
@@ -8918,7 +8918,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_MYSTICAL_FIRE] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_7
+        #if B_UPDATED_MOVE_DATA >= GEN_7
             .power = 75,
         #else
             .power = 65,
@@ -10002,7 +10002,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_MULTI_ATTACK] =
     {
-        #if B_UPDATED_MOVE_VALUES >= GEN_8
+        #if B_UPDATED_MOVE_DATA >= GEN_8
             .power = 120,
         #else
             .power = 90,

--- a/src/data/battle_moves.h
+++ b/src/data/battle_moves.h
@@ -184,6 +184,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_RAZOR_WIND] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_4
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGSROCK_AFFECTED | FLAG_HIGH_CRIT,
+        #else
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGSROCK_AFFECTED,
+        #endif
         .effect = EFFECT_TWO_TURNS_ATTACK,
         .power = 80,
         .type = TYPE_NORMAL,
@@ -192,7 +197,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_BOTH,
         .priority = 0,
-        .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGSROCK_AFFECTED | FLAG_HIGH_CRIT,
         .split = SPLIT_SPECIAL,
     },
 
@@ -780,7 +784,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_ACID] =
     {
-        .effect = EFFECT_SPECIAL_DEFENSE_DOWN_HIT,
+        #if B_UPDATED_MOVE_DATA >= GEN_4
+            .effect = EFFECT_SPECIAL_DEFENSE_DOWN_HIT,
+        #else
+            .effect = EFFECT_DEFENSE_DOWN_HIT,
+        #endif
         .power = 40,
         .type = TYPE_POISON,
         .accuracy = 100,
@@ -1942,7 +1950,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_WATERFALL] =
     {
-        .effect = EFFECT_FLINCH_HIT,
+        #if B_UPDATED_MOVE_DATA >= GEN_4
+            .effect = EFFECT_FLINCH_HIT,
+        #else
+            .effect = EFFECT_HIT,
+        #endif
         .power = 80,
         .type = TYPE_WATER,
         .accuracy = 100,
@@ -2681,9 +2693,13 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_CURSE] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_5
+            .type = TYPE_GHOST,
+        #else
+            .type = TYPE_MYSTERY,
+        #endif
         .effect = EFFECT_CURSE,
         .power = 0,
-        .type = TYPE_GHOST,
         .accuracy = 0,
         .pp = 10,
         .secondaryEffectChance = 0,
@@ -2857,9 +2873,13 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SWEET_KISS] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_6
+            .type = TYPE_FAIRY,
+        #else
+            .type = TYPE_NORMAL,
+        #endif
         .effect = EFFECT_CONFUSE,
         .power = 0,
-        .type = TYPE_FAIRY,
         .accuracy = 75,
         .pp = 10,
         .secondaryEffectChance = 0,
@@ -3141,9 +3161,13 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_CHARM] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_6
+            .type = TYPE_FAIRY,
+        #else
+            .type = TYPE_NORMAL,
+        #endif
         .effect = EFFECT_ATTACK_DOWN_2,
         .power = 0,
-        .type = TYPE_FAIRY,
         .accuracy = 100,
         .pp = 20,
         .secondaryEffectChance = 0,
@@ -3603,9 +3627,13 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_MOONLIGHT] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_6
+            .type = TYPE_FAIRY,
+        #else
+            .type = TYPE_NORMAL,
+        #endif
         .effect = EFFECT_MOONLIGHT,
         .power = 0,
-        .type = TYPE_FAIRY,
         .accuracy = 0,
         .pp = 5,
         .secondaryEffectChance = 0,
@@ -3687,7 +3715,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_CRUNCH] =
     {
-        .effect = EFFECT_DEFENSE_DOWN_HIT,
+        #if B_UPDATED_MOVE_DATA >= GEN_4
+            .effect = EFFECT_DEFENSE_DOWN_HIT,
+        #else
+            .effect = EFFECT_SPECIAL_DEFENSE_DOWN_HIT,
+        #endif
         .power = 80,
         .type = TYPE_DARK,
         .accuracy = 100,
@@ -4625,12 +4657,16 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_POISON_FANG] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_4
+            .secondaryEffectChance = 50,
+        #else
+            .secondaryEffectChance = 30,
+        #endif
         .effect = EFFECT_POISON_FANG,
         .power = 50,
         .type = TYPE_POISON,
         .accuracy = 100,
         .pp = 15,
-        .secondaryEffectChance = 50,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
         .flags = FLAG_MAKES_CONTACT | FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_SHEER_FORCE_BOOST | FLAG_STRONG_JAW_BOOST,
@@ -5224,7 +5260,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_VOLT_TACKLE] =
     {
-        .effect = EFFECT_RECOIL_33_STATUS,
+        #if B_UPDATED_MOVE_DATA >= GEN_4
+            .effect = EFFECT_RECOIL_33_STATUS,
+            .argument = STATUS1_PARALYSIS,
+        #else
+            .effect = EFFECT_RECOIL_33,
+        #endif
         .power = 120,
         .type = TYPE_ELECTRIC,
         .accuracy = 100,
@@ -5234,7 +5275,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .priority = 0,
         .flags = FLAG_MAKES_CONTACT | FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGSROCK_AFFECTED | FLAG_RECKLESS_BOOST | FLAG_SHEER_FORCE_BOOST,
         .split = SPLIT_PHYSICAL,
-        .argument = STATUS1_PARALYSIS,
     },
 
     [MOVE_MAGICAL_LEAF] =
@@ -8862,7 +8902,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_DIAMOND_STORM] =
     {
-        .effect = EFFECT_DEFENSE_UP2_HIT,
+        #if B_UPDATED_MOVE_DATA >= GEN_4
+            .effect = EFFECT_DEFENSE_UP2_HIT,
+        #else
+            .effect = EFFECT_DEFENSE_UP_HIT,
+        #endif
         .power = 100,
         .type = TYPE_ROCK,
         .accuracy = 95,
@@ -8904,6 +8948,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_WATER_SHURIKEN] =
     {
+        #if B_WATER_SHURIKEN_SPLIT >= GEN_7
+            .split = SPLIT_SPECIAL,
+        #else
+            .split = SPLIT_PHYSICAL,
+        #endif
         .effect = EFFECT_MULTI_HIT,
         .power = 15,
         .type = TYPE_WATER,
@@ -8913,7 +8962,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .target = MOVE_TARGET_SELECTED,
         .priority = 1,
         .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGSROCK_AFFECTED,
-        .split = SPLIT_SPECIAL,
     },
 
     [MOVE_MYSTICAL_FIRE] =
@@ -9289,7 +9337,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     {
         .effect = EFFECT_PLACEHOLDER,
         .power = 0,
-        .type = TYPE_MYSTERY,
+        .type = TYPE_DARK,
         .accuracy = 0,
         .pp = 0,
         .secondaryEffectChance = 0,

--- a/src/data/battle_moves.h
+++ b/src/data/battle_moves.h
@@ -264,8 +264,13 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     {
         #if B_UPDATED_MOVE_DATA >= GEN_6
             .accuracy = 0,
+            .flags = FLAG_MAGICCOAT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
+        #elif B_UPDATED_MOVE_DATA >= GEN_5
+            .accuracy = 100,
+            .flags = FLAG_MAGICCOAT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
         #else
             .accuracy = 100,
+            .flags = FLAG_MIRROR_MOVE_AFFECTED,
         #endif
         .effect = EFFECT_ROAR,
         .power = 0,
@@ -274,7 +279,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = -6,
-        .flags = FLAG_MAGICCOAT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
         .split = SPLIT_STATUS,
     },
 
@@ -706,8 +710,13 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     {
         #if B_UPDATED_MOVE_DATA >= GEN_6
             .accuracy = 0,
+            .flags = FLAG_MIRROR_MOVE_AFFECTED | FLAG_SOUND | FLAG_MAGICCOAT_AFFECTED,
+        #elif B_UPDATED_MOVE_DATA >= GEN_5
+            .accuracy = 100,
+            .flags = FLAG_MIRROR_MOVE_AFFECTED | FLAG_SOUND | FLAG_MAGICCOAT_AFFECTED,
         #else
             .accuracy = 100,
+            .flags = FLAG_MIRROR_MOVE_AFFECTED | FLAG_SOUND,
         #endif
         .effect = EFFECT_ROAR,
         .power = 0,
@@ -716,7 +725,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = -6,
-        .flags = FLAG_MIRROR_MOVE_AFFECTED | FLAG_SOUND | FLAG_MAGICCOAT_AFFECTED,
         .split = SPLIT_STATUS,
     },
 
@@ -766,10 +774,13 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     {
         #if B_UPDATED_MOVE_DATA >= GEN_5
             .accuracy = 100,
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_MAGICCOAT_AFFECTED,
         #elif B_UPDATED_MOVE_DATA == GEN_4
             .accuracy = 80,
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
         #else
             .accuracy = 55,
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
         #endif
         .effect = EFFECT_DISABLE,
         .power = 0,
@@ -778,7 +789,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
-        .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_MAGICCOAT_AFFECTED,
         .split = SPLIT_STATUS,
     },
 
@@ -882,15 +892,19 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     {
         #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 90,
+            .target = MOVE_TARGET_FOES_AND_ALLY,
+        #elif B_UPDATED_MOVE_DATA >= GEN_4
+            .power = 95,
+            .target = MOVE_TARGET_FOES_AND_ALLY,
         #else
             .power = 95,
+            .target = MOVE_TARGET_BOTH,
         #endif
         .effect = EFFECT_HIT,
         .type = TYPE_WATER,
         .accuracy = 100,
         .pp = 15,
         .secondaryEffectChance = 0,
-        .target = MOVE_TARGET_FOES_AND_ALLY,
         .priority = 0,
         .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGSROCK_AFFECTED | FLAG_DMG_UNDERWATER,
         .split = SPLIT_SPECIAL,
@@ -1050,6 +1064,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_COUNTER] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_4
+            .flags = FLAG_MAKES_CONTACT | FLAG_PROTECT_AFFECTED,
+        #else
+            .flags = FLAG_MAKES_CONTACT | FLAG_MIRROR_MOVE_AFFECTED,
+        #endif
         .effect = EFFECT_COUNTER,
         .power = 1,
         .type = TYPE_FIGHTING,
@@ -1058,7 +1077,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_DEPENDS,
         .priority = -5,
-        .flags = FLAG_MAKES_CONTACT | FLAG_PROTECT_AFFECTED,
         .split = SPLIT_PHYSICAL,
     },
 
@@ -2062,6 +2080,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_KINESIS] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_4
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_MAGICCOAT_AFFECTED,
+        #else
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
+        #endif
         .effect = EFFECT_ACCURACY_DOWN,
         .power = 0,
         .type = TYPE_PSYCHIC,
@@ -2070,7 +2093,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
-        .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_MAGICCOAT_AFFECTED,
         .split = SPLIT_STATUS,
     },
 
@@ -2148,17 +2170,19 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     {
         #if B_UPDATED_MOVE_DATA >= GEN_6
             .accuracy = 90,
+            .target = MOVE_TARGET_FOES_AND_ALLY,
         #elif B_UPDATED_MOVE_DATA == GEN_5
             .accuracy = 80,
+            .target = MOVE_TARGET_FOES_AND_ALLY,
         #else
             .accuracy = 55,
+            .target = MOVE_TARGET_BOTH,
         #endif
         .effect = EFFECT_POISON,
         .power = 0,
         .type = TYPE_POISON,
         .pp = 40,
         .secondaryEffectChance = 0,
-        .target = MOVE_TARGET_BOTH,
         .priority = 0,
         .flags = FLAG_PROTECT_AFFECTED | FLAG_MAGICCOAT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
         .split = SPLIT_STATUS,
@@ -2476,6 +2500,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_CONVERSION] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_5
+            .flags = FLAG_SNATCH_AFFECTED,
+        #else
+            .flags = 0,
+        #endif
         .effect = EFFECT_CONVERSION,
         .power = 0,
         .type = TYPE_NORMAL,
@@ -2484,7 +2513,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_USER,
         .priority = 0,
-        .flags = FLAG_SNATCH_AFFECTED,
         .split = SPLIT_STATUS,
     },
 
@@ -2548,8 +2576,10 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     {
         #if B_UPDATED_MOVE_DATA >= GEN_4
             .accuracy = 0,
+            .flags = FLAG_MAKES_CONTACT | FLAG_PROTECT_AFFECTED | FLAG_KINGSROCK_AFFECTED,
         #else
             .accuracy = 100,
+            .flags = FLAG_MAKES_CONTACT | FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGSROCK_AFFECTED,
         #endif
         .effect = EFFECT_RECOIL_25,
         .power = 50,
@@ -2558,7 +2588,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
-        .flags = FLAG_MAKES_CONTACT | FLAG_PROTECT_AFFECTED | FLAG_KINGSROCK_AFFECTED,
         .split = SPLIT_PHYSICAL,
     },
 
@@ -2611,6 +2640,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SPIDER_WEB] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_6
+            .flags = FLAG_MAGICCOAT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
+        #else
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MAGICCOAT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
+        #endif
         .effect = EFFECT_MEAN_LOOK,
         .power = 0,
         .type = TYPE_BUG,
@@ -2619,7 +2653,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
-        .flags = FLAG_MAGICCOAT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
         .split = SPLIT_STATUS,
     },
 
@@ -2725,13 +2758,17 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_CONVERSION_2] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_5
+            .target = MOVE_TARGET_USER,
+        #else
+            .target = MOVE_TARGET_FOES_AND_ALLY,
+        #endif
         .effect = EFFECT_CONVERSION_2,
         .power = 0,
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .pp = 30,
         .secondaryEffectChance = 0,
-        .target = MOVE_TARGET_USER,
         .priority = 0,
         .flags = 0,
         .split = SPLIT_STATUS,
@@ -2753,17 +2790,21 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_COTTON_SPORE] =
     {
-        #if B_UPDATED_MOVE_DATA >= GEN_5
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .accuracy = 100,
+            .target = MOVE_TARGET_BOTH,
+        #elif B_UPDATED_MOVE_DATA == GEN_5
+            .accuracy = 100,
+            .target = MOVE_TARGET_FOES_AND_ALLY,
         #else
             .accuracy = 85,
+            .target = MOVE_TARGET_FOES_AND_ALLY,
         #endif
         .effect = EFFECT_SPEED_DOWN_2,
         .power = 0,
         .type = TYPE_GRASS,
         .pp = 40,
         .secondaryEffectChance = 0,
-        .target = MOVE_TARGET_BOTH,
         .priority = 0,
         .flags = FLAG_PROTECT_AFFECTED | FLAG_MAGICCOAT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_POWDER,
         .split = SPLIT_STATUS,
@@ -2785,6 +2826,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SPITE] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_5
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_MAGICCOAT_AFFECTED,
+        #else
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
+        #endif
         .effect = EFFECT_SPITE,
         .power = 0,
         .type = TYPE_GHOST,
@@ -2793,7 +2839,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
-        .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_MAGICCOAT_AFFECTED,
         .split = SPLIT_STATUS,
     },
 
@@ -2859,6 +2904,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FAINT_ATTACK] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_4
+            .flags = FLAG_MAKES_CONTACT | FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGSROCK_AFFECTED,
+        #else
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGSROCK_AFFECTED,
+        #endif
         .effect = EFFECT_HIT,
         .power = 60,
         .type = TYPE_DARK,
@@ -2867,7 +2917,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
-        .flags = FLAG_MAKES_CONTACT | FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGSROCK_AFFECTED,
         .split = SPLIT_PHYSICAL,
     },
 
@@ -2947,6 +2996,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SPIKES] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_5
+            .flags = FLAG_MAGICCOAT_AFFECTED,
+        #else
+            .flags = 0,
+        #endif
         .effect = EFFECT_SPIKES,
         .power = 0,
         .type = TYPE_GROUND,
@@ -2955,7 +3009,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_OPPONENTS_FIELD,
         .priority = 0,
-        .flags = FLAG_MAGICCOAT_AFFECTED,
         .split = SPLIT_STATUS,
     },
 
@@ -2979,10 +3032,15 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FORESIGHT] =
     {
-        #if B_UPDATED_MOVE_DATA >= GEN_4
+        #if B_UPDATED_MOVE_DATA >= GEN_5
             .accuracy = 0,
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_MAGICCOAT_AFFECTED,
+        #elif B_UPDATED_MOVE_DATA >= GEN_4
+            .accuracy = 0,
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
         #else
             .accuracy = 100,
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
         #endif
         .effect = EFFECT_FORESIGHT,
         .power = 0,
@@ -2991,7 +3049,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
-        .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_MAGICCOAT_AFFECTED,
         .split = SPLIT_STATUS,
     },
 
@@ -3287,6 +3344,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_MEAN_LOOK] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_6
+            .flags = FLAG_MAGICCOAT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
+        #else
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MAGICCOAT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
+        #endif
         .effect = EFFECT_MEAN_LOOK,
         .power = 0,
         .type = TYPE_NORMAL,
@@ -3295,7 +3357,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
-        .flags = FLAG_MAGICCOAT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
         .split = SPLIT_STATUS,
     },
 
@@ -3497,6 +3558,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_ENCORE] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_5
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_MAGICCOAT_AFFECTED,
+        #else
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
+        #endif
         .effect = EFFECT_ENCORE,
         .power = 0,
         .type = TYPE_NORMAL,
@@ -3505,7 +3571,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
-        .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_MAGICCOAT_AFFECTED,
         .split = SPLIT_STATUS,
     },
 
@@ -3733,6 +3798,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_MIRROR_COAT] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_4
+            .flags = FLAG_PROTECT_AFFECTED,
+        #else
+            .flags = FLAG_MIRROR_MOVE_AFFECTED,
+        #endif
         .effect = EFFECT_MIRROR_COAT,
         .power = 1,
         .type = TYPE_PSYCHIC,
@@ -3741,12 +3811,16 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_DEPENDS,
         .priority = -5,
-        .flags = FLAG_PROTECT_AFFECTED,
         .split = SPLIT_SPECIAL,
     },
 
     [MOVE_PSYCH_UP] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_5
+            .flags = FLAG_SNATCH_AFFECTED,
+        #else
+            .flags = 0,
+        #endif
         .effect = EFFECT_PSYCH_UP,
         .power = 0,
         .type = TYPE_NORMAL,
@@ -3755,12 +3829,16 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
-        .flags = 0,
         .split = SPLIT_STATUS,
     },
 
     [MOVE_EXTREME_SPEED] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_5
+            .priority = 2,
+        #else
+            .priority = 1,
+        #endif
         .effect = EFFECT_HIT,
         .power = 80,
         .type = TYPE_NORMAL,
@@ -3768,13 +3846,17 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .pp = 5,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
-        .priority = 2,
         .flags = FLAG_MAKES_CONTACT | FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGSROCK_AFFECTED,
         .split = SPLIT_PHYSICAL,
     },
 
     [MOVE_ANCIENT_POWER] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_4
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_SHEER_FORCE_BOOST,
+        #else
+            .flags = FLAG_MAKES_CONTACT | FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_SHEER_FORCE_BOOST,
+        #endif
         .effect = EFFECT_ALL_STATS_UP_HIT,
         .power = 60,
         .type = TYPE_ROCK,
@@ -3783,7 +3865,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 10,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
-        .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_SHEER_FORCE_BOOST,
         .split = SPLIT_SPECIAL,
     },
 
@@ -3882,6 +3963,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FAKE_OUT] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_4
+            .flags = FLAG_MAKES_CONTACT | FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_SHEER_FORCE_BOOST,
+        #else
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_SHEER_FORCE_BOOST,
+        #endif
         .effect = EFFECT_FAKE_OUT,
         .power = 40,
         .type = TYPE_NORMAL,
@@ -3890,7 +3976,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 100,
         .target = MOVE_TARGET_SELECTED,
         .priority = 3,
-        .flags = FLAG_MAKES_CONTACT | FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_SHEER_FORCE_BOOST,
         .split = SPLIT_PHYSICAL,
     },
 
@@ -3996,6 +4081,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_TORMENT] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_5
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_MAGICCOAT_AFFECTED,
+        #else
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
+        #endif
         .effect = EFFECT_TORMENT,
         .power = 0,
         .type = TYPE_DARK,
@@ -4004,7 +4094,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
-        .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_MAGICCOAT_AFFECTED,
         .split = SPLIT_STATUS,
     },
 
@@ -4145,6 +4234,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_TAUNT] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_5
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MAGICCOAT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
+        #else
+            .flags = FLAG_PROTECT_AFFECTED,
+        #endif
         .effect = EFFECT_TAUNT,
         .power = 0,
         .type = TYPE_DARK,
@@ -4153,19 +4247,22 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
-        .flags = FLAG_PROTECT_AFFECTED | FLAG_MAGICCOAT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
         .split = SPLIT_STATUS,
     },
 
     [MOVE_HELPING_HAND] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_4
+            .target = MOVE_TARGET_ALLY,
+        #else
+            .target = MOVE_TARGET_USER,
+        #endif
         .effect = EFFECT_HELPING_HAND,
         .power = 0,
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .pp = 20,
         .secondaryEffectChance = 0,
-        .target = MOVE_TARGET_USER,
         .priority = 5,
         .flags = 0,
         .split = SPLIT_STATUS,
@@ -4201,6 +4298,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_WISH] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_5
+            .flags = FLAG_SNATCH_AFFECTED,
+        #else
+            .flags = 0,
+        #endif
         .effect = EFFECT_WISH,
         .power = 0,
         .type = TYPE_NORMAL,
@@ -4209,7 +4311,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_USER,
         .priority = 0,
-        .flags = FLAG_PROTECT_AFFECTED | FLAG_SNATCH_AFFECTED,
         .split = SPLIT_STATUS,
     },
 
@@ -4271,6 +4372,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_RECYCLE] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_5
+            .flags = FLAG_SNATCH_AFFECTED,
+        #else
+            .flags = 0,
+        #endif
         .effect = EFFECT_RECYCLE,
         .power = 0,
         .type = TYPE_NORMAL,
@@ -4279,7 +4385,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_USER,
         .priority = 0,
-        .flags = FLAG_SNATCH_AFFECTED,
         .split = SPLIT_STATUS,
     },
 
@@ -4387,6 +4492,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_IMPRISON] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_5
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_SNATCH_AFFECTED,
+        #else
+            .flags = FLAG_PROTECT_AFFECTED,
+        #endif
         .effect = EFFECT_IMPRISON,
         .power = 0,
         .type = TYPE_PSYCHIC,
@@ -4395,7 +4505,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_USER,
         .priority = 0,
-        .flags = FLAG_PROTECT_AFFECTED | FLAG_SNATCH_AFFECTED,
         .split = SPLIT_STATUS,
     },
 
@@ -4559,6 +4668,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_TEETER_DANCE] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_4
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_DANCE,
+        #else
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_DANCE,
+        #endif
         .effect = EFFECT_TEETER_DANCE,
         .power = 0,
         .type = TYPE_NORMAL,
@@ -4567,7 +4681,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_FOES_AND_ALLY,
         .priority = 0,
-        .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_DANCE,
         .split = SPLIT_STATUS,
     },
 
@@ -4812,8 +4925,13 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     {
         #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 130,
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGSROCK_AFFECTED,
+        #elif B_UPDATED_MOVE_DATA >= GEN_4
+            .power = 130,
+            .flags = FLAG_MAKES_CONTACT | FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGSROCK_AFFECTED,
         #else
             .power = 140,
+            .flags = FLAG_MAKES_CONTACT | FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGSROCK_AFFECTED,
         #endif
         .effect = EFFECT_OVERHEAT,
         .type = TYPE_FIRE,
@@ -4822,7 +4940,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 100,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
-        .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGSROCK_AFFECTED,
         .split = SPLIT_SPECIAL,
     },
 
@@ -4830,8 +4947,10 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     {
         #if B_UPDATED_MOVE_DATA >= GEN_4
             .accuracy = 0,
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_MAGICCOAT_AFFECTED,
         #else
             .accuracy = 100,
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
         #endif
         .effect = EFFECT_FORESIGHT,
         .power = 0,
@@ -4840,7 +4959,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
-        .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_MAGICCOAT_AFFECTED,
         .split = SPLIT_STATUS,
     },
 
@@ -5125,6 +5243,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_BLOCK] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_6
+            .flags = FLAG_MAGICCOAT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
+        #else
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MAGICCOAT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
+        #endif
         .effect = EFFECT_MEAN_LOOK,
         .power = 0,
         .type = TYPE_NORMAL,
@@ -5133,7 +5256,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
-        .flags = FLAG_MAGICCOAT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
         .split = SPLIT_STATUS,
     },
 
@@ -5241,12 +5363,19 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 60,
             .pp = 25,
+            .flags = FLAG_MAKES_CONTACT | FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
         #elif B_UPDATED_MOVE_DATA == GEN_5
             .power = 60,
             .pp = 40,
+            .flags = FLAG_MAKES_CONTACT | FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
+        #elif B_UPDATED_MOVE_DATA == GEN_4
+            .power = 40,
+            .pp = 40,
+            .flags = FLAG_MAKES_CONTACT | FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
         #else
             .power = 40,
             .pp = 40,
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
         #endif
         .effect = EFFECT_THIEF,
         .type = TYPE_NORMAL,
@@ -5254,7 +5383,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 100,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
-        .flags = FLAG_MAKES_CONTACT | FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
         .split = SPLIT_PHYSICAL,
     },
 
@@ -5460,6 +5588,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_MIRACLE_EYE] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_5
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MAGICCOAT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
+        #else
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
+        #endif
         .effect = EFFECT_MIRACLE_EYE,
         .power = 0,
         .type = TYPE_PSYCHIC,
@@ -5468,7 +5601,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
-        .flags = FLAG_PROTECT_AFFECTED | FLAG_MAGICCOAT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
         .split = SPLIT_STATUS,
     },
 
@@ -5521,6 +5653,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_HEALING_WISH] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_5
+            .flags = FLAG_SNATCH_AFFECTED,
+        #else
+            .flags = 0,
+        #endif
         .effect = EFFECT_HEALING_WISH,
         .power = 0,
         .type = TYPE_PSYCHIC,
@@ -5529,7 +5666,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_USER,
         .priority = 0,
-        .flags = FLAG_SNATCH_AFFECTED,
         .split = SPLIT_STATUS,
     },
 
@@ -5563,10 +5699,15 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FEINT] =
     {
-        #if B_UPDATED_MOVE_DATA >= GEN_5
+        #if B_UPDATED_MOVE_DATA >= GEN_6
             .power = 30,
+            .flags = FLAG_MIRROR_MOVE_AFFECTED,
+        #elif B_UPDATED_MOVE_DATA >= GEN_5
+            .power = 30,
+            .flags = 0,
         #else
             .power = 50,
+            .flags = 0,
         #endif
         .effect = EFFECT_FEINT,
         .type = TYPE_NORMAL,
@@ -5575,7 +5716,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 100,
         .target = MOVE_TARGET_SELECTED,
         .priority = 2,
-        .flags = FLAG_MIRROR_MOVE_AFFECTED,
         .split = SPLIT_PHYSICAL,
     },
 
@@ -5613,6 +5753,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_ACUPRESSURE] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_5
+            .flags = 0,
+        #else
+            .flags = FLAG_SNATCH_AFFECTED,
+        #endif
         .effect = EFFECT_ACUPRESSURE,
         .power = 0,
         .type = TYPE_NORMAL,
@@ -5621,12 +5766,16 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_USER | MOVE_TARGET_ALLY,
         .priority = 0,
-        .flags = 0,
         .split = SPLIT_STATUS,
     },
 
     [MOVE_METAL_BURST] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_4
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
+        #else
+            .flags = FLAG_MIRROR_MOVE_AFFECTED,
+        #endif
         .effect = EFFECT_METAL_BURST,
         .power = 0,
         .type = TYPE_STEEL,
@@ -5635,7 +5784,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_DEPENDS,
         .priority = 0,
-        .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
         .split = SPLIT_PHYSICAL,
     },
 
@@ -5701,6 +5849,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_EMBARGO] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_5
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MAGICCOAT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
+        #else
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
+        #endif
         .effect = EFFECT_EMBARGO,
         .power = 0,
         .type = TYPE_DARK,
@@ -5709,7 +5862,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
-        .flags = FLAG_PROTECT_AFFECTED | FLAG_MAGICCOAT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
         .split = SPLIT_STATUS,
     },
 
@@ -5761,6 +5913,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_HEAL_BLOCK] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_5
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MAGICCOAT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
+        #else
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
+        #endif
         .effect = EFFECT_HEAL_BLOCK,
         .power = 0,
         .type = TYPE_PSYCHIC,
@@ -5769,7 +5926,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
-        .flags = FLAG_PROTECT_AFFECTED | FLAG_MAGICCOAT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
         .split = SPLIT_STATUS,
     },
 
@@ -5789,6 +5945,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_POWER_TRICK] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_5
+            .flags = FLAG_SNATCH_AFFECTED,
+        #else
+            .flags = 0,
+        #endif
         .effect = EFFECT_POWER_TRICK,
         .power = 0,
         .type = TYPE_PSYCHIC,
@@ -5797,7 +5958,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_USER,
         .priority = 0,
-        .flags = FLAG_SNATCH_AFFECTED,
         .split = SPLIT_STATUS,
     },
 
@@ -5817,6 +5977,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_LUCKY_CHANT] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_5
+            .flags = FLAG_SNATCH_AFFECTED,
+        #else
+            .flags = 0,
+        #endif
         .effect = EFFECT_LUCKY_CHANT,
         .power = 0,
         .type = TYPE_NORMAL,
@@ -5825,7 +5990,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_USER,
         .priority = 0,
-        .flags = FLAG_SNATCH_AFFECTED,
         .split = SPLIT_STATUS,
     },
 
@@ -5951,6 +6115,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_TOXIC_SPIKES] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_5
+            .flags = FLAG_MAGICCOAT_AFFECTED,
+        #else
+            .flags = 0,
+        #endif
         .effect = EFFECT_TOXIC_SPIKES,
         .power = 0,
         .type = TYPE_POISON,
@@ -5959,7 +6128,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_OPPONENTS_FIELD,
         .priority = 0,
-        .flags = FLAG_MAGICCOAT_AFFECTED,
         .split = SPLIT_STATUS,
     },
 
@@ -5979,6 +6147,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_AQUA_RING] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_5
+            .flags = FLAG_SNATCH_AFFECTED,
+        #else
+            .flags = 0,
+        #endif
         .effect = EFFECT_AQUA_RING,
         .power = 0,
         .type = TYPE_WATER,
@@ -5987,12 +6160,16 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_USER,
         .priority = 0,
-        .flags = FLAG_SNATCH_AFFECTED,
         .split = SPLIT_STATUS,
     },
 
     [MOVE_MAGNET_RISE] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_5
+            .flags = FLAG_SNATCH_AFFECTED,
+        #else
+            .flags = 0,
+        #endif
         .effect = EFFECT_MAGNET_RISE,
         .power = 0,
         .type = TYPE_ELECTRIC,
@@ -6001,7 +6178,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_USER,
         .priority = 0,
-        .flags = FLAG_SNATCH_AFFECTED,
         .split = SPLIT_STATUS,
     },
 
@@ -6568,6 +6744,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_DEFOG] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_5
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MAGICCOAT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
+        #else
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
+        #endif
         .effect = EFFECT_DEFOG,
         .power = 0,
         .type = TYPE_FLYING,
@@ -6576,7 +6757,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
-        .flags = FLAG_PROTECT_AFFECTED | FLAG_MAGICCOAT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
         .split = SPLIT_STATUS,
     },
 
@@ -6776,6 +6956,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_STEALTH_ROCK] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_5
+            .flags = FLAG_MAGICCOAT_AFFECTED,
+        #else
+            .flags = 0,
+        #endif
         .effect = EFFECT_STEALTH_ROCK,
         .power = 0,
         .type = TYPE_ROCK,
@@ -6784,7 +6969,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_OPPONENTS_FIELD,
         .priority = 0,
-        .flags = FLAG_MAGICCOAT_AFFECTED,
         .split = SPLIT_STATUS,
     },
 
@@ -6990,6 +7174,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_LUNAR_DANCE] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_5
+            .flags = FLAG_DANCE | FLAG_SNATCH_AFFECTED,
+        #else
+            .flags = FLAG_DANCE,
+        #endif
         .effect = EFFECT_HEALING_WISH,
         .power = 0,
         .type = TYPE_PSYCHIC,
@@ -6998,7 +7187,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_USER,
         .priority = 0,
-        .flags = FLAG_DANCE | FLAG_SNATCH_AFFECTED,
         .split = SPLIT_STATUS,
     },
 
@@ -7157,6 +7345,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_WONDER_ROOM] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_6
+            .priority = 0,
+        #else
+            .priority = -7,
+        #endif
         .effect = EFFECT_WONDER_ROOM,
         .power = 0,
         .type = TYPE_PSYCHIC,
@@ -7164,7 +7357,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .pp = 10,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_USER,
-        .priority = 0,
         .flags = 0,
         .split = SPLIT_STATUS,
     },
@@ -7213,6 +7405,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_RAGE_POWDER] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_6
+            .priority = 2,
+        #else
+            .priority = 3,
+        #endif
         .effect = EFFECT_FOLLOW_ME,
         .power = 0,
         .type = TYPE_BUG,
@@ -7220,7 +7417,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .pp = 20,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_USER,
-        .priority = 2,
         .flags = FLAG_POWDER,
         .split = SPLIT_STATUS,
     },
@@ -7241,6 +7437,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_MAGIC_ROOM] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_6
+            .priority = 0,
+        #else
+            .priority = -7,
+        #endif
         .effect = EFFECT_MAGIC_ROOM,
         .power = 0,
         .type = TYPE_PSYCHIC,
@@ -7248,7 +7449,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .pp = 10,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_USER,
-        .priority = 0,
         .flags = 0,
         .split = SPLIT_STATUS,
     },
@@ -7591,6 +7791,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_ALLY_SWITCH] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_7
+            .priority = 2,
+        #else
+            .priority = 1,
+        #endif
         .effect = EFFECT_ALLY_SWITCH,
         .power = 0,
         .type = TYPE_PSYCHIC,
@@ -7598,7 +7803,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .pp = 15,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_USER,
-        .priority = 2,
         .flags = 0,
         .split = SPLIT_STATUS,
     },
@@ -7795,6 +7999,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_BESTOW] =
     {
+        #if B_UPDATED_MOVE_DATA >= GEN_6
+            .flags = FLAG_MIRROR_MOVE_AFFECTED,
+        #else
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED,
+        #endif
         .effect = EFFECT_BESTOW,
         .power = 0,
         .type = TYPE_NORMAL,
@@ -7803,7 +8012,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
-        .flags = FLAG_MIRROR_MOVE_AFFECTED,
         .split = SPLIT_STATUS,
     },
 

--- a/src/data/battle_moves.h
+++ b/src/data/battle_moves.h
@@ -4553,7 +4553,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
             .accuracy = 85,
         #endif
         .type = TYPE_STEEL,
-        .accuracy = 90,
         .pp = 10,
         .secondaryEffectChance = 20,
         .target = MOVE_TARGET_SELECTED,
@@ -7505,7 +7504,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         #else
             .power = 30,
         #endif
-        .power = 60,
         .type = TYPE_FIRE,
         .accuracy = 100,
         .pp = 15,

--- a/src/data/battle_moves.h
+++ b/src/data/battle_moves.h
@@ -198,11 +198,15 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SWORDS_DANCE] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .pp = 20,
+        #else
+            .pp = 30,
+        #endif
         .effect = EFFECT_ATTACK_UP_2,
         .power = 0,
         .type = TYPE_NORMAL,
         .accuracy = 0,
-        .pp = 20,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_USER,
         .priority = 0,
@@ -254,10 +258,14 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_WHIRLWIND] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .accuracy = 0,
+        #else
+            .accuracy = 100,
+        #endif
         .effect = EFFECT_ROAR,
         .power = 0,
         .type = TYPE_NORMAL,
-        .accuracy = 0,
         .pp = 20,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
@@ -286,10 +294,14 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_BIND] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_5
+            .accuracy = 85,
+        #else
+            .accuracy = 75,
+        #endif
         .effect = EFFECT_TRAP,
         .power = 15,
         .type = TYPE_NORMAL,
-        .accuracy = 85,
         .pp = 20,
         .secondaryEffectChance = 100,
         .target = MOVE_TARGET_SELECTED,
@@ -520,10 +532,14 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_WRAP] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_5
+            .accuracy = 90,
+        #else
+            .accuracy = 85,
+        #endif
         .effect = EFFECT_TRAP,
         .power = 15,
         .type = TYPE_NORMAL,
-        .accuracy = 90,
         .pp = 20,
         .secondaryEffectChance = 100,
         .target = MOVE_TARGET_SELECTED,
@@ -684,10 +700,14 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_ROAR] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .accuracy = 0,
+        #else
+            .accuracy = 100,
+        #endif
         .effect = EFFECT_ROAR,
         .power = 0,
         .type = TYPE_NORMAL,
-        .accuracy = 0,
         .pp = 20,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
@@ -740,10 +760,16 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_DISABLE] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_5
+            .accuracy = 100,
+        #elif B_UPDATED_MOVE_VALUES == GEN_4
+            .accuracy = 80,
+        #else
+            .accuracy = 55,
+        #endif
         .effect = EFFECT_DISABLE,
         .power = 0,
         .type = TYPE_NORMAL,
-        .accuracy = 100,
         .pp = 20,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
@@ -984,11 +1010,15 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SUBMISSION] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .pp = 20,
+        #else
+            .pp = 25,
+        #endif
         .effect = EFFECT_RECOIL_25,
         .power = 80,
         .type = TYPE_FIGHTING,
         .accuracy = 80,
-        .pp = 20,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -1104,11 +1134,15 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_GROWTH] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .pp = 20,
+        #else
+            .pp = 40,
+        #endif
         .effect = EFFECT_GROWTH,
         .power = 0,
         .type = TYPE_NORMAL,
         .accuracy = 0,
-        .pp = 20,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_USER,
         .priority = 0,
@@ -1289,10 +1323,14 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_THUNDER_WAVE] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_7
+            .accuracy = 90,
+        #else
+            .accuracy = 100,
+        #endif
         .effect = EFFECT_PARALYZE,
         .power = 0,
         .type = TYPE_ELECTRIC,
-        .accuracy = 90,
         .pp = 20,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
@@ -1381,10 +1419,14 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_TOXIC] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_5
+            .accuracy = 90,
+        #else
+            .accuracy = 85,
+        #endif
         .effect = EFFECT_TOXIC,
         .power = 0,
         .type = TYPE_POISON,
-        .accuracy = 90,
         .pp = 10,
         .secondaryEffectChance = 100,
         .target = MOVE_TARGET_SELECTED,
@@ -1563,11 +1605,15 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_RECOVER] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_4
+            .pp = 10,
+        #else
+            .pp = 20,
+        #endif
         .effect = EFFECT_RESTORE_HP,
         .power = 0,
         .type = TYPE_NORMAL,
         .accuracy = 0,
-        .pp = 10,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_USER,
         .priority = 0,
@@ -1591,11 +1637,15 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_MINIMIZE] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .pp = 10,
+        #else
+            .pp = 20,
+        #endif
         .effect = EFFECT_MINIMIZE,
         .power = 0,
         .type = TYPE_NORMAL,
         .accuracy = 0,
-        .pp = 10,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_USER,
         .priority = 0,
@@ -1661,11 +1711,15 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_BARRIER] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .pp = 20,
+        #else
+            .pp = 30,
+        #endif
         .effect = EFFECT_DEFENSE_UP_2,
         .power = 0,
         .type = TYPE_PSYCHIC,
         .accuracy = 0,
-        .pp = 20,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_USER,
         .priority = 0,
@@ -1731,14 +1785,19 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_BIDE] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_4
+            .accuracy = 0,
+            .priority = 1,
+        #else
+            .accuracy = 100,
+            .priority = 0,
+        #endif
         .effect = EFFECT_BIDE,
         .power = 1,
         .type = TYPE_NORMAL,
-        .accuracy = 0,
         .pp = 10,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_USER,
-        .priority = 1,
         .flags = FLAG_MAKES_CONTACT | FLAG_PROTECT_AFFECTED | FLAG_KINGSROCK_AFFECTED,
         .split = SPLIT_PHYSICAL,
     },
@@ -1897,11 +1956,16 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_CLAMP] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_5
+            .accuracy = 85,
+            .pp = 15,
+        #else
+            .accuracy = 75,
+            .pp = 10,
+        #endif
         .effect = EFFECT_TRAP,
         .power = 35,
         .type = TYPE_WATER,
-        .accuracy = 85,
-        .pp = 15,
         .secondaryEffectChance = 100,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -2036,10 +2100,16 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_GLARE] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .accuracy = 100,
+        #elif B_UPDATED_MOVE_VALUES == GEN_5
+            .accuracy = 90,
+        #else
+            .accuracy = 75,
+        #endif
         .effect = EFFECT_PARALYZE,
         .power = 0,
         .type = TYPE_NORMAL,
-        .accuracy = 100,
         .pp = 30,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
@@ -2064,10 +2134,16 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_POISON_GAS] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .accuracy = 90,
+        #elif B_UPDATED_MOVE_VALUES == GEN_5
+            .accuracy = 80,
+        #else
+            .accuracy = 55,
+        #endif
         .effect = EFFECT_POISON,
         .power = 0,
         .type = TYPE_POISON,
-        .accuracy = 90,
         .pp = 40,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_BOTH,
@@ -2200,10 +2276,14 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FLASH] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_4
+            .accuracy = 100,
+        #else
+            .accuracy = 70,
+        #endif
         .effect = EFFECT_ACCURACY_DOWN,
         .power = 0,
         .type = TYPE_NORMAL,
-        .accuracy = 100,
         .pp = 20,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
@@ -2214,10 +2294,14 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_PSYWAVE] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .accuracy = 100,
+        #else
+            .accuracy = 80,
+        #endif
         .effect = EFFECT_PSYWAVE,
         .power = 1,
         .type = TYPE_PSYCHIC,
-        .accuracy = 100,
         .pp = 15,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
@@ -2242,11 +2326,15 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_ACID_ARMOR] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .pp = 20,
+        #else
+            .pp = 40,
+        #endif
         .effect = EFFECT_DEFENSE_UP_2,
         .power = 0,
         .type = TYPE_POISON,
         .accuracy = 0,
-        .pp = 20,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_USER,
         .priority = 0,
@@ -2446,10 +2534,14 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_STRUGGLE] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_4
+            .accuracy = 0,
+        #else
+            .accuracy = 100,
+        #endif
         .effect = EFFECT_RECOIL_25,
         .power = 50,
         .type = TYPE_NORMAL,
-        .accuracy = 0,
         .pp = 1,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
@@ -2488,11 +2580,16 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_THIEF] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 60,
+            .pp = 25,
+        #else
+            .power = 40,
+            .pp = 10,
+        #endif
         .effect = EFFECT_THIEF,
-        .power = 60,
         .type = TYPE_DARK,
         .accuracy = 100,
-        .pp = 25,
         .secondaryEffectChance = 100,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -2516,10 +2613,14 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_MIND_READER] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_4
+            .accuracy = 0,
+        #else
+            .accuracy = 100,
+        #endif
         .effect = EFFECT_LOCK_ON,
         .power = 0,
         .type = TYPE_NORMAL,
-        .accuracy = 0,
         .pp = 5,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
@@ -2530,10 +2631,14 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_NIGHTMARE] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_4
+            .accuracy = 100,
+        #else
+            .accuracy = 0,
+        #endif
         .effect = EFFECT_NIGHTMARE,
         .power = 0,
         .type = TYPE_GHOST,
-        .accuracy = 100,
         .pp = 15,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
@@ -2632,10 +2737,14 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_COTTON_SPORE] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_5
+            .accuracy = 100,
+        #else
+            .accuracy = 85,
+        #endif
         .effect = EFFECT_SPEED_DOWN_2,
         .power = 0,
         .type = TYPE_GRASS,
-        .accuracy = 100,
         .pp = 40,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_BOTH,
@@ -2716,10 +2825,14 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SCARY_FACE] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_5
+            .accuracy = 100,
+        #else
+            .accuracy = 90,
+        #endif
         .effect = EFFECT_SPEED_DOWN_2,
         .power = 0,
         .type = TYPE_NORMAL,
-        .accuracy = 100,
         .pp = 10,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
@@ -2846,10 +2959,14 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FORESIGHT] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_4
+            .accuracy = 0,
+        #else
+            .accuracy = 100,
+        #endif
         .effect = EFFECT_FORESIGHT,
         .power = 0,
         .type = TYPE_NORMAL,
-        .accuracy = 0,
         .pp = 40,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
@@ -2916,10 +3033,14 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_BONE_RUSH] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_5
+            .accuracy = 90,
+        #else
+            .accuracy = 80,
+        #endif
         .effect = EFFECT_MULTI_HIT,
         .power = 25,
         .type = TYPE_GROUND,
-        .accuracy = 90,
         .pp = 10,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
@@ -2930,10 +3051,14 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_LOCK_ON] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_4
+            .accuracy = 100,
+        #else
+            .accuracy = 0,
+        #endif
         .effect = EFFECT_LOCK_ON,
         .power = 0,
         .type = TYPE_NORMAL,
-        .accuracy = 0,
         .pp = 5,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
@@ -3058,10 +3183,14 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SWAGGER] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_7
+            .accuracy = 85,
+        #else
+            .accuracy = 90,
+        #endif
         .effect = EFFECT_SWAGGER,
         .power = 0,
         .type = TYPE_NORMAL,
-        .accuracy = 85,
         .pp = 15,
         .secondaryEffectChance = 100,
         .target = MOVE_TARGET_SELECTED,
@@ -3753,11 +3882,15 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_STOCKPILE] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_4
+            .pp = 20,
+        #else
+            .pp = 10,
+        #endif
         .effect = EFFECT_STOCKPILE,
         .power = 0,
         .type = TYPE_NORMAL,
         .accuracy = 0,
-        .pp = 20,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_USER,
         .priority = 0,
@@ -3859,10 +3992,14 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_WILL_O_WISP] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .accuracy = 85,
+        #else
+            .accuracy = 75,
+        #endif
         .effect = EFFECT_WILL_O_WISP,
         .power = 0,
         .type = TYPE_FIRE,
-        .accuracy = 85,
         .pp = 15,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
@@ -4655,10 +4792,14 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_ODOR_SLEUTH] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_4
+            .accuracy = 0,
+        #else
+            .accuracy = 100,
+        #endif
         .effect = EFFECT_FORESIGHT,
         .power = 0,
         .type = TYPE_NORMAL,
-        .accuracy = 0,
         .pp = 40,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
@@ -4801,11 +4942,15 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_EXTRASENSORY] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .pp = 20,
+        #else
+            .pp = 30,
+        #endif
         .effect = EFFECT_FLINCH_MINIMIZE_HIT,
         .power = 80,
         .type = TYPE_PSYCHIC,
         .accuracy = 100,
-        .pp = 20,
         .secondaryEffectChance = 10,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -5168,10 +5313,14 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_ROCK_BLAST] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_5
+            .accuracy = 90,
+        #else
+            .accuracy = 80,
+        #endif
         .effect = EFFECT_MULTI_HIT,
         .power = 25,
         .type = TYPE_ROCK,
-        .accuracy = 90,
         .pp = 10,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
@@ -5212,14 +5361,14 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     {
         #if B_UPDATED_MOVE_VALUES >= GEN_5
             .power = 140,
-            .pp = 100,
+            .accuracy = 100,
         #else
             .power = 120,
-            .pp = 85,
+            .accuracy = 85,
         #endif
         .effect = EFFECT_FUTURE_SIGHT,
         .type = TYPE_STEEL,
-        .accuracy = 100,
+        .pp = 5,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -5406,11 +5555,15 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_TAILWIND] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .pp = 15,
+        #else
+            .pp = 30,
+        #endif
         .effect = EFFECT_TAILWIND,
         .power = 0,
         .type = TYPE_FLYING,
         .accuracy = 0,
-        .pp = 15,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_USER,
         .priority = 0,
@@ -5536,10 +5689,14 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_PSYCHO_SHIFT] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .accuracy = 100,
+        #else
+            .accuracy = 90,
+        #endif
         .effect = EFFECT_PSYCHO_SHIFT,
         .power = 0,
         .type = TYPE_PSYCHIC,
-        .accuracy = 100,
         .pp = 10,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
@@ -5941,11 +6098,15 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_AIR_SLASH] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .pp = 15,
+        #else
+            .pp = 20,
+        #endif
         .effect = EFFECT_FLINCH_HIT,
         .power = 75,
         .type = TYPE_FLYING,
         .accuracy = 95,
-        .pp = 15,
         .secondaryEffectChance = 30,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -6501,10 +6662,14 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_GUNK_SHOT] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .accuracy = 80,
+        #else
+            .accuracy = 70,
+        #endif
         .effect = EFFECT_POISON_HIT,
         .power = 120,
         .type = TYPE_POISON,
-        .accuracy = 80,
         .pp = 5,
         .secondaryEffectChance = 30,
         .target = MOVE_TARGET_SELECTED,
@@ -6835,10 +7000,14 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_DARK_VOID] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_7
+            .accuracy = 50,
+        #else
+            .accuracy = 80,
+        #endif
         .effect = EFFECT_SLEEP,
         .power = 0,
         .type = TYPE_DARK,
-        .accuracy = 50,
         .pp = 10,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_BOTH,
@@ -7844,11 +8013,15 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SACRED_SWORD] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .pp = 15,
+        #else
+            .pp = 20,
+        #endif
         .effect = EFFECT_HIT,
         .power = 90,
         .type = TYPE_FIGHTING,
         .accuracy = 100,
-        .pp = 15,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -8473,10 +8646,14 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_TOPSY_TURVY] =
     {
+        #if B_UPDATED_MOVE_VALUES >= GEN_7
+            .accuracy = 0,
+        #else
+            .accuracy = 100,
+        #endif
         .effect = EFFECT_TOPSY_TURVY,
         .power = 0,
         .type = TYPE_DARK,
-        .accuracy = 0,
         .pp = 20,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,

--- a/src/data/battle_moves.h
+++ b/src/data/battle_moves.h
@@ -268,12 +268,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FLY] =
     {
-        .effect = EFFECT_SEMI_INVULNERABLE,
         #if B_UPDATED_MOVE_VALUES >= GEN_4
             .power = 90,
         #else
             .power = 70,
         #endif
+        .effect = EFFECT_SEMI_INVULNERABLE,
         .type = TYPE_FLYING,
         .accuracy = 95,
         .pp = 15,
@@ -314,7 +314,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_VINE_WHIP] =
     {
-        .effect = EFFECT_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 45,
             .pp = 25,
@@ -325,6 +324,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
             .power = 35,
             .pp = 10,
         #endif
+        .effect = EFFECT_HIT,
         .type = TYPE_GRASS,
         .accuracy = 100,
         .secondaryEffectChance = 0,
@@ -378,7 +378,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_JUMP_KICK] =
     {
-        .effect = EFFECT_RECOIL_IF_MISS,
         #if B_UPDATED_MOVE_VALUES >= GEN_5
             .power = 100,
             .pp = 10,
@@ -389,6 +388,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
             .power = 70,
             .pp = 25,
         #endif
+        .effect = EFFECT_RECOIL_IF_MISS,
         .type = TYPE_FIGHTING,
         .accuracy = 95,
         .secondaryEffectChance = 0,
@@ -484,7 +484,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_TACKLE] =
     {
-        .effect = EFFECT_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_7
             .power = 40,
             .accuracy = 100,
@@ -495,6 +494,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
             .power = 35,
             .accuracy = 95,
         #endif
+        .effect = EFFECT_HIT,
         .type = TYPE_NORMAL,
         .pp = 35,
         .secondaryEffectChance = 0,
@@ -548,7 +548,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_THRASH] =
     {
-        .effect = EFFECT_RAMPAGE,
         #if B_UPDATED_MOVE_VALUES >= GEN_5
             .power = 120,
             .pp = 10,
@@ -556,6 +555,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
             .power = 90,
             .pp = 20,
         #endif
+        .effect = EFFECT_RAMPAGE,
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .secondaryEffectChance = 100,
@@ -623,7 +623,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_PIN_MISSILE] =
     {
-        .effect = EFFECT_MULTI_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 25,
             .accuracy = 95,
@@ -631,6 +630,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
             .power = 14,
             .accuracy = 85,
         #endif
+        .effect = EFFECT_MULTI_HIT,
         .type = TYPE_BUG,
         .pp = 20,
         .secondaryEffectChance = 0,
@@ -782,12 +782,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FLAMETHROWER] =
     {
-        .effect = EFFECT_BURN_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 90,
         #else
             .power = 95,
         #endif
+        .effect = EFFECT_BURN_HIT,
         .type = TYPE_FIRE,
         .accuracy = 100,
         .pp = 15,
@@ -828,12 +828,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_HYDRO_PUMP] =
     {
-        .effect = EFFECT_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 110,
         #else
             .power = 120,
         #endif
+        .effect = EFFECT_HIT,
         .type = TYPE_WATER,
         .accuracy = 80,
         .pp = 5,
@@ -846,12 +846,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SURF] =
     {
-        .effect = EFFECT_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 90,
         #else
             .power = 95,
         #endif
+        .effect = EFFECT_HIT,
         .type = TYPE_WATER,
         .accuracy = 100,
         .pp = 15,
@@ -864,12 +864,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_ICE_BEAM] =
     {
-        .effect = EFFECT_FREEZE_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 90,
         #else
             .power = 95,
         #endif
+        .effect = EFFECT_FREEZE_HIT,
         .type = TYPE_ICE,
         .accuracy = 100,
         .pp = 10,
@@ -882,12 +882,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_BLIZZARD] =
     {
-        .effect = EFFECT_FREEZE_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 110,
         #else
             .power = 120,
         #endif
+        .effect = EFFECT_FREEZE_HIT,
         .type = TYPE_ICE,
         .accuracy = 70,
         .pp = 5,
@@ -1054,15 +1054,15 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_ABSORB] =
     {
-        .effect = EFFECT_ABSORB,
-        .power = 20,
-        .type = TYPE_GRASS,
-        .accuracy = 100,
         #if B_UPDATED_MOVE_VALUES >= GEN_4
             .pp = 25,
         #else
             .pp = 20,
         #endif
+        .effect = EFFECT_ABSORB,
+        .power = 20,
+        .type = TYPE_GRASS,
+        .accuracy = 100,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -1072,15 +1072,15 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_MEGA_DRAIN] =
     {
-        .effect = EFFECT_ABSORB,
-        .power = 40,
-        .type = TYPE_GRASS,
-        .accuracy = 100,
         #if B_UPDATED_MOVE_VALUES >= GEN_4
             .pp = 15,
         #else
             .pp = 10,
         #endif
+        .effect = EFFECT_ABSORB,
+        .power = 40,
+        .type = TYPE_GRASS,
+        .accuracy = 100,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -1188,7 +1188,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_PETAL_DANCE] =
     {
-        .effect = EFFECT_RAMPAGE,
         #if B_UPDATED_MOVE_VALUES >= GEN_5
             .power = 120,
             .pp = 10,
@@ -1199,6 +1198,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
             .power = 70,
             .pp = 20,
         #endif
+        .effect = EFFECT_RAMPAGE,
         .type = TYPE_GRASS,
         .accuracy = 100,
         .secondaryEffectChance = 100,
@@ -1238,7 +1238,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FIRE_SPIN] =
     {
-        .effect = EFFECT_TRAP,
         #if B_UPDATED_MOVE_VALUES >= GEN_5
             .power = 35,
             .accuracy = 85,
@@ -1246,6 +1245,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
             .power = 15,
             .accuracy = 70,
         #endif
+        .effect = EFFECT_TRAP,
         .type = TYPE_FIRE,
         .pp = 15,
         .secondaryEffectChance = 100,
@@ -1271,12 +1271,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_THUNDERBOLT] =
     {
-        .effect = EFFECT_PARALYZE_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 90,
         #else
             .power = 95,
         #endif
+        .effect = EFFECT_PARALYZE_HIT,
         .type = TYPE_ELECTRIC,
         .accuracy = 100,
         .pp = 15,
@@ -1303,12 +1303,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_THUNDER] =
     {
-        .effect = EFFECT_THUNDER,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 110,
         #else
             .power = 120,
         #endif
+        .effect = EFFECT_THUNDER,
         .type = TYPE_ELECTRIC,
         .accuracy = 70,
         .pp = 10,
@@ -1363,12 +1363,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_DIG] =
     {
-        .effect = EFFECT_SEMI_INVULNERABLE,
         #if B_UPDATED_MOVE_VALUES >= GEN_4
             .power = 80,
         #else
             .power = 60,
         #endif
+        .effect = EFFECT_SEMI_INVULNERABLE,
         .type = TYPE_GROUND,
         .accuracy = 100,
         .pp = 10,
@@ -1801,12 +1801,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_LICK] =
     {
-        .effect = EFFECT_PARALYZE_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 30,
         #else
             .power = 20,
         #endif
+        .effect = EFFECT_PARALYZE_HIT,
         .type = TYPE_GHOST,
         .accuracy = 100,
         .pp = 30,
@@ -1819,12 +1819,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SMOG] =
     {
-        .effect = EFFECT_POISON_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 30,
         #else
             .power = 20,
         #endif
+        .effect = EFFECT_POISON_HIT,
         .type = TYPE_POISON,
         .accuracy = 70,
         .pp = 20,
@@ -1865,12 +1865,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FIRE_BLAST] =
     {
-        .effect = EFFECT_BURN_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 120,
         #else
             .power = 110,
         #endif
+        .effect = EFFECT_BURN_HIT,
         .type = TYPE_FIRE,
         .accuracy = 85,
         .pp = 5,
@@ -1925,7 +1925,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SKULL_BASH] =
     {
-        .effect = EFFECT_SKULL_BASH,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 130,
             .pp = 10,
@@ -1933,6 +1932,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
             .power = 100,
             .pp = 15,
         #endif
+        .effect = EFFECT_SKULL_BASH,
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .secondaryEffectChance = 0,
@@ -2014,7 +2014,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_HI_JUMP_KICK] =
     {
-        .effect = EFFECT_RECOIL_IF_MISS,
         #if B_UPDATED_MOVE_VALUES >= GEN_5
             .power = 130,
             .pp = 10,
@@ -2025,6 +2024,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
             .power = 85,
             .pp = 20,
         #endif
+        .effect = EFFECT_RECOIL_IF_MISS,
         .type = TYPE_FIGHTING,
         .accuracy = 90,
         .secondaryEffectChance = 0,
@@ -2092,7 +2092,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_LEECH_LIFE] =
     {
-        .effect = EFFECT_ABSORB,
         #if B_UPDATED_MOVE_VALUES >= GEN_7
             .power = 80,
             .pp = 10,
@@ -2100,6 +2099,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
             .power = 20,
             .pp = 15,
         #endif
+        .effect = EFFECT_ABSORB,
         .type = TYPE_BUG,
         .accuracy = 100,
         .secondaryEffectChance = 0,
@@ -2154,12 +2154,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_BUBBLE] =
     {
-        .effect = EFFECT_SPEED_DOWN_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 40,
         #else
             .power = 20,
         #endif
+        .effect = EFFECT_SPEED_DOWN_HIT,
         .type = TYPE_WATER,
         .accuracy = 100,
         .pp = 30,
@@ -2256,7 +2256,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_CRABHAMMER] =
     {
-        .effect = EFFECT_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 100,
             .accuracy = 90,
@@ -2267,6 +2266,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
             .power = 90,
             .accuracy = 85,
         #endif
+        .effect = EFFECT_HIT,
         .type = TYPE_WATER,
         .pp = 10,
         .secondaryEffectChance = 0,
@@ -2558,12 +2558,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SNORE] =
     {
-        .effect = EFFECT_SNORE,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 50,
         #else
             .power = 40,
         #endif
+        .effect = EFFECT_SNORE,
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .pp = 15,
@@ -2828,12 +2828,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_ZAP_CANNON] =
     {
-        .effect = EFFECT_PARALYZE_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_4
             .power = 120,
         #else
             .power = 100,
         #endif
+        .effect = EFFECT_PARALYZE_HIT,
         .type = TYPE_ELECTRIC,
         .accuracy = 50,
         .pp = 5,
@@ -2944,7 +2944,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_OUTRAGE] =
     {
-        .effect = EFFECT_RAMPAGE,
         #if B_UPDATED_MOVE_VALUES >= GEN_5
             .power = 120,
             .pp = 10,
@@ -2955,6 +2954,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
             .power = 90,
             .pp = 15,
         #endif
+        .effect = EFFECT_RAMPAGE,
         .type = TYPE_DRAGON,
         .accuracy = 100,
         .secondaryEffectChance = 100,
@@ -2980,7 +2980,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_GIGA_DRAIN] =
     {
-        .effect = EFFECT_ABSORB,
         #if B_UPDATED_MOVE_VALUES >= GEN_5
             .power = 75,
             .pp = 10,
@@ -2991,6 +2990,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
             .power = 60,
             .pp = 5,
         #endif
+        .effect = EFFECT_ABSORB,
         .type = TYPE_GRASS,
         .accuracy = 100,
         .secondaryEffectChance = 0,
@@ -3100,7 +3100,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FURY_CUTTER] =
     {
-        .effect = EFFECT_FURY_CUTTER,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 40,
         #elif B_UPDATED_MOVE_VALUES == GEN_5
@@ -3108,6 +3107,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         #else
             .power = 10,
         #endif
+        .effect = EFFECT_FURY_CUTTER,
         .type = TYPE_BUG,
         .accuracy = 95,
         .pp = 20,
@@ -3372,12 +3372,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_RAPID_SPIN] =
     {
-        .effect = EFFECT_RAPID_SPIN,
         #if B_UPDATED_MOVE_VALUES >= GEN_4
             .power = 50,
         #else
             .power = 20,
         #endif
+        .effect = EFFECT_RAPID_SPIN,
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .pp = 40,
@@ -3642,7 +3642,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FUTURE_SIGHT] =
     {
-        .effect = EFFECT_FUTURE_SIGHT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 120,
             .accuracy = 100,
@@ -3656,6 +3655,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
             .accuracy = 90,
             .pp = 15,
         #endif
+        .effect = EFFECT_FUTURE_SIGHT,
         .type = TYPE_PSYCHIC,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
@@ -3666,12 +3666,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_ROCK_SMASH] =
     {
-        .effect = EFFECT_DEFENSE_DOWN_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_4
             .power = 40,
         #else
             .power = 20,
         #endif
+        .effect = EFFECT_DEFENSE_DOWN_HIT,
         .type = TYPE_FIGHTING,
         .accuracy = 100,
         .pp = 15,
@@ -3684,7 +3684,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_WHIRLPOOL] =
     {
-        .effect = EFFECT_TRAP,
         #if B_UPDATED_MOVE_VALUES >= GEN_5
             .power = 35,
             .accuracy = 85,
@@ -3692,6 +3691,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
             .power = 15,
             .accuracy = 70,
         #endif
+        .effect = EFFECT_TRAP,
         .type = TYPE_WATER,
         .pp = 15,
         .secondaryEffectChance = 100,
@@ -3735,12 +3735,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_UPROAR] =
     {
-        .effect = EFFECT_UPROAR,
         #if B_UPDATED_MOVE_VALUES >= GEN_5
             .power = 90,
         #else
             .power = 50,
         #endif
+        .effect = EFFECT_UPROAR,
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .pp = 10,
@@ -3767,12 +3767,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SPIT_UP] =
     {
-        .effect = EFFECT_SPIT_UP,
         #if B_UPDATED_MOVE_VALUES >= GEN_4
             .power = 1,
         #else
             .power = 100,
         #endif
+        .effect = EFFECT_SPIT_UP,
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .pp = 10,
@@ -3799,12 +3799,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_HEAT_WAVE] =
     {
-        .effect = EFFECT_BURN_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 95,
         #else
             .power = 100,
         #endif
+        .effect = EFFECT_BURN_HIT,
         .type = TYPE_FIRE,
         .accuracy = 90,
         .pp = 10,
@@ -3915,12 +3915,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SMELLING_SALT] =
     {
-        .effect = EFFECT_SMELLINGSALT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 70,
         #else
             .power = 60,
         #endif
+        .effect = EFFECT_SMELLINGSALT,
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .pp = 10,
@@ -4158,12 +4158,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_KNOCK_OFF] =
     {
-        .effect = EFFECT_KNOCK_OFF,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 65,
         #else
             .power = 20,
         #endif
+        .effect = EFFECT_KNOCK_OFF,
         .type = TYPE_DARK,
         .accuracy = 100,
         .pp = 20,
@@ -4288,12 +4288,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_DIVE] =
     {
-        .effect = EFFECT_SEMI_INVULNERABLE,
         #if B_UPDATED_MOVE_VALUES >= GEN_4
             .power = 80,
         #else
             .power = 60,
         #endif
+        .effect = EFFECT_SEMI_INVULNERABLE,
         .type = TYPE_WATER,
         .accuracy = 100,
         .pp = 10,
@@ -4544,7 +4544,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_METEOR_MASH] =
     {
-        .effect = EFFECT_ATTACK_UP_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 90,
             .accuracy = 90,
@@ -4552,6 +4551,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
             .power = 100,
             .accuracy = 85,
         #endif
+        .effect = EFFECT_ATTACK_UP_HIT,
         .type = TYPE_STEEL,
         .pp = 10,
         .secondaryEffectChance = 20,
@@ -4619,12 +4619,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_AIR_CUTTER] =
     {
-        .effect = EFFECT_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 60,
         #else
             .power = 55,
         #endif
+        .effect = EFFECT_HIT,
         .type = TYPE_FLYING,
         .accuracy = 95,
         .pp = 25,
@@ -4637,12 +4637,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_OVERHEAT] =
     {
-        .effect = EFFECT_OVERHEAT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 130,
         #else
             .power = 140,
         #endif
+        .effect = EFFECT_OVERHEAT,
         .type = TYPE_FIRE,
         .accuracy = 90,
         .pp = 5,
@@ -4669,7 +4669,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_ROCK_TOMB] =
     {
-        .effect = EFFECT_SPEED_DOWN_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 60,
             .accuracy = 95,
@@ -4679,6 +4678,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
             .accuracy = 80,
             .pp = 10,
         #endif
+        .effect = EFFECT_SPEED_DOWN_HIT,
         .type = TYPE_ROCK,
         .secondaryEffectChance = 100,
         .target = MOVE_TARGET_SELECTED,
@@ -4829,7 +4829,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SAND_TOMB] =
     {
-        .effect = EFFECT_TRAP,
         #if B_UPDATED_MOVE_VALUES >= GEN_5
             .power = 35,
             .accuracy = 85,
@@ -4837,6 +4836,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
             .power = 15,
             .accuracy = 70,
         #endif
+        .effect = EFFECT_TRAP,
         .type = TYPE_GROUND,
         .pp = 15,
         .secondaryEffectChance = 100,
@@ -4862,12 +4862,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_MUDDY_WATER] =
     {
-        .effect = EFFECT_ACCURACY_DOWN_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 90,
         #else
             .power = 95,
         #endif
+        .effect = EFFECT_ACCURACY_DOWN_HIT,
         .type = TYPE_WATER,
         .accuracy = 85,
         .pp = 10,
@@ -4880,12 +4880,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_BULLET_SEED] =
     {
-        .effect = EFFECT_MULTI_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_5
             .power = 25,
         #else
             .power = 10,
         #endif
+        .effect = EFFECT_MULTI_HIT,
         .type = TYPE_GRASS,
         .accuracy = 100,
         .pp = 30,
@@ -4912,12 +4912,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_ICICLE_SPEAR] =
     {
-        .effect = EFFECT_MULTI_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_5
             .power = 25,
         #else
             .power = 10,
         #endif
+        .effect = EFFECT_MULTI_HIT,
         .type = TYPE_ICE,
         .accuracy = 100,
         .pp = 30,
@@ -5057,7 +5057,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_COVET] =
     {
-        .effect = EFFECT_THIEF,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 60,
             .pp = 25,
@@ -5068,6 +5067,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
             .power = 40,
             .pp = 40,
         #endif
+        .effect = EFFECT_THIEF,
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .secondaryEffectChance = 100,
@@ -5136,12 +5136,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_LEAF_BLADE] =
     {
-        .effect = EFFECT_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_4
             .power = 90,
         #else
             .power = 70,
         #endif
+        .effect = EFFECT_HIT,
         .type = TYPE_GRASS,
         .accuracy = 100,
         .pp = 15,
@@ -5210,7 +5210,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_DOOM_DESIRE] =
     {
-        .effect = EFFECT_FUTURE_SIGHT,
         #if B_UPDATED_MOVE_VALUES >= GEN_5
             .power = 140,
             .pp = 100,
@@ -5218,6 +5217,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
             .power = 120,
             .pp = 85,
         #endif
+        .effect = EFFECT_FUTURE_SIGHT,
         .type = TYPE_STEEL,
         .accuracy = 100,
         .secondaryEffectChance = 0,
@@ -5285,12 +5285,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_WAKE_UP_SLAP] =
     {
-        .effect = EFFECT_WAKE_UP_SLAP,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 70,
         #else
             .power = 60,
         #endif
+        .effect = EFFECT_WAKE_UP_SLAP,
         .type = TYPE_FIGHTING,
         .accuracy = 100,
         .pp = 10,
@@ -5374,12 +5374,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FEINT] =
     {
-        .effect = EFFECT_FEINT,
         #if B_UPDATED_MOVE_VALUES >= GEN_5
             .power = 30,
         #else
             .power = 50,
         #endif
+        .effect = EFFECT_FEINT,
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .pp = 10,
@@ -5490,12 +5490,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_ASSURANCE] =
     {
-        .effect = EFFECT_ASSURANCE,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 60,
         #else
             .power = 50,
         #endif
+        .effect = EFFECT_ASSURANCE,
         .type = TYPE_DARK,
         .accuracy = 100,
         .pp = 10,
@@ -5704,12 +5704,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_LAST_RESORT] =
     {
-        .effect = EFFECT_LAST_RESORT,
         #if B_UPDATED_MOVE_VALUES >= GEN_5
             .power = 140,
         #else
             .power = 130,
         #endif
+        .effect = EFFECT_LAST_RESORT,
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .pp = 5,
@@ -5736,12 +5736,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SUCKER_PUNCH] =
     {
-        .effect = EFFECT_SUCKER_PUNCH,
         #if B_UPDATED_MOVE_VALUES >= GEN_7
             .power = 70,
         #else
             .power = 80,
         #endif
+        .effect = EFFECT_SUCKER_PUNCH,
         .type = TYPE_DARK,
         .accuracy = 100,
         .pp = 5,
@@ -5839,12 +5839,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_AURA_SPHERE] =
     {
-        .effect = EFFECT_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 80,
         #else
             .power = 90,
         #endif
+        .effect = EFFECT_HIT,
         .type = TYPE_FIGHTING,
         .accuracy = 0,
         .pp = 20,
@@ -5983,12 +5983,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_DRAGON_PULSE] =
     {
-        .effect = EFFECT_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 85,
         #else
             .power = 90,
         #endif
+        .effect = EFFECT_HIT,
         .type = TYPE_DRAGON,
         .accuracy = 100,
         .pp = 10,
@@ -6015,12 +6015,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_POWER_GEM] =
     {
-        .effect = EFFECT_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 80,
         #else
             .power = 70,
         #endif
+        .effect = EFFECT_HIT,
         .type = TYPE_ROCK,
         .accuracy = 100,
         .pp = 20,
@@ -6033,7 +6033,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_DRAIN_PUNCH] =
     {
-        .effect = EFFECT_ABSORB,
         #if B_UPDATED_MOVE_VALUES >= GEN_5
             .power = 75,
             .pp = 10,
@@ -6041,6 +6040,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
             .power = 60,
             .pp = 5,
         #endif
+        .effect = EFFECT_ABSORB,
         .type = TYPE_FIGHTING,
         .accuracy = 100,
         .secondaryEffectChance = 0,
@@ -6080,12 +6080,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_ENERGY_BALL] =
     {
-        .effect = EFFECT_SPECIAL_DEFENSE_DOWN_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 90,
         #else
             .power = 80,
         #endif
+        .effect = EFFECT_SPECIAL_DEFENSE_DOWN_HIT,
         .type = TYPE_GRASS,
         .accuracy = 100,
         .pp = 10,
@@ -6395,12 +6395,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_DRACO_METEOR] =
     {
-        .effect = EFFECT_OVERHEAT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 130,
         #else
             .power = 140,
         #endif
+        .effect = EFFECT_OVERHEAT,
         .type = TYPE_DRAGON,
         .accuracy = 90,
         .pp = 5,
@@ -6441,12 +6441,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_LEAF_STORM] =
     {
-        .effect = EFFECT_OVERHEAT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 130,
         #else
             .power = 140,
         #endif
+        .effect = EFFECT_OVERHEAT,
         .type = TYPE_GRASS,
         .accuracy = 90,
         .pp = 5,
@@ -6599,12 +6599,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_CHATTER] =
     {
-        .effect = EFFECT_CONFUSE_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 65,
         #else
             .power = 60,
         #endif
+        .effect = EFFECT_CONFUSE_HIT,
         .type = TYPE_FLYING,
         .accuracy = 100,
         .pp = 20,
@@ -6813,7 +6813,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_MAGMA_STORM] =
     {
-        .effect = EFFECT_TRAP,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 100,
             .accuracy = 75,
@@ -6824,6 +6823,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
             .power = 120,
             .accuracy = 70,
         #endif
+        .effect = EFFECT_TRAP,
         .type = TYPE_FIRE,
         .pp = 5,
         .secondaryEffectChance = 100,
@@ -7060,12 +7060,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_STORM_THROW] =
     {
-        .effect = EFFECT_ALWAYS_CRIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 60,
         #else
             .power = 40,
         #endif
+        .effect = EFFECT_ALWAYS_CRIT,
         .type = TYPE_FIGHTING,
         .accuracy = 100,
         .pp = 10,
@@ -7134,7 +7134,6 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_SYNCHRONOISE] =
     {
-        .effect = EFFECT_SYNCHRONOISE,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 120,
             .pp = 10,
@@ -7142,6 +7141,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
             .power = 70,
             .pp = 15,
         #endif
+        .effect = EFFECT_SYNCHRONOISE,
         .type = TYPE_PSYCHIC,
         .accuracy = 100,
         .secondaryEffectChance = 0,
@@ -7209,12 +7209,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_LOW_SWEEP] =
     {
-        .effect = EFFECT_SPEED_DOWN_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 65,
         #else
             .power = 60,
         #endif
+        .effect = EFFECT_SPEED_DOWN_HIT,
         .type = TYPE_FIGHTING,
         .accuracy = 100,
         .pp = 20,
@@ -7438,12 +7438,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_HEX] =
     {
-        .effect = EFFECT_HEX,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 65,
         #else
             .power = 50,
         #endif
+        .effect = EFFECT_HEX,
         .type = TYPE_GHOST,
         .accuracy = 100,
         .pp = 10,
@@ -7498,12 +7498,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_INCINERATE] =
     {
-        .effect = EFFECT_INCINERATE,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 60,
         #else
             .power = 30,
         #endif
+        .effect = EFFECT_INCINERATE,
         .type = TYPE_FIRE,
         .accuracy = 100,
         .pp = 15,
@@ -7614,12 +7614,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_WATER_PLEDGE] =
     {
-        .effect = EFFECT_PLEDGE,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 80,
         #else
             .power = 50,
         #endif
+        .effect = EFFECT_PLEDGE,
         .type = TYPE_WATER,
         .accuracy = 100,
         .pp = 10,
@@ -7632,12 +7632,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FIRE_PLEDGE] =
     {
-        .effect = EFFECT_PLEDGE,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 80,
         #else
             .power = 50,
         #endif
+        .effect = EFFECT_PLEDGE,
         .type = TYPE_FIRE,
         .accuracy = 100,
         .pp = 10,
@@ -7650,12 +7650,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_GRASS_PLEDGE] =
     {
-        .effect = EFFECT_PLEDGE,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 80,
         #else
             .power = 50,
         #endif
+        .effect = EFFECT_PLEDGE,
         .type = TYPE_GRASS,
         .accuracy = 100,
         .pp = 10,
@@ -7682,12 +7682,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_STRUGGLE_BUG] =
     {
-        .effect = EFFECT_SPECIAL_ATTACK_DOWN_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 50,
         #else
             .power = 30,
         #endif
+        .effect = EFFECT_SPECIAL_ATTACK_DOWN_HIT,
         .type = TYPE_BUG,
         .accuracy = 100,
         .pp = 20,
@@ -7714,12 +7714,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FROST_BREATH] =
     {
-        .effect = EFFECT_ALWAYS_CRIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 60,
         #else
             .power = 40,
         #endif
+        .effect = EFFECT_ALWAYS_CRIT,
         .type = TYPE_ICE,
         .accuracy = 90,
         .pp = 10,
@@ -7970,12 +7970,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_HURRICANE] =
     {
-        .effect = EFFECT_HURRICANE,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 110,
         #else
             .power = 120,
         #endif
+        .effect = EFFECT_HURRICANE,
         .type = TYPE_FLYING,
         .accuracy = 70,
         .pp = 10,
@@ -8030,12 +8030,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_TECHNO_BLAST] =
     {
-        .effect = EFFECT_TECHNO_BLAST,
         #if B_UPDATED_MOVE_VALUES >= GEN_6
             .power = 120,
         #else
             .power = 85,
         #endif
+        .effect = EFFECT_TECHNO_BLAST,
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .pp = 5,
@@ -8232,12 +8232,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FLYING_PRESS] =
     {
-        .effect = EFFECT_TWO_TYPED_MOVE,
         #if B_UPDATED_MOVE_VALUES >= GEN_7
             .power = 100,
         #else
             .power = 80,
         #endif
+        .effect = EFFECT_TWO_TYPED_MOVE,
         .type = TYPE_FIGHTING,
         .accuracy = 95,
         .pp = 10,
@@ -8308,12 +8308,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FELL_STINGER] =
     {
-        .effect = EFFECT_FELL_STINGER,
         #if B_UPDATED_MOVE_VALUES >= GEN_7
             .power = 50,
         #else
             .power = 30,
         #endif
+        .effect = EFFECT_FELL_STINGER,
         .type = TYPE_BUG,
         .accuracy = 100,
         .pp = 25,
@@ -8384,12 +8384,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_PARABOLIC_CHARGE] =
     {
-        .effect = EFFECT_ABSORB,
         #if B_UPDATED_MOVE_VALUES >= GEN_7
             .power = 65,
         #else
             .power = 50,
         #endif
+        .effect = EFFECT_ABSORB,
         .type = TYPE_ELECTRIC,
         .accuracy = 100,
         .pp = 20,
@@ -8741,12 +8741,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_MYSTICAL_FIRE] =
     {
-        .effect = EFFECT_SPECIAL_ATTACK_DOWN_HIT,
         #if B_UPDATED_MOVE_VALUES >= GEN_7
             .power = 75,
         #else
             .power = 65,
         #endif
+        .effect = EFFECT_SPECIAL_ATTACK_DOWN_HIT,
         .type = TYPE_FIRE,
         .accuracy = 100,
         .pp = 10,
@@ -9825,12 +9825,12 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_MULTI_ATTACK] =
     {
-        .effect = EFFECT_PLACEHOLDER,
-        #if B_UPDATED_MOVE_VALUES >= GEN_4
+        #if B_UPDATED_MOVE_VALUES >= GEN_8
             .power = 120,
         #else
             .power = 90,
         #endif
+        .effect = EFFECT_PLACEHOLDER,
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .pp = 10,

--- a/src/data/battle_moves.h
+++ b/src/data/battle_moves.h
@@ -269,7 +269,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_FLY] =
     {
         .effect = EFFECT_SEMI_INVULNERABLE,
-        .power = 90,
+        #if B_UPDATED_MOVE_VALUES >= GEN_4
+            .power = 90,
+        #else
+            .power = 70,
+        #endif
         .type = TYPE_FLYING,
         .accuracy = 95,
         .pp = 15,
@@ -311,10 +315,18 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_VINE_WHIP] =
     {
         .effect = EFFECT_HIT,
-        .power = 45,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 45,
+            .pp = 25,
+        #elif B_UPDATED_MOVE_VALUES >= GEN_4
+            .power = 35,
+            .pp = 15,
+        #else
+            .power = 35,
+            .pp = 10,
+        #endif
         .type = TYPE_GRASS,
         .accuracy = 100,
-        .pp = 25,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -367,10 +379,18 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_JUMP_KICK] =
     {
         .effect = EFFECT_RECOIL_IF_MISS,
-        .power = 100,
+        #if B_UPDATED_MOVE_VALUES >= GEN_5
+            .power = 100,
+            .pp = 10,
+        #elif B_UPDATED_MOVE_VALUES == GEN_4
+            .power = 85,
+            .pp = 25,
+        #else
+            .power = 70,
+            .pp = 25,
+        #endif
         .type = TYPE_FIGHTING,
         .accuracy = 95,
-        .pp = 10,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -465,9 +485,17 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_TACKLE] =
     {
         .effect = EFFECT_HIT,
-        .power = 40,
+        #if B_UPDATED_MOVE_VALUES >= GEN_7
+            .power = 40,
+            .accuracy = 100,
+        #elif B_UPDATED_MOVE_VALUES >= GEN_5
+            .power = 50,
+            .accuracy = 100,
+        #else
+            .power = 35,
+            .accuracy = 95,
+        #endif
         .type = TYPE_NORMAL,
-        .accuracy = 100,
         .pp = 35,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
@@ -521,10 +549,15 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_THRASH] =
     {
         .effect = EFFECT_RAMPAGE,
-        .power = 120,
+        #if B_UPDATED_MOVE_VALUES >= GEN_5
+            .power = 120,
+            .pp = 10,
+        #else
+            .power = 90,
+            .pp = 20,
+        #endif
         .type = TYPE_NORMAL,
         .accuracy = 100,
-        .pp = 10,
         .secondaryEffectChance = 100,
         .target = MOVE_TARGET_RANDOM,
         .priority = 0,
@@ -591,9 +624,14 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_PIN_MISSILE] =
     {
         .effect = EFFECT_MULTI_HIT,
-        .power = 25,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 25,
+            .accuracy = 95,
+        #else
+            .power = 14,
+            .accuracy = 85,
+        #endif
         .type = TYPE_BUG,
-        .accuracy = 95,
         .pp = 20,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
@@ -745,7 +783,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_FLAMETHROWER] =
     {
         .effect = EFFECT_BURN_HIT,
-        .power = 90,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 90,
+        #else
+            .power = 95,
+        #endif
         .type = TYPE_FIRE,
         .accuracy = 100,
         .pp = 15,
@@ -787,7 +829,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_HYDRO_PUMP] =
     {
         .effect = EFFECT_HIT,
-        .power = 110,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 110,
+        #else
+            .power = 120,
+        #endif
         .type = TYPE_WATER,
         .accuracy = 80,
         .pp = 5,
@@ -801,7 +847,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_SURF] =
     {
         .effect = EFFECT_HIT,
-        .power = 90,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 90,
+        #else
+            .power = 95,
+        #endif
         .type = TYPE_WATER,
         .accuracy = 100,
         .pp = 15,
@@ -815,7 +865,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_ICE_BEAM] =
     {
         .effect = EFFECT_FREEZE_HIT,
-        .power = 90,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 90,
+        #else
+            .power = 95,
+        #endif
         .type = TYPE_ICE,
         .accuracy = 100,
         .pp = 10,
@@ -829,7 +883,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_BLIZZARD] =
     {
         .effect = EFFECT_FREEZE_HIT,
-        .power = 110,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 110,
+        #else
+            .power = 120,
+        #endif
         .type = TYPE_ICE,
         .accuracy = 70,
         .pp = 5,
@@ -1000,7 +1058,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .power = 20,
         .type = TYPE_GRASS,
         .accuracy = 100,
-        .pp = 25,
+        #if B_UPDATED_MOVE_VALUES >= GEN_4
+            .pp = 25,
+        #else
+            .pp = 20,
+        #endif
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -1014,7 +1076,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .power = 40,
         .type = TYPE_GRASS,
         .accuracy = 100,
-        .pp = 15,
+        #if B_UPDATED_MOVE_VALUES >= GEN_4
+            .pp = 15,
+        #else
+            .pp = 10,
+        #endif
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -1123,10 +1189,18 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_PETAL_DANCE] =
     {
         .effect = EFFECT_RAMPAGE,
-        .power = 120,
+        #if B_UPDATED_MOVE_VALUES >= GEN_5
+            .power = 120,
+            .pp = 10,
+        #elif B_UPDATED_MOVE_VALUES == GEN_4
+            .power = 90,
+            .pp = 20,
+        #else
+            .power = 70,
+            .pp = 20,
+        #endif
         .type = TYPE_GRASS,
         .accuracy = 100,
-        .pp = 10,
         .secondaryEffectChance = 100,
         .target = MOVE_TARGET_RANDOM,
         .priority = 0,
@@ -1165,9 +1239,14 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_FIRE_SPIN] =
     {
         .effect = EFFECT_TRAP,
-        .power = 35,
+        #if B_UPDATED_MOVE_VALUES >= GEN_5
+            .power = 35,
+            .accuracy = 85,
+        #else
+            .power = 15,
+            .accuracy = 70,
+        #endif
         .type = TYPE_FIRE,
-        .accuracy = 85,
         .pp = 15,
         .secondaryEffectChance = 100,
         .target = MOVE_TARGET_SELECTED,
@@ -1193,7 +1272,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_THUNDERBOLT] =
     {
         .effect = EFFECT_PARALYZE_HIT,
-        .power = 90,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 90,
+        #else
+            .power = 95,
+        #endif
         .type = TYPE_ELECTRIC,
         .accuracy = 100,
         .pp = 15,
@@ -1221,7 +1304,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_THUNDER] =
     {
         .effect = EFFECT_THUNDER,
-        .power = 110,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 110,
+        #else
+            .power = 120,
+        #endif
         .type = TYPE_ELECTRIC,
         .accuracy = 70,
         .pp = 10,
@@ -1277,7 +1364,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_DIG] =
     {
         .effect = EFFECT_SEMI_INVULNERABLE,
-        .power = 80,
+        #if B_UPDATED_MOVE_VALUES >= GEN_4
+            .power = 80,
+        #else
+            .power = 60,
+        #endif
         .type = TYPE_GROUND,
         .accuracy = 100,
         .pp = 10,
@@ -1711,7 +1802,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_LICK] =
     {
         .effect = EFFECT_PARALYZE_HIT,
-        .power = 30,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 30,
+        #else
+            .power = 20,
+        #endif
         .type = TYPE_GHOST,
         .accuracy = 100,
         .pp = 30,
@@ -1725,7 +1820,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_SMOG] =
     {
         .effect = EFFECT_POISON_HIT,
-        .power = 30,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 30,
+        #else
+            .power = 20,
+        #endif
         .type = TYPE_POISON,
         .accuracy = 70,
         .pp = 20,
@@ -1767,7 +1866,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_FIRE_BLAST] =
     {
         .effect = EFFECT_BURN_HIT,
-        .power = 110,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 120,
+        #else
+            .power = 110,
+        #endif
         .type = TYPE_FIRE,
         .accuracy = 85,
         .pp = 5,
@@ -1823,10 +1926,15 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_SKULL_BASH] =
     {
         .effect = EFFECT_SKULL_BASH,
-        .power = 130,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 130,
+            .pp = 10,
+        #else
+            .power = 100,
+            .pp = 15,
+        #endif
         .type = TYPE_NORMAL,
         .accuracy = 100,
-        .pp = 10,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -1907,10 +2015,18 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_HI_JUMP_KICK] =
     {
         .effect = EFFECT_RECOIL_IF_MISS,
-        .power = 130,
+        #if B_UPDATED_MOVE_VALUES >= GEN_5
+            .power = 130,
+            .pp = 10,
+        #elif B_UPDATED_MOVE_VALUES == GEN_4
+            .power = 100,
+            .pp = 20,
+        #else
+            .power = 85,
+            .pp = 20,
+        #endif
         .type = TYPE_FIGHTING,
         .accuracy = 90,
-        .pp = 10,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -1977,10 +2093,15 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_LEECH_LIFE] =
     {
         .effect = EFFECT_ABSORB,
-        .power = 80,
+        #if B_UPDATED_MOVE_VALUES >= GEN_7
+            .power = 80,
+            .pp = 10,
+        #else
+            .power = 20,
+            .pp = 15,
+        #endif
         .type = TYPE_BUG,
         .accuracy = 100,
-        .pp = 10,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -2034,7 +2155,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_BUBBLE] =
     {
         .effect = EFFECT_SPEED_DOWN_HIT,
-        .power = 40,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 40,
+        #else
+            .power = 20,
+        #endif
         .type = TYPE_WATER,
         .accuracy = 100,
         .pp = 30,
@@ -2132,9 +2257,17 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_CRABHAMMER] =
     {
         .effect = EFFECT_HIT,
-        .power = 100,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 100,
+            .accuracy = 90,
+        #elif B_UPDATED_MOVE_VALUES == GEN_5
+            .power = 90,
+            .accuracy = 90,
+        #else
+            .power = 90,
+            .accuracy = 85,
+        #endif
         .type = TYPE_WATER,
-        .accuracy = 90,
         .pp = 10,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
@@ -2426,7 +2559,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_SNORE] =
     {
         .effect = EFFECT_SNORE,
-        .power = 50,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 50,
+        #else
+            .power = 40,
+        #endif
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .pp = 15,
@@ -2692,7 +2829,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_ZAP_CANNON] =
     {
         .effect = EFFECT_PARALYZE_HIT,
-        .power = 120,
+        #if B_UPDATED_MOVE_VALUES >= GEN_4
+            .power = 120,
+        #else
+            .power = 100,
+        #endif
         .type = TYPE_ELECTRIC,
         .accuracy = 50,
         .pp = 5,
@@ -2804,10 +2945,18 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_OUTRAGE] =
     {
         .effect = EFFECT_RAMPAGE,
-        .power = 120,
+        #if B_UPDATED_MOVE_VALUES >= GEN_5
+            .power = 120,
+            .pp = 10,
+        #elif B_UPDATED_MOVE_VALUES == GEN_4
+            .power = 120,
+            .pp = 15,
+        #else
+            .power = 90,
+            .pp = 15,
+        #endif
         .type = TYPE_DRAGON,
         .accuracy = 100,
-        .pp = 10,
         .secondaryEffectChance = 100,
         .target = MOVE_TARGET_RANDOM,
         .priority = 0,
@@ -2832,10 +2981,18 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_GIGA_DRAIN] =
     {
         .effect = EFFECT_ABSORB,
-        .power = 75,
+        #if B_UPDATED_MOVE_VALUES >= GEN_5
+            .power = 75,
+            .pp = 10,
+        #elif B_UPDATED_MOVE_VALUES == GEN_4
+            .power = 60,
+            .pp = 10,
+        #else
+            .power = 60,
+            .pp = 5,
+        #endif
         .type = TYPE_GRASS,
         .accuracy = 100,
-        .pp = 10,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -2944,7 +3101,13 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_FURY_CUTTER] =
     {
         .effect = EFFECT_FURY_CUTTER,
-        .power = 40,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 40,
+        #elif B_UPDATED_MOVE_VALUES == GEN_5
+            .power = 20,
+        #else
+            .power = 10,
+        #endif
         .type = TYPE_BUG,
         .accuracy = 95,
         .pp = 20,
@@ -3210,7 +3373,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_RAPID_SPIN] =
     {
         .effect = EFFECT_RAPID_SPIN,
-        .power = 50,
+        #if B_UPDATED_MOVE_VALUES >= GEN_4
+            .power = 50,
+        #else
+            .power = 20,
+        #endif
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .pp = 40,
@@ -3476,10 +3643,20 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_FUTURE_SIGHT] =
     {
         .effect = EFFECT_FUTURE_SIGHT,
-        .power = 120,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 120,
+            .accuracy = 100,
+            .pp = 10,
+        #elif B_UPDATED_MOVE_VALUES == GEN_5
+            .power = 100,
+            .accuracy = 100,
+            .pp = 10,
+        #else
+            .power = 80,
+            .accuracy = 90,
+            .pp = 15,
+        #endif
         .type = TYPE_PSYCHIC,
-        .accuracy = 100,
-        .pp = 10,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -3490,7 +3667,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_ROCK_SMASH] =
     {
         .effect = EFFECT_DEFENSE_DOWN_HIT,
-        .power = 40,
+        #if B_UPDATED_MOVE_VALUES >= GEN_4
+            .power = 40,
+        #else
+            .power = 20,
+        #endif
         .type = TYPE_FIGHTING,
         .accuracy = 100,
         .pp = 15,
@@ -3504,9 +3685,14 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_WHIRLPOOL] =
     {
         .effect = EFFECT_TRAP,
-        .power = 35,
+        #if B_UPDATED_MOVE_VALUES >= GEN_5
+            .power = 35,
+            .accuracy = 85,
+        #else
+            .power = 15,
+            .accuracy = 70,
+        #endif
         .type = TYPE_WATER,
-        .accuracy = 85,
         .pp = 15,
         .secondaryEffectChance = 100,
         .target = MOVE_TARGET_SELECTED,
@@ -3518,7 +3704,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_BEAT_UP] =
     {
         .effect = EFFECT_BEAT_UP,
-        .power = 10,
+        #if B_BEAT_UP_DMG >= GEN_5
+            .power = 1,
+        #else
+            .power = 10,
+        #endif
         .type = TYPE_DARK,
         .accuracy = 100,
         .pp = 10,
@@ -3546,7 +3736,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_UPROAR] =
     {
         .effect = EFFECT_UPROAR,
-        .power = 90,
+        #if B_UPDATED_MOVE_VALUES >= GEN_5
+            .power = 90,
+        #else
+            .power = 50,
+        #endif
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .pp = 10,
@@ -3574,7 +3768,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_SPIT_UP] =
     {
         .effect = EFFECT_SPIT_UP,
-        .power = 100,
+        #if B_UPDATED_MOVE_VALUES >= GEN_4
+            .power = 1,
+        #else
+            .power = 100,
+        #endif
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .pp = 10,
@@ -3602,7 +3800,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_HEAT_WAVE] =
     {
         .effect = EFFECT_BURN_HIT,
-        .power = 95,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 95,
+        #else
+            .power = 100,
+        #endif
         .type = TYPE_FIRE,
         .accuracy = 90,
         .pp = 10,
@@ -3714,7 +3916,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_SMELLING_SALT] =
     {
         .effect = EFFECT_SMELLINGSALT,
-        .power = 70,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 70,
+        #else
+            .power = 60,
+        #endif
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .pp = 10,
@@ -3953,7 +4159,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_KNOCK_OFF] =
     {
         .effect = EFFECT_KNOCK_OFF,
-        .power = 65,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 65,
+        #else
+            .power = 20,
+        #endif
         .type = TYPE_DARK,
         .accuracy = 100,
         .pp = 20,
@@ -4079,7 +4289,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_DIVE] =
     {
         .effect = EFFECT_SEMI_INVULNERABLE,
-        .power = 80,
+        #if B_UPDATED_MOVE_VALUES >= GEN_4
+            .power = 80,
+        #else
+            .power = 60,
+        #endif
         .type = TYPE_WATER,
         .accuracy = 100,
         .pp = 10,
@@ -4331,7 +4545,13 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_METEOR_MASH] =
     {
         .effect = EFFECT_ATTACK_UP_HIT,
-        .power = 90,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 90,
+            .accuracy = 90,
+        #else
+            .power = 100,
+            .accuracy = 85,
+        #endif
         .type = TYPE_STEEL,
         .accuracy = 90,
         .pp = 10,
@@ -4401,7 +4621,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_AIR_CUTTER] =
     {
         .effect = EFFECT_HIT,
-        .power = 60,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 60,
+        #else
+            .power = 55,
+        #endif
         .type = TYPE_FLYING,
         .accuracy = 95,
         .pp = 25,
@@ -4415,7 +4639,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_OVERHEAT] =
     {
         .effect = EFFECT_OVERHEAT,
-        .power = 130,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 130,
+        #else
+            .power = 140,
+        #endif
         .type = TYPE_FIRE,
         .accuracy = 90,
         .pp = 5,
@@ -4443,10 +4671,16 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_ROCK_TOMB] =
     {
         .effect = EFFECT_SPEED_DOWN_HIT,
-        .power = 60,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 60,
+            .accuracy = 95,
+            .pp = 15,
+        #else
+            .power = 50,
+            .accuracy = 80,
+            .pp = 10,
+        #endif
         .type = TYPE_ROCK,
-        .accuracy = 95,
-        .pp = 15,
         .secondaryEffectChance = 100,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -4597,9 +4831,14 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_SAND_TOMB] =
     {
         .effect = EFFECT_TRAP,
-        .power = 35,
+        #if B_UPDATED_MOVE_VALUES >= GEN_5
+            .power = 35,
+            .accuracy = 85,
+        #else
+            .power = 15,
+            .accuracy = 70,
+        #endif
         .type = TYPE_GROUND,
-        .accuracy = 85,
         .pp = 15,
         .secondaryEffectChance = 100,
         .target = MOVE_TARGET_SELECTED,
@@ -4625,7 +4864,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_MUDDY_WATER] =
     {
         .effect = EFFECT_ACCURACY_DOWN_HIT,
-        .power = 90,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 90,
+        #else
+            .power = 95,
+        #endif
         .type = TYPE_WATER,
         .accuracy = 85,
         .pp = 10,
@@ -4639,7 +4882,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_BULLET_SEED] =
     {
         .effect = EFFECT_MULTI_HIT,
-        .power = 25,
+        #if B_UPDATED_MOVE_VALUES >= GEN_5
+            .power = 25,
+        #else
+            .power = 10,
+        #endif
         .type = TYPE_GRASS,
         .accuracy = 100,
         .pp = 30,
@@ -4667,7 +4914,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_ICICLE_SPEAR] =
     {
         .effect = EFFECT_MULTI_HIT,
-        .power = 25,
+        #if B_UPDATED_MOVE_VALUES >= GEN_5
+            .power = 25,
+        #else
+            .power = 10,
+        #endif
         .type = TYPE_ICE,
         .accuracy = 100,
         .pp = 30,
@@ -4808,10 +5059,18 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_COVET] =
     {
         .effect = EFFECT_THIEF,
-        .power = 60,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 60,
+            .pp = 25,
+        #elif B_UPDATED_MOVE_VALUES == GEN_5
+            .power = 60,
+            .pp = 40,
+        #else
+            .power = 40,
+            .pp = 40,
+        #endif
         .type = TYPE_NORMAL,
         .accuracy = 100,
-        .pp = 25,
         .secondaryEffectChance = 100,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -4879,7 +5138,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_LEAF_BLADE] =
     {
         .effect = EFFECT_HIT,
-        .power = 90,
+        #if B_UPDATED_MOVE_VALUES >= GEN_4
+            .power = 90,
+        #else
+            .power = 70,
+        #endif
         .type = TYPE_GRASS,
         .accuracy = 100,
         .pp = 15,
@@ -4949,10 +5212,15 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_DOOM_DESIRE] =
     {
         .effect = EFFECT_FUTURE_SIGHT,
-        .power = 140,
+        #if B_UPDATED_MOVE_VALUES >= GEN_5
+            .power = 140,
+            .pp = 100,
+        #else
+            .power = 120,
+            .pp = 85,
+        #endif
         .type = TYPE_STEEL,
         .accuracy = 100,
-        .pp = 5,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -5019,7 +5287,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_WAKE_UP_SLAP] =
     {
         .effect = EFFECT_WAKE_UP_SLAP,
-        .power = 70,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 70,
+        #else
+            .power = 60,
+        #endif
         .type = TYPE_FIGHTING,
         .accuracy = 100,
         .pp = 10,
@@ -5104,7 +5376,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_FEINT] =
     {
         .effect = EFFECT_FEINT,
-        .power = 30,
+        #if B_UPDATED_MOVE_VALUES >= GEN_5
+            .power = 30,
+        #else
+            .power = 50,
+        #endif
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .pp = 10,
@@ -5216,7 +5492,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_ASSURANCE] =
     {
         .effect = EFFECT_ASSURANCE,
-        .power = 60,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 60,
+        #else
+            .power = 50,
+        #endif
         .type = TYPE_DARK,
         .accuracy = 100,
         .pp = 10,
@@ -5426,7 +5706,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_LAST_RESORT] =
     {
         .effect = EFFECT_LAST_RESORT,
-        .power = 140,
+        #if B_UPDATED_MOVE_VALUES >= GEN_5
+            .power = 140,
+        #else
+            .power = 130,
+        #endif
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .pp = 5,
@@ -5454,7 +5738,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_SUCKER_PUNCH] =
     {
         .effect = EFFECT_SUCKER_PUNCH,
-        .power = 70,
+        #if B_UPDATED_MOVE_VALUES >= GEN_7
+            .power = 70,
+        #else
+            .power = 80,
+        #endif
         .type = TYPE_DARK,
         .accuracy = 100,
         .pp = 5,
@@ -5553,7 +5841,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_AURA_SPHERE] =
     {
         .effect = EFFECT_HIT,
-        .power = 80,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 80,
+        #else
+            .power = 90,
+        #endif
         .type = TYPE_FIGHTING,
         .accuracy = 0,
         .pp = 20,
@@ -5693,7 +5985,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_DRAGON_PULSE] =
     {
         .effect = EFFECT_HIT,
-        .power = 85,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 85,
+        #else
+            .power = 90,
+        #endif
         .type = TYPE_DRAGON,
         .accuracy = 100,
         .pp = 10,
@@ -5721,7 +6017,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_POWER_GEM] =
     {
         .effect = EFFECT_HIT,
-        .power = 80,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 80,
+        #else
+            .power = 70,
+        #endif
         .type = TYPE_ROCK,
         .accuracy = 100,
         .pp = 20,
@@ -5735,10 +6035,15 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_DRAIN_PUNCH] =
     {
         .effect = EFFECT_ABSORB,
-        .power = 75,
+        #if B_UPDATED_MOVE_VALUES >= GEN_5
+            .power = 75,
+            .pp = 10,
+        #else
+            .power = 60,
+            .pp = 5,
+        #endif
         .type = TYPE_FIGHTING,
         .accuracy = 100,
-        .pp = 10,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -5777,7 +6082,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_ENERGY_BALL] =
     {
         .effect = EFFECT_SPECIAL_DEFENSE_DOWN_HIT,
-        .power = 90,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 90,
+        #else
+            .power = 80,
+        #endif
         .type = TYPE_GRASS,
         .accuracy = 100,
         .pp = 10,
@@ -6088,7 +6397,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_DRACO_METEOR] =
     {
         .effect = EFFECT_OVERHEAT,
-        .power = 130,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 130,
+        #else
+            .power = 140,
+        #endif
         .type = TYPE_DRAGON,
         .accuracy = 90,
         .pp = 5,
@@ -6130,7 +6443,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_LEAF_STORM] =
     {
         .effect = EFFECT_OVERHEAT,
-        .power = 130,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 130,
+        #else
+            .power = 140,
+        #endif
         .type = TYPE_GRASS,
         .accuracy = 90,
         .pp = 5,
@@ -6284,7 +6601,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_CHATTER] =
     {
         .effect = EFFECT_CONFUSE_HIT,
-        .power = 65,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 65,
+        #else
+            .power = 60,
+        #endif
         .type = TYPE_FLYING,
         .accuracy = 100,
         .pp = 20,
@@ -6494,9 +6815,17 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_MAGMA_STORM] =
     {
         .effect = EFFECT_TRAP,
-        .power = 100,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 100,
+            .accuracy = 75,
+        #elif B_UPDATED_MOVE_VALUES == GEN_5
+            .power = 120,
+            .accuracy = 75,
+        #else
+            .power = 120,
+            .accuracy = 70,
+        #endif
         .type = TYPE_FIRE,
-        .accuracy = 75,
         .pp = 5,
         .secondaryEffectChance = 100,
         .target = MOVE_TARGET_SELECTED,
@@ -6733,7 +7062,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_STORM_THROW] =
     {
         .effect = EFFECT_ALWAYS_CRIT,
-        .power = 60,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 60,
+        #else
+            .power = 40,
+        #endif
         .type = TYPE_FIGHTING,
         .accuracy = 100,
         .pp = 10,
@@ -6803,10 +7136,15 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_SYNCHRONOISE] =
     {
         .effect = EFFECT_SYNCHRONOISE,
-        .power = 120,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 120,
+            .pp = 10,
+        #else
+            .power = 70,
+            .pp = 15,
+        #endif
         .type = TYPE_PSYCHIC,
         .accuracy = 100,
-        .pp = 10,
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_FOES_AND_ALLY,
         .priority = 0,
@@ -6873,7 +7211,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_LOW_SWEEP] =
     {
         .effect = EFFECT_SPEED_DOWN_HIT,
-        .power = 65,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 65,
+        #else
+            .power = 60,
+        #endif
         .type = TYPE_FIGHTING,
         .accuracy = 100,
         .pp = 20,
@@ -7098,7 +7440,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_HEX] =
     {
         .effect = EFFECT_HEX,
-        .power = 65,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 65,
+        #else
+            .power = 50,
+        #endif
         .type = TYPE_GHOST,
         .accuracy = 100,
         .pp = 10,
@@ -7154,6 +7500,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_INCINERATE] =
     {
         .effect = EFFECT_INCINERATE,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 60,
+        #else
+            .power = 30,
+        #endif
         .power = 60,
         .type = TYPE_FIRE,
         .accuracy = 100,
@@ -7266,7 +7617,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_WATER_PLEDGE] =
     {
         .effect = EFFECT_PLEDGE,
-        .power = 80,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 80,
+        #else
+            .power = 50,
+        #endif
         .type = TYPE_WATER,
         .accuracy = 100,
         .pp = 10,
@@ -7280,7 +7635,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_FIRE_PLEDGE] =
     {
         .effect = EFFECT_PLEDGE,
-        .power = 80,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 80,
+        #else
+            .power = 50,
+        #endif
         .type = TYPE_FIRE,
         .accuracy = 100,
         .pp = 10,
@@ -7294,7 +7653,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_GRASS_PLEDGE] =
     {
         .effect = EFFECT_PLEDGE,
-        .power = 80,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 80,
+        #else
+            .power = 50,
+        #endif
         .type = TYPE_GRASS,
         .accuracy = 100,
         .pp = 10,
@@ -7322,7 +7685,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_STRUGGLE_BUG] =
     {
         .effect = EFFECT_SPECIAL_ATTACK_DOWN_HIT,
-        .power = 50,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 50,
+        #else
+            .power = 30,
+        #endif
         .type = TYPE_BUG,
         .accuracy = 100,
         .pp = 20,
@@ -7350,7 +7717,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_FROST_BREATH] =
     {
         .effect = EFFECT_ALWAYS_CRIT,
-        .power = 60,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 60,
+        #else
+            .power = 40,
+        #endif
         .type = TYPE_ICE,
         .accuracy = 90,
         .pp = 10,
@@ -7602,7 +7973,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_HURRICANE] =
     {
         .effect = EFFECT_HURRICANE,
-        .power = 110,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 110,
+        #else
+            .power = 120,
+        #endif
         .type = TYPE_FLYING,
         .accuracy = 70,
         .pp = 10,
@@ -7658,7 +8033,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_TECHNO_BLAST] =
     {
         .effect = EFFECT_TECHNO_BLAST,
-        .power = 120,
+        #if B_UPDATED_MOVE_VALUES >= GEN_6
+            .power = 120,
+        #else
+            .power = 85,
+        #endif
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .pp = 5,
@@ -7856,7 +8235,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_FLYING_PRESS] =
     {
         .effect = EFFECT_TWO_TYPED_MOVE,
-        .power = 100,
+        #if B_UPDATED_MOVE_VALUES >= GEN_7
+            .power = 100,
+        #else
+            .power = 80,
+        #endif
         .type = TYPE_FIGHTING,
         .accuracy = 95,
         .pp = 10,
@@ -7928,7 +8311,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_FELL_STINGER] =
     {
         .effect = EFFECT_FELL_STINGER,
-        .power = 50,
+        #if B_UPDATED_MOVE_VALUES >= GEN_7
+            .power = 50,
+        #else
+            .power = 30,
+        #endif
         .type = TYPE_BUG,
         .accuracy = 100,
         .pp = 25,
@@ -8000,7 +8387,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_PARABOLIC_CHARGE] =
     {
         .effect = EFFECT_ABSORB,
-        .power = 65,
+        #if B_UPDATED_MOVE_VALUES >= GEN_7
+            .power = 65,
+        #else
+            .power = 50,
+        #endif
         .type = TYPE_ELECTRIC,
         .accuracy = 100,
         .pp = 20,
@@ -8353,7 +8744,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_MYSTICAL_FIRE] =
     {
         .effect = EFFECT_SPECIAL_ATTACK_DOWN_HIT,
-        .power = 75,
+        #if B_UPDATED_MOVE_VALUES >= GEN_7
+            .power = 75,
+        #else
+            .power = 65,
+        #endif
         .type = TYPE_FIRE,
         .accuracy = 100,
         .pp = 10,
@@ -9433,7 +9828,11 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_MULTI_ATTACK] =
     {
         .effect = EFFECT_PLACEHOLDER,
-        .power = 120,
+        #if B_UPDATED_MOVE_VALUES >= GEN_4
+            .power = 120,
+        #else
+            .power = 90,
+        #endif
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .pp = 10,

--- a/src/wild_encounter.c
+++ b/src/wild_encounter.c
@@ -610,7 +610,7 @@ bool8 StandardWildEncounter(u16 currMetaTileBehavior, u16 previousMetaTileBehavi
                 // try a regular wild land encounter
                 if (TryGenerateWildMon(gWildMonHeaders[headerId].landMonsInfo, WILD_AREA_LAND, WILD_CHECK_REPEL | WILD_CHECK_KEEN_EYE) == TRUE)
                 {
-                    if (USE_BATTLE_DEBUG && !GetSafariZoneFlag() && GetMonsStateToDoubles() == PLAYER_HAS_TWO_USABLE_MONS)
+                    if (TryDoDoubleWildBattle())
                     {
                         struct Pokemon mon1 = gEnemyParty[0];
                         TryGenerateWildMon(gWildMonHeaders[headerId].landMonsInfo, WILD_AREA_LAND, WILD_CHECK_KEEN_EYE);
@@ -652,7 +652,17 @@ bool8 StandardWildEncounter(u16 currMetaTileBehavior, u16 previousMetaTileBehavi
             {
                 if (TryGenerateWildMon(gWildMonHeaders[headerId].waterMonsInfo, WILD_AREA_WATER, WILD_CHECK_REPEL | WILD_CHECK_KEEN_EYE) == TRUE)
                 {
-                    BattleSetup_StartWildBattle();
+                    if (TryDoDoubleWildBattle())
+                    {
+                        struct Pokemon mon1 = gEnemyParty[0];
+                        TryGenerateWildMon(gWildMonHeaders[headerId].waterMonsInfo, WILD_AREA_WATER, WILD_CHECK_KEEN_EYE);
+                        gEnemyParty[1] = mon1;
+                        BattleSetup_StartDoubleWildBattle();
+                    }
+                    else
+                    {
+                        BattleSetup_StartWildBattle();
+                    }
                     return TRUE;
                 }
 
@@ -956,4 +966,17 @@ static void ApplyCleanseTagEncounterRateMod(u32 *encRate)
 {
     if (GetMonData(&gPlayerParty[0], MON_DATA_HELD_ITEM) == ITEM_CLEANSE_TAG)
         *encRate = *encRate * 2 / 3;
+}
+
+bool8 TryDoDoubleWildBattle(void)
+{
+    if (GetSafariZoneFlag() || GetMonsStateToDoubles() != PLAYER_HAS_TWO_USABLE_MONS)
+        return FALSE;
+    else if (B_FLAG_FORCE_DOUBLE_WILD != 0 && FlagGet(B_FLAG_FORCE_DOUBLE_WILD))
+        return TRUE;
+    #if B_DOUBLE_WILD_CHANCE != 0
+    else if ((Random() % 100) + 1 < B_DOUBLE_WILD_CHANCE)
+        return TRUE;
+    #endif
+    return FALSE;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Tweaking `battle_config` to accomodate `pokemon_config` and `item_config`
- Configurable double wild battle chance, surfing double battles and flag for forcing them.
- Organized interface settings into their own category.
- Adapting move changes to `battle_config`

## **Discord contact info**
AsparagusEduardo#6051