### PR TITLE
Gen8 move effects Fixes

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3094,6 +3094,7 @@ void FaintClearSetData(void)
     gProtectStructs[gActiveBattler].usedGravityPreventedMove = 0;
     gProtectStructs[gActiveBattler].usedThroatChopPreventedMove = 0;
     gProtectStructs[gActiveBattler].statRaised = 0;
+    gProtectStructs[gActiveBattler].statFell = 0;
 
     gDisableStructs[gActiveBattler].isFirstTurn = 2;
 

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -5165,6 +5165,7 @@ static void Cmd_moveend(void)
                     u8 battler = battlers[i];
                     if (IsBattlerAlive(battler)
                      && gProtectStructs[battler].statFell
+                     && gProtectStructs[battler].disableEjectPack == 0
                      && GetBattlerHoldEffect(battler, TRUE) == HOLD_EFFECT_EJECT_PACK
                      && !(gCurrentMove == MOVE_PARTING_SHOT && CanBattlerSwitch(gBattlerAttacker))  // Does not activate if attacker used Parting Shot and can switch out
                      && CountUsablePartyMons(battler) > 0)  // Has mon to switch into
@@ -9407,9 +9408,7 @@ static u32 ChangeStatBuffs(s8 statValue, u32 statId, u32 flags, const u8 *BS_ptr
             }
             else
             {
-                // Check eject pack. disableEjectPack set for edge cases (e.g. attacking weak armor'd eject pack holder with u-turn)
-                if (gProtectStructs[gActiveBattler].disableEjectPack == 0)
-                    gProtectStructs[gActiveBattler].statFell = 1;
+                gProtectStructs[gActiveBattler].statFell = 1;   // Eject pack, lash out
                 gBattleCommunication[MULTISTRING_CHOOSER] = (gBattlerTarget == gActiveBattler); // B_MSG_ATTACKER_STAT_FELL or B_MSG_DEFENDER_STAT_FELL
             }
         }

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -5997,6 +5997,7 @@ u8 ItemBattleEffects(u8 caseID, u8 battlerId, bool8 moveTurn)
                 break;
             case HOLD_EFFECT_EJECT_PACK:
                 if (gProtectStructs[battlerId].statFell
+                 && gProtectStructs[battlerId].disableEjectPack == 0
                  && !(gCurrentMove == MOVE_PARTING_SHOT && CanBattlerSwitch(gBattlerAttacker))) // Does not activate if attacker used Parting Shot and can switch out
                 {
                     gProtectStructs[battlerId].statFell = FALSE;


### PR DESCRIPTION
An edge case with weak armor + eject pack was conflicting with lash out. This PR fixes it and allows for further testing of the move effects.

basically, I had added a "disableEjectPack" field for when u turn is used on a weak armor'd mon holding eject pack. If this field was set, .statFell was not updated. Which prevents lash out from activating
so I moved that disableEjectPack check directly to the hold effect code
(and tested to make sure there was no regression) 