### PR TITLE
Fix stacking effect on HOLD_EFFECT_DOUBLE_PRIZE

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -485,7 +485,9 @@ struct BattleStruct
     u16 assistPossibleMoves[PARTY_SIZE * MAX_MON_MOVES]; // Each of mons can know max 4 moves.
     u8 focusPunchBattlerId;
     u8 battlerPreventingSwitchout;
-    u8 moneyMultiplier;
+    u8 moneyMultiplier:6;
+    u8 moneyMultiplierItem:1;
+    u8 moneyMultiplierMove:1;
     u8 savedTurnActionNumber;
     u8 switchInAbilitiesCounter;
     u8 faintedActionsState;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2851,9 +2851,10 @@ void SetMoveEffect(bool32 primary, u32 certain)
                 gBattlescriptCurrInstr = sMoveEffectBS_Ptrs[gBattleScripting.moveEffect];
                 break;
             case MOVE_EFFECT_HAPPY_HOUR:
-                if (GET_BATTLER_SIDE(gBattlerAttacker) == B_SIDE_PLAYER)
+                if (GET_BATTLER_SIDE(gBattlerAttacker) == B_SIDE_PLAYER && !gBattleStruct->moneyMultiplierMove)
                 {
                     gBattleStruct->moneyMultiplier *= 2;
+                    gBattleStruct->moneyMultiplierMove = 1;
                 }
                 gBattlescriptCurrInstr++;
                 break;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -5626,8 +5626,9 @@ u8 ItemBattleEffects(u8 caseID, u8 battlerId, bool8 moveTurn)
             switch (battlerHoldEffect)
             {
             case HOLD_EFFECT_DOUBLE_PRIZE:
-                if (GetBattlerSide(battlerId) == B_SIDE_PLAYER)
+                if (GetBattlerSide(battlerId) == B_SIDE_PLAYER && !gBattleStruct->moneyMultiplierItem)
                     gBattleStruct->moneyMultiplier *= 2;
+                    gBattleStruct->moneyMultiplierItem = 1;
                 break;
             case HOLD_EFFECT_RESTORE_STATS:
                 for (i = 0; i < NUM_BATTLE_STATS; i++)

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -5627,8 +5627,10 @@ u8 ItemBattleEffects(u8 caseID, u8 battlerId, bool8 moveTurn)
             {
             case HOLD_EFFECT_DOUBLE_PRIZE:
                 if (GetBattlerSide(battlerId) == B_SIDE_PLAYER && !gBattleStruct->moneyMultiplierItem)
+                {
                     gBattleStruct->moneyMultiplier *= 2;
                     gBattleStruct->moneyMultiplierItem = 1;
+                }
                 break;
             case HOLD_EFFECT_RESTORE_STATS:
                 for (i = 0; i < NUM_BATTLE_STATS; i++)


### PR DESCRIPTION
## Description
Addresses #1619 
`moneyMultiplier` was being doubled every time a mon with `HOLD_EFFECT_DOUBLE_PRIZE` switched in, or happy hour was used.

This PR adds two flags to `moneyMultiplier` that prevent `HOLD_EFFECT_DOUBLE_PRIZE` and Happy Hour from infinitely increasing it. `moneyMultiplier` can't be more than 4 (unless O-powers are implemented at some point), so reducing it to 6 bits is fine.

## **Discord contact info**
Buffel Saft#2205