### PR TITLE
Detect 'NOT x; NOT y;'

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -6315,6 +6315,7 @@ bool32 CanSleep(u32 battler)
     if (ability == ABILITY_INSOMNIA
       || ability == ABILITY_VITAL_SPIRIT
       || ability == ABILITY_COMATOSE
+      || ability == ABILITY_PURIFYING_SALT
       || gSideStatuses[GetBattlerSide(battler)] & SIDE_STATUS_SAFEGUARD
       || gBattleMons[battler].status1 & STATUS1_ANY
       || IsAbilityOnSide(battler, ABILITY_SWEET_VEIL)
@@ -6333,6 +6334,7 @@ bool32 CanBePoisoned(u32 battlerAttacker, u32 battlerTarget)
      || gBattleMons[battlerTarget].status1 & STATUS1_ANY
      || ability == ABILITY_IMMUNITY
      || ability == ABILITY_COMATOSE
+     || ability == ABILITY_PURIFYING_SALT
      || IsAbilityOnSide(battlerTarget, ABILITY_PASTEL_VEIL)
      || IsAbilityStatusProtected(battlerTarget)
      || IsBattlerTerrainAffected(battlerTarget, STATUS_FIELD_MISTY_TERRAIN))
@@ -6350,6 +6352,7 @@ bool32 CanBeBurned(u32 battler)
       || ability == ABILITY_WATER_BUBBLE
       || ability == ABILITY_COMATOSE
       || ability == ABILITY_THERMAL_EXCHANGE
+      || ability == ABILITY_PURIFYING_SALT
       || IsAbilityStatusProtected(battler)
       || IsBattlerTerrainAffected(battler, STATUS_FIELD_MISTY_TERRAIN))
         return FALSE;
@@ -6366,6 +6369,7 @@ bool32 CanBeParalyzed(u32 battler)
         gSideStatuses[GetBattlerSide(battler)] & SIDE_STATUS_SAFEGUARD
         || ability == ABILITY_LIMBER
         || ability == ABILITY_COMATOSE
+        || ability == ABILITY_PURIFYING_SALT
         || gBattleMons[battler].status1 & STATUS1_ANY
         || IsAbilityStatusProtected(battler)
         || IsBattlerTerrainAffected(battler, STATUS_FIELD_MISTY_TERRAIN))
@@ -6381,6 +6385,7 @@ bool32 CanBeFrozen(u32 battler)
       || gSideStatuses[GetBattlerSide(battler)] & SIDE_STATUS_SAFEGUARD
       || ability == ABILITY_MAGMA_ARMOR
       || ability == ABILITY_COMATOSE
+      || ability == ABILITY_PURIFYING_SALT
       || gBattleMons[battler].status1 & STATUS1_ANY
       || IsAbilityStatusProtected(battler)
       || IsBattlerTerrainAffected(battler, STATUS_FIELD_MISTY_TERRAIN))
@@ -6395,6 +6400,7 @@ bool32 CanGetFrostbite(u32 battler)
       || gSideStatuses[GetBattlerSide(battler)] & SIDE_STATUS_SAFEGUARD
       || ability == ABILITY_MAGMA_ARMOR
       || ability == ABILITY_COMATOSE
+      || ability == ABILITY_PURIFYING_SALT
       || gBattleMons[battler].status1 & STATUS1_ANY
       || IsAbilityStatusProtected(battler)
       || IsBattlerTerrainAffected(battler, STATUS_FIELD_MISTY_TERRAIN))

--- a/test/battle/ability/cute_charm.c
+++ b/test/battle/ability/cute_charm.c
@@ -21,10 +21,12 @@ SINGLE_BATTLE_TEST("Cute Charm inflicts infatuation on contact")
             MESSAGE("Foe Clefairy's Cute Charm infatuated Wobbuffet!");
             MESSAGE("Wobbuffet is in love with Foe Clefairy!");
         } else {
-            NOT ABILITY_POPUP(opponent, ABILITY_CUTE_CHARM);
-            NOT ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_INFATUATION, player);
-            NOT MESSAGE("Foe Clefairy's Cute Charm infatuated Wobbuffet!");
-            NOT MESSAGE("Wobbuffet is in love with Foe Clefairy!");
+            NONE_OF {
+                ABILITY_POPUP(opponent, ABILITY_CUTE_CHARM);
+                ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_INFATUATION, player);
+                MESSAGE("Foe Clefairy's Cute Charm infatuated Wobbuffet!");
+                MESSAGE("Wobbuffet is in love with Foe Clefairy!");
+            }
         }
     }
 }

--- a/test/battle/ability/flame_body.c
+++ b/test/battle/ability/flame_body.c
@@ -20,10 +20,12 @@ SINGLE_BATTLE_TEST("Flame Body inflicts burn on contact")
             MESSAGE("Foe Magmar's Flame Body burned Wobbuffet!");
             STATUS_ICON(player, burn: TRUE);
         } else {
-            NOT ABILITY_POPUP(opponent, ABILITY_FLAME_BODY);
-            NOT ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, player);
-            NOT MESSAGE("Foe Magmar's Flame Body burned Wobbuffet!");
-            NOT STATUS_ICON(player, burn: TRUE);
+            NONE_OF {
+                ABILITY_POPUP(opponent, ABILITY_FLAME_BODY);
+                ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, player);
+                MESSAGE("Foe Magmar's Flame Body burned Wobbuffet!");
+                STATUS_ICON(player, burn: TRUE);
+            }
         }
     }
 }

