### PR TITLE
Fix Toxic Orb and Flame Orb affecting Pokemon they shouldn't

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -6271,7 +6271,8 @@ u8 ItemBattleEffects(u8 caseID, u8 battlerId, bool8 moveTurn)
         case HOLD_EFFECT_TOXIC_ORB:
             if (!gBattleMons[battlerId].status1
                 && CanPoisonType(battlerId, battlerId)
-                && GetBattlerAbility(battlerId) != ABILITY_IMMUNITY)
+                && GetBattlerAbility(battlerId) != ABILITY_IMMUNITY
+                && IsBattlerAlive)
             {
                 effect = ITEM_STATUS_CHANGE;
                 gBattleMons[battlerId].status1 = STATUS1_TOXIC_POISON;
@@ -6282,7 +6283,8 @@ u8 ItemBattleEffects(u8 caseID, u8 battlerId, bool8 moveTurn)
         case HOLD_EFFECT_FLAME_ORB:
             if (!gBattleMons[battlerId].status1
                 && !IS_BATTLER_OF_TYPE(battlerId, TYPE_FIRE)
-                && GetBattlerAbility(battlerId) != ABILITY_WATER_VEIL)
+                && GetBattlerAbility(battlerId) != ABILITY_WATER_VEIL
+                && IsBattlerAlive)
             {
                 effect = ITEM_STATUS_CHANGE;
                 gBattleMons[battlerId].status1 = STATUS1_BURN;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -6272,6 +6272,7 @@ u8 ItemBattleEffects(u8 caseID, u8 battlerId, bool8 moveTurn)
             if (!gBattleMons[battlerId].status1
                 && CanPoisonType(battlerId, battlerId)
                 && GetBattlerAbility(battlerId) != ABILITY_IMMUNITY
+                && GetBattlerAbility(battlerId) != ABILITY_COMATOSE
                 && IsBattlerAlive)
             {
                 effect = ITEM_STATUS_CHANGE;
@@ -6284,6 +6285,8 @@ u8 ItemBattleEffects(u8 caseID, u8 battlerId, bool8 moveTurn)
             if (!gBattleMons[battlerId].status1
                 && !IS_BATTLER_OF_TYPE(battlerId, TYPE_FIRE)
                 && GetBattlerAbility(battlerId) != ABILITY_WATER_VEIL
+                && GetBattlerAbility(battlerId) != ABILITY_WATER_BUBBLE
+                && GetBattlerAbility(battlerId) != ABILITY_COMATOSE
                 && IsBattlerAlive)
             {
                 effect = ITEM_STATUS_CHANGE;


### PR DESCRIPTION
Issue: status orbs don't check if the holder is alive, so they'll inflict status conditions on a fainted mon. When the mon is revived it will still have the status condition. They also affect mons with Water Bubble (which should be unaffected by the Flame Orb) and Comatose (which should be unaffected by both orbs).

Fix: Added a check to both orbs to make sure the holder isn't fainted, and checks for Water Bubble and Comatose.

Discord: Buffel Saft#2205