### PR TITLE
Addressed inconsistency in behavior with Shiny mon with gender differences upon catch

### DIFF
--- a/src/pokedex.c
+++ b/src/pokedex.c
@@ -3989,10 +3989,7 @@ static void Task_DisplayCaughtMonDexPage(u8 taskId)
         gTasks[taskId].tState++;
         break;
     case 4:
-        if ((gBaseStats[dexNum].flags & FLAG_GENDER_DIFFERENCE))
-            spriteId = CreateMonPicSprite(dexNum, 0, ((u16)gTasks[taskId].tPersonalityHi << 16) | (u16)gTasks[taskId].tPersonalityLo, TRUE, MON_PAGE_X, MON_PAGE_Y, 0, TAG_NONE);
-        else
-            spriteId = CreateMonSpriteFromNationalDexNumber(dexNum, MON_PAGE_X, MON_PAGE_Y, 0);
+        spriteId = CreateMonPicSprite(dexNum, 0, ((u16)gTasks[taskId].tPersonalityHi << 16) | (u16)gTasks[taskId].tPersonalityLo, TRUE, MON_PAGE_X, MON_PAGE_Y, 0, TAG_NONE);
         gSprites[spriteId].oam.priority = 0;
         BeginNormalPaletteFade(PALETTES_ALL, 0, 0x10, 0, RGB_BLACK);
         SetVBlankCallback(gPokedexVBlankCB);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Addresses #2063.
As discussed in that issue, later gens show the dex entry upon catch with the personality of the caught mon, so to this PR applies that behavior to fix the edge case.

## **Discord contact info**
AsparagusEduardo#6051