### PR TITLE
remove assist array from battle struct

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -534,7 +534,6 @@ struct BattleStruct
     u8 wildVictorySong;
     u8 dynamicMoveType;
     u8 wrappedBy[MAX_BATTLERS_COUNT];
-    u16 assistPossibleMoves[PARTY_SIZE * MAX_MON_MOVES]; // Each of mons can know max 4 moves.
     u8 focusPunchBattlerId;
     u8 battlerPreventingSwitchout;
     u8 moneyMultiplier:6;

--- a/test/move_effect_assist.c
+++ b/test/move_effect_assist.c
@@ -1,0 +1,22 @@
+#include "global.h"
+#include "test_battle.h"
+
+ASSUMPTIONS
+{
+    ASSUME(gBattleMoves[MOVE_ASSIST].effect == EFFECT_ASSIST);
+}
+
+SINGLE_BATTLE_TEST("Assist fails if there are no valid moves to choose from")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) {Moves(MOVE_ASSIST, MOVE_CELEBRATE, MOVE_METRONOME, MOVE_ME_FIRST); }
+        PLAYER(SPECIES_WOBBUFFET) {Moves(MOVE_ASSIST, MOVE_ENDURE, MOVE_DRAGON_TAIL, MOVE_SPOTLIGHT); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_ASSIST); }
+    } SCENE {
+        MESSAGE("Wobbuffet used Assist!");
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSIST, player);
+        MESSAGE("But it failed!");
+    }
+}

--- a/test/test_runner_battle.c
+++ b/test/test_runner_battle.c
@@ -1227,6 +1227,7 @@ void Move(u32 sourceLine, struct BattlePokemon *battler, struct MoveContext ctx)
         const struct BattleMove *move = &gBattleMoves[moveId];
         if (move->target == MOVE_TARGET_RANDOM
          || move->target == MOVE_TARGET_BOTH
+         || move->target == MOVE_TARGET_DEPENDS
          || move->target == MOVE_TARGET_FOES_AND_ALLY
          || move->target == MOVE_TARGET_OPPONENTS_FIELD
          || move->target == MOVE_TARGET_ALL_BATTLERS)


### PR DESCRIPTION
I don't see a reason why assistPossibleMoves should exist if it's only used in one function, so I decided to remove it.
Also cleaned up a bit the assist battle script command.
Also wrote one test for Assist 
Also added MOVE_TARGET_DEPENDS to the test runner target function, so it doesn't ask for explicit target when using moves like Assist, Copycat, Counter, etc.