### PR TITLE
MOVE_REVIVAL_BLESSING Effect

### DIFF
--- a/asm/macros/battle_script.inc
+++ b/asm/macros/battle_script.inc
@@ -2263,3 +2263,8 @@
 	.macro hitswitchtargetfailed
 	various 0, VARIOUS_HIT_SWITCH_TARGET_FAILED
 	.endm
+
+	.macro tryrevivalblessing, jumpInstr:req
+	various 0, VARIOUS_TRY_REVIVAL_BLESSING
+	.4byte \jumpInstr
+	.endm

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -423,6 +423,18 @@ gBattleScriptsForMoveEffects::
 	.4byte BattleScript_EffectHitSetEntryHazard       @ EFFECT_HIT_SET_ENTRY_HAZARD
 	.4byte BattleScript_EffectDireClaw                @ EFFECT_DIRE_CLAW
 	.4byte BattleScript_EffectBarbBarrage             @ EFFECT_BARB_BARRAGE
+	.4byte BattleScript_EffectRevivalBlessing		  @ EFFECT_REVIVAL_BLESSING
+
+BattleScript_EffectRevivalBlessing::
+	attackcanceler
+	attackstring
+	ppreduce
+	attackanimation
+	waitanimation
+	tryrevivalblessing BattleScript_ButItFailed
+	printstring STRINGID_PKMNREVIVEDREADYTOFIGHT
+	waitmessage B_WAIT_TIME_LONG
+	goto BattleScript_MoveEnd
 
 BattleScript_StealthRockActivates::
 	setstealthrock BattleScript_MoveEnd

--- a/include/battle_ai_util.h
+++ b/include/battle_ai_util.h
@@ -165,6 +165,7 @@ s32 CountUsablePartyMons(u8 battlerId);
 bool32 IsPartyFullyHealedExceptBattler(u8 battler);
 bool32 PartyHasMoveSplit(u8 battlerId, u8 split);
 bool32 SideHasMoveSplit(u8 battlerId, u8 split);
+u8 CountFaintedPartyMons(u8 battlerId);
 
 // score increases
 void IncreaseStatUpScore(u8 battlerAtk, u8 battlerDef, u8 statId, s16 *score);

--- a/include/constants/battle_move_effects.h
+++ b/include/constants/battle_move_effects.h
@@ -404,7 +404,8 @@
 #define EFFECT_HIT_SET_ENTRY_HAZARD         398
 #define EFFECT_DIRE_CLAW                    399
 #define EFFECT_BARB_BARRAGE                 400
+#define EFFECT_REVIVAL_BLESSING             401
 
-#define NUM_BATTLE_MOVE_EFFECTS             401
+#define NUM_BATTLE_MOVE_EFFECTS             402
 
 #endif  // GUARD_CONSTANTS_BATTLE_MOVE_EFFECTS_H

--- a/include/constants/battle_script_commands.h
+++ b/include/constants/battle_script_commands.h
@@ -259,6 +259,7 @@
 #define VARIOUS_STORE_HEALING_WISH                  167
 #define VARIOUS_HIT_SWITCH_TARGET_FAILED            168
 #define VARIOUS_JUMP_IF_SHELL_TRAP                  169
+#define VARIOUS_TRY_REVIVAL_BLESSING                170
 
 // Cmd_manipulatedamage
 #define DMG_CHANGE_SIGN            0

--- a/include/constants/battle_string_ids.h
+++ b/include/constants/battle_string_ids.h
@@ -647,8 +647,9 @@
 #define STRINGID_STEALTHROCKDISAPPEAREDFROMTEAM       645
 #define STRINGID_COULDNTFULLYPROTECT                  646
 #define STRINGID_STOCKPILEDEFFECTWOREOFF              647
+#define STRINGID_PKMNREVIVEDREADYTOFIGHT              648
 
-#define BATTLESTRINGS_COUNT                           648
+#define BATTLESTRINGS_COUNT                           649
 
 // This is the string id that gBattleStringsTable starts with.
 // String ids before this (e.g. STRINGID_INTROMSG) are not in the table,

--- a/include/constants/party_menu.h
+++ b/include/constants/party_menu.h
@@ -48,6 +48,7 @@
 #define PARTY_ACTION_MOVE_TUTOR         12
 #define PARTY_ACTION_MINIGAME           13
 #define PARTY_ACTION_REUSABLE_ITEM      14  // Unused. The only reusable items are handled separately
