### PR TITLE
Fix Ruin ability calcs + Tests

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -8908,16 +8908,16 @@ static u32 CalcMoveBasePowerAfterModifiers(u16 move, u8 battlerAtk, u8 battlerDe
     }
 
     if (IsAbilityOnField(ABILITY_VESSEL_OF_RUIN) && atkAbility != ABILITY_VESSEL_OF_RUIN && IS_MOVE_SPECIAL(gCurrentMove))
-        MulModifier(&modifier, UQ_4_12(0.25));
+        MulModifier(&modifier, UQ_4_12(0.75));
 
     if (IsAbilityOnField(ABILITY_SWORD_OF_RUIN) && defAbility != ABILITY_SWORD_OF_RUIN && IS_MOVE_PHYSICAL(gCurrentMove))
-        MulModifier(&modifier, UQ_4_12(0.25));
+        MulModifier(&modifier, UQ_4_12(1.25));
 
     if (IsAbilityOnField(ABILITY_TABLETS_OF_RUIN) && atkAbility != ABILITY_TABLETS_OF_RUIN && IS_MOVE_PHYSICAL(gCurrentMove))
-        MulModifier(&modifier, UQ_4_12(0.25));
+        MulModifier(&modifier, UQ_4_12(0.75));
 
     if (IsAbilityOnField(ABILITY_BEADS_OF_RUIN) && defAbility != ABILITY_BEADS_OF_RUIN && IS_MOVE_SPECIAL(gCurrentMove))
-        MulModifier(&modifier, UQ_4_12(0.25));
+        MulModifier(&modifier, UQ_4_12(1.25));
 
     // attacker partner's abilities
     if (IsBattlerAlive(BATTLE_PARTNER(battlerAtk)))

--- a/test/ability_beads_of_ruin.c
+++ b/test/ability_beads_of_ruin.c
@@ -1,0 +1,53 @@
+#include "global.h"
+#include "test_battle.h"
+
+ASSUMPTIONS
+{
+    ASSUME(gBattleMoves[MOVE_WATER_GUN].split == SPLIT_SPECIAL);
+}
+
+SINGLE_BATTLE_TEST("Beads of Ruin reduces Sp. Def", s16 damage)
+{
+    u32 ability;
+
+    PARAMETRIZE { ability = ABILITY_SHADOW_TAG; }
+    PARAMETRIZE { ability = ABILITY_BEADS_OF_RUIN; }
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Ability(ability); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_WATER_GUN); }
+    } SCENE {
+        if (ability == ABILITY_BEADS_OF_RUIN) {
+            ABILITY_POPUP(player, ABILITY_BEADS_OF_RUIN);
+            MESSAGE("Wobbuffet's Beads of Ruin weakened the Sp. Def of all surrounding Pokémon!");
+        }
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.25), results[1].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Beads of Ruin does not reduce Sp. Def if opposing mon has the same ability", s16 damage)
+{
+    u32 ability;
+
+    PARAMETRIZE { ability = ABILITY_SHADOW_TAG; }
+    PARAMETRIZE { ability = ABILITY_BEADS_OF_RUIN; }
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Ability(ability); }
+        OPPONENT(SPECIES_WOBBUFFET) { Ability(ABILITY_BEADS_OF_RUIN); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_WATER_GUN); }
+    } SCENE {
+        if (ability == ABILITY_BEADS_OF_RUIN) {
+            ABILITY_POPUP(player, ABILITY_BEADS_OF_RUIN);
+            MESSAGE("Wobbuffet's Beads of Ruin weakened the Sp. Def of all surrounding Pokémon!");
+        }
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_EQ(results[0].damage, results[1].damage);
+    }
+}

--- a/test/ability_sword_of_ruin.c
+++ b/test/ability_sword_of_ruin.c
@@ -1,0 +1,53 @@
+#include "global.h"
+#include "test_battle.h"
+
+ASSUMPTIONS
+{
+    ASSUME(gBattleMoves[MOVE_TACKLE].split == SPLIT_PHYSICAL);
+}
+
+SINGLE_BATTLE_TEST("Sword of Ruin reduces Defense", s16 damage)
+{
+    u32 ability;
+
+    PARAMETRIZE { ability = ABILITY_SHADOW_TAG; }
+    PARAMETRIZE { ability = ABILITY_SWORD_OF_RUIN; }
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Ability(ability); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_TACKLE); }
+    } SCENE {
+        if (ability == ABILITY_SWORD_OF_RUIN) {
+            ABILITY_POPUP(player, ABILITY_SWORD_OF_RUIN);
+            MESSAGE("Wobbuffet's Sword of Ruin weakened the Defense of all surrounding Pokémon!");
+        }
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.25), results[1].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Sword of Ruin does not reduce Defense if opposing mon has the same ability", s16 damage)
+{
+    u32 ability;
+
+    PARAMETRIZE { ability = ABILITY_SHADOW_TAG; }
+    PARAMETRIZE { ability = ABILITY_SWORD_OF_RUIN; }
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Ability(ability); }
+        OPPONENT(SPECIES_WOBBUFFET) { Ability(ABILITY_SWORD_OF_RUIN); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_TACKLE); }
+    } SCENE {
+        if (ability == ABILITY_SWORD_OF_RUIN) {
+            ABILITY_POPUP(player, ABILITY_SWORD_OF_RUIN);
+            MESSAGE("Wobbuffet's Sword of Ruin weakened the Defense of all surrounding Pokémon!");
+        }
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_EQ(results[0].damage, results[1].damage);
+    }
+}

