### PR TITLE
Fix Fire Blast Power

### DIFF
--- a/src/data/battle_moves.h
+++ b/src/data/battle_moves.h
@@ -1951,9 +1951,9 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
     [MOVE_FIRE_BLAST] =
     {
         #if B_UPDATED_MOVE_DATA >= GEN_6
-            .power = 120,
-        #else
             .power = 110,
+        #else
+            .power = 120,
         #endif
         .effect = EFFECT_BURN_HIT,
         .type = TYPE_FIRE,


### PR DESCRIPTION
Fire Blast previously had 120 power for `B_UPDATED_MOVE_DATA >= GEN_6` instead of 110. This PR swaps them so the updated move data is correct

see https://bulbapedia.bulbagarden.net/wiki/List_of_modified_moves#Generation_V_to_Generation_VI