### PR TITLE
Mega Evolution alters turn order

### DIFF
--- a/include/constants/battle_config.h
+++ b/include/constants/battle_config.h
@@ -92,6 +92,11 @@
     #define GEN_8 5
 #endif
 
+
+// Mega Evolution settings
+#define B_MEGA_EVO_ALTER_TURN_ORDER GEN_7 // In gen6, mega evolving doesn't change the turn order when mega evolving occurs. This is fixed in gen 7
+
+
 // Calculation settings
 #define B_CRIT_CHANCE               GEN_7 // Chances of a critical hit landing. See CalcCritChanceStage.
 #define B_CRIT_MULTIPLIER           GEN_7 // In Gen6+, critical hits multiply damage by 1.5 instead of 2.

--- a/include/constants/battle_config.h
+++ b/include/constants/battle_config.h
@@ -92,10 +92,8 @@
     #define GEN_8 5
 #endif
 
-
 // Mega Evolution settings
 #define B_MEGA_EVO_TURN_ORDER GEN_7 // In Gen7, a Pokémon's Speed after Mega Evolution is used to determine turn order, not its Speed before.
-
 
 // Calculation settings
 #define B_CRIT_CHANCE               GEN_7 // Chances of a critical hit landing. See CalcCritChanceStage.

--- a/include/constants/battle_config.h
+++ b/include/constants/battle_config.h
@@ -94,7 +94,7 @@
 
 
 // Mega Evolution settings
-#define B_MEGA_EVO_ALTER_TURN_ORDER GEN_7 // In gen6, mega evolving doesn't change the turn order when mega evolving occurs. This is fixed in gen 7
+#define B_MEGA_EVO_TURN_ORDER GEN_7 // In Gen7, a Pokémon's Speed after Mega Evolution is used to determine turn order, not its Speed before.
 
 
 // Calculation settings

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4707,12 +4707,8 @@ static void TryChangeTurnOrder(void)
         {
             u8 battler1 = gBattlerByTurnOrder[i];
             u8 battler2 = gBattlerByTurnOrder[j];
-            if (gActionsByTurnOrder[i] != B_ACTION_USE_ITEM
-                && gActionsByTurnOrder[j] != B_ACTION_USE_ITEM
-                && gActionsByTurnOrder[i] != B_ACTION_SWITCH
-                && gActionsByTurnOrder[j] != B_ACTION_SWITCH
-                && gActionsByTurnOrder[i] != B_ACTION_THROW_BALL
-                && gActionsByTurnOrder[j] != B_ACTION_THROW_BALL)
+            if (gActionsByTurnOrder[i] = B_ACTION_USE_MOVE
+                && gActionsByTurnOrder[j] = B_ACTION_USE_MOVE)
             {
                 if (GetWhoStrikesFirst(battler1, battler2, FALSE))
                     SwapTurnOrder(i, j);

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4707,8 +4707,8 @@ static void TryChangeTurnOrder(void)
         {
             u8 battler1 = gBattlerByTurnOrder[i];
             u8 battler2 = gBattlerByTurnOrder[j];
-            if (gActionsByTurnOrder[i] = B_ACTION_USE_MOVE
-                && gActionsByTurnOrder[j] = B_ACTION_USE_MOVE)
+            if (gActionsByTurnOrder[i] == B_ACTION_USE_MOVE
+                && gActionsByTurnOrder[j] == B_ACTION_USE_MOVE)
             {
                 if (GetWhoStrikesFirst(battler1, battler2, FALSE))
                     SwapTurnOrder(i, j);

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4689,7 +4689,7 @@ static void CheckMegaEvolutionBeforeTurn(void)
         }
     }
 
-    #if B_MEGA_EVO_ALTER_TURN_ORDER <= GEN_6
+    #if B_MEGA_EVO_TURN_ORDER <= GEN_6
         gBattleMainFunc = CheckFocusPunch_ClearVarsBeforeTurnStarts;
         gBattleStruct->focusPunchBattlerId = 0;
     #else

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4717,8 +4717,8 @@ static void TryChangeTurnOrder(void)
                 if (GetWhoStrikesFirst(battler1, battler2, FALSE))
                     SwapTurnOrder(i, j);
             }
-	}
-     }
+        }
+    }
     gBattleMainFunc = CheckFocusPunch_ClearVarsBeforeTurnStarts;
     gBattleStruct->focusPunchBattlerId = 0;
 }

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -104,6 +104,7 @@ static void RunTurnActionsFunctions(void);
 static void SetActionsAndBattlersTurnOrder(void);
 static void sub_803CDF8(void);
 static bool8 AllAtActionConfirmed(void);
+static void TryChangeTurnOrder(void);
 static void CheckFocusPunch_ClearVarsBeforeTurnStarts(void);
 static void CheckMegaEvolutionBeforeTurn(void);
 static void CheckQuickClaw_CustapBerryActivation(void);
@@ -4688,9 +4689,40 @@ static void CheckMegaEvolutionBeforeTurn(void)
         }
     }
 
+    #if B_MEGA_EVO_ALTER_TURN_ORDER <= GEN_6
+        gBattleMainFunc = CheckFocusPunch_ClearVarsBeforeTurnStarts;
+        gBattleStruct->focusPunchBattlerId = 0;
+    #else
+        gBattleMainFunc = TryChangeTurnOrder; // This will just do nothing if no mon has mega evolved
+    #endif  
+}
+
+// In gen7, priority and speed are recalculated during the turn in which a pokemon mega evolves
+static void TryChangeTurnOrder(void)
+{
+    s32 i, j;
+    for (i = 0; i < gBattlersCount - 1; i++)
+    {
+        for (j = i + 1; j < gBattlersCount; j++)
+        {
+            u8 battler1 = gBattlerByTurnOrder[i];
+            u8 battler2 = gBattlerByTurnOrder[j];
+            if (gActionsByTurnOrder[i] != B_ACTION_USE_ITEM
+                && gActionsByTurnOrder[j] != B_ACTION_USE_ITEM
+                && gActionsByTurnOrder[i] != B_ACTION_SWITCH
+                && gActionsByTurnOrder[j] != B_ACTION_SWITCH
+                && gActionsByTurnOrder[i] != B_ACTION_THROW_BALL
+                && gActionsByTurnOrder[j] != B_ACTION_THROW_BALL)
+            {
+                if (GetWhoStrikesFirst(battler1, battler2, FALSE))
+                    SwapTurnOrder(i, j);
+            }
+	}
+     }
     gBattleMainFunc = CheckFocusPunch_ClearVarsBeforeTurnStarts;
     gBattleStruct->focusPunchBattlerId = 0;
 }
+
 
 static void CheckFocusPunch_ClearVarsBeforeTurnStarts(void)
 {


### PR DESCRIPTION
As the name suggests, after mega evolving, the turn order will be recalculated, as in genVII. Meaning a pokémon gaining/loosing prankster on the turn it mega evolves will actually have an effect if it uses a status move.
Same thing with speed boosting abilities or simply the speed being changed upon mega evolving.