### PR TITLE
Hyperspace Fury implemented

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -6058,6 +6058,17 @@ BattleScript_AtkDefDownTryDef:
 BattleScript_AtkDefDownRet:
 	return
 
+BattleScript_DefDown::
+	setbyte sSTAT_ANIM_PLAYED, FALSE
+	playstatchangeanimation BS_ATTACKER, BIT_DEF, STAT_CHANGE_CANT_PREVENT | STAT_CHANGE_NEGATIVE
+	setstatchanger STAT_DEF, 1, TRUE
+	statbuffchange MOVE_EFFECT_AFFECTS_USER | MOVE_EFFECT_CERTAIN | STAT_BUFF_ALLOW_PTR, BattleScript_DefDownRet
+	jumpifbyte CMP_EQUAL, cMULTISTRING_CHOOSER, 0x2, BattleScript_DefDownRet
+	printfromtable gStatDownStringIds
+	waitmessage 0x40
+BattleScript_DefDownRet:
+	return
+
 BattleScript_DefSpDefDown::
 	setbyte sSTAT_ANIM_PLAYED, FALSE
 	playstatchangeanimation BS_ATTACKER, BIT_DEF | BIT_SPDEF, STAT_CHANGE_CANT_PREVENT | STAT_CHANGE_NEGATIVE | STAT_CHANGE_MULTIPLE_STATS

--- a/include/battle_scripts.h
+++ b/include/battle_scripts.h
@@ -90,6 +90,7 @@ extern const u8 BattleScript_SelectingNotAllowedMoveTauntInPalace[];
 extern const u8 BattleScript_WishComesTrue[];
 extern const u8 BattleScript_IngrainTurnHeal[];
 extern const u8 BattleScript_AtkDefDown[];
+extern const u8 BattleScript_DefDown[]; // Hyperspace Fury
 extern const u8 BattleScript_DefSpDefDown[];
 extern const u8 BattleScript_KnockedOff[];
 extern const u8 BattleScript_MoveUsedIsImprisoned[];

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -3148,7 +3148,12 @@ void SetMoveEffect(bool32 primary, u32 certain)
                         BattleScriptPush(gBattlescriptCurrInstr + 1);
                         gBattlescriptCurrInstr = BattleScript_MoveEffectFeint;
                     }
-                }
+				}
+				if (gCurrentMove == MOVE_HYPERSPACE_FURY)
+				{
+					BattleScriptPush(gBattlescriptCurrInstr + 1);
+					gBattlescriptCurrInstr = BattleScript_DefDown;
+				}
                 break;
             case MOVE_EFFECT_SPECTRAL_THIEF:
                 gBattleStruct->stolenStats[0] = 0; // Stats to steal.

--- a/src/data/battle_moves.h
+++ b/src/data/battle_moves.h
@@ -9581,15 +9581,15 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_HYPERSPACE_FURY] =
     {
-        .effect = EFFECT_PLACEHOLDER,
-        .power = 0,
+        .effect = EFFECT_FEINT,
+        .power = 100,
         .type = TYPE_DARK,
         .accuracy = 0,
-        .pp = 0,
-        .secondaryEffectChance = 0,
+        .pp = 5,
+        .secondaryEffectChance = 100,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
-        .flags = 0,
+        .flags = FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGS_ROCK_AFFECTED,
         .split = SPLIT_PHYSICAL,
     },
 


### PR DESCRIPTION
## Description
Coded Hyperspace Fury by adding a BattleScript similar to Superpower's and Close Combat's and having it run from MOVE_EFFECT_FEINT.  In that, I added an "if" to check if the move is Hyperspace Fury.  Tested to properly lower Defense and break through Protect.

I think using .argument in battle_moves.h with PR #1486 could prove more effective. But I can't for the life of me understand how to get .argument and .effect to work between the PR's proposed "EFFECT_ATTACKER_DEFENSE_DOWN_HIT" and the current "EFFECT_FEINT".

## **Discord contact info**
MissingNoL#8910