### PR TITLE
Fix Shadow Sneak Animation

### DIFF
--- a/data/battle_anim_scripts.s
+++ b/data/battle_anim_scripts.s
@@ -2799,28 +2799,42 @@ Move_FIRE_FANG:
 	end
 
 Move_SHADOW_SNEAK:
-	loadspritegfx ANIM_TAG_LICK
-	setalpha 0, 16
-	delay 1
-	createvisualtask AnimTask_InitMementoShadow, 2
-	delay 1
-	createvisualtask AnimTask_MoveAttackerMementoShadow, 5
-	playsewithpan SE_M_PSYBEAM, SOUND_PAN_ATTACKER
-	delay 48
-	playsewithpan SE_M_PSYBEAM2, SOUND_PAN_ATTACKER
+	loadspritegfx ANIM_TAG_IMPACT
+	loadspritegfx ANIM_TAG_WHITE_SHADOW @Destiny Bond
+	loadspritegfx ANIM_TAG_QUICK_GUARD_HAND @Black Colour
+	loadspritegfx ANIM_TAG_POISON_BUBBLE @Poison
+	loadspritegfx ANIM_TAG_HANDS_AND_FEET
+	monbg ANIM_ATTACKER
+	launchtask AnimTask_BlendBattleAnimPal 0xa 0x5 ANIM_PAL_BG 0x1 0x0 0x7 0x0000
 	waitforvisualfinish
-	createvisualtask sub_8114470, 2
-	setalpha 0, 16
-	delay 1
-	playsewithpan SE_M_LICK, SOUND_PAN_TARGET
-	createsprite gLickSpriteTemplate, ANIM_TARGET, 2, 0, 0
-	createvisualtask AnimTask_ShakeMon2, 2, ANIM_TARGET, 1, 0, 16, 1
+	playsewithpan SE_M_FAINT_ATTACK, SOUND_PAN_ATTACKER
+	launchtask AnimTask_TranslateMonEllipticalRespectSide 0x2 0x5 0x0 0x12 0x6 0x1 0x3
+	launchtask AnimTask_AttackerFadeToInvisible 0x2 0x1 0x1
 	waitforvisualfinish
-	clearmonbg_23 ANIM_TARGET
-	delay 1
-	blendoff
-	delay 1
+	clearmonbg ANIM_ATTACKER
+	invisible ANIM_ATTACKER
+	delay 0x1
+	launchtask AnimTask_DestinyBondWhiteShadow 0x5 0x2 0x0 0x30
+	delay 0x30
+	launchtask AnimTask_BlendColorCycle 0x2 0x6 ANIM_PAL_DEF 0x2 0x2 0x0 0xF 0x0
+	createsprite gShadowSneakImpactSpriteTemplate, ANIM_TARGET, 2, 0xfff6, 0xfff6, 0x0
+	call ShadowSneakMovement
+	createsprite gShadowSneakImpactSpriteTemplate, ANIM_TARGET, 2, 0xa, 0x14, 0x0
+	call ShadowSneakMovement
+	createsprite gShadowSneakImpactSpriteTemplate, ANIM_TARGET, 2, 0xfffb, 0xa, 0x0
+	call ShadowSneakMovement
+	createsprite gShadowSneakImpactSpriteTemplate, ANIM_TARGET, 2, 0x11, 0xfff4, 0x0
+	call ShadowSneakMovement
+	waitforvisualfinish
+	visible ANIM_ATTACKER
+	launchtask AnimTask_BlendBattleAnimPal 0xa 0x5 ANIM_PAL_BG 0x1 0x7 0x0 0x0000
+	waitforvisualfinish
 	end
+ShadowSneakMovement:
+	playsewithpan SE_M_DOUBLE_SLAP, SOUND_PAN_TARGET
+	launchtask AnimTask_ShakeMon 0x2 0x5 ANIM_TARGET 0x3 0x0 0x6 0x1
+	delay 0x4
+	return
 
 Move_MUD_BOMB:
 	loadspritegfx ANIM_TAG_MUD_SAND

--- a/src/battle_anim_new.c
+++ b/src/battle_anim_new.c
@@ -66,6 +66,18 @@ static const union AffineAnimCmd sSquishTargetAffineAnimCmds[] =
 };
 
 //// GEN 4
+// shadow sneak
+const struct SpriteTemplate gShadowSneakImpactSpriteTemplate = 
+{
+    .tileTag = ANIM_TAG_IMPACT,
+    .paletteTag = ANIM_TAG_HANDS_AND_FEET,
+    .oam = &gOamData_AffineNormal_ObjBlend_32x32,
+    .anims = gDummySpriteAnimTable,
+    .images = NULL,
+    .affineAnims = gAffineAnims_IceCrystalHit,
+    .callback = AnimIceEffectParticle
+};
+
 // power trick
 const struct SpriteTemplate gPowerTrickSpriteTemplate = 
 {


### PR DESCRIPTION
## Description
Currently, shadow sneak does not properly return the ANIM_TARGET from the background, causing the level up box to not appear properly: https://discord.com/channels/442462691542695948/533083367818657792/785921673915793420

This PR replaces the shadow sneak animation with the CFRU one, shown in the GIF below. It's a better animation and fixes the issue above.
![shadow_sneak](https://user-images.githubusercontent.com/41651341/101526410-d098c200-3949-11eb-8af2-6823711860f1.gif)
