### PR TITLE
Fix Protosynthesis and Quark Drive boosts 

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -8826,14 +8826,16 @@ static u32 CalcMoveBasePowerAfterModifiers(u16 move, u8 battlerAtk, u8 battlerDe
     case ABILITY_PROTOSYNTHESIS:
         {
             u8 atkHighestStat = GetHighestStatId(battlerAtk);
-            if (gBattleWeather & B_WEATHER_SUN && WEATHER_HAS_EFFECT && (atkHighestStat == STAT_ATK || atkHighestStat == STAT_SPATK))
+            if (gBattleWeather & B_WEATHER_SUN && WEATHER_HAS_EFFECT
+            && ((IS_MOVE_PHYSICAL(move) && atkHighestStat == STAT_ATK) || (IS_MOVE_SPECIAL(move) && atkHighestStat == STAT_SPATK)))
                 MulModifier(&modifier, UQ_4_12(1.3));
         }
         break;
     case ABILITY_QUARK_DRIVE:
         {
             u8 atkHighestStat = GetHighestStatId(battlerAtk);
-            if (gFieldStatuses & STATUS_FIELD_ELECTRIC_TERRAIN && (atkHighestStat == STAT_ATK || atkHighestStat == STAT_SPATK))
+            if (gFieldStatuses & STATUS_FIELD_ELECTRIC_TERRAIN
+            && ((IS_MOVE_PHYSICAL(move) && atkHighestStat == STAT_ATK) || (IS_MOVE_SPECIAL(move) && atkHighestStat == STAT_SPATK)))
                 MulModifier(&modifier, UQ_4_12(1.3));
         }
         break;
@@ -8923,18 +8925,19 @@ static u32 CalcMoveBasePowerAfterModifiers(u16 move, u8 battlerAtk, u8 battlerDe
         break;
     case ABILITY_PROTOSYNTHESIS:
         {
-            u8 defHighestStat = GetHighestStatId(battlerDef);
-            if (gBattleWeather & B_WEATHER_SUN && WEATHER_HAS_EFFECT && (defHighestStat == STAT_DEF || defHighestStat == STAT_SPDEF))
+            u8 atkHighestStat = GetHighestStatId(battlerDef);
+            if (gBattleWeather & B_WEATHER_SUN && WEATHER_HAS_EFFECT
+            && ((IS_MOVE_PHYSICAL(move) && atkHighestStat == STAT_ATK) || (IS_MOVE_SPECIAL(move) && atkHighestStat == STAT_SPATK)))
                 MulModifier(&modifier, UQ_4_12(0.7));
         }
         break;
     case ABILITY_QUARK_DRIVE:
         {
-            u8 defHighestStat = GetHighestStatId(battlerDef);
-            if (gFieldStatuses & STATUS_FIELD_ELECTRIC_TERRAIN && (defHighestStat == STAT_DEF || defHighestStat == STAT_SPDEF))
+            u8 atkHighestStat = GetHighestStatId(battlerDef);
+            if (gFieldStatuses & STATUS_FIELD_ELECTRIC_TERRAIN
+            && ((IS_MOVE_PHYSICAL(move) && atkHighestStat == STAT_ATK) || (IS_MOVE_SPECIAL(move) && atkHighestStat == STAT_SPATK)))
                 MulModifier(&modifier, UQ_4_12(0.7));
         }
-        break;
     }
 
     holdEffectAtk = GetBattlerHoldEffect(battlerAtk, TRUE);

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -8925,19 +8925,20 @@ static u32 CalcMoveBasePowerAfterModifiers(u16 move, u8 battlerAtk, u8 battlerDe
         break;
     case ABILITY_PROTOSYNTHESIS:
         {
-            u8 atkHighestStat = GetHighestStatId(battlerDef);
+            u8 defHighestStat = GetHighestStatId(battlerDef);
             if (gBattleWeather & B_WEATHER_SUN && WEATHER_HAS_EFFECT
-            && ((IS_MOVE_PHYSICAL(move) && atkHighestStat == STAT_ATK) || (IS_MOVE_SPECIAL(move) && atkHighestStat == STAT_SPATK)))
+            && ((IS_MOVE_PHYSICAL(move) && defHighestStat == STAT_DEF) || (IS_MOVE_SPECIAL(move) && defHighestStat == STAT_SPDEF)))
                 MulModifier(&modifier, UQ_4_12(0.7));
         }
         break;
     case ABILITY_QUARK_DRIVE:
         {
-            u8 atkHighestStat = GetHighestStatId(battlerDef);
+            u8 defHighestStat = GetHighestStatId(battlerDef);
             if (gFieldStatuses & STATUS_FIELD_ELECTRIC_TERRAIN
-            && ((IS_MOVE_PHYSICAL(move) && atkHighestStat == STAT_ATK) || (IS_MOVE_SPECIAL(move) && atkHighestStat == STAT_SPATK)))
+            && ((IS_MOVE_PHYSICAL(move) && defHighestStat == STAT_DEF) || (IS_MOVE_SPECIAL(move) && defHighestStat == STAT_SPDEF)))
                 MulModifier(&modifier, UQ_4_12(0.7));
         }
