### PR TITLE
Fix Download

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4045,7 +4045,7 @@ u8 AbilityBattleEffects(u8 caseID, u8 battler, u16 ability, u8 special, u16 move
                 u32 opposingDef = 0, opposingSpDef = 0;
 
                 opposingBattler = BATTLE_OPPOSITE(battler);
-                for (i = 0; i < 2; opposingBattler ^= BIT_SIDE, i++)
+                for (i = 0; i < 2; opposingBattler ^= BIT_FLANK, i++)
                 {
                     if (IsBattlerAlive(opposingBattler))
                     {
@@ -4069,6 +4069,7 @@ u8 AbilityBattleEffects(u8 caseID, u8 battler, u16 ability, u8 special, u16 move
                 {
                     gBattleMons[battler].statStages[statId]++;
                     SET_STATCHANGER(statId, 1, FALSE);
+                    gBattlerAttacker = battler;
                     PREPARE_STAT_BUFFER(gBattleTextBuff1, statId);
                     BattleScriptPushCursorAndCallback(BattleScript_AttackerAbilityStatRaiseEnd3);
                     effect++;


### PR DESCRIPTION
Fix bugs with the Download ability.

## Description
Download had two problems:
1. It didn't set the user as the attacker and then called a battle script that raised the attacker's stat, causing it to regularly raise the foe's stats instead of the user's.
2. When looping through opposing battlers to determine which stat to raise, instead of checking the foe's ally's stats in the second iteration, it checked either the user's stats or its ally's stats, causing it to raise the wrong stat.

This PR fixes both issues.
## **Discord contact info**
Buffel Saft#2205