### PR TITLE
Fix protect struct fields being set during ai calcs

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -209,7 +209,11 @@ u8 BattleAI_ChooseMoveOrAction(void)
         ret = ChooseMoveOrAction_Singles();
     else
         ret = ChooseMoveOrAction_Doubles();
-
+    
+    // Clear protect structures, some flags may be set during AI calcs
+    // e.g. pranksterElevated from GetMovePriority
+    memset(&gProtectStructs[gActiveBattler], 0, sizeof(struct ProtectStruct));
+    
     gCurrentMove = savedCurrentMove;
     return ret;
 }

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3097,6 +3097,7 @@ void FaintClearSetData(void)
     gProtectStructs[gActiveBattler].usedThroatChopPreventedMove = 0;
     gProtectStructs[gActiveBattler].statRaised = 0;
     gProtectStructs[gActiveBattler].statFell = 0;
+    gProtectStructs[gActiveBattler].pranksterElevated = 0;
 
     gDisableStructs[gActiveBattler].isFirstTurn = 2;
 


### PR DESCRIPTION
Addresses #1753 

Certain gProtectStruct fields were being set during AI calculations, causing odd bugs such as prankster being blocked for non-status moves after switching. I vaguely remember odd behavior with quick claw which could be caused by this as well.

By setting the entirety of gProtectStructs to 0 after AI calcs we resolve the issue addressed in #1753:
![prankster_fix](https://user-images.githubusercontent.com/41651341/137150544-f6afcea1-5050-4c8d-8d5b-e7e0880149f2.gif)


