### PR TITLE
Updated IsViableZMove

### DIFF
--- a/src/battle_z_move.c
+++ b/src/battle_z_move.c
@@ -174,10 +174,8 @@ bool32 IsViableZMove(u8 battlerId, u16 move)
     if (gBattleTypeFlags & (BATTLE_TYPE_SAFARI | BATTLE_TYPE_WALLY_TUTORIAL | BATTLE_TYPE_FRONTIER))
         return FALSE;
 
-    #ifdef ITEM_Z_RING
-    if ((GetBattlerPosition(battlerId) == B_POSITION_PLAYER_LEFT || (!(gBattleTypeFlags & BATTLE_TYPE_MULTI) && GetBattlerPosition(battlerId) == B_POSITION_PLAYER_RIGHT)) && !CheckBagHasItem(ITEM_Z_RING, 1))
+    if ((GetBattlerPosition(battlerId) == B_POSITION_PLAYER_LEFT || (!(gBattleTypeFlags & BATTLE_TYPE_MULTI) && GetBattlerPosition(battlerId) == B_POSITION_PLAYER_RIGHT)) && !CheckBagHasItem(ITEM_Z_POWER_RING, 1))
         return FALSE;
-    #endif
 
     if (mega->alreadyEvolved[battlerPosition])
         return FALSE;   // Trainer has mega evolved


### PR DESCRIPTION
## Description
I'm not entirely sure why, but whether a Z-Move could be used or not depended in whether an item that does not exist in this project was defined at all or not.
Since there's no point for that I removed it, and I fixed the check to use the `ITEM_Z_POWER_RING` as it should.

## **Discord contact info**
Lunos#4026