### PR TITLE
Unified multi-strike move flags

### DIFF
--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -376,8 +376,7 @@ struct BattleMove
     u32 ignoreTypeIfFlyingAndUngrounded:1;
     u32 thawsUser:1;
     u32 ignoresSubstitute:1;
-    u32 twoStrikes:1; // May apply its effect on each hit.
-    u32 threeStrikes:1; // May apply its effect on each hit.
+    u32 strikeCount:8;  // Max 255 hits. Defaults to 1 if not set. May apply its effect on each hit.
     u32 meFirstBanned:1;
     u32 gravityBanned:1;
     u32 mimicBanned:1;

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -850,9 +850,9 @@ s32 AI_CalcDamage(u16 move, u8 battlerAtk, u8 battlerDef, u8 *typeEffectiveness,
             }
 
             // Handle other multi-strike moves
-            if (gBattleMoves[move].twoStrikes)
-                dmg *= 2;
-            else if (gBattleMoves[move].threeStrikes || (move == MOVE_WATER_SHURIKEN && gBattleMons[battlerAtk].species == SPECIES_GRENINJA_ASH))
+            if (gBattleMoves[move].strikeCount > 1)
+                dmg *= gBattleMoves[move].strikeCount;
+            else if (move == MOVE_WATER_SHURIKEN && gBattleMons[battlerAtk].species == SPECIES_GRENINJA_ASH)
                 dmg *= 3;
 
             if (dmg == 0)

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -16031,8 +16031,7 @@ bool8 IsMoveAffectedByParentalBond(u16 move, u8 battlerId)
 {
     if (move != MOVE_NONE && move != MOVE_STRUGGLE
         && gBattleMoves[move].split != SPLIT_STATUS
-        && !gBattleMoves[move].twoStrikes
-        && !gBattleMoves[move].threeStrikes)
+        && !gBattleMoves[move].strikeCount > 2)
     {
         u32 i;
         for (i = 0; i < ARRAY_COUNT(sParentalBondBannedEffects); i++)

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3737,21 +3737,17 @@ u8 AtkCanceller_UnableToUseMove(void)
 
                 PREPARE_BYTE_NUMBER_BUFFER(gBattleScripting.multihitString, 1, 0)
             }
-            else if (gBattleMoves[gCurrentMove].twoStrikes)
+            else if (gBattleMoves[gCurrentMove].strikeCount > 1)
             {
-                gMultiHitCounter = 2;
-                PREPARE_BYTE_NUMBER_BUFFER(gBattleScripting.multihitString, 1, 0)
-                if (gCurrentMove == MOVE_DRAGON_DARTS)
-                {
-                    // TODO
-                }
+                gMultiHitCounter = gBattleMoves[gCurrentMove].strikeCount;
+                PREPARE_BYTE_NUMBER_BUFFER(gBattleScripting.multihitString, 3, 0)
             }
-            else if (gBattleMoves[gCurrentMove].effect == EFFECT_TRIPLE_KICK || gBattleMoves[gCurrentMove].threeStrikes)
+            else if (gBattleMoves[gCurrentMove].effect == EFFECT_TRIPLE_KICK)
             {
                 gMultiHitCounter = 3;
                 PREPARE_BYTE_NUMBER_BUFFER(gBattleScripting.multihitString, 1, 0)
             }
-            #if B_BEAT_UP >= GEN_5
+        #if B_BEAT_UP >= GEN_5
             else if (gBattleMoves[gCurrentMove].effect == EFFECT_BEAT_UP)
             {
                 struct Pokemon* party = GetBattlerParty(gBattlerAttacker);
@@ -3769,7 +3765,7 @@ u8 AtkCanceller_UnableToUseMove(void)
                 gBattleStruct->beatUpSlot = 0;
                 PREPARE_BYTE_NUMBER_BUFFER(gBattleScripting.multihitString, 1, 0)
             }
-            #endif
+        #endif
             gBattleStruct->atkCancellerTracker++;
             break;
         case CANCELLER_END:

--- a/src/data/battle_moves.h
+++ b/src/data/battle_moves.h
@@ -428,7 +428,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_Z] =
         .split = SPLIT_PHYSICAL,
         .zMoveEffect = Z_EFFECT_NONE,
         .makesContact = TRUE,
-        .twoStrikes = TRUE,
+        .strikeCount = 2,
     },
 
     [MOVE_MEGA_KICK] =
@@ -716,7 +716,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_Z] =
         .zMoveEffect = Z_EFFECT_NONE,
         .sheerForceBoost = TRUE,
         .ignoresKingsRock = B_UPDATED_MOVE_FLAGS < GEN_5, // && B_UPDATED_MOVE_FLAGS > GEN_2
