### PR TITLE
Fixes erroneous Bad Dreams ability popup.

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4980,6 +4980,7 @@ u8 AbilityBattleEffects(u8 caseID, u8 battler, u16 ability, u8 special, u16 move
                     {
                         BattleScriptPushCursorAndCallback(BattleScript_BadDreamsActivates);
                         effect++;
+                        break;
                     }
                 }
                 break;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4974,8 +4974,14 @@ u8 AbilityBattleEffects(u8 caseID, u8 battler, u16 ability, u8 special, u16 move
                 gDisableStructs[gBattlerAttacker].truantCounter ^= 1;
                 break;
             case ABILITY_BAD_DREAMS:
-                BattleScriptPushCursorAndCallback(BattleScript_BadDreamsActivates);
-                effect++;
+                for (i = 0; i < MAX_BATTLERS_COUNT; i++)
+                {
+                    if (gBattleMons[i].status1 & STATUS1_SLEEP)
+                    {
+                        BattleScriptPushCursorAndCallback(BattleScript_BadDreamsActivates);
+                        effect++;
+                    }
+                }
                 break;
             SOLAR_POWER_HP_DROP:
             case ABILITY_SOLAR_POWER:


### PR DESCRIPTION
## Description
Currently on Upcoming the ability popup for Bad Dreams triggers even when no Pokemon are asleep. This PR fixes that by adding a loop over all battlers that checks for sleep before triggering the battlescript.

## Images
Before:
![baddreamsbug](https://user-images.githubusercontent.com/85393060/234247447-73eed8ce-0f11-4465-b027-c65570e72158.gif)

After, featuring a double battle with scuffed gameplay:
![baddreamsfix](https://user-images.githubusercontent.com/85393060/234247559-b37822d0-a7e0-4e2e-93de-629a8cf834c6.gif)



## Issue(s) that this PR fixes
N/A

## **Discord contact info**
Shae#9032