### PR TITLE
Fixes the check for speed on electrify

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -2447,7 +2447,7 @@ static s16 AI_CheckBadMove(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
             }
             break;
         case EFFECT_ELECTRIFY:
-            if (AI_WhoStrikesFirst(battlerAtk, battlerDef, move) == AI_IS_FASTER
+            if (AI_WhoStrikesFirst(battlerAtk, battlerDef, move) == AI_IS_SLOWER
               //|| GetMoveTypeSpecial(battlerDef, predictedMove) == TYPE_ELECTRIC // Move will already be electric type
               || PartnerMoveIsSameAsAttacker(BATTLE_PARTNER(battlerAtk), battlerDef, move, AI_DATA->partnerMove))
                 score -= 10;


### PR DESCRIPTION
The AI didn't get a minus score when it was slower then the player when trying to use Electrify.
Before:
![electrify_fail](https://user-images.githubusercontent.com/93446519/223973308-ad645c2d-6a4f-4f0e-9111-0566a43b1aa9.gif)
After:
Bulbasaur faster then Chinchou:
![electrify](https://user-images.githubusercontent.com/93446519/223971898-0f3b44dc-a025-41b4-a334-9311a61fe8d4.gif)

Bulbasaur slower:
![electrify2](https://user-images.githubusercontent.com/93446519/223972233-7df4db6a-495c-4e53-8db8-d1afa161e295.gif)
