### PR TITLE
Fix for Ceaseless Edge/Axe Kick visual glitch

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -452,7 +452,7 @@ BattleScript_StealthRockActivates::
 	setstealthrock BattleScript_MoveEnd
 	printfromtable gDmgHazardsStringIds
 	waitmessage B_WAIT_TIME_LONG
-	goto BattleScript_MoveEnd
+	return
 
 BattleScript_EffectDireClaw::
 	setmoveeffect MOVE_EFFECT_DIRE_CLAW
@@ -466,7 +466,7 @@ BattleScript_SpikesActivates::
 	trysetspikes BattleScript_MoveEnd
 	printfromtable gDmgHazardsStringIds
 	waitmessage B_WAIT_TIME_LONG
-	goto BattleScript_MoveEnd
+	return
 
 BattleScript_EffectAttackUpUserAlly:
 	jumpifnoally BS_ATTACKER, BattleScript_EffectAttackUp


### PR DESCRIPTION
## Description
Fixes Ceaseless Edge and potentially Axe Kick (move effect not done yet).
There was a 'visual' bug after Ceaseless Edge was used to faint a mon because the move didn't end correctly.
  
## Images
![CEASELESS_EDGE](https://user-images.githubusercontent.com/93446519/235522351-c83cd133-66a6-44dc-ba5a-9919c3b09953.gif)


## Issue(s) that this PR fixes
Fixes  #2958

## **Discord contact info**
AlexOnline#2331
