### PR TITLE
[Makefile] make -fanalyzer optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ MAKER_CODE  := 01
 REVISION    := 0
 MODERN      ?= 0
 TEST        ?= 0
+ANALYZE     ?= 0
 
 ifeq (modern,$(MAKECMDGOALS))
   MODERN := 1
@@ -118,7 +119,10 @@ LIBPATH := -L ../../tools/agbcc/lib
 LIB := $(LIBPATH) -lgcc -lc -L../../libagbsyscall -lagbsyscall
 else
 CC1              = $(shell $(PATH_MODERNCC) --print-prog-name=cc1) -quiet
-override CFLAGS += -mthumb -mthumb-interwork -O2 -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -fno-toplevel-reorder -Wno-pointer-to-int-cast -std=gnu17 -fanalyzer
+override CFLAGS += -mthumb -mthumb-interwork -O2 -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -fno-toplevel-reorder -Wno-pointer-to-int-cast -std=gnu17
+ifeq ($(ANALYZE),1)
+override CFLAGS += -fanalyzer
+endif
 ROM := $(MODERN_ROM_NAME)
 OBJ_DIR := $(MODERN_OBJ_DIR_NAME)
 LIBPATH := -L "$(dir $(shell $(PATH_MODERNCC) -mthumb -print-file-name=libgcc.a))" -L "$(dir $(shell $(PATH_MODERNCC) -mthumb -print-file-name=libnosys.a))" -L "$(dir $(shell $(PATH_MODERNCC) -mthumb -print-file-name=libc.a))"


### PR DESCRIPTION
Makes `-fanalyzer` optional when building the `modern` target.

## Description
Compilation is particularly slow when static analysis is performed during code generation. This does not remove the ability to perfrom static analyis, but rather adds a flag `ANALYZE` to manually enable `-fanalyzer` when compiling, e.g.
```
make modern ANALYZE=1
```

## **Discord contact info**
karathan