### PR TITLE
Reflect Ivy Cudgel type in interfaces

### DIFF
--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -1740,10 +1740,7 @@ static void MoveSelectionDisplayMoveType(u32 battler)
 
     if (moveInfo->moves[gMoveSelectionCursor[battler]] == MOVE_IVY_CUDGEL)
     {
-        if (GetBattlerSide(battler) == B_SIDE_OPPONENT)
-            mon = &gEnemyParty[gBattlerPartyIndexes[battler]];
-        else
-            mon = &gPlayerParty[gBattlerPartyIndexes[battler]];
+        mon = &GetSideParty(GetBattlerSide(battler))[gBattlerPartyIndexes[battler]];
         itemId = GetMonData(mon, MON_DATA_HELD_ITEM);
 
         if (ItemId_GetHoldEffect(itemId) == HOLD_EFFECT_MASK)

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -31,6 +31,7 @@
 #include "util.h"
 #include "window.h"
 #include "constants/battle_anim.h"
+#include "constants/hold_effects.h"
 #include "constants/items.h"
 #include "constants/moves.h"
 #include "constants/party_menu.h"
@@ -1727,6 +1728,9 @@ static void MoveSelectionDisplayPpNumber(u32 battler)
 static void MoveSelectionDisplayMoveType(u32 battler)
 {
     u8 *txtPtr;
+    u8 type;
+    u32 itemId;
+    struct Pokemon *mon;
     struct ChooseMoveStruct *moveInfo = (struct ChooseMoveStruct *)(&gBattleResources->bufferA[battler][4]);
 
     txtPtr = StringCopy(gDisplayedStringBattle, gText_MoveInterfaceType);
@@ -1734,7 +1738,23 @@ static void MoveSelectionDisplayMoveType(u32 battler)
     *(txtPtr)++ = EXT_CTRL_CODE_FONT;
     *(txtPtr)++ = FONT_NORMAL;
 
-    StringCopy(txtPtr, gTypeNames[gBattleMoves[moveInfo->moves[gMoveSelectionCursor[battler]]].type]);
+    if (moveInfo->moves[gMoveSelectionCursor[battler]] == MOVE_IVY_CUDGEL)
+    {
+        if (GetBattlerSide(battler) == B_SIDE_OPPONENT)
+            mon = &gEnemyParty[gBattlerPartyIndexes[battler]];
+        else
+            mon = &gPlayerParty[gBattlerPartyIndexes[battler]];
+        itemId = GetMonData(mon, MON_DATA_HELD_ITEM);
+
+        if (ItemId_GetHoldEffect(itemId) == HOLD_EFFECT_MASK)
+            type = ItemId_GetSecondaryId(itemId);
+        else
+            type = gBattleMoves[MOVE_IVY_CUDGEL].type;
+    }
+    else
+        type = gBattleMoves[moveInfo->moves[gMoveSelectionCursor[battler]]].type;
+
+    StringCopy(txtPtr, gTypeNames[type]);
     BattlePutTextOnWindow(gDisplayedStringBattle, B_WIN_MOVE_TYPE);
 }
 

--- a/src/pokemon_summary_screen.c
+++ b/src/pokemon_summary_screen.c
@@ -42,6 +42,7 @@
 #include "tv.h"
 #include "window.h"
 #include "constants/battle_move_effects.h"
+#include "constants/hold_effects.h"
 #include "constants/items.h"
 #include "constants/moves.h"
 #include "constants/party_menu.h"
@@ -3947,7 +3948,12 @@ static void SetMoveTypeIcons(void)
     for (i = 0; i < MAX_MON_MOVES; i++)
     {
         if (summary->moves[i] != MOVE_NONE)
-            SetTypeSpritePosAndPal(gBattleMoves[summary->moves[i]].type, 85, 32 + (i * 16), i + SPRITE_ARR_ID_TYPE);
+        {
+            if (summary->moves[i] == MOVE_IVY_CUDGEL && ItemId_GetHoldEffect(summary->item) == HOLD_EFFECT_MASK)
+                SetTypeSpritePosAndPal(ItemId_GetSecondaryId(summary->item), 85, 32 + (i * 16), i + SPRITE_ARR_ID_TYPE);
+            else
+                SetTypeSpritePosAndPal(gBattleMoves[summary->moves[i]].type, 85, 32 + (i * 16), i + SPRITE_ARR_ID_TYPE);
+        }
         else
             SetSpriteInvisibility(i + SPRITE_ARR_ID_TYPE, TRUE);
     }


### PR DESCRIPTION
Ivy Cudgel (and Tera Blast, which is for later) are the only moves in SV where the actual type used in calculations is shown in interfaces (as opposed to Raging Bull, Judgment etc, which just show the default type). This PR adds the Ivy Cudgel logic to the interfaces to show the correct type.

## Images
![pokeemerald-0](https://github.com/rh-hideout/pokeemerald-expansion/assets/16993385/d101c530-a137-4430-8068-dd751f454aa7)
![pokeemerald-1](https://github.com/rh-hideout/pokeemerald-expansion/assets/16993385/5ef1e534-fb6d-48ec-b8d9-f8e912a42912)

## **Discord contact info**
bassoonian