### PR TITLE
revert ai item usage code

### DIFF
--- a/include/battle_ai_main.h
+++ b/include/battle_ai_main.h
@@ -3,10 +3,9 @@
 
 // return values for BattleAI_ChooseMoveOrAction
 // 0 - 3 are move idx
-#define AI_CHOICE_FLEE      4
-#define AI_CHOICE_WATCH     5
-#define AI_CHOICE_SWITCH    7
-#define AI_CHOICE_USE_ITEM  8
+#define AI_CHOICE_FLEE 4
+#define AI_CHOICE_WATCH 5
+#define AI_CHOICE_SWITCH 7
 
 #define RETURN_SCORE_PLUS(val)      \
 {                                   \

--- a/include/battle_ai_switch_items.h
+++ b/include/battle_ai_switch_items.h
@@ -32,7 +32,7 @@ enum {
 };
 
 void GetAIPartyIndexes(u32 battlerId, s32 *firstId, s32 *lastId);
-u8 AI_TrySwitchOrUseItem(u8 currAction);
+void AI_TrySwitchOrUseItem(void);
 u8 GetMostSuitableMonToSwitchInto(void);
 bool32 ShouldSwitch(void);
 

--- a/include/battle_main.h
+++ b/include/battle_main.h
@@ -21,8 +21,6 @@ struct UnknownPokemonStruct4
     /*0x1D*/ u8 language;
 };
 
-struct ChooseMoveStruct;
-
 #define TYPE_NAME_LENGTH 6
 #define ABILITY_NAME_LENGTH 12
 
@@ -72,7 +70,6 @@ void RunBattleScriptCommands(void);
 bool8 TryRunFromBattle(u8 battlerId);
 void SpecialStatusesClear(void);
 void SetTypeBeforeUsingMove(u16 move, u8 battlerAtk);
-void FillChooseMoveStruct(struct ChooseMoveStruct *moveInfo);
 
 extern struct UnknownPokemonStruct4 gMultiPartnerParty[MULTI_PARTY_SIZE];
 

--- a/src/battle_controller_opponent.c
+++ b/src/battle_controller_opponent.c
@@ -1545,70 +1545,7 @@ static void OpponentHandlePrintSelectionString(void)
 
 static void OpponentHandleChooseAction(void)
 {
-    if (gBattleTypeFlags & BATTLE_TYPE_PALACE)
-    {
-        BtlController_EmitTwoReturnValues(1, B_ACTION_USE_MOVE, ChooseMoveAndTargetInBattlePalace());
-    }
-    else
-    {
-        u8 chosenMoveId;
-        struct ChooseMoveStruct moveInfo;
-
-        FillChooseMoveStruct(&moveInfo);        
-        if (gBattleTypeFlags & (BATTLE_TYPE_TRAINER | BATTLE_TYPE_FIRST_BATTLE | BATTLE_TYPE_SAFARI | BATTLE_TYPE_ROAMER))
-        {
-            BattleAI_SetupAIData(0xF);
-            chosenMoveId = BattleAI_ChooseMoveOrAction();
-            switch (chosenMoveId)
-            {
-            case AI_CHOICE_USE_ITEM:
-                BtlController_EmitTwoReturnValues(1, B_ACTION_USE_ITEM, 0);
-                break;
-            case AI_CHOICE_SWITCH:
-                BtlController_EmitTwoReturnValues(1, B_ACTION_SWITCH, 0);
-                break;
-            case AI_CHOICE_WATCH:
-                BtlController_EmitTwoReturnValues(1, B_ACTION_SAFARI_WATCH_CAREFULLY, 0);
-                break;
-            case AI_CHOICE_FLEE:
-                BtlController_EmitTwoReturnValues(1, B_ACTION_RUN, 0);
-                break;
-            default:
-                if (gBattleMoves[moveInfo.moves[chosenMoveId]].target & (MOVE_TARGET_USER_OR_SELECTED | MOVE_TARGET_USER))
-                    gBattlerTarget = gActiveBattler;
-                if (gBattleMoves[moveInfo.moves[chosenMoveId]].target & MOVE_TARGET_BOTH)
-                {
-                    gBattlerTarget = GetBattlerAtPosition(B_POSITION_PLAYER_LEFT);
-                    if (gAbsentBattlerFlags & gBitTable[gBattlerTarget])
-                        gBattlerTarget = GetBattlerAtPosition(B_POSITION_PLAYER_RIGHT);
-                }
-                
-                if (CanMegaEvolve(gActiveBattler)) { // If opponent can mega evolve, do it.
-                    BtlController_EmitTwoReturnValues(1, B_ACTION_USE_MOVE, (chosenMoveId) | (RET_MEGA_EVOLUTION) | (gBattlerTarget << 8));
-                } else {
-                    BtlController_EmitTwoReturnValues(1, B_ACTION_USE_MOVE, (chosenMoveId) | (gBattlerTarget << 8));
-                }
-                break;
-            }
-        }
-        else    // Wild pokemon - use random move
-        {
-            u16 move;
-            do
-            {
-                chosenMoveId = Random() & 3;
-                move = moveInfo.moves[chosenMoveId];
-            } while (move == MOVE_NONE);
-
-            if (gBattleMoves[move].target & (MOVE_TARGET_USER_OR_SELECTED | MOVE_TARGET_USER))
-                BtlController_EmitTwoReturnValues(1, B_ACTION_USE_MOVE, (chosenMoveId) | (gActiveBattler << 8));
-            else if (gBattleTypeFlags & BATTLE_TYPE_DOUBLE)
-                BtlController_EmitTwoReturnValues(1, B_ACTION_USE_MOVE, (chosenMoveId) | (GetBattlerAtPosition(Random() & 2) << 8));
-            else
-                BtlController_EmitTwoReturnValues(1, B_ACTION_USE_MOVE, (chosenMoveId) | (GetBattlerAtPosition(B_POSITION_PLAYER_LEFT) << 8));
-        }
-    }
-    
+    AI_TrySwitchOrUseItem();    // TODO consider move choice first
     OpponentBufferExecCompleted();
 }
 
