### PR TITLE
add type declarations to castform debug functions

### DIFF
--- a/src/pokemon_debug.c
+++ b/src/pokemon_debug.c
@@ -732,7 +732,7 @@ static void BattleLoadOpponentMonSpriteGfxCustom(u16 species, bool8 isFemale, bo
     LoadPalette(gDecompressionBuffer, 0x80 + battlerId * 16, 0x20);
 }
 
-static bool8 IsCastformForm(species)
+static bool8 IsCastformForm(u16 species)
 {
     if (species == SPECIES_CASTFORM_SUNNY || species == SPECIES_CASTFORM_RAINY || species == SPECIES_CASTFORM_SNOWY)
         return TRUE;
@@ -740,7 +740,7 @@ static bool8 IsCastformForm(species)
     return FALSE;
 }
 
-static u8 GetCastformYCustom(species)
+static u8 GetCastformYCustom(u16 species)
 {
     u8 ret;
     switch (species)


### PR DESCRIPTION
## Description
using `modern`, the compiler will throw a warning, defaulting these arguments to u32s. 
this should fix this warning.

## **Discord contact info**
Salem#3258