### PR TITLE
Reset battle vars and flags after player whites out

### DIFF
--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -143,7 +143,6 @@
 // Flag settings
 // To use the following features in scripting, replace the 0s with the flag ID you're assigning it to.
 // Eg: Replace with FLAG_UNUSED_0x264 so you can use that flag to toggle the feature.
-// Once these features are turned on within the game, they will remain on until they are explcitily turned off or until the player whites out. This can be turned off by disabling Overworld_ResetBattleFlagsAndVars.
 #define B_FLAG_INVERSE_BATTLE       0     // If this flag is set, the battle's type effectiveness are inversed. For example, fire is super effective against water.
 #define B_FLAG_FORCE_DOUBLE_WILD    0     // If this flag is set, all land and surfing wild battles will be double battles.
 #define B_SMART_WILD_AI_FLAG        0     // If not 0, you can set this flag in a script to enable smart wild pokemon
@@ -153,9 +152,11 @@
 // Var Settings
 // To use the following features in scripting, replace the 0s with the var ID you're assigning it to.
 // Eg: Replace with VAR_UNUSED_0x40F7 so you can use VAR_TERRAIN for that feature.
-// Once these features are turned on within the game, they will remain on until they are explcitily turned off or until the player whites out. This can be turned off by disabling Overworld_ResetBattleFlagsAndVars.
 #define VAR_TERRAIN                 0     // If this var has a value, assigning a STATUS_FIELD_xx_TERRAIN to it before battle causes the battle to start with that terrain active
 #define B_VAR_WILD_AI_FLAGS         0     // If not 0, you can use this var to add to default wild AI flags. NOT usable with flags above (1 << 15)
+
+//Flag and Var settings
+#define B_RESET_FLAGS_VARS_AFTER_WHITEOUT TRUE // If set to TRUE, Flag and Var settings (B_FLAG_INVERSE_BATTLE,B_FLAG_FORCE_DOUBLE_WILD,B_SMART_WILD_AI_FLAG,B_FLAG_NO_BAG_USE,B_FLAG_NO_CATCHING,B_VAR_WILD_AI_FLAGS, and VAR_TERRAIN) will be reset when the player whites out.
 
 // Terrain settings
 #define B_TERRAIN_BG_CHANGE         TRUE       // If set to TRUE, terrain moves permanently change the default battle background until the effect fades.

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -155,8 +155,8 @@
 #define VAR_TERRAIN                 0     // If this var has a value, assigning a STATUS_FIELD_xx_TERRAIN to it before battle causes the battle to start with that terrain active
 #define B_VAR_WILD_AI_FLAGS         0     // If not 0, you can use this var to add to default wild AI flags. NOT usable with flags above (1 << 15)
 
-//Flag and Var settings
-#define B_RESET_FLAGS_VARS_AFTER_WHITEOUT TRUE // If set to TRUE, Flag and Var settings (B_FLAG_INVERSE_BATTLE,B_FLAG_FORCE_DOUBLE_WILD,B_SMART_WILD_AI_FLAG,B_FLAG_NO_BAG_USE,B_FLAG_NO_CATCHING,B_VAR_WILD_AI_FLAGS, and VAR_TERRAIN) will be reset when the player whites out.
+// Flag and Var settings
+#define B_RESET_FLAGS_VARS_AFTER_WHITEOUT TRUE // If TRUE, Overworld_ResetBattleFlagsAndVars will reset battle-related Flags and Vars when the player whites out.
 
 // Terrain settings
 #define B_TERRAIN_BG_CHANGE         TRUE       // If set to TRUE, terrain moves permanently change the default battle background until the effect fades.

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -143,6 +143,7 @@
 // Flag settings
 // To use the following features in scripting, replace the 0s with the flag ID you're assigning it to.
 // Eg: Replace with FLAG_UNUSED_0x264 so you can use that flag to toggle the feature.
+// Once these features are turned on within the game, they will remain on until they are explcitily turned off or until the player whites out. This can be turned off by disabling Overworld_ResetBattleFlagsAndVars.
 #define B_FLAG_INVERSE_BATTLE       0     // If this flag is set, the battle's type effectiveness are inversed. For example, fire is super effective against water.
 #define B_FLAG_FORCE_DOUBLE_WILD    0     // If this flag is set, all land and surfing wild battles will be double battles.
 #define B_SMART_WILD_AI_FLAG        0     // If not 0, you can set this flag in a script to enable smart wild pokemon
