### PR TITLE
Fixed berserk not activating if mon falls to exactly half HP.

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -5209,7 +5209,7 @@ u8 AbilityBattleEffects(u8 caseID, u8 battler, u16 ability, u8 special, u16 move
              && TARGET_TURN_DAMAGED
              && IsBattlerAlive(battler)
             // Had more than half of hp before, now has less
-             && gBattleStruct->hpBefore[battler] > gBattleMons[battler].maxHP / 2
+             && gBattleStruct->hpBefore[battler] >= gBattleMons[battler].maxHP / 2
              && gBattleMons[battler].hp < gBattleMons[battler].maxHP / 2
              && (gMultiHitCounter == 0 || gMultiHitCounter == 1)
              && !(TestSheerForceFlag(gBattlerAttacker, gCurrentMove))


### PR DESCRIPTION
If the mon hits exactly half HP it won't trigger on the same turn because of the second check. The next turn it won't activate because of the firt check.