### PR TITLE
Fix Simple Beam

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -7910,15 +7910,15 @@ static void Cmd_various(void)
             gBattlescriptCurrInstr += 7;
         return;
     case VARIOUS_SET_SIMPLE_BEAM:
-        if (IsEntrainmentTargetOrSimpleBeamBannedAbility(gBattleMons[gActiveBattler].ability))
+        if (IsEntrainmentTargetOrSimpleBeamBannedAbility(gBattleMons[gBattlerTarget].ability)
+            || gBattleMons[gBattlerTarget].ability == ABILITY_SIMPLE)
         {
             gBattlescriptCurrInstr = T1_READ_PTR(gBattlescriptCurrInstr + 3);
         }
         else
         {
-            gBattleMons[gActiveBattler].ability = ABILITY_SIMPLE;
+            gBattleMons[gBattlerTarget].ability = ABILITY_SIMPLE;
             gBattlescriptCurrInstr += 7;
-            break;
         }
         return;
     case VARIOUS_TRY_ENTRAINMENT:


### PR DESCRIPTION
## Description
Makes the following changes to Simple Beam:
- No longer freezes the game
- Now fails if the target's ability is already Simple
- Explicitly checks and changes the target's ability instead of gActiveBattler's ability

## **Discord contact info**
Buffel Saft#2205