### PR TITLE
Added Castform's forms to HasTwoFramesAnimation

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -8143,7 +8143,10 @@ bool8 HasTwoFramesAnimation(u16 species)
     return (species != SPECIES_CASTFORM
          && species != SPECIES_SPINDA
          && species != SPECIES_UNOWN
-         && species != SPECIES_CHERRIM);
+         && species != SPECIES_CHERRIM
+         && species != SPECIES_CASTFORM_SUNNY
+         && species != SPECIES_CASTFORM_RAINY
+         && species != SPECIES_CASTFORM_SNOWY);
 }
 
 static bool8 ShouldSkipFriendshipChange(void)


### PR DESCRIPTION
## Description
Currently, the individual species for Castforms' forms that were added to the pokemon_expansion at some point glitch up InGame because they try to use a 2nd frame even though they lack one.
This PR fixes that by making `HasTwoFramesAnimation` filter them out. It's either that or copy-pasting a 2nd frame to each Castform form species' `anim_front.png`. This solution is probably cleaner.

## **Discord contact info**
Lunos#4026