### PR TITLE
Fixes Triple Kick effect and Z move damage calc

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -820,47 +820,47 @@ s32 AI_CalcDamage(u16 move, u8 battlerAtk, u8 battlerDef, u8 *typeEffectiveness,
         else
             dmg = (critDmg + normalDmg * (critChance - 1)) / critChance;
 
-        // Handle dynamic move damage
-        switch (gBattleMoves[move].effect)
+        if (!gBattleStruct->zmove.active)
         {
-        case EFFECT_LEVEL_DAMAGE:
-        case EFFECT_PSYWAVE:
-            dmg = gBattleMons[battlerAtk].level * (AI_DATA->abilities[battlerAtk] == ABILITY_PARENTAL_BOND ? 2 : 1);
-            break;
-        case EFFECT_DRAGON_RAGE:
-            dmg = 40 * (AI_DATA->abilities[battlerAtk] == ABILITY_PARENTAL_BOND ? 2 : 1);
-            break;
-        case EFFECT_SONICBOOM:
-            dmg = 20 * (AI_DATA->abilities[battlerAtk] == ABILITY_PARENTAL_BOND ? 2 : 1);
-            break;
-        case EFFECT_MULTI_HIT:
-            dmg *= (AI_DATA->abilities[battlerAtk] == ABILITY_SKILL_LINK ? 5 : 3);
-            break;
-        case EFFECT_TRIPLE_KICK:
-            dmg *= (AI_DATA->abilities[battlerAtk] == ABILITY_SKILL_LINK ? 6 : 5);
-            break;
-        case EFFECT_ENDEAVOR:
-            // If target has less HP than user, Endeavor does no damage
-            dmg = max(0, gBattleMons[battlerDef].hp - gBattleMons[battlerAtk].hp);
-            break;
-        case EFFECT_SUPER_FANG:
-            dmg = (AI_DATA->abilities[battlerAtk] == ABILITY_PARENTAL_BOND
-                ? max(2, gBattleMons[battlerDef].hp * 3 / 4)
-                : max(1, gBattleMons[battlerDef].hp / 2));
-            break;
-        case EFFECT_FINAL_GAMBIT:
-            dmg = gBattleMons[battlerAtk].hp;
-            break;
+            // Handle dynamic move damage
+            switch (gBattleMoves[move].effect)
+            {
+            case EFFECT_LEVEL_DAMAGE:
+            case EFFECT_PSYWAVE:
+                dmg = gBattleMons[battlerAtk].level * (AI_DATA->abilities[battlerAtk] == ABILITY_PARENTAL_BOND ? 2 : 1);
+                break;
+            case EFFECT_DRAGON_RAGE:
+                dmg = 40 * (AI_DATA->abilities[battlerAtk] == ABILITY_PARENTAL_BOND ? 2 : 1);
+                break;
+            case EFFECT_SONICBOOM:
+                dmg = 20 * (AI_DATA->abilities[battlerAtk] == ABILITY_PARENTAL_BOND ? 2 : 1);
+                break;
+            case EFFECT_MULTI_HIT:
+                dmg *= (AI_DATA->abilities[battlerAtk] == ABILITY_SKILL_LINK ? 5 : 3);
+                break;
+            case EFFECT_ENDEAVOR:
+                // If target has less HP than user, Endeavor does no damage
+                dmg = max(0, gBattleMons[battlerDef].hp - gBattleMons[battlerAtk].hp);
+                break;
+            case EFFECT_SUPER_FANG:
+                dmg = (AI_DATA->abilities[battlerAtk] == ABILITY_PARENTAL_BOND
+                    ? max(2, gBattleMons[battlerDef].hp * 3 / 4)
+                    : max(1, gBattleMons[battlerDef].hp / 2));
+                break;
+            case EFFECT_FINAL_GAMBIT:
+                dmg = gBattleMons[battlerAtk].hp;
+                break;
+            }
+
+            // Handle other multi-strike moves
+            if (gBattleMoves[move].flags & FLAG_TWO_STRIKES)
+                dmg *= 2;
+            else if (gBattleMoves[move].flags & FLAG_THREE_STRIKES || (move == MOVE_WATER_SHURIKEN && gBattleMons[battlerAtk].species == SPECIES_GRENINJA_ASH))
+                dmg *= 3;
+
+            if (dmg == 0)
+                dmg = 1;
         }
-
-        // Handle other multi-strike moves
-        if (gBattleMoves[move].flags & FLAG_TWO_STRIKES)
-            dmg *= 2;
-        else if (gBattleMoves[move].flags & FLAG_THREE_STRIKES || (move == MOVE_WATER_SHURIKEN && gBattleMons[battlerAtk].species == SPECIES_GRENINJA_ASH))
-            dmg *= 3;
-
-        if (dmg == 0)
-            dmg = 1;
     }
     else
     {

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -6783,7 +6783,7 @@ static bool32 GetMentalHerbEffect(u8 battlerId)
 static u8 TryConsumeMirrorHerb(u8 battlerId, bool32 execute)
 {
     u8 effect = 0;
-    
+
     if (gProtectStructs[battlerId].eatMirrorHerb) {
         gLastUsedItem = gBattleMons[battlerId].item;
         gBattleScripting.savedBattler = gBattlerAttacker;
@@ -8584,7 +8584,10 @@ static u16 CalcMoveBasePower(u16 move, u8 battlerAtk, u8 battlerDef)
         basePower = gBattleStruct->presentBasePower;
         break;
     case EFFECT_TRIPLE_KICK:
-        basePower *= (4 - gMultiHitCounter);
+        if (gMultiHitCounter == 0) // Calc damage with max BP for move consideration
+            basePower *= 6;
+        else
+            basePower *= (4 - gMultiHitCounter);
         break;
     case EFFECT_SPIT_UP:
         basePower = 100 * gDisableStructs[battlerAtk].stockpileCounter;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When the damage for `TRIPLE_KICK_EFFECT` was calculated, the BP was first calculated as `basePower * 4` and on top of it if it was either multiplied with 5/6 depending if the user had Skill link or not. 
The fix calculates the damage for `TRIPLE_KICK_EFFECT` as it would always get 3 hits when it is considered for usage, otherwise for each hit.
Triple Axle:
``` 
[INFO] GBA Debug: Multi Hit Counter: 0
[INFO] GBA Debug: Base Power: 120

[INFO] GBA Debug: Multi Hit Counter: 3
[INFO] GBA Debug: Base Power: 20

[INFO] GBA Debug: Multi Hit Counter: 2
[INFO] GBA Debug: Base Power: 40

[INFO] GBA Debug: Multi Hit Counter: 1
[INFO] GBA Debug: Base Power: 60
```
Triple Kick:
```
[INFO] GBA Debug: Multi Hit Counter: 0
[INFO] GBA Debug: Base Power: 60

[INFO] GBA Debug: Multi Hit Counter: 3
[INFO] GBA Debug: Base Power: 10

[INFO] GBA Debug: Multi Hit Counter: 2
[INFO] GBA Debug: Base Power: 20

[INFO] GBA Debug: Multi Hit Counter: 1
[INFO] GBA Debug: Base Power: 30
```

Also fixes z-move damage calculation. The effects of base moves were included in the calcs.  
## Images
Z moves calc without the fix:
![pokeemerald-8](https://user-images.githubusercontent.com/93446519/236667622-1da765c3-48f2-44ac-ac32-80512bdfdfac.png)
After the fix:
![pokeemerald-10](https://user-images.githubusercontent.com/93446519/236667748-d8f81a1c-f921-4f84-a820-aad29bf48a48.png)


## **Discord contact info**
AlexOnline#2331