### PR TITLE
Move battle tests off the heap

### DIFF
--- a/include/fieldmap.h
+++ b/include/fieldmap.h
@@ -22,6 +22,7 @@
 #include "main.h"
 
 extern struct BackupMapLayout gBackupMapLayout;
+extern u16 ALIGNED(4) sBackupMapData[MAX_MAP_DATA_SIZE];
 
 u32 MapGridGetMetatileIdAt(int, int);
 u32 MapGridGetMetatileBehaviorAt(int, int);

--- a/include/test/battle.h
+++ b/include/test/battle.h
@@ -679,6 +679,7 @@ struct BattleTestData
     u8 aiActionsPlayed[MAX_BATTLERS_COUNT];
     struct ExpectedAIAction expectedAiActions[MAX_BATTLERS_COUNT][MAX_EXPECTED_ACTIONS];
     struct ExpectedAiScore expectedAiScores[MAX_BATTLERS_COUNT][MAX_TURNS][MAX_AI_SCORE_COMPARISION_PER_TURN]; // Max 4 comparisions per turn
+    struct AILogLine aiLogLines[MAX_BATTLERS_COUNT][MAX_MON_MOVES][MAX_AI_LOG_LINES];
     u8 aiLogPrintedForMove[MAX_BATTLERS_COUNT]; // Marks ai score log as printed for move, so the same log isn't displayed multiple times.
 };
 
@@ -711,7 +712,7 @@ struct BattleTestRunnerState
 };
 
 extern const struct TestRunner gBattleTestRunner;
-extern struct BattleTestRunnerState *gBattleTestRunnerState;
+extern struct BattleTestRunnerState *const gBattleTestRunnerState;
 
 #define MEMBERS(...) VARARG_8(MEMBERS_, __VA_ARGS__)
 #define MEMBERS_0()

--- a/src/fieldmap.c
+++ b/src/fieldmap.c
@@ -25,7 +25,7 @@ struct ConnectionFlags
     u8 east:1;
 };
 
-EWRAM_DATA static u16 ALIGNED(4) sBackupMapData[MAX_MAP_DATA_SIZE] = {0};
+EWRAM_DATA u16 ALIGNED(4) sBackupMapData[MAX_MAP_DATA_SIZE] = {0};
 EWRAM_DATA struct MapHeader gMapHeader = {0};
 EWRAM_DATA struct Camera gCamera = {0};
 EWRAM_DATA static struct ConnectionFlags sMapConnectionFlags = {0};

--- a/test/test_runner_battle.c
+++ b/test/test_runner_battle.c
@@ -4,6 +4,7 @@
 #include "battle_anim.h"
 #include "battle_controllers.h"
 #include "characters.h"
+#include "fieldmap.h"
 #include "item_menu.h"
 #include "main.h"
 #include "malloc.h"
@@ -34,8 +35,9 @@
 #undef Q_4_12
 #define Q_4_12(n) (s32)((n) * 4096)
 
-static EWRAM_DATA struct AILogLine sAILogLines[MAX_BATTLERS_COUNT][MAX_MON_MOVES][MAX_AI_LOG_LINES] = {0};
-EWRAM_DATA struct BattleTestRunnerState *gBattleTestRunnerState = NULL;
+// Alias sBackupMapData to avoid using heap.
+struct BattleTestRunnerState *const gBattleTestRunnerState = (void *)sBackupMapData;
+STATIC_ASSERT(sizeof(struct BattleTestRunnerState) <= sizeof(sBackupMapData), sBackupMapDataSpace);
 
 static void CB2_BattleTest_NextParameter(void);
 static void CB2_BattleTest_NextTrial(void);
