### PR TITLE
Gave Razor Fang EVO_HELD_ITEM type/fieldUseFunc properties

### DIFF
--- a/src/data/items.h
+++ b/src/data/items.h
@@ -6045,8 +6045,8 @@ const struct Item gItems[] =
         .holdEffectParam = 10,
         .description = sRazorFangDesc,
         .pocket = POCKET_ITEMS,
-        .type = ITEM_USE_BAG_MENU,
-        .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
+        .type = EVO_HELD_ITEM_TYPE,
+        .fieldUseFunc = EVO_HELD_ITEM_FIELD_FUNC,
         .flingPower = 30,
     },
 

--- a/src/data/pokemon/item_effects.h
+++ b/src/data/pokemon/item_effects.h
@@ -566,6 +566,7 @@ const u8 *const gItemEffectTable[ITEMS_COUNT] =
     [ITEM_METAL_COAT]         = gItemEffect_EvoItem,
     [ITEM_KINGS_ROCK]         = gItemEffect_EvoItem,
     [ITEM_RAZOR_CLAW]         = gItemEffect_EvoItem,
+    [ITEM_RAZOR_FANG]         = gItemEffect_EvoItem,
     [ITEM_AUSPICIOUS_ARMOR]   = gItemEffect_EvoItem,
     [ITEM_MALICIOUS_ARMOR]    = gItemEffect_EvoItem,
     [ITEM_SCROLL_OF_DARKNESS] = gItemEffect_EvoItem,


### PR DESCRIPTION
## Description
Currently a Razor Fang can't be used from the bag to evolve Pokemon even when I_USE_EVO_HELD_ITEMS_FROM_BAG is set to true. This PR fixes that by changing Razor Fang's type to EVO_HELD_ITEM_TYPE and fieldUseFunc to EVO_HELD_ITEM_FIELD_FUNC


## **Discord contact info**
Frankfurter#8828