### PR TITLE
Test cleanup and improvements

### DIFF
--- a/test/battle/ability/prankster.c
+++ b/test/battle/ability/prankster.c
@@ -22,7 +22,6 @@ TO_DO_BATTLE_TEST("Prankster-affected moves called via After you affect Dark-typ
 TO_DO_BATTLE_TEST("Prankster-affected moves that are bounced back by Magic Bounce/Coat can affect Dark-type Pokémon");
 TO_DO_BATTLE_TEST("Prankster-affected moves that are bounced back by Magic Coat from a Pokémon with Prankster can't affect Dark-type Pokémon");
 TO_DO_BATTLE_TEST("Prankster-affected moves that target all Pokémon are successful regardless of the presence of Dark-type Pokémon");
-TO_DO_BATTLE_TEST("Prankster-affected moves that target all Pokémon are successful regardless of the presence of Dark-type Pokémon");
 TO_DO_BATTLE_TEST("Prankster-affected move effects don't affect Dark-type Pokémon");
 TO_DO_BATTLE_TEST("Prankster increases the priority of moves by 1");
 TO_DO_BATTLE_TEST("Prankster increases the priority of status Z-Moves by 1");

--- a/test/battle/hold_effect/critical_hit_up.c
+++ b/test/battle/hold_effect/critical_hit_up.c
@@ -46,11 +46,12 @@ SINGLE_BATTLE_TEST("Lansat Berry raises the holder's critical-hit-ratio by two s
     }
 }
 
-SINGLE_BATTLE_TEST("Lansat Berry raises the holder's critical-hit-ratio by two stages when HP drops to 1/4 or below")
+SINGLE_BATTLE_TEST("Lansat Berry raises the holder's critical-hit-ratio by two stages")
 {
     PASSES_RANDOMLY(1, 2, RNG_CRITICAL_HIT);
     GIVEN {
         ASSUME(gBattleMoves[MOVE_TACKLE].highCritRatio == FALSE);
+        ASSUME(B_CRIT_CHANCE >= GEN_6);
         PLAYER(SPECIES_WOBBUFFET) { MaxHP(160); HP(80); Item(ITEM_LANSAT_BERRY); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {

--- a/test/battle/hold_effect/critical_hit_up.c
+++ b/test/battle/hold_effect/critical_hit_up.c
@@ -21,13 +21,11 @@ SINGLE_BATTLE_TEST("Lansat Berry raises the holder's critical-hit-ratio by two s
         TURN { MOVE(opponent, move); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, move, opponent);
-        if (move == MOVE_TACKLE)
-        {
+        if (move == MOVE_TACKLE) {
             NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
             NOT MESSAGE("Wobbuffet used Lansat Berry to get pumped!");
         }
-        else
-        {
+        else {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
             MESSAGE("Wobbuffet used Lansat Berry to get pumped!");
         }

--- a/test/battle/hold_effect/jaboca_berry.c
+++ b/test/battle/hold_effect/jaboca_berry.c
@@ -39,3 +39,22 @@ SINGLE_BATTLE_TEST("Jaboca Berry causes the attacker to lose 1/8 of its max HP i
             EXPECT_EQ(player->maxHP / 8, damage);
     }
 }
+
+SINGLE_BATTLE_TEST("Jaboca Berry tirggers before Bug Bite can steal it")
+{
+    KNOWN_FAILING;
+    GIVEN {
+        ASSUME(gBattleMoves[MOVE_BUG_BITE].split == SPLIT_PHYSICAL);
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_JABOCA_BERRY); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_BUG_BITE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BUG_BITE, player);
+        HP_BAR(opponent);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
+        HP_BAR(player);
+        MESSAGE("Wyanut was hurt by Foe Wobbuffet's Jaboca Berry!");
+        NOT MESSAGE("Wynaut stole and ate Foe Wobbuffet's Jaboca Berry!");
+    }
+}

--- a/test/battle/hold_effect/kee_berry.c
+++ b/test/battle/hold_effect/kee_berry.c
@@ -4,23 +4,37 @@
 ASSUMPTIONS
 {
     ASSUME(gItems[ITEM_KEE_BERRY].holdEffect == HOLD_EFFECT_KEE_BERRY);
+    ASSUME(gBattleMoves[MOVE_TACKLE].split == SPLIT_PHYSICAL);
 }
 
 SINGLE_BATTLE_TEST("Kee Berry raises the holder's Defense by one stage when hit by a physical move")
 {
+    u16 move;
+
+    PARAMETRIZE { move = MOVE_SWIFT; }
+    PARAMETRIZE { move = MOVE_TACKLE; }
+
     GIVEN {
-        ASSUME(gBattleMoves[MOVE_TACKLE].split == SPLIT_PHYSICAL);
+        ASSUME(gBattleMoves[MOVE_SWIFT].split == SPLIT_SPECIAL);
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_KEE_BERRY); }
     } WHEN {
-        TURN { MOVE(player, MOVE_TACKLE); }
+        TURN { MOVE(player, move); }
     } SCENE {
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, player);
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
         HP_BAR(opponent);
-        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-        MESSAGE("Using Kee Berry, the Defense of Foe Wobbuffet rose!");
+        if (move == MOVE_TACKLE) {
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
+            MESSAGE("Using Kee Berry, the Defense of Foe Wobbuffet rose!");
+        } else {
+            NONE_OF {
+                ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
+                MESSAGE("Using Kee Berry, the Defense of Foe Wobbuffet rose!");
+            }
+        }
     } THEN {
-        EXPECT_EQ(opponent->statStages[STAT_DEF], DEFAULT_STAT_STAGE + 1);
+        if (move == MOVE_TACKLE)
+            EXPECT_EQ(opponent->statStages[STAT_DEF], DEFAULT_STAT_STAGE + 1);
     }
 }
 
@@ -28,7 +42,6 @@ SINGLE_BATTLE_TEST("Kee Berry raises the holder's Defense by two stages with Rip
 {
     GIVEN {
         ASSUME(P_GEN_8_POKEMON == TRUE);
-        ASSUME(gBattleMoves[MOVE_TACKLE].split == SPLIT_PHYSICAL);
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_APPLIN) { Item(ITEM_KEE_BERRY); Ability(ABILITY_RIPEN); }
     } WHEN {

--- a/test/battle/hold_effect/maranga_berry.c
+++ b/test/battle/hold_effect/maranga_berry.c
@@ -8,19 +8,32 @@ ASSUMPTIONS
 
 SINGLE_BATTLE_TEST("Maranga Berry raises the holder's Sp. Def by one stage when hit by a special move")
 {
+    u16 move = MOVE_NONE;
+    PARAMETRIZE { move = MOVE_TACKLE; }
+    PARAMETRIZE { move = MOVE_SWIFT; }
     GIVEN {
+        ASSUME(gBattleMoves[MOVE_TACKLE].split == SPLIT_PHYSICAL);
         ASSUME(gBattleMoves[MOVE_SWIFT].split == SPLIT_SPECIAL);
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_MARANGA_BERRY); }
     } WHEN {
-        TURN { MOVE(player, MOVE_SWIFT); }
+        TURN { MOVE(player, move); }
     } SCENE {
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_SWIFT, player);
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
         HP_BAR(opponent);
-        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-        MESSAGE("Using Maranga Berry, the Sp. Def of Foe Wobbuffet rose!");
+        if (move == MOVE_SWIFT) {
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
+            MESSAGE("Using Maranga Berry, the Sp. Def of Foe Wobbuffet rose!");
+        }
+        else {
+            NONE_OF {
+                ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
+                MESSAGE("Using Maranga Berry, the Sp. Def of Foe Wobbuffet rose!");
+            }
+        }
     } THEN {
-        EXPECT_EQ(opponent->statStages[STAT_SPDEF], DEFAULT_STAT_STAGE + 1);
+        if (move == MOVE_SWIFT)
+            EXPECT_EQ(opponent->statStages[STAT_SPDEF], DEFAULT_STAT_STAGE + 1);
     }
 }
 
