### PR TITLE
Fixes status z-moves overwrting damage dealing z-moves

### DIFF
--- a/src/battle_z_move.c
+++ b/src/battle_z_move.c
@@ -215,11 +215,7 @@ bool32 IsViableZMove(u8 battlerId, u16 move)
 
         if (move != MOVE_NONE && zMove != MOVE_Z_STATUS && gBattleMoves[move].type == ItemId_GetSecondaryId(item))
         {
-            if (IS_MOVE_STATUS(move))
-                gBattleStruct->zmove.chosenZMove = move;
-            else
-                gBattleStruct->zmove.chosenZMove = GetTypeBasedZMove(move, battlerId);
-
+            gBattleStruct->zmove.chosenZMove = GetTypeBasedZMove(move, battlerId);
             return TRUE;
         }
     }


### PR DESCRIPTION
## Description
Fixes status z-moves overwriting damage dealing z-moves. This happened when the status move was slotted in a slot the came after a regular damaging dealing move, as long as both had the same typing.  

## Images
Previously:
![overwritten_z_move](https://user-images.githubusercontent.com/93446519/233716021-ae951f88-8d91-4f60-a1a1-793f231b7497.gif)
After the PR:
![z_moves_normal](https://user-images.githubusercontent.com/93446519/233716096-deb702e3-aa09-441a-9cc5-a02adf42bc0f.gif)
Status z moves still work like intended:
![status_z_moves](https://user-images.githubusercontent.com/93446519/233716179-2868c6aa-5566-4849-9538-9230553bb94b.gif)

## Issue(s) that this PR fixes
Fixes  #2558

## **Discord contact info**
AlexOnline#2331