### PR TITLE
Window Track With Ball When Unhiding; Properly Show Window as Unhidden on First Creation

### DIFF
--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -3258,7 +3258,7 @@ static const struct SpriteSheet sSpriteSheet_LastUsedBallWindow =
 #define LAST_USED_BALL_Y      ((IsDoubleBattle()) ? 78 : 68)
 
 #define LAST_BALL_WIN_X_F       (LAST_USED_BALL_X_F - 1)
-#define LAST_BALL_WIN_X_0       (LAST_USED_BALL_X_0 - 0)
+#define LAST_BALL_WIN_X_0       (LAST_USED_BALL_X_0 - 1)
 #define LAST_USED_WIN_Y         (LAST_USED_BALL_Y - 8)
 
 #define sHide  data[0]
@@ -3314,7 +3314,7 @@ void TryAddLastUsedBallItemSprites(void)
         gBattleStruct->ballSpriteIds[1] = CreateSprite(&sSpriteTemplate_LastUsedBallWindow,
                                                        LAST_BALL_WIN_X_0,
                                                        LAST_USED_WIN_Y, 5);
-        gSprites[gBattleStruct->ballSpriteIds[0]].sHide = FALSE;   // restore
+        gSprites[gBattleStruct->ballSpriteIds[1]].sHide = FALSE;   // restore
     }
 #endif
 }


### PR DESCRIPTION
## Description
Reviewing the last ball shown code, the following 2 bugs were seen:
1. The ball and window do not fully move the same speed due to the Window's starting location being closer than the ball's by one pixel. It's hard to notice, but can be seen by cycling through frames. subtracting by one showed this issue to go away.
2. When first creating the window, the ball's sprite ID gets written as unhidden rather than the window. This doesn't cause issues functionally, as sHide (data[0]) defaults to 0.

## **Discord contact info**
devolov#4853