### PR TITLE
Implemented support for 128 bit tmhm learnsets.

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -1,0 +1,10 @@
+MIT Public License
+
+Copyright (c) 2022 ROM Hacking Hideout 
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+


### PR DESCRIPTION
First of all, the gTMHMLearnsets was changed to an array of 4 32 bit numbers.
Then the macro was changed to take in account tms that belong to the second half.
Consequently the function to check if a mon can learn a tm move was adapted.
I also added the defines necessary to both the list of tm items that take the name of the move as the list that associates tms with moves.

Stephen Lynx#9875

I remade the PR because the previous one was based off the wrong branch. I now pulled gen 8 learnsets and kept any learnset  that wasn't present on pory. The issue being that most mons lost the ability to learn hms.