### PR TITLE
v -> STATUS4_WATER_SPORT (battle_script_commands.c)

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -13476,7 +13476,7 @@ static void Cmd_settypebasedhalvers(void)
         #else
             if (!(gStatuses4[gBattlerAttacker] & STATUS4_WATER_SPORT))
             {
-                gStatuses4[gBattlerAttacker] |= v;
+                gStatuses4[gBattlerAttacker] |= STATUS4_WATER_SPORT;
                 gBattleCommunication[MULTISTRING_CHOOSER] = B_MSG_WEAKEN_FIRE;
                 worked = TRUE;
             }


### PR DESCRIPTION
In battle_script_commands.c, there was what appears to be a copy/paste error (someone must have hit "v" on their keyboard, instead of "ctrl + v") for Gen 3-5 Water Sport. This fixes that.

## Description
Literally just changes "v" to "STATUS4_WATER_SPORT". This was verified to be correct by MGriffin, Lunos, and AsparagusEd on Discord.

## **Discord contact info**
Yak Attack#8512
Uh I'm Petuuuuhhh, I'm banned from RHH; don't really care though, and if you decide you don't want to accept my PR because of this, I don't really care about that, either.