### PR TITLE
Fixed battlerId in Poison Touch's confusionSelfDmg check

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -5199,7 +5199,7 @@ u8 AbilityBattleEffects(u8 caseID, u8 battler, u16 ability, u8 special, u16 move
         case ABILITY_POISON_TOUCH:
             if (!(gMoveResultFlags & MOVE_RESULT_NO_EFFECT)
              && gBattleMons[gBattlerTarget].hp != 0
-             && !gProtectStructs[gBattlerTarget].confusionSelfDmg
+             && !gProtectStructs[gBattlerAttacker].confusionSelfDmg
              && CanBePoisoned(gBattlerTarget)
              && IsMoveMakingContact(move, gBattlerAttacker)
              && (Random() % 3) == 0)


### PR DESCRIPTION
## Description
I think I brought this up at some point inside the Discord server, but it was never fixed.

## **Discord contact info**
Lunos#4026