### PR TITLE
Fix Contrary Animation

### DIFF
--- a/include/constants/battle_script_commands.h
+++ b/include/constants/battle_script_commands.h
@@ -225,6 +225,7 @@
 // Cmd_statbuffchange
 #define STAT_BUFF_ALLOW_PTR                 (1 << 0)   // If set, allow use of jumpptr. Set in every use of statbuffchange
 #define STAT_BUFF_NOT_PROTECT_AFFECTED      (1 << 5)
+#define STAT_BUFF_UPDATE_MOVE_EFFECT        (1 << 6)
 
 // stat change flags for Cmd_playstatchangeanimation
 #define STAT_CHANGE_NEGATIVE             (1 << 0)

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -4673,6 +4673,7 @@ static void Cmd_playanimation(void)
         return;
     }
     #endif
+
     if (animId == B_ANIM_STATS_CHANGE
         || animId == B_ANIM_SNATCH_MOVE
         || animId == B_ANIM_MEGA_EVOLUTION

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -4659,7 +4659,7 @@ static void Cmd_endselectionscript(void)
 
 static void Cmd_playanimation(void)
 {
-    u16* argumentPtr;
+    const u16* argumentPtr;
     u8 animId = gBattlescriptCurrInstr[2];
 
     gActiveBattler = GetBattlerForBattleScript(gBattlescriptCurrInstr[1]);

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -4720,9 +4720,6 @@ static void Cmd_playanimation(void)
     }
     #endif
     
-    //if (animId == B_ANIM_STATS_CHANGE && GetBattlerAbility(gActiveBattler) == ABILITY_CONTRARY)
-        //ReverseStatAnimId(argumentPtr);
-
     if (animId == B_ANIM_STATS_CHANGE
         || animId == B_ANIM_SNATCH_MOVE
         || animId == B_ANIM_MEGA_EVOLUTION

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -4673,7 +4673,6 @@ static void Cmd_playanimation(void)
         return;
     }
     #endif
-    
     if (animId == B_ANIM_STATS_CHANGE
         || animId == B_ANIM_SNATCH_MOVE
         || animId == B_ANIM_MEGA_EVOLUTION

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -10034,7 +10034,6 @@ static u32 ChangeStatBuffs(s8 statValue, u32 statId, u32 flags, const u8 *BS_ptr
                 statValue = -1;
             else if (gBattleMons[gActiveBattler].statStages[statId] == 2 && statValue < -2)
                 statValue = -2;
-            
             gBattleTextBuff2[0] = B_BUFF_PLACEHOLDER_BEGIN;
             index = 1;
             if (statValue == -2)

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -3071,7 +3071,7 @@ void SetMoveEffect(bool32 primary, u32 certain)
                 if (NoAliveMonsForEitherParty()
                   || ChangeStatBuffs(SET_STAT_BUFF_VALUE(1),
                                     gBattleScripting.moveEffect - MOVE_EFFECT_ATK_PLUS_1 + 1,
-                                    affectsUser, 0))
+                                    affectsUser | STAT_BUFF_UPDATE_MOVE_EFFECT, 0))
                 {
                     gBattlescriptCurrInstr++;
                 }
@@ -3096,7 +3096,7 @@ void SetMoveEffect(bool32 primary, u32 certain)
             
                 if (ChangeStatBuffs(SET_STAT_BUFF_VALUE(1) | STAT_BUFF_NEGATIVE,
                   gBattleScripting.moveEffect - MOVE_EFFECT_ATK_MINUS_1 + 1,
-                  flags, gBattlescriptCurrInstr + 1))
+                  flags | STAT_BUFF_UPDATE_MOVE_EFFECT, gBattlescriptCurrInstr + 1))
                 {
                     if (!mirrorArmorReflected)
                         gBattlescriptCurrInstr++;
@@ -3119,7 +3119,7 @@ void SetMoveEffect(bool32 primary, u32 certain)
                 if (NoAliveMonsForEitherParty()
                   || ChangeStatBuffs(SET_STAT_BUFF_VALUE(2),
                                     gBattleScripting.moveEffect - MOVE_EFFECT_ATK_PLUS_2 + 1,
-                                    affectsUser, 0))
+                                    affectsUser | STAT_BUFF_UPDATE_MOVE_EFFECT, 0))
                 {
                     gBattlescriptCurrInstr++;
                 }
