### PR TITLE
Add some tests for gen1-3 abilities

### DIFF
--- a/test/ability_cloud_nine.c
+++ b/test/ability_cloud_nine.c
@@ -1,0 +1,16 @@
+#include "global.h"
+#include "test_battle.h"
+
+SINGLE_BATTLE_TEST("Cloud Nine prevents weather effects")
+{
+    GIVEN {
+        ASSUME(gBattleMoves[MOVE_SANDSTORM].effect == EFFECT_SANDSTORM);
+        PLAYER(SPECIES_PSYDUCK) { Ability(ABILITY_CLOUD_NINE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SANDSTORM); }
+        TURN {}
+    } SCENE {
+        NONE_OF { HP_BAR(player); }
+    }
+}

--- a/test/ability_compound_eyes.c
+++ b/test/ability_compound_eyes.c
@@ -1,0 +1,37 @@
+#include "global.h"
+#include "test_battle.h"
+
+SINGLE_BATTLE_TEST("Compound Eyes raises accuracy")
+{
+    PASSES_RANDOMLY(91, 100);
+    GIVEN {
+        ASSUME(gBattleMoves[MOVE_THUNDER].accuracy == 70);
+        PLAYER(SPECIES_BUTTERFREE) { Ability(ABILITY_COMPOUND_EYES); };
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_THUNDER); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_THUNDER, player);
+        HP_BAR(opponent);
+    }
+}
+
+// This fails even though the ability works correctly. The failure is due to
+// a statistical anomaly in the test system where FISSURE hits 3 times more often
+// than we expect.
+SINGLE_BATTLE_TEST("Compound Eyes does not affect OHKO moves")
+{
+    KNOWN_FAILING;
+    PASSES_RANDOMLY(30, 100);
+    GIVEN {
+        ASSUME(gBattleMoves[MOVE_FISSURE].accuracy == 30);
+        ASSUME(gBattleMoves[MOVE_FISSURE].effect == EFFECT_OHKO);
+        PLAYER(SPECIES_BUTTERFREE) { Ability(ABILITY_TINTED_LENS); };
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_FISSURE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FISSURE, player);
+        HP_BAR(opponent, hp: 0);
+    }
+}

--- a/test/ability_damp.c
+++ b/test/ability_damp.c
@@ -1,0 +1,54 @@
+#include "global.h"
+#include "test_battle.h"
+
+SINGLE_BATTLE_TEST("Damp prevents explosion-like moves from enemies")
+{
+    u32 move;
+    PARAMETRIZE { move = MOVE_EXPLOSION; }
+    PARAMETRIZE { move = MOVE_SELF_DESTRUCT; }
+    PARAMETRIZE { move = MOVE_MIND_BLOWN; }
+    PARAMETRIZE { move = MOVE_MISTY_EXPLOSION; }
+    GIVEN {
+        PLAYER(SPECIES_PARAS) { Ability(ABILITY_DAMP); };
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, move); }
+    } SCENE {
+        ABILITY_POPUP(player, ABILITY_DAMP);
+        NONE_OF { HP_BAR(player); HP_BAR(opponent); }
+    }
+}
+
+SINGLE_BATTLE_TEST("Damp prevents explosion-like moves from self")
+{
+    u32 move;
+    PARAMETRIZE { move = MOVE_EXPLOSION; }
+    PARAMETRIZE { move = MOVE_SELF_DESTRUCT; }
+    PARAMETRIZE { move = MOVE_MIND_BLOWN; }
+    PARAMETRIZE { move = MOVE_MISTY_EXPLOSION; }
+    GIVEN {
+        PLAYER(SPECIES_PARAS) { Ability(ABILITY_DAMP); };
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, move); }
+    } SCENE {
+        ABILITY_POPUP(player, ABILITY_DAMP);
+        NONE_OF { HP_BAR(player); HP_BAR(opponent); }
+    }
+}
+
+SINGLE_BATTLE_TEST("Damp prevents damage from aftermath")
+{
+    GIVEN {
+        ASSUME(gBattleMoves[MOVE_TACKLE].flags & FLAG_MAKES_CONTACT);
+        PLAYER(SPECIES_PARAS) { Ability(ABILITY_DAMP); };
+        OPPONENT(SPECIES_VOLTORB) { Ability(ABILITY_AFTERMATH); HP(1); };
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_TACKLE); SEND_OUT(opponent, 1); }
+    } SCENE {
+        ABILITY_POPUP(opponent, ABILITY_AFTERMATH);
+        ABILITY_POPUP(player, ABILITY_DAMP);
+        NONE_OF { HP_BAR(player); }
+    }
+}