--- a/test/battle/ability/leaf_guard.c
+++ b/test/battle/ability/leaf_guard.c
@@ -25,10 +25,13 @@ SINGLE_BATTLE_TEST("Leaf Guard prevents non-volatile status conditions in sun")
             NOT ANIMATION(ANIM_TYPE_MOVE, move, opponent);
             ABILITY_POPUP(player, ABILITY_LEAF_GUARD);
             MESSAGE("It doesn't affect Leafeon…");
+            NOT STATUS_ICON(player, status);
         } else {
-            NOT ABILITY_POPUP(player, ABILITY_LEAF_GUARD);
+            NONE_OF {
+                ABILITY_POPUP(player, ABILITY_LEAF_GUARD);
+                STATUS_ICON(player, status);
+            }
         }
-        NOT STATUS_ICON(player, status);
     }
 }
 
@@ -65,7 +68,9 @@ SINGLE_BATTLE_TEST("Leaf Guard prevents Rest during sun")
         TURN { MOVE(opponent, MOVE_SUNNY_DAY); MOVE(player, MOVE_REST); }
     } SCENE {
         MESSAGE("But it failed!");
-        NOT STATUS_ICON(player, sleep: TRUE);
-        NONE_OF { HP_BAR(player); }
+        NONE_OF {
+            STATUS_ICON(player, sleep: TRUE);
+            HP_BAR(player);
+        }
     }
 }

--- a/test/battle/ability/limber.c
+++ b/test/battle/ability/limber.c
@@ -10,7 +10,9 @@ SINGLE_BATTLE_TEST("Limber prevents paralysis")
         TURN { MOVE(opponent, MOVE_THUNDER_SHOCK); }
     } SCENE {
         HP_BAR(player);
-        NONE_OF { ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PRZ, player); }
-        NONE_OF { STATUS_ICON(player, paralysis: TRUE); }
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PRZ, player);
+            STATUS_ICON(player, paralysis: TRUE);
+        }
     }
 }

--- a/test/battle/ability/poison_point.c
+++ b/test/battle/ability/poison_point.c
@@ -21,10 +21,12 @@ SINGLE_BATTLE_TEST("Poison Point inflicts poison on contact")
             MESSAGE("Wobbuffet was poisoned by Foe Nidoran♂'s Poison Point!");
             STATUS_ICON(player, poison: TRUE);
         } else {
-            NOT ABILITY_POPUP(opponent, ABILITY_POISON_POINT);
-            NOT ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, player);
-            NOT MESSAGE("Wobbuffet was poisoned by Foe Nidoran♂'s Poison Point!");
-            NOT STATUS_ICON(player, poison: TRUE);
+            NONE_OF {
+                ABILITY_POPUP(opponent, ABILITY_POISON_POINT);
+                ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, player);
+                MESSAGE("Wobbuffet was poisoned by Foe Nidoran♂'s Poison Point!");
+                STATUS_ICON(player, poison: TRUE);
+            }
         }
     }
 }

--- a/test/battle/ability/purifying_salt.c
+++ b/test/battle/ability/purifying_salt.c
@@ -57,9 +57,12 @@ SINGLE_BATTLE_TEST("Purifying Salt grants immunity to status effects")
             NOT ANIMATION(ANIM_TYPE_MOVE, move, opponent);
             ABILITY_POPUP(player, ABILITY_PURIFYING_SALT);
             MESSAGE("It doesn't affect Wobbuffet…");
+            NOT STATUS_ICON(player, status);
         } else {
-            NOT ABILITY_POPUP(player, ABILITY_PURIFYING_SALT);
+            NONE_OF {
+                ABILITY_POPUP(player, ABILITY_PURIFYING_SALT);
+                STATUS_ICON(player, status);
+            }
         }
-        NOT STATUS_ICON(player, status);
     }
 }

--- a/test/battle/ability/sap_sipper.c
+++ b/test/battle/ability/sap_sipper.c
@@ -21,8 +21,10 @@ SINGLE_BATTLE_TEST("Sap Sipper negates effects from Grass-type moves")
     } WHEN {
         TURN { MOVE(opponent, MOVE_SPORE); }
     } SCENE {
-        NONE_OF { ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_SLP, player); }
-        NONE_OF { STATUS_ICON(player, sleep: TRUE); }
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_SLP, player);
+            STATUS_ICON(player, sleep: TRUE);
+        }
     }
 }
 
@@ -49,7 +51,9 @@ SINGLE_BATTLE_TEST("Sap Sipper does not increase Attack if already maxed")
         TURN { MOVE(player, MOVE_BELLY_DRUM); MOVE(opponent, MOVE_VINE_WHIP); }
     } SCENE {
         ABILITY_POPUP(player, ABILITY_SAP_SIPPER);
-        NONE_OF { ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player); }
-        NONE_OF { MESSAGE("Marill's Attack rose!"); }
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+            MESSAGE("Marill's Attack rose!");
+        }
     }
 }

--- a/test/battle/ability/static.c
+++ b/test/battle/ability/static.c
@@ -20,10 +20,12 @@ SINGLE_BATTLE_TEST("Static inflicts paralysis on contact")
             MESSAGE("Foe Pikachu's Static paralyzed Wobbuffet! It may be unable to move!");
             STATUS_ICON(player, paralysis: TRUE);
         } else {
-            NOT ABILITY_POPUP(opponent, ABILITY_STATIC);
-            NOT ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PRZ, player);
-            NOT MESSAGE("Foe Pikachu's Static paralyzed Wobbuffet! It may be unable to move!");
-            NOT STATUS_ICON(player, paralysis: TRUE);
+            NONE_OF {
+                ABILITY_POPUP(opponent, ABILITY_STATIC);
+                ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PRZ, player);
+                MESSAGE("Foe Pikachu's Static paralyzed Wobbuffet! It may be unable to move!");
+                STATUS_ICON(player, paralysis: TRUE);
+            }
         }
     }
 }