@@ -3143,7 +3143,7 @@ void SetMoveEffect(bool32 primary, u32 certain)
                     flags |= STAT_BUFF_ALLOW_PTR;
                 if (ChangeStatBuffs(SET_STAT_BUFF_VALUE(2) | STAT_BUFF_NEGATIVE,
                                     gBattleScripting.moveEffect - MOVE_EFFECT_ATK_MINUS_2 + 1,
-                                    flags, gBattlescriptCurrInstr + 1))
+                                    flags | STAT_BUFF_UPDATE_MOVE_EFFECT, gBattlescriptCurrInstr + 1))
                 {
                     if (!mirrorArmorReflected)
                         gBattlescriptCurrInstr++;
@@ -4657,9 +4657,55 @@ static void Cmd_endselectionscript(void)
     *(gBattlerAttacker + gBattleStruct->selectionScriptFinished) = TRUE;
 }
 
+static u32 ReverseStatAnimId(u16 *argumentPtr)
+{
+    u8 value = 0;
+    switch (GET_STAT_BUFF_VALUE_WITH_SIGN(gBattleScripting.statChanger))
+    {
+    case SET_STAT_BUFF_VALUE(1): // +1
+        value = STAT_ANIM_MINUS1;
+        break;
+    case SET_STAT_BUFF_VALUE(2): // +2
+        value = STAT_ANIM_MINUS2;
+        break;
+    case SET_STAT_BUFF_VALUE(3): // +3
+        value = STAT_ANIM_MINUS2;
+        break;
+    case SET_STAT_BUFF_VALUE(4): // +4
+        value = STAT_ANIM_MINUS2;
+        break;
+    case SET_STAT_BUFF_VALUE(5): // +5
+        value = STAT_ANIM_MINUS2;
+        break;
+    case SET_STAT_BUFF_VALUE(6): // +6
+        value = STAT_ANIM_MINUS2;
+        break;
+    case SET_STAT_BUFF_VALUE(1) | STAT_BUFF_NEGATIVE: // -1
+        value = STAT_ANIM_PLUS1;
+        break;
+    case SET_STAT_BUFF_VALUE(2) | STAT_BUFF_NEGATIVE: // -2
+        value = STAT_ANIM_PLUS2;
+        break;
+    case SET_STAT_BUFF_VALUE(3) | STAT_BUFF_NEGATIVE: // -3
+        value = STAT_ANIM_PLUS2;
+        break;
+    case SET_STAT_BUFF_VALUE(4) | STAT_BUFF_NEGATIVE: // -1
+        value = STAT_ANIM_PLUS2;
+        break;
+    case SET_STAT_BUFF_VALUE(5) | STAT_BUFF_NEGATIVE: // -2
+        value = STAT_ANIM_PLUS2;
+        break;
+    case SET_STAT_BUFF_VALUE(6) | STAT_BUFF_NEGATIVE: // -3
+        value = STAT_ANIM_PLUS2;
+        break;
+    }
+    
+    *argumentPtr = GET_STAT_BUFF_ID(gBattleScripting.statChanger) + value - 1;
+}
+
 static void Cmd_playanimation(void)
 {
-    const u16* argumentPtr;
+    u16* argumentPtr;
     u8 animId = gBattlescriptCurrInstr[2];
 
     gActiveBattler = GetBattlerForBattleScript(gBattlescriptCurrInstr[1]);
@@ -4673,6 +4719,9 @@ static void Cmd_playanimation(void)
         return;
     }
     #endif
+    
+    //if (animId == B_ANIM_STATS_CHANGE && GetBattlerAbility(gActiveBattler) == ABILITY_CONTRARY)
+        //ReverseStatAnimId(argumentPtr);
 
     if (animId == B_ANIM_STATS_CHANGE
         || animId == B_ANIM_SNATCH_MOVE
@@ -9815,6 +9864,72 @@ static void Cmd_setdrainedhp(void)
     gBattlescriptCurrInstr++;
 }
 
