### PR TITLE
Fixed Keldeo Resolute's animation

### DIFF
--- a/src/data/pokemon_graphics/front_pic_anims.h
+++ b/src/data/pokemon_graphics/front_pic_anims.h
@@ -8998,6 +8998,12 @@ static const union AnimCmd sAnim_LANDORUS_THERIAN_1[] =
     ANIMCMD_END,
 };
 
+static const union AnimCmd sAnim_KELDEO_RESOLUTE_1[] =
+{
+    ANIMCMD_FRAME(0, 1),
+    ANIMCMD_END,
+};
+
 static const union AnimCmd sAnim_MELOETTA_PIROUETTE_1[] =
 {
     ANIMCMD_FRAME(0, 1),
@@ -14321,6 +14327,11 @@ static const union AnimCmd *const sAnims_LANDORUS_THERIAN[] ={
     sAnim_LANDORUS_THERIAN_1,
 };
 
+static const union AnimCmd *const sAnims_KELDEO_RESOLUTE[] ={
+    sAnim_GeneralFrame0,
+    sAnim_KELDEO_RESOLUTE_1,
+};
+
 static const union AnimCmd *const sAnims_MELOETTA_PIROUETTE[] ={
     sAnim_GeneralFrame0,
     sAnim_MELOETTA_PIROUETTE_1,
@@ -15484,7 +15495,7 @@ const union AnimCmd *const *const gMonFrontAnimsPtrTable[] =
     ANIM_CMD(KYUREM_WHITE),
     ANIM_CMD(KYUREM_BLACK),
     ANIM_CMD(MELOETTA_PIROUETTE),
-    ANIM_CMD_FULL(KELDEO_RESOLUTE, sAnims_KELDEO),
+    ANIM_CMD(KELDEO_RESOLUTE),
     ANIM_CMD_FULL(GENESECT_DOUSE_DRIVE, sAnims_GENESECT),
     ANIM_CMD_FULL(GENESECT_SHOCK_DRIVE, sAnims_GENESECT),
     ANIM_CMD_FULL(GENESECT_BURN_DRIVE, sAnims_GENESECT),


### PR DESCRIPTION
## Description
This PR fixes an issue with Keldeo Resolute's animation brought up by @kevinmc37 in #1335

**Before**:
![untitled](https://media.discordapp.net/attachments/774393519569502268/804052487678066748/Untitled3180.gif)![Untitled3182](https://user-images.githubusercontent.com/4485172/106036665-6502e380-60b4-11eb-95ee-00e85ea4c88d.gif)

**After**:
![Untitled3184](https://user-images.githubusercontent.com/4485172/106036706-6df3b500-60b4-11eb-8b96-ac6f9128268b.gif)

## **Discord contact info**
Lunos#4026