### PR TITLE
Fixed switch-in abilities activating on terrain change

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -8839,7 +8839,6 @@ BattleScript_TerrainSeedLoop_NextBattler:
 	addbyte gBattlerTarget, 0x1
 	jumpifbytenotequal gBattlerTarget, gBattlersCount, BattleScript_TerrainSeedLoopIter
 	restoretarget
-	call BattleScript_ActivateSwitchInAbilities
 	return
 
 BattleScript_ActivateSwitchInAbilities:

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -2610,8 +2610,7 @@ BattleScript_EffectPsychicTerrain:
 	printfromtable gTerrainStringIds
 	waitmessage B_WAIT_TIME_LONG
 	playanimation BS_ATTACKER, B_ANIM_RESTORE_BG
-	call BattleScript_ActivateTerrainAbilities
-	call BattleScript_TerrainSeedLoop
+	call BattleScript_ActivateTerrainEffects
 	goto BattleScript_MoveEnd
 
 BattleScript_EffectTopsyTurvy:
@@ -6867,7 +6866,7 @@ BattleScript_OverworldTerrain::
 	printfromtable gTerrainStringIds
 	waitmessage B_WAIT_TIME_LONG
 	playanimation BS_SCRIPTING, B_ANIM_RESTORE_BG
-	call BattleScript_TerrainSeedLoop
+	call BattleScript_ActivateTerrainEffects
 	end3
 
 BattleScript_SideStatusWoreOff::
@@ -7346,8 +7345,7 @@ BattleScript_SeedSowerActivates::
 	printstring STRINGID_TERRAINBECOMESGRASSY
 	waitmessage B_WAIT_TIME_LONG
 	playanimation BS_SCRIPTING, B_ANIM_RESTORE_BG
-	call BattleScript_ActivateTerrainAbilities
-	call BattleScript_TerrainSeedLoop
+	call BattleScript_ActivateTerrainEffects
 	return
 
 BattleScript_AngerShellActivates::
@@ -8828,16 +8826,18 @@ BattleScript_SnowWarningActivates::
 	call BattleScript_WeatherFormChanges
 	end3
 
-BattleScript_TerrainSeedLoop:
+BattleScript_ActivateTerrainEffects:
 	savetarget
 	setbyte gBattlerTarget, 0
-BattleScript_TerrainSeedLoopIter:
+BattleScript_ActivateTerrainSeed:
 	copybyte sBATTLER, gBattlerTarget
-	doterrainseed BS_TARGET, BattleScript_TerrainSeedLoop_NextBattler
+	doterrainseed BS_TARGET, BattleScript_ActivateTerrainAbility
 	removeitem BS_TARGET
-BattleScript_TerrainSeedLoop_NextBattler:
+BattleScript_ActivateTerrainAbility:
+	activateterrainchangeabilities BS_TARGET
+BattleScript_ActivateTerrainEffects_Increment:
 	addbyte gBattlerTarget, 0x1
-	jumpifbytenotequal gBattlerTarget, gBattlersCount, BattleScript_TerrainSeedLoopIter
+	jumpifbytenotequal gBattlerTarget, gBattlersCount, BattleScript_ActivateTerrainSeed
 	restoretarget
 	return
 
@@ -8852,25 +8852,13 @@ BattleScript_ActivateSwitchInAbilities_Increment:
 	copybyte gBattlerAttacker, sBATTLER
 	return
 
-BattleScript_ActivateTerrainAbilities:
-	copybyte sBATTLER, gBattlerAttacker
-	setbyte gBattlerAttacker, 0
-BattleScript_ActivateTerrainAbilities_Loop:
-	activateterrainchangeabilities BS_ATTACKER
-BattleScript_ActivateTerrainAbilities_Increment:
-	addbyte gBattlerAttacker, 1
-	jumpifbytenotequal gBattlerAttacker, gBattlersCount, BattleScript_ActivateTerrainAbilities_Loop
-	copybyte gBattlerAttacker, sBATTLER
-	return
-
 BattleScript_ElectricSurgeActivates::
 	pause B_WAIT_TIME_SHORT
 	call BattleScript_AbilityPopUp
 	printstring STRINGID_TERRAINBECOMESELECTRIC
 	waitmessage B_WAIT_TIME_LONG
 	playanimation BS_SCRIPTING, B_ANIM_RESTORE_BG
