### PR TITLE
IS_BATTLER_OF_TYPE ignores third type if it's Mystery

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -633,7 +633,7 @@ struct BattleStruct
 #define TARGET_TURN_DAMAGED ((gSpecialStatuses[gBattlerTarget].physicalDmg != 0 || gSpecialStatuses[gBattlerTarget].specialDmg != 0))
 #define BATTLER_DAMAGED(battlerId) ((gSpecialStatuses[battlerId].physicalDmg != 0 || gSpecialStatuses[battlerId].specialDmg != 0))
 
-#define IS_BATTLER_OF_TYPE(battlerId, type)((gBattleMons[battlerId].type1 == type || gBattleMons[battlerId].type2 == type || gBattleMons[battlerId].type3 == type))
+#define IS_BATTLER_OF_TYPE(battlerId, type)((gBattleMons[battlerId].type1 == type || gBattleMons[battlerId].type2 == type || (gBattleMons[battlerId].type3 != TYPE_MYSTERY && gBattleMons[battlerId].type3 == type)))
 #define SET_BATTLER_TYPE(battlerId, type)           \
 {                                                   \
     gBattleMons[battlerId].type1 = type;            \


### PR DESCRIPTION
Battle Engine adds a third type to BattleMons to support moves like Trick-or-Treat and sets its value to TYPE_MYSTERY for every mon that enters a battle.
Currently, the only known issue caused by this is that it makes self-inflicted damage by the confusion status receive STAB.
By making sure that a third type is ignored unless it's not Mystery, any similar problem can be prevented.