### PR TITLE
Made Gen6 Exp Share flag easier to understand

### DIFF
--- a/include/config/item.h
+++ b/include/config/item.h
@@ -18,6 +18,8 @@
 #define I_REUSABLE_TMS          FALSE       // In Gen5-8, TMs are reusable. Setting this to TRUE will make all vanilla TMs reusable, though they can also be cherry-picked by setting their importance to 1.
 
 // Exp. Share config
+// To use this feature, replace the 0 with the flag ID you're assigning it to.
+// Eg: Replace with FLAG_UNUSED_0x264 so you can use that flag to toggle the feature.
 #define I_EXP_SHARE_FLAG        0           // If this flag is set, every Pokémon in the party will gain experience, regardless if they participated in the battle or not.
 #define I_EXP_SHARE_ITEM        GEN_5       // In Gen6+, the Exp. Share was changed from a held item to a Key item that toggles the effect described above.
 

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -11189,7 +11189,7 @@ bool32 IsAlly(u32 battlerAtk, u32 battlerDef)
 
 bool32 IsGen6ExpShareEnabled(void)
 {
-#if I_EXP_SHARE_ITEM < GEN_6
+#if I_EXP_SHARE_FLAG <= TEMP_FLAGS_END
     return FALSE;
 #else
     return FlagGet(I_EXP_SHARE_FLAG);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added missing description on how to use the Exp. Share flag.

Also fixed flawed implementation that didn't allow to use the flag in scripting without setting the item itself to Gen6+.

## **Discord contact info**
AsparagusEduardo