### PR TITLE
Commented out call to inexistent IsZMove func

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -2271,7 +2271,7 @@ static s16 AI_CheckBadMove(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
                   || MoveRequiresRecharging(instructedMove)
                   || MoveCallsOtherMove(instructedMove)
                   #ifdef ITEM_Z_RING
-                  || (IsZMove(instructedMove))
+                  //|| (IsZMove(instructedMove))
                   #endif
                   || (gLockedMoves[battlerDef] != 0 && gLockedMoves[battlerDef] != 0xFFFF)
                   || gBattleMons[battlerDef].status2 & STATUS2_MULTIPLETURNS


### PR DESCRIPTION
## Description
There's a call in `src/battle_ai_main.c` to a function that is not present anywhere in the rest of the branch.
This creates issues for users using merged branches. More specifically, users who may make use of the item_expansion branch along the battle_engine branch.
I decided to comment it out, in case the original author of the code eventually decides to incorporate the function.

## **Discord contact info**
Lunos#4026