### PR TITLE
Type effectivess related AI bugfixes

### DIFF
--- a/include/battle_ai_util.h
+++ b/include/battle_ai_util.h
@@ -85,7 +85,7 @@ s32 AI_CalcDamage(u16 move, u8 battlerAtk, u8 battlerDef);
 u8 GetMoveDamageResult(u16 move);
 u32 GetCurrDamageHpPercent(u8 battlerAtk, u8 battlerDef);
 u16 AI_GetTypeEffectiveness(u16 move, u8 battlerAtk, u8 battlerDef);
-u8 AI_GetMoveEffectiveness(u16 move, u8 battlerAtk, u8 battlerDef);
+u32 AI_GetMoveEffectiveness(u16 move, u8 battlerAtk, u8 battlerDef);
 u16 *GetMovesArray(u32 battler);
 bool32 IsConfusionMoveEffect(u16 moveEffect);
 bool32 HasMove(u32 battlerId, u32 move);

--- a/include/constants/battle_ai.h
+++ b/include/constants/battle_ai.h
@@ -15,11 +15,13 @@
 #define AI_TYPE_MOVE 4
 
 // type effectiveness
+#define AI_EFFECTIVENESS_x8     320
 #define AI_EFFECTIVENESS_x4     160
 #define AI_EFFECTIVENESS_x2     80
 #define AI_EFFECTIVENESS_x1     40
 #define AI_EFFECTIVENESS_x0_5   20
 #define AI_EFFECTIVENESS_x0_25  10
+#define AI_EFFECTIVENESS_x0_125 5
 #define AI_EFFECTIVENESS_x0     0
 
 // ai weather

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -555,7 +555,7 @@ static s16 AI_CheckBadMove(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
     s32 moveType;
     u16 moveTarget = AI_GetBattlerMoveTargetType(battlerAtk, move);
     u16 accuracy = AI_GetMoveAccuracy(battlerAtk, battlerDef, AI_DATA->atkAbility, AI_DATA->defAbility, AI_DATA->atkHoldEffect, AI_DATA->defHoldEffect, move);
-    u8 effectiveness = AI_GetMoveEffectiveness(move, battlerAtk, battlerDef);
+    u32 effectiveness = AI_GetMoveEffectiveness(move, battlerAtk, battlerDef);
     bool32 isDoubleBattle = IsValidDoubleBattle(battlerAtk);
     u32 i;
     u16 predictedMove = gLastMoves[battlerDef]; // TODO better move prediction
@@ -600,6 +600,7 @@ static s16 AI_CheckBadMove(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
         case AI_EFFECTIVENESS_x0:
             RETURN_SCORE_MINUS(20);
             break;
+        case AI_EFFECTIVENESS_x0_125:
         case AI_EFFECTIVENESS_x0_25:
             RETURN_SCORE_MINUS(10);
             break;
@@ -642,7 +643,7 @@ static s16 AI_CheckBadMove(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
                     RETURN_SCORE_MINUS(20);
                 break;
             case ABILITY_WONDER_GUARD:
-                if (effectiveness != AI_EFFECTIVENESS_x2 && effectiveness != AI_EFFECTIVENESS_x4)
+                if (effectiveness < AI_EFFECTIVENESS_x2)
                     return 0;
                 break;
             case ABILITY_SAP_SIPPER:
@@ -2524,33 +2525,17 @@ static s16 AI_TryToFaint(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
         
         switch (AI_GetMoveEffectiveness(move, battlerAtk, battlerDef))
         {
+        case AI_EFFECTIVENESS_x8:
+            score += 8;
+            break;
         case AI_EFFECTIVENESS_x4:
-            if (WEATHER_HAS_EFFECT
-             && gBattleWeather & B_WEATHER_STRONG_WINDS
-             && IS_BATTLER_OF_TYPE(battlerDef, TYPE_FLYING))
-            {
-                if (AI_RandLessThan(176)) //Consider it supereffective instead of hypereffective.
-                    score += 2;
-                else
-                    score++;
-            }
-            else
-                score += 4;
+            score += 4;
             break;
         case AI_EFFECTIVENESS_x2:
-            if (WEATHER_HAS_EFFECT
-             && gBattleWeather & B_WEATHER_STRONG_WINDS
-             && IS_BATTLER_OF_TYPE(battlerDef, TYPE_FLYING))
-            {
-                break; // Don't increase score, consider it neutral.
-            }
+            if (AI_RandLessThan(176))
+                score += 2;
             else
-            {
-                if (AI_RandLessThan(176))
-                    score += 2;
-                else
-                    score++;
-            }
+                score++;
             break;
         }
     }
@@ -2962,7 +2947,7 @@ static s16 AI_CheckViability(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
 {
     // move data
     u16 moveEffect = gBattleMoves[move].effect;
-    u8 effectiveness = AI_GetMoveEffectiveness(move, battlerAtk, battlerDef);
+    u32 effectiveness = AI_GetMoveEffectiveness(move, battlerAtk, battlerDef);
     u8 atkPriority = GetMovePriority(battlerAtk, move);
     u16 predictedMove = gLastMoves[battlerDef]; //for now
     bool32 isDoubleBattle = IsValidDoubleBattle(battlerAtk);

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -950,10 +950,9 @@ u16 AI_GetTypeEffectiveness(u16 move, u8 battlerAtk, u8 battlerDef)
     return typeEffectiveness;
 }
 
-u8 AI_GetMoveEffectiveness(u16 move, u8 battlerAtk, u8 battlerDef)
+u32 AI_GetMoveEffectiveness(u16 move, u8 battlerAtk, u8 battlerDef)
 {
-    u8 damageVar;
-    u32 effectivenessMultiplier;
+    u32 damageVar, effectivenessMultiplier;
 
     gMoveResultFlags = 0;
     gCurrentMove = move;
@@ -964,6 +963,9 @@ u8 AI_GetMoveEffectiveness(u16 move, u8 battlerAtk, u8 battlerDef)
     case UQ_4_12(0.0):
     default:
         damageVar = AI_EFFECTIVENESS_x0;
+        break;
+    case UQ_4_12(0.125):
+        damageVar = AI_EFFECTIVENESS_x0_125;
         break;
     case UQ_4_12(0.25):
         damageVar = AI_EFFECTIVENESS_x0_25;
@@ -979,6 +981,9 @@ u8 AI_GetMoveEffectiveness(u16 move, u8 battlerAtk, u8 battlerDef)
         break;
     case UQ_4_12(4.0):
         damageVar = AI_EFFECTIVENESS_x4;
+        break;
+    case UQ_4_12(8.0):
+        damageVar = AI_EFFECTIVENESS_x8;
         break;
     }
 


### PR DESCRIPTION
Adds missing AI interactions with x8 and x0.125 effectiveness attacks and removes a check for Strong Winds as that is already calculated in MulByTypeEffectiveness.