### PR TITLE
Detect memory leaks in tests

### DIFF
--- a/gflib/malloc.h
+++ b/gflib/malloc.h
@@ -11,11 +11,48 @@
 
 #define TRY_FREE_AND_SET_NULL(ptr) if (ptr != NULL) FREE_AND_SET_NULL(ptr)
 
+#define MALLOC_SYSTEM_ID 0xA3A3
+
+struct MemBlock
+{
+    // Whether this block is currently allocated.
+    u16 allocated:1;
+
+    u16 unused_00:4;
+
+    // High 11 bits of location pointer.
+    u16 locationHi:11;
+
+    // Magic number used for error checking. Should equal MALLOC_SYSTEM_ID.
+    u16 magic;
+
+    // Size of the block (not including this header struct).
+    u32 size:18;
+
+    // Low 14 bits of location pointer.
+    u32 locationLo:14;
+
+    // Previous block pointer. Equals sHeapStart if this is the first block.
+    struct MemBlock *prev;
+
+    // Next block pointer. Equals sHeapStart if this is the last block.
+    struct MemBlock *next;
+
+    // Data in the memory block. (Arrays of length 0 are a GNU extension.)
+    u8 data[0];
+};
+
 extern u8 gHeap[];
 
-void *Alloc(u32 size);
-void *AllocZeroed(u32 size);
+#define Alloc(size) Alloc_(size, __FILE__ ":" STR(__LINE__))
+#define AllocZeroed(size) AllocZeroed_(size, __FILE__ ":" STR(__LINE__))
+
+void *Alloc_(u32 size, const char *location);
+void *AllocZeroed_(u32 size, const char *location);
 void Free(void *pointer);
 void InitHeap(void *pointer, u32 size);
+
+const struct MemBlock *HeapHead(void);
+const char *MemBlockLocation(const struct MemBlock *block);
 
 #endif // GUARD_ALLOC_H

--- a/include/gba/defines.h
+++ b/include/gba/defines.h
@@ -22,6 +22,9 @@
 #define INTR_CHECK     (*(u16 *)0x3007FF8)
 #define INTR_VECTOR    (*(void **)0x3007FFC)
 
+#define ROM_START 0x8000000
+#define ROM_END 0xA000000
+
 #define EWRAM_START 0x02000000
 #define EWRAM_END   (EWRAM_START + 0x40000)
 #define IWRAM_START 0x03000000

--- a/include/global.h
+++ b/include/global.h
@@ -147,6 +147,9 @@
 #define CAT(a, b) CAT_(a, b)
 #define CAT_(a, b) a ## b
 
+#define STR(a) STR_(a)
+#define STR_(a) #a
+
 // Converts a string to a compound literal, essentially making it a pointer to const u8
 #define COMPOUND_STRING(str) (const u8[]) _(str)
 

--- a/test/test.h
+++ b/test/test.h
@@ -46,6 +46,7 @@ struct TestRunnerState
 
     u8 result;
     u8 expectedResult;
+    bool8 expectLeaks:1;
     u32 timeoutSeconds;
 };
 
@@ -69,6 +70,7 @@ extern struct TestRunnerState gTestRunnerState;
 void CB2_TestRunner(void);
 
 void Test_ExpectedResult(enum TestResult);
+void Test_ExpectLeaks(bool32);
 void Test_ExitWithResult(enum TestResult, const char *fmt, ...);
 
 s32 MgbaPrintf_(const char *fmt, ...);
@@ -159,6 +161,9 @@ s32 MgbaPrintf_(const char *fmt, ...);
 
 #define KNOWN_FAILING \
     Test_ExpectedResult(TEST_RESULT_FAIL)
+
+#define KNOWN_LEAKING \
+    Test_ExpectLeaks(TRUE)
 
 #define PARAMETRIZE if (gFunctionTestRunnerState->parameters++ == gFunctionTestRunnerState->runParameter)
 

--- a/test/test_battle.h
+++ b/test/test_battle.h
@@ -615,6 +615,7 @@ struct BattleTestRunnerState
     bool8 runThen:1;
     bool8 runFinally:1;
     bool8 runningFinally:1;
+    bool8 tearDownBattle:1;
     struct BattleTestData data;
     u8 *results;
     u8 checkProgressParameter;

--- a/test/test_runner_battle.c
+++ b/test/test_runner_battle.c
@@ -893,6 +893,15 @@ static void BattleTest_TearDown(void *data)
 {
     if (STATE)
     {
+        // Free resources that aren't cleaned up when the battle was
+        // aborted unexpectedly.
+        if (STATE->tearDownBattle)
+        {
+            FreeMonSpritesGfx();
+            FreeBattleSpritesData();
+            FreeBattleResources();
+            FreeAllWindowBuffers();
+        }
         FREE_AND_SET_NULL(STATE->results);
         FREE_AND_SET_NULL(STATE);
     }
@@ -923,6 +932,7 @@ static bool32 BattleTest_HandleExitWithResult(void *data, enum TestResult result
     }
     else
     {
+        STATE->tearDownBattle = TRUE;
         return FALSE;
     }
 }


### PR DESCRIPTION
Can use `KNOWN_LEAKING;` to specify that a test is known to leak memory. This is not particularly useful for battle tests, but could be useful for the generic tests introduced by #2696.

The location information is available in regular game builds. Thus it is available for use in debugging leaks in-game too. In the future we should consider replacing it with `NULL` if `NDEBUG` is defined. This is not currently possible because the tests do not force `NDEBUG` to be undefined.

To avoid changing the size of `struct MemBlock`s, I have stuffed the pointer into unused bits.

Example:
```diff
--- a/test/move_effect_absorb.c
+++ b/test/move_effect_absorb.c
@@ -12,6 +12,7 @@ SINGLE_BATTLE_TEST("Absorb recovers 50% of the damage dealt")
+        void *x = Alloc(0x8);
```
```
$ make check
Absorb recovers 50% of the damage dealt: FAIL
test/move_effect_absorb.c:15: 8 bytes not freed
```