@@ -147,9 +149,6 @@ static u32 BattleTest_EstimateCost(void *data)
 {
     u32 cost;
     const struct BattleTest *test = data;
-    STATE = AllocZeroed(sizeof(*STATE));
-    if (!STATE)
-        return 0;
     STATE->runRandomly = TRUE;
     InvokeTestFunction(test);
     cost = 1;
@@ -159,23 +158,21 @@ static u32 BattleTest_EstimateCost(void *data)
         cost *= 3;
     else if (STATE->trials > 1)
         cost *= STATE->trials;
-    FREE_AND_SET_NULL(STATE);
     return cost;
 }
 
 static void BattleTest_SetUp(void *data)
 {
     const struct BattleTest *test = data;
-    STATE = AllocZeroed(sizeof(*STATE));
-    if (!STATE)
-        Test_ExitWithResult(TEST_RESULT_ERROR, "OOM: STATE = AllocZerod(%d)", sizeof(*STATE));
+    memset(STATE, 0, sizeof(*STATE));
     InvokeTestFunction(test);
     STATE->parameters = STATE->parametersCount;
     if (STATE->parametersCount == 0 && test->resultsSize > 0)
         Test_ExitWithResult(TEST_RESULT_INVALID, "results without PARAMETRIZE");
-    STATE->results = AllocZeroed(test->resultsSize * STATE->parameters);
-    if (!STATE->results)
-        Test_ExitWithResult(TEST_RESULT_ERROR, "OOM: STATE->results = AllocZerod(%d)", sizeof(test->resultsSize * STATE->parameters));
+    if (sizeof(*STATE) + test->resultsSize * STATE->parameters > sizeof(sBackupMapData))
+        Test_ExitWithResult(TEST_RESULT_ERROR, "OOM: STATE (%d) + STATE->results (%d) too big for sBackupMapData (%d)", sizeof(*STATE), test->resultsSize * STATE->parameters, sizeof(sBackupMapData));
+    STATE->results = (void *)((char *)sBackupMapData + sizeof(struct BattleTestRunnerState));
+    memset(STATE->results, 0, test->resultsSize * STATE->parameters);
     switch (test->type)
     {
     case BATTLE_TEST_SINGLES:
@@ -938,7 +935,7 @@ static void PrintAiMoveLog(u32 battlerId, u32 moveSlot, u32 moveId, s32 totalSco
     MgbaPrintf_("Score Log for move %S:\n", gMoveNames[moveId]);
     for (i = 0; i < MAX_AI_LOG_LINES; i++)
     {
-        struct AILogLine *log = &sAILogLines[battlerId][moveSlot][i];
+        struct AILogLine *log = &DATA.aiLogLines[battlerId][moveSlot][i];
         if (log->file)
         {
             if (log->set)
@@ -974,7 +971,7 @@ static void ClearAiLog(u32 battlerId)
     u32 i, j;
     for (i = 0; i < MAX_MON_MOVES; i++)
     {
-        struct AILogLine *logs = sAILogLines[battlerId][i];
+        struct AILogLine *logs = DATA.aiLogLines[battlerId][i];
         for (j = 0; j < MAX_AI_LOG_LINES; j++)
             memset(&logs[j], 0, sizeof(struct AILogLine));
     }
@@ -1387,15 +1384,10 @@ static void CB2_BattleTest_NextTrial(void)
 
 static void BattleTest_TearDown(void *data)
 {
-    if (STATE)
-    {
-        // Free resources that aren't cleaned up when the battle was
-        // aborted unexpectedly.
-        if (STATE->tearDownBattle)
-            TearDownBattle();
-        FREE_AND_SET_NULL(STATE->results);
-        FREE_AND_SET_NULL(STATE);
-    }
+    // Free resources that aren't cleaned up when the battle was
+    // aborted unexpectedly.
+    if (STATE->tearDownBattle)
+        TearDownBattle();
 }
 
 static bool32 BattleTest_CheckProgress(void *data)
@@ -2534,8 +2526,6 @@ void QueueStatus(u32 sourceLine, struct BattlePokemon *battler, struct StatusEve
 void ValidateFinally(u32 sourceLine)
 {
     // Defer this error until after estimating the cost.
-    if (STATE->results == NULL)
-        return;
     INVALID_IF(STATE->parametersCount == 0, "FINALLY without PARAMETRIZE");
 }
 
@@ -2552,7 +2542,7 @@ struct AILogLine *GetLogLine(u32 battlerId, u32 moveIndex)
 
     for (i = 0; i < MAX_AI_LOG_LINES; i++)
     {
-        struct AILogLine *log = &sAILogLines[battlerId][moveIndex][i];
+        struct AILogLine *log = &DATA.aiLogLines[battlerId][moveIndex][i];
         if (log->file == NULL)
         {
             return log;


### PR DESCRIPTION
[Pawkkie found a situation where adding just a small amount of data to `AiLogicData` caused the tests to blow up](https://discord.com/channels/419213663107416084/1077168246555430962/1162249269445677156). #3398 is a similar story where adding data to `BattleTestRunnerState` caused tests to blow up.

This PR:
1. Makes a test fail on the spot of `Alloc` returns `NULL`.
2. Makes `gBattleTestRunnerState` alias `sMapLayoutData`, a 20kB buffer that goes unused in battle tests.

It seems unlikely that anybody would write battle code which relies on, e.g. `MapGrid_GetMetatileAt`, but if they do it will no longer work. Of course that would probably be broken in the tests anyway because they don't load a map, but the output will be much more confusing now.

It's possible that in the future we'll want to write tests that check features work gracefully when out of heap, in which case we'll need to revisit my `Alloc` change so that you can opt-out of the automatic failure.