### PR TITLE
Updated the list of abilities unaffected by Gastro Acid

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -11225,15 +11225,20 @@ static void Cmd_setgastroacid(void)
 {
     switch (gBattleMons[gBattlerTarget].ability)
     {
-    case ABILITY_MULTITYPE:
-    case ABILITY_STANCE_CHANGE:
-    case ABILITY_SCHOOLING:
-    case ABILITY_COMATOSE:
-    case ABILITY_SHIELDS_DOWN:
-    case ABILITY_DISGUISE:
-    case ABILITY_RKS_SYSTEM:
+    case ABILITY_AS_ONE_ICE_RIDER:
+    case ABILITY_AS_ONE_SHADOW_RIDER:
     case ABILITY_BATTLE_BOND:
+    case ABILITY_COMATOSE:
+    case ABILITY_DISGUISE:
+    case ABILITY_GULP_MISSILE:
+    case ABILITY_ICE_FACE:
+    case ABILITY_MULTITYPE:
     case ABILITY_POWER_CONSTRUCT:
+    case ABILITY_RKS_SYSTEM:
+    case ABILITY_SCHOOLING:
+    case ABILITY_SHIELDS_DOWN:
+    case ABILITY_STANCE_CHANGE:
+    case ABILITY_ZEN_MODE:
         gBattlescriptCurrInstr = T1_READ_PTR(gBattlescriptCurrInstr + 1);
         break;
     default:


### PR DESCRIPTION
## Description
The list was missing a few abilities that are not supposed to be affected by Gastro Acid, as per the following list.
https://bulbapedia.bulbagarden.net/wiki/Category:Abilities_that_cannot_be_suppressed

I also ordered them alphabetically because it was easier to read, but I can undo that if it's a bad idea.

## **Discord contact info**
Lunos#4026