### PR TITLE
Fixes Multi Hit and Powder moves called by Metronome

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -12990,6 +12990,11 @@ static void Cmd_metronome(void)
 
         if (!(sForbiddenMoves[gCurrentMove] & FORBIDDEN_METRONOME))
         {
+            if (gBattleMoves[gCurrentMove].effect == EFFECT_MULTI_HIT)
+                gBattleStruct->atkCancellerTracker = CANCELLER_MULTIHIT_MOVES;
+            else if (gBattleMoves[gCurrentMove].flags & FLAG_POWDER)
+                gBattleStruct->atkCancellerTracker = CANCELLER_POWDER_MOVE;
+
             gHitMarker &= ~HITMARKER_ATTACKSTRING_PRINTED;
             gBattlescriptCurrInstr = gBattleScriptsForMoveEffects[gBattleMoves[gCurrentMove].effect];
             gBattlerTarget = GetMoveTarget(gCurrentMove, NO_TARGET_OVERRIDE);


### PR DESCRIPTION
## Description
Fixes  #2860

Solves issue were Multi Hit moves hit only once when they were called by Metronome.
![metronome_multi_hit](https://user-images.githubusercontent.com/93446519/228573858-56d787cb-c1ab-446b-b098-b19b83e0cc75.gif)
Also solves Powder moves being able to hit Grass types when called by Metronome.
![metronome_powder_moves](https://user-images.githubusercontent.com/93446519/228574207-06a3a16a-819b-41bb-bf5c-6ac32b13bcc3.gif)

## **Discord contact info**
AlexOnline#2331