### PR TITLE
Corrected Final Gambit's move data and tweaked its effect

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -1082,16 +1082,12 @@ BattleScript_EffectFinalGambit:
 	waitstate
 	healthbarupdate BS_TARGET
 	datahpupdate BS_TARGET
-	critmessage
-	waitmessage 0x40
-	resultmessage
-	waitmessage 0x40
-	seteffectwithchance
-	tryfaintmon BS_TARGET, FALSE, NULL
-	jumpifmovehadnoeffect BattleScript_MoveEnd
 	healthbarupdate BS_ATTACKER
 	datahpupdate BS_ATTACKER
+	seteffectwithchance
 	tryfaintmon BS_ATTACKER, FALSE, NULL
+	tryfaintmon BS_TARGET, FALSE, NULL
+	jumpifmovehadnoeffect BattleScript_MoveEnd
 	goto BattleScript_MoveEnd
 
 BattleScript_EffectHitSwitchTarget:

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -1082,6 +1082,9 @@ BattleScript_EffectFinalGambit:
 	waitstate
 	healthbarupdate BS_TARGET
 	datahpupdate BS_TARGET
+	resultmessage
+	waitmessage 0x40
+	dmgtocurrattackerhp
 	healthbarupdate BS_ATTACKER
 	datahpupdate BS_ATTACKER
 	seteffectwithchance

--- a/src/data/battle_moves.h
+++ b/src/data/battle_moves.h
@@ -7986,7 +7986,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_FINAL_GAMBIT] =
     {
-        .effect = EFFECT_HIT_SWITCH_TARGET,
+        .effect = EFFECT_FINAL_GAMBIT,
         .power = 1,
         .type = TYPE_FIGHTING,
         .accuracy = 100,
@@ -7994,7 +7994,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
-        .flags = FLAG_PROTECT_AFFECTED,
+        .flags = FLAG_PROTECT_AFFECTED | FLAG_KINGSROCK_AFFECTED,
         .split = SPLIT_SPECIAL,
     },
 


### PR DESCRIPTION
## Description
After #1287, I decided to look into Final Gambit since it had the same effect as Dragon Tail assigned to it for some reason.
I found out that the move's true effect was already done. It was simply not assigned to the move in its data, for whatever reason.
On top of that, it was also missing the `FLAG_KINGSROCK_AFFECTED`, so I threw it in.
![Untitled1987](https://user-images.githubusercontent.com/4485172/101987397-9f363400-3c72-11eb-9582-63ff8a20249d.gif)

## **Discord contact info**
Lunos#4026