--- a/test/battle/ability/toxic_debris.c
+++ b/test/battle/ability/toxic_debris.c
@@ -17,10 +17,11 @@ SINGLE_BATTLE_TEST("Toxic Debris sets Toxic Spikes on the opposing side if hit b
         if (move == MOVE_TACKLE) {
             ABILITY_POPUP(player, ABILITY_TOXIC_DEBRIS);
             MESSAGE("Poison Spikes were scattered all around the opposing team's feet!");
-        }
-        else {
-            NOT ABILITY_POPUP(player, ABILITY_TOXIC_DEBRIS);
-            NOT MESSAGE("Poison Spikes were scattered all around the opposing team's feet!");
+        } else {
+            NONE_OF {
+                ABILITY_POPUP(player, ABILITY_TOXIC_DEBRIS);
+                MESSAGE("Poison Spikes were scattered all around the opposing team's feet!");
+            }
         }
     }
 }
@@ -42,8 +43,10 @@ SINGLE_BATTLE_TEST("Toxic Debris does not activate if two layers of Toxic Spikes
         ABILITY_POPUP(player, ABILITY_TOXIC_DEBRIS);
         MESSAGE("Poison Spikes were scattered all around the opposing team's feet!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
-        NOT ABILITY_POPUP(player, ABILITY_TOXIC_DEBRIS);
-        NOT MESSAGE("Poison Spikes were scattered all around the opposing team's feet!");
+        NONE_OF {
+            ABILITY_POPUP(player, ABILITY_TOXIC_DEBRIS);
+            MESSAGE("Poison Spikes were scattered all around the opposing team's feet!");
+        }
     }
 }
 
@@ -58,8 +61,10 @@ SINGLE_BATTLE_TEST("If a Substitute is hit, Toxic Debris does not set Toxic Spik
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SUBSTITUTE, player);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
-        NOT ABILITY_POPUP(player, ABILITY_TOXIC_DEBRIS);
-        NOT MESSAGE("Poison Spikes were scattered all around the opposing team's feet!");
+        NONE_OF {
+            ABILITY_POPUP(player, ABILITY_TOXIC_DEBRIS);
+            MESSAGE("Poison Spikes were scattered all around the opposing team's feet!");
+        }
     }
 }
 

--- a/test/battle/ability/wind_power.c
+++ b/test/battle/ability/wind_power.c
@@ -133,8 +133,10 @@ DOUBLE_BATTLE_TEST("Wind Power activates correctly for every battler with the ab
             ABILITY_POPUP(playerRight, ABILITY_WIND_POWER);
             MESSAGE("Being hit by Air Cutter charged Wobbuffet with power!");
         }
-        NOT HP_BAR(opponentLeft);
-        NOT HP_BAR(opponentRight);
+        NONE_OF {
+            HP_BAR(opponentLeft);
+            HP_BAR(opponentRight);
+        }
     }
     THEN {
         EXPECT_NE(playerLeft->hp, playerLeft->maxHP);

--- a/test/battle/hold_effect/attack_up.c
+++ b/test/battle/hold_effect/attack_up.c
@@ -21,13 +21,12 @@ SINGLE_BATTLE_TEST("Liechi Berry raises the holder's Attack by one stage when HP
         TURN { MOVE(opponent, move); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, move, opponent);
-        if (move == MOVE_TACKLE)
-        {
-            NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-            NOT MESSAGE("Using Liechi Berry, the Attack of Wobbuffet rose!");
-        }
-        else
-        {
+        if (move == MOVE_TACKLE) {
+            NONE_OF {
+                ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+                MESSAGE("Using Liechi Berry, the Attack of Wobbuffet rose!");
+            }
+        } else {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
             MESSAGE("Using Liechi Berry, the Attack of Wobbuffet rose!");
         }

--- a/test/battle/hold_effect/critical_hit_up.c
+++ b/test/battle/hold_effect/critical_hit_up.c
@@ -22,10 +22,11 @@ SINGLE_BATTLE_TEST("Lansat Berry raises the holder's critical-hit-ratio by two s
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, move, opponent);
         if (move == MOVE_TACKLE) {
-            NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-            NOT MESSAGE("Wobbuffet used Lansat Berry to get pumped!");
-        }
-        else {
+            NONE_OF {
+                ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+                MESSAGE("Wobbuffet used Lansat Berry to get pumped!");
+            }
+        } else {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
             MESSAGE("Wobbuffet used Lansat Berry to get pumped!");
         }

--- a/test/battle/hold_effect/defense_up.c
+++ b/test/battle/hold_effect/defense_up.c
@@ -21,13 +21,12 @@ SINGLE_BATTLE_TEST("Ganlon Berry raises the holder's Defense by one stage when H
         TURN { MOVE(opponent, move); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, move, opponent);
-        if (move == MOVE_TACKLE)
-        {
-            NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-            NOT MESSAGE("Using Ganlon Berry, the Defense of Wobbuffet rose!");
-        }
-        else
-        {
+        if (move == MOVE_TACKLE) {
+            NONE_OF {
+                ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+                MESSAGE("Using Ganlon Berry, the Defense of Wobbuffet rose!");
+            }
+        } else {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
             MESSAGE("Using Ganlon Berry, the Defense of Wobbuffet rose!");
         }

--- a/test/battle/hold_effect/kee_berry.c
+++ b/test/battle/hold_effect/kee_berry.c
@@ -67,7 +67,9 @@ SINGLE_BATTLE_TEST("Kee Berry is not triggered by a special move")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SWIFT, player);
         HP_BAR(opponent);
-        NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-        NOT MESSAGE("Using Kee Berry, the Defense of Foe Wobbuffet rose!");
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
+            MESSAGE("Using Kee Berry, the Defense of Foe Wobbuffet rose!");
+        }
     }
 }

--- a/test/battle/hold_effect/micle_berry.c
+++ b/test/battle/hold_effect/micle_berry.c
@@ -21,13 +21,12 @@ SINGLE_BATTLE_TEST("Micle Berry raises the holder's accuracy by 1.2 when HP drop
         TURN { MOVE(opponent, move); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, move, opponent);
-        if (move == MOVE_TACKLE)
-        {
-            NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-            NOT MESSAGE("Wobbuffet boosted the accuracy of its next move using Micle Berry!");
-        }
-        else
-        {
+        if (move == MOVE_TACKLE) {
+            NONE_OF {
+                ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+                MESSAGE("Wobbuffet boosted the accuracy of its next move using Micle Berry!");
+            }
+        } else {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
             MESSAGE("Wobbuffet boosted the accuracy of its next move using Micle Berry!");
         }
@@ -64,5 +63,3 @@ SINGLE_BATTLE_TEST("Micle Berry raises the holder's accuracy by 1.2")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SUBMISSION, player);
     }
 }
