### PR TITLE
Added src/data/map_group_count.h to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ prefabs.json
 *.diff
 *.sym
 *.js
+src/data/map_group_count.h


### PR DESCRIPTION
## Description
Title.
`src/data/map_group_count.h` is a file containing an array with map group counts that is automatically generated through mapjson and used by TheXaman's debug menu.
Realistically, there's no reason to taint the commits of the users by letting it be included in a commit.

## **Discord contact info**
lunos4026