### PR TITLE
Add female Basculegion to cry table

### DIFF
--- a/sound/cry_tables.inc
+++ b/sound/cry_tables.inc
@@ -2080,6 +2080,8 @@ gCryTable::
 	@ Calyrex
 	cry Cry_CalyrexIceRider
 	cry Cry_CalyrexShadowRider
+	@ Basculegion
+	cry Cry_Basculegion
 .else
 	@ Cramorant
 	cry Cry_Unown
@@ -2117,6 +2119,8 @@ gCryTable::
 	cry Cry_Unown
 	@ Calyrex
 	cry Cry_Unown
+	cry Cry_Unown
+	@ Basculegion
 	cry Cry_Unown
 .endif
 
@@ -4163,7 +4167,10 @@ gCryTable_Reverse::
 	@ Calyrex
 	cry_reverse Cry_CalyrexIceRider
 	cry_reverse Cry_CalyrexShadowRider
+	@ Basculegion
+	cry_reverse Cry_Basculegion
 .else
+	cry_reverse Cry_Unown
 	cry_reverse Cry_Unown
 	cry_reverse Cry_Unown
 	cry_reverse Cry_Unown


### PR DESCRIPTION
For the past 6 months, female Basculegion's cry was missing from the cry table. This meant that if anyone added species or farms after SPECIES_BASCULEGION_FEMALE, the cry indexes would be one off.

## **Discord contact info**
bassoonian