### PR TITLE
Fix overworld poison not working on newer generations config

### DIFF
--- a/src/field_control_avatar.c
+++ b/src/field_control_avatar.c
@@ -565,13 +565,11 @@ static bool8 TryStartStepCountScript(u16 metatileBehavior)
 
     if (!(gPlayerAvatar.flags & PLAYER_AVATAR_FLAG_FORCED_MOVE) && !MetatileBehavior_IsForcedMovementTile(metatileBehavior))
     {
-    #if OW_POISON_DAMAGE < GEN_5
         if (UpdatePoisonStepCounter() == TRUE)
         {
             ScriptContext_SetupScript(EventScript_FieldPoison);
             return TRUE;
         }
-    #endif
         if (ShouldEggHatch())
         {
             IncrementGameStat(GAME_STAT_HATCHED_EGGS);


### PR DESCRIPTION
## Description
We can't have that config under a define, otherwise the Pokémon will never take damage from being poisoned.

## **Discord contact info**
Jaizu#7841