### PR TITLE
Update tutor_learnsets.h

### DIFF
--- a/src/data/pokemon/tutor_learnsets.h
+++ b/src/data/pokemon/tutor_learnsets.h
@@ -37,12 +37,7 @@ const u16 gTutorMoves[] =
 
 static const u32 sTutorLearnsets[] =
 {
-    [SPECIES_NONE]          = TUTOR_LEARNSET(TUTOR(MOVE_DOUBLE_EDGE)
-                                            | TUTOR(MOVE_MEGA_KICK)
-                                            | TUTOR(MOVE_MEGA_PUNCH)
-                                            | TUTOR(MOVE_SEISMIC_TOSS)
-                                            | TUTOR(MOVE_SWORDS_DANCE)
-                                            | TUTOR(MOVE_THUNDER_WAVE)),
+    [SPECIES_NONE]          = (0),
 
     [SPECIES_BULBASAUR]     = TUTOR_LEARNSET(TUTOR(MOVE_BODY_SLAM)
                                             | TUTOR(MOVE_DEFENSE_CURL)


### PR DESCRIPTION
## Description
Around 17 months ago, a tutor learnset was given to `SPECIES_NONE`.
I don't see a reason to do this, so let's set that back to how it used to be.
Pointless changes are pointless, but it was already pointless to give a tutor learnset to a non-species in the first place.

## **Discord contact info**
Lunos#4026