### PR TITLE
use dka container for a more modern gcc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    container: devkitpro/devkitarm
     env:
       GAME_VERSION: EMERALD
       GAME_REVISION: 0
@@ -27,7 +28,7 @@ jobs:
           repository: pret/agbcc
 
       - name: Install binutils
-        run: sudo apt install gcc-arm-none-eabi binutils-arm-none-eabi libelf-dev
+        run: sudo apt install -y build-essential libpng-dev libelf-dev
         # build-essential, git, and libpng-dev are already installed
         # gcc-arm-none-eabi is only needed for the modern build
         # as an alternative to dkP


### PR DESCRIPTION
Switches the build environment in the CI to a DKP docker container.

## Description
Seemed like one of the easiest ways to get an up to date arm toolchain, it's also what a lot of people use to build the project, so it should match the user environment as well as provide a modern toolchain.

Depends on #3428 

## Issue(s) that this PR fixes
/

## **Discord contact info**
karathan