### PR TITLE
Silk trap Animation

### DIFF
--- a/data/battle_anim_scripts.s
+++ b/data/battle_anim_scripts.s
@@ -14370,6 +14370,21 @@ Move_SCORCHING_SANDS::
 
 Move_JUNGLE_HEALING::
 	goto Move_AROMATHERAPY
+		
+Move_SILK_TRAP::
+	loadspritegfx ANIM_TAG_PROTECT
+	loadspritegfx ANIM_TAG_SPIDER_WEB
+	splitbgprio ANIM_ATTACKER
+	playsewithpan SE_M_STRING_SHOT2, SOUND_PAN_TARGET
+	createsprite gSpiderWebSpriteTemplate, ANIM_ATTACKER, 2, 0, 0, FALSE
+	waitforvisualfinish
+	createvisualtask AnimTask_BlendParticle, 5, ANIM_TAG_PROTECT, 0, 10, 10, RGB_LIME_GREEN
+	monbg ANIM_ATK_PARTNER 
+	waitplaysewithpan SE_M_REFLECT, SOUND_PAN_ATTACKER, 0x10 
+	createsprite gProtectSpriteTemplate, ANIM_ATTACKER, 2, 24, 0, 90
+	waitforvisualfinish
+	clearmonbg ANIM_ATK_PARTNER 
+	end
 
 Move_WICKED_BLOW::
 Move_SURGING_STRIKES::
@@ -14406,7 +14421,6 @@ Move_SANDSEAR_STORM::
 Move_LUNAR_BLESSING::
 Move_TAKE_HEART::
 Move_TERA_BLAST::
-Move_SILK_TRAP::
 Move_AXE_KICK::
 Move_LAST_RESPECTS::
 Move_LUMINA_CRASH::

--- a/include/constants/rgb.h
+++ b/include/constants/rgb.h
@@ -8,6 +8,7 @@
 #define RGB(r, g, b)  ((r) | ((g) << 5) | ((b) << 10))
 #define RGB2(r, g, b) (((b) << 10) | ((g) << 5) | (r))
 #define _RGB(r, g, b) ((((b) & 0x1F) << 10) + (((g) & 0x1F) << 5) + ((r) & 0x1F))
+#define RGB2GBA(r, g, b) (((r >> 3) & 31) | (((g >> 3) & 31) << 5) | (((b >> 3) & 31) << 10))
 
 #define RGB_ALPHA       (1 << 15)
 #define IS_ALPHA(color) ((color) & RGB_ALPHA)
@@ -22,5 +23,7 @@
 #define RGB_MAGENTA    RGB(31, 0, 31)
 #define RGB_CYAN       RGB(0, 31, 31)
 #define RGB_WHITEALPHA (RGB_WHITE | RGB_ALPHA)
+
+#define RGB_LIME_GREEN  RGB2GBA(222, 230, 49)
 
 #endif // GUARD_RGB_H


### PR DESCRIPTION
Simple animation for silk trap. At the very least its a placeholder since the move effect is complete.
![silktrap](https://user-images.githubusercontent.com/41651341/215270647-5ee14cfc-98de-40ad-a21c-0220e8a67dff.gif)


Also adds `RGB2GBA` macro to convert 0-255 value RGB colors (e.g. from MS Paint) to gba colors