### PR TITLE
Fixed some move descriptions

### DIFF
--- a/src/data/text/move_descriptions.h
+++ b/src/data/text/move_descriptions.h
@@ -1778,7 +1778,7 @@ static const u8 sChargeBeamDescription[] = _(
     "May raise Sp. Atk.");
 
 static const u8 sWoodHammerDescription[] = _(
-    "Slams the body into a foe\n"
+    "Slams the body into a foe.\n"
     "The user gets hurt too.");
 
 static const u8 sAquaJetDescription[] = _(
@@ -2307,7 +2307,7 @@ static const u8 sWaterShurikenDescription[] = _(
 
 static const u8 sMysticalFireDescription[] = _(
     "Breathes a special, hot\n"
-    "fire. May lower Sp. Atk.");
+    "fire. Lowers Sp. Atk.");
 
 static const u8 sSpikyShieldDescription[] = _(
     "Evades attack, and damages\n"
@@ -2763,7 +2763,7 @@ static const u8 sBehemothBladeDescription[] = _(
     "2x damage to Dynamaxed foes.");
     
 static const u8 sBehemothBashDescription[] = _(
-    "Attacks as a sheild. Deals\n"
+    "Attacks as a shield. Deals\n"
     "2x damage to Dynamaxed foes.");
     
 static const u8 sAuraWheelDescription[] = _(
@@ -3356,7 +3356,7 @@ const u8 *const gMoveDescriptionPointers[MOVES_COUNT - 1] =
     [MOVE_DRAGON_PULSE - 1] = sDragonPulseDescription,
     [MOVE_DRAGON_RUSH - 1] = sDragonRushDescription,
     [MOVE_POWER_GEM - 1] = sPowerGemDescription,
-    [MOVE_DRAIN_PUNCH - 1] = sDrainingKissDescription,
+    [MOVE_DRAIN_PUNCH - 1] = sMegaDrainDescription,
     [MOVE_VACUUM_WAVE - 1] = sVacuumWaveDescription,
     [MOVE_FOCUS_BLAST - 1] = sFocusBlastDescription,
     [MOVE_ENERGY_BALL - 1] = sEnergyBallDescription,


### PR DESCRIPTION
## Description
Quick PR that fixes a few move descriptions:
Wood Hammer - Added a dot to the first phrase
Drain Punch - Pointed to Mega Drain's description (it was pointed to Draining Kiss', but it doesn't heal 75%)
Mystical Fire - Corrected to its actual effect (before it said that may lower SpA, but always does that)
Behemoth Bash - sheild -> shield 

## **Discord contact info**
SubzeroEclipse#7867