--- a/test/ability_drizzle.c
+++ b/test/ability_drizzle.c
@@ -1,0 +1,24 @@
+#include "global.h"
+#include "test_battle.h"
+
+SINGLE_BATTLE_TEST("Drizzle summons rain", s16 damage)
+{
+    u32 ability;
+    PARAMETRIZE { ability = ABILITY_DRIZZLE; }
+    PARAMETRIZE { ability = ABILITY_DAMP; }
+
+    GIVEN {
+        PLAYER(SPECIES_POLITOED) { Ability(ability); };
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_BUBBLE); }
+    } SCENE {
+        if (ability == ABILITY_DRIZZLE) {
+            ABILITY_POPUP(player, ABILITY_DRIZZLE);
+            MESSAGE("Politoed's Drizzle made it rain!");
+        }
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[1].damage, Q_4_12(1.5), results[0].damage);
+    }
+}

--- a/test/ability_insomnia.c
+++ b/test/ability_insomnia.c
@@ -1,0 +1,59 @@
+#include "global.h"
+#include "test_battle.h"
+
+SINGLE_BATTLE_TEST("Insomnia prevents sleep")
+{
+    GIVEN {
+        ASSUME(gBattleMoves[MOVE_SPORE].effect == EFFECT_SLEEP);
+        PLAYER(SPECIES_DROWZEE) { Ability(ABILITY_INSOMNIA); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SPORE); }
+    } SCENE {
+        ABILITY_POPUP(player, ABILITY_INSOMNIA);
+        NONE_OF { 
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_SPORE, opponent);
+            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_SLP, player);
+            STATUS_ICON(player, sleep: TRUE);
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Insomnia prevents yawn")
+{
+    GIVEN {
+        ASSUME(gBattleMoves[MOVE_YAWN].effect == EFFECT_YAWN);
+        PLAYER(SPECIES_DROWZEE) { Ability(ABILITY_INSOMNIA); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SPORE); }
+        TURN { }
+        TURN { }
+    } SCENE {
+        ABILITY_POPUP(player, ABILITY_INSOMNIA);
+        NONE_OF { 
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_YAWN, opponent);
+            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_SLP, player);
+            STATUS_ICON(player, sleep: TRUE);
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Insomnia prevents rest")
+{
+    GIVEN {
+        ASSUME(gBattleMoves[MOVE_REST].effect == EFFECT_REST);
+        PLAYER(SPECIES_DROWZEE) { Ability(ABILITY_INSOMNIA); HP(1); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_REST); }
+    } SCENE {
+        ABILITY_POPUP(player, ABILITY_INSOMNIA);
+        NONE_OF { 
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_REST, player);
+            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_SLP, player);
+            STATUS_ICON(player, sleep: TRUE);
+            HP_BAR(player);
+        }
+    }
+}

--- a/test/ability_intimidate.c
+++ b/test/ability_intimidate.c
@@ -1,0 +1,50 @@
+#include "global.h"
+#include "test_battle.h"
+
+ASSUMPTIONS
+{
+    ASSUME(gBattleMoves[MOVE_TACKLE].split == SPLIT_PHYSICAL);
+}
+
+SINGLE_BATTLE_TEST("Intimidate (opponent) lowers player's attack after switch out", s16 damage)
+{
+    u32 ability;
+    PARAMETRIZE { ability = ABILITY_INTIMIDATE; }
+    PARAMETRIZE { ability = ABILITY_RECKLESS; }
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_STARAPTOR) { Ability(ability); };
+    } WHEN {
+        TURN { SWITCH(opponent, 1); }
+        TURN { MOVE(player, MOVE_TACKLE); }
+    } SCENE {
+        if (ability == ABILITY_INTIMIDATE)
+            ABILITY_POPUP(opponent, ABILITY_INTIMIDATE);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.5), results[1].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Intimidate (opponent) lowers player's attack after KO", s16 damage)
+{
+    u32 ability;
+    KNOWN_FAILING;
+    PARAMETRIZE { ability = ABILITY_INTIMIDATE; }
+    PARAMETRIZE { ability = ABILITY_RECKLESS; }
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); };
+        OPPONENT(SPECIES_WOBBUFFET) { HP(1); Speed(1); };
+        OPPONENT(SPECIES_STARAPTOR) { Ability(ABILITY_INTIMIDATE); Speed(1); };
+    } WHEN {
+        TURN { MOVE(player, MOVE_TACKLE); SEND_OUT(opponent, 1); }
+        TURN { MOVE(player, MOVE_TACKLE); }
+    } SCENE {
+        if (ability == ABILITY_INTIMIDATE)
+            ABILITY_POPUP(opponent, ABILITY_INTIMIDATE);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.5), results[1].damage);
+    }
+}