-
-

--- a/test/battle/hold_effect/rowap_berry.c
+++ b/test/battle/hold_effect/rowap_berry.c
@@ -51,7 +51,9 @@ SINGLE_BATTLE_TEST("Rowap Berry is not triggered by a physical move")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, player);
         HP_BAR(opponent);
-        NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-        NOT MESSAGE("Wobbuffet was hurt by Foe Wobbuffet's Rowap Berry!");
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
+            MESSAGE("Wobbuffet was hurt by Foe Wobbuffet's Rowap Berry!");
+        }
     }
 }

--- a/test/battle/hold_effect/special_attack_up.c
+++ b/test/battle/hold_effect/special_attack_up.c
@@ -21,13 +21,12 @@ SINGLE_BATTLE_TEST("Petaya Berry raises the holder's Sp. Atk by one stage when H
         TURN { MOVE(opponent, move); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, move, opponent);
-        if (move == MOVE_TACKLE)
-        {
-            NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-            NOT MESSAGE("Using Petaya Berry, the Sp. Atk of Wobbuffet rose!");
-        }
-        else
-        {
+        if (move == MOVE_TACKLE) {
+            NONE_OF {
+                ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+                MESSAGE("Using Petaya Berry, the Sp. Atk of Wobbuffet rose!");
+            }
+        } else {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
             MESSAGE("Using Petaya Berry, the Sp. Atk of Wobbuffet rose!");
         }

--- a/test/battle/hold_effect/special_defense_up.c
+++ b/test/battle/hold_effect/special_defense_up.c
@@ -21,13 +21,12 @@ SINGLE_BATTLE_TEST("Apicot Berry raises the holder's Sp. Def by one stage when H
         TURN { MOVE(opponent, move); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, move, opponent);
-        if (move == MOVE_TACKLE)
-        {
-            NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-            NOT MESSAGE("Using Apicot Berry, the Sp. Def of Wobbuffet rose!");
-        }
-        else
-        {
+        if (move == MOVE_TACKLE) {
+            NONE_OF {
+                ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+                MESSAGE("Using Apicot Berry, the Sp. Def of Wobbuffet rose!");
+            }
+        } else {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
             MESSAGE("Using Apicot Berry, the Sp. Def of Wobbuffet rose!");
         }

--- a/test/battle/hold_effect/speed_up.c
+++ b/test/battle/hold_effect/speed_up.c
@@ -21,13 +21,12 @@ SINGLE_BATTLE_TEST("Salac Berry raises the holder's Speed by one stage when HP d
         TURN { MOVE(opponent, move); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, move, opponent);
-        if (move == MOVE_TACKLE)
-        {
-            NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-            NOT MESSAGE("Using Salac Berry, the Speed of Wobbuffet rose!");
-        }
-        else
-        {
+        if (move == MOVE_TACKLE) {
+            NONE_OF {
+                ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+                MESSAGE("Using Salac Berry, the Speed of Wobbuffet rose!");
+            }
+        } else {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
             MESSAGE("Using Salac Berry, the Speed of Wobbuffet rose!");
         }

--- a/test/battle/move_effect/absorb.c
+++ b/test/battle/move_effect/absorb.c
@@ -34,8 +34,10 @@ SINGLE_BATTLE_TEST("Absorb fails if Heal Block applies")
         TURN { MOVE(opponent, MOVE_HEAL_BLOCK); MOVE(player, MOVE_ABSORB); }
     } SCENE {
         MESSAGE("Wobbuffet was prevented from healing!");
-        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_ABSORB, player);
-        NOT HP_BAR(opponent);
-        NOT HP_BAR(player);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_ABSORB, player);
+            HP_BAR(opponent);
+            HP_BAR(player);
+        }
     }
 }

--- a/test/battle/move_effect/burn_hit.c
+++ b/test/battle/move_effect/burn_hit.c
@@ -32,7 +32,9 @@ SINGLE_BATTLE_TEST("Ember cannot burn a Fire-type Pokémon")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EMBER, player);
         HP_BAR(opponent);
