### PR TITLE
add check for Gorilla Tactics when resetting choicedMove from knock off

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -5330,7 +5330,8 @@ static bool32 TryKnockOffBattleScript(u32 battlerDef)
 
             gLastUsedItem = gBattleMons[battlerDef].item;
             gBattleMons[battlerDef].item = 0;
-            gBattleStruct->choicedMove[battlerDef] = 0;
+            if (gBattleMons[battlerDef].ability != ABILITY_GORILLA_TACTICS)
+                gBattleStruct->choicedMove[battlerDef] = 0;
             gWishFutureKnock.knockedOffMons[side] |= gBitTable[gBattlerPartyIndexes[battlerDef]];
             CheckSetUnburden(battlerDef);
 


### PR DESCRIPTION
currently, a pokemon that is locked into a move due to gorilla tactics will be able to choose a new move after an item is knock off it through Knock Off. this fixes that so that the move stays locked. 
Addresses #2851 
<!--- Provide a general summary of your changes in the Title above -->

added a simple ability check and only set choicedMove to 0 when ability is not gorilla tactics.
<!--- Describe your changes in detail -->

## **Discord contact info**
Salem#3258