### PR TITLE
Enable Mental Herb Description Toggling Based on B_MENTAL_HERB Config

### DIFF
--- a/src/data/text/item_descriptions.h
+++ b/src/data/text/item_descriptions.h
@@ -1041,16 +1041,16 @@ static const u8 sSootheBellDesc[] = _(
     "calms spirits and\n"
     "fosters friendship.");
 
-#ifndef BATTLE_ENGINE
-static const u8 sMentalHerbDesc[] = _(
-    "A hold item that\n"
-    "snaps Pokémon out\n"
-    "of infatuation.");
-#else
+#if defined(BATTLE_ENGINE) && B_MENTAL_HERB >= GEN_5
 static const u8 sMentalHerbDesc[] = _(
     "Snaps Pokémon out\n"
     "of move-binding\n"
     "effects.");
+#else
+static const u8 sMentalHerbDesc[] = _(
+    "A hold item that\n"
+    "snaps Pokémon out\n"
+    "of infatuation.");
 #endif
 
 static const u8 sChoiceBandDesc[] = _(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Improve ifdef for Mental Herb's description to be vanilla description when B_MENTAL_HERB is not equal to GEN_5 or greater and vice versa. Addresses the comment made by me in #1627 which was saying that this toggle should've been included like it was originally in #1355.
## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->
UltimaSoul#4017