-        NOT ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, opponent);
-        NOT STATUS_ICON(opponent, burn: TRUE);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, opponent);
+            STATUS_ICON(opponent, burn: TRUE);
+        }
     }
 }

--- a/test/battle/move_effect/dire_claw.c
+++ b/test/battle/move_effect/dire_claw.c
@@ -25,11 +25,9 @@ SINGLE_BATTLE_TEST("Dire Claw can inflict poison, paralysis or sleep")
         ANIMATION(ANIM_TYPE_STATUS, statusAnim, opponent);
         if (statusAnim == B_ANIM_STATUS_PRZ) {
             STATUS_ICON(opponent, paralysis: TRUE);
-        }
-        else if (statusAnim == B_ANIM_STATUS_SLP) {
+        } else if (statusAnim == B_ANIM_STATUS_SLP) {
             STATUS_ICON(opponent, sleep: TRUE);
-        }
-        else if (statusAnim == B_ANIM_STATUS_PSN) {
+        } else if (statusAnim == B_ANIM_STATUS_PSN) {
             STATUS_ICON(opponent, poison: TRUE);
         }
     }
@@ -53,12 +51,13 @@ SINGLE_BATTLE_TEST("Dire Claw cannot poison/paralyze poison/electric types respe
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DIRE_CLAW, player);
         HP_BAR(opponent);
-        NOT ANIMATION(ANIM_TYPE_STATUS, statusAnim, opponent);
-        if (statusAnim == B_ANIM_STATUS_PRZ) {
-            NOT STATUS_ICON(opponent, paralysis: TRUE);
-        }
-        else if (statusAnim == B_ANIM_STATUS_PSN) {
-            NOT STATUS_ICON(opponent, poison: TRUE);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_STATUS, statusAnim, opponent);
+            if (statusAnim == B_ANIM_STATUS_PRZ) {
+                STATUS_ICON(opponent, paralysis: TRUE);
+            } else if (statusAnim == B_ANIM_STATUS_PSN) {
+                STATUS_ICON(opponent, poison: TRUE);
+            }
         }
     }
 }
@@ -86,15 +85,15 @@ SINGLE_BATTLE_TEST("Dire Claw cannot poison/paralyze/cause to fall asleep pokemo
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DIRE_CLAW, player);
         HP_BAR(opponent);
-        NOT ANIMATION(ANIM_TYPE_STATUS, statusAnim, opponent);
-        if (statusAnim == B_ANIM_STATUS_PRZ) {
-            NOT STATUS_ICON(opponent, paralysis: TRUE);
-        }
-        else if (statusAnim == B_ANIM_STATUS_SLP) {
-            NOT STATUS_ICON(opponent, sleep: TRUE);
-        }
-        else if (statusAnim == B_ANIM_STATUS_PSN) {
-            NOT STATUS_ICON(opponent, poison: TRUE);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_STATUS, statusAnim, opponent);
+            if (statusAnim == B_ANIM_STATUS_PRZ) {
+                STATUS_ICON(opponent, paralysis: TRUE);
+            } else if (statusAnim == B_ANIM_STATUS_SLP) {
+                STATUS_ICON(opponent, sleep: TRUE);
+            } else if (statusAnim == B_ANIM_STATUS_PSN) {
+                STATUS_ICON(opponent, poison: TRUE);
+            }
         }
     }
 }
@@ -115,15 +114,15 @@ SINGLE_BATTLE_TEST("Dire Claw cannot poison/paralyze/cause to fall asleep a mon 
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DIRE_CLAW, player);
         HP_BAR(opponent);
-        NOT ANIMATION(ANIM_TYPE_STATUS, statusAnim, opponent);
-        if (statusAnim == B_ANIM_STATUS_PRZ) {
-            NOT STATUS_ICON(opponent, paralysis: TRUE);
-        }
-        else if (statusAnim == B_ANIM_STATUS_SLP) {
-            NOT STATUS_ICON(opponent, sleep: TRUE);
-        }
-        else if (statusAnim == B_ANIM_STATUS_PSN) {
-            NOT STATUS_ICON(opponent, poison: TRUE);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_STATUS, statusAnim, opponent);
+            if (statusAnim == B_ANIM_STATUS_PRZ) {
+                STATUS_ICON(opponent, paralysis: TRUE);
+            } else if (statusAnim == B_ANIM_STATUS_SLP) {
+                STATUS_ICON(opponent, sleep: TRUE);
+            } else if (statusAnim == B_ANIM_STATUS_PSN) {
+                STATUS_ICON(opponent, poison: TRUE);
+            }
         }
     }
 }

--- a/test/battle/move_effect/dream_eater.c
+++ b/test/battle/move_effect/dream_eater.c
@@ -47,8 +47,10 @@ SINGLE_BATTLE_TEST("Dream Eater fails if Heal Block applies")
         TURN { MOVE(opponent, MOVE_HEAL_BLOCK); MOVE(player, MOVE_DREAM_EATER); }
     } SCENE {
         MESSAGE("Wobbuffet was prevented from healing!");
-        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_DREAM_EATER, player);
-        NOT HP_BAR(opponent);
-        NOT HP_BAR(player);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_DREAM_EATER, player);
+            HP_BAR(opponent);
+            HP_BAR(player);
+        }
     }
 }

