### PR TITLE
Fix tests breaking on modern

### DIFF
--- a/include/test/battle.h
+++ b/include/test/battle.h
@@ -837,7 +837,12 @@ void SendOut(u32 sourceLine, struct BattlePokemon *, u32 partyIndex);
 #define ABILITY_POPUP(battler, ...) QueueAbility(__LINE__, battler, (struct AbilityEventContext) { __VA_ARGS__ })
 #define ANIMATION(type, id, ...) QueueAnimation(__LINE__, type, id, (struct AnimationEventContext) { __VA_ARGS__ })
 #define HP_BAR(battler, ...) QueueHP(__LINE__, battler, (struct HPEventContext) { APPEND_TRUE(__VA_ARGS__) })
-#define MESSAGE(pattern) QueueMessage(__LINE__, (const u8 []) _(pattern))
+// Static const is needed to make the modern compiler put the pattern variable in the .rodata section, instead of putting it on stack(which can break the game).
+#define MESSAGE(pattern)                \
+{                                       \
+    static const u8 msg[] = _(pattern); \
+    QueueMessage(__LINE__, msg);        \
+}
 #define STATUS_ICON(battler, status) QueueStatus(__LINE__, battler, (struct StatusEventContext) { status })
 
 enum QueueGroupType

--- a/include/test/battle.h
+++ b/include/test/battle.h
@@ -838,11 +838,7 @@ void SendOut(u32 sourceLine, struct BattlePokemon *, u32 partyIndex);
 #define ANIMATION(type, id, ...) QueueAnimation(__LINE__, type, id, (struct AnimationEventContext) { __VA_ARGS__ })
 #define HP_BAR(battler, ...) QueueHP(__LINE__, battler, (struct HPEventContext) { APPEND_TRUE(__VA_ARGS__) })
 // Static const is needed to make the modern compiler put the pattern variable in the .rodata section, instead of putting it on stack(which can break the game).
-#define MESSAGE(pattern)                \
-{                                       \
-    static const u8 msg[] = _(pattern); \
-    QueueMessage(__LINE__, msg);        \
-}
+#define MESSAGE(pattern) do {static const u8 msg[] = _(pattern); QueueMessage(__LINE__, msg);} while (0)
 #define STATUS_ICON(battler, status) QueueStatus(__LINE__, battler, (struct StatusEventContext) { status })
 
 enum QueueGroupType

--- a/ld_script_test.txt
+++ b/ld_script_test.txt
@@ -111,7 +111,7 @@ SECTIONS {
         test/*.o(.tests);
         __stop_tests = .;
         test/*.o(.text);
-        test/*.o(.rodata);
+        test/*.o(.rodata*);
     } =0
 
     /* DWARF debug sections.

--- a/ld_script_test.txt
+++ b/ld_script_test.txt
@@ -84,9 +84,9 @@ SECTIONS {
     .rodata :
     ALIGN(4)
     {
-        src/*.o(.rodata);
-        gflib/*.o(.rodata);
-        data/*.o(.rodata);
+        src/*.o(.rodata*);
+        gflib/*.o(.rodata*);
+        data/*.o(.rodata*);
     } =0
 
     song_data :

--- a/test/battle/move_effect/stockpile.c
+++ b/test/battle/move_effect/stockpile.c
@@ -48,11 +48,10 @@ SINGLE_BATTLE_TEST("Spit Up and Swallow don't work if used without Stockpile")
         TURN { MOVE(player, move); }
     } SCENE {
         NOT ANIMATION(ANIM_TYPE_MOVE, move, player);
-        if (move == MOVE_SWALLOW) {
+        if (move == MOVE_SWALLOW)
             MESSAGE("But it failed to swallow a thing!");
-        } else {
+        else
             MESSAGE("But it failed to spit up a thing!");
-        }
 
         ANIMATION(ANIM_TYPE_MOVE, MOVE_STOCKPILE, player);
         MESSAGE("Wobbuffet stockpiled 1!");
@@ -60,7 +59,8 @@ SINGLE_BATTLE_TEST("Spit Up and Swallow don't work if used without Stockpile")
         ANIMATION(ANIM_TYPE_MOVE, move, player);
         if (move == MOVE_SPIT_UP) {
             HP_BAR(opponent);
-        } else {
+        }
+        else {
             HP_BAR(player);
         }
     }
@@ -250,4 +250,3 @@ DOUBLE_BATTLE_TEST("Stockpile's Def and Sp. Def boost is lost after using Spit U
         EXPECT_MUL_EQ(results[2].dmgSpecialBefore,  UQ_4_12(1.0), results[2].dmgSpecialAfter);
     }
 }
-

--- a/test/battle/move_effect/stockpile.c
+++ b/test/battle/move_effect/stockpile.c
@@ -48,10 +48,11 @@ SINGLE_BATTLE_TEST("Spit Up and Swallow don't work if used without Stockpile")
         TURN { MOVE(player, move); }
     } SCENE {
         NOT ANIMATION(ANIM_TYPE_MOVE, move, player);
-        if (move == MOVE_SWALLOW)
+        if (move == MOVE_SWALLOW) {
             MESSAGE("But it failed to swallow a thing!");
-        else
+        } else {
             MESSAGE("But it failed to spit up a thing!");
+        }
 
         ANIMATION(ANIM_TYPE_MOVE, MOVE_STOCKPILE, player);
         MESSAGE("Wobbuffet stockpiled 1!");
@@ -59,8 +60,7 @@ SINGLE_BATTLE_TEST("Spit Up and Swallow don't work if used without Stockpile")
         ANIMATION(ANIM_TYPE_MOVE, move, player);
         if (move == MOVE_SPIT_UP) {
             HP_BAR(opponent);
-        }
-        else {
+        } else {
             HP_BAR(player);
         }
     }


### PR DESCRIPTION
Title.

As per Discord discussion.

```C
#define MESSAGE(pattern) QueueMessage(__LINE__, ( const u8 []) _(pattern))
```
On modern, this puts the pattern variable on stack instead of .rodata, which leads to all the invalid opcodes issues.
Putting `static` fixes the issue, as the variable is always placed in the `.rodata` section. 