### PR TITLE
Small AI fixes

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -2930,7 +2930,7 @@ static s16 AI_CheckViability(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
         if (AI_RandLessThan(128))
             IncreaseSleepScore(battlerAtk, battlerDef, move, &score);
         break;
-	case EFFECT_ABSORB:
+    case EFFECT_ABSORB:
         if (AI_DATA->atkHoldEffect == HOLD_EFFECT_BIG_ROOT)
             score++;
         if (effectiveness <= AI_EFFECTIVENESS_x0_5 && AI_RandLessThan(50))
@@ -2944,12 +2944,12 @@ static s16 AI_CheckViability(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
                 score++;
         }
         break;
-	case EFFECT_MIRROR_MOVE:
+    case EFFECT_MIRROR_MOVE:
         if (predictedMove != MOVE_NONE)
             return AI_CheckViability(battlerAtk, battlerDef, gLastMoves[battlerDef], score);
         break;
 // stat raising effects
-	case EFFECT_ATTACK_UP:
+    case EFFECT_ATTACK_UP:
     case EFFECT_ATTACK_UP_2:
         if (MovesWithSplitUnusable(battlerAtk, battlerDef, SPLIT_PHYSICAL))
         {
@@ -2970,7 +2970,7 @@ static s16 AI_CheckViability(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
             score--;
         }
         break;
-	case EFFECT_DEFENSE_UP:
+    case EFFECT_DEFENSE_UP:
     case EFFECT_DEFENSE_UP_2:
     case EFFECT_DEFENSE_UP_3:
         if (!HasMoveWithSplit(battlerDef, SPLIT_PHYSICAL))
@@ -2982,7 +2982,7 @@ static s16 AI_CheckViability(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
         else if (atkHpPercent < 40)
             score -= 2;
         break;
-	case EFFECT_SPEED_UP:
+    case EFFECT_SPEED_UP:
     case EFFECT_SPEED_UP_2:
         if (IsAiFaster(AI_CHECK_SLOWER))
         {
@@ -2994,7 +2994,7 @@ static s16 AI_CheckViability(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
             score -= 3;
         }
         break;
-	case EFFECT_SPECIAL_ATTACK_UP:
+    case EFFECT_SPECIAL_ATTACK_UP:
     case EFFECT_SPECIAL_ATTACK_UP_2:
     case EFFECT_SPECIAL_ATTACK_UP_3:
         if (MovesWithSplitUnusable(battlerAtk, battlerDef, SPLIT_SPECIAL))
@@ -3016,7 +3016,7 @@ static s16 AI_CheckViability(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
             score--;
         }
         break;
-	case EFFECT_SPECIAL_DEFENSE_UP:
+    case EFFECT_SPECIAL_DEFENSE_UP:
     case EFFECT_SPECIAL_DEFENSE_UP_2:
         if (!HasMoveWithSplit(battlerDef, SPLIT_SPECIAL))
             score -= 2;
@@ -3027,7 +3027,7 @@ static s16 AI_CheckViability(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
         else if (GetHealthPercentage(battlerAtk) < 40)
             score -= 2;
         break;
-	case EFFECT_ACCURACY_UP:
+    case EFFECT_ACCURACY_UP:
     case EFFECT_ACCURACY_UP_2:
         if (gBattleMons[battlerAtk].statStages[STAT_ACC] >= 9 && !AI_RandLessThan(50))
             score -= 2;
@@ -3036,7 +3036,7 @@ static s16 AI_CheckViability(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
         else 
             score++;
         break;
-	case EFFECT_EVASION_UP:
+    case EFFECT_EVASION_UP:
     case EFFECT_EVASION_UP_2:
         if (atkHpPercent > 90 && !AI_RandLessThan(100))
             score += 3;
@@ -3058,7 +3058,7 @@ static s16 AI_CheckViability(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
             score -= 2;
         break;
 // stat lowering effects
-	case EFFECT_ATTACK_DOWN:
+    case EFFECT_ATTACK_DOWN:
     case EFFECT_ATTACK_DOWN_2:
         if (!ShouldLowerAttack(battlerAtk, battlerDef, AI_DATA->defAbility))
             score -= 2;
@@ -3071,7 +3071,7 @@ static s16 AI_CheckViability(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
         else if (defHpPercent < 70)
             score -= 2;
         break;
-	case EFFECT_DEFENSE_DOWN:
+    case EFFECT_DEFENSE_DOWN:
     case EFFECT_DEFENSE_DOWN_2:
         if (!ShouldLowerDefense(battlerAtk, battlerDef, AI_DATA->defAbility))
             score -= 2;
@@ -3080,14 +3080,14 @@ static s16 AI_CheckViability(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
         if (defHpPercent <= 70)
             score -= 2;
         break;
-	case EFFECT_SPEED_DOWN:
+    case EFFECT_SPEED_DOWN:
     case EFFECT_SPEED_DOWN_2:
         if (IsAiFaster(AI_CHECK_FASTER))
             score -= 3;
         else if (!AI_RandLessThan(70))
             score += 2;
         break;
-	case EFFECT_SPECIAL_ATTACK_DOWN:
+    case EFFECT_SPECIAL_ATTACK_DOWN:
     case EFFECT_SPECIAL_ATTACK_DOWN_2:
         if (!ShouldLowerSpAtk(battlerAtk, battlerDef, AI_DATA->defAbility))
             score -= 2;
@@ -3100,7 +3100,7 @@ static s16 AI_CheckViability(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
         else if (defHpPercent < 70)
             score -= 2;
         break;
-	case EFFECT_SPECIAL_DEFENSE_DOWN:
+    case EFFECT_SPECIAL_DEFENSE_DOWN:
     case EFFECT_SPECIAL_DEFENSE_DOWN_2:
         if (!ShouldLowerSpDef(battlerAtk, battlerDef, AI_DATA->defAbility))
             score -= 2;
@@ -3110,7 +3110,7 @@ static s16 AI_CheckViability(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
         if (defHpPercent <= 70)
             score -= 2;
         break;
-	case EFFECT_ACCURACY_DOWN:
+    case EFFECT_ACCURACY_DOWN:
     case EFFECT_ACCURACY_DOWN_2:
         if (ShouldLowerAccuracy(battlerAtk, battlerDef, AI_DATA->defAbility))
             score -= 2;
@@ -3131,7 +3131,7 @@ static s16 AI_CheckViability(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
         else if (atkHpPercent < 40 || defHpPercent < 40 || !AI_RandLessThan(70))
             score -= 2;
         break;
-	case EFFECT_EVASION_DOWN:
+    case EFFECT_EVASION_DOWN:
     case EFFECT_EVASION_DOWN_2:
         if (!ShouldLowerEvasion(battlerAtk, battlerDef, AI_DATA->defAbility))
             score -= 2;
@@ -3144,7 +3144,7 @@ static s16 AI_CheckViability(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
         if (gBattleMons[battlerDef].statStages[STAT_EVASION] < 7 || AI_DATA->atkAbility == ABILITY_NO_GUARD)
             score -= 2;
         break;
-	case EFFECT_BIDE:
+    case EFFECT_BIDE:
         if (atkHpPercent < 90)
             score -= 2;
         break;
@@ -3275,10 +3275,12 @@ static s16 AI_CheckViability(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
             score += 5;
         break;
     case EFFECT_TRAP:
+        if (HasMoveEffect(battlerDef, EFFECT_RAPID_SPIN))
+	    break;
+        //fallthrough
     case EFFECT_MEAN_LOOK:
-        if (HasMoveEffect(battlerDef, EFFECT_RAPID_SPIN)
-          || IS_BATTLER_OF_TYPE(battlerDef, TYPE_GHOST)
-          || gBattleMons[battlerDef].status2 & STATUS2_WRAPPED)
+        if (IS_BATTLER_OF_TYPE(battlerDef, TYPE_GHOST)
+          || IsBattlerTrapped(battlerDef, TRUE))
         {
             break; // in this case its a bad attacking move
         }
@@ -3325,7 +3327,6 @@ static s16 AI_CheckViability(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
             score++;
         if (AI_DATA->atkAbility == ABILITY_SERENE_GRACE && AI_DATA->defAbility != ABILITY_CONTRARY)
             score++;
-        break;
         if (ShouldLowerSpeed(battlerAtk, battlerDef, AI_DATA->defAbility))
         {
             if (AI_DATA->atkAbility == ABILITY_SERENE_GRACE && AI_DATA->defAbility != ABILITY_CONTRARY)
@@ -3419,7 +3420,7 @@ static s16 AI_CheckViability(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
                     if (gLastMoves[battlerDef] == predictedMove)
                         score += 3;
                     else */if (CanMoveFaintBattler(gLastMoves[battlerDef], battlerDef, battlerAtk, 1))
-                        score += 2;; //Disable move that can kill attacker
+                        score += 2; //Disable move that can kill attacker
                 }
             }
             else if (predictedMove != MOVE_NONE && IS_MOVE_STATUS(predictedMove))
@@ -4150,7 +4151,7 @@ static s16 AI_CheckViability(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
         IncreaseStatUpScore(battlerAtk, battlerDef, STAT_SPDEF, &score);
         break;
     case EFFECT_SHELL_SMASH:
-        if (AI_DATA->atkHoldEffect == HOLD_EFFECT_POWER_HERB)
+        if (AI_DATA->atkHoldEffect == HOLD_EFFECT_RESTORE_STATS)
             score += 3;
         
         IncreaseStatUpScore(battlerAtk, battlerDef, STAT_SPEED, &score);


### PR DESCRIPTION
1. Minor formatting: tabs→spaces, etc.
2. Mean Look is not affected by Rapid Spin.
3. Mean Look and Wrap check `IsBattlerTrapped` instead of explicitly for `STATUS2_WRAPPED`.
4. Removed stray `break` in `EFFECT_SPEED_DOWN_HIT`.
5. Shell Smash is encouraged by holding a White Herb, not a Power Herb.

It's debatable whether 3 should actually use `IsBattlerTrapped` or not.
I assumed that 4 should have the `break` removed, but perhaps that previously-dead code path doesn't make sense?

I found these when I was skim-reading the AI and made the changes with the Github online editor, whichc means I haven't tested any of them, so please double-check they make sense.