--- a/test/battle/move_effect/freeze_hit.c
+++ b/test/battle/move_effect/freeze_hit.c
@@ -33,8 +33,10 @@ SINGLE_BATTLE_TEST("Powder Snow cannot freeze an Ice-type Pokémon")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_POWDER_SNOW, player);
         HP_BAR(opponent);
-        NOT ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_FRZ, opponent);
-        NOT STATUS_ICON(opponent, freeze: TRUE);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_FRZ, opponent);
+            STATUS_ICON(opponent, freeze: TRUE);
+        }
     }
 }
 
@@ -61,6 +63,6 @@ SINGLE_BATTLE_TEST("Blizzard bypasses accuracy checks in Hail and Snow")
     } WHEN {
         TURN { MOVE(opponent, move); MOVE(player, MOVE_BLIZZARD); }
     } SCENE {
-        NONE_OF { MESSAGE("Wobbuffet's attack missed!"); }
+        NOT MESSAGE("Wobbuffet's attack missed!");
     }
 }

--- a/test/battle/move_effect/paralyze_hit.c
+++ b/test/battle/move_effect/paralyze_hit.c
@@ -33,7 +33,9 @@ SINGLE_BATTLE_TEST("Thunder Shock cannot paralyze an Electric-type")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_THUNDER_SHOCK, player);
         HP_BAR(opponent);
-        NOT ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PRZ, opponent);
-        NOT STATUS_ICON(opponent, paralysis: TRUE);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PRZ, opponent);
+            STATUS_ICON(opponent, paralysis: TRUE);
+        }
     }
 }

--- a/test/battle/move_effect/poison_hit.c
+++ b/test/battle/move_effect/poison_hit.c
@@ -38,7 +38,9 @@ SINGLE_BATTLE_TEST("Poison cannot be inflicted on Poison and Steel-type Pokémon
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TWINEEDLE, player);
         HP_BAR(opponent);
-        NOT ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
-        NOT STATUS_ICON(opponent, poison: TRUE);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
+            STATUS_ICON(opponent, poison: TRUE);
+        }
     }
 }

--- a/test/battle/move_effect/protect.c
+++ b/test/battle/move_effect/protect.c
@@ -93,8 +93,8 @@ SINGLE_BATTLE_TEST("King's Shield, Silk Trap and Obstruct protect from damaging 
         } else {
             NOT ANIMATION(ANIM_TYPE_MOVE, usedMove, player);
             MESSAGE("Foe Wobbuffet protected itself!");
-            NOT HP_BAR(opponent);
             if (usedMove == MOVE_TACKLE) {
+                NOT HP_BAR(opponent);
                 ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
                 if (statId == STAT_ATK) {
                     MESSAGE("Wobbuffet's Attack fell!");
@@ -106,7 +106,10 @@ SINGLE_BATTLE_TEST("King's Shield, Silk Trap and Obstruct protect from damaging 
                     }
                 }
             } else {
-                NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+                NONE_OF {
+                    HP_BAR(opponent);
+                    ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+                }
             }
         }
     } THEN {
@@ -173,11 +176,14 @@ SINGLE_BATTLE_TEST("Baneful Bunker poisons pokemon for moves making contact")
         MESSAGE("Foe Wobbuffet protected itself!");
         NOT ANIMATION(ANIM_TYPE_MOVE, usedMove, player);
         MESSAGE("Foe Wobbuffet protected itself!");
-        NOT HP_BAR(opponent);
         if (usedMove == MOVE_TACKLE) {
+            NOT HP_BAR(opponent);
             STATUS_ICON(player, STATUS1_POISON);
         } else {
-            NOT STATUS_ICON(player, STATUS1_POISON);
+            NONE_OF {
+                HP_BAR(opponent);
+                STATUS_ICON(player, STATUS1_POISON);
+            }
         }
     }
 }
@@ -218,8 +224,10 @@ SINGLE_BATTLE_TEST("Recoil damage is not applied if target was protected")
         ANIMATION(ANIM_TYPE_MOVE, protectMove, opponent);
         MESSAGE("Foe Beautifly protected itself!");
         // MESSAGE("Rapidash used recoilMove!");
-        NOT ANIMATION(ANIM_TYPE_MOVE, recoilMove, player);
-        NOT MESSAGE("Rapidash is hit with recoil!");
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, recoilMove, player);
+            MESSAGE("Rapidash is hit with recoil!");
+        }
     }
 }
 
@@ -251,16 +259,17 @@ SINGLE_BATTLE_TEST("Multi-hit moves don't hit a protected target and fail only o
         // Each effect happens only once.
         if (move == MOVE_KINGS_SHIELD || move == MOVE_SILK_TRAP || move == MOVE_OBSTRUCT) {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-            NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-        }
-        else if (move == MOVE_SPIKY_SHIELD) {
+        } else if (move == MOVE_SPIKY_SHIELD) {
             HP_BAR(player);
-            NOT HP_BAR(player);
-        }
-        else if (move == MOVE_BANEFUL_BUNKER) {
+        } else if (move == MOVE_BANEFUL_BUNKER) {
             STATUS_ICON(player, STATUS1_POISON);
         }
         NONE_OF {
+            if (move == MOVE_KINGS_SHIELD || move == MOVE_SILK_TRAP || move == MOVE_OBSTRUCT) {
+                ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+            } else if (move == MOVE_SPIKY_SHIELD) {
+                HP_BAR(player);
+            }
             MESSAGE("Hit 2 time(s)!");
             MESSAGE("Hit 3 time(s)!");
             MESSAGE("Hit 4 time(s)!");

--- a/test/battle/move_effect/roost.c
+++ b/test/battle/move_effect/roost.c
@@ -36,8 +36,10 @@ SINGLE_BATTLE_TEST("Roost fails when user is at full HP")
         TURN { MOVE(player, MOVE_ROOST); }
     } SCENE {
         MESSAGE("Wobbuffet's HP is full!");
-        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
-        NOT HP_BAR(player);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
+            HP_BAR(player);
+        }
     }
 }
 
