### PR TITLE
Fix lock when teaching a TM/HM after learning a move by level up.

### DIFF
--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -4928,6 +4928,7 @@ void ItemUseCB_TMHM(u8 taskId, TaskFunc task)
     u16 move = ItemIdToBattleMoveId(item);
 
     gPartyMenu.data1 = move;
+    gPartyMenu.learnMoveState = 0;
 
     PlaySE(SE_SELECT);
     mon = &gPlayerParty[gPartyMenu.slotId];


### PR DESCRIPTION
Fixed an bug that caused the game to lock after teaching a TM/HM

When a pokemon learns a move by level up the struct gPartyMenu.learnMoveState gets setted to 1 in order to check whether there is another move to learn at the same level or not.
When learning a TM/HM it should be set at 0 or the game locks.

The bug was introduced on  #ed02c4b425028a4fe2cf622653f352ec10914736
Because of how counterintuitively coded it originally was...

Discord Mauro#5782