+static u16 ReverseStatChangeMoveEffect(u16 moveEffect)
+{
+    switch (moveEffect)
+    {
+    // +1
+    case MOVE_EFFECT_ATK_PLUS_1:
+        return MOVE_EFFECT_ATK_MINUS_1;
+    case MOVE_EFFECT_DEF_PLUS_1:
+        return MOVE_EFFECT_DEF_MINUS_1;
+    case MOVE_EFFECT_SPD_PLUS_1:
+        return MOVE_EFFECT_SPD_MINUS_1;
+    case MOVE_EFFECT_SP_ATK_PLUS_1:
+        return MOVE_EFFECT_SP_ATK_MINUS_1;
+    case MOVE_EFFECT_SP_DEF_PLUS_1:
+        return MOVE_EFFECT_SP_DEF_MINUS_1;
+    case MOVE_EFFECT_ACC_PLUS_1:
+        return MOVE_EFFECT_ACC_MINUS_1;
+    case MOVE_EFFECT_EVS_PLUS_1:
+        return MOVE_EFFECT_EVS_MINUS_1;
+    // -1
+    case MOVE_EFFECT_ATK_MINUS_1:
+        return MOVE_EFFECT_ATK_PLUS_1;
+    case MOVE_EFFECT_DEF_MINUS_1:
+        return MOVE_EFFECT_DEF_PLUS_1;
+    case MOVE_EFFECT_SPD_MINUS_1:
+        return MOVE_EFFECT_SPD_PLUS_1;
+    case MOVE_EFFECT_SP_ATK_MINUS_1:
+        return MOVE_EFFECT_SP_ATK_PLUS_1;
+    case MOVE_EFFECT_SP_DEF_MINUS_1:
+        return MOVE_EFFECT_SP_DEF_PLUS_1;
+    case MOVE_EFFECT_ACC_MINUS_1:
+        return MOVE_EFFECT_ACC_PLUS_1;
+    case MOVE_EFFECT_EVS_MINUS_1:
+    // +2
+    case MOVE_EFFECT_ATK_PLUS_2:
+        return MOVE_EFFECT_ATK_MINUS_2;
+    case MOVE_EFFECT_DEF_PLUS_2:
+        return MOVE_EFFECT_DEF_MINUS_2;
+    case MOVE_EFFECT_SPD_PLUS_2:
+        return MOVE_EFFECT_SPD_MINUS_2;
+    case MOVE_EFFECT_SP_ATK_PLUS_2:
+        return MOVE_EFFECT_SP_ATK_MINUS_2;
+    case MOVE_EFFECT_SP_DEF_PLUS_2:
+        return MOVE_EFFECT_SP_DEF_MINUS_2;
+    case MOVE_EFFECT_ACC_PLUS_2:
+        return MOVE_EFFECT_ACC_MINUS_2;
+    case MOVE_EFFECT_EVS_PLUS_2:
+        return MOVE_EFFECT_EVS_MINUS_2;
+    // -2
+    case MOVE_EFFECT_ATK_MINUS_2:
+        return MOVE_EFFECT_ATK_PLUS_2;
+    case MOVE_EFFECT_DEF_MINUS_2:
+        return MOVE_EFFECT_DEF_PLUS_2;
+    case MOVE_EFFECT_SPD_MINUS_2:
+        return MOVE_EFFECT_SPD_PLUS_2;
+    case MOVE_EFFECT_SP_ATK_MINUS_2:
+        return MOVE_EFFECT_SP_ATK_PLUS_2;
+    case MOVE_EFFECT_SP_DEF_MINUS_2:
+        return MOVE_EFFECT_SP_DEF_PLUS_2;
+    case MOVE_EFFECT_ACC_MINUS_2:
+        return MOVE_EFFECT_ACC_PLUS_2;
+    case MOVE_EFFECT_EVS_MINUS_2:
+        return MOVE_EFFECT_EVS_PLUS_2;
+    }
+}
+
 static u32 ChangeStatBuffs(s8 statValue, u32 statId, u32 flags, const u8 *BS_ptr)
 {
     bool32 certain = FALSE;
@@ -9843,6 +9958,11 @@ static u32 ChangeStatBuffs(s8 statValue, u32 statId, u32 flags, const u8 *BS_ptr
     {
         statValue ^= STAT_BUFF_NEGATIVE;
         gBattleScripting.statChanger ^= STAT_BUFF_NEGATIVE;
+        if (flags & STAT_BUFF_UPDATE_MOVE_EFFECT)
+        {
+            flags &= ~(STAT_BUFF_UPDATE_MOVE_EFFECT);
+            gBattleScripting.moveEffect = ReverseStatChangeMoveEffect(gBattleScripting.moveEffect);
+        }
     }
     else if (GetBattlerAbility(gActiveBattler) == ABILITY_SIMPLE)
     {
@@ -9963,6 +10083,7 @@ static u32 ChangeStatBuffs(s8 statValue, u32 statId, u32 flags, const u8 *BS_ptr
                 statValue = -1;
             else if (gBattleMons[gActiveBattler].statStages[statId] == 2 && statValue < -2)
                 statValue = -2;
+            
             gBattleTextBuff2[0] = B_BUFF_PLACEHOLDER_BEGIN;
             index = 1;
             if (statValue == -2)

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -4657,52 +4657,6 @@ static void Cmd_endselectionscript(void)
     *(gBattlerAttacker + gBattleStruct->selectionScriptFinished) = TRUE;
 }
 
-static u32 ReverseStatAnimId(u16 *argumentPtr)
-{
-    u8 value = 0;
-    switch (GET_STAT_BUFF_VALUE_WITH_SIGN(gBattleScripting.statChanger))
-    {
-    case SET_STAT_BUFF_VALUE(1): // +1
-        value = STAT_ANIM_MINUS1;
-        break;
-    case SET_STAT_BUFF_VALUE(2): // +2
-        value = STAT_ANIM_MINUS2;
-        break;
-    case SET_STAT_BUFF_VALUE(3): // +3
-        value = STAT_ANIM_MINUS2;
-        break;
-    case SET_STAT_BUFF_VALUE(4): // +4
-        value = STAT_ANIM_MINUS2;
-        break;
-    case SET_STAT_BUFF_VALUE(5): // +5
-        value = STAT_ANIM_MINUS2;
-        break;
-    case SET_STAT_BUFF_VALUE(6): // +6
-        value = STAT_ANIM_MINUS2;
-        break;
-    case SET_STAT_BUFF_VALUE(1) | STAT_BUFF_NEGATIVE: // -1
-        value = STAT_ANIM_PLUS1;
-        break;
-    case SET_STAT_BUFF_VALUE(2) | STAT_BUFF_NEGATIVE: // -2
-        value = STAT_ANIM_PLUS2;
-        break;
-    case SET_STAT_BUFF_VALUE(3) | STAT_BUFF_NEGATIVE: // -3
-        value = STAT_ANIM_PLUS2;
-        break;
-    case SET_STAT_BUFF_VALUE(4) | STAT_BUFF_NEGATIVE: // -1
-        value = STAT_ANIM_PLUS2;
-        break;
-    case SET_STAT_BUFF_VALUE(5) | STAT_BUFF_NEGATIVE: // -2
-        value = STAT_ANIM_PLUS2;
-        break;
-    case SET_STAT_BUFF_VALUE(6) | STAT_BUFF_NEGATIVE: // -3
-        value = STAT_ANIM_PLUS2;
-        break;
-    }
-    
-    *argumentPtr = GET_STAT_BUFF_ID(gBattleScripting.statChanger) + value - 1;
-}
-
 static void Cmd_playanimation(void)
 {
     u16* argumentPtr;


### PR DESCRIPTION
All of the `MOVE_EFFECT_<stat>_<up/down>_x` effects were not showing the proper stat up/down animation when used by/on a battler with contrary. Addresses #1783 

Treecko has Contrary:
![contraryfix](https://user-images.githubusercontent.com/41651341/141512020-34726ba8-cfb4-4fb9-acf7-27f61d2d69b7.gif)

It isn't the prettiest solution, but it works