@@ -152,6 +153,7 @@
 // Var Settings
 // To use the following features in scripting, replace the 0s with the var ID you're assigning it to.
 // Eg: Replace with VAR_UNUSED_0x40F7 so you can use VAR_TERRAIN for that feature.
+// Once these features are turned on within the game, they will remain on until they are explcitily turned off or until the player whites out. This can be turned off by disabling Overworld_ResetBattleFlagsAndVars.
 #define VAR_TERRAIN                 0     // If this var has a value, assigning a STATUS_FIELD_xx_TERRAIN to it before battle causes the battle to start with that terrain active
 #define B_VAR_WILD_AI_FLAGS         0     // If not 0, you can use this var to add to default wild AI flags. NOT usable with flags above (1 << 15)
 

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -401,15 +401,16 @@ void Overworld_ResetStateAfterDigEscRope(void)
     FlagClear(FLAG_SYS_USE_FLASH);
 }
 
-void Overworld_ResetBattleFlagsAndVars(void)
+#if B_RESET_FLAGS_VARS_AFTER_WHITEOUT  == TRUE
+    void Overworld_ResetBattleFlagsAndVars(void)
 {
-#if VAR_TERRAIN != 0
-    VarSet(VAR_TERRAIN, 0);
-#endif
+    #if VAR_TERRAIN != 0
+        VarSet(VAR_TERRAIN, 0);
+    #endif
 
-#if B_VAR_WILD_AI_FLAGS != 0
-    VarSet(B_VAR_WILD_AI_FLAGS,0);
-#endif
+    #if B_VAR_WILD_AI_FLAGS != 0
+        VarSet(B_VAR_WILD_AI_FLAGS,0);
+    #endif
 
     FlagClear(B_FLAG_INVERSE_BATTLE);
     FlagClear(B_FLAG_FORCE_DOUBLE_WILD);
@@ -417,6 +418,7 @@ void Overworld_ResetBattleFlagsAndVars(void)
     FlagClear(B_FLAG_NO_BAG_USE);
     FlagClear(B_FLAG_NO_CATCHING);
 }
+#endif
 
 static void Overworld_ResetStateAfterWhiteOut(void)
 {
@@ -426,7 +428,9 @@ static void Overworld_ResetStateAfterWhiteOut(void)
     FlagClear(FLAG_SYS_SAFARI_MODE);
     FlagClear(FLAG_SYS_USE_STRENGTH);
     FlagClear(FLAG_SYS_USE_FLASH);
+#if B_RESET_FLAGS_VARS_AFTER_WHITEOUT  == TRUE
     Overworld_ResetBattleFlagsAndVars();
+#endif
     // If you were defeated by Kyogre/Groudon and the step counter has
     // maxed out, end the abnormal weather.
     if (VarGet(VAR_SHOULD_END_ABNORMAL_WEATHER) == 1)

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -401,6 +401,23 @@ void Overworld_ResetStateAfterDigEscRope(void)
     FlagClear(FLAG_SYS_USE_FLASH);
 }
 
