### PR TITLE
better handle throwing balls in a double wild battle

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4004,7 +4004,8 @@ static void HandleTurnActionSelectionState(void)
                     }
                     else if (WILD_DOUBLE_BATTLE
                              && position == B_POSITION_PLAYER_RIGHT
-                             && (gBattleStruct->throwingPokeBall || gChosenActionByBattler[GetBattlerAtPosition(B_POSITION_PLAYER_LEFT)] == B_ACTION_RUN))
+                             && (gBattleStruct->throwingPokeBall || gChosenActionByBattler[GetBattlerAtPosition(B_POSITION_PLAYER_LEFT)] == B_ACTION_RUN)
+                             && gChosenActionByBattler[GetBattlerAtPosition(B_POSITION_PLAYER_LEFT)] != B_ACTION_NOTHING_FAINTED)
                     {
                         gBattleStruct->throwingPokeBall = FALSE;
                         gChosenActionByBattler[gActiveBattler] = B_ACTION_NOTHING_FAINTED; // Not fainted, but it cannot move, because of the throwing ball.
@@ -4418,7 +4419,10 @@ static void HandleTurnActionSelectionState(void)
     {
         RecordedBattle_CheckMovesetChanges(B_RECORD_MODE_RECORDING);
 
-        if (WILD_DOUBLE_BATTLE && gBattleStruct->throwingPokeBall) {
+        if (WILD_DOUBLE_BATTLE
+            && gBattleStruct->throwingPokeBall
+            && gChosenActionByBattler[B_POSITION_PLAYER_RIGHT] != B_ACTION_NOTHING_FAINTED)
+        {
             // if we choose to throw a ball with our second mon, skip the action of the first
             // (if we have chosen throw ball with first, second's is already skipped)
             gChosenActionByBattler[B_POSITION_PLAYER_LEFT] = B_ACTION_NOTHING_FAINTED;

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4421,11 +4421,11 @@ static void HandleTurnActionSelectionState(void)
 
         if (WILD_DOUBLE_BATTLE
             && gBattleStruct->throwingPokeBall
-            && gChosenActionByBattler[B_POSITION_PLAYER_RIGHT] != B_ACTION_NOTHING_FAINTED)
+            && gChosenActionByBattler[GetBattlerAtPosition(B_POSITION_PLAYER_RIGHT)] != B_ACTION_NOTHING_FAINTED)
         {
             // if we choose to throw a ball with our second mon, skip the action of the first
             // (if we have chosen throw ball with first, second's is already skipped)
-            gChosenActionByBattler[B_POSITION_PLAYER_LEFT] = B_ACTION_NOTHING_FAINTED;
+            gChosenActionByBattler[GetBattlerAtPosition(B_POSITION_PLAYER_LEFT)] = B_ACTION_NOTHING_FAINTED;
         }
 
         gBattleMainFunc = SetActionsAndBattlersTurnOrder;


### PR DESCRIPTION
Fixes issues with throwing balls when the player has only a single pokemon in a double wild battle.

## Description
Without this patch, if one of the player's pokemon faints and they don't have another pokemon to replace it, throwing a ball results in odd behavior, such as the player's turn getting skipped. The game already checks to ensure that if the player would like to throw a ball in a double wild battle, the player does not get multiple turns by setting the action of the player's other mon to `B_ACTION_NOTHING_FAINTED`. This patch ensures that both the player's actions don't get set to that.

If there's a better way to do this, I'm happy to learn. This is my first attempt at making a change to the battle engine.

## **Discord contact info**
walkingeye#6360