### PR TITLE
Remove unused macro to fix syntax highlights

### DIFF
--- a/include/global.h
+++ b/include/global.h
@@ -20,7 +20,6 @@
 #define BLOCK_CROSS_JUMP asm("");
 
 // to help in decompiling
-#define asm_comment(x) asm volatile("@ -- " x " -- ")
 #define asm_unified(x) asm(".syntax unified\n" x "\n.syntax divided")
 #define NAKED __attribute__((naked))
 


### PR DESCRIPTION
## Description
There's a macro in global.h that was used during the disassembly/decompilation process that's no longer used anywhere in the codebase. It unfortunately causes the syntax highlighting in VSCode to break for the majority of the file afterwards due to an @ symbol inside quotes. This PR just removes the macro entirely - in addition to being unused, it doesn't appear particularly helpful otherwise.

## **Discord contact info**
crater.