### PR TITLE
Added a macro to flush the text box in battles

### DIFF
--- a/asm/macros/battle_script.inc
+++ b/asm/macros/battle_script.inc
@@ -2383,3 +2383,8 @@
 	getbattlerfainted \battler
 	jumpifbyte CMP_EQUAL, gBattleCommunication, \value, \ptr
 	.endm
+
+	.macro flushtextbox
+	printstring STRINGID_EMPTYSTRING3
+	waitmessage 1
+	.endm

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -757,8 +757,7 @@ BattleScript_AffectionBasedStatusHeal_Continue:
 	end2
 
 BattleScript_ShellTrapSetUp::
-	printstring STRINGID_EMPTYSTRING3
-	waitmessage 0x1
+	flushtextbox
 	playanimation BS_ATTACKER, B_ANIM_SHELL_TRAP_SETUP, NULL
 	printstring STRINGID_PREPARESHELLTRAP
 	waitmessage B_WAIT_TIME_LONG
@@ -831,8 +830,7 @@ BattleScript_EffectCourtChange::
 
 BattleScript_BeakBlastSetUp::
 	setbeakblast BS_ATTACKER
-	printstring STRINGID_EMPTYSTRING3
-	waitmessage 1
+	flushtextbox
 	playanimation BS_ATTACKER, B_ANIM_BEAK_BLAST_SETUP, NULL
 	printstring STRINGID_HEATUPBEAK
 	waitmessage B_WAIT_TIME_LONG
@@ -856,7 +854,7 @@ BattleScript_EffectMeteorBeam::
 
 BattleScript_FirstChargingTurnMeteorBeam::
 	attackcanceler
-	printstring STRINGID_EMPTYSTRING3
+	flushtextbox
 	ppreduce
 	attackanimation
 	waitanimation
@@ -1536,8 +1534,7 @@ BattleScript_MoveEffectCoreEnforcer::
 	waitmessage B_WAIT_TIME_LONG
 	trytoclearprimalweather
 	tryrevertweatherform
-	printstring STRINGID_EMPTYSTRING3
-	waitmessage 1
+	flushtextbox
 BattleScript_CoreEnforcerRet:
 	return
 
@@ -1631,8 +1628,7 @@ BattleScript_EffectPartingShotSwitch:
 	switchindataupdate BS_ATTACKER
 	hpthresholds BS_ATTACKER
 	trytoclearprimalweather
-	printstring STRINGID_EMPTYSTRING3
-	waitmessage 1
+	flushtextbox
 	printstring STRINGID_SWITCHINMON
 	switchinanim BS_ATTACKER, TRUE
 	waitstate
@@ -1987,8 +1983,7 @@ BattleScript_SynchronoiseLoop:
 	waitmessage B_WAIT_TIME_LONG
 	resultmessage
 	waitmessage B_WAIT_TIME_LONG
-	printstring STRINGID_EMPTYSTRING3
-	waitmessage 1
+	flushtextbox
 	tryfaintmon BS_TARGET
 BattleScript_SynchronoiseMoveTargetEnd:
 	moveendto MOVEEND_NEXT_TARGET
@@ -2672,8 +2667,7 @@ BattleScript_EffectSimpleBeam:
 	waitmessage B_WAIT_TIME_LONG
 	trytoclearprimalweather
 	tryrevertweatherform
-	printstring STRINGID_EMPTYSTRING3
-	waitmessage 1
+	flushtextbox
 	tryendneutralizinggas BS_TARGET
 	goto BattleScript_MoveEnd
 
@@ -2726,8 +2720,7 @@ BattleScript_EffectHealingWish:
 	switchindataupdate BS_ATTACKER
 	hpthresholds BS_ATTACKER
 	trytoclearprimalweather
-	printstring STRINGID_EMPTYSTRING3
-	waitmessage 1
+	flushtextbox
 	printstring STRINGID_SWITCHINMON
 	switchinanim BS_ATTACKER, TRUE
 	waitstate
@@ -2772,8 +2765,7 @@ BattleScript_EffectWorrySeed:
 	waitmessage B_WAIT_TIME_LONG
 	trytoclearprimalweather
 	tryrevertweatherform
