### PR TITLE
Fix data corruption from HideMegaTriggerSprite

### DIFF
--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -1516,8 +1516,11 @@ bool32 IsMegaTriggerSpriteActive(void)
 
 void HideMegaTriggerSprite(void)
 {
-    ChangeMegaTriggerSprite(gBattleStruct->mega.triggerSpriteId, 0);
-    gSprites[gBattleStruct->mega.triggerSpriteId].tHide = TRUE;
+    if (gBattleStruct->mega.triggerSpriteId != 0xFF)
+    {
+        ChangeMegaTriggerSprite(gBattleStruct->mega.triggerSpriteId, 0);
+        gSprites[gBattleStruct->mega.triggerSpriteId].tHide = TRUE;
+    }
 }
 
 void DestroyMegaTriggerSprite(void)


### PR DESCRIPTION
## Description
the function `HideMegaTriggerSprite` is missing a check to make sure the sprite ID actually exists. If the sprite doesn't exist, `gBattleStruct->mega.triggerSpriteId` is set to `0xFF`, which means `gSprites[gBattleStruct->mega.triggerSpriteId].tHide = TRUE` is setting some unknown value outside the bounds of the sprite data to 1.

This bug appeared in my own game as setting one of the trainer's pokemon's max HP to 1, resulting in battle-breaking problems. It is likely the culprit for several unexplained bugs we've seen in the past.

The fix is simple, we just need to make sure `gBattleStruct->mega.triggerSpriteId != 0xFF` in `HideMegaTriggerSprite`
