### PR TITLE
Fixed KNOWN_FAILING tests running memory leak checks when unneeded

### DIFF
--- a/test/test_runner.c
+++ b/test/test_runner.c
@@ -155,7 +155,7 @@ void CB2_TestRunner(void)
         if (gTestRunnerState.test->runner->tearDown)
             gTestRunnerState.test->runner->tearDown(gTestRunnerState.test->data);
 
-        if (gTestRunnerState.result == gTestRunnerState.expectedResult
+        if (gTestRunnerState.result == TEST_RESULT_PASS
          && !gTestRunnerState.expectLeaks)
         {
             const struct MemBlock *head = HeapHead();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
After #3076, memory leak checks were running despite the test exiting an expected result. Now they should only run if the test itself passes and when it's not expecting leaks.

## Images
No more of this:
![imagen](https://github.com/rh-hideout/pokeemerald-expansion/assets/2904965/626e2640-6921-404c-ba45-e02c7de377f9)

## **Discord contact info**
AsparagusEduardo