### PR TITLE
Fix Terrain BG on new battles

### DIFF
--- a/src/battle_util2.c
+++ b/src/battle_util2.c
@@ -45,7 +45,8 @@ void FreeBattleResources(void)
 {
     if (gBattleTypeFlags & BATTLE_TYPE_TRAINER_HILL)
         FreeTrainerHillBattleStruct();
-
+    
+    gFieldStatuses = 0;
     if (gBattleResources != NULL)
     {
         FREE_AND_SET_NULL(gBattleStruct);


### PR DESCRIPTION
## Description

Previously, ending a battle with an active terrain would mess up the battle transition/background on subsequent battles. Setting `gFieldStatuses` to 0 at the end of battle resolves this.