-	printstring STRINGID_EMPTYSTRING3
-	waitmessage 1
+	flushtextbox
 	goto BattleScript_MoveEnd
 
 BattleScript_EffectPowerSplit:
@@ -2904,8 +2896,7 @@ BattleScript_EffectGastroAcid:
 	waitmessage B_WAIT_TIME_LONG
 	trytoclearprimalweather
 	tryrevertweatherform
-	printstring STRINGID_EMPTYSTRING3
-	waitmessage 1
+	flushtextbox
 	tryendneutralizinggas BS_TARGET
 	goto BattleScript_MoveEnd
 
@@ -3115,8 +3106,7 @@ BattleScript_EffectHitEscape:
 	switchindataupdate BS_ATTACKER
 	hpthresholds BS_ATTACKER
 	trytoclearprimalweather
-	printstring STRINGID_EMPTYSTRING3
-	waitmessage 1
+	flushtextbox
 	printstring STRINGID_SWITCHINMON
 	switchinanim BS_ATTACKER, TRUE
 	waitstate
@@ -3772,8 +3762,7 @@ BattleScript_DoMultiHit::
 	critmessage
 	waitmessage B_WAIT_TIME_LONG
 	multihitresultmessage
-	printstring STRINGID_EMPTYSTRING3
-	waitmessage 1
+	flushtextbox
 	addbyte sMULTIHIT_STRING + 4, 1
 	moveendto MOVEEND_NEXT_TARGET
 	jumpifbyte CMP_COMMON_BITS, gMoveResultFlags, MOVE_RESULT_FOE_ENDURED, BattleScript_MultiHitPrintStrings
@@ -3964,7 +3953,7 @@ BattleScript_TwoTurnMovesSecondTurn::
 
 BattleScriptFirstChargingTurn::
 	attackcanceler
-	printstring STRINGID_EMPTYSTRING3
+	flushtextbox
 	ppreduce
 	attackstring
 BattleScriptFirstChargingTurnAfterAttackString:
@@ -4139,8 +4128,7 @@ BattleScript_EffectTransform::
 	attackstring
 	ppreduce
 	trytoclearprimalweather
-	printstring STRINGID_EMPTYSTRING3
-	waitmessage 1
+	flushtextbox
 	transformdataexecution
 	attackanimation
 	waitanimation
@@ -5041,8 +5029,7 @@ BattleScript_EffectBatonPass::
 	switchindataupdate BS_ATTACKER
 	hpthresholds BS_ATTACKER
 	trytoclearprimalweather
-	printstring STRINGID_EMPTYSTRING3
-	waitmessage 1
+	flushtextbox
 	printstring STRINGID_SWITCHINMON
 	switchinanim BS_ATTACKER, TRUE
 	waitstate
@@ -6369,8 +6356,7 @@ BattleScript_FaintedMonTryChoose:
 	switchindataupdate BS_ATTACKER
 	hpthresholds BS_ATTACKER
 	trytoclearprimalweather
-	printstring STRINGID_EMPTYSTRING3
-	waitmessage 1
+	flushtextbox
 	printstring STRINGID_SWITCHINMON
 	hidepartystatussummary BS_ATTACKER
 	switchinanim BS_ATTACKER, 0
@@ -6382,8 +6368,7 @@ BattleScript_FaintedMonSendOutNew:
 	switchindataupdate BS_FAINTED
 	hpthresholds BS_FAINTED
 	trytoclearprimalweather
-	printstring STRINGID_EMPTYSTRING3
-	waitmessage 1
+	flushtextbox
 	printstring STRINGID_SWITCHINMON
 	hidepartystatussummary BS_FAINTED
 	switchinanim BS_FAINTED, FALSE
@@ -6417,8 +6402,7 @@ BattleScript_LinkHandleFaintedMonLoop::
 	switchindataupdate BS_FAINTED
 	hpthresholds BS_FAINTED
 	trytoclearprimalweather
-	printstring STRINGID_EMPTYSTRING3
-	waitmessage 1
+	flushtextbox
 	printstring STRINGID_SWITCHINMON
 	hidepartystatussummary BS_FAINTED
 	switchinanim BS_FAINTED, FALSE
