### PR TITLE
Revival Blessing's effect script plays its animation even if the move were to fail due to not having fainted allies.

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -435,9 +435,9 @@ BattleScript_EffectRevivalBlessing::
 	attackcanceler
 	attackstring
 	ppreduce
+	tryrevivalblessing BattleScript_ButItFailed
 	attackanimation
 	waitanimation
-	tryrevivalblessing BattleScript_ButItFailed
 	printstring STRINGID_PKMNREVIVEDREADYTOFIGHT
 	waitmessage B_WAIT_TIME_LONG
     jumpifbyte CMP_EQUAL, gBattleCommunication, TRUE, BattleScript_EffectRevivalBlessingSendOut


### PR DESCRIPTION
Fixes #2906. 

## **Discord contact info**
Agustin#1522