### PR TITLE
Mirror Herb

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -9427,12 +9427,31 @@ BattleScript_TotemFlaredToLife::
 	playanimation BS_ATTACKER, B_ANIM_TOTEM_FLARE
 	printstring STRINGID_AURAFLAREDTOLIFE
 	waitmessage B_WAIT_TIME_LONG
-	goto BattleScript_ApplyTotemVarBoost
+	call BattleScript_ApplyTotemVarBoost
+	end2
+
+@ remove the mirror herb, do totem loop
+BattleScript_MirrorHerbCopyStatChangeEnd2::
+	call BattleScript_MirrorHerbCopyStatChange
+	end2
+
+BattleScript_MirrorHerbCopyStatChange::
+	playanimation BS_SCRIPTING, B_ANIM_HELD_ITEM_EFFECT, NULL
+	printstring STRINGID_MIRRORHERBCOPIED
+	waitmessage B_WAIT_TIME_LONG
+	removeitem BS_SCRIPTING
+	call BattleScript_TotemVar_Ret
+	copybyte gBattlerAttacker, sSAVED_BATTLER	@ restore the original attacker just to be safe
+	return
 
 BattleScript_TotemVar::
+	call BattleScript_TotemVar_Ret
+	end2
+
+BattleScript_TotemVar_Ret:
 	gettotemboost BattleScript_ApplyTotemVarBoost
 BattleScript_TotemVarEnd:
-	end2
+	return
 BattleScript_ApplyTotemVarBoost:
 	statbuffchange STAT_BUFF_ALLOW_PTR, BattleScript_TotemVarEnd
 	setgraphicalstatchangevalues
@@ -9440,7 +9459,7 @@ BattleScript_ApplyTotemVarBoost:
 BattleScript_TotemVarPrintStatMsg:
 	printfromtable gStatUpStringIds
 	waitmessage B_WAIT_TIME_LONG
-	goto BattleScript_TotemVar  @loop until stats bitfield is empty
+	goto BattleScript_TotemVar_Ret  @loop until stats bitfield is empty
 
 BattleScript_AnnounceAirLockCloudNine::
 	call BattleScript_AbilityPopUp

--- a/include/battle.h
+++ b/include/battle.h
@@ -147,6 +147,7 @@ struct ProtectStruct
     u16 pranksterElevated:1;
     u16 quickDraw:1;
     u16 beakBlastCharge:1;
+    u16 eatMirrorHerb:1;
     u32 physicalDmg;
     u32 specialDmg;
     u8 physicalBattlerId;
@@ -492,6 +493,12 @@ struct StolenItem
     u16 stolen:1;
 };
 
+struct TotemBoost
+{
+    u8 stats;   // bitfield for each battle stat that is set if the stat changes
+    s8 statChanges[NUM_BATTLE_STATS - 1];    // highest bit being set decreases the stat
+}; /* size = 8 */
+
 struct BattleStruct
 {
     u8 turnEffectsTracker;
@@ -620,6 +627,7 @@ struct BattleStruct
     u8 stickyWebUser;
     u8 appearedInBattle; // Bitfield to track which Pokemon appeared in battle. Used for Burmy's form change
     u8 skyDropTargets[MAX_BATTLERS_COUNT]; // For Sky Drop, to account for if multiple Pokemon use Sky Drop in a double battle.
+    struct TotemBoost statBoosts[MAX_BATTLERS_COUNT];       // mirror herb copies stat changes. needed for multiple stat changes
 };
 
 #define F_DYNAMIC_TYPE_1 (1 << 6)
@@ -809,12 +817,6 @@ struct MonSpritesGfx
     void *unusedPtr;
     u16 *buffer;
 };
-
-struct TotemBoost
-{
-    u8 stats;   // bitfield for each battle stat that is set if the stat changes
-    s8 statChanges[NUM_BATTLE_STATS - 1];    // highest bit being set decreases the stat
-}; /* size = 8 */
 
 // All battle variables are declared in battle_main.c
 extern u16 gBattle_BG0_X;

--- a/include/battle_scripts.h
+++ b/include/battle_scripts.h
@@ -420,6 +420,8 @@ extern const u8 BattleScript_MagicianActivates[];
 extern const u8 BattleScript_BeakBlastSetUp[];
 extern const u8 BattleScript_BeakBlastBurn[];
 extern const u8 BattleScript_DefDownSpeedUp[];
+extern const u8 BattleScript_MirrorHerbCopyStatChange[];
+extern const u8 BattleScript_MirrorHerbCopyStatChangeEnd2[];
 
 // zmoves
 extern const u8 BattleScript_ZMoveActivateDamaging[];

--- a/include/constants/battle_string_ids.h
+++ b/include/constants/battle_string_ids.h
@@ -624,8 +624,9 @@
 #define STRINGID_ZMOVESTATUP                          622
 #define STRINGID_ZMOVEHPTRAP                          623
 #define STRINGID_TERRAINREMOVED                       624