@@ -40,21 +53,5 @@ SINGLE_BATTLE_TEST("Maranga Berry raises the holder's Sp. Def by two stages with
         MESSAGE("Using Maranga Berry, the Sp. Def of Foe Applin sharply rose!");
     } THEN {
         EXPECT_EQ(opponent->statStages[STAT_SPDEF], DEFAULT_STAT_STAGE + 2);
-    }
-}
-
-SINGLE_BATTLE_TEST("Maranga Berry raises the holder's Sp. Def by one stage when hit by a special move")
-{
-    GIVEN {
-        ASSUME(gBattleMoves[MOVE_TACKLE].split == SPLIT_PHYSICAL);
-        PLAYER(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_MARANGA_BERRY); }
-    } WHEN {
-        TURN { MOVE(player, MOVE_TACKLE); }
-    } SCENE {
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, player);
-        HP_BAR(opponent);
-        NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-        NOT MESSAGE("Using Maranga Berry, the Sp. Def of Foe Wobbuffet rose!");
     }
 }

--- a/test/battle/hold_effect/rowap_berry.c
+++ b/test/battle/hold_effect/rowap_berry.c
@@ -9,21 +9,34 @@ ASSUMPTIONS
 SINGLE_BATTLE_TEST("Rowap Berry causes the attacker to lose 1/8 of its max HP if a special move was used")
 {
     s16 damage;
+    u16 move;
+
+    PARAMETRIZE { move = MOVE_SWIFT; }
+    PARAMETRIZE { move = MOVE_TACKLE; }
 
     GIVEN {
         ASSUME(gBattleMoves[MOVE_SWIFT].split == SPLIT_SPECIAL);
+        ASSUME(gBattleMoves[MOVE_TACKLE].split == SPLIT_PHYSICAL);
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_ROWAP_BERRY); }
     } WHEN {
-        TURN { MOVE(player, MOVE_SWIFT); }
+        TURN { MOVE(player, move); }
     } SCENE {
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_SWIFT, player);
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
         HP_BAR(opponent);
