### PR TITLE
Attempt primal reversion whenever a pokemon is switched out

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -1682,6 +1682,7 @@ BattleScript_EffectPartingShotSwitch:
 	printstring STRINGID_SWITCHINMON
 	switchinanim BS_ATTACKER, TRUE
 	waitstate
+	call BattleScript_TryPrimalReversionRet
 	switchineffects BS_ATTACKER
 BattleScript_PartingShotEnd:
 	end
@@ -2790,6 +2791,7 @@ BattleScript_EffectHealingWish:
 	printstring STRINGID_SWITCHINMON
 	switchinanim BS_ATTACKER, TRUE
 	waitstate
+	call BattleScript_TryPrimalReversionRet
 	switchineffects BS_ATTACKER
 .endif
 BattleScript_EffectHealingWishEnd:
@@ -3198,6 +3200,7 @@ BattleScript_EffectHitEscape:
 	printstring STRINGID_SWITCHINMON
 	switchinanim BS_ATTACKER, TRUE
 	waitstate
+	call BattleScript_TryPrimalReversionRet
 	switchineffects BS_ATTACKER
 BattleScript_HitEscapeEnd:
 	end
@@ -5127,6 +5130,7 @@ BattleScript_EffectBatonPass::
 	printstring STRINGID_SWITCHINMON
 	switchinanim BS_ATTACKER, TRUE
 	waitstate
+	call BattleScript_TryPrimalReversionRet
 	switchineffects BS_ATTACKER
 	goto BattleScript_MoveEnd
 
@@ -5444,6 +5448,7 @@ BattleScript_EffectTeleportNew:
 	printstring STRINGID_SWITCHINMON
 	switchinanim BS_ATTACKER, TRUE
 	waitstate
+	call BattleScript_TryPrimalReversionRet
 	switchineffects BS_ATTACKER
 BattleScript_EffectTeleportNewEnd:
 	goto BattleScript_MoveEnd
@@ -6499,6 +6504,7 @@ BattleScript_FaintedMonTryChoose:
 	switchinanim BS_ATTACKER, 0
 	waitstate
 	setbyte sSHIFT_SWITCHED, 1
+	call BattleScript_TryPrimalReversionRet
 BattleScript_FaintedMonSendOutNew:
 	drawpartystatussummary BS_FAINTED
 	getswitchedmondata BS_FAINTED
@@ -6513,6 +6519,7 @@ BattleScript_FaintedMonSendOutNew:
 	waitstate
 	resetplayerfainted
 	trytrainerslidelastonmsg BS_FAINTED
+	call BattleScript_TryPrimalReversionRet
 	jumpifbytenotequal sSHIFT_SWITCHED, sZero, BattleScript_FaintedMonShiftSwitched
 BattleScript_FaintedMonSendOutNewEnd:
 	switchineffects BS_FAINTED
@@ -6546,6 +6553,8 @@ BattleScript_LinkHandleFaintedMonLoop::
 	hidepartystatussummary BS_FAINTED
 	switchinanim BS_FAINTED, FALSE
 	waitstate
+	copybyte gBattlerAttacker, gBattlerFainted
+	call BattleScript_TryPrimalReversionRet
 	switchineffects BS_FAINTED_LINK_MULTIPLE_1
 	jumpifbytenotequal gBattlerFainted, gBattlersCount, BattleScript_LinkHandleFaintedMonLoop
 BattleScript_LinkHandleFaintedMonMultipleEnd::
@@ -6770,9 +6779,7 @@ BattleScript_DoSwitchOut::
 	hidepartystatussummary BS_ATTACKER
 	switchinanim BS_ATTACKER, FALSE
 	waitstate
-	jumpifcantreverttoprimal BattleScript_DoSwitchOut2
-	call BattleScript_PrimalReversionRet
-BattleScript_DoSwitchOut2:
+	call BattleScript_TryPrimalReversionRet
 	switchineffects BS_ATTACKER
 	moveendcase MOVEEND_STATUS_IMMUNITY_ABILITIES
 	moveendcase MOVEEND_MIRROR_MOVE
@@ -7940,7 +7947,8 @@ BattleScript_PrimalReversion::
 	switchinabilities BS_ATTACKER
 	end2
 
-BattleScript_PrimalReversionRet::
+BattleScript_TryPrimalReversionRet::
+	jumpifcantreverttoprimal BattleScript_TryPrimalReversionRetEnd
 	printstring STRINGID_EMPTYSTRING3
 	waitmessage 1
 	setbyte gIsCriticalHit, 0
@@ -7951,6 +7959,7 @@ BattleScript_PrimalReversionRet::
 	handleprimalreversion BS_ATTACKER, 2
 	printstring STRINGID_PKMNREVERTEDTOPRIMAL
 	waitmessage B_WAIT_TIME_LONG
+BattleScript_TryPrimalReversionRetEnd:
 	return
 
 BattleScript_AttackerFormChange::
@@ -8572,6 +8581,8 @@ BattleScript_EmergencyExitNoPopUp::
 	printstring STRINGID_SWITCHINMON
 	switchinanim BS_TARGET, TRUE
 	waitstate
+	copybyte gBattlerAttacker, gBattlerTarget
+	call BattleScript_TryPrimalReversionRet
 	switchineffects BS_TARGET
 BattleScript_EmergencyExitRet:
 	return
@@ -10355,6 +10366,8 @@ BattleScript_EjectButtonActivates::
 	printstring 0x3
 	switchinanim BS_SCRIPTING 0x1
 	waitstate
+	copybyte gBattlerAttacker, gBattleScripting
+	call BattleScript_TryPrimalReversionRet
 	switchineffects BS_SCRIPTING
 BattleScript_EjectButtonEnd:
 	return


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As described in #3028, primal reversion currently is not triggered after switching out after the player's and/or the opponent's pokemon faints. I also found some other cases where switching out doesn't trigger primal reversion (and I think it should?):
- After the move "parting shot" is used
- After the move "healing wish" is used
- After the move "baton pass" is used
- After the move "teleport" is used
- After a move with `EFFECT_HIT_ESCAPE` is used
- After the ability "wimp out" is triggered
- After an eject button/pack is triggered
- After multiple pokemon faint in link battles

I didn't realise that this issue had already been spotted and was being worked on [here](https://github.com/rh-hideout/pokeemerald-expansion/pull/3029) while I was also working on a fix. I'm not sure if the way I've done this is particularly elegant - the other PR looks more straightforward as a fix but it also [seems to have bugs](https://github.com/rh-hideout/pokeemerald-expansion/pull/3029#issuecomment-1567528275) so I thought I'd submit my changes as well.

## Images
<!-- Please provide with relevant GIFs or images to make it easier for reviewers to accept your PR quicker.-->
<!-- If it doesn't apply, feel free to remove this section. -->
I've recorded a GIF of this working after the player's pokemon faints. If you'd like me to record all of the instances listed above, I can do that.
![primal-reversion-after-faint](https://github.com/rh-hideout/pokeemerald-expansion/assets/6616877/58a6e195-ee19-4535-a8c2-3fc10faa77d4)

## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, fixes #2222." -->
<!-- If it doesn't apply, feel free to remove this section. -->
Fixes #3028

## **Discord contact info**
<!--- formatted as name#numbers, e.g. Lunos#4026 -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
gamebriel#4784