### PR TITLE
Fix Escape Rope Message when on gen 8 mechanics

### DIFF
--- a/src/item_use.c
+++ b/src/item_use.c
@@ -922,6 +922,9 @@ static void ItemUseOnFieldCB_EscapeRope(u8 taskId)
     Overworld_ResetStateAfterDigEscRope();
     #if I_KEY_ESCAPE_ROPE < GEN_8
         RemoveUsedItem();
+    #else
+        CopyItemName(gSpecialVar_ItemId, gStringVar2);
+        StringExpandPlaceholders(gStringVar4, gText_PlayerUsedVar2);
     #endif
     gTasks[taskId].data[0] = 0;
     DisplayItemMessageOnField(taskId, gStringVar4, Task_UseDigEscapeRopeOnField);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes the message produced by escape rope being incorrect when on gen 8 mechanics.

## Description
<!--- Describe your changes in detail -->
When on gen 8 mechanics, the call to RemoveUsedItem is ignored, which results in gStringVar4 not being set to the escape rope message. This pull request makes it so on gen 8 mechanics, gStringVar4 is properly set to the escape rope message.

## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
Lemon Rush#2220
<!--- Contributors must join https://discord.gg/d5dubZ3 -->