### PR TITLE
Made Techno Blast's animation change depending on the Drive held

### DIFF
--- a/src/battle_anim_new.c
+++ b/src/battle_anim_new.c
@@ -14,6 +14,7 @@
 #include "battle_scripts.h"
 #include "battle_controllers.h"
 #include "constants/moves.h"
+#include "constants/hold_effects.h"
 
 //// function declarations
 static void SpriteCB_SpriteToCentreOfSide(struct Sprite* sprite);

--- a/src/battle_anim_new.c
+++ b/src/battle_anim_new.c
@@ -5001,8 +5001,9 @@ void AnimTask_PurpleFlamesOnTarget(u8 taskId)
 
 void AnimTask_TechnoBlast(u8 taskId)
 {
-    //gBattleAnimArgs[0] = gItems[GetBattlerPartyData(gBattleAnimAttacker).item].holdEffectParam;
-    gBattleAnimArgs[0] = ItemId_GetHoldEffectParam(gBattleMons[gBattleAnimAttacker].item);
+    if (ItemId_GetHoldEffect(gBattleMons[gBattleAnimAttacker].item) == HOLD_EFFECT_DRIVE)
+        gBattleAnimArgs[0] = ItemId_GetSecondaryId(gBattleMons[gBattleAnimAttacker].item);
+    else
+        gBattleAnimArgs[0] = 0;
     DestroyAnimVisualTask(taskId);
 }
-


### PR DESCRIPTION
I'm PR'ing this now because I'm not sure if I'll be able to solve the animations crashing the game.

## Description
Partly solves #1266
Techno Blast's animation was set out of a handful options depending on the holdEffectParam of the item the user was currently holding.
I made it check for `HOLD_EFFECT_DRIVE` and use their secondaryId, which is where they have their types set for use.

## **Discord contact info**
Lunos#4026