-        .twoStrikes = TRUE,
+        .strikeCount = 2,
     },
 
     [MOVE_PIN_MISSILE] =
@@ -2680,7 +2680,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_Z] =
         .priority = 0,
         .split = SPLIT_PHYSICAL,
         .zMoveEffect = Z_EFFECT_NONE,
-        .twoStrikes = TRUE,
+        .strikeCount = 2,
     },
 
     [MOVE_REST] =
@@ -7767,7 +7767,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_Z] =
         .split = SPLIT_PHYSICAL,
         .zMoveEffect = Z_EFFECT_NONE,
         .makesContact = TRUE,
-        .twoStrikes = TRUE,
+        .strikeCount = 2,
     },
 
     [MOVE_ROAR_OF_TIME] =
@@ -8930,7 +8930,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_Z] =
         .split = SPLIT_PHYSICAL,
         .zMoveEffect = Z_EFFECT_NONE,
         .makesContact = TRUE,
-        .twoStrikes = TRUE,
+        .strikeCount = 2,
     },
 
     [MOVE_HEART_STAMP] =
@@ -9158,7 +9158,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_Z] =
         .split = SPLIT_PHYSICAL,
         .zMoveEffect = Z_EFFECT_NONE,
         .makesContact = TRUE,
-        .twoStrikes = TRUE,
+        .strikeCount = 2,
     },
 
     [MOVE_SEARING_SHOT] =
@@ -11540,7 +11540,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_Z] =
         .makesContact = TRUE,
         .punchingMove = TRUE,
         .sheerForceBoost = TRUE,
-        .twoStrikes = TRUE,
+        .strikeCount = 2,
         .minimizeDoubleDamage = B_UPDATED_MOVE_FLAGS < GEN_8,
         .metronomeBanned = TRUE,
     },
@@ -11668,7 +11668,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_Z] =
         .priority = 0,
         .split = SPLIT_PHYSICAL,
         .zMoveEffect = Z_EFFECT_NONE,
-        .twoStrikes = TRUE,
+        .strikeCount = 2,
     },
 
     [MOVE_TEATIME] =
@@ -12372,7 +12372,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_Z] =
         .split = SPLIT_PHYSICAL,
         .zMoveEffect = Z_EFFECT_NONE,
         .makesContact = TRUE,
-        .twoStrikes = TRUE,
+        .strikeCount = 2,
     },
 
     [MOVE_SCORCHING_SANDS] =
@@ -12441,7 +12441,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_Z] =
         .zMoveEffect = Z_EFFECT_NONE,
         .makesContact = TRUE,
         .punchingMove = TRUE,
-        .threeStrikes = TRUE,
+        .strikeCount = 3,
         .metronomeBanned = TRUE,
     },
 
@@ -13241,7 +13241,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_Z] =
         .split = SPLIT_PHYSICAL,
         .zMoveEffect = Z_EFFECT_NONE,
         .makesContact = TRUE,
-        .threeStrikes = TRUE,
+        .strikeCount = 3,
     },
 
     [MOVE_MORTAL_SPIN] =
@@ -13566,7 +13566,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_Z] =
         .priority = 0,
         .split = SPLIT_SPECIAL,
         .zMoveEffect = Z_EFFECT_NONE,
-        .twoStrikes = TRUE,
+        .strikeCount = 2,
         .metronomeBanned = TRUE,
     },
 

--- a/test/move_flag_three_strikes.c
+++ b/test/move_flag_three_strikes.c
@@ -8,7 +8,7 @@ SINGLE_BATTLE_TEST("Three-strike flag turns a move into a 3-hit move")
     s16 thirdHit;
 
     GIVEN {
-        ASSUME(gBattleMoves[MOVE_TRIPLE_DIVE].threeStrikes);
+        ASSUME(gBattleMoves[MOVE_TRIPLE_DIVE].strikeCount == 3);
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
@@ -34,7 +34,7 @@ SINGLE_BATTLE_TEST("Surging Strikes hits 3 times with each hit being a critical 
     s16 thirdHit;
 
     GIVEN {
-        ASSUME(gBattleMoves[MOVE_SURGING_STRIKES].threeStrikes);
+        ASSUME(gBattleMoves[MOVE_SURGING_STRIKES].strikeCount == 3);
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Unified `twoStrikes` and `threeStrikes` flags into `strikeCount`.
- A value of 0 is treated as 1 hit.
- Supports up to 255 hits (can be reduced if needed).

## Images
100-hit example
![mGBA_t2Ahl81kld](https://github.com/rh-hideout/pokeemerald-expansion/assets/2904965/3f305843-1885-4841-88da-6bf60f91b240)

## **Discord contact info**
AsparagusEduardo