### PR TITLE
Add Sand Spit Ability

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -7714,3 +7714,13 @@ BattleScript_AnnounceAirLockCloudNine::
 	waitmessage 0x40
 	call BattleScript_WeatherFormChanges
 	end3
+
+BattleScript_SandSpitActivates::
+	pause 0x20
+	call BattleScript_AbilityPopUp
+	setsandstorm
+	printstring STRINGID_PKMNSXWHIPPEDUPSANDSTORM
+	waitmessage 0x40
+	playanimation BS_BATTLER_0, B_ANIM_SANDSTORM_CONTINUES, NULL
+	call BattleScript_WeatherFormChanges
+	return

--- a/include/battle_scripts.h
+++ b/include/battle_scripts.h
@@ -350,5 +350,6 @@ extern const u8 BattleScript_EmergencyExitWild[];
 extern const u8 BattleScript_EmergencyExitWildNoPopUp[];
 extern const u8 BattleScript_CheekPouchActivates[];
 extern const u8 BattleScript_AnnounceAirLockCloudNine[];
+extern const u8 BattleScript_SandSpitActivates[];
 
 #endif // GUARD_BATTLE_SCRIPTS_H

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4590,6 +4590,19 @@ u8 AbilityBattleEffects(u8 caseID, u8 battler, u16 ability, u8 special, u16 move
                 effect++;
             }
             break;
+        case ABILITY_SAND_SPIT:
+            if (!(gMoveResultFlags & MOVE_RESULT_NO_EFFECT)
+             && gBattleMons[gBattlerAttacker].hp != 0
+             && !gProtectStructs[gBattlerAttacker].confusionSelfDmg
+             && TARGET_TURN_DAMAGED
+             && gBattleMons[gBattlerTarget].hp != 0
+             && TryChangeBattleWeather(battler, ENUM_WEATHER_SANDSTORM, TRUE))
+            {
+                BattleScriptPushCursor();
+                gBattlescriptCurrInstr = BattleScript_SandSpitActivates;
+                effect++;
+            }
+            break;
         }
         break;
     case ABILITYEFFECT_MOVE_END_ATTACKER: // Same as above, but for attacker


### PR DESCRIPTION
## Description
Sand Spit: Summons a sand storm when damaged (contact move not required): [more info](https://bulbapedia.bulbagarden.net/wiki/Sand_Spit_%28Ability%29)


![sand_spit](https://user-images.githubusercontent.com/41651341/103703639-22dafc00-4f65-11eb-9ecf-1375c3ee5d73.gif)
