### PR TITLE
Fixes: Pokémon Debug isn't loading female icon palettes correctly

### DIFF
--- a/include/pokemon_icon.h
+++ b/include/pokemon_icon.h
@@ -23,6 +23,7 @@ void FreeAndDestroyMonIconSprite(struct Sprite *sprite);
 u8 CreateMonIcon(u16 species, void (*callback)(struct Sprite *), s16 x, s16 y, u8 subpriority, u32 personality);
 u8 UpdateMonIconFrame(struct Sprite *sprite);
 void LoadMonIconPalette(u16 species);
+void LoadMonIconPalettePersonality(u16 species, u32 personality);
 void SpriteCB_MonIcon(struct Sprite *sprite);
 void SetPartyHPBarSprite(struct Sprite *sprite, u8 animNum);
 u8 GetMonIconPaletteIndexFromSpecies(u16 species);

--- a/src/pokemon_debug.c
+++ b/src/pokemon_debug.c
@@ -1686,7 +1686,7 @@ static void ReloadPokemonSprites(struct PokemonDebugMenu *data)
     FreeMonIconPalettes();
 
     AllocateMonSpritesGfx();
-    LoadMonIconPalette(species);
+    LoadMonIconPalettePersonality(species, (data->isFemale ? FEMALE_PERSONALITY : MALE_PERSONALITY));
 
     //Update instructions
     PrintInstructionsOnWindow(data);

--- a/src/pokemon_icon.c
+++ b/src/pokemon_icon.c
@@ -2760,6 +2760,17 @@ void LoadMonIconPalette(u16 species)
         LoadSpritePalette(&gMonIconPaletteTable[palIndex]);
 }
 
+void LoadMonIconPalettePersonality(u16 species, u32 personality)
+{
+    u8 palIndex;
+    if (ShouldShowFemaleDifferences(species, personality))
+        palIndex = gMonIconPaletteIndicesFemale[species];
+    else
+        palIndex = gMonIconPaletteIndices[species];
+    if (IndexOfSpritePaletteTag(gMonIconPaletteTable[palIndex].tag) == 0xFF)
+        LoadSpritePalette(&gMonIconPaletteTable[palIndex]);
+}
+
 void FreeMonIconPalettes(void)
 {
     u8 i;


### PR DESCRIPTION
Fixes: #2246 
The function previously used is only used in the base game to load genderless mail icons, this PR introduces a new function that takes the personality into account

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## **Discord contact info**
TheXaman#5612