### PR TITLE
fix several issues in BS_ItemCureStatus

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -16506,10 +16506,11 @@ void BS_ItemCureStatus(void) {
     {
         gBattleMons[gBattlerAttacker].status2 &= ~GetItemStatus2Mask(gLastUsedItem); 
         gBattlerTarget = BATTLE_PARTNER(gBattlerAttacker);
-        if (GetItemStatus1Mask(gLastUsedItem) & STATUS1_SLEEP)
-            gBattleMons[gBattlerAttacker].status2 &= ~STATUS2_NIGHTMARE;
     }
     
+    if (GetItemStatus1Mask(gLastUsedItem) & STATUS1_SLEEP)
+        gBattleMons[gBattlerAttacker].status2 &= ~STATUS2_NIGHTMARE;
+
     PREPARE_SPECIES_BUFFER(gBattleTextBuff1, GetMonData(&party[gBattleStruct->itemPartyIndex[gBattlerAttacker]], MON_DATA_SPECIES));
     gBattlescriptCurrInstr = cmd->nextInstr;
 }

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -16500,7 +16500,9 @@ void BS_ItemCureStatus(void) {
     
     // Heal Status2 conditions if battler is active.
     if (gBattleStruct->itemPartyIndex[gBattlerAttacker] == gBattlerPartyIndexes[gBattlerAttacker])
-        gBattleMons[gBattleStruct->itemPartyIndex[gBattlerAttacker]].status2 &= ~GetItemStatus2Mask(gLastUsedItem); 
+    {
+        gBattleMons[gBattlerAttacker].status2 &= ~GetItemStatus2Mask(gLastUsedItem);
+    }
     else if (gBattleTypeFlags & BATTLE_TYPE_DOUBLE
                 && gBattleStruct->itemPartyIndex[gBattlerAttacker] == gBattlerPartyIndexes[BATTLE_PARTNER(gBattlerAttacker)])
     {


### PR DESCRIPTION
## Description
1. gBattleMons was using party indices instead of battle indices, therefore only ever healing a mon whichs party index matches with its battle index.
2. added brackets for readability
3. fix nightmare only being healed in double battles by moving the check into the scope of the entire function. 

fixes #2919 
## **Discord contact info**
Salem#3258