### PR TITLE
[sprites] remove potential dangling template ptr from struct Sprite

### DIFF
--- a/gflib/sprite.c
+++ b/gflib/sprite.c
@@ -159,7 +159,8 @@ static const struct Sprite sDummySprite =
     .oam = DUMMY_OAM_DATA,
     .anims = gDummySpriteAnimTable,
     .affineAnims = gDummySpriteAffineAnimTable,
-    .template = &gDummySpriteTemplate,
+    .tileTag = TAG_NONE,
+    .paletteTag = TAG_NONE,
     .callback = SpriteCallbackDummy,
     .x = DISPLAY_WIDTH + 64,
     .y = DISPLAY_HEIGHT,
@@ -500,7 +501,8 @@ u8 CreateSpriteAt(u8 index, const struct SpriteTemplate *template, s16 x, s16 y,
     sprite->oam = *template->oam;
     sprite->anims = template->anims;
     sprite->affineAnims = template->affineAnims;
-    sprite->template = template;
+    sprite->tileTag = template->tileTag;
+    sprite->paletteTag = template->paletteTag;
     sprite->callback = template->callback;
     sprite->x = x;
     sprite->y = y;
@@ -810,23 +812,23 @@ void FreeSpriteTiles(struct Sprite *sprite)
 {
 // UB: template pointer may point to freed temporary storage
 #ifdef UBFIX
-    if (!sprite || !sprite->template)
+    if (!sprite)
         return;
 #endif
 
-    if (sprite->template->tileTag != TAG_NONE)
-        FreeSpriteTilesByTag(sprite->template->tileTag);
+    if (sprite->tileTag != TAG_NONE)
+        FreeSpriteTilesByTag(sprite->tileTag);
 }
 
 void FreeSpritePalette(struct Sprite *sprite)
 {
 // UB: template pointer may point to freed temporary storage
 #ifdef UBFIX
-    if (!sprite || !sprite->template)
+    if (!sprite)
         return;
 #endif
 
-    FreeSpritePaletteByTag(sprite->template->paletteTag);
+    FreeSpritePaletteByTag(sprite->paletteTag);
 }
 
 void FreeSpriteOamMatrix(struct Sprite *sprite)

--- a/gflib/sprite.h
+++ b/gflib/sprite.h
@@ -196,7 +196,8 @@ struct Sprite
     /*0x08*/ const union AnimCmd *const *anims;
     /*0x0C*/ const struct SpriteFrameImage *images;
     /*0x10*/ const union AffineAnimCmd *const *affineAnims;
-    /*0x14*/ const struct SpriteTemplate *template;
+    /*0x14*/ u16 tileTag;
+    /*0x16*/ u16 paletteTag;
     /*0x18*/ const struct SubspriteTable *subspriteTables;
     /*0x1C*/ SpriteCallback callback;
 

--- a/include/fldeff_misc.h
+++ b/include/fldeff_misc.h
@@ -27,7 +27,6 @@ void FldEffPoison_Start(void);
 bool32 FldEffPoison_IsActive(void);
 void DoWateringBerryTreeAnim(void);
 u8 CreateRecordMixingLights(void);
-void DestroyRecordMixingLights(void);
 
 extern const struct SpritePalette gSpritePalette_SecretPower_Cave;
 extern const struct SpritePalette gSpritePalette_SecretPower_Plant;

--- a/src/battle_anim_effects_1.c
+++ b/src/battle_anim_effects_1.c
@@ -6401,7 +6401,7 @@ static void AnimTask_MoonlightEndFade_Step(u8 taskId)
             u8 spriteId;
             for (spriteId = 0; spriteId < MAX_SPRITES; spriteId++)
             {
-                if (gSprites[spriteId].template == &gMoonSpriteTemplate || gSprites[spriteId].template == &gMoonlightSparkleSpriteTemplate)
+                if (gSprites[spriteId].callback == AnimMoon || gSprites[spriteId].callback == AnimMoonlightSparkle)
                     gSprites[spriteId].data[0] = 1;
             }
 

--- a/src/battle_anim_normal.c
+++ b/src/battle_anim_normal.c
@@ -854,7 +854,7 @@ void AnimTask_TintPalettes(u8 taskId)
 
     if (gTasks[taskId].tFlagsScenery & 1)
     {
-        paletteIndex = IndexOfSpritePaletteTag(gSprites[gHealthboxSpriteIds[attackerBattler]].template->paletteTag);
+        paletteIndex = IndexOfSpritePaletteTag(gSprites[gHealthboxSpriteIds[attackerBattler]].paletteTag);
         selectedPalettes |= (1 << paletteIndex) << 16;
     }
 

--- a/src/battle_anim_throw.c
+++ b/src/battle_anim_throw.c
@@ -1616,7 +1616,7 @@ static void SpriteCB_Ball_FadeOut(struct Sprite *sprite)
         sprite->oam.objMode = ST_OAM_OBJ_BLEND;
         SetGpuReg(REG_OFFSET_BLDCNT, BLDCNT_EFFECT_BLEND | BLDCNT_TGT2_ALL);
         SetGpuReg(REG_OFFSET_BLDALPHA, BLDALPHA_BLEND(16, 0));
-        paletteIndex = IndexOfSpritePaletteTag(sprite->template->paletteTag);
+        paletteIndex = IndexOfSpritePaletteTag(sprite->paletteTag);
         BeginNormalPaletteFade(1 << (paletteIndex + 0x10), 0, 0, 16, RGB_WHITE);
         sprite->sState++;
         break;

--- a/src/field_weather_effect.c
+++ b/src/field_weather_effect.c
@@ -2368,7 +2368,7 @@ static void DestroyBubbleSprites(void)
     {
         for (i = 0; i < MAX_SPRITES; i++)
         {
-            if (gSprites[i].template == &sBubbleSpriteTemplate)
+            if (gSprites[i].tileTag == GFXTAG_BUBBLE)
                 DestroySprite(&gSprites[i]);
         }
 

--- a/src/fldeff_misc.c
+++ b/src/fldeff_misc.c
@@ -1310,17 +1310,3 @@ u8 CreateRecordMixingLights(void)
     }
     return spriteId;
 }
