### PR TITLE
Z-Move Indicator was wrongly displayed in double battles

### DIFF
--- a/src/battle_z_move.c
+++ b/src/battle_z_move.c
@@ -372,7 +372,7 @@ static void ShowZMoveTriggerSprite(void)
 {
     struct Sprite *sprite = &gSprites[gBattleStruct->zmove.triggerSpriteId];
     gBattleStruct->zmove.viable = TRUE;
-    CreateZMoveTriggerSprite(sprite->tBattler, TRUE);
+    CreateZMoveTriggerSprite(gActiveBattler, TRUE);
 }
 
 void DestroyZMoveTriggerSprite(void)

--- a/src/battle_z_move.c
+++ b/src/battle_z_move.c
@@ -50,7 +50,7 @@ static u16 GetSignatureZMove(u16 move, u16 species, u16 item);
 static u16 GetTypeBasedZMove(u16 move, u8 battler);
 static void ZMoveSelectionDisplayPpNumber(void);
 static void ZMoveSelectionDisplayPower(u16 move, u16 zMove);
-static void ShowZMoveTriggerSprite(void);
+static void ShowZMoveTriggerSprite(u8 battleId);
 static bool32 AreStatsMaxed(u8 battlerId, u8 n);
 static u8 GetZMoveScore(u8 battlerAtk, u8 battlerDef, u16 baseMove, u16 zMove);
 static void ZMoveSelectionDisplayMoveType(u16 zMove);
@@ -258,7 +258,7 @@ bool32 TryChangeZIndicator(u8 battlerId, u8 moveIndex)
     if (gBattleStruct->zmove.viable && !viableZMove)
         HideZMoveTriggerSprite();   // Was a viable z move, now is not -> slide out
     else if (!gBattleStruct->zmove.viable && viableZMove)
-        ShowZMoveTriggerSprite();   // Was not a viable z move, now is -> slide back in
+        ShowZMoveTriggerSprite(battlerId);   // Was not a viable z move, now is -> slide back in
 }
 
 #define SINGLES_Z_TRIGGER_POS_X_OPTIMAL     (29)
@@ -368,11 +368,11 @@ void HideZMoveTriggerSprite(void)
     gBattleStruct->zmove.viable = FALSE;
 }
 
-static void ShowZMoveTriggerSprite(void)
+static void ShowZMoveTriggerSprite(u8 battlerId)
 {
     struct Sprite *sprite = &gSprites[gBattleStruct->zmove.triggerSpriteId];
     gBattleStruct->zmove.viable = TRUE;
-    CreateZMoveTriggerSprite(gActiveBattler, TRUE);
+    CreateZMoveTriggerSprite(battlerId, TRUE);
 }
 
 void DestroyZMoveTriggerSprite(void)


### PR DESCRIPTION
Fix for issue #2425

The PR fixes an issue with the Z-move indicator. It was displayed in the wrong battler health box.

![z_indicator](https://user-images.githubusercontent.com/93446519/218276491-69c5ee21-0599-49d4-b0da-bd49cbb44225.gif)
