### PR TITLE
Add ai delay timer

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -679,6 +679,8 @@ struct BattleStruct
     bool8 trainerSlideMegaEvolutionMsgDone;
     bool8 trainerSlideZMoveMsgDone;
     bool8 trainerSlideBeforeFirstTurnMsgDone;
+    u32 aiDelayTimer; // Counts number of frames AI takes to choose an action.
+    u32 aiDelayFrames; // Number of frames it took to choose an action.
 };
 
 // The palaceFlags member of struct BattleStruct contains 1 flag per move to indicate which moves the AI should consider,

--- a/include/battle_ai_main.h
+++ b/include/battle_ai_main.h
@@ -27,7 +27,7 @@ u8 BattleAI_ChooseMoveOrAction(void);
 void Ai_InitPartyStruct(void);
 void Ai_UpdateSwitchInData(u32 battler);
 void Ai_UpdateFaintData(u32 battler);
-void GetAiLogicData(void);
+void SetAiLogicDataForTurn(void);
 
 extern u8 sBattler_AI;
 

--- a/include/config/debug.h
+++ b/include/config/debug.h
@@ -9,6 +9,7 @@
 
 // Battle Debug Menu
 #define DEBUG_BATTLE_MENU               TRUE    // If set to TRUE, enables a debug menu to use in battles by pressing the Select button.
+#define DEBUG_AI_DELAY_TIMER            FALSE   // If set to TRUE, displays the number of frames it takes for the AI to choose a move. Replaces the "What will PKMN do" text. Useful for devs or anyone who modifies the AI code and wants to see if it doesn't take too long to run.
 
 // Pokémon Debug
 #define DEBUG_POKEMON_MENU              TRUE    // Enables a debug menu for pokemon sprites and icons, accessed by pressing SELECT in the summary screen.

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -353,11 +353,12 @@ void SetAiLogicDataForTurn(void)
     u8 effectiveness;
     s32 dmg;
 
-    gBattleStruct->aiDelayTimer = gMain.vblankCounter1;
     memset(AI_DATA, 0, sizeof(struct AiLogicData));
 
     if (!(gBattleTypeFlags & BATTLE_TYPE_HAS_AI) && !IsWildMonSmart())
         return;
+
+    gBattleStruct->aiDelayTimer = gMain.vblankCounter1;
 
     // get/assume all battler data
     for (i = 0; i < gBattlersCount; i++)

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -1,4 +1,5 @@
 #include "global.h"
+#include "main.h"
 #include "malloc.h"
 #include "battle.h"
 #include "battle_anim.h"
@@ -335,7 +336,7 @@ void Ai_UpdateFaintData(u32 battler)
     aiMon->isFainted = TRUE;
 }
 
-static void SetBattlerAiData(u8 battler)
+static void SetBattlerAiData(u32 battler)
 {
     AI_DATA->abilities[battler] = AI_GetAbility(battler);
     AI_DATA->items[battler] = gBattleMons[battler].item;
@@ -346,12 +347,13 @@ static void SetBattlerAiData(u8 battler)
     AI_DATA->moveLimitations[battler] = CheckMoveLimitations(battler, 0, MOVE_LIMITATIONS_ALL);
 }
 
