### PR TITLE
Fix AI issue giving decrementing score to confuse hit instead of confuse

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -1333,7 +1333,7 @@ bool32 IsConfusionMoveEffect(u16 moveEffect)
 {
     switch (moveEffect)
     {
-    case EFFECT_CONFUSE_HIT:
+    case EFFECT_CONFUSE:
     case EFFECT_SWAGGER:
     case EFFECT_FLATTER:
     case EFFECT_TEETER_DANCE:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
AI was giving minus score to moves like strange steam and water pulse in misty terrain instead of moves like confuse ray, this should fix that.
<!--- Describe your changes in detail -->
## **Discord contact info**
Tennis#4004