### PR TITLE
Added functionality to the B_NEW_SURF_PARTICLE_PALETTE anim. config label

### DIFF
--- a/src/battle_anim_water.c
+++ b/src/battle_anim_water.c
@@ -1010,7 +1010,10 @@ void AnimTask_CreateSurfWave(u8 taskId)
     {
     case ANIM_SURF_PAL_SURF:
     default:
-        LoadCompressedPalette(gBattleAnimBgPalette_Surf, animBg.paletteId * 16, 32);
+        if (B_NEW_SURF_PARTICLE_PALETTE == TRUE)
+            LoadCompressedPalette(gBattleAnimSpritePal_NewSurf, animBg.paletteId * 16, 32);
+        else
+            LoadCompressedPalette(gBattleAnimBgPalette_Surf, animBg.paletteId * 16, 32);
         break;
     case ANIM_SURF_PAL_MUDDY_WATER:
         LoadCompressedPalette(gBattleAnimBackgroundImageMuddyWater_Pal, animBg.paletteId * 16, 32);


### PR DESCRIPTION
## Description
The anim. setting `B_NEW_SURF_PARTICLE_PALETTE` wasn't doing anything at all, so I went ahead and gave it a reason to exist.
When set to `TRUE` it'll make Surf use a more Gen. 4 like palette for its animation.
![Untitled887](https://user-images.githubusercontent.com/4485172/98428333-cac86c00-207f-11eb-8887-c93e449a5e58.gif)

## **Discord contact info**
Lunos#4026