### PR TITLE
Fixed redundant calls in Teleport's battle script

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -5399,15 +5399,15 @@ BattleScript_EffectHurricane:
 	goto BattleScript_EffectHit
 
 BattleScript_EffectTeleport:
-	attackcanceler
-	attackstring
 .if B_TELEPORT_BEHAVIOR >= GEN_7
 	jumpifbattletype BATTLE_TYPE_TRAINER, BattleScript_EffectBatonPass
 	jumpifside BS_ATTACKER, B_SIDE_PLAYER, BattleScript_EffectBatonPass
 .else
-	jumpifbattletype BATTLE_TYPE_TRAINER, BattleScript_ButItFailed
+	jumpifbattletype BATTLE_TYPE_TRAINER, BattleScript_ButItFailedAtkCanceler
 .endif
 BattleScript_EffectTeleportTryToRunAway:
+	attackcanceler
+	attackstring
 	ppreduce
 	getifcantrunfrombattle BS_ATTACKER
 	jumpifbyte CMP_EQUAL, gBattleCommunication, BATTLE_RUN_FORBIDDEN, BattleScript_ButItFailed
@@ -5544,6 +5544,8 @@ BattleScript_EffectFakeOut::
 	setmoveeffect MOVE_EFFECT_FLINCH
 	goto BattleScript_EffectHit
 
+BattleScript_ButItFailedAtkCanceler::
+	attackcanceler
 BattleScript_ButItFailedAtkStringPpReduce::
 	attackstring
 BattleScript_ButItFailedPpReduce::

--- a/include/battle_scripts.h
+++ b/include/battle_scripts.h
@@ -471,6 +471,7 @@ extern const u8 BattleScript_StealthRockActivates[];
 extern const u8 BattleScript_SpikesActivates[];
 extern const u8 BattleScript_BerserkGeneRet[];
 extern const u8 BattleScript_TargetFormChangeWithStringNoPopup[];
+extern const u8 BattleScript_ButItFailedAtkCanceler[];
 
 // zmoves
 extern const u8 BattleScript_ZMoveActivateDamaging[];


### PR DESCRIPTION
## Description
`BattleScript_EffectTeleport` always calls `attackcanceler` and `attackstring`, but then it jumps to `BattleScript_EffectBatonPass` under certain conditions, when that battle script calls them too.
This PR addresses that by relocating those `attackcanceler` and `attackstring` calls and adding a new battle script to jump to during trainer battles.

## **Discord contact info**
Lunos#4026