### PR TITLE
fix dire hit and paralyze heal

### DIFF
--- a/src/item.c
+++ b/src/item.c
@@ -973,6 +973,8 @@ u32 GetItemStatus1Mask(u16 itemId)
     const u8 *effect = GetItemEffect(itemId);
     switch (effect[3])
     {
+        case ITEM3_PARALYSIS:
+            return STATUS1_PARALYSIS;
         case ITEM3_FREEZE:
             return STATUS1_FREEZE;
         case ITEM3_BURN:

--- a/src/item_use.c
+++ b/src/item_use.c
@@ -1154,7 +1154,7 @@ static bool32 CannotUseBagBattleItem(u16 itemId)
     }
     // Dire Hit
     if (battleUsage == EFFECT_ITEM_SET_FOCUS_ENERGY
-        && !(gBattleMons[gBattlerInMenuId].status2 & STATUS2_FOCUS_ENERGY))
+        && (gBattleMons[gBattlerInMenuId].status2 & STATUS2_FOCUS_ENERGY))
     {
         cannotUse++;
     }


### PR DESCRIPTION
these battle items werent working correctly. this fixes that.

## Description
Dire Hit checked if the pokemon did **not** have `STATUS2_FOCUS_ENERGY` to increment the `cannotUse` counter.
It now checks if it does already have the status.
The case for paralysis was missing, so I added it. 

## Images
![asda](https://user-images.githubusercontent.com/65783283/233296735-0cd24b02-5715-444f-ab39-414288187d2d.gif)
![asdd](https://user-images.githubusercontent.com/65783283/233296950-fa8c7063-c5e9-4b4b-919a-ffa26144a06d.gif)

## **Discord contact info**
Salem#3258