### PR TITLE
Fix potential dex pic bug

### DIFF
--- a/src/pokedex.c
+++ b/src/pokedex.c
@@ -3989,7 +3989,7 @@ static void Task_DisplayCaughtMonDexPage(u8 taskId)
         gTasks[taskId].tState++;
         break;
     case 4:
-        spriteId = CreateMonPicSprite(dexNum, 0, ((u16)gTasks[taskId].tPersonalityHi << 16) | (u16)gTasks[taskId].tPersonalityLo, TRUE, MON_PAGE_X, MON_PAGE_Y, 0, TAG_NONE);
+        spriteId = CreateMonPicSprite(NationalPokedexNumToSpecies(dexNum), 0, ((u16)gTasks[taskId].tPersonalityHi << 16) | (u16)gTasks[taskId].tPersonalityLo, TRUE, MON_PAGE_X, MON_PAGE_Y, 0, TAG_NONE);
         gSprites[spriteId].oam.priority = 0;
         BeginNormalPaletteFade(PALETTES_ALL, 0, 0x10, 0, RGB_BLACK);
         SetVBlankCallback(gPokedexVBlankCB);


### PR DESCRIPTION
A recent change to pokemon expansion replaced CreateMonSpriteFromNationalDexNumber  with CreateMonPicSprite in Task_DisplayCaughtMonDexPage.
The former asks for national dex number while the latter asks for species number.
This causes no issues unless the dex order or species order is changed. If they are changed,  the wrong sprite is created.