### PR TITLE
Clear fixedPopup when gTestRunnerHeadless

### DIFF
--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -3188,8 +3188,8 @@ void DestroyAbilityPopUp(u8 battlerId)
     {
         gSprites[gBattleStruct->abilityPopUpSpriteIds[battlerId][0]].tFrames = 0;
         gSprites[gBattleStruct->abilityPopUpSpriteIds[battlerId][1]].tFrames = 0;
-        gBattleScripting.fixedPopup = FALSE;
     }
+    gBattleScripting.fixedPopup = FALSE;
 }
 
 static void Task_FreeAbilityPopUpGfx(u8 taskId)


### PR DESCRIPTION
Previously fixedPopup = FALSE was unconditional, but it was erroneously changed in f1b9872bf0a.