### PR TITLE
Fix ball resetting when hatching an Egg

### DIFF
--- a/src/egg_hatch.c
+++ b/src/egg_hatch.c
@@ -378,9 +378,6 @@ static void AddHatchedMonToParty(u8 id)
 
     GetMonNickname2(mon, gStringVar1);
 
-    ball = ITEM_POKE_BALL;
-    SetMonData(mon, MON_DATA_POKEBALL, &ball);
-
     // A met level of 0 is interpreted on the summary screen as "hatched at"
     metLevel = 0;
     SetMonData(mon, MON_DATA_MET_LEVEL, &metLevel);


### PR DESCRIPTION
## Description
This SetMonData was making the feature introduced in 1b0ce96e12f876821333f43ce555552e0ff3f65d broken and useless, since the Egg would reset the ball when hatching.

## **Discord contact info**
Jaizu#0001