### PR TITLE
Update field_specials.c

### DIFF
--- a/src/field_specials.c
+++ b/src/field_specials.c
@@ -1055,7 +1055,7 @@ static void PCTurnOffEffect(void)
     u16 tileId = 0;
     u8 playerDirection = GetPlayerFacingDirection();
 
-    if (IsPlayerInFrontOfPC() == TRUE)
+    if (IsPlayerInFrontOfPC() == FALSE)
         return;
     switch (playerDirection)
     {


### PR DESCRIPTION
## Description
Lunos from the Past's stupidity 1 - Reviewers 0 :P
**EDIT**: Funny joke aside, we don't want `PCTurnOffEffect` to exit prematurely if the Player is standing in front of a PC, we want it to exit if they *aren't*, because then there'd be no PC to turn off 😆 

## **Discord contact info**
Lunos#4026