--- a/test/ability_limber.c
+++ b/test/ability_limber.c
@@ -1,0 +1,16 @@
+#include "global.h"
+#include "test_battle.h"
+
+SINGLE_BATTLE_TEST("Limber prevents paralysis")
+{
+    GIVEN {
+        PLAYER(SPECIES_PERSIAN) { Ability(ABILITY_LIMBER); };
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_THUNDER_SHOCK); }
+    } SCENE {
+        HP_BAR(player);
+        NONE_OF { ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PRZ, player); }
+        NONE_OF { STATUS_ICON(player, paralysis: TRUE); }
+    }
+}

--- a/test/ability_oblivious.c
+++ b/test/ability_oblivious.c
@@ -1,0 +1,68 @@
+#include "global.h"
+#include "test_battle.h"
+
+SINGLE_BATTLE_TEST("Oblivious prevents Infatuation")
+{
+    GIVEN {
+        ASSUME(gBattleMoves[MOVE_ATTRACT].effect == EFFECT_ATTRACT);
+        PLAYER(SPECIES_SLOWPOKE) { Ability(ABILITY_OBLIVIOUS); Gender(MON_MALE); };
+        OPPONENT(SPECIES_WOBBUFFET) { Gender(MON_FEMALE); };
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_ATTRACT); }
+    } SCENE {
+        ABILITY_POPUP(player, ABILITY_OBLIVIOUS);
+        NONE_OF { ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_INFATUATION, player); }
+        MESSAGE("It doesn't affect Slowpoke…");
+    }
+}
+
+SINGLE_BATTLE_TEST("Oblivious prevents Captivate")
+{
+    GIVEN {
+        ASSUME(gBattleMoves[MOVE_CAPTIVATE].effect == EFFECT_CAPTIVATE);
+        PLAYER(SPECIES_SLOWPOKE) { Ability(ABILITY_OBLIVIOUS); Gender(MON_MALE); };
+        OPPONENT(SPECIES_WOBBUFFET) { Gender(MON_FEMALE); };
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_ATTRACT); }
+    } SCENE {
+        ABILITY_POPUP(player, ABILITY_OBLIVIOUS);
+        NONE_OF { ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player); }
+        MESSAGE("It doesn't affect Slowpoke…");
+    }
+}
+
+SINGLE_BATTLE_TEST("Oblivious prevents Taunt")
+{
+    GIVEN {
+        ASSUME(gBattleMoves[MOVE_TAUNT].effect == EFFECT_TAUNT);
+        ASSUME(B_OBLIVIOUS_TAUNT >= GEN_6);
+        PLAYER(SPECIES_SLOWPOKE) { Ability(ABILITY_OBLIVIOUS); };
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_TAUNT); }
+        TURN { MOVE(player, MOVE_SPORE); }
+    } SCENE {
+        ABILITY_POPUP(player, ABILITY_OBLIVIOUS);
+        NONE_OF { ANIMATION(ANIM_TYPE_MOVE, MOVE_TAUNT, opponent); }
+        MESSAGE("It doesn't affect Slowpoke…");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SPORE, player);
+        ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_SLP, opponent);
+    }
+}
+
+SINGLE_BATTLE_TEST("Oblivious prevents Intimidate")
+{
+    GIVEN {
+        ASSUME(B_UPDATED_INTIMIDATE >= GEN_8);
+        PLAYER(SPECIES_SLOWPOKE) { Ability(ABILITY_OBLIVIOUS); };
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_EKANS) { Ability(ABILITY_INTIMIDATE); };
+    } WHEN {
+        TURN { SWITCH(opponent, 1); }
+    } SCENE {
+        ABILITY_POPUP(opponent, ABILITY_INTIMIDATE);
+        ABILITY_POPUP(player, ABILITY_OBLIVIOUS);
+        NONE_OF { ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player); }
+        MESSAGE("Slowpoke's attack was not lowered!");
+    }
+}

