### PR TITLE
[battle_debug] fix charbase overflow

### DIFF
--- a/src/battle_debug.c
+++ b/src/battle_debug.c
@@ -559,7 +559,7 @@ static const struct BgTemplate sBgTemplates[] =
    },
    {
        .bg = 1,
-       .charBaseIndex = 10,
+       .charBaseIndex = 2,
        .mapBaseIndex = 20,
        .screenSize = 0,
        .paletteMode = 0,


### PR DESCRIPTION
Fixes rh-hideout/pokeemerald-expansion#1825

## Description
Sets init value to 2 which is inferred anyways due to the overflow

## **Discord contact info**
Karathan#1337