@@ -52,8 +54,10 @@ SINGLE_BATTLE_TEST("Roost fails if the user is under the effects of Heal Block")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_HEAL_BLOCK, opponent);
         MESSAGE("Wobbuffet was prevented from healing!"); // Message when Heal Block is applied
         MESSAGE("Wobbuffet was prevented from healing!"); // Message when trying to heal under Heal Block
-        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
-        NOT HP_BAR(player);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
+            HP_BAR(player);
+        }
     }
 }
 
@@ -340,8 +344,10 @@ SINGLE_BATTLE_TEST("Roost's suppression prevents Reflect Type from copying any F
         // Turn 3: EQ has no effect
         MESSAGE("Swellow used Earthquake!");
         MESSAGE("It doesn't affect Foe Wobbuffet…");
-        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, player);
-        NOT HP_BAR(opponent);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, player);
+            HP_BAR(opponent);
+        }
     }
 }
 
@@ -357,8 +363,10 @@ SINGLE_BATTLE_TEST("Roost does not suppress the ungrounded effect of Levitate")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
         MESSAGE("Flygon regained health!");
         MESSAGE("Foe Wobbuffet used Earthquake!");
-        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
-        NOT HP_BAR(player);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
+            HP_BAR(player);
+        }
     }
 }
 
@@ -374,8 +382,10 @@ SINGLE_BATTLE_TEST("Roost does not suppress the ungrounded effect of Air Balloon
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
         MESSAGE("Wobbuffet regained health!");
         MESSAGE("Foe Wobbuffet used Earthquake!");
-        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
-        NOT HP_BAR(player);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
+            HP_BAR(player);
+        }
     }
 }
 
@@ -397,8 +407,10 @@ SINGLE_BATTLE_TEST("Roost does not suppress the ungrounded effect of Magnet Rise
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
         MESSAGE("Wobbuffet regained health!");
         MESSAGE("Foe Wobbuffet used Earthquake!");
-        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
-        NOT HP_BAR(player);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
+            HP_BAR(player);
+        }
     }
 }
 
@@ -421,8 +433,10 @@ SINGLE_BATTLE_TEST("Roost does not suppress the ungrounded effect of Telekinesis
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
         MESSAGE("Wobbuffet regained health!");
         MESSAGE("Foe Wobbuffet used Earthquake!");
-        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
-        NOT HP_BAR(player);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
+            HP_BAR(player);
+        }
     }
 }
 

--- a/test/battle/move_effect/teatime.c
+++ b/test/battle/move_effect/teatime.c
@@ -149,8 +149,10 @@ SINGLE_BATTLE_TEST("Teatime does not affect Pokémon in the semi-invulnerable tu
         }
     } SCENE {
         MESSAGE("Wobbuffet used Teatime!");
-        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, player);
-        NOT MESSAGE("Using Liechi Berry, the Attack of Foe Wobbuffet rose!");
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, player);
+            MESSAGE("Using Liechi Berry, the Attack of Foe Wobbuffet rose!");
+        }
     }
 }
 
@@ -206,7 +208,7 @@ SINGLE_BATTLE_TEST("Teatime triggers Lightning Rod if it has been affected by El
         PLAYER(SPECIES_PIKACHU) { Ability(ABILITY_LIGHTNING_ROD); Item(item); }
         OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_LIECHI_BERRY); }
     } WHEN {
-        TURN { 
+        TURN {
             MOVE(player, move);
             MOVE(opponent, MOVE_TEATIME);
         }

--- a/test/battle/move_effect/toxic.c
+++ b/test/battle/move_effect/toxic.c
@@ -40,9 +40,11 @@ SINGLE_BATTLE_TEST("Toxic cannot miss if used by a Poison-type")
             ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
             STATUS_ICON(opponent, badPoison: TRUE);
         } else {
-            NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_TOXIC, player);
-            NOT ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
-            NOT STATUS_ICON(opponent, badPoison: TRUE);
+            NONE_OF {
+                ANIMATION(ANIM_TYPE_MOVE, MOVE_TOXIC, player);
+                ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
+                STATUS_ICON(opponent, badPoison: TRUE);
+            }
         }
     }
 }

--- a/test/battle/move_effect/tri_attack.c
+++ b/test/battle/move_effect/tri_attack.c
@@ -25,11 +25,9 @@ SINGLE_BATTLE_TEST("Tri Attack can inflict paralysis, burn or freeze")
         ANIMATION(ANIM_TYPE_STATUS, statusAnim, opponent);
         if (statusAnim == B_ANIM_STATUS_BRN) {
             STATUS_ICON(opponent, burn: TRUE);
-        }
-        else if (statusAnim == B_ANIM_STATUS_FRZ) {
+        } else if (statusAnim == B_ANIM_STATUS_FRZ) {
             STATUS_ICON(opponent, freeze: TRUE);
-        }
-        else if (statusAnim == B_ANIM_STATUS_PRZ) {
+        } else if (statusAnim == B_ANIM_STATUS_PRZ) {
             STATUS_ICON(opponent, paralysis: TRUE);
         }
     }
