### PR TITLE
Fixed Nature Power move on different terrains.

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -11301,7 +11301,7 @@ static void Cmd_setcharge(void)
 static void Cmd_callterrainattack(void) // nature power
 {
     gHitMarker &= ~(HITMARKER_ATTACKSTRING_PRINTED);
-    gCurrentMove = sNaturePowerMoves[gBattleTerrain];
+    gCurrentMove = GetNaturePowerMove();
     gBattlerTarget = GetMoveTarget(gCurrentMove, 0);
     BattleScriptPush(gBattleScriptsForMoveEffects[gBattleMoves[gCurrentMove].effect]);
     gBattlescriptCurrInstr++;
@@ -11309,7 +11309,14 @@ static void Cmd_callterrainattack(void) // nature power
 
 u16 GetNaturePowerMove(void)
 {
-    //TODO terrain
+    if (gFieldStatuses & STATUS_FIELD_MISTY_TERRAIN)
+      return MOVE_MOONBLAST;
+    else if (gFieldStatuses & STATUS_FIELD_ELECTRIC_TERRAIN)
+      return MOVE_THUNDERBOLT;
+    else if (gFieldStatuses & STATUS_FIELD_GRASSY_TERRAIN)
+      return MOVE_ENERGY_BALL;
+    else if (gFieldStatuses & STATUS_FIELD_PSYCHIC_TERRAIN)
+      return MOVE_PSYCHIC;
     return sNaturePowerMoves[gBattleTerrain];
 }
 


### PR DESCRIPTION
Changed GetNaturePowerMove to return the right move when used with terrain active based on:

https://bulbapedia.bulbagarden.net/wiki/Nature_Power_(move)#Generation_VII

## Description
Just a simple switch to check for each terrain.

## **Discord contact info**
alterrp#2960