### PR TITLE
Added B_DOUBLE_WILD_REQUIRE_2_MONS to use of B_DOUBLE_WILD_CHANCE even when there is only one Pokémon in the party

### DIFF
--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -183,6 +183,7 @@
 
 // Other settings
 #define B_DOUBLE_WILD_CHANCE        0          // % chance of encountering two Pokémon in a Wild Encounter.
+#define B_DOUBLE_WILD_REQUIRE_2_MONS    FALSE   // If set to TRUE, when the player only has one Pokémon in the party, randomly generated wild battles will always be a Single battle, regardless of the number used in B_DOUBLE_WILD_CHANCE.
 #define B_MULTI_BATTLE_WHITEOUT     GEN_LATEST // In Gen4+, multi battles end when the Player and also their Partner don't have any more Pokémon to fight.
 #define B_EVOLUTION_AFTER_WHITEOUT  GEN_LATEST // In Gen6+, Pokemon that qualify for evolution after battle will evolve even if the player loses.
 #define B_WILD_NATURAL_ENEMIES      TRUE       // If set to TRUE, certain wild mon species will attack other species when partnered in double wild battles (eg. Zangoose vs Seviper)

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -183,7 +183,7 @@
 
 // Other settings
 #define B_DOUBLE_WILD_CHANCE        0          // % chance of encountering two Pokémon in a Wild Encounter.
-#define B_DOUBLE_WILD_REQUIRE_2_MONS    FALSE   // If set to TRUE, when the player only has one Pokémon in the party, randomly generated wild battles will always be a Single battle, regardless of the number used in B_DOUBLE_WILD_CHANCE.
+#define B_DOUBLE_WILD_REQUIRE_2_MONS    FALSE   // If set to TRUE, Wild Double Battles will default to Single Battles when the player only has 1 usuable Pokémon, ignoring B_DOUBLE_WILD_CHANCE and B_FLAG_FORCE_DOUBLE_WILD. 
 #define B_MULTI_BATTLE_WHITEOUT     GEN_LATEST // In Gen4+, multi battles end when the Player and also their Partner don't have any more Pokémon to fight.
 #define B_EVOLUTION_AFTER_WHITEOUT  GEN_LATEST // In Gen6+, Pokemon that qualify for evolution after battle will evolve even if the player loses.
 #define B_WILD_NATURAL_ENEMIES      TRUE       // If set to TRUE, certain wild mon species will attack other species when partnered in double wild battles (eg. Zangoose vs Seviper)

