### PR TITLE
Fix Thousand Arrows

### DIFF
--- a/include/constants/pokemon.h
+++ b/include/constants/pokemon.h
@@ -267,6 +267,7 @@
 #define FLAG_DANCE                  (1 << 21)
 #define FLAG_DMG_IN_AIR             (1 << 22) // X2 dmg on air, always hits target on air
 #define FLAG_HIT_IN_AIR             (1 << 23) // dmg is normal, always hits target on air
+#define FLAG_DAMAGE_AIRBORNE        (1 << 24) // Makes a Ground type move do 1x damage to flying and levitating targets
 
 // Split defines.
 #define SPLIT_PHYSICAL  0x0

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -7831,8 +7831,6 @@ static void MulByTypeEffectiveness(u16 *modifier, u16 move, u8 moveType, u8 batt
         mod = UQ_4_12(2.0);
     if (moveType == TYPE_GROUND && defType == TYPE_FLYING && IsBattlerGrounded(battlerDef) && mod == UQ_4_12(0.0))
         mod = UQ_4_12(1.0);
-    if (gBattleMoves[move].flags & FLAG_DAMAGE_AIRBORNE && defType == TYPE_FLYING) // Thousand Arrows
-        mod = UQ_4_12(1.0);
 
     if (gProtectStructs[battlerDef].kingsShielded && gBattleMoves[move].effect != EFFECT_FEINT)
         mod = UQ_4_12(1.0);
@@ -7884,6 +7882,14 @@ static u16 CalcTypeEffectivenessMultiplierInternal(u16 move, u8 moveType, u8 bat
             RecordAbilityBattle(battlerDef, ABILITY_LEVITATE);
         }
     }
+
+    // Thousand Arrows ignores type modifiers for flying mons
+    if (!IsBattlerGrounded(battlerDef) && (gBattleMoves[move].flags & FLAG_DAMAGE_AIRBORNE)
+        && (gBattleMons[battlerDef].type1 == TYPE_FLYING || gBattleMons[battlerDef].type2 == TYPE_FLYING || gBattleMons[battlerDef].type3 == TYPE_FLYING))
+    {
+        modifier = UQ_4_12(1.0);
+    }
+
     if (GetBattlerAbility(battlerDef) == ABILITY_WONDER_GUARD && modifier <= UQ_4_12(1.0) && gBattleMoves[move].power)
     {
         modifier = UQ_4_12(0.0);

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -7831,6 +7831,8 @@ static void MulByTypeEffectiveness(u16 *modifier, u16 move, u8 moveType, u8 batt
         mod = UQ_4_12(2.0);
     if (moveType == TYPE_GROUND && defType == TYPE_FLYING && IsBattlerGrounded(battlerDef) && mod == UQ_4_12(0.0))
         mod = UQ_4_12(1.0);
+    if (gBattleMoves[move].flags & FLAG_DAMAGE_AIRBORNE && defType == TYPE_FLYING) // Thousand Arrows
+        mod = UQ_4_12(1.0);
 
     if (gProtectStructs[battlerDef].kingsShielded && gBattleMoves[move].effect != EFFECT_FEINT)
         mod = UQ_4_12(1.0);
@@ -7870,7 +7872,7 @@ static u16 CalcTypeEffectivenessMultiplierInternal(u16 move, u8 moveType, u8 bat
         && gBattleMons[battlerDef].type3 != gBattleMons[battlerDef].type1)
         MulByTypeEffectiveness(&modifier, move, moveType, battlerDef, gBattleMons[battlerDef].type3, battlerAtk, recordAbilities);
 
-    if (moveType == TYPE_GROUND && !IsBattlerGrounded(battlerDef))
+    if (moveType == TYPE_GROUND && !IsBattlerGrounded(battlerDef) && !(gBattleMoves[move].flags & FLAG_DAMAGE_AIRBORNE))
     {
         modifier = UQ_4_12(0.0);
         if (recordAbilities && GetBattlerAbility(battlerDef) == ABILITY_LEVITATE)

--- a/src/data/battle_moves.h
+++ b/src/data/battle_moves.h
@@ -9488,10 +9488,10 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .type = TYPE_GROUND,
         .accuracy = 100,
         .pp = 10,
-        .secondaryEffectChance = 0,
+        .secondaryEffectChance = 100,
         .target = MOVE_TARGET_BOTH,
         .priority = 0,
-        .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGS_ROCK_AFFECTED | FLAG_HIT_IN_AIR,
+        .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGS_ROCK_AFFECTED | FLAG_HIT_IN_AIR | FLAG_DAMAGE_AIRBORNE,
         .split = SPLIT_PHYSICAL,
     },
 


### PR DESCRIPTION
Add a new move flag that allows a ground type move to hit airborne targets, and fix Thousand Arrows' effect chance.

## Description
Thousand Arrows can do now damage to:
- Flying type targets; it'll do 1x damage regardless of their secondary typing.
- Targets with Levitate
- Targets holding an Air Balloon
- Targets under the effect of Magnet Rise and Telekinesis

Also fix Thousand Arrows' effect chance; it should be 100%, not 0%. This will make it knock any airborne targets it hits to the ground.

## **Discord contact info**
Buffel Saft#2205