### PR TITLE
Performance improvement for specific tests

### DIFF
--- a/test/test_runner.c
+++ b/test/test_runner.c
@@ -162,17 +162,18 @@ void CB2_TestRunner(void)
         break;
 
     case STATE_ASSIGN_TEST:
-        if (gTestRunnerState.test == __stop_tests)
+        while (1)
         {
-            gTestRunnerState.state = STATE_EXIT;
-            return;
-        }
-
-        if (gTestRunnerState.test->runner != &gAssumptionsRunner
-          && !PrefixMatch(gTestRunnerArgv, gTestRunnerState.test->name))
-        {
-            gTestRunnerState.state = STATE_NEXT_TEST;
-            return;
+            if (gTestRunnerState.test == __stop_tests)
+            {
+                gTestRunnerState.state = STATE_EXIT;
+                return;
+            }
+            if (gTestRunnerState.test->runner != &gAssumptionsRunner
+              && !PrefixMatch(gTestRunnerArgv, gTestRunnerState.test->name))
+                ++gTestRunnerState.test;
+            else
+                break;
         }
 
         MgbaPrintf_(":N%s", gTestRunnerState.test->name);


### PR DESCRIPTION
## Description
### The issue
Currently, the test runner's name prefix matching process is extremely slow. For example, if I do `make pokeemerald-test.elf TESTS='Spikes' DINFO=1 -j`, and boot the test elf in mgba, it takes ~36 seconds (upcoming: ~40 seconds) to actually get into the battle scene.

### The cause
The state machine in `CB2_TestRunner` is not efficient. If a non-assumption test doesn't match the specified prefix, it will wait two frames before trying to match the next test.

### The solution
We can simply ignore Vblank and run serial code until we find a suitable test or run out of tests. The waiting time (before battle scene) can be reduced to less than 10 seconds with the change.

## **Discord contact info**
jiang