### PR TITLE
Fix issue with Enamorus Therian cry define order

### DIFF
--- a/sound/direct_sound_data.inc
+++ b/sound/direct_sound_data.inc
@@ -4247,6 +4247,10 @@ Cry_LandorusTherian::
 	.incbin "sound/direct_sound_samples/cries/landorus_therian.bin"
 
 	.align 2
+Cry_EnamorusTherian::
+	.incbin "sound/direct_sound_samples/cries/enamorus_therian.bin"
+
+	.align 2
 Cry_KyuremWhite::
 	.incbin "sound/direct_sound_samples/cries/kyurem_white.bin"
 
@@ -4359,10 +4363,6 @@ Cry_CalyrexIceRider::
 	.align 2
 Cry_CalyrexShadowRider::
 	.incbin "sound/direct_sound_samples/cries/calyrex_shadow_rider.bin"
-
-	.align 2
-Cry_EnamorusTherian::
-	.incbin "sound/direct_sound_samples/cries/enamorus_therian.bin"
 
 .endif
 


### PR DESCRIPTION
## Description
Moved the definition for Cry_EnamorusTherian to below Cry_LandorusTherian, which fixes a compiler error that would occur if GEN 7 and GEN 8 pokemon were disabled.

## **Discord contact info**
lucas#7562