-void GetAiLogicData(void)
+void SetAiLogicDataForTurn(void)
 {
     u32 battlerAtk, battlerDef, i, move;
     u8 effectiveness;
     s32 dmg;
 
+    gBattleStruct->aiDelayTimer = gMain.vblankCounter1;
     memset(AI_DATA, 0, sizeof(struct AiLogicData));
 
     if (!(gBattleTypeFlags & BATTLE_TYPE_HAS_AI) && !IsWildMonSmart())

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -1889,6 +1889,19 @@ static void HandleChooseActionAfterDma3(u32 battler)
     {
         gBattle_BG0_X = 0;
         gBattle_BG0_Y = DISPLAY_HEIGHT;
+        if (gBattleStruct->aiDelayTimer != 0)
+        {
+            gBattleStruct->aiDelayFrames = gMain.vblankCounter1 - gBattleStruct->aiDelayTimer;
+            gBattleStruct->aiDelayTimer = 0;
+            #if DEBUG_AI_DELAY_TIMER
+            {
+                static const u8 sText_AIDelay[] = _("AI delay:\n{B_BUFF1} frames");
+                PREPARE_HWORD_NUMBER_BUFFER(gBattleTextBuff1, 3, gBattleStruct->aiDelayFrames);
+                BattleStringExpandPlaceholdersToDisplayedString(sText_AIDelay);
+                BattlePutTextOnWindow(gDisplayedStringBattle, B_WIN_ACTION_PROMPT);
+            }
+            #endif // DEBUG_AI_DELAY_TIMER
+        }
         gBattlerControllerFuncs[battler] = HandleInputChooseAction;
     }
 }

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3724,7 +3724,7 @@ static void DoBattleIntro(void)
             gBattleStruct->switchInAbilitiesCounter = 0;
             gBattleStruct->switchInItemsCounter = 0;
             gBattleStruct->overworldWeatherDone = FALSE;
-            GetAiLogicData(); // get assumed abilities, hold effects, etc of all battlers
+            SetAiLogicDataForTurn(); // get assumed abilities, hold effects, etc of all battlers
             Ai_InitPartyStruct(); // Save mons party counts, and first 2/4 mons on the battlefield.
             gBattleMainFunc = TryDoEventsBeforeFirstTurn;
         }
@@ -3857,7 +3857,7 @@ static void TryDoEventsBeforeFirstTurn(void)
 
     gRandomTurnNumber = Random();
 
-    GetAiLogicData(); // get assumed abilities, hold effects, etc of all battlers
+    SetAiLogicDataForTurn(); // get assumed abilities, hold effects, etc of all battlers
 
     if (gBattleTypeFlags & BATTLE_TYPE_ARENA)
     {
@@ -3949,7 +3949,7 @@ void BattleTurnPassed(void)
 
     *(&gBattleStruct->absentBattlerFlags) = gAbsentBattlerFlags;
     BattlePutTextOnWindow(gText_EmptyString3, B_WIN_MSG);
-    GetAiLogicData(); // get assumed abilities, hold effects, etc of all battlers
+    SetAiLogicDataForTurn(); // get assumed abilities, hold effects, etc of all battlers
     gBattleMainFunc = HandleTurnActionSelectionState;
     gRandomTurnNumber = Random();
 


### PR DESCRIPTION
Adds a timer which counts how long it takes for the AI to decide which action and move to choose.
The number of frames will be displayed in the battle box replacing the "What will PKMN do" text.
Uses new config define DEBUG_AI_DELAY_TIMER

I also changed GetAiLogicData function's name to SetAiLogicDataForTurn, because it made more sense to me, but I can revert it or change to something else if needed.

Current benchmarks on upcoming are:
- 11 frames when choosing a move
- 48 frames when AI switches(note it may actually be closer to 30 or 50 depending on how many pokemon the AI party has). It takes too long, and the lag is way too noticeable, it'll be fixed in #3253
- 45 frames in a double battle
When building with modern these all take less frames(which is all the more reason to ditch agbcc)
![upcoming_single](https://github.com/rh-hideout/pokeemerald-expansion/assets/16259973/d8950e7b-31cc-4354-ab96-bad3a017488e)
![pokeemerald_modern_02](https://github.com/rh-hideout/pokeemerald-expansion/assets/16259973/6da42ed9-a381-43d9-af83-badc9c40d2c1)
![upcoming_double](https://github.com/rh-hideout/pokeemerald-expansion/assets/16259973/809d5146-d089-449c-b4e2-cb651b2f0216)
![modern_upcoming_double](https://github.com/rh-hideout/pokeemerald-expansion/assets/16259973/bedf7ca8-b70e-4bb6-9280-220edd388343)
![upcoming_single_switch](https://github.com/rh-hideout/pokeemerald-expansion/assets/16259973/078ff5a0-f67d-4dfc-92a5-821dcca819bb)
![modern_upcoming_single_switch](https://github.com/rh-hideout/pokeemerald-expansion/assets/16259973/042348be-dd65-41f8-930e-549d081e740e)
