### PR TITLE
Corrected the conditionals used for B_SPEED_BUFFING_RAPID_SPIN and I_GEM_BOOST_POWER

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -5128,7 +5128,7 @@ BattleScript_EffectBatonPass::
 	goto BattleScript_MoveEnd
 
 BattleScript_EffectRapidSpin::
-.if B_SPEED_BUFFING_RAPID_SPIN == GEN_8
+.if B_SPEED_BUFFING_RAPID_SPIN >= GEN_8
 	attackcanceler
 	accuracycheck BattleScript_PrintMoveMissed, ACC_CURR_MOVE
 	attackstring

--- a/src/data/items.h
+++ b/src/data/items.h
@@ -6,7 +6,7 @@
     #define EVO_HELD_ITEM_FIELD_FUNC ItemUseOutOfBattle_CannotUse
 #endif
 
-#if I_GEM_BOOST_POWER >= GEN_5
+#if I_GEM_BOOST_POWER >= GEN_6
     #define GEM_BOOST_PARAM 30
 #else
     #define GEM_BOOST_PARAM 50


### PR DESCRIPTION
## Description
Alex/rainonline told me in the Discord server that the conditionals we were using for the preproc configs that handle Rapid Spin's speed-raising effect and the power of the Gem items were incorrect.
This PR corrects that.
Rapid Spin can still raise the Speed stat in the Gen. 9 games so using checking if the preproc config was set to `== GEN_8` was incorrect, and the power of the gems started to be 30 on Gen. 6, it was 50 on the Gen. 5 games.

## **Discord contact info**
lunos4026