### PR TITLE
better echoed voice power boost

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -7195,10 +7195,9 @@ static u16 CalcMoveBasePower(u16 move, u8 battlerAtk, u8 battlerDef)
         // gBattleStruct->sameMoveTurns incremented in ppreduce
         if (gBattleStruct->sameMoveTurns[battlerAtk] != 0)
         {
-            if (gBattleStruct->sameMoveTurns[battlerAtk] >= 5)
-                basePower *= 5;
-            else
-                basePower *= gBattleStruct->sameMoveTurns[battlerAtk];
+            basePower += (40 * gBattleStruct->sameMoveTurns[battlerAtk]);
+            if (basePower > 200)
+                basePower = 200;
         }
         break;
     case EFFECT_PAYBACK:

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -7195,7 +7195,7 @@ static u16 CalcMoveBasePower(u16 move, u8 battlerAtk, u8 battlerDef)
         // gBattleStruct->sameMoveTurns incremented in ppreduce
         if (gBattleStruct->sameMoveTurns[battlerAtk] != 0)
         {
-            basePower += (40 * gBattleStruct->sameMoveTurns[battlerAtk]);
+            basePower += (basePower * gBattleStruct->sameMoveTurns[battlerAtk]);
             if (basePower > 200)
                 basePower = 200;
         }


### PR DESCRIPTION
increments basePower by 40 * same move counter instead of multiplying base power by the counter, so 2nd usage of echoed voice will be `basePower += 40`, 2nd usage `basePower += 80`, etc.

Also caps base power to 200.