### PR TITLE
Added Grav Apple's power boost

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -7702,6 +7702,10 @@ static u16 CalcMoveBasePower(u16 move, u8 battlerAtk, u8 battlerDef)
         if (gBattleMons[battlerAtk].species == SPECIES_GRENINJA_ASH)
             basePower = 20;
         break;
+    case MOVE_GRAV_APPLE:
+        if (gFieldStatuses & STATUS_FIELD_GRAVITY)
+            basePower = 120;
+        break;
     }
 
     if (basePower == 0)


### PR DESCRIPTION
## Description
Closes #1077
This one's simple enough so I thought taking it out of the way would be nice.
I didn't add an entirely new move effect for it because I didn't see it as something necessary.
The move's `.effect` field already has `EFFECT_DEFENSE_DOWN_HIT` set to it, so the only thing left to add is the change in base power while Gravity is in effect, something that's perfect for the `switch` case I added to `CalcMoveBasePower` back when I added Battle Bond.

If that's no good though, let me know and I'll cook up an effect with the corresponding battle script.

## **Discord contact info**
Lunos#4026