### PR TITLE
Fixed ACE_POKEMON_FUNCTIONALITY

### DIFF
--- a/include/constants/battle_ai.h
+++ b/include/constants/battle_ai.h
@@ -56,7 +56,7 @@
 #define AI_FLAG_STALL                 (1 << 13)  // AI stalls battle and prefers secondary damage/trapping/etc. TODO not finished
 #define AI_FLAG_SCREENER              (1 << 14)  // AI prefers screening effects like reflect, mist, etc. TODO unfinished
 #define AI_FLAG_SMART_SWITCHING       (1 << 15)  // AI includes a lot more switching checks
-#define AI_FLAG_ACE_POKEMON           (1 << 16)  // AI has Ace Pokemon. The last Pokemon in the party will not used until last remaining.
+//#define AI_FLAG_ACE_POKEMON           (1 << 16)  // AI has Ace Pokemon. The last Pokemon in the party will not used until last remaining.
 
 // 'other' ai logic flags
 #define AI_FLAG_ROAMING               (1 << 29)

--- a/include/constants/battle_ai.h
+++ b/include/constants/battle_ai.h
@@ -56,7 +56,7 @@
 #define AI_FLAG_STALL                 (1 << 13)  // AI stalls battle and prefers secondary damage/trapping/etc. TODO not finished
 #define AI_FLAG_SCREENER              (1 << 14)  // AI prefers screening effects like reflect, mist, etc. TODO unfinished
 #define AI_FLAG_SMART_SWITCHING       (1 << 15)  // AI includes a lot more switching checks
-//#define AI_FLAG_ACE_POKEMON           (1 << 16)  // AI has Ace Pokemon. The last Pokemon in the party will not used until last remaining.
+#define AI_FLAG_ACE_POKEMON           (1 << 16)  // AI has an Ace Pokemon. The last Pokemon in the party will not be used until it's the last one remaining.
 
 // 'other' ai logic flags
 #define AI_FLAG_ROAMING               (1 << 29)

--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -109,9 +109,9 @@ static bool8 ShouldSwitchIfWonderGuard(void)
             continue;
         if (i == gBattlerPartyIndexes[gActiveBattler])
             continue;
