### PR TITLE
Fix for wrong mon position for scripted wild doubles

### DIFF
--- a/src/script_pokemon_util.c
+++ b/src/script_pokemon_util.c
@@ -172,12 +172,12 @@ void CreateScriptedDoubleWildMon(u16 species1, u8 level1, u16 item1, u16 species
         SetMonData(&gEnemyParty[0], MON_DATA_HELD_ITEM, heldItem1);
     }
 
-    CreateMon(&gEnemyParty[3], species2, level2, 32, 0, 0, OT_ID_PLAYER_ID, 0);
+    CreateMon(&gEnemyParty[1], species2, level2, 32, 0, 0, OT_ID_PLAYER_ID, 0);
     if (item2)
     {
         heldItem2[0] = item2;
         heldItem2[1] = item2 >> 8;
-        SetMonData(&gEnemyParty[3], MON_DATA_HELD_ITEM, heldItem2);
+        SetMonData(&gEnemyParty[1], MON_DATA_HELD_ITEM, heldItem2);
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes issue with scripted wild double battles where one mon was centered. Issue was caused by `gEnemyPartyCount` having the wrong value because the second mon was set to the 4th slot in function `CreateScriptedDoubleWildMon`. The correct count was needed by `WhichBattleCoords`.
Changes were tested with the script provided by ghoulslash:
```
	givemon SPECIES_XATU, 40, 0
	givemon SPECIES_AGGRON, 40, 0
	setwildbattle SPECIES_VOLCARONA, 40, 0, SPECIES_VOLCARONA, 35, 0
	dowildbattle
```

## Images
![pokeemerald-17](https://github.com/rh-hideout/pokeemerald-expansion/assets/93446519/4c3de658-7850-4044-a7b5-3eac4a79fdd0)


## Issue(s) that this PR fixes
Fixes  #2993

## **Discord contact info**
AlexOnline#2331