### PR TITLE
Fix Sticky Barb activating on fainted Pokémon

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -7822,6 +7822,7 @@ u8 ItemBattleEffects(u8 caseID, u8 battlerId, bool8 moveTurn)
                   && !DoesSubstituteBlockMove(gBattlerAttacker, battlerId, gCurrentMove)
                   && IsBattlerAlive(gBattlerAttacker)
                   && CanStealItem(gBattlerAttacker, gBattlerTarget, gBattleMons[gBattlerTarget].item)
+                  && gBattleMons[gBattlerAttacker].hp != 0
                   && gBattleMons[gBattlerAttacker].item == ITEM_NONE)
                 {
                     // No sticky hold checks.


### PR DESCRIPTION
## Description
Fixes Sticky Barb activating on fainted Pokémon, which made the game softlock.

## **Discord contact info**
Jaizu#0001