@@ -6642,8 +6626,7 @@ BattleScript_DoSwitchOut::
 	switchindataupdate BS_ATTACKER
 	hpthresholds BS_ATTACKER
 	trytoclearprimalweather
-	printstring STRINGID_EMPTYSTRING3
-	waitmessage 1
+	flushtextbox
 	printstring STRINGID_SWITCHINMON
 	hidepartystatussummary BS_ATTACKER
 	switchinanim BS_ATTACKER, FALSE
@@ -6938,8 +6921,7 @@ BattleScript_RoarSuccessSwitch::
 	getswitchedmondata BS_TARGET
 	switchindataupdate BS_TARGET
 	trytoclearprimalweather
-	printstring STRINGID_EMPTYSTRING3
-	waitmessage 1
+	flushtextbox
 	switchinanim BS_TARGET, FALSE
 	waitstate
 	printstring STRINGID_PKMNWASDRAGGEDOUT
@@ -7765,15 +7747,14 @@ BattleScript_MoveEffectClearSmog::
 	return
 
 BattleScript_FocusPunchSetUp::
-	printstring STRINGID_EMPTYSTRING3
-	waitmessage 1
+	flushtextbox
 	playanimation BS_ATTACKER, B_ANIM_FOCUS_PUNCH_SETUP
 	printstring STRINGID_PKMNTIGHTENINGFOCUS
 	waitmessage B_WAIT_TIME_LONG
 	end3
 
 BattleScript_MegaEvolution::
-	printstring STRINGID_EMPTYSTRING3
+	flushtextbox
 	trytrainerslidemegaevolutionmsg BS_ATTACKER
 	printstring STRINGID_MEGAEVOREACTING
 BattleScript_MegaEvolutionAfterString:
@@ -7789,7 +7770,7 @@ BattleScript_MegaEvolutionAfterString:
 	end3
 
 BattleScript_WishMegaEvolution::
-	printstring STRINGID_EMPTYSTRING3
+	flushtextbox
 	trytrainerslidemegaevolutionmsg BS_ATTACKER
 	printstring STRINGID_FERVENTWISHREACHED
 	goto BattleScript_MegaEvolutionAfterString
@@ -7804,8 +7785,7 @@ BattleScript_PrimalReversionRestoreAttacker::
 	end2
 
 BattleScript_PrimalReversionRet::
-	printstring STRINGID_EMPTYSTRING3
-	waitmessage 1
+	flushtextbox
 	setbyte gIsCriticalHit, 0
 	handleprimalreversion BS_ATTACKER, 0
 	handleprimalreversion BS_ATTACKER, 1
@@ -7818,7 +7798,7 @@ BattleScript_PrimalReversionRet::
 	return
 
 BattleScript_UltraBurst::
-	printstring STRINGID_EMPTYSTRING3
+	flushtextbox
 	trytrainerslidezmovemsg BS_ATTACKER
 	printstring STRINGID_ULTRABURSTREACTING
 	waitmessage B_WAIT_TIME_LONG
@@ -7836,8 +7816,7 @@ BattleScript_AttackerFormChange::
 	pause 5
 	copybyte gBattlerAbility, gBattlerAttacker
 	call BattleScript_AbilityPopUp
-	printstring STRINGID_EMPTYSTRING3
-	waitmessage 1
+	flushtextbox
 BattleScript_AttackerFormChangeNoPopup::
 	handleformchange BS_ATTACKER, 0
 	handleformchange BS_ATTACKER, 1
@@ -7884,8 +7863,7 @@ BattleScript_CudChewActivates::
 	end3
 
 BattleScript_TargetFormChangeNoPopup:
-	printstring STRINGID_EMPTYSTRING3
-	waitmessage 1
+	flushtextbox
 	handleformchange BS_TARGET, 0
 	handleformchange BS_TARGET, 1
 	playanimation BS_TARGET, B_ANIM_FORM_CHANGE
@@ -7916,8 +7894,7 @@ BattleScript_TargetFormChangeWithStringNoPopup::
 BattleScript_BattlerFormChangeWithStringEnd3::
 	pause 5
 	call BattleScript_AbilityPopUp
