### PR TITLE
Improve Hydra output

### DIFF
--- a/test/test_runner.c
+++ b/test/test_runner.c
@@ -187,7 +187,17 @@ void CB2_TestRunner(void)
 
             switch (gTestRunnerState.result)
             {
-            case TEST_RESULT_FAIL: result = "FAIL"; break;
+            case TEST_RESULT_FAIL:
+                if (gTestRunnerState.expectedResult == TEST_RESULT_FAIL)
+                {
+                    result = "KNOWN_FAILING";
+                    color = "\e[33m";
+                }
+                else
+                {
+                    result = "FAIL";
+                }
+                break;
             case TEST_RESULT_PASS: result = "PASS"; break;
             case TEST_RESULT_SKIP: result = "SKIP"; break;
             case TEST_RESULT_INVALID: result = "INVALID"; break;


### PR DESCRIPTION
## Description
Tests that are expected to fail, and do fail are now displayed as `KNOWN_FAILING` with a yellow CLI color to indicate it.

![image](https://user-images.githubusercontent.com/3799173/219393417-64ad9389-202b-4e20-9000-618747613dca.png)


## **Discord contact info**
Karathan#1337