### PR TITLE
Fixed issue with GetNextBall not working properly

### DIFF
--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -233,7 +233,7 @@ static u16 GetNextBall(u16 ballId)
     {
         if (ballId == gBagPockets[BALLS_POCKET].itemSlots[i].itemId)
         {
-            ballNext = gBagPockets[BALLS_POCKET].itemSlots[i].itemId;
+            ballNext = gBagPockets[BALLS_POCKET].itemSlots[i+1].itemId;
             break;
         }
     }


### PR DESCRIPTION
When looping through Poke Balls, GetNextBall was selecting the current ball as the next one, which prevented it selecting the correct next ball. This PR fixes that by having it actually look at the next ball.

## Description
<!--- Describe your changes in detail -->

## Images
![getNextBallFix](https://github.com/rh-hideout/pokeemerald-expansion/assets/35279583/e67aa036-8a1a-42ec-b1de-cb4f302e0713)

## Issue(s) that this PR fixes
Fixes #3496

## **Discord contact info**
frankfurter0