### PR TITLE
battle_config.h tweaks

### DIFF
--- a/include/battle_debug.h
+++ b/include/battle_debug.h
@@ -1,8 +1,6 @@
 #ifndef GUARD_BATTLE_DEBUG_H
 #define GUARD_BATTLE_DEBUG_H
 
-#define USE_BATTLE_DEBUG TRUE
-
 void CB2_BattleDebugMenu(void);
 
 #endif // GUARD_BATTLE_DEBUG_H

--- a/include/constants/battle_config.h
+++ b/include/constants/battle_config.h
@@ -165,7 +165,8 @@
 #define B_NEW_IMPACT_PALETTE            TRUE    // If set to TRUE, it updates the basic 'hit' palette.
 #define B_NEW_SURF_PARTICLE_PALETTE     TRUE    // If set to TRUE, it updates Surf's wave palette.
 
-#define HIDE_HEALTHBOXES_DURING_ANIMS   TRUE    //if TRUE, hides healthboxes during move animations
-#define B_TERRAIN_BG_CHANGE             TRUE    // If TRUE, terrain moves permanently change the default battle background until the effect fades.
+#define HIDE_HEALTHBOXES_DURING_ANIMS   TRUE    // If set to TRUE, hides healthboxes during move animations
+#define B_TERRAIN_BG_CHANGE             TRUE    // If set to TRUE, terrain moves permanently change the default battle background until the effect fades.
+#define USE_BATTLE_DEBUG                TRUE    // If set to TRUE, enables a debug menu to use in battles by pressing the Select button.
 
 #endif // GUARD_CONSTANTS_BATTLE_CONFIG_H

--- a/include/constants/battle_config.h
+++ b/include/constants/battle_config.h
@@ -167,6 +167,6 @@
 
 #define HIDE_HEALTHBOXES_DURING_ANIMS   TRUE    // If set to TRUE, hides healthboxes during move animations
 #define B_TERRAIN_BG_CHANGE             TRUE    // If set to TRUE, terrain moves permanently change the default battle background until the effect fades.
-#define USE_BATTLE_DEBUG                TRUE    // If set to TRUE, enables a debug menu to use in battles by pressing the Select button.
+#define B_ENABLE_DEBUG                  TRUE    // If set to TRUE, enables a debug menu to use in battles by pressing the Select button.
 
 #endif // GUARD_CONSTANTS_BATTLE_CONFIG_H

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -331,7 +331,7 @@ static void HandleInputChooseAction(void)
     {
         SwapHpBarsWithHpText();
     }
-    else if (USE_BATTLE_DEBUG && gMain.newKeys & SELECT_BUTTON)
+    else if (B_ENABLE_DEBUG && gMain.newKeys & SELECT_BUTTON)
     {
         BtlController_EmitTwoReturnValues(1, B_ACTION_DEBUG, 0);
         PlayerBufferExecCompleted();

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -6155,7 +6155,7 @@ u32 GetBattlerHoldEffect(u8 battlerId, bool32 checkNegating)
 
     gPotentialItemEffectBattler = battlerId;
 
-    if (USE_BATTLE_DEBUG && gBattleStruct->debugHoldEffects[battlerId] != 0 && gBattleMons[battlerId].item)
+    if (B_ENABLE_DEBUG && gBattleStruct->debugHoldEffects[battlerId] != 0 && gBattleMons[battlerId].item)
         return gBattleStruct->debugHoldEffects[battlerId];
     else if (gBattleMons[battlerId].item == ITEM_ENIGMA_BERRY)
         return gEnigmaBerries[battlerId].holdEffect;
@@ -7624,7 +7624,7 @@ bool32 CanMegaEvolve(u8 battlerId)
     // Check if there is an entry in the evolution table for regular Mega Evolution.
     if (GetMegaEvolutionSpecies(species, itemId) != SPECIES_NONE)
     {
-        if (USE_BATTLE_DEBUG && gBattleStruct->debugHoldEffects[battlerId])
+        if (B_ENABLE_DEBUG && gBattleStruct->debugHoldEffects[battlerId])
             holdEffect = gBattleStruct->debugHoldEffects[battlerId];
         else if (itemId == ITEM_ENIGMA_BERRY)
             holdEffect = gEnigmaBerries[battlerId].holdEffect;


### PR DESCRIPTION
## Description
It was brought to attention yesterday that unlike every other battle related configuration, the constant that toggled the in battle debug menu was located outside of `include/constants/battle_config.h` so I moved it there for consistency sake.
I also tweaked the comments for `HIDE_HEALTHBOXES_DURING_ANIMS` and `B_TERRAIN_BG_CHANGE` because they were inconsistent with many many comments above them.

## **Discord contact info**
Lunos#4026