### PR TITLE
fix compound eyes ohko test

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -12562,7 +12562,7 @@ static void Cmd_tryKO(void)
             if (gCurrentMove == MOVE_SHEER_COLD && !IS_BATTLER_OF_TYPE(gBattlerAttacker, TYPE_ICE))
                 odds -= 10;
         #endif
-            if (Random() % 100 + 1 < odds && gBattleMons[gBattlerAttacker].level >= gBattleMons[gBattlerTarget].level)
+            if (RandomPercentage(RNG_ACCURACY, odds) && gBattleMons[gBattlerAttacker].level >= gBattleMons[gBattlerTarget].level)
                 lands = TRUE;
         }
 

--- a/test/ability_compound_eyes.c
+++ b/test/ability_compound_eyes.c
@@ -21,12 +21,11 @@ SINGLE_BATTLE_TEST("Compound Eyes raises accuracy")
 // than we expect.
 SINGLE_BATTLE_TEST("Compound Eyes does not affect OHKO moves")
 {
-    KNOWN_FAILING;
     PASSES_RANDOMLY(30, 100, RNG_ACCURACY);
     GIVEN {
         ASSUME(gBattleMoves[MOVE_FISSURE].accuracy == 30);
         ASSUME(gBattleMoves[MOVE_FISSURE].effect == EFFECT_OHKO);
-        PLAYER(SPECIES_BUTTERFREE) { Ability(ABILITY_TINTED_LENS); };
+        PLAYER(SPECIES_BUTTERFREE) { Ability(ABILITY_COMPOUND_EYES); };
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
         TURN { MOVE(player, MOVE_FISSURE); }


### PR DESCRIPTION
## Description
Changes `tryKO` to use the new rng tags. This fixes the compound eyes test against ohko moves.

## **Discord contact info**
Karathan#1337