### PR TITLE
Callnative functions take ScriptContext argument

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -1807,7 +1807,7 @@ static void DebugAction_Util_PoisonMons(u8 taskId)
     PlaySE(SE_FIELD_POISON);
 }
 
-void CheckSaveBlock1Size(void)
+void CheckSaveBlock1Size(struct ScriptContext *ctx)
 {
     u32 currSb1Size = sizeof(struct SaveBlock1);
     u32 maxSb1Size = SECTOR_DATA_SIZE * (SECTOR_ID_SAVEBLOCK1_END - SECTOR_ID_SAVEBLOCK1_START + 1);
@@ -1815,7 +1815,7 @@ void CheckSaveBlock1Size(void)
     ConvertIntToDecimalStringN(gStringVar2, maxSb1Size, STR_CONV_MODE_LEFT_ALIGN, 6);
 }
 
-void CheckSaveBlock2Size(void)
+void CheckSaveBlock2Size(struct ScriptContext *ctx)
 {
     u32 currSb2Size = (sizeof(struct SaveBlock2));
     u32 maxSb2Size = SECTOR_DATA_SIZE;
@@ -1823,7 +1823,7 @@ void CheckSaveBlock2Size(void)
     ConvertIntToDecimalStringN(gStringVar2, maxSb2Size, STR_CONV_MODE_LEFT_ALIGN, 6);
 }
 
-void CheckPokemonStorageSize(void)
+void CheckPokemonStorageSize(struct ScriptContext *ctx)
 {
     u32 currPkmnStorageSize = sizeof(struct PokemonStorage);
     u32 maxPkmnStorageSize = SECTOR_DATA_SIZE * (SECTOR_ID_PKMN_STORAGE_END - SECTOR_ID_PKMN_STORAGE_START + 1);

--- a/src/item_use.c
+++ b/src/item_use.c
@@ -914,7 +914,7 @@ static void Task_UseRepel(u8 taskId)
             DisplayItemMessageInBattlePyramid(taskId, gStringVar4, Task_CloseBattlePyramidBagMessage);
     }
 }
-void HandleUseExpiredRepel(void)
+void HandleUseExpiredRepel(struct ScriptContext *ctx)
 {
 #if VAR_LAST_REPEL_LURE_USED != 0
     VarSet(VAR_REPEL_STEP_COUNT, ItemId_GetHoldEffectParam(VarGet(VAR_LAST_REPEL_LURE_USED)));
@@ -959,7 +959,7 @@ static void Task_UseLure(u8 taskId)
     }
 }
 
-void HandleUseExpiredLure(void)
+void HandleUseExpiredLure(struct ScriptContext *ctx)
 {
 #if VAR_LAST_REPEL_LURE_USED != 0
     VarSet(VAR_REPEL_STEP_COUNT, ItemId_GetHoldEffectParam(VarGet(VAR_LAST_REPEL_LURE_USED)) | REPEL_LURE_MASK);

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -51,7 +51,7 @@
 #include "constants/event_objects.h"
 
 typedef u16 (*SpecialFunc)(void);
-typedef void (*NativeFunc)(void);
+typedef void (*NativeFunc)(struct ScriptContext *ctx);
 
 EWRAM_DATA const u8 *gRamScriptRetAddr = NULL;
 static EWRAM_DATA u32 sAddressOffset = 0; // For relative addressing in vgoto etc., used by saved scripts (e.g. Mystery Event)
@@ -136,7 +136,7 @@ bool8 ScrCmd_callnative(struct ScriptContext *ctx)
 {
     NativeFunc func = (NativeFunc)ScriptReadWord(ctx);
 
-    func();
+    func(ctx);
     return FALSE;
 }
 

--- a/src/script_menu.c
+++ b/src/script_menu.c
@@ -118,7 +118,7 @@ static void DrawMultichoiceMenu(u8 left, u8 top, u8 multichoiceId, bool8 ignoreB
 }
 
 #if I_REPEL_LURE_MENU == TRUE
-void TryDrawRepelMenu(void)
+void TryDrawRepelMenu(struct ScriptContext *ctx)
 {
     static const u16 repelItems[] = {ITEM_REPEL, ITEM_SUPER_REPEL, ITEM_MAX_REPEL};
     struct MenuAction menuItems[ARRAY_COUNT(repelItems) + 1] = {NULL};
@@ -144,7 +144,7 @@ void TryDrawRepelMenu(void)
     gSpecialVar_Result = (count > 1);
 }
 
-void HandleRepelMenuChoice(void)
+void HandleRepelMenuChoice(struct ScriptContext *ctx)
 {
     gSpecialVar_0x8004 = VarGet(VAR_0x8004 + gSpecialVar_Result); // Get item Id;
     VarSet(VAR_REPEL_STEP_COUNT, ItemId_GetHoldEffectParam(gSpecialVar_0x8004));
@@ -153,7 +153,7 @@ void HandleRepelMenuChoice(void)
 #endif
 }
 
-void TryDrawLureMenu(void)
+void TryDrawLureMenu(struct ScriptContext *ctx)
 {
     static const u16 lureItems[] = {ITEM_LURE, ITEM_SUPER_LURE, ITEM_MAX_LURE};
     struct MenuAction menuItems[ARRAY_COUNT(lureItems) + 1] = {NULL};
@@ -180,7 +180,7 @@ void TryDrawLureMenu(void)
     gSpecialVar_Result = (count > 1);
 }
 
-void HandleLureMenuChoice(void)
+void HandleLureMenuChoice(struct ScriptContext *ctx)
 {
     gSpecialVar_0x8004 = VarGet(VAR_0x8004 + gSpecialVar_Result); // Get item Id;
     VarSet(VAR_REPEL_STEP_COUNT, ItemId_GetHoldEffectParam(gSpecialVar_0x8004) | REPEL_LURE_MASK);


### PR DESCRIPTION
Adds a `struct ScriptContext` argument to `NativeFunc` to allow more convenient scripting with `callnative`. We can make macros similar to battle scripts with .byte fields afterwards and use those in our callnative function

e.g.
```
.macro gettilebehaviorat x:req, y:req
    callnative NativeFunc_gettilebehaviorat
    .2byte \x
    .2byte \y
 .endm

void NativeFunc_gettilebehaviorat(struct ScriptContext *ctx)
{
    u16 x    = VarGet(ScriptReadHalfword(ctx));
    u16 y    = VarGet(ScriptReadHalfword(ctx));

    gSpecialVar_Result = MapGridGetMetatileBehaviorAt(x + MAP_OFFSET, y + MAP_OFFSET);
}
```