### PR TITLE
Fix how AI categorizes Weak moves and give priority to always hits moves when needed

### DIFF
--- a/include/battle_ai_util.h
+++ b/include/battle_ai_util.h
@@ -85,6 +85,7 @@ bool32 ShouldLowerEvasion(u8 battlerAtk, u8 battlerDef, u16 defAbility);
 bool32 IsAffectedByPowder(u8 battler, u16 ability, u16 holdEffect);
 bool32 MovesWithSplitUnusable(u32 attacker, u32 target, u32 split);
 s32 AI_CalcDamage(u16 move, u8 battlerAtk, u8 battlerDef, u8 *effectiveness, bool32 considerZPower);
+u32 GetNoOfHitsToKO(u32 dmg, s32 hp);
 u8 GetMoveDamageResult(u16 move);
 u32 GetCurrDamageHpPercent(u8 battlerAtk, u8 battlerDef);
 u16 AI_GetTypeEffectiveness(u16 move, u8 battlerAtk, u8 battlerDef);

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -3102,6 +3102,19 @@ static bool32 IsPinchBerryItemEffect(u16 holdEffect)
     return FALSE;
 }
 
+static u32 GetAIMostDamagingMove(u8 battlerAtk, u8 battlerDef)
+{
+    u32 i, id = 0;
+    u32 mostDmg = 0;
+
+    for (i = 0; i < MAX_MON_MOVES; i++)
+    {
+        if (AI_DATA->simulatedDmg[battlerAtk][battlerDef][i] > mostDmg)
+            id = i, mostDmg = AI_DATA->simulatedDmg[battlerAtk][battlerDef][i];
+    }
+    return id;
+}
+
 // AI_FLAG_CHECK_VIABILITY - a weird mix of increasing and decreasing scores
 static s16 AI_CheckViability(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
 {
@@ -3122,6 +3135,14 @@ static s16 AI_CheckViability(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
     // check always hits
     if (!IS_MOVE_STATUS(move) && gBattleMoves[move].accuracy == 0)
     {
+        // If 2 moves can KO the target in the same number of turns, but one of them always hits and there is a risk the other move could miss, prioritize the always hits move.
+        if (gBattleMons[battlerDef].statStages[STAT_EVASION] > 6 || gBattleMons[battlerAtk].statStages[STAT_ACC] < 6)
+        {
+            u32 mostDmgMoveId = GetAIMostDamagingMove(battlerAtk, battlerDef);
+            u32 *dmgs = AI_DATA->simulatedDmg[battlerAtk][battlerDef];
+            if (GetNoOfHitsToKO(dmgs[mostDmgMoveId], gBattleMons[battlerDef].hp) == GetNoOfHitsToKO(dmgs[AI_THINKING_STRUCT->movesetIndex], gBattleMons[battlerDef].hp))
+                score++;
+        }
         if (gBattleMons[battlerDef].statStages[STAT_EVASION] >= 10 || gBattleMons[battlerAtk].statStages[STAT_ACC] <= 2)
             score++;
         if (AI_RandLessThan(100) && (gBattleMons[battlerDef].statStages[STAT_EVASION] >= 8 || gBattleMons[battlerAtk].statStages[STAT_ACC] <= 4))

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -3102,7 +3102,7 @@ static bool32 IsPinchBerryItemEffect(u16 holdEffect)
     return FALSE;
 }
 
-static u32 GetAIMostDamagingMove(u8 battlerAtk, u8 battlerDef)
+static u32 GetAIMostDamagingMoveId(u8 battlerAtk, u8 battlerDef)
 {
     u32 i, id = 0;
     u32 mostDmg = 0;
@@ -3138,7 +3138,7 @@ static s16 AI_CheckViability(u8 battlerAtk, u8 battlerDef, u16 move, s16 score)
         // If 2 moves can KO the target in the same number of turns, but one of them always hits and there is a risk the other move could miss, prioritize the always hits move.
         if (gBattleMons[battlerDef].statStages[STAT_EVASION] > 6 || gBattleMons[battlerAtk].statStages[STAT_ACC] < 6)
         {
-            u32 mostDmgMoveId = GetAIMostDamagingMove(battlerAtk, battlerDef);
+            u32 mostDmgMoveId = GetAIMostDamagingMoveId(battlerAtk, battlerDef);
             u32 *dmgs = AI_DATA->simulatedDmg[battlerAtk][battlerDef];
             if (GetNoOfHitsToKO(dmgs[mostDmgMoveId], gBattleMons[battlerDef].hp) == GetNoOfHitsToKO(dmgs[AI_THINKING_STRUCT->movesetIndex], gBattleMons[battlerDef].hp))
                 score++;

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -939,6 +939,11 @@ static u32 WhichMoveBetter(u32 move1, u32 move2)
     return 2;
 }
 
+u32 GetNoOfHitsToKO(u32 dmg, s32 hp)
+{
+    return hp / (dmg + 1) + 1;
+}
+
 u8 GetMoveDamageResult(u16 move)
 {
     s32 i, checkedMove, bestId, currId, hp;
@@ -1004,9 +1009,8 @@ u8 GetMoveDamageResult(u16 move)
         currId = AI_THINKING_STRUCT->movesetIndex;
         if (currId == bestId)
             AI_THINKING_STRUCT->funcResult = MOVE_POWER_BEST;
-        // Compare percentage difference.
         else if ((moveDmgs[currId] >= hp || moveDmgs[bestId] < hp) // If current move can faint as well, or if neither can
-                 && (moveDmgs[bestId] * 100 / hp) - (moveDmgs[currId] * 100 / hp) <= 30
+                 && GetNoOfHitsToKO(moveDmgs[currId], hp) - GetNoOfHitsToKO(moveDmgs[bestId], hp) <= 2 // Consider a move weak if it needs to be used at least 2 times more to faint the target, compared to the best move.
                  && WhichMoveBetter(gBattleMons[sBattler_AI].moves[bestId], gBattleMons[sBattler_AI].moves[currId]) != 0)
             AI_THINKING_STRUCT->funcResult = MOVE_POWER_GOOD;
         else


### PR DESCRIPTION
Fixes #2944

Right now AI treats a move as a MOVE_POWER_WEAK when it has to be used against the target more than 2 times, compared to the best damaging move, to faint the target.
So for example if Tackle deals 10 dmg, Ember deals 30, and the target has 45, it treats Tackle as weak, because it needs 5 hits and Ember only 2.

Also, made a little change to always hits moves. In a scenario, where Shock Wave and Thunderbolt would both faint the target in the same number of turns, but the mon's accuracy is lowered, 1 point is given to Shock Wave.

![pokeemerald_02](https://github.com/rh-hideout/pokeemerald-expansion/assets/16259973/e6fe0216-9820-4ebc-9a88-122c40c4041e)
![pokeemerald_01](https://github.com/rh-hideout/pokeemerald-expansion/assets/16259973/c7ddd25e-87b6-41fb-86e0-acd56e037f5e)
