### PR TITLE
Prevent Ability Popup overwrites

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -6554,7 +6554,7 @@ BattleScript_DefiantActivates::
 BattleScript_AbilityPopUp:
 	showabilitypopup BS_ABILITY_BATTLER
 	recordability BS_ABILITY_BATTLER
-	pause 0x10
+	pause 40
 	return
 
 BattleScript_SpeedBoostActivates::


### PR DESCRIPTION
## Description
Increases the `pause` length in `BattleScript_AbilityPopUp` to prevent multiple ability popups from overwriting the previous.

**OLD**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; **NEW**
![popup_old](https://user-images.githubusercontent.com/41651341/98706788-80bfde80-233c-11eb-9a54-638f840db392.gif) ![dual-popup](https://user-images.githubusercontent.com/41651341/98706714-6a198780-233c-11eb-8ab2-0a74dea9f161.gif)
