### PR TITLE
Fix anger shell activating when fainted

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -5778,6 +5778,7 @@ u8 AbilityBattleEffects(u8 caseID, u8 battler, u16 ability, u8 special, u16 move
             if (!(gMoveResultFlags & MOVE_RESULT_NO_EFFECT)
              && !gProtectStructs[gBattlerAttacker].confusionSelfDmg
              && TARGET_TURN_DAMAGED
+             && IsBattlerAlive(gBattlerTarget)
              && (gBattleMons[gBattlerTarget].hp <= gBattleMons[gBattlerTarget].maxHP / 2)
              && !(TestSheerForceFlag(gBattlerAttacker, gCurrentMove)))
             {


### PR DESCRIPTION
Anger shell currently activates if the target faints. this fixes that.