### PR TITLE
Change `EGG_MOVES_ARRAY_COUNT` to 19 to include all added egg moves

### DIFF
--- a/include/constants/daycare.h
+++ b/include/constants/daycare.h
@@ -21,7 +21,7 @@
 #define DAYCARE_EXITED_LEVEL_MENU 2 // would be redundant with above if GF had used the same value
 
 // Array buffers
-#define EGG_MOVES_ARRAY_COUNT           10
+#define EGG_MOVES_ARRAY_COUNT           19
 #define EGG_LVL_UP_MOVES_ARRAY_COUNT    (MAX_LEVEL_UP_MOVES > 50 ? MAX_LEVEL_UP_MOVES : 50)
 
 #endif //GUARD_DAYCARE_CONSTANTS_H


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changes `EGG_MOVES_ARRAY_COUNT` to 19 to actually include all the added egg moves in `u16 gEggMoves[]` and let them be learned e.g. at the daycare.
The max value seems to be 19 with Buneary using it (checked by AsparagusEduardo#6051).

## **Discord contact info**
TheXaman#5612