### PR TITLE
Fix src/battle_anim.c

### DIFF
--- a/src/battle_anim.c
+++ b/src/battle_anim.c
@@ -18,7 +18,7 @@
 #include "task.h"
 #include "constants/battle_anim.h"
 #include "constants/battle_config.h"
-#include "constants/battle_moves.h"
+#include "constants/moves.h"
 
 #define ANIM_SPRITE_INDEX_COUNT 8
 


### PR DESCRIPTION
## Description
On the latest commit involving the `src/battle_anim.c` file, the header file `include/constants/battle_moves.h` was included to be read even though there isn't such a file in the project, and as a result, a ROM of the battle_engine couldn't be built.

The correct file to make `src/battle_anim.c` read is `include/constants/moves.h`.

## **Discord contact info**
Lunos#4026