### PR TITLE
Fix Sap Sipper not blocking Bullet Seed

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -5135,6 +5135,9 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
                 #endif
                 }
             }
+
+            if (effect)
+                gMultiHitCounter = 0; // Prevent multi-hit moves from hitting more than once after move has been absorbed.
         }
         break;
     case ABILITYEFFECT_MOVE_END: // Think contact abilities.

--- a/test/battle/ability/defiant.c
+++ b/test/battle/ability/defiant.c
@@ -115,3 +115,26 @@ DOUBLE_BATTLE_TEST("Defiant sharply raises opponent's Attack after Intimidate")
         EXPECT_EQ(opponentRight->statStages[STAT_ATK], (abilityRight == ABILITY_DEFIANT) ? DEFAULT_STAT_STAGE + 2 : DEFAULT_STAT_STAGE - 2);
     }
 }
+
+SINGLE_BATTLE_TEST("Defiant activates after Sticky Web lowers Speed")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_MANKEY) { Ability(ABILITY_DEFIANT); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_STICKY_WEB); }
+        TURN { SWITCH(player, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_STICKY_WEB, opponent);
+        // Switch-in - Sticky Web activates
+        MESSAGE("Go! Mankey!");
+        MESSAGE("Mankey was caught in a Sticky Web!");
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        MESSAGE("Mankey's Speed fell!");
+        // Defiant activates
+        ABILITY_POPUP(player, ABILITY_DEFIANT);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        MESSAGE("Mankey's Attack sharply rose!");
+    }
+}

--- a/test/battle/ability/sap_sipper.c
+++ b/test/battle/ability/sap_sipper.c
@@ -57,3 +57,24 @@ SINGLE_BATTLE_TEST("Sap Sipper does not increase Attack if already maxed")
         }
     }
 }
+
+SINGLE_BATTLE_TEST("Sap Sipper blocks multi-hit grass type moves")
+{
+    GIVEN {
+        ASSUME(gBattleMoves[MOVE_BULLET_SEED].effect == EFFECT_MULTI_HIT);
+        PLAYER(SPECIES_MARILL) { Ability(ABILITY_SAP_SIPPER); }
+        OPPONENT(SPECIES_SHELLDER) { Ability(ABILITY_SKILL_LINK); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_BULLET_SEED); }
+    } SCENE {
+        MESSAGE("Foe Shellder used Bullet Seed!");
+        ABILITY_POPUP(player, ABILITY_SAP_SIPPER);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        MESSAGE("Marill's Attack rose!");
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_BULLET_SEED, opponent);
+            HP_BAR(player);
+            MESSAGE("Hit 5 time(s)!");
+        }
+    }
+}


### PR DESCRIPTION
Fixes Sap Sipper activating only for the first of Bullet Seed.

Also has one test for Defiant + Sticky Web.