### PR TITLE
Fix echoed voice power boost

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -217,7 +217,6 @@ struct FieldTimer
     u8 mistyTerrainTimer;
     u8 electricTerrainTimer;
     u8 psychicTerrainTimer;
-    u8 echoVoiceCounter;
     u8 gravityTimer;
     u8 fairyLockTimer;
 };

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1743,7 +1743,7 @@ static void Cmd_ppreduce(void)
     if (!(gHitMarker & (HITMARKER_NO_PPDEDUCT | HITMARKER_NO_ATTACKSTRING)) && gBattleMons[gBattlerAttacker].pp[gCurrMovePos])
     {
         gProtectStructs[gBattlerAttacker].notFirstStrike = 1;
-        // For item Metronome
+        // For item Metronome, echoed voice
         if (gCurrentMove == gLastResultingMoves[gBattlerAttacker]
             && !(gMoveResultFlags & MOVE_RESULT_NO_EFFECT)
             && !WasUnableToUseMove(gBattlerAttacker))

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -7192,12 +7192,13 @@ static u16 CalcMoveBasePower(u16 move, u8 battlerAtk, u8 battlerDef)
             basePower = 150;
         break;
     case EFFECT_ECHOED_VOICE:
-        if (gFieldTimers.echoVoiceCounter != 0)
+        // gBattleStruct->sameMoveTurns incremented in ppreduce
+        if (gBattleStruct->sameMoveTurns[battlerAtk] != 0)
         {
-            if (gFieldTimers.echoVoiceCounter >= 5)
+            if (gBattleStruct->sameMoveTurns[battlerAtk] >= 5)
                 basePower *= 5;
             else
-                basePower *= gFieldTimers.echoVoiceCounter;
+                basePower *= gBattleStruct->sameMoveTurns[battlerAtk];
         }
         break;
     case EFFECT_PAYBACK:


### PR DESCRIPTION
Fixes Echoed Voice. `echoVoiceCounter` was redundant, and so was removed and replaced with `gBattleStruct->sameMoveTurns`, which is what the metronome item uses for the power boost.

Closes #1640 