+void Overworld_ResetBattleFlagsAndVars(void)
+{
+#if VAR_TERRAIN != 0
+    VarSet(VAR_TERRAIN, 0);
+#endif
+
+#if B_VAR_WILD_AI_FLAGS != 0
+    VarSet(B_VAR_WILD_AI_FLAGS,0);
+#endif
+
+    FlagClear(B_FLAG_INVERSE_BATTLE);
+    FlagClear(B_FLAG_FORCE_DOUBLE_WILD);
+    FlagClear(B_SMART_WILD_AI_FLAG);
+    FlagClear(B_FLAG_NO_BAG_USE);
+    FlagClear(B_FLAG_NO_CATCHING);
+}
+
 static void Overworld_ResetStateAfterWhiteOut(void)
 {
     ResetInitialPlayerAvatarState();
@@ -409,9 +426,7 @@ static void Overworld_ResetStateAfterWhiteOut(void)
     FlagClear(FLAG_SYS_SAFARI_MODE);
     FlagClear(FLAG_SYS_USE_STRENGTH);
     FlagClear(FLAG_SYS_USE_FLASH);
-#if VAR_TERRAIN != 0
-    VarSet(VAR_TERRAIN, 0);
-#endif
+    Overworld_ResetBattleFlagsAndVars();
     // If you were defeated by Kyogre/Groudon and the step counter has
     // maxed out, end the abnormal weather.
     if (VarGet(VAR_SHOULD_END_ABNORMAL_WEATHER) == 1)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
[\[Original discussion\]](https://discord.com/channels/419213663107416084/1077168246555430962/1089621327272497274)

# Current Problem
In the current version of expansion, when the flag `B_FLAG_INVERSE_BATTLE` is set and the player whites out, the flag is still set for all other battles the player participates in until it is explicitly turned off.

The most common use cases of the flag are for specific battles (similar to its actual usage within the core series of the franchise) or at most, a series of battles that utilize the mechanic.

The current implementation is broken - if the goal of the flag is to allow a quick and easy flag to be set for developers to enable different battles, then that functionality should also cover the range of expected functions within the game, which includes whiting out.

![Gif showing the current functionality of B_FLAG_INVERSE_BATTLE and _VAR_TERRAIN](https://i.imgur.com/wSPcN4z.gif)

`VAR_TERRAIN` is in the same spirit, **but** there is [a line](https://github.com/rh-hideout/pokeemerald-expansion/blob/8d8819b7972f7bd772c1dd8f0f71a2134315cc23/src/overworld.c#L413) in `Overworld_ResetStateAfterWhiteOut` that fixes this problem.
```
#if VAR_TERRAIN != 0
    VarSet(VAR_TERRAIN, 0);
#endif
```
This means the current functionality of the Terrains is
> When the developer sets a terrain, it remains for all subsequent battles until the player faints or is explicitly turned off.

# Proposed Solution
I have added functionality so that the following is true:

> If `B_RESET_FLAGS_VARS_AFTER_WHITEOUT` is `TRUE`, when the developer sets a special var or flag related to the functionality of battles, it remains for all subsequent battles until the player faints or is explicitly turned off.

> If `B_RESET_FLAGS_VARS_AFTER_WHITEOUT` is `FALSE`, when the developer sets a special var or flag related to the functionality of battles, it remains for all subsequent battles until it is explicitly turned off.

![Gif showing the functionality of B_FLAG_INVERSE_BATTLE and _VAR_TERRAIN contained in this PR](https://i.imgur.com/ic70Vrr.gif)

# Testing
This was tested using `B_FLAG_INVERSE_BATTLE` and `VAR_TERRAIN`, but I have no reason to believe it would not work for other cases as well.

## data/scripts/debug.inc
 ```
 TestOne:
    .string "grassy terrain and \ninverse battles \nare now on"
    .string "$"

TestTwo:
    .string "nothing has been explicitly turned on"
    .string "$"

Debug_Script_1::
    givemon SPECIES_REGIDRAGO,79,ITEM_LEFTOVERS 
	end

Debug_Script_2::
    givemon SPECIES_REGIDRAGO,79,ITEM_LEFTOVERS 
    message TestOne
    setvar VAR_UNUSED_0x408B,STATUS_FIELD_GRASSY_TERRAIN
    setflag FLAG_UNUSED_0x020 
    trainerbattle_single TRAINER_DRAKE,gText_Blank,gText_Blank
	end

Debug_Script_3::
    message TestTwo
    trainerbattle_single TRAINER_DRAKE,gText_Blank,gText_Blank
	end
```

## include/config/battle.h
```c
#define B_OBEDIENCE_MECHANICS       GEN_3// In PLA+ (here Gen8+), obedience restrictions also apply to non-outsider Pok├⌐mon, albeit based on their level met rather than actual level

#define VAR_TERRAIN                 VAR_UNUSED_0x408B     // If this var has a value, assigning a STATUS_FIELD_xx_TERRAIN to it before battle causes the battle to start with that terrain active

#define B_FLAG_INVERSE_BATTLE       FLAG_UNUSED_0x020     // If this flag is set, the battle's type effectiveness are inversed. For example, fire is super effective against water.

#define B_RESET_FLAGS_VARS_AFTER_WHITEOUT TRUE // If set to TRUE, the Flag and Var settings (such as B_FLAG_INVERSE_BATTLE and VAR_TERRAIN will be reset when the player whites out.
```

## **Discord contact info**
psf#2936
<!--- Contributors must join https://discord.gg/d5dubZ3 -->