### PR TITLE
Incoming Survivability - Recommit to Dev branch

### DIFF
--- a/include/battle_ai_switch_items.h
+++ b/include/battle_ai_switch_items.h
@@ -33,7 +33,7 @@ enum {
 
 void GetAIPartyIndexes(u32 battlerId, s32 *firstId, s32 *lastId);
 void AI_TrySwitchOrUseItem(void);
-u8 GetMostSuitableMonToSwitchInto(void);
+u8 GetMostSuitableMonToSwitchInto(bool8);
 bool32 ShouldSwitch(void);
 
 #endif // GUARD_BATTLE_AI_SWITCH_ITEMS_H

--- a/include/battle_ai_switch_items.h
+++ b/include/battle_ai_switch_items.h
@@ -33,7 +33,7 @@ enum {
 
 void GetAIPartyIndexes(u32 battlerId, s32 *firstId, s32 *lastId);
 void AI_TrySwitchOrUseItem(void);
-u8 GetMostSuitableMonToSwitchInto(bool8);
+u8 GetMostSuitableMonToSwitchInto(bool8 checkSurvivability);
 bool32 ShouldSwitch(void);
 
 #endif // GUARD_BATTLE_AI_SWITCH_ITEMS_H

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -356,7 +356,7 @@ static u8 ChooseMoveOrAction_Singles(void)
                     break;
             }
 
-            if (i == MAX_MON_MOVES && GetMostSuitableMonToSwitchInto() != PARTY_SIZE)
+            if (i == MAX_MON_MOVES && GetMostSuitableMonToSwitchInto(TRUE) != PARTY_SIZE)
             {
                 AI_THINKING_STRUCT->switchMon = TRUE;
                 return AI_CHOICE_SWITCH;
@@ -370,7 +370,7 @@ static u8 ChooseMoveOrAction_Singles(void)
             && gDisableStructs[sBattler_AI].truantCounter
             && gBattleMons[sBattler_AI].hp >= gBattleMons[sBattler_AI].maxHP / 2)
         {
-            if (GetMostSuitableMonToSwitchInto() != PARTY_SIZE)
+            if (GetMostSuitableMonToSwitchInto(TRUE) != PARTY_SIZE)
             {
                 AI_THINKING_STRUCT->switchMon = TRUE;
                 return AI_CHOICE_SWITCH;

--- a/src/battle_controller_opponent.c
+++ b/src/battle_controller_opponent.c
@@ -1676,8 +1676,7 @@ static void OpponentHandleChoosePokemon(void)
 
     if (*(gBattleStruct->AI_monToSwitchIntoId + gActiveBattler) == PARTY_SIZE)
     {
-        chosenMonId = GetMostSuitableMonToSwitchInto();
-
+        chosenMonId = GetMostSuitableMonToSwitchInto(TRUE);
         if (chosenMonId == PARTY_SIZE)
         {
             s32 battler1, battler2, firstId, lastId;
@@ -1691,7 +1690,6 @@ static void OpponentHandleChoosePokemon(void)
                 battler1 = GetBattlerAtPosition(B_POSITION_OPPONENT_LEFT);
                 battler2 = GetBattlerAtPosition(B_POSITION_OPPONENT_RIGHT);
                 pokemonInBattle = 2;
-
             }
 
             GetAIPartyIndexes(gActiveBattler, &firstId, &lastId);
@@ -1699,6 +1697,7 @@ static void OpponentHandleChoosePokemon(void)
             for (chosenMonId = (lastId-1); chosenMonId >= firstId; chosenMonId--)
             {
                 if (GetMonData(&gEnemyParty[chosenMonId], MON_DATA_HP) != 0
+                    && GetMonData(&gEnemyParty[chosenMonId], MON_DATA_SPECIES2) != SPECIES_NONE
                     && chosenMonId != gBattlerPartyIndexes[battler1]
                     && chosenMonId != gBattlerPartyIndexes[battler2]
                     && (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON

--- a/src/battle_controller_player_partner.c
+++ b/src/battle_controller_player_partner.c
@@ -1548,7 +1548,7 @@ static void PlayerPartnerHandleChooseItem(void)
 
 static void PlayerPartnerHandleChoosePokemon(void)
 {
-    s32 chosenMonId = GetMostSuitableMonToSwitchInto();
+    s32 chosenMonId = GetMostSuitableMonToSwitchInto(TRUE);
 
     if (chosenMonId == 6) // just switch to the next mon
     {


### PR DESCRIPTION
References Issue #2320 as a partial fix.

Adds additional logic for AI Switching. Enable AI_FLAG_SMART_SWITCHING to activate.
Checks survivability of incoming Pokemon, as there is no sense of switching into a Pokemon that will immediately get KO'd by the active player.
Additional improvements to GetMostSuitableMonToSwitchInto.