### PR TITLE
Fix Z effect descriptions being cut off

### DIFF
--- a/src/battle_bg.c
+++ b/src/battle_bg.c
@@ -204,7 +204,7 @@ static const struct WindowTemplate sStandardBattleWindowTemplates[] =
         .bg = 0,
         .tilemapLeft = 2,
         .tilemapTop = 57,
-        .width = 8,
+        .width = 16,    //for z effect descriptions
         .height = 2,
         .paletteNum = 5,
         .baseBlock = 0x0328,
@@ -216,7 +216,7 @@ static const struct WindowTemplate sStandardBattleWindowTemplates[] =
         .width = 8,
         .height = 2,
         .paletteNum = 5,
-        .baseBlock = 0x0338,
+        .baseBlock = 0x0340,
     },
     [B_WIN_PP] = {
         .bg = 0,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The text describing Z status moves in battle is cut off when it exceeds a tile width of 8. The description in the first image below should say "Reset Lowered Stats" as per `battle_z_move.c`.
The reason for the cutoff is that the `B_WIN_MOVE_NAME_3` window template only has a width of 8. This PR extends it to 16 as per the change to `B_WIN_MOVE_NAME_1` to accommodate Z move names.

## Images
<!-- Please provide with relevant GIFs or images to make it easier for reviewers to accept your PR quicker.-->
<!-- If it doesn't apply, feel free to remove this section. -->
Before
![pokeemerald-0](https://github.com/rh-hideout/pokeemerald-expansion/assets/6616877/b9807fdf-1960-432a-bcda-7140118f1f69)
After
![pokeemerald-1](https://github.com/rh-hideout/pokeemerald-expansion/assets/6616877/d99ce829-0441-4608-a9e1-b92d32026cd6)

## **Discord contact info**
<!--- formatted as name#numbers, e.g. Lunos#4026 -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
`gamebriel#4784`