### PR TITLE
Corrected the ability 1 of Calyrex's forms

### DIFF
--- a/src/data/pokemon/base_stats.h
+++ b/src/data/pokemon/base_stats.h
@@ -34175,7 +34175,7 @@ const struct BaseStats gBaseStats[] =
         .eggGroup1 = EGG_GROUP_UNDISCOVERED,
         .eggGroup2 = EGG_GROUP_UNDISCOVERED,
         #ifdef BATTLE_ENGINE
-            .abilities = {ABILITY_AS_ONE, ABILITY_NONE},
+            .abilities = {ABILITY_AS_ONE_ICE_RIDER, ABILITY_NONE},
         #else
             .abilities = {ABILITY_NONE, ABILITY_NONE},
         #endif
@@ -34203,7 +34203,7 @@ const struct BaseStats gBaseStats[] =
         .eggGroup1 = EGG_GROUP_UNDISCOVERED,
         .eggGroup2 = EGG_GROUP_UNDISCOVERED,
         #ifdef BATTLE_ENGINE
-            .abilities = {ABILITY_AS_ONE, ABILITY_NONE},
+            .abilities = {ABILITY_AS_ONE_SHADOW_RIDER, ABILITY_NONE},
         #else
             .abilities = {ABILITY_NONE, ABILITY_NONE},
         #endif


### PR DESCRIPTION
## Description
There isn't an `ABILITY_AS_ONE` defined in the `include/constants/abilities.h` of the battle_engine branch, so this wasn't building a ROM correctly.
https://github.com/rh-hideout/pokeemerald-expansion/blob/pokemon_expansion/src/data/pokemon/base_stats.h#L34158
https://github.com/rh-hideout/pokeemerald-expansion/blob/battle_engine/include/constants/abilities.h#L290

This PR adddresses that.

## **Discord contact info**
Lunos#4026