### PR TITLE
Adds GetMovesArray in CanTargetFaintAi

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -477,7 +477,7 @@ bool32 IsAiBattlerAware(u32 battlerId)
 {
     if (AI_THINKING_STRUCT->aiFlags & AI_FLAG_OMNISCIENT)
         return TRUE;
-    
+
     return BattlerHasAi(battlerId);
 }
 
@@ -1129,7 +1129,7 @@ bool32 CanTargetFaintAi(u8 battlerDef, u8 battlerAtk)
 {
     s32 i, dmg;
     u32 unusable = AI_DATA->moveLimitations[battlerDef];
-    u16 *moves = gBattleResources->battleHistory->usedMoves[battlerDef];
+    u16 *moves = GetMovesArray(battlerDef);
 
     for (i = 0; i < MAX_MON_MOVES; i++)
     {


### PR DESCRIPTION
## Description
Replaces `gBattleResources->battleHistory->usedMoves[battlerDef]` with `GetMovesArray(battlerDef)`.
Technically a small bug because the AI couldn't see the players moves on turn one if `CanTargetFaintAi` was called with `AI_FLAG_OMNISCIENT` but I also feel like it is a leftover because everything else uses `GetMovesArray` involving moves.

## **Discord contact info**
AlexOnline#2331