-	printstring STRINGID_EMPTYSTRING3
-	waitmessage 1
+	flushtextbox
 	handleformchange BS_SCRIPTING, 0
 	handleformchange BS_SCRIPTING, 1
 	playanimation BS_SCRIPTING, B_ANIM_FORM_CHANGE, NULL
@@ -9794,7 +9771,7 @@ BattleScript_ActionSelectionItemsCantBeUsed::
 	endselectionscript
 
 BattleScript_FlushMessageBox::
-	printstring STRINGID_EMPTYSTRING3
+	flushtextbox
 	return
 
 BattleScript_PalacePrintFlavorText::
@@ -9981,8 +9958,7 @@ BattleScript_AnnounceAirLockCloudNine::
 	end3
 
 BattleScript_QuickClawActivation::
-	printstring STRINGID_EMPTYSTRING3
-	waitmessage 1
+	flushtextbox
 	playanimation BS_ATTACKER, B_ANIM_HELD_ITEM_EFFECT
 	waitanimation
 	printstring STRINGID_CANACTFASTERTHANKSTO
@@ -9990,16 +9966,14 @@ BattleScript_QuickClawActivation::
 	end2
 
 BattleScript_QuickDrawActivation::
-	printstring STRINGID_EMPTYSTRING3
-	waitmessage 1
+	flushtextbox
 	call BattleScript_AbilityPopUp
 	printstring STRINGID_CANACTFASTERTHANKSTO
 	waitmessage B_WAIT_TIME_LONG
 	end2
 
 BattleScript_CustapBerryActivation::
-	printstring STRINGID_EMPTYSTRING3
-	waitmessage 1
+	flushtextbox
 	playanimation BS_ATTACKER, B_ANIM_HELD_ITEM_EFFECT
 	waitanimation
 	printstring STRINGID_CANACTFASTERTHANKSTO
@@ -10047,7 +10021,7 @@ BattleScript_JabocaRowapBerryActivate_Dmg:
 
 @ z moves / effects
 BattleScript_ZMoveActivateDamaging::
-	printstring STRINGID_EMPTYSTRING3
+	flushtextbox
 	trytrainerslidezmovemsg BS_ATTACKER
 	printstring STRINGID_ZPOWERSURROUNDS
 	playanimation BS_ATTACKER, B_ANIM_ZMOVE_ACTIVATE, NULL
@@ -10056,7 +10030,7 @@ BattleScript_ZMoveActivateDamaging::
 	return
 
 BattleScript_ZMoveActivateStatus::
-	printstring STRINGID_EMPTYSTRING3
+	flushtextbox
 	trytrainerslidezmovemsg BS_ATTACKER
 	savetarget
 	printstring STRINGID_ZPOWERSURROUNDS
@@ -10267,8 +10241,7 @@ BattleScript_EjectButtonActivates::
 	switchindataupdate BS_SCRIPTING
 	hpthresholds BS_SCRIPTING
 	trytoclearprimalweather
-	printstring STRINGID_EMPTYSTRING3
-	waitmessage 1
+	flushtextbox
 	printstring 0x3
 	switchinanim BS_SCRIPTING 0x1
 	waitstate
@@ -10648,7 +10621,7 @@ BattleScript_EffectSteelsurge::
 @@@ END MAX MOVES @@@
 
 BattleScript_DynamaxBegins::
-	printstring STRINGID_EMPTYSTRING3
+	flushtextbox
 	returnatktoball
 	pause B_WAIT_TIME_SHORT
 	returntoball BS_SCRIPTING
@@ -10659,7 +10632,7 @@ BattleScript_DynamaxBegins::
 	end3
 
 BattleScript_DynamaxEnds::
-	printstring STRINGID_EMPTYSTRING3
+	flushtextbox
 	updatedynamax
 	playanimation BS_SCRIPTING, B_ANIM_FORM_CHANGE
 	waitanimation


### PR DESCRIPTION
## Description
I came up with the thought to replace the bunch of `printstring STRINGID_EMPTYSTRING3` and `waitmessage 1` commands that we're using to flush the text box in battles with a macro, so I did it.
Not only it makes the code that composes the affected battle scripts slightly more readable, it reduces the number of lines in the file. Granted, it's not a huge gain, but it's still a gain in the end.

## **Discord contact info**
lunos4026