### PR TITLE
Made Z-Moves unusable without PP

### DIFF
--- a/src/battle_z_move.c
+++ b/src/battle_z_move.c
@@ -166,12 +166,20 @@ bool32 IsViableZMove(u8 battlerId, u16 move)
     u32 item;
     u16 holdEffect;
     u16 species;
+    int moveSlotIndex;
+
+    species = gBattleMons[battlerId].species;
+    item = gBattleMons[battlerId].item;
+
+    for (moveSlotIndex = 0; moveSlotIndex < MAX_MON_MOVES; moveSlotIndex++)
+    {
+        if (gBattleMons[battlerId].moves[moveSlotIndex] == move && gBattleMons[battlerId].pp[moveSlotIndex] == 0)
+            return FALSE;
+    }
 
     if (gBattleStruct->zmove.used[battlerId])
         return FALSE;
 
-    species = gBattleMons[battlerId].species;
-    item = gBattleMons[battlerId].item;
     if (gBattleTypeFlags & (BATTLE_TYPE_SAFARI | BATTLE_TYPE_WALLY_TUTORIAL | BATTLE_TYPE_FRONTIER))
         return FALSE;
 


### PR DESCRIPTION
## Description
Fixes an issue brought up by Aaghat#2527 in which a Z-Move could be chosen even if the base move didn't have PP left.

Before:
![mGBA_20221029_113430370](https://user-images.githubusercontent.com/4485172/198837255-25c72b03-7b82-4b0e-b6c5-dec7fab76c35.gif)

After:
![mGBA_20221029_113147940](https://user-images.githubusercontent.com/4485172/198837193-b2ad857b-2229-489a-994e-0e3b7c37076f.gif)

## **Discord contact info**
Lunos#4026