### PR TITLE
restore items in wild battles

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -5404,7 +5404,6 @@ static void HandleEndTurn_FinishBattle(void)
         BeginFastPaletteFade(3);
         FadeOutMapMusic(5);
     #if B_TRAINERS_KNOCK_OFF_ITEMS == TRUE || B_RESTORE_HELD_BATTLE_ITEMS == TRUE
-        if (gBattleTypeFlags & BATTLE_TYPE_TRAINER)
             TryRestoreHeldItems();
     #endif
         for (i = 0; i < PARTY_SIZE; i++)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Follow up on PR #2932. 
Items are also restored in wild battles.

Also Knock Off shouldn't activate it's effect in wild battles (discussed on discord) but there is already a PR that takes care of it (#2130)

## **Discord contact info**
AlexOnline#2331