### PR TITLE
Mega evolution may change order

### DIFF
--- a/include/constants/battle_config.h
+++ b/include/constants/battle_config.h
@@ -93,7 +93,7 @@
 #endif
 
 // Mega Evolution settings
-#define B_MEGA_INFO_CHANGE_ORDER    GEN_7 // In gen6, mega evolving doesn't change the turn order the turn you mega evolve. This is fixed in gen 7
+#define B_MEGA_EVO_CHANGE_ORDER    GEN_7 // In gen6, mega evolving doesn't change the turn order the turn you mega evolve. This is fixed in gen 7
 
 // Calculation settings
 #define B_CRIT_CHANCE               GEN_7 // Chances of a critical hit landing. See CalcCritChanceStage.

--- a/include/constants/battle_config.h
+++ b/include/constants/battle_config.h
@@ -92,6 +92,9 @@
     #define GEN_8 5
 #endif
 
+// Mega Evolution settings
+#define B_MEGA_INFO_CHANGE_ORDER    GEN_7 // In gen6, mega evolving doesn't change the turn order the turn you mega evolve. This is fixed in gen 7
+
 // Calculation settings
 #define B_CRIT_CHANCE               GEN_7 // Chances of a critical hit landing. See CalcCritChanceStage.
 #define B_CRIT_MULTIPLIER           GEN_7 // In Gen6+, critical hits multiply damage by 1.5 instead of 2.

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4688,7 +4688,7 @@ static void CheckMegaEvolutionBeforeTurn(void)
             }
         }
     }
-    if (B_MEGA_EVO_CHANGE_ORDER = GEN_6)
+    if (B_MEGA_EVO_CHANGE_ORDER <= GEN_6)
     {
         gBattleMainFunc = CheckQuickClaw_CustapBerryActivation;
         gBattleStruct->quickClawBattlerId = 0;

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -104,6 +104,7 @@ static void RunTurnActionsFunctions(void);
 static void SetActionsAndBattlersTurnOrder(void);
 static void sub_803CDF8(void);
 static bool8 AllAtActionConfirmed(void);
+static void CheckIfTurnOrderMustChangeAfterMega(void)
 static void CheckFocusPunch_ClearVarsBeforeTurnStarts(void);
 static void CheckMegaEvolutionBeforeTurn(void);
 static void CheckQuickClaw_CustapBerryActivation(void);
@@ -4688,6 +4689,29 @@ static void CheckMegaEvolutionBeforeTurn(void)
         }
     }
 
+    gBattleMainFunc = CheckIfTurnOrderMustChangeAfterMega;
+}
+
+static void CheckIfTurnOrderMustChangeAfterMega(void)
+{
+    for (i = 0; i < gBattlersCount - 1; i++)
+    {
+        for (j = i + 1; j < gBattlersCount; j++)
+        {
+            u8 battler1 = gBattlerByTurnOrder[i];
+            u8 battler2 = gBattlerByTurnOrder[j];
+            if (gActionsByTurnOrder[i] != B_ACTION_USE_ITEM
+                && gActionsByTurnOrder[j] != B_ACTION_USE_ITEM
+                && gActionsByTurnOrder[i] != B_ACTION_SWITCH
+                && gActionsByTurnOrder[j] != B_ACTION_SWITCH
+                && gActionsByTurnOrder[i] != B_ACTION_THROW_BALL
+                && gActionsByTurnOrder[j] != B_ACTION_THROW_BALL)
+            {
+                if (GetWhoStrikesFirst(battler1, battler2, FALSE))
+                    SwapTurnOrder(i, j);
+            }
+        }
+    }
     gBattleMainFunc = CheckFocusPunch_ClearVarsBeforeTurnStarts;
     gBattleStruct->focusPunchBattlerId = 0;
 }

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4688,8 +4688,7 @@ static void CheckMegaEvolutionBeforeTurn(void)
             }
         }
     }
-
-    gBattleMainFunc = CheckIfTurnOrderMustChangeAfterMega;
+    gBattleMainFunc = CheckIfTurnOrderMustChangeAfterMega; // This will just do nothing is no mon mega evolve
 }
 
 static void CheckIfTurnOrderMustChangeAfterMega(void)

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4718,8 +4718,8 @@ static void TryChangeTurnOrder(void)
                 if (GetWhoStrikesFirst(battler1, battler2, FALSE))
                     SwapTurnOrder(i, j);
             }
