### PR TITLE
Reincorporated badge based stat boosts

### DIFF
--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -127,6 +127,6 @@ bool32 CanBattlerGetOrLoseItem(u8 battlerId, u16 itemId);
 struct Pokemon *GetIllusionMonPtr(u32 battlerId);
 void ClearIllusionMon(u32 battlerId);
 bool32 SetIllusionMon(struct Pokemon *mon, u32 battlerId);
-static bool8 ShouldGetStatBadgeBoost(u16 flagId, u8 battlerId);
+bool8 ShouldGetStatBadgeBoost(u16 flagId, u8 battlerId);
 
 #endif // GUARD_BATTLE_UTIL_H

--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -127,5 +127,6 @@ bool32 CanBattlerGetOrLoseItem(u8 battlerId, u16 itemId);
 struct Pokemon *GetIllusionMonPtr(u32 battlerId);
 void ClearIllusionMon(u32 battlerId);
 bool32 SetIllusionMon(struct Pokemon *mon, u32 battlerId);
+static bool8 ShouldGetStatBadgeBoost(u16 flagId, u8 battlerId);
 
 #endif // GUARD_BATTLE_UTIL_H

--- a/include/constants/battle_config.h
+++ b/include/constants/battle_config.h
@@ -70,6 +70,7 @@
 #define B_MULTI_HIT_CHANCE          GEN_6 // In Gen5+, multi-hit moves have different %. See Cmd_setmultihitcounter for values.
 #define B_RECOIL_IF_MISS_DMG        GEN_6 // In Gen5+, Jump Kick and Hi Jump Kick will always do half of the user's max HP when missing.
 #define B_PSYWAVE_DMG               GEN_6 // Psywave's damage formula. See Cmd_psywavedamageeffect.
+#define B_BADGE_BOOST               GEN_4 // In Gen4+, Gym Badges no longer boost a Pokémon's stats
 
 // Move settings
 #define B_FELL_STINGER_STAT_RAISE   GEN_6 // In Gen7+, it raises Atk by 3 stages instead of 2 if it causes the target to faint.

--- a/include/constants/battle_config.h
+++ b/include/constants/battle_config.h
@@ -70,7 +70,7 @@
 #define B_MULTI_HIT_CHANCE          GEN_6 // In Gen5+, multi-hit moves have different %. See Cmd_setmultihitcounter for values.
 #define B_RECOIL_IF_MISS_DMG        GEN_6 // In Gen5+, Jump Kick and Hi Jump Kick will always do half of the user's max HP when missing.
 #define B_PSYWAVE_DMG               GEN_6 // Psywave's damage formula. See Cmd_psywavedamageeffect.
