### PR TITLE
Fix ability description strings

### DIFF
--- a/src/data/text/abilities.h
+++ b/src/data/text/abilities.h
@@ -109,8 +109,8 @@ static const u8 sAftermathDescription[] = _("Fainting damages the foe.");
 static const u8 sAnticipationDescription[] = _("Senses dangerous moves.");
 static const u8 sForewarnDescription[] = _("Determines a foe's move.");
 static const u8 sUnawareDescription[] = _("Ignores stat changes.");
-static const u8 sTintedLensDescription[] = _("Ups “not very effective“.");
-static const u8 sFilterDescription[] = _("Weakens “super effective.“.");
+static const u8 sTintedLensDescription[] = _("Ups “not very effective”.");
+static const u8 sFilterDescription[] = _("Weakens “super effective”.");
 static const u8 sSlowStartDescription[] = _("Takes a while to get going.");
 static const u8 sScrappyDescription[] = _("Hits Ghost-type Pokémon.");
 static const u8 sStormDrainDescription[] = _("Draws in Water moves.");
@@ -220,7 +220,7 @@ static const u8 sPsychicSurgeDescription[] = _("Field becomes weird.");
 static const u8 sMistySurgeDescription[] = _("Field becomes misty.");
 static const u8 sGrassySurgeDescription[] = _("Field becomes grassy.");
 static const u8 sFullMetalBodyDescription[] = _("Prevents stat reduction.");
-static const u8 sNeuroforceDescription[] = _("Ups “super effective.“.");
+static const u8 sNeuroforceDescription[] = _("Ups “super effective”.");
 
 const u8 gAbilityNames[ABILITIES_COUNT_GEN7][ABILITY_NAME_LENGTH + 1] =
 {

--- a/src/data/text/abilities.h
+++ b/src/data/text/abilities.h
@@ -23,7 +23,7 @@ static const u8 sSuctionCupsDescription[] = _("Firmly anchors the body.");
 static const u8 sIntimidateDescription[] = _("Lowers the foe's Attack.");
 static const u8 sShadowTagDescription[] = _("Prevents the foe's escape.");
 static const u8 sRoughSkinDescription[] = _("Hurts to touch.");
-static const u8 sWonderGuardDescription[] = _("“Super effective” hits.");
+static const u8 sWonderGuardDescription[] = _("“Supereffective” hits.");
 static const u8 sLevitateDescription[] = _("Not hit by Ground attacks.");
 static const u8 sEffectSporeDescription[] = _("Leaves spores on contact.");
 static const u8 sSynchronizeDescription[] = _("Passes on status problems.");
@@ -110,7 +110,7 @@ static const u8 sAnticipationDescription[] = _("Senses dangerous moves.");
 static const u8 sForewarnDescription[] = _("Determines a foe's move.");
 static const u8 sUnawareDescription[] = _("Ignores stat changes.");
 static const u8 sTintedLensDescription[] = _("Ups “not very effective”.");
-static const u8 sFilterDescription[] = _("Weakens “super effective”.");
+static const u8 sFilterDescription[] = _("Weakens “supereffective”.");
 static const u8 sSlowStartDescription[] = _("Takes a while to get going.");
 static const u8 sScrappyDescription[] = _("Hits Ghost-type Pokémon.");
 static const u8 sStormDrainDescription[] = _("Draws in Water moves.");
@@ -220,7 +220,7 @@ static const u8 sPsychicSurgeDescription[] = _("Field becomes weird.");
 static const u8 sMistySurgeDescription[] = _("Field becomes misty.");
 static const u8 sGrassySurgeDescription[] = _("Field becomes grassy.");
 static const u8 sFullMetalBodyDescription[] = _("Prevents stat reduction.");
-static const u8 sNeuroforceDescription[] = _("Ups “super effective”.");
+static const u8 sNeuroforceDescription[] = _("Ups “supereffective”.");
 
 const u8 gAbilityNames[ABILITIES_COUNT_GEN7][ABILITY_NAME_LENGTH + 1] =
 {


### PR DESCRIPTION
fix quotes around "effective" in some ability descriptions

eg. `“super effective.“` -> `“super effective.”`

## **Discord contact info**
ghoulslash#3839