### PR TITLE
Updated ENDTURN_PLASMA_FISTS

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3223,8 +3223,7 @@ u8 DoBattlerEndTurnEffects(void)
             gBattleStruct->turnEffectsTracker++;
             break;
         case ENDTURN_PLASMA_FISTS:
-            for (i = 0; i < gBattlersCount; i++)
-                gStatuses4[i] &= ~STATUS4_PLASMA_FISTS;
+            gStatuses4[gActiveBattler] &= ~STATUS4_PLASMA_FISTS;
             gBattleStruct->turnEffectsTracker++;
             break;
         case ENDTURN_BATTLER_COUNT:  // done


### PR DESCRIPTION
## Description
The function in which `ENDTURN_PLASMA_FISTS` is located *(`DoBattlerEndTurnEffects`)* loops across all battlers by default.
When I wrote that ENDTURN effect, I didn't really know about that.
This PR removes the pointless `for` loop I made it run.
Please test before merging anyway, to be extra sure.

## **Discord contact info**
Lunos#4026