### PR TITLE
Fix Item Activation Messages

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2356,6 +2356,7 @@ static void Cmd_resultmessage(void)
     if (gSpecialStatuses[gBattlerTarget].berryReduced
         && !(gMoveResultFlags & MOVE_RESULT_NO_EFFECT))
     {
+        gLastUsedItem = gBattleMons[gBattlerTarget].item;
         gSpecialStatuses[gBattlerTarget].berryReduced = 0;
         BattleScriptPushCursor();
         gBattlescriptCurrInstr = BattleScript_PrintBerryReduceString;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -7288,9 +7288,14 @@ static void Cmd_various(void)
         return;
     case VARIOUS_JUMP_IF_NO_HOLD_EFFECT:
         if (GetBattlerHoldEffect(gActiveBattler, TRUE) != gBattlescriptCurrInstr[3])
+        {
             gBattlescriptCurrInstr = T1_READ_PTR(gBattlescriptCurrInstr + 4);
+        }
         else
+        {
+            gLastUsedItem = gBattleMons[gActiveBattler].item;   // For B_LAST_USED_ITEM
             gBattlescriptCurrInstr += 8;
+        }
         return;
     case VARIOUS_JUMP_IF_NO_ALLY:
         if (!IsBattlerAlive(BATTLE_PARTNER(gActiveBattler)))


### PR DESCRIPTION
`gLastUsedItem` was not getting updated during the some checks, causing the string to print incorrectly sometimes (see #1638)

This fixes:
- Power Herb
- Resist Berries

![power_herb](https://user-images.githubusercontent.com/41651341/132700642-88ae06b0-7dfc-4c8d-9802-f465e235ba6b.gif)

![resist_berry](https://user-images.githubusercontent.com/41651341/132702418-82b7f146-0f02-4308-81ec-cf096ce947c7.gif)

Closes #1638 
