### PR TITLE
Initialize clock offset in debug menu cheat start if not already set

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -43,6 +43,7 @@
 #include "pokemon_storage_system.h"
 #include "random.h"
 #include "region_map.h"
+#include "rtc.h"
 #include "script.h"
 #include "script_pokemon_util.h"
 #include "sound.h"
@@ -1984,6 +1985,9 @@ static void DebugAction_Util_Clear_Boxes(u8 taskId)
 }
 static void DebugAction_Util_CheatStart(u8 taskId)
 {
+    if (!FlagGet(FLAG_SYS_CLOCK_SET))
+        RtcInitLocalTimeOffset(0, 0);
+
     InitTimeBasedEvents();
     Debug_DestroyMenu_Full_Script(taskId, Debug_CheatStart);
 }


### PR DESCRIPTION
## Description
This adds some corner case coverage to the debug menu cheat start script. If the clock offset has not been set yet, it sets the clock offset to 0 minutes and 0 seconds. This allows time-based events to initialize correctly for hacks that use a simulated "fake" RTC when using the cheat start.

I figure this may help out in the future as potentially more folks pull in Anon822's fake RTC tutorial on the pokeemerald wiki's tutorial page.

## **Discord contact info**
User: RavePossum