### PR TITLE
Add back NUM_SPECIES to sSpeciesToBackAnimSet definition.

### DIFF
--- a/src/pokemon_animation.c
+++ b/src/pokemon_animation.c
@@ -212,7 +212,7 @@ static struct PokemonAnimData sAnims[MAX_BATTLERS_COUNT];
 static u8 sAnimIdx;
 static bool32 sIsSummaryAnim;
 
-static const u8 sSpeciesToBackAnimSet[] =
+static const u8 sSpeciesToBackAnimSet[NUM_SPECIES] =
 {
     [SPECIES_BULBASAUR]  = BACK_ANIM_DIP_RIGHT_SIDE,
     [SPECIES_IVYSAUR]    = BACK_ANIM_H_SLIDE,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Egg originally did add `NUM_SPECIES` here to have placeholder entries for added mons, but it was recently removed in the sync PR #1469. Adding this back fixes #1522.
## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->
UltimaSoul#4017