### PR TITLE
Gave a holdEffectParam to the Adamant, Lustrous and Griseous Orbs

### DIFF
--- a/src/data/items.h
+++ b/src/data/items.h
@@ -5327,6 +5327,9 @@ const struct Item gItems[] =
         .name = _("Adamant Orb"),
         .itemId = ITEM_ADAMANT_ORB,
         .price = 0,
+        #if defined(BATTLE_ENGINE)
+            .holdEffectParam = 20,
+        #endif
         .holdEffect = HOLD_EFFECT_ADAMANT_ORB,
         .description = sAdamantOrbDesc,
         .pocket = POCKET_ITEMS,
@@ -5339,6 +5342,9 @@ const struct Item gItems[] =
         .name = _("Lustrous Orb"),
         .itemId = ITEM_LUSTROUS_ORB,
         .price = 0,
+        #if defined(BATTLE_ENGINE)
+            .holdEffectParam = 20,
+        #endif
         .holdEffect = HOLD_EFFECT_LUSTROUS_ORB,
         .description = sLustrousOrbDesc,
         .pocket = POCKET_ITEMS,
@@ -5351,6 +5357,9 @@ const struct Item gItems[] =
         .name = _("Griseous Orb"),
         .itemId = ITEM_GRISEOUS_ORB,
         .price = 0,
+        #if defined(BATTLE_ENGINE)
+            .holdEffectParam = 20,
+        #endif
         .holdEffect = HOLD_EFFECT_GRISEOUS_ORB,
         .description = sGriseousOrbDesc,
         .pocket = POCKET_ITEMS,


### PR DESCRIPTION
## Description
To calculate the amount of power they boost, the battle_engine branch makes use of their `holdEffectParam`, as it can be seen in the `CalcMoveBasePowerAfterModifiers` function.
However, they don't have a `holdEffectParam` set, which means that a Dialga, Palkia or Giratina holding them won't see any benefits at all.
This PR corrects that.

## **Discord contact info**
Lunos#4026