### PR TITLE
Converted Get(Box)MonData2 to proper functions

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -4719,7 +4719,10 @@ u32 GetMonData3(struct Pokemon *mon, s32 field, u8 *data)
     return ret;
 }
 
-u32 GetMonData2(struct Pokemon *mon, s32 field) __attribute__((alias("GetMonData3")));
+u32 GetMonData2(struct Pokemon *mon, s32 field)
+{
+    return GetMonData3(mon, field, NULL);
+}
 
 /* GameFreak called GetBoxMonData with either 2 or 3 arguments, for type
  * safety we have a GetBoxMonData macro (in include/pokemon.h) which
@@ -5089,7 +5092,10 @@ u32 GetBoxMonData3(struct BoxPokemon *boxMon, s32 field, u8 *data)
     return retVal;
 }
 
-u32 GetBoxMonData2(struct BoxPokemon *boxMon, s32 field) __attribute__((alias("GetBoxMonData3")));
+u32 GetBoxMonData2(struct BoxPokemon *boxMon, s32 field)
+{
+    return GetBoxMonData3(boxMon, field, NULL);
+}
 
 #define SET8(lhs) (lhs) = *data
 #define SET16(lhs) (lhs) = data[0] + (data[1] << 8)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixing a potential issue found by @Pawkkie, where using `Get(Box)MonData` in a macro caused issues without a `NULL` as the 3rd argument.

eg.
```diff
#define CALC_STAT(base, iv, ev, statIndex, field)               \
{                                                               \
    u8 baseStat = gSpeciesInfo[species].base;                   \
    s32 n = (((2 * baseStat + iv + ev / 4) * level) / 100) + 5; \
-   u8 nature = GetNature(mon);                                 \
+   u8 nature = GetMonData(mon, MON_DATA_NATURE);               \
    n = ModifyStatByNature(nature, n, statIndex);               \
    if (B_FRIENDSHIP_BOOST == TRUE)                             \
        n = n + ((n * 10 * friendship) / (MAX_FRIENDSHIP * 100));\
    SetMonData(mon, field, &n);                                 \
}
```
Discord message: https://discord.com/channels/419213663107416084/1077168246555430962/1162529804894085151

<!--- Describe your changes in detail -->

## Images
![image](https://github.com/rh-hideout/pokeemerald-expansion/assets/2904965/abaf49b3-527a-4e6b-b5a6-9f9d152a1753)

## **Discord contact info**
AsparagusEduardo