### PR TITLE
Allow exiting the Battle Debug menu pressing B

### DIFF
--- a/src/battle_debug.c
+++ b/src/battle_debug.c
@@ -1107,7 +1107,7 @@ static void Task_DebugMenuProcessInput(u8 taskId)
     struct BattleDebugMenu *data = GetStructPtr(taskId);
 
     // Exit the menu.
-    if (JOY_NEW(SELECT_BUTTON))
+    if (JOY_NEW(SELECT_BUTTON) || ((JOY_NEW(B_BUTTON)) && data->activeWindow == ACTIVE_WIN_MAIN))
     {
         BeginNormalPaletteFade(-1, 0, 0, 0x10, 0);
         gTasks[taskId].func = Task_DebugMenuFadeOut;


### PR DESCRIPTION
## Description
This was the intended behavior since everywhere that SELECT_BUTTON is used it also allows B_BUTTON to be used. 
This breaks without checking the current active window, which I assume that's the reason Egg didn't bother adding B_BUTTON there and called it a day.

## **Discord contact info**
Jaizu#0001