### PR TITLE
Ghost Escape config AI fix

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -606,7 +606,7 @@ bool32 AtMaxHp(u8 battlerId)
 bool32 IsBattlerTrapped(u8 battler, bool8 checkSwitch)
 {
     u8 holdEffect = AI_DATA->holdEffects[battler];
-    if (IS_BATTLER_OF_TYPE(battler, TYPE_GHOST)
+    if ((B_GHOSTS_ESCAPE >= GEN_6 && IS_BATTLER_OF_TYPE(battler, TYPE_GHOST))
       || (checkSwitch && holdEffect == HOLD_EFFECT_SHED_SHELL)
       || (!checkSwitch && GetBattlerAbility(battler) == ABILITY_RUN_AWAY)
       || (!checkSwitch && holdEffect == HOLD_EFFECT_CAN_ALWAYS_RUN))


### PR DESCRIPTION
## Description
`IsBattlerTrapped` wasn't accounting for `B_GHOSTS_ESCAPE` config.

## **Discord contact info**
AsparagusEduardo#6051