-        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-        HP_BAR(player, captureDamage: &damage);
-        MESSAGE("Wobbuffet was hurt by Foe Wobbuffet's Rowap Berry!");
+        if (move == MOVE_SWIFT) {
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
+            HP_BAR(player, captureDamage: &damage);
+            MESSAGE("Wobbuffet was hurt by Foe Wobbuffet's Rowap Berry!");
+        } else {
+            NONE_OF {
+                ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
+                MESSAGE("Wobbuffet was hurt by Foe Wobbuffet's Rowap Berry!");
+            }
+        }
     } THEN {
-        EXPECT_EQ(player->maxHP / 8, damage);
+        if (move == MOVE_SWIFT)
+            EXPECT_EQ(player->maxHP / 8, damage);
     }
 }
 

--- a/test/battle/move_effect/bug_bite.c
+++ b/test/battle/move_effect/bug_bite.c
@@ -114,18 +114,15 @@ SINGLE_BATTLE_TEST("Bug Bite eats the target's berry and immediately gains its e
     }
 }
 
-// To verify in the actual games.
-// Bulbapedia - The effect of a Jaboca Berry will activate before the Berry can be stolen.
-// Showdown - Jaboca Berry is stolen and eaten and nothing happens. This is how it currently works on expansion.
-TO_DO_BATTLE_TEST("Bug Bite interaction with Jaboca Berry.");
-
 SINGLE_BATTLE_TEST("Tanga Berry activates before Bug Bite")
 {
     GIVEN {
+        ASSUME(gItems[ITEM_TANGA_BERRY].holdEffect == HOLD_EFFECT_RESIST_BERRY);
+        ASSUME(gItems[ITEM_TANGA_BERRY].holdEffectParam == TYPE_BUG);
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET) {Item(ITEM_TANGA_BERRY); }
     } WHEN {
-            TURN { MOVE(player, MOVE_BUG_BITE); }
+        TURN { MOVE(player, MOVE_BUG_BITE); }
     } SCENE {
         MESSAGE("Wobbuffet used Bug Bite!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);

--- a/test/battle/move_effect/multi_hit.c
+++ b/test/battle/move_effect/multi_hit.c
@@ -25,11 +25,12 @@ SINGLE_BATTLE_TEST("Multi hit Moves hit the maximum amount with Skill Link")
     }
 }
 
-SINGLE_BATTLE_TEST("Multi hit Moves hit twice 35 Percent of the time")
+SINGLE_BATTLE_TEST("Multi hit Moves hit twice 35% of the time")
 {
     PASSES_RANDOMLY(35, 100, RNG_HITS);
 
     GIVEN {
+        ASSUME(B_MULTI_HIT_CHANCE >= GEN_5);
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
@@ -41,11 +42,12 @@ SINGLE_BATTLE_TEST("Multi hit Moves hit twice 35 Percent of the time")
     }
 }
 
-SINGLE_BATTLE_TEST("Multi hit Moves hit thrice 35 Percent of the time")
+SINGLE_BATTLE_TEST("Multi hit Moves hit thrice 35% of the time")
 {
     PASSES_RANDOMLY(35, 100, RNG_HITS);
 
     GIVEN {
+        ASSUME(B_MULTI_HIT_CHANCE >= GEN_5);
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
@@ -58,11 +60,12 @@ SINGLE_BATTLE_TEST("Multi hit Moves hit thrice 35 Percent of the time")
     }
 }
 
-SINGLE_BATTLE_TEST("Multi hit Moves hit four times 35 Percent of the time")
+SINGLE_BATTLE_TEST("Multi hit Moves hit four times 15% of the time")
 {
     PASSES_RANDOMLY(15, 100, RNG_HITS);
 
     GIVEN {
+        ASSUME(B_MULTI_HIT_CHANCE >= GEN_5);
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
@@ -76,11 +79,12 @@ SINGLE_BATTLE_TEST("Multi hit Moves hit four times 35 Percent of the time")
     }
 }
 
-SINGLE_BATTLE_TEST("Multi hit Moves hit four times 35 Percent of the time")
+SINGLE_BATTLE_TEST("Multi hit Moves hit five times 15% of the time")
 {
     PASSES_RANDOMLY(15, 100, RNG_HITS);
 
     GIVEN {
+        ASSUME(B_MULTI_HIT_CHANCE >= GEN_5);
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Removed duplicated Prankster TO_DO test.
- Corrected Multi-hit test names (4 and 5 hits stated 35% instead of 15%).
- Grouped Maranga Berry's Physical vs Special tests using `PARAMETRIZE`.
- Improved Jaboca, Kee and Rowap tests by @AlexOn1ine 

## **Discord contact info**
AsparagusEduardo