### PR TITLE
Fix protect-like moves

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -100,7 +100,6 @@ struct DisableStruct
     u8 truantCounter:1;
     u8 truantSwitchInHack:1;
     u8 mimickedMoves:4;
-    u8 touchedProtectLike: 1;
     u8 rechargeTimer;
     u8 autotomizeCount;
     u8 slowStartTimer;
@@ -145,6 +144,7 @@ struct ProtectStruct
     u32 usedThroatChopPreventedMove:1;
     u32 micle:1;
     u32 custap:1;    // also quick claw
+    u32 touchedProtectLike:1;
     u32 physicalDmg;
     u32 specialDmg;
     u8 physicalBattlerId;

--- a/include/battle.h
+++ b/include/battle.h
@@ -100,6 +100,7 @@ struct DisableStruct
     u8 truantCounter:1;
     u8 truantSwitchInHack:1;
     u8 mimickedMoves:4;
+    u8 touchedProtectLike: 1;
     u8 rechargeTimer;
     u8 autotomizeCount;
     u8 slowStartTimer;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1456,7 +1456,7 @@ static void Cmd_attackcanceler(void)
      && gBattleMoves[gCurrentMove].effect != EFFECT_SUCKER_PUNCH)
     {
         if (gBattleMoves[gCurrentMove].flags & FLAG_MAKES_CONTACT)
-            gDisableStructs[gBattlerAttacker].touchedProtectLike = 1;
+            gProtectStructs[gBattlerAttacker].touchedProtectLike = 1;
         CancelMultiTurnMoves(gBattlerAttacker);
         gMoveResultFlags |= MOVE_RESULT_MISSED;
         gLastLandedMoves[gBattlerTarget] = 0;
@@ -4779,11 +4779,11 @@ static void Cmd_moveend(void)
         switch (gBattleScripting.moveendState)
         {
         case MOVEEND_PROTECT_LIKE_EFFECT:
-            if (gDisableStructs[gBattlerAttacker].touchedProtectLike)
+            if (gProtectStructs[gBattlerAttacker].touchedProtectLike)
             {
                 if (gProtectStructs[gBattlerTarget].spikyShielded && GetBattlerAbility(gBattlerAttacker) != ABILITY_MAGIC_GUARD)
                 {
-                    gDisableStructs[gBattlerAttacker].touchedProtectLike = 0;
+                    gProtectStructs[gBattlerAttacker].touchedProtectLike = 0;
                     gBattleMoveDamage = gBattleMons[gBattlerAttacker].maxHP / 8;
                     if (gBattleMoveDamage == 0)
                         gBattleMoveDamage = 1;
@@ -4794,7 +4794,7 @@ static void Cmd_moveend(void)
                 }
                 else if (gProtectStructs[gBattlerTarget].kingsShielded)
                 {
-                    gDisableStructs[gBattlerAttacker].touchedProtectLike = 0;
+                    gProtectStructs[gBattlerAttacker].touchedProtectLike = 0;
                     i = gBattlerAttacker;
                     gBattlerAttacker = gBattlerTarget;
                     gBattlerTarget = i; // gBattlerTarget and gBattlerAttacker are swapped in order to activate Defiant, if applicable
@@ -4805,7 +4805,7 @@ static void Cmd_moveend(void)
                 }
                 else if (gProtectStructs[gBattlerTarget].banefulBunkered)
                 {
-                    gDisableStructs[gBattlerAttacker].touchedProtectLike = 0;
+                    gProtectStructs[gBattlerAttacker].touchedProtectLike = 0;
                     gBattleScripting.moveEffect = MOVE_EFFECT_POISON | MOVE_EFFECT_AFFECTS_USER;
                     PREPARE_MOVE_BUFFER(gBattleTextBuff1, MOVE_BANEFUL_BUNKER);
                     BattleScriptPushCursor();

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1452,7 +1452,8 @@ static void Cmd_attackcanceler(void)
     }
     else if (IsBattlerProtected(gBattlerTarget, gCurrentMove)
      && (gCurrentMove != MOVE_CURSE || IS_BATTLER_OF_TYPE(gBattlerAttacker, TYPE_GHOST))
-     && ((!IsTwoTurnsMove(gCurrentMove) || (gBattleMons[gBattlerAttacker].status2 & STATUS2_MULTIPLETURNS))))
+     && ((!IsTwoTurnsMove(gCurrentMove) || (gBattleMons[gBattlerAttacker].status2 & STATUS2_MULTIPLETURNS)))
+     && gBattleMoves[gCurrentMove].effect != EFFECT_SUCKER_PUNCH)
     {
         if (gBattleMoves[gCurrentMove].flags & FLAG_MAKES_CONTACT)
             gDisableStructs[gBattlerAttacker].touchedProtectLike = 1;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1454,6 +1454,8 @@ static void Cmd_attackcanceler(void)
      && (gCurrentMove != MOVE_CURSE || IS_BATTLER_OF_TYPE(gBattlerAttacker, TYPE_GHOST))
      && ((!IsTwoTurnsMove(gCurrentMove) || (gBattleMons[gBattlerAttacker].status2 & STATUS2_MULTIPLETURNS))))
     {
+        if (gBattleMoves[gCurrentMove].flags & FLAG_MAKES_CONTACT)
+            gDisableStructs[gBattlerAttacker].touchedProtectLike = 1;
         CancelMultiTurnMoves(gBattlerAttacker);
         gMoveResultFlags |= MOVE_RESULT_MISSED;
         gLastLandedMoves[gBattlerTarget] = 0;
@@ -4776,10 +4778,11 @@ static void Cmd_moveend(void)
         switch (gBattleScripting.moveendState)
         {
         case MOVEEND_PROTECT_LIKE_EFFECT:
-            if (gBattleMoves[gCurrentMove].flags & FLAG_MAKES_CONTACT)
+            if (gDisableStructs[gBattlerAttacker].touchedProtectLike)
             {
                 if (gProtectStructs[gBattlerTarget].spikyShielded && GetBattlerAbility(gBattlerAttacker) != ABILITY_MAGIC_GUARD)
                 {
+                    gDisableStructs[gBattlerAttacker].touchedProtectLike = 0;
                     gBattleMoveDamage = gBattleMons[gBattlerAttacker].maxHP / 8;
                     if (gBattleMoveDamage == 0)
                         gBattleMoveDamage = 1;
@@ -4790,6 +4793,7 @@ static void Cmd_moveend(void)
                 }
                 else if (gProtectStructs[gBattlerTarget].kingsShielded)
                 {
+                    gDisableStructs[gBattlerAttacker].touchedProtectLike = 0;
                     i = gBattlerAttacker;
                     gBattlerAttacker = gBattlerTarget;
                     gBattlerTarget = i; // gBattlerTarget and gBattlerAttacker are swapped in order to activate Defiant, if applicable
@@ -4800,6 +4804,7 @@ static void Cmd_moveend(void)
                 }
                 else if (gProtectStructs[gBattlerTarget].banefulBunkered)
                 {
+                    gDisableStructs[gBattlerAttacker].touchedProtectLike = 0;
                     gBattleScripting.moveEffect = MOVE_EFFECT_POISON | MOVE_EFFECT_AFFECTS_USER;
                     PREPARE_MOVE_BUFFER(gBattleTextBuff1, MOVE_BANEFUL_BUNKER);
                     BattleScriptPushCursor();


### PR DESCRIPTION
Addresses #1609. Makes Protect-like moves (King's Shield, Spiky Shield etc.) activate only if the attacker would've touched the target. I.e. the extra effect of these moves won't activate if the attacker's move fails for some other reason, or if it's a charge turn, etc.

This is done by moving the check for activating these effects into the attack canceller for Protect (this is similar to what the CFRU does).

![dig](https://user-images.githubusercontent.com/28769716/131634901-500f0552-4899-4155-9720-d9ae2c45b687.gif)
![sleep](https://user-images.githubusercontent.com/28769716/131635836-0e552a5f-d5ff-40c7-bcd8-8f37b86566de.gif)

Also fixes Sucker Punch to behave correctly vs Protect, as it was printing the "target protected itself!" string:
![Sucker punch](https://user-images.githubusercontent.com/28769716/131648785-adb71ae1-39f3-49da-a76f-16664b180a0b.gif)
Tested in USUM - "But it failed!" is the correct string.


Buffel Saft#2205