### PR TITLE
Battle Item Refactor Fixes

### DIFF
--- a/data/battle_scripts_2.s
+++ b/data/battle_scripts_2.s
@@ -59,9 +59,9 @@ BattleScript_ItemRestoreHP::
     end
 
 BattleScript_ItemRestoreHP_SendOutRevivedBattler:
-    switchinanim BS_ATTACKER, FALSE
+    switchinanim BS_SCRIPTING, FALSE
     waitstate
-    switchineffects BS_ATTACKER
+    switchineffects BS_SCRIPTING
     end
 
 BattleScript_ItemCureStatus::

--- a/data/scripts/debug.inc
+++ b/data/scripts/debug.inc
@@ -68,6 +68,12 @@ Debug_FlagsNotSetBattleConfigMessage_Text:
 	.string "'include/config/battle.h'!$"
 
 Debug_Script_1::
+	givemon SPECIES_TREECKO, 20, ITEM_NONE
+	givemon SPECIES_TORCHIC, 20, ITEM_NONE
+	giveitem ITEM_REVIVE, 3
+	giveitem ITEM_HYPER_POTION, 3
+	setwildbattle SPECIES_UNOWN, 20, 0, SPECIES_UNOWN, 20, 0
+	dowildbattle
 	end
 
 Debug_Script_2::

--- a/data/scripts/debug.inc
+++ b/data/scripts/debug.inc
@@ -68,12 +68,6 @@ Debug_FlagsNotSetBattleConfigMessage_Text:
 	.string "'include/config/battle.h'!$"
 
 Debug_Script_1::
-	givemon SPECIES_TREECKO, 20, ITEM_NONE
-	givemon SPECIES_TORCHIC, 20, ITEM_NONE
-	giveitem ITEM_REVIVE, 3
-	giveitem ITEM_HYPER_POTION, 3
-	setwildbattle SPECIES_UNOWN, 20, 0, SPECIES_UNOWN, 20, 0
-	dowildbattle
 	end
 
 Debug_Script_2::

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -312,13 +312,10 @@ static void HandleInputChooseAction(void)
          && !(gAbsentBattlerFlags & gBitTable[GetBattlerAtPosition(B_POSITION_PLAYER_LEFT)])
          && !(gBattleTypeFlags & BATTLE_TYPE_MULTI))
         {
+            // Return item to bag if partner had selected one.
             if (gBattleResources->bufferA[gActiveBattler][1] == B_ACTION_USE_ITEM)
             {
-                // Add item to bag if it is a ball
-                if (itemId <= LAST_BALL)
-                    AddBagItem(itemId, 1);
-                else
-                    return;
+                AddBagItem(itemId, 1);
             }
             PlaySE(SE_SELECT);
             BtlController_EmitTwoReturnValues(BUFFER_B, B_ACTION_CANCEL_PARTNER, 0);

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -16444,7 +16444,8 @@ u8 GetFirstFaintedPartyIndex(u8 battlerId)
     return PARTY_SIZE;
 }
 
-void BS_ItemRestoreHP(void) {
+void BS_ItemRestoreHP(void)
+{
     NATIVE_ARGS();
     u16 healAmount;
     u32 battlerId = MAX_BATTLERS_COUNT;
@@ -16499,6 +16500,7 @@ void BS_ItemRestoreHP(void) {
         if (gBattleTypeFlags & BATTLE_TYPE_DOUBLE && battlerId != MAX_BATTLERS_COUNT)
         {
             gAbsentBattlerFlags &= ~gBitTable[battlerId];
+            gBattleScripting.battler = battlerId;
             gBattleCommunication[MULTIUSE_STATE] = TRUE;
         }
     }
@@ -16506,7 +16508,8 @@ void BS_ItemRestoreHP(void) {
     gBattlescriptCurrInstr = cmd->nextInstr;
 }
 
-void BS_ItemCureStatus(void) {
+void BS_ItemCureStatus(void)
+{
     NATIVE_ARGS();
     struct Pokemon *party = GetBattlerParty(gBattlerAttacker);
 
@@ -16534,7 +16537,8 @@ void BS_ItemCureStatus(void) {
     gBattlescriptCurrInstr = cmd->nextInstr;
 }
 
-void BS_ItemIncreaseStat(void) {
+void BS_ItemIncreaseStat(void)
+{
     NATIVE_ARGS();
     u16 statId = GetItemEffect(gLastUsedItem)[1];
     u16 stages = ItemId_GetHoldEffectParam(gLastUsedItem);
@@ -16542,7 +16546,8 @@ void BS_ItemIncreaseStat(void) {
     gBattlescriptCurrInstr = cmd->nextInstr;
 }
 
-void BS_ItemRestorePP(void) {
+void BS_ItemRestorePP(void)
+{
     NATIVE_ARGS();
     const u8 *effect = GetItemEffect(gLastUsedItem);
     u32 i, pp, maxPP, moveId, loopEnd;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -16324,7 +16324,7 @@ void BS_CheckParentalBondCounter(void)
 void BS_GetBattlerSide(void)
 {
     NATIVE_ARGS(u8 battler);
-    gBattleCommunication[0] = GetBattlerSide(cmd->battler);   
+    gBattleCommunication[0] = GetBattlerSide(GetBattlerForBattleScript(cmd->battler));   
     gBattlescriptCurrInstr = cmd->nextInstr;
 }
 


### PR DESCRIPTION
I should've gotten to these sooner, but this fixes a few outstanding issues.

## #2943: Revives are buggy in 1v2 Battles.
This was a simple fix. The battle script to send out the revived battler was changed to use `BS_SCRIPTING` and `gBattleScripting.battler` was set when an item required a revive animation. Originally, it was using `BS_ATTACKER`, meaning it would perform a send out animation on the battler that used the item.

![Revive Fix](https://github.com/rh-hideout/pokeemerald-expansion/assets/103095241/28bf726e-bb31-4f87-970f-baa7ef3ebab8)


## #2967: Unable to cancel actions in a double battle after using an item.
I don't understand this fix if I'm being totally honest, but it works. In `battle_controller_player.c`, where `B_ACTION_CANCEL_PARTNER_ACTION` is supposed to be returned, I removed the Poke Ball check to return an item to the player's bag when cancelling an action after the first battler used an item. This was not meant to be the fix, but I couldn't find where to look next, and when doing some debug printing I noticed it was enough. Wonderful.

![Cancel Fix](https://github.com/rh-hideout/pokeemerald-expansion/assets/103095241/6b04927d-8063-4fb5-9254-e16ba2605157)

## #2967: Bad item use battlestring.
This was a fix to `BS_GetBattlerSide`, which erroneously uses `cmd->battler` without passing it through `GetBattlerForBattleScript`. This means `BS_ATTACKER` will always be `1`, so it will always print the enemy trainer string, which looks bugged for the player. There are other natives that seem to make this error as well.

![Name Fix](https://github.com/rh-hideout/pokeemerald-expansion/assets/103095241/f765d0aa-23d5-4201-9728-a1efe2cdc360)

## Issue(s) that this PR fixes
Fixes #2943 and #2967.

## **Discord contact info**
Agustin#1522