@@ -54,15 +52,15 @@ SINGLE_BATTLE_TEST("Tri Attack cannot paralyze/burn/freeze electric/fire/ice typ
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TRI_ATTACK, player);
         HP_BAR(opponent);
-        NOT ANIMATION(ANIM_TYPE_STATUS, statusAnim, opponent);
-        if (statusAnim == B_ANIM_STATUS_BRN) {
-            NOT STATUS_ICON(opponent, burn: TRUE);
-        }
-        else if (statusAnim == B_ANIM_STATUS_FRZ) {
-            NOT STATUS_ICON(opponent, freeze: TRUE);
-        }
-        else if (statusAnim == B_ANIM_STATUS_PRZ) {
-            NOT STATUS_ICON(opponent, paralysis: TRUE);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_STATUS, statusAnim, opponent);
+            if (statusAnim == B_ANIM_STATUS_BRN) {
+                STATUS_ICON(opponent, burn: TRUE);
+            } else if (statusAnim == B_ANIM_STATUS_FRZ) {
+                STATUS_ICON(opponent, freeze: TRUE);
+            } else if (statusAnim == B_ANIM_STATUS_PRZ) {
+                STATUS_ICON(opponent, paralysis: TRUE);
+            }
         }
     }
 }
@@ -92,15 +90,15 @@ SINGLE_BATTLE_TEST("Tri Attack cannot paralyze/burn/freeze pokemon with abilitie
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TRI_ATTACK, player);
         HP_BAR(opponent);
-        NOT ANIMATION(ANIM_TYPE_STATUS, statusAnim, opponent);
-        if (statusAnim == B_ANIM_STATUS_BRN) {
-            NOT STATUS_ICON(opponent, burn: TRUE);
-        }
-        else if (statusAnim == B_ANIM_STATUS_FRZ) {
-            NOT STATUS_ICON(opponent, freeze: TRUE);
-        }
-        else if (statusAnim == B_ANIM_STATUS_PRZ) {
-            NOT STATUS_ICON(opponent, paralysis: TRUE);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_STATUS, statusAnim, opponent);
+            if (statusAnim == B_ANIM_STATUS_BRN) {
+                STATUS_ICON(opponent, burn: TRUE);
+            } else if (statusAnim == B_ANIM_STATUS_FRZ) {
+                STATUS_ICON(opponent, freeze: TRUE);
+            } else if (statusAnim == B_ANIM_STATUS_PRZ) {
+                STATUS_ICON(opponent, paralysis: TRUE);
+            }
         }
     }
 }
@@ -121,15 +119,15 @@ SINGLE_BATTLE_TEST("Tri Attack cannot paralyze/burn/freeze a mon which is alread
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TRI_ATTACK, player);
         HP_BAR(opponent);
-        NOT ANIMATION(ANIM_TYPE_STATUS, statusAnim, opponent);
-        if (statusAnim == B_ANIM_STATUS_BRN) {
-            NOT STATUS_ICON(opponent, burn: TRUE);
-        }
-        else if (statusAnim == B_ANIM_STATUS_FRZ) {
-            NOT STATUS_ICON(opponent, freeze: TRUE);
-        }
-        else if (statusAnim == B_ANIM_STATUS_PRZ) {
-            NOT STATUS_ICON(opponent, paralysis: TRUE);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_STATUS, statusAnim, opponent);
+            if (statusAnim == B_ANIM_STATUS_BRN) {
+                STATUS_ICON(opponent, burn: TRUE);
+            } else if (statusAnim == B_ANIM_STATUS_FRZ) {
+                STATUS_ICON(opponent, freeze: TRUE);
+            } else if (statusAnim == B_ANIM_STATUS_PRZ) {
+                STATUS_ICON(opponent, paralysis: TRUE);
+            }
         }
     }
 }

--- a/test/test_runner_battle.c
+++ b/test/test_runner_battle.c
@@ -1657,8 +1657,18 @@ static const char *const sQueueGroupTypeMacros[] =
 void OpenQueueGroup(u32 sourceLine, enum QueueGroupType type)
 {
     INVALID_IF(DATA.queueGroupType, "%s inside %s", sQueueGroupTypeMacros[type], sQueueGroupTypeMacros[DATA.queueGroupType]);
-    DATA.queueGroupType = type;
-    DATA.queueGroupStart = DATA.queuedEventsCount;
+    if (DATA.queuedEventsCount > 0
+     && DATA.queuedEvents[DATA.queueGroupStart].groupType == QUEUE_GROUP_NONE_OF
+     && DATA.queuedEvents[DATA.queueGroupStart].groupSize == DATA.queuedEventsCount - DATA.queueGroupStart
+     && type == QUEUE_GROUP_NONE_OF)
+    {
+        INVALID("'NOT x; NOT y;', did you mean 'NONE_OF { x; y; }'?");
+    }
+    else
+    {
+        DATA.queueGroupType = type;
+        DATA.queueGroupStart = DATA.queuedEventsCount;
+    }
 }
 
 void CloseQueueGroup(u32 sourceLine)


### PR DESCRIPTION
`NOT x; NOT y;` does not behave how you would expect, so this PR detects uses of that and tells the developer to write `NONE_OF { x; y; }` instead.

Purifying Salt's can't-be-frozen test was erroneously passing because of this, so that has been fixed too.