### PR TITLE
Fixed mons mot disobeying with Gen8 mechanics disabled

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -8115,8 +8115,6 @@ u8 IsMonDisobedient(void)
     if (!IsOtherTrainer(gBattleMons[gBattlerAttacker].otId, gBattleMons[gBattlerAttacker].otName))
         levelReferenced = gBattleMons[gBattlerAttacker].metLevel;
     else
-#else
-    if (gBattleMons[gBattlerAttacker].level <= obedienceLevel)
 #endif
         levelReferenced = gBattleMons[gBattlerAttacker].level;
 


### PR DESCRIPTION
## Description
Makes overleveled Pokémon disobey the player again when Gen 7 mechanics are set by removing a check which overrode setting levelReferenced.

All credit for the fix goes to i0brendan0.

## Issue(s) that this PR fixes
#2984 

## **Discord contact info**
SubzeroEclipse#2104