### PR TITLE
Removed repeated stat change defines

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -10671,9 +10671,6 @@ static u16 ReverseStatChangeMoveEffect(u16 moveEffect)
     }
 }
 
-#define STAT_CHANGE_WORKED      0
-#define STAT_CHANGE_DIDNT_WORK  1
-
 static u32 ChangeStatBuffs(s8 statValue, u32 statId, u32 flags, const u8 *BS_ptr)
 {
     bool32 certain = FALSE;


### PR DESCRIPTION
## Description
For w/e reason, the constants `STAT_CHANGE_WORKED` and `STAT_CHANGE_DIDNT_WORK` were defined twice in `src/battle_script_commands.c` which is the file that uses them.
This PR removes the pointless copies.

## **Discord contact info**
Lunos#4026