### PR TITLE
Z-Moves bypass protection

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -10036,6 +10036,11 @@ BattleScript_HealReplacementZMove::
 	datahpupdate BS_SCRIPTING
 	return
 
+BattleScript_CouldntFullyProtect::
+	printstring STRINGID_COULDNTFULLYPROTECT
+	waitmessage B_WAIT_TIME_LONG
+	return
+
 BattleScript_EffectExtremeEvoboost::
 	attackcanceler
 	attackstring

--- a/include/battle_scripts.h
+++ b/include/battle_scripts.h
@@ -461,5 +461,6 @@ extern const u8 BattleScript_RecoverHPZMove[];
 extern const u8 BattleScript_StatUpZMove[];
 extern const u8 BattleScript_HealReplacementZMove[];
 extern const u8 BattleScript_EffectExtremeEvoboost[];
+extern const u8 BattleScript_CouldntFullyProtect[];
 
 #endif // GUARD_BATTLE_SCRIPTS_H

--- a/include/constants/battle_string_ids.h
+++ b/include/constants/battle_string_ids.h
@@ -639,8 +639,9 @@
 #define STRINGID_ABILITYWEAKENEDFSURROUNDINGMONSSTAT  637
 #define STRINGID_ATTACKERGAINEDSTRENGTHFROMTHEFALLEN  638
 #define STRINGID_PKMNSABILITYPREVENTSABILITY          639
+#define STRINGID_COULDNTFULLYPROTECT                  640
 
-#define BATTLESTRINGS_COUNT                           640
+#define BATTLESTRINGS_COUNT                           641
 
 // This is the string id that gBattleStringsTable starts with.
 // String ids before this (e.g. STRINGID_INTROMSG) are not in the table,

--- a/src/battle_message.c
+++ b/src/battle_message.c
@@ -774,9 +774,11 @@ static const u8 sText_StatWasHeightened[] = _("{B_SCR_ACTIVE_NAME_WITH_PREFIX}'s
 static const u8 sText_ElectricTerrainActivatedAbility[] = _("The Electric Terrain activated\n{B_SCR_ACTIVE_NAME_WITH_PREFIX}'s {B_LAST_ABILITY}!");
 static const u8 sText_AbilityWeakenedSurroundingMonsStat[] = _("{B_ATK_NAME_WITH_PREFIX}'s {B_ATK_ABILITY}\nweakened the {B_BUFF1} of\lall surrounding Pokémon!\p");
 static const u8 sText_AttackerGainedStrengthFromTheFallen[] = _("{B_ATK_NAME_WITH_PREFIX} gained strength\nfrom the fallen!");
+static const u8 sText_CouldntFullyProtect[] = _("{B_DEF_NAME_WITH_PREFIX} couldn't fully protect\nitself and got hurt!");
 
 const u8 *const gBattleStringsTable[BATTLESTRINGS_COUNT] =
 {
+    [STRINGID_COULDNTFULLYPROTECT - BATTLESTRINGS_TABLE_START] = sText_CouldntFullyProtect,
     [STRINGID_ATTACKERGAINEDSTRENGTHFROMTHEFALLEN - BATTLESTRINGS_TABLE_START] = sText_AttackerGainedStrengthFromTheFallen,
     [STRINGID_ABILITYWEAKENEDFSURROUNDINGMONSSTAT - BATTLESTRINGS_TABLE_START] = sText_AbilityWeakenedSurroundingMonsStat,
     [STRINGID_ELECTRICTERRAINACTIVATEDABILITY - BATTLESTRINGS_TABLE_START] = sText_ElectricTerrainActivatedAbility,

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1590,6 +1590,14 @@ static void Cmd_attackcanceler(void)
         return;
     }
 
+    // Z-moves and Max Moves bypass protection, but deal reduced damage (factored in CalcFinalDmg)
+    if (gBattleStruct->zmove.active && IS_BATTLER_PROTECTED(gBattlerTarget))
+    {
+        BattleScriptPush(cmd->nextInstr);
+        gBattlescriptCurrInstr = BattleScript_CouldntFullyProtect;
+        return;
+    }
+
     for (i = 0; i < gBattlersCount; i++)
     {
         if ((gProtectStructs[gBattlerByTurnOrder[i]].stealMove) && gBattleMoves[gCurrentMove].flags & FLAG_SNATCH_AFFECTED)

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -8229,9 +8229,15 @@ bool32 IsBattlerProtected(u8 battlerId, u16 move)
             return FALSE;
     }
 
-        if (move == MOVE_TEATIME)
+    if (move == MOVE_TEATIME)
     {
-            return FALSE;
+        return FALSE;
+    }
+
+    // Z-Moves and Max Moves bypass protection
+    if (gBattleStruct->zmove.active)
+    {
+        return FALSE;
     }
 
     // Protective Pads doesn't stop Unseen Fist from bypassing Protect effects, so IsMoveMakingContact() isn't used here.
@@ -9616,6 +9622,12 @@ static u32 CalcFinalDmg(u32 dmg, u16 move, u8 battlerAtk, u8 battlerDef, u8 move
             MulModifier(&finalModifier, UQ_4_12(0.5));
         else
             MulModifier(&finalModifier, UQ_4_12(0.25));
+    }
+
+    // Z-Moves and Max Moves bypass Protect and do 25% of their original damage
+    if (gBattleStruct->zmove.active && IS_BATTLER_PROTECTED(battlerDef))
+    {
+        MulModifier(&finalModifier, UQ_4_12(0.25));
     }
 
     // attacker's abilities


### PR DESCRIPTION
"Create a problem then sell the solution." Addresses #2728. This might need a little more testing, but it's a pretty simple implementation. I was having some issues with Z-Scratch turning into regular Growl, but the branch was clean so I will assume this was due to save issues. Demo below:

![Z Moves - Protect](https://user-images.githubusercontent.com/103095241/220822426-223f3a24-b905-456e-9cec-c6795b9621c4.gif)


## **Discord Contact Info**
Agustin#1522