### PR TITLE
Fix test_runner.c modern warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,11 @@ ELF = $(ROM:.gba=.elf)
 MAP = $(ROM:.gba=.map)
 SYM = $(ROM:.gba=.sym)
 
+ifeq ($(MODERN),0)
 TEST_OBJ_DIR_NAME := build/test
+else
+TEST_OBJ_DIR_NAME := build/modern-test
+endif
 TESTELF = $(ROM:.gba=-test.elf)
 HEADLESSELF = $(ROM:.gba=-test-headless.elf)
 

--- a/include/test/test.h
+++ b/include/test/test.h
@@ -47,6 +47,7 @@ struct TestRunnerState
     u8 expectedResult;
     bool8 expectLeaks:1;
     bool8 inBenchmark:1;
+    bool8 tearDown:1;
     u32 timeoutSeconds;
 };
 

--- a/test/test_runner.c
+++ b/test/test_runner.c
@@ -56,9 +56,10 @@ static bool32 PrefixMatch(const char *pattern, const char *string)
 enum
 {
     STATE_INIT,
-    STATE_NEXT_TEST,
+    STATE_ASSIGN_TEST,
     STATE_RUN_TEST,
     STATE_REPORT_RESULT,
+    STATE_NEXT_TEST,
     STATE_EXIT,
 };
 
@@ -152,17 +153,15 @@ void CB2_TestRunner(void)
         }
         else
         {
-            gTestRunnerState.state = STATE_NEXT_TEST;
-            gTestRunnerState.test = __start_tests - 1;
+            gTestRunnerState.state = STATE_ASSIGN_TEST;
+            gTestRunnerState.test = __start_tests;
         }
         gTestRunnerState.exitCode = 0;
         gTestRunnerState.skipFilename = NULL;
 
         break;
 
-    case STATE_NEXT_TEST:
-        gTestRunnerState.test++;
-
+    case STATE_ASSIGN_TEST:
         if (gTestRunnerState.test == __stop_tests)
         {
             gTestRunnerState.state = STATE_EXIT;
@@ -172,6 +171,7 @@ void CB2_TestRunner(void)
         if (gTestRunnerState.test->runner != &gAssumptionsRunner
           && !PrefixMatch(gTestRunnerArgv, gTestRunnerState.test->name))
         {
+            gTestRunnerState.state = STATE_NEXT_TEST;
             return;
         }
 
@@ -191,6 +191,8 @@ void CB2_TestRunner(void)
         sCurrentTest.address = (uintptr_t)gTestRunnerState.test;
         sCurrentTest.state = CURRENT_TEST_STATE_ESTIMATE;
 
+        // If AssignCostToRunner fails, we want to report the failure.
+        gTestRunnerState.state = STATE_REPORT_RESULT;
         if (AssignCostToRunner() == gTestRunnerI)
             gTestRunnerState.state = STATE_RUN_TEST;
         else
@@ -204,7 +206,10 @@ void CB2_TestRunner(void)
         SeedRng(0);
         SeedRng2(0);
         if (gTestRunnerState.test->runner->setUp)
+        {
             gTestRunnerState.test->runner->setUp(gTestRunnerState.test->data);
+            gTestRunnerState.tearDown = TRUE;
+        }
         // NOTE: Assumes that the compiler interns __FILE__.
         if (gTestRunnerState.skipFilename == gTestRunnerState.test->filename) // Assumption fails for tests in this file.
         {
@@ -216,13 +221,17 @@ void CB2_TestRunner(void)
             gTestRunnerState.test->runner->run(gTestRunnerState.test->data);
         }
         break;
+
     case STATE_REPORT_RESULT:
         REG_TM2CNT_H = 0;
 
         gTestRunnerState.state = STATE_NEXT_TEST;
 
-        if (gTestRunnerState.test->runner->tearDown)
+        if (gTestRunnerState.tearDown && gTestRunnerState.test->runner->tearDown)
+        {
             gTestRunnerState.test->runner->tearDown(gTestRunnerState.test->data);
+            gTestRunnerState.tearDown = FALSE;
+        }
 
         if (gTestRunnerState.result == TEST_RESULT_PASS
          && !gTestRunnerState.expectLeaks)
@@ -340,6 +349,11 @@ void CB2_TestRunner(void)
                 MgbaPrintf_(":F%s%s\e[0m", color, result);
         }
 
+        break;
+
+    case STATE_NEXT_TEST:
+        gTestRunnerState.state = STATE_ASSIGN_TEST;
+        gTestRunnerState.test++;
         break;
 
     case STATE_EXIT:

--- a/tools/mgba-rom-test-hydra/main.c
+++ b/tools/mgba-rom-test-hydra/main.c
@@ -2,9 +2,9 @@
  * parses the output to display human-readable progress.
  *
  * Output lines starting with "GBA Debug: :" are parsed as commands to
- * Hydra, other output lines starting with "GBA Debug: " are parsed as
- * output from the current test, and any other lines are parsed as
- * output from the mgba-rom-test process itself.
+ * Hydra, other output lines starting with "GBA Debug: " or with "GBA: "
+ * are parsed as output from the current test, and any other lines are
+ * parsed as output from the mgba-rom-test process itself.
  *
  * COMMANDS
  * N: Sets the test name to the remainder of the line.
@@ -75,10 +75,17 @@ static void handle_read(int i, struct Runner *runner)
     {
         eol++;
         size_t n = eol - sol;
-        if (runner->input_buffer_size >= strlen("GBA Debug: ")
-         && !strncmp(sol, "GBA Debug: ", strlen("GBA Debug: ")))
+        char *soc;
+        if (runner->input_buffer_size >= strlen("GBA: ")
+         && !strncmp(sol, "GBA: ", strlen("GBA: ")))
         {
-            char *soc = sol + strlen("GBA Debug: ");
+            soc = sol + strlen("GBA: ");
+            goto buffer_output;
+        }
+        else if (runner->input_buffer_size >= strlen("GBA Debug: ")
+              && !strncmp(sol, "GBA Debug: ", strlen("GBA Debug: ")))
+        {
+            soc = sol + strlen("GBA Debug: ");
             if (soc[0] == ':')
             {
                 switch (soc[1])


### PR DESCRIPTION
`gTestRunnerState.test = __start_tests - 1;` is UB. Rearranged the test runner code so that we can initialize to `__start_tests` instead.

Also:
- Creates a separate `modern-test` directory so that you can switch between `make check MODERN=0` and `make check MODERN=1`.
- Buffers `GBA: `-prefixed lines, so that something like an illegal opcode error gets reported as belonging to the right test.

Once this lands we should merge `master` with `upcoming` so that we can switch to building with `MODERN=1` by default. The "CreateNPCTrainerPartyForTrainer generates customized Pokémon" test fails when built with modern, but not with agbcc. I haven't looked into this, and I don't think it's related to this PR(?)