### PR TITLE
Refactor CanThrowLastUsedBall and related functions

### DIFF
--- a/include/item_use.h
+++ b/include/item_use.h
@@ -35,10 +35,10 @@ u8 CanUseDigOrEscapeRopeOnCurMap(void);
 u8 CheckIfItemIsTMHMOrEvolutionStone(u16 itemId);
 
 enum {
-    BALL_FAIL_TWO_PRESENT_MONS,
-    BALL_FAIL_NO_ROOM,
-    BALL_FAIL_SEMI_INVULNERABLE,
-    BALL_SUCCESS,
+    BALL_THROW_UNABLE_TWO_MONS,
+    BALL_THROW_UNABLE_NO_ROOM,
+    BALL_THROW_UNABLE_SEMI_INVULNERABLE,
+    BALL_THROW_ABLE,
 };
 
 bool32 CanThrowBall(void);

--- a/include/item_use.h
+++ b/include/item_use.h
@@ -33,6 +33,14 @@ void ItemUseInBattle_EnigmaBerry(u8);
 void Task_UseDigEscapeRopeOnField(u8 taskId);
 u8 CanUseDigOrEscapeRopeOnCurMap(void);
 u8 CheckIfItemIsTMHMOrEvolutionStone(u16 itemId);
-u32 CanThrowBall(void);
+
+enum {
+    BALL_FAIL_TWO_PRESENT_MONS,
+    BALL_FAIL_NO_ROOM,
+    BALL_FAIL_SEMI_INVULNERABLE,
+    BALL_SUCCESS,
+};
+
+bool32 CanThrowBall(void);
 
 #endif // GUARD_ITEM_USE_H

--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -3276,19 +3276,23 @@ static const struct SpriteSheet sSpriteSheet_LastUsedBallWindow =
 
 bool32 CanThrowLastUsedBall(void)
 {
-    #if B_LAST_USED_BALL == FALSE
+#if B_LAST_USED_BALL == FALSE
+    return FALSE;
+#else
+    if (!CanThrowBall())
         return FALSE;
-    #else
-        return (!(CanThrowBall() != 0
-         || (gBattleTypeFlags & BATTLE_TYPE_TRAINER)
-         || !CheckBagHasItem(gLastThrownBall, 1)));
-     #endif
-}
+    if (gBattleTypeFlags & BATTLE_TYPE_TRAINER)
+        return FALSE;
+    if (!CheckBagHasItem(gLastThrownBall, 1))
+        return FALSE;
 
+    return TRUE;
+#endif
+}
 
 void TryAddLastUsedBallItemSprites(void)
 {
-    #if B_LAST_USED_BALL == TRUE
+#if B_LAST_USED_BALL == TRUE
     if (gLastThrownBall == 0
       || (gLastThrownBall != 0 && !CheckBagHasItem(gLastThrownBall, 1)))
     {
@@ -3297,10 +3301,8 @@ void TryAddLastUsedBallItemSprites(void)
         CompactItemsInBagPocket(&gBagPockets[BALLS_POCKET]);
         gLastThrownBall = gBagPockets[BALLS_POCKET].itemSlots[0].itemId;
     }
-    
-    if (CanThrowBall() != 0
-     || (gBattleTypeFlags & BATTLE_TYPE_TRAINER)
-     || !CheckBagHasItem(gLastThrownBall, 1))
+
+    if (!CanThrowLastUsedBall())
         return;
 
     // ball
@@ -3321,11 +3323,11 @@ void TryAddLastUsedBallItemSprites(void)
     if (gBattleStruct->ballSpriteIds[1] == MAX_SPRITES)
     {
         gBattleStruct->ballSpriteIds[1] = CreateSprite(&sSpriteTemplate_LastUsedBallWindow,
-           LAST_BALL_WIN_X_0,
-           LAST_USED_WIN_Y, 5);
+                                                       LAST_BALL_WIN_X_0,
+                                                       LAST_USED_WIN_Y, 5);
         gSprites[gBattleStruct->ballSpriteIds[0]].sHide = FALSE;   // restore
     }
-    #endif
+#endif
 }
 
 static void DestroyLastUsedBallWinGfx(struct Sprite *sprite)
@@ -3380,7 +3382,7 @@ static void SpriteCB_LastUsedBall(struct Sprite *sprite)
 
 static void TryHideOrRestoreLastUsedBall(u8 caseId)
 {
-    #if B_LAST_USED_BALL == TRUE
+#if B_LAST_USED_BALL == TRUE
     if (gBattleStruct->ballSpriteIds[0] == MAX_SPRITES)
         return;
 
@@ -3399,23 +3401,22 @@ static void TryHideOrRestoreLastUsedBall(u8 caseId)
             gSprites[gBattleStruct->ballSpriteIds[1]].sHide = FALSE;   // restore
         break;
     }