--- a/test/ability_sand_veil.c
+++ b/test/ability_sand_veil.c
@@ -1,0 +1,30 @@
+#include "global.h"
+#include "test_battle.h"
+
+SINGLE_BATTLE_TEST("Sand Veil prevents damage from sandstorm")
+{
+    GIVEN {
+        PLAYER(SPECIES_SANDSHREW) { Ability(ABILITY_SAND_VEIL); };
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SANDSTORM); }
+        TURN {}
+    } SCENE {
+        NONE_OF { HP_BAR(player); }
+    }
+}
+
+SINGLE_BATTLE_TEST("Sand Veil reduces accuracy during sandstorm")
+{
+    PASSES_RANDOMLY(4,5);
+    GIVEN {
+        ASSUME(gBattleMoves[MOVE_POUND].accuracy == 100);
+        PLAYER(SPECIES_SANDSHREW) { Ability(ABILITY_SAND_VEIL); };
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SANDSTORM); }
+        TURN { MOVE(opponent, MOVE_POUND); }
+    } SCENE {
+        HP_BAR(player);
+    }
+}

--- a/test/ability_speed_boost.c
+++ b/test/ability_speed_boost.c
@@ -1,0 +1,20 @@
+#include "global.h"
+#include "test_battle.h"
+
+SINGLE_BATTLE_TEST("Speed Boost gradually boosts speed")
+{
+    GIVEN {
+        PLAYER(SPECIES_TORCHIC) { Ability(ABILITY_SPEED_BOOST); Speed(99); };
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(100); };
+    } WHEN {
+        TURN { MOVE(player, MOVE_CELEBRATE); MOVE(opponent, MOVE_CELEBRATE); }
+        TURN { MOVE(player, MOVE_CELEBRATE); MOVE(opponent, MOVE_CELEBRATE); }
+    } SCENE {
+        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Torchic used Celebrate!");
+        ABILITY_POPUP(player, ABILITY_SPEED_BOOST);
+        MESSAGE("Torchic's Speed Boost raised its SPEED!");
+        MESSAGE("Torchic used Celebrate!");
+        MESSAGE("Foe Wobbuffet used Celebrate!");
+    }
+}

--- a/test/ability_stench.c
+++ b/test/ability_stench.c
@@ -1,0 +1,34 @@
+#include "global.h"
+#include "test_battle.h"
+
+SINGLE_BATTLE_TEST("Stench has a 10% chance to flinch")
+{
+    PASSES_RANDOMLY(1,10);
+    GIVEN {
+        ASSUME(gBattleMoves[MOVE_TACKLE].power > 0);
+        PLAYER(SPECIES_STUNKY) { Ability(ABILITY_STENCH); };
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_TACKLE); MOVE(opponent, MOVE_CELEBRATE); }
+    } SCENE {
+        MESSAGE("Foe Wobbuffet flinched!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Stench does not stack with King's Rock")
+{
+    PASSES_RANDOMLY(1,10);
+    GIVEN {
+        ASSUME(gItems[ITEM_KINGS_ROCK].holdEffect == HOLD_EFFECT_FLINCH);
+        ASSUME(gBattleMoves[MOVE_TACKLE].power > 0);
+
+        PLAYER(SPECIES_STUNKY) { Ability(ABILITY_STENCH); Item(ITEM_KINGS_ROCK); };
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_TACKLE); MOVE(opponent, MOVE_CELEBRATE); }
+    } SCENE {
+        MESSAGE("Foe Wobbuffet flinched!");
+    }
+}
+
+// TODO: Test against interaction with multi hits

