### PR TITLE
Fixed B_X_ITEMS_BUFF boosting 2 stages only in Gen 7

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -4454,7 +4454,7 @@ bool8 PokemonUseItemEffects(struct Pokemon *mon, u16 item, u8 partyIndex, u8 mov
             if ((itemEffect[i] & ITEM0_X_ATTACK)
              && gBattleMons[gActiveBattler].statStages[STAT_ATK] < MAX_STAT_STAGE)
             {
-                if (B_X_ITEMS_BUFF == GEN_7)
+                if (B_X_ITEMS_BUFF >= GEN_7)
                     gBattleMons[gActiveBattler].statStages[STAT_ATK] += 2;
                 else
                     gBattleMons[gActiveBattler].statStages[STAT_ATK] += itemEffect[i] & ITEM0_X_ATTACK;
@@ -4472,7 +4472,7 @@ bool8 PokemonUseItemEffects(struct Pokemon *mon, u16 item, u8 partyIndex, u8 mov
             if ((itemEffect[i] & ITEM1_X_DEFEND)
              && gBattleMons[gActiveBattler].statStages[STAT_DEF] < MAX_STAT_STAGE)
             {
-                if (B_X_ITEMS_BUFF == GEN_7)
+                if (B_X_ITEMS_BUFF >= GEN_7)
                     gBattleMons[gActiveBattler].statStages[STAT_DEF] += 2;
                 else
                     gBattleMons[gActiveBattler].statStages[STAT_DEF] += (itemEffect[i] & ITEM1_X_DEFEND) >> 4;
@@ -4485,7 +4485,7 @@ bool8 PokemonUseItemEffects(struct Pokemon *mon, u16 item, u8 partyIndex, u8 mov
             if ((itemEffect[i] & ITEM1_X_SPEED)
              && gBattleMons[gActiveBattler].statStages[STAT_SPEED] < MAX_STAT_STAGE)
             {
-                if (B_X_ITEMS_BUFF == GEN_7)
+                if (B_X_ITEMS_BUFF >= GEN_7)
                     gBattleMons[gActiveBattler].statStages[STAT_SPEED] += 2;
                 else
                     gBattleMons[gActiveBattler].statStages[STAT_SPEED] += itemEffect[i] & ITEM1_X_SPEED;
@@ -4500,7 +4500,7 @@ bool8 PokemonUseItemEffects(struct Pokemon *mon, u16 item, u8 partyIndex, u8 mov
             if ((itemEffect[i] & ITEM2_X_ACCURACY)
              && gBattleMons[gActiveBattler].statStages[STAT_ACC] < MAX_STAT_STAGE)
             {
-                if (B_X_ITEMS_BUFF == GEN_7)
+                if (B_X_ITEMS_BUFF >= GEN_7)
                     gBattleMons[gActiveBattler].statStages[STAT_ACC] += 2;
                 else
                     gBattleMons[gActiveBattler].statStages[STAT_ACC] += (itemEffect[i] & ITEM2_X_ACCURACY) >> 4;
@@ -4513,7 +4513,7 @@ bool8 PokemonUseItemEffects(struct Pokemon *mon, u16 item, u8 partyIndex, u8 mov
             if ((itemEffect[i] & ITEM2_X_SPATK)
              && gBattleMons[gActiveBattler].statStages[STAT_SPATK] < MAX_STAT_STAGE)
             {
-                if (B_X_ITEMS_BUFF == GEN_7)
+                if (B_X_ITEMS_BUFF >= GEN_7)
                     gBattleMons[gActiveBattler].statStages[STAT_SPATK] += 2;
                 else
                     gBattleMons[gActiveBattler].statStages[STAT_SPATK] += itemEffect[i] & ITEM2_X_SPATK;
@@ -4529,7 +4529,7 @@ bool8 PokemonUseItemEffects(struct Pokemon *mon, u16 item, u8 partyIndex, u8 mov
             if ((itemEffect[i] & ITEM1_X_ATTACK)
              && gBattleMons[gActiveBattler].statStages[STAT_ATK] < MAX_STAT_STAGE)
             {
-                if (B_X_ITEMS_BUFF == GEN_7)
+                if (B_X_ITEMS_BUFF >= GEN_7)
                     gBattleMons[gActiveBattler].statStages[STAT_ATK] += 2;
                 else
                     gBattleMons[gActiveBattler].statStages[STAT_ATK] += 1;
@@ -4542,7 +4542,7 @@ bool8 PokemonUseItemEffects(struct Pokemon *mon, u16 item, u8 partyIndex, u8 mov
             if ((itemEffect[i] & ITEM1_X_DEFENSE)
              && gBattleMons[gActiveBattler].statStages[STAT_DEF] < MAX_STAT_STAGE)
             {
-                if (B_X_ITEMS_BUFF == GEN_7)
+                if (B_X_ITEMS_BUFF >= GEN_7)
                     gBattleMons[gActiveBattler].statStages[STAT_DEF] += 2;
                 else
                     gBattleMons[gActiveBattler].statStages[STAT_DEF] += 1;
@@ -4555,7 +4555,7 @@ bool8 PokemonUseItemEffects(struct Pokemon *mon, u16 item, u8 partyIndex, u8 mov
             if ((itemEffect[i] & ITEM1_X_SPEED)
              && gBattleMons[gActiveBattler].statStages[STAT_SPEED] < MAX_STAT_STAGE)
             {
-                if (B_X_ITEMS_BUFF == GEN_7)
+                if (B_X_ITEMS_BUFF >= GEN_7)
                     gBattleMons[gActiveBattler].statStages[STAT_SPEED] += 2;
                 else
                     gBattleMons[gActiveBattler].statStages[STAT_SPEED] += 1;
@@ -4568,7 +4568,7 @@ bool8 PokemonUseItemEffects(struct Pokemon *mon, u16 item, u8 partyIndex, u8 mov
             if ((itemEffect[i] & ITEM1_X_SPATK)
              && gBattleMons[gActiveBattler].statStages[STAT_SPATK] < MAX_STAT_STAGE)
             {
-                if (B_X_ITEMS_BUFF == GEN_7)
+                if (B_X_ITEMS_BUFF >= GEN_7)
                     gBattleMons[gActiveBattler].statStages[STAT_SPATK] += 2;
                 else
                     gBattleMons[gActiveBattler].statStages[STAT_SPATK] += 1;
@@ -4581,7 +4581,7 @@ bool8 PokemonUseItemEffects(struct Pokemon *mon, u16 item, u8 partyIndex, u8 mov
             if ((itemEffect[i] & ITEM1_X_SPDEF)
              && gBattleMons[gActiveBattler].statStages[STAT_SPDEF] < MAX_STAT_STAGE)
             {
-                if (B_X_ITEMS_BUFF == GEN_7)
+                if (B_X_ITEMS_BUFF >= GEN_7)
                     gBattleMons[gActiveBattler].statStages[STAT_SPDEF] += 2;
                 else
                     gBattleMons[gActiveBattler].statStages[STAT_SPDEF] += 1;
@@ -4594,7 +4594,7 @@ bool8 PokemonUseItemEffects(struct Pokemon *mon, u16 item, u8 partyIndex, u8 mov
             if ((itemEffect[i] & ITEM1_X_ACCURACY)
              && gBattleMons[gActiveBattler].statStages[STAT_ACC] < MAX_STAT_STAGE)
             {
-                if (B_X_ITEMS_BUFF == GEN_7)
+                if (B_X_ITEMS_BUFF >= GEN_7)
                     gBattleMons[gActiveBattler].statStages[STAT_ACC] += 2;
                 else
                     gBattleMons[gActiveBattler].statStages[STAT_ACC] += 1;
@@ -5148,7 +5148,7 @@ static void BufferStatRoseMessage(s32 arg0)
 {
     gBattlerTarget = gBattlerInMenuId;
     StringCopy(gBattleTextBuff1, gStatNamesTable[sStatsToRaise[arg0]]);
-    if (B_X_ITEMS_BUFF == GEN_7)
+    if (B_X_ITEMS_BUFF >= GEN_7)
     {
         StringCopy(gBattleTextBuff2, gText_StatSharply);
         StringAppend(gBattleTextBuff2, gText_StatRose);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If B_X_ITEMS_BUFF is set to GEN_8, it will go back to boost only one stat. This PR fixes it.

## **Discord contact info**
AsparagusEduardo#6051