### PR TITLE
Fix Wood Hammer To Have 1/3rd Recoil

### DIFF
--- a/src/data/battle_moves.h
+++ b/src/data/battle_moves.h
@@ -8150,7 +8150,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_Z] =
 
     [MOVE_WOOD_HAMMER] =
     {
-        .effect = EFFECT_RECOIL_25,
+        .effect = EFFECT_RECOIL_33,
         .power = 120,
         .type = TYPE_GRASS,
         .accuracy = 100,


### PR DESCRIPTION
Wood Hammer was set to 1/4th recoil before, now its 1/3rd

Archie#5000