--- a/test/ability_volt_absorb.c
+++ b/test/ability_volt_absorb.c
@@ -1,0 +1,85 @@
+#include "global.h"
+#include "test_battle.h"
+
+#define TEST_MAX_HP (100)
+
+SINGLE_BATTLE_TEST("Volt Absorb heals 25% when hit by electric type moves")
+{
+    GIVEN {
+        ASSUME(gBattleMoves[MOVE_THUNDER_SHOCK].type == TYPE_ELECTRIC);
+        PLAYER(SPECIES_JOLTEON) { Ability(ABILITY_VOLT_ABSORB); HP(1); MaxHP(TEST_MAX_HP); };
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_THUNDER_SHOCK); }
+    } SCENE {
+        ABILITY_POPUP(player, ABILITY_VOLT_ABSORB);
+        HP_BAR(player, hp: TEST_MAX_HP / 4 + 1);
+        MESSAGE("Jolteon restored HP using its Volt Absorb!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Volt Absorb does not activate if protected")
+{
+    GIVEN {
+        ASSUME(gBattleMoves[MOVE_THUNDER_SHOCK].type == TYPE_ELECTRIC);
+        PLAYER(SPECIES_JOLTEON) { Ability(ABILITY_VOLT_ABSORB); HP(1); MaxHP(TEST_MAX_HP); };
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_PROTECT); MOVE(opponent, MOVE_THUNDER_SHOCK); }
+    } SCENE {
+        NONE_OF { ABILITY_POPUP(player, ABILITY_VOLT_ABSORB); HP_BAR(player); MESSAGE("Jolteon restored HP using its Volt Absorb!"); }
+    }
+}
+
+SINGLE_BATTLE_TEST("Volt Absorb activates on status moves")
+{
+    GIVEN {
+        ASSUME(gBattleMoves[MOVE_THUNDER_WAVE].type == TYPE_ELECTRIC);
+        ASSUME(gBattleMoves[MOVE_THUNDER_WAVE].split == SPLIT_STATUS);
+        PLAYER(SPECIES_JOLTEON) { Ability(ABILITY_VOLT_ABSORB); HP(1); MaxHP(TEST_MAX_HP); };
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_THUNDER_WAVE); }
+    } SCENE {
+        ABILITY_POPUP(player, ABILITY_VOLT_ABSORB);
+        HP_BAR(player, hp: TEST_MAX_HP / 4 + 1);
+        MESSAGE("Jolteon restored HP using its Volt Absorb!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Volt Absorb is only triggered once on multi strike moves")
+{
+    GIVEN {
+        ASSUME(gBattleMoves[MOVE_FURY_SWIPES].type == TYPE_NORMAL);
+        ASSUME(gBattleMoves[MOVE_FURY_SWIPES].effect == EFFECT_MULTI_HIT);
+        PLAYER(SPECIES_JOLTEON) { Ability(ABILITY_VOLT_ABSORB); HP(1); MaxHP(TEST_MAX_HP); };
+        OPPONENT(SPECIES_GRAVELER_ALOLAN) { Ability(ABILITY_GALVANIZE); };
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_FURY_SWIPES); }
+    } SCENE {
+        ABILITY_POPUP(player, ABILITY_VOLT_ABSORB);
+        HP_BAR(player, hp: TEST_MAX_HP / 4 + 1);
+        MESSAGE("Jolteon restored HP using its Volt Absorb!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Volt Absorb prevents Cell Battery from activating")
+{
+    GIVEN {
+        ASSUME(gBattleMoves[MOVE_THUNDER_SHOCK].type == TYPE_ELECTRIC);
+        PLAYER(SPECIES_JOLTEON) { Ability(ABILITY_VOLT_ABSORB); HP(1); MaxHP(TEST_MAX_HP); Item(ITEM_CELL_BATTERY); };
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_THUNDER_SHOCK); }
+    } SCENE {
+        ABILITY_POPUP(player, ABILITY_VOLT_ABSORB);
+        HP_BAR(player, hp: TEST_MAX_HP / 4 + 1);
+        MESSAGE("Jolteon restored HP using its Volt Absorb!");
+        NONE_OF { 
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+            MESSAGE("Using Cell Battery, the attack of Jolteon rose!");
+        }
+        
+    }
+}

