### PR TITLE
remove duplicate gender switch case

### DIFF
--- a/src/main_menu.c
+++ b/src/main_menu.c
@@ -1505,11 +1505,6 @@ static void Task_NewGameBirchSpeech_ChooseGender(u8 taskId)
     switch (gender)
     {
         case MALE:
-            PlaySE(SE_SELECT);
-            gSaveBlock2Ptr->playerGender = gender;
-            NewGameBirchSpeech_ClearGenderWindow(1, 1);
-            gTasks[taskId].func = Task_NewGameBirchSpeech_WhatsYourName;
-            break;
         case FEMALE:
             PlaySE(SE_SELECT);
             gSaveBlock2Ptr->playerGender = gender;


### PR DESCRIPTION
removes duplicate, code in the gender select switch and lets the case fall through instead
note: cant remove switch entirely due to other possible inputs

## **Discord contact info**
u8-Salem