### PR TITLE
Fixed Rivalry's effect + Tests

### DIFF
--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -247,6 +247,7 @@ bool32 ChangeTypeBasedOnTerrain(u32 battler);
 void RemoveConfusionStatus(u32 battler);
 u8 GetBattlerGender(u32 battler);
 bool32 AreBattlersOfOppositeGender(u32 battler1, u32 battler2);
+bool32 AreBattlersOfSameGender(u32 battler1, u32 battler2);
 u32 CalcSecondaryEffectChance(u32 battler, u8 secondaryEffectChance);
 u8 GetBattlerType(u32 battler, u8 typeIndex);
 

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -8905,9 +8905,9 @@ static inline u32 CalcMoveBasePowerAfterModifiers(u32 move, u32 battlerAtk, u32 
            modifier = uq4_12_multiply(modifier, UQ_4_12(1.3));
         break;
     case ABILITY_RIVALRY:
-        if (AreBattlersOfOppositeGender(battlerAtk, battlerDef))
+        if (AreBattlersOfSameGender(battlerAtk, battlerDef))
             modifier = uq4_12_multiply(modifier, UQ_4_12(1.25));
-        else
+        else if (AreBattlersOfOppositeGender(battlerAtk, battlerDef))
             modifier = uq4_12_multiply(modifier, UQ_4_12(0.75));
         break;
     case ABILITY_ANALYTIC:
@@ -11172,6 +11172,14 @@ bool32 AreBattlersOfOppositeGender(u32 battler1, u32 battler2)
     u8 gender2 = GetBattlerGender(battler2);
 
     return (gender1 != MON_GENDERLESS && gender2 != MON_GENDERLESS && gender1 != gender2);
+}
+
+bool32 AreBattlersOfSameGender(u32 battler1, u32 battler2)
+{
+    u8 gender1 = GetBattlerGender(battler1);
+    u8 gender2 = GetBattlerGender(battler2);
+
+    return (gender1 != MON_GENDERLESS && gender2 != MON_GENDERLESS && gender1 == gender2);
 }
 
 u32 CalcSecondaryEffectChance(u32 battler, u8 secondaryEffectChance)

--- a/test/battle/ability/rivalry.c
+++ b/test/battle/ability/rivalry.c
@@ -1,0 +1,99 @@
+#include "global.h"
+#include "test/battle.h"
+
+ASSUMPTIONS
+{
+    ASSUME(gSpeciesInfo[SPECIES_NIDOKING].genderRatio == MON_MALE);
+    ASSUME(gSpeciesInfo[SPECIES_NIDOQUEEN].genderRatio == MON_FEMALE);
+    ASSUME(gSpeciesInfo[SPECIES_PORYGON].genderRatio == MON_GENDERLESS);
+}
+
+SINGLE_BATTLE_TEST("Rivalry increases power by x1.25 towards Pokémon of the same gender", s16 damage)
+{
+    u16 species, ability;
+    PARAMETRIZE { species = SPECIES_NIDOKING; ability = ABILITY_POISON_POINT; }
+    PARAMETRIZE { species = SPECIES_NIDOKING; ability = ABILITY_RIVALRY; }
+    PARAMETRIZE { species = SPECIES_NIDOQUEEN; ability = ABILITY_POISON_POINT; }
+    PARAMETRIZE { species = SPECIES_NIDOQUEEN; ability = ABILITY_RIVALRY; }
+
+    GIVEN {
+        PLAYER(species) { Ability(ability); }
+        OPPONENT(species);
+    } WHEN {
+        TURN { MOVE(player, MOVE_TACKLE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.25), results[1].damage);
+        EXPECT_MUL_EQ(results[2].damage, Q_4_12(1.25), results[3].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Rivalry decreases power by x0.75 towards Pokémon of different gender", s16 damage)
+{
+    u16 species1, species2, ability;
+    PARAMETRIZE { species1 = SPECIES_NIDOKING; species2 = SPECIES_NIDOQUEEN; ability = ABILITY_POISON_POINT; }
+    PARAMETRIZE { species1 = SPECIES_NIDOKING; species2 = SPECIES_NIDOQUEEN; ability = ABILITY_RIVALRY; }
+    PARAMETRIZE { species1 = SPECIES_NIDOQUEEN; species2 = SPECIES_NIDOKING; ability = ABILITY_POISON_POINT; }
+    PARAMETRIZE { species1 = SPECIES_NIDOQUEEN; species2 = SPECIES_NIDOKING; ability = ABILITY_RIVALRY; }
+
+    GIVEN {
+        PLAYER(species1) { Ability(ability); }
+        OPPONENT(species2);
+    } WHEN {
+        TURN { MOVE(player, MOVE_TACKLE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(0.75), results[1].damage);
+        EXPECT_MUL_EQ(results[2].damage, Q_4_12(0.75), results[3].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Rivalry doesn't modify power if the attacker is genderless", s16 damage)
+{
+    u16 species, ability;
+    PARAMETRIZE { species = SPECIES_NIDOKING; ability = ABILITY_POISON_POINT; }
+    PARAMETRIZE { species = SPECIES_NIDOKING; ability = ABILITY_RIVALRY; }
+    PARAMETRIZE { species = SPECIES_NIDOQUEEN; ability = ABILITY_POISON_POINT; }
+    PARAMETRIZE { species = SPECIES_NIDOQUEEN; ability = ABILITY_RIVALRY; }
+
+    GIVEN {
+        ASSUME(gSpeciesInfo[SPECIES_PORYGON].abilities[0] == ABILITY_TRACE);
+        PLAYER(SPECIES_PORYGON) { Ability(ABILITY_TRACE); } // No genderless mon naturally gets Rivalry
+        OPPONENT(species) { Ability(ability); };
+    } WHEN {
+        TURN { MOVE(player, MOVE_TACKLE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT(results[0].damage == results[1].damage);
+        EXPECT(results[2].damage == results[3].damage);
+    }
+}
+
+
+SINGLE_BATTLE_TEST("Rivalry doesn't modify power if the target is genderless", s16 damage)
+{
+    u16 species, ability;
+    PARAMETRIZE { species = SPECIES_NIDOKING; ability = ABILITY_POISON_POINT; }
+    PARAMETRIZE { species = SPECIES_NIDOKING; ability = ABILITY_RIVALRY; }
+    PARAMETRIZE { species = SPECIES_NIDOQUEEN; ability = ABILITY_POISON_POINT; }
+    PARAMETRIZE { species = SPECIES_NIDOQUEEN; ability = ABILITY_RIVALRY; }
+
+    GIVEN {
+        PLAYER(species) { Ability(ability); };
+        OPPONENT(SPECIES_PORYGON);
+    } WHEN {
+        TURN { MOVE(player, MOVE_TACKLE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT(results[0].damage == results[1].damage);
+        EXPECT(results[2].damage == results[3].damage);
+    }
+}


### PR DESCRIPTION
## Description
- It was doing the opposite if neither attacker or target were genderless.
- It wasn't accounting for genderless mon.

Thanks to @PCG06 for finding this issue.

Note: maybe the function names could be renamed, but not sure to what.

## **Discord contact info**
AsparagusEduardo