### PR TITLE
Fix Enigma Berry check in CanMegaEvolve

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -9333,8 +9333,13 @@ bool32 CanMegaEvolve(u8 battlerId)
     {
         if (B_ENABLE_DEBUG && gBattleStruct->debugHoldEffects[battlerId])
             holdEffect = gBattleStruct->debugHoldEffects[battlerId];
+#ifdef ITEM_EXPANSION
+        else if (itemId == ITEM_ENIGMA_BERRY_E_READER)
+            holdEffect = gEnigmaBerries[battlerId].holdEffect;
+#else
         else if (itemId == ITEM_ENIGMA_BERRY)
             holdEffect = gEnigmaBerries[battlerId].holdEffect;
+#endif
         else
             holdEffect = ItemId_GetHoldEffect(itemId);
 


### PR DESCRIPTION
## Description
`CanMegaEvolve` was reading the E-Reader Ligma Berry's effect if the battler scanned by it was holding the Gen. 4+ Enigma Berry.
This PR corrects that.

## **Discord contact info**
Lunos#4026