### PR TITLE
Made Cmd_jumpifnopursuitswitchdmg and Cmd_pursuitdoubles use Pursuit's effect ID instead of its move ID

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -15073,10 +15073,10 @@ static void Cmd_pursuitdoubles(void)
     if (gBattleTypeFlags & BATTLE_TYPE_DOUBLE
         && !(gAbsentBattlerFlags & gBitTable[gActiveBattler])
         && gChosenActionByBattler[gActiveBattler] == B_ACTION_USE_MOVE
-        && gChosenMoveByBattler[gActiveBattler] == MOVE_PURSUIT)
+        && gBattleMoves[gChosenMoveByBattler[gActiveBattler]].effect == EFFECT_PURSUIT)
     {
         gActionsByTurnOrder[gActiveBattler] = B_ACTION_TRY_FINISH;
-        gCurrentMove = MOVE_PURSUIT;
+        gCurrentMove = gChosenMoveByBattler[gActiveBattler];
         gBattlescriptCurrInstr = cmd->nextInstr;
         gBattleScripting.animTurn = 1;
         gBattleScripting.savedBattler = gBattlerAttacker;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -13643,7 +13643,7 @@ static void Cmd_jumpifnopursuitswitchdmg(void)
         && !(gBattleMons[gBattlerTarget].status1 & (STATUS1_SLEEP | STATUS1_FREEZE))
         && gBattleMons[gBattlerAttacker].hp
         && !gDisableStructs[gBattlerTarget].truantCounter
-        && gChosenMoveByBattler[gBattlerTarget] == MOVE_PURSUIT)
+        && gBattleMoves[gChosenMoveByBattler[gBattlerTarget]].effect == EFFECT_PURSUIT)
     {
         s32 i;
 
@@ -13653,7 +13653,7 @@ static void Cmd_jumpifnopursuitswitchdmg(void)
                 gActionsByTurnOrder[i] = B_ACTION_TRY_FINISH;
         }
 
-        gCurrentMove = MOVE_PURSUIT;
+        gCurrentMove = gChosenMoveByBattler[gBattlerTarget];
         gCurrMovePos = gChosenMovePos = *(gBattleStruct->chosenMovePositions + gBattlerTarget);
         gBattlescriptCurrInstr = cmd->nextInstr;
         gBattleScripting.animTurn = 1;


### PR DESCRIPTION
## Description
For whatever reason, right now the expansion's `Cmd_jumpifnopursuitswitchdmg` battle script function *(which handles the usage of Pursuit when an opponent is about to switch out their Pokémon)* uses Pursuit's move ID instead of its effect ID.
This is a bit limiting for a user who may very well want to add add copies/clones of Pursuit, as they would have to go there and modify things by themselves.
This PR addresses that by making the function read the effect of Pursuit, which is `EFFECT_PURSUIT`, instead of hardcoding `gCurrentMove` to Pursuit's move ID. That way, any moves that a user may want to add and that also use that same effect besides Pursuit itself can work normally too.

## **Discord contact info**
lunos4026