--- a/src/wild_encounter.c
+++ b/src/wild_encounter.c
@@ -1097,7 +1097,11 @@ static void ApplyCleanseTagEncounterRateMod(u32 *encRate)
 
 bool8 TryDoDoubleWildBattle(void)
 {
+#if B_DOUBLE_WILD_REQUIRE_2_MONS == TRUE
     if (GetSafariZoneFlag() || GetMonsStateToDoubles() != PLAYER_HAS_TWO_USABLE_MONS)
+#else
+    if (GetSafariZoneFlag())
+#endif
         return FALSE;
 #if B_FLAG_FORCE_DOUBLE_WILD != 0
     else if (FlagGet(B_FLAG_FORCE_DOUBLE_WILD))


### PR DESCRIPTION
## Description

[Original Dicussion](https://discord.com/channels/419213663107416084/1077168246555430962/1090625094327488602)

### Current Problem

In the current version of expansion, regardless of the value of `B_DOUBLE_WILD_CHANCE`, if the player only has one Pokémon in their party, all generated wild battles will be single battles.

This is due to a check in `TryDoDoubleWildBattle`, which, if the player only has one Pokémon, the game will not generate a wild double battle.

```c
    if (GetSafariZoneFlag() || GetMonsStateToDoubles() != PLAYER_HAS_TWO_USABLE_MONS)
```

### Showcase

```c
#define B_DOUBLE_WILD_CHANCE        100

```
![The first battle occurs when the player has two Pokémon in their party and starts a wild battle, which is a double battle.  The game is then reset, the player is only given one Pokémon in their party, and a wild battle starts. This battle is a single battle, despite B_DOUBLE_WILD_CHANCE being set to 100.](https://user-images.githubusercontent.com/77138753/228633690-21826003-c37a-4f2f-b241-dc4108568f1f.gif)

The first battle occurs when the player has two Pokémon in their party and starts a wild battle, which is a double battle. 

The game is then reset, the player is only given one Pokémon in their party, and a wild battle starts. 

**This battle is a single battle, despite B_DOUBLE_WILD_CHANCE being set to 100.**

### Proposed Solution

This PR adds a new define for developers to use, as well as a new check in `TryDoDoubleWildBattle`.

#### [`include/config/battle/h`](https://github.com/PokemonSanFran/pokeemerald-expansion/blob/6a7466c92982bb63f98554857f0ce48cf1347c2b/include/config/battle.h)

```c
#define B_DOUBLE_WILD_REQUIRE_2_MONS    FALSE   // If set to TRUE, when the player only has one Pokémon in the party, randomly generated wild battles will always be a Single battle, regardless of the number used in B_DOUBLE_WILD_CHANCE.
```

#### [`src/wild_encounter.c`](https://github.com/PokemonSanFran/pokeemerald-expansion/blob/6a7466c92982bb63f98554857f0ce48cf1347c2b/src/wild_encounter.c)

```diff
bool8 TryDoDoubleWildBattle(void)
{
+ #if B_DOUBLE_WILD_REQUIRE_2_MONS == TRUE
    if (GetSafariZoneFlag() || GetMonsStateToDoubles() != PLAYER_HAS_TWO_USABLE_MONS)
+ #else
+     if (GetSafariZoneFlag())
+ #endif
        return FALSE;
#if B_FLAG_FORCE_DOUBLE_WILD != 0
    else if (FlagGet(B_FLAG_FORCE_DOUBLE_WILD))
        return TRUE;
#endif
#if B_DOUBLE_WILD_CHANCE != 0
    else if ((Random() % 100) + 1 <= B_DOUBLE_WILD_CHANCE)
        return TRUE;
#endif
    return FALSE;
}
```

#### Showcase

```c
#define B_DOUBLE_WILD_CHANCE        100
#define B_DOUBLE_WILD_REQUIRE_2_MONS    FALSE

```
![![The first battle occurs when the player has two Pokémon in their party and starts a wild battle, which is a double battle. The game is then reset, the player is only given one Pokémon in their party, and a wild battle starts. This battle is a now a double battle.]](https://user-images.githubusercontent.com/77138753/228633815-dea816f4-7ba2-4819-a0ba-7ff6f4b1fe58.gif)


The first battle occurs when the player has two Pokémon in their party and starts a wild battle, which is a double battle. 

The game is then reset, the player is only given one Pokémon in their party, and a wild battle starts. 

**This battle is a now a double battle.**

When `B_DOUBLE_WILD_REQUIRE_2_MONS` is set to `FALSE`, the behavior functions the same as the Problem Showcase.

### Testing

#### `include/config/battle/h`

```c
#define B_DOUBLE_WILD_CHANCE        100
#define B_DOUBLE_WILD_REQUIRE_2_MONS    FALSE

```

#### `data/scripts/debug.inc`

```
Debug_Script_1::
    givemon SPECIES_TAPU_KOKO,100,ITEM_NONE
    givemon SPECIES_LUGIA,100,ITEM_LIFE_ORB
    warpsilent MAP_ROUTE120,31,7
	end

Debug_Script_2::
    givemon SPECIES_TAPU_KOKO,100,ITEM_NONE
    warpsilent MAP_ROUTE120,31,7
	end
```

After running either debug script, walk around until a battle starts.                                                                                   

## **Discord contact info**
psf#2936
<!--- Contributors must join https://discord.gg/d5dubZ3 -->