### PR TITLE
Include expansion_branches.h in global.h

### DIFF
--- a/include/global.h
+++ b/include/global.h
@@ -10,6 +10,7 @@
 #include "constants/vars.h"
 #include "constants/species.h"
 #include "constants/berry.h"
+#include "constants/expansion_branches.h"
 
 // Prevent cross-jump optimization.
 #define BLOCK_CROSS_JUMP asm("");


### PR DESCRIPTION
Allows testing for defines when the branch doesn't exist