### PR TITLE
Fix USE_ITEM explicit targets

### DIFF
--- a/include/recorded_battle.h
+++ b/include/recorded_battle.h
@@ -45,6 +45,7 @@ enum
     RECORDED_PARTY_INDEX,
     RECORDED_BATTLE_PALACE_ACTION,
     RECORDED_ITEM_ID,
+    RECORDED_ITEM_TARGET,
 };
 
 extern u32 gRecordedBattleRngSeed;

--- a/src/battle_controller_recorded_opponent.c
+++ b/src/battle_controller_recorded_opponent.c
@@ -1441,6 +1441,7 @@ static void RecordedOpponentHandleChooseItem(void)
     u8 byte1 = RecordedBattle_GetBattlerAction(RECORDED_ITEM_ID, gActiveBattler);
     u8 byte2 = RecordedBattle_GetBattlerAction(RECORDED_ITEM_ID, gActiveBattler);
     gBattleStruct->chosenItem[gActiveBattler] = (byte1 << 8) | byte2;
+    gBattleStruct->itemPartyIndex[gActiveBattler] = RecordedBattle_GetBattlerAction(RECORDED_ITEM_TARGET, gActiveBattler);
     BtlController_EmitOneReturnValue(BUFFER_B, gBattleStruct->chosenItem[gActiveBattler]);
     RecordedOpponentBufferExecCompleted();
 }

--- a/src/battle_controller_recorded_player.c
+++ b/src/battle_controller_recorded_player.c
@@ -1465,6 +1465,7 @@ static void RecordedPlayerHandleChooseItem(void)
     u8 byte1 = RecordedBattle_GetBattlerAction(RECORDED_ITEM_ID, gActiveBattler);
     u8 byte2 = RecordedBattle_GetBattlerAction(RECORDED_ITEM_ID, gActiveBattler);
     gBattleStruct->chosenItem[gActiveBattler] = (byte1 << 8) | byte2;
+    gBattleStruct->itemPartyIndex[gActiveBattler] = RecordedBattle_GetBattlerAction(RECORDED_ITEM_TARGET, gActiveBattler);
     BtlController_EmitOneReturnValue(BUFFER_B, gBattleStruct->chosenItem[gActiveBattler]);
     RecordedPlayerBufferExecCompleted();
 }

--- a/test/test_runner_battle.c
+++ b/test/test_runner_battle.c
@@ -1540,9 +1540,11 @@ void UseItem(u32 sourceLine, struct BattlePokemon *battler, struct ItemContext c
     PushBattlerAction(sourceLine, battlerId, RECORDED_ITEM_ID, (ctx.itemId >> 8) & 0xFF);
     PushBattlerAction(sourceLine, battlerId, RECORDED_ITEM_ID, ctx.itemId & 0xFF);
     if (ctx.explicitPartyIndex)
-        gBattleStruct->itemPartyIndex[battlerId] = ctx.partyIndex;
-    if (ctx.explicitMove)
-        gBattleStruct->itemPartyIndex[battlerId] = i;
+        PushBattlerAction(sourceLine, battlerId, RECORDED_ITEM_TARGET, ctx.partyIndex);
+    else if (ctx.explicitMove)
+        PushBattlerAction(sourceLine, battlerId, RECORDED_ITEM_TARGET, i);
+    else
+        PushBattlerAction(sourceLine, battlerId, RECORDED_ITEM_TARGET, 0);
     DATA.actionBattlers |= 1 << battlerId;
 }
 


### PR DESCRIPTION
```c
     if (ctx.explicitPartyIndex)
         gBattleStruct->itemPartyIndex[battlerId] = ctx.partyIndex;
     if (ctx.explicitMove)
         gBattleStruct->itemPartyIndex[battlerId] = i;
```
These are setting variables that get overwritten with PARTY_SIZE at the start of the turn. &gPlayerParty[6] == &gEnemyParty[0].

I have replaced them with writing to the battle record in the tests, and reading from it in the battle controllers.

We should really make the controllers emit the `itemPartyIndex` rather than writing to it directly. As-is, any recorded battles with an item usage or any link battles with an item usage will go horribly wrong.