### PR TITLE
Debug Menu improvements

### DIFF
--- a/data/scripts/debug.inc
+++ b/data/scripts/debug.inc
@@ -41,18 +41,31 @@ Debug_CheatStart::
 	release
 	end
 
-Debug_FlagsNotSetMessage::
+Debug_FlagsNotSetOverworldConfigMessage::
 	lockall
-	message Debug_FlagsNotSetMessage_Text
+	message Debug_FlagsNotSetOverworldConfigMessage_Text
 	waitmessage
 	waitbuttonpress
 	releaseall
 	end
 
-Debug_FlagsNotSetMessage_Text:
+Debug_FlagsNotSetOverworldConfigMessage_Text:
 	.string "Feature unavailable!\n"
 	.string "Please define a usable flag in:\l"
-	.string "'include/constants/overworld{UNDERSCORE}config.h'!$"
+	.string "'include/config/overworld.h'!$"
+
+Debug_FlagsNotSetBattleConfigMessage::
+	lockall
+	message Debug_FlagsNotSetBattleConfigMessage_Text
+	waitmessage
+	waitbuttonpress
+	releaseall
+	end
+
+Debug_FlagsNotSetBattleConfigMessage_Text:
+	.string "Feature unavailable!\n"
+	.string "Please define a usable flag in:\l"
+	.string "'include/config/battle.h'!$"
 
 Debug_Script_1::
 	end

--- a/include/config/debug.h
+++ b/include/config/debug.h
@@ -2,15 +2,10 @@
 #define GUARD_CONFIG_DEBUG_H
 
 // Overworld Debug
-#define DEBUG_OVERWORLD_MENU            TRUE                // Enables a overworld debug menu for changing flags, variables, giving pokemon and more, accessed by holding R and pressing START while in the overworld by default.
+#define DEBUG_OVERWORLD_MENU            TRUE                // Enables an overworld debug menu to change flags, variables, giving pokemon and more, accessed by holding R and pressing START while in the overworld by default.
 #define DEBUG_OVERWORLD_HELD_KEYS       (R_BUTTON)          // The keys required to be held to open the debug menu.
 #define DEBUG_OVERWORLD_TRIGGER_EVENT   pressedStartButton  // The event that opens the menu when holding the key(s) defined in DEBUG_OVERWORLD_HELD_KEYS.
 #define DEBUG_OVERWORLD_IN_MENU         FALSE               // Replaces the overworld debug menu button combination with a start menu entry (above Pokédex).
-
-// Debug Flags
-// To use the following debug features, replace the 0s with the flag ID you're assigning it to.
-// Eg: Replace with FLAG_UNUSED_0x264 so you can use that flag to toggle the feature.
-#define DEBUG_FLAG_NO_COLLISION         0       // If this flag is set, the debug function in the Utility submenu to disable player collision can be used.
 
 // Battle Debug Menu
 #define DEBUG_BATTLE_MENU               TRUE    // If set to TRUE, enables a debug menu to use in battles by pressing the Select button.

--- a/include/config/overworld.h
+++ b/include/config/overworld.h
@@ -9,5 +9,6 @@
 // Eg: Replace with FLAG_UNUSED_0x264 so you can use that flag to toggle the feature.
 #define OW_FLAG_NO_ENCOUNTER        0  // If this flag is set, wild encounters will be disabled.
 #define OW_FLAG_NO_TRAINER_SEE      0  // If this flag is set, trainers will not battle the player unless they're talked to.
+#define OW_FLAG_NO_COLLISION        0  // If this flag is set, the player will be able to walk over tiles with collision. Mainly intended for debugging purposes.
 
 #endif // GUARD_CONFIG_OVERWORLD_H

--- a/src/debug.c
+++ b/src/debug.c
@@ -275,7 +275,8 @@ static void DebugAction_Sound_MUS_SelectId(u8 taskId);
 static void DebugTask_HandleMenuInput(u8 taskId, void (*HandleInput)(u8));
 static void DebugAction_OpenSubMenu(u8 taskId, struct ListMenuTemplate LMtemplate);
 
-extern u8 Debug_FlagsNotSetMessage[];
+extern u8 Debug_FlagsNotSetOverworldConfigMessage[];
+extern u8 Debug_FlagsNotSetBattleConfigMessage[];
 extern u8 Debug_Script_1[];
 extern u8 Debug_Script_2[];
 extern u8 Debug_Script_3[];
