### PR TITLE
fix uninitialized ai modifier variable in ai calc damage

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -802,6 +802,7 @@ s32 AI_CalcDamage(u16 move, u8 battlerAtk, u8 battlerDef, u8 *typeEffectiveness,
     }
     else
     {
+        effectivenessMultiplier = CalcTypeEffectivenessMultiplier(move, moveType, battlerAtk, battlerDef, FALSE);
         dmg = 0;
     }
 
@@ -1166,7 +1167,7 @@ s32 AI_GetAbility(u32 battlerId)
     // We've had ability overwritten by e.g. Worry Seed. It is not part of AI_PARTY in case of switching
     if (gBattleStruct->overwrittenAbilities[battlerId])
         return gBattleStruct->overwrittenAbilities[battlerId];
-    
+
     // The AI knows its own ability.
     if (IsBattlerAIControlled(battlerId))
         return knownAbility;


### PR DESCRIPTION
Fixes #2346

Before:
![pokeemerald_01](https://user-images.githubusercontent.com/16259973/220861573-1560c7e3-5478-4c37-90e1-5e920ea411da.png)


After:
![pokeemerald_02](https://user-images.githubusercontent.com/16259973/220861587-8e0dc648-6286-4a4c-a4ea-4b33bea7b8eb.png)
