### PR TITLE
Fixed testrunner UB with RandomElement.

### DIFF
--- a/test/test_runner_battle.c
+++ b/test/test_runner_battle.c
@@ -402,7 +402,7 @@ const void *RandomElementArray(enum RandomTag tag, const void *array, size_t siz
 
     if (turn && turn->rng.tag == tag)
     {
-        u32 element;
+        u32 element = 0;
         for (index = 0; index < count; index++)
         {
             memcpy(&element, (const u8 *)array + size * index, size);


### PR DESCRIPTION
## Description
There was a variable `u32 element` that wasn't assigned a value when used, so when data was copied onto it there would sometimes be junk bits leftover.

## **Discord contact info**
Agustin#1522