### PR TITLE
Corrected the item descriptions of some berries

### DIFF
--- a/src/data/text/item_descriptions.h
+++ b/src/data/text/item_descriptions.h
@@ -751,27 +751,27 @@ static const u8 sIapapaBerryDesc[] = _(
     "may confuse.");
 
 static const u8 sRazzBerryDesc[] = _(
-    "Pokéblock ingredient.\n"
+    "{POKEBLOCK} ingredient.\n"
     "Plant in loamy soil\n"
     "to grow Razz.");
 
 static const u8 sBlukBerryDesc[] = _(
-    "Pokéblock ingredient.\n"
+    "{POKEBLOCK} ingredient.\n"
     "Plant in loamy soil\n"
     "to grow Bluk.");
 
 static const u8 sNanabBerryDesc[] = _(
-    "Pokéblock ingredient.\n"
+    "{POKEBLOCK} ingredient.\n"
     "Plant in loamy soil\n"
     "to grow Nanab.");
 
 static const u8 sWepearBerryDesc[] = _(
-    "Pokéblock ingredient.\n"
+    "{POKEBLOCK} ingredient.\n"
     "Plant in loamy soil\n"
     "to grow Wepear.");
 
 static const u8 sPinapBerryDesc[] = _(
-    "Pokéblock ingredient.\n"
+    "{POKEBLOCK} ingredient.\n"
     "Plant in loamy soil\n"
     "to grow Pinap.");
 
@@ -806,47 +806,47 @@ static const u8 sTamatoBerryDesc[] = _(
     "base Speed.");
 
 static const u8 sCornnBerryDesc[] = _(
-    "Pokéblock ingredient.\n"
+    "{POKEBLOCK} ingredient.\n"
     "Plant in loamy soil\n"
     "to grow Cornn.");
 
 static const u8 sMagostBerryDesc[] = _(
-    "Pokéblock ingredient.\n"
+    "{POKEBLOCK} ingredient.\n"
     "Plant in loamy soil\n"
     "to grow Magost.");
 
 static const u8 sRabutaBerryDesc[] = _(
-    "Pokéblock ingredient.\n"
+    "{POKEBLOCK} ingredient.\n"
     "Plant in loamy soil\n"
     "to grow Rabuta.");
 
 static const u8 sNomelBerryDesc[] = _(
-    "Pokéblock ingredient.\n"
+    "{POKEBLOCK} ingredient.\n"
     "Plant in loamy soil\n"
     "to grow Nomel.");
 
 static const u8 sSpelonBerryDesc[] = _(
-    "Pokéblock ingredient.\n"
+    "{POKEBLOCK} ingredient.\n"
     "Plant in loamy soil\n"
     "to grow Spelon.");
 
 static const u8 sPamtreBerryDesc[] = _(
-    "Pokéblock ingredient.\n"
+    "{POKEBLOCK} ingredient.\n"
     "Plant in loamy soil\n"
     "to grow Pamtre.");
 
 static const u8 sWatmelBerryDesc[] = _(
-    "Pokéblock ingredient.\n"
+    "{POKEBLOCK} ingredient.\n"
     "Plant in loamy soil\n"
     "to grow Watmel.");
 
 static const u8 sDurinBerryDesc[] = _(
-    "Pokéblock ingredient.\n"
+    "{POKEBLOCK} ingredient.\n"
     "Plant in loamy soil\n"
     "to grow Durin.");
 
 static const u8 sBelueBerryDesc[] = _(
-    "Pokéblock ingredient.\n"
+    "{POKEBLOCK} ingredient.\n"
     "Plant in loamy soil\n"
     "to grow Belue.");
 
@@ -891,7 +891,7 @@ static const u8 sMicleBerryDesc[] = _(
     "move in a pinch.");
 
 static const u8 sEnigmaBerryDesc[] = _(
-    "Pokéblock ingredient.\n"
+    "{POKEBLOCK} ingredient.\n"
     "Plant in loamy soil\n"
     "to grow a mystery.");
 


### PR DESCRIPTION
## Description
"Pokéblock ingredient" doesn't fit in a single line of the box in which item descriptions are printed, which is why the `{POKEBLOCK}` character was used.
This PR reverts some descriptions to make use of it again.

Before -> After
![](https://media.discordapp.net/attachments/774393519569502268/840701857860026429/Untitled5099.png)![Untitled5100](https://user-images.githubusercontent.com/4485172/117554137-0098de00-b02c-11eb-8e0a-506e971551f4.png)

## **Discord contact info**
Lunos#4026