### PR TITLE
Fixes Triple Dive effect

### DIFF
--- a/include/constants/pokemon.h
+++ b/include/constants/pokemon.h
@@ -238,8 +238,9 @@
 #define FLAG_THAW_USER                            (1 << 25)
 #define FLAG_HIT_IN_SUBSTITUTE                    (1 << 26) // Hyperspace Fury
 #define FLAG_TWO_STRIKES                          (1 << 27) // A move with this flag will strike twice, and may apply its effect on each hit
-#define FLAG_WIND_MOVE                            (1 << 28)
-#define FLAG_SLICING_MOVE                         (1 << 29)
+#define FLAG_THREE_STRIKES                        (1 << 28) // A move with this flag will strike thrice, and may apply its effect on each hit
+#define FLAG_WIND_MOVE                            (1 << 29)
+#define FLAG_SLICING_MOVE                         (1 << 30)
 
 // Split defines.
 #define SPLIT_PHYSICAL  0x0

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -477,7 +477,7 @@ bool32 IsAiBattlerAware(u32 battlerId)
 {
     if (AI_THINKING_STRUCT->aiFlags & AI_FLAG_OMNISCIENT)
         return TRUE;
-    
+
     return BattlerHasAi(battlerId);
 }
 
@@ -856,7 +856,7 @@ s32 AI_CalcDamage(u16 move, u8 battlerAtk, u8 battlerDef, u8 *typeEffectiveness,
         // Handle other multi-strike moves
         if (gBattleMoves[move].flags & FLAG_TWO_STRIKES)
             dmg *= 2;
-        else if (move == MOVE_SURGING_STRIKES || (move == MOVE_WATER_SHURIKEN && gBattleMons[battlerAtk].species == SPECIES_GRENINJA_ASH))
+        else if (gBattleMoves[move].flags & FLAG_THREE_STRIKES || (move == MOVE_WATER_SHURIKEN && gBattleMons[battlerAtk].species == SPECIES_GRENINJA_ASH))
             dmg *= 3;
 
         if (dmg == 0)

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3739,7 +3739,7 @@ u8 AtkCanceller_UnableToUseMove(void)
                     // TODO
                 }
             }
-            else if (gBattleMoves[gCurrentMove].flags & FLAG_THREE_STRIKES)
+            else if (gBattleMoves[gCurrentMove].effect == EFFECT_TRIPLE_KICK || gBattleMoves[gCurrentMove].flags & FLAG_THREE_STRIKES)
             {
                 gMultiHitCounter = 3;
                 PREPARE_BYTE_NUMBER_BUFFER(gBattleScripting.multihitString, 1, 0)

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3739,7 +3739,7 @@ u8 AtkCanceller_UnableToUseMove(void)
                     // TODO
                 }
             }
-            else if (gBattleMoves[gCurrentMove].effect == EFFECT_TRIPLE_KICK || gCurrentMove == MOVE_SURGING_STRIKES)
+            else if (gBattleMoves[gCurrentMove].flags & FLAG_THREE_STRIKES)
             {
                 gMultiHitCounter = 3;
                 PREPARE_BYTE_NUMBER_BUFFER(gBattleScripting.multihitString, 1, 0)

--- a/src/data/battle_moves.h
+++ b/src/data/battle_moves.h
@@ -12316,7 +12316,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_Z] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
-        .flags = FLAG_MAKES_CONTACT | FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGS_ROCK_AFFECTED | FLAG_IRON_FIST_BOOST,
+        .flags = FLAG_MAKES_CONTACT | FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGS_ROCK_AFFECTED | FLAG_IRON_FIST_BOOST | FLAG_THREE_STRIKES,
         .split = SPLIT_PHYSICAL,
         .zMoveEffect = Z_EFFECT_NONE,
     },
@@ -13080,7 +13080,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_Z] =
 
     [MOVE_TRIPLE_DIVE] =
     {
-        .effect = EFFECT_TRIPLE_KICK,
+        .effect = EFFECT_HIT,
         .power = 30,
         .type = TYPE_WATER,
         .accuracy = 95,
@@ -13088,7 +13088,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_Z] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
-        .flags = FLAG_MAKES_CONTACT | FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGS_ROCK_AFFECTED,
+        .flags = FLAG_MAKES_CONTACT | FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGS_ROCK_AFFECTED | FLAG_THREE_STRIKES,
         .split = SPLIT_PHYSICAL,
         .zMoveEffect = Z_EFFECT_NONE,
     },

--- a/test/move_effect_triple_kick.c
+++ b/test/move_effect_triple_kick.c
@@ -1,32 +1,12 @@
 #include "global.h"
 #include "test_battle.h"
 
-
-SINGLE_BATTLE_TEST("Triple Kick effect damage on Triple Axel is increaased by 20 for each hit")
+ASSUMPTIONS
 {
-    s16 firstHit;
-    s16 secondHit;
-    s16 thirdHit;
-
-    GIVEN {
-        PLAYER(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_WOBBUFFET);
-    } WHEN {
-        TURN { MOVE(player, MOVE_TRIPLE_AXEL); }
-    } SCENE {
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_TRIPLE_AXEL, player);
-        HP_BAR(opponent, captureDamage: &firstHit);
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_TRIPLE_AXEL, player);
-        HP_BAR(opponent, captureDamage: &secondHit);
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_TRIPLE_AXEL, player);
-        HP_BAR(opponent, captureDamage: &thirdHit);
-    } FINALLY {
-        EXPECT_EQ(secondHit, firstHit * 2);
-        EXPECT_EQ(thirdHit, firstHit * 3);
-    }
+    ASSUME(gBattleMoves[MOVE_TRIPLE_KICK].effect & EFFECT_TRIPLE_KICK);
 }
 
