### PR TITLE
Corrected `CanEvolve` function

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -7688,7 +7688,8 @@ static bool32 CanEvolve(u32 species)
 
     for (i = 0; i < EVOS_PER_MON; i++)
     {
-        if (gEvolutionTable[species][i].method && gEvolutionTable[species][i].method != EVO_MEGA_EVOLUTION)
+        if (gEvolutionTable[species][i].method && gEvolutionTable[species][i].method != EVO_MEGA_EVOLUTION
+         && gEvolutionTable[species][i].method && gEvolutionTable[species][i].method != EVO_MOVE_MEGA_EVOLUTION)
             return TRUE;
     }
     return FALSE;


### PR DESCRIPTION
## Description
The `CanEvolve` function is used to determine which Pokémon should be affected by the Eviolite's effect, that is, only those that can evolve.
This function makes sure to leave `EVO_MEGA_EVOLUTION` out of the equation, however, it doesn't do anything about `EVO_MOVE_MEGA_EVOLUTION`. As a result, Rayquaza can take advantage of the Eviolite unfairly.
This PR corrects that.

## **Discord contact info**
Lunos#4026