### PR TITLE
Fixed selling TMs set as reusable

### DIFF
--- a/src/item_menu.c
+++ b/src/item_menu.c
@@ -2075,7 +2075,7 @@ static void Task_ItemContext_Sell(u8 taskId)
 {
     s16 *data = gTasks[taskId].data;
 
-    if (ItemId_GetPrice(gSpecialVar_ItemId) == 0)
+    if (ItemId_GetPrice(gSpecialVar_ItemId) == 0 || ItemId_GetImportance(gSpecialVar_ItemId))
     {
         CopyItemName(gSpecialVar_ItemId, gStringVar2);
         StringExpandPlaceholders(gStringVar4, gText_CantBuyKeyItem);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes the issue by also checking the importance field when selling items, which will also allow to buy Key Items while not being able to sell them.

## Issue(s) that this PR fixes
Fixes #3046 

## **Discord contact info**
AsapragusEduardo