### PR TITLE
Fixed IsPlayerInFrontOfPC

### DIFF
--- a/src/field_specials.c
+++ b/src/field_specials.c
@@ -961,9 +961,12 @@ static bool8 IsPlayerInFrontOfPC(void)
     GetXYCoordsOneStepInFrontOfPlayer(&x, &y);
     tileInFront = MapGridGetMetatileIdAt(x, y);
 
-    return ((tileInFront == METATILE_BrendansMaysHouse_BrendanPC_On || tileInFront == METATILE_BrendansMaysHouse_BrendanPC_Off)
-         || (tileInFront == METATILE_BrendansMaysHouse_MayPC_On || tileInFront == METATILE_BrendansMaysHouse_MayPC_Off)
-         || (tileInFront == METATILE_Building_PC_On || tileInFront == METATILE_Building_PC_Off));
+    return (tileInFront == METATILE_BrendansMaysHouse_BrendanPC_On
+         || tileInFront == METATILE_BrendansMaysHouse_BrendanPC_Off
+         || tileInFront == METATILE_BrendansMaysHouse_MayPC_On
+         || tileInFront == METATILE_BrendansMaysHouse_MayPC_Off
+         || tileInFront == METATILE_Building_PC_On
+         || tileInFront == METATILE_Building_PC_Off);
 }
 
 void DoPCTurnOnEffect(void)

--- a/src/field_specials.c
+++ b/src/field_specials.c
@@ -961,9 +961,9 @@ static bool8 IsPlayerInFrontOfPC(void)
     GetXYCoordsOneStepInFrontOfPlayer(&x, &y);
     tileInFront = MapGridGetMetatileIdAt(x, y);
 
-    return (tileInFront == METATILE_BrendansMaysHouse_BrendanPC_Off
-         || tileInFront == METATILE_BrendansMaysHouse_MayPC_Off
-         || tileInFront == METATILE_Building_PC_Off);
+    return ((tileInFront == METATILE_BrendansMaysHouse_BrendanPC_On || tileInFront == METATILE_BrendansMaysHouse_BrendanPC_Off)
+         || (tileInFront == METATILE_BrendansMaysHouse_MayPC_On || tileInFront == METATILE_BrendansMaysHouse_MayPC_Off)
+         || (tileInFront == METATILE_Building_PC_On || tileInFront == METATILE_Building_PC_Off));
 }
 
 void DoPCTurnOnEffect(void)


### PR DESCRIPTION
## Description
*Obviously*, if the Player accesses a PC once, the tile in front of them is no longer gonna be the tile with a PC's screen turned off, duh.

**EDIT**: Before | After
![](https://media.discordapp.net/attachments/774393519569502268/1023445618686963732/unknown.png)![mGBA_20220925_055341174](https://user-images.githubusercontent.com/4485172/192135716-2291b815-a8e7-44ec-bb8a-e5f897b38ef3.gif)

## **Discord contact info**
Lunos#4026