+#define PARTY_ACTION_CHOOSE_FAINTED_MON 15
 
 // IDs for DisplayPartyMenuStdMessage, to display the message at the bottom of the party menu
 #define PARTY_MSG_CHOOSE_MON                0

--- a/include/party_menu.h
+++ b/include/party_menu.h
@@ -75,6 +75,7 @@ void ChooseMonForMoveTutor(void);
 void ChooseMonForWirelessMinigame(void);
 void OpenPartyMenuInBattle(u8 partyAction);
 void ChooseMonForInBattleItem(void);
+void ChooseMonForRevivalBlessing(void);
 void BufferBattlePartyCurrentOrder(void);
 void BufferBattlePartyCurrentOrderBySide(u8 battlerId, u8 flankId);
 void SwitchPartyOrderLinkMulti(u8 battlerId, u8 slot, u8 arrayIndex);

--- a/include/pokemon_storage_system.h
+++ b/include/pokemon_storage_system.h
@@ -29,6 +29,7 @@ extern struct PokemonStorage *gPokemonStoragePtr;
 void DrawTextWindowAndBufferTiles(const u8 *string, void *dst, u8 zero1, u8 zero2, s32 bytesToBuffer);
 u8 CountMonsInBox(u8 boxId);
 s16 GetFirstFreeBoxSpot(u8 boxId);
+u8 CountPartyNonEggMons(void);
 u8 CountPartyAliveNonEggMonsExcept(u8 slotToIgnore);
 u16 CountPartyAliveNonEggMons_IgnoreVar0x8004Slot(void);
 u8 CountPartyMons(void);

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -2610,6 +2610,15 @@ static s16 AI_CheckBadMove(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
             if (gBattleMons[battlerAtk].hp <= gBattleMons[battlerAtk].maxHP / 3)
                 score -= 10;
             break;*/
+        case EFFECT_REVIVAL_BLESSING:
+            if (CountFaintedPartyMons(battlerAtk) == 0)
+                score -= 10;
+            else if (CanAIFaintTarget(battlerAtk, battlerDef, 0))
+                score -= 10;
+            else if (CanTargetFaintAi(battlerDef, battlerAtk)
+             && AI_WhoStrikesFirst(battlerAtk, battlerDef, move) == AI_IS_SLOWER)
+                score -= 10;
+            break;
         case EFFECT_PLACEHOLDER:
             return 0;   // cannot even select
     } // move effect checks
@@ -4794,6 +4803,10 @@ static s16 AI_CheckViability(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
         {
             score++;
         }
+        break;
+    case EFFECT_REVIVAL_BLESSING:
+        if (CountFaintedPartyMons(battlerAtk) != 0)
+            score += 2;
         break;
     //case EFFECT_EXTREME_EVOBOOST: // TODO
         //break;

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -3749,3 +3749,40 @@ bool32 ShouldUseZMove(u8 battlerAtk, u8 battlerDef, u16 chosenMove)
 
     return FALSE;
 }
+
+// Copied from CountUsablePartyMons.
+u8 CountFaintedPartyMons(u8 battlerId)
+{
+    s32 battlerOnField1, battlerOnField2, i, ret;
+    struct Pokemon *party;
+
+    if (GetBattlerSide(battlerId) == B_SIDE_PLAYER)
+        party = gPlayerParty;
+    else
+        party = gEnemyParty;
+
+    if (gBattleTypeFlags & BATTLE_TYPE_DOUBLE)
+    {
+        battlerOnField1 = gBattlerPartyIndexes[battlerId];
+        battlerOnField2 = gBattlerPartyIndexes[GetBattlerAtPosition(BATTLE_PARTNER(GetBattlerPosition(battlerId)))];
+    }
+    else // In singles there's only one battlerId by side.
+    {
+        battlerOnField1 = gBattlerPartyIndexes[battlerId];
+        battlerOnField2 = gBattlerPartyIndexes[battlerId];
+    }
+
+    ret = 0;
+    for (i = 0; i < PARTY_SIZE; i++)
+    {
+        if (i != battlerOnField1 && i != battlerOnField2
+         && GetMonData(&party[i], MON_DATA_HP) == 0
+         && GetMonData(&party[i], MON_DATA_SPECIES_OR_EGG) != SPECIES_NONE
+         && GetMonData(&party[i], MON_DATA_SPECIES_OR_EGG) != SPECIES_EGG)
+        {
+            ret++;
+        }
+    }
+
+    return ret;
+}

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -1575,7 +1575,10 @@ static void OpenPartyMenuToChooseMon(void)
         caseId = gTasks[gBattleControllerData[gActiveBattler]].data[0];
         DestroyTask(gBattleControllerData[gActiveBattler]);
         FreeAllWindowBuffers();
