### PR TITLE
Fixes Protosynthesis and Quark Drive ability pop up

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -103,6 +103,8 @@ struct DisableStruct
     u8 toxicSpikesDone:1;
     u8 stickyWebDone:1;
     u8 stealthRockDone:1;
+    u8 weatherAbilityDone:1;
+    u8 terrainAbilityDone:1;
 };
 
 struct ProtectStruct
@@ -193,8 +195,6 @@ struct SpecialStatus
     u8 dancerUsedMove:1;
     u8 dancerOriginalTarget:3;
     // End of byte
-    u8 weatherAbilityDone:1;
-    u8 terrainAbilityDone:1;
     u8 emergencyExited:1;
     u8 afterYou:1;
 };

--- a/test/battle/ability/protosynthesis.c
+++ b/test/battle/ability/protosynthesis.c
@@ -85,3 +85,50 @@ SINGLE_BATTLE_TEST("Protosynthesis either boosts Defense or Special Defense, not
             EXPECT_EQ(damage[0], damage[1]);
     }
 }
+
+SINGLE_BATTLE_TEST("Protosynthesis ability pop up activates only once during the duration of sunny day")
+{
+    u16 turns;
+
+    GIVEN {
+        PLAYER(SPECIES_BELLSPROUT) { Ability(ABILITY_PROTOSYNTHESIS); }
+        OPPONENT(SPECIES_NINETALES) { Ability(ABILITY_DROUGHT); };
+    } WHEN {
+        for (turns = 0; turns < 5; turns++)
+            TURN {}
+        TURN { MOVE(opponent, MOVE_SUNNY_DAY); }
+    } SCENE {
+        ABILITY_POPUP(opponent, ABILITY_DROUGHT);
+        ABILITY_POPUP(player, ABILITY_PROTOSYNTHESIS);
+        MESSAGE("The harsh sunlight activated Bellsprout's Protosynthesis!");
+        MESSAGE("Bellsprout's Attack was heightened!");
+        NONE_OF {
+            for (turns = 0; turns < 4; turns++) {
+                ABILITY_POPUP(player, ABILITY_PROTOSYNTHESIS);
+                MESSAGE("The harsh sunlight activated Bellsprout's Protosynthesis!");
+                MESSAGE("Bellsprout's Attack was heightened!");
+            }
+        }
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SUNNY_DAY, opponent);
+        ABILITY_POPUP(player, ABILITY_PROTOSYNTHESIS);
+        MESSAGE("The harsh sunlight activated Bellsprout's Protosynthesis!");
+        MESSAGE("Bellsprout's Attack was heightened!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Protosynthesis activates on switch-in")
+{
+    KNOWN_FAILING; // Fails because of wrong species
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_BELLSPROUT) { Ability(ABILITY_PROTOSYNTHESIS); }
+        OPPONENT(SPECIES_NINETALES) { Ability(ABILITY_DROUGHT); };
+    } WHEN {
+        TURN { SWITCH(player, 1); }
+    } SCENE {
+        ABILITY_POPUP(opponent, ABILITY_DROUGHT);
+        ABILITY_POPUP(player, ABILITY_PROTOSYNTHESIS);
+        MESSAGE("The harsh sunlight activated Bellsprout's Protosynthesis!");
+        MESSAGE("Bellsprout's Attack was heightened!");
+    }
+}

--- a/test/battle/ability/quark_drive.c
+++ b/test/battle/ability/quark_drive.c
@@ -85,3 +85,51 @@ SINGLE_BATTLE_TEST("Quark Drive either boosts Defense or Special Defense, not bo
             EXPECT_EQ(damage[0], damage[1]);
     }
 }
+
+SINGLE_BATTLE_TEST("Quark Drive ability pop up activates only once during the duration of electric terrain")
+{
+    u16 turns;
+
+    GIVEN {
+        PLAYER(SPECIES_BELLSPROUT) { Ability(ABILITY_QUARK_DRIVE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_ELECTRIC_TERRAIN); }
+        for (turns = 0; turns < 4; turns++)
+            TURN {}
+        TURN { MOVE(opponent, MOVE_ELECTRIC_TERRAIN); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ELECTRIC_TERRAIN, opponent);
+        ABILITY_POPUP(player, ABILITY_QUARK_DRIVE);
+        MESSAGE("The Electric Terrain activated Bellsprout's Quark Drive!");
+        MESSAGE("Bellsprout's Attack was heightened!");
+        NONE_OF {
+            for (turns = 0; turns < 4; turns++) {
+                ABILITY_POPUP(player, ABILITY_QUARK_DRIVE);
+                MESSAGE("The Electric Terrain activated Bellsprout's Quark Drive!");
+                MESSAGE("Bellsprout's Attack was heightened!");
+            }
+        }
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ELECTRIC_TERRAIN, opponent);
+        ABILITY_POPUP(player, ABILITY_QUARK_DRIVE);
+        MESSAGE("The Electric Terrain activated Bellsprout's Quark Drive!");
+        MESSAGE("Bellsprout's Attack was heightened!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Quark Drive activates on switch-in")
+{
+    KNOWN_FAILING; // Fails because of wrong species
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_BELLSPROUT) { Ability(ABILITY_QUARK_DRIVE); }
+        OPPONENT(SPECIES_TAPU_KOKO) { Ability(ABILITY_ELECTRIC_SURGE); };
+    } WHEN {
+        TURN { SWITCH(player, 1); }
+    } SCENE {
+        ABILITY_POPUP(opponent, ABILITY_ELECTRIC_SURGE);
+        ABILITY_POPUP(player, ABILITY_QUARK_DRIVE);
+        MESSAGE("The Electric Terrain activated Bellsprout's Quark Drive!");
+        MESSAGE("Bellsprout's Attack was heightened!");
+    }
+}


### PR DESCRIPTION
Fixes #3255

Abilities were activated each turn if a field effect was on the field. 
Two tests fail because of illegal abilities. Once this is ported back to upcoming, I'll change it to the correct species. 