### PR TITLE
Add config for Mew and Deoxys fateful encounter disobedience

### DIFF
--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -207,6 +207,7 @@
 #define B_OBEDIENCE_MECHANICS           GEN_7      // In PLA+ (here Gen8+), obedience restrictions also apply to non-outsider Pokémon, albeit based on their level met rather than actual level
 #define B_USE_FROSTBITE                 FALSE      // In PLA, Frostbite replaces Freeze. Enabling this flag does the same here. Moves can still be cherry-picked to either Freeze or Frostbite. Freeze-Dry, Secret Power & Tri Attack depend on this config.
 #define B_OVERWORLD_SNOW                GEN_LATEST // In Gen9+, overworld Snow will summon snow instead of hail.
+#define B_MEW_DEOXYS_OBEDIENCE          GEN_LATEST // In Gen3+, Mew and Deoxys will obey even if they don't have the fateful encounter flag.
 
 // Animation Settings
 #define B_NEW_SWORD_PARTICLE            TRUE    // If set to TRUE, it updates Swords Dance's particle.

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -207,7 +207,7 @@
 #define B_OBEDIENCE_MECHANICS           GEN_7      // In PLA+ (here Gen8+), obedience restrictions also apply to non-outsider Pokémon, albeit based on their level met rather than actual level
 #define B_USE_FROSTBITE                 FALSE      // In PLA, Frostbite replaces Freeze. Enabling this flag does the same here. Moves can still be cherry-picked to either Freeze or Frostbite. Freeze-Dry, Secret Power & Tri Attack depend on this config.
 #define B_OVERWORLD_SNOW                GEN_LATEST // In Gen9+, overworld Snow will summon snow instead of hail.
-#define B_MEW_DEOXYS_OBEDIENCE          GEN_LATEST // In Gen3+, Mew and Deoxys will obey even if they don't have the fateful encounter flag.
+#define B_MEW_DEOXYS_OBEDIENCE          GEN_LATEST // In Gen4+, Mew and Deoxys will obey even if they don't have the fateful encounter flag.
 
 // Animation Settings
 #define B_NEW_SWORD_PARTICLE            TRUE    // If set to TRUE, it updates Swords Dance's particle.

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -8032,14 +8032,18 @@ u32 GetMoveTarget(u16 move, u8 setTarget)
     return targetBattler;
 }
 
-static bool32 IsBattlerModernFatefulEncounter(u8 battler)
+static bool32 IsBattlerModernFatefulEncounter(u8 battler) //Function name is misleading, this only checks if a Mew or Deoxys has the fateful encounter flag.
 {
+#if B_MEW_DEOXYS_OBEDIENCE >= GEN_3
+    return TRUE;
+#else
     if (GetBattlerSide(battler) == B_SIDE_OPPONENT)
         return TRUE;
     if (GetMonData(&gPlayerParty[gBattlerPartyIndexes[battler]], MON_DATA_SPECIES, NULL) != SPECIES_DEOXYS
         && GetMonData(&gPlayerParty[gBattlerPartyIndexes[battler]], MON_DATA_SPECIES, NULL) != SPECIES_MEW)
             return TRUE;
     return GetMonData(&gPlayerParty[gBattlerPartyIndexes[battler]], MON_DATA_MODERN_FATEFUL_ENCOUNTER, NULL);
+#endif
 }
 
 u8 IsMonDisobedient(void)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds a config for if Mew and Deoxys should disobey if they don't have the fateful encounter flag, and thus it is now disabled by default.

## **Discord contact info**
kittenchilly