### PR TITLE
Z-moves bypass protection

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -10330,3 +10330,8 @@ BattleScript_PokemonCantUseTheMove::
 	printstring STRINGID_BUTPOKEMONCANTUSETHEMOVE
 	waitmessage B_WAIT_TIME_LONG
 	goto BattleScript_MoveEnd
+
+BattleScript_CouldntFullyProtect::
+	printstring STRINGID_COULDNTFULLYPROTECT
+	waitmessage B_WAIT_TIME_LONG
+	return

--- a/include/battle_scripts.h
+++ b/include/battle_scripts.h
@@ -453,6 +453,7 @@ extern const u8 BattleScript_DampPreventsAftermath[];
 extern const u8 BattleScript_HealingWishActivates[];
 extern const u8 BattleScript_LunarDanceActivates[];
 extern const u8 BattleScript_ShellTrapSetUp[];
+extern const u8 BattleScript_CouldntFullyProtect[];
 
 // zmoves
 extern const u8 BattleScript_ZMoveActivateDamaging[];

--- a/include/constants/battle_string_ids.h
+++ b/include/constants/battle_string_ids.h
@@ -641,8 +641,9 @@
 #define STRINGID_PKMNSABILITYPREVENTSABILITY          639
 #define STRINGID_PREPARESHELLTRAP                     640
 #define STRINGID_SHELLTRAPDIDNTWORK                   641
+#define STRINGID_COULDNTFULLYPROTECT                  642
 
-#define BATTLESTRINGS_COUNT                           642
+#define BATTLESTRINGS_COUNT                           643
 
 // This is the string id that gBattleStringsTable starts with.
 // String ids before this (e.g. STRINGID_INTROMSG) are not in the table,

--- a/src/battle_message.c
+++ b/src/battle_message.c
@@ -776,9 +776,11 @@ static const u8 sText_AbilityWeakenedSurroundingMonsStat[] = _("{B_ATK_NAME_WITH
 static const u8 sText_AttackerGainedStrengthFromTheFallen[] = _("{B_ATK_NAME_WITH_PREFIX} gained strength\nfrom the fallen!");
 static const u8 sText_PrepareShellTrap[] = _("{B_ATK_NAME_WITH_PREFIX} set a shell trap!");
 static const u8 sText_ShellTrapDidntWork[] = _("{B_ATK_NAME_WITH_PREFIX}'s shell trap didn't work!");
+static const u8 sText_CouldntFullyProtect[] = _("{B_DEF_NAME_WITH_PREFIX} couldn't fully protect\nitself and got hurt!");
 
 const u8 *const gBattleStringsTable[BATTLESTRINGS_COUNT] =
 {
+    [STRINGID_COULDNTFULLYPROTECT - BATTLESTRINGS_TABLE_START] = sText_CouldntFullyProtect,
     [STRINGID_ATTACKERGAINEDSTRENGTHFROMTHEFALLEN - BATTLESTRINGS_TABLE_START] = sText_AttackerGainedStrengthFromTheFallen,
     [STRINGID_ABILITYWEAKENEDFSURROUNDINGMONSSTAT - BATTLESTRINGS_TABLE_START] = sText_AbilityWeakenedSurroundingMonsStat,
     [STRINGID_ELECTRICTERRAINACTIVATEDABILITY - BATTLESTRINGS_TABLE_START] = sText_ElectricTerrainActivatedAbility,

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1591,6 +1591,14 @@ static void Cmd_attackcanceler(void)
         return;
     }
 
+    // Z-moves and Max Moves bypass protection, but deal reduced damage (factored in CalcFinalDmg)
+    if (gBattleStruct->zmove.active && IS_BATTLER_PROTECTED(gBattlerTarget))
+    {
+        BattleScriptPush(cmd->nextInstr);
+        gBattlescriptCurrInstr = BattleScript_CouldntFullyProtect;
+        return;
+    }
+
     for (i = 0; i < gBattlersCount; i++)
     {
         if ((gProtectStructs[gBattlerByTurnOrder[i]].stealMove) && gBattleMoves[gCurrentMove].flags & FLAG_SNATCH_AFFECTED)

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -8243,9 +8243,15 @@ bool32 IsBattlerProtected(u8 battlerId, u16 move)
             return FALSE;
     }
 
-        if (move == MOVE_TEATIME)
+    if (move == MOVE_TEATIME)
     {
-            return FALSE;
+        return FALSE;
+    }
+
+    // Z-Moves and Max Moves bypass protection
+    if (gBattleStruct->zmove.active)
+    {
+        return FALSE;
     }
 
     // Protective Pads doesn't stop Unseen Fist from bypassing Protect effects, so IsMoveMakingContact() isn't used here.
@@ -9630,6 +9636,12 @@ static u32 CalcFinalDmg(u32 dmg, u16 move, u8 battlerAtk, u8 battlerDef, u8 move
             MulModifier(&finalModifier, UQ_4_12(0.5));
         else
             MulModifier(&finalModifier, UQ_4_12(0.25));
+    }
+
+    // Z-Moves and Max Moves bypass Protect and do 25% of their original damage
+    if (gBattleStruct->zmove.active && IS_BATTLER_PROTECTED(battlerDef))
+    {
+        MulModifier(&finalModifier, UQ_4_12(0.25));
     }
 
     // attacker's abilities


### PR DESCRIPTION
Addresses my #2728. I had some issues with Breakneck Blitz just turning into Growl, but since I worked on a clean branch I am assuming it is a savefile issue or something. The implementation is pretty simple so hopefully not buggy, but wasn't extensively tested. Demo below:

![Z Moves - Protect](https://user-images.githubusercontent.com/103095241/220823546-91b17589-b9c6-4265-aeec-1c54c366b2b7.gif)

## **Discord Contact Info**
Agustin#1522