### PR TITLE
Fix Intimidate targetting dead sides and false postpones

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -8627,6 +8627,7 @@ BattleScript_IntimidateActivates::
 BattleScript_IntimidateLoop:
 	jumpifbyteequal gBattlerTarget, gBattlerAttacker, BattleScript_IntimidateLoopIncrement
 	jumpiftargetally BattleScript_IntimidateLoopIncrement
+	jumpifabsent BS_TARGET, BattleScript_IntimidateLoopIncrement
 	jumpifstatus2 BS_TARGET, STATUS2_SUBSTITUTE, BattleScript_IntimidateLoopIncrement
 	jumpifholdeffect BS_TARGET, HOLD_EFFECT_CLEAR_AMULET, BattleScript_IntimidatePrevented_Item
 	jumpifability BS_TARGET, ABILITY_CLEAR_BODY, BattleScript_IntimidatePrevented

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -6973,9 +6973,9 @@ bool32 ShouldPostponeSwitchInAbilities(u32 battlerId)
     // Checks for double battle, so abilities like Intimidate wait until all battlers are switched-in before activating.
     if (IsDoubleBattle())
     {
-        if (aliveOpposing1 && !aliveOpposing2 && !HasNoMonsToSwitch(BATTLE_OPPOSITE(battlerId), PARTY_SIZE, PARTY_SIZE))
+        if (aliveOpposing1 && !aliveOpposing2 && !HasNoMonsToSwitch(BATTLE_PARTNER(BATTLE_OPPOSITE(battlerId)), PARTY_SIZE, PARTY_SIZE))
             return TRUE;
-        if (!aliveOpposing1 && aliveOpposing2 && !HasNoMonsToSwitch(BATTLE_PARTNER(BATTLE_OPPOSITE(battlerId)), PARTY_SIZE, PARTY_SIZE))
+        if (!aliveOpposing1 && aliveOpposing2 && !HasNoMonsToSwitch(BATTLE_OPPOSITE(battlerId), PARTY_SIZE, PARTY_SIZE))
             return TRUE;
     }
 

--- a/test/ability_intimidate.c
+++ b/test/ability_intimidate.c
@@ -122,3 +122,40 @@ SINGLE_BATTLE_TEST("Intimidate and Eject Button force the opponent to Attack")
         }
     }
 }
+
+DOUBLE_BATTLE_TEST("Intimidate activates on an empty slot")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_CROAGUNK);
+        PLAYER(SPECIES_WYNAUT);
+        PLAYER(SPECIES_HITMONTOP) { Ability(ABILITY_INTIMIDATE); };
+        OPPONENT(SPECIES_RALTS);
+        OPPONENT(SPECIES_AZURILL);
+    } WHEN {
+        TURN {
+            SWITCH(playerLeft, 2);
+            MOVE(playerRight, MOVE_GUNK_SHOT, target: opponentLeft);
+            MOVE(opponentRight, MOVE_SPLASH);
+        }
+        TURN {
+            SWITCH(playerLeft, 3);
+            MOVE(playerRight, MOVE_SPLASH);
+            }
+
+
+    } SCENE {
+        MESSAGE("Wobbuffet, that's enough! Come back!");
+        MESSAGE("Go! Wynaut!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_GUNK_SHOT, playerRight);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SPLASH, opponentRight);
+        MESSAGE("Wynaut, that's enough! Come back!");
+        MESSAGE("Go! Hitmontop!");
+        ABILITY_POPUP(playerLeft, ABILITY_INTIMIDATE);
+        NONE_OF {
+            MESSAGE("Hitmontop's Intimidate cuts Foe Ralts's attack!");
+        }
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);
+        MESSAGE("Hitmontop's Intimidate cuts Foe Azurill's attack!");
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently Intimidate when targetting in two trainer doubles with one side dead will falsely postpone until end of turn instead of activiating on that one side. This fixes that. Also fixes issue where when intimidating that pokemon get intimidated.

![Before](https://user-images.githubusercontent.com/69943962/226897847-375ac96d-e8b8-40cf-bb86-d0418dbd1cfd.mp4)
![After](https://user-images.githubusercontent.com/69943962/226898133-83b06b41-3846-4a7e-bc9b-2542b274cc8c.mp4)


## **Discord contact info**
Tennis#4004
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->