### PR TITLE
Decapitalizations of POKEMON

### DIFF
--- a/src/data/text/abilities.h
+++ b/src/data/text/abilities.h
@@ -1,5 +1,5 @@
 static const u8 sNoneDescription[] = _("No special ability.");
-static const u8 sStenchDescription[] = _("Helps repel wild POKéMON.");
+static const u8 sStenchDescription[] = _("Helps repel wild Pokémon.");
 static const u8 sDrizzleDescription[] = _("Summons rain in battle.");
 static const u8 sSpeedBoostDescription[] = _("Gradually boosts Speed.");
 static const u8 sBattleArmorDescription[] = _("Blocks critical hits.");
@@ -40,7 +40,7 @@ static const u8 sPoisonPointDescription[] = _("Poisons foe on contact.");
 static const u8 sInnerFocusDescription[] = _("Prevents flinching.");
 static const u8 sMagmaArmorDescription[] = _("Prevents freezing.");
 static const u8 sWaterVeilDescription[] = _("Prevents burns.");
-static const u8 sMagnetPullDescription[] = _("Traps Steel-type POKéMON.");
+static const u8 sMagnetPullDescription[] = _("Traps Steel-type Pokémon.");
 static const u8 sSoundproofDescription[] = _("Avoids sound-based moves.");
 static const u8 sRainDishDescription[] = _("Slight HP recovery in rain.");
 static const u8 sSandStreamDescription[] = _("Summons a sandstorm.");


### PR DESCRIPTION
## Description
Two "POKEMON" texts were capitalized as opposed to others that were lowercased.

## **Discord contact info**
MissingNoL#8910