### PR TITLE
Rename output roms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,5 +56,5 @@ jobs:
           MODERN: 1
           TEST: 1
         run: |
-          make -j${nproc} -O pokeemerald_modern-test.elf
+          make -j${nproc} -O pokeemerald-test.elf
           make -j${nproc} check

--- a/Makefile
+++ b/Makefile
@@ -69,12 +69,12 @@ else
   CPP := $(PREFIX)cpp
 endif
 
-ROM_NAME := pokeemerald.gba
+ROM_NAME := pokeemerald_agbcc.gba
 ELF_NAME := $(ROM_NAME:.gba=.elf)
 MAP_NAME := $(ROM_NAME:.gba=.map)
 OBJ_DIR_NAME := build/emerald
 
-MODERN_ROM_NAME := pokeemerald_modern.gba
+MODERN_ROM_NAME := pokeemerald.gba
 MODERN_ELF_NAME := $(MODERN_ROM_NAME:.gba=.elf)
 MODERN_MAP_NAME := $(MODERN_ROM_NAME:.gba=.map)
 MODERN_OBJ_DIR_NAME := build/modern


### PR DESCRIPTION
With modern now being the default output and agbcc requiring the explicit mention that modern used to require, it only makes sense to rename the output files to accomodate this change.

## **Discord contact info**
bassoonian