### PR TITLE
remove duplicate CanBePoisoned condition

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -6413,7 +6413,6 @@ bool32 CanBePoisoned(u8 battlerAttacker, u8 battlerTarget)
      || ability == ABILITY_IMMUNITY
      || ability == ABILITY_COMATOSE
      || IsAbilityOnSide(battlerTarget, ABILITY_PASTEL_VEIL)
-     || gBattleMons[battlerTarget].status1 & STATUS1_ANY
      || IsAbilityStatusProtected(battlerTarget)
      || IsBattlerTerrainAffected(battlerTarget, STATUS_FIELD_MISTY_TERRAIN))
         return FALSE;


### PR DESCRIPTION
## Description
removes a duplicate condition for `CanBePoisoned` (marked orange here)

```diff --git a/src/battle_util.c b/src/battle_util.c
index cd65d58093..e8c9b8d8cd 100644
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -6411,11 +6411,10 @@ bool32 CanBePoisoned(u8 battlerAttacker, u8 battlerTarget)
      || gSideStatuses[GetBattlerSide(battlerTarget)] & SIDE_STATUS_SAFEGUARD
!     || gBattleMons[battlerTarget].status1 & STATUS1_ANY
      || ability == ABILITY_IMMUNITY
      || ability == ABILITY_COMATOSE
      || IsAbilityOnSide(battlerTarget, ABILITY_PASTEL_VEIL)
-     || gBattleMons[battlerTarget].status1 & STATUS1_ANY
      || IsAbilityStatusProtected(battlerTarget)
      || IsBattlerTerrainAffected(battlerTarget, STATUS_FIELD_MISTY_TERRAIN))
         return FALSE;
     return TRUE;
 }
 ```

## Issue(s) that this PR fixes
fixes #2987 

## **Discord contact info**
Salem#3258