### PR TITLE
prevent overwriting wild mon held items

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -6459,6 +6459,9 @@ void SetWildMonHeldItem(void)
 
         for (i = 0; i < count; i++)
         {
+            if (GetMonData(&gEnemyParty[i], MON_DATA_HELD_ITEM) != ITEM_NONE)
+                continue; // prevent ovewriting previously set item
+            
             rnd = Random() % 100;
             species = GetMonData(&gEnemyParty[i], MON_DATA_SPECIES, 0);
             if (gMapHeader.mapLayoutId == LAYOUT_ALTERING_CAVE)

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -6459,7 +6459,7 @@ void SetWildMonHeldItem(void)
 
         for (i = 0; i < count; i++)
         {
-            if (GetMonData(&gEnemyParty[i], MON_DATA_HELD_ITEM) != ITEM_NONE)
+            if (GetMonData(&gEnemyParty[i], MON_DATA_HELD_ITEM, NULL) != ITEM_NONE)
                 continue; // prevent ovewriting previously set item
             
             rnd = Random() % 100;


### PR DESCRIPTION
If a wild pokemon is a given an item through e.g. `setwildbattle`, the item will not get overwritten by `SetWildMonHeldItem`.