### PR TITLE
Updated Cmd_handleballthrow

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -13586,7 +13586,7 @@ static void Cmd_handleballthrow(void)
         else
             catchRate = gBaseStats[gBattleMons[gBattlerTarget].species].catchRate;
 
-        #ifdef POKEMON_EXPANSION
+        #if defined POKEMON_EXPANSION && defined ITEM_EXPANSION
         if (gBaseStats[gBattleMons[gBattlerTarget].species].flags & FLAG_ULTRA_BEAST)
         {
             if (gLastUsedItem == ITEM_BEAST_BALL)
@@ -13764,7 +13764,7 @@ static void Cmd_handleballthrow(void)
         #endif
         }
 
-        #ifdef POKEMON_EXPANSION
+        #if defined POKEMON_EXPANSION && defined ITEM_EXPANSION
         }
         #endif
 


### PR DESCRIPTION
## Description
I suppose nobody found this until now because no one other than me tried to use the BE and the PE without the IE in recent times, but currently, a branch that only contains those 2 branches cannot build due to references to `ITEM_BEAST_BALL`, an item that only exists in the item_expansion.
This PR addresses that.

## **Discord contact info**
Lunos#4026