### PR TITLE
Removed the special behavior for Deoxys from the GetMonIconTiles func…

### DIFF
--- a/src/pokemon_icon.c
+++ b/src/pokemon_icon.c
@@ -2145,10 +2145,6 @@ void SpriteCB_MonIcon(struct Sprite *sprite)
 const u8* GetMonIconTiles(u16 species, bool32 handleDeoxys)
 {
     const u8* iconSprite = gMonIconTable[species];
-    if (species == SPECIES_DEOXYS && handleDeoxys == TRUE)
-    {
-        iconSprite = (const u8*)(0x400 + (u32)iconSprite); // use the specific Deoxys form icon (Speed in this case)
-    }
     return iconSprite;
 }
 


### PR DESCRIPTION
## Description
For whatever reason, the duct-taped base or original iteration of Deoxys was using Chimecho's icon sprite.
This PR addresses that following @AsparagusEduardo's instructions.

## **Discord contact info**
Lunos#4026