### PR TITLE
Fixed a wrong instance of IS_MOVE_STATUS in IsViableZMove

### DIFF
--- a/src/battle_z_move.c
+++ b/src/battle_z_move.c
@@ -212,7 +212,7 @@ bool32 IsViableZMove(u8 battlerId, u16 move)
         
         if (move != MOVE_NONE && zMove != MOVE_Z_STATUS && gBattleMoves[move].type == ItemId_GetSecondaryId(item))
         {
-            if (IS_MOVE_STATUS(gBattleMoves[move].split))
+            if (IS_MOVE_STATUS(move))
                 gBattleStruct->zmove.chosenZMove = move;
             else
                 gBattleStruct->zmove.chosenZMove = GetTypeBasedZMove(move, battlerId);


### PR DESCRIPTION
## Description
Spotted by blecoutre#8678.
The `IS_MOVE_STATUS` macro is expected to take a move as a parameter, not a move's category.

## **Discord contact info**
Lunos#4026