### PR TITLE
Corrected the move data for Gen 4 Overheat

### DIFF
--- a/src/data/battle_moves.h
+++ b/src/data/battle_moves.h
@@ -4939,8 +4939,8 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
             .power = 130,
             .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGS_ROCK_AFFECTED,
         #elif B_UPDATED_MOVE_DATA >= GEN_4
-            .power = 130,
-            .flags = FLAG_MAKES_CONTACT | FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGS_ROCK_AFFECTED,
+            .power = 140,
+            .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGS_ROCK_AFFECTED,
         #else
             .power = 140,
             .flags = FLAG_MAKES_CONTACT | FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGS_ROCK_AFFECTED,


### PR DESCRIPTION
The contact flag was removed in Gen 4, and the base power was lowered in Gen 6. Currently, the changes are flipped around.