### PR TITLE
[ai] use expected value move dmg calculation

### DIFF
--- a/include/battle_script_commands.h
+++ b/include/battle_script_commands.h
@@ -13,6 +13,7 @@ struct StatFractions
 };
 
 s32 CalcCritChanceStage(u8 battlerAtk, u8 battlerDef, u32 move, bool32 recordAbility);
+s8 GetInverseCritChance(u8 battlerAtk, u8 battlerDef, u32 move);
 u32 GetTotalAccuracy(u32 battlerAtk, u32 battlerDef, u32 move);
 u8 GetBattlerTurnOrderNum(u8 battlerId);
 bool32 NoAliveMonsForEitherParty(void);

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -737,6 +737,8 @@ s32 AI_CalcDamage(u16 move, u8 battlerAtk, u8 battlerDef)
     switch (gBattleMoves[move].effect)
     {
     case EFFECT_LEVEL_DAMAGE:
+    case EFFECT_PSYWAVE:
+        //psywave's expected damage is equal to the user's level
         dmg = gBattleMons[battlerAtk].level;
         break;
     case EFFECT_DRAGON_RAGE:
@@ -744,16 +746,6 @@ s32 AI_CalcDamage(u16 move, u8 battlerAtk, u8 battlerDef)
         break;
     case EFFECT_SONICBOOM:
         dmg = 20;
-        break;
-    case EFFECT_PSYWAVE:
-        {
-            u32 randDamage;
-            if (B_PSYWAVE_DMG >= GEN_6)
-                randDamage = (Random() % 101);
-            else
-                randDamage = (Random() % 11) * 10;
-            dmg = gBattleMons[battlerAtk].level * (randDamage + 50) / 100;
-        }
         break;
     //case EFFECT_METAL_BURST:
     //case EFFECT_COUNTER:

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -711,7 +711,8 @@ static bool32 AI_GetIfCrit(u32 move, u8 battlerAtk, u8 battlerDef)
 
 s32 AI_CalcDamage(u16 move, u8 battlerAtk, u8 battlerDef)
 {
-    s32 dmg, moveType;
+    s32 dmg, moveType, critDmg, normalDmg;
+    s8 critChance;
 
     SaveBattlerData(battlerAtk);
     SaveBattlerData(battlerDef);
@@ -722,7 +723,15 @@ s32 AI_CalcDamage(u16 move, u8 battlerAtk, u8 battlerDef)
     gBattleStruct->dynamicMoveType = 0;
     SetTypeBeforeUsingMove(move, battlerAtk);
     GET_MOVE_TYPE(move, moveType);
-    dmg = CalculateMoveDamage(move, battlerAtk, battlerDef, moveType, 0, AI_GetIfCrit(move, battlerAtk, battlerDef), FALSE, FALSE);
+
+    critChance = GetInverseCritChance(battlerAtk, battlerDef, move);
+    normalDmg = CalculateMoveDamage(move, battlerAtk, battlerDef, moveType, 0, FALSE, FALSE, FALSE);
+    critDmg = CalculateMoveDamage(move, battlerAtk, battlerDef, moveType, 0, TRUE, FALSE, FALSE);
+
+    if(critChance == -1)
+        dmg = normalDmg;
+    else
+        dmg = (critDmg + normalDmg * (critChance - 1)) / critChance;
 
     // handle dynamic move damage
     switch (gBattleMoves[move].effect)
@@ -749,7 +758,8 @@ s32 AI_CalcDamage(u16 move, u8 battlerAtk, u8 battlerDef)
     //case EFFECT_METAL_BURST:
     //case EFFECT_COUNTER:
     default:
-        dmg *= (100 - (Random() % 10)) / 100;   // add random factor
+        //do not add the random factor, it's an average case analysis
+        //dmg *= (100 - (Random() % 10)) / 100;   // add random factor
         break;
     }
 

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1822,6 +1822,15 @@ s32 CalcCritChanceStage(u8 battlerAtk, u8 battlerDef, u32 move, bool32 recordAbi
     return critChance;
 }
 
+s8 GetInverseCritChance(u8 battlerAtk, u8 battlerDef, u32 move)
+{
+    s32 critChanceIndex = CalcCritChanceStage(battlerAtk, battlerDef, move, FALSE);
+    if(critChanceIndex < 0)
+        return -1;
+    else
+        return sCriticalHitChance[critChanceIndex];
+}
+
 static void Cmd_critcalc(void)
 {
     s32 critChance = CalcCritChanceStage(gBattlerAttacker, gBattlerTarget, gCurrentMove, TRUE);


### PR DESCRIPTION
Changes how AI calculates critical hits in its simulated damage by providing expected move damage instead of fishing for crits in its simulation.

## **Discord contact info**
Karathan#1337