### PR TITLE
Changed 999999 in DebugAction_Give_MaxMoney to MAX_MONEY constant

### DIFF
--- a/include/money.h
+++ b/include/money.h
@@ -1,6 +1,8 @@
 #ifndef GUARD_MONEY_H
 #define GUARD_MONEY_H
 
+#define MAX_MONEY 999999
+
 u32 GetMoney(u32 *moneyPtr);
 void SetMoney(u32 *moneyPtr, u32 newValue);
 bool8 IsEnoughMoney(u32 *moneyPtr, u32 cost);

--- a/src/debug.c
+++ b/src/debug.c
@@ -2758,7 +2758,7 @@ static void DebugAction_Give_Pokemon_ComplexCreateMon(u8 taskId) //https://githu
 
 static void DebugAction_Give_MaxMoney(u8 taskId)
 {
-    SetMoney(&gSaveBlock1Ptr->money, 999999);
+    SetMoney(&gSaveBlock1Ptr->money, MAX_MONEY);
 }
 
 static void DebugAction_Give_MaxCoins(u8 taskId)

--- a/src/money.c
+++ b/src/money.c
@@ -10,8 +10,6 @@
 #include "strings.h"
 #include "decompress.h"
 
-#define MAX_MONEY 999999
-
 EWRAM_DATA static u8 sMoneyBoxWindowId = 0;
 EWRAM_DATA static u8 sMoneyLabelSpriteId = 0;
 


### PR DESCRIPTION
## Description

# Current Problem
In the current version of expansion, when the player uses the Debug Menu to give themselves `MAX_MONEY`, they do not actually give themselves that value. The script is hardcoded to give the player ¥999999. If the developer changes the value of `MAX_MONEY` to something else, this debug script could accidentally give the player a surprising amount.

```c
static void DebugAction_Give_MaxMoney(u8 taskId)
{
    SetMoney(&gSaveBlock1Ptr->money, 999999);
}

```

# Proposed Solution

1. Change `DebugAction_Give_MaxMoney` to give `MAX_MONEY` instead of 999999.
2. Move the define for `MAX_MONEY` from [`src/money.c`](https://github.com/PokemonSanFran/pokeemerald-expansion/blob/a85ca13a504c8b335eddcd5d5aaf32008eae8030/src/money.c) to [`include/money.h`](https://github.com/PokemonSanFran/pokeemerald-expansion/blob/a85ca13a504c8b335eddcd5d5aaf32008eae8030/include/money.h), so that it can be accessed by [`src/debug.c`](https://github.com/PokemonSanFran/pokeemerald-expansion/blob/a85ca13a504c8b335eddcd5d5aaf32008eae8030/src/debug.c).

I know the convention is to store defines in `include/constants`, but I could not find an appropriate file for it, so I opted for `include/money.h`.


# Testing

## data/scripts/debug.inc
 ```diff
+AddMoneyText::
+    .string "Here is ¥100.$"
+
+AddMoneyMaxText::
+    .string "Here is ¥4,294,967,295.$"
+
Debug_Script_1::
+    showmoneybox 0,0
+    addmoney 100
+    updatemoneybox
+    playse SE_SHOP
+    msgbox AddMoneyText, MSGBOX_DEFAULT
+    hidemoneybox
+    release
    end

Debug_Script_2::
+    showmoneybox 0,0
+    addmoney 4294967295 
+    updatemoneybox
+    playse SE_SHOP
+    msgbox AddMoneyMaxText, MSGBOX_DEFAULT
+    hidemoneybox
+    release
    end
```

## [include/money.h](https://github.com/PokemonSanFran/pokeemerald-expansion/blob/a85ca13a504c8b335eddcd5d5aaf32008eae8030/include/money.h)
```diff
#define GUARD_MONEY_H

+#define MAX_MONEY 999999
+
u32 GetMoney(u32 *moneyPtr);
```

## [src/money.c](https://github.com/PokemonSanFran/pokeemerald-expansion/blob/a85ca13a504c8b335eddcd5d5aaf32008eae8030/src/money.c)
```diff
-#define MAX_MONEY 999999
-
EWRAM_DATA static u8 sMoneyBoxWindowId = 0;
EWRAM_DATA static u8 sMoneyLabelSpriteId = 0;
```

`MAX_MONEY` is used to prevent the player from gaining too much money, and from overflowing the value of Max Money.

https://github.com/rh-hideout/pokeemerald-expansion/assets/77138753/fd2ad406-7eeb-48d9-9e8c-a55ec4cd5185

## **Discord contact info**
psf#2936