### PR TITLE
Make Big Root affect absorb moves

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -2234,6 +2234,7 @@ BattleScript_EffectAbsorb::
 	resultmessage
 	waitmessage 0x40
 	setdrainedhp
+	manipulatedamage DMG_BIG_ROOT
 	orword gHitMarker, HITMARKER_IGNORE_SUBSTITUTE
 	jumpifability BS_TARGET, ABILITY_LIQUID_OOZE, BattleScript_AbsorbLiquidOoze
 	setbyte cMULTISTRING_CHOOSER, 0x0
@@ -2361,6 +2362,7 @@ BattleScript_DreamEaterWorked:
 	resultmessage
 	waitmessage 0x40
 	setdrainedhp
+	manipulatedamage DMG_BIG_ROOT
 	orword gHitMarker, HITMARKER_IGNORE_SUBSTITUTE
 	healthbarupdate BS_ATTACKER
 	datahpupdate BS_ATTACKER

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -8877,15 +8877,16 @@ static void Cmd_stockpiletohpheal(void)
     }
 }
 
+// Sign change for drained HP handled in GetDrainedBigRootHp
 static void Cmd_setdrainedhp(void)
 {
     if (gBattleMoves[gCurrentMove].argument != 0)
-        gBattleMoveDamage = -(gHpDealt * gBattleMoves[gCurrentMove].argument / 100);
+        gBattleMoveDamage = (gHpDealt * gBattleMoves[gCurrentMove].argument / 100);
     else
-        gBattleMoveDamage = -(gHpDealt / 2);
+        gBattleMoveDamage = (gHpDealt / 2);
 
     if (gBattleMoveDamage == 0)
-        gBattleMoveDamage = -1;
+        gBattleMoveDamage = 1;
 
     gBattlescriptCurrInstr++;
 }


### PR DESCRIPTION
## Description
Big Root should increase the amount of HP recovered by Absorb, Giga Drain etc. This part of its effect wasn't implemented.
This PR fixes this by calling manipulatedamage DMG_BIG_ROOT after each use of setdrainedhp in battle scripts. 

Because GetDrainedBigRootHp and setdrainedhp both change the sign of the damage calculated (so it heals instead of damaging the attacker), I've removed the sign change from setdrainedhp to stop them from cancelling each other out. Without this change GetDrainedBigRootHp would make gBattleMoveDamage a negative number, and then setdrainedhp would make it positive again.

GetDrainedBigRootHp is always called after setdrainedhp, so this doesn't affect anything elsewhere.

## **Discord contact info**
Buffel Saft#2205