### PR TITLE
Fixed the offensive boost (Gen. 3-6 specifically) of the Soul Dew

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -8091,7 +8091,7 @@ static u32 CalcMoveBasePowerAfterModifiers(u16 move, u8 battlerAtk, u8 battlerDe
         #if B_SOUL_DEW_BOOST >= GEN_7
         if ((gBattleMons[battlerAtk].species == SPECIES_LATIAS || gBattleMons[battlerAtk].species == SPECIES_LATIOS) && (moveType == TYPE_PSYCHIC || moveType == TYPE_DRAGON))
         #else
-        if ((gBattleMons[battlerAtk].species == SPECIES_LATIAS || gBattleMons[battlerAtk].species == SPECIES_LATIOS) && !(gBattleTypeFlags & BATTLE_TYPE_FRONTIER))
+        if ((gBattleMons[battlerAtk].species == SPECIES_LATIAS || gBattleMons[battlerAtk].species == SPECIES_LATIOS) && !(gBattleTypeFlags & BATTLE_TYPE_FRONTIER) && IS_MOVE_SPECIAL(move))
         #endif
             MulModifier(&modifier, holdEffectModifier);
         break;


### PR DESCRIPTION
## Description
Kleneexfeu brought up the Soul Dew's effect in Pret's Discord, and I instantly remembered that I forgot to ensure that the offensive side of its Gen. 3-6 effect only applies to special based moves.
The defensive side already handles it thanks to `!usesDefStat`.

## **Discord contact info**
Lunos#4026