### PR TITLE
Remove soundMove from Steam Eruption and replace it with sheerForceBoost

### DIFF
--- a/src/data/battle_moves.h
+++ b/src/data/battle_moves.h
@@ -9942,7 +9942,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_Z] =
         .priority = 0,
         .split = SPLIT_SPECIAL,
         .zMoveEffect = Z_EFFECT_NONE,
-        .soundMove = TRUE,
+        .sheerForceBoost = TRUE,
         .thawsUser = TRUE,
         .metronomeBanned = TRUE,
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail --> Steam Eruption had `soundMove`  instead of `sheerForceBoost`.
This PR fixes that very small issue.

## **Discord contact info**
<!--- formatted as name#numbers, e.g. Lunos#4026 --> pcg06
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->