### PR TITLE
Status moves should not be considered for type effectiveness

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -802,7 +802,16 @@ s32 AI_CalcDamage(u16 move, u8 battlerAtk, u8 battlerDef, u8 *typeEffectiveness,
     }
     else
     {
-        effectivenessMultiplier = CalcTypeEffectivenessMultiplier(move, moveType, battlerAtk, battlerDef, FALSE);
+        #if B_GLARE_GHOST == GEN_3
+        else if (move == MOVE_GLARE || move == MOVE_THUNDER_WAVE)
+            effectivenessMultiplier = CalcTypeEffectivenessMultiplier(move, moveType, battlerAtk, battlerDef, FALSE);
+        else
+#       endif
+        if (move == MOVE_THUNDER_WAVE)
+            effectivenessMultiplier = CalcTypeEffectivenessMultiplier(move, moveType, battlerAtk, battlerDef, FALSE);
+        else
+            effectivenessMultiplier = UQ_4_12(1.0);
+
         dmg = 0;
     }
 

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -802,16 +802,7 @@ s32 AI_CalcDamage(u16 move, u8 battlerAtk, u8 battlerDef, u8 *typeEffectiveness,
     }
     else
     {
-        #if B_GLARE_GHOST == GEN_3
-        else if (move == MOVE_GLARE || move == MOVE_THUNDER_WAVE)
-            effectivenessMultiplier = CalcTypeEffectivenessMultiplier(move, moveType, battlerAtk, battlerDef, FALSE);
-        else
-#       endif
-        if (move == MOVE_THUNDER_WAVE)
-            effectivenessMultiplier = CalcTypeEffectivenessMultiplier(move, moveType, battlerAtk, battlerDef, FALSE);
-        else
-            effectivenessMultiplier = UQ_4_12(1.0);
-
+        effectivenessMultiplier = CalcTypeEffectivenessMultiplier(move, moveType, battlerAtk, battlerDef, FALSE);
         dmg = 0;
     }
 

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -9851,7 +9851,17 @@ static u16 CalcTypeEffectivenessMultiplierInternal(u16 move, u8 moveType, u8 bat
         && gBattleMons[battlerDef].type3 != gBattleMons[battlerDef].type1)
         MulByTypeEffectiveness(&modifier, move, moveType, battlerDef, gBattleMons[battlerDef].type3, battlerAtk, recordAbilities);
 
-    if (moveType == TYPE_GROUND && !IsBattlerGrounded2(battlerDef, TRUE) && !(gBattleMoves[move].flags & FLAG_DMG_UNGROUNDED_IGNORE_TYPE_IF_FLYING))
+    if (gBattleMoves[move].split == SPLIT_STATUS && move != MOVE_THUNDER_WAVE)
+    {
+        modifier = UQ_4_12(1.0);
+        #if B_GLARE_GHOST <= GEN_3
+            if (move == MOVE_GLARE && IS_BATTLER_OF_TYPE(battlerDef, TYPE_GHOST))
+            {
+                modifier = UQ_4_12(0.0);
+            }
+        #endif
+    }
+    else if (moveType == TYPE_GROUND && !IsBattlerGrounded2(battlerDef, TRUE) && !(gBattleMoves[move].flags & FLAG_DMG_UNGROUNDED_IGNORE_TYPE_IF_FLYING))
     {
         modifier = UQ_4_12(0.0);
         if (recordAbilities && defAbility == ABILITY_LEVITATE)
@@ -9867,12 +9877,6 @@ static u16 CalcTypeEffectivenessMultiplierInternal(u16 move, u8 moveType, u8 bat
     else if (move == MOVE_SHEER_COLD && IS_BATTLER_OF_TYPE(battlerDef, TYPE_ICE))
     {
         modifier = UQ_4_12(0.0);
-    }
-#endif
-#if B_GLARE_GHOST >= GEN_4
-    else if (move == MOVE_GLARE && IS_BATTLER_OF_TYPE(battlerDef, TYPE_GHOST))
-    {
-        modifier = UQ_4_12(1.0);
     }
 #endif
 


### PR DESCRIPTION
Fixes #2742

Before:
![pokeemerald-7](https://user-images.githubusercontent.com/93446519/221355326-2b01f7cf-26d7-4241-b7d4-019146aef406.png)

After:
![pokeemerald-8](https://user-images.githubusercontent.com/93446519/221355328-d3acaa36-dbbb-407c-8e87-2130e2c5549d.png)

In the example Sand Attack previously got a -20 score against flying types even though the move should be able to hit flying types.