### PR TITLE
Consider called move in AI_CalcDamage

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -675,6 +675,24 @@ struct BattleStruct
         typeArg = gBattleMoves[move].type;                            \
 }
 
+#define GET_MOVE_CALLED(move, targetArg)                              \
+{                                                                     \
+    switch (gBattleMoves[move].effect)                                \
+    {                                                                 \
+    case EFFECT_COPYCAT:                                              \
+    case EFFECT_MIRROR_MOVE:                                          \
+    case EFFECT_MIMIC:                                                \
+        move = gLastMoves[targetArg];                                 \
+        break;                                                        \
+    case EFFECT_ME_FIRST:                                             \
+        move = AI_DATA->predictedMoves[targetArg];                    \
+        break;                                                        \
+    case EFFECT_NATURE_POWER:                                         \
+        move = GetNaturePowerMove();                                  \
+        break;                                                        \
+    }                                                                 \
+}                                                                       
+
 #define IS_MOVE_PHYSICAL(move)(GetBattleMoveSplit(move) == SPLIT_PHYSICAL)
 #define IS_MOVE_SPECIAL(move)(GetBattleMoveSplit(move) == SPLIT_SPECIAL)
 #define IS_MOVE_STATUS(move)(gBattleMoves[move].split == SPLIT_STATUS)

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -745,9 +745,7 @@ s32 AI_CalcDamage(u16 move, u8 battlerAtk, u8 battlerDef, u8 *typeEffectiveness,
 
     gBattleStruct->dynamicMoveType = 0;
 
-    if (move == MOVE_NATURE_POWER)
-        move = GetNaturePowerMove();
-
+    GET_MOVE_CALLED(move, battlerDef);  //For simulated damage for Me First, Copycat, Nature Power, Mimic. Predicted move is the last used move.
     SetTypeBeforeUsingMove(move, battlerAtk);
     GET_MOVE_TYPE(move, moveType);
 

--- a/src/data/battle_moves.h
+++ b/src/data/battle_moves.h
@@ -1821,7 +1821,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_Z] =
     [MOVE_MIMIC] =
     {
         .effect = EFFECT_MIMIC,
-        .power = 0,
+        .power = 1,
         .type = TYPE_NORMAL,
         .accuracy = 0,
         .pp = 10,
@@ -2112,7 +2112,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_Z] =
     [MOVE_MIRROR_MOVE] =
     {
         .effect = EFFECT_MIRROR_MOVE,
-        .power = 0,
+        .power = 1,
         .type = TYPE_FLYING,
         .accuracy = 0,
         .pp = 20,
@@ -6913,7 +6913,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_Z] =
     [MOVE_ME_FIRST] =
     {
         .effect = EFFECT_ME_FIRST,
-        .power = 0,
+        .power = 1,
         .type = TYPE_NORMAL,
         .accuracy = 0,
         .pp = 20,
@@ -6929,7 +6929,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_Z] =
     [MOVE_COPYCAT] =
     {
         .effect = EFFECT_COPYCAT,
-        .power = 0,
+        .power = 1,
         .type = TYPE_NORMAL,
         .accuracy = 0,
         .pp = 20,


### PR DESCRIPTION
Moves like Me First, Copycat, Nature Power, Mirror Move and Mimic needs to be changed to the move called by them for simulate damage in AI_CalcDamage.

Note: Me First uses predictedMoves which is currently not functional as it should.