### PR TITLE
AI handles dynamic move types

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -520,6 +520,9 @@ static s16 AI_CheckBadMove(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
     u32 i;
     u16 predictedMove = gLastMoves[battlerDef]; // TODO better move prediction
     
+    SetTypeBeforeUsingMove(move, battlerAtk);
+    GET_MOVE_TYPE(move, moveType);
+
     if (IsTargetingPartner(battlerAtk, battlerDef))
         return score;
     
@@ -2472,7 +2475,10 @@ static s16 AI_DoubleBattle(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
     bool32 attackerHasBadAbility = (GetAbilityRating(AI_DATA->atkAbility) < 0);
     bool32 partnerHasBadAbility = (GetAbilityRating(atkPartnerAbility) < 0);
     u16 predictedMove = gLastMoves[battlerDef]; //for now
-        
+
+    SetTypeBeforeUsingMove(move, battlerAtk);
+    GET_MOVE_TYPE(move, moveType);
+
     // check what effect partner is using
     if (AI_DATA->partnerMove != 0)
     {
@@ -4751,7 +4757,10 @@ static s16 AI_HPAware(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
 {
     u16 effect = gBattleMoves[move].effect;
     u8 moveType = gBattleMoves[move].type;
-    
+
+    SetTypeBeforeUsingMove(move, battlerAtk);
+    GET_MOVE_TYPE(move, moveType);
+
     if (IsTargetingPartner(battlerAtk, battlerDef))
     {
         if ((effect == EFFECT_HEAL_PULSE || effect == EFFECT_HIT_ENEMY_HEAL_ALLY)


### PR DESCRIPTION
## Description
This will make the AI account for the type of moves like Weather Ball, Hidden Power and Revelation Dance when considering abilities that make them useless. E.g. Water-type Hidden Power vs. Storm Drain.
Example:
![AI dynamic move types](https://user-images.githubusercontent.com/28769716/136172004-91170f80-7658-4647-98b3-80a819684370.gif)
Kyogre only has Dark Pulse and Weather Ball here. After Dry Skin is revealed it knows that Weather Ball will do nothing, so it uses Dark Pulse instead.

## **Discord contact info**
Buffel Saft#2205