### PR TITLE
Update Confuse Berry Hold Effect (Item Expansion)

### DIFF
--- a/src/data/items.h
+++ b/src/data/items.h
@@ -7037,13 +7037,22 @@ const struct Item gItems[] =
         .flingPower = 10,
     },
 
+#ifndef BATTLE_ENGINE
+    #define CONFUSE_BERRY_HEAL_FRACTION 8
+#else
+    #if B_CONFUSE_BERRIES_HEAL >= GEN_8
+        #define CONFUSE_BERRY_HEAL_FRACTION 3
+    #elseif B_CONFUSE_BERRIES_HEAL == GEN_7
+        #define CONFUSE_BERRY_HEAL_FRACTION 2
+#endif
+
     [ITEM_FIGY_BERRY] =
     {
         .name = _("Figy Berry"),
         .itemId = ITEM_FIGY_BERRY,
         .price = 20,
         .holdEffect = HOLD_EFFECT_CONFUSE_SPICY,
-        .holdEffectParam = 8,
+        .holdEffectParam = CONFUSE_BERRY_HEAL_FRACTION,
         .description = sFigyBerryDesc,
         .pocket = POCKET_BERRIES,
         .type = ITEM_USE_BAG_MENU,
@@ -7057,7 +7066,7 @@ const struct Item gItems[] =
         .itemId = ITEM_WIKI_BERRY,
         .price = 20,
         .holdEffect = HOLD_EFFECT_CONFUSE_DRY,
-        .holdEffectParam = 8,
+        .holdEffectParam = CONFUSE_BERRY_HEAL_FRACTION,
         .description = sWikiBerryDesc,
         .pocket = POCKET_BERRIES,
         .type = ITEM_USE_BAG_MENU,
@@ -7071,7 +7080,7 @@ const struct Item gItems[] =
         .itemId = ITEM_MAGO_BERRY,
         .price = 20,
         .holdEffect = HOLD_EFFECT_CONFUSE_SWEET,
-        .holdEffectParam = 8,
+        .holdEffectParam = CONFUSE_BERRY_HEAL_FRACTION,
         .description = sMagoBerryDesc,
         .pocket = POCKET_BERRIES,
         .type = ITEM_USE_BAG_MENU,
@@ -7085,7 +7094,7 @@ const struct Item gItems[] =
         .itemId = ITEM_AGUAV_BERRY,
         .price = 20,
         .holdEffect = HOLD_EFFECT_CONFUSE_BITTER,
-        .holdEffectParam = 8,
+        .holdEffectParam = CONFUSE_BERRY_HEAL_FRACTION,
         .description = sAguavBerryDesc,
         .pocket = POCKET_BERRIES,
         .type = ITEM_USE_BAG_MENU,
@@ -7099,13 +7108,15 @@ const struct Item gItems[] =
         .itemId = ITEM_IAPAPA_BERRY,
         .price = 20,
         .holdEffect = HOLD_EFFECT_CONFUSE_SOUR,
-        .holdEffectParam = 8,
+        .holdEffectParam = CONFUSE_BERRY_HEAL_FRACTION,
         .description = sIapapaBerryDesc,
         .pocket = POCKET_BERRIES,
         .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
         .flingPower = 10,
     },
+
+#undef CONFUSE_BERRY_HEAL_FRACTION
 
     [ITEM_RAZZ_BERRY] =
     {

--- a/src/data/items.h
+++ b/src/data/items.h
@@ -7039,7 +7039,7 @@ const struct Item gItems[] =
 
 #if defined(BATTLE_ENGINE) && B_CONFUSE_BERRIES_HEAL >= GEN_8
     #define CONFUSE_BERRY_HEAL_FRACTION 3
-#else if defined(BATTLE_ENGINE) && B_CONFUSE_BERRIES_HEAL == GEN_7
+#elseif defined(BATTLE_ENGINE) && B_CONFUSE_BERRIES_HEAL == GEN_7
     #define CONFUSE_BERRY_HEAL_FRACTION 2
 #else
     #define CONFUSE_BERRY_HEAL_FRACTION 8

--- a/src/data/items.h
+++ b/src/data/items.h
@@ -7037,13 +7037,12 @@ const struct Item gItems[] =
         .flingPower = 10,
     },
 
-#ifndef BATTLE_ENGINE
-    #define CONFUSE_BERRY_HEAL_FRACTION 8
+#if defined(BATTLE_ENGINE) && B_CONFUSE_BERRIES_HEAL >= GEN_8
+    #define CONFUSE_BERRY_HEAL_FRACTION 3
+#else if defined(BATTLE_ENGINE) && B_CONFUSE_BERRIES_HEAL == GEN_7
+    #define CONFUSE_BERRY_HEAL_FRACTION 2
 #else
-    #if B_CONFUSE_BERRIES_HEAL >= GEN_8
-        #define CONFUSE_BERRY_HEAL_FRACTION 3
-    #elseif B_CONFUSE_BERRIES_HEAL == GEN_7
-        #define CONFUSE_BERRY_HEAL_FRACTION 2
+    #define CONFUSE_BERRY_HEAL_FRACTION 8
 #endif
 
     [ITEM_FIGY_BERRY] =

--- a/src/data/items.h
+++ b/src/data/items.h
@@ -7039,7 +7039,7 @@ const struct Item gItems[] =
 
 #if defined(BATTLE_ENGINE) && B_CONFUSE_BERRIES_HEAL >= GEN_8
     #define CONFUSE_BERRY_HEAL_FRACTION 3
-#elseif defined(BATTLE_ENGINE) && B_CONFUSE_BERRIES_HEAL == GEN_7
+#elif defined(BATTLE_ENGINE) && B_CONFUSE_BERRIES_HEAL == GEN_7
     #define CONFUSE_BERRY_HEAL_FRACTION 2
 #else
     #define CONFUSE_BERRY_HEAL_FRACTION 8


### PR DESCRIPTION
Added a config for these behaviors:

**Generations III-VI**
A confuse Berry, when held by a Pokémon, will restore 1/8 of its HP when its HP drops to ½ or below, but causes confusion to Pokémon that dislike the its flavor.
**Generation VII**
A confuse Berry now restores ½ of the holder's HP when it drops to ¼ or below.
**Generation VIII**
The restored amount decreased to 1/3 of the holder's HP. 

Requires https://github.com/rh-hideout/pokeemerald-expansion/pull/2123 to work