### PR TITLE
Fixed score for Work up and Growth

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -1117,10 +1117,11 @@ static s16 AI_CheckBadMove(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
             break;
         case EFFECT_GROWTH:
         case EFFECT_ATTACK_SPATK_UP:    // work up
-            if (!BattlerStatCanRise(battlerAtk, AI_DATA->abilities[battlerAtk], STAT_ATK) || !HasMoveWithSplit(battlerAtk, SPLIT_PHYSICAL))
+            if ((!BattlerStatCanRise(battlerAtk, AI_DATA->abilities[battlerAtk], STAT_ATK) && !BattlerStatCanRise(battlerAtk, AI_DATA->abilities[battlerAtk], STAT_SPATK))
+             || (!HasMoveWithSplit(battlerAtk, SPLIT_PHYSICAL)  && !HasMoveWithSplit(battlerAtk, SPLIT_SPECIAL)))
                 score -= 10;
-            else if (!BattlerStatCanRise(battlerAtk, AI_DATA->abilities[battlerAtk], STAT_SPATK) || !HasMoveWithSplit(battlerAtk, SPLIT_SPECIAL))
-                score -= 8;
+            // else if (!BattlerStatCanRise(battlerAtk, AI_DATA->abilities[battlerAtk], STAT_SPATK) || !HasMoveWithSplit(battlerAtk, SPLIT_SPECIAL))
+            //     score -= 8;
             break;
         case EFFECT_ROTOTILLER:
             if (isDoubleBattle)

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -1120,8 +1120,6 @@ static s16 AI_CheckBadMove(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
             if ((!BattlerStatCanRise(battlerAtk, AI_DATA->abilities[battlerAtk], STAT_ATK) && !BattlerStatCanRise(battlerAtk, AI_DATA->abilities[battlerAtk], STAT_SPATK))
              || (!HasMoveWithSplit(battlerAtk, SPLIT_PHYSICAL)  && !HasMoveWithSplit(battlerAtk, SPLIT_SPECIAL)))
                 score -= 10;
-            // else if (!BattlerStatCanRise(battlerAtk, AI_DATA->abilities[battlerAtk], STAT_SPATK) || !HasMoveWithSplit(battlerAtk, SPLIT_SPECIAL))
-            //     score -= 8;
             break;
         case EFFECT_ROTOTILLER:
             if (isDoubleBattle)

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -1118,7 +1118,7 @@ static s16 AI_CheckBadMove(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
         case EFFECT_GROWTH:
         case EFFECT_ATTACK_SPATK_UP:    // work up
             if ((!BattlerStatCanRise(battlerAtk, AI_DATA->abilities[battlerAtk], STAT_ATK) && !BattlerStatCanRise(battlerAtk, AI_DATA->abilities[battlerAtk], STAT_SPATK))
-             || (!HasMoveWithSplit(battlerAtk, SPLIT_PHYSICAL)  && !HasMoveWithSplit(battlerAtk, SPLIT_SPECIAL)))
+             || (!HasDamagingMove(battlerAtk)))
                 score -= 10;
             break;
         case EFFECT_ROTOTILLER:


### PR DESCRIPTION
Work Up and Growth got a -10 / -8 score when either only a Special or Physical move were present.
Since those moves increase both Special Attack and Attack they shouldn't get a decrease if one split move is present.   

Before:
![pokeemerald-1](https://user-images.githubusercontent.com/93446519/223777335-c9555bf8-acfe-4f75-b782-10f307972974.png)

After:
![pokeemerald-0](https://user-images.githubusercontent.com/93446519/223777291-25dcd69f-3dab-4576-92d3-8b0d10d5dca4.png)