### PR TITLE
Fix Buffering abilities > 255

### DIFF
--- a/src/battle_message.c
+++ b/src/battle_message.c
@@ -3432,7 +3432,7 @@ static void ExpandBattleTextBuffPlaceholders(const u8 *src, u8 *dst)
             srcID += 2;
             break;
         case B_BUFF_ABILITY: // ability names
-            StringAppend(dst, gAbilityNames[src[srcID + 1]]);
+            StringAppend(dst, gAbilityNames[T1_READ_16(&src[srcID + 1])]);
             srcID += 3;
             break;
         case B_BUFF_ITEM: // item name


### PR DESCRIPTION
## Description
No example for this one since I couldn't think of an example to use. I found it by testing a custom ability in my game that is a special attack version of intimidate, which uses `PREPARE_ABILITY_BUFFER`.