### PR TITLE
Fixed Gen5+ multihit odds.

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -10494,19 +10494,20 @@ static void Cmd_setmultihitcounter(void)
         }
         else if (B_MULTI_HIT_CHANCE >= GEN_5)
         {
-            // 2 and 3 hits: 33.3%
-            // 4 and 5 hits: 16.7%
-            gMultiHitCounter = Random() % 4;
-            if (gMultiHitCounter > 2)
-            {
-                gMultiHitCounter = (Random() % 3);
-                if (gMultiHitCounter < 2)
-                    gMultiHitCounter = 2;
-                else
-                    gMultiHitCounter = 3;
-            }
+            // Based on Gen 5's odds
+            // 35% for 2 hits
+            // 35% for 3 hits
+            // 15% for 4 hits
+            // 15% for 5 hits
+            gMultiHitCounter = Random() % 100;
+            if (gMultiHitCounter < 35)
+                gMultiHitCounter = 2;
+            else if (gMultiHitCounter < 35 + 35)
+                gMultiHitCounter = 3;
+            else if (gMultiHitCounter < 35 + 35 + 15)
+                gMultiHitCounter = 4;
             else
-                gMultiHitCounter += 3;
+                gMultiHitCounter = 5;
         }
         else
         {


### PR DESCRIPTION
Fixed the odds for # of hits for mulithit moves in Gen 5 and later

## Description
The odds for multihot moves in Gen 5 and later were incorrect, causing those moves to hit 3, 4, or 5 hits more often than they should.

I've adjusted the calculation to match Gen 5 and later, see: https://bulbapedia.bulbagarden.net/wiki/Bullet_Seed_(move)

or: https://www.smogon.com/dex/bw/moves/bullet-seed/