-        }
-    }
+	}
+     }
     gBattleMainFunc = CheckFocusPunch_ClearVarsBeforeTurnStarts;
     gBattleStruct->focusPunchBattlerId = 0;
 }

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4695,7 +4695,7 @@ static void CheckMegaEvolutionBeforeTurn(void)
     }
     else
     {
-        gBattleMainFunc = CheckIfTurnOrderMustChangeAfterMega; // This will just do nothing if no mon has mega evolved
+        gBattleMainFunc = TryChangeTurnOrder; // This will just do nothing if no mon has mega evolved
     }
 }
 

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4699,6 +4699,7 @@ static void CheckMegaEvolutionBeforeTurn(void)
     }
 }
 
+// In gen7, priority and speed is recalculated during the turn in which a pokemon mega evolve
 static void TryChangeTurnOrder(void)
 {
     for (i = 0; i < gBattlersCount - 1; i++)

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4690,8 +4690,8 @@ static void CheckMegaEvolutionBeforeTurn(void)
     }
     if (B_MEGA_EVO_CHANGE_ORDER <= GEN_6)
     {
-        gBattleMainFunc = CheckQuickClaw_CustapBerryActivation;
-        gBattleStruct->quickClawBattlerId = 0;
+        gBattleMainFunc = CheckFocusPunch_ClearVarsBeforeTurnStarts;
+        gBattleStruct->focusPunchBattlerId = 0;
     }
     else
     {

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4695,7 +4695,7 @@ static void CheckMegaEvolutionBeforeTurn(void)
     }
     else
     {
-        gBattleMainFunc = CheckIfTurnOrderMustChangeAfterMega; // This will just do nothing is no mon mega evolve
+        gBattleMainFunc = CheckIfTurnOrderMustChangeAfterMega; // This will just do nothing if no mon has mega evolved
     }
 }
 

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4702,6 +4702,7 @@ static void CheckMegaEvolutionBeforeTurn(void)
 // In gen7, priority and speed is recalculated during the turn in which a pokemon mega evolve
 static void TryChangeTurnOrder(void)
 {
+    s32 i, j;
     for (i = 0; i < gBattlersCount - 1; i++)
     {
         for (j = i + 1; j < gBattlersCount; j++)

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4688,15 +4688,12 @@ static void CheckMegaEvolutionBeforeTurn(void)
             }
         }
     }
-    if (B_MEGA_EVO_CHANGE_ORDER <= GEN_6)
-    {
+    #if B_MEGA_EVO_CHANGE_ORDER <= GEN_6
         gBattleMainFunc = CheckFocusPunch_ClearVarsBeforeTurnStarts;
         gBattleStruct->focusPunchBattlerId = 0;
-    }
-    else
-    {
+    #else
         gBattleMainFunc = TryChangeTurnOrder; // This will just do nothing if no mon has mega evolved
-    }
+    #endif  
 }
 
 // In gen7, priority and speed is recalculated during the turn in which a pokemon mega evolve

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -104,7 +104,7 @@ static void RunTurnActionsFunctions(void);
 static void SetActionsAndBattlersTurnOrder(void);
 static void sub_803CDF8(void);
 static bool8 AllAtActionConfirmed(void);
-static void CheckIfTurnOrderMustChangeAfterMega(void)
+static void TryChangeTurnOrder(void);
 static void CheckFocusPunch_ClearVarsBeforeTurnStarts(void);
 static void CheckMegaEvolutionBeforeTurn(void);
 static void CheckQuickClaw_CustapBerryActivation(void);
@@ -4688,10 +4688,18 @@ static void CheckMegaEvolutionBeforeTurn(void)
             }
         }
     }
-    gBattleMainFunc = CheckIfTurnOrderMustChangeAfterMega; // This will just do nothing is no mon mega evolve
+    if (B_MEGA_EVO_CHANGE_ORDER = GEN_6)
+    {
+        gBattleMainFunc = CheckQuickClaw_CustapBerryActivation;
+        gBattleStruct->quickClawBattlerId = 0;
+    }
+    else
+    {
+        gBattleMainFunc = CheckIfTurnOrderMustChangeAfterMega; // This will just do nothing is no mon mega evolve
+    }
 }
 
-static void CheckIfTurnOrderMustChangeAfterMega(void)
+static void TryChangeTurnOrder(void)
 {
     for (i = 0; i < gBattlersCount - 1; i++)
     {


### PR DESCRIPTION
https://github.com/rh-hideout/pokeemerald-expansion/issues/535 raises a problem with mega evolution.
This PR should solve it.

EDIT: After several tests, this works the intended way. However, it may be interesting ti include other turn order calculation in this PR. For example:
-Weather is sandstorm, double battle, start of a turn
-Cacturn' sand rush is active
-One mon switches-out/another switches in, with drizzle
-Drizzle is triggered, sand rush shouldn't be considered this turn, but with the current system it is, because an action during the battle phase changed the turn order, but it wasn't recalculated.

Same logic can be applied with tailwind used in double battles, and possibly other scenari I haven't thought about.

This is a change brought in gen 8. Should this be done in another PR?