### PR TITLE
Reverting P_SHINY_BASE_CHANCE implementation as it wasn't accuerate to Gen6+

### DIFF
--- a/include/config/pokemon.h
+++ b/include/config/pokemon.h
@@ -9,7 +9,6 @@
 #define P_LEGENDARY_PERFECT_IVS GEN_LATEST  // Since Gen 6, Legendaries, Mythicals and Ultra Beasts found in the wild or given through gifts have at least 3 perfect IVs.
 #define P_KADABRA_EVERSTONE     GEN_LATEST  // Since Gen 4, Kadabra can evolve even when holding an Everstone.
 #define P_NIDORAN_M_DITTO_BREED GEN_LATEST  // Since Gen 5, when Nidoran♂ breeds with Ditto it can produce Nidoran♀ offspring. Before, it would only yield male offspring. This change also applies to Volbeat.
-#define P_SHINY_BASE_CHANCE     GEN_LATEST  // Since Gen 6, the base chances of encountering a Shiny Pokémon was raised to 1/4096. This config adds an extra roll to the calculation, which effectively does the same thing.
 
 // Flag settings
 // To use the following features in scripting, replace the 0s with the flag ID you're assigning it to.

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -3481,11 +3481,7 @@ void CreateBoxMon(struct BoxPokemon *boxMon, u16 species, u8 level, u8 fixedIV, 
         else
 #endif
         {
-        #if P_SHINY_BASE_CHANCE >= GEN_6
-            u32 totalRerolls = 1;
-        #else
             u32 totalRerolls = 0;
-        #endif
             if (CheckBagHasItem(ITEM_SHINY_CHARM, 1))
                 totalRerolls += I_SHINY_CHARM_REROLLS;
             if (LURE_STEP_COUNT != 0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Doing research, I realized that simply adding an extra roll to 1/8192 shiny chances doesn't equate to 1/4096 shiny chances. The more rolls, the more of a difference there is. Only really the first roll chances ends up being equivalent.

I think I want to add a field in #2372 to determine if a mon is shiny and that way users changing SHINY_ODDS will not change existing mon from and into shinies.

![image](https://user-images.githubusercontent.com/2904965/209739001-abc69938-2529-498a-9604-25ab414e9cef.png)

## **Discord contact info**
AsparagusEduardo#6051