### PR TITLE
fix GetBattleAnimMoveTargets logic

### DIFF
--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -54,7 +54,8 @@
 
 #define WEATHER_HAS_EFFECT ((!IsAbilityOnField(ABILITY_CLOUD_NINE) && !IsAbilityOnField(ABILITY_AIR_LOCK)))
 
-#define IS_WHOLE_SIDE_ALIVE(battler)((IsBattlerAlive(battler) && IsBattlerAlive(BATTLE_PARTNER(battler))))
+#define IS_WHOLE_SIDE_ALIVE(battler)    ((IsBattlerAlive(battler) && IsBattlerAlive(BATTLE_PARTNER(battler))))
+#define IS_ALIVE_AND_PRESENT(battler)   (IsBattlerAlive(battler) && IsBattlerSpritePresent(battler))
 
 // for Natural Gift and Fling
 struct TypePower

--- a/src/battle_anim.c
+++ b/src/battle_anim.c
@@ -440,30 +440,22 @@ static u8 GetBattleAnimMoveTargets(u8 battlerArgIndex, u8 *targets)
     u32 battler = gBattleAnimArgs[battlerArgIndex];
     switch (GetBattlerMoveTargetType(gBattleAnimAttacker, gAnimMoveIndex))
     {
+    case MOVE_TARGET_FOES_AND_ALLY:
+        if (IS_ALIVE_AND_PRESENT(BATTLE_PARTNER(BATTLE_OPPOSITE(battler)))) {
+            targets[idx++] = BATTLE_PARTNER(BATTLE_OPPOSITE(battler)); 
+            numTargets++;
+        }
+        // fallthrough
     case MOVE_TARGET_BOTH:
-        if (IsBattlerAlive(battler)) {
+        if (IS_ALIVE_AND_PRESENT(battler)) {
             targets[idx++] = battler;
             numTargets++;
         }
         battler = BATTLE_PARTNER(battler);
-        if (IsBattlerAlive(battler)) {
+        if (IS_ALIVE_AND_PRESENT(battler)) {
             targets[idx++] = battler;
             numTargets++;
-        }
-        break;
-    case MOVE_TARGET_FOES_AND_ALLY:
-        if (IsBattlerAlive(battler)) {
-            targets[idx++] = battler;
-            numTargets++;
-        }
-        if (IsBattlerAlive(BATTLE_PARTNER(battler))) {
-            targets[idx++] = BATTLE_PARTNER(battler);
-            numTargets++;
-        }
-        if (IsBattlerAlive(BATTLE_PARTNER(BATTLE_OPPOSITE(battler)))) {
-            targets[idx++] = BATTLE_PARTNER(BATTLE_OPPOSITE(battler)); 
-            numTargets++;
-        }
+        }       
         break;
     default:
         targets[0] = gBattleAnimArgs[battlerArgIndex]; // original

--- a/src/battle_anim.c
+++ b/src/battle_anim.c
@@ -435,30 +435,33 @@ static void Cmd_unloadspritegfx(void)
 
 static u8 GetBattleAnimMoveTargets(u8 battlerArgIndex, u8 *targets)
 {
-    u8 numTargets = 1;
+    u8 numTargets = 0;
+    int idx = 0;
+    u32 battler = gBattleAnimArgs[battlerArgIndex];
     switch (GetBattlerMoveTargetType(gBattleAnimAttacker, gAnimMoveIndex))
     {
     case MOVE_TARGET_BOTH:
-        targets[0] = gBattleAnimArgs[battlerArgIndex];
-        numTargets = 1;
-        if (IsBattlerAlive(BATTLE_PARTNER(targets[0])))
-        {
-            targets[1] = BATTLE_PARTNER(targets[0]);
-            numTargets = 2;
+        if (IsBattlerAlive(battler)) {
+            targets[idx++] = battler;
+            numTargets++;
+        }
+        battler = BATTLE_PARTNER(battler);
+        if (IsBattlerAlive(battler)) {
+            targets[idx++] = battler;
+            numTargets++;
         }
         break;
     case MOVE_TARGET_FOES_AND_ALLY:
-        targets[0] = gBattleAnimArgs[battlerArgIndex];
-        numTargets = 1;
-        if (IsBattlerAlive(BATTLE_PARTNER(targets[0])))
-        {
-            targets[1] = BATTLE_PARTNER(targets[0]);
+        if (IsBattlerAlive(battler)) {
+            targets[idx++] = battler;
             numTargets++;
         }
-
-        if (IsBattlerAlive(BATTLE_PARTNER(BATTLE_OPPOSITE(targets[0]))))
-        {
-            targets[2] = BATTLE_PARTNER(BATTLE_OPPOSITE(targets[0]));
+        if (IsBattlerAlive(BATTLE_PARTNER(battler))) {
+            targets[idx++] = BATTLE_PARTNER(battler);
+            numTargets++;
+        }
+        if (IsBattlerAlive(BATTLE_PARTNER(BATTLE_OPPOSITE(battler)))) {
+            targets[idx++] = BATTLE_PARTNER(BATTLE_OPPOSITE(battler)); 
             numTargets++;
         }
         break;
@@ -551,7 +554,9 @@ static void CreateSpriteOnTargets(const struct SpriteTemplate *template, u8 argV
     subpriority = GetSubpriorityForMoveAnim(argVar);
 
     ntargets = GetBattleAnimMoveTargets(battlerArgIndex, targets);
-
+    if (ntargets == 0)
+        return;
+    
     for (i = 0; i < ntargets; i++) {
 
         if (overwriteAnimTgt)
@@ -676,7 +681,9 @@ static void Cmd_createvisualtaskontargets(void)
     }
 
     numArgs = GetBattleAnimMoveTargets(battlerArgIndex, targets);
-
+    if (numArgs == 0)
+        return;
+    
     for (i = 0; i < numArgs; i++)
     {
         gBattleAnimArgs[battlerArgIndex] = targets[i];


### PR DESCRIPTION
Previously, GetBattleAnimMoveTargets assumed the original target was always viable. This adjusts to target only the alive battlers. It also adds a failsafe check for if there are no viable targets (which shouldnt happen anyway, of course)