### PR TITLE
Made gAbilityNames and gAbilityDescriptionPointers read from ABILITIES_COUNT

### DIFF
--- a/src/data/text/abilities.h
+++ b/src/data/text/abilities.h
@@ -255,7 +255,7 @@ static const u8 sGrimNeighDescription[] = _("KOs boost Sp. Atk stat.");
 static const u8 sAsOneIceRiderDescription[] = _("Unnerve and Chilling Neigh.");
 static const u8 sAsOneShadowRiderDescription[] = _("Unnerve and Grim Neigh.");
 
-const u8 gAbilityNames[ABILITIES_COUNT_GEN8][ABILITY_NAME_LENGTH + 1] =
+const u8 gAbilityNames[ABILITIES_COUNT][ABILITY_NAME_LENGTH + 1] =
 {
     [ABILITY_NONE] = _("-------"),
     [ABILITY_STENCH] = _("Stench"),
@@ -527,7 +527,7 @@ const u8 gAbilityNames[ABILITIES_COUNT_GEN8][ABILITY_NAME_LENGTH + 1] =
     [ABILITY_AS_ONE_SHADOW_RIDER] = _("As One"),
 };
 
-const u8 *const gAbilityDescriptionPointers[ABILITIES_COUNT_GEN8] =
+const u8 *const gAbilityDescriptionPointers[ABILITIES_COUNT] =
 {
     [ABILITY_NONE] = sNoneDescription,
     [ABILITY_STENCH] = sStenchDescription,


### PR DESCRIPTION
## Description
Title. There is not a single reason to make them read the abilities from `ABILITIES_COUNT_GEN8`, and it can get in the way of users who want to implement original abilities in their projects.

## **Discord contact info**
Lunos#4026