### PR TITLE
Fixed IS_DITTO macro

### DIFF
--- a/src/daycare.c
+++ b/src/daycare.c
@@ -28,7 +28,7 @@
 
 extern const struct Evolution gEvolutionTable[][EVOS_PER_MON];
 
-#define IS_DITTO(species) (gBaseStats[species].eggGroup1 == EGG_GROUP_DITTO || gBaseStats[species].eggGroup2 == EGG_GROUP_DITTO)
+#define IS_DITTO(species) (gSpeciesInfo[species].eggGroups[0] == EGG_GROUP_DITTO || gSpeciesInfo[species].eggGroups[1] == EGG_GROUP_DITTO)
 
 static void ClearDaycareMonMail(struct DaycareMail *mail);
 static void SetInitialEggData(struct Pokemon *mon, u16 species, struct DayCare *daycare);


### PR DESCRIPTION
## Description
The `IS_DITTO` macro used by the `P_NATURE_INHERITANCE` preproc config at `include/config/pokemon.h` was sorely outdated and was blocking the compiler from building a ROM when set to a value like `GEN_3`.
This PR fixes that.

## **Discord contact info**
lunos4026