### PR TITLE
CanBeConfused properly checks the battlerId passed into it

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -6546,8 +6546,8 @@ bool32 CanBeFrozen(u8 battlerId)
 
 bool32 CanBeConfused(u8 battlerId)
 {
-    if (GetBattlerAbility(gEffectBattler) == ABILITY_OWN_TEMPO
-      || gBattleMons[gEffectBattler].status2 & STATUS2_CONFUSION
+    if (GetBattlerAbility(battlerId) == ABILITY_OWN_TEMPO
+      || gBattleMons[battlerId].status2 & STATUS2_CONFUSION
       || IsBattlerTerrainAffected(battlerId, STATUS_FIELD_MISTY_TERRAIN))
         return FALSE;
     return TRUE;


### PR DESCRIPTION
It turns out `CanBeConfused` doesn't properly use check its argument `battlerId`, and instead checks `gEffectBattler`. This was giving me grief. Easy fix!

## **Discord Contact Info**
Agustin#1522