### PR TITLE
Initialize save to empty in test runner

### DIFF
--- a/test/test_runner.c
+++ b/test/test_runner.c
@@ -2,6 +2,7 @@
 #include "global.h"
 #include "characters.h"
 #include "gpu_regs.h"
+#include "load_save.h"
 #include "main.h"
 #include "malloc.h"
 #include "random.h"
@@ -113,6 +114,10 @@ void CB2_TestRunner(void)
             gTestRunnerState.exitCode = 2;
             return;
         }
+
+        MoveSaveBlocks_ResetHeap();
+        ClearSav1();
+        ClearSav2();
 
         gIntrTable[7] = Intr_Timer2;
 


### PR DESCRIPTION
Needs confirmation from @pkmnsnfrn, but hopefully this should fix their problems with some of the flags appearing to be set.

The issue seems to be that `gSaveBlock1Ptr` was `NULL`, so reading the flags gets garbage.

Closes #3214 