### PR TITLE
Teatime tests (and fixes)

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -514,11 +514,12 @@ BattleScript_EffectTeatime::
 @ at least one battler is affected
 	attackanimation
 	waitanimation
+	setbyte gBattlerTarget, 0
 BattleScript_TeatimeLoop:
-	jumpifteainvulnerable BS_TARGET, BattleScript_Teatimevul
 	jumpifrodaffected BS_TARGET, BattleScript_Teatimerod
 	jumpifabsorbaffected BS_TARGET, BattleScript_Teatimesorb
 	jumpifmotoraffected BS_TARGET, BattleScript_Teatimemotor
+	jumpifteainvulnerable BS_TARGET, BattleScript_Teatimevul @ in semi-invulnerable state OR held item is not a Berry
 	orword gHitMarker, HITMARKER_NO_ANIMATIONS | HITMARKER_IGNORE_SUBSTITUTE | HITMARKER_IGNORE_DISGUISE
 	setbyte sBERRY_OVERRIDE, TRUE   @ override the requirements for eating berries
 	consumeberry BS_TARGET, TRUE  @ consume the berry, then restore the item from changedItems
@@ -536,6 +537,12 @@ BattleScript_Teatimevul:
 	goto BattleScript_MoveEnd
 BattleScript_Teatimesorb:
 	call BattleScript_AbilityPopUpTarget
+	tryhealquarterhealth BS_TARGET BattleScript_Teatimesorb_end
+	healthbarupdate BS_TARGET
+	datahpupdate BS_TARGET
+	printstring STRINGID_PKMNREGAINEDHEALTH
+	waitmessage B_WAIT_TIME_LONG
+BattleScript_Teatimesorb_end:
 	moveendto MOVEEND_NEXT_TARGET
 	jumpifnexttargetvalid BattleScript_TeatimeLoop
 	moveendcase MOVEEND_CLEAR_BITS

