### PR TITLE
Test improvements

### DIFF
--- a/include/test/battle.h
+++ b/include/test/battle.h
@@ -472,8 +472,8 @@
 
 enum { BATTLE_TEST_SINGLES, BATTLE_TEST_DOUBLES };
 
-typedef void (*SingleBattleTestFunction)(void *, u32, struct BattlePokemon *, struct BattlePokemon *);
-typedef void (*DoubleBattleTestFunction)(void *, u32, struct BattlePokemon *, struct BattlePokemon *, struct BattlePokemon *, struct BattlePokemon *);
+typedef void (*SingleBattleTestFunction)(void *, const u32, struct BattlePokemon *, struct BattlePokemon *);
+typedef void (*DoubleBattleTestFunction)(void *, const u32, struct BattlePokemon *, struct BattlePokemon *, struct BattlePokemon *, struct BattlePokemon *);
 
 struct BattleTest
 {
@@ -660,7 +660,7 @@ extern struct BattleTestRunnerState *gBattleTestRunnerState;
 
 #define SINGLE_BATTLE_TEST(_name, ...) \
     struct CAT(Result, __LINE__) { MEMBERS(__VA_ARGS__) }; \
-    static void CAT(Test, __LINE__)(struct CAT(Result, __LINE__) *, u32, struct BattlePokemon *, struct BattlePokemon *); \
+    static void CAT(Test, __LINE__)(struct CAT(Result, __LINE__) *, const u32, struct BattlePokemon *, struct BattlePokemon *); \
     __attribute__((section(".tests"))) static const struct Test CAT(sTest, __LINE__) = \
     { \
         .name = _name, \
@@ -674,11 +674,11 @@ extern struct BattleTestRunnerState *gBattleTestRunnerState;
             .resultsSize = sizeof(struct CAT(Result, __LINE__)), \
         }, \
     }; \
-    static void CAT(Test, __LINE__)(struct CAT(Result, __LINE__) *results, u32 i, struct BattlePokemon *player, struct BattlePokemon *opponent)
+    static void CAT(Test, __LINE__)(struct CAT(Result, __LINE__) *results, const u32 i, struct BattlePokemon *player, struct BattlePokemon *opponent)
 
 #define DOUBLE_BATTLE_TEST(_name, ...) \
     struct CAT(Result, __LINE__) { MEMBERS(__VA_ARGS__) }; \
-    static void CAT(Test, __LINE__)(struct CAT(Result, __LINE__) *, u32, struct BattlePokemon *, struct BattlePokemon *, struct BattlePokemon *, struct BattlePokemon *); \
+    static void CAT(Test, __LINE__)(struct CAT(Result, __LINE__) *, const u32, struct BattlePokemon *, struct BattlePokemon *, struct BattlePokemon *, struct BattlePokemon *); \
     __attribute__((section(".tests"))) static const struct Test CAT(sTest, __LINE__) = \
     { \
         .name = _name, \
@@ -692,7 +692,7 @@ extern struct BattleTestRunnerState *gBattleTestRunnerState;
             .resultsSize = sizeof(struct CAT(Result, __LINE__)), \
         }, \
     }; \
-    static void CAT(Test, __LINE__)(struct CAT(Result, __LINE__) *results, u32 i, struct BattlePokemon *playerLeft, struct BattlePokemon *opponentLeft, struct BattlePokemon *playerRight, struct BattlePokemon *opponentRight)
+    static void CAT(Test, __LINE__)(struct CAT(Result, __LINE__) *results, const u32 i, struct BattlePokemon *playerLeft, struct BattlePokemon *opponentLeft, struct BattlePokemon *playerRight, struct BattlePokemon *opponentRight)
 
 /* Parametrize */
 

--- a/test/battle/move_effect/salt_cure.c
+++ b/test/battle/move_effect/salt_cure.c
@@ -8,18 +8,19 @@ ASSUMPTIONS
 
 SINGLE_BATTLE_TEST("Salt Cure inflicts 1/8 of the target's maximum HP as damage per turn")
 {
+    u32 j;
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
         TURN { MOVE(player, MOVE_SALT_CURE); }
-        for (i = 0; i < 3; i++)
+        for (j = 0; j < 3; j++)
             TURN {}
     } SCENE {
         s32 maxHP = GetMonData(&OPPONENT_PARTY[0], MON_DATA_MAX_HP);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SALT_CURE, player);
         MESSAGE("Foe Wobbuffet is being salt cured!");
