### PR TITLE
Triple kick power calc rework

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -8052,7 +8052,7 @@ static u16 CalcMoveBasePower(u16 move, u8 battlerAtk, u8 battlerDef)
         basePower = gBattleStruct->presentBasePower;
         break;
     case EFFECT_TRIPLE_KICK:
-        basePower += gBattleScripting.tripleKickPower;
+        basePower *= (4 - gMultiHitCounter);
         break;
     case EFFECT_SPIT_UP:
         basePower = 100 * gDisableStructs[battlerAtk].stockpileCounter;


### PR DESCRIPTION
Currently, moves that use EFFECT_TRIPLE_KICK deal too much damage. This can be fixed by just changing a "+=" to "=" in battle_util.c.
However, the battle script for this effect has some hard coded checks to find out what the base power of the move should be and utilizes a global when there is really no need to.
I decided to change it into a more flexible form that simply uses the move's base power and multiplies it based on the number of hits.