+#define STRINGID_MIRRORHERBCOPIED                     625
 
-#define BATTLESTRINGS_COUNT                           625
+#define BATTLESTRINGS_COUNT                           626
 
 // This is the string id that gBattleStringsTable starts with.
 // String ids before this (e.g. STRINGID_INTROMSG) are not in the table,

--- a/include/constants/hold_effects.h
+++ b/include/constants/hold_effects.h
@@ -152,6 +152,9 @@
 #define HOLD_EFFECT_HEAVY_DUTY_BOOTS    173
 #define HOLD_EFFECT_THROAT_SPRAY        174
 
+// Gen9 hold effects
+#define HOLD_EFFECT_MIRROR_HERB         175
+
 #define HOLD_EFFECT_CHOICE(holdEffect)((holdEffect == HOLD_EFFECT_CHOICE_BAND || holdEffect == HOLD_EFFECT_CHOICE_SCARF || holdEffect == HOLD_EFFECT_CHOICE_SPECS))
 
 // Terrain seed params

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3627,6 +3627,8 @@ static void TryDoEventsBeforeFirstTurn(void)
     {
         if (gTotemBoosts[i].stats != 0)
         {
+            memcpy(&gBattleStruct->statBoosts[i], &gTotemBoosts[i], sizeof(struct TotemBoost));
+            memset(&gTotemBoosts[i], 0, sizeof(struct TotemBoost));
             gBattlerAttacker = i;
             BattleScriptExecute(BattleScript_TotemVar);
             return;

--- a/src/battle_message.c
+++ b/src/battle_message.c
@@ -753,10 +753,11 @@ static const u8 sText_TargetTooHeavy[] = _("But the target\nwas too heavy!");
 static const u8 sText_MeteorBeamCharging[] = _("{B_ATK_NAME_WITH_PREFIX} is overflowing\nwith space energy!");
 static const u8 sText_HeatingUpBeak[] = _("{B_ATK_NAME_WITH_PREFIX} started\nheating up its beak!");
 static const u8 sText_CourtChange[] = _("{B_ATK_NAME_WITH_PREFIX} swapped the battle\neffects affecting each side!");
-
+static const u8 sText_MirrorHerbCopied[] = _("{B_SCR_ACTIVE_NAME_WITH_PREFIX}'s {B_LAST_ITEM} copied\nthe stat changes!");
 
 const u8 *const gBattleStringsTable[BATTLESTRINGS_COUNT] =
 {
+    [STRINGID_MIRRORHERBCOPIED - BATTLESTRINGS_TABLE_START] = sText_MirrorHerbCopied,
     [STRINGID_ZPOWERSURROUNDS - BATTLESTRINGS_TABLE_START] = sText_ZPowerSurrounds,
     [STRINGID_ZMOVEUNLEASHED - BATTLESTRINGS_TABLE_START] = sText_ZPowerUnleashed,
     [STRINGID_ZMOVERESETSSTATS - BATTLESTRINGS_TABLE_START] = sText_ZMoveResetsStats,

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -9011,7 +9011,7 @@ static void Cmd_various(void)
         break;
     case VARIOUS_TOTEM_BOOST:
         gActiveBattler = gBattlerAttacker;
-        if (gTotemBoosts[gActiveBattler].stats == 0)
+        if (gBattleStruct->statBoosts[gActiveBattler].stats == 0)
         {
             gBattlescriptCurrInstr += 7;    // stats done, exit
         }
@@ -9019,19 +9019,19 @@ static void Cmd_various(void)
         {
             for (i = 0; i < (NUM_BATTLE_STATS - 1); i++)
             {
-                if (gTotemBoosts[gActiveBattler].stats & (1 << i))
+                if (gBattleStruct->statBoosts[gActiveBattler].stats & (1 << i))
                 {
-                    if (gTotemBoosts[gActiveBattler].statChanges[i] <= -1)
-                        SET_STATCHANGER(i + 1, abs(gTotemBoosts[gActiveBattler].statChanges[i]), TRUE);
+                    if (gBattleStruct->statBoosts[gActiveBattler].statChanges[i] <= -1)
+                        SET_STATCHANGER(i + 1, abs(gBattleStruct->statBoosts[gActiveBattler].statChanges[i]), TRUE);
                     else
-                        SET_STATCHANGER(i + 1, gTotemBoosts[gActiveBattler].statChanges[i], FALSE);
+                        SET_STATCHANGER(i + 1, gBattleStruct->statBoosts[gActiveBattler].statChanges[i], FALSE);
 
-                    gTotemBoosts[gActiveBattler].stats &= ~(1 << i);
+                    gBattleStruct->statBoosts[gActiveBattler].stats &= ~(1 << i);
                     gBattleScripting.battler = gActiveBattler;
                     gBattlerTarget = gActiveBattler;
-                    if (gTotemBoosts[gActiveBattler].stats & 0x80)
+                    if (gBattleStruct->statBoosts[gActiveBattler].stats & 0x80)
                     {
-                        gTotemBoosts[gActiveBattler].stats &= ~0x80; // set 'aura flared to life' flag
+                        gBattleStruct->statBoosts[gActiveBattler].stats &= ~0x80; // set 'aura flared to life' flag
                         gBattlescriptCurrInstr = BattleScript_TotemFlaredToLife;
                     }
                     else
@@ -10475,6 +10475,18 @@ static u32 ChangeStatBuffs(s8 statValue, u32 statId, u32 flags, const u8 *BS_ptr
         {
             gBattleCommunication[MULTISTRING_CHOOSER] = (gBattlerTarget == gActiveBattler);
             gProtectStructs[gActiveBattler].statRaised = TRUE;
+        }
+        
+        // check mirror herb
+        for (index = 0; index < gBattlersCount; index++) {
+            if (GetBattlerSide(index) == GetBattlerSide(gActiveBattler))
+                continue; // only triggers on opposing side 
+            if (GetBattlerHoldEffect(index, TRUE) == HOLD_EFFECT_MIRROR_HERB
+             && gBattleMons[index].statStages[statId] < MAX_STAT_STAGE) {
+                gProtectStructs[index].eatMirrorHerb = 1;
+                gBattleStruct->statBoosts[index].stats |= (1 << (statId - 1));    // start at atk instead of HP
+                gBattleStruct->statBoosts[index].statChanges[statId - 1] = statValue;   // start at atk instead of HP
+            }
         }
     }
 

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -6433,6 +6433,27 @@ static bool32 GetMentalHerbEffect(u8 battlerId)
     return ret;
 }
 
+static u8 TryConsumeMirrorHerb(u8 battlerId, bool32 execute)
+{
+    u8 effect = 0;
+
+    // TODO should this have its own MOVEEND case? MOVEEND_ITEM_EFFECTS_ALL is pretty far down the list...
+    if (gProtectStructs[battlerId].eatMirrorHerb) {
+        gLastUsedItem = gBattleMons[battlerId].item;
+        gBattleScripting.savedBattler = gBattlerAttacker;
+        gBattleScripting.battler = gBattlerAttacker = battlerId;
+        gProtectStructs[battlerId].eatMirrorHerb = 0;
+        if (execute) {
+            BattleScriptExecute(BattleScript_MirrorHerbCopyStatChangeEnd2);
+        } else {
+            BattleScriptPushCursor();
+            gBattlescriptCurrInstr = BattleScript_MirrorHerbCopyStatChange;
+        }
+        effect = ITEM_STATS_CHANGE;
+    }
+    return effect;
+}
+
 u8 ItemBattleEffects(u8 caseID, u8 battlerId, bool8 moveTurn)
 {
     int i = 0, moveType;
@@ -6958,6 +6979,9 @@ u8 ItemBattleEffects(u8 caseID, u8 battlerId, bool8 moveTurn)
                 if (!moveTurn)
                     effect = TrySetMicleBerry(battlerId, gLastUsedItem, TRUE);
                 break;
+            case HOLD_EFFECT_MIRROR_HERB:
+                effect = TryConsumeMirrorHerb(battlerId, TRUE);
+                break;
             }
 
             if (effect)
@@ -7157,6 +7181,9 @@ u8 ItemBattleEffects(u8 caseID, u8 battlerId, bool8 moveTurn)
                     gBattlescriptCurrInstr = BattleScript_WhiteHerbRet;
                     return effect;
                 }
+                break;
+            case HOLD_EFFECT_MIRROR_HERB:
+                effect = TryConsumeMirrorHerb(battlerId, FALSE);
                 break;
             }
 


### PR DESCRIPTION
Getting a jump start on Gen 9 :)

![mirror_herb](https://user-images.githubusercontent.com/41651341/185978566-101a60df-b84f-4454-a69e-313ad433695b.gif)

IMPLEMENTATION NOTES:
- Positive stat stages are copied to gBattleStruct->statBoosts (name?), which is of type `struct TotemBoost` so we can re-use the totem boost scripts/code.
- Totem boosts are now copied to gBattleStruct so that the mirror herb would be usable in link battles (instead of being in EWRAM_
- all positive stat changes are copied, and the mirror herb activates in `ITEMEFFECT_MOVE_END`. We will have to wait for the official games to know when the stats are copied over, but we can always add new MOVEEND and ITEMEFFECT cases as we please. Hijacking battle scripts mid-animation like Mirror Armor seemed hacky/annoying for multi-stat changes like Work Up/etc.