@@ -1619,9 +1556,74 @@ static void OpponentHandleYesNoBox(void)
 
 static void OpponentHandleChooseMove(void)
 {
-    u8 *bufferB = gBattleResources->bufferB[gActiveBattler];
-    BtlController_EmitTwoReturnValues(1, 10, bufferB[2] | (bufferB[3] << 8));
-    OpponentBufferExecCompleted();
+    if (gBattleTypeFlags & BATTLE_TYPE_PALACE)
+    {
+        BtlController_EmitTwoReturnValues(1, 10, ChooseMoveAndTargetInBattlePalace());
+        OpponentBufferExecCompleted();
+    }
+    else
+    {
+        u8 chosenMoveId;
+        struct ChooseMoveStruct *moveInfo = (struct ChooseMoveStruct*)(&gBattleResources->bufferA[gActiveBattler][4]);
+        
+        if (gBattleTypeFlags & (BATTLE_TYPE_TRAINER | BATTLE_TYPE_FIRST_BATTLE | BATTLE_TYPE_SAFARI | BATTLE_TYPE_ROAMER))
+        {
+            BattleAI_SetupAIData(0xF);
+            chosenMoveId = BattleAI_ChooseMoveOrAction();
+            
+            switch (chosenMoveId)
+            {
+            case AI_CHOICE_WATCH:
+                BtlController_EmitTwoReturnValues(1, B_ACTION_SAFARI_WATCH_CAREFULLY, 0);
+                break;
+            case AI_CHOICE_FLEE:
+                BtlController_EmitTwoReturnValues(1, B_ACTION_RUN, 0);
+                break;
+            case AI_CHOICE_SWITCH:
+                BtlController_EmitTwoReturnValues(1, 10, 0xFFFF);
+                break;
+            case 6:
+                BtlController_EmitTwoReturnValues(1, 15, gBattlerTarget);
+                break;
+            default:
+                if (gBattleMoves[moveInfo->moves[chosenMoveId]].target & (MOVE_TARGET_USER_OR_SELECTED | MOVE_TARGET_USER))
+                    gBattlerTarget = gActiveBattler;
+                if (gBattleMoves[moveInfo->moves[chosenMoveId]].target & MOVE_TARGET_BOTH)
+                {
+                    gBattlerTarget = GetBattlerAtPosition(B_POSITION_PLAYER_LEFT);
+                    if (gAbsentBattlerFlags & gBitTable[gBattlerTarget])
+                        gBattlerTarget = GetBattlerAtPosition(B_POSITION_PLAYER_RIGHT);
+                }
+                
+                // If opponent can mega evolve, do it.
+                if (CanMegaEvolve(gActiveBattler))
+                    BtlController_EmitTwoReturnValues(1, 10, (chosenMoveId) | (RET_MEGA_EVOLUTION) | (gBattlerTarget << 8));
+                else
+                    BtlController_EmitTwoReturnValues(1, 10, (chosenMoveId) | (gBattlerTarget << 8));
+                break;
+            }
+            
+            OpponentBufferExecCompleted();
+        }
+        else // Wild pokemon - use random move
+        {
+            u16 move;
+            do
+            {
+                chosenMoveId = Random() & 3;
+                move = moveInfo->moves[chosenMoveId];
+            } while (move == MOVE_NONE);
+
+            if (gBattleMoves[move].target & (MOVE_TARGET_USER_OR_SELECTED | MOVE_TARGET_USER))
+                BtlController_EmitTwoReturnValues(1, 10, (chosenMoveId) | (gActiveBattler << 8));
+            else if (gBattleTypeFlags & BATTLE_TYPE_DOUBLE)
+                BtlController_EmitTwoReturnValues(1, 10, (chosenMoveId) | (GetBattlerAtPosition(Random() & 2) << 8));
+            else
+                BtlController_EmitTwoReturnValues(1, 10, (chosenMoveId) | (GetBattlerAtPosition(B_POSITION_PLAYER_LEFT) << 8));
+
+            OpponentBufferExecCompleted();
+        }
+    }
 }
 
 static void OpponentHandleChooseItem(void)

