### PR TITLE
Add Logic for Heal Pulse effects in double battles

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -3009,6 +3009,13 @@ static s16 AI_DoubleBattle(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
                     RETURN_SCORE_PLUS(1);
                 }
                 break;
+            case EFFECT_HEAL_PULSE:
+            case EFFECT_HIT_ENEMY_HEAL_ALLY:
+                if (AI_WhoStrikesFirst(battlerAtk, FOE(battlerAtk), move) == AI_IS_FASTER
+                  && AI_WhoStrikesFirst(battlerAtk, BATTLE_PARTNER(FOE(battlerAtk)), move) == AI_IS_FASTER
+                  && gBattleMons[battlerAtkPartner].hp < gBattleMons[battlerAtkPartner].maxHP / 2)
+                    RETURN_SCORE_PLUS(1);
+                break;
             } // attacker move effects
         } // check partner protecting
 


### PR DESCRIPTION
Consider Heal Pulse and Pollen Puff in double battles.

Add logic to consider EFFECT_HEAL_PULSE EFFECT_HIT_ENEMY_HEAL_ALLY on partner pokemon in AI_DoubleBattle.

![image](https://user-images.githubusercontent.com/93446519/217525468-22670fc0-8608-46c1-8206-7bf1aade6c6d.png)
![image](https://user-images.githubusercontent.com/93446519/217525483-7f7ae93c-ca00-46e6-9217-6b183de52d30.png)
![image](https://user-images.githubusercontent.com/93446519/217525494-66c91434-b152-40f1-9581-1679a3c700ea.png)