--- a/test/ability_tablets_of_ruin.c
+++ b/test/ability_tablets_of_ruin.c
@@ -1,0 +1,53 @@
+#include "global.h"
+#include "test_battle.h"
+
+ASSUMPTIONS
+{
+    ASSUME(gBattleMoves[MOVE_TACKLE].split == SPLIT_PHYSICAL);
+}
+
+SINGLE_BATTLE_TEST("Tablets of Ruin reduces Attack", s16 damage)
+{
+    u32 ability;
+
+    PARAMETRIZE { ability = ABILITY_SHADOW_TAG; }
+    PARAMETRIZE { ability = ABILITY_TABLETS_OF_RUIN; }
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Ability(ability); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_TACKLE); }
+    } SCENE {
+        if (ability == ABILITY_TABLETS_OF_RUIN) {
+            ABILITY_POPUP(player, ABILITY_TABLETS_OF_RUIN);
+            MESSAGE("Wobbuffet's Tablets of Ruin weakened the Attack of all surrounding Pokémon!");
+        }
+        HP_BAR(player, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(0.75), results[1].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Tablets of Ruin does not reduce Attack if an opposing mon has the same ability", s16 damage)
+{
+    u32 ability;
+
+    PARAMETRIZE { ability = ABILITY_SHADOW_TAG; }
+    PARAMETRIZE { ability = ABILITY_TABLETS_OF_RUIN; }
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Ability(ability); }
+        OPPONENT(SPECIES_WOBBUFFET) { Ability(ABILITY_TABLETS_OF_RUIN); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_TACKLE); }
+    } SCENE {
+        if (ability == ABILITY_TABLETS_OF_RUIN) {
+            ABILITY_POPUP(player, ABILITY_TABLETS_OF_RUIN);
+            MESSAGE("Wobbuffet's Tablets of Ruin weakened the Attack of all surrounding Pokémon!");
+        }
+        HP_BAR(player, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_EQ(results[0].damage, results[1].damage);
+    }
+}

--- a/test/ability_vessel_of_ruin.c
+++ b/test/ability_vessel_of_ruin.c
@@ -1,0 +1,53 @@
+#include "global.h"
+#include "test_battle.h"
+
+ASSUMPTIONS
+{
+    ASSUME(gBattleMoves[MOVE_WATER_GUN].split == SPLIT_SPECIAL);
+}
+
+SINGLE_BATTLE_TEST("Vessel of Ruin reduces Sp. Atk", s16 damage)
+{
+    u32 ability;
+
+    PARAMETRIZE { ability = ABILITY_SHADOW_TAG; }
+    PARAMETRIZE { ability = ABILITY_VESSEL_OF_RUIN; }
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Ability(ability); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_WATER_GUN); }
+    } SCENE {
+        if (ability == ABILITY_VESSEL_OF_RUIN) {
+            ABILITY_POPUP(player, ABILITY_VESSEL_OF_RUIN);
+            MESSAGE("Wobbuffet's Vessel of Ruin weakened the Sp. Atk of all surrounding Pokémon!");
+        }
+        HP_BAR(player, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(0.75), results[1].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Vessel of Ruin does not reduce Sp. Atk if opposing mon has the same ability", s16 damage)
+{
+    u32 ability;
+
+    PARAMETRIZE { ability = ABILITY_SHADOW_TAG; }
+    PARAMETRIZE { ability = ABILITY_VESSEL_OF_RUIN; }
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Ability(ability); }
+        OPPONENT(SPECIES_WOBBUFFET) { Ability(ABILITY_VESSEL_OF_RUIN); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_WATER_GUN); }
+    } SCENE {
+        if (ability == ABILITY_VESSEL_OF_RUIN) {
+            ABILITY_POPUP(player, ABILITY_VESSEL_OF_RUIN);
+            MESSAGE("Wobbuffet's Vessel of Ruin weakened the Sp. Atk of all surrounding Pokémon!");
+        }
+        HP_BAR(player, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_EQ(results[0].damage, results[1].damage);
+    }
+}


### PR DESCRIPTION
Damage Calcs were wrong for these four abilities.
```
ABILITY_VESSEL_OF_RUIN
ABILITY_SWORD_OF_RUIN
ABILITY_TABLETS_OF_RUIN
ABILITY_BEADS_OF_RUIN
```