### PR TITLE
Updated the Casteliacone's name

### DIFF
--- a/src/data/items.h
+++ b/src/data/items.h
@@ -846,7 +846,7 @@ const struct Item gItems[] =
 
     [ITEM_CASTELIACONE] =
     {
-        .name = _("CasteliaCone"),
+        .name = _("Casteliacone"),
         .itemId = ITEM_CASTELIACONE,
         .price = 350,
         .description = sCasteliaconeDesc,


### PR DESCRIPTION
## Description
Current name implies the item is called "Castelia Cone", when it shouldn't. The item is called "Casteliacone" in the official games.

## **Discord contact info**
Lunos#4026