### PR TITLE
Test Runner support for illegal abilities

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -6,7 +6,7 @@
 // still has them in the ROM. This is because the developers forgot
 // to define NDEBUG before release, however this has been changed as
 // Ruby's actual debug build does not use the AGBPrint features.
-// #define NDEBUG
+#define NDEBUG
 
 // To enable printf debugging, comment out "#define NDEBUG". This allows
 // the various AGBPrint functions to be used. (See include/gba/isagbprint.h).

--- a/include/config.h
+++ b/include/config.h
@@ -6,7 +6,7 @@
 // still has them in the ROM. This is because the developers forgot
 // to define NDEBUG before release, however this has been changed as
 // Ruby's actual debug build does not use the AGBPrint features.
-#define NDEBUG
+// #define NDEBUG
 
 // To enable printf debugging, comment out "#define NDEBUG". This allows
 // the various AGBPrint functions to be used. (See include/gba/isagbprint.h).

--- a/include/test_runner.h
+++ b/include/test_runner.h
@@ -17,6 +17,8 @@ void TestRunner_Battle_AfterLastTurn(void);
 
 void TestRunner_Battle_CheckBattleRecordActionType(u32 battlerId, u32 recordIndex, u32 actionType);
 
+u32 TestRunner_Battle_GetForcedAbility(u32 side, u32 partyIndex);
+
 #else
 
 #define TestRunner_Battle_RecordAbilityPopUp(...) (void)0
@@ -27,6 +29,8 @@ void TestRunner_Battle_CheckBattleRecordActionType(u32 battlerId, u32 recordInde
 #define TestRunner_Battle_AfterLastTurn(...) (void)0
 
 #define TestRunner_Battle_CheckBattleRecordActionType(...) (void)0
+
+#define TestRunner_Battle_GetForcedAbility(...) (u32)0
 
 #endif
 

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3302,6 +3302,14 @@ void SwitchInClearSetData(void)
     // Clear selected party ID so Revival Blessing doesn't get confused.
     gSelectedMonPartyId = PARTY_SIZE;
 
+    // Allow for illegal abilities within tests.
+    if (gTestRunnerEnabled)
+    {
+        u32 side = GetBattlerSide(gActiveBattler);
+        u32 partyIndex = gBattlerPartyIndexes[gActiveBattler];
+        gBattleMons[gActiveBattler].ability = gBattleStruct->overwrittenAbilities[gActiveBattler] = TestRunner_Battle_GetForcedAbility(side, partyIndex);
+    }
+
     Ai_UpdateSwitchInData(gActiveBattler);
 }
 
@@ -3791,6 +3799,18 @@ static void TryDoEventsBeforeFirstTurn(void)
             struct Pokemon *mon = &party[gBattlerPartyIndexes[i]];
             if (gBattleMons[i].hp == 0 || gBattleMons[i].species == SPECIES_NONE || GetMonData(mon, MON_DATA_IS_EGG))
                 gAbsentBattlerFlags |= gBitTable[i];
+        }
+    }
+
+    // Allow for illegal abilities within tests.
+    if (gTestRunnerEnabled && gBattleStruct->switchInAbilitiesCounter == 0)
+    {
+        for (i = 0; i < gBattlersCount; ++i)
+        {
+            u32 side = GetBattlerSide(i);
+            u32 partyIndex = gBattlerPartyIndexes[i];
+            if (TestRunner_Battle_GetForcedAbility(side, partyIndex))
+                gBattleMons[i].ability = gBattleStruct->overwrittenAbilities[i] = TestRunner_Battle_GetForcedAbility(side, partyIndex);
         }
     }
 

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3307,7 +3307,8 @@ void SwitchInClearSetData(void)
     {
         u32 side = GetBattlerSide(gActiveBattler);
         u32 partyIndex = gBattlerPartyIndexes[gActiveBattler];
-        gBattleMons[gActiveBattler].ability = gBattleStruct->overwrittenAbilities[gActiveBattler] = TestRunner_Battle_GetForcedAbility(side, partyIndex);
+        if (TestRunner_Battle_GetForcedAbility(side, partyIndex))
+            gBattleMons[i].ability = gBattleStruct->overwrittenAbilities[i] = TestRunner_Battle_GetForcedAbility(side, partyIndex);
     }
 
     Ai_UpdateSwitchInData(gActiveBattler);

--- a/test/test_battle.h
+++ b/test/test_battle.h
@@ -574,6 +574,7 @@ struct BattleTestData
     struct Pokemon *currentMon;
     u8 gender;
     u8 nature;
+    u16 forcedAbilities[NUM_BATTLE_SIDES][PARTY_SIZE];
 
     u8 currentMonIndexes[MAX_BATTLERS_COUNT];
     u8 turnState;

--- a/test/test_runner_battle.c
+++ b/test/test_runner_battle.c
@@ -1090,14 +1090,11 @@ void Ability_(u32 sourceLine, u32 ability)
             break;
         }
     }
-
     // Store forced ability to be set when the battle starts if invalid.
     if (i == NUM_ABILITY_SLOTS)
     {
         DATA.forcedAbilities[DATA.currentSide][DATA.currentPartyIndex] = ability;
     }
-        
-    // INVALID_IF(i == NUM_ABILITY_SLOTS, "%S cannot have %S", gSpeciesNames[species], gAbilityNames[ability]);
 }
 
 void Level_(u32 sourceLine, u32 level)

--- a/test/test_runner_battle.c
+++ b/test/test_runner_battle.c
@@ -1090,7 +1090,14 @@ void Ability_(u32 sourceLine, u32 ability)
             break;
         }
     }
-    INVALID_IF(i == NUM_ABILITY_SLOTS, "%S cannot have %S", gSpeciesNames[species], gAbilityNames[ability]);
+
+    // Store forced ability to be set when the battle starts if invalid.
+    if (i == NUM_ABILITY_SLOTS)
+    {
+        DATA.forcedAbilities[DATA.currentSide][DATA.currentPartyIndex] = ability;
+    }
+        
+    // INVALID_IF(i == NUM_ABILITY_SLOTS, "%S cannot have %S", gSpeciesNames[species], gAbilityNames[ability]);
 }
 
 void Level_(u32 sourceLine, u32 level)
@@ -1773,4 +1780,9 @@ void ValidateFinally(u32 sourceLine)
     if (STATE->results == NULL)
         return;
     INVALID_IF(STATE->parametersCount == 0, "FINALLY without PARAMETRIZE");
+}
+
+u32 TestRunner_Battle_GetForcedAbility(u32 side, u32 partyIndex)
+{
+    return DATA.forcedAbilities[side][partyIndex];
 }


### PR DESCRIPTION
## Description
There isn't a way to test abilities that aren't attached to Pokémon yet, so I added a way to force abilities in tests. Thanks to @mrgriffin for mentioning `gBattleStruct->overwrittenAbilities`, since I think this is actually a pretty non-hacky way of making things work. I haven't tested it in edge cases like Skill Swap or Trace, but I want to say it would work fine.

## Images
![Illegal Ability Tests](https://github.com/rh-hideout/pokeemerald-expansion/assets/103095241/af487029-3ee4-4ced-833b-f625c6c1464d)

## **Discord contact info**
Agustin#1522