### PR TITLE
Fix ability select in debug givemon

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -2327,7 +2327,7 @@ static void DebugAction_Give_Pokemon_SelectNature(u8 taskId)
 }
 static void DebugAction_Give_Pokemon_SelectAbility(u8 taskId)
 {
-    u8 abilityId;
+    u16 abilityId;
     u8 abilityCount = NUM_ABILITY_SLOTS - 1; //-1 for proper iteration
     u8 i = 0;
 


### PR DESCRIPTION
Fixes abilities with a value of over 255 looping back to 0 when selecting the ability in the custom GiveMon feature of the OW debug menu.

## Issue(s) that this PR fixes
Fixes #2997 

## **Discord contact info**
Jasper#5206