+        break;
     }
 
     holdEffectAtk = GetBattlerHoldEffect(battlerAtk, TRUE);

--- a/test/ability_protosynthesis.c
+++ b/test/ability_protosynthesis.c
@@ -1,0 +1,87 @@
+#include "global.h"
+#include "test_battle.h"
+
+ASSUMPTIONS
+{
+    ASSUME(gBattleMoves[MOVE_TACKLE].split == SPLIT_PHYSICAL);
+    ASSUME(gBattleMoves[MOVE_ROUND].split == SPLIT_SPECIAL);
+}
+
+SINGLE_BATTLE_TEST("Protosynthesis boosts the highest stat")
+{
+    GIVEN {
+        PLAYER(SPECIES_ABRA) { Ability(ABILITY_PROTOSYNTHESIS); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_SUNNY_DAY); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SUNNY_DAY, player);
+        ABILITY_POPUP(player, ABILITY_PROTOSYNTHESIS);
+        MESSAGE("The harsh sunlight activated Abra's Protosynthesis!");
+        MESSAGE("Abra's Sp. Atk was heightened!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Protosynthesis boosts either Attack or Special Attack, not both")
+{
+    u16 species;
+    u32 move;
+    u16 damage[2];
+
+    PARAMETRIZE { species = SPECIES_BELLSPROUT; move = MOVE_TACKLE; }
+    PARAMETRIZE { species = SPECIES_BELLSPROUT; move = MOVE_ROUND; }
+
+    PARAMETRIZE { species = SPECIES_ABRA; move = MOVE_TACKLE; }
+    PARAMETRIZE { species = SPECIES_ABRA; move = MOVE_ROUND; }
+
+    GIVEN {
+        PLAYER(species) { Ability(ABILITY_PROTOSYNTHESIS); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, move); }
+        TURN { MOVE(opponent, MOVE_SUNNY_DAY); MOVE(player, move); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        HP_BAR(opponent, captureDamage: &damage[0]);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SUNNY_DAY, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        HP_BAR(opponent, captureDamage: &damage[1]);
+    } THEN {
+        if ((move == MOVE_TACKLE && species == SPECIES_BELLSPROUT) || (move == MOVE_ROUND && species == SPECIES_ABRA))
+            EXPECT_MUL_EQ(damage[0], Q_4_12(1.3), damage[1]);
+        else
+            EXPECT_EQ(damage[0], damage[1]);
+    }
+}
+
+SINGLE_BATTLE_TEST("Protosynthesis either boosts Defense or Special Defense, not both")
+{
+    u16 species;
+    u32 move;
+    u16 damage[2];
+
+    PARAMETRIZE { species = SPECIES_ONIX; move = MOVE_TACKLE; }
+    PARAMETRIZE { species = SPECIES_ONIX; move = MOVE_ROUND; }
+
+    PARAMETRIZE { species = SPECIES_BLASTOISE; move = MOVE_TACKLE; }
+    PARAMETRIZE { species = SPECIES_BLASTOISE; move = MOVE_ROUND; }
+
+    GIVEN {
+        PLAYER(species) { Ability(ABILITY_PROTOSYNTHESIS); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, move); }
+        TURN { MOVE(player, MOVE_SUNNY_DAY); MOVE(opponent, move); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, opponent);
+        HP_BAR(player, captureDamage: &damage[0]);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SUNNY_DAY, player);
+        ANIMATION(ANIM_TYPE_MOVE, move, opponent);
+        HP_BAR(player, captureDamage: &damage[1]);
+    } THEN {
+        if ((move == MOVE_TACKLE && species == SPECIES_ONIX) || (move == MOVE_ROUND && species == SPECIES_BLASTOISE))
+            EXPECT_MUL_EQ(damage[0], Q_4_12(0.7), damage[1]);
+        else
+            EXPECT_EQ(damage[0], damage[1]);
+    }
+}

