### PR TITLE
Updated Ability Patch for Gen 9 functionality

### DIFF
--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -4663,7 +4663,6 @@ void Task_AbilityPatch(u8 taskId)
         // Can't use.
         if (gSpeciesInfo[tSpecies].abilities[tAbilityNum] == 0
             || !tSpecies
-            || GetMonData(&gPlayerParty[tMonId], MON_DATA_ABILITY_NUM, NULL) > 1
             )
         {
             gPartyMenuUseExitCallback = FALSE;
@@ -4734,7 +4733,10 @@ void ItemUseCB_AbilityPatch(u8 taskId, TaskFunc task)
     tState = 0;
     tMonId = gPartyMenu.slotId;
     tSpecies = GetMonData(&gPlayerParty[tMonId], MON_DATA_SPECIES, NULL);
-    tAbilityNum = 2;
+    if (GetMonData(&gPlayerParty[tMonId], MON_DATA_ABILITY_NUM, NULL) == 2)
+        tAbilityNum = 0;
+    else
+        tAbilityNum = 2;
     SetWordTaskArg(taskId, tOldFunc, (uintptr_t)(gTasks[taskId].func));
     gTasks[taskId].func = Task_AbilityPatch;
 }


### PR DESCRIPTION
## Description
In Scarlet and Violet, the Ability Patch is able to switch a Pokémon's ability from a Hidden Ability to its first slotted ability. This PR implements that

## **Discord contact info**
Frankfurter#8828
