### PR TITLE
ROM space on debug menu

### DIFF
--- a/data/scripts/debug.inc
+++ b/data/scripts/debug.inc
@@ -104,13 +104,16 @@ Debug_CheckSaveBlock::
 	end
 
 Debug_SaveBlock1Size::
-	.string "SaveBlock1 size: {STR_VAR_1}/{STR_VAR_2}.$"
+	.string "SaveBlock1 size: {STR_VAR_1}b/{STR_VAR_2}b.\n"
+	.string "Free space: {STR_VAR_3}b.$"
 
 Debug_SaveBlock2Size::
-	.string "SaveBlock2 size: {STR_VAR_1}/{STR_VAR_2}.$"
+	.string "SaveBlock2 size: {STR_VAR_1}b/{STR_VAR_2}b.\n"
+	.string "Free space: {STR_VAR_3}b.$"
 
 Debug_PokemonStorageSize::
-	.string "{PKMN}Storage size: {STR_VAR_1}/{STR_VAR_2}.$"
+	.string "{PKMN}Storage size: {STR_VAR_1}b/{STR_VAR_2}b.\n"
+	.string "Free space: {STR_VAR_3}b.$"
 
 Debug_CheckROMSpace::
 	callnative CheckROMSize
@@ -119,7 +122,8 @@ Debug_CheckROMSpace::
 	end
 
 Debug_ROMSize::
-	.string "ROM size: {STR_VAR_1}MB/32MB.$"
+	.string "ROM size: {STR_VAR_1}MB/32MB.\n"
+	.string "Free space: {STR_VAR_2}MB.$"
 
 Debug_HatchAnEgg::
 	lockall

--- a/data/scripts/debug.inc
+++ b/data/scripts/debug.inc
@@ -112,6 +112,15 @@ Debug_SaveBlock2Size::
 Debug_PokemonStorageSize::
 	.string "{PKMN}Storage size: {STR_VAR_1}/{STR_VAR_2}.$"
 
+Debug_CheckROMSpace::
+	callnative CheckROMSize
+	msgbox Debug_ROMSize, MSGBOX_DEFAULT
+	release
+	end
+
+Debug_ROMSize::
+	.string "ROM size: {STR_VAR_1}MB/32MB.$"
+
 Debug_HatchAnEgg::
 	lockall
 	getpartysize

--- a/ld_script.txt
+++ b/ld_script.txt
@@ -1325,6 +1325,8 @@ SECTIONS {
         data/*.o(.rodata);
     } = 0
 
+    __rom_end = .;
+
     /* DWARF debug sections.
        Symbols in the DWARF debugging sections are relative to the beginning
        of the section so we begin them at 0.  */

--- a/ld_script_modern.txt
+++ b/ld_script_modern.txt
@@ -130,6 +130,8 @@ SECTIONS {
         src/graphics.o(.rodata);
     } =0
 
+    __rom_end = .;
+
     /* DWARF debug sections.
        Symbols in the DWARF debugging sections are relative to the beginning
        of the section so we begin them at 0.  */

--- a/ld_script_test.txt
+++ b/ld_script_test.txt
@@ -114,6 +114,8 @@ SECTIONS {
         test/*.o(.rodata*);
     } =0
 
+    __rom_end = .;
+
     /* DWARF debug sections.
        Symbols in the DWARF debugging sections are relative to the beginning
        of the section so we begin them at 0.  */

--- a/src/debug.c
+++ b/src/debug.c
@@ -62,7 +62,6 @@
 #include "constants/species.h"
 #include "constants/weather.h"
 #include "save.h"
-#include "tv.h"
 
 #if DEBUG_OVERWORLD_MENU == TRUE
 // *******************************
@@ -1807,6 +1806,7 @@ void CheckSaveBlock1Size(struct ScriptContext *ctx)
     u32 maxSb1Size = SECTOR_DATA_SIZE * (SECTOR_ID_SAVEBLOCK1_END - SECTOR_ID_SAVEBLOCK1_START + 1);
     ConvertIntToDecimalStringN(gStringVar1, currSb1Size, STR_CONV_MODE_LEFT_ALIGN, 6);
     ConvertIntToDecimalStringN(gStringVar2, maxSb1Size, STR_CONV_MODE_LEFT_ALIGN, 6);
+    ConvertIntToDecimalStringN(gStringVar3, maxSb1Size - currSb1Size, STR_CONV_MODE_LEFT_ALIGN, 6);
 }
 
 void CheckSaveBlock2Size(struct ScriptContext *ctx)
@@ -1815,6 +1815,7 @@ void CheckSaveBlock2Size(struct ScriptContext *ctx)
     u32 maxSb2Size = SECTOR_DATA_SIZE;
     ConvertIntToDecimalStringN(gStringVar1, currSb2Size, STR_CONV_MODE_LEFT_ALIGN, 6);
     ConvertIntToDecimalStringN(gStringVar2, maxSb2Size, STR_CONV_MODE_LEFT_ALIGN, 6);
+    ConvertIntToDecimalStringN(gStringVar3, maxSb2Size - currSb2Size, STR_CONV_MODE_LEFT_ALIGN, 6);
 }
 
 void CheckPokemonStorageSize(struct ScriptContext *ctx)
