### PR TITLE
Fixes Terrains freezing the game after player mon faints

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -2056,6 +2056,8 @@ static bool32 EndTurnTerrain(u32 terrainFlag, u32 stringTableId)
 {
     if (gFieldStatuses & terrainFlag)
     {
+        if (terrainFlag & STATUS_FIELD_GRASSY_TERRAIN)
+            BattleScriptExecute(BattleScript_GrassyTerrainHeals);
         if (!(gFieldStatuses & STATUS_FIELD_TERRAIN_PERMANENT) && --gFieldTimers.terrainTimer == 0)
         {
             gFieldStatuses &= ~terrainFlag;
@@ -2065,10 +2067,8 @@ static bool32 EndTurnTerrain(u32 terrainFlag, u32 stringTableId)
                 gBattleCommunication[MULTISTRING_CHOOSER] = stringTableId;
                 BattleScriptExecute(BattleScript_TerrainEnds);
             }
+            return TRUE;
         }
-        if (terrainFlag & STATUS_FIELD_GRASSY_TERRAIN)
-            BattleScriptExecute(BattleScript_GrassyTerrainHeals);
-        return TRUE;
     }
     return FALSE;
 }
@@ -6807,7 +6807,7 @@ static bool32 GetMentalHerbEffect(u8 battlerId)
 static u8 TryConsumeMirrorHerb(u8 battlerId, bool32 execute)
 {
     u8 effect = 0;
-    
+
     if (gProtectStructs[battlerId].eatMirrorHerb) {
         gLastUsedItem = gBattleMons[battlerId].item;
         gBattleScripting.savedBattler = gBattlerAttacker;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As AaghatIsLive commented in an already closed issue (#2948) terrains (except grassy terrain) froze the game after a mon fainted.

The PR should fix it.

## Images
<!-- Please provide with relevant GIFs or images to make it easier for reviewers to accept your PR quicker.-->
<!-- If it doesn't apply, feel free to remove this section. -->
Before:
![terrains_freeze_freeze](https://github.com/rh-hideout/pokeemerald-expansion/assets/93446519/3a288dde-cea1-42a5-ac2d-98227d792b0b)
After:
![terrains_freeze_normal](https://github.com/rh-hideout/pokeemerald-expansion/assets/93446519/c153d8f0-785d-4a07-a6ad-58e04d1b82ea)

## **Discord contact info**

AlexOnline#2331