### PR TITLE
fix debug menu not removing list menu task

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -750,6 +750,7 @@ static void DebugAction_DestroyExtraWindow(u8 taskId)
     ClearStdWindowAndFrame(gTasks[taskId].data[2], TRUE);
     RemoveWindow(gTasks[taskId].data[2]);
 
+    DestroyListMenuTask(gTasks[taskId].data[0], NULL, NULL);
     DestroyTask(taskId);
     ScriptContext_Enable();
     UnfreezeObjectEvents();


### PR DESCRIPTION
Fixes #3041

The menu was freezing, because the list menu task was not getting removed in some cases. Which means that after X tries, there would be no free tasks to create one.