### PR TITLE
Fixed Trainer class ball not assigned to second Pokémon

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -1964,7 +1964,6 @@ u8 CreateNPCTrainerPartyFromTrainer(struct Pokemon *party, const struct Trainer 
     u8 fixedIV;
     s32 i, j;
     u8 monsCount;
-    s32 ball = -1;
     if (battleTypeFlags & BATTLE_TYPE_TRAINER && !(battleTypeFlags & (BATTLE_TYPE_FRONTIER
                                                                         | BATTLE_TYPE_EREADER_TRAINER
                                                                         | BATTLE_TYPE_TRAINER_HILL)))
@@ -1986,6 +1985,7 @@ u8 CreateNPCTrainerPartyFromTrainer(struct Pokemon *party, const struct Trainer 
 
         for (i = 0; i < monsCount; i++)
         {
+            s32 ball = -1;
             u32 personalityHash = GeneratePartyHash(trainer, i);
             if (trainer->doubleBattle == TRUE)
                 personalityValue = 0x80;


### PR DESCRIPTION
## Description
Fixed the bug in the Trainer class ball feature as discussed in Discord by moving the ball variable inside of the party loop. Thanks to AsparagusEduardo for the fix =)

## Issue(s) that this PR fixes
Fixes #3057 

## **Discord contact info**
subzeroeclipse