--- a/test/move_effect_teatime.c
+++ b/test/move_effect_teatime.c
@@ -1,0 +1,270 @@
+#include "global.h"
+#include "test_battle.h"
+
+ASSUMPTIONS
+{
+    ASSUME(gBattleMoves[MOVE_TEATIME].effect == EFFECT_TEATIME);
+    ASSUME(gItems[ITEM_LIECHI_BERRY].holdEffect == HOLD_EFFECT_ATTACK_UP);
+}
+
+SINGLE_BATTLE_TEST("Teatime causes the user to consume its Berry, ignoring HP requirements")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_LIECHI_BERRY); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_NONE); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_TEATIME); }
+    } SCENE {
+        MESSAGE("Wobbuffet used Teatime!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, player);
+        MESSAGE("Using Liechi Berry, the Attack of Wobbuffet rose!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Teatime causes the user to consume its Berry, even in the pressence of Unnerve")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_LIECHI_BERRY); }
+        OPPONENT(SPECIES_EKANS) { Ability(ABILITY_UNNERVE); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_TEATIME); }
+    } SCENE {
+        MESSAGE("Wobbuffet used Teatime!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, player);
+        MESSAGE("Using Liechi Berry, the Attack of Wobbuffet rose!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Teatime causes the user to consume its Berry, even under the effects of Wonder Room")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_LIECHI_BERRY); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN {
+            MOVE(opponent, MOVE_WONDER_ROOM);
+            MOVE(player, MOVE_TEATIME);
+        }
+    } SCENE {
+        MESSAGE("Wobbuffet used Teatime!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, player);
+        MESSAGE("Using Liechi Berry, the Attack of Wobbuffet rose!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Teatime causes the user to consume its Berry, ignoring HP requirements, when not used by the Player")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_NONE); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_LIECHI_BERRY); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_TEATIME); }
+    } SCENE {
+        MESSAGE("Foe Wobbuffet used Teatime!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, opponent);
+        MESSAGE("Using Liechi Berry, the Attack of Foe Wobbuffet rose!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Teatime causes other Pokemon to consume their Berry even if the user doesn't have a Berry as its held item")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_NONE); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_LIECHI_BERRY); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_TEATIME); }
+    } SCENE {
+        MESSAGE("Wobbuffet used Teatime!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, player);
+        MESSAGE("Using Liechi Berry, the Attack of Foe Wobbuffet rose!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Teatime causes other Pokemon to consume their Berry even if the user doesn't have a Berry as its held item, when not used by the Player")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_LIECHI_BERRY); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_NONE); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_TEATIME); }
+    } SCENE {
+        MESSAGE("Foe Wobbuffet used Teatime!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, opponent);
+        MESSAGE("Using Liechi Berry, the Attack of Wobbuffet rose!");
+    }
+}
+
+DOUBLE_BATTLE_TEST("Teatime causes all Pokémon to consume their berry")
+{
+    struct BattlePokemon *user;
+    PARAMETRIZE { user = playerLeft; }
+    PARAMETRIZE { user = playerRight; }
+    PARAMETRIZE { user = opponentLeft; }
+    PARAMETRIZE { user = opponentRight; }
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_LIECHI_BERRY); }
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_LIECHI_BERRY); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_LIECHI_BERRY); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_LIECHI_BERRY); }
+    } WHEN {
+        TURN { MOVE(user, MOVE_TEATIME); }
+    } SCENE {
+        if (user == playerLeft || user == playerRight)
+        {
+            MESSAGE("Wobbuffet used Teatime!");
+        } else {
+            MESSAGE("Foe Wobbuffet used Teatime!");
+        }
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, user);
+        MESSAGE("Using Liechi Berry, the Attack of Wobbuffet rose!");
+        MESSAGE("Using Liechi Berry, the Attack of Foe Wobbuffet rose!");
+        MESSAGE("Using Liechi Berry, the Attack of Wobbuffet rose!");
+        MESSAGE("Using Liechi Berry, the Attack of Foe Wobbuffet rose!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Teatime fails if no Pokémon is holding a Berry")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_NONE); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_NONE); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_TEATIME); }
+    } SCENE {
+        MESSAGE("Wobbuffet used Teatime!");
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, player);
+        MESSAGE("But it failed!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Teatime does not affect Pokémon in the semi-invulnerable turn of a move")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_NONE); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_LIECHI_BERRY); }
+    } WHEN {
+        TURN { 
+            MOVE(opponent, MOVE_FLY);
+            MOVE(player, MOVE_TEATIME);
+        }
+    } SCENE {
+        MESSAGE("Wobbuffet used Teatime!");
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, player);
+        NOT MESSAGE("Using Liechi Berry, the Attack of Foe Wobbuffet rose!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Teatime triggers Volt Absorb if it has been affected by Electrify or Plasma Fists, even when not holding a Berry")
+{
+    u32 move;
+    u32 item = ITEM_LIECHI_BERRY;
+    bool8 shouldTriggerAbility = TRUE;
+
+    PARAMETRIZE { move = MOVE_CELEBRATE; shouldTriggerAbility = FALSE; }
+    PARAMETRIZE { move = MOVE_ELECTRIFY; }
+    PARAMETRIZE { move = MOVE_PLASMA_FISTS; }
+    PARAMETRIZE { move = MOVE_ELECTRIFY; item = ITEM_NONE; }
+    PARAMETRIZE { move = MOVE_PLASMA_FISTS; item = ITEM_NONE; }
+
+    GIVEN {
+        PLAYER(SPECIES_JOLTEON) { Ability(ABILITY_VOLT_ABSORB); Item(item); HP(55); MaxHP(100); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_LIECHI_BERRY); }
+    } WHEN {
+        TURN { 
+            MOVE(player, move);
+            MOVE(opponent, MOVE_TEATIME);
+        }
+    } SCENE {
+        MESSAGE("Foe Wobbuffet used Teatime!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, opponent);
+        if (shouldTriggerAbility)
+        {
+            ABILITY_POPUP(player, ABILITY_VOLT_ABSORB);
+            HP_BAR(player, damage: -25);
+            NOT MESSAGE("Using Liechi Berry, the Attack of Jolteon rose!");
+        } else {
+            NOT ABILITY_POPUP(player, ABILITY_VOLT_ABSORB);
+            MESSAGE("Using Liechi Berry, the Attack of Jolteon rose!");
+        }
+        MESSAGE("Using Liechi Berry, the Attack of Foe Wobbuffet rose!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Teatime triggers Lightning Rod if it has been affected by Electrify or Plasma Fists, even when not holding a Berry")
+{
+    u32 move;
+    u32 item = ITEM_LIECHI_BERRY;
+    bool8 shouldTriggerAbility = TRUE;
+
+    PARAMETRIZE { move = MOVE_CELEBRATE; shouldTriggerAbility = FALSE; }
+    PARAMETRIZE { move = MOVE_ELECTRIFY; }
+    PARAMETRIZE { move = MOVE_PLASMA_FISTS; }
+    PARAMETRIZE { move = MOVE_ELECTRIFY; item = ITEM_NONE; }
+    PARAMETRIZE { move = MOVE_PLASMA_FISTS; item = ITEM_NONE; }
+
+    GIVEN {
+        PLAYER(SPECIES_PIKACHU) { Ability(ABILITY_LIGHTNING_ROD); Item(item); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_LIECHI_BERRY); }
+    } WHEN {
+        TURN { 
+            MOVE(player, move);
+            MOVE(opponent, MOVE_TEATIME);
+        }
+    } SCENE {
+        MESSAGE("Foe Wobbuffet used Teatime!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, opponent);
+        if (shouldTriggerAbility)
+        {
+            ABILITY_POPUP(player, ABILITY_LIGHTNING_ROD);
+            MESSAGE("Pikachu's Sp. Atk rose!");
+            NOT MESSAGE("Using Liechi Berry, the Attack of Pikachu rose!");
+        } else {
+            NONE_OF {
+                ABILITY_POPUP(player, ABILITY_LIGHTNING_ROD);
+                MESSAGE("Pikachu's Sp. Atk rose!");
+            }
+            MESSAGE("Using Liechi Berry, the Attack of Pikachu rose!");
+        }
+        MESSAGE("Using Liechi Berry, the Attack of Foe Wobbuffet rose!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Teatime triggers Motor Drive if it has been affected by Electrify or Plasma Fists, even when not holding a Berry")
+{
+    u32 move;
+    u32 item= ITEM_LIECHI_BERRY;
+    bool8 shouldTriggerAbility = TRUE;
+
+    PARAMETRIZE { move = MOVE_CELEBRATE; shouldTriggerAbility = FALSE; }
+    PARAMETRIZE { move = MOVE_ELECTRIFY; }
+    PARAMETRIZE { move = MOVE_PLASMA_FISTS; }
+    PARAMETRIZE { move = MOVE_ELECTRIFY; item = ITEM_NONE; }
+    PARAMETRIZE { move = MOVE_PLASMA_FISTS; item = ITEM_NONE; }
+
+    GIVEN {
+        ASSUME(P_GEN_4_POKEMON == TRUE);
+        PLAYER(SPECIES_ELECTIVIRE) { Ability(ABILITY_MOTOR_DRIVE); Item(item); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_LIECHI_BERRY); }
+    } WHEN {
+        TURN { 
+            MOVE(player, move);
+            MOVE(opponent, MOVE_TEATIME);
+        }
+    } SCENE {
+        MESSAGE("Foe Wobbuffet used Teatime!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, opponent);
+        if (shouldTriggerAbility)
+        {
+            ABILITY_POPUP(player, ABILITY_MOTOR_DRIVE);
+            MESSAGE("Electivire's Speed rose!");
+            NOT MESSAGE("Using Liechi Berry, the Attack of Electivire rose!");
+        } else {
+            NONE_OF {
+                ABILITY_POPUP(player, ABILITY_MOTOR_DRIVE);
+                MESSAGE("Electivire's Speed rose!");
+            }
+            MESSAGE("Using Liechi Berry, the Attack of Electivire rose!");
+        }
+        MESSAGE("Using Liechi Berry, the Attack of Foe Wobbuffet rose!");
+    }
+}


### PR DESCRIPTION
This adds tests for Teatime and fixes some interactions.

## Description

I noticed Teatime would skip some Pokémon. For example, when not being used by the player, the player Pokémon would not consume its berry.

I added some tests based on the very niche interactions around Electrify/Plasma Fists and Volt Absorb, Lightning Rod and Motor Drive, which should trigger their effects (heal, raise Sp. Atk or raise Speed.) These interactions are based on what Bulbapedia and Pokémon Showdown do, as I'm not able to test this interaction in an official game. If this is a problem, I'm happy to revert to the old behaviour with regards to these abilities.

## **Discord contact info**
hetoord