### PR TITLE
Shuckle makes Berry Juice

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -9565,6 +9565,16 @@ static void Cmd_weatherdamage(void)
                 if (gBattleMoveDamage == 0)
                     gBattleMoveDamage = 1;
             }
+           else if (species == SPECIES_SHUCKLE
+               && heldItem >= FIRST_BERRY_INDEX
+               && heldItem <= LAST_BERRY_INDEX)
+           {
+               if (!(Random() % 16))
+               {
+                   heldItem = ITEM_BERRY_JUICE;
+                   SetMonData(&gPlayerParty[i], MON_DATA_HELD_ITEM, &heldItem);
+               }
+           }
         }
     }
 
@@ -11568,6 +11578,16 @@ static void Cmd_pickup(void)
                 heldItem = GetBattlePyramidPickupItemId();
                 SetMonData(&gPlayerParty[i], MON_DATA_HELD_ITEM, &heldItem);
             }
+           else if (species == SPECIES_SHUCKLE
+               && heldItem >= FIRST_BERRY_INDEX
+               && heldItem <= LAST_BERRY_INDEX)
+           {
+               if (!(Random() % 16))
+               {
+                   heldItem = ITEM_BERRY_JUICE;
+                   SetMonData(&gPlayerParty[i], MON_DATA_HELD_ITEM, &heldItem);
+               }
+           }
             #if (defined ITEM_HONEY)
             else if (ability == ABILITY_HONEY_GATHER
                 && species != 0


### PR DESCRIPTION
Extracted from here: https://github.com/pret/pokeemerald/wiki/Shuckle-makes-Berry-Juice

## Description
In Gold, Silver and Crystal only, Shuckle could randomly make Berry Juice by holding a berry after winning a battle. Let's implement it back!

## **Discord contact info**
Jaizu#4989