### PR TITLE
Fix shiny animation not respecting Illusion mon target and Imposter revealing opponent ability

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -9373,8 +9373,8 @@ BattleScript_FriskActivates::
 	end3
 
 BattleScript_ImposterActivates::
-	transformdataexecution
 	call BattleScript_AbilityPopUp
+	transformdataexecution
 	playmoveanimation BS_ATTACKER, MOVE_TRANSFORM
 	waitanimation
 	printstring STRINGID_IMPOSTERTRANSFORM

--- a/src/battle_anim_throw.c
+++ b/src/battle_anim_throw.c
@@ -2484,9 +2484,14 @@ void TryShinyAnimation(u8 battler, struct Pokemon *mon)
     u32 otId, personality;
     u32 shinyValue;
     u8 taskCirc, taskDgnl;
+    struct Pokemon* illusionMon;
 
     isShiny = FALSE;
     gBattleSpritesDataPtr->healthBoxesData[battler].triedShinyMonAnim = TRUE;
+    illusionMon = GetIllusionMonPtr(battler);
+    if (illusionMon != NULL)
+        mon = illusionMon;
+    
     otId = GetMonData(mon, MON_DATA_OT_ID);
     personality = GetMonData(mon, MON_DATA_PERSONALITY);
 

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -10398,12 +10398,19 @@ bool32 SetIllusionMon(struct Pokemon *mon, u32 battlerId)
 {
     struct Pokemon *party, *partnerMon;
     s32 i, id;
+    u8 side, partyCount;
 
     gBattleStruct->illusion[battlerId].set = 1;
     if (GetMonAbility(mon) != ABILITY_ILLUSION)
         return FALSE;
 
     party = GetBattlerParty(battlerId);
+    side = GetBattlerSide(battlerId);
+    partyCount = side == B_SIDE_PLAYER ? gPlayerPartyCount : gEnemyPartyCount;
+
+    // If this pokemon is last in the party, ignore Illusion.
+    if (&party[partyCount - 1] == mon)
+        return FALSE;
 
     if (IsBattlerAlive(BATTLE_PARTNER(battlerId)))
         partnerMon = &party[gBattlerPartyIndexes[BATTLE_PARTNER(battlerId)]];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When an Illusion user is sent out, the shiny animation (stars) does not respect the shininess of the illusion target (which of course ruins the illusion... ☹️)
This fix will instead use the result of `GetIllusionMonPtr` if it is non-null.

This also fixes #2971 - the Imposter ability no longer reveals the ability of the opponent in the ability popup and instead properly shows 'Imposter'.

## Images

### Illusion
|**Illusion user is shiny, target is not**|**Target is shiny, Illusion user is not**|**Fixed**|
|-|-|-|
|![illusionShinyNoAnim](https://user-images.githubusercontent.com/39687914/236861110-e5777833-8461-4a45-938b-76c4826b6d1a.gif)|![illusionNotShinyAnim](https://user-images.githubusercontent.com/39687914/236861611-da724ffb-7b56-4c26-8cec-a8f42614d54f.gif)|![illusionFix](https://user-images.githubusercontent.com/39687914/236863619-4b5d254e-0c47-4f54-82e7-2080552ad763.gif)|

### Imposter
|**Imposter reveals opponent ability**|**Fixed**|
|-|-|
|![imposterBroken](https://user-images.githubusercontent.com/39687914/236868423-fc295f86-07d1-47e3-8ed5-a4eec36987fe.gif)|![imposterFixed](https://user-images.githubusercontent.com/39687914/236868457-9a6efd9e-f2ad-4ddc-98b7-4f5e489efd97.gif)|


## **Discord contact info**
Ultimate_Bob#2163