### PR TITLE
Adds configable nature colors

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -74,7 +74,8 @@
 #define GEN_LATEST GEN_9
 
 // General settings
-#define EXPANSION_INTRO   TRUE    // If TRUE, a custom RHH intro will play after the vanilla copyright screen.
-#define POKEDEX_PLUS_HGSS FALSE   // If TRUE, enables the custom HGSS style Pokedex.
+#define EXPANSION_INTRO              TRUE    // If TRUE, a custom RHH intro will play after the vanilla copyright screen.
+#define POKEDEX_PLUS_HGSS            FALSE   // If TRUE, enables the custom HGSS style Pokedex.
+#define SUMMARY_SCREEN_NATURE_COLORS TRUE    // If TRUE, nature-based stat boosts and reductions will be red and blue in the summary screen.
 
 #endif // GUARD_CONFIG_H

--- a/src/pokemon_summary_screen.c
+++ b/src/pokemon_summary_screen.c
@@ -3473,12 +3473,12 @@ static void PrintRibbonCount(void)
 
 static void BufferStat(u8 *dst, s8 natureMod, u32 stat, u32 strId, u32 n)
 {
-    static const u8 sTextNatureDown[] = _("{COLOR}{09}");
+    static const u8 sTextNatureDown[] = _("{COLOR}{08}");
     static const u8 sTextNatureUp[] = _("{COLOR}{05}");
     static const u8 sTextNatureNeutral[] = _("{COLOR}{01}");
     u8 *txtPtr;
 
-    if (natureMod == 0)
+    if (natureMod == 0 || !SUMMARY_SCREEN_NATURE_COLORS)
         txtPtr = StringCopy(dst, sTextNatureNeutral);
     else if (natureMod > 0)
         txtPtr = StringCopy(dst, sTextNatureUp);


### PR DESCRIPTION
Incorporates @DizzyEggg's [nature color branch](https://github.com/DizzyEggg/pokeemerald/tree/nature_color) (as such, don't squash when merging!). It also adds a config to easily toggle them and updates the reduction color to blue per @AsparagusEduardo's [tutorial](https://github.com/pret/pokeemerald/wiki/Colored-stats-by-nature-in-summary-screen).

## Issue(s) that this PR fixes
Fixes #2535 

## **Discord contact info**
bassoonian