### PR TITLE
Removed pointless for loop in CB2_InitBattleInternal

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -596,14 +596,11 @@ static void CB2_InitBattleInternal(void)
     gSaveBlock2Ptr->frontier.disableRecordBattle = FALSE;
 
     for (i = 0; i < PARTY_SIZE; i++)
+    {
         AdjustFriendship(&gPlayerParty[i], FRIENDSHIP_EVENT_LEAGUE_BATTLE);
 
-    // Apply party-wide start-of-battle form changes
-    for (i = 0; i < PARTY_SIZE; i++)
-    {
-        // Player's side
+        // Apply party-wide start-of-battle form changes for both sides.
         TryFormChange(i, B_SIDE_PLAYER, FORM_CHANGE_BEGIN_BATTLE);
-        // Opponent's side
         TryFormChange(i, B_SIDE_OPPONENT, FORM_CHANGE_BEGIN_BATTLE);
     }
 


### PR DESCRIPTION
## Description
Title.
Yesterday, I was looking at `CB2_InitBattleInternal` for reasons and I noticed that it was running 2 for loops to apply changes on the Pokémon in the Player's and the Opponent's parties.
However, it only really needs to run 1, as far as I can tell.
This PR corrects that.

## **Discord contact info**
lunos4026