@@ -1556,16 +1557,16 @@ static void DebugAction_Flags_ToggleFrontierPass(u8 taskId)
 }
 static void DebugAction_Flags_CollisionOnOff(u8 taskId)
 {
-#if DEBUG_FLAG_NO_COLLISION == 0
+#if OW_FLAG_NO_COLLISION == 0
     Debug_DestroyMenu_Full(taskId);
     LockPlayerFieldControls();
-    ScriptContext_SetupScript(Debug_FlagsNotSetMessage);
+    ScriptContext_SetupScript(Debug_FlagsNotSetOverworldConfigMessage);
 #else
-    if (FlagGet(DEBUG_FLAG_NO_COLLISION))
+    if (FlagGet(OW_FLAG_NO_COLLISION))
         PlaySE(SE_PC_OFF);
     else
         PlaySE(SE_PC_LOGIN);
-    FlagToggle(DEBUG_FLAG_NO_COLLISION);
+    FlagToggle(OW_FLAG_NO_COLLISION);
 #endif
 }
 static void DebugAction_Flags_EncounterOnOff(u8 taskId)
@@ -1573,7 +1574,7 @@ static void DebugAction_Flags_EncounterOnOff(u8 taskId)
 #if OW_FLAG_NO_ENCOUNTER == 0
     Debug_DestroyMenu_Full(taskId);
     LockPlayerFieldControls();
-    ScriptContext_SetupScript(Debug_FlagsNotSetMessage);
+    ScriptContext_SetupScript(Debug_FlagsNotSetOverworldConfigMessage);
 #else
     if (FlagGet(OW_FLAG_NO_ENCOUNTER))
         PlaySE(SE_PC_OFF);
@@ -1587,7 +1588,7 @@ static void DebugAction_Flags_TrainerSeeOnOff(u8 taskId)
 #if OW_FLAG_NO_TRAINER_SEE == 0
     Debug_DestroyMenu_Full(taskId);
     LockPlayerFieldControls();
-    ScriptContext_SetupScript(Debug_FlagsNotSetMessage);
+    ScriptContext_SetupScript(Debug_FlagsNotSetOverworldConfigMessage);
 #else
     if (FlagGet(OW_FLAG_NO_TRAINER_SEE))
         PlaySE(SE_PC_OFF);
@@ -1601,7 +1602,7 @@ static void DebugAction_Flags_BagUseOnOff(u8 taskId)
 #if B_FLAG_NO_BAG_USE == 0
     Debug_DestroyMenu_Full(taskId);
     LockPlayerFieldControls();
-    ScriptContext_SetupScript(Debug_FlagsNotSetMessage);
+    ScriptContext_SetupScript(Debug_FlagsNotSetBattleConfigMessage);
 #else
     if (FlagGet(B_FLAG_NO_BAG_USE))
         PlaySE(SE_PC_OFF);
@@ -1612,10 +1613,10 @@ static void DebugAction_Flags_BagUseOnOff(u8 taskId)
 }
 static void DebugAction_Flags_CatchingOnOff(u8 taskId)
 {
-#if B_FLAG_NO_CATCHING_USE == 0
+#if B_FLAG_NO_CATCHING == 0
     Debug_DestroyMenu_Full(taskId);
     LockPlayerFieldControls();
-    ScriptContext_SetupScript(Debug_FlagsNotSetMessage);
+    ScriptContext_SetupScript(Debug_FlagsNotSetBattleConfigMessage);
 #else
     if (FlagGet(B_FLAG_NO_CATCHING))
         PlaySE(SE_PC_OFF);

--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -4654,8 +4654,8 @@ u8 GetCollisionAtCoords(struct ObjectEvent *objectEvent, s16 x, s16 y, u32 dir)
 {
     u8 direction = dir;
 
-#if DEBUG_FLAG_NO_COLLISION != 0
-    if (FlagGet(DEBUG_FLAG_NO_COLLISION))
+#if OW_FLAG_NO_COLLISION != 0
+    if (FlagGet(OW_FLAG_NO_COLLISION))
         return COLLISION_NONE;
 #endif
 


### PR DESCRIPTION
## Description
HunarPG#2786 and I spotted some weird things in the debug menu, so I decided to go ahead and correct most of them.
- Updated the text string used by Debug_FlagsNotSetMessage.
- Renamed Debug_FlagsNotSetMessage to Debug_FlagsNotSetOverworldConfigMessage.
- Added an equivalent for the battle config file called Debug_FlagsNotSetBattleConfigMessage,
- DEBUG_FLAG_NO_COLLISION -> OW_FLAG_NO_COLLISION
  - And moved it to include/config/overworld.h, because at the end of the day it's still an overworld flag just like the other 2 already in that file.
- Corrected miswritten preproc config in DebugAction_Flags_CatchingOnOff.
- Updated the comment that describes the effect of DEBUG_OVERWORLD_MENU reducing the number of characters a tiny bit and fixing a typo.
- Added a new option to clear the PC boxes inside the debug menu's Utilities section.
- Made DebugAction_Give_FillPC give different individual species starting with Bulbasaur instead of 420 Deoxys.
  - Made it set the Seen and Caught Pokédex flags for each of those species.
  - Made it enable the FLAG_SYS_POKEMON_GET for user's convenience.

## **Discord contact info**
Lunos#4026