### PR TITLE
Fix Brick Break

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -13120,7 +13120,8 @@ static void Cmd_removelightscreenreflect(void) // brick break
     bool32 failed;
     
     #if B_BRICK_BREAK >= GEN_4
-        side = GetBattlerSide(gBattlerAttacker);
+    // From Gen 4 onwards, Brick Break can remove screens on the user's side if used on an ally
+        side = GetBattlerSide(gBattlerTarget);
     #else
         side = GetBattlerSide(gBattlerAttacker) ^ BIT_SIDE;
     #endif


### PR DESCRIPTION
Gen 4+ Brick Break should remove screens on the target's side, not the attacker's (unless they're on the same side).

## **Discord contact info**
Buffel Saft#2205