### PR TITLE
Fixed a small buffer overflow in AI_CV_Recycle_ItemsToEncourage

### DIFF
--- a/data/battle_ai_scripts.s
+++ b/data/battle_ai_scripts.s
@@ -2409,9 +2409,9 @@ AI_CV_Recycle_End:
 	end
 
 AI_CV_Recycle_ItemsToEncourage:
-    .byte ITEM_CHESTO_BERRY
-    .byte ITEM_LUM_BERRY
-    .byte ITEM_STARF_BERRY
+    .2byte ITEM_CHESTO_BERRY
+    .2byte ITEM_LUM_BERRY
+    .2byte ITEM_STARF_BERRY
     .byte -1
 
 AI_CV_Revenge:


### PR DESCRIPTION
## Description
There's a battle script that checks for some items using `.byte`, but after the recent revamp in the item_expansion, those items are placed well beyond the limits of a byte, causing a buffer overflow.
This PR fixes that, for the people who may use the IE without using the BE.

## **Discord contact info**
Lunos#4026