### PR TITLE
Incoming survivability

### DIFF
--- a/include/battle_ai_switch_items.h
+++ b/include/battle_ai_switch_items.h
@@ -33,7 +33,7 @@ enum {
 
 void GetAIPartyIndexes(u32 battlerId, s32 *firstId, s32 *lastId);
 void AI_TrySwitchOrUseItem(void);
-u8 GetMostSuitableMonToSwitchInto(void);
+u8 GetMostSuitableMonToSwitchInto(bool8);
 bool32 ShouldSwitch(void);
 
 #endif // GUARD_BATTLE_AI_SWITCH_ITEMS_H

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -356,7 +356,7 @@ static u8 ChooseMoveOrAction_Singles(void)
                     break;
             }
 
-            if (i == MAX_MON_MOVES && GetMostSuitableMonToSwitchInto() != PARTY_SIZE)
+            if (i == MAX_MON_MOVES && GetMostSuitableMonToSwitchInto(TRUE) != PARTY_SIZE)
             {
                 AI_THINKING_STRUCT->switchMon = TRUE;
                 return AI_CHOICE_SWITCH;
@@ -370,7 +370,7 @@ static u8 ChooseMoveOrAction_Singles(void)
             && gDisableStructs[sBattler_AI].truantCounter
             && gBattleMons[sBattler_AI].hp >= gBattleMons[sBattler_AI].maxHP / 2)
         {
-            if (GetMostSuitableMonToSwitchInto() != PARTY_SIZE)
+            if (GetMostSuitableMonToSwitchInto(TRUE) != PARTY_SIZE)
             {
                 AI_THINKING_STRUCT->switchMon = TRUE;
                 return AI_CHOICE_SWITCH;

--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -587,7 +587,7 @@ static u32 GetBestMonBatonPass(struct Pokemon *party, int firstId, int lastId, u
         if (invalidMons & gBitTable[i])
             continue;
 
-        if (AI_CheckSurvivabilty(checkSurvivability, BATTLE_OPPOSITE(i), i))
+        if (AI_CheckSurvivabilty(checkSurvivability, BATTLE_OPPOSITE(gActiveBattler), i))
             continue;
 
         for (j = 0; j < MAX_MON_MOVES; j++)
@@ -620,7 +620,7 @@ static u32 GetBestMonTypeMatchup(struct Pokemon *party, int firstId, int lastId,
     // Find the mon whose type is the most suitable defensively.
     for (i = firstId; i < lastId; i++)
     {
-        if (AI_CheckSurvivabilty(checkSurvivability, BATTLE_OPPOSITE(i), i))
+        if (AI_CheckSurvivabilty(checkSurvivability, BATTLE_OPPOSITE(gActiveBattler), i))
             continue;
 
         if (!(gBitTable[i] & invalidMons) && !(gBitTable[i] & bits))
@@ -657,7 +657,7 @@ static u32 GetBestMonTypeMatchup(struct Pokemon *party, int firstId, int lastId,
          // Find the mon that has an attack most suited offensively
         for (i = firstId; i < lastId; i++)
         {
-            if (AI_CheckSurvivabilty(checkSurvivability, BATTLE_OPPOSITE(i), i))
+            if (AI_CheckSurvivabilty(checkSurvivability, BATTLE_OPPOSITE(gActiveBattler), i))
                 continue;
 
             for (i = 0; i < MAX_MON_MOVES; i++)
@@ -688,7 +688,7 @@ static u32 GetBestMonDmg(struct Pokemon *party, int firstId, int lastId, u8 inva
         if (gBitTable[i] & invalidMons)
             continue;
 
-        if (AI_CheckSurvivabilty(checkSurvivability, BATTLE_OPPOSITE(i), i))
+        if (AI_CheckSurvivabilty(checkSurvivability, BATTLE_OPPOSITE(gActiveBattler), i))
             continue;
 
         for (j = 0; j < MAX_MON_MOVES; j++)
@@ -995,12 +995,16 @@ static bool32 AI_CheckSurvivabilty(bool8 checkSurvivability, int playerPokemon, 
 
     if (AI_THINKING_STRUCT->aiFlags & AI_FLAG_SMART_SWITCHING)
         {
-            if (CanTargetFaintAiWithMod(playerPokemon, aiPokemon , 0, 0)) 
+            //Opponent can OHKO AI, don't send this Pokemon out
+            if (CanTargetFaintAiWithMod(playerPokemon, aiPokemon, 0, 0)) 
                 return TRUE;
-            else if (CanTargetFaintAiWithMod(playerPokemon, aiPokemon, 0, 2) //Can 2HKO AI
-                    && !WillAIStrikeFirst())
-                return TRUE;
+
+            //Opponent can 2HKO AI and AI cannot strike first
+            //ToDo: Modify for switches when AI has already attacked (Volt Switch etc.)
+            if (CanTargetFaintAiWithMod(playerPokemon, aiPokemon, 0, 2)        
+                && GetWhoStrikesFirst(playerPokemon, aiPokemon, TRUE) == 0)
+                 return TRUE;  
         }
-    
+
     return FALSE;
 }

--- a/src/battle_controller_opponent.c
+++ b/src/battle_controller_opponent.c
@@ -1673,7 +1673,7 @@ static void OpponentHandleChoosePokemon(void)
 
     if (*(gBattleStruct->AI_monToSwitchIntoId + gActiveBattler) == PARTY_SIZE)
     {
-        chosenMonId = GetMostSuitableMonToSwitchInto();
+        chosenMonId = GetMostSuitableMonToSwitchInto(TRUE);
 
         if (chosenMonId == PARTY_SIZE)
         {

--- a/src/battle_controller_player_partner.c
+++ b/src/battle_controller_player_partner.c
@@ -1548,7 +1548,7 @@ static void PlayerPartnerHandleChooseItem(void)
 
 static void PlayerPartnerHandleChoosePokemon(void)
 {
-    s32 chosenMonId = GetMostSuitableMonToSwitchInto();
+    s32 chosenMonId = GetMostSuitableMonToSwitchInto(TRUE);
 
     if (chosenMonId == 6) // just switch to the next mon
     {


### PR DESCRIPTION
References Issue #2320 as a partial fix.

Adds additional logic for AI Switching. Enable `AI_FLAG_SMART_SWITCHING` to activate.
Checks survivability of incoming Pokemon, as there is no sense of switching into a Pokemon that will immediately get KO'd by the active player.
Additional improvements to `GetMostSuitableMonToSwitchInto`.