### PR TITLE
Fix debug memory overflow

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -211,6 +211,8 @@ enum { //Sound
 #define DEBUG_NUMBER_ICON_X 210
 #define DEBUG_NUMBER_ICON_Y 50
 
+#define DEBUG_MAX_MENU_ITEMS 50
+
 // *******************************
 struct DebugMonData
 {
@@ -234,7 +236,7 @@ struct DebugMonData
 struct DebugMenuListData
 {
     struct ListMenuItem listItems[20 + 1];
-    u8 itemNames[PC_ITEMS_COUNT + 1][26];
+    u8 itemNames[DEBUG_MAX_MENU_ITEMS + 1][26];
     u8 listId;
 };
 
@@ -1132,6 +1134,8 @@ static void Debug_RefreshListMenu(u8 taskId)
         totalItems = 7;
     }
 
+    // Failsafe to prevent memory corruption
+    totalItems = min(totalItems, DEBUG_MAX_MENU_ITEMS);
     // Copy item names for all entries but the last (which is Cancel)
     for(i = 0; i < totalItems; i++)
     {


### PR DESCRIPTION
## Description
TheXaman's debug menu used PC_ITEMS_COUNT as an artifact, which would lead to memory issues if it was reduced in value (more specifically any reduction below 19). This PR fixes this issue by introducing a new DEBUG_MAX_MENU_ITEMS and a failsafe by limiting totalItems to the value of DEBUG_MAX_MENU_ITEMS if it would be larger, causing a limit in the amount of items shown rather than silently overwriting memory.

## **Discord contact info**
bassoonian