### PR TITLE
Make Hydra respect -jN

### DIFF
--- a/test/test_battle.h
+++ b/test/test_battle.h
@@ -1,7 +1,7 @@
 /* Embedded DSL for automated black-box testing of battle mechanics.
  *
  * To run all the tests use:
- *     make check
+ *     make check -j
  * To run specific tests, e.g. Spikes ones, use:
  *     make check TESTS='Spikes'
  * To build a ROM (pokemerald-test.elf) that can be opened in mgba to

--- a/tools/mgba-rom-test-hydra/main.c
+++ b/tools/mgba-rom-test-hydra/main.c
@@ -17,6 +17,7 @@
 #include <fcntl.h>
 #include <math.h>
 #include <poll.h>
+#include <regex.h>
 #include <signal.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -36,6 +37,8 @@
 #define MAX_PROCESSES               32 // See also test/test.h
 #define MAX_FAILED_TESTS_TO_LIST    100
 #define MAX_TEST_LIST_BUFFER_LENGTH 256
+
+#define ARRAY_COUNT(arr) (sizeof((arr)) / sizeof((arr)[0]))
 
 struct Runner
 {
@@ -249,6 +252,23 @@ int main(int argc, char *argv[])
     }
 
     nrunners = sysconf(_SC_NPROCESSORS_ONLN);
+    const char *makeflags = getenv("MAKEFLAGS");
+    if (makeflags)
+    {
+        int e;
+        regex_t preg;
+        regmatch_t pmatch[4];
+        if ((e = regcomp(&preg, "(^| )-j([0-9]+)($| )", REG_EXTENDED)) != 0)
+        {
+            char errbuf[256];
+            regerror(e, &preg, errbuf, sizeof(errbuf));
+            fprintf(stderr, "regcomp failed: '%s'\n", errbuf);
+            exit(2);
+        }
+        if (regexec(&preg, makeflags, ARRAY_COUNT(pmatch), pmatch, 0) != REG_NOMATCH)
+            sscanf(makeflags + pmatch[2].rm_so, "%d", &nrunners);
+        regfree(&preg);
+    }
     if (nrunners > MAX_PROCESSES)
         nrunners = MAX_PROCESSES;
     runners_digits = ceil(log10(nrunners));


### PR DESCRIPTION
Currently Hydra always runs `nproc` number of processes, regardless of the `-j` parameter passed to `make`. This PR makes Hydra parse `MAKEFLAGS` and set `nrunners` to the specified number, if one is specified. If one isn't specified, or plain `-j` is passed, then Hydra has its current behavior of spawning `nproc` processes.

EDIT: For the release notes, let's encourage people to `make check -j` or `make check -jN` rather than just `make check` :)