### PR TITLE
Consider Nature Power in AI_CalcDamage

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -744,6 +744,10 @@ s32 AI_CalcDamage(u16 move, u8 battlerAtk, u8 battlerDef, u8 *typeEffectiveness,
     SetBattlerData(battlerDef);
 
     gBattleStruct->dynamicMoveType = 0;
+
+    if (move == MOVE_NATURE_POWER)
+            move = GetNaturePowerMove();
+
     SetTypeBeforeUsingMove(move, battlerAtk);
     GET_MOVE_TYPE(move, moveType);
 

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -746,7 +746,7 @@ s32 AI_CalcDamage(u16 move, u8 battlerAtk, u8 battlerDef, u8 *typeEffectiveness,
     gBattleStruct->dynamicMoveType = 0;
 
     if (move == MOVE_NATURE_POWER)
-            move = GetNaturePowerMove();
+        move = GetNaturePowerMove();
 
     SetTypeBeforeUsingMove(move, battlerAtk);
     GET_MOVE_TYPE(move, moveType);

--- a/src/data/battle_moves.h
+++ b/src/data/battle_moves.h
@@ -4847,7 +4847,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_Z] =
     [MOVE_NATURE_POWER] =
     {
         .effect = EFFECT_NATURE_POWER,
-        .power = 0,
+        .power = 1,
         .type = TYPE_NORMAL,
         .accuracy = 0,
         .pp = 20,


### PR DESCRIPTION
Fixes  #2775

Credit to Benício Gonçalves from Discord.

Turns Nature Power into the appropriate move in `AI_CalcDamage`.
![pokeemerald-10](https://user-images.githubusercontent.com/93446519/221361703-4ace9e17-8149-4eb0-857e-155905665a9c.png)
