### PR TITLE
Fix TryChangeBattleTerrain overwriting gBattlerAttacker and ABILITYEFFECT_ON_TERRAIN

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -8803,14 +8803,14 @@ BattleScript_ActivateSwitchInAbilities_Increment:
 	return
 
 BattleScript_ActivateTerrainAbilities:
-	copybyte sBATTLER, gBattlerAttacker
-	setbyte gBattlerAttacker, 0
+	savetarget
+	setbyte gBattlerTarget, 0
 BattleScript_ActivateTerrainAbilities_Loop:
 	activateterrainchangeabilities BS_ATTACKER
 BattleScript_ActivateTerrainAbilities_Increment:
-	addbyte gBattlerAttacker, 1
-	jumpifbytenotequal gBattlerAttacker, gBattlersCount, BattleScript_ActivateTerrainAbilities_Loop
-	copybyte gBattlerAttacker, sBATTLER
+	addbyte gBattlerTarget, 1
+	jumpifbytenotequal gBattlerTarget, gBattlersCount, BattleScript_ActivateTerrainAbilities_Loop
+	restoretarget
 	return
 
 BattleScript_ElectricSurgeActivates::

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4205,7 +4205,7 @@ static bool32 TryChangeBattleTerrain(u32 battler, u32 statusFlag, u8 *timer)
         else
             *timer = 5;
 
-        gBattlerAttacker = gBattleScripting.battler = battler;
+        gBattleScripting.battler = battler;
         return TRUE;
     }
 

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -6230,7 +6230,6 @@ u8 AbilityBattleEffects(u8 caseID, u8 battler, u16 ability, u8 special, u16 move
         }
         break;
     case ABILITYEFFECT_ON_TERRAIN:  // For ability effects that activate when the field terrain changes.
-        battler = gBattlerAbility = gBattleScripting.battler;
         gLastUsedAbility = GetBattlerAbility(battler);
         switch (gLastUsedAbility)
         {
@@ -6239,6 +6238,7 @@ u8 AbilityBattleEffects(u8 caseID, u8 battler, u16 ability, u8 special, u16 move
             {
                 gSpecialStatuses[battler].terrainAbilityDone = TRUE;
                 ChangeTypeBasedOnTerrain(battler);
+                gBattlerAbility = gBattleScripting.battler = battler;
                 BattleScriptPushCursorAndCallback(BattleScript_MimicryActivates_End3);
                 effect++;
             }
@@ -6247,6 +6247,7 @@ u8 AbilityBattleEffects(u8 caseID, u8 battler, u16 ability, u8 special, u16 move
             if (!gSpecialStatuses[battler].terrainAbilityDone && IsBattlerTerrainAffected(battler, STATUS_FIELD_ELECTRIC_TERRAIN))
             {
                 gSpecialStatuses[battler].terrainAbilityDone = TRUE;
+                gBattlerAbility = gBattleScripting.battler = battler;
                 PREPARE_STAT_BUFFER(gBattleTextBuff1, GetHighestStatId(battler));
                 BattleScriptPushCursorAndCallback(BattleScript_QuarkDriveActivates);
                 effect++;


### PR DESCRIPTION
Fixes seed sower in doubles and probably other abilities. Also makes `BattleScript_ActivateTerrainAbilities` use gBattlerTarget as an iterator (with savetarget/restoretarget)

Also fix ABILITYEFFECT_ON_TERRAIN setting gBattlerAbility incorrectly