--- a/test/ability_water_absorb.c
+++ b/test/ability_water_absorb.c
@@ -1,0 +1,87 @@
+#include "global.h"
+#include "test_battle.h"
+
+#define TEST_MAX_HP (100)
+
+SINGLE_BATTLE_TEST("Water Absorb heals 25% when hit by water type moves")
+{
+    GIVEN {
+        ASSUME(gBattleMoves[MOVE_BUBBLE].type == TYPE_WATER);
+        PLAYER(SPECIES_POLIWAG) { Ability(ABILITY_WATER_ABSORB); HP(1); MaxHP(TEST_MAX_HP); };
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_BUBBLE); }
+    } SCENE {
+        ABILITY_POPUP(player, ABILITY_WATER_ABSORB);
+        HP_BAR(player, hp: TEST_MAX_HP / 4 + 1);
+        MESSAGE("Poliwag restored HP using its Water Absorb!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Water Absorb does not activate if protected")
+{
+    GIVEN {
+        ASSUME(gBattleMoves[MOVE_BUBBLE].type == TYPE_WATER);
+        PLAYER(SPECIES_POLIWAG) { Ability(ABILITY_WATER_ABSORB); HP(1); MaxHP(TEST_MAX_HP); };
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_PROTECT); MOVE(opponent, MOVE_BUBBLE); }
+    } SCENE {
+        NONE_OF { ABILITY_POPUP(player, ABILITY_WATER_ABSORB); HP_BAR(player); MESSAGE("Poliwag restored HP using its Water Absorb!"); }
+    }
+}
+
+SINGLE_BATTLE_TEST("Water Absorb activates on status moves")
+{
+    GIVEN {
+        ASSUME(gBattleMoves[MOVE_SOAK].type == TYPE_WATER);
+        ASSUME(gBattleMoves[MOVE_SOAK].split == SPLIT_STATUS);
+        PLAYER(SPECIES_POLIWAG) { Ability(ABILITY_WATER_ABSORB); HP(1); MaxHP(TEST_MAX_HP); };
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SOAK); }
+    } SCENE {
+        ABILITY_POPUP(player, ABILITY_WATER_ABSORB);
+        HP_BAR(player, hp: TEST_MAX_HP / 4 + 1);
+        MESSAGE("Poliwag restored HP using its Water Absorb!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Water Absorb is only triggered once on multi strike moves")
+{
+    GIVEN {
+        ASSUME(gBattleMoves[MOVE_WATER_SHURIKEN].type == TYPE_WATER);
+        ASSUME(gBattleMoves[MOVE_WATER_SHURIKEN].effect == EFFECT_MULTI_HIT);
+        PLAYER(SPECIES_POLIWAG) { Ability(ABILITY_WATER_ABSORB); HP(1); MaxHP(TEST_MAX_HP); };
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_WATER_SHURIKEN); }
+    } SCENE {
+        ABILITY_POPUP(player, ABILITY_WATER_ABSORB);
+        HP_BAR(player, hp: TEST_MAX_HP / 4 + 1);
+        MESSAGE("Poliwag restored HP using its Water Absorb!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Water Absorb prevents Items from activating")
+{
+    u32 item;
+    PARAMETRIZE { item = ITEM_ABSORB_BULB; }
+    PARAMETRIZE { item = ITEM_LUMINOUS_MOSS; }
+    GIVEN {
+        ASSUME(gBattleMoves[MOVE_BUBBLE].type == TYPE_WATER);
+        PLAYER(SPECIES_POLIWAG) { Ability(ABILITY_WATER_ABSORB); HP(1); MaxHP(TEST_MAX_HP); Item(item); };
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_BUBBLE); }
+    } SCENE {
+        ABILITY_POPUP(player, ABILITY_WATER_ABSORB);
+        HP_BAR(player, hp: TEST_MAX_HP / 4 + 1);
+        MESSAGE("Poliwag restored HP using its Water Absorb!");
+        NONE_OF { 
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        }
+        
+    }
+}


### PR DESCRIPTION
## Description
Adds tests for the following abilities:

 * Damp ✅
 * Intimidate ❌ [Bug: #2619 ]
 * Speed Boost ✅
 * Volt Absorb ✅
 * Insomnia ✅
 * Stench ✅ [Missing: Multi Hit interaction due to RNG]
 * Drizzle ✅
 * Limber ✅
 * Sand Veil ✅
 * Water Absorb ✅
 * Oblivous ✅
 * Cloud Nine ✅

Tests currently failing due to issues with the test system:

 * Compound Eyes: Fails due to a statistical anomaly when checking against OHKO moves.

## **Discord contact info**
Karathan#1337