### PR TITLE
Fixed compile issue when disabling overworld debug menu

### DIFF
--- a/data/scripts/debug.inc
+++ b/data/scripts/debug.inc
@@ -1,3 +1,5 @@
+.if DEBUG_OVERWORLD_MENU == TRUE
+
 Debug_ShowFieldMessageStringVar4::
 	special ShowFieldMessageStringVar4
 	waitmessage
@@ -109,3 +111,5 @@ Debug_SaveBlock2Size::
 
 Debug_PokemonStorageSize::
 	.string "{PKMN}Storage size: {STR_VAR_1}/{STR_VAR_2}.$"
+
+.endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Scripts used for the Overworld Debug menu were using callnatives to call functions that ended up not existing when the setting was off. This PR fixes that issue by surrounding the file by the same ifdefs used in `src/debug.c`.

## Images
![imagen](https://github.com/rh-hideout/pokeemerald-expansion/assets/2904965/2d0b7ffe-4184-4251-8920-c85d488ba34a)

## Issue(s) that this PR fixes
Fixes #3023 

## **Discord contact info**
AsparagusEduardo#6051