### PR TITLE
Fixed VSCode shenanigans

### DIFF
--- a/include/test_runner.h
+++ b/include/test_runner.h
@@ -24,8 +24,6 @@ void TestRunner_Battle_CheckBattleRecordActionType(u32 battlerId, u32 recordInde
 
 u32 TestRunner_Battle_GetForcedAbility(u32 side, u32 partyIndex);
 
-s32 MgbaPrintf_(const char *fmt, ...);
-
 #else
 
 #define TestRunner_Battle_RecordAbilityPopUp(...) (void)0
@@ -44,8 +42,6 @@ s32 MgbaPrintf_(const char *fmt, ...);
 #define TestRunner_Battle_CheckBattleRecordActionType(...) (void)0
 
 #define TestRunner_Battle_GetForcedAbility(...) (u32)0
-
-#define MgbaPrintf_(...) (u32)0
 
 #endif
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`MgbaPrintf_` was already defined in `include/test/test.h`, and adding it again caused issues with how IDEs like VSCode detected
`u32`.

## Images
![image](https://github.com/rh-hideout/pokeemerald-expansion/assets/2904965/71951887-5079-4ddd-b40a-98a2de300972)

## **Discord contact info**
AsparagusEdoardo