### PR TITLE
Fixed Pokémon Expansion flag name in Battle Engine

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -13375,7 +13375,7 @@ static void Cmd_handleballthrow(void)
             catchRate = gBaseStats[gBattleMons[gBattlerTarget].species].catchRate;
 
         #ifdef POKEMON_EXPANSION
-        if (gBaseStats[gBattleMons[gBattlerTarget].species].flags & F_ULTRA_BEAST)
+        if (gBaseStats[gBattleMons[gBattlerTarget].species].flags & FLAG_ULTRA_BEAST)
         {
             if (gLastUsedItem == ITEM_BEAST_BALL)
                 ballMultiplier = 50;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Missing companion PR to #2016, was causing issues while merging both PE and BE.

## **Discord contact info**
AsparagusEduardo#6051