--- a/src/battle_controller_player_partner.c
+++ b/src/battle_controller_player_partner.c
@@ -1509,37 +1509,7 @@ static void PlayerPartnerHandlePrintSelectionString(void)
 
 static void PlayerPartnerHandleChooseAction(void)
 {
-    u8 chosenMoveId;
-    struct ChooseMoveStruct *moveInfo = (struct ChooseMoveStruct*)(&gBattleResources->bufferA[gActiveBattler][4]);
-
-    BattleAI_SetupAIData(0xF);
-    chosenMoveId = BattleAI_ChooseMoveOrAction();
-
-    switch (chosenMoveId)
-    {
-    case AI_CHOICE_USE_ITEM:
-        BtlController_EmitTwoReturnValues(1, B_ACTION_USE_ITEM, 0);
-        break;
-    case AI_CHOICE_SWITCH:
-        BtlController_EmitTwoReturnValues(1, B_ACTION_SWITCH, 0);
-        break;
-    default:
-        if (gBattleMoves[moveInfo->moves[chosenMoveId]].target & (MOVE_TARGET_USER | MOVE_TARGET_USER_OR_SELECTED))
-            gBattlerTarget = gActiveBattler;
-        if (gBattleMoves[moveInfo->moves[chosenMoveId]].target & MOVE_TARGET_BOTH)
-        {
-            gBattlerTarget = GetBattlerAtPosition(B_POSITION_OPPONENT_LEFT);
-            if (gAbsentBattlerFlags & gBitTable[gBattlerTarget])
-                gBattlerTarget = GetBattlerAtPosition(B_POSITION_OPPONENT_RIGHT);
-        }
-
-        if (CanMegaEvolve(gActiveBattler)) // If partner can mega evolve, do it.
-            BtlController_EmitTwoReturnValues(1, B_ACTION_USE_MOVE, (chosenMoveId) | (RET_MEGA_EVOLUTION) | (gBattlerTarget << 8));
-        else
-            BtlController_EmitTwoReturnValues(1, B_ACTION_USE_MOVE, (chosenMoveId) | (gBattlerTarget << 8));
-        break;
-    }
-    
+    AI_TrySwitchOrUseItem();
     PlayerPartnerBufferExecCompleted();
 }
 
