### PR TITLE
Added a check for the Mega Bracelet in CanMegaEvolve

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -7834,6 +7834,13 @@ bool32 CanMegaEvolve(u8 battlerId)
     u8 partnerPosition = GetBattlerPosition(BATTLE_PARTNER(battlerId));
     struct MegaEvolutionData *mega = &(((struct ChooseMoveStruct*)(&gBattleResources->bufferA[gActiveBattler][4]))->mega);
 
+#ifdef ITEM_EXPANSION
+    // Check if Player has a Mega Bracelet
+    if ((GetBattlerPosition(battlerId) == B_POSITION_PLAYER_LEFT || (!(gBattleTypeFlags & BATTLE_TYPE_MULTI) && GetBattlerPosition(battlerId) == B_POSITION_PLAYER_RIGHT))
+     && !CheckBagHasItem(ITEM_MEGA_BRACELET, 1))
+        return FALSE;
+#endif
+
     // Check if trainer already mega evolved a pokemon.
     if (mega->alreadyEvolved[battlerPosition])
         return FALSE;


### PR DESCRIPTION
## Description
Currently, Mega Evolutions don't check for a Keystone item, like the Mega Bracelet present in the ITEM_EXPANSION branch.
This PR addresses that.

## **Discord contact info**
Lunos#4026