-        for (i = 0; i < 4; i++) {
+        for (j = 0; j < 4; j++) {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_SALT_CURE_DAMAGE, opponent);
             HP_BAR(opponent, damage: maxHP / 8);
             MESSAGE("Foe Wobbuffet is hurt by Salt Cure!");

--- a/test/battle/status1/bad_poison.c
+++ b/test/battle/status1/bad_poison.c
@@ -3,21 +3,23 @@
 
 SINGLE_BATTLE_TEST("Bad poison deals 1/16th cumulative damage per turn")
 {
+    u32 j;
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET) { Status1(STATUS1_TOXIC_POISON); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
-        for (i = 0; i < 4; i++)
+        for (j = 0; j < 4; j++)
             TURN {}
     } SCENE {
         s32 maxHP = GetMonData(&PLAYER_PARTY[0], MON_DATA_MAX_HP);
-        for (i = 0; i < 4; i++)
-            HP_BAR(player, damage: maxHP / 16 * (i + 1));
+        for (j = 0; j < 4; j++)
+            HP_BAR(player, damage: maxHP / 16 * (j + 1));
     }
 }
 
 SINGLE_BATTLE_TEST("Bad poison cumulative damage resets on switch")
 {
+    u32 j;
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET) { Status1(STATUS1_TOXIC_POISON); }
         PLAYER(SPECIES_WYNAUT);
@@ -31,9 +33,9 @@ SINGLE_BATTLE_TEST("Bad poison cumulative damage resets on switch")
         TURN {}
     } SCENE {
         s32 maxHP = GetMonData(&PLAYER_PARTY[0], MON_DATA_MAX_HP);
-        for (i = 0; i < 2; i++)
-            HP_BAR(player, damage: maxHP / 16 * (i + 1));
-        for (i = 0; i < 2; i++)
-            HP_BAR(player, damage: maxHP / 16 * (i + 1));
+        for (j = 0; j < 2; j++)
+            HP_BAR(player, damage: maxHP / 16 * (j + 1));
+        for (j = 0; j < 2; j++)
+            HP_BAR(player, damage: maxHP / 16 * (j + 1));
     }
 }

--- a/test/battle/status1/burn.c
+++ b/test/battle/status1/burn.c
@@ -3,16 +3,17 @@
 
 SINGLE_BATTLE_TEST("Burn deals 1/16th damage per turn")
 {
+    u32 j;
     GIVEN {
         ASSUME(B_BURN_DAMAGE >= GEN_LATEST);
         PLAYER(SPECIES_WOBBUFFET) { Status1(STATUS1_BURN); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
-        for (i = 0; i < 4; i++)
+        for (j = 0; j < 4; j++)
             TURN {}
     } SCENE {
         s32 maxHP = GetMonData(&PLAYER_PARTY[0], MON_DATA_MAX_HP);
-        for (i = 0; i < 4; i++)
+        for (j = 0; j < 4; j++)
             HP_BAR(player, damage: maxHP / 16);
     }
 }

--- a/test/battle/status1/poison.c
+++ b/test/battle/status1/poison.c
@@ -3,15 +3,16 @@
 
 SINGLE_BATTLE_TEST("Poison deals 1/8th damage per turn")
 {
+    u32 j;
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET) { Status1(STATUS1_POISON); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
-        for (i = 0; i < 4; i++)
+        for (j = 0; j < 4; j++)
             TURN {}
     } SCENE {
         s32 maxHP = GetMonData(&PLAYER_PARTY[0], MON_DATA_MAX_HP);
-        for (i = 0; i < 4; i++)
+        for (j = 0; j < 4; j++)
             HP_BAR(player, damage: maxHP / 8);
     }
 }

--- a/test/battle/status1/sleep.c
+++ b/test/battle/status1/sleep.c
@@ -3,7 +3,7 @@
 
 SINGLE_BATTLE_TEST("Sleep prevents the battler from using a move")
 {
-    u32 turns;
+    u32 turns, j;
     PARAMETRIZE { turns = 1; }
     PARAMETRIZE { turns = 2; }
     PARAMETRIZE { turns = 3; }
@@ -11,10 +11,10 @@ SINGLE_BATTLE_TEST("Sleep prevents the battler from using a move")
         PLAYER(SPECIES_WOBBUFFET) { Status1(STATUS1_SLEEP_TURN(turns)); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
-        for (i = 0; i < turns; i++)
+        for (j = 0; j < turns; j++)
             TURN { MOVE(player, MOVE_CELEBRATE); }
     } SCENE {
-        for (i = 0; i < turns - 1; i++)
+        for (j = 0; j < turns - 1; j++)
             MESSAGE("Wobbuffet is fast asleep.");
         MESSAGE("Wobbuffet woke up!");
         STATUS_ICON(player, none: TRUE);

--- a/test/test_runner.c
+++ b/test/test_runner.c
@@ -88,7 +88,7 @@ static u32 AssignCostToRunner(void)
     u32 minCostProcess;
 
     if (gTestRunnerState.test->runner == &gAssumptionsRunner)
-        return 0;
+        return gTestRunnerI;
 
     minCostProcess = MinCostProcess();
 


### PR DESCRIPTION
Includes a [missing change](https://github.com/rh-hideout/pokeemerald-expansion/pull/3368#discussion_r1342333793) from #3368.

Also changes `i` to be `const` [as suggested on Discord](https://discord.com/channels/419213663107416084/1077009799293710357/1161728544745984030) which prevents developers from assigning to `i`, which is important to prevent accidentally interfering with `PARAMETRIZE`. This is the first time I've ever wanted to apply `const` to a non-pointer parameter, so that's interesting!