### PR TITLE
Disable Gen8+ Obedience Mechanics by default

### DIFF
--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -196,7 +196,7 @@
 #define B_WILD_NATURAL_ENEMIES          TRUE       // If set to TRUE, certain wild mon species will attack other species when partnered in double wild battles (eg. Zangoose vs Seviper)
 #define B_AFFECTION_MECHANICS           FALSE      // In Gen6+, there's a stat called affection that can trigger different effects in battle. From LGPE onwards, those effects use friendship instead.
 #define B_TRAINER_CLASS_POKE_BALLS      GEN_LATEST // In Gen7+, trainers will use certain types of Poké Balls depending on their trainer class.
-#define B_OBEDIENCE_MECHANICS           GEN_LATEST // In PLA+ (here Gen8+), obedience restrictions also apply to non-outsider Pokémon, albeit based on their level met rather than actual level
+#define B_OBEDIENCE_MECHANICS           GEN_7      // In PLA+ (here Gen8+), obedience restrictions also apply to non-outsider Pokémon, albeit based on their level met rather than actual level
 #define B_USE_FROSTBITE                 FALSE      // In PLA, Frostbite replaces Freeze. Enabling this flag does the same here. Moves can still be cherry-picked to either Freeze or Frostbite. Freeze-Dry, Secret Power & Tri Attack depend on this config.
 
 // Animation Settings


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Due to the fact that we're not changing default obedience levels, any Pokémon caught above level 10 will disobey until badge 2, which is causing users a bit of a headache.
This PR will disable the feature by default to avoid running into the issue unknowingly. 

## **Discord contact info**
AsparagusEduardo#6051 