-SINGLE_BATTLE_TEST("Triple Kick effect damage on Triple Kick is increaased by 10 for each hit")
+SINGLE_BATTLE_TEST("Triple Kick damage is increaased by its base damage for each hit")
 {
     s16 firstHit;
     s16 secondHit;

--- a/test/move_effect_triple_kick.c
+++ b/test/move_effect_triple_kick.c
@@ -1,0 +1,51 @@
+#include "global.h"
+#include "test_battle.h"
+
+
+SINGLE_BATTLE_TEST("Triple Kick effect damage on Triple Axel is increaased by 20 for each hit")
+{
+    s16 firstHit;
+    s16 secondHit;
+    s16 thirdHit;
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_TRIPLE_AXEL); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TRIPLE_AXEL, player);
+        HP_BAR(opponent, captureDamage: &firstHit);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TRIPLE_AXEL, player);
+        HP_BAR(opponent, captureDamage: &secondHit);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TRIPLE_AXEL, player);
+        HP_BAR(opponent, captureDamage: &thirdHit);
+    } FINALLY {
+        EXPECT_EQ(secondHit, firstHit * 2);
+        EXPECT_EQ(thirdHit, firstHit * 3);
+    }
+}
+
+SINGLE_BATTLE_TEST("Triple Kick effect damage on Triple Kick is increaased by 10 for each hit")
+{
+    s16 firstHit;
+    s16 secondHit;
+    s16 thirdHit;
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_TRIPLE_KICK); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TRIPLE_KICK, player);
+        HP_BAR(opponent, captureDamage: &firstHit);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TRIPLE_KICK, player);
+        HP_BAR(opponent, captureDamage: &secondHit);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TRIPLE_KICK, player);
+        HP_BAR(opponent, captureDamage: &thirdHit);
+    } FINALLY {
+        EXPECT_EQ(secondHit, firstHit * 2);
+        EXPECT_EQ(thirdHit, firstHit * 3);
+    }
+}

--- a/test/move_flag_three_strikes.c
+++ b/test/move_flag_three_strikes.c
@@ -1,0 +1,56 @@
+#include "global.h"
+#include "test_battle.h"
+
+
+SINGLE_BATTLE_TEST("Three Strikes are used on Triple Dive")
+{
+    s16 firstHit;
+    s16 secondHit;
+    s16 thirdHit;
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_TRIPLE_DIVE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TRIPLE_DIVE, player);
+        HP_BAR(opponent, captureDamage: &firstHit);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TRIPLE_DIVE, player);
+        HP_BAR(opponent, captureDamage: &secondHit);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TRIPLE_DIVE, player);
+        HP_BAR(opponent, captureDamage: &thirdHit);
+    } FINALLY {
+        EXPECT_EQ(firstHit, secondHit);
+        EXPECT_EQ(secondHit, thirdHit);
+        EXPECT_EQ(firstHit, thirdHit);
+    }
+}
+
+SINGLE_BATTLE_TEST("Three Strikes on Surging Strikes do critical damage")
+{
+    s16 firstHit;
+    s16 secondHit;
+    s16 thirdHit;
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_SURGING_STRIKES); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SURGING_STRIKES, player);
+        HP_BAR(opponent, captureDamage: &firstHit);
+        MESSAGE("A critical hit!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SURGING_STRIKES, player);
+        HP_BAR(opponent, captureDamage: &secondHit);
+        MESSAGE("A critical hit!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SURGING_STRIKES, player);
+        HP_BAR(opponent, captureDamage: &thirdHit);
+        MESSAGE("A critical hit!");
+    } FINALLY {
+        EXPECT_EQ(firstHit, secondHit);
+        EXPECT_EQ(secondHit, thirdHit);
+        EXPECT_EQ(firstHit, thirdHit);
+    }
+}

--- a/test/move_flag_three_strikes.c
+++ b/test/move_flag_three_strikes.c
@@ -1,14 +1,14 @@
 #include "global.h"
 #include "test_battle.h"
 
-
-SINGLE_BATTLE_TEST("Three Strikes are used on Triple Dive")
+SINGLE_BATTLE_TEST("Three-strike flag turns a move into a 3-hit move")
 {
     s16 firstHit;
     s16 secondHit;
     s16 thirdHit;
 
     GIVEN {
+        ASSUME(gBattleMoves[MOVE_TRIPLE_DIVE].flags & FLAG_THREE_STRIKES);
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
@@ -27,13 +27,14 @@ SINGLE_BATTLE_TEST("Three Strikes are used on Triple Dive")
     }
 }
 
-SINGLE_BATTLE_TEST("Three Strikes on Surging Strikes do critical damage")
+SINGLE_BATTLE_TEST("Surging Strikes hits 3 times with each hit being a critical hit")
 {
     s16 firstHit;
     s16 secondHit;
     s16 thirdHit;
 
     GIVEN {
+        ASSUME(gBattleMoves[MOVE_SURGING_STRIKES].flags & FLAG_THREE_STRIKES);
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {


### PR DESCRIPTION
## Description
Fixes Triple Dive effect by adding `FLAG_THREE_STRIKES`. The flag is additionally used for Surging Strikes. 

## Images
Triple Dive:
![triple_dive](https://user-images.githubusercontent.com/93446519/233870311-b296b4be-0760-4a49-adae-8be46109898b.gif)
Surging Strikes:
![surging_strikes](https://user-images.githubusercontent.com/93446519/233870320-fbeecc91-8a31-414e-b2e2-d5f2651d5d30.gif)

## Issue(s) that this PR fixes
Fixes #2795

## **Discord contact info**
<!--- formatted as name#numbers, e.g. Lunos#4026 -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->