--- a/test/ability_quark_drive.c
+++ b/test/ability_quark_drive.c
@@ -1,0 +1,87 @@
+#include "global.h"
+#include "test_battle.h"
+
+ASSUMPTIONS
+{
+    ASSUME(gBattleMoves[MOVE_TACKLE].split == SPLIT_PHYSICAL);
+    ASSUME(gBattleMoves[MOVE_ROUND].split == SPLIT_SPECIAL);
+}
+
+SINGLE_BATTLE_TEST("Quark Drive boosts the highest stat")
+{
+    GIVEN {
+        PLAYER(SPECIES_ABRA) { Ability(ABILITY_QUARK_DRIVE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_ELECTRIC_TERRAIN); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ELECTRIC_TERRAIN, player);
+        ABILITY_POPUP(player, ABILITY_QUARK_DRIVE);
+        MESSAGE("The Electric Terrain activated Abra's Quark Drive!");
+        MESSAGE("Abra's Sp. Atk was heightened!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Quark Drive boosts either Attack or Special Attack, not both")
+{
+    u16 species;
+    u32 move;
+    u16 damage[2];
+
+    PARAMETRIZE { species = SPECIES_BELLSPROUT; move = MOVE_TACKLE; }
+    PARAMETRIZE { species = SPECIES_BELLSPROUT; move = MOVE_ROUND; }
+
+    PARAMETRIZE { species = SPECIES_ABRA; move = MOVE_TACKLE; }
+    PARAMETRIZE { species = SPECIES_ABRA; move = MOVE_ROUND; }
+
+    GIVEN {
+        PLAYER(species) { Ability(ABILITY_QUARK_DRIVE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, move); }
+        TURN { MOVE(opponent, MOVE_ELECTRIC_TERRAIN); MOVE(player, move); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        HP_BAR(opponent, captureDamage: &damage[0]);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ELECTRIC_TERRAIN, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        HP_BAR(opponent, captureDamage: &damage[1]);
+    } THEN {
+        if ((move == MOVE_TACKLE && species == SPECIES_BELLSPROUT) || (move == MOVE_ROUND && species == SPECIES_ABRA))
+            EXPECT_MUL_EQ(damage[0], Q_4_12(1.3), damage[1]);
+        else
+            EXPECT_EQ(damage[0], damage[1]);
+    }
+}
+
+SINGLE_BATTLE_TEST("Quark Drive either boosts Defense or Special Defense, not both")
+{
+    u16 species;
+    u32 move;
+    u16 damage[2];
+
+    PARAMETRIZE { species = SPECIES_ONIX; move = MOVE_TACKLE; }
+    PARAMETRIZE { species = SPECIES_ONIX; move = MOVE_ROUND; }
+
+    PARAMETRIZE { species = SPECIES_BLASTOISE; move = MOVE_TACKLE; }
+    PARAMETRIZE { species = SPECIES_BLASTOISE; move = MOVE_ROUND; }
+
+    GIVEN {
+        PLAYER(species) { Ability(ABILITY_QUARK_DRIVE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, move); }
+        TURN { MOVE(player, MOVE_ELECTRIC_TERRAIN); MOVE(opponent, move); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, opponent);
+        HP_BAR(player, captureDamage: &damage[0]);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ELECTRIC_TERRAIN, player);
+        ANIMATION(ANIM_TYPE_MOVE, move, opponent);
+        HP_BAR(player, captureDamage: &damage[1]);
+    } THEN {
+        if ((move == MOVE_TACKLE && species == SPECIES_ONIX) || (move == MOVE_ROUND && species == SPECIES_BLASTOISE))
+            EXPECT_MUL_EQ(damage[0], Q_4_12(0.7), damage[1]);
+        else
+            EXPECT_EQ(damage[0], damage[1]);
+    }
+}


### PR DESCRIPTION
Currently both Atk/Sp.Atk and Def/Sp.Def are boosted if either of them is the highest stat.
This should fix it.

## Images
Protosynthesis Nidoqueen.
Before:
![pokeemerald-15](https://github.com/rh-hideout/pokeemerald-expansion/assets/93446519/ea3e878f-9e8c-4fd1-b1e0-afc633cec229)
After:
![pokeemerald-14](https://github.com/rh-hideout/pokeemerald-expansion/assets/93446519/e659832e-c3d9-4ba7-92ec-f62b46fe6023)

## **Discord contact info**
rainonline