-	call BattleScript_ActivateTerrainAbilities
-	call BattleScript_TerrainSeedLoop
+	call BattleScript_ActivateTerrainEffects
 	end3
 
 BattleScript_MistySurgeActivates::
@@ -8879,8 +8867,7 @@ BattleScript_MistySurgeActivates::
 	printstring STRINGID_TERRAINBECOMESMISTY
 	waitmessage B_WAIT_TIME_LONG
 	playanimation BS_SCRIPTING, B_ANIM_RESTORE_BG
-	call BattleScript_ActivateTerrainAbilities
-	call BattleScript_TerrainSeedLoop
+	call BattleScript_ActivateTerrainEffects
 	end3
 
 BattleScript_GrassySurgeActivates::
@@ -8889,8 +8876,7 @@ BattleScript_GrassySurgeActivates::
 	printstring STRINGID_TERRAINBECOMESGRASSY
 	waitmessage B_WAIT_TIME_LONG
 	playanimation BS_SCRIPTING, B_ANIM_RESTORE_BG
-	call BattleScript_ActivateTerrainAbilities
-	call BattleScript_TerrainSeedLoop
+	call BattleScript_ActivateTerrainEffects
 	end3
 
 BattleScript_PsychicSurgeActivates::
@@ -8899,8 +8885,7 @@ BattleScript_PsychicSurgeActivates::
 	printstring STRINGID_TERRAINBECOMESPSYCHIC
 	waitmessage B_WAIT_TIME_LONG
 	playanimation BS_SCRIPTING, B_ANIM_RESTORE_BG
-	call BattleScript_ActivateTerrainAbilities
-	call BattleScript_TerrainSeedLoop
+	call BattleScript_ActivateTerrainEffects
 	end3
 
 BattleScript_HurtTarget_NoString:
@@ -10183,7 +10168,6 @@ BattleScript_EffectHitSetRemoveTerrain:
 	setterrain BattleScript_TryFaint
 	playanimation BS_ATTACKER, B_ANIM_RESTORE_BG
 	printfromtable gTerrainStringIds
-	call BattleScript_ActivateTerrainAbilities
 BattleScript_TryFaint:
 	tryfaintmon BS_TARGET
 	goto BattleScript_MoveEnd

--- a/test/terrain_electric.c
+++ b/test/terrain_electric.c
@@ -1,0 +1,63 @@
+#include "global.h"
+#include "test_battle.h"
+
+SINGLE_BATTLE_TEST("Electric Terrain protects grounded battlers from falling asleep")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_CLAYDOL) { Ability(ABILITY_LEVITATE); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_ELECTRIC_TERRAIN); MOVE(opponent, MOVE_SPORE); }
+        TURN { MOVE(player, MOVE_SPORE); }
+    } SCENE {
+        MESSAGE("Wobbuffet used ElctrcTrrain!");
+        MESSAGE("Foe Claydol used Spore!");
+        MESSAGE("Wobbuffet surrounds itself with electrified terrain!");
+        MESSAGE("Wobbuffet used Spore!");
+        MESSAGE("Foe Claydol fell asleep!");
+        STATUS_ICON(opponent, sleep: TRUE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Electric Terrain activates Electric Seed and Mimicry")
+{
+    GIVEN {
+        ASSUME(P_GEN_8_POKEMON == TRUE);
+        ASSUME(gItems[ITEM_ELECTRIC_SEED].holdEffect == HOLD_EFFECT_SEEDS);
+        ASSUME(gItems[ITEM_ELECTRIC_SEED].holdEffectParam == HOLD_EFFECT_PARAM_ELECTRIC_TERRAIN);
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_ELECTRIC_SEED); }
+        OPPONENT(SPECIES_STUNFISK_GALARIAN) { Ability(ABILITY_MIMICRY); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_ELECTRIC_TERRAIN); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        MESSAGE("Using Electric Seed, the defense of Wobbuffet rose!");
+        ABILITY_POPUP(opponent);
+        MESSAGE("Foe Stunfisk's type changed to Electr!");
+    } FINALLY {
+        EXPECT_EQ(gBattleMons[B_POSITION_OPPONENT_LEFT].type1, TYPE_ELECTRIC);
+    }
+}
+
+SINGLE_BATTLE_TEST("Electric Terrain increases power of Electric-type moves by 30/50 percent", s16 damage)
+{
+    bool32 terrain;
+    PARAMETRIZE { terrain = FALSE; }
+    PARAMETRIZE { terrain = TRUE; }
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        if (terrain)
+            TURN { MOVE(player, MOVE_ELECTRIC_TERRAIN); }
+        TURN { MOVE(player, MOVE_THUNDER_SHOCK); }
+    } SCENE {
+        MESSAGE("Wobbuffet used ThunderShock!");
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        if (B_TERRAIN_TYPE_BOOST >= GEN_8)
+            EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.3), results[1].damage);
+        else
+            EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.5), results[1].damage);
+    }
+}

