### PR TITLE
Updated trainer slide-in array

### DIFF
--- a/src/battle_message.c
+++ b/src/battle_message.c
@@ -26,6 +26,7 @@
 #include "constants/frontier_util.h"
 #include "constants/items.h"
 #include "constants/moves.h"
+#include "constants/opponents.h"
 #include "constants/species.h"
 #include "constants/trainers.h"
 #include "constants/trainer_hill.h"
@@ -3878,7 +3879,9 @@ struct TrainerSlide
 
 static const struct TrainerSlide sTrainerSlides[] =
 {
-    {0x291, sText_AarghAlmostHadIt, sText_BoxIsFull, sText_123Poof},
+    // Put any trainer slide-in messages inside this array.
+    // Example:
+    // {TRAINER_WALLY_VR_2, sText_AarghAlmostHadIt, sText_BoxIsFull, sText_123Poof},
 };
 
 static u32 GetEnemyMonCount(bool32 onlyAlive)

--- a/src/battle_message.c
+++ b/src/battle_message.c
@@ -3879,9 +3879,15 @@ struct TrainerSlide
 
 static const struct TrainerSlide sTrainerSlides[] =
 {
-    // Put any trainer slide-in messages inside this array.
-    // Example:
-    // {TRAINER_WALLY_VR_2, sText_AarghAlmostHadIt, sText_BoxIsFull, sText_123Poof},
+    /* Put any trainer slide-in messages inside this array.
+    Example:
+    {
+        .trainerId = TRAINER_WALLY_VR_2,
+        .msgLastSwitchIn = sText_AarghAlmostHadIt,
+        .msgLastLowHp = sText_BoxIsFull,
+        .msgFirstDown = sText_123Poof,
+    },
+    */
 };
 
 static u32 GetEnemyMonCount(bool32 onlyAlive)


### PR DESCRIPTION
## Description
There isn't a reason to keep a placeholder or an example put inside the array directly.
People playing through a project created with the battle_engine and that use trainer 0x291/657 could unexpectedly come across it in their projects which isn't nice.
I also took the chance to `#include "constants/opponents.h"` so trainer constants can be used.

## **Discord contact info**
Lunos#4026