### PR TITLE
Fixed Shadow Force

### DIFF
--- a/src/data/battle_moves.h
+++ b/src/data/battle_moves.h
@@ -7415,6 +7415,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
         .split = SPLIT_PHYSICAL,
+        .argument = MOVE_EFFECT_FEINT,
     },
 
     [MOVE_HONE_CLAWS] =


### PR DESCRIPTION
## Description
Just like Phantom Force, Shadow Force is supposed to break through protections for the remainder of the turn in which it hits.
https://bulbapedia.bulbagarden.net/wiki/Shadow_Force_(move)

## **Discord contact info**
Lunos#4026