--- a/test/terrain_grassy.c
+++ b/test/terrain_grassy.c
@@ -15,5 +15,72 @@ SINGLE_BATTLE_TEST("Grassy Terrain recovers 1/16th HP at end of turn")
     }
 }
 
-TO_DO_BATTLE_TEST("Grassy Terrain increases power of Grass-type moves by 30/50 percent")
-TO_DO_BATTLE_TEST("Grassy Terrain decreases power of Earthquake, Magnitude and Bulldoze by 50 percent")
+SINGLE_BATTLE_TEST("Grassy Terrain activates Grassy Seed and Mimicry")
+{
+    GIVEN {
+        ASSUME(P_GEN_8_POKEMON == TRUE);
+        ASSUME(gItems[ITEM_GRASSY_SEED].holdEffect == HOLD_EFFECT_SEEDS);
+        ASSUME(gItems[ITEM_GRASSY_SEED].holdEffectParam == HOLD_EFFECT_PARAM_GRASSY_TERRAIN);
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_GRASSY_SEED); }
+        OPPONENT(SPECIES_STUNFISK_GALARIAN) { Ability(ABILITY_MIMICRY); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_GRASSY_TERRAIN); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        MESSAGE("Using Grassy Seed, the defense of Wobbuffet rose!");
+        ABILITY_POPUP(opponent);
+        MESSAGE("Foe Stunfisk's type changed to Grass!");
+    } FINALLY {
+        EXPECT_EQ(gBattleMons[B_POSITION_OPPONENT_LEFT].type1, TYPE_GRASS);
+    }
+}
+
+SINGLE_BATTLE_TEST("Grassy Terrain increases power of Grass-type moves by 30/50 percent", s16 damage)
+{
+    bool32 terrain;
+    PARAMETRIZE { terrain = FALSE; }
+    PARAMETRIZE { terrain = TRUE; }
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        if (terrain)
+            TURN { MOVE(player, MOVE_GRASSY_TERRAIN); }
+        TURN { MOVE(player, MOVE_ABSORB); }
+    } SCENE {
+        MESSAGE("Wobbuffet used Absorb!");
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        if (B_TERRAIN_TYPE_BOOST >= GEN_8)
+            EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.3), results[1].damage);
+        else
+            EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.5), results[1].damage);
+    }
+}
+
+// Magnitude is not tested because its damage is variable.
+SINGLE_BATTLE_TEST("Grassy Terrain decreases power of Earthquake and Bulldoze by 50 percent", s16 damage)
+{
+    bool32 terrain;
+    u16 move;
+    PARAMETRIZE { terrain = FALSE; move = MOVE_EARTHQUAKE; } // 0
+    PARAMETRIZE { terrain = TRUE; move = MOVE_EARTHQUAKE; } // 1
+    PARAMETRIZE { terrain = FALSE; move = MOVE_BULLDOZE; } // 2
+    PARAMETRIZE { terrain = TRUE; move = MOVE_BULLDOZE; } // 3
+    GIVEN {
+        ASSUME(gBattleMoves[MOVE_EARTHQUAKE].effect == EFFECT_EARTHQUAKE);
+        ASSUME(gBattleMoves[MOVE_BULLDOZE].effect == EFFECT_BULLDOZE);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        if (terrain)
+            TURN { MOVE(player, MOVE_GRASSY_TERRAIN); }
+        TURN { MOVE(player, move); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(0.5), results[1].damage);
+        EXPECT_MUL_EQ(results[2].damage, Q_4_12(0.5), results[3].damage);
+    }
+}

