### PR TITLE
Fix Babydoll eyes animation

### DIFF
--- a/data/battle_anim_scripts.s
+++ b/data/battle_anim_scripts.s
@@ -9451,6 +9451,7 @@ Move_BABY_DOLL_EYES::
 	loadspritegfx ANIM_TAG_PINK_CLOUD
 	loadspritegfx ANIM_TAG_OPENING_EYE @eye
 	setalpha 8, 8
+	monbg ANIM_DEF_PARTNER
 	launchtask AnimTask_BlendBattleAnimPal 0xa 0x5 ANIM_PAL_BG 0x0 0x0 0xA 0x7FFF
 	waitforvisualfinish
 	launchtemplate gOpeningEyeSpriteTemplate 0x5 0x4 0x0 0x0 0x1 0x0
@@ -9463,6 +9464,7 @@ Move_BABY_DOLL_EYES::
 	launchtask AnimTask_ShakeMon2 0x2 0x5 0x3 0x1 0x0 0x9 0x1
 	launchtask AnimTask_BlendBattleAnimPal 0xa 0x5 ANIM_PAL_BG 0x0 0xA 0x0 0x7FFF
 	waitforvisualfinish
+	clearmonbg ANIM_DEF_PARTNER
 	blendoff
 	end
 


### PR DESCRIPTION
## Description
I notice this in a random test. babydoll eyes when used on the player appears behind the mon. This PR fixes the issue:
![pokeemerald-1](https://user-images.githubusercontent.com/41651341/100921213-760aec00-3499-11eb-81be-a8055e9463b0.png) --> ![pokeemerald-0](https://user-images.githubusercontent.com/41651341/100921215-773c1900-3499-11eb-87ef-54087310df93.png)

