### PR TITLE
Update tailwind timer To Gen5

### DIFF
--- a/include/constants/battle_config.h
+++ b/include/constants/battle_config.h
@@ -112,6 +112,7 @@
 #define B_PP_REDUCED_BY_SPITE       GEN_6 // In Gen4+, Spite reduces the foe's last move's PP by 4, instead of 2 to 5.
 #define B_CAN_SPITE_FAIL            GEN_6 // In Gen4+, Spite can no longer fail if the foe's last move only has 1 remaining PP.
 #define B_CRASH_IF_TARGET_IMMUNE    GEN_6 // In Gen4+, The user of Jump Kick or Hi Jump Kick will "keep going and crash" if it attacks a target that is immune to the move.
+#define B_TAILWIND_TIMER            GEN_5 // In Gen5+, Tailwind lasts 4 turns instead of 3.
 
 // Ability settings
 #define B_ABILITY_WEATHER           GEN_6 // In Gen6+, ability-induced weather lasts 5 turns. Before, it lasted until the battle ended or until it was changed by a move.

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -10208,7 +10208,7 @@ static void Cmd_settailwind(void)
     {
         gSideStatuses[side] |= SIDE_STATUS_TAILWIND;
         gSideTimers[side].tailwindBattlerId = gBattlerAttacker;
-        gSideTimers[side].tailwindTimer = 3;
+        gSideTimers[side].tailwindTimer = (B_TAILWIND_TIMER >= GEN_5) ? 4 : 3;
         gBattlescriptCurrInstr += 5;
     }
     else


### PR DESCRIPTION
## Description
Add config option `B_TAILWIND_TIMER` to update tailwind to last 4 turns instead of 3