@@ -1823,6 +1824,7 @@ void CheckPokemonStorageSize(struct ScriptContext *ctx)
     u32 maxPkmnStorageSize = SECTOR_DATA_SIZE * (SECTOR_ID_PKMN_STORAGE_END - SECTOR_ID_PKMN_STORAGE_START + 1);
     ConvertIntToDecimalStringN(gStringVar1, currPkmnStorageSize, STR_CONV_MODE_LEFT_ALIGN, 6);
     ConvertIntToDecimalStringN(gStringVar2, maxPkmnStorageSize, STR_CONV_MODE_LEFT_ALIGN, 6);
+    ConvertIntToDecimalStringN(gStringVar3, maxPkmnStorageSize - currPkmnStorageSize, STR_CONV_MODE_LEFT_ALIGN, 6);
 }
 
 static void DebugAction_Util_CheckSaveBlock(u8 taskId)
@@ -1841,7 +1843,7 @@ enum RoundMode
 
 static u8 *ConvertQ22_10ToDecimalString(u8 *string, u32 q22_10, u32 decimalDigits, enum RoundMode roundMode)
 {
-    string = ConvertIntToDecimalStringN(string, q22_10 >> 10, STR_CONV_MODE_LEFT_ALIGN, CountDigits(q22_10 >> 10));
+    string = ConvertIntToDecimalStringN(string, q22_10 >> 10, STR_CONV_MODE_LEFT_ALIGN, 10);
 
     if (decimalDigits == 0)
         return string;
@@ -1875,7 +1877,9 @@ void CheckROMSize(struct ScriptContext *ctx)
     extern u8 __rom_end[];
     u32 currROMSizeB = __rom_end - (const u8 *)ROM_START;
     u32 currROMSizeKB = (currROMSizeB + 1023) / 1024;
+    u32 currROMFreeKB = ((const u8 *)ROM_END - __rom_end) / 1024;
     ConvertQ22_10ToDecimalString(gStringVar1, currROMSizeKB, 2, ROUND_CEILING);
+    ConvertQ22_10ToDecimalString(gStringVar2, currROMFreeKB, 2, ROUND_FLOOR);
 }
 
 static void DebugAction_Util_CheckROMSpace(u8 taskId)


### PR DESCRIPTION
Based on [this Discord comment](<https://discord.com/channels/419213663107416084/1077168246555430962/1162078321224458310>).

Currently 23.22MB/32MB on agbcc and 23.17MB/32MB on modern (GCC 13.2.0). Obviously a byte count like in the save block message would be completely useless. So I chose to round to two decimal places, with `ROUND_CEILING` because I think it's more annoying to think you have enough space and actually not, than the opposite.

![image](https://github.com/rh-hideout/pokeemerald-expansion/assets/2904965/0e76562f-72aa-4481-9085-144e2908616e)

TBH it might make more sense to print out how much free space is available (both for the ROM and for save blocks)?