### PR TITLE
Dont copy opponent personality when swapping mon sprite during mega evo

### DIFF
--- a/src/battle_anim_effects_3.c
+++ b/src/battle_anim_effects_3.c
@@ -2339,6 +2339,7 @@ void AnimTask_TransformMon(u8 taskId)
     u8 *src;
     u16 *bgTilemap;
     u16 stretch;
+    bool32 megaEvo;
 
     switch (gTasks[taskId].data[0])
     {
@@ -2364,7 +2365,8 @@ void AnimTask_TransformMon(u8 taskId)
         }
         break;
     case 2:
-        HandleSpeciesGfxDataChange(gBattleAnimAttacker, gBattleAnimTarget, gTasks[taskId].data[10], gBattleAnimArgs[1], TRUE);
+        megaEvo = gBattleAnimArgs[1];
+        HandleSpeciesGfxDataChange(gBattleAnimAttacker, gBattleAnimTarget, gTasks[taskId].data[10], megaEvo, !megaEvo);
         GetBgDataForTransform(&animBg, gBattleAnimAttacker);
 
         if (IsContest())


### PR DESCRIPTION
## Description
The Mega Evolution/Primal Reversion transformation animation uses `HandleSpeciesGfxDataChange` to swap sprites to the new species, but always passes `TRUE` into the `trackEnemyPersonality` param. This causes the opposing mon's personality to be used when swapping sprite palettes resulting in an issue where a shiny Pokemon will almost always mega evolve into its non-shiny colours (since its personality determines shiny). This is only cosmetic; opening a menu such as bag and then closing again will display the correct sprite palette again.

This change will pass in false for the `trackEnemyPersonality` param if `megaEvo` is non-zero so that its proper shiny/non-shiny palette will be used.

## Images
![image](https://user-images.githubusercontent.com/39687914/226981742-4dbbe2ef-9c36-4e3a-8beb-a8c4a33d424c.png)
![image](https://user-images.githubusercontent.com/39687914/226981970-468c4495-2e80-453c-8aa0-ba30d284a428.png)


## **Discord contact info**
Ultimate_Bob#2163