### PR TITLE
Adds support for placing Pokémon in the PC with the B button

### DIFF
--- a/include/config/overworld.h
+++ b/include/config/overworld.h
@@ -7,6 +7,9 @@
 // Other settings
 #define OW_POISON_DAMAGE            GEN_LATEST // In Gen4, Pokémon no longer faint from Poison in the overworld. In Gen5+, they no longer take damage at all.
 
+// PC settings
+#define OW_PC_PRESS_B               GEN_LATEST // In Gen4, pressing B when holding a Pokémon is equivalent to placing it. In Gen3, it gives the "You're holding a Pokémon!" error.
+
 // Overworld flags
 // To use the following features in scripting, replace the 0s with the flag ID you're assigning it to.
 // Eg: Replace with FLAG_UNUSED_0x264 so you can use that flag to toggle the feature.

--- a/src/pokemon_storage_system.c
+++ b/src/pokemon_storage_system.c
@@ -3685,9 +3685,14 @@ static void Task_OnBPressed(u8 taskId)
     case 0:
         if (IsMonBeingMoved())
         {
+        #if OW_PC_PRESS_B < GEN_4
             PlaySE(SE_FAILURE);
             PrintMessage(MSG_HOLDING_POKE);
             sStorage->state = 1;
+        #else
+            PlaySE(SE_SELECT);
+            SetPokeStorageTask(Task_PlaceMon);
+        #endif
         }
         else if (IsMovingItem())
         {


### PR DESCRIPTION
## Description
Adds a simple config. In Gen4+, pressing B while holding a Pokémon in the PC is equivalent to placing them down. This config (set to GEN_LATEST by default) trivially adds said functionality for a more modern feel.

## **Discord contact info**
bassoonian