### PR TITLE
Centered opponents in 2v1 battles.

### DIFF
--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -1,6 +1,7 @@
 #include "global.h"
 #include "malloc.h"
 #include "battle.h"
+#include "battle_setup.h"
 #include "pokemon.h"
 #include "battle_controllers.h"
 #include "battle_interface.h"
@@ -697,8 +698,14 @@ u32 WhichBattleCoords(u32 battlerId) // 0 - singles, 1 - doubles
         && gPlayerPartyCount == 1
         && !(gBattleTypeFlags & BATTLE_TYPE_MULTI))
         return 0;
-    else
-        return IsDoubleBattle();
+
+    // gEnemyParty count is calculated at the start of battle.
+    if (GetBattlerPosition(battlerId) == B_POSITION_OPPONENT_LEFT
+        && ((!(gBattleTypeFlags & BATTLE_TYPE_TRAINER) && gEnemyPartyCount == 1)
+        || (BATTLE_TWO_VS_ONE_OPPONENT)))
+        return 0;
+    
+    return IsDoubleBattle();
 }
 
 u8 CreateBattlerHealthboxSprites(u8 battlerId)

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3173,6 +3173,8 @@ static void BattleStartClearSetData(void)
     }
 
     gBattleStruct->swapDamageCategory = FALSE; // Photon Geyser, Shell Side Arm, Light That Burns the Sky
+
+    CalculateEnemyPartyCount(); // Can be used to check whether Doubles opponent is alone.
 }
 
 void SwitchInClearSetData(void)


### PR DESCRIPTION
Very simple fix, maybe too simple? I tried to catch the bug of `gEnemyParty` getting recalculated mid-battle, which happens during a few trainer AI checks. It shouldn't happen in a wild battle, so I think this is clean.

![image](https://user-images.githubusercontent.com/103095241/227835278-3b0953f4-cbad-4c41-af9d-b34b900498a7.png)


## **Discord Contact Info**
Agustin#1522