-    #endif
+#endif
 }
 
 void TryHideLastUsedBall(void)
 {
-    #if B_LAST_USED_BALL == TRUE
+#if B_LAST_USED_BALL == TRUE
     TryHideOrRestoreLastUsedBall(0);
-    #endif
+#endif
 }
 
 void TryRestoreLastUsedBall(void)
 {
-    #if B_LAST_USED_BALL == TRUE
+#if B_LAST_USED_BALL == TRUE
     if (gBattleStruct->ballSpriteIds[0] != MAX_SPRITES)
         TryHideOrRestoreLastUsedBall(1);
     else
         TryAddLastUsedBallItemSprites();
-    #endif
+#endif
 }
-

--- a/src/item_use.c
+++ b/src/item_use.c
@@ -936,33 +936,33 @@ void ItemUseOutOfBattle_EvolutionStone(u8 taskId)
     SetUpItemUseCallback(taskId);
 }
 
-static u32 GetBallThrowFailState(void)
+static u32 GetBallThrowableState(void)
 {
     if (IsBattlerAlive(GetBattlerAtPosition(B_POSITION_OPPONENT_LEFT))
         && IsBattlerAlive(GetBattlerAtPosition(B_POSITION_OPPONENT_RIGHT)))
-        return BALL_FAIL_TWO_PRESENT_MONS;
+        return BALL_THROW_UNABLE_TWO_MONS;
     else if (IsPlayerPartyAndPokemonStorageFull() == TRUE)
-        return BALL_FAIL_NO_ROOM;
+        return BALL_THROW_UNABLE_NO_ROOM;
 #if B_SEMI_INVULNERABLE_CATCH >= GEN_4
     else if (gStatuses3[GetCatchingBattler()] & STATUS3_SEMI_INVULNERABLE)
-        return BALL_FAIL_SEMI_INVULNERABLE;
+        return BALL_THROW_UNABLE_SEMI_INVULNERABLE;
 #endif
 
-    return BALL_SUCCESS;
+    return BALL_THROW_ABLE;
 }
 
 bool32 CanThrowBall(void)
 {
-    return (GetBallThrowFailState() == BALL_SUCCESS);
+    return (GetBallThrowableState() == BALL_THROW_ABLE);
 }
 
 static const u8 sText_CantThrowPokeBall_TwoMons[] = _("Cannot throw a ball!\nThere are two Pokémon out there!\p");
 static const u8 sText_CantThrowPokeBall_SemiInvulnerable[] = _("Cannot throw a ball!\nThere's no Pokémon in sight!\p");
 void ItemUseInBattle_PokeBall(u8 taskId)
 {
-    switch (GetBallThrowFailState())
+    switch (GetBallThrowableState())
     {
-    case BALL_SUCCESS:
+    case BALL_THROW_ABLE:
     default:
         RemoveBagItem(gSpecialVar_ItemId, 1);
         if (!InBattlePyramid())
@@ -970,20 +970,20 @@ void ItemUseInBattle_PokeBall(u8 taskId)
         else
             CloseBattlePyramidBag(taskId);
         break;
-    case BALL_FAIL_TWO_PRESENT_MONS:
+    case BALL_THROW_UNABLE_TWO_MONS:
         if (!InBattlePyramid())
             DisplayItemMessage(taskId, 1, sText_CantThrowPokeBall_TwoMons, CloseItemMessage);
         else
             DisplayItemMessageInBattlePyramid(taskId, sText_CantThrowPokeBall_TwoMons, Task_CloseBattlePyramidBagMessage);
         break;
-    case BALL_FAIL_NO_ROOM:
+    case BALL_THROW_UNABLE_NO_ROOM:
         if (!InBattlePyramid())
             DisplayItemMessage(taskId, 1, gText_BoxFull, CloseItemMessage);
         else
             DisplayItemMessageInBattlePyramid(taskId, gText_BoxFull, Task_CloseBattlePyramidBagMessage);
         break;
     #if B_SEMI_INVULNERABLE_CATCH >= GEN_4
-    case BALL_FAIL_SEMI_INVULNERABLE:
+    case BALL_THROW_UNABLE_SEMI_INVULNERABLE:
         if (!InBattlePyramid())
             DisplayItemMessage(taskId, 1, sText_CantThrowPokeBall_SemiInvulnerable, CloseItemMessage);
         else


### PR DESCRIPTION
## Description
This PR clarifies some confusing semantics particularly with `CanThrowBall` previously returning `0` for success, and removes a redundant repetition of `CanThrowLastUsedBall`'s logic later on in `TryAddLastUsedBallItemSprites`.

## **Discord contact info**
Spherical Ice#4683