### PR TITLE
Move battle tests off the heap

### DIFF
--- a/include/fieldmap.h
+++ b/include/fieldmap.h
@@ -22,6 +22,7 @@
 #include "main.h"
 
 extern struct BackupMapLayout gBackupMapLayout;
+extern u16 ALIGNED(4) sBackupMapData[MAX_MAP_DATA_SIZE];
 
 u32 MapGridGetMetatileIdAt(int, int);
 u32 MapGridGetMetatileBehaviorAt(int, int);

--- a/include/test/battle.h
+++ b/include/test/battle.h
@@ -626,7 +626,7 @@ struct BattleTestRunnerState
 };
 
 extern const struct TestRunner gBattleTestRunner;
-extern struct BattleTestRunnerState *gBattleTestRunnerState;
+extern struct BattleTestRunnerState *const gBattleTestRunnerState;
 
 #define MEMBERS(...) VARARG_8(MEMBERS_, __VA_ARGS__)
 #define MEMBERS_0()

--- a/src/fieldmap.c
+++ b/src/fieldmap.c
@@ -25,7 +25,7 @@ struct ConnectionFlags
     u8 east:1;
 };
 
-EWRAM_DATA static u16 ALIGNED(4) sBackupMapData[MAX_MAP_DATA_SIZE] = {0};
+EWRAM_DATA u16 ALIGNED(4) sBackupMapData[MAX_MAP_DATA_SIZE] = {0};
 EWRAM_DATA struct MapHeader gMapHeader = {0};
 EWRAM_DATA struct Camera gCamera = {0};
 EWRAM_DATA static struct ConnectionFlags sMapConnectionFlags = {0};


### PR DESCRIPTION
Same as #3413, but for `master` instead of `upcoming`. Doesn't include the change to where the AI log lines go, because that's not on `master` yet :)