### PR TITLE
Fix powder immunity for self-targeting moves

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3176,7 +3176,7 @@ u8 AtkCanceller_UnableToUseMove(void)
             gBattleStruct->atkCancellerTracker++;
             break;
         case CANCELLER_POWDER_MOVE:
-            if (gBattleMoves[gCurrentMove].flags & FLAG_POWDER)
+            if ((gBattleMoves[gCurrentMove].flags & FLAG_POWDER) && (gBattlerAttacker != gBattlerTarget))
             {
                 if ((B_POWDER_GRASS >= GEN_6 && IS_BATTLER_OF_TYPE(gBattlerTarget, TYPE_GRASS))
                     || GetBattlerAbility(gBattlerTarget) == ABILITY_OVERCOAT)


### PR DESCRIPTION
Addresses #1269

Currently, powder moves work incorrectly if the user is a grass type and the move targets the user. E.g. This means Amoonguss is immune to its own Rage Powder, making one of its best moves completely useless for it.

## Description
Add a condition to skip the powder canceller check if the target is the move's user.

## **Discord contact info**
Buffel Saft#2205