### PR TITLE
Remove Techno Blast and Judgment from battle scripts

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -316,8 +316,7 @@ gBattleScriptsForMoveEffects:: @ 82D86A8
 	.4byte BattleScript_EffectClearSmog
 	.4byte BattleScript_EffectHitSwitchTarget
 	.4byte BattleScript_EffectFinalGambit
-	.4byte BattleScript_EffectTechnoBlast
-	.4byte BattleScript_EffectJudgment
+	.4byte BattleScript_EffectChangeTypeOnItem
 	.4byte BattleScript_EffectAutotomize
 	.4byte BattleScript_EffectCopycat
 	.4byte BattleScript_EffectDefog
@@ -2046,8 +2045,7 @@ BattleScript_EffectPsyshock:
 BattleScript_EffectWeatherBall:
 BattleScript_EffectHiddenPower:
 BattleScript_EffectTwoTypedMove:
-BattleScript_EffectTechnoBlast:
-BattleScript_EffectJudgment:
+BattleScript_EffectChangeTypeOnItem:
 BattleScript_EffectFusionCombo:
 BattleScript_EffectRevelationDance:
 BattleScript_EffectBelch:


### PR DESCRIPTION
This was causing every move after judgment to use the wrong effect (off by one).

Thank you eatthepear for catching this and providing a fix