### PR TITLE
Fix Spiky Shield/Jump Kick freeze

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -7293,6 +7293,7 @@ BattleScript_RockyHelmetActivatesDmg:
 	return
 
 BattleScript_SpikyShieldEffect::
+	jumpifabsent BS_ATTACKER, BattleScript_SpikyShieldRet
 	orword gHitMarker, HITMARKER_IGNORE_SUBSTITUTE | HITMARKER_x100000
 	bichalfword gMoveResultFlags, MOVE_RESULT_NO_EFFECT
 	healthbarupdate BS_ATTACKER
@@ -7300,6 +7301,7 @@ BattleScript_SpikyShieldEffect::
 	printstring STRINGID_PKMNHURTSWITH
 	waitmessage 0x40
 	tryfaintmon BS_ATTACKER, FALSE, NULL
+BattleScript_SpikyShieldRet::
 	return
 
 BattleScript_KingsShieldEffect::


### PR DESCRIPTION
Stop Spiky Shield freezing the game if an attacker faints itself before taking damage from Spiky Shield.

## Description
Spiky Shield no longer tries to hurt a Pokemon that has already fainted. Previously this would freeze the game if Jump Kick recoil fainted a Pokemon due to the target using Spiky Shield. 

I'm pretty sure recoil if miss is the only effect that can cause this, but this should also prevent any future issues with Spiky Shield damage.

## **Discord contact info**
Buffel Saft#2205