### PR TITLE
Magic Room Affects Macho Brace/Power Item Speed Drop

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4251,7 +4251,7 @@ u32 GetBattlerTotalSpeedStat(u8 battlerId)
     }
 
     // item effects
-    if (GetBattlerHoldEffect(battlerId, FALSE) == HOLD_EFFECT_MACHO_BRACE || GetBattlerHoldEffect(battlerId, FALSE) == HOLD_EFFECT_POWER_ITEM)
+    if (holdEffect == HOLD_EFFECT_MACHO_BRACE || holdEffect == HOLD_EFFECT_POWER_ITEM)
         speed /= 2;
     else if (holdEffect == HOLD_EFFECT_IRON_BALL)
         speed /= 2;


### PR DESCRIPTION
## Description
According to [Bulbapedia](https://bulbapedia.bulbagarden.net/wiki/Magic_Room_%28move%29), Magic Room blocks the speed drop of macho brace/power items, which is not the case in the Battle Engine.

