### PR TITLE
fix incorrect test runner documentation

### DIFF
--- a/test/test_battle.h
+++ b/test/test_battle.h
@@ -369,7 +369,7 @@
  *     s16 damage;
  *     HP_BAR(player, captureDamage: &damage);
  * If none of the above are used, causes the test to fail if the HP
- * changes at all.
+ * does not change at all.
  *
  * MESSAGE(pattern)
  * Causes the test to fail if the message in pattern is not displayed.


### PR DESCRIPTION
## Description
The documentation incorrectly stated that `HP_BAR(battler)` fails if the hp of the battler changes at all, when the opposite is the case and intended. this fixes this.

## **Discord contact info**
Salem#3258