### PR TITLE
add hp check to ITEMEFFECT_ORBS

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -7844,7 +7844,7 @@ u8 ItemBattleEffects(u8 caseID, u8 battlerId, bool8 moveTurn)
         switch (battlerHoldEffect)
         {
         case HOLD_EFFECT_TOXIC_ORB:
-            if (IsBattlerAlive(battlerId) && CanBePoisoned(battlerId, battlerId))
+            if (CanBePoisoned(battlerId, battlerId))
             {
                 effect = ITEM_STATUS_CHANGE;
                 gBattleMons[battlerId].status1 = STATUS1_TOXIC_POISON;
@@ -7853,7 +7853,7 @@ u8 ItemBattleEffects(u8 caseID, u8 battlerId, bool8 moveTurn)
             }
             break;
         case HOLD_EFFECT_FLAME_ORB:
-            if (IsBattlerAlive(battlerId) && CanBeBurned(battlerId))
+            if (CanBeBurned(battlerId))
             {
                 effect = ITEM_STATUS_CHANGE;
                 gBattleMons[battlerId].status1 = STATUS1_BURN;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -2701,8 +2701,11 @@ u8 DoBattlerEndTurnEffects(void)
             gBattleStruct->turnEffectsTracker++;
             break;
         case ENDTURN_ORBS:
-            if (ItemBattleEffects(ITEMEFFECT_ORBS, gActiveBattler, FALSE))
+            if (gBattleMons[gActiveBattler].hp != 0
+                    && ItemBattleEffects(ITEMEFFECT_ORBS, gActiveBattler, FALSE))
+            {
                 effect++;
+            }
             gBattleStruct->turnEffectsTracker++;
             break;
         case ENDTURN_LEECH_SEED:  // leech seed

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -2701,11 +2701,8 @@ u8 DoBattlerEndTurnEffects(void)
             gBattleStruct->turnEffectsTracker++;
             break;
         case ENDTURN_ORBS:
-            if (gBattleMons[gActiveBattler].hp != 0
-                    && ItemBattleEffects(ITEMEFFECT_ORBS, gActiveBattler, FALSE))
-            {
+            if (IsBattlerAlive(gActiveBattler) && ItemBattleEffects(ITEMEFFECT_ORBS, gActiveBattler, FALSE))
                 effect++;
-            }
             gBattleStruct->turnEffectsTracker++;
             break;
         case ENDTURN_LEECH_SEED:  // leech seed


### PR DESCRIPTION
Prevents orb effects/sticky barb from triggering if the holder is fainted