### PR TITLE
Fixed duplicate item strings in Bag/Party menus with battle items

### DIFF
--- a/data/battle_scripts_2.s
+++ b/data/battle_scripts_2.s
@@ -49,14 +49,13 @@ BattleScript_UseItemMessage:
 BattleScript_ItemRestoreHP::
     call BattleScript_UseItemMessage
     itemrestorehp
-    printstring STRINGID_ITEMRESTOREDSPECIESHEALTH
-    waitmessage B_WAIT_TIME_LONG
     jumpifbyte CMP_EQUAL, gBattleCommunication, TRUE, BattleScript_ItemRestoreHP_SendOutRevivedBattler
     bichalfword gMoveResultFlags, MOVE_RESULT_NO_EFFECT
     orword gHitMarker, HITMARKER_IGNORE_SUBSTITUTE
     healthbarupdate BS_ATTACKER
     datahpupdate BS_ATTACKER
-    updatestatusicon BS_ATTACKER
+    printstring STRINGID_ITEMRESTOREDSPECIESHEALTH
+    waitmessage B_WAIT_TIME_LONG
     end
 
 BattleScript_ItemRestoreHP_SendOutRevivedBattler:
@@ -68,22 +67,22 @@ BattleScript_ItemRestoreHP_SendOutRevivedBattler:
 BattleScript_ItemCureStatus::
     call BattleScript_UseItemMessage
     itemcurestatus
+    updatestatusicon BS_ATTACKER
     printstring STRINGID_ITEMCUREDSPECIESSTATUS
     waitmessage B_WAIT_TIME_LONG
-    updatestatusicon BS_ATTACKER
     end
 
 BattleScript_ItemHealAndCureStatus::
     call BattleScript_UseItemMessage
     itemrestorehp
     curestatus BS_ATTACKER
-    printstring STRINGID_ITEMRESTOREDSPECIESHEALTH
-    waitmessage B_WAIT_TIME_LONG
     bichalfword gMoveResultFlags, MOVE_RESULT_NO_EFFECT
     orword gHitMarker, HITMARKER_IGNORE_SUBSTITUTE
     healthbarupdate BS_ATTACKER
     datahpupdate BS_ATTACKER
     updatestatusicon BS_ATTACKER
+    printstring STRINGID_ITEMRESTOREDSPECIESHEALTH
+    waitmessage B_WAIT_TIME_LONG
     end
 
 BattleScript_ItemIncreaseStat::
@@ -255,4 +254,5 @@ BattleScript_TrainerBSlideMsgRet::
 
 BattleScript_TrainerBSlideMsgEnd2::
     call BattleScript_TrainerBSlideMsgRet
+    end2
     end2

--- a/data/battle_scripts_2.s
+++ b/data/battle_scripts_2.s
@@ -255,4 +255,3 @@ BattleScript_TrainerBSlideMsgRet::
 BattleScript_TrainerBSlideMsgEnd2::
     call BattleScript_TrainerBSlideMsgRet
     end2
-    end2

--- a/src/battle_message.c
+++ b/src/battle_message.c
@@ -465,7 +465,7 @@ const u8 *const gPokeblockWasTooXStringTable[FLAVOR_COUNT] =
     [FLAVOR_SOUR]   = sText_PokeblockWasTooSour
 };
 
-static const u8 sText_PlayerUsedItem[] = _("{B_PLAYER_NAME} used\n{B_LAST_ITEM}!");
+static const u8 sText_PlayerUsedItem[] = _("You used\n{B_LAST_ITEM}!");
 static const u8 sText_WallyUsedItem[] = _("WALLY used\n{B_LAST_ITEM}!");
 static const u8 sText_Trainer1UsedItem[] = _("{B_ATK_TRAINER_CLASS} {B_ATK_TRAINER_NAME}\nused {B_LAST_ITEM}!");
 static const u8 sText_TrainerBlockedBall[] = _("The TRAINER blocked the BALL!");
