### PR TITLE
[battle_engine] fix multi hit/stormdrain-like interactions

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -8072,7 +8072,8 @@ BattleScript_MoveStatDrain::
 	printstring STRINGID_TARGETABILITYSTATRAISE
 	waitmessage B_WAIT_TIME_LONG
 	clearsemiinvulnerablebit
-	tryfaintmon BS_ATTACKER, FALSE, NULL
+	tryfaintmon BS_ATTACKER, FALSE, NULL @ this should be removed, unless I'm missing something
+	orhalfword gMoveResultFlags, MOVE_RESULT_DOESNT_AFFECT_FOE
 	goto BattleScript_MoveEnd
 
 BattleScript_MonMadeMoveUseless_PPLoss::
@@ -8083,7 +8084,7 @@ BattleScript_MonMadeMoveUseless::
 	call BattleScript_AbilityPopUp
 	printstring STRINGID_PKMNSXMADEYUSELESS
 	waitmessage B_WAIT_TIME_LONG
-	tryfaintmon BS_ATTACKER, FALSE, NULL
+	tryfaintmon BS_ATTACKER, FALSE, NULL @ this should be removed, unless I'm missing something
 	orhalfword gMoveResultFlags, MOVE_RESULT_DOESNT_AFFECT_FOE
 	goto BattleScript_MoveEnd
 
@@ -8095,7 +8096,8 @@ BattleScript_FlashFireBoost::
 	call BattleScript_AbilityPopUp
 	printfromtable gFlashFireStringIds
 	waitmessage B_WAIT_TIME_LONG
-	tryfaintmon BS_ATTACKER, FALSE, NULL
+	tryfaintmon BS_ATTACKER, FALSE, NULL @ this should be removed, unless I'm missing something
+	orhalfword gMoveResultFlags, MOVE_RESULT_DOESNT_AFFECT_FOE
 	goto BattleScript_MoveEnd
 
 BattleScript_AbilityPreventsPhasingOut::

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -8057,6 +8057,7 @@ BattleScript_MoveHPDrain::
 	datahpupdate BS_TARGET
 	printstring STRINGID_PKMNRESTOREDHPUSING
 	waitmessage B_WAIT_TIME_LONG
+	tryfaintmon BS_ATTACKER, FALSE, NULL @ necessary for moves that faint the user and could change type (galvanized explosion..)
 	orhalfword gMoveResultFlags, MOVE_RESULT_DOESNT_AFFECT_FOE
 	goto BattleScript_MoveEnd
 
@@ -8072,7 +8073,7 @@ BattleScript_MoveStatDrain::
 	printstring STRINGID_TARGETABILITYSTATRAISE
 	waitmessage B_WAIT_TIME_LONG
 	clearsemiinvulnerablebit
-	tryfaintmon BS_ATTACKER, FALSE, NULL @ this should be removed, unless I'm missing something
+	tryfaintmon BS_ATTACKER, FALSE, NULL @ necessary for moves that faint the user and could change type (galvanized explosion..)
 	orhalfword gMoveResultFlags, MOVE_RESULT_DOESNT_AFFECT_FOE
 	goto BattleScript_MoveEnd
 
@@ -8084,7 +8085,7 @@ BattleScript_MonMadeMoveUseless::
 	call BattleScript_AbilityPopUp
 	printstring STRINGID_PKMNSXMADEYUSELESS
 	waitmessage B_WAIT_TIME_LONG
-	tryfaintmon BS_ATTACKER, FALSE, NULL @ this should be removed, unless I'm missing something
+	tryfaintmon BS_ATTACKER, FALSE, NULL @ necessary for moves that faint the user and could change type (galvanized explosion..)
 	orhalfword gMoveResultFlags, MOVE_RESULT_DOESNT_AFFECT_FOE
 	goto BattleScript_MoveEnd
 
@@ -8096,7 +8097,7 @@ BattleScript_FlashFireBoost::
 	call BattleScript_AbilityPopUp
 	printfromtable gFlashFireStringIds
 	waitmessage B_WAIT_TIME_LONG
-	tryfaintmon BS_ATTACKER, FALSE, NULL @ this should be removed, unless I'm missing something
+	tryfaintmon BS_ATTACKER, FALSE, NULL @ necessary for moves that faint the user and could change type (galvanized explosion..)
 	orhalfword gMoveResultFlags, MOVE_RESULT_DOESNT_AFFECT_FOE
 	goto BattleScript_MoveEnd
 


### PR DESCRIPTION
To avoid hits passed the first one to go through storm drain (and possibly flash fire), I added the orhalfword used in water absorb battlescript.
I added comments on the lines that I think should be deleted because I don't see what purpose they serve. Following a water absorb or storm drain-like activation, the user cannot faint since rocky helmet, life orb and friends wouldn't activate. Any input is welcome :)
EDIT: doesn't fix scenario like galvanized explosion being blocked by volt absorb or motor drive in double. After volt absorb is activated, no other target will take damage. This is a bug from the battle engine, I'll see if I can fix it in this PR.