### PR TITLE
Tweaked Protean's effect's InGame appearance

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -8299,6 +8299,7 @@ BattleScript_MimicryActivatesEnd3::
 	end3
 
 BattleScript_ProteanActivates::
+	pause B_WAIT_TIME_SHORTEST
 	call BattleScript_AbilityPopUp
 	printstring STRINGID_PKMNCHANGEDTYPE
 	waitmessage B_WAIT_TIME_LONG

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -1251,7 +1251,7 @@ BattleScript_EffectAromaticMistWorks:
 	setstatchanger STAT_SPDEF, 1, FALSE
 	statbuffchange STAT_BUFF_ALLOW_PTR, BattleScript_EffectAromaticMistEnd
 	jumpifbyte CMP_NOT_EQUAL, cMULTISTRING_CHOOSER, B_MSG_STAT_WONT_INCREASE, BattleScript_AromaticMistAnim
-	pause 16
+	pause B_WAIT_TIME_SHORTEST
 	printstring STRINGID_TARGETSTATWONTGOHIGHER
 	waitmessage B_WAIT_TIME_LONG
 	goto BattleScript_EffectAromaticMistEnd
@@ -7147,7 +7147,7 @@ BattleScript_EnduredMsg::
 
 BattleScript_SturdiedMsg::
 	copybyte gBattlerAbility, gBattlerTarget
-	pause 16
+	pause B_WAIT_TIME_SHORTEST
 	call BattleScript_AbilityPopUp
 	printstring STRINGID_ENDUREDSTURDY
 	waitmessage B_WAIT_TIME_LONG
@@ -8395,7 +8395,7 @@ BattleScript_WeakArmorActivates::
 	statbuffchange STAT_BUFF_ALLOW_PTR, BattleScript_WeakArmorActivatesSpeed
 	jumpifbyte CMP_LESS_THAN, cMULTISTRING_CHOOSER, B_MSG_STAT_WONT_DECREASE, BattleScript_WeakArmorDefAnim
 	jumpifbyte CMP_EQUAL, cMULTISTRING_CHOOSER, B_MSG_STAT_FELL_EMPTY, BattleScript_WeakArmorActivatesSpeed
-	pause 16
+	pause B_WAIT_TIME_SHORTEST
 	printfromtable gStatDownStringIds
 	waitmessage B_WAIT_TIME_LONG
 	goto BattleScript_WeakArmorActivatesSpeed
@@ -8409,7 +8409,7 @@ BattleScript_WeakArmorActivatesSpeed:
 	statbuffchange STAT_BUFF_ALLOW_PTR, BattleScript_WeakArmorActivatesEnd
 	jumpifbyte CMP_LESS_THAN, cMULTISTRING_CHOOSER, B_MSG_STAT_WONT_INCREASE, BattleScript_WeakArmorSpeedAnim
 	jumpifbyte CMP_EQUAL, cMULTISTRING_CHOOSER, B_MSG_STAT_ROSE_EMPTY, BattleScript_WeakArmorActivatesEnd
-	pause 16
+	pause B_WAIT_TIME_SHORTEST
 	printstring STRINGID_TARGETSTATWONTGOHIGHER
 	waitmessage B_WAIT_TIME_LONG
 	goto BattleScript_WeakArmorActivatesEnd

--- a/include/constants/battle.h
+++ b/include/constants/battle.h
@@ -396,9 +396,10 @@
 
 #define BATTLE_TERRAIN_COUNT            22
 
-#define B_WAIT_TIME_LONG  64
-#define B_WAIT_TIME_MED   48
-#define B_WAIT_TIME_SHORT 32
+#define B_WAIT_TIME_LONG     64
+#define B_WAIT_TIME_MED      48
+#define B_WAIT_TIME_SHORT    32
+#define B_WAIT_TIME_SHORTEST 16
 
 #define CHERRIM_OVERCAST  0
 #define CHERRIM_SUNSHINE  1

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1428,6 +1428,8 @@ static void Cmd_attackcanceler(void)
         SET_BATTLER_TYPE(gBattlerAttacker, moveType);
         gBattlerAbility = gBattlerAttacker;
         BattleScriptPushCursor();
+        PrepareStringBattle(STRINGID_EMPTYSTRING3, gBattlerAttacker);
+        gBattleCommunication[MSG_DISPLAY] = 1;
         gBattlescriptCurrInstr = BattleScript_ProteanActivates;
         return;
     }


### PR DESCRIPTION
## Description
> I don't like how the battle moves window remains opened as the ability pop up slides though. I feel we should probably make Protean print an empty string.

Before:

https://user-images.githubusercontent.com/4485172/149034487-33e10da3-78f7-495a-9555-8615299000df.mp4

After:
![pic](https://media.discordapp.net/attachments/774393519569502268/930594995029811220/pn_11012022_1951.gif)

## **Discord contact info**
Lunos#4026