### PR TITLE
Add missing absorbing abilities to FindMonThatAbsorbsOpponentsMove

### DIFF
--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -142,11 +142,12 @@ static bool8 ShouldSwitchIfWonderGuard(void)
 static bool8 FindMonThatAbsorbsOpponentsMove(void)
 {
     u8 battlerIn1, battlerIn2;
-    u16 absorbingTypeAbility;
+    u8 numAbsorbingAbilities = 0; 
+    u16 absorbingTypeAbilities[3]; // Array size is maximum number of absorbing abilities for a single type
     s32 firstId;
     s32 lastId; // + 1
     struct Pokemon *party;
-    s32 i;
+    s32 i, j;
 
     if (HasSuperEffectiveMoveAgainstOpponents(TRUE) && Random() % 3 != 0)
         return FALSE;
@@ -171,19 +172,40 @@ static bool8 FindMonThatAbsorbsOpponentsMove(void)
         battlerIn2 = gActiveBattler;
     }
 
+    // Create an array of possible absorb abilities so the AI considers all of them
     if (gBattleMoves[gLastLandedMoves[gActiveBattler]].type == TYPE_FIRE)
-        absorbingTypeAbility = ABILITY_FLASH_FIRE;
+    {
+        absorbingTypeAbilities[0] = ABILITY_FLASH_FIRE;
+        numAbsorbingAbilities = 1;
+    }
     else if (gBattleMoves[gLastLandedMoves[gActiveBattler]].type == TYPE_WATER)
-        absorbingTypeAbility = ABILITY_WATER_ABSORB;
+    {
+        absorbingTypeAbilities[0] = ABILITY_WATER_ABSORB;
+        absorbingTypeAbilities[1] = ABILITY_STORM_DRAIN;
+        absorbingTypeAbilities[2] = ABILITY_DRY_SKIN;
+        numAbsorbingAbilities = 3;
+    }
     else if (gBattleMoves[gLastLandedMoves[gActiveBattler]].type == TYPE_ELECTRIC)
-        absorbingTypeAbility = ABILITY_VOLT_ABSORB;
+    {
+        absorbingTypeAbilities[0] = ABILITY_VOLT_ABSORB;
+        absorbingTypeAbilities[1] = ABILITY_MOTOR_DRIVE;
+        absorbingTypeAbilities[2] = ABILITY_LIGHTNING_ROD;
+        numAbsorbingAbilities = 3;
+    }
     else if (gBattleMoves[gLastLandedMoves[gActiveBattler]].type == TYPE_GRASS)
-        absorbingTypeAbility = ABILITY_SAP_SIPPER;
+    {
+        absorbingTypeAbilities[0] = ABILITY_SAP_SIPPER;
+        numAbsorbingAbilities = 1;
+    }
     else
         return FALSE;
 
-    if (AI_DATA->abilities[gActiveBattler] == absorbingTypeAbility)
+    // Check current mon for all absorbing abilities
+    for (i = 0; i < numAbsorbingAbilities; i++)
+    {
+        if (AI_DATA->abilities[gActiveBattler] == absorbingTypeAbilities[i])
         return FALSE;
+    }
 
     GetAIPartyIndexes(gActiveBattler, &firstId, &lastId);
 
@@ -210,18 +232,18 @@ static bool8 FindMonThatAbsorbsOpponentsMove(void)
             continue;
 
         monAbility = GetMonAbility(&party[i]);
-        if (absorbingTypeAbility == monAbility
-        || (absorbingTypeAbility == ABILITY_WATER_ABSORB && (monAbility == ABILITY_STORM_DRAIN || monAbility == ABILITY_DRY_SKIN))
-        || (absorbingTypeAbility == ABILITY_VOLT_ABSORB && (monAbility == ABILITY_MOTOR_DRIVE || monAbility == ABILITY_LIGHTNING_ROD))
-        )
+
+        for (j = 0; j < numAbsorbingAbilities; j++)
         {
-            // we found a mon.
-            *(gBattleStruct->AI_monToSwitchIntoId + gActiveBattler) = i;
-            BtlController_EmitTwoReturnValues(BUFFER_B, B_ACTION_SWITCH, 0);
-            return TRUE;
+            if (absorbingTypeAbilities[j] == monAbility && Random() & 1)
+            {
+                // we found a mon.
+                *(gBattleStruct->AI_monToSwitchIntoId + gActiveBattler) = i;
+                BtlController_EmitTwoReturnValues(1, B_ACTION_SWITCH, 0);
+                return TRUE;
+            }
         }
     }
-
     return FALSE;
 }
 

--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -177,6 +177,8 @@ static bool8 FindMonThatAbsorbsOpponentsMove(void)
         absorbingTypeAbility = ABILITY_WATER_ABSORB;
     else if (gBattleMoves[gLastLandedMoves[gActiveBattler]].type == TYPE_ELECTRIC)
         absorbingTypeAbility = ABILITY_VOLT_ABSORB;
+    else if (gBattleMoves[gLastLandedMoves[gActiveBattler]].type == TYPE_GRASS)
+        absorbingTypeAbility = ABILITY_SAP_SIPPER;
     else
         return FALSE;
 
@@ -208,7 +210,10 @@ static bool8 FindMonThatAbsorbsOpponentsMove(void)
             continue;
 
         monAbility = GetMonAbility(&party[i]);
-        if (absorbingTypeAbility == monAbility && Random() & 1)
+        if (absorbingTypeAbility == monAbility
+        || (absorbingTypeAbility == ABILITY_WATER_ABSORB && (monAbility == ABILITY_STORM_DRAIN || monAbility == ABILITY_DRY_SKIN))
+        || (absorbingTypeAbility == ABILITY_VOLT_ABSORB && (monAbility == ABILITY_MOTOR_DRIVE || monAbility == ABILITY_LIGHTNING_ROD))
+        )
         {
             // we found a mon.
             *(gBattleStruct->AI_monToSwitchIntoId + gActiveBattler) = i;

--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -198,13 +198,15 @@ static bool8 FindMonThatAbsorbsOpponentsMove(void)
         numAbsorbingAbilities = 1;
     }
     else
+    {
         return FALSE;
+    }
 
     // Check current mon for all absorbing abilities
     for (i = 0; i < numAbsorbingAbilities; i++)
     {
         if (AI_DATA->abilities[gActiveBattler] == absorbingTypeAbilities[i])
-        return FALSE;
+            return FALSE;
     }
 
     GetAIPartyIndexes(gActiveBattler, &firstId, &lastId);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds consideration for Sap Sipper, Storm Drain, Dry Skin, Motor Drive, and Lightning Rod to the `FindMonThatAbsorbsOpponentsMove` function, which is called by the ShouldSwitch function and affects the switch AI.

This works fine for Flash Fire, Water Absorb, and Volt Absorb by default, just adding the missing abilities. This was initially brought up by EZBREEZY on [Discord](https://discord.com/channels/419213663107416084/1077168246555430962/1138553428755349624), and Alex suggested I PR it.

## **Discord contact info**
Pawkkie