-        OpenPartyMenuInBattle(caseId);
+        if (caseId == PARTY_ACTION_CHOOSE_FAINTED_MON)
+            ChooseMonForRevivalBlessing();
+        else
+            OpenPartyMenuInBattle(caseId);
     }
 }
 

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3173,6 +3173,7 @@ static void BattleStartClearSetData(void)
     }
 
     gBattleStruct->swapDamageCategory = FALSE; // Photon Geyser, Shell Side Arm, Light That Burns the Sky
+    gSelectedMonPartyId = PARTY_SIZE; // Revival Blessing
 }
 
 void SwitchInClearSetData(void)
@@ -3284,6 +3285,9 @@ void SwitchInClearSetData(void)
     gSpecialStatuses[gActiveBattler].specialDmg = 0;
 
     gBattleStruct->overwrittenAbilities[gActiveBattler] = ABILITY_NONE;
+
+    // Clear selected party ID so Revival Blessing doesn't get confused.
+    gSelectedMonPartyId = PARTY_SIZE;
 
     Ai_UpdateSwitchInData(gActiveBattler);
 }

--- a/src/battle_message.c
+++ b/src/battle_message.c
@@ -782,9 +782,11 @@ static const u8 sText_PrepareShellTrap[] = _("{B_ATK_NAME_WITH_PREFIX} set a she
 static const u8 sText_ShellTrapDidntWork[] = _("{B_ATK_NAME_WITH_PREFIX}'s shell trap didn't work!");
 static const u8 sText_CouldntFullyProtect[] = _("{B_DEF_NAME_WITH_PREFIX} couldn't fully protect\nitself and got hurt!");
 static const u8 sText_StockpiledEffectWoreOff[] = _("{B_ATK_NAME_WITH_PREFIX}'s stockpiled\neffect wore off!");
+static const u8 sText_PkmnRevivedReadyToFight[] = _("{B_BUFF1} was revived and\nis ready to fight again!");
 
 const u8 *const gBattleStringsTable[BATTLESTRINGS_COUNT] =
 {
+    [STRINGID_PKMNREVIVEDREADYTOFIGHT - BATTLESTRINGS_TABLE_START] = sText_PkmnRevivedReadyToFight,
     [STRINGID_STOCKPILEDEFFECTWOREOFF - BATTLESTRINGS_TABLE_START] = sText_StockpiledEffectWoreOff,
     [STRINGID_COULDNTFULLYPROTECT - BATTLESTRINGS_TABLE_START] = sText_CouldntFullyProtect,
     [STRINGID_ATTACKERGAINEDSTRENGTHFROMTHEFALLEN - BATTLESTRINGS_TABLE_START] = sText_AttackerGainedStrengthFromTheFallen,

--- a/src/data/battle_moves.h
+++ b/src/data/battle_moves.h
@@ -13048,7 +13048,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_Z] =
 
     [MOVE_REVIVAL_BLESSING] =
     {
-        .effect = EFFECT_PLACEHOLDER, // EFFECT_REVIVAL_BLESSING
+        .effect = EFFECT_REVIVAL_BLESSING,
         .power = 0,
         .type = TYPE_NORMAL,
         .accuracy = 0,

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -1354,6 +1354,18 @@ static void HandleChooseMonSelection(u8 taskId, s8 *slotPtr)
                 TryEnterMonForMinigame(taskId, (u8)*slotPtr);
             }
             break;
+        case PARTY_ACTION_CHOOSE_FAINTED_MON:
+            if (GetMonData(&gPlayerParty[GetCursorSelectionMonId()], MON_DATA_HP) > 0)
+            {
+                PlaySE(SE_FAILURE);
+            }
+            else if (IsSelectedMonNotEgg((u8 *)slotPtr))
+            {
+                PlaySE(SE_SELECT);
+                gSelectedMonPartyId = GetCursorSelectionMonId();
+                Task_ClosePartyMenu(taskId);
+            }
+            break;
         default:
         case PARTY_ACTION_ABILITY_PREVENTS:
         case PARTY_ACTION_SWITCHING:
@@ -1379,6 +1391,7 @@ static void HandleChooseMonCancel(u8 taskId, s8 *slotPtr)
     switch (gPartyMenu.action)
     {
     case PARTY_ACTION_SEND_OUT:
+    case PARTY_ACTION_CHOOSE_FAINTED_MON:
         PlaySE(SE_FAILURE);
         break;
     case PARTY_ACTION_SWITCH:
@@ -6199,6 +6212,13 @@ static u8 GetPartyLayoutFromBattleType(void)
 void OpenPartyMenuInBattle(u8 partyAction)
 {
     InitPartyMenu(PARTY_MENU_TYPE_IN_BATTLE, GetPartyLayoutFromBattleType(), partyAction, FALSE, PARTY_MSG_CHOOSE_MON, Task_HandleChooseMonInput, CB2_SetUpReshowBattleScreenAfterMenu);
+    ReshowBattleScreenDummy();
+    UpdatePartyToBattleOrder();
+}
+
+void ChooseMonForRevivalBlessing(void)
+{
+    InitPartyMenu(PARTY_MENU_TYPE_IN_BATTLE, GetPartyLayoutFromBattleType(), PARTY_ACTION_CHOOSE_FAINTED_MON, FALSE, PARTY_MSG_CHOOSE_MON, Task_HandleChooseMonInput, CB2_SetUpReshowBattleScreenAfterMenu);
     ReshowBattleScreenDummy();
     UpdatePartyToBattleOrder();
 }


### PR DESCRIPTION
## Description ##
Closes #2495. This PR implements Revival Blessing, which allows the user to select a Pokémon in their party and revive it to 50% HP if there is a fainted party member, and fails otherwise. If a battler besides the player uses the move (i.e. player partner or opponent), it currently revives the first fainted battler in their party.

**TODO:** Write tests. Test the AI a bit more.

## Showcases ##
**Revival Blessing used by Player**
![Revival Blessing](https://user-images.githubusercontent.com/103095241/229938303-72b1629d-fb31-45a2-b90e-82d6c3adc229.gif)

**Revival Blessing used by Opponent**
![Revival Blessing Opponent](https://user-images.githubusercontent.com/103095241/229938361-f2cbd99d-48c3-4337-8938-cca02c6bfc52.gif)

## What does the code do? ##
This PR adds a new script command `tryrevivalblessing` (code in `VARIOUS_TRY_REVIVAL_BLESSING`) that, for the player, opens the party menu and once a Pokémon is selected, revives it and brings it to 50% HP. The party menu is called only for the player, using the Battle Controller just as it would be for U-turn and the like. I don't entirely understand how it works, but I do know that setting the `u8 *data` field to what it is now fixed a lot of issues.

A new constant `PARTY_ACTION_CHOOSE_FAINTED_MON` is added for the party menu logic to work. If this action is in use, the player can **not** select a battler that is still alive or close the menu once it is opened. In addition, it will not open the selection menu when a viable battler is selected, and instead terminate immediately and store the result in `gSelectedMonPartyId`.

The script command encoding is a little funky. It first checks if there is any fainted battler to revive, and if it fails it cuts to the `failInstr`. Next, it checks if the user is a player partner or opponent and bypasses the Battle Controller use if true, choosing the first fainted party member as the target. Next, perhaps a bit weirdly, it checks if a battler has been selected and revives it and prepares the string buffer for the battle string. Finally, if it makes it past the previous checks, it will open the party menu and **NOT** increment to the next script instruction. This is done so the command is run again with the now-selected battler marked. As a result, for the typical player use, this command will have to run-throughs.

The existing variable `gSelectedMonPartyId` is used for all the logic above, and is now set to `PARTY_SIZE` whenever a battler is switched in or a party member revived by this move to mark it as empty. It is set to `PARTY_SIZE` at the beginning of battle, as well.

Finally, currently the AI increments the viability of the move if there are any fainted party members. It marks it as a bad move if there are no fainted party members, it will faint before using the move, or it can faint the target. This might need some touching up and hasn't been tested thoroughly.

## **Discord Contact Info** ##
Agustin#1522