### PR TITLE
Fixed PokemonSubstruct3 alignment

### DIFF
--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -142,7 +142,7 @@ struct PokemonSubstruct3
 
  /* 0x02 */ u16 metLevel:7;
  /* 0x02 */ u16 metGame:4;
- /* 0x03 */ u16 unused3_3:4;
+ /* 0x03 */ u16 unused1:4;
  /* 0x03 */ u16 otGender:1;
 
  /* 0x04 */ u32 hpIV:5;
@@ -152,6 +152,7 @@ struct PokemonSubstruct3
  /* 0x05 */ u32 spAttackIV:5;
  /* 0x06 */ u32 spDefenseIV:5;
  /* 0x07 */ u32 isEgg:1;
+ /* 0x07 */ u32 unused2:1;
 
  /* 0x08 */ u32 coolRibbon:3;
  /* 0x08 */ u32 beautyRibbon:3;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
[3 years and 2 days ago](https://github.com/RH-Hideout/pokeemerald-expansion/commit/cef9dfe22c3760f6d61b896330009367a313ef0f), when `abilityNum` was changed to have 2 bits, its previous field was eliminated instead of renamed to unused. This caused ribbon shifting and confusion regarding the remaining available space in Saveblock.

## **Discord contact info**
AsparagusEduardo#6051