### PR TITLE
Fixed Cheat Start not initiating time-based events

### DIFF
--- a/include/clock.h
+++ b/include/clock.h
@@ -3,6 +3,7 @@
 
 // TODO: time of day and seconds in a day defines
 
+void InitTimeBasedEvents(void);
 void DoTimeBasedEvents(void);
 
 #endif // GUARD_CLOCK_H

--- a/src/clock.c
+++ b/src/clock.c
@@ -15,7 +15,7 @@
 static void UpdatePerDay(struct Time *localTime);
 static void UpdatePerMinute(struct Time *localTime);
 
-static void InitTimeBasedEvents(void)
+void InitTimeBasedEvents(void)
 {
     FlagSet(FLAG_SYS_CLOCK_SET);
     RtcCalcLocalTime();

--- a/src/debug.c
+++ b/src/debug.c
@@ -9,6 +9,7 @@
 #include "global.h"
 #include "battle.h"
 #include "battle_setup.h"
+#include "clock.h"
 #include "coins.h"
 #include "credits.h"
 #include "data.h"
@@ -1983,6 +1984,7 @@ static void DebugAction_Util_Clear_Boxes(u8 taskId)
 }
 static void DebugAction_Util_CheatStart(u8 taskId)
 {
+    InitTimeBasedEvents();
     Debug_DestroyMenu_Full_Script(taskId, Debug_CheatStart);
 }
 static void DebugAction_Util_HatchAnEgg(u8 taskId)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Time-based events were not running when doing a Cheat Start, causing headaches for testing new RTC features.

## **Discord contact info**
AsparagusEduardo