-
-void DestroyRecordMixingLights(void)
-{
-    int i;
-
-    for (i = 0; i < MAX_SPRITES; i++)
-    {
-        if (gSprites[i].template == &sSpriteTemplate_RecordMixLights)
-        {
-            FreeSpritePalette(&gSprites[i]);
-            DestroySprite(&gSprites[i]);
-        }
-    }
-}

--- a/src/record_mixing.c
+++ b/src/record_mixing.c
@@ -303,6 +303,7 @@ static void Task_RecordMixing_SoundEffect(u8 taskId)
 
 #undef tCounter
 
+#define tSpriteId    data[1]
 #define tTimer       data[8]
 #define tLinkTaskId  data[10]
 #define tSoundTaskId data[15]
@@ -321,7 +322,7 @@ static void Task_RecordMixing_Main(u8 taskId)
         VarSet(VAR_TEMP_MIXED_RECORDS, 1);
         sReadyToReceive = FALSE;
         PrepareExchangePacket();
-        CreateRecordMixingLights();
+        tSpriteId = CreateRecordMixingLights();
         tState = 1;
         tLinkTaskId = CreateTask(Task_MixingRecordsRecv, 80);
         tSoundTaskId = CreateTask(Task_RecordMixing_SoundEffect, 81);
@@ -331,7 +332,8 @@ static void Task_RecordMixing_Main(u8 taskId)
         {
             tState = 2;
             FlagSet(FLAG_SYS_MIX_RECORD);
-            DestroyRecordMixingLights();
+            FreeSpritePalette(&gSprites[tSpriteId]);
+            DestroySprite(&gSprites[tSpriteId]);
             DestroyTask(tSoundTaskId);
         }
         break;


### PR DESCRIPTION
## Description
Fixes potential Use after Free when accessing `struct Sprite`.`template` by removing the template pointer from the sprite structure. Instead we store the tile and palette tag which is commonly used when accessing the template.

## **Discord contact info**
karathan