@@ -1550,6 +1520,26 @@ static void PlayerPartnerHandleYesNoBox(void)
 
 static void PlayerPartnerHandleChooseMove(void)
 {
+    u8 chosenMoveId;
+    struct ChooseMoveStruct *moveInfo = (struct ChooseMoveStruct*)(&gBattleResources->bufferA[gActiveBattler][4]);
+
+    BattleAI_SetupAIData(0xF);
+    chosenMoveId = BattleAI_ChooseMoveOrAction();
+
+    if (gBattleMoves[moveInfo->moves[chosenMoveId]].target & (MOVE_TARGET_USER | MOVE_TARGET_USER_OR_SELECTED))
+        gBattlerTarget = gActiveBattler;
+    if (gBattleMoves[moveInfo->moves[chosenMoveId]].target & MOVE_TARGET_BOTH)
+    {
+        gBattlerTarget = GetBattlerAtPosition(B_POSITION_OPPONENT_LEFT);
+        if (gAbsentBattlerFlags & gBitTable[gBattlerTarget])
+            gBattlerTarget = GetBattlerAtPosition(B_POSITION_OPPONENT_RIGHT);
+    }
+
+    if (CanMegaEvolve(gActiveBattler)) // If partner can mega evolve, do it.
+        BtlController_EmitTwoReturnValues(1, 10, (chosenMoveId) | (RET_MEGA_EVOLUTION) | (gBattlerTarget << 8));
+    else
+        BtlController_EmitTwoReturnValues(1, 10, (chosenMoveId) | (gBattlerTarget << 8));
+    
     PlayerPartnerBufferExecCompleted();
 }
 

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3877,7 +3877,22 @@ static void HandleTurnActionSelectionState(void)
                     {
                         struct ChooseMoveStruct moveInfo;
 
-                        FillChooseMoveStruct(&moveInfo);
+                        moveInfo.mega = gBattleStruct->mega;
+                        moveInfo.species = gBattleMons[gActiveBattler].species;
+                        moveInfo.monType1 = gBattleMons[gActiveBattler].type1;
+                        moveInfo.monType2 = gBattleMons[gActiveBattler].type2;
+                        moveInfo.monType3 = gBattleMons[gActiveBattler].type3;
+
+                        for (i = 0; i < MAX_MON_MOVES; i++)
+                        {
+                            moveInfo.moves[i] = gBattleMons[gActiveBattler].moves[i];
+                            moveInfo.currentPp[i] = gBattleMons[gActiveBattler].pp[i];
+                            moveInfo.maxPp[i] = CalculatePPWithBonus(
+                                                            gBattleMons[gActiveBattler].moves[i],
+                                                            gBattleMons[gActiveBattler].ppBonuses,
+                                                            i);
+                        }
+                        
                         BtlController_EmitChooseMove(0, (gBattleTypeFlags & BATTLE_TYPE_DOUBLE) != 0, FALSE, &moveInfo);
                         MarkBattlerForControllerExec(gActiveBattler);
                     }
@@ -5300,26 +5315,5 @@ void SetTotemBoost(void)
             gTotemBoosts[battlerId].statChanges[i] = *(&gSpecialVar_0x8001 + i);
             gTotemBoosts[battlerId].stats |= 0x80;  // used as a flag for the "totem flared to life" script
         }
-    }
-}
-
-void FillChooseMoveStruct(struct ChooseMoveStruct * moveInfo)
-{
-    int i;
-
-    moveInfo->mega = gBattleStruct->mega;
-    moveInfo->species = gBattleMons[gActiveBattler].species;
-    moveInfo->monType1 = gBattleMons[gActiveBattler].type1;
-    moveInfo->monType2 = gBattleMons[gActiveBattler].type2;
-    moveInfo->monType3 = gBattleMons[gActiveBattler].type3;
-
-    for (i = 0; i < MAX_MON_MOVES; i++)
-    {
-        moveInfo->moves[i] = gBattleMons[gActiveBattler].moves[i];
-        moveInfo->currentPp[i] = gBattleMons[gActiveBattler].pp[i];
-        moveInfo->maxPp[i] = CalculatePPWithBonus(
-                                        gBattleMons[gActiveBattler].moves[i],
-                                        gBattleMons[gActiveBattler].ppBonuses,
-                                        i);
     }
 }


### PR DESCRIPTION
Addresses #1953 by removing the AI's consideration of its chosen move during `ShouldUseItem`

I could not reproduce the bugs reported in #1953 prior to the changes so this PR is experimental.