--- a/test/terrain_misty.c
+++ b/test/terrain_misty.c
@@ -1,0 +1,80 @@
+#include "global.h"
+#include "test_battle.h"
+
+SINGLE_BATTLE_TEST("Misty Terrain protects grounded battlers from non-volatile status conditions")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_CLAYDOL) { Ability(ABILITY_LEVITATE); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_MISTY_TERRAIN); MOVE(opponent, MOVE_TOXIC); }
+        TURN { MOVE(player, MOVE_TOXIC); }
+    } SCENE {
+        MESSAGE("Wobbuffet used MistyTerrain!");
+        MESSAGE("Foe Claydol used Toxic!");
+        MESSAGE("Wobbuffet surrounds itself with a protective mist!");
+        NOT { STATUS_ICON(opponent, badPoison: TRUE); }
+        MESSAGE("Wobbuffet used Toxic!");
+        STATUS_ICON(opponent, badPoison: TRUE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Misty Terrain activates Misty Seed and Mimicry")
+{
+    GIVEN {
+        ASSUME(P_GEN_8_POKEMON == TRUE);
+        ASSUME(gItems[ITEM_MISTY_SEED].holdEffect == HOLD_EFFECT_SEEDS);
+        ASSUME(gItems[ITEM_MISTY_SEED].holdEffectParam == HOLD_EFFECT_PARAM_MISTY_TERRAIN);
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_MISTY_SEED); }
+        OPPONENT(SPECIES_STUNFISK_GALARIAN) { Ability(ABILITY_MIMICRY); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_MISTY_TERRAIN); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        MESSAGE("Using Misty Seed, the sp. defense of Wobbuffet rose!");
+        ABILITY_POPUP(opponent);
+        MESSAGE("Foe Stunfisk's type changed to Fairy!");
+    } FINALLY {
+        EXPECT_EQ(gBattleMons[B_POSITION_OPPONENT_LEFT].type1, TYPE_FAIRY);
+    }
+}
+
+SINGLE_BATTLE_TEST("Misty Terrain does not increase the power of Fairy-type moves", s16 damage)
+{
+    bool32 terrain;
+    PARAMETRIZE { terrain = FALSE; }
+    PARAMETRIZE { terrain = TRUE; }
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        if (terrain)
+            TURN { MOVE(player, MOVE_MISTY_TERRAIN); }
+        TURN { MOVE(player, MOVE_MOONBLAST); }
+    } SCENE {
+        MESSAGE("Wobbuffet used Moonblast!");
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_EQ(results[0].damage, results[1].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Misty Terrain decreases power of Dragon-type moves by 50 percent", s16 damage)
+{
+    bool32 terrain;
+    PARAMETRIZE { terrain = FALSE; }
+    PARAMETRIZE { terrain = TRUE; }
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        if (terrain)
+            TURN { MOVE(player, MOVE_MISTY_TERRAIN); }
+        TURN { MOVE(player, MOVE_DRAGON_CLAW); }
+    } SCENE {
+        MESSAGE("Wobbuffet used Dragon Claw!");
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(0.5), results[1].damage);
+    }
+}

