### PR TITLE
Add missing berry tree spritesheet rules

### DIFF
--- a/spritesheet_rules.mk
+++ b/spritesheet_rules.mk
@@ -596,6 +596,18 @@ $(OBJEVENTGFXDIR)/berry_trees/colbur.4bpp: %.4bpp: %.png
 $(OBJEVENTGFXDIR)/berry_trees/roseli.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -mwidth 2 -mheight 4
 
+$(OBJEVENTGFXDIR)/berry_trees/custap.4bpp: %.4bpp: %.png
+	$(GFX) $< $@ -mwidth 2 -mheight 4
+
+$(OBJEVENTGFXDIR)/berry_trees/jaboca.4bpp: %.4bpp: %.png
+	$(GFX) $< $@ -mwidth 2 -mheight 4
+
+$(OBJEVENTGFXDIR)/berry_trees/rowap.4bpp: %.4bpp: %.png
+	$(GFX) $< $@ -mwidth 2 -mheight 4
+
+$(OBJEVENTGFXDIR)/berry_trees/micle.4bpp: %.4bpp: %.png
+	$(GFX) $< $@ -mwidth 2 -mheight 4
+
 
 $(OBJEVENTGFXDIR)/misc/breakable_rock.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -mwidth 2 -mheight 2


### PR DESCRIPTION
Fixes this issue:

![image](https://user-images.githubusercontent.com/56992013/170897336-bd054039-cbdd-4687-80fb-da17ac28d4ac.png)
