### PR TITLE
Fix Early Mummy Activation

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4357,6 +4357,7 @@ u8 AbilityBattleEffects(u8 caseID, u8 battler, u16 ability, u8 special, u16 move
         case ABILITY_MUMMY:
             if (!(gMoveResultFlags & MOVE_RESULT_NO_EFFECT)
              && IsBattlerAlive(gBattlerAttacker)
+             && TARGET_TURN_DAMAGED
              && (gBattleMoves[move].flags & FLAG_MAKES_CONTACT))
             {
                 switch (gBattleMons[gBattlerAttacker].ability)


### PR DESCRIPTION
## Description
Fixes mummy activating on the turn an attacker uses Dig/Fly

![dig_mummy_bug](https://user-images.githubusercontent.com/41651341/102126146-f1f52480-3e07-11eb-944b-eafb4a2893c6.gif) ![dig_mummy_fix](https://user-images.githubusercontent.com/41651341/102126155-f4577e80-3e07-11eb-86c1-ea754d724043.gif)