--- a/test/terrain_psychic.c
+++ b/test/terrain_psychic.c
@@ -1,0 +1,138 @@
+#include "global.h"
+#include "test_battle.h"
+
+SINGLE_BATTLE_TEST("Psychic Terrain protects grounded battlers from priority moves")
+{
+    GIVEN {
+        PLAYER(SPECIES_CLAYDOL) { Ability(ABILITY_LEVITATE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_PSYCHIC_TERRAIN); }
+        TURN { MOVE(player, MOVE_QUICK_ATTACK); MOVE(opponent, MOVE_QUICK_ATTACK); }
+    } SCENE {
+        MESSAGE("Claydol used PsychcTrrain!");
+        MESSAGE("Claydol cannot use Quick Attack!");
+        NOT { HP_BAR(opponent); }
+        MESSAGE("Foe Wobbuffet used Quick Attack!");
+        HP_BAR(player);
+    }
+}
+
+SINGLE_BATTLE_TEST("Psychic Terrain activates Psychic Seed and Mimicry")
+{
+    GIVEN {
+        ASSUME(P_GEN_8_POKEMON == TRUE);
+        ASSUME(gItems[ITEM_PSYCHIC_SEED].holdEffect == HOLD_EFFECT_SEEDS);
+        ASSUME(gItems[ITEM_PSYCHIC_SEED].holdEffectParam == HOLD_EFFECT_PARAM_PSYCHIC_TERRAIN);
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_PSYCHIC_SEED); }
+        OPPONENT(SPECIES_STUNFISK_GALARIAN) { Ability(ABILITY_MIMICRY); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_PSYCHIC_TERRAIN); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        MESSAGE("Using Psychic Seed, the sp. defense of Wobbuffet rose!");
+        ABILITY_POPUP(opponent);
+        MESSAGE("Foe Stunfisk's type changed to Psychc!");
+    } FINALLY {
+        EXPECT_EQ(gBattleMons[B_POSITION_OPPONENT_LEFT].type1, TYPE_PSYCHIC);
+    }
+}
+
+SINGLE_BATTLE_TEST("Psychic Terrain increases power of Psychic-type moves by 30/50 percent", s16 damage)
+{
+    bool32 terrain;
+    PARAMETRIZE { terrain = FALSE; }
+    PARAMETRIZE { terrain = TRUE; }
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        if (terrain)
+            TURN { MOVE(player, MOVE_PSYCHIC_TERRAIN); }
+        TURN { MOVE(player, MOVE_CONFUSION); }
+    } SCENE {
+        MESSAGE("Wobbuffet used Confusion!");
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        if (B_TERRAIN_TYPE_BOOST >= GEN_8)
+            EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.3), results[1].damage);
+        else
+            EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.5), results[1].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Psychic Terrain doesn't block priority moves that target the user", s16 damage)
+{
+    GIVEN {
+        PLAYER(SPECIES_SABLEYE) { Ability(ABILITY_PRANKSTER); HP(1); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_PSYCHIC_TERRAIN); }
+        TURN { MOVE(player, MOVE_RECOVER); }
+    } SCENE {
+        MESSAGE("Sableye used PsychcTrrain!");
+        MESSAGE("Sableye used Recover!");
+        HP_BAR(player);
+    }
+}
+
+SINGLE_BATTLE_TEST("Psychic Terrain doesn't block priority moves that target all battlers", s16 damage)
+{
+    KNOWN_FAILING;
+    GIVEN {
+        PLAYER(SPECIES_SABLEYE) { Ability(ABILITY_PRANKSTER); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_PSYCHIC_TERRAIN); }
+        TURN { MOVE(player, MOVE_HAZE); }
+    } SCENE {
+        MESSAGE("Sableye used PsychcTrrain!");
+        MESSAGE("Sableye used Haze!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Psychic Terrain doesn't block priority moves that target all opponents", s16 damage)
+{
+    KNOWN_FAILING;
+    GIVEN {
+        PLAYER(SPECIES_SABLEYE) { Ability(ABILITY_PRANKSTER); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_PSYCHIC_TERRAIN); }
+        TURN { MOVE(player, MOVE_SPIKES); }
+    } SCENE {
+        MESSAGE("Sableye used PsychcTrrain!");
+        MESSAGE("Sableye used Spikes!");
+    }
+}
+
+DOUBLE_BATTLE_TEST("Psychic Terrain doesn't block priority moves that target allies", s16 damage)
+{
+    GIVEN {
+        PLAYER(SPECIES_SABLEYE) { Ability(ABILITY_PRANKSTER); }
+        PLAYER(SPECIES_WOBBUFFET) { HP(1); }
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_PSYCHIC_TERRAIN); }
+        TURN { MOVE(playerLeft, MOVE_HEAL_PULSE, target: playerRight); }
+    } SCENE {
+        MESSAGE("Sableye used PsychcTrrain!");
+        MESSAGE("Sableye used Heal Pulse!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Psychic Terrain doesn't block priority field moves", s16 damage)
+{
+    KNOWN_FAILING;
+    GIVEN {
+        PLAYER(SPECIES_SABLEYE) { Ability(ABILITY_PRANKSTER); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_PSYCHIC_TERRAIN); }
+        TURN { MOVE(player, MOVE_SUNNY_DAY); }
+    } SCENE {
+        MESSAGE("Sableye used PsychcTrrain!");
+        MESSAGE("Sableye used Sunny Day!");
+    }
+}


### PR DESCRIPTION
## Description ##
Fixes #2880. This PR removes an erroneous call to `activateswitchinabilities` in the `TerrainSeed` loop and combines both the `TerrainSeedLoop` and `TerrainAbilitiesLoop` into one loop for terrain effects so you don't have to call each individually (and so it doesn't have to loop over every battler twice).

This PR also adds tests for every terrain effect! This includes some edge cases for Psychic Terrain that appear to be inaccurate at the moment, so they have been marked with `KNOWN_FAILING`. These bugs have been pointed out in #2882, but are not fixed in this PR. 