### PR TITLE
fixed bolt beak switch-in boost

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -8119,7 +8119,8 @@ static u16 CalcMoveBasePower(u16 move, u8 battlerAtk, u8 battlerDef)
             basePower *= 2;
         break;
     case EFFECT_BOLT_BEAK:
-        if (GetBattlerTurnOrderNum(battlerAtk) < GetBattlerTurnOrderNum(battlerDef))
+        if (GetBattlerTurnOrderNum(battlerAtk) < GetBattlerTurnOrderNum(battlerDef)
+            || gDisableStructs[battlerDef].isFirstTurn == 2)
             basePower *= 2;
         break;
     case EFFECT_ROUND:


### PR DESCRIPTION
Addresses #1968. Bolt Beak now deals double damage if the target switches in. Uses the fact that isFirstTurn is set to 2 when a switch is made (because it is decremented after the turn ends) instead of creating a new variable; doesn't seem to cause issues. Gifs showcase damage boost applying after switching out and after U-turn.

**Regular Switch-In**
![Bolt Beak Fix](https://user-images.githubusercontent.com/103095241/167073878-4b8a72bf-830c-401f-8d0c-52aa8495ddb7.gif)

**U-turn**
![Bolt Beak Fix 2](https://user-images.githubusercontent.com/103095241/167073880-e57f7ac8-300f-4e18-9cb2-5a007a9c8759.gif)

**Before Fix**
![Bolt Beak Pre-Fix](https://user-images.githubusercontent.com/103095241/167183907-6d060d6e-c6bd-466c-a949-46561b542620.gif)


## **Discord Contact Info**
Agustin#1522