### PR TITLE
Updated AnimTask_PrimalReversion

### DIFF
--- a/data/battle_anim_scripts.s
+++ b/data/battle_anim_scripts.s
@@ -24841,7 +24841,7 @@ General_StrongWinds::
 General_PrimalReversion::
 	launchtask AnimTask_PrimalReversion 0x5 0x0
 	jumpargeq 0x0, ITEM_RED_ORB, General_PrimalReversion_Omega
-	jumpargeq 0x1, ITEM_BLUE_ORB, General_PrimalReversion_Alpha
+	jumpargeq 0x0, ITEM_BLUE_ORB, General_PrimalReversion_Alpha
 General_PrimalReversion_Alpha:
 	loadspritegfx ANIM_TAG_ALPHA_STONE
 	loadspritegfx ANIM_TAG_MEGA_PARTICLES

--- a/src/battle_anim_new.c
+++ b/src/battle_anim_new.c
@@ -7857,7 +7857,7 @@ static void SpriteCB_TwinkleOnBattler(struct Sprite *sprite)
 
 void AnimTask_PrimalReversion(u8 taskId)
 {
-    if (gBattleMons[gBattleAnimAttacker].item == ITEM_RED_ORB)
+    if (gBattleMons[gBattleAnimAttacker].item == ITEM_RED_ORB || gBattleMons[gBattleAnimAttacker].item == ITEM_BLUE_ORB)
         gBattleAnimArgs[0] = gBattleMons[gBattleAnimAttacker].item;
     else
         gBattleAnimArgs[0] = 0;


### PR DESCRIPTION
## Description
This function was working correctly before, but it wasn't laid out correctly.
It's supposed to set the first battle animation argument to either the Red or the Blue Orb to decide which Primal Reversion animation to play.
I noticed it just now and decided to fix it.

## **Discord contact info**
Lunos#4026