@@ -783,9 +783,9 @@ static const u8 sText_ShellTrapDidntWork[] = _("{B_ATK_NAME_WITH_PREFIX}'s shell
 static const u8 sText_CouldntFullyProtect[] = _("{B_DEF_NAME_WITH_PREFIX} couldn't fully protect\nitself and got hurt!");
 static const u8 sText_StockpiledEffectWoreOff[] = _("{B_ATK_NAME_WITH_PREFIX}'s stockpiled\neffect wore off!");
 static const u8 sText_PkmnRevivedReadyToFight[] = _("{B_BUFF1} was revived and\nis ready to fight again!");
-static const u8 sText_ItemRestoredSpeciesHealth[] = _("{B_LAST_ITEM} restored\n{B_BUFF1}'s health!");
-static const u8 sText_ItemCuredSpeciesStatus[] = _("{B_LAST_ITEM} cured\n{B_BUFF1}'s status!");
-static const u8 sText_ItemRestoredSpeciesPP[] = _("{B_LAST_ITEM} restored\n{B_BUFF1}'s PP!");
+static const u8 sText_ItemRestoredSpeciesHealth[] = _("{B_BUFF1} had its\nHP restored!");
+static const u8 sText_ItemCuredSpeciesStatus[] = _("{B_BUFF1} had\nits status healed!");
+static const u8 sText_ItemRestoredSpeciesPP[] = _("{B_BUFF1} had its\nPP restored!");
 
 const u8 *const gBattleStringsTable[BATTLESTRINGS_COUNT] =
 {

--- a/src/item_use.c
+++ b/src/item_use.c
@@ -1229,10 +1229,11 @@ void ItemUseInBattle_BagMenu(u8 taskId)
     {
         PlaySE(SE_SELECT);
         RemoveUsedItem();
+        ScheduleBgCopyTilemapToVram(2);
         if (!InBattlePyramid())
-            DisplayItemMessage(taskId, FONT_NORMAL, gStringVar4, Task_FadeAndCloseBagMenu);
+            gTasks[taskId].func = Task_FadeAndCloseBagMenu;
         else
-            DisplayItemMessageInBattlePyramid(taskId, gStringVar4, CloseBattlePyramidBag);
+            gTasks[taskId].func = CloseBattlePyramidBag;
     }
 }
 

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -4470,11 +4470,8 @@ void ItemUseCB_BattleScript(u8 taskId, TaskFunc task)
         gBattleStruct->itemPartyIndex[gBattlerInMenuId] = GetPartyIdFromBattleSlot(gPartyMenu.slotId);
         gPartyMenuUseExitCallback = TRUE;
         PlaySE(SE_SELECT);
-        CopyItemName(gSpecialVar_ItemId, gStringVar2);
-        StringExpandPlaceholders(gStringVar4, gText_PlayerUsedVar2);
-        DisplayPartyMenuMessage(gStringVar4, TRUE);
-        ScheduleBgCopyTilemapToVram(2);
         RemoveBagItem(gSpecialVar_ItemId, 1);
+        ScheduleBgCopyTilemapToVram(2);
         gTasks[taskId].func = task;
     }
 }
@@ -4943,9 +4940,6 @@ static void TryUseItemOnMove(u8 taskId)
             gChosenMovePos = ptr->data1;
             gPartyMenuUseExitCallback = TRUE;
             RemoveBagItem(gSpecialVar_ItemId, 1);
-            CopyItemName(gSpecialVar_ItemId, gStringVar2);
-            StringExpandPlaceholders(gStringVar4, gText_PlayerUsedVar2);
-            DisplayPartyMenuMessage(gStringVar4, TRUE);
             ScheduleBgCopyTilemapToVram(2);
             gTasks[taskId].func = Task_ClosePartyMenuAfterText;
         }        


### PR DESCRIPTION
## Description
In Gen 8/9, items used in battle don't print a message on success inside the bag or party menu. My last PR messed up this behavior. It also makes it so "restored HP" and "cured status" messages print after the battle box is updated.

## Images
Updated behavior:
![No Dupe Message](https://user-images.githubusercontent.com/103095241/232236826-b7e070a5-8e26-4a77-8a9d-c18e0060d12f.gif)
![No Dupe Message (2)](https://user-images.githubusercontent.com/103095241/232237329-71099536-9c6e-403a-89db-6931304ec5dd.gif)

## Issue(s) that this PR fixes
Fixes #2913 

## **Discord contact info**
Agustin#1522