-        if (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON 
+        /*if (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON 
             && i == (CalculateEnemyPartyCount()-1))
-            continue;
+            continue;*/
 
         for (opposingBattler = GetBattlerAtPosition(opposingPosition), j = 0; j < MAX_MON_MOVES; j++)
         {
@@ -202,9 +202,9 @@ static bool8 FindMonThatAbsorbsOpponentsMove(void)
             continue;
         if (i == *(gBattleStruct->monToSwitchIntoId + battlerIn2))
             continue;
-        if (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON 
+        /*if (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON 
             && i == (CalculateEnemyPartyCount()-1))
-            continue;
+            continue;*/
         
 
         species = GetMonData(&party[i], MON_DATA_SPECIES);
@@ -283,9 +283,9 @@ static bool8 ShouldSwitchIfGameStatePrompt(void)
                     
                         for (i = firstId; i < lastId; i++)
                         {
-                            if (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON 
+                            /*if (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON 
                                 && i == (CalculateEnemyPartyCount()-1))
-                                break;
+                                break;*/
 
                             //Look for mon in party that is able to be switched into and has ability that sets terrain
                             if (GetMonData(&party[i], MON_DATA_HP) != 0
@@ -574,9 +574,9 @@ static bool8 FindMonWithFlagsAndSuperEffective(u16 flags, u8 moduloPercent)
             continue;
         if (i == *(gBattleStruct->monToSwitchIntoId + battlerIn2))
             continue;
-        if (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON 
+        /*if (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON 
             && i == (CalculateEnemyPartyCount()-1))
-            continue;
+            continue;*/
 
 
         species = GetMonData(&party[i], MON_DATA_SPECIES);
@@ -666,9 +666,9 @@ bool32 ShouldSwitch(void)
             continue;
         if (i == *(gBattleStruct->monToSwitchIntoId + battlerIn2))
             continue;
-        if (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON
+        /*if (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON
             && i == (CalculateEnemyPartyCount()-1))
-            continue;
+            continue;*/
 
         availableToSwitch++;
     }
@@ -756,9 +756,9 @@ void AI_TrySwitchOrUseItem(void)
                             continue;
                         if (monToSwitchId == *(gBattleStruct->monToSwitchIntoId + battlerIn2))
                             continue;
-                        if (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON 
+                        /*if (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON 
                             && monToSwitchId == (CalculateEnemyPartyCount()-1))
-                            continue;
+                            continue;*/
 
                         break;
                     }
@@ -957,8 +957,8 @@ u8 GetMostSuitableMonToSwitchInto(void)
             || i == *(gBattleStruct->monToSwitchIntoId + battlerIn1)
             || i == *(gBattleStruct->monToSwitchIntoId + battlerIn2)
             || (GetMonAbility(&party[i]) == ABILITY_TRUANT && IsTruantMonVulnerable(gActiveBattler, opposingBattler)) // While not really invalid per say, not really wise to switch into this mon.
-            || (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON 
-                && i == (CalculateEnemyPartyCount()-1))) //Save Ace Pokemon for last
+            /*|| (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON 
+                && i == (CalculateEnemyPartyCount()-1))*/) //Save Ace Pokemon for last
             invalidMons |= gBitTable[i];
         else
             aliveCount++;

--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -109,9 +109,9 @@ static bool8 ShouldSwitchIfWonderGuard(void)
             continue;
         if (i == gBattlerPartyIndexes[gActiveBattler])
             continue;
-        /*if (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON 
+        if (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON 
             && i == (CalculateEnemyPartyCount()-1))
-            continue;*/
+            continue;
 
         for (opposingBattler = GetBattlerAtPosition(opposingPosition), j = 0; j < MAX_MON_MOVES; j++)
         {
@@ -202,9 +202,9 @@ static bool8 FindMonThatAbsorbsOpponentsMove(void)
             continue;
         if (i == *(gBattleStruct->monToSwitchIntoId + battlerIn2))
             continue;
-        /*if (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON 
+        if (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON 
             && i == (CalculateEnemyPartyCount()-1))
-            continue;*/
+            continue;
         
 
         species = GetMonData(&party[i], MON_DATA_SPECIES);
@@ -283,9 +283,9 @@ static bool8 ShouldSwitchIfGameStatePrompt(void)
                     
                         for (i = firstId; i < lastId; i++)
                         {
-                            /*if (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON 
+                            if (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON 
                                 && i == (CalculateEnemyPartyCount()-1))
-                                break;*/
+                                break;
 
                             //Look for mon in party that is able to be switched into and has ability that sets terrain
                             if (GetMonData(&party[i], MON_DATA_HP) != 0
@@ -574,9 +574,9 @@ static bool8 FindMonWithFlagsAndSuperEffective(u16 flags, u8 moduloPercent)
             continue;
         if (i == *(gBattleStruct->monToSwitchIntoId + battlerIn2))
             continue;
-        /*if (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON 
+        if (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON 
             && i == (CalculateEnemyPartyCount()-1))
-            continue;*/
+            continue;
 
 
         species = GetMonData(&party[i], MON_DATA_SPECIES);
@@ -666,9 +666,9 @@ bool32 ShouldSwitch(void)
             continue;
         if (i == *(gBattleStruct->monToSwitchIntoId + battlerIn2))
             continue;
-        /*if (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON
+        if (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON
             && i == (CalculateEnemyPartyCount()-1))
-            continue;*/
+            continue;
 
         availableToSwitch++;
     }
@@ -756,9 +756,9 @@ void AI_TrySwitchOrUseItem(void)
                             continue;
                         if (monToSwitchId == *(gBattleStruct->monToSwitchIntoId + battlerIn2))
                             continue;
-                        /*if (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON 
+                        if (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON 
                             && monToSwitchId == (CalculateEnemyPartyCount()-1))
-                            continue;*/
+                            continue;
 
                         break;
                     }
@@ -957,8 +957,8 @@ u8 GetMostSuitableMonToSwitchInto(void)
             || i == *(gBattleStruct->monToSwitchIntoId + battlerIn1)
             || i == *(gBattleStruct->monToSwitchIntoId + battlerIn2)
             || (GetMonAbility(&party[i]) == ABILITY_TRUANT && IsTruantMonVulnerable(gActiveBattler, opposingBattler)) // While not really invalid per say, not really wise to switch into this mon.
-            /*|| (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON 
-                && i == (CalculateEnemyPartyCount()-1))*/) //Save Ace Pokemon for last
+            || ((AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON)
+                && i == (CalculateEnemyPartyCount() - 1))) //Save Ace Pokemon for last
             invalidMons |= gBitTable[i];
         else
             aliveCount++;

--- a/src/battle_controller_opponent.c
+++ b/src/battle_controller_opponent.c
@@ -1699,9 +1699,9 @@ static void OpponentHandleChoosePokemon(void)
                 if (GetMonData(&gEnemyParty[chosenMonId], MON_DATA_HP) != 0
                     && chosenMonId != gBattlerPartyIndexes[battler1]
                     && chosenMonId != gBattlerPartyIndexes[battler2]
-                    && (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON
+                    /*&& (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON
                         && (!(chosenMonId == (CalculateEnemyPartyCount()-1))
-                            || CountAIAliveNonEggMonsExcept(PARTY_SIZE) == pokemonInBattle)))
+                            || CountAIAliveNonEggMonsExcept(PARTY_SIZE) == pokemonInBattle))*/)
                 {
                     break;
                 }

--- a/src/battle_controller_opponent.c
+++ b/src/battle_controller_opponent.c
@@ -1701,7 +1701,7 @@ static void OpponentHandleChoosePokemon(void)
                     && chosenMonId != gBattlerPartyIndexes[battler2]
                     && (!(AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON)
                         || chosenMonId != CalculateEnemyPartyCount() - 1
-                            || CountAIAliveNonEggMonsExcept(PARTY_SIZE) == pokemonInBattle))
+                        || CountAIAliveNonEggMonsExcept(PARTY_SIZE) == pokemonInBattle))
                 {
                     break;
                 }

--- a/src/battle_controller_opponent.c
+++ b/src/battle_controller_opponent.c
@@ -1699,9 +1699,9 @@ static void OpponentHandleChoosePokemon(void)
                 if (GetMonData(&gEnemyParty[chosenMonId], MON_DATA_HP) != 0
                     && chosenMonId != gBattlerPartyIndexes[battler1]
                     && chosenMonId != gBattlerPartyIndexes[battler2]
-                    /*&& (AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON
-                        && (!(chosenMonId == (CalculateEnemyPartyCount()-1))
-                            || CountAIAliveNonEggMonsExcept(PARTY_SIZE) == pokemonInBattle))*/)
+                    && (!(AI_THINKING_STRUCT->aiFlags & AI_FLAG_ACE_POKEMON)
+                        || chosenMonId != CalculateEnemyPartyCount() - 1
+                            || CountAIAliveNonEggMonsExcept(PARTY_SIZE) == pokemonInBattle))
                 {
                     break;
                 }


### PR DESCRIPTION
EDITED by @AsparagusEduardo:
- Fixes #2333.

Original description
> Removed ACE_POKEMON_FUNCTIONALITY.

> For some reason, if this AI Flag was not turned on, this skipped over the functionality of choosing the next pokemon inline.
> Functionality works when this flag is enabled, but not when it is not...?

>Removing functionality for now. I will fix it with another pull request.