### PR TITLE
Fixed AI_WhoStrikesFirst considering status priority moves when it shouldn't

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -1096,10 +1096,11 @@ u8 AI_WhoStrikesFirst(u8 battlerAI, u8 battler2, u16 moveConsidered)
     prioAI = GetMovePriority(battlerAI, moveConsidered);
     for (i = 0; i < MAX_MON_MOVES; i++)
     {
-        if (battler2Moves[i] == 0 || battler2Moves[i] == 0xFFFF)
+        prioBattler2 = GetMovePriority(battler2, battler2Moves[i]);
+        if (battler2Moves[i] == 0 || battler2Moves[i] == 0xFFFF
+            || (prioBattler2 > prioAI && !CanIndexMoveFaintTarget(battler2, battlerAI, i , 2)))
             continue;
 
-        prioBattler2 = GetMovePriority(battler2, battler2Moves[i]);
         if (prioAI > prioBattler2)
             fasterAI++;
         else if (prioBattler2 > prioAI)


### PR DESCRIPTION
## Description
**Current behaviour:**
If the player revealed any priority move, `AI_WhoStrikesFirst` always returns AI_IS_SLOWER if `consideredMove` is of priority 0.

**New behaviour:**
As a rule of thumb, the AI should exclude status priority moves from consideration since this function is about who STRIKES first. Granted, not the best solution but better than current behaviour.
As a middle ground, any move that does not faint the AI in two hits (this includes status moves) and is of higher priority than `consideredMove` is excluded from consideration.

Feedback appreciated since this is my first PR. :)

## **Discord contact info**
joggel