### PR TITLE
Fix multihit moves vs damage reducing berries

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -7519,6 +7519,7 @@ BattleScript_BerryReduceDmg::
 BattleScript_PrintBerryReduceString::
 	waitmessage B_WAIT_TIME_LONG
 	printstring STRINGID_BERRYDMGREDUCES
+	waitmessage B_WAIT_TIME_LONG
 	return
 
 BattleScript_BerryCureConfusionEnd2::

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1967,6 +1967,15 @@ static void Cmd_multihitresultmessage(void)
         }
     }
     gBattlescriptCurrInstr++;
+
+    // Print berry reducing message after result message.
+    if (gSpecialStatuses[gBattlerTarget].berryReduced
+        && !(gMoveResultFlags & MOVE_RESULT_NO_EFFECT))
+    {
+        gSpecialStatuses[gBattlerTarget].berryReduced = 0;
+        BattleScriptPushCursor();
+        gBattlescriptCurrInstr = BattleScript_PrintBerryReduceString;
+    }
 }
 
 static void Cmd_attackanimation(void)


### PR DESCRIPTION
## Description
Addresses #1651:
![fix damage berry](https://user-images.githubusercontent.com/28769716/133028058-7f13f116-5300-4bf3-84b4-447b1a2a79b2.gif)

The extra waitmessage command is ugly but appears to be needed - if it's moved after the printstring, the message isn't displayed long enough on single hit moves, so I've left it there and added another one, which is needed for multihit moves.

## **Discord contact info**
Buffel Saft#2205