-#define B_BADGE_BOOST               GEN_4 // In Gen4+, Gym Badges no longer boost a Pokémon's stats
+#define B_BADGE_BOOST               GEN_6 // In Gen4+, Gym Badges no longer boost a Pokémon's stats
 
 // Move settings
 #define B_FELL_STINGER_STAT_RAISE   GEN_6 // In Gen7+, it raises Atk by 3 stages instead of 2 if it causes the target to faint.

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4236,8 +4236,7 @@ u32 GetBattlerTotalSpeedStat(u8 battlerId)
     // player's badge boost
     if (!(gBattleTypeFlags & (BATTLE_TYPE_LINK | BATTLE_TYPE_x2000000 | BATTLE_TYPE_FRONTIER))
         && ShouldGetStatBadgeBoost(FLAG_BADGE03_GET, battlerId)
-        && GetBattlerSide(battlerId) == B_SIDE_PLAYER
-        && B_BADGE_BOOST == GEN_3)
+        && GetBattlerSide(battlerId) == B_SIDE_PLAYER)
     {
         speed = (speed * 110) / 100;
     }

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4236,7 +4236,8 @@ u32 GetBattlerTotalSpeedStat(u8 battlerId)
     // player's badge boost
     if (!(gBattleTypeFlags & (BATTLE_TYPE_LINK | BATTLE_TYPE_x2000000 | BATTLE_TYPE_FRONTIER))
         && FlagGet(FLAG_BADGE03_GET)
-        && GetBattlerSide(battlerId) == B_SIDE_PLAYER)
+        && GetBattlerSide(battlerId) == B_SIDE_PLAYER
+        && B_BADGE_BOOST == GEN_3)
     {
         speed = (speed * 110) / 100;
     }

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4235,7 +4235,7 @@ u32 GetBattlerTotalSpeedStat(u8 battlerId)
 
     // player's badge boost
     if (!(gBattleTypeFlags & (BATTLE_TYPE_LINK | BATTLE_TYPE_x2000000 | BATTLE_TYPE_FRONTIER))
-        && FlagGet(FLAG_BADGE03_GET)
+        && ShouldGetStatBadgeBoost(FLAG_BADGE03_GET, battlerId)
         && GetBattlerSide(battlerId) == B_SIDE_PLAYER
         && B_BADGE_BOOST == GEN_3)
     {

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -6939,13 +6939,10 @@ static u32 CalcAttackStat(u16 move, u8 battlerAtk, u8 battlerDef, u8 moveType, b
 
     // The offensive stats of a Player's Pokémon are boosted by x1.1 (+10%) if they have the 1st badge and 7th badges.
     // Having the 1st badge boosts physical attack while having the 7th badge boosts special attack.
-    if (B_BADGE_BOOST == GEN_3)
-    {
-        if (ShouldGetStatBadgeBoost(FLAG_BADGE01_GET, battlerAtk) && IS_MOVE_PHYSICAL(move))
-            MulModifier(&modifier, UQ_4_12(1.1));
-        if (ShouldGetStatBadgeBoost(FLAG_BADGE07_GET, battlerAtk) && IS_MOVE_SPECIAL(move))
-            MulModifier(&modifier, UQ_4_12(1.1));
-    }
+    if (ShouldGetStatBadgeBoost(FLAG_BADGE01_GET, battlerAtk) && IS_MOVE_PHYSICAL(move))
+        MulModifier(&modifier, UQ_4_12(1.1));
+    if (ShouldGetStatBadgeBoost(FLAG_BADGE07_GET, battlerAtk) && IS_MOVE_SPECIAL(move))
+        MulModifier(&modifier, UQ_4_12(1.1));
 
     return ApplyModifier(modifier, atkStat);
 }
@@ -7081,13 +7078,10 @@ static u32 CalcDefenseStat(u16 move, u8 battlerAtk, u8 battlerDef, u8 moveType, 
 
     // The defensive stats of a Player's Pokémon are boosted by x1.1 (+10%) if they have the 5th badge and 7th badges.
     // Having the 5th badge boosts physical defense while having the 7th badge boosts special defense.
-    if (B_BADGE_BOOST == GEN_3)
-    {
-        if (ShouldGetStatBadgeBoost(FLAG_BADGE05_GET, battlerDef) && IS_MOVE_PHYSICAL(move))
-            MulModifier(&modifier, UQ_4_12(1.1));
-        if (ShouldGetStatBadgeBoost(FLAG_BADGE07_GET, battlerDef) && IS_MOVE_SPECIAL(move))
-            MulModifier(&modifier, UQ_4_12(1.1));
-    }
+    if (ShouldGetStatBadgeBoost(FLAG_BADGE05_GET, battlerDef) && IS_MOVE_PHYSICAL(move))
+        MulModifier(&modifier, UQ_4_12(1.1));
+    if (ShouldGetStatBadgeBoost(FLAG_BADGE07_GET, battlerDef) && IS_MOVE_SPECIAL(move))
+        MulModifier(&modifier, UQ_4_12(1.1));
 
     return ApplyModifier(modifier, defStat);
 }
@@ -7690,8 +7684,7 @@ bool8 ShouldGetStatBadgeBoost(u16 badgeFlag, u8 battlerId)
 {
     if (B_BADGE_BOOST != GEN_3)
         return FALSE;
-
-    if (gBattleTypeFlags & (BATTLE_TYPE_LINK | BATTLE_TYPE_EREADER_TRAINER | BATTLE_TYPE_x2000000 | BATTLE_TYPE_FRONTIER))
+    else if (gBattleTypeFlags & (BATTLE_TYPE_LINK | BATTLE_TYPE_EREADER_TRAINER | BATTLE_TYPE_x2000000 | BATTLE_TYPE_FRONTIER))
         return FALSE;
     else if (GetBattlerSide(battlerId) != B_SIDE_PLAYER)
         return FALSE;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -6937,10 +6937,11 @@ static u32 CalcAttackStat(u16 move, u8 battlerAtk, u8 battlerDef, u8 moveType, b
         break;
     }
 
-    // The attack stat of a Player's Pokémon is boosted by x1.1 (+10%) if they have the 1st and 7th Badges
+    // The offensive stats of a Player's Pokémon are boosted by x1.1 (+10%) if they have the 1st badge and 7th badges.
+    // Having the 1st badge boosts physical attack while having the 7th badge boosts special attack.
     if (B_BADGE_BOOST == GEN_3)
     {
-        if (ShouldGetStatBadgeBoost(FLAG_BADGE01_GET, battlerAtk) && !(IS_MOVE_SPECIAL(move)))
+        if (ShouldGetStatBadgeBoost(FLAG_BADGE01_GET, battlerAtk) && IS_MOVE_PHYSICAL(move))
             MulModifier(&modifier, UQ_4_12(1.1));
         if (ShouldGetStatBadgeBoost(FLAG_BADGE07_GET, battlerAtk) && IS_MOVE_SPECIAL(move))
             MulModifier(&modifier, UQ_4_12(1.1));
@@ -7078,12 +7079,13 @@ static u32 CalcDefenseStat(u16 move, u8 battlerAtk, u8 battlerDef, u8 moveType, 
     if (IS_BATTLER_OF_TYPE(battlerDef, TYPE_ROCK) && WEATHER_HAS_EFFECT && gBattleWeather & WEATHER_SANDSTORM_ANY && !usesDefStat)
         MulModifier(&modifier, UQ_4_12(1.5));
 
-    // The defense stat of a Player's Pokémon is boosted by x1.1 (+10%) if they have the 5th and 7th Badges
+    // The defensive stats of a Player's Pokémon are boosted by x1.1 (+10%) if they have the 5th badge and 7th badges.
+    // Having the 5th badge boosts physical defense while having the 7th badge boosts special defense.
     if (B_BADGE_BOOST == GEN_3)
     {
         if (ShouldGetStatBadgeBoost(FLAG_BADGE05_GET, battlerDef) && IS_MOVE_PHYSICAL(move))
             MulModifier(&modifier, UQ_4_12(1.1));
-        if (ShouldGetStatBadgeBoost(FLAG_BADGE07_GET, battlerDef) && !(IS_MOVE_PHYSICAL(move)))
+        if (ShouldGetStatBadgeBoost(FLAG_BADGE07_GET, battlerDef) && IS_MOVE_SPECIAL(move))
             MulModifier(&modifier, UQ_4_12(1.1));
     }
 
@@ -7686,6 +7688,9 @@ bool32 SetIllusionMon(struct Pokemon *mon, u32 battlerId)
 
 static bool8 ShouldGetStatBadgeBoost(u16 badgeFlag, u8 battlerId)
 {
+    if (B_BADGE_BOOST != GEN_3)
+        return FALSE;
+
     if (gBattleTypeFlags & (BATTLE_TYPE_LINK | BATTLE_TYPE_EREADER_TRAINER | BATTLE_TYPE_x2000000 | BATTLE_TYPE_FRONTIER))
         return FALSE;
     else if (GetBattlerSide(battlerId) != B_SIDE_PLAYER)

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -7686,7 +7686,7 @@ bool32 SetIllusionMon(struct Pokemon *mon, u32 battlerId)
     return FALSE;
 }
 
-static bool8 ShouldGetStatBadgeBoost(u16 badgeFlag, u8 battlerId)
+bool8 ShouldGetStatBadgeBoost(u16 badgeFlag, u8 battlerId)
 {
     if (B_BADGE_BOOST != GEN_3)
         return FALSE;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -40,6 +40,7 @@
 #include "trig.h"
 #include "window.h"
 #include "constants/songs.h"
+#include "constants/trainers.h"
 
 extern const u8 *const gBattleScriptsForMoveEffects[];
 extern const u8 *const gBattlescriptsForBallThrow[];
@@ -6936,6 +6937,15 @@ static u32 CalcAttackStat(u16 move, u8 battlerAtk, u8 battlerDef, u8 moveType, b
         break;
     }
 
+    // The attack stat of a Player's Pokémon is boosted by x1.1 (+10%) if they have the 1st and 7th Badges
+    if (B_BADGE_BOOST == GEN_3)
+    {
+        if (ShouldGetStatBadgeBoost(FLAG_BADGE01_GET, battlerAtk) && !(IS_MOVE_SPECIAL(move)))
+            MulModifier(&modifier, UQ_4_12(1.1));
+        if (ShouldGetStatBadgeBoost(FLAG_BADGE07_GET, battlerAtk) && IS_MOVE_SPECIAL(move))
+            MulModifier(&modifier, UQ_4_12(1.1));
+    }
+
     return ApplyModifier(modifier, atkStat);
 }
 
@@ -7067,6 +7077,15 @@ static u32 CalcDefenseStat(u16 move, u8 battlerAtk, u8 battlerDef, u8 moveType, 
     // sandstorm sp.def boost for rock types
     if (IS_BATTLER_OF_TYPE(battlerDef, TYPE_ROCK) && WEATHER_HAS_EFFECT && gBattleWeather & WEATHER_SANDSTORM_ANY && !usesDefStat)
         MulModifier(&modifier, UQ_4_12(1.5));
+
+    // The defense stat of a Player's Pokémon is boosted by x1.1 (+10%) if they have the 5th and 7th Badges
+    if (B_BADGE_BOOST == GEN_3)
+    {
+        if (ShouldGetStatBadgeBoost(FLAG_BADGE05_GET, battlerDef) && IS_MOVE_PHYSICAL(move))
+            MulModifier(&modifier, UQ_4_12(1.1));
+        if (ShouldGetStatBadgeBoost(FLAG_BADGE07_GET, battlerDef) && !(IS_MOVE_PHYSICAL(move)))
+            MulModifier(&modifier, UQ_4_12(1.1));
+    }
 
     return ApplyModifier(modifier, defStat);
 }
@@ -7663,4 +7682,18 @@ bool32 SetIllusionMon(struct Pokemon *mon, u32 battlerId)
     }
 
     return FALSE;
+}
+
+static bool8 ShouldGetStatBadgeBoost(u16 badgeFlag, u8 battlerId)
+{
+    if (gBattleTypeFlags & (BATTLE_TYPE_LINK | BATTLE_TYPE_EREADER_TRAINER | BATTLE_TYPE_x2000000 | BATTLE_TYPE_FRONTIER))
+        return FALSE;
+    else if (GetBattlerSide(battlerId) != B_SIDE_PLAYER)
+        return FALSE;
+    else if (gBattleTypeFlags & BATTLE_TYPE_TRAINER && gTrainerBattleOpponent_A == TRAINER_SECRET_BASE)
+        return FALSE;
+    else if (FlagGet(badgeFlag))
+        return TRUE;
+    else
+        return FALSE;
 }

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -58,7 +58,6 @@ static union PokemonSubstruct *GetSubstruct(struct BoxPokemon *boxMon, u32 perso
 static void EncryptBoxMon(struct BoxPokemon *boxMon);
 static void DecryptBoxMon(struct BoxPokemon *boxMon);
 static void sub_806E6CC(u8 taskId);
-static bool8 ShouldGetStatBadgeBoost(u16 flagId, u8 battlerId);
 static u16 GiveMoveToBoxMon(struct BoxPokemon *boxMon, u16 move);
 static bool8 ShouldSkipFriendshipChange(void);
 
@@ -3074,20 +3073,6 @@ u8 CountAliveMonsInBattle(u8 caseId)
     }
 
     return retVal;
-}
-
-static bool8 ShouldGetStatBadgeBoost(u16 badgeFlag, u8 battlerId)
-{
-    if (gBattleTypeFlags & (BATTLE_TYPE_LINK | BATTLE_TYPE_EREADER_TRAINER | BATTLE_TYPE_x2000000 | BATTLE_TYPE_FRONTIER))
-        return FALSE;
-    else if (GetBattlerSide(battlerId) != B_SIDE_PLAYER)
-        return FALSE;
-    else if (gBattleTypeFlags & BATTLE_TYPE_TRAINER && gTrainerBattleOpponent_A == TRAINER_SECRET_BASE)
-        return FALSE;
-    else if (FlagGet(badgeFlag))
-        return TRUE;
-    else
-        return FALSE;
 }
 
 u8 GetDefaultMoveTarget(u8 battlerId)


### PR DESCRIPTION
## Description
In the Gen. 4 of mainline Pokémon games, the stat boosts provided by having certain badges were removed.
I decided to reincorporate them behind a battle configuration option because why not.

## **Discord contact info**
Lunos#4026

I don't think I missed anything, but if I did, let me know.