### PR TITLE
Allow buffering move, species, ability and item names in tests

### DIFF
--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -194,7 +194,7 @@
 #define B_CRITICAL_CAPTURE          TRUE       // If set to TRUE, Critical Capture will be enabled.
 #define B_LAST_USED_BALL            TRUE       // If TRUE, the "last used ball" feature from Gen 7 will be implemented
 #define B_LAST_USED_BALL_BUTTON     R_BUTTON   // If last used ball is implemented, this button (or button combo) will trigger throwing the last used ball.
-#define B_LAST_USED_BALL_CYCLE      TRUE      // If TRUE, then holding B_LAST_USED_BALL_BUTTON while pressing the D-Pad cycles through the balls
+#define B_LAST_USED_BALL_CYCLE      TRUE       // If TRUE, then holding B_LAST_USED_BALL_BUTTON while pressing the D-Pad cycles through the balls
 
 // Other settings
 #define B_DOUBLE_WILD_CHANCE            0          // % chance of encountering two Pokémon in a Wild Encounter.

--- a/include/test/battle.h
+++ b/include/test/battle.h
@@ -841,6 +841,9 @@ void SendOut(u32 sourceLine, struct BattlePokemon *, u32 partyIndex);
 #define MESSAGE(pattern) do {static const u8 msg[] = _(pattern); QueueMessage(__LINE__, msg);} while (0)
 #define STATUS_ICON(battler, status) QueueStatus(__LINE__, battler, (struct StatusEventContext) { status })
 
+#define MOVE_NAME(move) "▶M" STR(move) "▶"
+#define ABILITY_NAME(ability) "▶A" STR(ability) "▶"
+
 enum QueueGroupType
 {
     QUEUE_GROUP_NONE,

--- a/include/test/battle.h
+++ b/include/test/battle.h
@@ -843,6 +843,8 @@ void SendOut(u32 sourceLine, struct BattlePokemon *, u32 partyIndex);
 
 #define MOVE_NAME(move) "▶M" STR(move) "▶"
 #define ABILITY_NAME(ability) "▶A" STR(ability) "▶"
+#define SPECIES_NAME(species) "▶S" STR(species) "▶"
+#define ITEM_NAME(item) "▶I" STR(item) "▶"
 
 enum QueueGroupType
 {

--- a/test/battle/ability/anger_shell.c
+++ b/test/battle/ability/anger_shell.c
@@ -49,15 +49,15 @@ SINGLE_BATTLE_TEST("Anger Shell lowers Def/Sp.Def by 1 and raises Atk/Sp.Atk/Spd
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
         ABILITY_POPUP(player, ABILITY_ANGER_SHELL);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-        MESSAGE("Wobbuffet's Defense fell!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Defense fell!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-        MESSAGE("Wobbuffet's Sp. Def fell!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Sp. Def fell!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-        MESSAGE("Wobbuffet's Attack rose!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Attack rose!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-        MESSAGE("Wobbuffet's Sp. Atk rose!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Sp. Atk rose!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-        MESSAGE("Wobbuffet's Speed rose!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Speed rose!");
     } THEN {
         EXPECT_EQ(player->statStages[STAT_DEF], DEFAULT_STAT_STAGE - 1);
         EXPECT_EQ(player->statStages[STAT_SPDEF], DEFAULT_STAT_STAGE - 1);

--- a/test/battle/ability/bad_dreams.c
+++ b/test/battle/ability/bad_dreams.c
@@ -20,13 +20,13 @@ SINGLE_BATTLE_TEST("Bad Dreams causes the sleeping enemy Pokemon to lose 1/8 of 
     } SCENE {
         if (status == STATUS1_SLEEP) {
             ABILITY_POPUP(player, ABILITY_BAD_DREAMS);
-            MESSAGE("Foe Wobbuffet is tormented!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is tormented!");
             HP_BAR(opponent);
         }
         else {
             NONE_OF {
                 ABILITY_POPUP(player, ABILITY_BAD_DREAMS);
-                MESSAGE("Foe Wobbuffet is tormented!");
+                MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is tormented!");
                 HP_BAR(opponent);
             };
         }
@@ -52,7 +52,7 @@ DOUBLE_BATTLE_TEST("Bad Dreams does not activate if only the partner Pokemon is 
     } SCENE {
         NONE_OF {
             ABILITY_POPUP(playerLeft, ABILITY_BAD_DREAMS);
-            MESSAGE("Wobbuffet is tormented!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is tormented!");
             HP_BAR(playerRight);
         };
     } THEN {
@@ -73,9 +73,9 @@ DOUBLE_BATTLE_TEST("Bad Dreams activates for both sleeping pokemon on the player
         TURN {;}
     } SCENE {
         ABILITY_POPUP(opponentLeft, ABILITY_BAD_DREAMS);
-        MESSAGE("Wobbuffet is tormented!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is tormented!");
         HP_BAR(playerLeft);
-        MESSAGE("Wobbuffet is tormented!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is tormented!");
         HP_BAR(playerRight);
     } THEN {
         EXPECT_EQ(opponentLeft->hp, opponentLeft->maxHP);
@@ -98,12 +98,12 @@ DOUBLE_BATTLE_TEST("Bad Dreams faints both sleeping Pokemon on player side")
         TURN {SEND_OUT(playerLeft, 2); SEND_OUT(playerRight, 3);}
     } SCENE {
         ABILITY_POPUP(opponentLeft, ABILITY_BAD_DREAMS);
-        MESSAGE("Wobbuffet is tormented!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is tormented!");
         HP_BAR(playerLeft);
-        MESSAGE("Wobbuffet fainted!");
-        MESSAGE("Wobbuffet is tormented!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " fainted!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is tormented!");
         HP_BAR(playerRight);
-        MESSAGE("Wobbuffet fainted!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " fainted!");
     }
 }
 
@@ -120,11 +120,11 @@ DOUBLE_BATTLE_TEST("Bad Dreams faints both sleeping Pokemon on opponent side")
         TURN {SEND_OUT(opponentLeft, 2); SEND_OUT(opponentRight, 3);}
     } SCENE {
         ABILITY_POPUP(playerLeft, ABILITY_BAD_DREAMS);
-        MESSAGE("Foe Wobbuffet is tormented!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is tormented!");
         HP_BAR(opponentLeft);
-        MESSAGE("Foe Wobbuffet fainted!");
-        MESSAGE("Foe Wobbuffet is tormented!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " fainted!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is tormented!");
         HP_BAR(opponentRight);
-        MESSAGE("Foe Wobbuffet fainted!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " fainted!");
     }
 }

--- a/test/battle/ability/battle_bond.c
+++ b/test/battle/ability/battle_bond.c
@@ -17,10 +17,10 @@ SINGLE_BATTLE_TEST("Battle Bond does not transform species other than Greninja")
         TURN { MOVE(player, MOVE_WATER_GUN); SEND_OUT(opponent, 1); }
     } SCENE {
         HP_BAR(opponent);
-        MESSAGE("Foe Wobbuffet fainted!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " fainted!");
         NONE_OF {
             ABILITY_POPUP(player, ABILITY_BATTLE_BOND);
-            MESSAGE("Wobbuffet became fully charged due to its bond with its trainer!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " became fully charged due to its bond with its trainer!");
         }
     } THEN {
         EXPECT(player->species == SPECIES_WOBBUFFET);
@@ -55,15 +55,15 @@ SINGLE_BATTLE_TEST("Battle Bond transforms player's Greninja - Singles")
 
     } SCENE {
         HP_BAR(opponent);
-        MESSAGE("Foe Wobbuffet fainted!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " fainted!");
         if (monsCountOpponent != 1) {
             ABILITY_POPUP(player, ABILITY_BATTLE_BOND);
-            MESSAGE("Greninja became fully charged due to its bond with its trainer!");
-            MESSAGE("Greninja became Ash-Greninja!");
+            MESSAGE(SPECIES_NAME(SPECIES_GRENINJA) " became fully charged due to its bond with its trainer!");
+            MESSAGE(SPECIES_NAME(SPECIES_GRENINJA) " became Ash-Greninja!");
         } else {
             NONE_OF {
                 ABILITY_POPUP(player, ABILITY_BATTLE_BOND);
-                MESSAGE("Greninja became fully charged due to its bond with its trainer!");
+                MESSAGE(SPECIES_NAME(SPECIES_GRENINJA) " became fully charged due to its bond with its trainer!");
             }
         }
     } FINALLY {
@@ -102,15 +102,15 @@ SINGLE_BATTLE_TEST("Battle Bond transforms opponent's Greninja - Singles")
 
     } SCENE {
         HP_BAR(player);
-        MESSAGE("Wobbuffet fainted!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " fainted!");
         if (monsCountPlayer != 1) {
             ABILITY_POPUP(opponent, ABILITY_BATTLE_BOND);
-            MESSAGE("Foe Greninja became fully charged due to its bond with its trainer!");
-            MESSAGE("Foe Greninja became Ash-Greninja!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_GRENINJA) " became fully charged due to its bond with its trainer!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_GRENINJA) " became Ash-Greninja!");
         } else {
             NONE_OF {
                 ABILITY_POPUP(opponent, ABILITY_BATTLE_BOND);
-                MESSAGE("Foe Greninja became fully charged due to its bond with its trainer!");
+                MESSAGE("Foe " SPECIES_NAME(SPECIES_GRENINJA) " became fully charged due to its bond with its trainer!");
             }
         }
     } FINALLY {
@@ -151,10 +151,10 @@ DOUBLE_BATTLE_TEST("Battle Bond transforms player's Greninja when fainting its A
 
     } SCENE {
         HP_BAR(playerRight);
-        MESSAGE("Wobbuffet fainted!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " fainted!");
         ABILITY_POPUP(playerLeft, ABILITY_BATTLE_BOND);
-        MESSAGE("Greninja became fully charged due to its bond with its trainer!");
-        MESSAGE("Greninja became Ash-Greninja!");
+        MESSAGE(SPECIES_NAME(SPECIES_GRENINJA) " became fully charged due to its bond with its trainer!");
+        MESSAGE(SPECIES_NAME(SPECIES_GRENINJA) " became Ash-Greninja!");
     } FINALLY {
         EXPECT(playerLeft->species == SPECIES_GRENINJA_ASH);
     }

--- a/test/battle/ability/beads_of_ruin.c
+++ b/test/battle/ability/beads_of_ruin.c
@@ -21,7 +21,7 @@ SINGLE_BATTLE_TEST("Beads of Ruin reduces Sp. Def", s16 damage)
     } SCENE {
         if (ability == ABILITY_BEADS_OF_RUIN) {
             ABILITY_POPUP(player, ABILITY_BEADS_OF_RUIN);
-            MESSAGE("Wobbuffet's Beads of Ruin weakened the Sp. Def of all surrounding Pokémon!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Beads of Ruin weakened the Sp. Def of all surrounding Pokémon!");
         }
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
@@ -44,7 +44,7 @@ SINGLE_BATTLE_TEST("Beads of Ruin does not reduce Sp. Def if opposing mon has th
     } SCENE {
         if (ability == ABILITY_BEADS_OF_RUIN) {
             ABILITY_POPUP(player, ABILITY_BEADS_OF_RUIN);
-            MESSAGE("Wobbuffet's Beads of Ruin weakened the Sp. Def of all surrounding Pokémon!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Beads of Ruin weakened the Sp. Def of all surrounding Pokémon!");
         }
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {

--- a/test/battle/ability/beast_boost.c
+++ b/test/battle/ability/beast_boost.c
@@ -24,19 +24,19 @@ SINGLE_BATTLE_TEST("Beast Boost boosts the most proficient stat when knocking ou
         ABILITY_POPUP(player, ABILITY_BEAST_BOOST);
         switch(i) {
             case 0:
-                MESSAGE("Nihilego's Beast Boost raised its Attack!");
+                MESSAGE(SPECIES_NAME(SPECIES_NIHILEGO) "'s Beast Boost raised its Attack!");
                 break;
             case 1:
-                MESSAGE("Nihilego's Beast Boost raised its Defense!");
+                MESSAGE(SPECIES_NAME(SPECIES_NIHILEGO) "'s Beast Boost raised its Defense!");
                 break;
             case 2:
-                MESSAGE("Nihilego's Beast Boost raised its Sp. Atk!");
+                MESSAGE(SPECIES_NAME(SPECIES_NIHILEGO) "'s Beast Boost raised its Sp. Atk!");
                 break;
             case 3:
-                MESSAGE("Nihilego's Beast Boost raised its Sp. Def!");
+                MESSAGE(SPECIES_NAME(SPECIES_NIHILEGO) "'s Beast Boost raised its Sp. Def!");
                 break;
             case 4:
-                MESSAGE("Nihilego's Beast Boost raised its Speed!");
+                MESSAGE(SPECIES_NAME(SPECIES_NIHILEGO) "'s Beast Boost raised its Speed!");
                 break;
         }
     }

--- a/test/battle/ability/clear_body.c
+++ b/test/battle/ability/clear_body.c
@@ -19,7 +19,7 @@ SINGLE_BATTLE_TEST("Clear Body prevents intimidate")
         ABILITY_POPUP(player, ABILITY_INTIMIDATE);
         NONE_OF { ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player); }
         ABILITY_POPUP(opponent, ABILITY_CLEAR_BODY);
-        MESSAGE("Foe Beldum's Clear Body prevents stat loss!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_BELDUM) "'s Clear Body prevents stat loss!");
         HP_BAR(player, captureDamage: &turnTwoHit);
     } THEN {
         EXPECT_EQ(turnOneHit, turnTwoHit);

--- a/test/battle/ability/contrary.c
+++ b/test/battle/ability/contrary.c
@@ -90,7 +90,7 @@ SINGLE_BATTLE_TEST("Contrary raises stats after using a move which would normall
         TURN { MOVE(opponent, MOVE_OVERHEAT); }
         TURN { MOVE(opponent, MOVE_OVERHEAT); }
     } SCENE {
-        MESSAGE("Foe Spinda used Overheat!");
+        MESSAGE("Foe Spinda used " MOVE_NAME(MOVE_OVERHEAT) "!");
         HP_BAR(player, captureDamage: &results[i].damageBefore);
         if (ability == ABILITY_CONTRARY) {
             // ABILITY_POPUP(opponent, ABILITY_CONTRARY);
@@ -102,7 +102,7 @@ SINGLE_BATTLE_TEST("Contrary raises stats after using a move which would normall
             MESSAGE("Foe Spinda's Sp. Atk harshly fell!");
         }
 
-        // MESSAGE("Foe Spinda used Overheat!");
+        // MESSAGE("Foe Spinda used " MOVE_NAME(MOVE_OVERHEAT) "!");
         HP_BAR(player, captureDamage: &results[i].damageAfter);
         if (ability == ABILITY_CONTRARY) {
             // ABILITY_POPUP(opponent, ABILITY_CONTRARY);
@@ -134,10 +134,10 @@ SINGLE_BATTLE_TEST("Contrary lowers a stat after using a move which would normal
         TURN { MOVE(opponent, MOVE_SWORDS_DANCE); }
         TURN { MOVE(opponent, MOVE_TACKLE); }
     } SCENE {
-        MESSAGE("Foe Spinda used Tackle!");
+        MESSAGE("Foe Spinda used " MOVE_NAME(MOVE_TACKLE) "!");
         HP_BAR(player, captureDamage: &results[i].damageBefore);
 
-        //MESSAGE("Foe Spinda used Swords Dance!");
+        //MESSAGE("Foe Spinda used " MOVE_NAME(MOVE_SWORDS_DANCE) "!");
         if (ability == ABILITY_CONTRARY) {
             // ABILITY_POPUP(opponent, ABILITY_CONTRARY);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
@@ -148,7 +148,7 @@ SINGLE_BATTLE_TEST("Contrary lowers a stat after using a move which would normal
             MESSAGE("Foe Spinda's Attack sharply rose!");
         }
 
-        // MESSAGE("Foe Spinda used Tackle!");
+        // MESSAGE("Foe Spinda used " MOVE_NAME(MOVE_TACKLE) "!");
         HP_BAR(player, captureDamage: &results[i].damageAfter);
     }
     FINALLY {
@@ -169,7 +169,7 @@ SINGLE_BATTLE_TEST("Contrary raises a stat after using a move which would normal
     } WHEN {
         TURN { MOVE(player, MOVE_GROWL); MOVE(opponent, MOVE_TACKLE); }
     } SCENE {
-        MESSAGE("Wobbuffet used Growl!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_GROWL) "!");
         if (ability == ABILITY_CONTRARY) {
             // ABILITY_POPUP(opponent, ABILITY_CONTRARY);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
@@ -180,7 +180,7 @@ SINGLE_BATTLE_TEST("Contrary raises a stat after using a move which would normal
             MESSAGE("Foe Spinda's Attack fell!");
         }
 
-        MESSAGE("Foe Spinda used Tackle!");
+        MESSAGE("Foe Spinda used " MOVE_NAME(MOVE_TACKLE) "!");
         HP_BAR(player, captureDamage: &results[i].damage);
     }
     FINALLY {

--- a/test/battle/ability/contrary.c
+++ b/test/battle/ability/contrary.c
@@ -21,7 +21,7 @@ SINGLE_BATTLE_TEST("Contrary raises Attack when Intimidated in a single battle",
         if (ability == ABILITY_CONTRARY) {
             ABILITY_POPUP(opponent, ABILITY_CONTRARY);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-            MESSAGE("Foe Spinda's Attack rose!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_SPINDA) "'s Attack rose!");
         }
         HP_BAR(player, captureDamage: &results[i].damage);
     }
@@ -51,18 +51,18 @@ DOUBLE_BATTLE_TEST("Contrary raises Attack when Intimidated in a double battle",
         if (abilityLeft == ABILITY_CONTRARY) {
             ABILITY_POPUP(opponentLeft, ABILITY_CONTRARY);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
-            MESSAGE("Foe Spinda's Attack rose!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_SPINDA) "'s Attack rose!");
         } else {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
-            MESSAGE("Mightyena's Intimidate cuts Foe Spinda's attack!");
+            MESSAGE(SPECIES_NAME(SPECIES_MIGHTYENA) "'s Intimidate cuts Foe Spinda's attack!");
         }
         if (abilityRight == ABILITY_CONTRARY) {
             ABILITY_POPUP(opponentRight, ABILITY_CONTRARY);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);
-            MESSAGE("Foe Spinda's Attack rose!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_SPINDA) "'s Attack rose!");
         } else {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);
-            MESSAGE("Mightyena's Intimidate cuts Foe Spinda's attack!");
+            MESSAGE(SPECIES_NAME(SPECIES_MIGHTYENA) "'s Intimidate cuts Foe Spinda's attack!");
         }
         HP_BAR(playerLeft, captureDamage: &results[i].damageLeft);
         HP_BAR(playerRight, captureDamage: &results[i].damageRight);
@@ -90,28 +90,28 @@ SINGLE_BATTLE_TEST("Contrary raises stats after using a move which would normall
         TURN { MOVE(opponent, MOVE_OVERHEAT); }
         TURN { MOVE(opponent, MOVE_OVERHEAT); }
     } SCENE {
-        MESSAGE("Foe Spinda used " MOVE_NAME(MOVE_OVERHEAT) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_SPINDA) " used " MOVE_NAME(MOVE_OVERHEAT) "!");
         HP_BAR(player, captureDamage: &results[i].damageBefore);
         if (ability == ABILITY_CONTRARY) {
             // ABILITY_POPUP(opponent, ABILITY_CONTRARY);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-            MESSAGE("Foe Spinda's Sp. Atk sharply rose!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_SPINDA) "'s Sp. Atk sharply rose!");
         }
         else {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-            MESSAGE("Foe Spinda's Sp. Atk harshly fell!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_SPINDA) "'s Sp. Atk harshly fell!");
         }
 
-        // MESSAGE("Foe Spinda used " MOVE_NAME(MOVE_OVERHEAT) "!");
+        // MESSAGE("Foe " SPECIES_NAME(SPECIES_SPINDA) " used " MOVE_NAME(MOVE_OVERHEAT) "!");
         HP_BAR(player, captureDamage: &results[i].damageAfter);
         if (ability == ABILITY_CONTRARY) {
             // ABILITY_POPUP(opponent, ABILITY_CONTRARY);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-            MESSAGE("Foe Spinda's Sp. Atk sharply rose!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_SPINDA) "'s Sp. Atk sharply rose!");
         }
         else {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-            MESSAGE("Foe Spinda's Sp. Atk harshly fell!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_SPINDA) "'s Sp. Atk harshly fell!");
         }
     }
     FINALLY {
@@ -134,21 +134,21 @@ SINGLE_BATTLE_TEST("Contrary lowers a stat after using a move which would normal
         TURN { MOVE(opponent, MOVE_SWORDS_DANCE); }
         TURN { MOVE(opponent, MOVE_TACKLE); }
     } SCENE {
-        MESSAGE("Foe Spinda used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_SPINDA) " used " MOVE_NAME(MOVE_TACKLE) "!");
         HP_BAR(player, captureDamage: &results[i].damageBefore);
 
-        //MESSAGE("Foe Spinda used " MOVE_NAME(MOVE_SWORDS_DANCE) "!");
+        //MESSAGE("Foe " SPECIES_NAME(SPECIES_SPINDA) " used " MOVE_NAME(MOVE_SWORDS_DANCE) "!");
         if (ability == ABILITY_CONTRARY) {
             // ABILITY_POPUP(opponent, ABILITY_CONTRARY);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-            MESSAGE("Foe Spinda's Attack harshly fell!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_SPINDA) "'s Attack harshly fell!");
         }
         else {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-            MESSAGE("Foe Spinda's Attack sharply rose!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_SPINDA) "'s Attack sharply rose!");
         }
 
-        // MESSAGE("Foe Spinda used " MOVE_NAME(MOVE_TACKLE) "!");
+        // MESSAGE("Foe " SPECIES_NAME(SPECIES_SPINDA) " used " MOVE_NAME(MOVE_TACKLE) "!");
         HP_BAR(player, captureDamage: &results[i].damageAfter);
     }
     FINALLY {
@@ -169,18 +169,18 @@ SINGLE_BATTLE_TEST("Contrary raises a stat after using a move which would normal
     } WHEN {
         TURN { MOVE(player, MOVE_GROWL); MOVE(opponent, MOVE_TACKLE); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_GROWL) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_GROWL) "!");
         if (ability == ABILITY_CONTRARY) {
             // ABILITY_POPUP(opponent, ABILITY_CONTRARY);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-            MESSAGE("Foe Spinda's Attack rose!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_SPINDA) "'s Attack rose!");
         }
         else {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-            MESSAGE("Foe Spinda's Attack fell!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_SPINDA) "'s Attack fell!");
         }
 
-        MESSAGE("Foe Spinda used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_SPINDA) " used " MOVE_NAME(MOVE_TACKLE) "!");
         HP_BAR(player, captureDamage: &results[i].damage);
     }
     FINALLY {

--- a/test/battle/ability/contrary.c
+++ b/test/battle/ability/contrary.c
@@ -54,7 +54,7 @@ DOUBLE_BATTLE_TEST("Contrary raises Attack when Intimidated in a double battle",
             MESSAGE("Foe " SPECIES_NAME(SPECIES_SPINDA) "'s Attack rose!");
         } else {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
-            MESSAGE(SPECIES_NAME(SPECIES_MIGHTYENA) "'s Intimidate cuts Foe Spinda's attack!");
+            MESSAGE(SPECIES_NAME(SPECIES_MIGHTYENA) "'s Intimidate cuts Foe " SPECIES_NAME(SPECIES_SPINDA) "'s attack!");
         }
         if (abilityRight == ABILITY_CONTRARY) {
             ABILITY_POPUP(opponentRight, ABILITY_CONTRARY);
@@ -62,7 +62,7 @@ DOUBLE_BATTLE_TEST("Contrary raises Attack when Intimidated in a double battle",
             MESSAGE("Foe " SPECIES_NAME(SPECIES_SPINDA) "'s Attack rose!");
         } else {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);
-            MESSAGE(SPECIES_NAME(SPECIES_MIGHTYENA) "'s Intimidate cuts Foe Spinda's attack!");
+            MESSAGE(SPECIES_NAME(SPECIES_MIGHTYENA) "'s Intimidate cuts Foe " SPECIES_NAME(SPECIES_SPINDA) "'s attack!");
         }
         HP_BAR(playerLeft, captureDamage: &results[i].damageLeft);
         HP_BAR(playerRight, captureDamage: &results[i].damageRight);

--- a/test/battle/ability/cute_charm.c
+++ b/test/battle/ability/cute_charm.c
@@ -19,13 +19,13 @@ SINGLE_BATTLE_TEST("Cute Charm inflicts infatuation on contact")
             ABILITY_POPUP(opponent, ABILITY_CUTE_CHARM);
             ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_INFATUATION, player);
             MESSAGE("Foe " SPECIES_NAME(SPECIES_CLEFAIRY) "'s Cute Charm infatuated Wobbuffet!");
-            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is in love with Foe Clefairy!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is in love with Foe " SPECIES_NAME(SPECIES_CLEFAIRY) "!");
         } else {
             NONE_OF {
                 ABILITY_POPUP(opponent, ABILITY_CUTE_CHARM);
                 ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_INFATUATION, player);
                 MESSAGE("Foe " SPECIES_NAME(SPECIES_CLEFAIRY) "'s Cute Charm infatuated Wobbuffet!");
-                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is in love with Foe Clefairy!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is in love with Foe " SPECIES_NAME(SPECIES_CLEFAIRY) "!");
             }
         }
     }

--- a/test/battle/ability/cute_charm.c
+++ b/test/battle/ability/cute_charm.c
@@ -18,14 +18,14 @@ SINGLE_BATTLE_TEST("Cute Charm inflicts infatuation on contact")
         if (gBattleMoves[move].makesContact) {
             ABILITY_POPUP(opponent, ABILITY_CUTE_CHARM);
             ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_INFATUATION, player);
-            MESSAGE("Foe Clefairy's Cute Charm infatuated Wobbuffet!");
-            MESSAGE("Wobbuffet is in love with Foe Clefairy!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_CLEFAIRY) "'s Cute Charm infatuated Wobbuffet!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is in love with Foe Clefairy!");
         } else {
             NONE_OF {
                 ABILITY_POPUP(opponent, ABILITY_CUTE_CHARM);
                 ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_INFATUATION, player);
-                MESSAGE("Foe Clefairy's Cute Charm infatuated Wobbuffet!");
-                MESSAGE("Wobbuffet is in love with Foe Clefairy!");
+                MESSAGE("Foe " SPECIES_NAME(SPECIES_CLEFAIRY) "'s Cute Charm infatuated Wobbuffet!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is in love with Foe Clefairy!");
             }
         }
     }

--- a/test/battle/ability/defiant.c
+++ b/test/battle/ability/defiant.c
@@ -21,35 +21,35 @@ DOUBLE_BATTLE_TEST("Defiant sharply raises player's Attack after Intimidate")
         //1st mon Intimidate
         ABILITY_POPUP(opponentLeft, ABILITY_INTIMIDATE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
-        MESSAGE("Foe Gyarados's Intimidate cuts Mankey's attack!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_GYARADOS) "'s Intimidate cuts Mankey's attack!");
         if (abilityLeft == ABILITY_DEFIANT) {
             ABILITY_POPUP(playerLeft, ABILITY_DEFIANT);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
-            MESSAGE("Mankey's Attack sharply rose!");
+            MESSAGE(SPECIES_NAME(SPECIES_MANKEY) "'s Attack sharply rose!");
         }
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerRight);
-        MESSAGE("Foe Gyarados's Intimidate cuts Primeape's attack!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_GYARADOS) "'s Intimidate cuts Primeape's attack!");
         if (abilityRight == ABILITY_DEFIANT) {
             ABILITY_POPUP(playerRight, ABILITY_DEFIANT);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerRight);
-            MESSAGE("Primeape's Attack sharply rose!");
+            MESSAGE(SPECIES_NAME(SPECIES_PRIMEAPE) "'s Attack sharply rose!");
         }
 
         //2nd mon Intimidate
         ABILITY_POPUP(opponentRight, ABILITY_INTIMIDATE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
-        MESSAGE("Foe Arbok's Intimidate cuts Mankey's attack!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_ARBOK) "'s Intimidate cuts Mankey's attack!");
         if (abilityLeft == ABILITY_DEFIANT) {
             ABILITY_POPUP(playerLeft, ABILITY_DEFIANT);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
-            MESSAGE("Mankey's Attack sharply rose!");
+            MESSAGE(SPECIES_NAME(SPECIES_MANKEY) "'s Attack sharply rose!");
         }
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerRight);
-        MESSAGE("Foe Arbok's Intimidate cuts Primeape's attack!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_ARBOK) "'s Intimidate cuts Primeape's attack!");
         if (abilityRight == ABILITY_DEFIANT) {
             ABILITY_POPUP(playerRight, ABILITY_DEFIANT);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerRight);
-            MESSAGE("Primeape's Attack sharply rose!");
+            MESSAGE(SPECIES_NAME(SPECIES_PRIMEAPE) "'s Attack sharply rose!");
         }
     } FINALLY {
         // -2 from Intimidates and +4 from Defiants gets +2 total
@@ -79,35 +79,35 @@ DOUBLE_BATTLE_TEST("Defiant sharply raises opponent's Attack after Intimidate")
         //1st mon Intimidate
         ABILITY_POPUP(playerLeft, ABILITY_INTIMIDATE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
-        MESSAGE("Gyarados's Intimidate cuts Foe Mankey's attack!");
+        MESSAGE(SPECIES_NAME(SPECIES_GYARADOS) "'s Intimidate cuts Foe Mankey's attack!");
         if (abilityLeft == ABILITY_DEFIANT) {
             ABILITY_POPUP(opponentLeft, ABILITY_DEFIANT);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
-            MESSAGE("Foe Mankey's Attack sharply rose!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_MANKEY) "'s Attack sharply rose!");
         }
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);
-        MESSAGE("Gyarados's Intimidate cuts Foe Primeape's attack!");
+        MESSAGE(SPECIES_NAME(SPECIES_GYARADOS) "'s Intimidate cuts Foe Primeape's attack!");
         if (abilityRight == ABILITY_DEFIANT) {
             ABILITY_POPUP(opponentRight, ABILITY_DEFIANT);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);
-            MESSAGE("Foe Primeape's Attack sharply rose!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_PRIMEAPE) "'s Attack sharply rose!");
         }
 
         //2nd mon Intimidate
         ABILITY_POPUP(playerRight, ABILITY_INTIMIDATE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
-        MESSAGE("Arbok's Intimidate cuts Foe Mankey's attack!");
+        MESSAGE(SPECIES_NAME(SPECIES_ARBOK) "'s Intimidate cuts Foe Mankey's attack!");
         if (abilityLeft == ABILITY_DEFIANT) {
             ABILITY_POPUP(opponentLeft, ABILITY_DEFIANT);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
-            MESSAGE("Foe Mankey's Attack sharply rose!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_MANKEY) "'s Attack sharply rose!");
         }
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);
-        MESSAGE("Arbok's Intimidate cuts Foe Primeape's attack!");
+        MESSAGE(SPECIES_NAME(SPECIES_ARBOK) "'s Intimidate cuts Foe Primeape's attack!");
         if (abilityRight == ABILITY_DEFIANT) {
             ABILITY_POPUP(opponentRight, ABILITY_DEFIANT);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);
-            MESSAGE("Foe Primeape's Attack sharply rose!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_PRIMEAPE) "'s Attack sharply rose!");
         }
     } FINALLY {
         // -2 from Intimidates and +4 from Defiants gets +2 total
@@ -128,13 +128,13 @@ SINGLE_BATTLE_TEST("Defiant activates after Sticky Web lowers Speed")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_STICKY_WEB, opponent);
         // Switch-in - Sticky Web activates
-        MESSAGE("Go! Mankey!");
-        MESSAGE("Mankey was caught in a Sticky Web!");
+        MESSAGE("Go! " SPECIES_NAME(SPECIES_MANKEY) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_MANKEY) " was caught in a Sticky Web!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-        MESSAGE("Mankey's Speed fell!");
+        MESSAGE(SPECIES_NAME(SPECIES_MANKEY) "'s Speed fell!");
         // Defiant activates
         ABILITY_POPUP(player, ABILITY_DEFIANT);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-        MESSAGE("Mankey's Attack sharply rose!");
+        MESSAGE(SPECIES_NAME(SPECIES_MANKEY) "'s Attack sharply rose!");
     }
 }

--- a/test/battle/ability/defiant.c
+++ b/test/battle/ability/defiant.c
@@ -79,14 +79,14 @@ DOUBLE_BATTLE_TEST("Defiant sharply raises opponent's Attack after Intimidate")
         //1st mon Intimidate
         ABILITY_POPUP(playerLeft, ABILITY_INTIMIDATE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
-        MESSAGE(SPECIES_NAME(SPECIES_GYARADOS) "'s Intimidate cuts Foe Mankey's attack!");
+        MESSAGE(SPECIES_NAME(SPECIES_GYARADOS) "'s Intimidate cuts Foe " SPECIES_NAME(SPECIES_MANKEY) "'s attack!");
         if (abilityLeft == ABILITY_DEFIANT) {
             ABILITY_POPUP(opponentLeft, ABILITY_DEFIANT);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
             MESSAGE("Foe " SPECIES_NAME(SPECIES_MANKEY) "'s Attack sharply rose!");
         }
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);
-        MESSAGE(SPECIES_NAME(SPECIES_GYARADOS) "'s Intimidate cuts Foe Primeape's attack!");
+        MESSAGE(SPECIES_NAME(SPECIES_GYARADOS) "'s Intimidate cuts Foe " SPECIES_NAME(SPECIES_PRIMEAPE) "'s attack!");
         if (abilityRight == ABILITY_DEFIANT) {
             ABILITY_POPUP(opponentRight, ABILITY_DEFIANT);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);
@@ -96,14 +96,14 @@ DOUBLE_BATTLE_TEST("Defiant sharply raises opponent's Attack after Intimidate")
         //2nd mon Intimidate
         ABILITY_POPUP(playerRight, ABILITY_INTIMIDATE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
-        MESSAGE(SPECIES_NAME(SPECIES_ARBOK) "'s Intimidate cuts Foe Mankey's attack!");
+        MESSAGE(SPECIES_NAME(SPECIES_ARBOK) "'s Intimidate cuts Foe " SPECIES_NAME(SPECIES_MANKEY) "'s attack!");
         if (abilityLeft == ABILITY_DEFIANT) {
             ABILITY_POPUP(opponentLeft, ABILITY_DEFIANT);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
             MESSAGE("Foe " SPECIES_NAME(SPECIES_MANKEY) "'s Attack sharply rose!");
         }
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);
-        MESSAGE(SPECIES_NAME(SPECIES_ARBOK) "'s Intimidate cuts Foe Primeape's attack!");
+        MESSAGE(SPECIES_NAME(SPECIES_ARBOK) "'s Intimidate cuts Foe " SPECIES_NAME(SPECIES_PRIMEAPE) "'s attack!");
         if (abilityRight == ABILITY_DEFIANT) {
             ABILITY_POPUP(opponentRight, ABILITY_DEFIANT);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);

--- a/test/battle/ability/desolate_land.c
+++ b/test/battle/ability/desolate_land.c
@@ -16,11 +16,11 @@ SINGLE_BATTLE_TEST("Desolate Land blocks damaging Water-type moves")
         TURN { MOVE(opponent, MOVE_WATER_GUN); }
         TURN { MOVE(opponent, MOVE_WATER_GUN); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_WATER_GUN) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_WATER_GUN) "!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_WATER_GUN, opponent);
         MESSAGE("The Water-type attack evaporated in the harsh sunlight!");
         NOT HP_BAR(player);
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_WATER_GUN) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_WATER_GUN) "!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_WATER_GUN, opponent);
         MESSAGE("The Water-type attack evaporated in the harsh sunlight!");
         NOT HP_BAR(player);
@@ -42,7 +42,7 @@ DOUBLE_BATTLE_TEST("Desolate Land blocks damaging Water-type moves and prints th
     } WHEN {
         TURN { MOVE(opponentLeft, MOVE_SURF); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_SURF) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SURF) "!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_SURF, opponentLeft);
         MESSAGE("The Water-type attack evaporated in the harsh sunlight!");
         NOT MESSAGE("The Water-type attack evaporated in the harsh sunlight!");
@@ -62,6 +62,6 @@ SINGLE_BATTLE_TEST("Desolate Land does not block a move if pokemon is asleep and
         TURN { MOVE(opponent, MOVE_WATER_GUN); }
     } SCENE {
         NOT MESSAGE("The Water-type attack evaporated in the harsh sunlight!");
-        MESSAGE("Foe Wobbuffet is fast asleep.");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is fast asleep.");
     }
 }

--- a/test/battle/ability/desolate_land.c
+++ b/test/battle/ability/desolate_land.c
@@ -16,11 +16,11 @@ SINGLE_BATTLE_TEST("Desolate Land blocks damaging Water-type moves")
         TURN { MOVE(opponent, MOVE_WATER_GUN); }
         TURN { MOVE(opponent, MOVE_WATER_GUN); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used Water Gun!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_WATER_GUN) "!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_WATER_GUN, opponent);
         MESSAGE("The Water-type attack evaporated in the harsh sunlight!");
         NOT HP_BAR(player);
-        MESSAGE("Foe Wobbuffet used Water Gun!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_WATER_GUN) "!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_WATER_GUN, opponent);
         MESSAGE("The Water-type attack evaporated in the harsh sunlight!");
         NOT HP_BAR(player);
@@ -42,7 +42,7 @@ DOUBLE_BATTLE_TEST("Desolate Land blocks damaging Water-type moves and prints th
     } WHEN {
         TURN { MOVE(opponentLeft, MOVE_SURF); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used Surf!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_SURF) "!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_SURF, opponentLeft);
         MESSAGE("The Water-type attack evaporated in the harsh sunlight!");
         NOT MESSAGE("The Water-type attack evaporated in the harsh sunlight!");

--- a/test/battle/ability/download.c
+++ b/test/battle/ability/download.c
@@ -22,7 +22,7 @@ SINGLE_BATTLE_TEST("Download raises Attack if player has lower Def than Sp. Def"
         {
             ABILITY_POPUP(opponent, ABILITY_DOWNLOAD);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-            MESSAGE("Foe Porygon's Download raised its Attack!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_PORYGON) "'s Download raised its Attack!");
         }
         HP_BAR(player, captureDamage: &results[i].damage);
     } FINALLY {
@@ -45,7 +45,7 @@ SINGLE_BATTLE_TEST("Download raises Sp.Attack if enemy has lower Sp. Def than De
         {
             ABILITY_POPUP(player, ABILITY_DOWNLOAD);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-            MESSAGE("Porygon's Download raised its Sp. Atk!");
+            MESSAGE(SPECIES_NAME(SPECIES_PORYGON) "'s Download raised its Sp. Atk!");
         }
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
@@ -72,14 +72,14 @@ SINGLE_BATTLE_TEST("Download doesn't activate if target hasn't been sent out yet
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, player);
         // Everyone faints.
 
-        MESSAGE("Go! Porygon!");
-        MESSAGE("2 sent out Porygon2!");
+        MESSAGE("Go! " SPECIES_NAME(SPECIES_PORYGON) "!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_PORYGON) "2!");
 
         if (ability == ABILITY_DOWNLOAD)
         {
             ABILITY_POPUP(player, ABILITY_DOWNLOAD);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-            MESSAGE("Porygon's Download raised its Attack!");
+            MESSAGE(SPECIES_NAME(SPECIES_PORYGON) "'s Download raised its Attack!");
             ABILITY_POPUP(opponent, ABILITY_DOWNLOAD);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
             MESSAGE("Foe Porygon2's Download raised its Sp. Atk!");

--- a/test/battle/ability/download.c
+++ b/test/battle/ability/download.c
@@ -82,7 +82,7 @@ SINGLE_BATTLE_TEST("Download doesn't activate if target hasn't been sent out yet
             MESSAGE(SPECIES_NAME(SPECIES_PORYGON) "'s Download raised its Attack!");
             ABILITY_POPUP(opponent, ABILITY_DOWNLOAD);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-            MESSAGE("Foe Porygon2's Download raised its Sp. Atk!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_PORYGON) "2's Download raised its Sp. Atk!");
         }
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, player);
         HP_BAR(opponent, captureDamage: &results[i].damagePhysical);

--- a/test/battle/ability/drizzle.c
+++ b/test/battle/ability/drizzle.c
@@ -15,7 +15,7 @@ SINGLE_BATTLE_TEST("Drizzle summons rain", s16 damage)
     } SCENE {
         if (ability == ABILITY_DRIZZLE) {
             ABILITY_POPUP(player, ABILITY_DRIZZLE);
-            MESSAGE("Politoed's Drizzle made it rain!");
+            MESSAGE(SPECIES_NAME(SPECIES_POLITOED) "'s Drizzle made it rain!");
         }
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {

--- a/test/battle/ability/dry_skin.c
+++ b/test/battle/ability/dry_skin.c
@@ -46,7 +46,7 @@ SINGLE_BATTLE_TEST("Dry Skin increases damage taken from Fire-type moves by 25%"
     } WHEN {
         TURN { MOVE(player, MOVE_EMBER); }
     } SCENE {
-        MESSAGE("Wobbuffet used Ember!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_EMBER) "!");
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
         // Due to numerics related to rounding on each applied multiplier,

--- a/test/battle/ability/dry_skin.c
+++ b/test/battle/ability/dry_skin.c
@@ -24,7 +24,7 @@ SINGLE_BATTLE_TEST("Dry Skin heals 1/8th Max HP in Rain")
         TURN { MOVE(player, MOVE_RAIN_DANCE); }
     } SCENE {
         ABILITY_POPUP(player, ABILITY_DRY_SKIN);
-        MESSAGE("Parasect's Dry Skin restored its HP a little!");
+        MESSAGE(SPECIES_NAME(SPECIES_PARASECT) "'s Dry Skin restored its HP a little!");
         HP_BAR(player, damage: -(200 / 8));
     }
 }
@@ -46,7 +46,7 @@ SINGLE_BATTLE_TEST("Dry Skin increases damage taken from Fire-type moves by 25%"
     } WHEN {
         TURN { MOVE(player, MOVE_EMBER); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_EMBER) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_EMBER) "!");
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
         // Due to numerics related to rounding on each applied multiplier,

--- a/test/battle/ability/dry_skin.c
+++ b/test/battle/ability/dry_skin.c
@@ -68,7 +68,7 @@ SINGLE_BATTLE_TEST("Dry Skin heals 25% when hit by water type moves")
     } SCENE {
         ABILITY_POPUP(player, ABILITY_DRY_SKIN);
         HP_BAR(player, damage: -50);
-        MESSAGE("Parasect restored HP using its Dry Skin!");
+        MESSAGE(SPECIES_NAME(SPECIES_PARASECT) " restored HP using its Dry Skin!");
     }
 }
 
@@ -81,7 +81,7 @@ SINGLE_BATTLE_TEST("Dry Skin does not activate if protected")
     } WHEN {
         TURN { MOVE(player, MOVE_PROTECT); MOVE(opponent, MOVE_BUBBLE); }
     } SCENE {
-        NONE_OF { ABILITY_POPUP(player, ABILITY_DRY_SKIN); HP_BAR(player); MESSAGE("Parasect restored HP using its Dry Skin!"); }
+        NONE_OF { ABILITY_POPUP(player, ABILITY_DRY_SKIN); HP_BAR(player); MESSAGE(SPECIES_NAME(SPECIES_PARASECT) " restored HP using its Dry Skin!"); }
     }
 }
 
@@ -97,7 +97,7 @@ SINGLE_BATTLE_TEST("Dry Skin is only triggered once on multi strike moves")
     } SCENE {
         ABILITY_POPUP(player, ABILITY_DRY_SKIN);
         HP_BAR(player, damage: -50);
-        MESSAGE("Parasect restored HP using its Dry Skin!");
+        MESSAGE(SPECIES_NAME(SPECIES_PARASECT) " restored HP using its Dry Skin!");
     }
 }
 
@@ -115,7 +115,7 @@ SINGLE_BATTLE_TEST("Dry Skin prevents Absorb Bulb and Luminous Moss from activat
     } SCENE {
         ABILITY_POPUP(player, ABILITY_DRY_SKIN);
         HP_BAR(player, damage: -50);
-        MESSAGE("Parasect restored HP using its Dry Skin!");
+        MESSAGE(SPECIES_NAME(SPECIES_PARASECT) " restored HP using its Dry Skin!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);

--- a/test/battle/ability/earth_eater.c
+++ b/test/battle/ability/earth_eater.c
@@ -12,7 +12,7 @@ SINGLE_BATTLE_TEST("Earth Eater heals 25% when hit by ground type moves")
     } SCENE {
         ABILITY_POPUP(player, ABILITY_EARTH_EATER);
         HP_BAR(player, damage: -25);
-        MESSAGE("Wobbuffet restored HP using its Earth Eater!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " restored HP using its Earth Eater!");
     }
 }
 
@@ -25,7 +25,7 @@ SINGLE_BATTLE_TEST("Earth Eater does not activate if protected")
     } WHEN {
         TURN { MOVE(player, MOVE_PROTECT); MOVE(opponent, MOVE_MUD_SLAP); }
     } SCENE {
-        NONE_OF { ABILITY_POPUP(player, ABILITY_EARTH_EATER); HP_BAR(player); MESSAGE("Wobbuffet restored HP using its Earth Eater!"); }
+        NONE_OF { ABILITY_POPUP(player, ABILITY_EARTH_EATER); HP_BAR(player); MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " restored HP using its Earth Eater!"); }
     }
 }
 
@@ -41,6 +41,6 @@ SINGLE_BATTLE_TEST("Earth Eater activates on status moves")
     } SCENE {
         ABILITY_POPUP(player, ABILITY_EARTH_EATER);
         HP_BAR(player, damage: -25);
-        MESSAGE("Wobbuffet restored HP using its Earth Eater!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " restored HP using its Earth Eater!");
     }
 }

--- a/test/battle/ability/flame_body.c
+++ b/test/battle/ability/flame_body.c
@@ -17,13 +17,13 @@ SINGLE_BATTLE_TEST("Flame Body inflicts burn on contact")
         if (gBattleMoves[move].makesContact) {
             ABILITY_POPUP(opponent, ABILITY_FLAME_BODY);
             ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, player);
-            MESSAGE("Foe Magmar's Flame Body burned Wobbuffet!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_MAGMAR) "'s Flame Body burned Wobbuffet!");
             STATUS_ICON(player, burn: TRUE);
         } else {
             NONE_OF {
                 ABILITY_POPUP(opponent, ABILITY_FLAME_BODY);
                 ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, player);
-                MESSAGE("Foe Magmar's Flame Body burned Wobbuffet!");
+                MESSAGE("Foe " SPECIES_NAME(SPECIES_MAGMAR) "'s Flame Body burned Wobbuffet!");
                 STATUS_ICON(player, burn: TRUE);
             }
         }

--- a/test/battle/ability/flower_gift.c
+++ b/test/battle/ability/flower_gift.c
@@ -11,7 +11,7 @@ SINGLE_BATTLE_TEST("Flower Gift transforms Cherrim in harsh sunlight")
     } SCENE {
         ABILITY_POPUP(player, ABILITY_FLOWER_GIFT);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
-        MESSAGE("Cherrim transformed!");
+        MESSAGE(SPECIES_NAME(SPECIES_CHERRIM) " transformed!");
     } THEN {
         EXPECT_EQ(player->species, SPECIES_CHERRIM_SUNSHINE);
     }
@@ -29,11 +29,11 @@ SINGLE_BATTLE_TEST("Flower Gift transforms Cherrim back to normal when weather c
         // transforms in sun
         ABILITY_POPUP(player, ABILITY_FLOWER_GIFT);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
-        MESSAGE("Cherrim transformed!");
+        MESSAGE(SPECIES_NAME(SPECIES_CHERRIM) " transformed!");
         // back to normal
         ABILITY_POPUP(player, ABILITY_FLOWER_GIFT);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
-        MESSAGE("Cherrim transformed!");
+        MESSAGE(SPECIES_NAME(SPECIES_CHERRIM) " transformed!");
     } THEN {
         EXPECT_EQ(player->species, SPECIES_CHERRIM);
     }
@@ -52,10 +52,10 @@ SINGLE_BATTLE_TEST("Flower Gift transforms Cherrim back to normal when its abili
         // transforms in sun
         ABILITY_POPUP(player, ABILITY_FLOWER_GIFT);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
-        MESSAGE("Cherrim transformed!");
+        MESSAGE(SPECIES_NAME(SPECIES_CHERRIM) " transformed!");
         // back to normal
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
-        MESSAGE("Cherrim transformed!");
+        MESSAGE(SPECIES_NAME(SPECIES_CHERRIM) " transformed!");
     } THEN {
         EXPECT_EQ(player->species, SPECIES_CHERRIM);
     }
@@ -81,7 +81,7 @@ DOUBLE_BATTLE_TEST("Flower Gift increases the attack of Cherrim and its allies b
         if (sunny) {
             ABILITY_POPUP(playerLeft, ABILITY_FLOWER_GIFT);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, playerLeft);
-            MESSAGE("Cherrim transformed!");
+            MESSAGE(SPECIES_NAME(SPECIES_CHERRIM) " transformed!");
         }
         // player uses Tackle
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, playerLeft);
@@ -114,7 +114,7 @@ DOUBLE_BATTLE_TEST("Flower Gift increases the Sp. Def of Cherrim and its allies 
         if (sunny) {
             ABILITY_POPUP(playerLeft, ABILITY_FLOWER_GIFT);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, playerLeft);
-            MESSAGE("Cherrim transformed!");
+            MESSAGE(SPECIES_NAME(SPECIES_CHERRIM) " transformed!");
         }
         // opponentLeft uses Hyper Voice
         ANIMATION(ANIM_TYPE_MOVE, MOVE_HYPER_VOICE, opponentLeft);
@@ -140,7 +140,7 @@ SINGLE_BATTLE_TEST("Flower Gift transforms Cherrim back when it switches out")
         // transforms in sun
         ABILITY_POPUP(player, ABILITY_FLOWER_GIFT);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
-        MESSAGE("Cherrim transformed!");
+        MESSAGE(SPECIES_NAME(SPECIES_CHERRIM) " transformed!");
         MESSAGE("Cherrim, that's enough! Come back!");
     } THEN {
         EXPECT_EQ(GetMonData(&gPlayerParty[0], MON_DATA_SPECIES), SPECIES_CHERRIM);
@@ -161,7 +161,7 @@ SINGLE_BATTLE_TEST("Flower Gift transforms Cherrim back when it uses a move that
         // transforms in sun
         ABILITY_POPUP(player, ABILITY_FLOWER_GIFT);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
-        MESSAGE("Cherrim transformed!");
+        MESSAGE(SPECIES_NAME(SPECIES_CHERRIM) " transformed!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_U_TURN, player);
     } THEN {
         EXPECT_EQ(GetMonData(&gPlayerParty[0], MON_DATA_SPECIES), SPECIES_CHERRIM);

--- a/test/battle/ability/fluffy.c
+++ b/test/battle/ability/fluffy.c
@@ -22,7 +22,7 @@ SINGLE_BATTLE_TEST("Fluffy halves damage taken from moves that make direct conta
     } WHEN {
         TURN { MOVE(player, MOVE_TACKLE); }
     } SCENE {
-        MESSAGE("Wobbuffet used Tackle!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
         EXPECT_MUL_EQ(results[0].damage, UQ_4_12(0.5), results[1].damage);
@@ -40,7 +40,7 @@ SINGLE_BATTLE_TEST("Fluffy doubles damage taken from fire type moves", s16 damag
     } WHEN {
         TURN { MOVE(player, MOVE_EMBER); }
     } SCENE {
-        MESSAGE("Wobbuffet used Ember!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_EMBER) "!");
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
         EXPECT_MUL_EQ(results[0].damage, UQ_4_12(2.0), results[1].damage);
@@ -58,7 +58,7 @@ SINGLE_BATTLE_TEST("Fluffy does not alter damage of fire-type moves that make di
     } WHEN {
         TURN { MOVE(player, MOVE_FIRE_PUNCH); }
     } SCENE {
-        MESSAGE("Wobbuffet used Fire Punch!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FIRE_PUNCH) "!");
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
         EXPECT_EQ(results[0].damage, results[1].damage);

--- a/test/battle/ability/fluffy.c
+++ b/test/battle/ability/fluffy.c
@@ -22,7 +22,7 @@ SINGLE_BATTLE_TEST("Fluffy halves damage taken from moves that make direct conta
     } WHEN {
         TURN { MOVE(player, MOVE_TACKLE); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
         EXPECT_MUL_EQ(results[0].damage, UQ_4_12(0.5), results[1].damage);
@@ -40,7 +40,7 @@ SINGLE_BATTLE_TEST("Fluffy doubles damage taken from fire type moves", s16 damag
     } WHEN {
         TURN { MOVE(player, MOVE_EMBER); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_EMBER) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_EMBER) "!");
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
         EXPECT_MUL_EQ(results[0].damage, UQ_4_12(2.0), results[1].damage);
@@ -58,7 +58,7 @@ SINGLE_BATTLE_TEST("Fluffy does not alter damage of fire-type moves that make di
     } WHEN {
         TURN { MOVE(player, MOVE_FIRE_PUNCH); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FIRE_PUNCH) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_FIRE_PUNCH) "!");
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
         EXPECT_EQ(results[0].damage, results[1].damage);

--- a/test/battle/ability/forecast.c
+++ b/test/battle/ability/forecast.c
@@ -16,7 +16,7 @@ SINGLE_BATTLE_TEST("Forecast transforms Castform in weather from an opponent's m
     } SCENE {
         ABILITY_POPUP(player, ABILITY_FORECAST);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
-        MESSAGE("Castform transformed!");
+        MESSAGE(SPECIES_NAME(SPECIES_CASTFORM) " transformed!");
     } THEN {
         switch (move)
         {
@@ -49,7 +49,7 @@ SINGLE_BATTLE_TEST("Forecast transforms Castform in weather from its own move")
     } SCENE {
         ABILITY_POPUP(player, ABILITY_FORECAST);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
-        MESSAGE("Castform transformed!");
+        MESSAGE(SPECIES_NAME(SPECIES_CASTFORM) " transformed!");
     } THEN {
         switch (move)
         {
@@ -84,7 +84,7 @@ DOUBLE_BATTLE_TEST("Forecast transforms Castform in weather from a partner's mov
     } SCENE {
         ABILITY_POPUP(playerLeft, ABILITY_FORECAST);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, playerLeft);
-        MESSAGE("Castform transformed!");
+        MESSAGE(SPECIES_NAME(SPECIES_CASTFORM) " transformed!");
     } THEN {
         switch (move)
         {
@@ -119,16 +119,16 @@ DOUBLE_BATTLE_TEST("Forecast transforms all Castforms present in weather")
     } SCENE {
         ABILITY_POPUP(playerLeft, ABILITY_FORECAST);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, playerLeft);
-        MESSAGE("Castform transformed!");
+        MESSAGE(SPECIES_NAME(SPECIES_CASTFORM) " transformed!");
         ABILITY_POPUP(opponentLeft, ABILITY_FORECAST);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, opponentLeft);
-        MESSAGE("Foe Castform transformed!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_CASTFORM) " transformed!");
         ABILITY_POPUP(playerRight, ABILITY_FORECAST);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, playerRight);
-        MESSAGE("Castform transformed!");
+        MESSAGE(SPECIES_NAME(SPECIES_CASTFORM) " transformed!");
         ABILITY_POPUP(opponentRight, ABILITY_FORECAST);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, opponentRight);
-        MESSAGE("Foe Castform transformed!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_CASTFORM) " transformed!");
     } THEN {
         switch (move)
         {
@@ -170,7 +170,7 @@ SINGLE_BATTLE_TEST("Forecast transforms Castform in weather from an ability")
     } SCENE {
         ABILITY_POPUP(player, ABILITY_FORECAST);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
-        MESSAGE("Castform transformed!");
+        MESSAGE(SPECIES_NAME(SPECIES_CASTFORM) " transformed!");
     } THEN {
         switch (ability)
         {
@@ -202,7 +202,7 @@ SINGLE_BATTLE_TEST("Forecast transforms Castform in primal weather")
         ABILITY_POPUP(opponent, ability);
         ABILITY_POPUP(player, ABILITY_FORECAST);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
-        MESSAGE("Castform transformed!");
+        MESSAGE(SPECIES_NAME(SPECIES_CASTFORM) " transformed!");
     } THEN {
         switch (ability)
         {
@@ -232,11 +232,11 @@ SINGLE_BATTLE_TEST("Forecast transforms Castform back to normal when weather exp
         // transforms
         ABILITY_POPUP(player, ABILITY_FORECAST);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
-        MESSAGE("Castform transformed!");
+        MESSAGE(SPECIES_NAME(SPECIES_CASTFORM) " transformed!");
         // back to normal
         ABILITY_POPUP(player, ABILITY_FORECAST);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
-        MESSAGE("Castform transformed!");
+        MESSAGE(SPECIES_NAME(SPECIES_CASTFORM) " transformed!");
     } THEN {
         EXPECT_EQ(player->species, SPECIES_CASTFORM);
     }
@@ -254,11 +254,11 @@ SINGLE_BATTLE_TEST("Forecast transforms Castform back to normal when Sandstorm i
         // transforms
         ABILITY_POPUP(player, ABILITY_FORECAST);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
-        MESSAGE("Castform transformed!");
+        MESSAGE(SPECIES_NAME(SPECIES_CASTFORM) " transformed!");
         // back to normal
         ABILITY_POPUP(player, ABILITY_FORECAST);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
-        MESSAGE("Castform transformed!");
+        MESSAGE(SPECIES_NAME(SPECIES_CASTFORM) " transformed!");
     } THEN {
         EXPECT_EQ(player->species, SPECIES_CASTFORM);
     }
@@ -278,12 +278,12 @@ SINGLE_BATTLE_TEST("Forecast transforms Castform back to normal under Air Lock")
         // transforms
         ABILITY_POPUP(player, ABILITY_FORECAST);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
-        MESSAGE("Castform transformed!");
+        MESSAGE(SPECIES_NAME(SPECIES_CASTFORM) " transformed!");
         // back to normal
         ABILITY_POPUP(opponent, ABILITY_AIR_LOCK);
         ABILITY_POPUP(player, ABILITY_FORECAST);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
-        MESSAGE("Castform transformed!");
+        MESSAGE(SPECIES_NAME(SPECIES_CASTFORM) " transformed!");
     } THEN {
         EXPECT_EQ(player->species, SPECIES_CASTFORM);
     }
@@ -304,7 +304,7 @@ SINGLE_BATTLE_TEST("Forecast transforms Castform on switch-in")
         // turn 2
         ABILITY_POPUP(player, ABILITY_FORECAST);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
-        MESSAGE("Castform transformed!");
+        MESSAGE(SPECIES_NAME(SPECIES_CASTFORM) " transformed!");
     } THEN {
         EXPECT_EQ(player->species, SPECIES_CASTFORM_RAINY);
     }
@@ -322,11 +322,11 @@ SINGLE_BATTLE_TEST("Forecast transforms Castform when weather changes")
         // transforms
         ABILITY_POPUP(player, ABILITY_FORECAST);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
-        MESSAGE("Castform transformed!");
+        MESSAGE(SPECIES_NAME(SPECIES_CASTFORM) " transformed!");
         // transforms again
         ABILITY_POPUP(player, ABILITY_FORECAST);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
-        MESSAGE("Castform transformed!");
+        MESSAGE(SPECIES_NAME(SPECIES_CASTFORM) " transformed!");
     } THEN {
         EXPECT_EQ(player->species, SPECIES_CASTFORM_SUNNY);
     }
@@ -345,10 +345,10 @@ SINGLE_BATTLE_TEST("Forecast transforms Castform back to normal when its ability
         // transforms in sun
         ABILITY_POPUP(player, ABILITY_FORECAST);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
-        MESSAGE("Castform transformed!");
+        MESSAGE(SPECIES_NAME(SPECIES_CASTFORM) " transformed!");
         // back to normal
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
-        MESSAGE("Castform transformed!");
+        MESSAGE(SPECIES_NAME(SPECIES_CASTFORM) " transformed!");
     } THEN {
         EXPECT_EQ(player->species, SPECIES_CASTFORM);
     }
@@ -368,7 +368,7 @@ SINGLE_BATTLE_TEST("Forecast transforms Castform back when it switches out")
         // transforms in sun
         ABILITY_POPUP(player, ABILITY_FORECAST);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
-        MESSAGE("Castform transformed!");
+        MESSAGE(SPECIES_NAME(SPECIES_CASTFORM) " transformed!");
         MESSAGE("Castform, that's enough! Come back!");
     } THEN {
         EXPECT_EQ(GetMonData(&gPlayerParty[0], MON_DATA_SPECIES), SPECIES_CASTFORM);
@@ -389,7 +389,7 @@ SINGLE_BATTLE_TEST("Forecast transforms Castform back when it uses a move that f
         // transforms in sun
         ABILITY_POPUP(player, ABILITY_FORECAST);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
-        MESSAGE("Castform transformed!");
+        MESSAGE(SPECIES_NAME(SPECIES_CASTFORM) " transformed!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_U_TURN, player);
     } THEN {
         EXPECT_EQ(GetMonData(&gPlayerParty[0], MON_DATA_SPECIES), SPECIES_CASTFORM);

--- a/test/battle/ability/full_metal_body.c
+++ b/test/battle/ability/full_metal_body.c
@@ -19,7 +19,7 @@ SINGLE_BATTLE_TEST("Full Metal Body prevents intimidate")
         ABILITY_POPUP(player, ABILITY_INTIMIDATE);
         NONE_OF { ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player); }
         ABILITY_POPUP(opponent, ABILITY_FULL_METAL_BODY);
-        MESSAGE("Foe Solgaleo's Full Metal Body prevents stat loss!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_SOLGALEO) "'s Full Metal Body prevents stat loss!");
         HP_BAR(player, captureDamage: &turnTwoHit);
     } THEN {
         EXPECT_EQ(turnOneHit, turnTwoHit);

--- a/test/battle/ability/gale_wings.c
+++ b/test/battle/ability/gale_wings.c
@@ -15,12 +15,12 @@ SINGLE_BATTLE_TEST("Gale Wings only grants priority at full HP")
         TURN { MOVE(player, MOVE_AERIAL_ACE); }
     } SCENE {
         if (hp == 100) {
-            MESSAGE("Talonflame used " MOVE_NAME(MOVE_AERIAL_ACE) "!");
-            MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+            MESSAGE(SPECIES_NAME(SPECIES_TALONFLAME) " used " MOVE_NAME(MOVE_AERIAL_ACE) "!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
         }
         else {
-            MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
-            MESSAGE("Talonflame used " MOVE_NAME(MOVE_AERIAL_ACE) "!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+            MESSAGE(SPECIES_NAME(SPECIES_TALONFLAME) " used " MOVE_NAME(MOVE_AERIAL_ACE) "!");
         }
     }
 }
@@ -40,12 +40,12 @@ SINGLE_BATTLE_TEST("Gale Wings only grants priority to Flying-type moves")
         TURN { MOVE(player, move); }
     } SCENE {
         if (move == MOVE_AERIAL_ACE) {
-            MESSAGE("Talonflame used " MOVE_NAME(MOVE_AERIAL_ACE) "!");
-            MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+            MESSAGE(SPECIES_NAME(SPECIES_TALONFLAME) " used " MOVE_NAME(MOVE_AERIAL_ACE) "!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
         }
         else {
-            MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
-            MESSAGE("Talonflame used " MOVE_NAME(MOVE_FLARE_BLITZ) "!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+            MESSAGE(SPECIES_NAME(SPECIES_TALONFLAME) " used " MOVE_NAME(MOVE_FLARE_BLITZ) "!");
         }
     }
 }

--- a/test/battle/ability/gale_wings.c
+++ b/test/battle/ability/gale_wings.c
@@ -15,12 +15,12 @@ SINGLE_BATTLE_TEST("Gale Wings only grants priority at full HP")
         TURN { MOVE(player, MOVE_AERIAL_ACE); }
     } SCENE {
         if (hp == 100) {
-            MESSAGE("Talonflame used Aerial Ace!");
-            MESSAGE("Foe Wobbuffet used Celebrate!");
+            MESSAGE("Talonflame used " MOVE_NAME(MOVE_AERIAL_ACE) "!");
+            MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
         }
         else {
-            MESSAGE("Foe Wobbuffet used Celebrate!");
-            MESSAGE("Talonflame used Aerial Ace!");
+            MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+            MESSAGE("Talonflame used " MOVE_NAME(MOVE_AERIAL_ACE) "!");
         }
     }
 }
@@ -40,12 +40,12 @@ SINGLE_BATTLE_TEST("Gale Wings only grants priority to Flying-type moves")
         TURN { MOVE(player, move); }
     } SCENE {
         if (move == MOVE_AERIAL_ACE) {
-            MESSAGE("Talonflame used Aerial Ace!");
-            MESSAGE("Foe Wobbuffet used Celebrate!");
+            MESSAGE("Talonflame used " MOVE_NAME(MOVE_AERIAL_ACE) "!");
+            MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
         }
         else {
-            MESSAGE("Foe Wobbuffet used Celebrate!");
-            MESSAGE("Talonflame used Flare Blitz!");
+            MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+            MESSAGE("Talonflame used " MOVE_NAME(MOVE_FLARE_BLITZ) "!");
         }
     }
 }

--- a/test/battle/ability/hunger_switch.c
+++ b/test/battle/ability/hunger_switch.c
@@ -13,8 +13,8 @@ SINGLE_BATTLE_TEST("Hunger Switch switches Morpeko's forms at the end of the tur
     } WHEN {
         TURN { MOVE(player, MOVE_CELEBRATE); }
     } SCENE {
-        MESSAGE("Morpeko used Celebrate!");
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Morpeko used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
     } THEN {
         if (species == SPECIES_MORPEKO)

--- a/test/battle/ability/hunger_switch.c
+++ b/test/battle/ability/hunger_switch.c
@@ -13,8 +13,8 @@ SINGLE_BATTLE_TEST("Hunger Switch switches Morpeko's forms at the end of the tur
     } WHEN {
         TURN { MOVE(player, MOVE_CELEBRATE); }
     } SCENE {
-        MESSAGE("Morpeko used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_MORPEKO) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
     } THEN {
         if (species == SPECIES_MORPEKO)

--- a/test/battle/ability/hydration.c
+++ b/test/battle/ability/hydration.c
@@ -10,7 +10,7 @@ SINGLE_BATTLE_TEST("Hydration cures non-volatile Status conditions if it is rain
         TURN { MOVE(player, MOVE_RAIN_DANCE); }
     } SCENE {
         ABILITY_POPUP(player, ABILITY_HYDRATION);
-        MESSAGE("Vaporeon's Hydration cured its burn problem!");
+        MESSAGE(SPECIES_NAME(SPECIES_VAPOREON) "'s Hydration cured its burn problem!");
         STATUS_ICON(player, none: TRUE);
     }
 }

--- a/test/battle/ability/hyper_cutter.c
+++ b/test/battle/ability/hyper_cutter.c
@@ -19,7 +19,7 @@ SINGLE_BATTLE_TEST("Hyper Cutter prevents intimidate")
         ABILITY_POPUP(player, ABILITY_INTIMIDATE);
         NONE_OF { ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player); }
         ABILITY_POPUP(opponent, ABILITY_HYPER_CUTTER);
-        MESSAGE("Foe Krabby's Attack was not lowered!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_KRABBY) "'s Attack was not lowered!");
         HP_BAR(player, captureDamage: &turnTwoHit);
     } THEN {
         EXPECT_EQ(turnOneHit, turnTwoHit);

--- a/test/battle/ability/ice_body.c
+++ b/test/battle/ability/ice_body.c
@@ -22,7 +22,7 @@ SINGLE_BATTLE_TEST("Ice Body recovers 1/16th of Max HP in hail.")
         TURN { MOVE(opponent, MOVE_HAIL); }
     } SCENE {
         ABILITY_POPUP(player, ABILITY_ICE_BODY);
-        MESSAGE("Glalie's Ice Body healed it a little bit!");
+        MESSAGE(SPECIES_NAME(SPECIES_GLALIE) "'s Ice Body healed it a little bit!");
         HP_BAR(player, damage: -(100 / 16));
     }
 }

--- a/test/battle/ability/immunity.c
+++ b/test/battle/ability/immunity.c
@@ -24,7 +24,7 @@ SINGLE_BATTLE_TEST("Immunity prevents Toxic bad poison")
     } WHEN {
         TURN { MOVE(player, MOVE_TOXIC); }
     } SCENE {
-        MESSAGE("Wobbuffet used Toxic!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TOXIC) "!");
         ABILITY_POPUP(opponent, ABILITY_IMMUNITY);
         MESSAGE("Foe Snorlax's Immunity prevents poisoning!");
         NOT STATUS_ICON(opponent, poison: TRUE);

--- a/test/battle/ability/immunity.c
+++ b/test/battle/ability/immunity.c
@@ -24,9 +24,9 @@ SINGLE_BATTLE_TEST("Immunity prevents Toxic bad poison")
     } WHEN {
         TURN { MOVE(player, MOVE_TOXIC); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TOXIC) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TOXIC) "!");
         ABILITY_POPUP(opponent, ABILITY_IMMUNITY);
-        MESSAGE("Foe Snorlax's Immunity prevents poisoning!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_SNORLAX) "'s Immunity prevents poisoning!");
         NOT STATUS_ICON(opponent, poison: TRUE);
     }
 }

--- a/test/battle/ability/inner_focus.c
+++ b/test/battle/ability/inner_focus.c
@@ -38,7 +38,7 @@ SINGLE_BATTLE_TEST("Inner Focus prevents flinching")
         }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_FAKE_OUT, player);
-        NONE_OF { MESSAGE("Foe Zubat flinched!"); }
+        NONE_OF { MESSAGE("Foe " SPECIES_NAME(SPECIES_ZUBAT) " flinched!"); }
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
     }
 }
@@ -52,6 +52,6 @@ SINGLE_BATTLE_TEST("Inner Focus is ignored by Mold Breaker")
         TURN { MOVE(player, MOVE_FAKE_OUT); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_FAKE_OUT, player);
-        MESSAGE("Foe Zubat flinched!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_ZUBAT) " flinched!");
     }
 }

--- a/test/battle/ability/inner_focus.c
+++ b/test/battle/ability/inner_focus.c
@@ -20,7 +20,7 @@ SINGLE_BATTLE_TEST("Inner Focus prevents intimidate")
         ABILITY_POPUP(player, ABILITY_INTIMIDATE);
         NONE_OF { ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player); }
         ABILITY_POPUP(opponent, ABILITY_INNER_FOCUS);
-        MESSAGE("Foe Zubat's Attack was not lowered!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_ZUBAT) "'s Attack was not lowered!");
         HP_BAR(player, captureDamage: &turnTwoHit);
     } THEN {
         EXPECT_EQ(turnOneHit, turnTwoHit);

--- a/test/battle/ability/intimidate.c
+++ b/test/battle/ability/intimidate.c
@@ -118,7 +118,7 @@ SINGLE_BATTLE_TEST("Intimidate and Eject Button force the opponent to Attack")
         MESSAGE("Foe Hitmontop's Intimidate cuts Wobbuffet's attack!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
-            MESSAGE("Foe Hitmontop used Tackle!");
+            MESSAGE("Foe Hitmontop used " MOVE_NAME(MOVE_TACKLE) "!");
         }
     }
 }

--- a/test/battle/ability/intimidate.c
+++ b/test/battle/ability/intimidate.c
@@ -23,7 +23,7 @@ SINGLE_BATTLE_TEST("Intimidate (opponent) lowers player's attack after switch ou
         {
             ABILITY_POPUP(opponent, ABILITY_INTIMIDATE);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-            MESSAGE("Foe Arbok's Intimidate cuts Wobbuffet's attack!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_ARBOK) "'s Intimidate cuts Wobbuffet's attack!");
         }
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
@@ -49,7 +49,7 @@ SINGLE_BATTLE_TEST("Intimidate (opponent) lowers player's attack after KO", s16 
         {
             ABILITY_POPUP(opponent, ABILITY_INTIMIDATE);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-            MESSAGE("Foe Arbok's Intimidate cuts Wobbuffet's attack!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_ARBOK) "'s Intimidate cuts Wobbuffet's attack!");
         }
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
@@ -77,22 +77,22 @@ DOUBLE_BATTLE_TEST("Intimidate doesn't activate on an empty field in a double ba
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, playerLeft);
         // Everyone faints.
 
-        MESSAGE("Go! Ekans!");
-        MESSAGE("2 sent out Arbok!");
-        MESSAGE("Go! Abra!");
-        MESSAGE("2 sent out Wynaut!");
+        MESSAGE("Go! " SPECIES_NAME(SPECIES_EKANS) "!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_ARBOK) "!");
+        MESSAGE("Go! " SPECIES_NAME(SPECIES_ABRA) "!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WYNAUT) "!");
 
         ABILITY_POPUP(playerLeft, ABILITY_INTIMIDATE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
-        MESSAGE("Ekans's Intimidate cuts Foe Arbok's attack!");
+        MESSAGE(SPECIES_NAME(SPECIES_EKANS) "'s Intimidate cuts Foe Arbok's attack!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);
-        MESSAGE("Ekans's Intimidate cuts Foe Wynaut's attack!");
+        MESSAGE(SPECIES_NAME(SPECIES_EKANS) "'s Intimidate cuts Foe Wynaut's attack!");
 
         ABILITY_POPUP(opponentLeft, ABILITY_INTIMIDATE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
-        MESSAGE("Foe Arbok's Intimidate cuts Ekans's attack!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_ARBOK) "'s Intimidate cuts Ekans's attack!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerRight);
-        MESSAGE("Foe Arbok's Intimidate cuts Abra's attack!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_ARBOK) "'s Intimidate cuts Abra's attack!");
     }
 }
 
@@ -112,13 +112,13 @@ SINGLE_BATTLE_TEST("Intimidate and Eject Button force the opponent to Attack")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_QUICK_ATTACK, player);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-        MESSAGE("Foe Wobbuffet is switched out with the Eject Button!");
-        MESSAGE("2 sent out Hitmontop!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is switched out with the Eject Button!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_HITMONTOP) "!");
         ABILITY_POPUP(opponent, ABILITY_INTIMIDATE);
-        MESSAGE("Foe Hitmontop's Intimidate cuts Wobbuffet's attack!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_HITMONTOP) "'s Intimidate cuts Wobbuffet's attack!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
-            MESSAGE("Foe Hitmontop used " MOVE_NAME(MOVE_TACKLE) "!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_HITMONTOP) " used " MOVE_NAME(MOVE_TACKLE) "!");
         }
     }
 }
@@ -146,16 +146,16 @@ DOUBLE_BATTLE_TEST("Intimidate activates on an empty slot")
 
     } SCENE {
         MESSAGE("Wobbuffet, that's enough! Come back!");
-        MESSAGE("Go! Wynaut!");
+        MESSAGE("Go! " SPECIES_NAME(SPECIES_WYNAUT) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_GUNK_SHOT, playerRight);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SPLASH, opponentRight);
         MESSAGE("Wynaut, that's enough! Come back!");
-        MESSAGE("Go! Hitmontop!");
+        MESSAGE("Go! " SPECIES_NAME(SPECIES_HITMONTOP) "!");
         ABILITY_POPUP(playerLeft, ABILITY_INTIMIDATE);
         NONE_OF {
-            MESSAGE("Hitmontop's Intimidate cuts Foe Ralts's attack!");
+            MESSAGE(SPECIES_NAME(SPECIES_HITMONTOP) "'s Intimidate cuts Foe Ralts's attack!");
         }
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);
-        MESSAGE("Hitmontop's Intimidate cuts Foe Azurill's attack!");
+        MESSAGE(SPECIES_NAME(SPECIES_HITMONTOP) "'s Intimidate cuts Foe Azurill's attack!");
     }
 }

--- a/test/battle/ability/intimidate.c
+++ b/test/battle/ability/intimidate.c
@@ -84,9 +84,9 @@ DOUBLE_BATTLE_TEST("Intimidate doesn't activate on an empty field in a double ba
 
         ABILITY_POPUP(playerLeft, ABILITY_INTIMIDATE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
-        MESSAGE(SPECIES_NAME(SPECIES_EKANS) "'s Intimidate cuts Foe Arbok's attack!");
+        MESSAGE(SPECIES_NAME(SPECIES_EKANS) "'s Intimidate cuts Foe " SPECIES_NAME(SPECIES_ARBOK) "'s attack!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);
-        MESSAGE(SPECIES_NAME(SPECIES_EKANS) "'s Intimidate cuts Foe Wynaut's attack!");
+        MESSAGE(SPECIES_NAME(SPECIES_EKANS) "'s Intimidate cuts Foe " SPECIES_NAME(SPECIES_WYNAUT) "'s attack!");
 
         ABILITY_POPUP(opponentLeft, ABILITY_INTIMIDATE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
@@ -153,9 +153,9 @@ DOUBLE_BATTLE_TEST("Intimidate activates on an empty slot")
         MESSAGE("Go! " SPECIES_NAME(SPECIES_HITMONTOP) "!");
         ABILITY_POPUP(playerLeft, ABILITY_INTIMIDATE);
         NONE_OF {
-            MESSAGE(SPECIES_NAME(SPECIES_HITMONTOP) "'s Intimidate cuts Foe Ralts's attack!");
+            MESSAGE(SPECIES_NAME(SPECIES_HITMONTOP) "'s Intimidate cuts Foe " SPECIES_NAME(SPECIES_RALTS) "'s attack!");
         }
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);
-        MESSAGE(SPECIES_NAME(SPECIES_HITMONTOP) "'s Intimidate cuts Foe Azurill's attack!");
+        MESSAGE(SPECIES_NAME(SPECIES_HITMONTOP) "'s Intimidate cuts Foe " SPECIES_NAME(SPECIES_AZURILL) "'s attack!");
     }
 }

--- a/test/battle/ability/leaf_guard.c
+++ b/test/battle/ability/leaf_guard.c
@@ -24,7 +24,7 @@ SINGLE_BATTLE_TEST("Leaf Guard prevents non-volatile status conditions in sun")
         if (move != MOVE_POWDER_SNOW) {
             NOT ANIMATION(ANIM_TYPE_MOVE, move, opponent);
             ABILITY_POPUP(player, ABILITY_LEAF_GUARD);
-            MESSAGE("It doesn't affect Leafeon…");
+            MESSAGE("It doesn't affect " SPECIES_NAME(SPECIES_LEAFEON) "…");
             NOT STATUS_ICON(player, status);
         } else {
             NONE_OF {
@@ -49,10 +49,10 @@ SINGLE_BATTLE_TEST("Leaf Guard prevents status conditions from Flame Orb and Tox
         TURN { MOVE(player, MOVE_SUNNY_DAY); }
     } SCENE {
         if (item == ITEM_FLAME_ORB) {
-            NONE_OF { MESSAGE("Leafeon was burned!"); STATUS_ICON(player, burn: TRUE); }
+            NONE_OF { MESSAGE(SPECIES_NAME(SPECIES_LEAFEON) " was burned!"); STATUS_ICON(player, burn: TRUE); }
         }
         else {
-            NONE_OF { MESSAGE("Leafeon is badly poisoned!"); STATUS_ICON(player, poison: TRUE); }
+            NONE_OF { MESSAGE(SPECIES_NAME(SPECIES_LEAFEON) " is badly poisoned!"); STATUS_ICON(player, poison: TRUE); }
         }
     }
 }

--- a/test/battle/ability/magic_bounce.c
+++ b/test/battle/ability/magic_bounce.c
@@ -13,7 +13,7 @@ SINGLE_BATTLE_TEST("Magic Bounce bounces back status moves")
     } SCENE {
         ABILITY_POPUP(opponent, ABILITY_MAGIC_BOUNCE);
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_TOXIC, player);
-        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) "'s Toxic was bounced back by Foe Espeon's Magic Bounce!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) "'s Toxic was bounced back by Foe " SPECIES_NAME(SPECIES_ESPEON) "'s Magic Bounce!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TOXIC, opponent);
         STATUS_ICON(player, badPoison: TRUE);
     }
@@ -31,7 +31,7 @@ SINGLE_BATTLE_TEST("Magic Bounce bounces back powder moves")
     } SCENE {
         ABILITY_POPUP(opponent, ABILITY_MAGIC_BOUNCE);
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_TOXIC, player);
-        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) "'s Stun Spore was bounced back by Foe Espeon's Magic Bounce!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) "'s Stun Spore was bounced back by Foe " SPECIES_NAME(SPECIES_ESPEON) "'s Magic Bounce!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_STUN_SPORE, opponent);
         STATUS_ICON(player, paralysis: TRUE);
     }
@@ -49,7 +49,7 @@ SINGLE_BATTLE_TEST("Magic Bounce cannot bounce back powder moves against Grass T
     } SCENE {
         ABILITY_POPUP(opponent, ABILITY_MAGIC_BOUNCE);
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_STUN_SPORE, player);
-        MESSAGE(SPECIES_NAME(SPECIES_ODDISH) "'s Stun Spore was bounced back by Foe Espeon's Magic Bounce!");
+        MESSAGE(SPECIES_NAME(SPECIES_ODDISH) "'s Stun Spore was bounced back by Foe " SPECIES_NAME(SPECIES_ESPEON) "'s Magic Bounce!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_STUN_SPORE, opponent);
         MESSAGE("It doesn't affect " SPECIES_NAME(SPECIES_ODDISH) "…");
         NOT STATUS_ICON(player, paralysis: TRUE);
@@ -70,7 +70,7 @@ DOUBLE_BATTLE_TEST("Magic Bounce bounces back moves hitting both foes at two foe
     } SCENE {
         ABILITY_POPUP(opponentLeft, ABILITY_MAGIC_BOUNCE);
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_LEER, playerLeft);
-        MESSAGE(SPECIES_NAME(SPECIES_ABRA) "'s Leer was bounced back by Foe Espeon's Magic Bounce!");
+        MESSAGE(SPECIES_NAME(SPECIES_ABRA) "'s Leer was bounced back by Foe " SPECIES_NAME(SPECIES_ESPEON) "'s Magic Bounce!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_LEER, opponentLeft);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
         MESSAGE(SPECIES_NAME(SPECIES_ABRA) "'s Defense fell!");

--- a/test/battle/ability/magic_bounce.c
+++ b/test/battle/ability/magic_bounce.c
@@ -13,7 +13,7 @@ SINGLE_BATTLE_TEST("Magic Bounce bounces back status moves")
     } SCENE {
         ABILITY_POPUP(opponent, ABILITY_MAGIC_BOUNCE);
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_TOXIC, player);
-        MESSAGE("Wynaut's Toxic was bounced back by Foe Espeon's Magic Bounce!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) "'s Toxic was bounced back by Foe Espeon's Magic Bounce!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TOXIC, opponent);
         STATUS_ICON(player, badPoison: TRUE);
     }
@@ -31,7 +31,7 @@ SINGLE_BATTLE_TEST("Magic Bounce bounces back powder moves")
     } SCENE {
         ABILITY_POPUP(opponent, ABILITY_MAGIC_BOUNCE);
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_TOXIC, player);
-        MESSAGE("Wynaut's Stun Spore was bounced back by Foe Espeon's Magic Bounce!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) "'s Stun Spore was bounced back by Foe Espeon's Magic Bounce!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_STUN_SPORE, opponent);
         STATUS_ICON(player, paralysis: TRUE);
     }
@@ -49,9 +49,9 @@ SINGLE_BATTLE_TEST("Magic Bounce cannot bounce back powder moves against Grass T
     } SCENE {
         ABILITY_POPUP(opponent, ABILITY_MAGIC_BOUNCE);
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_STUN_SPORE, player);
-        MESSAGE("Oddish's Stun Spore was bounced back by Foe Espeon's Magic Bounce!");
+        MESSAGE(SPECIES_NAME(SPECIES_ODDISH) "'s Stun Spore was bounced back by Foe Espeon's Magic Bounce!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_STUN_SPORE, opponent);
-        MESSAGE("It doesn't affect Oddish…");
+        MESSAGE("It doesn't affect " SPECIES_NAME(SPECIES_ODDISH) "…");
         NOT STATUS_ICON(player, paralysis: TRUE);
     }
 }
@@ -70,14 +70,14 @@ DOUBLE_BATTLE_TEST("Magic Bounce bounces back moves hitting both foes at two foe
     } SCENE {
         ABILITY_POPUP(opponentLeft, ABILITY_MAGIC_BOUNCE);
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_LEER, playerLeft);
-        MESSAGE("Abra's Leer was bounced back by Foe Espeon's Magic Bounce!");
+        MESSAGE(SPECIES_NAME(SPECIES_ABRA) "'s Leer was bounced back by Foe Espeon's Magic Bounce!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_LEER, opponentLeft);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
-        MESSAGE("Abra's Defense fell!");
+        MESSAGE(SPECIES_NAME(SPECIES_ABRA) "'s Defense fell!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerRight);
-        MESSAGE("Kadabra's Defense fell!");
+        MESSAGE(SPECIES_NAME(SPECIES_KADABRA) "'s Defense fell!");
         // Also check if second original target gets hit by Leer as this was once bugged
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);
-        MESSAGE("Foe Wynaut's Defense fell!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) "'s Defense fell!");
     }
 }

--- a/test/battle/ability/mirror_armor.c
+++ b/test/battle/ability/mirror_armor.c
@@ -192,7 +192,7 @@ DOUBLE_BATTLE_TEST("Mirror Armor lowers Speed of the partner Pokemon after Court
     } SCENE {
         MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_STICKY_WEB) "!");
         MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " used " MOVE_NAME(MOVE_COURT_CHANGE) "!");
-        MESSAGE("Foe Wynaut swapped the battle effects affecting each side!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " swapped the battle effects affecting each side!");
         MESSAGE("Go! " SPECIES_NAME(SPECIES_CORVIKNIGH) "!");
         MESSAGE(SPECIES_NAME(SPECIES_CORVIKNIGHT) " was caught in a Sticky Web!");
         ABILITY_POPUP(playerRight, ABILITY_MIRROR_ARMOR);

--- a/test/battle/ability/mirror_armor.c
+++ b/test/battle/ability/mirror_armor.c
@@ -60,7 +60,7 @@ SINGLE_BATTLE_TEST("Mirror Armor triggers even if the attacking Pokemon also has
     } WHEN {
         TURN { MOVE(opponent, MOVE_LEER); }
     } SCENE {
-        MESSAGE("Foe Corviknigh used Leer!");
+        MESSAGE("Foe Corviknigh used " MOVE_NAME(MOVE_LEER) "!");
         ABILITY_POPUP(player, ABILITY_MIRROR_ARMOR);
         NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
@@ -79,7 +79,7 @@ SINGLE_BATTLE_TEST("Mirror Armor doesn't lower the stats of an attacking Pokemon
     } WHEN {
         TURN { MOVE(opponent, MOVE_LEER); }
     } SCENE {
-        MESSAGE("Foe Wynaut used Leer!");
+        MESSAGE("Foe Wynaut used " MOVE_NAME(MOVE_LEER) "!");
         ABILITY_POPUP(player, ABILITY_MIRROR_ARMOR);
         ABILITY_POPUP(opponent, ABILITY_CLEAR_BODY);
         MESSAGE("Foe Wynaut's Clear Body prevents stat loss!");
@@ -118,9 +118,9 @@ SINGLE_BATTLE_TEST("Mirror Armor doesn't lower the stats of an attacking Pokemon
         TURN { MOVE(opponent, MOVE_SUBSTITUTE); }
         TURN { MOVE(opponent, MOVE_LEER); }
     } SCENE {
-        MESSAGE("Foe Wynaut used Substitute!");
+        MESSAGE("Foe Wynaut used " MOVE_NAME(MOVE_SUBSTITUTE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SUBSTITUTE, opponent);
-        MESSAGE("Foe Wynaut used Leer!");
+        MESSAGE("Foe Wynaut used " MOVE_NAME(MOVE_LEER) "!");
         ABILITY_POPUP(player, ABILITY_MIRROR_ARMOR);
         NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
     } THEN {
@@ -137,7 +137,7 @@ SINGLE_BATTLE_TEST("Mirror Armor raises the stat of an attacking Pokemon with Co
     } WHEN {
         TURN { MOVE(opponent, MOVE_LEER); }
     } SCENE {
-        MESSAGE("Foe Shuckle used Leer!");
+        MESSAGE("Foe Shuckle used " MOVE_NAME(MOVE_LEER) "!");
         ABILITY_POPUP(player, ABILITY_MIRROR_ARMOR);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
         MESSAGE("Foe Shuckle's Defense rose!");
@@ -158,10 +158,10 @@ SINGLE_BATTLE_TEST("Mirror Armor doesn't lower the stat of the attacking Pokemon
         TURN { MOVE(player, MOVE_SCREECH); }
         TURN { MOVE(opponent, MOVE_LEER); }
     } SCENE {
-        MESSAGE("Corviknigh used Screech!");
-        MESSAGE("Corviknigh used Screech!");
-        MESSAGE("Corviknigh used Screech!");
-        MESSAGE("Foe Wynaut used Leer!");
+        MESSAGE("Corviknigh used " MOVE_NAME(MOVE_SCREECH) "!");
+        MESSAGE("Corviknigh used " MOVE_NAME(MOVE_SCREECH) "!");
+        MESSAGE("Corviknigh used " MOVE_NAME(MOVE_SCREECH) "!");
+        MESSAGE("Foe Wynaut used " MOVE_NAME(MOVE_LEER) "!");
         ABILITY_POPUP(player, ABILITY_MIRROR_ARMOR);
         NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
         MESSAGE("Foe Wynaut's Defense won't go lower!");
@@ -190,8 +190,8 @@ DOUBLE_BATTLE_TEST("Mirror Armor lowers Speed of the partner Pokemon after Court
         TURN { SWITCH(playerRight, 2);}
         TURN { }
     } SCENE {
-        MESSAGE("Wobbuffet used Sticky Web!");
-        MESSAGE("Foe Wynaut used Court Change!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_STICKY_WEB) "!");
+        MESSAGE("Foe Wynaut used " MOVE_NAME(MOVE_COURT_CHANGE) "!");
         MESSAGE("Foe Wynaut swapped the battle effects affecting each side!");
         MESSAGE("Go! Corviknigh!");
         MESSAGE("Corviknigh was caught in a Sticky Web!");

--- a/test/battle/ability/mirror_armor.c
+++ b/test/battle/ability/mirror_armor.c
@@ -28,22 +28,22 @@ SINGLE_BATTLE_TEST("Mirror Armor lowers a stat of the attacking pokemon")
         switch (statId)
         {
         case STAT_DEF:
-            MESSAGE("Foe Wynaut's Defense fell!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) "'s Defense fell!");
             break;
         case STAT_ATK:
-            MESSAGE("Foe Wynaut's Attack fell!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) "'s Attack fell!");
             break;
         case STAT_EVASION:
-            MESSAGE("Foe Wynaut's evasiveness harshly fell!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) "'s evasiveness harshly fell!");
             break;
         case STAT_ACC:
-            MESSAGE("Foe Wynaut's accuracy fell!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) "'s accuracy fell!");
             break;
         case STAT_SPATK:
-            MESSAGE("Foe Wynaut's Sp. Atk fell!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) "'s Sp. Atk fell!");
             break;
         case STAT_SPDEF:
-            MESSAGE("Foe Wynaut's Sp. Def harshly fell!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) "'s Sp. Def harshly fell!");
             break;
         }
     } THEN {
@@ -60,11 +60,11 @@ SINGLE_BATTLE_TEST("Mirror Armor triggers even if the attacking Pokemon also has
     } WHEN {
         TURN { MOVE(opponent, MOVE_LEER); }
     } SCENE {
-        MESSAGE("Foe Corviknigh used " MOVE_NAME(MOVE_LEER) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_CORVIKNIGHT) " used " MOVE_NAME(MOVE_LEER) "!");
         ABILITY_POPUP(player, ABILITY_MIRROR_ARMOR);
         NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-        MESSAGE("Foe Corviknigh's Defense fell!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_CORVIKNIGHT) "'s Defense fell!");
     } THEN {
         EXPECT_EQ(player->statStages[STAT_DEF], DEFAULT_STAT_STAGE);
         EXPECT_EQ(opponent->statStages[STAT_DEF], DEFAULT_STAT_STAGE - 1);
@@ -79,10 +79,10 @@ SINGLE_BATTLE_TEST("Mirror Armor doesn't lower the stats of an attacking Pokemon
     } WHEN {
         TURN { MOVE(opponent, MOVE_LEER); }
     } SCENE {
-        MESSAGE("Foe Wynaut used " MOVE_NAME(MOVE_LEER) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " used " MOVE_NAME(MOVE_LEER) "!");
         ABILITY_POPUP(player, ABILITY_MIRROR_ARMOR);
         ABILITY_POPUP(opponent, ABILITY_CLEAR_BODY);
-        MESSAGE("Foe Wynaut's Clear Body prevents stat loss!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) "'s Clear Body prevents stat loss!");
     } THEN {
         EXPECT_EQ(player->statStages[STAT_DEF], DEFAULT_STAT_STAGE);
         EXPECT_EQ(opponent->statStages[STAT_DEF], DEFAULT_STAT_STAGE);
@@ -100,7 +100,7 @@ SINGLE_BATTLE_TEST("Mirror Armor lowers the Attack of Pokemon with Intimidate")
         ABILITY_POPUP(opponent, ABILITY_INTIMIDATE);
         ABILITY_POPUP(player, ABILITY_MIRROR_ARMOR);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-        MESSAGE("Foe Gyarados's Attack fell!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_GYARADOS) "'s Attack fell!");
     } THEN {
         EXPECT_EQ(player->statStages[STAT_ATK], DEFAULT_STAT_STAGE);
         EXPECT_EQ(opponent->statStages[STAT_ATK], DEFAULT_STAT_STAGE - 1);
@@ -118,9 +118,9 @@ SINGLE_BATTLE_TEST("Mirror Armor doesn't lower the stats of an attacking Pokemon
         TURN { MOVE(opponent, MOVE_SUBSTITUTE); }
         TURN { MOVE(opponent, MOVE_LEER); }
     } SCENE {
-        MESSAGE("Foe Wynaut used " MOVE_NAME(MOVE_SUBSTITUTE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " used " MOVE_NAME(MOVE_SUBSTITUTE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SUBSTITUTE, opponent);
-        MESSAGE("Foe Wynaut used " MOVE_NAME(MOVE_LEER) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " used " MOVE_NAME(MOVE_LEER) "!");
         ABILITY_POPUP(player, ABILITY_MIRROR_ARMOR);
         NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
     } THEN {
@@ -137,10 +137,10 @@ SINGLE_BATTLE_TEST("Mirror Armor raises the stat of an attacking Pokemon with Co
     } WHEN {
         TURN { MOVE(opponent, MOVE_LEER); }
     } SCENE {
-        MESSAGE("Foe Shuckle used " MOVE_NAME(MOVE_LEER) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_SHUCKLE) " used " MOVE_NAME(MOVE_LEER) "!");
         ABILITY_POPUP(player, ABILITY_MIRROR_ARMOR);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-        MESSAGE("Foe Shuckle's Defense rose!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_SHUCKLE) "'s Defense rose!");
     } THEN {
         EXPECT_EQ(player->statStages[STAT_DEF], DEFAULT_STAT_STAGE);
         EXPECT_EQ(opponent->statStages[STAT_DEF], DEFAULT_STAT_STAGE + 1);
@@ -158,13 +158,13 @@ SINGLE_BATTLE_TEST("Mirror Armor doesn't lower the stat of the attacking Pokemon
         TURN { MOVE(player, MOVE_SCREECH); }
         TURN { MOVE(opponent, MOVE_LEER); }
     } SCENE {
-        MESSAGE("Corviknigh used " MOVE_NAME(MOVE_SCREECH) "!");
-        MESSAGE("Corviknigh used " MOVE_NAME(MOVE_SCREECH) "!");
-        MESSAGE("Corviknigh used " MOVE_NAME(MOVE_SCREECH) "!");
-        MESSAGE("Foe Wynaut used " MOVE_NAME(MOVE_LEER) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_CORVIKNIGHT) " used " MOVE_NAME(MOVE_SCREECH) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_CORVIKNIGHT) " used " MOVE_NAME(MOVE_SCREECH) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_CORVIKNIGHT) " used " MOVE_NAME(MOVE_SCREECH) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " used " MOVE_NAME(MOVE_LEER) "!");
         ABILITY_POPUP(player, ABILITY_MIRROR_ARMOR);
         NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-        MESSAGE("Foe Wynaut's Defense won't go lower!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) "'s Defense won't go lower!");
     } THEN {
         EXPECT_EQ(player->statStages[STAT_DEF], DEFAULT_STAT_STAGE);
         EXPECT_EQ(opponent->statStages[STAT_DEF], MIN_STAT_STAGE);
@@ -190,13 +190,13 @@ DOUBLE_BATTLE_TEST("Mirror Armor lowers Speed of the partner Pokemon after Court
         TURN { SWITCH(playerRight, 2);}
         TURN { }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_STICKY_WEB) "!");
-        MESSAGE("Foe Wynaut used " MOVE_NAME(MOVE_COURT_CHANGE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_STICKY_WEB) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " used " MOVE_NAME(MOVE_COURT_CHANGE) "!");
         MESSAGE("Foe Wynaut swapped the battle effects affecting each side!");
-        MESSAGE("Go! Corviknigh!");
-        MESSAGE("Corviknigh was caught in a Sticky Web!");
+        MESSAGE("Go! " SPECIES_NAME(SPECIES_CORVIKNIGH) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_CORVIKNIGHT) " was caught in a Sticky Web!");
         ABILITY_POPUP(playerRight, ABILITY_MIRROR_ARMOR);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
-        MESSAGE("Wobbuffet's Speed fell!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Speed fell!");
     }
 }

--- a/test/battle/ability/oblivious.c
+++ b/test/battle/ability/oblivious.c
@@ -12,7 +12,7 @@ SINGLE_BATTLE_TEST("Oblivious prevents Infatuation")
     } SCENE {
         ABILITY_POPUP(player, ABILITY_OBLIVIOUS);
         NONE_OF { ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_INFATUATION, player); }
-        MESSAGE("It doesn't affect Slowpoke…");
+        MESSAGE("It doesn't affect " SPECIES_NAME(SPECIES_SLOWPOKE) "…");
     }
 }
 
@@ -27,7 +27,7 @@ SINGLE_BATTLE_TEST("Oblivious prevents Captivate")
     } SCENE {
         ABILITY_POPUP(player, ABILITY_OBLIVIOUS);
         NONE_OF { ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player); }
-        MESSAGE("It doesn't affect Slowpoke…");
+        MESSAGE("It doesn't affect " SPECIES_NAME(SPECIES_SLOWPOKE) "…");
     }
 }
 
@@ -44,7 +44,7 @@ SINGLE_BATTLE_TEST("Oblivious prevents Taunt")
     } SCENE {
         ABILITY_POPUP(player, ABILITY_OBLIVIOUS);
         NONE_OF { ANIMATION(ANIM_TYPE_MOVE, MOVE_TAUNT, opponent); }
-        MESSAGE("It doesn't affect Slowpoke…");
+        MESSAGE("It doesn't affect " SPECIES_NAME(SPECIES_SLOWPOKE) "…");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SPORE, player);
         ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_SLP, opponent);
     }
@@ -63,6 +63,6 @@ SINGLE_BATTLE_TEST("Oblivious prevents Intimidate")
         ABILITY_POPUP(opponent, ABILITY_INTIMIDATE);
         ABILITY_POPUP(player, ABILITY_OBLIVIOUS);
         NONE_OF { ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player); }
-        MESSAGE("Slowpoke's Attack was not lowered!");
+        MESSAGE(SPECIES_NAME(SPECIES_SLOWPOKE) "'s Attack was not lowered!");
     }
 }

--- a/test/battle/ability/overcoat.c
+++ b/test/battle/ability/overcoat.c
@@ -12,7 +12,7 @@ SINGLE_BATTLE_TEST("Overcoat blocks powder and spore moves")
     } SCENE {
         ABILITY_POPUP(opponent, ABILITY_OVERCOAT);
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_STUN_SPORE, player);
-        MESSAGE("It doesn't affect Foe Pineco…");
+        MESSAGE("It doesn't affect Foe " SPECIES_NAME(SPECIES_PINECO) "…");
     }
 }
 

--- a/test/battle/ability/own_tempo.c
+++ b/test/battle/ability/own_tempo.c
@@ -20,7 +20,7 @@ SINGLE_BATTLE_TEST("Own Tempo prevents intimidate")
         ABILITY_POPUP(player, ABILITY_INTIMIDATE);
         NONE_OF { ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player); }
         ABILITY_POPUP(opponent, ABILITY_OWN_TEMPO);
-        MESSAGE("Foe Slowpoke's Attack was not lowered!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_SLOWPOKE) "'s Attack was not lowered!");
         HP_BAR(player, captureDamage: &turnTwoHit);
     } THEN {
         EXPECT_EQ(turnOneHit, turnTwoHit);
@@ -37,7 +37,7 @@ SINGLE_BATTLE_TEST("Own Tempo prevents confusion from moves by the opponent")
         TURN { MOVE(player, MOVE_CONFUSE_RAY); }
     } SCENE {
         ABILITY_POPUP(opponent, ABILITY_OWN_TEMPO);
-        MESSAGE("Foe Slowpoke's Own Tempo prevents confusion!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_SLOWPOKE) "'s Own Tempo prevents confusion!");
     }
 }
 
@@ -57,7 +57,7 @@ SINGLE_BATTLE_TEST("Own Tempo prevents confusion from moves by the user")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_PETAL_DANCE, opponent);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_PETAL_DANCE, opponent);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_PETAL_DANCE, opponent);
-        NONE_OF { MESSAGE("Foe Slowpoke became confused due to fatigue!"); }
+        NONE_OF { MESSAGE("Foe " SPECIES_NAME(SPECIES_SLOWPOKE) " became confused due to fatigue!"); }
     }
 }
 
@@ -72,12 +72,12 @@ SINGLE_BATTLE_TEST("Own Tempo cures confusion obtained from an opponent with Mol
         TURN { MOVE(player, MOVE_CONFUSE_RAY); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CONFUSE_RAY, player);
-        MESSAGE("Foe Slowpoke became confused!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_SLOWPOKE) " became confused!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_CONFUSION, opponent);
         }
         ABILITY_POPUP(opponent, ABILITY_OWN_TEMPO);
-        MESSAGE("Foe Slowpoke's Own Tempo cured its confusion problem!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_SLOWPOKE) "'s Own Tempo cured its confusion problem!");
     }
 }
 
@@ -95,10 +95,10 @@ SINGLE_BATTLE_TEST("Own Tempo cures confusion if it's obtained via Skill Swap")
         }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CONFUSE_RAY, player);
-        MESSAGE("Foe Wobbuffet became confused!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " became confused!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SKILL_SWAP, player);
         ABILITY_POPUP(opponent, ABILITY_OWN_TEMPO);
-        MESSAGE("Foe Wobbuffet's Own Tempo cured its confusion problem!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Own Tempo cured its confusion problem!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
     }
 }

--- a/test/battle/ability/parental_bond.c
+++ b/test/battle/ability/parental_bond.c
@@ -12,9 +12,9 @@ SINGLE_BATTLE_TEST("Parental Bond converts Tackle into a two-strike move")
     } WHEN {
         TURN { MOVE(player, MOVE_TACKLE, megaEvolve: TRUE); MOVE(opponent, MOVE_CELEBRATE); }
     } SCENE {
-        MESSAGE("Kangaskhan's Kangaskhanite is reacting to 1's Mega Ring!");
+        MESSAGE(SPECIES_NAME(SPECIES_KANGASKHAN) "'s Kangaskhanite is reacting to 1's Mega Ring!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MEGA_EVOLUTION, player);
-        MESSAGE("Kangaskhan has Mega Evolved into Mega Kangaskhan!");
+        MESSAGE(SPECIES_NAME(SPECIES_KANGASKHAN) " has Mega Evolved into Mega Kangaskhan!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, player);
         HP_BAR(opponent);
         HP_BAR(opponent);

--- a/test/battle/ability/pastel_veil.c
+++ b/test/battle/ability/pastel_veil.c
@@ -76,7 +76,7 @@ SINGLE_BATTLE_TEST("Pastel Veil prevents Toxic bad poison")
     } WHEN {
         TURN { MOVE(player, MOVE_TOXIC); }
     } SCENE {
-        MESSAGE("Wobbuffet used Toxic!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TOXIC) "!");
         ABILITY_POPUP(opponent, ABILITY_PASTEL_VEIL);
         MESSAGE("Foe Ponyta is protected by a pastel veil!");
         NOT STATUS_ICON(opponent, badPoison: TRUE);
@@ -94,7 +94,7 @@ DOUBLE_BATTLE_TEST("Pastel Veil prevents Toxic bad poison on partner")
     } WHEN {
         TURN { MOVE(playerLeft, MOVE_TOXIC, target: opponentRight); }
     } SCENE {
-        MESSAGE("Wobbuffet used Toxic!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TOXIC) "!");
         ABILITY_POPUP(opponentLeft, ABILITY_PASTEL_VEIL);
         MESSAGE("Foe Wynaut is protected by a pastel veil!");
         NOT STATUS_ICON(opponentRight, badPoison: TRUE);

--- a/test/battle/ability/pastel_veil.c
+++ b/test/battle/ability/pastel_veil.c
@@ -44,7 +44,7 @@ SINGLE_BATTLE_TEST("Pastel Veil immediately cures Mold Breaker poison")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TOXIC, player);
         STATUS_ICON(opponent, badPoison: TRUE);
         ABILITY_POPUP(opponent, ABILITY_PASTEL_VEIL);
-        MESSAGE("Foe Ponyta's Pastel Veil cured its poison problem!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_PONYTA) "'s Pastel Veil cured its poison problem!");
         STATUS_ICON(opponent, none: TRUE);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
     }
@@ -76,9 +76,9 @@ SINGLE_BATTLE_TEST("Pastel Veil prevents Toxic bad poison")
     } WHEN {
         TURN { MOVE(player, MOVE_TOXIC); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TOXIC) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TOXIC) "!");
         ABILITY_POPUP(opponent, ABILITY_PASTEL_VEIL);
-        MESSAGE("Foe Ponyta is protected by a pastel veil!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_PONYTA) " is protected by a pastel veil!");
         NOT STATUS_ICON(opponent, badPoison: TRUE);
     }
 }
@@ -94,9 +94,9 @@ DOUBLE_BATTLE_TEST("Pastel Veil prevents Toxic bad poison on partner")
     } WHEN {
         TURN { MOVE(playerLeft, MOVE_TOXIC, target: opponentRight); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TOXIC) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TOXIC) "!");
         ABILITY_POPUP(opponentLeft, ABILITY_PASTEL_VEIL);
-        MESSAGE("Foe Wynaut is protected by a pastel veil!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " is protected by a pastel veil!");
         NOT STATUS_ICON(opponentRight, badPoison: TRUE);
     }
 }
@@ -112,7 +112,7 @@ SINGLE_BATTLE_TEST("Pastel Veil prevents Toxic Spikes poison")
         TURN { MOVE(player, MOVE_TOXIC_SPIKES); }
         TURN { SWITCH(opponent, 1); }
     } SCENE {
-        MESSAGE("2 sent out Ponyta!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_PONYTA) "!");
         NOT STATUS_ICON(opponent, poison: TRUE);
     }
 }
@@ -130,7 +130,7 @@ DOUBLE_BATTLE_TEST("Pastel Veil prevents Toxic Spikes poison on partner")
         TURN { MOVE(playerLeft, MOVE_TOXIC_SPIKES); }
         TURN { SWITCH(opponentRight, 2); }
     } SCENE {
-        MESSAGE("2 sent out Wynaut!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WYNAUT) "!");
         NOT STATUS_ICON(opponentRight, poison: TRUE);
     }
 }
@@ -145,9 +145,9 @@ DOUBLE_BATTLE_TEST("Pastel Veil cures partner's poison on initial switch in")
     } WHEN {
         TURN {}
     } SCENE {
-        MESSAGE("2 sent out Wobbuffet and Ponyta!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WOBBUFFET) " and Ponyta!");
         ABILITY_POPUP(opponentRight, ABILITY_PASTEL_VEIL);
-        MESSAGE("Foe Wobbuffet was cured of its poisoning!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " was cured of its poisoning!");
         STATUS_ICON(opponentLeft, none: TRUE);
     }
 }
@@ -163,9 +163,9 @@ DOUBLE_BATTLE_TEST("Pastel Veil cures partner's poison on switch in")
     } WHEN {
         TURN { SWITCH(opponentRight, 2); }
     } SCENE {
-        MESSAGE("2 sent out Ponyta!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_PONYTA) "!");
         ABILITY_POPUP(opponentRight, ABILITY_PASTEL_VEIL);
-        MESSAGE("Foe Wobbuffet was cured of its poisoning!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " was cured of its poisoning!");
         STATUS_ICON(opponentLeft, none: TRUE);
     }
 }

--- a/test/battle/ability/poison_heal.c
+++ b/test/battle/ability/poison_heal.c
@@ -14,7 +14,7 @@ SINGLE_BATTLE_TEST("Poison Heal heals from (Toxic) Poison damage")
         TURN { MOVE(player, MOVE_CELEBRATE); }
     } SCENE {
         ABILITY_POPUP(player, ABILITY_POISON_HEAL);
-        MESSAGE("The poisoning healed Shroomish a little bit!");
+        MESSAGE("The poisoning healed " SPECIES_NAME(SPECIES_SHROOMISH) " a little bit!");
         HP_BAR(player, damage: -50);
     }
 }
@@ -32,11 +32,11 @@ SINGLE_BATTLE_TEST("Poison Heal heals from Toxic Poison damage are constant")
         TURN { }
     } SCENE {
         ABILITY_POPUP(player, ABILITY_POISON_HEAL);
-        MESSAGE("The poisoning healed Shroomish a little bit!");
+        MESSAGE("The poisoning healed " SPECIES_NAME(SPECIES_SHROOMISH) " a little bit!");
         HP_BAR(player, captureDamage: &turnOneHit);
 
         ABILITY_POPUP(player, ABILITY_POISON_HEAL);
-        MESSAGE("The poisoning healed Shroomish a little bit!");
+        MESSAGE("The poisoning healed " SPECIES_NAME(SPECIES_SHROOMISH) " a little bit!");
         HP_BAR(player, captureDamage: &turnTwoHit);
     } THEN {
         EXPECT_EQ(turnOneHit, turnTwoHit);
@@ -53,7 +53,7 @@ SINGLE_BATTLE_TEST("Poison Heal does not heal or cause damage when under Heal Bl
     } SCENE {
         NONE_OF {
             ABILITY_POPUP(player, ABILITY_POISON_HEAL);
-            MESSAGE("The poisoning healed Shroomish a little bit!");
+            MESSAGE("The poisoning healed " SPECIES_NAME(SPECIES_SHROOMISH) " a little bit!");
             HP_BAR(player, damage: -50);
         }
     }
@@ -69,7 +69,7 @@ SINGLE_BATTLE_TEST("Poison Heal activates before Toxic Orb")
     } SCENE {
         NONE_OF {
             ABILITY_POPUP(player, ABILITY_POISON_HEAL);
-            MESSAGE("The poisoning healed Shroomish a little bit!");
+            MESSAGE("The poisoning healed " SPECIES_NAME(SPECIES_SHROOMISH) " a little bit!");
             HP_BAR(player, damage: -50);
             HP_BAR(player, damage: 50);
         }

--- a/test/battle/ability/poison_point.c
+++ b/test/battle/ability/poison_point.c
@@ -18,13 +18,13 @@ SINGLE_BATTLE_TEST("Poison Point inflicts poison on contact")
         if (gBattleMoves[move].makesContact) {
             ABILITY_POPUP(opponent, ABILITY_POISON_POINT);
             ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, player);
-            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was poisoned by Foe Nidoran♂'s Poison Point!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was poisoned by Foe " SPECIES_NAME(SPECIES_NIDORAN_M) "'s Poison Point!");
             STATUS_ICON(player, poison: TRUE);
         } else {
             NONE_OF {
                 ABILITY_POPUP(opponent, ABILITY_POISON_POINT);
                 ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, player);
-                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was poisoned by Foe Nidoran♂'s Poison Point!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was poisoned by Foe " SPECIES_NAME(SPECIES_NIDORAN_M) "'s Poison Point!");
                 STATUS_ICON(player, poison: TRUE);
             }
         }

--- a/test/battle/ability/poison_point.c
+++ b/test/battle/ability/poison_point.c
@@ -18,13 +18,13 @@ SINGLE_BATTLE_TEST("Poison Point inflicts poison on contact")
         if (gBattleMoves[move].makesContact) {
             ABILITY_POPUP(opponent, ABILITY_POISON_POINT);
             ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, player);
-            MESSAGE("Wobbuffet was poisoned by Foe Nidoran♂'s Poison Point!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was poisoned by Foe Nidoran♂'s Poison Point!");
             STATUS_ICON(player, poison: TRUE);
         } else {
             NONE_OF {
                 ABILITY_POPUP(opponent, ABILITY_POISON_POINT);
                 ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, player);
-                MESSAGE("Wobbuffet was poisoned by Foe Nidoran♂'s Poison Point!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was poisoned by Foe Nidoran♂'s Poison Point!");
                 STATUS_ICON(player, poison: TRUE);
             }
         }

--- a/test/battle/ability/prankster.c
+++ b/test/battle/ability/prankster.c
@@ -11,7 +11,7 @@ SINGLE_BATTLE_TEST("Prankster-affected moves don't affect Dark-type Pokémon")
         TURN { MOVE(opponent, MOVE_CONFUSE_RAY); }
     } SCENE {
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_CONFUSE_RAY, player);
-        MESSAGE("It doesn't affect Umbreon…");
+        MESSAGE("It doesn't affect " SPECIES_NAME(SPECIES_UMBREON) "…");
     }
 }
 TO_DO_BATTLE_TEST("Prankster-affected moves affect Ally Dark-type Pokémon")

--- a/test/battle/ability/primordial_sea.c
+++ b/test/battle/ability/primordial_sea.c
@@ -16,11 +16,11 @@ SINGLE_BATTLE_TEST("Primordial Sea blocks damaging Fire-type moves")
         TURN { MOVE(opponent, MOVE_EMBER); }
         TURN { MOVE(opponent, MOVE_EMBER); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used Ember!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_EMBER) "!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_EMBER, opponent);
         MESSAGE("The Fire-type attack fizzled out\nin the heavy rain!");
         NOT HP_BAR(player);
-        MESSAGE("Foe Wobbuffet used Ember!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_EMBER) "!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_EMBER, opponent);
         MESSAGE("The Fire-type attack fizzled out\nin the heavy rain!");
         NOT HP_BAR(player);
@@ -42,7 +42,7 @@ DOUBLE_BATTLE_TEST("Primordial Sea blocks damaging Fire-type moves and prints th
     } WHEN {
         TURN { MOVE(opponentLeft, MOVE_ERUPTION); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used Eruption!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_ERUPTION) "!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_ERUPTION, opponentLeft);
         MESSAGE("The Fire-type attack fizzled out\nin the heavy rain!");
         NOT MESSAGE("The Fire-type attack fizzled out\nin the heavy rain!");

--- a/test/battle/ability/primordial_sea.c
+++ b/test/battle/ability/primordial_sea.c
@@ -16,11 +16,11 @@ SINGLE_BATTLE_TEST("Primordial Sea blocks damaging Fire-type moves")
         TURN { MOVE(opponent, MOVE_EMBER); }
         TURN { MOVE(opponent, MOVE_EMBER); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_EMBER) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_EMBER) "!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_EMBER, opponent);
         MESSAGE("The Fire-type attack fizzled out\nin the heavy rain!");
         NOT HP_BAR(player);
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_EMBER) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_EMBER) "!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_EMBER, opponent);
         MESSAGE("The Fire-type attack fizzled out\nin the heavy rain!");
         NOT HP_BAR(player);
@@ -42,7 +42,7 @@ DOUBLE_BATTLE_TEST("Primordial Sea blocks damaging Fire-type moves and prints th
     } WHEN {
         TURN { MOVE(opponentLeft, MOVE_ERUPTION); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_ERUPTION) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_ERUPTION) "!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_ERUPTION, opponentLeft);
         MESSAGE("The Fire-type attack fizzled out\nin the heavy rain!");
         NOT MESSAGE("The Fire-type attack fizzled out\nin the heavy rain!");
@@ -61,6 +61,6 @@ SINGLE_BATTLE_TEST("Primordial Sea does not block a move if pokemon is asleep an
         TURN { MOVE(opponent, MOVE_EMBER); }
     } SCENE {
         NOT MESSAGE("The Fire-type attack fizzled out\nin the heavy rain!");
-        MESSAGE("Foe Wobbuffet is fast asleep.");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is fast asleep.");
     }
 }

--- a/test/battle/ability/protosynthesis.c
+++ b/test/battle/ability/protosynthesis.c
@@ -18,7 +18,7 @@ SINGLE_BATTLE_TEST("Protosynthesis boosts the highest stat")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SUNNY_DAY, player);
         ABILITY_POPUP(player, ABILITY_PROTOSYNTHESIS);
         MESSAGE("The harsh sunlight activated Abra's Protosynthesis!");
-        MESSAGE("Abra's Sp. Atk was heightened!");
+        MESSAGE(SPECIES_NAME(SPECIES_ABRA) "'s Sp. Atk was heightened!");
     }
 }
 

--- a/test/battle/ability/purifying_salt.c
+++ b/test/battle/ability/purifying_salt.c
@@ -56,7 +56,7 @@ SINGLE_BATTLE_TEST("Purifying Salt grants immunity to status effects")
         if (move != MOVE_POWDER_SNOW) {
             NOT ANIMATION(ANIM_TYPE_MOVE, move, opponent);
             ABILITY_POPUP(player, ABILITY_PURIFYING_SALT);
-            MESSAGE("It doesn't affect Wobbuffet…");
+            MESSAGE("It doesn't affect " SPECIES_NAME(SPECIES_WOBBUFFET) "…");
             NOT STATUS_ICON(player, status);
         } else {
             NONE_OF {

--- a/test/battle/ability/quark_drive.c
+++ b/test/battle/ability/quark_drive.c
@@ -18,7 +18,7 @@ SINGLE_BATTLE_TEST("Quark Drive boosts the highest stat")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ELECTRIC_TERRAIN, player);
         ABILITY_POPUP(player, ABILITY_QUARK_DRIVE);
         MESSAGE("The Electric Terrain activated Abra's Quark Drive!");
-        MESSAGE("Abra's Sp. Atk was heightened!");
+        MESSAGE(SPECIES_NAME(SPECIES_ABRA) "'s Sp. Atk was heightened!");
     }
 }
 

--- a/test/battle/ability/quick_draw.c
+++ b/test/battle/ability/quick_draw.c
@@ -11,7 +11,7 @@ SINGLE_BATTLE_TEST("Quick Draw has a 30% chance of going first")
         TURN { MOVE(player, MOVE_TACKLE); }
     } SCENE {
         ABILITY_POPUP(player, ABILITY_QUICK_DRAW);
-        MESSAGE("Slowbro used " MOVE_NAME(MOVE_TACKLE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_SLOWBRO) " used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
     }
 }

--- a/test/battle/ability/quick_draw.c
+++ b/test/battle/ability/quick_draw.c
@@ -11,7 +11,7 @@ SINGLE_BATTLE_TEST("Quick Draw has a 30% chance of going first")
         TURN { MOVE(player, MOVE_TACKLE); }
     } SCENE {
         ABILITY_POPUP(player, ABILITY_QUICK_DRAW);
-        MESSAGE("Slowbro used Tackle!");
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Slowbro used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
     }
 }

--- a/test/battle/ability/rain_dish.c
+++ b/test/battle/ability/rain_dish.c
@@ -10,7 +10,7 @@ SINGLE_BATTLE_TEST("Rain Dish recovers 1/16th of Max HP in Rain")
         TURN { MOVE(opponent, MOVE_RAIN_DANCE); }
     } SCENE {
         ABILITY_POPUP(player, ABILITY_RAIN_DISH);
-        MESSAGE("Ludicolo's Rain Dish restored its HP a little!");
+        MESSAGE(SPECIES_NAME(SPECIES_LUDICOLO) "'s Rain Dish restored its HP a little!");
         HP_BAR(player, damage: -(100 / 16));
     }
 }

--- a/test/battle/ability/rattled.c
+++ b/test/battle/ability/rattled.c
@@ -34,10 +34,10 @@ SINGLE_BATTLE_TEST("Rattled boosts speed by 1 when hit by Bug, Dark or Ghost typ
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
             MESSAGE("Foe Sudowoodo's Speed rose!");
         }
-        MESSAGE("Foe Sudowoodo used Celebrate!");
+        MESSAGE("Foe Sudowoodo used " MOVE_NAME(MOVE_CELEBRATE) "!");
         // Sudowoodo is now faster
         if (move != MOVE_TACKLE){
-            MESSAGE("Foe Sudowoodo used Celebrate!");
+            MESSAGE("Foe Sudowoodo used " MOVE_NAME(MOVE_CELEBRATE) "!");
             ANIMATION(ANIM_TYPE_MOVE, move, player);
             HP_BAR(opponent);
             ABILITY_POPUP(opponent, ABILITY_RATTLED);
@@ -47,7 +47,7 @@ SINGLE_BATTLE_TEST("Rattled boosts speed by 1 when hit by Bug, Dark or Ghost typ
         else {
             ANIMATION(ANIM_TYPE_MOVE, move, player);
             HP_BAR(opponent);
-            MESSAGE("Foe Sudowoodo used Celebrate!");
+            MESSAGE("Foe Sudowoodo used " MOVE_NAME(MOVE_CELEBRATE) "!");
         }
     }
 }
@@ -82,7 +82,7 @@ SINGLE_BATTLE_TEST("Rattled triggers correctly when hit by U-Turn") // Specific 
     } WHEN {
         TURN { MOVE(player, MOVE_U_TURN); SEND_OUT(player, 1); }
     } SCENE {
-        MESSAGE("Wobbuffet used U-turn!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_U_TURN) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_U_TURN, player);
         HP_BAR(opponent);
         ABILITY_POPUP(opponent, ABILITY_RATTLED);

--- a/test/battle/ability/rattled.c
+++ b/test/battle/ability/rattled.c
@@ -63,7 +63,7 @@ SINGLE_BATTLE_TEST("Rattled boosts speed by 1 when affected by Intimidate")
     } SCENE {
         ABILITY_POPUP(player, ABILITY_INTIMIDATE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-        MESSAGE(SPECIES_NAME(SPECIES_GYARADOS) "'s Intimidate cuts Foe Sudowoodo's attack!");
+        MESSAGE(SPECIES_NAME(SPECIES_GYARADOS) "'s Intimidate cuts Foe " SPECIES_NAME(SPECIES_SUDOWOODO) "'s attack!");
         ABILITY_POPUP(opponent, ABILITY_RATTLED);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
         MESSAGE("Foe " SPECIES_NAME(SPECIES_SUDOWOODO) "'s Speed rose!");

--- a/test/battle/ability/rattled.c
+++ b/test/battle/ability/rattled.c
@@ -32,22 +32,22 @@ SINGLE_BATTLE_TEST("Rattled boosts speed by 1 when hit by Bug, Dark or Ghost typ
         if (move != MOVE_TACKLE) {
             ABILITY_POPUP(opponent, ABILITY_RATTLED);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-            MESSAGE("Foe Sudowoodo's Speed rose!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_SUDOWOODO) "'s Speed rose!");
         }
-        MESSAGE("Foe Sudowoodo used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_SUDOWOODO) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
         // Sudowoodo is now faster
         if (move != MOVE_TACKLE){
-            MESSAGE("Foe Sudowoodo used " MOVE_NAME(MOVE_CELEBRATE) "!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_SUDOWOODO) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
             ANIMATION(ANIM_TYPE_MOVE, move, player);
             HP_BAR(opponent);
             ABILITY_POPUP(opponent, ABILITY_RATTLED);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-            MESSAGE("Foe Sudowoodo's Speed rose!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_SUDOWOODO) "'s Speed rose!");
         }
         else {
             ANIMATION(ANIM_TYPE_MOVE, move, player);
             HP_BAR(opponent);
-            MESSAGE("Foe Sudowoodo used " MOVE_NAME(MOVE_CELEBRATE) "!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_SUDOWOODO) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
         }
     }
 }
@@ -63,10 +63,10 @@ SINGLE_BATTLE_TEST("Rattled boosts speed by 1 when affected by Intimidate")
     } SCENE {
         ABILITY_POPUP(player, ABILITY_INTIMIDATE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-        MESSAGE("Gyarados's Intimidate cuts Foe Sudowoodo's attack!");
+        MESSAGE(SPECIES_NAME(SPECIES_GYARADOS) "'s Intimidate cuts Foe Sudowoodo's attack!");
         ABILITY_POPUP(opponent, ABILITY_RATTLED);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-        MESSAGE("Foe Sudowoodo's Speed rose!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_SUDOWOODO) "'s Speed rose!");
     }
 }
 
@@ -82,12 +82,12 @@ SINGLE_BATTLE_TEST("Rattled triggers correctly when hit by U-Turn") // Specific 
     } WHEN {
         TURN { MOVE(player, MOVE_U_TURN); SEND_OUT(player, 1); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_U_TURN) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_U_TURN) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_U_TURN, player);
         HP_BAR(opponent);
         ABILITY_POPUP(opponent, ABILITY_RATTLED);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-        MESSAGE("Foe Sudowoodo's Speed rose!");
-        MESSAGE("Go! Wynaut!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_SUDOWOODO) "'s Speed rose!");
+        MESSAGE("Go! " SPECIES_NAME(SPECIES_WYNAUT) "!");
     }
 }

--- a/test/battle/ability/sap_sipper.c
+++ b/test/battle/ability/sap_sipper.c
@@ -67,7 +67,7 @@ SINGLE_BATTLE_TEST("Sap Sipper blocks multi-hit grass type moves")
     } WHEN {
         TURN { MOVE(opponent, MOVE_BULLET_SEED); }
     } SCENE {
-        MESSAGE("Foe Shellder used Bullet Seed!");
+        MESSAGE("Foe Shellder used " MOVE_NAME(MOVE_BULLET_SEED) "!");
         ABILITY_POPUP(player, ABILITY_SAP_SIPPER);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
         MESSAGE("Marill's Attack rose!");

--- a/test/battle/ability/sap_sipper.c
+++ b/test/battle/ability/sap_sipper.c
@@ -38,7 +38,7 @@ SINGLE_BATTLE_TEST("Sap Sipper increases Attack by one stage when hit by a Grass
     } SCENE {
         ABILITY_POPUP(player, ABILITY_SAP_SIPPER);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-        MESSAGE("Marill's Attack rose!");
+        MESSAGE(SPECIES_NAME(SPECIES_MARILL) "'s Attack rose!");
     }
 }
 
@@ -53,7 +53,7 @@ SINGLE_BATTLE_TEST("Sap Sipper does not increase Attack if already maxed")
         ABILITY_POPUP(player, ABILITY_SAP_SIPPER);
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-            MESSAGE("Marill's Attack rose!");
+            MESSAGE(SPECIES_NAME(SPECIES_MARILL) "'s Attack rose!");
         }
     }
 }
@@ -67,10 +67,10 @@ SINGLE_BATTLE_TEST("Sap Sipper blocks multi-hit grass type moves")
     } WHEN {
         TURN { MOVE(opponent, MOVE_BULLET_SEED); }
     } SCENE {
-        MESSAGE("Foe Shellder used " MOVE_NAME(MOVE_BULLET_SEED) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_SHELLDER) " used " MOVE_NAME(MOVE_BULLET_SEED) "!");
         ABILITY_POPUP(player, ABILITY_SAP_SIPPER);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-        MESSAGE("Marill's Attack rose!");
+        MESSAGE(SPECIES_NAME(SPECIES_MARILL) "'s Attack rose!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_BULLET_SEED, opponent);
             HP_BAR(player);

--- a/test/battle/ability/schooling.c
+++ b/test/battle/ability/schooling.c
@@ -25,8 +25,8 @@ SINGLE_BATTLE_TEST("Schooling switches Level 20+ Wishiwashi's form when HP is 25
             ABILITY_POPUP(player, ABILITY_SCHOOLING);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
         }
-        MESSAGE("Wishiwashi used Celebrate!");
-        MESSAGE("Foe Wobbuffet used Super Fang!");
+        MESSAGE("Wishiwashi used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_SUPER_FANG) "!");
         HP_BAR(player);
         if (level >= 20)
         {
@@ -65,8 +65,8 @@ SINGLE_BATTLE_TEST("Schooling switches Level 20+ Wishiwashi's form when HP is ov
             ABILITY_POPUP(player, ABILITY_SCHOOLING);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
         }
-        MESSAGE("Wishiwashi used Celebrate!");
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Wishiwashi used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
     } THEN {
         if (level >= 20 && overQuarterHP)
             EXPECT_EQ(player->species, SPECIES_WISHIWASHI_SCHOOL);
@@ -94,8 +94,8 @@ SINGLE_BATTLE_TEST("Schooling switches Level 20+ Wishiwashi's form when HP is he
     } WHEN {
         TURN { MOVE(player, MOVE_CELEBRATE); MOVE(opponent, MOVE_HEAL_PULSE); }
     } SCENE {
-        MESSAGE("Wishiwashi used Celebrate!");
-        MESSAGE("Foe Wobbuffet used Heal Pulse!");
+        MESSAGE("Wishiwashi used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_HEAL_PULSE) "!");
         HP_BAR(player);
         if (level >= 20)
         {

--- a/test/battle/ability/schooling.c
+++ b/test/battle/ability/schooling.c
@@ -25,8 +25,8 @@ SINGLE_BATTLE_TEST("Schooling switches Level 20+ Wishiwashi's form when HP is 25
             ABILITY_POPUP(player, ABILITY_SCHOOLING);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
         }
-        MESSAGE("Wishiwashi used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_SUPER_FANG) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WISHIWASHI) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SUPER_FANG) "!");
         HP_BAR(player);
         if (level >= 20)
         {
@@ -65,8 +65,8 @@ SINGLE_BATTLE_TEST("Schooling switches Level 20+ Wishiwashi's form when HP is ov
             ABILITY_POPUP(player, ABILITY_SCHOOLING);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
         }
-        MESSAGE("Wishiwashi used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WISHIWASHI) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
     } THEN {
         if (level >= 20 && overQuarterHP)
             EXPECT_EQ(player->species, SPECIES_WISHIWASHI_SCHOOL);
@@ -94,8 +94,8 @@ SINGLE_BATTLE_TEST("Schooling switches Level 20+ Wishiwashi's form when HP is he
     } WHEN {
         TURN { MOVE(player, MOVE_CELEBRATE); MOVE(opponent, MOVE_HEAL_PULSE); }
     } SCENE {
-        MESSAGE("Wishiwashi used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_HEAL_PULSE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WISHIWASHI) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_HEAL_PULSE) "!");
         HP_BAR(player);
         if (level >= 20)
         {

--- a/test/battle/ability/scrappy.c
+++ b/test/battle/ability/scrappy.c
@@ -61,6 +61,6 @@ SINGLE_BATTLE_TEST("Scrappy doesn't bypass a Ghost-type's Wonder Guard")
             HP_BAR(opponent);
         }
         ABILITY_POPUP(opponent, ABILITY_WONDER_GUARD);
-        MESSAGE("Foe Shedinja avoided damage with Wonder Guard!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_SHEDINJA) " avoided damage with Wonder Guard!");
     }
 }

--- a/test/battle/ability/scrappy.c
+++ b/test/battle/ability/scrappy.c
@@ -20,7 +20,7 @@ SINGLE_BATTLE_TEST("Scrappy prevents intimidate")
         ABILITY_POPUP(player, ABILITY_INTIMIDATE);
         NONE_OF { ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player); }
         ABILITY_POPUP(opponent, ABILITY_SCRAPPY);
-        MESSAGE("Foe Kangaskhan's Attack was not lowered!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_KANGASKHAN) "'s Attack was not lowered!");
         HP_BAR(player, captureDamage: &turnTwoHit);
     } THEN {
         EXPECT_EQ(turnOneHit, turnTwoHit);

--- a/test/battle/ability/seed_sower.c
+++ b/test/battle/ability/seed_sower.c
@@ -9,7 +9,7 @@ SINGLE_BATTLE_TEST("Seed Sower sets up Grassy Terrain when hit by an attack")
     } WHEN {
         TURN { MOVE(opponent, MOVE_TACKLE); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
         HP_BAR(player);
         ABILITY_POPUP(player);
         MESSAGE("Grass grew to cover the battlefield!");

--- a/test/battle/ability/seed_sower.c
+++ b/test/battle/ability/seed_sower.c
@@ -9,7 +9,7 @@ SINGLE_BATTLE_TEST("Seed Sower sets up Grassy Terrain when hit by an attack")
     } WHEN {
         TURN { MOVE(opponent, MOVE_TACKLE); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used Tackle!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
         HP_BAR(player);
         ABILITY_POPUP(player);
         MESSAGE("Grass grew to cover the battlefield!");

--- a/test/battle/ability/sheer_force.c
+++ b/test/battle/ability/sheer_force.c
@@ -37,7 +37,7 @@ SINGLE_BATTLE_TEST("Sheer Force boosts power, but removes secondary effects of m
                 STATUS_ICON(opponent, STATUS1_TOXIC_POISON);
                 STATUS_ICON(opponent, STATUS1_PARALYSIS);
                 MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is confused!");
-                MESSAGE("Wobbuffet flinched!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " flinched!");
             }
             // Volt Tackle/Flare Blitz edge case: recoil happens, but target isn't statused
             if (gBattleMoves[move].effect == EFFECT_RECOIL_33_STATUS)

--- a/test/battle/ability/sheer_force.c
+++ b/test/battle/ability/sheer_force.c
@@ -36,14 +36,14 @@ SINGLE_BATTLE_TEST("Sheer Force boosts power, but removes secondary effects of m
                 STATUS_ICON(opponent, STATUS1_BURN);
                 STATUS_ICON(opponent, STATUS1_TOXIC_POISON);
                 STATUS_ICON(opponent, STATUS1_PARALYSIS);
-                MESSAGE("Wobbuffet is confused!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is confused!");
                 MESSAGE("Wobbuffet flinched!");
             }
             // Volt Tackle/Flare Blitz edge case: recoil happens, but target isn't statused
             if (gBattleMoves[move].effect == EFFECT_RECOIL_33_STATUS)
             {
                 HP_BAR(player);
-                MESSAGE("Tauros is hit with recoil!");
+                MESSAGE(SPECIES_NAME(SPECIES_TAUROS) " is hit with recoil!");
             }
         }
     } FINALLY {

--- a/test/battle/ability/speed_boost.c
+++ b/test/battle/ability/speed_boost.c
@@ -10,11 +10,11 @@ SINGLE_BATTLE_TEST("Speed Boost gradually boosts Speed")
         TURN { MOVE(player, MOVE_CELEBRATE); MOVE(opponent, MOVE_CELEBRATE); }
         TURN { MOVE(player, MOVE_CELEBRATE); MOVE(opponent, MOVE_CELEBRATE); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used Celebrate!");
-        MESSAGE("Torchic used Celebrate!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Torchic used " MOVE_NAME(MOVE_CELEBRATE) "!");
         ABILITY_POPUP(player, ABILITY_SPEED_BOOST);
         MESSAGE("Torchic's Speed Boost raised its SPEED!");
-        MESSAGE("Torchic used Celebrate!");
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Torchic used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
     }
 }

--- a/test/battle/ability/speed_boost.c
+++ b/test/battle/ability/speed_boost.c
@@ -10,11 +10,11 @@ SINGLE_BATTLE_TEST("Speed Boost gradually boosts Speed")
         TURN { MOVE(player, MOVE_CELEBRATE); MOVE(opponent, MOVE_CELEBRATE); }
         TURN { MOVE(player, MOVE_CELEBRATE); MOVE(opponent, MOVE_CELEBRATE); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Torchic used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_TORCHIC) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
         ABILITY_POPUP(player, ABILITY_SPEED_BOOST);
-        MESSAGE("Torchic's Speed Boost raised its SPEED!");
-        MESSAGE("Torchic used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_TORCHIC) "'s Speed Boost raised its SPEED!");
+        MESSAGE(SPECIES_NAME(SPECIES_TORCHIC) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
     }
 }

--- a/test/battle/ability/static.c
+++ b/test/battle/ability/static.c
@@ -17,13 +17,13 @@ SINGLE_BATTLE_TEST("Static inflicts paralysis on contact")
         if (gBattleMoves[move].makesContact) {
             ABILITY_POPUP(opponent, ABILITY_STATIC);
             ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PRZ, player);
-            MESSAGE("Foe Pikachu's Static paralyzed Wobbuffet! It may be unable to move!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_PIKACHU) "'s Static paralyzed Wobbuffet! It may be unable to move!");
             STATUS_ICON(player, paralysis: TRUE);
         } else {
             NONE_OF {
                 ABILITY_POPUP(opponent, ABILITY_STATIC);
                 ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PRZ, player);
-                MESSAGE("Foe Pikachu's Static paralyzed Wobbuffet! It may be unable to move!");
+                MESSAGE("Foe " SPECIES_NAME(SPECIES_PIKACHU) "'s Static paralyzed Wobbuffet! It may be unable to move!");
                 STATUS_ICON(player, paralysis: TRUE);
             }
         }

--- a/test/battle/ability/stench.c
+++ b/test/battle/ability/stench.c
@@ -11,7 +11,7 @@ SINGLE_BATTLE_TEST("Stench has a 10% chance to flinch")
     } WHEN {
         TURN { MOVE(player, MOVE_TACKLE); MOVE(opponent, MOVE_CELEBRATE); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet flinched!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " flinched!");
     }
 }
 
@@ -27,7 +27,7 @@ SINGLE_BATTLE_TEST("Stench does not stack with King's Rock")
     } WHEN {
         TURN { MOVE(player, MOVE_TACKLE); MOVE(opponent, MOVE_CELEBRATE); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet flinched!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " flinched!");
     }
 }
 

--- a/test/battle/ability/sturdy.c
+++ b/test/battle/ability/sturdy.c
@@ -10,9 +10,9 @@ SINGLE_BATTLE_TEST("Sturdy prevents OHKO moves")
     } WHEN {
         TURN { MOVE(opponent, MOVE_FISSURE); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_FISSURE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_FISSURE) "!");
         ABILITY_POPUP(player, ABILITY_STURDY);
-        MESSAGE("Geodude was protected by Sturdy!");
+        MESSAGE(SPECIES_NAME(SPECIES_GEODUDE) " was protected by Sturdy!");
     } THEN {
         EXPECT_EQ(player->hp, player->maxHP);
     }

--- a/test/battle/ability/sturdy.c
+++ b/test/battle/ability/sturdy.c
@@ -10,7 +10,7 @@ SINGLE_BATTLE_TEST("Sturdy prevents OHKO moves")
     } WHEN {
         TURN { MOVE(opponent, MOVE_FISSURE); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used Fissure!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_FISSURE) "!");
         ABILITY_POPUP(player, ABILITY_STURDY);
         MESSAGE("Geodude was protected by Sturdy!");
     } THEN {

--- a/test/battle/ability/sword_of_ruin.c
+++ b/test/battle/ability/sword_of_ruin.c
@@ -21,7 +21,7 @@ SINGLE_BATTLE_TEST("Sword of Ruin reduces Defense", s16 damage)
     } SCENE {
         if (ability == ABILITY_SWORD_OF_RUIN) {
             ABILITY_POPUP(player, ABILITY_SWORD_OF_RUIN);
-            MESSAGE("Wobbuffet's Sword of Ruin weakened the Defense of all surrounding Pokémon!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Sword of Ruin weakened the Defense of all surrounding Pokémon!");
         }
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
@@ -44,7 +44,7 @@ SINGLE_BATTLE_TEST("Sword of Ruin does not reduce Defense if opposing mon has th
     } SCENE {
         if (ability == ABILITY_SWORD_OF_RUIN) {
             ABILITY_POPUP(player, ABILITY_SWORD_OF_RUIN);
-            MESSAGE("Wobbuffet's Sword of Ruin weakened the Defense of all surrounding Pokémon!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Sword of Ruin weakened the Defense of all surrounding Pokémon!");
         }
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {

--- a/test/battle/ability/tablets_of_ruin.c
+++ b/test/battle/ability/tablets_of_ruin.c
@@ -21,7 +21,7 @@ SINGLE_BATTLE_TEST("Tablets of Ruin reduces Attack", s16 damage)
     } SCENE {
         if (ability == ABILITY_TABLETS_OF_RUIN) {
             ABILITY_POPUP(player, ABILITY_TABLETS_OF_RUIN);
-            MESSAGE("Wobbuffet's Tablets of Ruin weakened the Attack of all surrounding Pokémon!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Tablets of Ruin weakened the Attack of all surrounding Pokémon!");
         }
         HP_BAR(player, captureDamage: &results[i].damage);
     } FINALLY {
@@ -44,7 +44,7 @@ SINGLE_BATTLE_TEST("Tablets of Ruin does not reduce Attack if an opposing mon ha
     } SCENE {
         if (ability == ABILITY_TABLETS_OF_RUIN) {
             ABILITY_POPUP(player, ABILITY_TABLETS_OF_RUIN);
-            MESSAGE("Wobbuffet's Tablets of Ruin weakened the Attack of all surrounding Pokémon!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Tablets of Ruin weakened the Attack of all surrounding Pokémon!");
         }
         HP_BAR(player, captureDamage: &results[i].damage);
     } FINALLY {

--- a/test/battle/ability/toxic_debris.c
+++ b/test/battle/ability/toxic_debris.c
@@ -94,7 +94,7 @@ SINGLE_BATTLE_TEST("Toxic Debris activates if user faints after physical hit")
         TURN { MOVE(opponent, MOVE_TACKLE); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
-        MESSAGE("Wobbuffet fainted!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " fainted!");
         ABILITY_POPUP(player, ABILITY_TOXIC_DEBRIS);
         MESSAGE("Poison Spikes were scattered all around the opposing team's feet!");
     }
@@ -111,6 +111,6 @@ SINGLE_BATTLE_TEST("Air Balloon is popped after Toxic Debris activates")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
         ABILITY_POPUP(player, ABILITY_TOXIC_DEBRIS);
         MESSAGE("Poison Spikes were scattered all around the opposing team's feet!");
-        MESSAGE("Wobbuffet's Air Balloon popped!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Air Balloon popped!");
     }
 }

--- a/test/battle/ability/vessel_of_ruin.c
+++ b/test/battle/ability/vessel_of_ruin.c
@@ -21,7 +21,7 @@ SINGLE_BATTLE_TEST("Vessel of Ruin reduces Sp. Atk", s16 damage)
     } SCENE {
         if (ability == ABILITY_VESSEL_OF_RUIN) {
             ABILITY_POPUP(player, ABILITY_VESSEL_OF_RUIN);
-            MESSAGE("Wobbuffet's Vessel of Ruin weakened the Sp. Atk of all surrounding Pokémon!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Vessel of Ruin weakened the Sp. Atk of all surrounding Pokémon!");
         }
         HP_BAR(player, captureDamage: &results[i].damage);
     } FINALLY {
@@ -44,7 +44,7 @@ SINGLE_BATTLE_TEST("Vessel of Ruin does not reduce Sp. Atk if opposing mon has t
     } SCENE {
         if (ability == ABILITY_VESSEL_OF_RUIN) {
             ABILITY_POPUP(player, ABILITY_VESSEL_OF_RUIN);
-            MESSAGE("Wobbuffet's Vessel of Ruin weakened the Sp. Atk of all surrounding Pokémon!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Vessel of Ruin weakened the Sp. Atk of all surrounding Pokémon!");
         }
         HP_BAR(player, captureDamage: &results[i].damage);
     } FINALLY {

--- a/test/battle/ability/volt_absorb.c
+++ b/test/battle/ability/volt_absorb.c
@@ -12,7 +12,7 @@ SINGLE_BATTLE_TEST("Volt Absorb heals 25% when hit by electric type moves")
     } SCENE {
         ABILITY_POPUP(player, ABILITY_VOLT_ABSORB);
         HP_BAR(player, damage: -25);
-        MESSAGE("Jolteon restored HP using its Volt Absorb!");
+        MESSAGE(SPECIES_NAME(SPECIES_JOLTEON) " restored HP using its Volt Absorb!");
     }
 }
 
@@ -25,7 +25,7 @@ SINGLE_BATTLE_TEST("Volt Absorb does not activate if protected")
     } WHEN {
         TURN { MOVE(player, MOVE_PROTECT); MOVE(opponent, MOVE_THUNDER_SHOCK); }
     } SCENE {
-        NONE_OF { ABILITY_POPUP(player, ABILITY_VOLT_ABSORB); HP_BAR(player); MESSAGE("Jolteon restored HP using its Volt Absorb!"); }
+        NONE_OF { ABILITY_POPUP(player, ABILITY_VOLT_ABSORB); HP_BAR(player); MESSAGE(SPECIES_NAME(SPECIES_JOLTEON) " restored HP using its Volt Absorb!"); }
     }
 }
 
@@ -41,7 +41,7 @@ SINGLE_BATTLE_TEST("Volt Absorb activates on status moves")
     } SCENE {
         ABILITY_POPUP(player, ABILITY_VOLT_ABSORB);
         HP_BAR(player, damage: -25);
-        MESSAGE("Jolteon restored HP using its Volt Absorb!");
+        MESSAGE(SPECIES_NAME(SPECIES_JOLTEON) " restored HP using its Volt Absorb!");
     }
 }
 
@@ -57,7 +57,7 @@ SINGLE_BATTLE_TEST("Volt Absorb is only triggered once on multi strike moves")
     } SCENE {
         ABILITY_POPUP(player, ABILITY_VOLT_ABSORB);
         HP_BAR(player, damage: -25);
-        MESSAGE("Jolteon restored HP using its Volt Absorb!");
+        MESSAGE(SPECIES_NAME(SPECIES_JOLTEON) " restored HP using its Volt Absorb!");
     }
 }
 
@@ -76,7 +76,7 @@ DOUBLE_BATTLE_TEST("Volt Absorb does not stop Electric Typed Explosion from dama
     } SCENE {
         ABILITY_POPUP(playerLeft, ABILITY_VOLT_ABSORB);
         HP_BAR(playerLeft, damage: -25);
-        MESSAGE("Jolteon restored HP using its Volt Absorb!");
+        MESSAGE(SPECIES_NAME(SPECIES_JOLTEON) " restored HP using its Volt Absorb!");
         HP_BAR(playerRight, captureDamage: &damage1);
         HP_BAR(opponentRight, captureDamage: &damage2);
     } THEN {
@@ -96,7 +96,7 @@ SINGLE_BATTLE_TEST("Volt Absorb prevents Cell Battery from activating")
     } SCENE {
         ABILITY_POPUP(player, ABILITY_VOLT_ABSORB);
         HP_BAR(player, damage: -25);
-        MESSAGE("Jolteon restored HP using its Volt Absorb!");
+        MESSAGE(SPECIES_NAME(SPECIES_JOLTEON) " restored HP using its Volt Absorb!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);

--- a/test/battle/ability/water_absorb.c
+++ b/test/battle/ability/water_absorb.c
@@ -12,7 +12,7 @@ SINGLE_BATTLE_TEST("Water Absorb heals 25% when hit by water type moves")
     } SCENE {
         ABILITY_POPUP(player, ABILITY_WATER_ABSORB);
         HP_BAR(player, damage: -25);
-        MESSAGE("Poliwag restored HP using its Water Absorb!");
+        MESSAGE(SPECIES_NAME(SPECIES_POLIWAG) " restored HP using its Water Absorb!");
     }
 }
 
@@ -25,7 +25,7 @@ SINGLE_BATTLE_TEST("Water Absorb does not activate if protected")
     } WHEN {
         TURN { MOVE(player, MOVE_PROTECT); MOVE(opponent, MOVE_BUBBLE); }
     } SCENE {
-        NONE_OF { ABILITY_POPUP(player, ABILITY_WATER_ABSORB); HP_BAR(player); MESSAGE("Poliwag restored HP using its Water Absorb!"); }
+        NONE_OF { ABILITY_POPUP(player, ABILITY_WATER_ABSORB); HP_BAR(player); MESSAGE(SPECIES_NAME(SPECIES_POLIWAG) " restored HP using its Water Absorb!"); }
     }
 }
 
@@ -41,7 +41,7 @@ SINGLE_BATTLE_TEST("Water Absorb activates on status moves")
     } SCENE {
         ABILITY_POPUP(player, ABILITY_WATER_ABSORB);
         HP_BAR(player, damage: -25);
-        MESSAGE("Poliwag restored HP using its Water Absorb!");
+        MESSAGE(SPECIES_NAME(SPECIES_POLIWAG) " restored HP using its Water Absorb!");
     }
 }
 
@@ -57,7 +57,7 @@ SINGLE_BATTLE_TEST("Water Absorb is only triggered once on multi strike moves")
     } SCENE {
         ABILITY_POPUP(player, ABILITY_WATER_ABSORB);
         HP_BAR(player, damage: -25);
-        MESSAGE("Poliwag restored HP using its Water Absorb!");
+        MESSAGE(SPECIES_NAME(SPECIES_POLIWAG) " restored HP using its Water Absorb!");
     }
 }
 
@@ -75,7 +75,7 @@ SINGLE_BATTLE_TEST("Water Absorb prevents Absorb Bulb and Luminous Moss from act
     } SCENE {
         ABILITY_POPUP(player, ABILITY_WATER_ABSORB);
         HP_BAR(player, damage: -25);
-        MESSAGE("Poliwag restored HP using its Water Absorb!");
+        MESSAGE(SPECIES_NAME(SPECIES_POLIWAG) " restored HP using its Water Absorb!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);

--- a/test/battle/ability/weak_armor.c
+++ b/test/battle/ability/weak_armor.c
@@ -27,14 +27,14 @@ SINGLE_BATTLE_TEST("Weak Armor lowers Defense by 1 and boosts Speed by 2 when hi
         if (move == MOVE_TACKLE) {
             ABILITY_POPUP(player, ABILITY_WEAK_ARMOR);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-            MESSAGE("Slugma's Weak Armor lowered its Defense!");
-            MESSAGE("Slugma's Weak Armor raised its Speed!");
+            MESSAGE(SPECIES_NAME(SPECIES_SLUGMA) "'s Weak Armor lowered its Defense!");
+            MESSAGE(SPECIES_NAME(SPECIES_SLUGMA) "'s Weak Armor raised its Speed!");
         } else {
             NONE_OF {
                 ABILITY_POPUP(player, ABILITY_WEAK_ARMOR);
                 ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-                MESSAGE("Slugma's Weak Armor lowered its Defense!");
-                MESSAGE("Slugma's Weak Armor raised its Speed!");
+                MESSAGE(SPECIES_NAME(SPECIES_SLUGMA) "'s Weak Armor lowered its Defense!");
+                MESSAGE(SPECIES_NAME(SPECIES_SLUGMA) "'s Weak Armor raised its Speed!");
             }
         }
     } THEN {
@@ -61,14 +61,14 @@ SINGLE_BATTLE_TEST("Weak Armor does not trigger when brought in by Dragon Tail a
         ANIMATION(ANIM_TYPE_MOVE, MOVE_STEALTH_ROCK, opponent);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_TAIL, opponent);
         HP_BAR(player);
-        MESSAGE("Slugma was dragged out!");
+        MESSAGE(SPECIES_NAME(SPECIES_SLUGMA) " was dragged out!");
         HP_BAR(player);
         MESSAGE("Pointed stones dug into Slugma!");
         NONE_OF {
             ABILITY_POPUP(player, ABILITY_WEAK_ARMOR);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-            MESSAGE("Slugma's Weak Armor lowered its Defense!");
-            MESSAGE("Slugma's Weak Armor raised its Speed!");
+            MESSAGE(SPECIES_NAME(SPECIES_SLUGMA) "'s Weak Armor lowered its Defense!");
+            MESSAGE(SPECIES_NAME(SPECIES_SLUGMA) "'s Weak Armor raised its Speed!");
         }
     } THEN {
         EXPECT_EQ(player->statStages[STAT_DEF], DEFAULT_STAT_STAGE);
@@ -92,11 +92,11 @@ SINGLE_BATTLE_TEST("Weak Armor still lowers boosts Speed if Defense can't go any
         ABILITY_POPUP(player, ABILITY_WEAK_ARMOR);
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-            MESSAGE("Slugma's Weak Armor lowered its Defense!");
+            MESSAGE(SPECIES_NAME(SPECIES_SLUGMA) "'s Weak Armor lowered its Defense!");
         }
-        MESSAGE("Slugma's Defense won't go lower!");
+        MESSAGE(SPECIES_NAME(SPECIES_SLUGMA) "'s Defense won't go lower!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-        MESSAGE("Slugma's Weak Armor raised its Speed!");
+        MESSAGE(SPECIES_NAME(SPECIES_SLUGMA) "'s Weak Armor raised its Speed!");
     } THEN {
         EXPECT_EQ(player->statStages[STAT_DEF], MIN_STAT_STAGE);
         EXPECT_EQ(player->statStages[STAT_SPEED], DEFAULT_STAT_STAGE + 2);
@@ -118,12 +118,12 @@ SINGLE_BATTLE_TEST("Weak Armor still lowers Defense if Speed can't go any higher
         HP_BAR(player);
         ABILITY_POPUP(player, ABILITY_WEAK_ARMOR);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-        MESSAGE("Slugma's Weak Armor lowered its Defense!");
+        MESSAGE(SPECIES_NAME(SPECIES_SLUGMA) "'s Weak Armor lowered its Defense!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-            MESSAGE("Slugma's Weak Armor raised its Speed!");
+            MESSAGE(SPECIES_NAME(SPECIES_SLUGMA) "'s Weak Armor raised its Speed!");
         }
-        MESSAGE("Slugma's Speed won't go higher!");
+        MESSAGE(SPECIES_NAME(SPECIES_SLUGMA) "'s Speed won't go higher!");
     } THEN {
         EXPECT_EQ(player->statStages[STAT_DEF], DEFAULT_STAT_STAGE - 1);
         EXPECT_EQ(player->statStages[STAT_SPEED], MAX_STAT_STAGE);
@@ -145,21 +145,21 @@ SINGLE_BATTLE_TEST("Weak Armor doesn't interrupt multi hit moves if Defense can'
         {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_FURY_SWIPES, opponent);
             ABILITY_POPUP(player, ABILITY_WEAK_ARMOR);
-            MESSAGE("Magcargo's Weak Armor lowered its Defense!");
-            MESSAGE("Magcargo's Weak Armor raised its Speed!");
+            MESSAGE(SPECIES_NAME(SPECIES_MAGCARGO) "'s Weak Armor lowered its Defense!");
+            MESSAGE(SPECIES_NAME(SPECIES_MAGCARGO) "'s Weak Armor raised its Speed!");
         }
         ANIMATION(ANIM_TYPE_MOVE, MOVE_FURY_SWIPES, opponent);
         ABILITY_POPUP(player, ABILITY_WEAK_ARMOR);
-        MESSAGE("Magcargo's Defense won't go lower!");
-        MESSAGE("Magcargo's Weak Armor raised its Speed!");
+        MESSAGE(SPECIES_NAME(SPECIES_MAGCARGO) "'s Defense won't go lower!");
+        MESSAGE(SPECIES_NAME(SPECIES_MAGCARGO) "'s Weak Armor raised its Speed!");
         for (j = 0; j < 2; j++)
         {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_FURY_SWIPES, opponent);
             // Ability doesn't activate if neither stat can be changed.
             NONE_OF {
                 ABILITY_POPUP(player, ABILITY_WEAK_ARMOR);
-                MESSAGE("Magcargo's Defense won't go lower!");
-                MESSAGE("Magcargo's Speed won't go higher!");
+                MESSAGE(SPECIES_NAME(SPECIES_MAGCARGO) "'s Defense won't go lower!");
+                MESSAGE(SPECIES_NAME(SPECIES_MAGCARGO) "'s Speed won't go higher!");
             }
         }
     } THEN {
@@ -181,14 +181,14 @@ SINGLE_BATTLE_TEST("Weak Armor doesn't interrupt multi hit moves if Speed can't 
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_FURY_SWIPES, opponent);
         ABILITY_POPUP(player, ABILITY_WEAK_ARMOR);
-        MESSAGE("Magcargo's Weak Armor lowered its Defense!");
-        MESSAGE("Magcargo's Weak Armor raised its Speed!");
+        MESSAGE(SPECIES_NAME(SPECIES_MAGCARGO) "'s Weak Armor lowered its Defense!");
+        MESSAGE(SPECIES_NAME(SPECIES_MAGCARGO) "'s Weak Armor raised its Speed!");
         for (j = 0; j < 4; j++)
         {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_FURY_SWIPES, opponent);
             ABILITY_POPUP(player, ABILITY_WEAK_ARMOR);
-            MESSAGE("Magcargo's Weak Armor lowered its Defense!");
-            MESSAGE("Magcargo's Speed won't go higher!");
+            MESSAGE(SPECIES_NAME(SPECIES_MAGCARGO) "'s Weak Armor lowered its Defense!");
+            MESSAGE(SPECIES_NAME(SPECIES_MAGCARGO) "'s Speed won't go higher!");
         }
     } THEN {
         EXPECT_EQ(player->statStages[STAT_DEF], DEFAULT_STAT_STAGE - 5);

--- a/test/battle/ability/white_smoke.c
+++ b/test/battle/ability/white_smoke.c
@@ -19,7 +19,7 @@ SINGLE_BATTLE_TEST("White Smoke prevents intimidate")
         ABILITY_POPUP(player, ABILITY_INTIMIDATE);
         NONE_OF { ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player); }
         ABILITY_POPUP(opponent, ABILITY_WHITE_SMOKE);
-        MESSAGE("Foe Torkoal's White Smoke prevents stat loss!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_TORKOAL) "'s White Smoke prevents stat loss!");
         HP_BAR(player, captureDamage: &turnTwoHit);
     } THEN {
         EXPECT_EQ(turnOneHit, turnTwoHit);

--- a/test/battle/ability/wind_power.c
+++ b/test/battle/ability/wind_power.c
@@ -82,7 +82,7 @@ SINGLE_BATTLE_TEST("Wind Power sets up Charge for opponent when hit by a wind mo
         HP_BAR(opponent);
         if (move == MOVE_AIR_CUTTER) {
             ABILITY_POPUP(opponent, ABILITY_WIND_POWER);
-            MESSAGE("Being hit by " MOVE_NAME(MOVE_AIR_CUTTER) " charged Foe Wobbuffet with power!");
+            MESSAGE("Being hit by " MOVE_NAME(MOVE_AIR_CUTTER) " charged Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " with power!");
         }
 
         ANIMATION(ANIM_TYPE_MOVE, MOVE_THUNDERBOLT, opponent);
@@ -92,7 +92,7 @@ SINGLE_BATTLE_TEST("Wind Power sets up Charge for opponent when hit by a wind mo
         HP_BAR(opponent);
         if (move == MOVE_AIR_CUTTER) {
             ABILITY_POPUP(opponent, ABILITY_WIND_POWER);
-            MESSAGE("Being hit by " MOVE_NAME(MOVE_AIR_CUTTER) " charged Foe Wobbuffet with power!");
+            MESSAGE("Being hit by " MOVE_NAME(MOVE_AIR_CUTTER) " charged Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " with power!");
         }
     }
     THEN {
@@ -205,10 +205,10 @@ DOUBLE_BATTLE_TEST("Wind Power activates correctly when Tailwind is used")
             ANIMATION(ANIM_TYPE_MOVE, MOVE_TAILWIND, opponentLeft);
 
             ABILITY_POPUP(opponentLeft, ABILITY_WIND_POWER);
-            MESSAGE("Being hit by " MOVE_NAME(MOVE_TAILWIND) " charged Foe Wobbuffet with power!");
+            MESSAGE("Being hit by " MOVE_NAME(MOVE_TAILWIND) " charged Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " with power!");
 
             ABILITY_POPUP(opponentRight, ABILITY_WIND_POWER);
-            MESSAGE("Being hit by " MOVE_NAME(MOVE_TAILWIND) " charged Foe Wobbuffet with power!");
+            MESSAGE("Being hit by " MOVE_NAME(MOVE_TAILWIND) " charged Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " with power!");
         }
         else {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_TAILWIND, playerLeft);

--- a/test/battle/ability/wind_power.c
+++ b/test/battle/ability/wind_power.c
@@ -37,7 +37,7 @@ SINGLE_BATTLE_TEST("Wind Power sets up Charge for player when hit by a wind move
         HP_BAR(player);
         if (move == MOVE_AIR_CUTTER) {
             ABILITY_POPUP(player, ABILITY_WIND_POWER);
-            MESSAGE("Being hit by Air Cutter charged Wobbuffet with power!");
+            MESSAGE("Being hit by " MOVE_NAME(MOVE_AIR_CUTTER) " charged Wobbuffet with power!");
         }
 
         ANIMATION(ANIM_TYPE_MOVE, MOVE_THUNDERBOLT, player);
@@ -47,7 +47,7 @@ SINGLE_BATTLE_TEST("Wind Power sets up Charge for player when hit by a wind move
         HP_BAR(player);
         if (move == MOVE_AIR_CUTTER) {
             ABILITY_POPUP(player, ABILITY_WIND_POWER);
-            MESSAGE("Being hit by Air Cutter charged Wobbuffet with power!");
+            MESSAGE("Being hit by " MOVE_NAME(MOVE_AIR_CUTTER) " charged Wobbuffet with power!");
         }
     }
     THEN {
@@ -82,7 +82,7 @@ SINGLE_BATTLE_TEST("Wind Power sets up Charge for opponent when hit by a wind mo
         HP_BAR(opponent);
         if (move == MOVE_AIR_CUTTER) {
             ABILITY_POPUP(opponent, ABILITY_WIND_POWER);
-            MESSAGE("Being hit by Air Cutter charged Foe Wobbuffet with power!");
+            MESSAGE("Being hit by " MOVE_NAME(MOVE_AIR_CUTTER) " charged Foe Wobbuffet with power!");
         }
 
         ANIMATION(ANIM_TYPE_MOVE, MOVE_THUNDERBOLT, opponent);
@@ -92,7 +92,7 @@ SINGLE_BATTLE_TEST("Wind Power sets up Charge for opponent when hit by a wind mo
         HP_BAR(opponent);
         if (move == MOVE_AIR_CUTTER) {
             ABILITY_POPUP(opponent, ABILITY_WIND_POWER);
-            MESSAGE("Being hit by Air Cutter charged Foe Wobbuffet with power!");
+            MESSAGE("Being hit by " MOVE_NAME(MOVE_AIR_CUTTER) " charged Foe Wobbuffet with power!");
         }
     }
     THEN {
@@ -126,12 +126,12 @@ DOUBLE_BATTLE_TEST("Wind Power activates correctly for every battler with the ab
         HP_BAR(playerLeft);
         if (abilityLeft == ABILITY_WIND_POWER) {
             ABILITY_POPUP(playerLeft, ABILITY_WIND_POWER);
-            MESSAGE("Being hit by Air Cutter charged Wobbuffet with power!");
+            MESSAGE("Being hit by " MOVE_NAME(MOVE_AIR_CUTTER) " charged Wobbuffet with power!");
         }
         HP_BAR(playerRight);
         if (abilityRight == ABILITY_WIND_POWER) {
             ABILITY_POPUP(playerRight, ABILITY_WIND_POWER);
-            MESSAGE("Being hit by Air Cutter charged Wobbuffet with power!");
+            MESSAGE("Being hit by " MOVE_NAME(MOVE_AIR_CUTTER) " charged Wobbuffet with power!");
         }
         NONE_OF {
             HP_BAR(opponentLeft);
@@ -167,12 +167,12 @@ DOUBLE_BATTLE_TEST("Wind Power activates correctly for every battler with the ab
         HP_BAR(playerLeft);
         if (abilityLeft == ABILITY_WIND_POWER) {
             ABILITY_POPUP(playerLeft, ABILITY_WIND_POWER);
-            MESSAGE("Being hit by PetalBlizzrd charged Wobbuffet with power!");
+            MESSAGE("Being hit by " MOVE_NAME(MOVE_PETAL_BLIZZARD) " charged Wobbuffet with power!");
         }
         HP_BAR(playerRight);
         if (abilityRight == ABILITY_WIND_POWER) {
             ABILITY_POPUP(playerRight, ABILITY_WIND_POWER);
-            MESSAGE("Being hit by PetalBlizzrd charged Wobbuffet with power!");
+            MESSAGE("Being hit by " MOVE_NAME(MOVE_PETAL_BLIZZARD) " charged Wobbuffet with power!");
         }
         HP_BAR(opponentRight);
         NOT HP_BAR(opponentLeft);
@@ -205,19 +205,19 @@ DOUBLE_BATTLE_TEST("Wind Power activates correctly when Tailwind is used")
             ANIMATION(ANIM_TYPE_MOVE, MOVE_TAILWIND, opponentLeft);
 
             ABILITY_POPUP(opponentLeft, ABILITY_WIND_POWER);
-            MESSAGE("Being hit by Tailwind charged Foe Wobbuffet with power!");
+            MESSAGE("Being hit by " MOVE_NAME(MOVE_TAILWIND) " charged Foe Wobbuffet with power!");
 
             ABILITY_POPUP(opponentRight, ABILITY_WIND_POWER);
-            MESSAGE("Being hit by Tailwind charged Foe Wobbuffet with power!");
+            MESSAGE("Being hit by " MOVE_NAME(MOVE_TAILWIND) " charged Foe Wobbuffet with power!");
         }
         else {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_TAILWIND, playerLeft);
 
             ABILITY_POPUP(playerLeft, ABILITY_WIND_POWER);
-            MESSAGE("Being hit by Tailwind charged Wobbuffet with power!");
+            MESSAGE("Being hit by " MOVE_NAME(MOVE_TAILWIND) " charged Wobbuffet with power!");
 
             ABILITY_POPUP(playerRight, ABILITY_WIND_POWER);
-            MESSAGE("Being hit by Tailwind charged Wobbuffet with power!");
+            MESSAGE("Being hit by " MOVE_NAME(MOVE_TAILWIND) " charged Wobbuffet with power!");
         }
     }
 }

--- a/test/battle/ability/zen_mode.c
+++ b/test/battle/ability/zen_mode.c
@@ -20,8 +20,8 @@ SINGLE_BATTLE_TEST("Zen Mode switches Darmanitan's form when HP is half or less 
     } WHEN {
             TURN { MOVE(player, MOVE_CELEBRATE); MOVE(opponent, MOVE_TACKLE); }
     } SCENE {
-        MESSAGE("Darmanitan used Celebrate!");
-        MESSAGE("Foe Wobbuffet used Tackle!");
+        MESSAGE("Darmanitan used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
         HP_BAR(player);
         ABILITY_POPUP(player, ABILITY_ZEN_MODE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
@@ -52,8 +52,8 @@ SINGLE_BATTLE_TEST("Zen Mode switches Darmanitan's form when HP is half or less 
     } SCENE {
         ABILITY_POPUP(player, ABILITY_ZEN_MODE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
-        MESSAGE("Darmanitan used Celebrate!");
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Darmanitan used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
     } THEN {
         EXPECT_LE(player->hp, player->maxHP / 2);
         EXPECT_EQ(player->species, zenSpecies);
@@ -81,8 +81,8 @@ SINGLE_BATTLE_TEST("Zen Mode switches Darmanitan's form when HP is healed above 
     } SCENE {
         ABILITY_POPUP(player, ABILITY_ZEN_MODE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
-        MESSAGE("Darmanitan used Celebrate!");
-        MESSAGE("Foe Wobbuffet used Heal Pulse!");
+        MESSAGE("Darmanitan used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_HEAL_PULSE) "!");
         HP_BAR(player);
         ABILITY_POPUP(player, ABILITY_ZEN_MODE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);

--- a/test/battle/ability/zen_mode.c
+++ b/test/battle/ability/zen_mode.c
@@ -20,8 +20,8 @@ SINGLE_BATTLE_TEST("Zen Mode switches Darmanitan's form when HP is half or less 
     } WHEN {
             TURN { MOVE(player, MOVE_CELEBRATE); MOVE(opponent, MOVE_TACKLE); }
     } SCENE {
-        MESSAGE("Darmanitan used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_DARMANITAN) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
         HP_BAR(player);
         ABILITY_POPUP(player, ABILITY_ZEN_MODE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
@@ -52,8 +52,8 @@ SINGLE_BATTLE_TEST("Zen Mode switches Darmanitan's form when HP is half or less 
     } SCENE {
         ABILITY_POPUP(player, ABILITY_ZEN_MODE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
-        MESSAGE("Darmanitan used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_DARMANITAN) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
     } THEN {
         EXPECT_LE(player->hp, player->maxHP / 2);
         EXPECT_EQ(player->species, zenSpecies);
@@ -81,8 +81,8 @@ SINGLE_BATTLE_TEST("Zen Mode switches Darmanitan's form when HP is healed above 
     } SCENE {
         ABILITY_POPUP(player, ABILITY_ZEN_MODE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
-        MESSAGE("Darmanitan used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_HEAL_PULSE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_DARMANITAN) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_HEAL_PULSE) "!");
         HP_BAR(player);
         ABILITY_POPUP(player, ABILITY_ZEN_MODE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);

--- a/test/battle/crit_chance.c
+++ b/test/battle/crit_chance.c
@@ -245,7 +245,7 @@ SINGLE_BATTLE_TEST("Dire Hit increases a battler's critical hit chance by 2 stag
         TURN { MOVE(player, MOVE_SCRATCH); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_FOCUS_ENERGY, player);
-        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used Dire Hit to get pumped!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " ITEM_NAME(ITEM_DIRE_HIT) " to get pumped!");
         MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SCRATCH) "!");
         MESSAGE("A critical hit!");
     }

--- a/test/battle/crit_chance.c
+++ b/test/battle/crit_chance.c
@@ -246,7 +246,7 @@ SINGLE_BATTLE_TEST("Dire Hit increases a battler's critical hit chance by 2 stag
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_FOCUS_ENERGY, player);
         MESSAGE("Wobbuffet used Dire Hit to get pumped!");
-        MESSAGE("Wobbuffet used Scratch!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SCRATCH) "!");
         MESSAGE("A critical hit!");
     }
 }

--- a/test/battle/crit_chance.c
+++ b/test/battle/crit_chance.c
@@ -245,8 +245,8 @@ SINGLE_BATTLE_TEST("Dire Hit increases a battler's critical hit chance by 2 stag
         TURN { MOVE(player, MOVE_SCRATCH); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_FOCUS_ENERGY, player);
-        MESSAGE("Wobbuffet used Dire Hit to get pumped!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SCRATCH) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used Dire Hit to get pumped!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SCRATCH) "!");
         MESSAGE("A critical hit!");
     }
 }

--- a/test/battle/damage_formula.c
+++ b/test/battle/damage_formula.c
@@ -32,7 +32,7 @@ SINGLE_BATTLE_TEST("Damage calculation matches Gen5+")
         }
     }
     SCENE{
-        MESSAGE("Glaceon used " MOVE_NAME(MOVE_ICE_FANG) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_GLACEON) " used " MOVE_NAME(MOVE_ICE_FANG) "!");
         HP_BAR(opponent, captureDamage: &dmg);
     }
     THEN{
@@ -69,7 +69,7 @@ SINGLE_BATTLE_TEST("Damage calculation matches Gen5+ (Muscle Band, crit)")
         }
     }
     SCENE{
-        MESSAGE("Glaceon used " MOVE_NAME(MOVE_ICE_FANG) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_GLACEON) " used " MOVE_NAME(MOVE_ICE_FANG) "!");
         HP_BAR(opponent, captureDamage: &dmg);
     }
     THEN{

--- a/test/battle/damage_formula.c
+++ b/test/battle/damage_formula.c
@@ -32,7 +32,7 @@ SINGLE_BATTLE_TEST("Damage calculation matches Gen5+")
         }
     }
     SCENE{
-        MESSAGE("Glaceon used Ice Fang!");
+        MESSAGE("Glaceon used " MOVE_NAME(MOVE_ICE_FANG) "!");
         HP_BAR(opponent, captureDamage: &dmg);
     }
     THEN{
@@ -69,7 +69,7 @@ SINGLE_BATTLE_TEST("Damage calculation matches Gen5+ (Muscle Band, crit)")
         }
     }
     SCENE{
-        MESSAGE("Glaceon used Ice Fang!");
+        MESSAGE("Glaceon used " MOVE_NAME(MOVE_ICE_FANG) "!");
         HP_BAR(opponent, captureDamage: &dmg);
     }
     THEN{

--- a/test/battle/form_change/battle_switch.c
+++ b/test/battle/form_change/battle_switch.c
@@ -15,8 +15,8 @@ SINGLE_BATTLE_TEST("Aegislash reverts to Shield Form upon switching out")
     } SCENE {
         ABILITY_POPUP(player, ABILITY_STANCE_CHANGE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
-        MESSAGE("Aegislash used " MOVE_NAME(MOVE_TACKLE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_AEGISLASH) " used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
     } THEN {
         EXPECT_EQ(player->species, SPECIES_AEGISLASH);
     }

--- a/test/battle/form_change/battle_switch.c
+++ b/test/battle/form_change/battle_switch.c
@@ -15,8 +15,8 @@ SINGLE_BATTLE_TEST("Aegislash reverts to Shield Form upon switching out")
     } SCENE {
         ABILITY_POPUP(player, ABILITY_STANCE_CHANGE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
-        MESSAGE("Aegislash used Tackle!");
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Aegislash used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
     } THEN {
         EXPECT_EQ(player->species, SPECIES_AEGISLASH);
     }

--- a/test/battle/form_change/faint.c
+++ b/test/battle/form_change/faint.c
@@ -11,8 +11,8 @@ SINGLE_BATTLE_TEST("Aegislash reverts to Shield Form upon fainting")
     } WHEN {
         TURN { MOVE(opponent, MOVE_GUST); SEND_OUT(player, 1); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_GUST) "!");
-        MESSAGE("Aegislash fainted!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_GUST) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_AEGISLASH) " fainted!");
     } THEN {
         EXPECT_EQ(GetMonData(&PLAYER_PARTY[0], MON_DATA_SPECIES), SPECIES_AEGISLASH);
     }

--- a/test/battle/form_change/faint.c
+++ b/test/battle/form_change/faint.c
@@ -11,7 +11,7 @@ SINGLE_BATTLE_TEST("Aegislash reverts to Shield Form upon fainting")
     } WHEN {
         TURN { MOVE(opponent, MOVE_GUST); SEND_OUT(player, 1); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used Gust!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_GUST) "!");
         MESSAGE("Aegislash fainted!");
     } THEN {
         EXPECT_EQ(GetMonData(&PLAYER_PARTY[0], MON_DATA_SPECIES), SPECIES_AEGISLASH);

--- a/test/battle/form_change/mega_evolution.c
+++ b/test/battle/form_change/mega_evolution.c
@@ -80,8 +80,8 @@ SINGLE_BATTLE_TEST("Mega Evolution affects turn order")
     } WHEN {
         TURN { MOVE(player, MOVE_CELEBRATE, megaEvolve: TRUE); }
     } SCENE {
-        MESSAGE("Gardevoir used Celebrate!");
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Gardevoir used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
     } THEN {
         ASSUME(player->speed == 205);
     }
@@ -98,8 +98,8 @@ SINGLE_BATTLE_TEST("Abilities replaced by Mega Evolution do not affect turn orde
     } WHEN {
         TURN { MOVE(player, MOVE_CELEBRATE, megaEvolve: TRUE); }
     } SCENE {
-        MESSAGE("Sableye used Celebrate!");
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Sableye used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
     } THEN {
         ASSUME(player->speed == 45);
     }

--- a/test/battle/form_change/mega_evolution.c
+++ b/test/battle/form_change/mega_evolution.c
@@ -9,9 +9,9 @@ SINGLE_BATTLE_TEST("Venusaur can Mega Evolve holding Venusaurite")
     } WHEN {
         TURN { MOVE(player, MOVE_CELEBRATE, megaEvolve: TRUE); }
     } SCENE {
-        MESSAGE("Venusaur's Venusaurite is reacting to 1's Mega Ring!");
+        MESSAGE(SPECIES_NAME(SPECIES_VENUSAUR) "'s Venusaurite is reacting to 1's Mega Ring!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MEGA_EVOLUTION, player);
-        MESSAGE("Venusaur has Mega Evolved into Mega Venusaur!");
+        MESSAGE(SPECIES_NAME(SPECIES_VENUSAUR) " has Mega Evolved into Mega Venusaur!");
     } THEN {
         EXPECT_EQ(player->species, SPECIES_VENUSAUR_MEGA);
     }
@@ -27,12 +27,12 @@ DOUBLE_BATTLE_TEST("Mega Evolution's order is determined by Speed - opponent fas
     } WHEN {
         TURN { MOVE(opponentLeft, MOVE_CELEBRATE, megaEvolve: TRUE); MOVE(playerLeft, MOVE_CELEBRATE, megaEvolve: TRUE); }
     } SCENE {
-        MESSAGE("Foe Gardevoir's Gardevoirite is reacting to 2's Mega Ring!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_GARDEVOIR) "'s Gardevoirite is reacting to 2's Mega Ring!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MEGA_EVOLUTION, opponentLeft);
-        MESSAGE("Foe Gardevoir has Mega Evolved into Mega Gardevoir!");
-        MESSAGE("Venusaur's Venusaurite is reacting to 1's Mega Ring!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_GARDEVOIR) " has Mega Evolved into Mega Gardevoir!");
+        MESSAGE(SPECIES_NAME(SPECIES_VENUSAUR) "'s Venusaurite is reacting to 1's Mega Ring!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MEGA_EVOLUTION, playerLeft);
-        MESSAGE("Venusaur has Mega Evolved into Mega Venusaur!");
+        MESSAGE(SPECIES_NAME(SPECIES_VENUSAUR) " has Mega Evolved into Mega Venusaur!");
     }
 }
 
@@ -46,12 +46,12 @@ DOUBLE_BATTLE_TEST("Mega Evolution's order is determined by Speed - player faste
     } WHEN {
         TURN { MOVE(opponentLeft, MOVE_CELEBRATE, megaEvolve: TRUE); MOVE(playerLeft, MOVE_CELEBRATE, megaEvolve: TRUE); }
     } SCENE {
-        MESSAGE("Venusaur's Venusaurite is reacting to 1's Mega Ring!");
+        MESSAGE(SPECIES_NAME(SPECIES_VENUSAUR) "'s Venusaurite is reacting to 1's Mega Ring!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MEGA_EVOLUTION, playerLeft);
-        MESSAGE("Venusaur has Mega Evolved into Mega Venusaur!");
-        MESSAGE("Foe Gardevoir's Gardevoirite is reacting to 2's Mega Ring!");
+        MESSAGE(SPECIES_NAME(SPECIES_VENUSAUR) " has Mega Evolved into Mega Venusaur!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_GARDEVOIR) "'s Gardevoirite is reacting to 2's Mega Ring!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MEGA_EVOLUTION, opponentLeft);
-        MESSAGE("Foe Gardevoir has Mega Evolved into Mega Gardevoir!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_GARDEVOIR) " has Mega Evolved into Mega Gardevoir!");
     }
 }
 
@@ -65,7 +65,7 @@ SINGLE_BATTLE_TEST("Rayquaza can Mega Evolve knowing Dragon Ascent")
     } SCENE {
         MESSAGE("1's fervent wish has reached Rayquaza!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MEGA_EVOLUTION, player);
-        MESSAGE("Rayquaza has Mega Evolved into Mega Rayquaza!");
+        MESSAGE(SPECIES_NAME(SPECIES_RAYQUAZA) " has Mega Evolved into Mega Rayquaza!");
     } THEN {
         EXPECT_EQ(player->species, SPECIES_RAYQUAZA_MEGA);
     }
@@ -80,8 +80,8 @@ SINGLE_BATTLE_TEST("Mega Evolution affects turn order")
     } WHEN {
         TURN { MOVE(player, MOVE_CELEBRATE, megaEvolve: TRUE); }
     } SCENE {
-        MESSAGE("Gardevoir used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_GARDEVOIR) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
     } THEN {
         ASSUME(player->speed == 205);
     }
@@ -98,8 +98,8 @@ SINGLE_BATTLE_TEST("Abilities replaced by Mega Evolution do not affect turn orde
     } WHEN {
         TURN { MOVE(player, MOVE_CELEBRATE, megaEvolve: TRUE); }
     } SCENE {
-        MESSAGE("Sableye used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_SABLEYE) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
     } THEN {
         ASSUME(player->speed == 45);
     }
@@ -119,17 +119,17 @@ DOUBLE_BATTLE_TEST("Mega Evolution happens after switching, but before Focus Pun
         TURN {}
     } SCENE {
         MESSAGE("2 withdrew Wobbuffet!");
-        MESSAGE("2 sent out Wobbuffet!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
 
-        MESSAGE("Venusaur's Venusaurite is reacting to 1's Mega Ring!");
+        MESSAGE(SPECIES_NAME(SPECIES_VENUSAUR) "'s Venusaurite is reacting to 1's Mega Ring!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MEGA_EVOLUTION, playerRight);
-        MESSAGE("Venusaur has Mega Evolved into Mega Venusaur!");
+        MESSAGE(SPECIES_NAME(SPECIES_VENUSAUR) " has Mega Evolved into Mega Venusaur!");
 
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FOCUS_PUNCH_SETUP, playerRight);
-        MESSAGE("Venusaur is tightening its focus!");
+        MESSAGE(SPECIES_NAME(SPECIES_VENUSAUR) " is tightening its focus!");
 
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FOCUS_PUNCH_SETUP, playerLeft);
-        MESSAGE("Wobbuffet is tightening its focus!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is tightening its focus!");
     }
 }
 
@@ -143,11 +143,11 @@ SINGLE_BATTLE_TEST("Regular Mega Evolution and Fervent Wish Mega Evolution can h
     } SCENE {
         MESSAGE("1's fervent wish has reached Rayquaza!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MEGA_EVOLUTION, player);
-        MESSAGE("Rayquaza has Mega Evolved into Mega Rayquaza!");
+        MESSAGE(SPECIES_NAME(SPECIES_RAYQUAZA) " has Mega Evolved into Mega Rayquaza!");
 
-        MESSAGE("Foe Gardevoir's Gardevoirite is reacting to 2's Mega Ring!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_GARDEVOIR) "'s Gardevoirite is reacting to 2's Mega Ring!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MEGA_EVOLUTION, opponent);
-        MESSAGE("Foe Gardevoir has Mega Evolved into Mega Gardevoir!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_GARDEVOIR) " has Mega Evolved into Mega Gardevoir!");
     } THEN {
         EXPECT_EQ(player->species, SPECIES_RAYQUAZA_MEGA);
         EXPECT_EQ(opponent->species, SPECIES_GARDEVOIR_MEGA);

--- a/test/battle/form_change/primal_reversion.c
+++ b/test/battle/form_change/primal_reversion.c
@@ -15,12 +15,12 @@ SINGLE_BATTLE_TEST("Primal reversion happens for Groudon only when holding Red O
     } SCENE {
         if (heldItem == ITEM_RED_ORB) {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_PRIMAL_REVERSION, player);
-            MESSAGE("Groudon's Primal Reversion! It reverted to its primal form!");
+            MESSAGE(SPECIES_NAME(SPECIES_GROUDON) "'s Primal Reversion! It reverted to its primal form!");
         }
         else {
             NONE_OF {
                 ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_PRIMAL_REVERSION, player);
-                MESSAGE("Groudon's Primal Reversion! It reverted to its primal form!");
+                MESSAGE(SPECIES_NAME(SPECIES_GROUDON) "'s Primal Reversion! It reverted to its primal form!");
             }
         }
     } THEN {
@@ -47,12 +47,12 @@ SINGLE_BATTLE_TEST("Primal reversion happens for Kyogre only when holding Blue O
     } SCENE {
         if (heldItem == ITEM_BLUE_ORB) {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_PRIMAL_REVERSION, opponent);
-            MESSAGE("Foe Kyogre's Primal Reversion! It reverted to its primal form!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_KYOGRE) "'s Primal Reversion! It reverted to its primal form!");
         }
         else {
             NONE_OF {
                 ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_PRIMAL_REVERSION, opponent);
-                MESSAGE("Foe Kyogre's Primal Reversion! It reverted to its primal form!");
+                MESSAGE("Foe " SPECIES_NAME(SPECIES_KYOGRE) "'s Primal Reversion! It reverted to its primal form!");
             }
         }
     } THEN {
@@ -76,13 +76,13 @@ DOUBLE_BATTLE_TEST("Primal reversion's order is determined by Speed - opponent f
         TURN { MOVE(opponentLeft, MOVE_CELEBRATE); }
     } SCENE {
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_PRIMAL_REVERSION, opponentRight);
-        MESSAGE("Foe Kyogre's Primal Reversion! It reverted to its primal form!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_KYOGRE) "'s Primal Reversion! It reverted to its primal form!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_PRIMAL_REVERSION, playerRight);
-        MESSAGE("Groudon's Primal Reversion! It reverted to its primal form!");
+        MESSAGE(SPECIES_NAME(SPECIES_GROUDON) "'s Primal Reversion! It reverted to its primal form!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_PRIMAL_REVERSION, opponentLeft);
-        MESSAGE("Foe Groudon's Primal Reversion! It reverted to its primal form!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_GROUDON) "'s Primal Reversion! It reverted to its primal form!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_PRIMAL_REVERSION, playerLeft);
-        MESSAGE("Kyogre's Primal Reversion! It reverted to its primal form!");
+        MESSAGE(SPECIES_NAME(SPECIES_KYOGRE) "'s Primal Reversion! It reverted to its primal form!");
     } THEN {
         EXPECT_EQ(playerLeft->species, SPECIES_KYOGRE_PRIMAL);
         EXPECT_EQ(opponentLeft->species, SPECIES_GROUDON_PRIMAL);
@@ -102,13 +102,13 @@ DOUBLE_BATTLE_TEST("Primal reversion's order is determined by Speed - player fas
         TURN { MOVE(opponentLeft, MOVE_CELEBRATE); }
     } SCENE {
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_PRIMAL_REVERSION, playerRight);
-        MESSAGE("Groudon's Primal Reversion! It reverted to its primal form!");
+        MESSAGE(SPECIES_NAME(SPECIES_GROUDON) "'s Primal Reversion! It reverted to its primal form!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_PRIMAL_REVERSION, playerLeft);
-        MESSAGE("Kyogre's Primal Reversion! It reverted to its primal form!");
+        MESSAGE(SPECIES_NAME(SPECIES_KYOGRE) "'s Primal Reversion! It reverted to its primal form!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_PRIMAL_REVERSION, opponentLeft);
-        MESSAGE("Foe Groudon's Primal Reversion! It reverted to its primal form!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_GROUDON) "'s Primal Reversion! It reverted to its primal form!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_PRIMAL_REVERSION, opponentRight);
-        MESSAGE("Foe Kyogre's Primal Reversion! It reverted to its primal form!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_KYOGRE) "'s Primal Reversion! It reverted to its primal form!");
     } THEN {
         EXPECT_EQ(playerLeft->species, SPECIES_KYOGRE_PRIMAL);
         EXPECT_EQ(opponentLeft->species, SPECIES_GROUDON_PRIMAL);
@@ -128,9 +128,9 @@ SINGLE_BATTLE_TEST("Primal reversion happens after a mon is sent out after a mon
         TURN { MOVE(opponent, MOVE_TACKLE); SEND_OUT(player, 1); }
         TURN { MOVE(opponent, MOVE_TACKLE); }
     } SCENE {
-        MESSAGE("Wobbuffet fainted!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " fainted!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_PRIMAL_REVERSION, player);
-        MESSAGE("Groudon's Primal Reversion! It reverted to its primal form!");
+        MESSAGE(SPECIES_NAME(SPECIES_GROUDON) "'s Primal Reversion! It reverted to its primal form!");
     } THEN {
         EXPECT_EQ(player->species, SPECIES_GROUDON_PRIMAL);
     }
@@ -147,7 +147,7 @@ SINGLE_BATTLE_TEST("Primal reversion happens after a mon is switched in")
         TURN { MOVE(opponent, MOVE_CELEBRATE); }
     } SCENE {
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_PRIMAL_REVERSION, player);
-        MESSAGE("Groudon's Primal Reversion! It reverted to its primal form!");
+        MESSAGE(SPECIES_NAME(SPECIES_GROUDON) "'s Primal Reversion! It reverted to its primal form!");
     } THEN {
         EXPECT_EQ(player->species, SPECIES_GROUDON_PRIMAL);
     }
@@ -165,10 +165,10 @@ SINGLE_BATTLE_TEST("Primal reversion happens after a switch-in caused by Eject B
         TURN { MOVE(opponent, MOVE_TACKLE); SEND_OUT(player, 1); }
         TURN { MOVE(opponent, MOVE_TACKLE); }
     } SCENE {
-        MESSAGE("Wobbuffet is switched out with the Eject Button!");
-        MESSAGE("Go! Groudon!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is switched out with the Eject Button!");
+        MESSAGE("Go! " SPECIES_NAME(SPECIES_GROUDON) "!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_PRIMAL_REVERSION, player);
-        MESSAGE("Groudon's Primal Reversion! It reverted to its primal form!");
+        MESSAGE(SPECIES_NAME(SPECIES_GROUDON) "'s Primal Reversion! It reverted to its primal form!");
     } THEN {
         EXPECT_EQ(player->species, SPECIES_GROUDON_PRIMAL);
     }
@@ -186,9 +186,9 @@ SINGLE_BATTLE_TEST("Primal reversion happens after a switch-in caused by Red Car
         TURN { MOVE(player, MOVE_TACKLE); }
     } SCENE {
         MESSAGE("Foe Wobbuffet held up its Red Card against Wobbuffet!");
-        MESSAGE("Groudon was dragged out!");
+        MESSAGE(SPECIES_NAME(SPECIES_GROUDON) " was dragged out!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_PRIMAL_REVERSION, player);
-        MESSAGE("Groudon's Primal Reversion! It reverted to its primal form!");
+        MESSAGE(SPECIES_NAME(SPECIES_GROUDON) "'s Primal Reversion! It reverted to its primal form!");
     } THEN {
         EXPECT_EQ(player->species, SPECIES_GROUDON_PRIMAL);
     }
@@ -205,11 +205,11 @@ SINGLE_BATTLE_TEST("Primal reversion happens after the entry hazards damage")
         TURN { MOVE(opponent, MOVE_SPIKES); }
         TURN { MOVE(opponent, MOVE_SPIKES); SWITCH(player, 1);}
     } SCENE {
-        MESSAGE("Go! Groudon!");
+        MESSAGE("Go! " SPECIES_NAME(SPECIES_GROUDON) "!");
         HP_BAR(player);
-        MESSAGE("Groudon is hurt by spikes!");
+        MESSAGE(SPECIES_NAME(SPECIES_GROUDON) " is hurt by spikes!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_PRIMAL_REVERSION, player);
-        MESSAGE("Groudon's Primal Reversion! It reverted to its primal form!");
+        MESSAGE(SPECIES_NAME(SPECIES_GROUDON) "'s Primal Reversion! It reverted to its primal form!");
     } THEN {
         EXPECT_EQ(player->species, SPECIES_GROUDON_PRIMAL);
     }

--- a/test/battle/form_change/primal_reversion.c
+++ b/test/battle/form_change/primal_reversion.c
@@ -185,7 +185,7 @@ SINGLE_BATTLE_TEST("Primal reversion happens after a switch-in caused by Red Car
     } WHEN {
         TURN { MOVE(player, MOVE_TACKLE); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet held up its Red Card against Wobbuffet!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " held up its Red Card against Wobbuffet!");
         MESSAGE(SPECIES_NAME(SPECIES_GROUDON) " was dragged out!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_PRIMAL_REVERSION, player);
         MESSAGE(SPECIES_NAME(SPECIES_GROUDON) "'s Primal Reversion! It reverted to its primal form!");

--- a/test/battle/form_change/ultra_burst.c
+++ b/test/battle/form_change/ultra_burst.c
@@ -68,8 +68,8 @@ SINGLE_BATTLE_TEST("Ultra Burst affects turn order")
     } WHEN {
         TURN { MOVE(player, MOVE_CELEBRATE, ultraBurst: TRUE); }
     } SCENE {
-        MESSAGE("Necrozma used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_NECROZMA) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
     } THEN {
         ASSUME(player->speed == 263);
     }
@@ -90,17 +90,17 @@ DOUBLE_BATTLE_TEST("Ultra Burst happens after switching, but before Focus Punch-
         TURN {}
     } SCENE {
         MESSAGE("2 withdrew Wobbuffet!");
-        MESSAGE("2 sent out Wobbuffet!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
 
         MESSAGE("Bright light is about to burst out of Necrozma!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ULTRA_BURST, playerRight);
         MESSAGE("Necrozma regained its true power through Ultra Burst!");
 
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FOCUS_PUNCH_SETUP, playerRight);
-        MESSAGE("Necrozma is tightening its focus!");
+        MESSAGE(SPECIES_NAME(SPECIES_NECROZMA) " is tightening its focus!");
 
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FOCUS_PUNCH_SETUP, playerLeft);
-        MESSAGE("Wobbuffet is tightening its focus!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is tightening its focus!");
     }
 }
 
@@ -117,9 +117,9 @@ SINGLE_BATTLE_TEST("Ultra Burst and Mega Evolution can happen on the same turn")
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ULTRA_BURST, player);
         MESSAGE("Necrozma regained its true power through Ultra Burst!");
 
-        MESSAGE("Foe Gardevoir's Gardevoirite is reacting to 2's Mega Ring!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_GARDEVOIR) "'s Gardevoirite is reacting to 2's Mega Ring!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MEGA_EVOLUTION, opponent);
-        MESSAGE("Foe Gardevoir has Mega Evolved into Mega Gardevoir!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_GARDEVOIR) " has Mega Evolved into Mega Gardevoir!");
     } THEN {
         EXPECT_EQ(player->species, SPECIES_NECROZMA_ULTRA);
         EXPECT_EQ(opponent->species, SPECIES_GARDEVOIR_MEGA);

--- a/test/battle/form_change/ultra_burst.c
+++ b/test/battle/form_change/ultra_burst.c
@@ -12,7 +12,7 @@ SINGLE_BATTLE_TEST("Dusk Mane Necrozma can Ultra Burst holding Ultranecrozium Z"
     } SCENE {
         MESSAGE("Bright light is about to burst out of Necrozma!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ULTRA_BURST, player);
-        MESSAGE("Necrozma regained its true power through Ultra Burst!");
+        MESSAGE(SPECIES_NAME(SPECIES_NECROZMA) " regained its true power through Ultra Burst!");
     } THEN {
         EXPECT_EQ(player->species, SPECIES_NECROZMA_ULTRA);
     }
@@ -29,12 +29,12 @@ DOUBLE_BATTLE_TEST("Ultra Burst's order is determined by Speed - opponent faster
     } WHEN {
         TURN { MOVE(opponentLeft, MOVE_CELEBRATE, ultraBurst: TRUE); MOVE(playerLeft, MOVE_CELEBRATE, ultraBurst: TRUE); }
     } SCENE {
-        MESSAGE("Bright light is about to burst out of Foe Necrozma!");
+        MESSAGE("Bright light is about to burst out of Foe " SPECIES_NAME(SPECIES_NECROZMA) "!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ULTRA_BURST, opponentLeft);
-        MESSAGE("Foe Necrozma regained its true power through Ultra Burst!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_NECROZMA) " regained its true power through Ultra Burst!");
         MESSAGE("Bright light is about to burst out of Necrozma!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ULTRA_BURST, playerLeft);
-        MESSAGE("Necrozma regained its true power through Ultra Burst!");
+        MESSAGE(SPECIES_NAME(SPECIES_NECROZMA) " regained its true power through Ultra Burst!");
     }
 }
 
@@ -51,10 +51,10 @@ DOUBLE_BATTLE_TEST("Ultra Burst's order is determined by Speed - player faster")
     } SCENE {
         MESSAGE("Bright light is about to burst out of Necrozma!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ULTRA_BURST, playerLeft);
-        MESSAGE("Necrozma regained its true power through Ultra Burst!");
-        MESSAGE("Bright light is about to burst out of Foe Necrozma!");
+        MESSAGE(SPECIES_NAME(SPECIES_NECROZMA) " regained its true power through Ultra Burst!");
+        MESSAGE("Bright light is about to burst out of Foe " SPECIES_NAME(SPECIES_NECROZMA) "!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ULTRA_BURST, opponentLeft);
-        MESSAGE("Foe Necrozma regained its true power through Ultra Burst!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_NECROZMA) " regained its true power through Ultra Burst!");
     }
 }
 
@@ -94,7 +94,7 @@ DOUBLE_BATTLE_TEST("Ultra Burst happens after switching, but before Focus Punch-
 
         MESSAGE("Bright light is about to burst out of Necrozma!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ULTRA_BURST, playerRight);
-        MESSAGE("Necrozma regained its true power through Ultra Burst!");
+        MESSAGE(SPECIES_NAME(SPECIES_NECROZMA) " regained its true power through Ultra Burst!");
 
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FOCUS_PUNCH_SETUP, playerRight);
         MESSAGE(SPECIES_NAME(SPECIES_NECROZMA) " is tightening its focus!");
@@ -115,7 +115,7 @@ SINGLE_BATTLE_TEST("Ultra Burst and Mega Evolution can happen on the same turn")
     } SCENE {
         MESSAGE("Bright light is about to burst out of Necrozma!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ULTRA_BURST, player);
-        MESSAGE("Necrozma regained its true power through Ultra Burst!");
+        MESSAGE(SPECIES_NAME(SPECIES_NECROZMA) " regained its true power through Ultra Burst!");
 
         MESSAGE("Foe " SPECIES_NAME(SPECIES_GARDEVOIR) "'s Gardevoirite is reacting to 2's Mega Ring!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MEGA_EVOLUTION, opponent);

--- a/test/battle/form_change/ultra_burst.c
+++ b/test/battle/form_change/ultra_burst.c
@@ -68,8 +68,8 @@ SINGLE_BATTLE_TEST("Ultra Burst affects turn order")
     } WHEN {
         TURN { MOVE(player, MOVE_CELEBRATE, ultraBurst: TRUE); }
     } SCENE {
-        MESSAGE("Necrozma used Celebrate!");
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Necrozma used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
     } THEN {
         ASSUME(player->speed == 263);
     }

--- a/test/battle/hold_effect/air_balloon.c
+++ b/test/battle/hold_effect/air_balloon.c
@@ -18,9 +18,9 @@ SINGLE_BATTLE_TEST("Air Balloon prevents the holder from taking damage from grou
         TURN { MOVE(opponent, MOVE_EARTHQUAKE); }
     } SCENE {
         MESSAGE("Wobbuffet floats in the air with its Air Balloon!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
-        MESSAGE("It doesn't affect Wobbuffet…");
+        MESSAGE("It doesn't affect " SPECIES_NAME(SPECIES_WOBBUFFET) "…");
     }
 }
 
@@ -33,8 +33,8 @@ SINGLE_BATTLE_TEST("Air Balloon pops when the holder is hit by a move that is no
         TURN { MOVE(opponent, MOVE_TACKLE); }
     } SCENE {
         MESSAGE("Wobbuffet floats in the air with its Air Balloon!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
-        MESSAGE("Wobbuffet's Air Balloon popped!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Air Balloon popped!");
     }
 }
 
@@ -48,11 +48,11 @@ SINGLE_BATTLE_TEST("Air Balloon no longer prevents the holder from taking damage
         TURN { MOVE(opponent, MOVE_EARTHQUAKE); }
     } SCENE {
         MESSAGE("Wobbuffet floats in the air with its Air Balloon!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
-        MESSAGE("Wobbuffet's Air Balloon popped!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Air Balloon popped!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
-        NOT MESSAGE("It doesn't affect Wobbuffet…");
+        NOT MESSAGE("It doesn't affect " SPECIES_NAME(SPECIES_WOBBUFFET) "…");
     }
 }
 
@@ -68,9 +68,9 @@ SINGLE_BATTLE_TEST("Air Balloon can not be restored with Recycle after it has be
         }
     } SCENE {
         MESSAGE("Wobbuffet floats in the air with its Air Balloon!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
-        MESSAGE("Wobbuffet's Air Balloon popped!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_RECYCLE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Air Balloon popped!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_RECYCLE) "!");
         MESSAGE("But it failed!");
     }
 }
@@ -84,7 +84,7 @@ SINGLE_BATTLE_TEST("Air Balloon prevents the user from being healed by Grassy Te
         TURN { MOVE(player, MOVE_GRASSY_TERRAIN); }
     } SCENE {
         MESSAGE("Wobbuffet floats in the air with its Air Balloon!");
-        NOT MESSAGE("Wobbuffet is healed by the Grassy Terrain!");
+        NOT MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is healed by the Grassy Terrain!");
     }
 }
 
@@ -98,7 +98,7 @@ SINGLE_BATTLE_TEST("Air Balloon pops before it can be stolen with Magician")
         TURN { MOVE(opponent, MOVE_TACKLE); }
     } SCENE {
         MESSAGE("Wobbuffet floats in the air with its Air Balloon!");
-        MESSAGE("Wobbuffet's Air Balloon popped!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Air Balloon popped!");
         NOT ABILITY_POPUP(opponent, ABILITY_MAGICIAN);
     }
 }
@@ -117,7 +117,7 @@ SINGLE_BATTLE_TEST("Air Balloon pops before it can be stolen with Thief or Covet
         TURN { MOVE(opponent, move); }
     } SCENE {
         MESSAGE("Wobbuffet floats in the air with its Air Balloon!");
-        MESSAGE("Wobbuffet's Air Balloon popped!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Air Balloon popped!");
         NOT MESSAGE("Foe Wobbuffet stole Wobbuffet's Air Balloon!");
     }
 }

--- a/test/battle/hold_effect/air_balloon.c
+++ b/test/battle/hold_effect/air_balloon.c
@@ -118,6 +118,6 @@ SINGLE_BATTLE_TEST("Air Balloon pops before it can be stolen with Thief or Covet
     } SCENE {
         MESSAGE("Wobbuffet floats in the air with its Air Balloon!");
         MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Air Balloon popped!");
-        NOT MESSAGE("Foe Wobbuffet stole Wobbuffet's Air Balloon!");
+        NOT MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " stole Wobbuffet's Air Balloon!");
     }
 }

--- a/test/battle/hold_effect/air_balloon.c
+++ b/test/battle/hold_effect/air_balloon.c
@@ -18,7 +18,7 @@ SINGLE_BATTLE_TEST("Air Balloon prevents the holder from taking damage from grou
         TURN { MOVE(opponent, MOVE_EARTHQUAKE); }
     } SCENE {
         MESSAGE("Wobbuffet floats in the air with its Air Balloon!");
-        MESSAGE("Foe Wobbuffet used Earthquake!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
         MESSAGE("It doesn't affect Wobbuffet…");
     }
@@ -33,7 +33,7 @@ SINGLE_BATTLE_TEST("Air Balloon pops when the holder is hit by a move that is no
         TURN { MOVE(opponent, MOVE_TACKLE); }
     } SCENE {
         MESSAGE("Wobbuffet floats in the air with its Air Balloon!");
-        MESSAGE("Foe Wobbuffet used Tackle!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
         MESSAGE("Wobbuffet's Air Balloon popped!");
     }
 }
@@ -48,9 +48,9 @@ SINGLE_BATTLE_TEST("Air Balloon no longer prevents the holder from taking damage
         TURN { MOVE(opponent, MOVE_EARTHQUAKE); }
     } SCENE {
         MESSAGE("Wobbuffet floats in the air with its Air Balloon!");
-        MESSAGE("Foe Wobbuffet used Tackle!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
         MESSAGE("Wobbuffet's Air Balloon popped!");
-        MESSAGE("Foe Wobbuffet used Earthquake!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
         NOT MESSAGE("It doesn't affect Wobbuffet…");
     }
@@ -68,9 +68,9 @@ SINGLE_BATTLE_TEST("Air Balloon can not be restored with Recycle after it has be
         }
     } SCENE {
         MESSAGE("Wobbuffet floats in the air with its Air Balloon!");
-        MESSAGE("Foe Wobbuffet used Tackle!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
         MESSAGE("Wobbuffet's Air Balloon popped!");
-        MESSAGE("Wobbuffet used Recycle!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_RECYCLE) "!");
         MESSAGE("But it failed!");
     }
 }

--- a/test/battle/hold_effect/berserk_gene.c
+++ b/test/battle/hold_effect/berserk_gene.c
@@ -22,7 +22,7 @@ SINGLE_BATTLE_TEST("Berserk Gene sharply raises attack at the start of a single 
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
             MESSAGE("Using Berserk Gene, the Attack of Wobbuffet sharply rose!");
             ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_CONFUSION, player);
-            MESSAGE("Wobbuffet became confused!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " became confused!");
         }
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
@@ -48,7 +48,7 @@ DOUBLE_BATTLE_TEST("Berserk Gene sharply raises attack at the start of a double 
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerRight);
             MESSAGE("Using Berserk Gene, the Attack of Wobbuffet sharply rose!");
             ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_CONFUSION, playerRight);
-            MESSAGE("Wobbuffet became confused!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " became confused!");
         }
         HP_BAR(opponentLeft, captureDamage: &results[i].damage);
     } FINALLY {
@@ -74,7 +74,7 @@ SINGLE_BATTLE_TEST("Berserk Gene activates on switch in", s16 damage)
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
             MESSAGE("Using Berserk Gene, the Attack of Wobbuffet sharply rose!");
             ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_CONFUSION, player);
-            MESSAGE("Wobbuffet became confused!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " became confused!");
         }
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
@@ -100,10 +100,10 @@ SINGLE_BATTLE_TEST("Berserk Gene does not confuse a Pokemon with Own Tempo but s
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
             MESSAGE("Using Berserk Gene, the Attack of Slowbro sharply rose!");
             ABILITY_POPUP(player, ABILITY_OWN_TEMPO);
-            MESSAGE("Slowbro's Own Tempo prevents confusion!");
+            MESSAGE(SPECIES_NAME(SPECIES_SLOWBRO) "'s Own Tempo prevents confusion!");
         }
         HP_BAR(opponent, captureDamage: &results[i].damage);
-        NOT MESSAGE("Slowbro became confused!");
+        NOT MESSAGE(SPECIES_NAME(SPECIES_SLOWBRO) " became confused!");
     } FINALLY {
         EXPECT_MUL_EQ(results[0].damage, Q_4_12(2.0), results[1].damage);
     }
@@ -137,10 +137,10 @@ DOUBLE_BATTLE_TEST("Berserk Gene does not confuse a Pokemon with Own Tempo but s
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, (positionLeft != 0) ? playerLeft : playerRight);
             MESSAGE("Using Berserk Gene, the Attack of Slowbro sharply rose!");
             ABILITY_POPUP((positionLeft != 0) ? playerLeft : playerRight, ABILITY_OWN_TEMPO);
-            MESSAGE("Slowbro's Own Tempo prevents confusion!");
+            MESSAGE(SPECIES_NAME(SPECIES_SLOWBRO) "'s Own Tempo prevents confusion!");
         }
         HP_BAR(opponentLeft, captureDamage: &results[i].damage);
-        NOT MESSAGE("Slowbro became confused!");
+        NOT MESSAGE(SPECIES_NAME(SPECIES_SLOWBRO) " became confused!");
     } FINALLY {
         EXPECT_MUL_EQ(results[0].damage, Q_4_12(2.0), results[1].damage);
         EXPECT_MUL_EQ(results[0].damage, Q_4_12(2.0), results[2].damage);
@@ -177,8 +177,8 @@ SINGLE_BATTLE_TEST("Berserk Gene does not confuse when Safeguard is active")
     } SCENE {
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
         MESSAGE("Using Berserk Gene, the Attack of Wobbuffet sharply rose!");
-        MESSAGE("Wobbuffet's party is protected by Safeguard!");
-        NOT MESSAGE("Wobbuffet became confused!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s party is protected by Safeguard!");
+        NOT MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " became confused!");
     }
 }
 

--- a/test/battle/hold_effect/clear_amulet.c
+++ b/test/battle/hold_effect/clear_amulet.c
@@ -22,7 +22,7 @@ SINGLE_BATTLE_TEST("Clear Amulet prevents Intimidate")
         HP_BAR(player, captureDamage: &turnOneHit);
         ABILITY_POPUP(player, ABILITY_INTIMIDATE);
         NONE_OF { ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player); }
-        MESSAGE("Foe Wobbuffet's Attack was not lowered!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Attack was not lowered!");
         HP_BAR(player, captureDamage: &turnTwoHit);
     } THEN {
         EXPECT_EQ(turnOneHit, turnTwoHit);
@@ -59,25 +59,25 @@ SINGLE_BATTLE_TEST("Clear Amulet prevents stat reducing effects")
         switch (move)
         {
         case MOVE_GROWL:
-            MESSAGE("Foe Wobbuffet's Attack was not lowered!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Attack was not lowered!");
             break;
         case MOVE_LEER:
-            MESSAGE("Foe Wobbuffet's Defense was not lowered!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Defense was not lowered!");
             break;
         case MOVE_CONFIDE:
-            MESSAGE("Foe Wobbuffet's Sp. Atk was not lowered!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Sp. Atk was not lowered!");
             break;
         case MOVE_FAKE_TEARS:
-            MESSAGE("Foe Wobbuffet's Sp. Def was not lowered!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Sp. Def was not lowered!");
             break;
         case MOVE_SCARY_FACE:
-            MESSAGE("Foe Wobbuffet's Speed was not lowered!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Speed was not lowered!");
             break;
         case MOVE_SWEET_SCENT:
-            MESSAGE("Foe Wobbuffet's evasiveness was not lowered!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s evasiveness was not lowered!");
             break;
         case MOVE_SAND_ATTACK:
-            MESSAGE("Foe Wobbuffet's accuracy was not lowered!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s accuracy was not lowered!");
             break;
         }
     }

--- a/test/battle/hold_effect/critical_hit_up.c
+++ b/test/battle/hold_effect/critical_hit_up.c
@@ -24,11 +24,11 @@ SINGLE_BATTLE_TEST("Lansat Berry raises the holder's critical-hit-ratio by two s
         if (move == MOVE_TACKLE) {
             NONE_OF {
                 ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-                MESSAGE("Wobbuffet used Lansat Berry to get pumped!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used Lansat Berry to get pumped!");
             }
         } else {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-            MESSAGE("Wobbuffet used Lansat Berry to get pumped!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used Lansat Berry to get pumped!");
         }
     }
 }
@@ -43,7 +43,7 @@ SINGLE_BATTLE_TEST("Lansat Berry raises the holder's critical-hit-ratio by two s
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_RAGE, opponent);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-        MESSAGE("Bellsprout used Lansat Berry to get pumped!");
+        MESSAGE(SPECIES_NAME(SPECIES_BELLSPROUT) " used Lansat Berry to get pumped!");
     }
 }
 
@@ -60,7 +60,7 @@ SINGLE_BATTLE_TEST("Lansat Berry raises the holder's critical-hit-ratio by two s
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_RAGE, opponent);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-        MESSAGE("Wobbuffet used Lansat Berry to get pumped!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used Lansat Berry to get pumped!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, player);
         MESSAGE("A critical hit!");
     }

--- a/test/battle/hold_effect/cure_status.c
+++ b/test/battle/hold_effect/cure_status.c
@@ -204,7 +204,7 @@ SINGLE_BATTLE_TEST("Opponent Pokemon can be further poisoned with Toxic spikes a
         TURN { SWITCH(opponent, 1); }
         TURN { SWITCH(opponent, 0); }
     } SCENE {
-        MESSAGE("Wobbuffet used Toxic Spikes!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TOXIC_SPIKES) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TOXIC_SPIKES, player);
         MESSAGE("Poison Spikes were scattered all around the opposing team's feet!");
         // 1st switch-in
@@ -245,7 +245,7 @@ SINGLE_BATTLE_TEST("Player Pokemon can be further poisoned with Toxic spikes aft
         TURN { SWITCH(player, 1); }
         TURN { SWITCH(player, 2); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used Toxic Spikes!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TOXIC_SPIKES) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TOXIC_SPIKES, opponent);
         MESSAGE("Poison Spikes were scattered all around your team's feet!");
         // 1st switch-in

--- a/test/battle/hold_effect/cure_status.c
+++ b/test/battle/hold_effect/cure_status.c
@@ -204,22 +204,22 @@ SINGLE_BATTLE_TEST("Opponent Pokemon can be further poisoned with Toxic spikes a
         TURN { SWITCH(opponent, 1); }
         TURN { SWITCH(opponent, 0); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TOXIC_SPIKES) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TOXIC_SPIKES) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TOXIC_SPIKES, player);
         MESSAGE("Poison Spikes were scattered all around the opposing team's feet!");
         // 1st switch-in
-        MESSAGE("2 sent out Wynaut!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WYNAUT) "!");
         ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
         STATUS_ICON(opponent, poison: TRUE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
         if (item == ITEM_PECHA_BERRY) {
-            MESSAGE("Foe Wynaut's Pecha Berry cured poison!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) "'s Pecha Berry cured poison!");
         } else {
-            MESSAGE("Foe Wynaut's Lum Berry cured its poison problem!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) "'s Lum Berry cured its poison problem!");
         }
         STATUS_ICON(opponent, poison: FALSE);
         // 2nd switch-in
-        MESSAGE("2 sent out Wobbuffet!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
         ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
         STATUS_ICON(opponent, poison: TRUE);
     }
@@ -245,22 +245,22 @@ SINGLE_BATTLE_TEST("Player Pokemon can be further poisoned with Toxic spikes aft
         TURN { SWITCH(player, 1); }
         TURN { SWITCH(player, 2); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TOXIC_SPIKES) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TOXIC_SPIKES) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TOXIC_SPIKES, opponent);
         MESSAGE("Poison Spikes were scattered all around your team's feet!");
         // 1st switch-in
-        MESSAGE("Go! Wobbuffet!");
+        MESSAGE("Go! " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
         ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, player);
         STATUS_ICON(player, poison: TRUE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
         if (item == ITEM_PECHA_BERRY) {
-            MESSAGE("Wobbuffet's Pecha Berry cured poison!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Pecha Berry cured poison!");
         } else {
-            MESSAGE("Wobbuffet's Lum Berry cured its poison problem!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Lum Berry cured its poison problem!");
         }
         STATUS_ICON(player, poison: FALSE);
         // 2nd switch-in
-        MESSAGE("Go! Wynaut!");
+        MESSAGE("Go! " SPECIES_NAME(SPECIES_WYNAUT) "!");
         ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, player);
         STATUS_ICON(player, poison: TRUE);
     }

--- a/test/battle/hold_effect/eject_button.c
+++ b/test/battle/hold_effect/eject_button.c
@@ -21,7 +21,7 @@ SINGLE_BATTLE_TEST("Eject Button is not triggered when there is nothing to switc
         ANIMATION(ANIM_TYPE_MOVE, MOVE_QUICK_ATTACK, player);
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-            MESSAGE("Foe Wobbuffet is switched out with the Eject Button!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is switched out with the Eject Button!");
         }
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
     }
@@ -42,7 +42,7 @@ SINGLE_BATTLE_TEST("Eject Button is not activated by a Sheer Force boosted move"
         ANIMATION(ANIM_TYPE_MOVE, MOVE_FLAMETHROWER, player);
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-            MESSAGE("Foe Wobbuffet is switched out with the Eject Button!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is switched out with the Eject Button!");
         }
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
     }
@@ -66,7 +66,7 @@ SINGLE_BATTLE_TEST("Eject Button will not activate under Substitute")
         MESSAGE("The SUBSTITUTE took damage for Foe Raichu!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-            MESSAGE("Foe Raichu is switched out with the Eject Button!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_RAICHU) " is switched out with the Eject Button!");
         }
     }
 }
@@ -85,8 +85,8 @@ SINGLE_BATTLE_TEST("Eject Button is not blocked by trapping abilities or moves")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, player);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-        MESSAGE("Foe Wobbuffet is switched out with the Eject Button!");
-        MESSAGE("2 sent out Wobbuffet!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is switched out with the Eject Button!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
     }
 }
 
@@ -105,7 +105,7 @@ SINGLE_BATTLE_TEST("Eject Button is not triggered after the mon loses Eject Butt
         ANIMATION(ANIM_TYPE_MOVE, MOVE_KNOCK_OFF, player);
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-            MESSAGE("Foe Wobbuffet is switched out with the Eject Button!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is switched out with the Eject Button!");
         }
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
     }
@@ -144,10 +144,10 @@ SINGLE_BATTLE_TEST("Eject Button has no chance to activate after Dragon Tail")
         }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_TAIL, player);
-        MESSAGE("Foe Chansey was dragged out!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_CHANSEY) " was dragged out!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-            MESSAGE("Foe Chansey is switched out with the Eject Button!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_CHANSEY) " is switched out with the Eject Button!");
         }
     }
 }
@@ -166,7 +166,7 @@ SINGLE_BATTLE_TEST("Eject Button prevents Volt Switch / U-Turn from activating")
         }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_VOLT_SWITCH, player);
-        MESSAGE("Foe Wobbuffet is switched out with the Eject Button!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is switched out with the Eject Button!");
     }
 }
 
@@ -184,6 +184,6 @@ SINGLE_BATTLE_TEST("Eject Button is activated before Emergency Exit")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_THUNDERBOLT, player);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-        MESSAGE("Foe Golisopod is switched out with the Eject Button!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_GOLISOPOD) " is switched out with the Eject Button!");
     }
 }

--- a/test/battle/hold_effect/eject_button.c
+++ b/test/battle/hold_effect/eject_button.c
@@ -61,9 +61,9 @@ SINGLE_BATTLE_TEST("Eject Button will not activate under Substitute")
         }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SUBSTITUTE, opponent);
-        MESSAGE("Foe Raichu made a SUBSTITUTE!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_RAICHU) " made a SUBSTITUTE!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, player);
-        MESSAGE("The SUBSTITUTE took damage for Foe Raichu!");
+        MESSAGE("The SUBSTITUTE took damage for Foe " SPECIES_NAME(SPECIES_RAICHU) "!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
             MESSAGE("Foe " SPECIES_NAME(SPECIES_RAICHU) " is switched out with the Eject Button!");
@@ -126,7 +126,7 @@ SINGLE_BATTLE_TEST("Eject Button is not triggered after given to player by Picke
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, player);
         ABILITY_POPUP(opponent, ABILITY_PICKPOCKET);
-        MESSAGE("Foe Sneasel stole Regieleki's Eject Button!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_SNEASEL) " stole Regieleki's Eject Button!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
     }
 }

--- a/test/battle/hold_effect/enigma_berry.c
+++ b/test/battle/hold_effect/enigma_berry.c
@@ -18,7 +18,7 @@ SINGLE_BATTLE_TEST("Enigma Berry recovers 25% of HP if hit by super effective mo
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ENDURE, player);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BITE, opponent);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-        MESSAGE("Wynaut's Enigma Berry restored health!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) "'s Enigma Berry restored health!");
         HP_BAR(player, damage: -maxHP / 4);
     }
 }
@@ -35,7 +35,7 @@ SINGLE_BATTLE_TEST("Enigma Berry does nothing if not hit by super effective move
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BITE, opponent);
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-            MESSAGE("Mightyena's Enigma Berry restored health!");
+            MESSAGE(SPECIES_NAME(SPECIES_MIGHTYENA) "'s Enigma Berry restored health!");
         }
     }
 }
@@ -54,7 +54,7 @@ SINGLE_BATTLE_TEST("Enigma Berry does nothing if Heal Block applies")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BITE, opponent);
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-            MESSAGE("Wynaut's Enigma Berry restored health!");
+            MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) "'s Enigma Berry restored health!");
         }
     }
 }

--- a/test/battle/hold_effect/jaboca_berry.c
+++ b/test/battle/hold_effect/jaboca_berry.c
@@ -27,11 +27,11 @@ SINGLE_BATTLE_TEST("Jaboca Berry causes the attacker to lose 1/8 of its max HP i
         if (move == MOVE_TACKLE) {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
             HP_BAR(player, captureDamage: &damage);
-            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was hurt by Foe Wobbuffet's Jaboca Berry!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was hurt by Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Jaboca Berry!");
         } else {
             NONE_OF {
                 ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was hurt by Foe Wobbuffet's Jaboca Berry!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was hurt by Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Jaboca Berry!");
             }
         }
     } THEN {
@@ -54,7 +54,7 @@ SINGLE_BATTLE_TEST("Jaboca Berry tirggers before Bug Bite can steal it")
         HP_BAR(opponent);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
         HP_BAR(player);
-        MESSAGE(SPECIES_NAME(SPECIES_WYANUT) " was hurt by Foe Wobbuffet's Jaboca Berry!");
-        NOT MESSAGE("Wynaut stole and ate Foe Wobbuffet's Jaboca Berry!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYANUT) " was hurt by Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Jaboca Berry!");
+        NOT MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " stole and ate Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Jaboca Berry!");
     }
 }

--- a/test/battle/hold_effect/jaboca_berry.c
+++ b/test/battle/hold_effect/jaboca_berry.c
@@ -27,11 +27,11 @@ SINGLE_BATTLE_TEST("Jaboca Berry causes the attacker to lose 1/8 of its max HP i
         if (move == MOVE_TACKLE) {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
             HP_BAR(player, captureDamage: &damage);
-            MESSAGE("Wobbuffet was hurt by Foe Wobbuffet's Jaboca Berry!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was hurt by Foe Wobbuffet's Jaboca Berry!");
         } else {
             NONE_OF {
                 ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-                MESSAGE("Wobbuffet was hurt by Foe Wobbuffet's Jaboca Berry!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was hurt by Foe Wobbuffet's Jaboca Berry!");
             }
         }
     } THEN {
@@ -54,7 +54,7 @@ SINGLE_BATTLE_TEST("Jaboca Berry tirggers before Bug Bite can steal it")
         HP_BAR(opponent);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
         HP_BAR(player);
-        MESSAGE("Wyanut was hurt by Foe Wobbuffet's Jaboca Berry!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYANUT) " was hurt by Foe Wobbuffet's Jaboca Berry!");
         NOT MESSAGE("Wynaut stole and ate Foe Wobbuffet's Jaboca Berry!");
     }
 }

--- a/test/battle/hold_effect/kee_berry.c
+++ b/test/battle/hold_effect/kee_berry.c
@@ -25,11 +25,11 @@ SINGLE_BATTLE_TEST("Kee Berry raises the holder's Defense by one stage when hit 
         HP_BAR(opponent);
         if (move == MOVE_TACKLE) {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-            MESSAGE("Using Kee Berry, the Defense of Foe Wobbuffet rose!");
+            MESSAGE("Using Kee Berry, the Defense of Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " rose!");
         } else {
             NONE_OF {
                 ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-                MESSAGE("Using Kee Berry, the Defense of Foe Wobbuffet rose!");
+                MESSAGE("Using Kee Berry, the Defense of Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " rose!");
             }
         }
     } THEN {
@@ -50,7 +50,7 @@ SINGLE_BATTLE_TEST("Kee Berry raises the holder's Defense by two stages with Rip
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, player);
         HP_BAR(opponent);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-        MESSAGE("Using Kee Berry, the Defense of Foe Applin sharply rose!");
+        MESSAGE("Using Kee Berry, the Defense of Foe " SPECIES_NAME(SPECIES_APPLIN) " sharply rose!");
     } THEN {
         EXPECT_EQ(opponent->statStages[STAT_DEF], DEFAULT_STAT_STAGE + 2);
     }
@@ -69,7 +69,7 @@ SINGLE_BATTLE_TEST("Kee Berry is not triggered by a special move")
         HP_BAR(opponent);
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-            MESSAGE("Using Kee Berry, the Defense of Foe Wobbuffet rose!");
+            MESSAGE("Using Kee Berry, the Defense of Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " rose!");
         }
     }
 }

--- a/test/battle/hold_effect/leftovers.c
+++ b/test/battle/hold_effect/leftovers.c
@@ -16,7 +16,7 @@ SINGLE_BATTLE_TEST("Leftovers recovers 1/16th HP at end of turn")
     } SCENE {
         s32 maxHP = GetMonData(&PLAYER_PARTY[0], MON_DATA_MAX_HP);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-        MESSAGE("Wobbuffet's Leftovers restored its HP a little!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Leftovers restored its HP a little!");
         HP_BAR(player, damage: -maxHP / 16);
     }
 }
@@ -31,7 +31,7 @@ SINGLE_BATTLE_TEST("Leftovers does nothing if max HP")
     } SCENE {
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-            MESSAGE("Wobbuffet's Leftovers restored its HP a little!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Leftovers restored its HP a little!");
             HP_BAR(player);
         }
     }
@@ -47,7 +47,7 @@ SINGLE_BATTLE_TEST("Leftovers does nothing if Heal Block applies")
     } SCENE {
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-            MESSAGE("Wobbuffet's Leftovers restored its HP a little!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Leftovers restored its HP a little!");
             HP_BAR(player);
         }
     }

--- a/test/battle/hold_effect/maranga_berry.c
+++ b/test/battle/hold_effect/maranga_berry.c
@@ -23,12 +23,12 @@ SINGLE_BATTLE_TEST("Maranga Berry raises the holder's Sp. Def by one stage when 
         HP_BAR(opponent);
         if (move == MOVE_SWIFT) {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-            MESSAGE("Using Maranga Berry, the Sp. Def of Foe Wobbuffet rose!");
+            MESSAGE("Using Maranga Berry, the Sp. Def of Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " rose!");
         }
         else {
             NONE_OF {
                 ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-                MESSAGE("Using Maranga Berry, the Sp. Def of Foe Wobbuffet rose!");
+                MESSAGE("Using Maranga Berry, the Sp. Def of Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " rose!");
             }
         }
     } THEN {
@@ -50,7 +50,7 @@ SINGLE_BATTLE_TEST("Maranga Berry raises the holder's Sp. Def by two stages with
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SWIFT, player);
         HP_BAR(opponent);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-        MESSAGE("Using Maranga Berry, the Sp. Def of Foe Applin sharply rose!");
+        MESSAGE("Using Maranga Berry, the Sp. Def of Foe " SPECIES_NAME(SPECIES_APPLIN) " sharply rose!");
     } THEN {
         EXPECT_EQ(opponent->statStages[STAT_SPDEF], DEFAULT_STAT_STAGE + 2);
     }

--- a/test/battle/hold_effect/metronome.c
+++ b/test/battle/hold_effect/metronome.c
@@ -121,11 +121,11 @@ SINGLE_BATTLE_TEST("Metronome Item counts charging turn of moves for its attacki
         TURN { MOVE(player, MOVE_SOLAR_BEAM); }
         TURN { SKIP_TURN(player); }
     } SCENE {
-        MESSAGE("Wobbuffet used Solar Beam!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SOLAR_BEAM) "!");
         MESSAGE("Wobbuffet took in sunlight!");
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
         MESSAGE("Congratulations, 1!");
-        MESSAGE("Wobbuffet used Solar Beam!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SOLAR_BEAM) "!");
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
         EXPECT_MUL_EQ(results[0].damage, UQ_4_12(1.2), results[1].damage);

--- a/test/battle/hold_effect/metronome.c
+++ b/test/battle/hold_effect/metronome.c
@@ -121,11 +121,11 @@ SINGLE_BATTLE_TEST("Metronome Item counts charging turn of moves for its attacki
         TURN { MOVE(player, MOVE_SOLAR_BEAM); }
         TURN { SKIP_TURN(player); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SOLAR_BEAM) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SOLAR_BEAM) "!");
         MESSAGE("Wobbuffet took in sunlight!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
         MESSAGE("Congratulations, 1!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SOLAR_BEAM) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SOLAR_BEAM) "!");
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
         EXPECT_MUL_EQ(results[0].damage, UQ_4_12(1.2), results[1].damage);

--- a/test/battle/hold_effect/red_card.c
+++ b/test/battle/hold_effect/red_card.c
@@ -20,7 +20,7 @@ SINGLE_BATTLE_TEST("Red Card switches the attacker with a random non-fainted rep
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-        MESSAGE("Wobbuffet held up its Red Card against Foe Wobbuffet!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " held up its Red Card against Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
         MESSAGE("Foe " SPECIES_NAME(SPECIES_BULBASAUR) " was dragged out!");
     } THEN {
         EXPECT(player->item == ITEM_NONE);
@@ -43,7 +43,7 @@ DOUBLE_BATTLE_TEST("Red Card switches the target with a random non-battler, non-
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentLeft);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, playerLeft);
-        MESSAGE("Wobbuffet held up its Red Card against Foe Wobbuffet!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " held up its Red Card against Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
         MESSAGE("Foe " SPECIES_NAME(SPECIES_BULBASAUR) " was dragged out!");
     } THEN {
         EXPECT(playerLeft->item == ITEM_NONE);
@@ -63,7 +63,7 @@ SINGLE_BATTLE_TEST("Red Card does not activate if holder faints")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-            MESSAGE("Wobbuffet held up its Red Card against Foe Wobbuffet!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " held up its Red Card against Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
         }
     } THEN {
         EXPECT(player->item == ITEM_NONE);
@@ -82,7 +82,7 @@ SINGLE_BATTLE_TEST("Red Card does not activate if target is behind a Substitute"
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-            MESSAGE("Wobbuffet held up its Red Card against Foe Wobbuffet!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " held up its Red Card against Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
         }
     } THEN {
         EXPECT(player->item == ITEM_RED_CARD); // Not activated, so still has the item.
@@ -102,7 +102,7 @@ SINGLE_BATTLE_TEST("Red Card activates after the last hit of a multi-hit move")
         HP_BAR(player);
         HP_BAR(player);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-        MESSAGE("Wobbuffet held up its Red Card against Foe Wobbuffet!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " held up its Red Card against Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
     } THEN {
         EXPECT(player->item == ITEM_NONE);
     }
@@ -119,7 +119,7 @@ SINGLE_BATTLE_TEST("Red Card does not activate if no replacements")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-            MESSAGE("Wobbuffet held up its Red Card against Foe Wobbuffet!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " held up its Red Card against Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
         }
     } THEN {
         EXPECT(player->item == ITEM_RED_CARD); // Not activated, so still has the item.
@@ -138,7 +138,7 @@ SINGLE_BATTLE_TEST("Red Card does not activate if replacements fainted")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-            MESSAGE("Wobbuffet held up its Red Card against Foe Wobbuffet!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " held up its Red Card against Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
         }
     } THEN {
         EXPECT(player->item == ITEM_RED_CARD); // Not activated, so still has the item.
@@ -157,7 +157,7 @@ SINGLE_BATTLE_TEST("Red Card does not activate if knocked off")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_KNOCK_OFF, opponent);
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-            MESSAGE("Wobbuffet held up its Red Card against Foe Wobbuffet!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " held up its Red Card against Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
         }
     } THEN {
         EXPECT(player->item == ITEM_NONE);
@@ -182,11 +182,11 @@ SINGLE_BATTLE_TEST("Red Card does not activate if stolen by a move")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_THIEF, opponent);
         if (activate) {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-            MESSAGE("Wobbuffet held up its Red Card against Foe Wobbuffet!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " held up its Red Card against Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
         } else {
             NONE_OF {
                 ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-                MESSAGE("Wobbuffet held up its Red Card against Foe Wobbuffet!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " held up its Red Card against Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
             }
         }
     } THEN {
@@ -212,11 +212,11 @@ SINGLE_BATTLE_TEST("Red Card does not activate if stolen by Magician")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
         if (activate) {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-            MESSAGE("Wobbuffet held up its Red Card against Foe Fennekin!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " held up its Red Card against Foe " SPECIES_NAME(SPECIES_FENNEKIN) "!");
         } else {
             NONE_OF {
                 ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-                MESSAGE("Wobbuffet held up its Red Card against Foe Fennekin!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " held up its Red Card against Foe " SPECIES_NAME(SPECIES_FENNEKIN) "!");
             }
         }
     } THEN {
@@ -241,13 +241,13 @@ DOUBLE_BATTLE_TEST("Red Card activates for only the fastest target")
         // Fastest target's Red Card activates.
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROCK_SLIDE, opponentLeft);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, playerLeft);
-        MESSAGE("Wobbuffet held up its Red Card against Foe Wobbuffet!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " held up its Red Card against Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
         MESSAGE("Foe " SPECIES_NAME(SPECIES_UNOWN) " was dragged out!");
 
         // Slower target's Red Card still able to activate on other battler.
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentRight);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, playerRight);
-        MESSAGE("Wynaut held up its Red Card against Foe Wynaut!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " held up its Red Card against Foe " SPECIES_NAME(SPECIES_WYNAUT) "!");
         MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " was dragged out!");
     } THEN {
         EXPECT(playerLeft->item == ITEM_NONE);
@@ -272,14 +272,14 @@ DOUBLE_BATTLE_TEST("Red Card activates but fails if the attacker is rooted")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentLeft);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, playerLeft);
-        MESSAGE("Wobbuffet held up its Red Card against Foe Wobbuffet!");
-        MESSAGE("Foe Wobbuffet anchored itself with its roots!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " held up its Red Card against Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " anchored itself with its roots!");
 
         // Red Card already consumed so cannot activate.
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentRight);
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, playerRight);
-            MESSAGE("Wynaut held up its Red Card against Foe Wynaut!");
+            MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " held up its Red Card against Foe " SPECIES_NAME(SPECIES_WYNAUT) "!");
         }
     }
 }
@@ -300,14 +300,14 @@ DOUBLE_BATTLE_TEST("Red Card activates but fails if the attacker has Suction Cup
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentLeft);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, playerLeft);
-        MESSAGE("Wobbuffet held up its Red Card against Foe Octillery!");
-        MESSAGE("Foe Octillery anchors itself with Suction Cups!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " held up its Red Card against Foe " SPECIES_NAME(SPECIES_OCTILLERY) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_OCTILLERY) " anchors itself with Suction Cups!");
 
         // Red Card already consumed so cannot activate.
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentRight);
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, playerRight);
-            MESSAGE("Wynaut held up its Red Card against Foe Wynaut!");
+            MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " held up its Red Card against Foe " SPECIES_NAME(SPECIES_WYNAUT) "!");
         }
     }
 }
@@ -329,11 +329,11 @@ SINGLE_BATTLE_TEST("Red Card does not activate if switched by Dragon Tail")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_TAIL, opponent);
         if (activate) {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-            MESSAGE("Wobbuffet held up its Red Card against Foe Wobbuffet!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " held up its Red Card against Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
         } else {
             NONE_OF {
                 ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-                MESSAGE("Wobbuffet held up its Red Card against Foe Wobbuffet!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " held up its Red Card against Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
             }
         }
     }
@@ -350,7 +350,7 @@ SINGLE_BATTLE_TEST("Red Card activates and overrides U-turn")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_U_TURN, opponent);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-        MESSAGE("Wobbuffet held up its Red Card against Foe Wobbuffet!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " held up its Red Card against Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
     }
 }
 
@@ -371,11 +371,11 @@ SINGLE_BATTLE_TEST("Red Card does not activate if attacker's Sheer Force applied
         ANIMATION(ANIM_TYPE_MOVE, move, opponent);
         if (activate) {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-            MESSAGE("Wobbuffet held up its Red Card against Foe Tauros!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " held up its Red Card against Foe " SPECIES_NAME(SPECIES_TAUROS) "!");
         } else {
             NONE_OF {
                 ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-                MESSAGE("Wobbuffet held up its Red Card against Foe Tauros!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " held up its Red Card against Foe " SPECIES_NAME(SPECIES_TAUROS) "!");
             }
         }
     }
@@ -394,7 +394,7 @@ SINGLE_BATTLE_TEST("Red Card activates before Emergency Exit")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-        MESSAGE("Golisopod held up its Red Card against Foe Wobbuffet!");
+        MESSAGE(SPECIES_NAME(SPECIES_GOLISOPOD) " held up its Red Card against Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
         ABILITY_POPUP(player, ABILITY_EMERGENCY_EXIT);
         MESSAGE("Go! " SPECIES_NAME(SPECIES_WIMPOD) "!");
     }
@@ -417,14 +417,14 @@ SINGLE_BATTLE_TEST("Red Card is consumed after dragged out replacement has its S
         // 2nd turn Red Card activation
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, player);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-        MESSAGE("Foe Wobbuffet held up its Red Card against Wobbuffet!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " held up its Red Card against Wobbuffet!");
         MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " was dragged out!");
         MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " was caught in a Sticky Web!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
         // 3rd turn, Red Card was consumed, it can't trigger again
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-            MESSAGE("Foe Wobbuffet held up its Red Card against Wynaut!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " held up its Red Card against Wynaut!");
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
         }
     } THEN {

--- a/test/battle/hold_effect/red_card.c
+++ b/test/battle/hold_effect/red_card.c
@@ -21,7 +21,7 @@ SINGLE_BATTLE_TEST("Red Card switches the attacker with a random non-fainted rep
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
         MESSAGE("Wobbuffet held up its Red Card against Foe Wobbuffet!");
-        MESSAGE("Foe Bulbasaur was dragged out!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_BULBASAUR) " was dragged out!");
     } THEN {
         EXPECT(player->item == ITEM_NONE);
     }
@@ -44,7 +44,7 @@ DOUBLE_BATTLE_TEST("Red Card switches the target with a random non-battler, non-
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentLeft);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, playerLeft);
         MESSAGE("Wobbuffet held up its Red Card against Foe Wobbuffet!");
-        MESSAGE("Foe Bulbasaur was dragged out!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_BULBASAUR) " was dragged out!");
     } THEN {
         EXPECT(playerLeft->item == ITEM_NONE);
     }
@@ -242,13 +242,13 @@ DOUBLE_BATTLE_TEST("Red Card activates for only the fastest target")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROCK_SLIDE, opponentLeft);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, playerLeft);
         MESSAGE("Wobbuffet held up its Red Card against Foe Wobbuffet!");
-        MESSAGE("Foe Unown was dragged out!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_UNOWN) " was dragged out!");
 
         // Slower target's Red Card still able to activate on other battler.
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentRight);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, playerRight);
         MESSAGE("Wynaut held up its Red Card against Foe Wynaut!");
-        MESSAGE("Foe Wobbuffet was dragged out!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " was dragged out!");
     } THEN {
         EXPECT(playerLeft->item == ITEM_NONE);
         EXPECT(playerRight->item == ITEM_NONE);
@@ -396,7 +396,7 @@ SINGLE_BATTLE_TEST("Red Card activates before Emergency Exit")
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
         MESSAGE("Golisopod held up its Red Card against Foe Wobbuffet!");
         ABILITY_POPUP(player, ABILITY_EMERGENCY_EXIT);
-        MESSAGE("Go! Wimpod!");
+        MESSAGE("Go! " SPECIES_NAME(SPECIES_WIMPOD) "!");
     }
 }
 
@@ -418,8 +418,8 @@ SINGLE_BATTLE_TEST("Red Card is consumed after dragged out replacement has its S
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, player);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
         MESSAGE("Foe Wobbuffet held up its Red Card against Wobbuffet!");
-        MESSAGE("Wynaut was dragged out!");
-        MESSAGE("Wynaut was caught in a Sticky Web!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " was dragged out!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " was caught in a Sticky Web!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
         // 3rd turn, Red Card was consumed, it can't trigger again
         NONE_OF {

--- a/test/battle/hold_effect/rowap_berry.c
+++ b/test/battle/hold_effect/rowap_berry.c
@@ -27,11 +27,11 @@ SINGLE_BATTLE_TEST("Rowap Berry causes the attacker to lose 1/8 of its max HP if
         if (move == MOVE_SWIFT) {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
             HP_BAR(player, captureDamage: &damage);
-            MESSAGE("Wobbuffet was hurt by Foe Wobbuffet's Rowap Berry!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was hurt by Foe Wobbuffet's Rowap Berry!");
         } else {
             NONE_OF {
                 ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-                MESSAGE("Wobbuffet was hurt by Foe Wobbuffet's Rowap Berry!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was hurt by Foe Wobbuffet's Rowap Berry!");
             }
         }
     } THEN {
@@ -53,7 +53,7 @@ SINGLE_BATTLE_TEST("Rowap Berry is not triggered by a physical move")
         HP_BAR(opponent);
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-            MESSAGE("Wobbuffet was hurt by Foe Wobbuffet's Rowap Berry!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was hurt by Foe Wobbuffet's Rowap Berry!");
         }
     }
 }

--- a/test/battle/hold_effect/rowap_berry.c
+++ b/test/battle/hold_effect/rowap_berry.c
@@ -27,11 +27,11 @@ SINGLE_BATTLE_TEST("Rowap Berry causes the attacker to lose 1/8 of its max HP if
         if (move == MOVE_SWIFT) {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
             HP_BAR(player, captureDamage: &damage);
-            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was hurt by Foe Wobbuffet's Rowap Berry!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was hurt by Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Rowap Berry!");
         } else {
             NONE_OF {
                 ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was hurt by Foe Wobbuffet's Rowap Berry!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was hurt by Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Rowap Berry!");
             }
         }
     } THEN {
@@ -53,7 +53,7 @@ SINGLE_BATTLE_TEST("Rowap Berry is not triggered by a physical move")
         HP_BAR(opponent);
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was hurt by Foe Wobbuffet's Rowap Berry!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was hurt by Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Rowap Berry!");
         }
     }
 }

--- a/test/battle/hold_effect/safety_goggles.c
+++ b/test/battle/hold_effect/safety_goggles.c
@@ -16,7 +16,7 @@ SINGLE_BATTLE_TEST("Safety Goggles block powder and spore moves")
         TURN { MOVE(player, MOVE_STUN_SPORE); }
     } SCENE {
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_STUN_SPORE, player);
-        MESSAGE("Foe Abra is not affected thanks to its SafetyGoggles!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_ABRA) " is not affected thanks to its SafetyGoggles!");
     }
 }
 
@@ -28,7 +28,7 @@ SINGLE_BATTLE_TEST("Safety Goggles blocks damage from Hail")
     } WHEN {
         TURN { MOVE(player, MOVE_HAIL); }
     } SCENE {
-        NOT MESSAGE("Foe Wobbuffet is pelted by HAIL!");
+        NOT MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is pelted by HAIL!");
     }
 }
 
@@ -40,7 +40,7 @@ SINGLE_BATTLE_TEST("Safety Goggles blocks damage from Sandstorm")
     } WHEN {
         TURN { MOVE(player, MOVE_SANDSTORM); }
     } SCENE {
-        NOT MESSAGE("Foe Wobbuffet is buffeted by the sandstorm!");
+        NOT MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is buffeted by the sandstorm!");
     }
 }
 

--- a/test/battle/hold_effect/white_herb.c
+++ b/test/battle/hold_effect/white_herb.c
@@ -17,7 +17,7 @@ SINGLE_BATTLE_TEST("White Herb restores stats when they're lowered")
     } SCENE {
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-        MESSAGE("Wobbuffet's White Herb restored its status!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s White Herb restored its status!");
     } THEN {
         EXPECT(player->item == ITEM_NONE);
         EXPECT(player->statStages[STAT_DEF] = DEFAULT_STAT_STAGE);
@@ -35,7 +35,7 @@ SINGLE_BATTLE_TEST("White Herb restores stats after Attack was lowered by Intimi
         ABILITY_POPUP(opponent, ABILITY_INTIMIDATE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-        MESSAGE("Wobbuffet's White Herb restored its status!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s White Herb restored its status!");
     } THEN {
         EXPECT(player->item == ITEM_NONE);
         EXPECT(player->statStages[STAT_DEF] = DEFAULT_STAT_STAGE);
@@ -58,9 +58,9 @@ DOUBLE_BATTLE_TEST("White Herb restores stats after Attack was lowered by Intimi
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);
 
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponentLeft);
-        MESSAGE("Foe Wobbuffet's White Herb restored its status!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s White Herb restored its status!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponentRight);
-        MESSAGE("Foe Wynaut's White Herb restored its status!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) "'s White Herb restored its status!");
     } THEN {
         EXPECT(opponentLeft->item == ITEM_NONE);
         EXPECT(opponentLeft->statStages[STAT_DEF] = DEFAULT_STAT_STAGE);

--- a/test/battle/item_effect/cure_status.c
+++ b/test/battle/item_effect/cure_status.c
@@ -10,7 +10,7 @@ SINGLE_BATTLE_TEST("Paralyze Heal heals a battler from being paralyzed")
     } WHEN {
         TURN { USE_ITEM(player, ITEM_PARALYZE_HEAL, partyIndex: 0); }
     } SCENE {
-        MESSAGE("Wobbuffet had its status healed!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " had its status healed!");
     } THEN {
         EXPECT_EQ(player->status1, STATUS1_NONE);
     }
@@ -25,7 +25,7 @@ SINGLE_BATTLE_TEST("Antidote heals a battler from being poisoned")
     } WHEN {
         TURN { USE_ITEM(player, ITEM_ANTIDOTE, partyIndex: 0); }
     } SCENE {
-        MESSAGE("Wobbuffet had its status healed!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " had its status healed!");
     } THEN {
         EXPECT_EQ(player->status1, STATUS1_NONE);
     }
@@ -40,7 +40,7 @@ SINGLE_BATTLE_TEST("Antidote heals a battler from being badly poisoned")
     } WHEN {
         TURN { USE_ITEM(player, ITEM_ANTIDOTE, partyIndex: 0); }
     } SCENE {
-        MESSAGE("Wobbuffet had its status healed!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " had its status healed!");
     } THEN {
         EXPECT_EQ(player->status1, STATUS1_NONE);
     }
@@ -55,7 +55,7 @@ SINGLE_BATTLE_TEST("Awakening heals a battler from being asleep")
     } WHEN {
         TURN { USE_ITEM(player, ITEM_AWAKENING, partyIndex: 0); }
     } SCENE {
-        MESSAGE("Wobbuffet had its status healed!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " had its status healed!");
     } THEN {
         EXPECT_EQ(player->status1, STATUS1_NONE);
     }
@@ -70,7 +70,7 @@ SINGLE_BATTLE_TEST("Burn Heal heals a battler from being burned")
     } WHEN {
         TURN { USE_ITEM(player, ITEM_BURN_HEAL, partyIndex: 0); }
     } SCENE {
-        MESSAGE("Wobbuffet had its status healed!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " had its status healed!");
     } THEN {
         EXPECT_EQ(player->status1, STATUS1_NONE);
     }
@@ -85,7 +85,7 @@ SINGLE_BATTLE_TEST("Ice Heal heals a battler from being paralyzed")
     } WHEN {
         TURN { USE_ITEM(player, ITEM_ICE_HEAL, partyIndex: 0); }
     } SCENE {
-        MESSAGE("Wobbuffet had its status healed!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " had its status healed!");
     } THEN {
         EXPECT_EQ(player->status1, STATUS1_NONE);
     }
@@ -107,7 +107,7 @@ SINGLE_BATTLE_TEST("Full Heal heals a battler from any primary status")
     } WHEN {
         TURN { USE_ITEM(player, ITEM_FULL_HEAL, partyIndex: 0); }
     } SCENE {
-        MESSAGE("Wobbuffet had its status healed!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " had its status healed!");
     } THEN {
         EXPECT_EQ(player->status1, STATUS1_NONE);
     }
@@ -129,7 +129,7 @@ SINGLE_BATTLE_TEST("Heal Powder heals a battler from any primary status")
     } WHEN {
         TURN { USE_ITEM(player, ITEM_HEAL_POWDER, partyIndex: 0); }
     } SCENE {
-        MESSAGE("Wobbuffet had its status healed!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " had its status healed!");
     } THEN {
         EXPECT_EQ(player->status1, STATUS1_NONE);
     }
@@ -151,7 +151,7 @@ SINGLE_BATTLE_TEST("Pewter Crunchies heals a battler from any primary status")
     } WHEN {
         TURN { USE_ITEM(player, ITEM_PEWTER_CRUNCHIES, partyIndex: 0); }
     } SCENE {
-        MESSAGE("Wobbuffet had its status healed!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " had its status healed!");
     } THEN {
         EXPECT_EQ(player->status1, STATUS1_NONE);
     }
@@ -173,7 +173,7 @@ SINGLE_BATTLE_TEST("Lava Cookies heals a battler from any primary status")
     } WHEN {
         TURN { USE_ITEM(player, ITEM_LAVA_COOKIE, partyIndex: 0); }
     } SCENE {
-        MESSAGE("Wobbuffet had its status healed!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " had its status healed!");
     } THEN {
         EXPECT_EQ(player->status1, STATUS1_NONE);
     }
@@ -195,7 +195,7 @@ SINGLE_BATTLE_TEST("Rage Candy Bar heals a battler from any primary status")
     } WHEN {
         TURN { USE_ITEM(player, ITEM_RAGE_CANDY_BAR, partyIndex: 0); }
     } SCENE {
-        MESSAGE("Wobbuffet had its status healed!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " had its status healed!");
     } THEN {
         EXPECT_EQ(player->status1, STATUS1_NONE);
     }
@@ -217,7 +217,7 @@ SINGLE_BATTLE_TEST("Old Gateu heals a battler from any primary status")
     } WHEN {
         TURN { USE_ITEM(player, ITEM_OLD_GATEAU, partyIndex: 0); }
     } SCENE {
-        MESSAGE("Wobbuffet had its status healed!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " had its status healed!");
     } THEN {
         EXPECT_EQ(player->status1, STATUS1_NONE);
     }
@@ -239,7 +239,7 @@ SINGLE_BATTLE_TEST("Casteliacone heals a battler from any primary status")
     } WHEN {
         TURN { USE_ITEM(player, ITEM_CASTELIACONE, partyIndex: 0); }
     } SCENE {
-        MESSAGE("Wobbuffet had its status healed!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " had its status healed!");
     } THEN {
         EXPECT_EQ(player->status1, STATUS1_NONE);
     }
@@ -261,7 +261,7 @@ SINGLE_BATTLE_TEST("Lumiose Galette heals a battler from any primary status")
     } WHEN {
         TURN { USE_ITEM(player, ITEM_LUMIOSE_GALETTE, partyIndex: 0); }
     } SCENE {
-        MESSAGE("Wobbuffet had its status healed!");;
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " had its status healed!");;
     } THEN {
         EXPECT_EQ(player->status1, STATUS1_NONE);
     }
@@ -283,7 +283,7 @@ SINGLE_BATTLE_TEST("Shalour Sable heals a battler from any primary status")
     } WHEN {
         TURN { USE_ITEM(player, ITEM_SHALOUR_SABLE, partyIndex: 0); }
     } SCENE {
-        MESSAGE("Wobbuffet had its status healed!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " had its status healed!");
     } THEN {
         EXPECT_EQ(player->status1, STATUS1_NONE);
     }
@@ -305,7 +305,7 @@ SINGLE_BATTLE_TEST("Big Malasada heals a battler from any primary status")
     } WHEN {
         TURN { USE_ITEM(player, ITEM_BIG_MALASADA, partyIndex: 0); }
     } SCENE {
-        MESSAGE("Wobbuffet had its status healed!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " had its status healed!");
     } THEN {
         EXPECT_EQ(player->status1, STATUS1_NONE);
     }
@@ -332,7 +332,7 @@ SINGLE_BATTLE_TEST("Full Heal, Heal Powder and Local Specialties heal a battler 
         TURN { MOVE(opponent, MOVE_CONFUSE_RAY); }
         TURN { USE_ITEM(player, item, partyIndex: 0); }
     } SCENE {
-        MESSAGE("Wobbuffet had its status healed!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " had its status healed!");
     } THEN {
         EXPECT_EQ(player->status2, STATUS1_NONE); // because we dont have STATUS2_NONE
     }

--- a/test/battle/item_effect/heal_and_cure_status.c
+++ b/test/battle/item_effect/heal_and_cure_status.c
@@ -17,7 +17,7 @@ SINGLE_BATTLE_TEST("Full Restore restores a battler's HP and cures any primary s
     } WHEN {
         TURN{ USE_ITEM(player, ITEM_FULL_RESTORE, partyIndex: 0); }
     } SCENE {
-        MESSAGE("Wobbuffet had its HP restored!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " had its HP restored!");
     } THEN {
         EXPECT_EQ(player->hp, player->maxHP);
         EXPECT_EQ(player->status1, STATUS1_NONE);
@@ -35,7 +35,7 @@ SINGLE_BATTLE_TEST("Full Restore restores a battler's HP and cures confusion")
         TURN{ USE_ITEM(player, ITEM_FULL_RESTORE, partyIndex: 0); }
         TURN{ MOVE(player, MOVE_TACKLE); }
     } SCENE {
-        MESSAGE("Wobbuffet had its HP restored!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " had its HP restored!");
         NONE_OF { MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is confused!"); }
     } THEN {
         EXPECT_EQ(player->hp, player->maxHP);

--- a/test/battle/item_effect/heal_and_cure_status.c
+++ b/test/battle/item_effect/heal_and_cure_status.c
@@ -36,7 +36,7 @@ SINGLE_BATTLE_TEST("Full Restore restores a battler's HP and cures confusion")
         TURN{ MOVE(player, MOVE_TACKLE); }
     } SCENE {
         MESSAGE("Wobbuffet had its HP restored!");
-        NONE_OF { MESSAGE("Wobbuffet is confused!"); }
+        NONE_OF { MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is confused!"); }
     } THEN {
         EXPECT_EQ(player->hp, player->maxHP);
     }

--- a/test/battle/item_effect/increase_stat.c
+++ b/test/battle/item_effect/increase_stat.c
@@ -14,7 +14,7 @@ SINGLE_BATTLE_TEST("X Attack sharply raises battler's Attack stat", s16 damage)
         if (useItem) TURN { USE_ITEM(player, ITEM_X_ATTACK); }
         TURN { MOVE(player, MOVE_TACKLE); }
     } SCENE {
-        MESSAGE("Wobbuffet used Tackle!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
         if (B_X_ITEMS_BUFF >= GEN_7)
@@ -37,7 +37,7 @@ SINGLE_BATTLE_TEST("X Defense sharply raises battler's Defense stat", s16 damage
         if (useItem) TURN { USE_ITEM(player, ITEM_X_DEFENSE); }
         TURN { MOVE(opponent, MOVE_TACKLE); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used Tackle!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
         HP_BAR(player, captureDamage: &results[i].damage);
     } FINALLY {
         if (B_X_ITEMS_BUFF >= GEN_7)
@@ -60,7 +60,7 @@ SINGLE_BATTLE_TEST("X Sp. Atk sharply raises battler's Sp. Attack stat", s16 dam
         if (useItem) TURN { USE_ITEM(player, ITEM_X_SP_ATK); }
         TURN { MOVE(player, MOVE_DISARMING_VOICE); }
     } SCENE {
-        MESSAGE("Wobbuffet used DisrmngVoice!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_DISARMING_VOICE) "!");
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
         if (B_X_ITEMS_BUFF >= GEN_7)
@@ -83,7 +83,7 @@ SINGLE_BATTLE_TEST("X Sp. Def sharply raises battler's Sp. Defense stat", s16 da
         if (useItem) TURN { USE_ITEM(player, ITEM_X_SP_DEF); }
         TURN { MOVE(opponent, MOVE_DISARMING_VOICE); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used DisrmngVoice!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_DISARMING_VOICE) "!");
         HP_BAR(player, captureDamage: &results[i].damage);
     } FINALLY {
         if (B_X_ITEMS_BUFF >= GEN_7)
@@ -116,13 +116,13 @@ SINGLE_BATTLE_TEST("X Speed sharply raises battler's Speed stat", s16 damage)
     } SCENE {
         if (useItem)
         {
-            MESSAGE("Wobbuffet used Tackle!");
-            MESSAGE("Foe Wobbuffet used Tackle!");
+            MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
+            MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
         }
         else
         {
-            MESSAGE("Foe Wobbuffet used Tackle!");
-            MESSAGE("Wobbuffet used Tackle!");
+            MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
+            MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
         }
     }
 }
@@ -143,7 +143,7 @@ SINGLE_BATTLE_TEST("X Accuracy sharply raises battler's Accuracy stat")
         TURN { USE_ITEM(player, ITEM_X_ACCURACY); }
         TURN { MOVE(player, MOVE_SING); }
     } SCENE {
-        MESSAGE("Wobbuffet used Sing!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SING) "!");
         MESSAGE("Foe Wobbuffet fell asleep!");
     }
 }
@@ -161,7 +161,7 @@ SINGLE_BATTLE_TEST("Max Mushrooms raises battler's Attack stat", s16 damage)
         if (useItem) TURN { USE_ITEM(player, ITEM_MAX_MUSHROOMS); }
         TURN { MOVE(player, MOVE_TACKLE); }
     } SCENE {
-        MESSAGE("Wobbuffet used Tackle!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
         EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.5), results[1].damage);
@@ -181,7 +181,7 @@ SINGLE_BATTLE_TEST("Max Mushrooms raises battler's Defense stat", s16 damage)
         if (useItem) TURN { USE_ITEM(player, ITEM_MAX_MUSHROOMS); }
         TURN { MOVE(opponent, MOVE_TACKLE); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used Tackle!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
         HP_BAR(player, captureDamage: &results[i].damage);
     } FINALLY {
         EXPECT_MUL_EQ(results[0].damage, Q_4_12(0.66), results[1].damage);
@@ -201,7 +201,7 @@ SINGLE_BATTLE_TEST("Max Mushrooms raises battler's Sp. Attack stat", s16 damage)
         if (useItem) TURN { USE_ITEM(player, ITEM_MAX_MUSHROOMS); }
         TURN { MOVE(player, MOVE_DISARMING_VOICE); }
     } SCENE {
-        MESSAGE("Wobbuffet used DisrmngVoice!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_DISARMING_VOICE) "!");
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
         EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.5), results[1].damage);
@@ -221,7 +221,7 @@ SINGLE_BATTLE_TEST("Max Mushrooms battler's Sp. Defense stat", s16 damage)
         if (useItem) TURN { USE_ITEM(player, ITEM_MAX_MUSHROOMS); }
         TURN { MOVE(opponent, MOVE_DISARMING_VOICE); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used DisrmngVoice!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_DISARMING_VOICE) "!");
         HP_BAR(player, captureDamage: &results[i].damage);
     } FINALLY {
         EXPECT_MUL_EQ(results[0].damage, Q_4_12(0.66), results[1].damage);
@@ -243,13 +243,13 @@ SINGLE_BATTLE_TEST("Max Mushrooms raises battler's Speed stat", s16 damage)
     } SCENE {
         if (useItem)
         {
-            MESSAGE("Wobbuffet used Tackle!");
-            MESSAGE("Foe Wobbuffet used Tackle!");
+            MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
+            MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
         }
         else
         {
-            MESSAGE("Foe Wobbuffet used Tackle!");
-            MESSAGE("Wobbuffet used Tackle!");
+            MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
+            MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
         }
     }
 }

--- a/test/battle/item_effect/increase_stat.c
+++ b/test/battle/item_effect/increase_stat.c
@@ -144,7 +144,7 @@ SINGLE_BATTLE_TEST("X Accuracy sharply raises battler's Accuracy stat")
         TURN { MOVE(player, MOVE_SING); }
     } SCENE {
         MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SING) "!");
-        MESSAGE("Foe Wobbuffet fell asleep!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " fell asleep!");
     }
 }
 

--- a/test/battle/item_effect/increase_stat.c
+++ b/test/battle/item_effect/increase_stat.c
@@ -14,7 +14,7 @@ SINGLE_BATTLE_TEST("X Attack sharply raises battler's Attack stat", s16 damage)
         if (useItem) TURN { USE_ITEM(player, ITEM_X_ATTACK); }
         TURN { MOVE(player, MOVE_TACKLE); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
         if (B_X_ITEMS_BUFF >= GEN_7)
@@ -37,7 +37,7 @@ SINGLE_BATTLE_TEST("X Defense sharply raises battler's Defense stat", s16 damage
         if (useItem) TURN { USE_ITEM(player, ITEM_X_DEFENSE); }
         TURN { MOVE(opponent, MOVE_TACKLE); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
         HP_BAR(player, captureDamage: &results[i].damage);
     } FINALLY {
         if (B_X_ITEMS_BUFF >= GEN_7)
@@ -60,7 +60,7 @@ SINGLE_BATTLE_TEST("X Sp. Atk sharply raises battler's Sp. Attack stat", s16 dam
         if (useItem) TURN { USE_ITEM(player, ITEM_X_SP_ATK); }
         TURN { MOVE(player, MOVE_DISARMING_VOICE); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_DISARMING_VOICE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_DISARMING_VOICE) "!");
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
         if (B_X_ITEMS_BUFF >= GEN_7)
@@ -83,7 +83,7 @@ SINGLE_BATTLE_TEST("X Sp. Def sharply raises battler's Sp. Defense stat", s16 da
         if (useItem) TURN { USE_ITEM(player, ITEM_X_SP_DEF); }
         TURN { MOVE(opponent, MOVE_DISARMING_VOICE); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_DISARMING_VOICE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_DISARMING_VOICE) "!");
         HP_BAR(player, captureDamage: &results[i].damage);
     } FINALLY {
         if (B_X_ITEMS_BUFF >= GEN_7)
@@ -116,13 +116,13 @@ SINGLE_BATTLE_TEST("X Speed sharply raises battler's Speed stat", s16 damage)
     } SCENE {
         if (useItem)
         {
-            MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
-            MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
         }
         else
         {
-            MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
-            MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
         }
     }
 }
@@ -143,7 +143,7 @@ SINGLE_BATTLE_TEST("X Accuracy sharply raises battler's Accuracy stat")
         TURN { USE_ITEM(player, ITEM_X_ACCURACY); }
         TURN { MOVE(player, MOVE_SING); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SING) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SING) "!");
         MESSAGE("Foe Wobbuffet fell asleep!");
     }
 }
@@ -161,7 +161,7 @@ SINGLE_BATTLE_TEST("Max Mushrooms raises battler's Attack stat", s16 damage)
         if (useItem) TURN { USE_ITEM(player, ITEM_MAX_MUSHROOMS); }
         TURN { MOVE(player, MOVE_TACKLE); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
         EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.5), results[1].damage);
@@ -181,7 +181,7 @@ SINGLE_BATTLE_TEST("Max Mushrooms raises battler's Defense stat", s16 damage)
         if (useItem) TURN { USE_ITEM(player, ITEM_MAX_MUSHROOMS); }
         TURN { MOVE(opponent, MOVE_TACKLE); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
         HP_BAR(player, captureDamage: &results[i].damage);
     } FINALLY {
         EXPECT_MUL_EQ(results[0].damage, Q_4_12(0.66), results[1].damage);
@@ -201,7 +201,7 @@ SINGLE_BATTLE_TEST("Max Mushrooms raises battler's Sp. Attack stat", s16 damage)
         if (useItem) TURN { USE_ITEM(player, ITEM_MAX_MUSHROOMS); }
         TURN { MOVE(player, MOVE_DISARMING_VOICE); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_DISARMING_VOICE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_DISARMING_VOICE) "!");
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
         EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.5), results[1].damage);
@@ -221,7 +221,7 @@ SINGLE_BATTLE_TEST("Max Mushrooms battler's Sp. Defense stat", s16 damage)
         if (useItem) TURN { USE_ITEM(player, ITEM_MAX_MUSHROOMS); }
         TURN { MOVE(opponent, MOVE_DISARMING_VOICE); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_DISARMING_VOICE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_DISARMING_VOICE) "!");
         HP_BAR(player, captureDamage: &results[i].damage);
     } FINALLY {
         EXPECT_MUL_EQ(results[0].damage, Q_4_12(0.66), results[1].damage);
@@ -243,13 +243,13 @@ SINGLE_BATTLE_TEST("Max Mushrooms raises battler's Speed stat", s16 damage)
     } SCENE {
         if (useItem)
         {
-            MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
-            MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
         }
         else
         {
-            MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
-            MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
         }
     }
 }

--- a/test/battle/item_effect/revive.c
+++ b/test/battle/item_effect/revive.c
@@ -13,7 +13,7 @@ SINGLE_BATTLE_TEST("Revive restores a fainted battler's HP to half")
         TURN { USE_ITEM(player, ITEM_REVIVE, partyIndex: 0); }
         TURN { SWITCH(player, 0); }
     } SCENE {
-        MESSAGE("Wynaut had its HP restored!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " had its HP restored!");
     } THEN {
         EXPECT_EQ(player->hp, 100);
     }
@@ -31,7 +31,7 @@ SINGLE_BATTLE_TEST("Max Revive restores a fainted battler's HP fully")
         TURN { USE_ITEM(player, ITEM_MAX_REVIVE, partyIndex: 0); }
         TURN { SWITCH(player, 0); }
     } SCENE {
-        MESSAGE("Wynaut had its HP restored!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " had its HP restored!");
     } THEN {
         EXPECT_EQ(player->hp, 200);
     }
@@ -49,7 +49,7 @@ SINGLE_BATTLE_TEST("Revival Herb restores a fainted battler's HP fully")
         TURN { USE_ITEM(player, ITEM_REVIVAL_HERB, partyIndex: 0); }
         TURN { SWITCH(player, 0); }
     } SCENE {
-        MESSAGE("Wynaut had its HP restored!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " had its HP restored!");
     } THEN {
         EXPECT_EQ(player->hp, 200);
     }
@@ -67,7 +67,7 @@ SINGLE_BATTLE_TEST("Max Honey restores a fainted battler's HP fully")
         TURN { USE_ITEM(player, ITEM_MAX_HONEY, partyIndex: 0); }
         TURN { SWITCH(player, 0); }
     } SCENE {
-        MESSAGE("Wynaut had its HP restored!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " had its HP restored!");
     } THEN {
         EXPECT_EQ(player->hp, 200);
     }

--- a/test/battle/item_effect/set_mist.c
+++ b/test/battle/item_effect/set_mist.c
@@ -13,7 +13,7 @@ SINGLE_BATTLE_TEST("Guard Spec. sets Mist effect on the battlers side")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_MIST, player);
         MESSAGE("Ally became shrouded in MIST!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_GROWL) "!");
-        MESSAGE("Wobbuffet is protected by MIST!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_GROWL) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is protected by MIST!");
     }
 }

--- a/test/battle/item_effect/set_mist.c
+++ b/test/battle/item_effect/set_mist.c
@@ -13,7 +13,7 @@ SINGLE_BATTLE_TEST("Guard Spec. sets Mist effect on the battlers side")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_MIST, player);
         MESSAGE("Ally became shrouded in MIST!");
-        MESSAGE("Foe Wobbuffet used Growl!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_GROWL) "!");
         MESSAGE("Wobbuffet is protected by MIST!");
     }
 }

--- a/test/battle/move_effect/absorb.c
+++ b/test/battle/move_effect/absorb.c
@@ -33,7 +33,7 @@ SINGLE_BATTLE_TEST("Absorb fails if Heal Block applies")
     } WHEN {
         TURN { MOVE(opponent, MOVE_HEAL_BLOCK); MOVE(player, MOVE_ABSORB); }
     } SCENE {
-        MESSAGE("Wobbuffet was prevented from healing!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was prevented from healing!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_ABSORB, player);
             HP_BAR(opponent);

--- a/test/battle/move_effect/accuracy_down.c
+++ b/test/battle/move_effect/accuracy_down.c
@@ -18,7 +18,7 @@ SINGLE_BATTLE_TEST("Sand Attack lowers Accuracy")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SAND_ATTACK, player);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-        MESSAGE("Foe Wobbuffet's accuracy fell!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s accuracy fell!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
     }
 }

--- a/test/battle/move_effect/after_you.c
+++ b/test/battle/move_effect/after_you.c
@@ -46,7 +46,7 @@ DOUBLE_BATTLE_TEST("After You does nothing if the target has already moved")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, playerLeft);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponentLeft);
-        MESSAGE("Foe Wynaut used After You!");
+        MESSAGE("Foe Wynaut used " MOVE_NAME(MOVE_AFTER_YOU) "!");
         MESSAGE("But it failed!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, playerRight);
     }

--- a/test/battle/move_effect/after_you.c
+++ b/test/battle/move_effect/after_you.c
@@ -46,7 +46,7 @@ DOUBLE_BATTLE_TEST("After You does nothing if the target has already moved")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, playerLeft);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponentLeft);
-        MESSAGE("Foe Wynaut used " MOVE_NAME(MOVE_AFTER_YOU) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " used " MOVE_NAME(MOVE_AFTER_YOU) "!");
         MESSAGE("But it failed!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, playerRight);
     }

--- a/test/battle/move_effect/assist.c
+++ b/test/battle/move_effect/assist.c
@@ -15,7 +15,7 @@ SINGLE_BATTLE_TEST("Assist fails if there are no valid moves to choose from")
     } WHEN {
         TURN { MOVE(player, MOVE_ASSIST); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_ASSIST) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_ASSIST) "!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSIST, player);
         MESSAGE("But it failed!");
     }

--- a/test/battle/move_effect/assist.c
+++ b/test/battle/move_effect/assist.c
@@ -15,7 +15,7 @@ SINGLE_BATTLE_TEST("Assist fails if there are no valid moves to choose from")
     } WHEN {
         TURN { MOVE(player, MOVE_ASSIST); }
     } SCENE {
-        MESSAGE("Wobbuffet used Assist!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_ASSIST) "!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSIST, player);
         MESSAGE("But it failed!");
     }

--- a/test/battle/move_effect/attack_down.c
+++ b/test/battle/move_effect/attack_down.c
@@ -22,7 +22,7 @@ SINGLE_BATTLE_TEST("Growl lowers Attack", s16 damage)
         if (lowerAttack) {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_GROWL, player);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-            MESSAGE("Foe Wobbuffet's Attack fell!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Attack fell!");
         }
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
         HP_BAR(player, captureDamage: &results[i].damage);

--- a/test/battle/move_effect/attack_up.c
+++ b/test/battle/move_effect/attack_up.c
@@ -22,7 +22,7 @@ SINGLE_BATTLE_TEST("Meditate raises Attack", s16 damage)
         if (raiseAttack) {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_MEDITATE, player);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-            MESSAGE("Wobbuffet's Attack rose!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Attack rose!");
         }
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, player);
         HP_BAR(opponent, captureDamage: &results[i].damage);

--- a/test/battle/move_effect/attack_up_user_ally.c
+++ b/test/battle/move_effect/attack_up_user_ally.c
@@ -22,7 +22,7 @@ SINGLE_BATTLE_TEST("Howl raises user's Attack", s16 damage)
         if (raiseAttack) {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_HOWL, player);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-            MESSAGE("Wobbuffet's Attack rose!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Attack rose!");
         }
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, player);
         HP_BAR(opponent, captureDamage: &results[i].damage);
@@ -50,9 +50,9 @@ DOUBLE_BATTLE_TEST("Howl raises user's and partner's Attack", s16 damageLeft, s1
         if (raiseAttack) {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_HOWL, playerLeft);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
-            MESSAGE("Wobbuffet's Attack rose!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Attack rose!");
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerRight);
-            MESSAGE("Wynaut's Attack rose!");
+            MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) "'s Attack rose!");
         }
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, playerLeft);
         HP_BAR(opponentLeft, captureDamage: &results[i].damageLeft);
@@ -83,13 +83,13 @@ DOUBLE_BATTLE_TEST("Howl does not work on partner if it has Soundproof")
 
         ANIMATION(ANIM_TYPE_MOVE, MOVE_HOWL, playerLeft);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
-        MESSAGE("Wobbuffet's Attack rose!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Attack rose!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerRight);
-            MESSAGE("Wynaut's Attack rose!");
+            MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) "'s Attack rose!");
         }
         ABILITY_POPUP(playerRight, ABILITY_SOUNDPROOF);
-        MESSAGE("Voltorb's Soundproof blocks Howl!");
+        MESSAGE(SPECIES_NAME(SPECIES_VOLTORB) "'s Soundproof blocks Howl!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, playerRight);
         HP_BAR(opponentLeft, captureDamage: &damage[1]);
     } THEN {

--- a/test/battle/move_effect/axe_kick.c
+++ b/test/battle/move_effect/axe_kick.c
@@ -46,7 +46,7 @@ SINGLE_BATTLE_TEST("Axe Kick deals damage half the hp to user if it fails")
         TURN { MOVE(player, MOVE_AXE_KICK, hit: FALSE); }
     } SCENE {
         s32 maxHP = GetMonData(&PLAYER_PARTY[0], MON_DATA_MAX_HP);
-        MESSAGE("Wobbuffet used Axe Kick!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_AXE_KICK) "!");
         MESSAGE("Wobbuffet's attack missed!");
         MESSAGE("Wobbuffet kept going and crashed!");
         HP_BAR(player, hp: maxHP / 2);

--- a/test/battle/move_effect/axe_kick.c
+++ b/test/battle/move_effect/axe_kick.c
@@ -30,8 +30,8 @@ SINGLE_BATTLE_TEST("Axe Kick deals damage half the hp to user if def battler pro
     } SCENE {
         s32 maxHP = GetMonData(&PLAYER_PARTY[0], MON_DATA_MAX_HP);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_PROTECT, opponent);
-        MESSAGE("Foe Wobbuffet protected itself!");
-        MESSAGE("Foe Wobbuffet protected itself!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " protected itself!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " protected itself!");
         MESSAGE("Wobbuffet kept going and crashed!");
         HP_BAR(player, hp: maxHP / 2);
     }

--- a/test/battle/move_effect/axe_kick.c
+++ b/test/battle/move_effect/axe_kick.c
@@ -16,7 +16,7 @@ SINGLE_BATTLE_TEST("Axe Kick confuses the target")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_AXE_KICK, player);
         ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_CONFUSION, opponent);
-        MESSAGE("Foe Wobbuffet became confused!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " became confused!");
     }
 }
 
@@ -46,8 +46,8 @@ SINGLE_BATTLE_TEST("Axe Kick deals damage half the hp to user if it fails")
         TURN { MOVE(player, MOVE_AXE_KICK, hit: FALSE); }
     } SCENE {
         s32 maxHP = GetMonData(&PLAYER_PARTY[0], MON_DATA_MAX_HP);
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_AXE_KICK) "!");
-        MESSAGE("Wobbuffet's attack missed!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_AXE_KICK) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s attack missed!");
         MESSAGE("Wobbuffet kept going and crashed!");
         HP_BAR(player, hp: maxHP / 2);
     }

--- a/test/battle/move_effect/beak_blast.c
+++ b/test/battle/move_effect/beak_blast.c
@@ -20,14 +20,14 @@ DOUBLE_BATTLE_TEST("Beak Blast's charging message is shown before other moves ar
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_BEAK_BLAST_SETUP, playerLeft);
         MESSAGE("Wynaut started heating up its beak!");
 
-        MESSAGE("Wobbuffet used Celebrate!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, playerRight);
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponentRight);
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponentLeft);
 
-        MESSAGE("Wynaut used Beak Blast!");
+        MESSAGE("Wynaut used " MOVE_NAME(MOVE_BEAK_BLAST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BEAK_BLAST, playerLeft);
         HP_BAR(opponentLeft);
     }
@@ -48,24 +48,24 @@ DOUBLE_BATTLE_TEST("Beak Blast burns all who make contact with the pokemon")
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_BEAK_BLAST_SETUP, playerLeft);
         MESSAGE("Wynaut started heating up its beak!");
 
-        MESSAGE("Wobbuffet used Celebrate!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, playerRight);
 
-        MESSAGE("Foe Wobbuffet used Tackle!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentLeft);
         HP_BAR(playerLeft);
         ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, opponentLeft);
         MESSAGE("Foe Wobbuffet was burned!");
         STATUS_ICON(opponentLeft, burn: TRUE);
 
-        MESSAGE("Foe Wobbuffet used Tackle!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentRight);
         HP_BAR(playerLeft);
         ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, opponentRight);
         MESSAGE("Foe Wobbuffet was burned!");
         STATUS_ICON(opponentRight, burn: TRUE);
 
-        MESSAGE("Wynaut used Beak Blast!");
+        MESSAGE("Wynaut used " MOVE_NAME(MOVE_BEAK_BLAST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BEAK_BLAST, playerLeft);
         HP_BAR(opponentLeft);
     }
@@ -106,7 +106,7 @@ SINGLE_BATTLE_TEST("Beak Blast burns only when contact moves are used")
             }
         }
 
-        MESSAGE("Wobbuffet used Beak Blast!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_BEAK_BLAST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BEAK_BLAST, player);
         HP_BAR(opponent);
     }

--- a/test/battle/move_effect/beak_blast.c
+++ b/test/battle/move_effect/beak_blast.c
@@ -20,14 +20,14 @@ DOUBLE_BATTLE_TEST("Beak Blast's charging message is shown before other moves ar
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_BEAK_BLAST_SETUP, playerLeft);
         MESSAGE("Wynaut started heating up its beak!");
 
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, playerRight);
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponentRight);
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponentLeft);
 
-        MESSAGE("Wynaut used " MOVE_NAME(MOVE_BEAK_BLAST) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " used " MOVE_NAME(MOVE_BEAK_BLAST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BEAK_BLAST, playerLeft);
         HP_BAR(opponentLeft);
     }
@@ -48,24 +48,24 @@ DOUBLE_BATTLE_TEST("Beak Blast burns all who make contact with the pokemon")
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_BEAK_BLAST_SETUP, playerLeft);
         MESSAGE("Wynaut started heating up its beak!");
 
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, playerRight);
 
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentLeft);
         HP_BAR(playerLeft);
         ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, opponentLeft);
-        MESSAGE("Foe Wobbuffet was burned!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " was burned!");
         STATUS_ICON(opponentLeft, burn: TRUE);
 
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentRight);
         HP_BAR(playerLeft);
         ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, opponentRight);
-        MESSAGE("Foe Wobbuffet was burned!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " was burned!");
         STATUS_ICON(opponentRight, burn: TRUE);
 
-        MESSAGE("Wynaut used " MOVE_NAME(MOVE_BEAK_BLAST) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " used " MOVE_NAME(MOVE_BEAK_BLAST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BEAK_BLAST, playerLeft);
         HP_BAR(opponentLeft);
     }
@@ -95,18 +95,18 @@ SINGLE_BATTLE_TEST("Beak Blast burns only when contact moves are used")
 
         if (burn) {
             ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, opponent);
-            MESSAGE("Foe Wobbuffet was burned!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " was burned!");
             STATUS_ICON(opponent, burn: TRUE);
         }
         else {
             NONE_OF {
                 ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, opponent);
-                MESSAGE("Foe Wobbuffet was burned!");
+                MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " was burned!");
                 STATUS_ICON(opponent, burn: TRUE);
             }
         }
 
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_BEAK_BLAST) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_BEAK_BLAST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BEAK_BLAST, player);
         HP_BAR(opponent);
     }

--- a/test/battle/move_effect/bide.c
+++ b/test/battle/move_effect/bide.c
@@ -22,7 +22,7 @@ SINGLE_BATTLE_TEST("Bide deals twice the taken damage over two turns")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BIDE, player);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
         HP_BAR(player, captureDamage: &damage1);
-        MESSAGE("Wobbuffet is storing energy!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is storing energy!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
         HP_BAR(player, captureDamage: &damage2);
         MESSAGE("Wobbuffet unleashed energy!");

--- a/test/battle/move_effect/bug_bite.c
+++ b/test/battle/move_effect/bug_bite.c
@@ -45,9 +45,9 @@ SINGLE_BATTLE_TEST("Bug Bite eats the target's berry and immediately gains its e
 
     } SCENE {
         if (item == ITEM_CHESTO_BERRY) {
-            MESSAGE("Wobbuffet used Sleep Talk!");
+            MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SLEEP_TALK) "!");
         }
-        MESSAGE("Wobbuffet used Bug Bite!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_BUG_BITE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BUG_BITE, player);
         HP_BAR(opponent);
         if (effect == HOLD_EFFECT_RESTORE_HP || effect == HOLD_EFFECT_ENIGMA_BERRY) {
@@ -124,7 +124,7 @@ SINGLE_BATTLE_TEST("Tanga Berry activates before Bug Bite")
     } WHEN {
         TURN { MOVE(player, MOVE_BUG_BITE); }
     } SCENE {
-        MESSAGE("Wobbuffet used Bug Bite!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_BUG_BITE) "!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
         MESSAGE("Foe Wobbuffet ate its Tanga Berry!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BUG_BITE, player);

--- a/test/battle/move_effect/bug_bite.c
+++ b/test/battle/move_effect/bug_bite.c
@@ -126,10 +126,10 @@ SINGLE_BATTLE_TEST("Tanga Berry activates before Bug Bite")
     } SCENE {
         MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_BUG_BITE) "!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-        MESSAGE("Foe Wobbuffet ate its Tanga Berry!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " ate its Tanga Berry!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BUG_BITE, player);
         HP_BAR(opponent);
-        MESSAGE("Tanga Berry weakened the damage to Foe Wobbuffet!");
+        MESSAGE("Tanga Berry weakened the damage to Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
     } THEN {
         EXPECT_EQ(player->item, ITEM_NONE);
     }

--- a/test/battle/move_effect/bug_bite.c
+++ b/test/battle/move_effect/bug_bite.c
@@ -45,35 +45,35 @@ SINGLE_BATTLE_TEST("Bug Bite eats the target's berry and immediately gains its e
 
     } SCENE {
         if (item == ITEM_CHESTO_BERRY) {
-            MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SLEEP_TALK) "!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SLEEP_TALK) "!");
         }
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_BUG_BITE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_BUG_BITE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BUG_BITE, player);
         HP_BAR(opponent);
         if (effect == HOLD_EFFECT_RESTORE_HP || effect == HOLD_EFFECT_ENIGMA_BERRY) {
             if (item == ITEM_ORAN_BERRY) {
-                MESSAGE("Wobbuffet's Oran Berry restored health!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Oran Berry restored health!");
             } else if (item == ITEM_SITRUS_BERRY) {
-                MESSAGE("Wobbuffet's Sitrus Berry restored health!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Sitrus Berry restored health!");
             } else {
-                MESSAGE("Wobbuffet's Enigma Berry restored health!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Enigma Berry restored health!");
             }
             HP_BAR(player);
         }
         else if (effect == HOLD_EFFECT_RESTORE_PP) {
-            MESSAGE("Wobbuffet's Leppa Berry restored Bug Bite's PP!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Leppa Berry restored Bug Bite's PP!");
         }
         else if (status1 != STATUS1_NONE) {
             if (status1 == STATUS1_BURN) {
-                MESSAGE("Wobbuffet's Rawst Berry healed its burn!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Rawst Berry healed its burn!");
             } else if (status1 == STATUS1_SLEEP) {
-                MESSAGE("Wobbuffet's Chesto Berry woke it from its sleep!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Chesto Berry woke it from its sleep!");
             } else if (status1 == STATUS1_PARALYSIS) {
-                MESSAGE("Wobbuffet's Cheri Berry cured paralysis!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Cheri Berry cured paralysis!");
             } else if (status1 == STATUS1_TOXIC_POISON || status1 == STATUS1_POISON) {
-                MESSAGE("Wobbuffet's Pecha Berry cured poison!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Pecha Berry cured poison!");
             } else if (status1 == STATUS1_FROSTBITE) {
-                MESSAGE("Wobbuffet's Aspear Berry healed its frostbite!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Aspear Berry healed its frostbite!");
             }
             NOT STATUS_ICON(player, status1);
         }
@@ -124,7 +124,7 @@ SINGLE_BATTLE_TEST("Tanga Berry activates before Bug Bite")
     } WHEN {
         TURN { MOVE(player, MOVE_BUG_BITE); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_BUG_BITE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_BUG_BITE) "!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
         MESSAGE("Foe Wobbuffet ate its Tanga Berry!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BUG_BITE, player);

--- a/test/battle/move_effect/burn_up.c
+++ b/test/battle/move_effect/burn_up.c
@@ -19,7 +19,7 @@ SINGLE_BATTLE_TEST("Burn Up user loses its Fire-type")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BURN_UP, player);
         MESSAGE("Cyndaquil burned itself out!");
-        MESSAGE("Cyndaquil used " MOVE_NAME(MOVE_BURN_UP) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_CYNDAQUIL) " used " MOVE_NAME(MOVE_BURN_UP) "!");
         MESSAGE("But it failed!");
     }
 }
@@ -33,7 +33,7 @@ SINGLE_BATTLE_TEST("Burn Up fails if the user isn't a Fire-type")
         TURN { MOVE(player, MOVE_BURN_UP); }
     } SCENE {
         NONE_OF { ANIMATION(ANIM_TYPE_MOVE, MOVE_BURN_UP, player); }
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_BURN_UP) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_BURN_UP) "!");
         MESSAGE("But it failed!");
     }
 }

--- a/test/battle/move_effect/burn_up.c
+++ b/test/battle/move_effect/burn_up.c
@@ -19,7 +19,7 @@ SINGLE_BATTLE_TEST("Burn Up user loses its Fire-type")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BURN_UP, player);
         MESSAGE("Cyndaquil burned itself out!");
-        MESSAGE("Cyndaquil used Burn Up!");
+        MESSAGE("Cyndaquil used " MOVE_NAME(MOVE_BURN_UP) "!");
         MESSAGE("But it failed!");
     }
 }
@@ -33,7 +33,7 @@ SINGLE_BATTLE_TEST("Burn Up fails if the user isn't a Fire-type")
         TURN { MOVE(player, MOVE_BURN_UP); }
     } SCENE {
         NONE_OF { ANIMATION(ANIM_TYPE_MOVE, MOVE_BURN_UP, player); }
-        MESSAGE("Wobbuffet used Burn Up!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_BURN_UP) "!");
         MESSAGE("But it failed!");
     }
 }

--- a/test/battle/move_effect/corrosive_gas.c
+++ b/test/battle/move_effect/corrosive_gas.c
@@ -19,7 +19,7 @@ SINGLE_BATTLE_TEST("Corrosive Gas destroys the target's item or fails if the tar
     } WHEN {
         TURN { MOVE(player, MOVE_CORROSIVE_GAS); }
     } SCENE {
-        MESSAGE("Wobbuffet used CorrosiveGas!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CORROSIVE_GAS) "!");
         if (item == ITEM_POTION) {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_CORROSIVE_GAS, player);
             MESSAGE("Wobbuffet corroded Foe Wobbuffet's Potion!");
@@ -40,11 +40,11 @@ SINGLE_BATTLE_TEST("Corrosive Gas doesn't destroy the item of a Pokemon with the
     } WHEN {
         TURN { MOVE(player, MOVE_CORROSIVE_GAS); }
     } SCENE {
-        MESSAGE("Wobbuffet used CorrosiveGas!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CORROSIVE_GAS) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CORROSIVE_GAS, player);
         NOT MESSAGE("Wobbuffet corroded Foe Wobbuffet's Potion!");
         ABILITY_POPUP(opponent, ABILITY_STICKY_HOLD);
-        MESSAGE("Foe Muk's Sticky Hold made CorrosiveGas ineffective!");
+        MESSAGE("Foe Muk's Sticky Hold made " MOVE_NAME(MOVE_CORROSIVE_GAS) " ineffective!");
     } THEN {
         EXPECT_EQ(opponent->item, ITEM_POISON_BARB);
     }
@@ -59,10 +59,10 @@ SINGLE_BATTLE_TEST("Items lost to Corrosive Gas cannot be restored by Recycle")
     } WHEN {
         TURN { MOVE(player, MOVE_CORROSIVE_GAS); MOVE(opponent, MOVE_RECYCLE); }
     } SCENE {
-        MESSAGE("Wobbuffet used CorrosiveGas!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CORROSIVE_GAS) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CORROSIVE_GAS, player);
         MESSAGE("Wobbuffet corroded Foe Wobbuffet's Oran Berry!");
-        MESSAGE("Foe Wobbuffet used Recycle!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_RECYCLE) "!");
         MESSAGE("But it failed!");
     } THEN {
         EXPECT_EQ(opponent->item, ITEM_NONE);
@@ -93,7 +93,7 @@ DOUBLE_BATTLE_TEST("Corrosive Gas destroys foes and ally's items if they have on
     } WHEN {
         TURN { MOVE(playerRight, MOVE_CORROSIVE_GAS); }
     } SCENE {
-        MESSAGE("Wynaut used CorrosiveGas!");
+        MESSAGE("Wynaut used " MOVE_NAME(MOVE_CORROSIVE_GAS) "!");
         if (itemPlayerLeft == ITEM_CHERI_BERRY) {
             MESSAGE("Wynaut corroded Wobbuffet's Cheri Berry!");
         } else {

--- a/test/battle/move_effect/corrosive_gas.c
+++ b/test/battle/move_effect/corrosive_gas.c
@@ -22,10 +22,10 @@ SINGLE_BATTLE_TEST("Corrosive Gas destroys the target's item or fails if the tar
         MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CORROSIVE_GAS) "!");
         if (item == ITEM_POTION) {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_CORROSIVE_GAS, player);
-            MESSAGE("Wobbuffet corroded Foe Wobbuffet's Potion!");
+            MESSAGE("Wobbuffet corroded Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Potion!");
         }
         else {
-            MESSAGE("It had no effect on Foe Wobbuffet!");
+            MESSAGE("It had no effect on Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
         }
     } THEN {
         EXPECT_EQ(opponent->item, ITEM_NONE);
@@ -42,7 +42,7 @@ SINGLE_BATTLE_TEST("Corrosive Gas doesn't destroy the item of a Pokemon with the
     } SCENE {
         MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CORROSIVE_GAS) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CORROSIVE_GAS, player);
-        NOT MESSAGE("Wobbuffet corroded Foe Wobbuffet's Potion!");
+        NOT MESSAGE("Wobbuffet corroded Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Potion!");
         ABILITY_POPUP(opponent, ABILITY_STICKY_HOLD);
         MESSAGE("Foe " SPECIES_NAME(SPECIES_MUK) "'s Sticky Hold made " MOVE_NAME(MOVE_CORROSIVE_GAS) " ineffective!");
     } THEN {
@@ -61,7 +61,7 @@ SINGLE_BATTLE_TEST("Items lost to Corrosive Gas cannot be restored by Recycle")
     } SCENE {
         MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CORROSIVE_GAS) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CORROSIVE_GAS, player);
-        MESSAGE("Wobbuffet corroded Foe Wobbuffet's Oran Berry!");
+        MESSAGE("Wobbuffet corroded Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Oran Berry!");
         MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_RECYCLE) "!");
         MESSAGE("But it failed!");
     } THEN {
@@ -100,14 +100,14 @@ DOUBLE_BATTLE_TEST("Corrosive Gas destroys foes and ally's items if they have on
             MESSAGE("It had no effect on Wobbuffet!");
         }
         if (itemOpponentLeft == ITEM_ORAN_BERRY) {
-            MESSAGE("Wynaut corroded Foe Abra's Oran Berry!");
+            MESSAGE("Wynaut corroded Foe " SPECIES_NAME(SPECIES_ABRA) "'s Oran Berry!");
         } else {
-            MESSAGE("It had no effect on Foe Abra!");
+            MESSAGE("It had no effect on Foe " SPECIES_NAME(SPECIES_ABRA) "!");
         }
         if (itemOpponentRight == ITEM_CHESTO_BERRY) {
-            MESSAGE("Wynaut corroded Foe Kadabra's Chesto Berry!");
+            MESSAGE("Wynaut corroded Foe " SPECIES_NAME(SPECIES_KADABRA) "'s Chesto Berry!");
         } else {
-            MESSAGE("It had no effect on Foe Kadabra!");
+            MESSAGE("It had no effect on Foe " SPECIES_NAME(SPECIES_KADABRA) "!");
         }
 
     } THEN {

--- a/test/battle/move_effect/corrosive_gas.c
+++ b/test/battle/move_effect/corrosive_gas.c
@@ -19,7 +19,7 @@ SINGLE_BATTLE_TEST("Corrosive Gas destroys the target's item or fails if the tar
     } WHEN {
         TURN { MOVE(player, MOVE_CORROSIVE_GAS); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CORROSIVE_GAS) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CORROSIVE_GAS) "!");
         if (item == ITEM_POTION) {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_CORROSIVE_GAS, player);
             MESSAGE("Wobbuffet corroded Foe Wobbuffet's Potion!");
@@ -40,11 +40,11 @@ SINGLE_BATTLE_TEST("Corrosive Gas doesn't destroy the item of a Pokemon with the
     } WHEN {
         TURN { MOVE(player, MOVE_CORROSIVE_GAS); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CORROSIVE_GAS) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CORROSIVE_GAS) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CORROSIVE_GAS, player);
         NOT MESSAGE("Wobbuffet corroded Foe Wobbuffet's Potion!");
         ABILITY_POPUP(opponent, ABILITY_STICKY_HOLD);
-        MESSAGE("Foe Muk's Sticky Hold made " MOVE_NAME(MOVE_CORROSIVE_GAS) " ineffective!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_MUK) "'s Sticky Hold made " MOVE_NAME(MOVE_CORROSIVE_GAS) " ineffective!");
     } THEN {
         EXPECT_EQ(opponent->item, ITEM_POISON_BARB);
     }
@@ -59,10 +59,10 @@ SINGLE_BATTLE_TEST("Items lost to Corrosive Gas cannot be restored by Recycle")
     } WHEN {
         TURN { MOVE(player, MOVE_CORROSIVE_GAS); MOVE(opponent, MOVE_RECYCLE); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CORROSIVE_GAS) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CORROSIVE_GAS) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CORROSIVE_GAS, player);
         MESSAGE("Wobbuffet corroded Foe Wobbuffet's Oran Berry!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_RECYCLE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_RECYCLE) "!");
         MESSAGE("But it failed!");
     } THEN {
         EXPECT_EQ(opponent->item, ITEM_NONE);
@@ -93,7 +93,7 @@ DOUBLE_BATTLE_TEST("Corrosive Gas destroys foes and ally's items if they have on
     } WHEN {
         TURN { MOVE(playerRight, MOVE_CORROSIVE_GAS); }
     } SCENE {
-        MESSAGE("Wynaut used " MOVE_NAME(MOVE_CORROSIVE_GAS) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " used " MOVE_NAME(MOVE_CORROSIVE_GAS) "!");
         if (itemPlayerLeft == ITEM_CHERI_BERRY) {
             MESSAGE("Wynaut corroded Wobbuffet's Cheri Berry!");
         } else {

--- a/test/battle/move_effect/court_change.c
+++ b/test/battle/move_effect/court_change.c
@@ -21,24 +21,24 @@ DOUBLE_BATTLE_TEST("Court Change swaps entry hazards used by the opponent")
         TURN { MOVE(playerLeft, MOVE_COURT_CHANGE); }
         TURN { SWITCH(playerLeft, 2); SWITCH(opponentLeft, 2); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_STICKY_WEB) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_STEALTH_ROCK) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_SPIKES) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TOXIC_SPIKES) "!");
-        MESSAGE("Wynaut used " MOVE_NAME(MOVE_COURT_CHANGE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_STICKY_WEB) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_STEALTH_ROCK) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SPIKES) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TOXIC_SPIKES) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " used " MOVE_NAME(MOVE_COURT_CHANGE) "!");
         MESSAGE("Wynaut swapped the battle effects affecting each side!");
-        MESSAGE("Go! Wynaut!");
+        MESSAGE("Go! " SPECIES_NAME(SPECIES_WYNAUT) "!");
         NONE_OF {
-            MESSAGE("Wynaut is hurt by spikes!");
+            MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " is hurt by spikes!");
             MESSAGE("Pointed stones dug into Wynaut!");
-            MESSAGE("Wynaut was poisoned!");
-            MESSAGE("Wynaut was caught in a Sticky Web!");
+            MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " was poisoned!");
+            MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " was caught in a Sticky Web!");
         }
-        MESSAGE("2 sent out Wobbuffet!");
-        MESSAGE("Foe Wobbuffet is hurt by spikes!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is hurt by spikes!");
         MESSAGE("Pointed stones dug into Foe Wobbuffet!");
-        MESSAGE("Foe Wobbuffet was poisoned!");
-        MESSAGE("Foe Wobbuffet was caught in a Sticky Web!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " was poisoned!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " was caught in a Sticky Web!");
     }
 }
 
@@ -57,23 +57,23 @@ DOUBLE_BATTLE_TEST("Court Change swaps entry hazards used by the player")
         TURN { MOVE(opponentLeft, MOVE_COURT_CHANGE); }
         TURN { SWITCH(opponentLeft, 2); SWITCH(playerLeft, 2); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_STICKY_WEB) "!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_STEALTH_ROCK) "!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SPIKES) "!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TOXIC_SPIKES) "!");
-        MESSAGE("Foe Wynaut used " MOVE_NAME(MOVE_COURT_CHANGE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_STICKY_WEB) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_STEALTH_ROCK) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SPIKES) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TOXIC_SPIKES) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " used " MOVE_NAME(MOVE_COURT_CHANGE) "!");
         MESSAGE("Foe Wynaut swapped the battle effects affecting each side!");
-        MESSAGE("Go! Wobbuffet!");
-        MESSAGE("Wobbuffet is hurt by spikes!");
+        MESSAGE("Go! " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is hurt by spikes!");
         MESSAGE("Pointed stones dug into Wobbuffet!");
-        MESSAGE("Wobbuffet was poisoned!");
-        MESSAGE("Wobbuffet was caught in a Sticky Web!");
-        MESSAGE("2 sent out Wynaut!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was poisoned!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was caught in a Sticky Web!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WYNAUT) "!");
         NONE_OF {
-            MESSAGE("Foe Wynaut is hurt by spikes!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " is hurt by spikes!");
             MESSAGE("Pointed stones dug into Foe Wynaut!");
-            MESSAGE("Foe Wynaut was poisoned!");
-            MESSAGE("Foe Wynaut was caught in a Sticky Web!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " was poisoned!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " was caught in a Sticky Web!");
         }
     }
 }
@@ -97,13 +97,13 @@ DOUBLE_BATTLE_TEST("Court Change used by the player swaps Mist, Safeguard, Lucky
         TURN { }
         TURN { }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_MIST) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_SAFEGUARD) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_LUCKY_CHANT) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_REFLECT) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_LIGHT_SCREEN) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TAILWIND) "!");
-        MESSAGE("Wynaut used " MOVE_NAME(MOVE_COURT_CHANGE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_MIST) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SAFEGUARD) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_LUCKY_CHANT) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_REFLECT) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_LIGHT_SCREEN) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TAILWIND) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " used " MOVE_NAME(MOVE_COURT_CHANGE) "!");
         MESSAGE("Wynaut swapped the battle effects affecting each side!");
         // The effects now end for the player side.
         MESSAGE("Ally's Mist wore off!");
@@ -134,13 +134,13 @@ DOUBLE_BATTLE_TEST("Court Change used by the opponent swaps Mist, Safeguard, Luc
         TURN { }
         TURN { }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_MIST) "!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SAFEGUARD) "!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LUCKY_CHANT) "!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_REFLECT) "!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LIGHT_SCREEN) "!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TAILWIND) "!");
-        MESSAGE("Foe Wynaut used " MOVE_NAME(MOVE_COURT_CHANGE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_MIST) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SAFEGUARD) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_LUCKY_CHANT) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_REFLECT) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_LIGHT_SCREEN) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TAILWIND) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " used " MOVE_NAME(MOVE_COURT_CHANGE) "!");
         MESSAGE("Foe Wynaut swapped the battle effects affecting each side!");
         // The effects now end for the player side.
         MESSAGE("Foe's Mist wore off!");

--- a/test/battle/move_effect/court_change.c
+++ b/test/battle/move_effect/court_change.c
@@ -21,11 +21,11 @@ DOUBLE_BATTLE_TEST("Court Change swaps entry hazards used by the opponent")
         TURN { MOVE(playerLeft, MOVE_COURT_CHANGE); }
         TURN { SWITCH(playerLeft, 2); SWITCH(opponentLeft, 2); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used Sticky Web!");
-        MESSAGE("Foe Wobbuffet used Stealth Rock!");
-        MESSAGE("Foe Wobbuffet used Spikes!");
-        MESSAGE("Foe Wobbuffet used Toxic Spikes!");
-        MESSAGE("Wynaut used Court Change!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_STICKY_WEB) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_STEALTH_ROCK) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_SPIKES) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TOXIC_SPIKES) "!");
+        MESSAGE("Wynaut used " MOVE_NAME(MOVE_COURT_CHANGE) "!");
         MESSAGE("Wynaut swapped the battle effects affecting each side!");
         MESSAGE("Go! Wynaut!");
         NONE_OF {
@@ -57,11 +57,11 @@ DOUBLE_BATTLE_TEST("Court Change swaps entry hazards used by the player")
         TURN { MOVE(opponentLeft, MOVE_COURT_CHANGE); }
         TURN { SWITCH(opponentLeft, 2); SWITCH(playerLeft, 2); }
     } SCENE {
-        MESSAGE("Wobbuffet used Sticky Web!");
-        MESSAGE("Wobbuffet used Stealth Rock!");
-        MESSAGE("Wobbuffet used Spikes!");
-        MESSAGE("Wobbuffet used Toxic Spikes!");
-        MESSAGE("Foe Wynaut used Court Change!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_STICKY_WEB) "!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_STEALTH_ROCK) "!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SPIKES) "!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TOXIC_SPIKES) "!");
+        MESSAGE("Foe Wynaut used " MOVE_NAME(MOVE_COURT_CHANGE) "!");
         MESSAGE("Foe Wynaut swapped the battle effects affecting each side!");
         MESSAGE("Go! Wobbuffet!");
         MESSAGE("Wobbuffet is hurt by spikes!");
@@ -97,13 +97,13 @@ DOUBLE_BATTLE_TEST("Court Change used by the player swaps Mist, Safeguard, Lucky
         TURN { }
         TURN { }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used Mist!");
-        MESSAGE("Foe Wobbuffet used Safeguard!");
-        MESSAGE("Foe Wobbuffet used Lucky Chant!");
-        MESSAGE("Foe Wobbuffet used Reflect!");
-        MESSAGE("Foe Wobbuffet used Light Screen!");
-        MESSAGE("Foe Wobbuffet used Tailwind!");
-        MESSAGE("Wynaut used Court Change!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_MIST) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_SAFEGUARD) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_LUCKY_CHANT) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_REFLECT) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_LIGHT_SCREEN) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TAILWIND) "!");
+        MESSAGE("Wynaut used " MOVE_NAME(MOVE_COURT_CHANGE) "!");
         MESSAGE("Wynaut swapped the battle effects affecting each side!");
         // The effects now end for the player side.
         MESSAGE("Ally's Mist wore off!");
@@ -134,13 +134,13 @@ DOUBLE_BATTLE_TEST("Court Change used by the opponent swaps Mist, Safeguard, Luc
         TURN { }
         TURN { }
     } SCENE {
-        MESSAGE("Wobbuffet used Mist!");
-        MESSAGE("Wobbuffet used Safeguard!");
-        MESSAGE("Wobbuffet used Lucky Chant!");
-        MESSAGE("Wobbuffet used Reflect!");
-        MESSAGE("Wobbuffet used Light Screen!");
-        MESSAGE("Wobbuffet used Tailwind!");
-        MESSAGE("Foe Wynaut used Court Change!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_MIST) "!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SAFEGUARD) "!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LUCKY_CHANT) "!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_REFLECT) "!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LIGHT_SCREEN) "!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TAILWIND) "!");
+        MESSAGE("Foe Wynaut used " MOVE_NAME(MOVE_COURT_CHANGE) "!");
         MESSAGE("Foe Wynaut swapped the battle effects affecting each side!");
         // The effects now end for the player side.
         MESSAGE("Foe's Mist wore off!");

--- a/test/battle/move_effect/court_change.c
+++ b/test/battle/move_effect/court_change.c
@@ -26,7 +26,7 @@ DOUBLE_BATTLE_TEST("Court Change swaps entry hazards used by the opponent")
         MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SPIKES) "!");
         MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TOXIC_SPIKES) "!");
         MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " used " MOVE_NAME(MOVE_COURT_CHANGE) "!");
-        MESSAGE("Wynaut swapped the battle effects affecting each side!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " swapped the battle effects affecting each side!");
         MESSAGE("Go! " SPECIES_NAME(SPECIES_WYNAUT) "!");
         NONE_OF {
             MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " is hurt by spikes!");
@@ -36,7 +36,7 @@ DOUBLE_BATTLE_TEST("Court Change swaps entry hazards used by the opponent")
         }
         MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
         MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is hurt by spikes!");
-        MESSAGE("Pointed stones dug into Foe Wobbuffet!");
+        MESSAGE("Pointed stones dug into Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
         MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " was poisoned!");
         MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " was caught in a Sticky Web!");
     }
@@ -62,7 +62,7 @@ DOUBLE_BATTLE_TEST("Court Change swaps entry hazards used by the player")
         MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SPIKES) "!");
         MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TOXIC_SPIKES) "!");
         MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " used " MOVE_NAME(MOVE_COURT_CHANGE) "!");
-        MESSAGE("Foe Wynaut swapped the battle effects affecting each side!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " swapped the battle effects affecting each side!");
         MESSAGE("Go! " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
         MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is hurt by spikes!");
         MESSAGE("Pointed stones dug into Wobbuffet!");
@@ -71,7 +71,7 @@ DOUBLE_BATTLE_TEST("Court Change swaps entry hazards used by the player")
         MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WYNAUT) "!");
         NONE_OF {
             MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " is hurt by spikes!");
-            MESSAGE("Pointed stones dug into Foe Wynaut!");
+            MESSAGE("Pointed stones dug into Foe " SPECIES_NAME(SPECIES_WYNAUT) "!");
             MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " was poisoned!");
             MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " was caught in a Sticky Web!");
         }
@@ -104,7 +104,7 @@ DOUBLE_BATTLE_TEST("Court Change used by the player swaps Mist, Safeguard, Lucky
         MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_LIGHT_SCREEN) "!");
         MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TAILWIND) "!");
         MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " used " MOVE_NAME(MOVE_COURT_CHANGE) "!");
-        MESSAGE("Wynaut swapped the battle effects affecting each side!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " swapped the battle effects affecting each side!");
         // The effects now end for the player side.
         MESSAGE("Ally's Mist wore off!");
         MESSAGE("Ally's party is no longer protected by Safeguard!");
@@ -141,7 +141,7 @@ DOUBLE_BATTLE_TEST("Court Change used by the opponent swaps Mist, Safeguard, Luc
         MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_LIGHT_SCREEN) "!");
         MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TAILWIND) "!");
         MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " used " MOVE_NAME(MOVE_COURT_CHANGE) "!");
-        MESSAGE("Foe Wynaut swapped the battle effects affecting each side!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " swapped the battle effects affecting each side!");
         // The effects now end for the player side.
         MESSAGE("Foe's Mist wore off!");
         MESSAGE("Foe's party is no longer protected by Safeguard!");

--- a/test/battle/move_effect/defense_down.c
+++ b/test/battle/move_effect/defense_down.c
@@ -22,7 +22,7 @@ SINGLE_BATTLE_TEST("Tail Whip lowers Defense", s16 damage)
         if (lowerDefense) {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_TAIL_WHIP, player);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-            MESSAGE("Foe Wobbuffet's Defense fell!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Defense fell!");
         }
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, player);
         HP_BAR(opponent, captureDamage: &results[i].damage);

--- a/test/battle/move_effect/defense_up.c
+++ b/test/battle/move_effect/defense_up.c
@@ -22,7 +22,7 @@ SINGLE_BATTLE_TEST("Harden raises Defense", s16 damage)
         if (raiseDefense) {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_HARDEN, player);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-            MESSAGE("Wobbuffet's Defense rose!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Defense rose!");
         }
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
         HP_BAR(player, captureDamage: &results[i].damage);

--- a/test/battle/move_effect/defog.c
+++ b/test/battle/move_effect/defog.c
@@ -29,7 +29,7 @@ SINGLE_BATTLE_TEST("Defog lowers evasiveness by 1")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DEFOG, player);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-        MESSAGE("Foe Wobbuffet's evasiveness fell!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s evasiveness fell!");
     }
 }
 
@@ -41,12 +41,12 @@ SINGLE_BATTLE_TEST("Defog does not lower evasiveness if target behind Substitute
     } WHEN {
         TURN { MOVE(opponent, MOVE_SUBSTITUTE); MOVE(player, MOVE_DEFOG); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_SUBSTITUTE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SUBSTITUTE) "!");
         MESSAGE("But it failed!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_DEFOG, player);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-            MESSAGE("Foe Wobbuffet's evasiveness fell!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s evasiveness fell!");
         }
     }
 }
@@ -72,13 +72,13 @@ DOUBLE_BATTLE_TEST("Defog lowers evasiveness by 1 and removes Reflect and Light 
         ANIMATION(ANIM_TYPE_MOVE, move, playerLeft);
         if (move == MOVE_DEFOG) {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
-            MESSAGE("Foe Wobbuffet's evasiveness fell!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s evasiveness fell!");
             MESSAGE("Foe's Reflect wore off!");
             MESSAGE("Foe's Light Screen wore off!");
         }
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
         HP_BAR(opponentLeft, captureDamage: &results[i].damagePhysical);
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_GUST) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_GUST) "!");
         HP_BAR(opponentRight, captureDamage: &results[i].damageSpecial);
     } FINALLY {
         EXPECT_MUL_EQ(results[1].damagePhysical, Q_4_12(1.5), results[0].damagePhysical);
@@ -105,27 +105,27 @@ DOUBLE_BATTLE_TEST("Defog lowers evasiveness by 1 and removes Mist and Safeguard
         ANIMATION(ANIM_TYPE_MOVE, MOVE_MIST, opponentLeft);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SAFEGUARD, opponentRight);
         if (move == MOVE_DEFOG) {
-            MESSAGE("Foe Wobbuffet is protected by MIST!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is protected by MIST!");
             ANIMATION(ANIM_TYPE_MOVE, move, playerLeft);
             MESSAGE("Foe's Mist wore off!");
             MESSAGE("Foe's Safeguard wore off!");
         }
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SCREECH) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SCREECH) "!");
         if (move == MOVE_DEFOG) {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_SCREECH, playerLeft);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
         }
         else {
-            MESSAGE("Foe Wobbuffet is protected by MIST!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is protected by MIST!");
             NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
         }
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TOXIC) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TOXIC) "!");
         if (move == MOVE_DEFOG) {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_TOXIC, playerRight);
             STATUS_ICON(opponentRight, badPoison: TRUE);
         }
         else {
-            MESSAGE("Foe Wobbuffet's party is protected by Safeguard!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s party is protected by Safeguard!");
             NOT STATUS_ICON(opponentRight, badPoison: TRUE);
         }
     }
@@ -153,27 +153,27 @@ DOUBLE_BATTLE_TEST("Defog lowers evasiveness by 1 and removes Stealth Rock and S
         ANIMATION(ANIM_TYPE_MOVE, move, playerLeft);
         if (move == MOVE_DEFOG) {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
-            MESSAGE("Foe Wobbuffet's evasiveness fell!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s evasiveness fell!");
             MESSAGE("The pointed stones disappeared from around your team!");
             MESSAGE("The sticky web has disappeared from the ground around your team!");
         }
         // Switch happens
         MESSAGE("Wobbuffet, that's enough! Come back!");
-        MESSAGE("Go! Wobbuffet!");
+        MESSAGE("Go! " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
         if (move != MOVE_DEFOG) {
             HP_BAR(playerLeft);
             MESSAGE("Pointed stones dug into Wobbuffet!");
-            MESSAGE("Wobbuffet was caught in a Sticky Web!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was caught in a Sticky Web!");
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
-            MESSAGE("Wobbuffet's Speed fell!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Speed fell!");
         }
         else {
             NONE_OF {
                 HP_BAR(playerLeft);
                 MESSAGE("Pointed stones dug into Wobbuffet!");
-                MESSAGE("Wobbuffet was caught in a Sticky Web!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was caught in a Sticky Web!");
                 ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
-                MESSAGE("Wobbuffet's Speed fell!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Speed fell!");
             }
         }
     }
@@ -197,20 +197,20 @@ SINGLE_BATTLE_TEST("Defog lowers evasiveness by 1 and removes Spikes from player
         ANIMATION(ANIM_TYPE_MOVE, move, player);
         if (move == MOVE_DEFOG) {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-            MESSAGE("Foe Wobbuffet's evasiveness fell!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s evasiveness fell!");
             MESSAGE("The spikes disappeared from the ground around your team!");
         }
         // Switch happens
         MESSAGE("Wobbuffet, that's enough! Come back!");
-        MESSAGE("Go! Wobbuffet!");
+        MESSAGE("Go! " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
         if (move != MOVE_DEFOG) {
             HP_BAR(player);
-            MESSAGE("Wobbuffet is hurt by spikes!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is hurt by spikes!");
         }
         else {
             NONE_OF {
                 HP_BAR(player);
-                MESSAGE("Wobbuffet is hurt by spikes!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is hurt by spikes!");
             }
         }
     }
@@ -234,7 +234,7 @@ SINGLE_BATTLE_TEST("Defog lowers evasiveness by 1 and removes terrain")
         ANIMATION(ANIM_TYPE_MOVE, move, player);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DEFOG, opponent);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-        MESSAGE("Wobbuffet's evasiveness fell!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s evasiveness fell!");
         if (move == MOVE_PSYCHIC_TERRAIN) {
             MESSAGE("The weirdness disappeared from the battlefield.");
         }
@@ -269,19 +269,19 @@ SINGLE_BATTLE_TEST("Defog lowers evasiveness by 1 and removes Toxic Spikes from 
         ANIMATION(ANIM_TYPE_MOVE, move, opponent);
         if (move == MOVE_DEFOG) {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-            MESSAGE("Wobbuffet's evasiveness fell!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s evasiveness fell!");
             MESSAGE("The poison spikes disappeared from the ground around the opposing team!");
         }
         // Switch happens
-        MESSAGE("2 sent out Wobbuffet!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
         if (move != MOVE_DEFOG) {
-            MESSAGE("Foe Wobbuffet was poisoned!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " was poisoned!");
             ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
             STATUS_ICON(opponent, poison: TRUE);
         }
         else {
             NONE_OF {
-                MESSAGE("Foe Wobbuffet was poisoned!");
+                MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " was poisoned!");
                 ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
                 STATUS_ICON(opponent, poison: TRUE);
             }
@@ -312,12 +312,12 @@ DOUBLE_BATTLE_TEST("Defog lowers evasiveness by 1 and removes Aurora Veil from p
         ANIMATION(ANIM_TYPE_MOVE, move, opponentLeft);
         if (move == MOVE_DEFOG) {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
-            MESSAGE("Glalie's evasiveness fell!");
+            MESSAGE(SPECIES_NAME(SPECIES_GLALIE) "'s evasiveness fell!");
             MESSAGE("Ally's Aurora Veil wore off!");
         }
-        MESSAGE("Foe Glalie used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_GLALIE) " used " MOVE_NAME(MOVE_TACKLE) "!");
         HP_BAR(playerLeft, captureDamage: &results[i].damagePhysical);
-        MESSAGE("Foe Glalie used " MOVE_NAME(MOVE_GUST) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_GLALIE) " used " MOVE_NAME(MOVE_GUST) "!");
         HP_BAR(playerRight, captureDamage: &results[i].damageSpecial);
     } FINALLY {
         EXPECT_MUL_EQ(results[1].damagePhysical, Q_4_12(1.5), results[0].damagePhysical);
@@ -346,8 +346,8 @@ DOUBLE_BATTLE_TEST("Defog lowers evasiveness by 1 and removes everything it can"
         TURN { MOVE(playerLeft, MOVE_REFLECT); MOVE(playerRight, MOVE_LIGHT_SCREEN); MOVE(opponentLeft, MOVE_REFLECT); MOVE(opponentRight, MOVE_SAFEGUARD); }
         TURN { MOVE(playerLeft, MOVE_MIST); MOVE(playerRight, MOVE_SAFEGUARD); MOVE(opponentLeft, MOVE_MIST); MOVE(opponentRight, MOVE_DEFOG, target: playerLeft); }
     } SCENE {
-        MESSAGE("Foe Glalie used " MOVE_NAME(MOVE_DEFOG) "!");
-        MESSAGE("Glalie is protected by MIST!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_GLALIE) " used " MOVE_NAME(MOVE_DEFOG) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_GLALIE) " is protected by MIST!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DEFOG, opponentRight);
         // Player side
         MESSAGE("Ally's Reflect wore off!");

--- a/test/battle/move_effect/defog.c
+++ b/test/battle/move_effect/defog.c
@@ -41,7 +41,7 @@ SINGLE_BATTLE_TEST("Defog does not lower evasiveness if target behind Substitute
     } WHEN {
         TURN { MOVE(opponent, MOVE_SUBSTITUTE); MOVE(player, MOVE_DEFOG); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used Substitute!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_SUBSTITUTE) "!");
         MESSAGE("But it failed!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_DEFOG, player);
@@ -76,9 +76,9 @@ DOUBLE_BATTLE_TEST("Defog lowers evasiveness by 1 and removes Reflect and Light 
             MESSAGE("Foe's Reflect wore off!");
             MESSAGE("Foe's Light Screen wore off!");
         }
-        MESSAGE("Wobbuffet used Tackle!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
         HP_BAR(opponentLeft, captureDamage: &results[i].damagePhysical);
-        MESSAGE("Wobbuffet used Gust!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_GUST) "!");
         HP_BAR(opponentRight, captureDamage: &results[i].damageSpecial);
     } FINALLY {
         EXPECT_MUL_EQ(results[1].damagePhysical, Q_4_12(1.5), results[0].damagePhysical);
@@ -110,7 +110,7 @@ DOUBLE_BATTLE_TEST("Defog lowers evasiveness by 1 and removes Mist and Safeguard
             MESSAGE("Foe's Mist wore off!");
             MESSAGE("Foe's Safeguard wore off!");
         }
-        MESSAGE("Wobbuffet used Screech!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SCREECH) "!");
         if (move == MOVE_DEFOG) {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_SCREECH, playerLeft);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
@@ -119,7 +119,7 @@ DOUBLE_BATTLE_TEST("Defog lowers evasiveness by 1 and removes Mist and Safeguard
             MESSAGE("Foe Wobbuffet is protected by MIST!");
             NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
         }
-        MESSAGE("Wobbuffet used Toxic!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TOXIC) "!");
         if (move == MOVE_DEFOG) {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_TOXIC, playerRight);
             STATUS_ICON(opponentRight, badPoison: TRUE);
@@ -315,9 +315,9 @@ DOUBLE_BATTLE_TEST("Defog lowers evasiveness by 1 and removes Aurora Veil from p
             MESSAGE("Glalie's evasiveness fell!");
             MESSAGE("Ally's Aurora Veil wore off!");
         }
-        MESSAGE("Foe Glalie used Tackle!");
+        MESSAGE("Foe Glalie used " MOVE_NAME(MOVE_TACKLE) "!");
         HP_BAR(playerLeft, captureDamage: &results[i].damagePhysical);
-        MESSAGE("Foe Glalie used Gust!");
+        MESSAGE("Foe Glalie used " MOVE_NAME(MOVE_GUST) "!");
         HP_BAR(playerRight, captureDamage: &results[i].damageSpecial);
     } FINALLY {
         EXPECT_MUL_EQ(results[1].damagePhysical, Q_4_12(1.5), results[0].damagePhysical);
@@ -346,7 +346,7 @@ DOUBLE_BATTLE_TEST("Defog lowers evasiveness by 1 and removes everything it can"
         TURN { MOVE(playerLeft, MOVE_REFLECT); MOVE(playerRight, MOVE_LIGHT_SCREEN); MOVE(opponentLeft, MOVE_REFLECT); MOVE(opponentRight, MOVE_SAFEGUARD); }
         TURN { MOVE(playerLeft, MOVE_MIST); MOVE(playerRight, MOVE_SAFEGUARD); MOVE(opponentLeft, MOVE_MIST); MOVE(opponentRight, MOVE_DEFOG, target: playerLeft); }
     } SCENE {
-        MESSAGE("Foe Glalie used Defog!");
+        MESSAGE("Foe Glalie used " MOVE_NAME(MOVE_DEFOG) "!");
         MESSAGE("Glalie is protected by MIST!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DEFOG, opponentRight);
         // Player side

--- a/test/battle/move_effect/double_shock.c
+++ b/test/battle/move_effect/double_shock.c
@@ -19,7 +19,7 @@ SINGLE_BATTLE_TEST("Double Shock user loses its Electric-type")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DOUBLE_SHOCK, player);
         MESSAGE("Pikachu used up all of its electricity!");
-        MESSAGE("Pikachu used Double Shock!");
+        MESSAGE("Pikachu used " MOVE_NAME(MOVE_DOUBLE_SHOCK) "!");
         MESSAGE("But it failed!");
     }
 }
@@ -33,7 +33,7 @@ SINGLE_BATTLE_TEST("Double Shock fails if the user isn't an Electric-type")
         TURN { MOVE(player, MOVE_DOUBLE_SHOCK); }
     } SCENE {
         NONE_OF { ANIMATION(ANIM_TYPE_MOVE, MOVE_DOUBLE_SHOCK, player); }
-        MESSAGE("Wobbuffet used Double Shock!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_DOUBLE_SHOCK) "!");
         MESSAGE("But it failed!");
     }
 }

--- a/test/battle/move_effect/double_shock.c
+++ b/test/battle/move_effect/double_shock.c
@@ -18,8 +18,8 @@ SINGLE_BATTLE_TEST("Double Shock user loses its Electric-type")
         TURN { MOVE(player, MOVE_DOUBLE_SHOCK); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DOUBLE_SHOCK, player);
-        MESSAGE("Pikachu used up all of its electricity!");
-        MESSAGE("Pikachu used " MOVE_NAME(MOVE_DOUBLE_SHOCK) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_PIKACHU) " used up all of its electricity!");
+        MESSAGE(SPECIES_NAME(SPECIES_PIKACHU) " used " MOVE_NAME(MOVE_DOUBLE_SHOCK) "!");
         MESSAGE("But it failed!");
     }
 }
@@ -33,7 +33,7 @@ SINGLE_BATTLE_TEST("Double Shock fails if the user isn't an Electric-type")
         TURN { MOVE(player, MOVE_DOUBLE_SHOCK); }
     } SCENE {
         NONE_OF { ANIMATION(ANIM_TYPE_MOVE, MOVE_DOUBLE_SHOCK, player); }
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_DOUBLE_SHOCK) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_DOUBLE_SHOCK) "!");
         MESSAGE("But it failed!");
     }
 }
@@ -48,6 +48,6 @@ SINGLE_BATTLE_TEST("Double Shock user loses its Electric-type if enemy faints")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DOUBLE_SHOCK, player);
         HP_BAR(opponent, hp: 0);
-        MESSAGE("Pikachu used up all of its electricity!");
+        MESSAGE(SPECIES_NAME(SPECIES_PIKACHU) " used up all of its electricity!");
     }
 }

--- a/test/battle/move_effect/dream_eater.c
+++ b/test/battle/move_effect/dream_eater.c
@@ -32,8 +32,8 @@ SINGLE_BATTLE_TEST("Dream Eater fails on awake targets")
     } WHEN {
         TURN { MOVE(player, MOVE_DREAM_EATER); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_DREAM_EATER) "!");
-        MESSAGE("Foe Wobbuffet wasn't affected!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_DREAM_EATER) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " wasn't affected!");
     }
 }
 
@@ -46,7 +46,7 @@ SINGLE_BATTLE_TEST("Dream Eater fails if Heal Block applies")
     } WHEN {
         TURN { MOVE(opponent, MOVE_HEAL_BLOCK); MOVE(player, MOVE_DREAM_EATER); }
     } SCENE {
-        MESSAGE("Wobbuffet was prevented from healing!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was prevented from healing!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_DREAM_EATER, player);
             HP_BAR(opponent);

--- a/test/battle/move_effect/dream_eater.c
+++ b/test/battle/move_effect/dream_eater.c
@@ -32,7 +32,7 @@ SINGLE_BATTLE_TEST("Dream Eater fails on awake targets")
     } WHEN {
         TURN { MOVE(player, MOVE_DREAM_EATER); }
     } SCENE {
-        MESSAGE("Wobbuffet used Dream Eater!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_DREAM_EATER) "!");
         MESSAGE("Foe Wobbuffet wasn't affected!");
     }
 }

--- a/test/battle/move_effect/encore.c
+++ b/test/battle/move_effect/encore.c
@@ -52,7 +52,7 @@ SINGLE_BATTLE_TEST("Encore has no effect if no previous move")
     } WHEN {
         TURN { MOVE(opponent, MOVE_ENCORE); MOVE(player, MOVE_CELEBRATE); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_ENCORE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_ENCORE) "!");
         MESSAGE("But it failed!");
     }
 }

--- a/test/battle/move_effect/encore.c
+++ b/test/battle/move_effect/encore.c
@@ -52,7 +52,7 @@ SINGLE_BATTLE_TEST("Encore has no effect if no previous move")
     } WHEN {
         TURN { MOVE(opponent, MOVE_ENCORE); MOVE(player, MOVE_CELEBRATE); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used Encore!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_ENCORE) "!");
         MESSAGE("But it failed!");
     }
 }

--- a/test/battle/move_effect/evasion_up.c
+++ b/test/battle/move_effect/evasion_up.c
@@ -18,7 +18,7 @@ SINGLE_BATTLE_TEST("Double Team raises Evasion")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DOUBLE_TEAM, player);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-        MESSAGE("Wobbuffet's evasiveness rose!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s evasiveness rose!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
     }
 }

--- a/test/battle/move_effect/explosion.c
+++ b/test/battle/move_effect/explosion.c
@@ -16,7 +16,7 @@ SINGLE_BATTLE_TEST("Explosion causes the user to faint")
     } SCENE {
         HP_BAR(player, hp: 0);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, player);
-        MESSAGE("Wobbuffet fainted!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " fainted!");
     }
 }
 
@@ -32,8 +32,8 @@ SINGLE_BATTLE_TEST("Explosion causes the user & the target to faint")
         HP_BAR(player, hp: 0);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, player);
         HP_BAR(opponent, hp: 0);
-        MESSAGE("Foe Wobbuffet fainted!");
-        MESSAGE("Wobbuffet fainted!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " fainted!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " fainted!");
     }
 }
 
@@ -47,7 +47,7 @@ SINGLE_BATTLE_TEST("Explosion causes the user to faint even if it misses")
     } SCENE {
         HP_BAR(player, hp: 0);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, player);
-        MESSAGE("Wobbuffet fainted!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " fainted!");
     }
 }
 
@@ -63,9 +63,9 @@ SINGLE_BATTLE_TEST("Explosion causes the user to faint even if it has no effect"
     } SCENE {
         HP_BAR(player, hp: 0);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, player);
-        MESSAGE("It doesn't affect Foe Gastly…");
+        MESSAGE("It doesn't affect Foe " SPECIES_NAME(SPECIES_GASTLY) "…");
         NOT HP_BAR(opponent);
-        MESSAGE("Wobbuffet fainted!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " fainted!");
     }
 }
 
@@ -83,11 +83,11 @@ DOUBLE_BATTLE_TEST("Explosion causes everyone to faint in a double battle")
         HP_BAR(playerLeft, hp: 0);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, playerLeft);
         HP_BAR(opponentLeft, hp: 0);
-        MESSAGE("Foe Abra fainted!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_ABRA) " fainted!");
         HP_BAR(playerRight, hp: 0);
-        MESSAGE("Wynaut fainted!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " fainted!");
         HP_BAR(opponentRight, hp: 0);
-        MESSAGE("Foe Kadabra fainted!");
-        MESSAGE("Wobbuffet fainted!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_KADABRA) " fainted!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " fainted!");
     }
 }

--- a/test/battle/move_effect/flinch_hit.c
+++ b/test/battle/move_effect/flinch_hit.c
@@ -25,20 +25,20 @@ SINGLE_BATTLE_TEST("Headbutt flinches the target if attacker is faster")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_HEADBUTT, player);
         HP_BAR(opponent);
         if (isFaster) {
-            MESSAGE("Foe Wobbuffet flinched!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " flinched!");
             NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
         } else {
-            NOT MESSAGE("Foe Wobbuffet flinched!");
+            NOT MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " flinched!");
         }
 
         // 2nd turn
         ANIMATION(ANIM_TYPE_MOVE, MOVE_HEADBUTT, player);
         HP_BAR(opponent);
         if (isFaster) {
-            MESSAGE("Foe Wobbuffet flinched!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " flinched!");
             NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
         } else {
-            NOT MESSAGE("Foe Wobbuffet flinched!");
+            NOT MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " flinched!");
         }
     }
 }
@@ -55,17 +55,17 @@ SINGLE_BATTLE_TEST("Protect always works when used after flinching")
     } SCENE {
         // 1st turn
         ANIMATION(ANIM_TYPE_MOVE, MOVE_PROTECT, player);
-        MESSAGE("Wobbuffet protected itself!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " protected itself!");
 
         // 2nd turn
         ANIMATION(ANIM_TYPE_MOVE, MOVE_HEADBUTT, opponent);
         HP_BAR(player);
-        MESSAGE("Wobbuffet flinched!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " flinched!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, player);
 
         // 3rd turn
         ANIMATION(ANIM_TYPE_MOVE, MOVE_PROTECT, player);
-        MESSAGE("Wobbuffet protected itself!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " protected itself!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_HEADBUTT, opponent);
     }
 }

--- a/test/battle/move_effect/fling.c
+++ b/test/battle/move_effect/fling.c
@@ -142,7 +142,7 @@ SINGLE_BATTLE_TEST("Fling - Item is lost when target protects itself")
         MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_PROTECT) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_PROTECT, opponent);
         MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_FLING) "!");
-        MESSAGE("Foe Wobbuffet protected itself!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " protected itself!");
 
         MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_FLING) "!");
         MESSAGE("But it failed!");
@@ -187,7 +187,7 @@ SINGLE_BATTLE_TEST("Fling doesn't consume the item if pokemon is asleep/frozen/p
         }
         else {
             MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is fast asleep.");
-            MESSAGE("Wobbuffet woke up!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " woke up!");
         }
         MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_FLING) "!");
         if (item != ITEM_NONE) {
@@ -241,7 +241,7 @@ SINGLE_BATTLE_TEST("Fling applies special effects when throwing specific Items")
             STATUS_ICON(opponent, STATUS1_TOXIC_POISON);
             break;
         case EFFECT_FLINCH_HIT:
-            MESSAGE("Foe Wobbuffet flinched!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " flinched!");
             break;
         }
     }
@@ -313,23 +313,23 @@ SINGLE_BATTLE_TEST("Fling - thrown berry's effect activates for the target even 
         else if (statId != 0) {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
             if (statId == STAT_ATK) {
-                MESSAGE("Using Liechi Berry, the Attack of Foe Wobbuffet rose!");
+                MESSAGE("Using Liechi Berry, the Attack of Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " rose!");
             } else if (statId == STAT_DEF) {
                 if (item == ITEM_GANLON_BERRY) {
-                    MESSAGE("Using Ganlon Berry, the Defense of Foe Wobbuffet rose!");
+                    MESSAGE("Using Ganlon Berry, the Defense of Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " rose!");
                 } else {
-                    MESSAGE("Using Kee Berry, the Defense of Foe Wobbuffet rose!");
+                    MESSAGE("Using Kee Berry, the Defense of Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " rose!");
                 }
             } else if (statId == STAT_SPDEF) {
                 if (item == ITEM_APICOT_BERRY) {
-                    MESSAGE("Using Apicot Berry, the Sp. Def of Foe Wobbuffet rose!");
+                    MESSAGE("Using Apicot Berry, the Sp. Def of Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " rose!");
                 } else {
-                    MESSAGE("Using Maranga Berry, the Sp. Def of Foe Wobbuffet rose!");
+                    MESSAGE("Using Maranga Berry, the Sp. Def of Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " rose!");
                 }
             } else if (statId == STAT_SPEED) {
-                MESSAGE("Using Salac Berry, the Speed of Foe Wobbuffet rose!");
+                MESSAGE("Using Salac Berry, the Speed of Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " rose!");
             } else if (statId == STAT_SPATK) {
-                MESSAGE("Using Petaya Berry, the Sp. Atk of Foe Wobbuffet rose!");
+                MESSAGE("Using Petaya Berry, the Sp. Atk of Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " rose!");
             }
         }
     } THEN {

--- a/test/battle/move_effect/fling.c
+++ b/test/battle/move_effect/fling.c
@@ -19,7 +19,7 @@ SINGLE_BATTLE_TEST("Fling fails if pokemon holds no item")
     } WHEN {
         TURN { MOVE(player, MOVE_FLING);}
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FLING) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_FLING) "!");
         if (item != ITEM_NONE) {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_FLING, player);
             HP_BAR(opponent);
@@ -46,7 +46,7 @@ SINGLE_BATTLE_TEST("Fling fails if pokemon is under the effects of Embargo or Ma
         TURN { MOVE(opponent, move); }
         TURN { MOVE(player, MOVE_FLING); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FLING) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_FLING) "!");
         if (move == MOVE_CELEBRATE) {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_FLING, player);
             HP_BAR(opponent);
@@ -71,7 +71,7 @@ SINGLE_BATTLE_TEST("Fling fails for pokemon with Klutz ability")
     } WHEN {
         TURN { MOVE(player, MOVE_FLING); }
     } SCENE {
-        MESSAGE("Buneary used " MOVE_NAME(MOVE_FLING) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_BUNEARY) " used " MOVE_NAME(MOVE_FLING) "!");
         if (ability != ABILITY_KLUTZ) {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_FLING, player);
             HP_BAR(opponent);
@@ -92,13 +92,13 @@ SINGLE_BATTLE_TEST("Fling's thrown item can be regained with Recycle")
         TURN { MOVE(player, MOVE_RECYCLE);}
         TURN { MOVE(player, MOVE_FLING);}
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FLING) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_FLING) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_FLING, player);
         HP_BAR(opponent);
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_RECYCLE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_RECYCLE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_RECYCLE, player);
         MESSAGE("Wobbuffet found one Razor Claw!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FLING) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_FLING) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_FLING, player);
         HP_BAR(opponent);
     }
@@ -115,14 +115,14 @@ SINGLE_BATTLE_TEST("Fling - Item is lost even when there is no target")
         TURN { MOVE(opponent, MOVE_SELF_DESTRUCT); MOVE(player, MOVE_FLING); SEND_OUT(opponent, 1); }
         TURN { MOVE(player, MOVE_FLING); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_SELF_DESTRUCT) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SELF_DESTRUCT) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SELF_DESTRUCT, opponent);
         HP_BAR(player);
-        MESSAGE("Foe Wobbuffet fainted!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FLING) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " fainted!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_FLING) "!");
         MESSAGE("But it failed!");
 
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FLING) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_FLING) "!");
         MESSAGE("But it failed!");
     } THEN {
         EXPECT_EQ(player->item, ITEM_NONE);
@@ -139,12 +139,12 @@ SINGLE_BATTLE_TEST("Fling - Item is lost when target protects itself")
         TURN { MOVE(opponent, MOVE_PROTECT); MOVE(player, MOVE_FLING);}
         TURN { MOVE(player, MOVE_FLING); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_PROTECT) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_PROTECT) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_PROTECT, opponent);
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FLING) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_FLING) "!");
         MESSAGE("Foe Wobbuffet protected itself!");
 
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FLING) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_FLING) "!");
         MESSAGE("But it failed!");
     } THEN {
         EXPECT_EQ(player->item, ITEM_NONE);
@@ -179,17 +179,17 @@ SINGLE_BATTLE_TEST("Fling doesn't consume the item if pokemon is asleep/frozen/p
         }
     } SCENE {
         if (status == STATUS1_FREEZE) {
-            MESSAGE("Wobbuffet is frozen solid!");
-            MESSAGE("Wobbuffet was defrosted!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is frozen solid!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was defrosted!");
         }
         else if (status == STATUS1_PARALYSIS) {
-            MESSAGE("Wobbuffet is paralyzed! It can't move!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is paralyzed! It can't move!");
         }
         else {
-            MESSAGE("Wobbuffet is fast asleep.");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is fast asleep.");
             MESSAGE("Wobbuffet woke up!");
         }
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FLING) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_FLING) "!");
         if (item != ITEM_NONE) {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_FLING, player);
             HP_BAR(opponent);
@@ -219,25 +219,25 @@ SINGLE_BATTLE_TEST("Fling applies special effects when throwing specific Items")
     } WHEN {
         TURN { MOVE(player, MOVE_FLING); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FLING) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_FLING) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_FLING, player);
         HP_BAR(opponent);
         switch (effect)
         {
         case EFFECT_WILL_O_WISP:
-            MESSAGE("Foe Wobbuffet was burned!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " was burned!");
             STATUS_ICON(opponent, STATUS1_BURN);
             break;
         case EFFECT_PARALYZE:
-            MESSAGE("Foe Wobbuffet is paralyzed! It may be unable to move!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is paralyzed! It may be unable to move!");
             STATUS_ICON(opponent, STATUS1_PARALYSIS);
             break;
         case EFFECT_POISON:
-            MESSAGE("Foe Wobbuffet was poisoned!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " was poisoned!");
             STATUS_ICON(opponent, STATUS1_POISON);
             break;
         case EFFECT_TOXIC:
-            MESSAGE("Foe Wobbuffet is badly poisoned!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is badly poisoned!");
             STATUS_ICON(opponent, STATUS1_TOXIC_POISON);
             break;
         case EFFECT_FLINCH_HIT:
@@ -278,35 +278,35 @@ SINGLE_BATTLE_TEST("Fling - thrown berry's effect activates for the target even 
     } WHEN {
         TURN { MOVE(player, MOVE_FLING); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FLING) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_FLING) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_FLING, player);
         HP_BAR(opponent);
         if (effect == HOLD_EFFECT_RESTORE_HP) {
             if (item == ITEM_ORAN_BERRY) {
-                MESSAGE("Foe Wobbuffet's Oran Berry restored health!");
+                MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Oran Berry restored health!");
             } else if (item == ITEM_SITRUS_BERRY) {
-                MESSAGE("Foe Wobbuffet's Sitrus Berry restored health!");
+                MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Sitrus Berry restored health!");
             } else {
-                MESSAGE("Wobbuffet's Enigma Berry restored health!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Enigma Berry restored health!");
             }
             HP_BAR(opponent);
         }
         else if (effect == HOLD_EFFECT_RESTORE_PP) {
-            MESSAGE("Foe Wobbuffet's Leppa Berry restored Celebrate's PP!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Leppa Berry restored Celebrate's PP!");
         }
         else if (status1 != STATUS1_NONE) {
             if (status1 == STATUS1_BURN) {
-                MESSAGE("Foe Wobbuffet's Rawst Berry healed its burn!");
+                MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Rawst Berry healed its burn!");
             } else if (status1 == STATUS1_SLEEP) {
-                MESSAGE("Foe Wobbuffet's Chesto Berry woke it from its sleep!");
+                MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Chesto Berry woke it from its sleep!");
             } else if (status1 == STATUS1_FREEZE) {
-                MESSAGE("Foe Wobbuffet's Aspear Berry defrosted it!");
+                MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Aspear Berry defrosted it!");
             } else if (status1 == STATUS1_FROSTBITE) {
-                MESSAGE("Foe Wobbuffet's Aspear Berry healed its frostbite!");
+                MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Aspear Berry healed its frostbite!");
             } else if (status1 == STATUS1_PARALYSIS) {
-                MESSAGE("Foe Wobbuffet's Cheri Berry cured paralysis!");
+                MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Cheri Berry cured paralysis!");
             } else if (status1 == STATUS1_TOXIC_POISON || status1 == STATUS1_POISON) {
-                MESSAGE("Foe Wobbuffet's Pecha Berry cured poison!");
+                MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Pecha Berry cured poison!");
             }
             NOT STATUS_ICON(opponent, status1);
         }

--- a/test/battle/move_effect/fling.c
+++ b/test/battle/move_effect/fling.c
@@ -19,7 +19,7 @@ SINGLE_BATTLE_TEST("Fling fails if pokemon holds no item")
     } WHEN {
         TURN { MOVE(player, MOVE_FLING);}
     } SCENE {
-        MESSAGE("Wobbuffet used Fling!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FLING) "!");
         if (item != ITEM_NONE) {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_FLING, player);
             HP_BAR(opponent);
@@ -46,7 +46,7 @@ SINGLE_BATTLE_TEST("Fling fails if pokemon is under the effects of Embargo or Ma
         TURN { MOVE(opponent, move); }
         TURN { MOVE(player, MOVE_FLING); }
     } SCENE {
-        MESSAGE("Wobbuffet used Fling!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FLING) "!");
         if (move == MOVE_CELEBRATE) {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_FLING, player);
             HP_BAR(opponent);
@@ -71,7 +71,7 @@ SINGLE_BATTLE_TEST("Fling fails for pokemon with Klutz ability")
     } WHEN {
         TURN { MOVE(player, MOVE_FLING); }
     } SCENE {
-        MESSAGE("Buneary used Fling!");
+        MESSAGE("Buneary used " MOVE_NAME(MOVE_FLING) "!");
         if (ability != ABILITY_KLUTZ) {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_FLING, player);
             HP_BAR(opponent);
@@ -92,13 +92,13 @@ SINGLE_BATTLE_TEST("Fling's thrown item can be regained with Recycle")
         TURN { MOVE(player, MOVE_RECYCLE);}
         TURN { MOVE(player, MOVE_FLING);}
     } SCENE {
-        MESSAGE("Wobbuffet used Fling!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FLING) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_FLING, player);
         HP_BAR(opponent);
-        MESSAGE("Wobbuffet used Recycle!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_RECYCLE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_RECYCLE, player);
         MESSAGE("Wobbuffet found one Razor Claw!");
-        MESSAGE("Wobbuffet used Fling!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FLING) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_FLING, player);
         HP_BAR(opponent);
     }
@@ -115,14 +115,14 @@ SINGLE_BATTLE_TEST("Fling - Item is lost even when there is no target")
         TURN { MOVE(opponent, MOVE_SELF_DESTRUCT); MOVE(player, MOVE_FLING); SEND_OUT(opponent, 1); }
         TURN { MOVE(player, MOVE_FLING); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used SelfDestruct!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_SELF_DESTRUCT) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SELF_DESTRUCT, opponent);
         HP_BAR(player);
         MESSAGE("Foe Wobbuffet fainted!");
-        MESSAGE("Wobbuffet used Fling!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FLING) "!");
         MESSAGE("But it failed!");
 
-        MESSAGE("Wobbuffet used Fling!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FLING) "!");
         MESSAGE("But it failed!");
     } THEN {
         EXPECT_EQ(player->item, ITEM_NONE);
@@ -139,12 +139,12 @@ SINGLE_BATTLE_TEST("Fling - Item is lost when target protects itself")
         TURN { MOVE(opponent, MOVE_PROTECT); MOVE(player, MOVE_FLING);}
         TURN { MOVE(player, MOVE_FLING); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used Protect!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_PROTECT) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_PROTECT, opponent);
-        MESSAGE("Wobbuffet used Fling!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FLING) "!");
         MESSAGE("Foe Wobbuffet protected itself!");
 
-        MESSAGE("Wobbuffet used Fling!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FLING) "!");
         MESSAGE("But it failed!");
     } THEN {
         EXPECT_EQ(player->item, ITEM_NONE);
@@ -189,7 +189,7 @@ SINGLE_BATTLE_TEST("Fling doesn't consume the item if pokemon is asleep/frozen/p
             MESSAGE("Wobbuffet is fast asleep.");
             MESSAGE("Wobbuffet woke up!");
         }
-        MESSAGE("Wobbuffet used Fling!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FLING) "!");
         if (item != ITEM_NONE) {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_FLING, player);
             HP_BAR(opponent);
@@ -219,7 +219,7 @@ SINGLE_BATTLE_TEST("Fling applies special effects when throwing specific Items")
     } WHEN {
         TURN { MOVE(player, MOVE_FLING); }
     } SCENE {
-        MESSAGE("Wobbuffet used Fling!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FLING) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_FLING, player);
         HP_BAR(opponent);
         switch (effect)
@@ -278,7 +278,7 @@ SINGLE_BATTLE_TEST("Fling - thrown berry's effect activates for the target even 
     } WHEN {
         TURN { MOVE(player, MOVE_FLING); }
     } SCENE {
-        MESSAGE("Wobbuffet used Fling!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FLING) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_FLING, player);
         HP_BAR(opponent);
         if (effect == HOLD_EFFECT_RESTORE_HP) {

--- a/test/battle/move_effect/focus_punch.c
+++ b/test/battle/move_effect/focus_punch.c
@@ -21,17 +21,17 @@ SINGLE_BATTLE_TEST("Focus Punch activates only if not damaged")
         TURN { MOVE(player, MOVE_FOCUS_PUNCH); MOVE(opponent, move); }
     } SCENE {
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FOCUS_PUNCH_SETUP, player);
-        MESSAGE("Wobbuffet is tightening its focus!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is tightening its focus!");
         ANIMATION(ANIM_TYPE_MOVE, move, opponent);
 
         if (activate) {
-            MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FOCUS_PUNCH) "!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_FOCUS_PUNCH) "!");
             ANIMATION(ANIM_TYPE_MOVE, MOVE_FOCUS_PUNCH, player);
             HP_BAR(opponent);
         } else {
             MESSAGE("Wobbuffet lost its focus and couldn't move!");
             NONE_OF {
-                MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FOCUS_PUNCH) "!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_FOCUS_PUNCH) "!");
                 ANIMATION(ANIM_TYPE_MOVE, MOVE_FOCUS_PUNCH, player);
                 HP_BAR(opponent);
             }
@@ -51,22 +51,22 @@ DOUBLE_BATTLE_TEST("Focus Punch activation is based on Speed")
     }
     SCENE {
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FOCUS_PUNCH_SETUP, opponentRight);
-        MESSAGE("Foe Wynaut is tightening its focus!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " is tightening its focus!");
 
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FOCUS_PUNCH_SETUP, playerRight);
-        MESSAGE("Wynaut is tightening its focus!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " is tightening its focus!");
 
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FOCUS_PUNCH_SETUP, playerLeft);
-        MESSAGE("Wobbuffet is tightening its focus!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is tightening its focus!");
 
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FOCUS_PUNCH_SETUP, opponentLeft);
-        MESSAGE("Foe Wobbuffet is tightening its focus!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is tightening its focus!");
 
-        MESSAGE("Foe Wynaut used " MOVE_NAME(MOVE_FOCUS_PUNCH) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " used " MOVE_NAME(MOVE_FOCUS_PUNCH) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_FOCUS_PUNCH, opponentRight);
         HP_BAR(playerLeft);
 
-        MESSAGE("Wynaut used " MOVE_NAME(MOVE_FOCUS_PUNCH) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " used " MOVE_NAME(MOVE_FOCUS_PUNCH) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_FOCUS_PUNCH, playerRight);
         HP_BAR(opponentLeft);
 

--- a/test/battle/move_effect/focus_punch.c
+++ b/test/battle/move_effect/focus_punch.c
@@ -25,13 +25,13 @@ SINGLE_BATTLE_TEST("Focus Punch activates only if not damaged")
         ANIMATION(ANIM_TYPE_MOVE, move, opponent);
 
         if (activate) {
-            MESSAGE("Wobbuffet used Focus Punch!");
+            MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FOCUS_PUNCH) "!");
             ANIMATION(ANIM_TYPE_MOVE, MOVE_FOCUS_PUNCH, player);
             HP_BAR(opponent);
         } else {
             MESSAGE("Wobbuffet lost its focus and couldn't move!");
             NONE_OF {
-                MESSAGE("Wobbuffet used Focus Punch!");
+                MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FOCUS_PUNCH) "!");
                 ANIMATION(ANIM_TYPE_MOVE, MOVE_FOCUS_PUNCH, player);
                 HP_BAR(opponent);
             }
@@ -62,11 +62,11 @@ DOUBLE_BATTLE_TEST("Focus Punch activation is based on Speed")
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FOCUS_PUNCH_SETUP, opponentLeft);
         MESSAGE("Foe Wobbuffet is tightening its focus!");
 
-        MESSAGE("Foe Wynaut used Focus Punch!");
+        MESSAGE("Foe Wynaut used " MOVE_NAME(MOVE_FOCUS_PUNCH) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_FOCUS_PUNCH, opponentRight);
         HP_BAR(playerLeft);
 
-        MESSAGE("Wynaut used Focus Punch!");
+        MESSAGE("Wynaut used " MOVE_NAME(MOVE_FOCUS_PUNCH) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_FOCUS_PUNCH, playerRight);
         HP_BAR(opponentLeft);
 

--- a/test/battle/move_effect/focus_punch.c
+++ b/test/battle/move_effect/focus_punch.c
@@ -29,7 +29,7 @@ SINGLE_BATTLE_TEST("Focus Punch activates only if not damaged")
             ANIMATION(ANIM_TYPE_MOVE, MOVE_FOCUS_PUNCH, player);
             HP_BAR(opponent);
         } else {
-            MESSAGE("Wobbuffet lost its focus and couldn't move!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " lost its focus and couldn't move!");
             NONE_OF {
                 MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_FOCUS_PUNCH) "!");
                 ANIMATION(ANIM_TYPE_MOVE, MOVE_FOCUS_PUNCH, player);
@@ -70,7 +70,7 @@ DOUBLE_BATTLE_TEST("Focus Punch activation is based on Speed")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_FOCUS_PUNCH, playerRight);
         HP_BAR(opponentLeft);
 
-        MESSAGE("Wobbuffet lost its focus and couldn't move!");
-        MESSAGE("Foe Wobbuffet lost its focus and couldn't move!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " lost its focus and couldn't move!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " lost its focus and couldn't move!");
     }
 }

--- a/test/battle/move_effect/freeze_hit.c
+++ b/test/battle/move_effect/freeze_hit.c
@@ -48,7 +48,7 @@ SINGLE_BATTLE_TEST("Freeze cannot be inflicted in Sunlight")
     } WHEN {
         TURN { MOVE(opponent, MOVE_SUNNY_DAY); MOVE(player, MOVE_ICE_BEAM); }
     } SCENE {
-        NOT MESSAGE("Wobbuffet was frozen solid!");
+        NOT MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was frozen solid!");
     }
 }
 
@@ -63,6 +63,6 @@ SINGLE_BATTLE_TEST("Blizzard bypasses accuracy checks in Hail and Snow")
     } WHEN {
         TURN { MOVE(opponent, move); MOVE(player, MOVE_BLIZZARD); }
     } SCENE {
-        NOT MESSAGE("Wobbuffet's attack missed!");
+        NOT MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s attack missed!");
     }
 }

--- a/test/battle/move_effect/healing_wish.c
+++ b/test/battle/move_effect/healing_wish.c
@@ -19,7 +19,7 @@ SINGLE_BATTLE_TEST("Healing Wish causes the user to faint and fully heals the re
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_HEALING_WISH, player);
         HP_BAR(player, hp: 0);
-        MESSAGE("Gardevoir fainted!");
+        MESSAGE(SPECIES_NAME(SPECIES_GARDEVOIR) " fainted!");
         MESSAGE("The healing wish came true for Wynaut!");
         HP_BAR(player, hp: 100);
         STATUS_ICON(player, none: TRUE);
@@ -41,8 +41,8 @@ DOUBLE_BATTLE_TEST("Lunar Dance causes the user to faint and fully heals the rep
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_LUNAR_DANCE, playerLeft);
         HP_BAR(playerLeft, hp: 0);
-        MESSAGE("Gardevoir fainted!");
-        MESSAGE("Wynaut became cloaked in mystical moonlight!");
+        MESSAGE(SPECIES_NAME(SPECIES_GARDEVOIR) " fainted!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " became cloaked in mystical moonlight!");
         HP_BAR(playerLeft, hp: 100);
         STATUS_ICON(playerLeft, none: TRUE);
         MESSAGE("Wynaut regained health!");
@@ -63,7 +63,7 @@ SINGLE_BATTLE_TEST("Healing Wish effect activates only if the switched pokemon c
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_HEALING_WISH, player);
         HP_BAR(player, hp: 0);
-        MESSAGE("Gardevoir fainted!");
+        MESSAGE(SPECIES_NAME(SPECIES_GARDEVOIR) " fainted!");
         NONE_OF {
             MESSAGE("The healing wish came true for Wynaut!");
             MESSAGE("Wynaut regained health!");

--- a/test/battle/move_effect/healing_wish.c
+++ b/test/battle/move_effect/healing_wish.c
@@ -23,7 +23,7 @@ SINGLE_BATTLE_TEST("Healing Wish causes the user to faint and fully heals the re
         MESSAGE("The healing wish came true for Wynaut!");
         HP_BAR(player, hp: 100);
         STATUS_ICON(player, none: TRUE);
-        MESSAGE("Wynaut regained health!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " regained health!");
     }
 }
 
@@ -45,7 +45,7 @@ DOUBLE_BATTLE_TEST("Lunar Dance causes the user to faint and fully heals the rep
         MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " became cloaked in mystical moonlight!");
         HP_BAR(playerLeft, hp: 100);
         STATUS_ICON(playerLeft, none: TRUE);
-        MESSAGE("Wynaut regained health!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " regained health!");
     }
 }
 
@@ -66,13 +66,13 @@ SINGLE_BATTLE_TEST("Healing Wish effect activates only if the switched pokemon c
         MESSAGE(SPECIES_NAME(SPECIES_GARDEVOIR) " fainted!");
         NONE_OF {
             MESSAGE("The healing wish came true for Wynaut!");
-            MESSAGE("Wynaut regained health!");
+            MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " regained health!");
         }
         ANIMATION(ANIM_TYPE_MOVE, MOVE_U_TURN, player);
         MESSAGE("Do it! Wynaut!");
         MESSAGE("The healing wish came true for Wynaut!");
         HP_BAR(player, hp: 100);
         STATUS_ICON(player, none: TRUE);
-        MESSAGE("Wynaut regained health!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " regained health!");
     }
 }

--- a/test/battle/move_effect/hit_escape.c
+++ b/test/battle/move_effect/hit_escape.c
@@ -17,7 +17,7 @@ SINGLE_BATTLE_TEST("U-turn switches the user out")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_U_TURN, player);
         HP_BAR(opponent);
-        MESSAGE("Go! Wynaut!");
+        MESSAGE("Go! " SPECIES_NAME(SPECIES_WYNAUT) "!");
     }
 }
 
@@ -76,7 +76,7 @@ SINGLE_BATTLE_TEST("U-turn does not switch the user out if Wimp Out activates")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_U_TURN, player);
         HP_BAR(opponent);
         ABILITY_POPUP(opponent, ABILITY_WIMP_OUT);
-        MESSAGE("2 sent out Wobbuffet!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
     }
 }
 

--- a/test/battle/move_effect/hit_set_entry_hazardss.c
+++ b/test/battle/move_effect/hit_set_entry_hazardss.c
@@ -29,10 +29,10 @@ SINGLE_BATTLE_TEST("Stone Axe / Ceaseless Edge set up hazards after hitting the 
         else {
             MESSAGE("Pointed stones float in the air around the opposing team!");
         }
-        MESSAGE("2 sent out Wobbuffet!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
         if (move == MOVE_CEASELESS_EDGE) {
             HP_BAR(opponent, damage: maxHP / 8);
-            MESSAGE("Foe Wobbuffet is hurt by spikes!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is hurt by spikes!");
         }
         else {
             HP_BAR(opponent, damage: maxHP / 8);
@@ -72,9 +72,9 @@ SINGLE_BATTLE_TEST("Ceaseless Edge can set up to 3 layers of Spikes")
         HP_BAR(opponent);
         NOT MESSAGE("Spikes were scattered all around the opposing team!");
 
-        MESSAGE("2 sent out Wynaut!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WYNAUT) "!");
         HP_BAR(opponent, damage: maxHP / 4);
-        MESSAGE("Foe Wynaut is hurt by spikes!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " is hurt by spikes!");
     }
 }
 
@@ -109,7 +109,7 @@ SINGLE_BATTLE_TEST("Stone Axe can set up pointed stones only once")
         HP_BAR(opponent);
         NOT MESSAGE("Pointed stones float in the air around the opposing team!");
 
-        MESSAGE("2 sent out Wynaut!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WYNAUT) "!");
         HP_BAR(opponent, damage: maxHP / 8);
         MESSAGE("Pointed stones dug into Foe Wynaut!");
     }

--- a/test/battle/move_effect/hit_set_entry_hazardss.c
+++ b/test/battle/move_effect/hit_set_entry_hazardss.c
@@ -36,7 +36,7 @@ SINGLE_BATTLE_TEST("Stone Axe / Ceaseless Edge set up hazards after hitting the 
         }
         else {
             HP_BAR(opponent, damage: maxHP / 8);
-            MESSAGE("Pointed stones dug into Foe Wobbuffet!");
+            MESSAGE("Pointed stones dug into Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
         }
     }
 }
@@ -111,7 +111,7 @@ SINGLE_BATTLE_TEST("Stone Axe can set up pointed stones only once")
 
         MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WYNAUT) "!");
         HP_BAR(opponent, damage: maxHP / 8);
-        MESSAGE("Pointed stones dug into Foe Wynaut!");
+        MESSAGE("Pointed stones dug into Foe " SPECIES_NAME(SPECIES_WYNAUT) "!");
     }
 }
 

--- a/test/battle/move_effect/hit_switch_target.c
+++ b/test/battle/move_effect/hit_switch_target.c
@@ -20,7 +20,7 @@ SINGLE_BATTLE_TEST("Dragon Tail switches the target with a random non-fainted re
         TURN { MOVE(player, MOVE_DRAGON_TAIL); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_TAIL, player);
-        MESSAGE("Foe Bulbasaur was dragged out!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_BULBASAUR) " was dragged out!");
     }
 }
 
@@ -39,7 +39,7 @@ DOUBLE_BATTLE_TEST("Dragon Tail switches the target with a random non-battler, n
         TURN { MOVE(playerLeft, MOVE_DRAGON_TAIL, target: opponentRight); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_TAIL, playerLeft);
-        MESSAGE("Foe Bulbasaur was dragged out!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_BULBASAUR) " was dragged out!");
     }
 }
 

--- a/test/battle/move_effect/hurricane.c
+++ b/test/battle/move_effect/hurricane.c
@@ -29,7 +29,7 @@ SINGLE_BATTLE_TEST("Hurricane bypasses accuracy checks in Rain")
     } WHEN {
         TURN { MOVE(opponent, MOVE_RAIN_DANCE); MOVE(player, MOVE_HURRICANE); }
     } SCENE {
-        NONE_OF { MESSAGE("Wobbuffet's attack missed!"); }
+        NONE_OF { MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s attack missed!"); }
     }
 }
 TO_DO_BATTLE_TEST("Hurricane Veil can hit airborne targets") // Fly, Bounce, Sky Drop

--- a/test/battle/move_effect/knock_off.c
+++ b/test/battle/move_effect/knock_off.c
@@ -20,7 +20,7 @@ SINGLE_BATTLE_TEST("Knock Off knocks a healing berry before it has the chance to
             MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Sitrus Berry restored health!");
         }
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ITEM_KNOCKOFF);
-        MESSAGE("Wobbuffet knocked off Foe Wobbuffet's Sitrus Berry!");
+        MESSAGE("Wobbuffet knocked off Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Sitrus Berry!");
     }
 }
 
@@ -41,13 +41,13 @@ SINGLE_BATTLE_TEST("Knock Off activates after Rocky Helmet and Weakness Policy")
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
         if (item == ITEM_WEAKNESS_POLICY) {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE);
-            MESSAGE("Using WeaknssPolicy, the Attack of Foe Wobbuffet sharply rose!");
-            MESSAGE("Using WeaknssPolicy, the Sp. Atk of Foe Wobbuffet sharply rose!");
+            MESSAGE("Using WeaknssPolicy, the Attack of Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " sharply rose!");
+            MESSAGE("Using WeaknssPolicy, the Sp. Atk of Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " sharply rose!");
         } else if (item == ITEM_ROCKY_HELMET) {
             HP_BAR(player);
-            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was hurt by Foe Wobbuffet's Rocky Helmet!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was hurt by Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Rocky Helmet!");
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ITEM_KNOCKOFF);
-            MESSAGE("Wobbuffet knocked off Foe Wobbuffet's Rocky Helmet!");
+            MESSAGE("Wobbuffet knocked off Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Rocky Helmet!");
         }
     }
 }

--- a/test/battle/move_effect/knock_off.c
+++ b/test/battle/move_effect/knock_off.c
@@ -17,7 +17,7 @@ SINGLE_BATTLE_TEST("Knock Off knocks a healing berry before it has the chance to
         ANIMATION(ANIM_TYPE_MOVE, MOVE_KNOCK_OFF, player);
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-            MESSAGE("Foe Wobbuffet's Sitrus Berry restored health!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Sitrus Berry restored health!");
         }
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ITEM_KNOCKOFF);
         MESSAGE("Wobbuffet knocked off Foe Wobbuffet's Sitrus Berry!");
@@ -45,7 +45,7 @@ SINGLE_BATTLE_TEST("Knock Off activates after Rocky Helmet and Weakness Policy")
             MESSAGE("Using WeaknssPolicy, the Sp. Atk of Foe Wobbuffet sharply rose!");
         } else if (item == ITEM_ROCKY_HELMET) {
             HP_BAR(player);
-            MESSAGE("Wobbuffet was hurt by Foe Wobbuffet's Rocky Helmet!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was hurt by Foe Wobbuffet's Rocky Helmet!");
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ITEM_KNOCKOFF);
             MESSAGE("Wobbuffet knocked off Foe Wobbuffet's Rocky Helmet!");
         }

--- a/test/battle/move_effect/last_resort.c
+++ b/test/battle/move_effect/last_resort.c
@@ -15,9 +15,9 @@ SINGLE_BATTLE_TEST("Last Resort always fails if it's the only known move")
         TURN { MOVE(player, MOVE_LAST_RESORT); }
         TURN { MOVE(player, MOVE_LAST_RESORT); }
     } SCENE {
-        MESSAGE("Wobbuffet used Last Resort!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LAST_RESORT) "!");
         MESSAGE("But it failed!");
-        MESSAGE("Wobbuffet used Last Resort!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LAST_RESORT) "!");
         MESSAGE("But it failed!");
         NOT HP_BAR(opponent);
     }
@@ -33,10 +33,10 @@ SINGLE_BATTLE_TEST("Last Resort works only when all of the known moves have been
         TURN { MOVE(player, MOVE_TACKLE); }
         TURN { MOVE(player, MOVE_LAST_RESORT); }
     } SCENE {
-        MESSAGE("Wobbuffet used Last Resort!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LAST_RESORT) "!");
         MESSAGE("But it failed!");
-        MESSAGE("Wobbuffet used Tackle!");
-        MESSAGE("Wobbuffet used Last Resort!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LAST_RESORT) "!");
         HP_BAR(opponent);
     }
 }
@@ -53,13 +53,13 @@ SINGLE_BATTLE_TEST("Last Resort works only when all of the known moves have been
         TURN { MOVE(player, MOVE_SCRATCH); }
         TURN { MOVE(player, MOVE_LAST_RESORT); }
     } SCENE {
-        MESSAGE("Wobbuffet used Last Resort!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LAST_RESORT) "!");
         MESSAGE("But it failed!");
-        MESSAGE("Wobbuffet used Tackle!");
-        MESSAGE("Wobbuffet used Last Resort!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LAST_RESORT) "!");
         MESSAGE("But it failed!");
-        MESSAGE("Wobbuffet used Scratch!");
-        MESSAGE("Wobbuffet used Last Resort!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SCRATCH) "!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LAST_RESORT) "!");
         HP_BAR(opponent);
     }
 }
@@ -78,16 +78,16 @@ SINGLE_BATTLE_TEST("Last Resort works only when all of the known moves have been
         TURN { MOVE(player, MOVE_GUST); }
         TURN { MOVE(player, MOVE_LAST_RESORT); }
     } SCENE {
-        MESSAGE("Wobbuffet used Last Resort!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LAST_RESORT) "!");
         MESSAGE("But it failed!");
-        MESSAGE("Wobbuffet used Tackle!");
-        MESSAGE("Wobbuffet used Last Resort!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LAST_RESORT) "!");
         MESSAGE("But it failed!");
-        MESSAGE("Wobbuffet used Scratch!");
-        MESSAGE("Wobbuffet used Last Resort!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SCRATCH) "!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LAST_RESORT) "!");
         MESSAGE("But it failed!");
-        MESSAGE("Wobbuffet used Gust!");
-        MESSAGE("Wobbuffet used Last Resort!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_GUST) "!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LAST_RESORT) "!");
         HP_BAR(opponent);
     }
 }
@@ -103,13 +103,13 @@ SINGLE_BATTLE_TEST("Last Resort works with Sleep Talk")
         TURN { MOVE(player, MOVE_SLEEP_TALK); }
     } SCENE {
         // Turn 1
-        MESSAGE("Wobbuffet used Sleep Talk!");
-        MESSAGE("Wobbuffet used Last Resort!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SLEEP_TALK) "!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LAST_RESORT) "!");
         NOT MESSAGE("But it failed!");
         HP_BAR(opponent);
         // Turn 2
-        MESSAGE("Wobbuffet used Sleep Talk!");
-        MESSAGE("Wobbuffet used Last Resort!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SLEEP_TALK) "!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LAST_RESORT) "!");
         NOT MESSAGE("But it failed!");
         HP_BAR(opponent);
     }

--- a/test/battle/move_effect/last_resort.c
+++ b/test/battle/move_effect/last_resort.c
@@ -15,9 +15,9 @@ SINGLE_BATTLE_TEST("Last Resort always fails if it's the only known move")
         TURN { MOVE(player, MOVE_LAST_RESORT); }
         TURN { MOVE(player, MOVE_LAST_RESORT); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LAST_RESORT) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_LAST_RESORT) "!");
         MESSAGE("But it failed!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LAST_RESORT) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_LAST_RESORT) "!");
         MESSAGE("But it failed!");
         NOT HP_BAR(opponent);
     }
@@ -33,10 +33,10 @@ SINGLE_BATTLE_TEST("Last Resort works only when all of the known moves have been
         TURN { MOVE(player, MOVE_TACKLE); }
         TURN { MOVE(player, MOVE_LAST_RESORT); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LAST_RESORT) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_LAST_RESORT) "!");
         MESSAGE("But it failed!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LAST_RESORT) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_LAST_RESORT) "!");
         HP_BAR(opponent);
     }
 }
@@ -53,13 +53,13 @@ SINGLE_BATTLE_TEST("Last Resort works only when all of the known moves have been
         TURN { MOVE(player, MOVE_SCRATCH); }
         TURN { MOVE(player, MOVE_LAST_RESORT); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LAST_RESORT) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_LAST_RESORT) "!");
         MESSAGE("But it failed!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LAST_RESORT) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_LAST_RESORT) "!");
         MESSAGE("But it failed!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SCRATCH) "!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LAST_RESORT) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SCRATCH) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_LAST_RESORT) "!");
         HP_BAR(opponent);
     }
 }
@@ -78,16 +78,16 @@ SINGLE_BATTLE_TEST("Last Resort works only when all of the known moves have been
         TURN { MOVE(player, MOVE_GUST); }
         TURN { MOVE(player, MOVE_LAST_RESORT); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LAST_RESORT) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_LAST_RESORT) "!");
         MESSAGE("But it failed!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LAST_RESORT) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_LAST_RESORT) "!");
         MESSAGE("But it failed!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SCRATCH) "!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LAST_RESORT) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SCRATCH) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_LAST_RESORT) "!");
         MESSAGE("But it failed!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_GUST) "!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LAST_RESORT) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_GUST) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_LAST_RESORT) "!");
         HP_BAR(opponent);
     }
 }
@@ -103,13 +103,13 @@ SINGLE_BATTLE_TEST("Last Resort works with Sleep Talk")
         TURN { MOVE(player, MOVE_SLEEP_TALK); }
     } SCENE {
         // Turn 1
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SLEEP_TALK) "!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LAST_RESORT) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SLEEP_TALK) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_LAST_RESORT) "!");
         NOT MESSAGE("But it failed!");
         HP_BAR(opponent);
         // Turn 2
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SLEEP_TALK) "!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LAST_RESORT) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SLEEP_TALK) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_LAST_RESORT) "!");
         NOT MESSAGE("But it failed!");
         HP_BAR(opponent);
     }

--- a/test/battle/move_effect/leech_seed.c
+++ b/test/battle/move_effect/leech_seed.c
@@ -17,7 +17,7 @@ SINGLE_BATTLE_TEST("Leech Seed doesn't affect Grass-type Pokémon")
         TURN { MOVE(player, MOVE_LEECH_SEED); }
     } SCENE {
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_LEECH_SEED, player);
-        MESSAGE("It doesn't affect Foe Oddish…");
+        MESSAGE("It doesn't affect Foe " SPECIES_NAME(SPECIES_ODDISH) "…");
     }
 }
 TO_DO_BATTLE_TEST("Leech Seed doesn't affect already seeded targets")

--- a/test/battle/move_effect/make_it_rain.c
+++ b/test/battle/move_effect/make_it_rain.c
@@ -21,13 +21,13 @@ SINGLE_BATTLE_TEST("Make It Rain lowers special attack by one stage")
         HP_BAR(opponent, captureDamage: &damage[0]);
         MESSAGE("Coins scattered everywhere!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-        MESSAGE("Wobbuffet's Sp. Atk fell!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Sp. Atk fell!");
 
         ANIMATION(ANIM_TYPE_MOVE, MOVE_MAKE_IT_RAIN, player);
         HP_BAR(opponent, captureDamage: &damage[1]);
         MESSAGE("Coins scattered everywhere!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-        MESSAGE("Wobbuffet's Sp. Atk fell!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Sp. Atk fell!");
     } THEN {
         EXPECT_MUL_EQ(damage[0], Q_4_12(0.66), damage[1]);
     }
@@ -48,11 +48,11 @@ DOUBLE_BATTLE_TEST("Make It Rain lowers special attack by one stage if it hits b
         NONE_OF {
             MESSAGE("Coins scattered everywhere!");
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
-            MESSAGE("Wobbuffet's Sp. Atk fell!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Sp. Atk fell!");
         }
         HP_BAR(opponentRight);
         MESSAGE("Coins scattered everywhere!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
-        MESSAGE("Wobbuffet's Sp. Atk fell!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Sp. Atk fell!");
     }
 }

--- a/test/battle/move_effect/metronome.c
+++ b/test/battle/move_effect/metronome.c
@@ -14,9 +14,9 @@ SINGLE_BATTLE_TEST("Metronome picks a random move")
     } WHEN {
         TURN { MOVE(player, MOVE_METRONOME, WITH_RNG(RNG_METRONOME, MOVE_SCRATCH)); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_METRONOME) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_METRONOME) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_METRONOME, player);
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SCRATCH) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SCRATCH) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
         HP_BAR(opponent);
     }
@@ -33,11 +33,11 @@ SINGLE_BATTLE_TEST("Metronome's called powder move fails against Grass Types")
     } WHEN {
         TURN { MOVE(player, MOVE_METRONOME, WITH_RNG(RNG_METRONOME, MOVE_POISON_POWDER)); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_METRONOME) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_METRONOME) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_METRONOME, player);
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_POISON_POWDER) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_POISON_POWDER) "!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_POISON_POWDER, player);
-        MESSAGE("It doesn't affect Foe Tangela…");
+        MESSAGE("It doesn't affect Foe " SPECIES_NAME(SPECIES_TANGELA) "…");
         NOT STATUS_ICON(opponent, poison: TRUE);
     }
 }
@@ -51,9 +51,9 @@ SINGLE_BATTLE_TEST("Metronome's called multi-hit move hits multiple times")
     } WHEN {
         TURN { MOVE(player, MOVE_METRONOME, WITH_RNG(RNG_METRONOME, MOVE_ROCK_BLAST)); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_METRONOME) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_METRONOME) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_METRONOME, player);
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_ROCK_BLAST) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_ROCK_BLAST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROCK_BLAST, player);
         HP_BAR(opponent);
         MESSAGE("Hit 5 time(s)!");

--- a/test/battle/move_effect/metronome.c
+++ b/test/battle/move_effect/metronome.c
@@ -14,9 +14,9 @@ SINGLE_BATTLE_TEST("Metronome picks a random move")
     } WHEN {
         TURN { MOVE(player, MOVE_METRONOME, WITH_RNG(RNG_METRONOME, MOVE_SCRATCH)); }
     } SCENE {
-        MESSAGE("Wobbuffet used Metronome!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_METRONOME) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_METRONOME, player);
-        MESSAGE("Wobbuffet used Scratch!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SCRATCH) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
         HP_BAR(opponent);
     }
@@ -33,9 +33,9 @@ SINGLE_BATTLE_TEST("Metronome's called powder move fails against Grass Types")
     } WHEN {
         TURN { MOVE(player, MOVE_METRONOME, WITH_RNG(RNG_METRONOME, MOVE_POISON_POWDER)); }
     } SCENE {
-        MESSAGE("Wobbuffet used Metronome!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_METRONOME) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_METRONOME, player);
-        MESSAGE("Wobbuffet used PoisonPowder!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_POISON_POWDER) "!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_POISON_POWDER, player);
         MESSAGE("It doesn't affect Foe Tangela…");
         NOT STATUS_ICON(opponent, poison: TRUE);
@@ -51,9 +51,9 @@ SINGLE_BATTLE_TEST("Metronome's called multi-hit move hits multiple times")
     } WHEN {
         TURN { MOVE(player, MOVE_METRONOME, WITH_RNG(RNG_METRONOME, MOVE_ROCK_BLAST)); }
     } SCENE {
-        MESSAGE("Wobbuffet used Metronome!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_METRONOME) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_METRONOME, player);
-        MESSAGE("Wobbuffet used Rock Blast!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_ROCK_BLAST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROCK_BLAST, player);
         HP_BAR(opponent);
         MESSAGE("Hit 5 time(s)!");

--- a/test/battle/move_effect/mind_blown.c
+++ b/test/battle/move_effect/mind_blown.c
@@ -16,7 +16,7 @@ SINGLE_BATTLE_TEST("Mind Blown makes the user lose 1/2 of its HP")
     } SCENE {
         HP_BAR(player, damage: 200);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_MIND_BLOWN, player);
-        NOT MESSAGE("Wobbuffet fainted!"); // Wobb had more than 1/2 of its HP, so it can't faint.
+        NOT MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " fainted!"); // Wobb had more than 1/2 of its HP, so it can't faint.
     }
 }
 
@@ -32,7 +32,7 @@ DOUBLE_BATTLE_TEST("Mind Blown makes the user lose 1/2 of its HP in a double bat
     } SCENE {
         HP_BAR(playerLeft, damage: 200);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_MIND_BLOWN, playerLeft);
-        NOT MESSAGE("Wobbuffet fainted!"); // Wobb had more than 1/2 of its HP, so it can't faint.
+        NOT MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " fainted!"); // Wobb had more than 1/2 of its HP, so it can't faint.
     }
 }
 
@@ -46,7 +46,7 @@ SINGLE_BATTLE_TEST("Mind Blown causes the user to faint when below 1/2 of its HP
     } SCENE {
         HP_BAR(player, hp: 0);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_MIND_BLOWN, player);
-        MESSAGE("Wobbuffet fainted!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " fainted!");
     }
 }
 
@@ -62,7 +62,7 @@ DOUBLE_BATTLE_TEST("Mind Blown causes the user to faint when below 1/2 of its HP
     } SCENE {
         HP_BAR(playerLeft, hp: 0);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_MIND_BLOWN, playerLeft);
-        MESSAGE("Wobbuffet fainted!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " fainted!");
     }
 }
 
@@ -78,8 +78,8 @@ SINGLE_BATTLE_TEST("Mind Blown causes the user & the target to faint when below 
         HP_BAR(player, hp: 0);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_MIND_BLOWN, player);
         HP_BAR(opponent, hp: 0);
-        MESSAGE("Foe Wobbuffet fainted!");
-        MESSAGE("Wobbuffet fainted!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " fainted!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " fainted!");
     }
 }
 
@@ -97,11 +97,11 @@ DOUBLE_BATTLE_TEST("Mind Blown causes everyone to faint in a double battle")
         HP_BAR(playerLeft, hp: 0);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_MIND_BLOWN, playerLeft);
         HP_BAR(opponentLeft, hp: 0);
-        MESSAGE("Foe Abra fainted!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_ABRA) " fainted!");
         HP_BAR(playerRight, hp: 0);
-        MESSAGE("Wynaut fainted!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " fainted!");
         HP_BAR(opponentRight, hp: 0);
-        MESSAGE("Foe Kadabra fainted!");
-        MESSAGE("Wobbuffet fainted!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_KADABRA) " fainted!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " fainted!");
     }
 }

--- a/test/battle/move_effect/mirror_move.c
+++ b/test/battle/move_effect/mirror_move.c
@@ -16,8 +16,8 @@ SINGLE_BATTLE_TEST("Mirror Move copies the last used move by the target")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
         HP_BAR(player);
-        MESSAGE("Wobbuffet used Mirror Move!");
-        MESSAGE("Wobbuffet used Tackle!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_MIRROR_MOVE) "!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, player);
         HP_BAR(opponent);
     }
@@ -31,7 +31,7 @@ SINGLE_BATTLE_TEST("Mirror Move fails if no move was used before")
     } WHEN {
         TURN { MOVE(player, MOVE_MIRROR_MOVE); MOVE(opponent, MOVE_TACKLE); }
     } SCENE {
-        MESSAGE("Wobbuffet used Mirror Move!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_MIRROR_MOVE) "!");
         MESSAGE("The Mirror Move failed!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
         HP_BAR(player);
@@ -51,8 +51,8 @@ SINGLE_BATTLE_TEST("Mirror Move's called powder move fails against Grass Types")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_STUN_SPORE, player);
         STATUS_ICON(opponent, paralysis: TRUE);
-        MESSAGE("Foe Wobbuffet used Mirror Move!");
-        MESSAGE("Foe Wobbuffet used Stun Spore!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_MIRROR_MOVE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_STUN_SPORE) "!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_STUN_SPORE, opponent);
         MESSAGE("It doesn't affect Oddish…");
         NOT STATUS_ICON(player, paralysis: TRUE);
@@ -71,8 +71,8 @@ SINGLE_BATTLE_TEST("Mirror Move's called multi-hit move hits multiple times")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BULLET_SEED, player);
         HP_BAR(opponent);
         MESSAGE("Hit 5 time(s)!");
-        MESSAGE("Foe Wobbuffet used Mirror Move!");
-        MESSAGE("Foe Wobbuffet used Bullet Seed!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_MIRROR_MOVE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_BULLET_SEED) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BULLET_SEED, opponent);
         HP_BAR(player);
         MESSAGE("Hit 5 time(s)!");

--- a/test/battle/move_effect/mirror_move.c
+++ b/test/battle/move_effect/mirror_move.c
@@ -16,8 +16,8 @@ SINGLE_BATTLE_TEST("Mirror Move copies the last used move by the target")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
         HP_BAR(player);
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_MIRROR_MOVE) "!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_MIRROR_MOVE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, player);
         HP_BAR(opponent);
     }
@@ -31,7 +31,7 @@ SINGLE_BATTLE_TEST("Mirror Move fails if no move was used before")
     } WHEN {
         TURN { MOVE(player, MOVE_MIRROR_MOVE); MOVE(opponent, MOVE_TACKLE); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_MIRROR_MOVE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_MIRROR_MOVE) "!");
         MESSAGE("The Mirror Move failed!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
         HP_BAR(player);
@@ -51,10 +51,10 @@ SINGLE_BATTLE_TEST("Mirror Move's called powder move fails against Grass Types")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_STUN_SPORE, player);
         STATUS_ICON(opponent, paralysis: TRUE);
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_MIRROR_MOVE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_STUN_SPORE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_MIRROR_MOVE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_STUN_SPORE) "!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_STUN_SPORE, opponent);
-        MESSAGE("It doesn't affect Oddish…");
+        MESSAGE("It doesn't affect " SPECIES_NAME(SPECIES_ODDISH) "…");
         NOT STATUS_ICON(player, paralysis: TRUE);
     }
 }
@@ -71,8 +71,8 @@ SINGLE_BATTLE_TEST("Mirror Move's called multi-hit move hits multiple times")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BULLET_SEED, player);
         HP_BAR(opponent);
         MESSAGE("Hit 5 time(s)!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_MIRROR_MOVE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_BULLET_SEED) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_MIRROR_MOVE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_BULLET_SEED) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BULLET_SEED, opponent);
         HP_BAR(player);
         MESSAGE("Hit 5 time(s)!");

--- a/test/battle/move_effect/mortal_spin.c
+++ b/test/battle/move_effect/mortal_spin.c
@@ -17,7 +17,7 @@ SINGLE_BATTLE_TEST("Mortal Spin blows away hazards and poisons foe")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_STEALTH_ROCK, opponent);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_MORTAL_SPIN, player);
         MESSAGE("Wobbuffet blew away Stealth Rock!");
-        MESSAGE("Foe Wobbuffet was poisoned!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " was poisoned!");
         STATUS_ICON(opponent, poison: TRUE);
     }
 }

--- a/test/battle/move_effect/multi_hit.c
+++ b/test/battle/move_effect/multi_hit.c
@@ -154,9 +154,9 @@ SINGLE_BATTLE_TEST("Scale Shot decreases defense and increases speed after final
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SCALE_SHOT, player);
         MESSAGE("Hit 5 time(s)!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-        MESSAGE("Wobbuffet's Defense fell!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Defense fell!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-        MESSAGE("Wobbuffet's Speed rose!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Speed rose!");
     }
 }
 
@@ -178,8 +178,8 @@ SINGLE_BATTLE_TEST("Endure does not prevent multiple hits and stat changes occur
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SCALE_SHOT, player);
         MESSAGE("Hit 5 time(s)!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-        MESSAGE("Wobbuffet's Defense fell!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Defense fell!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-        MESSAGE("Wobbuffet's Speed rose!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Speed rose!");
     }
 }

--- a/test/battle/move_effect/ohko.c
+++ b/test/battle/move_effect/ohko.c
@@ -17,7 +17,7 @@ SINGLE_BATTLE_TEST("Sheer Cold doesn't affect Ice-type Pokémon")
         TURN { MOVE(player, MOVE_SHEER_COLD); }
     } SCENE {
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_SHEER_COLD, player);
-        MESSAGE("It doesn't affect Foe Glalie…");
+        MESSAGE("It doesn't affect Foe " SPECIES_NAME(SPECIES_GLALIE) "…");
     }
 }
 TO_DO_BATTLE_TEST("Fissure faints the target, skipping regular damage calculations")

--- a/test/battle/move_effect/protect.c
+++ b/test/battle/move_effect/protect.c
@@ -97,12 +97,12 @@ SINGLE_BATTLE_TEST("King's Shield, Silk Trap and Obstruct protect from damaging 
                 NOT HP_BAR(opponent);
                 ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
                 if (statId == STAT_ATK) {
-                    MESSAGE("Wobbuffet's Attack fell!");
+                    MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Attack fell!");
                 } else if (statId == STAT_SPEED) {
-                    MESSAGE("Wobbuffet's Speed fell!");
+                    MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Speed fell!");
                 } else if (statId == STAT_DEF) {
                     if (lowersBy == 2) {
-                        MESSAGE("Wobbuffet's Defense harshly fell!");
+                        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Defense harshly fell!");
                     }
                 }
             } else {
@@ -149,8 +149,8 @@ SINGLE_BATTLE_TEST("Spiky Shield does 1/8 dmg of max hp of attackers making cont
         if (usedMove == MOVE_TACKLE) {
             HP_BAR(player, maxHp / 8);
             if (hp == 1) {
-                MESSAGE("Wobbuffet fainted!");
-                MESSAGE("Go! Wobbuffet!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " fainted!");
+                MESSAGE("Go! " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
             }
         }
     }
@@ -218,15 +218,15 @@ SINGLE_BATTLE_TEST("Recoil damage is not applied if target was protected")
         TURN {}
     } SCENE {
         // 1st turn
-        MESSAGE("Foe Beautifly used " MOVE_NAME(MOVE_TACKLE) "!");
-        MESSAGE("Rapidash used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_BEAUTIFLY) " used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_RAPIDASH) " used " MOVE_NAME(MOVE_TACKLE) "!");
         // 2nd turn
         ANIMATION(ANIM_TYPE_MOVE, protectMove, opponent);
         MESSAGE("Foe Beautifly protected itself!");
-        // MESSAGE("Rapidash used " MOVE_NAME(MOVE_RECOILMOVE) "!");
+        // MESSAGE(SPECIES_NAME(SPECIES_RAPIDASH) " used " MOVE_NAME(MOVE_RECOILMOVE) "!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, recoilMove, player);
-            MESSAGE("Rapidash is hit with recoil!");
+            MESSAGE(SPECIES_NAME(SPECIES_RAPIDASH) " is hit with recoil!");
         }
     }
 }
@@ -253,7 +253,7 @@ SINGLE_BATTLE_TEST("Multi-hit moves don't hit a protected target and fail only o
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, move, opponent);
         MESSAGE("Foe Beautifly protected itself!");
-        MESSAGE("Rapidash used " MOVE_NAME(MOVE_ARM_THRUST) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_RAPIDASH) " used " MOVE_NAME(MOVE_ARM_THRUST) "!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_ARM_THRUST, player);
         MESSAGE("Foe Beautifly protected itself!");
         // Each effect happens only once.
@@ -298,10 +298,10 @@ DOUBLE_BATTLE_TEST("Wide Guard protects self and ally from multi-target moves")
         TURN { MOVE(opponentLeft, MOVE_WIDE_GUARD); MOVE(playerLeft, move, target:opponentLeft); }
         TURN {}
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_WIDE_GUARD) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_WIDE_GUARD) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_WIDE_GUARD, opponentLeft);
         if (move == MOVE_TACKLE) {
-            MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
             ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, playerLeft);
             HP_BAR(opponentLeft);
         } else if (move == MOVE_HYPER_VOICE) {
@@ -341,10 +341,10 @@ DOUBLE_BATTLE_TEST("Quick Guard protects self and ally from priority moves")
         TURN { MOVE(opponentLeft, MOVE_QUICK_GUARD); MOVE(playerLeft, move, target:targetOpponent); }
         TURN {}
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_QUICK_GUARD) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_QUICK_GUARD) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_QUICK_GUARD, opponentLeft);
         if (move == MOVE_TACKLE) {
-            MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
             ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, playerLeft);
             HP_BAR(targetOpponent);
         } else if (move == MOVE_QUICK_ATTACK) {
@@ -379,7 +379,7 @@ DOUBLE_BATTLE_TEST("Crafty Shield protects self and ally from status moves")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CRAFTY_SHIELD, opponentLeft);
         if (move == MOVE_LEER) {
-            MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LEER) "!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_LEER) "!");
             MESSAGE("Foe Wobbuffet protected itself!");
             NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
             MESSAGE("Foe Wobbuffet protected itself!");

--- a/test/battle/move_effect/protect.c
+++ b/test/battle/move_effect/protect.c
@@ -46,9 +46,9 @@ SINGLE_BATTLE_TEST("Protect, Detect, Spiky Shield and Baneful Bunker protect fro
         TURN {}
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, protectMove, opponent);
-        MESSAGE("Foe Wobbuffet protected itself!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " protected itself!");
         NOT ANIMATION(ANIM_TYPE_MOVE, usedMove, player);
-        MESSAGE("Foe Wobbuffet protected itself!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " protected itself!");
         if (usedMove == MOVE_LEER) {
             NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
         } else {
@@ -85,14 +85,14 @@ SINGLE_BATTLE_TEST("King's Shield, Silk Trap and Obstruct protect from damaging 
         TURN {}
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, protectMove, opponent);
-        MESSAGE("Foe Wobbuffet protected itself!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " protected itself!");
         if (usedMove == MOVE_LEER) {
             ANIMATION(ANIM_TYPE_MOVE, usedMove, player);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-            NOT MESSAGE("Foe Wobbuffet protected itself!");
+            NOT MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " protected itself!");
         } else {
             NOT ANIMATION(ANIM_TYPE_MOVE, usedMove, player);
-            MESSAGE("Foe Wobbuffet protected itself!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " protected itself!");
             if (usedMove == MOVE_TACKLE) {
                 NOT HP_BAR(opponent);
                 ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
@@ -142,9 +142,9 @@ SINGLE_BATTLE_TEST("Spiky Shield does 1/8 dmg of max hp of attackers making cont
         TURN {}
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SPIKY_SHIELD, opponent);
-        MESSAGE("Foe Wobbuffet protected itself!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " protected itself!");
         NOT ANIMATION(ANIM_TYPE_MOVE, usedMove, player);
-        MESSAGE("Foe Wobbuffet protected itself!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " protected itself!");
         NOT HP_BAR(opponent);
         if (usedMove == MOVE_TACKLE) {
             HP_BAR(player, maxHp / 8);
@@ -173,9 +173,9 @@ SINGLE_BATTLE_TEST("Baneful Bunker poisons pokemon for moves making contact")
         TURN {}
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BANEFUL_BUNKER, opponent);
-        MESSAGE("Foe Wobbuffet protected itself!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " protected itself!");
         NOT ANIMATION(ANIM_TYPE_MOVE, usedMove, player);
-        MESSAGE("Foe Wobbuffet protected itself!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " protected itself!");
         if (usedMove == MOVE_TACKLE) {
             NOT HP_BAR(opponent);
             STATUS_ICON(player, STATUS1_POISON);
@@ -222,7 +222,7 @@ SINGLE_BATTLE_TEST("Recoil damage is not applied if target was protected")
         MESSAGE(SPECIES_NAME(SPECIES_RAPIDASH) " used " MOVE_NAME(MOVE_TACKLE) "!");
         // 2nd turn
         ANIMATION(ANIM_TYPE_MOVE, protectMove, opponent);
-        MESSAGE("Foe Beautifly protected itself!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_BEAUTIFLY) " protected itself!");
         // MESSAGE(SPECIES_NAME(SPECIES_RAPIDASH) " used " MOVE_NAME(MOVE_RECOILMOVE) "!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, recoilMove, player);
@@ -252,10 +252,10 @@ SINGLE_BATTLE_TEST("Multi-hit moves don't hit a protected target and fail only o
         TURN {}
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, move, opponent);
-        MESSAGE("Foe Beautifly protected itself!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_BEAUTIFLY) " protected itself!");
         MESSAGE(SPECIES_NAME(SPECIES_RAPIDASH) " used " MOVE_NAME(MOVE_ARM_THRUST) "!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_ARM_THRUST, player);
-        MESSAGE("Foe Beautifly protected itself!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_BEAUTIFLY) " protected itself!");
         // Each effect happens only once.
         if (move == MOVE_KINGS_SHIELD || move == MOVE_SILK_TRAP || move == MOVE_OBSTRUCT) {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
@@ -306,15 +306,15 @@ DOUBLE_BATTLE_TEST("Wide Guard protects self and ally from multi-target moves")
             HP_BAR(opponentLeft);
         } else if (move == MOVE_HYPER_VOICE) {
             NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_HYPER_VOICE, playerLeft);
-            MESSAGE("Foe Wobbuffet protected itself!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " protected itself!");
             NOT HP_BAR(opponentLeft);
-            MESSAGE("Foe Wobbuffet protected itself!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " protected itself!");
             NOT HP_BAR(opponentRight);
         } else { // Surf
-            MESSAGE("Foe Wobbuffet protected itself!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " protected itself!");
             NOT HP_BAR(opponentLeft);
             HP_BAR(playerRight);
-            MESSAGE("Foe Wobbuffet protected itself!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " protected itself!");
             NOT HP_BAR(opponentRight);
         }
     }
@@ -349,7 +349,7 @@ DOUBLE_BATTLE_TEST("Quick Guard protects self and ally from priority moves")
             HP_BAR(targetOpponent);
         } else if (move == MOVE_QUICK_ATTACK) {
             NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_QUICK_ATTACK, playerLeft);
-            MESSAGE("Foe Wobbuffet protected itself!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " protected itself!");
             NOT HP_BAR(targetOpponent);
         }
     }
@@ -380,16 +380,16 @@ DOUBLE_BATTLE_TEST("Crafty Shield protects self and ally from status moves")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CRAFTY_SHIELD, opponentLeft);
         if (move == MOVE_LEER) {
             MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_LEER) "!");
-            MESSAGE("Foe Wobbuffet protected itself!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " protected itself!");
             NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
-            MESSAGE("Foe Wobbuffet protected itself!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " protected itself!");
             NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);
         } else {
             if (move == MOVE_HYPER_VOICE || targetOpponent == opponentLeft) {
-                NOT MESSAGE("Foe Wobbuffet protected itself!");
+                NOT MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " protected itself!");
                 HP_BAR(opponentLeft);
             } else if (move == MOVE_HYPER_VOICE || targetOpponent == opponentRight) {
-                NOT MESSAGE("Foe Wobbuffet protected itself!");
+                NOT MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " protected itself!");
                 HP_BAR(opponentRight);
             }
         }

--- a/test/battle/move_effect/protect.c
+++ b/test/battle/move_effect/protect.c
@@ -218,12 +218,12 @@ SINGLE_BATTLE_TEST("Recoil damage is not applied if target was protected")
         TURN {}
     } SCENE {
         // 1st turn
-        MESSAGE("Foe Beautifly used Tackle!");
-        MESSAGE("Rapidash used Tackle!");
+        MESSAGE("Foe Beautifly used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE("Rapidash used " MOVE_NAME(MOVE_TACKLE) "!");
         // 2nd turn
         ANIMATION(ANIM_TYPE_MOVE, protectMove, opponent);
         MESSAGE("Foe Beautifly protected itself!");
-        // MESSAGE("Rapidash used recoilMove!");
+        // MESSAGE("Rapidash used " MOVE_NAME(MOVE_RECOILMOVE) "!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, recoilMove, player);
             MESSAGE("Rapidash is hit with recoil!");
@@ -253,7 +253,7 @@ SINGLE_BATTLE_TEST("Multi-hit moves don't hit a protected target and fail only o
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, move, opponent);
         MESSAGE("Foe Beautifly protected itself!");
-        MESSAGE("Rapidash used Arm Thrust!");
+        MESSAGE("Rapidash used " MOVE_NAME(MOVE_ARM_THRUST) "!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_ARM_THRUST, player);
         MESSAGE("Foe Beautifly protected itself!");
         // Each effect happens only once.
@@ -298,10 +298,10 @@ DOUBLE_BATTLE_TEST("Wide Guard protects self and ally from multi-target moves")
         TURN { MOVE(opponentLeft, MOVE_WIDE_GUARD); MOVE(playerLeft, move, target:opponentLeft); }
         TURN {}
     } SCENE {
-        MESSAGE("Foe Wobbuffet used Wide Guard!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_WIDE_GUARD) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_WIDE_GUARD, opponentLeft);
         if (move == MOVE_TACKLE) {
-            MESSAGE("Wobbuffet used Tackle!");
+            MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
             ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, playerLeft);
             HP_BAR(opponentLeft);
         } else if (move == MOVE_HYPER_VOICE) {
@@ -341,10 +341,10 @@ DOUBLE_BATTLE_TEST("Quick Guard protects self and ally from priority moves")
         TURN { MOVE(opponentLeft, MOVE_QUICK_GUARD); MOVE(playerLeft, move, target:targetOpponent); }
         TURN {}
     } SCENE {
-        MESSAGE("Foe Wobbuffet used Quick Guard!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_QUICK_GUARD) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_QUICK_GUARD, opponentLeft);
         if (move == MOVE_TACKLE) {
-            MESSAGE("Wobbuffet used Tackle!");
+            MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
             ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, playerLeft);
             HP_BAR(targetOpponent);
         } else if (move == MOVE_QUICK_ATTACK) {
@@ -379,7 +379,7 @@ DOUBLE_BATTLE_TEST("Crafty Shield protects self and ally from status moves")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CRAFTY_SHIELD, opponentLeft);
         if (move == MOVE_LEER) {
-            MESSAGE("Wobbuffet used Leer!");
+            MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_LEER) "!");
             MESSAGE("Foe Wobbuffet protected itself!");
             NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
             MESSAGE("Foe Wobbuffet protected itself!");

--- a/test/battle/move_effect/recoil_if_miss.c
+++ b/test/battle/move_effect/recoil_if_miss.c
@@ -78,9 +78,9 @@ SINGLE_BATTLE_TEST("Jump Kick's recoil happens after Spiky Shield damage and Pok
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SPIKY_SHIELD, opponent);
         MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_JUMP_KICK) "!");
-        MESSAGE("Foe Wobbuffet protected itself!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " protected itself!");
         HP_BAR(player, damage: maxHp / 8);
-        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was hurt by Foe Wobbuffet's Spiky Shield!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was hurt by Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Spiky Shield!");
         if (faintOnSpiky){
             MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " fainted!");
             MESSAGE("Go! " SPECIES_NAME(SPECIES_WYNAUT) "!");

--- a/test/battle/move_effect/recoil_if_miss.c
+++ b/test/battle/move_effect/recoil_if_miss.c
@@ -15,7 +15,7 @@ SINGLE_BATTLE_TEST("Jump Kick has 50% recoil on miss")
         TURN { MOVE(player, MOVE_JUMP_KICK, hit: FALSE); }
     } SCENE {
         s32 maxHP = GetMonData(&PLAYER_PARTY[0], MON_DATA_MAX_HP);
-        MESSAGE("Wobbuffet used Jump Kick!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_JUMP_KICK) "!");
         MESSAGE("Wobbuffet's attack missed!");
         MESSAGE("Wobbuffet kept going and crashed!");
         HP_BAR(player, damage: maxHP / 2);
@@ -77,7 +77,7 @@ SINGLE_BATTLE_TEST("Jump Kick's recoil happens after Spiky Shield damage and Pok
         TURN { ; }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SPIKY_SHIELD, opponent);
-        MESSAGE("Wobbuffet used Jump Kick!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_JUMP_KICK) "!");
         MESSAGE("Foe Wobbuffet protected itself!");
         HP_BAR(player, damage: maxHp / 8);
         MESSAGE("Wobbuffet was hurt by Foe Wobbuffet's Spiky Shield!");

--- a/test/battle/move_effect/recoil_if_miss.c
+++ b/test/battle/move_effect/recoil_if_miss.c
@@ -15,8 +15,8 @@ SINGLE_BATTLE_TEST("Jump Kick has 50% recoil on miss")
         TURN { MOVE(player, MOVE_JUMP_KICK, hit: FALSE); }
     } SCENE {
         s32 maxHP = GetMonData(&PLAYER_PARTY[0], MON_DATA_MAX_HP);
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_JUMP_KICK) "!");
-        MESSAGE("Wobbuffet's attack missed!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_JUMP_KICK) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s attack missed!");
         MESSAGE("Wobbuffet kept going and crashed!");
         HP_BAR(player, damage: maxHP / 2);
     }
@@ -77,13 +77,13 @@ SINGLE_BATTLE_TEST("Jump Kick's recoil happens after Spiky Shield damage and Pok
         TURN { ; }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SPIKY_SHIELD, opponent);
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_JUMP_KICK) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_JUMP_KICK) "!");
         MESSAGE("Foe Wobbuffet protected itself!");
         HP_BAR(player, damage: maxHp / 8);
-        MESSAGE("Wobbuffet was hurt by Foe Wobbuffet's Spiky Shield!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was hurt by Foe Wobbuffet's Spiky Shield!");
         if (faintOnSpiky){
-            MESSAGE("Wobbuffet fainted!");
-            MESSAGE("Go! Wynaut!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " fainted!");
+            MESSAGE("Go! " SPECIES_NAME(SPECIES_WYNAUT) "!");
             NONE_OF {
                 MESSAGE("Wobbuffet kept going and crashed!");
                 HP_BAR(player);
@@ -92,8 +92,8 @@ SINGLE_BATTLE_TEST("Jump Kick's recoil happens after Spiky Shield damage and Pok
             MESSAGE("Wobbuffet kept going and crashed!");
             HP_BAR(player);
             if (faintOnJumpKick) {
-                MESSAGE("Wobbuffet fainted!");
-                MESSAGE("Go! Wynaut!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " fainted!");
+                MESSAGE("Go! " SPECIES_NAME(SPECIES_WYNAUT) "!");
             }
         }
     }

--- a/test/battle/move_effect/reflect.c
+++ b/test/battle/move_effect/reflect.c
@@ -71,7 +71,7 @@ SINGLE_BATTLE_TEST("Reflect fails if already active")
         TURN { MOVE(player, MOVE_REFLECT); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_REFLECT, player);
-        MESSAGE("Wobbuffet used Reflect!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_REFLECT) "!");
         MESSAGE("But it failed!");
     }
 }

--- a/test/battle/move_effect/reflect.c
+++ b/test/battle/move_effect/reflect.c
@@ -71,7 +71,7 @@ SINGLE_BATTLE_TEST("Reflect fails if already active")
         TURN { MOVE(player, MOVE_REFLECT); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_REFLECT, player);
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_REFLECT) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_REFLECT) "!");
         MESSAGE("But it failed!");
     }
 }

--- a/test/battle/move_effect/reflect_type.c
+++ b/test/battle/move_effect/reflect_type.c
@@ -40,7 +40,7 @@ SINGLE_BATTLE_TEST("Reflect Type does not affect any of Arceus' forms")
     } WHEN {
         TURN { MOVE(player, MOVE_REFLECT_TYPE); }
     } SCENE {
-        MESSAGE("Wobbuffet used Reflect Type!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_REFLECT_TYPE) "!");
         MESSAGE("But it failed!");
     }
 }
@@ -81,7 +81,7 @@ SINGLE_BATTLE_TEST("Reflect Type does not affect any of Silvally's forms")
     } WHEN {
         TURN { MOVE(player, MOVE_REFLECT_TYPE); }
     } SCENE {
-        MESSAGE("Wobbuffet used Reflect Type!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_REFLECT_TYPE) "!");
         MESSAGE("But it failed!");
     }
 }
@@ -98,11 +98,11 @@ SINGLE_BATTLE_TEST("Reflect Type does not affect Pokémon with no types")
     } WHEN {
         TURN { MOVE(player, MOVE_BURN_UP); MOVE(opponent, MOVE_REFLECT_TYPE); }
     } SCENE {
-        MESSAGE("Arcanine used Burn Up!");
+        MESSAGE("Arcanine used " MOVE_NAME(MOVE_BURN_UP) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BURN_UP, player);
         HP_BAR(opponent);
         MESSAGE("Arcanine burned itself out!");
-        MESSAGE("Foe Poliwrath used Reflect Type!");
+        MESSAGE("Foe Poliwrath used " MOVE_NAME(MOVE_REFLECT_TYPE) "!");
         MESSAGE("But it failed!");
     }
 }
@@ -119,7 +119,7 @@ SINGLE_BATTLE_TEST("Reflect Type copies a target's dual types")
     } WHEN {
         TURN { MOVE(player, MOVE_REFLECT_TYPE); }
     } SCENE {
-        MESSAGE("Arcanine used Reflect Type!");
+        MESSAGE("Arcanine used " MOVE_NAME(MOVE_REFLECT_TYPE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_REFLECT_TYPE, player);
         MESSAGE("Arcanine's type changed to match the Foe Poliwrath's!");
     } THEN {
@@ -141,7 +141,7 @@ SINGLE_BATTLE_TEST("Reflect Type copies a target's pure type")
     } WHEN {
         TURN { MOVE(player, MOVE_REFLECT_TYPE); }
     } SCENE {
-        MESSAGE("Arcanine used Reflect Type!");
+        MESSAGE("Arcanine used " MOVE_NAME(MOVE_REFLECT_TYPE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_REFLECT_TYPE, player);
         MESSAGE("Arcanine's type changed to match the Foe Sudowoodo's!");
     } THEN {
@@ -166,16 +166,16 @@ SINGLE_BATTLE_TEST("Reflect Type defaults to Normal type for the user's type1 an
         TURN { MOVE(player, MOVE_REFLECT_TYPE); }
     } SCENE {
         // Turn 1
-        MESSAGE("Foe Arcanine used Burn Up!");
+        MESSAGE("Foe Arcanine used " MOVE_NAME(MOVE_BURN_UP) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BURN_UP, opponent);
         HP_BAR(player);
         MESSAGE("Foe Arcanine burned itself out!");
         // Turn 2
-        MESSAGE("Wobbuffet used Forest'sCurs!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FORESTS_CURSE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_FORESTS_CURSE, player);
         MESSAGE("Grass type was added to Foe Arcanine!");
         // Turn 3
-        MESSAGE("Wobbuffet used Reflect Type!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_REFLECT_TYPE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_REFLECT_TYPE, player);
         MESSAGE("Wobbuffet's type changed to match the Foe Arcanine's!");
     } THEN {

--- a/test/battle/move_effect/reflect_type.c
+++ b/test/battle/move_effect/reflect_type.c
@@ -121,7 +121,7 @@ SINGLE_BATTLE_TEST("Reflect Type copies a target's dual types")
     } SCENE {
         MESSAGE(SPECIES_NAME(SPECIES_ARCANINE) " used " MOVE_NAME(MOVE_REFLECT_TYPE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_REFLECT_TYPE, player);
-        MESSAGE(SPECIES_NAME(SPECIES_ARCANINE) "'s type changed to match the Foe Poliwrath's!");
+        MESSAGE(SPECIES_NAME(SPECIES_ARCANINE) "'s type changed to match the Foe " SPECIES_NAME(SPECIES_POLIWRATH) "'s!");
     } THEN {
         EXPECT_EQ(player->type1, TYPE_WATER);
         EXPECT_EQ(player->type2, TYPE_FIGHTING);
@@ -143,7 +143,7 @@ SINGLE_BATTLE_TEST("Reflect Type copies a target's pure type")
     } SCENE {
         MESSAGE(SPECIES_NAME(SPECIES_ARCANINE) " used " MOVE_NAME(MOVE_REFLECT_TYPE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_REFLECT_TYPE, player);
-        MESSAGE(SPECIES_NAME(SPECIES_ARCANINE) "'s type changed to match the Foe Sudowoodo's!");
+        MESSAGE(SPECIES_NAME(SPECIES_ARCANINE) "'s type changed to match the Foe " SPECIES_NAME(SPECIES_SUDOWOODO) "'s!");
     } THEN {
         EXPECT_EQ(player->type1, TYPE_ROCK);
         EXPECT_EQ(player->type2, TYPE_ROCK);
@@ -169,15 +169,15 @@ SINGLE_BATTLE_TEST("Reflect Type defaults to Normal type for the user's type1 an
         MESSAGE("Foe " SPECIES_NAME(SPECIES_ARCANINE) " used " MOVE_NAME(MOVE_BURN_UP) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BURN_UP, opponent);
         HP_BAR(player);
-        MESSAGE("Foe Arcanine burned itself out!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_ARCANINE) " burned itself out!");
         // Turn 2
         MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_FORESTS_CURSE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_FORESTS_CURSE, player);
-        MESSAGE("Grass type was added to Foe Arcanine!");
+        MESSAGE("Grass type was added to Foe " SPECIES_NAME(SPECIES_ARCANINE) "!");
         // Turn 3
         MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_REFLECT_TYPE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_REFLECT_TYPE, player);
-        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s type changed to match the Foe Arcanine's!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s type changed to match the Foe " SPECIES_NAME(SPECIES_ARCANINE) "'s!");
     } THEN {
         EXPECT_EQ(player->type1, TYPE_NORMAL);
         EXPECT_EQ(player->type2, TYPE_NORMAL);

--- a/test/battle/move_effect/reflect_type.c
+++ b/test/battle/move_effect/reflect_type.c
@@ -40,7 +40,7 @@ SINGLE_BATTLE_TEST("Reflect Type does not affect any of Arceus' forms")
     } WHEN {
         TURN { MOVE(player, MOVE_REFLECT_TYPE); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_REFLECT_TYPE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_REFLECT_TYPE) "!");
         MESSAGE("But it failed!");
     }
 }
@@ -81,7 +81,7 @@ SINGLE_BATTLE_TEST("Reflect Type does not affect any of Silvally's forms")
     } WHEN {
         TURN { MOVE(player, MOVE_REFLECT_TYPE); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_REFLECT_TYPE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_REFLECT_TYPE) "!");
         MESSAGE("But it failed!");
     }
 }
@@ -98,11 +98,11 @@ SINGLE_BATTLE_TEST("Reflect Type does not affect Pokémon with no types")
     } WHEN {
         TURN { MOVE(player, MOVE_BURN_UP); MOVE(opponent, MOVE_REFLECT_TYPE); }
     } SCENE {
-        MESSAGE("Arcanine used " MOVE_NAME(MOVE_BURN_UP) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_ARCANINE) " used " MOVE_NAME(MOVE_BURN_UP) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BURN_UP, player);
         HP_BAR(opponent);
         MESSAGE("Arcanine burned itself out!");
-        MESSAGE("Foe Poliwrath used " MOVE_NAME(MOVE_REFLECT_TYPE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_POLIWRATH) " used " MOVE_NAME(MOVE_REFLECT_TYPE) "!");
         MESSAGE("But it failed!");
     }
 }
@@ -119,9 +119,9 @@ SINGLE_BATTLE_TEST("Reflect Type copies a target's dual types")
     } WHEN {
         TURN { MOVE(player, MOVE_REFLECT_TYPE); }
     } SCENE {
-        MESSAGE("Arcanine used " MOVE_NAME(MOVE_REFLECT_TYPE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_ARCANINE) " used " MOVE_NAME(MOVE_REFLECT_TYPE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_REFLECT_TYPE, player);
-        MESSAGE("Arcanine's type changed to match the Foe Poliwrath's!");
+        MESSAGE(SPECIES_NAME(SPECIES_ARCANINE) "'s type changed to match the Foe Poliwrath's!");
     } THEN {
         EXPECT_EQ(player->type1, TYPE_WATER);
         EXPECT_EQ(player->type2, TYPE_FIGHTING);
@@ -141,9 +141,9 @@ SINGLE_BATTLE_TEST("Reflect Type copies a target's pure type")
     } WHEN {
         TURN { MOVE(player, MOVE_REFLECT_TYPE); }
     } SCENE {
-        MESSAGE("Arcanine used " MOVE_NAME(MOVE_REFLECT_TYPE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_ARCANINE) " used " MOVE_NAME(MOVE_REFLECT_TYPE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_REFLECT_TYPE, player);
-        MESSAGE("Arcanine's type changed to match the Foe Sudowoodo's!");
+        MESSAGE(SPECIES_NAME(SPECIES_ARCANINE) "'s type changed to match the Foe Sudowoodo's!");
     } THEN {
         EXPECT_EQ(player->type1, TYPE_ROCK);
         EXPECT_EQ(player->type2, TYPE_ROCK);
@@ -166,18 +166,18 @@ SINGLE_BATTLE_TEST("Reflect Type defaults to Normal type for the user's type1 an
         TURN { MOVE(player, MOVE_REFLECT_TYPE); }
     } SCENE {
         // Turn 1
-        MESSAGE("Foe Arcanine used " MOVE_NAME(MOVE_BURN_UP) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_ARCANINE) " used " MOVE_NAME(MOVE_BURN_UP) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BURN_UP, opponent);
         HP_BAR(player);
         MESSAGE("Foe Arcanine burned itself out!");
         // Turn 2
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FORESTS_CURSE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_FORESTS_CURSE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_FORESTS_CURSE, player);
         MESSAGE("Grass type was added to Foe Arcanine!");
         // Turn 3
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_REFLECT_TYPE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_REFLECT_TYPE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_REFLECT_TYPE, player);
-        MESSAGE("Wobbuffet's type changed to match the Foe Arcanine's!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s type changed to match the Foe Arcanine's!");
     } THEN {
         EXPECT_EQ(player->type1, TYPE_NORMAL);
         EXPECT_EQ(player->type2, TYPE_NORMAL);

--- a/test/battle/move_effect/revival_blessing.c
+++ b/test/battle/move_effect/revival_blessing.c
@@ -5,12 +5,6 @@
 // behaviors. These have been tested in-game, in double, in multi, and in link battles. AI will always
 // revive their first fainted party member in order.
 
-#if B_EXPANDED_MOVE_NAMES
-#define REVIVAL_BLESSING "Revival Blessing"
-#else
-#define REVIVAL_BLESSING "RevivlBlesng"
-#endif
-
 ASSUMPTIONS
 {
     ASSUME(gBattleMoves[MOVE_REVIVAL_BLESSING].effect == EFFECT_REVIVAL_BLESSING);
@@ -26,7 +20,7 @@ SINGLE_BATTLE_TEST("Revival Blessing revives a chosen fainted party member for t
     } WHEN {
         TURN { MOVE(player, MOVE_REVIVAL_BLESSING); SEND_OUT(player, 2); }
     } SCENE {
-        MESSAGE("Wobbuffet used " REVIVAL_BLESSING "!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_REVIVAL_BLESSING) "!");
         MESSAGE("Wynaut was revived and is ready to fight again!");
     }
 }
@@ -41,7 +35,7 @@ SINGLE_BATTLE_TEST("Revival Blessing revives a fainted party member for an oppon
     } WHEN {
         TURN { MOVE(opponent, MOVE_REVIVAL_BLESSING); SEND_OUT(opponent, 1); }
     } SCENE {
-        MESSAGE("Foe Raichu used " REVIVAL_BLESSING "!");
+        MESSAGE("Foe Raichu used " MOVE_NAME(MOVE_REVIVAL_BLESSING) "!");
         MESSAGE("Pichu was revived and is ready to fight again!");
     }
 }
@@ -54,7 +48,7 @@ SINGLE_BATTLE_TEST("Revival Blessing fails if no party members are fainted")
     } WHEN {
         TURN { MOVE(player, MOVE_REVIVAL_BLESSING); }
     } SCENE {
-        MESSAGE("Wobbuffet used " REVIVAL_BLESSING "!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_REVIVAL_BLESSING) "!");
         MESSAGE("But it failed!");
     }
 }
@@ -82,10 +76,10 @@ TO_DO_BATTLE_TEST("Revival Blessing cannot revive a partner's party member");
 //         TURN { MOVE(user, MOVE_REVIVAL_BLESSING); }
 //     } SCENE {
 //         if (user == opponentLeft) {
-//             MESSAGE("Foe Wobbuffet used " REVIVAL_BLESSING "!");
+//             MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_REVIVAL_BLESSING) "!");
 //             MESSAGE("But it failed!");
 //         } else {
-//             MESSAGE("Foe Wynaut used " REVIVAL_BLESSING "!");
+//             MESSAGE("Foe Wynaut used " MOVE_NAME(MOVE_REVIVAL_BLESSING) "!");
 //             MESSAGE("Wynaut was revived and is ready to fight again!");
 //         }
 //     }
@@ -106,10 +100,10 @@ TO_DO_BATTLE_TEST("Revived battlers still lose their turn");
 //                MOVE(opponentLeft, MOVE_REVIVAL_BLESSING);
 //                SEND_OUT(opponentLeft, 1); }
 //     } SCENE {
-//         MESSAGE("Wobbuffet used Tackle!");
+//         MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
 //         MESSAGE("Foe Wynaut fainted!");
-//         MESSAGE("Foe Wobbuffet used " REVIVAL_BLESSING "!");
+//         MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_REVIVAL_BLESSING) "!");
 //         MESSAGE("Wynaut was revived and is ready to fight again!");
-//         NOT { MESSAGE("Wynaut used Celebrate!"); }
+//         NOT { MESSAGE("Wynaut used " MOVE_NAME(MOVE_CELEBRATE) "!"); }
 //     }
 // }

--- a/test/battle/move_effect/revival_blessing.c
+++ b/test/battle/move_effect/revival_blessing.c
@@ -20,8 +20,8 @@ SINGLE_BATTLE_TEST("Revival Blessing revives a chosen fainted party member for t
     } WHEN {
         TURN { MOVE(player, MOVE_REVIVAL_BLESSING); SEND_OUT(player, 2); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_REVIVAL_BLESSING) "!");
-        MESSAGE("Wynaut was revived and is ready to fight again!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_REVIVAL_BLESSING) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " was revived and is ready to fight again!");
     }
 }
 
@@ -35,8 +35,8 @@ SINGLE_BATTLE_TEST("Revival Blessing revives a fainted party member for an oppon
     } WHEN {
         TURN { MOVE(opponent, MOVE_REVIVAL_BLESSING); SEND_OUT(opponent, 1); }
     } SCENE {
-        MESSAGE("Foe Raichu used " MOVE_NAME(MOVE_REVIVAL_BLESSING) "!");
-        MESSAGE("Pichu was revived and is ready to fight again!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_RAICHU) " used " MOVE_NAME(MOVE_REVIVAL_BLESSING) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_PICHU) " was revived and is ready to fight again!");
     }
 }
 
@@ -48,7 +48,7 @@ SINGLE_BATTLE_TEST("Revival Blessing fails if no party members are fainted")
     } WHEN {
         TURN { MOVE(player, MOVE_REVIVAL_BLESSING); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_REVIVAL_BLESSING) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_REVIVAL_BLESSING) "!");
         MESSAGE("But it failed!");
     }
 }
@@ -76,11 +76,11 @@ TO_DO_BATTLE_TEST("Revival Blessing cannot revive a partner's party member");
 //         TURN { MOVE(user, MOVE_REVIVAL_BLESSING); }
 //     } SCENE {
 //         if (user == opponentLeft) {
-//             MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_REVIVAL_BLESSING) "!");
+//             MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_REVIVAL_BLESSING) "!");
 //             MESSAGE("But it failed!");
 //         } else {
-//             MESSAGE("Foe Wynaut used " MOVE_NAME(MOVE_REVIVAL_BLESSING) "!");
-//             MESSAGE("Wynaut was revived and is ready to fight again!");
+//             MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " used " MOVE_NAME(MOVE_REVIVAL_BLESSING) "!");
+//             MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " was revived and is ready to fight again!");
 //         }
 //     }
 // }
@@ -100,10 +100,10 @@ TO_DO_BATTLE_TEST("Revived battlers still lose their turn");
 //                MOVE(opponentLeft, MOVE_REVIVAL_BLESSING);
 //                SEND_OUT(opponentLeft, 1); }
 //     } SCENE {
-//         MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
-//         MESSAGE("Foe Wynaut fainted!");
-//         MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_REVIVAL_BLESSING) "!");
-//         MESSAGE("Wynaut was revived and is ready to fight again!");
-//         NOT { MESSAGE("Wynaut used " MOVE_NAME(MOVE_CELEBRATE) "!"); }
+//         MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
+//         MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " fainted!");
+//         MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_REVIVAL_BLESSING) "!");
+//         MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " was revived and is ready to fight again!");
+//         NOT { MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " used " MOVE_NAME(MOVE_CELEBRATE) "!"); }
 //     }
 // }

--- a/test/battle/move_effect/roar.c
+++ b/test/battle/move_effect/roar.c
@@ -50,7 +50,7 @@ SINGLE_BATTLE_TEST("Roar fails if no replacements")
     } WHEN {
         TURN { MOVE(player, MOVE_ROAR); }
     } SCENE {
-        MESSAGE("Wobbuffet used Roar!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_ROAR) "!");
         MESSAGE("But it failed!");
     }
 }
@@ -64,7 +64,7 @@ SINGLE_BATTLE_TEST("Roar fails if replacements fainted")
     } WHEN {
         TURN { MOVE(player, MOVE_ROAR); }
     } SCENE {
-        MESSAGE("Wobbuffet used Roar!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_ROAR) "!");
         MESSAGE("But it failed!");
     }
 }

--- a/test/battle/move_effect/roar.c
+++ b/test/battle/move_effect/roar.c
@@ -19,7 +19,7 @@ SINGLE_BATTLE_TEST("Roar switches the target with a random non-fainted replaceme
         TURN { MOVE(player, MOVE_ROAR); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROAR, player);
-        MESSAGE("Foe Bulbasaur was dragged out!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_BULBASAUR) " was dragged out!");
     }
 }
 
@@ -38,7 +38,7 @@ DOUBLE_BATTLE_TEST("Roar switches the target with a random non-battler, non-fain
         TURN { MOVE(playerLeft, MOVE_ROAR, target: opponentRight); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROAR, playerLeft);
-        MESSAGE("Foe Bulbasaur was dragged out!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_BULBASAUR) " was dragged out!");
     }
 }
 
@@ -50,7 +50,7 @@ SINGLE_BATTLE_TEST("Roar fails if no replacements")
     } WHEN {
         TURN { MOVE(player, MOVE_ROAR); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_ROAR) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_ROAR) "!");
         MESSAGE("But it failed!");
     }
 }
@@ -64,7 +64,7 @@ SINGLE_BATTLE_TEST("Roar fails if replacements fainted")
     } WHEN {
         TURN { MOVE(player, MOVE_ROAR); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_ROAR) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_ROAR) "!");
         MESSAGE("But it failed!");
     }
 }

--- a/test/battle/move_effect/roost.c
+++ b/test/battle/move_effect/roost.c
@@ -35,7 +35,7 @@ SINGLE_BATTLE_TEST("Roost fails when user is at full HP")
     } WHEN {
         TURN { MOVE(player, MOVE_ROOST); }
     } SCENE {
-        MESSAGE("Wobbuffet's HP is full!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s HP is full!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
             HP_BAR(player);
@@ -52,8 +52,8 @@ SINGLE_BATTLE_TEST("Roost fails if the user is under the effects of Heal Block")
         TURN { MOVE(opponent, MOVE_HEAL_BLOCK); MOVE(player, MOVE_ROOST); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_HEAL_BLOCK, opponent);
-        MESSAGE("Wobbuffet was prevented from healing!"); // Message when Heal Block is applied
-        MESSAGE("Wobbuffet was prevented from healing!"); // Message when trying to heal under Heal Block
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was prevented from healing!"); // Message when Heal Block is applied
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was prevented from healing!"); // Message when trying to heal under Heal Block
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
             HP_BAR(player);
@@ -94,16 +94,16 @@ SINGLE_BATTLE_TEST("Roost suppresses the user's Flying-typing this turn, then re
         TURN { MOVE(opponent, MOVE_EARTHQUAKE); }
     } SCENE {
         // Turn 1: EQ hits when Roosted
-        MESSAGE("Skarmory used " MOVE_NAME(MOVE_ROOST) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_SKARMORY) " used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
         MESSAGE("Skarmory regained health!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
         MESSAGE("It's super effective!");
         // Turn 2: EQ has no effect because Roost expired
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
-        MESSAGE("It doesn't affect Skarmory…");
+        MESSAGE("It doesn't affect " SPECIES_NAME(SPECIES_SKARMORY) "…");
         NOT HP_BAR(player);
     }
 }
@@ -139,7 +139,7 @@ SINGLE_BATTLE_TEST("Roost, if used by a Flying/Flying type, treats the user as a
     } WHEN {
         TURN { MOVE(player, MOVE_ROOST); MOVE(opponent, damagingMove); }
     } SCENE {
-        MESSAGE("Tornadus used " MOVE_NAME(MOVE_ROOST) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_TORNADUS) " used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
         MESSAGE("Tornadus regained health!");
 
@@ -153,7 +153,7 @@ SINGLE_BATTLE_TEST("Roost, if used by a Flying/Flying type, treats the user as a
             else if (damagingMove == MOVE_LICK)
             {
                 NOT ANIMATION(ANIM_TYPE_MOVE, damagingMove, opponent);
-                MESSAGE("It doesn't affect Tornadus…");
+                MESSAGE("It doesn't affect " SPECIES_NAME(SPECIES_TORNADUS) "…");
             }
             else
             {
@@ -161,7 +161,7 @@ SINGLE_BATTLE_TEST("Roost, if used by a Flying/Flying type, treats the user as a
                 NONE_OF {
                     MESSAGE("It's super effective!");
                     MESSAGE("It's not very effective…");
-                    MESSAGE("It doesn't affect Tornadus…");
+                    MESSAGE("It doesn't affect " SPECIES_NAME(SPECIES_TORNADUS) "…");
                 }
             }
         }
@@ -171,7 +171,7 @@ SINGLE_BATTLE_TEST("Roost, if used by a Flying/Flying type, treats the user as a
             NONE_OF {
                 MESSAGE("It's super effective!");
                 MESSAGE("It's not very effective…");
-                MESSAGE("It doesn't affect Tornadus…");
+                MESSAGE("It doesn't affect " SPECIES_NAME(SPECIES_TORNADUS) "…");
             }
         }
     }
@@ -209,18 +209,18 @@ SINGLE_BATTLE_TEST("Roost, if used by a Mystery/Flying type, treats the user as 
         TURN { MOVE(player, MOVE_ROOST); MOVE(opponent, damagingMove); }
     } SCENE {
         // Turn 1: Use Burn Up to change from Fire/Flying to Mystery/Flying
-        MESSAGE("Moltres used " MOVE_NAME(MOVE_BURN_UP) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_MOLTRES) " used " MOVE_NAME(MOVE_BURN_UP) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BURN_UP, player);
         MESSAGE("Moltres burned itself out!");
         // Turn 2: Use Roost to now be treated as a Mystery/Mystery type
-        MESSAGE("Moltres used " MOVE_NAME(MOVE_ROOST) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_MOLTRES) " used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
         MESSAGE("Moltres regained health!");
         ANIMATION(ANIM_TYPE_MOVE, damagingMove, opponent);
         NONE_OF {
             MESSAGE("It's super effective!");
             MESSAGE("It's not very effective…");
-            MESSAGE("It doesn't affect Moltres…");
+            MESSAGE("It doesn't affect " SPECIES_NAME(SPECIES_MOLTRES) "…");
         }
     }
 }
@@ -240,15 +240,15 @@ DOUBLE_BATTLE_TEST("Roost suppresses the user's not-yet-aquired Flying-type this
                MOVE(opponentLeft, MOVE_GUST, target: playerLeft);
                MOVE(opponentRight, MOVE_EARTHQUAKE, target: playerLeft); }
     } SCENE {
-        MESSAGE("Kecleon used " MOVE_NAME(MOVE_ROOST) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_KECLEON) " used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, playerLeft);
         MESSAGE("Kecleon regained health!");
-        MESSAGE("Foe Pidgey used " MOVE_NAME(MOVE_GUST) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_PIDGEY) " used " MOVE_NAME(MOVE_GUST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_GUST, opponentLeft);
-        MESSAGE("Kecleon's Color Change made it the Flying type!");
-        MESSAGE("Foe Sandshrew used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_KECLEON) "'s Color Change made it the Flying type!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_SANDSHREW) " used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponentRight);
-        MESSAGE("Kecleon's Color Change made it the Ground type!");
+        MESSAGE(SPECIES_NAME(SPECIES_KECLEON) "'s Color Change made it the Ground type!");
     }
 }
 
@@ -262,10 +262,10 @@ SINGLE_BATTLE_TEST("Roost prevents a Flying-type user from being protected by De
     } WHEN {
         TURN { MOVE(player, MOVE_ROOST); MOVE(opponent, MOVE_ICE_BEAM); }
     } SCENE {
-        MESSAGE("Rayquaza used " MOVE_NAME(MOVE_ROOST) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_RAYQUAZA) " used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
         MESSAGE("Rayquaza regained health!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_ICE_BEAM) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_ICE_BEAM) "!");
         NOT MESSAGE("The mysterious strong winds weakened the attack!");
     }
 }
@@ -281,13 +281,13 @@ SINGLE_BATTLE_TEST("Roost does not undo other type-changing effects at the end o
         TURN { MOVE(player, MOVE_ROOST); MOVE(opponent, MOVE_SOAK); }
         TURN { MOVE(opponent, MOVE_VINE_WHIP); }
     } SCENE {
-        MESSAGE("Swellow used " MOVE_NAME(MOVE_ROOST) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_SWELLOW) " used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
-        MESSAGE("Swellow regained health!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_SOAK) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_SWELLOW) " regained health!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SOAK) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SOAK, opponent);
-        MESSAGE("Swellow transformed into the Water type!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_VINE_WHIP) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_SWELLOW) " transformed into the Water type!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_VINE_WHIP) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_VINE_WHIP, opponent);
         MESSAGE("It's super effective!");
     }
@@ -304,10 +304,10 @@ SINGLE_BATTLE_TEST("Roost's effect is lifted after Grassy Terrain's healing")
     } WHEN {
         TURN { MOVE(player, MOVE_ROOST); }
     } SCENE {
-        MESSAGE("Swellow used " MOVE_NAME(MOVE_ROOST) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_SWELLOW) " used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
         MESSAGE("Swellow regained health!");
-        MESSAGE("Swellow is healed by the grassy terrain!");
+        MESSAGE(SPECIES_NAME(SPECIES_SWELLOW) " is healed by the grassy terrain!");
         HP_BAR(player);
     }
 }
@@ -328,22 +328,22 @@ SINGLE_BATTLE_TEST("Roost's suppression prevents Reflect Type from copying any F
         TURN { MOVE(player, MOVE_EARTHQUAKE); }
     } SCENE {
         // Turn 1: Reflect Type on Roosted Normal/Flying
-        MESSAGE("Swellow used " MOVE_NAME(MOVE_ROOST) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_SWELLOW) " used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
         MESSAGE("Swellow regained health!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_REFLECT_TYPE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_REFLECT_TYPE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_REFLECT_TYPE, opponent);
-        MESSAGE("Foe Wobbuffet's type changed to match the Swellow's!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s type changed to match the Swellow's!");
         // Turn 2: EQ hits, Reflect Type on non-Roosted Normal/Flying
-        MESSAGE("Swellow used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_SWELLOW) " used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, player);
         HP_BAR(opponent);
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_REFLECT_TYPE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_REFLECT_TYPE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_REFLECT_TYPE, opponent);
-        MESSAGE("Foe Wobbuffet's type changed to match the Swellow's!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s type changed to match the Swellow's!");
         // Turn 3: EQ has no effect
-        MESSAGE("Swellow used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
-        MESSAGE("It doesn't affect Foe Wobbuffet…");
+        MESSAGE(SPECIES_NAME(SPECIES_SWELLOW) " used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
+        MESSAGE("It doesn't affect Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "…");
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, player);
             HP_BAR(opponent);
@@ -359,10 +359,10 @@ SINGLE_BATTLE_TEST("Roost does not suppress the ungrounded effect of Levitate")
     } WHEN {
         TURN { MOVE(player, MOVE_ROOST); MOVE(opponent, MOVE_EARTHQUAKE); }
     } SCENE {
-        MESSAGE("Flygon used " MOVE_NAME(MOVE_ROOST) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_FLYGON) " used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
         MESSAGE("Flygon regained health!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
             HP_BAR(player);
@@ -378,10 +378,10 @@ SINGLE_BATTLE_TEST("Roost does not suppress the ungrounded effect of Air Balloon
     } WHEN {
         TURN { MOVE(player, MOVE_ROOST); MOVE(opponent, MOVE_EARTHQUAKE); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_ROOST) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
         MESSAGE("Wobbuffet regained health!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
             HP_BAR(player);
@@ -399,14 +399,14 @@ SINGLE_BATTLE_TEST("Roost does not suppress the ungrounded effect of Magnet Rise
         TURN { MOVE(player, MOVE_ROOST); MOVE(opponent, MOVE_EARTHQUAKE); }
     } SCENE {
         // Turn 1: Magnet Rise
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_MAGNET_RISE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_MAGNET_RISE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_MAGNET_RISE, player);
         MESSAGE("Wobbuffet levitated on electromagnetism!");
         // Turn 2
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_ROOST) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
         MESSAGE("Wobbuffet regained health!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
             HP_BAR(player);
@@ -425,14 +425,14 @@ SINGLE_BATTLE_TEST("Roost does not suppress the ungrounded effect of Telekinesis
         TURN { MOVE(player, MOVE_ROOST); MOVE(opponent, MOVE_EARTHQUAKE); }
     } SCENE {
         // Turn 1: Telekinesis
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TELEKINESIS) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TELEKINESIS) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TELEKINESIS, opponent);
-        MESSAGE("Wobbuffet was hurled into the air!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was hurled into the air!");
         // Turn 2
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_ROOST) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
         MESSAGE("Wobbuffet regained health!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
             HP_BAR(player);

--- a/test/battle/move_effect/roost.c
+++ b/test/battle/move_effect/roost.c
@@ -94,14 +94,14 @@ SINGLE_BATTLE_TEST("Roost suppresses the user's Flying-typing this turn, then re
         TURN { MOVE(opponent, MOVE_EARTHQUAKE); }
     } SCENE {
         // Turn 1: EQ hits when Roosted
-        MESSAGE("Skarmory used Roost!");
+        MESSAGE("Skarmory used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
         MESSAGE("Skarmory regained health!");
-        MESSAGE("Foe Wobbuffet used Earthquake!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
         MESSAGE("It's super effective!");
         // Turn 2: EQ has no effect because Roost expired
-        MESSAGE("Foe Wobbuffet used Earthquake!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
         MESSAGE("It doesn't affect Skarmory…");
         NOT HP_BAR(player);
@@ -139,7 +139,7 @@ SINGLE_BATTLE_TEST("Roost, if used by a Flying/Flying type, treats the user as a
     } WHEN {
         TURN { MOVE(player, MOVE_ROOST); MOVE(opponent, damagingMove); }
     } SCENE {
-        MESSAGE("Tornadus used Roost!");
+        MESSAGE("Tornadus used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
         MESSAGE("Tornadus regained health!");
 
@@ -209,11 +209,11 @@ SINGLE_BATTLE_TEST("Roost, if used by a Mystery/Flying type, treats the user as 
         TURN { MOVE(player, MOVE_ROOST); MOVE(opponent, damagingMove); }
     } SCENE {
         // Turn 1: Use Burn Up to change from Fire/Flying to Mystery/Flying
-        MESSAGE("Moltres used Burn Up!");
+        MESSAGE("Moltres used " MOVE_NAME(MOVE_BURN_UP) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BURN_UP, player);
         MESSAGE("Moltres burned itself out!");
         // Turn 2: Use Roost to now be treated as a Mystery/Mystery type
-        MESSAGE("Moltres used Roost!");
+        MESSAGE("Moltres used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
         MESSAGE("Moltres regained health!");
         ANIMATION(ANIM_TYPE_MOVE, damagingMove, opponent);
@@ -240,13 +240,13 @@ DOUBLE_BATTLE_TEST("Roost suppresses the user's not-yet-aquired Flying-type this
                MOVE(opponentLeft, MOVE_GUST, target: playerLeft);
                MOVE(opponentRight, MOVE_EARTHQUAKE, target: playerLeft); }
     } SCENE {
-        MESSAGE("Kecleon used Roost!");
+        MESSAGE("Kecleon used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, playerLeft);
         MESSAGE("Kecleon regained health!");
-        MESSAGE("Foe Pidgey used Gust!");
+        MESSAGE("Foe Pidgey used " MOVE_NAME(MOVE_GUST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_GUST, opponentLeft);
         MESSAGE("Kecleon's Color Change made it the Flying type!");
-        MESSAGE("Foe Sandshrew used Earthquake!");
+        MESSAGE("Foe Sandshrew used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponentRight);
         MESSAGE("Kecleon's Color Change made it the Ground type!");
     }
@@ -262,10 +262,10 @@ SINGLE_BATTLE_TEST("Roost prevents a Flying-type user from being protected by De
     } WHEN {
         TURN { MOVE(player, MOVE_ROOST); MOVE(opponent, MOVE_ICE_BEAM); }
     } SCENE {
-        MESSAGE("Rayquaza used Roost!");
+        MESSAGE("Rayquaza used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
         MESSAGE("Rayquaza regained health!");
-        MESSAGE("Foe Wobbuffet used Ice Beam!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_ICE_BEAM) "!");
         NOT MESSAGE("The mysterious strong winds weakened the attack!");
     }
 }
@@ -281,13 +281,13 @@ SINGLE_BATTLE_TEST("Roost does not undo other type-changing effects at the end o
         TURN { MOVE(player, MOVE_ROOST); MOVE(opponent, MOVE_SOAK); }
         TURN { MOVE(opponent, MOVE_VINE_WHIP); }
     } SCENE {
-        MESSAGE("Swellow used Roost!");
+        MESSAGE("Swellow used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
         MESSAGE("Swellow regained health!");
-        MESSAGE("Foe Wobbuffet used Soak!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_SOAK) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SOAK, opponent);
         MESSAGE("Swellow transformed into the Water type!");
-        MESSAGE("Foe Wobbuffet used Vine Whip!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_VINE_WHIP) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_VINE_WHIP, opponent);
         MESSAGE("It's super effective!");
     }
@@ -304,7 +304,7 @@ SINGLE_BATTLE_TEST("Roost's effect is lifted after Grassy Terrain's healing")
     } WHEN {
         TURN { MOVE(player, MOVE_ROOST); }
     } SCENE {
-        MESSAGE("Swellow used Roost!");
+        MESSAGE("Swellow used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
         MESSAGE("Swellow regained health!");
         MESSAGE("Swellow is healed by the grassy terrain!");
@@ -328,21 +328,21 @@ SINGLE_BATTLE_TEST("Roost's suppression prevents Reflect Type from copying any F
         TURN { MOVE(player, MOVE_EARTHQUAKE); }
     } SCENE {
         // Turn 1: Reflect Type on Roosted Normal/Flying
-        MESSAGE("Swellow used Roost!");
+        MESSAGE("Swellow used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
         MESSAGE("Swellow regained health!");
-        MESSAGE("Foe Wobbuffet used Reflect Type!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_REFLECT_TYPE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_REFLECT_TYPE, opponent);
         MESSAGE("Foe Wobbuffet's type changed to match the Swellow's!");
         // Turn 2: EQ hits, Reflect Type on non-Roosted Normal/Flying
-        MESSAGE("Swellow used Earthquake!");
+        MESSAGE("Swellow used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, player);
         HP_BAR(opponent);
-        MESSAGE("Foe Wobbuffet used Reflect Type!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_REFLECT_TYPE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_REFLECT_TYPE, opponent);
         MESSAGE("Foe Wobbuffet's type changed to match the Swellow's!");
         // Turn 3: EQ has no effect
-        MESSAGE("Swellow used Earthquake!");
+        MESSAGE("Swellow used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
         MESSAGE("It doesn't affect Foe Wobbuffet…");
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, player);
@@ -359,10 +359,10 @@ SINGLE_BATTLE_TEST("Roost does not suppress the ungrounded effect of Levitate")
     } WHEN {
         TURN { MOVE(player, MOVE_ROOST); MOVE(opponent, MOVE_EARTHQUAKE); }
     } SCENE {
-        MESSAGE("Flygon used Roost!");
+        MESSAGE("Flygon used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
         MESSAGE("Flygon regained health!");
-        MESSAGE("Foe Wobbuffet used Earthquake!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
             HP_BAR(player);
@@ -378,10 +378,10 @@ SINGLE_BATTLE_TEST("Roost does not suppress the ungrounded effect of Air Balloon
     } WHEN {
         TURN { MOVE(player, MOVE_ROOST); MOVE(opponent, MOVE_EARTHQUAKE); }
     } SCENE {
-        MESSAGE("Wobbuffet used Roost!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
         MESSAGE("Wobbuffet regained health!");
-        MESSAGE("Foe Wobbuffet used Earthquake!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
             HP_BAR(player);
@@ -399,14 +399,14 @@ SINGLE_BATTLE_TEST("Roost does not suppress the ungrounded effect of Magnet Rise
         TURN { MOVE(player, MOVE_ROOST); MOVE(opponent, MOVE_EARTHQUAKE); }
     } SCENE {
         // Turn 1: Magnet Rise
-        MESSAGE("Wobbuffet used Magnet Rise!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_MAGNET_RISE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_MAGNET_RISE, player);
         MESSAGE("Wobbuffet levitated on electromagnetism!");
         // Turn 2
-        MESSAGE("Wobbuffet used Roost!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
         MESSAGE("Wobbuffet regained health!");
-        MESSAGE("Foe Wobbuffet used Earthquake!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
             HP_BAR(player);
@@ -425,14 +425,14 @@ SINGLE_BATTLE_TEST("Roost does not suppress the ungrounded effect of Telekinesis
         TURN { MOVE(player, MOVE_ROOST); MOVE(opponent, MOVE_EARTHQUAKE); }
     } SCENE {
         // Turn 1: Telekinesis
-        MESSAGE("Foe Wobbuffet used Telekinesis!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TELEKINESIS) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TELEKINESIS, opponent);
         MESSAGE("Wobbuffet was hurled into the air!");
         // Turn 2
-        MESSAGE("Wobbuffet used Roost!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
         MESSAGE("Wobbuffet regained health!");
-        MESSAGE("Foe Wobbuffet used Earthquake!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
             HP_BAR(player);

--- a/test/battle/move_effect/roost.c
+++ b/test/battle/move_effect/roost.c
@@ -96,7 +96,7 @@ SINGLE_BATTLE_TEST("Roost suppresses the user's Flying-typing this turn, then re
         // Turn 1: EQ hits when Roosted
         MESSAGE(SPECIES_NAME(SPECIES_SKARMORY) " used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
-        MESSAGE("Skarmory regained health!");
+        MESSAGE(SPECIES_NAME(SPECIES_SKARMORY) " regained health!");
         MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
         MESSAGE("It's super effective!");
@@ -141,7 +141,7 @@ SINGLE_BATTLE_TEST("Roost, if used by a Flying/Flying type, treats the user as a
     } SCENE {
         MESSAGE(SPECIES_NAME(SPECIES_TORNADUS) " used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
-        MESSAGE("Tornadus regained health!");
+        MESSAGE(SPECIES_NAME(SPECIES_TORNADUS) " regained health!");
 
         if (B_ROOST_PURE_FLYING >= GEN_5) // >= Gen. 5, Pokemon becomes pure Normal-type
         {
@@ -215,7 +215,7 @@ SINGLE_BATTLE_TEST("Roost, if used by a Mystery/Flying type, treats the user as 
         // Turn 2: Use Roost to now be treated as a Mystery/Mystery type
         MESSAGE(SPECIES_NAME(SPECIES_MOLTRES) " used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
-        MESSAGE("Moltres regained health!");
+        MESSAGE(SPECIES_NAME(SPECIES_MOLTRES) " regained health!");
         ANIMATION(ANIM_TYPE_MOVE, damagingMove, opponent);
         NONE_OF {
             MESSAGE("It's super effective!");
@@ -242,7 +242,7 @@ DOUBLE_BATTLE_TEST("Roost suppresses the user's not-yet-aquired Flying-type this
     } SCENE {
         MESSAGE(SPECIES_NAME(SPECIES_KECLEON) " used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, playerLeft);
-        MESSAGE("Kecleon regained health!");
+        MESSAGE(SPECIES_NAME(SPECIES_KECLEON) " regained health!");
         MESSAGE("Foe " SPECIES_NAME(SPECIES_PIDGEY) " used " MOVE_NAME(MOVE_GUST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_GUST, opponentLeft);
         MESSAGE(SPECIES_NAME(SPECIES_KECLEON) "'s Color Change made it the Flying type!");
@@ -264,7 +264,7 @@ SINGLE_BATTLE_TEST("Roost prevents a Flying-type user from being protected by De
     } SCENE {
         MESSAGE(SPECIES_NAME(SPECIES_RAYQUAZA) " used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
-        MESSAGE("Rayquaza regained health!");
+        MESSAGE(SPECIES_NAME(SPECIES_RAYQUAZA) " regained health!");
         MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_ICE_BEAM) "!");
         NOT MESSAGE("The mysterious strong winds weakened the attack!");
     }
@@ -306,7 +306,7 @@ SINGLE_BATTLE_TEST("Roost's effect is lifted after Grassy Terrain's healing")
     } SCENE {
         MESSAGE(SPECIES_NAME(SPECIES_SWELLOW) " used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
-        MESSAGE("Swellow regained health!");
+        MESSAGE(SPECIES_NAME(SPECIES_SWELLOW) " regained health!");
         MESSAGE(SPECIES_NAME(SPECIES_SWELLOW) " is healed by the grassy terrain!");
         HP_BAR(player);
     }
@@ -330,7 +330,7 @@ SINGLE_BATTLE_TEST("Roost's suppression prevents Reflect Type from copying any F
         // Turn 1: Reflect Type on Roosted Normal/Flying
         MESSAGE(SPECIES_NAME(SPECIES_SWELLOW) " used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
-        MESSAGE("Swellow regained health!");
+        MESSAGE(SPECIES_NAME(SPECIES_SWELLOW) " regained health!");
         MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_REFLECT_TYPE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_REFLECT_TYPE, opponent);
         MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s type changed to match the Swellow's!");
@@ -361,7 +361,7 @@ SINGLE_BATTLE_TEST("Roost does not suppress the ungrounded effect of Levitate")
     } SCENE {
         MESSAGE(SPECIES_NAME(SPECIES_FLYGON) " used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
-        MESSAGE("Flygon regained health!");
+        MESSAGE(SPECIES_NAME(SPECIES_FLYGON) " regained health!");
         MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
@@ -380,7 +380,7 @@ SINGLE_BATTLE_TEST("Roost does not suppress the ungrounded effect of Air Balloon
     } SCENE {
         MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
-        MESSAGE("Wobbuffet regained health!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " regained health!");
         MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
@@ -405,7 +405,7 @@ SINGLE_BATTLE_TEST("Roost does not suppress the ungrounded effect of Magnet Rise
         // Turn 2
         MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
-        MESSAGE("Wobbuffet regained health!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " regained health!");
         MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
@@ -431,7 +431,7 @@ SINGLE_BATTLE_TEST("Roost does not suppress the ungrounded effect of Telekinesis
         // Turn 2
         MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_ROOST) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
-        MESSAGE("Wobbuffet regained health!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " regained health!");
         MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_EARTHQUAKE) "!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);

--- a/test/battle/move_effect/salt_cure.c
+++ b/test/battle/move_effect/salt_cure.c
@@ -19,11 +19,11 @@ SINGLE_BATTLE_TEST("Salt Cure inflicts 1/8 of the target's maximum HP as damage 
     } SCENE {
         s32 maxHP = GetMonData(&OPPONENT_PARTY[0], MON_DATA_MAX_HP);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SALT_CURE, player);
-        MESSAGE("Foe Wobbuffet is being salt cured!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is being salt cured!");
         for (j = 0; j < 4; j++) {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_SALT_CURE_DAMAGE, opponent);
             HP_BAR(opponent, damage: maxHP / 8);
-            MESSAGE("Foe Wobbuffet is hurt by Salt Cure!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is hurt by Salt Cure!");
         }
     }
 }
@@ -62,12 +62,12 @@ SINGLE_BATTLE_TEST("Salt Cure is removed when the afflicted Pokémon is switched
         TURN { SWITCH(opponent, 1); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SALT_CURE, player);
-        MESSAGE("Foe Wobbuffet is being salt cured!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is being salt cured!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_SALT_CURE_DAMAGE, opponent);
-        MESSAGE("Foe Wobbuffet is hurt by Salt Cure!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is hurt by Salt Cure!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_SALT_CURE_DAMAGE, opponent);
-            MESSAGE("Foe Wobbuffet is hurt by Salt Cure!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is hurt by Salt Cure!");
         }
     }
 }
@@ -81,7 +81,7 @@ SINGLE_BATTLE_TEST("If Salt Cure faints the target no status will be applied")
         TURN { MOVE(player, MOVE_SALT_CURE); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SALT_CURE, player);
-        NOT MESSAGE("Foe Wobbuffet is being salt cured!");
-        MESSAGE("Foe Wobbuffet fainted!");
+        NOT MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is being salt cured!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " fainted!");
     }
 }

--- a/test/battle/move_effect/shell_trap.c
+++ b/test/battle/move_effect/shell_trap.c
@@ -28,13 +28,13 @@ SINGLE_BATTLE_TEST("Shell Trap activates only if hit by a physical move")
         ANIMATION(ANIM_TYPE_MOVE, move, opponent);
 
         if (activate) {
-            MESSAGE("Wobbuffet used Shell Trap!");
+            MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SHELL_TRAP) "!");
             ANIMATION(ANIM_TYPE_MOVE, MOVE_SHELL_TRAP, player);
             HP_BAR(opponent);
         } else {
             MESSAGE("Wobbuffet's shell trap didn't work!");
             NONE_OF {
-                MESSAGE("Wobbuffet used Shell Trap!");
+                MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SHELL_TRAP) "!");
                 ANIMATION(ANIM_TYPE_MOVE, MOVE_SHELL_TRAP, player);
                 HP_BAR(opponent);
             }
@@ -59,13 +59,13 @@ SINGLE_BATTLE_TEST("Shell Trap does not activate if attacker's Sheer Force appli
         MESSAGE("Wobbuffet set a shell trap!");
         ANIMATION(ANIM_TYPE_MOVE, move, opponent);
         if (activate) {
-            MESSAGE("Wobbuffet used Shell Trap!");
+            MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SHELL_TRAP) "!");
             ANIMATION(ANIM_TYPE_MOVE, MOVE_SHELL_TRAP, player);
             HP_BAR(opponent);
         } else {
             MESSAGE("Wobbuffet's shell trap didn't work!");
             NONE_OF {
-                MESSAGE("Wobbuffet used Shell Trap!");
+                MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SHELL_TRAP) "!");
                 ANIMATION(ANIM_TYPE_MOVE, MOVE_SHELL_TRAP, player);
                 HP_BAR(opponent);
             }
@@ -88,7 +88,7 @@ SINGLE_BATTLE_TEST("Shell Trap does not activate if battler faints before being 
         MESSAGE("Wobbuffet fainted!");
         MESSAGE("Go! Wobbuffet!");
         NONE_OF {
-            MESSAGE("Wobbuffet used Shell Trap!");
+            MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SHELL_TRAP) "!");
             ANIMATION(ANIM_TYPE_MOVE, MOVE_SHELL_TRAP, player);
             HP_BAR(opponent);
         }
@@ -108,14 +108,14 @@ DOUBLE_BATTLE_TEST("Shell Trap activates immediately after being hit on turn 1 a
     } SCENE {
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_SHELL_TRAP_SETUP, playerLeft);
         MESSAGE("Wobbuffet set a shell trap!");
-        MESSAGE("Foe Wobbuffet used Tackle!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentLeft);
-        MESSAGE("Wobbuffet used Shell Trap!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SHELL_TRAP) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SHELL_TRAP, playerLeft);
         HP_BAR(opponentLeft);
         HP_BAR(opponentRight);
-        MESSAGE("Wobbuffet used Celebrate!");
-        MESSAGE("Foe Wynaut used Celebrate!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wynaut used " MOVE_NAME(MOVE_CELEBRATE) "!");
     }
 }
 
@@ -132,14 +132,14 @@ DOUBLE_BATTLE_TEST("Shell Trap activates immediately after being hit on turn 2 a
     } SCENE {
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_SHELL_TRAP_SETUP, playerLeft);
         MESSAGE("Wobbuffet set a shell trap!");
-        MESSAGE("Foe Wynaut used Celebrate!");
-        MESSAGE("Foe Wobbuffet used Tackle!");
+        MESSAGE("Foe Wynaut used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentLeft);
-        MESSAGE("Wobbuffet used Shell Trap!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SHELL_TRAP) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SHELL_TRAP, playerLeft);
         HP_BAR(opponentLeft);
         HP_BAR(opponentRight);
-        MESSAGE("Wobbuffet used Celebrate!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
     }
 }
 
@@ -156,11 +156,11 @@ DOUBLE_BATTLE_TEST("Shell Trap activates immediately after being hit on turn 3 a
     } SCENE {
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_SHELL_TRAP_SETUP, playerLeft);
         MESSAGE("Wobbuffet set a shell trap!");
-        MESSAGE("Wobbuffet used Celebrate!");
-        MESSAGE("Foe Wynaut used Celebrate!");
-        MESSAGE("Foe Wobbuffet used Tackle!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wynaut used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentLeft);
-        MESSAGE("Wobbuffet used Shell Trap!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SHELL_TRAP) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SHELL_TRAP, playerLeft);
         HP_BAR(opponentLeft);
         HP_BAR(opponentRight);

--- a/test/battle/move_effect/shell_trap.c
+++ b/test/battle/move_effect/shell_trap.c
@@ -28,13 +28,13 @@ SINGLE_BATTLE_TEST("Shell Trap activates only if hit by a physical move")
         ANIMATION(ANIM_TYPE_MOVE, move, opponent);
 
         if (activate) {
-            MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SHELL_TRAP) "!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SHELL_TRAP) "!");
             ANIMATION(ANIM_TYPE_MOVE, MOVE_SHELL_TRAP, player);
             HP_BAR(opponent);
         } else {
-            MESSAGE("Wobbuffet's shell trap didn't work!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s shell trap didn't work!");
             NONE_OF {
-                MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SHELL_TRAP) "!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SHELL_TRAP) "!");
                 ANIMATION(ANIM_TYPE_MOVE, MOVE_SHELL_TRAP, player);
                 HP_BAR(opponent);
             }
@@ -59,13 +59,13 @@ SINGLE_BATTLE_TEST("Shell Trap does not activate if attacker's Sheer Force appli
         MESSAGE("Wobbuffet set a shell trap!");
         ANIMATION(ANIM_TYPE_MOVE, move, opponent);
         if (activate) {
-            MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SHELL_TRAP) "!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SHELL_TRAP) "!");
             ANIMATION(ANIM_TYPE_MOVE, MOVE_SHELL_TRAP, player);
             HP_BAR(opponent);
         } else {
-            MESSAGE("Wobbuffet's shell trap didn't work!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s shell trap didn't work!");
             NONE_OF {
-                MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SHELL_TRAP) "!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SHELL_TRAP) "!");
                 ANIMATION(ANIM_TYPE_MOVE, MOVE_SHELL_TRAP, player);
                 HP_BAR(opponent);
             }
@@ -85,10 +85,10 @@ SINGLE_BATTLE_TEST("Shell Trap does not activate if battler faints before being 
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_SHELL_TRAP_SETUP, player);
         MESSAGE("Wobbuffet set a shell trap!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
-        MESSAGE("Wobbuffet fainted!");
-        MESSAGE("Go! Wobbuffet!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " fainted!");
+        MESSAGE("Go! " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
         NONE_OF {
-            MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SHELL_TRAP) "!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SHELL_TRAP) "!");
             ANIMATION(ANIM_TYPE_MOVE, MOVE_SHELL_TRAP, player);
             HP_BAR(opponent);
         }
@@ -108,14 +108,14 @@ DOUBLE_BATTLE_TEST("Shell Trap activates immediately after being hit on turn 1 a
     } SCENE {
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_SHELL_TRAP_SETUP, playerLeft);
         MESSAGE("Wobbuffet set a shell trap!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentLeft);
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SHELL_TRAP) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SHELL_TRAP) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SHELL_TRAP, playerLeft);
         HP_BAR(opponentLeft);
         HP_BAR(opponentRight);
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wynaut used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
     }
 }
 
@@ -132,14 +132,14 @@ DOUBLE_BATTLE_TEST("Shell Trap activates immediately after being hit on turn 2 a
     } SCENE {
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_SHELL_TRAP_SETUP, playerLeft);
         MESSAGE("Wobbuffet set a shell trap!");
-        MESSAGE("Foe Wynaut used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentLeft);
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SHELL_TRAP) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SHELL_TRAP) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SHELL_TRAP, playerLeft);
         HP_BAR(opponentLeft);
         HP_BAR(opponentRight);
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
     }
 }
 
@@ -156,11 +156,11 @@ DOUBLE_BATTLE_TEST("Shell Trap activates immediately after being hit on turn 3 a
     } SCENE {
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_SHELL_TRAP_SETUP, playerLeft);
         MESSAGE("Wobbuffet set a shell trap!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wynaut used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TACKLE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TACKLE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentLeft);
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SHELL_TRAP) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SHELL_TRAP) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SHELL_TRAP, playerLeft);
         HP_BAR(opponentLeft);
         HP_BAR(opponentRight);

--- a/test/battle/move_effect/sleep.c
+++ b/test/battle/move_effect/sleep.c
@@ -29,7 +29,7 @@ SINGLE_BATTLE_TEST("Hypnosis inflicts 1-3 turns of sleep")
         for (count = 0; count < turns; ++count)
         {
             if (count < turns - 1)
-                MESSAGE("Foe Wobbuffet is fast asleep.");
+                MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is fast asleep.");
             ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_SLP, opponent);
         }
         MESSAGE("Foe Wobbuffet woke up!");

--- a/test/battle/move_effect/sleep.c
+++ b/test/battle/move_effect/sleep.c
@@ -24,7 +24,7 @@ SINGLE_BATTLE_TEST("Hypnosis inflicts 1-3 turns of sleep")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_HYPNOSIS, player);
         ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_SLP, opponent);
-        MESSAGE("Foe Wobbuffet fell asleep!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " fell asleep!");
         STATUS_ICON(opponent, sleep: TRUE);
         for (count = 0; count < turns; ++count)
         {
@@ -32,7 +32,7 @@ SINGLE_BATTLE_TEST("Hypnosis inflicts 1-3 turns of sleep")
                 MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is fast asleep.");
             ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_SLP, opponent);
         }
-        MESSAGE("Foe Wobbuffet woke up!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " woke up!");
         STATUS_ICON(opponent, none: TRUE);
     }
 }

--- a/test/battle/move_effect/special_attack_down.c
+++ b/test/battle/move_effect/special_attack_down.c
@@ -22,7 +22,7 @@ SINGLE_BATTLE_TEST("Confide lowers Special Attack", s16 damage)
         if (lowerSpecialAttack) {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_CONFIDE, player);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-            MESSAGE("Foe Wobbuffet's Sp. Atk fell!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Sp. Atk fell!");
         }
         ANIMATION(ANIM_TYPE_MOVE, MOVE_GUST, opponent);
         HP_BAR(player, captureDamage: &results[i].damage);

--- a/test/battle/move_effect/special_attack_up_3.c
+++ b/test/battle/move_effect/special_attack_up_3.c
@@ -22,7 +22,7 @@ SINGLE_BATTLE_TEST("Tail Glow drastically raises Special Attack", s16 damage)
         if (raiseSpecialAttack) {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_TAIL_GLOW, player);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-            MESSAGE("Wobbuffet's Sp. Atk drastically rose!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Sp. Atk drastically rose!");
         }
         ANIMATION(ANIM_TYPE_MOVE, MOVE_GUST, player);
         HP_BAR(opponent, captureDamage: &results[i].damage);

--- a/test/battle/move_effect/spikes.c
+++ b/test/battle/move_effect/spikes.c
@@ -56,7 +56,7 @@ SINGLE_BATTLE_TEST("Spikes fails after 3 layers")
         MESSAGE("Spikes were scattered all around the opposing team!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SPIKES, player);
         MESSAGE("Spikes were scattered all around the opposing team!");
-        MESSAGE("Wobbuffet used Spikes!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SPIKES) "!");
         MESSAGE("But it failed!");
         MESSAGE("2 sent out Wynaut!");
         HP_BAR(opponent, damage: maxHP / 4);

--- a/test/battle/move_effect/spikes.c
+++ b/test/battle/move_effect/spikes.c
@@ -30,9 +30,9 @@ SINGLE_BATTLE_TEST("Spikes damage on switch in")
             ANIMATION(ANIM_TYPE_MOVE, MOVE_SPIKES, player);
             MESSAGE("Spikes were scattered all around the opposing team!");
         }
-        MESSAGE("2 sent out Wynaut!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WYNAUT) "!");
         HP_BAR(opponent, damage: maxHP / divisor);
-        MESSAGE("Foe Wynaut is hurt by spikes!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " is hurt by spikes!");
     }
 }
 
@@ -56,11 +56,11 @@ SINGLE_BATTLE_TEST("Spikes fails after 3 layers")
         MESSAGE("Spikes were scattered all around the opposing team!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SPIKES, player);
         MESSAGE("Spikes were scattered all around the opposing team!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SPIKES) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SPIKES) "!");
         MESSAGE("But it failed!");
-        MESSAGE("2 sent out Wynaut!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WYNAUT) "!");
         HP_BAR(opponent, damage: maxHP / 4);
-        MESSAGE("Foe Wynaut is hurt by spikes!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " is hurt by spikes!");
     }
 }
 
@@ -77,12 +77,12 @@ SINGLE_BATTLE_TEST("Spikes damage on subsequent switch ins")
     } SCENE {
         s32 maxHP0 = GetMonData(&OPPONENT_PARTY[0], MON_DATA_MAX_HP);
         s32 maxHP1 = GetMonData(&OPPONENT_PARTY[1], MON_DATA_MAX_HP);
-        MESSAGE("2 sent out Wynaut!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WYNAUT) "!");
         HP_BAR(opponent, damage: maxHP1 / 8);
-        MESSAGE("Foe Wynaut is hurt by spikes!");
-        MESSAGE("2 sent out Wobbuffet!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " is hurt by spikes!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
         HP_BAR(opponent, damage: maxHP0 / 8);
-        MESSAGE("Foe Wobbuffet is hurt by spikes!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is hurt by spikes!");
     }
 }
 

--- a/test/battle/move_effect/spin_out.c
+++ b/test/battle/move_effect/spin_out.c
@@ -16,6 +16,6 @@ SINGLE_BATTLE_TEST("Spin Out lowers speed by 2 stages")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SPIN_OUT, player);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-        MESSAGE("Wobbuffet's Speed harshly fell!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Speed harshly fell!");
     }
 }

--- a/test/battle/move_effect/sticky_web.c
+++ b/test/battle/move_effect/sticky_web.c
@@ -35,11 +35,11 @@ SINGLE_BATTLE_TEST("Sticky Web can only be set up 1 time")
         TURN { MOVE(player, MOVE_STICKY_WEB); }
         TURN { MOVE(player, MOVE_STICKY_WEB); }
     } SCENE {
-        MESSAGE("Wobbuffet used Sticky Web!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_STICKY_WEB) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_STICKY_WEB, player);
         MESSAGE("A sticky web spreads out on the ground around the opposing team!");
 
-        MESSAGE("Wobbuffet used Sticky Web!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_STICKY_WEB) "!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_STICKY_WEB, player);
         MESSAGE("But it failed!");
     }

--- a/test/battle/move_effect/sticky_web.c
+++ b/test/battle/move_effect/sticky_web.c
@@ -19,10 +19,10 @@ SINGLE_BATTLE_TEST("Sticky Web lowers Speed by 1 on switch-in")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_STICKY_WEB, player);
         MESSAGE("A sticky web spreads out on the ground around the opposing team!");
-        MESSAGE("2 sent out Wynaut!");
-        MESSAGE("Foe Wynaut was caught in a Sticky Web!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WYNAUT) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " was caught in a Sticky Web!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-        MESSAGE("Foe Wynaut's Speed fell!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) "'s Speed fell!");
     }
 }
 
@@ -35,11 +35,11 @@ SINGLE_BATTLE_TEST("Sticky Web can only be set up 1 time")
         TURN { MOVE(player, MOVE_STICKY_WEB); }
         TURN { MOVE(player, MOVE_STICKY_WEB); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_STICKY_WEB) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_STICKY_WEB) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_STICKY_WEB, player);
         MESSAGE("A sticky web spreads out on the ground around the opposing team!");
 
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_STICKY_WEB) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_STICKY_WEB) "!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_STICKY_WEB, player);
         MESSAGE("But it failed!");
     }
@@ -64,14 +64,14 @@ DOUBLE_BATTLE_TEST("Sticky Web lowers Speed by 1 in a double battle after Explos
         ANIMATION(ANIM_TYPE_MOVE, MOVE_STICKY_WEB, playerRight);
         MESSAGE("A sticky web spreads out on the ground around the opposing team!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, playerLeft);
-        MESSAGE("2 sent out Wynaut!");
-        MESSAGE("Foe Wynaut was caught in a Sticky Web!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WYNAUT) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " was caught in a Sticky Web!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
-        MESSAGE("Foe Wynaut's Speed fell!");
-        MESSAGE("2 sent out Wynaut!");
-        MESSAGE("Foe Wynaut was caught in a Sticky Web!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) "'s Speed fell!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WYNAUT) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " was caught in a Sticky Web!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);
-        MESSAGE("Foe Wynaut's Speed fell!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) "'s Speed fell!");
     }
 }
 
@@ -88,10 +88,10 @@ SINGLE_BATTLE_TEST("Sticky Web raises Speed by 1 for a Pokemon with Contrary")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_STICKY_WEB, player);
         MESSAGE("A sticky web spreads out on the ground around the opposing team!");
-        MESSAGE("2 sent out Shuckle!");
-        MESSAGE("Foe Shuckle was caught in a Sticky Web!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_SHUCKLE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_SHUCKLE) " was caught in a Sticky Web!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-        MESSAGE("Foe Shuckle's Speed rose!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_SHUCKLE) "'s Speed rose!");
     }
 }
 
@@ -124,14 +124,14 @@ DOUBLE_BATTLE_TEST("Sticky Web has correct interactions with Mirror Armor - the 
         ANIMATION(ANIM_TYPE_MOVE, MOVE_STICKY_WEB, BATTLER_PLAYER);
         MESSAGE("A sticky web spreads out on the ground around the opposing team!");
 
-        MESSAGE("Go! Corviknigh!");
-        MESSAGE("Corviknigh was caught in a Sticky Web!");
+        MESSAGE("Go! " SPECIES_NAME(SPECIES_CORVIKNIGHT) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_CORVIKNIGHT) " was caught in a Sticky Web!");
         ABILITY_POPUP(playerRight, ABILITY_MIRROR_ARMOR);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, BATTLER_OPPONENT);
         if (opponentSetUpper == 0) {
-            MESSAGE("Foe Caterpie's Speed fell!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_CATERPIE) "'s Speed fell!");
         } else {
-            MESSAGE("Foe Weedle's Speed fell!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WEEDLE) "'s Speed fell!");
         }
     }
 }
@@ -172,8 +172,8 @@ DOUBLE_BATTLE_TEST("Sticky Web has correct interactions with Mirror Armor - no o
             MESSAGE("A sticky web spreads out on the ground around the opposing team!");
         }
 
-        MESSAGE("Go! Corviknigh!");
-        MESSAGE("Corviknigh was caught in a Sticky Web!");
+        MESSAGE("Go! " SPECIES_NAME(SPECIES_CORVIKNIGHT) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_CORVIKNIGHT) " was caught in a Sticky Web!");
         ABILITY_POPUP(playerRight, ABILITY_MIRROR_ARMOR);
         NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
     } THEN {
@@ -217,13 +217,13 @@ DOUBLE_BATTLE_TEST("Sticky Web has correct interactions with Mirror Armor - no o
         MESSAGE("A sticky web spreads out on the ground around your team!");
 
         ANIMATION(ANIM_TYPE_MOVE, MOVE_MEMENTO, opponentLeft);
-        MESSAGE("Foe Caterpie fainted!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_CATERPIE) " fainted!");
         if (hasReplacement) {
-            MESSAGE("2 sent out Pidgey!");
+            MESSAGE("2 sent out " SPECIES_NAME(SPECIES_PIDGEY) "!");
         }
 
-        MESSAGE("Go! Corviknigh!");
-        MESSAGE("Corviknigh was caught in a Sticky Web!");
+        MESSAGE("Go! " SPECIES_NAME(SPECIES_CORVIKNIGHT) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_CORVIKNIGHT) " was caught in a Sticky Web!");
         ABILITY_POPUP(playerRight, ABILITY_MIRROR_ARMOR);
         NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
     } THEN {

--- a/test/battle/move_effect/stockpile.c
+++ b/test/battle/move_effect/stockpile.c
@@ -160,8 +160,8 @@ SINGLE_BATTLE_TEST("Stockpile temporarily raises Def and Sp. Def", s16 dmgPyhsic
         if (move == MOVE_STOCKPILE) {
             MESSAGE("Wobbuffet stockpiled 1!");
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-            MESSAGE("Wobbuffet's Defense rose!");
-            MESSAGE("Wobbuffet's Sp. Def rose!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Defense rose!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Sp. Def rose!");
         }
 
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
@@ -216,26 +216,26 @@ DOUBLE_BATTLE_TEST("Stockpile's Def and Sp. Def boost is lost after using Spit U
         ANIMATION(ANIM_TYPE_MOVE, move, playerLeft);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
         if (count == 1) {
-            MESSAGE("Wobbuffet's Defense fell!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Defense fell!");
         }
         else if (count == 2) {
-            MESSAGE("Wobbuffet's Defense harshly fell!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Defense harshly fell!");
         }
         else {
-            MESSAGE("Wobbuffet's Defense severely fell!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Defense severely fell!");
         }
 
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
         if (count == 1) {
-            MESSAGE("Wobbuffet's Sp. Def fell!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Sp. Def fell!");
         }
         else if (count == 2) {
-            MESSAGE("Wobbuffet's Sp. Def harshly fell!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Sp. Def harshly fell!");
         }
         else {
-            MESSAGE("Wobbuffet's Sp. Def severely fell!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s Sp. Def severely fell!");
         }
-        MESSAGE("Wobbuffet's stockpiled effect wore off!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s stockpiled effect wore off!");
 
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentLeft);
         HP_BAR(playerLeft, captureDamage: &results[i].dmgPhysicalAfter);

--- a/test/battle/move_effect/strength_sap.c
+++ b/test/battle/move_effect/strength_sap.c
@@ -24,7 +24,7 @@ SINGLE_BATTLE_TEST("Strength Sap lowers Attack by 1 and restores HP based on tar
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
         MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Attack fell!");
         HP_BAR(player, captureDamage: &results[i].hp);
-        MESSAGE("Foe Wobbuffet had its energy drained!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " had its energy drained!");
     } THEN {
         EXPECT_EQ(results[i].hp * -1, atkStat);
     }
@@ -51,8 +51,8 @@ SINGLE_BATTLE_TEST("Strength Sap works exactly the same when attacker is behind 
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
         MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Attack fell!");
         HP_BAR(player, captureDamage: &results[i].hp);
-        NOT MESSAGE("The SUBSTITUTE took damage for Foe Wobbuffet!");
-        MESSAGE("Foe Wobbuffet had its energy drained!");
+        NOT MESSAGE("The SUBSTITUTE took damage for Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " had its energy drained!");
     } THEN {
         EXPECT_EQ(results[i].hp * -1, atkStat);
     }

--- a/test/battle/move_effect/strength_sap.c
+++ b/test/battle/move_effect/strength_sap.c
@@ -19,7 +19,7 @@ SINGLE_BATTLE_TEST("Strength Sap lowers Attack by 1 and restores HP based on tar
     } WHEN {
         TURN { MOVE(player, MOVE_STRENGTH_SAP); }
     } SCENE {
-        MESSAGE("Wobbuffet used Strength Sap!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_STRENGTH_SAP) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_STRENGTH_SAP, player);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
         MESSAGE("Foe Wobbuffet's Attack fell!");
@@ -46,7 +46,7 @@ SINGLE_BATTLE_TEST("Strength Sap works exactly the same when attacker is behind 
         TURN { MOVE(player, MOVE_STRENGTH_SAP); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SUBSTITUTE, player);
-        MESSAGE("Wobbuffet used Strength Sap!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_STRENGTH_SAP) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_STRENGTH_SAP, player);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
         MESSAGE("Foe Wobbuffet's Attack fell!");

--- a/test/battle/move_effect/strength_sap.c
+++ b/test/battle/move_effect/strength_sap.c
@@ -19,10 +19,10 @@ SINGLE_BATTLE_TEST("Strength Sap lowers Attack by 1 and restores HP based on tar
     } WHEN {
         TURN { MOVE(player, MOVE_STRENGTH_SAP); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_STRENGTH_SAP) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_STRENGTH_SAP) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_STRENGTH_SAP, player);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-        MESSAGE("Foe Wobbuffet's Attack fell!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Attack fell!");
         HP_BAR(player, captureDamage: &results[i].hp);
         MESSAGE("Foe Wobbuffet had its energy drained!");
     } THEN {
@@ -46,10 +46,10 @@ SINGLE_BATTLE_TEST("Strength Sap works exactly the same when attacker is behind 
         TURN { MOVE(player, MOVE_STRENGTH_SAP); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SUBSTITUTE, player);
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_STRENGTH_SAP) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_STRENGTH_SAP) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_STRENGTH_SAP, player);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-        MESSAGE("Foe Wobbuffet's Attack fell!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Attack fell!");
         HP_BAR(player, captureDamage: &results[i].hp);
         NOT MESSAGE("The SUBSTITUTE took damage for Foe Wobbuffet!");
         MESSAGE("Foe Wobbuffet had its energy drained!");

--- a/test/battle/move_effect/tailwind.c
+++ b/test/battle/move_effect/tailwind.c
@@ -19,20 +19,20 @@ SINGLE_BATTLE_TEST("Tailwind applies for 4 turns")
         TURN {}
         TURN {}
     } SCENE {
-        MESSAGE("Foe Wobbuffet used Celebrate!");
-        MESSAGE("Wobbuffet used Tailwind!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TAILWIND) "!");
 
-        MESSAGE("Wobbuffet used Celebrate!");
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
 
-        MESSAGE("Wobbuffet used Celebrate!");
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
 
-        MESSAGE("Wobbuffet used Celebrate!");
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
 
-        MESSAGE("Foe Wobbuffet used Celebrate!");
-        MESSAGE("Wobbuffet used Celebrate!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
     }
 }
 
@@ -47,9 +47,9 @@ DOUBLE_BATTLE_TEST("Tailwind affects partner on first turn")
     } WHEN {
         TURN { MOVE(playerLeft, MOVE_TAILWIND); }
     } SCENE {
-        MESSAGE("Wobbuffet used Tailwind!");
-        MESSAGE("Wynaut used Celebrate!");
-        MESSAGE("Foe Wobbuffet used Celebrate!");
-        MESSAGE("Foe Wynaut used Celebrate!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TAILWIND) "!");
+        MESSAGE("Wynaut used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wynaut used " MOVE_NAME(MOVE_CELEBRATE) "!");
     }
 }

--- a/test/battle/move_effect/tailwind.c
+++ b/test/battle/move_effect/tailwind.c
@@ -19,20 +19,20 @@ SINGLE_BATTLE_TEST("Tailwind applies for 4 turns")
         TURN {}
         TURN {}
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TAILWIND) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TAILWIND) "!");
 
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
 
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
 
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
 
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
     }
 }
 
@@ -47,9 +47,9 @@ DOUBLE_BATTLE_TEST("Tailwind affects partner on first turn")
     } WHEN {
         TURN { MOVE(playerLeft, MOVE_TAILWIND); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TAILWIND) "!");
-        MESSAGE("Wynaut used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wynaut used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TAILWIND) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WYNAUT) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WYNAUT) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
     }
 }

--- a/test/battle/move_effect/take_heart.c
+++ b/test/battle/move_effect/take_heart.c
@@ -34,13 +34,13 @@ SINGLE_BATTLE_TEST("Take Heart cures the user of all status conditions")
         TURN { MOVE(player, MOVE_TAKE_HEART); }
     } SCENE {
         if (status1 == STATUS1_SLEEP) {
-            MESSAGE("Wobbuffet is fast asleep.");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is fast asleep.");
         } else if (status1 == STATUS1_FREEZE) {
             PASSES_RANDOMLY(20, 100, RNG_FROZEN);
             STATUS_ICON(player, none: TRUE);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
         } else {
-            MESSAGE("Wobbuffet's status returned to normal!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s status returned to normal!");
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
         }
     }

--- a/test/battle/move_effect/teatime.c
+++ b/test/battle/move_effect/teatime.c
@@ -15,7 +15,7 @@ SINGLE_BATTLE_TEST("Teatime causes the user to consume its Berry, ignoring HP re
     } WHEN {
         TURN { MOVE(player, MOVE_TEATIME); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TEATIME) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TEATIME) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, player);
         MESSAGE("Using Liechi Berry, the Attack of Wobbuffet rose!");
     }
@@ -29,7 +29,7 @@ SINGLE_BATTLE_TEST("Teatime causes the user to consume its Berry, even in the pr
     } WHEN {
         TURN { MOVE(player, MOVE_TEATIME); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TEATIME) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TEATIME) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, player);
         MESSAGE("Using Liechi Berry, the Attack of Wobbuffet rose!");
     }
@@ -46,7 +46,7 @@ SINGLE_BATTLE_TEST("Teatime causes the user to consume its Berry, even under the
             MOVE(player, MOVE_TEATIME);
         }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TEATIME) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TEATIME) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, player);
         MESSAGE("Using Liechi Berry, the Attack of Wobbuffet rose!");
     }
@@ -60,7 +60,7 @@ SINGLE_BATTLE_TEST("Teatime causes the user to consume its Berry, ignoring HP re
     } WHEN {
         TURN { MOVE(opponent, MOVE_TEATIME); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TEATIME) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TEATIME) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, opponent);
         MESSAGE("Using Liechi Berry, the Attack of Foe Wobbuffet rose!");
     }
@@ -74,7 +74,7 @@ SINGLE_BATTLE_TEST("Teatime causes other Pokemon to consume their Berry even if 
     } WHEN {
         TURN { MOVE(player, MOVE_TEATIME); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TEATIME) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TEATIME) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, player);
         MESSAGE("Using Liechi Berry, the Attack of Foe Wobbuffet rose!");
     }
@@ -88,7 +88,7 @@ SINGLE_BATTLE_TEST("Teatime causes other Pokemon to consume their Berry even if 
     } WHEN {
         TURN { MOVE(opponent, MOVE_TEATIME); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TEATIME) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TEATIME) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, opponent);
         MESSAGE("Using Liechi Berry, the Attack of Wobbuffet rose!");
     }
@@ -111,9 +111,9 @@ DOUBLE_BATTLE_TEST("Teatime causes all Pokémon to consume their berry")
     } SCENE {
         if (user == playerLeft || user == playerRight)
         {
-            MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TEATIME) "!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TEATIME) "!");
         } else {
-            MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TEATIME) "!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TEATIME) "!");
         }
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, user);
         MESSAGE("Using Liechi Berry, the Attack of Wobbuffet rose!");
@@ -131,7 +131,7 @@ SINGLE_BATTLE_TEST("Teatime fails if no Pokémon is holding a Berry")
     } WHEN {
         TURN { MOVE(player, MOVE_TEATIME); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TEATIME) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TEATIME) "!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, player);
         MESSAGE("But it failed!");
     }
@@ -148,7 +148,7 @@ SINGLE_BATTLE_TEST("Teatime does not affect Pokémon in the semi-invulnerable tu
             MOVE(player, MOVE_TEATIME);
         }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TEATIME) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TEATIME) "!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, player);
             MESSAGE("Using Liechi Berry, the Attack of Foe Wobbuffet rose!");
@@ -177,7 +177,7 @@ SINGLE_BATTLE_TEST("Teatime triggers Volt Absorb if it has been affected by Elec
             MOVE(opponent, MOVE_TEATIME);
         }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TEATIME) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TEATIME) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, opponent);
         if (shouldTriggerAbility)
         {
@@ -213,17 +213,17 @@ SINGLE_BATTLE_TEST("Teatime triggers Lightning Rod if it has been affected by El
             MOVE(opponent, MOVE_TEATIME);
         }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TEATIME) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TEATIME) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, opponent);
         if (shouldTriggerAbility)
         {
             ABILITY_POPUP(player, ABILITY_LIGHTNING_ROD);
-            MESSAGE("Pikachu's Sp. Atk rose!");
+            MESSAGE(SPECIES_NAME(SPECIES_PIKACHU) "'s Sp. Atk rose!");
             NOT MESSAGE("Using Liechi Berry, the Attack of Pikachu rose!");
         } else {
             NONE_OF {
                 ABILITY_POPUP(player, ABILITY_LIGHTNING_ROD);
-                MESSAGE("Pikachu's Sp. Atk rose!");
+                MESSAGE(SPECIES_NAME(SPECIES_PIKACHU) "'s Sp. Atk rose!");
             }
             MESSAGE("Using Liechi Berry, the Attack of Pikachu rose!");
         }
@@ -253,17 +253,17 @@ SINGLE_BATTLE_TEST("Teatime triggers Motor Drive if it has been affected by Elec
             MOVE(opponent, MOVE_TEATIME);
         }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TEATIME) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TEATIME) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, opponent);
         if (shouldTriggerAbility)
         {
             ABILITY_POPUP(player, ABILITY_MOTOR_DRIVE);
-            MESSAGE("Electivire's Speed rose!");
+            MESSAGE(SPECIES_NAME(SPECIES_ELECTIVIRE) "'s Speed rose!");
             NOT MESSAGE("Using Liechi Berry, the Attack of Electivire rose!");
         } else {
             NONE_OF {
                 ABILITY_POPUP(player, ABILITY_MOTOR_DRIVE);
-                MESSAGE("Electivire's Speed rose!");
+                MESSAGE(SPECIES_NAME(SPECIES_ELECTIVIRE) "'s Speed rose!");
             }
             MESSAGE("Using Liechi Berry, the Attack of Electivire rose!");
         }

--- a/test/battle/move_effect/teatime.c
+++ b/test/battle/move_effect/teatime.c
@@ -15,7 +15,7 @@ SINGLE_BATTLE_TEST("Teatime causes the user to consume its Berry, ignoring HP re
     } WHEN {
         TURN { MOVE(player, MOVE_TEATIME); }
     } SCENE {
-        MESSAGE("Wobbuffet used Teatime!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TEATIME) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, player);
         MESSAGE("Using Liechi Berry, the Attack of Wobbuffet rose!");
     }
@@ -29,7 +29,7 @@ SINGLE_BATTLE_TEST("Teatime causes the user to consume its Berry, even in the pr
     } WHEN {
         TURN { MOVE(player, MOVE_TEATIME); }
     } SCENE {
-        MESSAGE("Wobbuffet used Teatime!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TEATIME) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, player);
         MESSAGE("Using Liechi Berry, the Attack of Wobbuffet rose!");
     }
@@ -46,7 +46,7 @@ SINGLE_BATTLE_TEST("Teatime causes the user to consume its Berry, even under the
             MOVE(player, MOVE_TEATIME);
         }
     } SCENE {
-        MESSAGE("Wobbuffet used Teatime!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TEATIME) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, player);
         MESSAGE("Using Liechi Berry, the Attack of Wobbuffet rose!");
     }
@@ -60,7 +60,7 @@ SINGLE_BATTLE_TEST("Teatime causes the user to consume its Berry, ignoring HP re
     } WHEN {
         TURN { MOVE(opponent, MOVE_TEATIME); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used Teatime!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TEATIME) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, opponent);
         MESSAGE("Using Liechi Berry, the Attack of Foe Wobbuffet rose!");
     }
@@ -74,7 +74,7 @@ SINGLE_BATTLE_TEST("Teatime causes other Pokemon to consume their Berry even if 
     } WHEN {
         TURN { MOVE(player, MOVE_TEATIME); }
     } SCENE {
-        MESSAGE("Wobbuffet used Teatime!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TEATIME) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, player);
         MESSAGE("Using Liechi Berry, the Attack of Foe Wobbuffet rose!");
     }
@@ -88,7 +88,7 @@ SINGLE_BATTLE_TEST("Teatime causes other Pokemon to consume their Berry even if 
     } WHEN {
         TURN { MOVE(opponent, MOVE_TEATIME); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used Teatime!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TEATIME) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, opponent);
         MESSAGE("Using Liechi Berry, the Attack of Wobbuffet rose!");
     }
@@ -111,9 +111,9 @@ DOUBLE_BATTLE_TEST("Teatime causes all Pokémon to consume their berry")
     } SCENE {
         if (user == playerLeft || user == playerRight)
         {
-            MESSAGE("Wobbuffet used Teatime!");
+            MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TEATIME) "!");
         } else {
-            MESSAGE("Foe Wobbuffet used Teatime!");
+            MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TEATIME) "!");
         }
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, user);
         MESSAGE("Using Liechi Berry, the Attack of Wobbuffet rose!");
@@ -131,7 +131,7 @@ SINGLE_BATTLE_TEST("Teatime fails if no Pokémon is holding a Berry")
     } WHEN {
         TURN { MOVE(player, MOVE_TEATIME); }
     } SCENE {
-        MESSAGE("Wobbuffet used Teatime!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TEATIME) "!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, player);
         MESSAGE("But it failed!");
     }
@@ -148,7 +148,7 @@ SINGLE_BATTLE_TEST("Teatime does not affect Pokémon in the semi-invulnerable tu
             MOVE(player, MOVE_TEATIME);
         }
     } SCENE {
-        MESSAGE("Wobbuffet used Teatime!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TEATIME) "!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, player);
             MESSAGE("Using Liechi Berry, the Attack of Foe Wobbuffet rose!");
@@ -177,7 +177,7 @@ SINGLE_BATTLE_TEST("Teatime triggers Volt Absorb if it has been affected by Elec
             MOVE(opponent, MOVE_TEATIME);
         }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used Teatime!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TEATIME) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, opponent);
         if (shouldTriggerAbility)
         {
@@ -213,7 +213,7 @@ SINGLE_BATTLE_TEST("Teatime triggers Lightning Rod if it has been affected by El
             MOVE(opponent, MOVE_TEATIME);
         }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used Teatime!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TEATIME) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, opponent);
         if (shouldTriggerAbility)
         {
@@ -253,7 +253,7 @@ SINGLE_BATTLE_TEST("Teatime triggers Motor Drive if it has been affected by Elec
             MOVE(opponent, MOVE_TEATIME);
         }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used Teatime!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TEATIME) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, opponent);
         if (shouldTriggerAbility)
         {

--- a/test/battle/move_effect/teatime.c
+++ b/test/battle/move_effect/teatime.c
@@ -62,7 +62,7 @@ SINGLE_BATTLE_TEST("Teatime causes the user to consume its Berry, ignoring HP re
     } SCENE {
         MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TEATIME) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, opponent);
-        MESSAGE("Using Liechi Berry, the Attack of Foe Wobbuffet rose!");
+        MESSAGE("Using Liechi Berry, the Attack of Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " rose!");
     }
 }
 
@@ -76,7 +76,7 @@ SINGLE_BATTLE_TEST("Teatime causes other Pokemon to consume their Berry even if 
     } SCENE {
         MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TEATIME) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, player);
-        MESSAGE("Using Liechi Berry, the Attack of Foe Wobbuffet rose!");
+        MESSAGE("Using Liechi Berry, the Attack of Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " rose!");
     }
 }
 
@@ -117,9 +117,9 @@ DOUBLE_BATTLE_TEST("Teatime causes all Pokémon to consume their berry")
         }
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, user);
         MESSAGE("Using Liechi Berry, the Attack of Wobbuffet rose!");
-        MESSAGE("Using Liechi Berry, the Attack of Foe Wobbuffet rose!");
+        MESSAGE("Using Liechi Berry, the Attack of Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " rose!");
         MESSAGE("Using Liechi Berry, the Attack of Wobbuffet rose!");
-        MESSAGE("Using Liechi Berry, the Attack of Foe Wobbuffet rose!");
+        MESSAGE("Using Liechi Berry, the Attack of Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " rose!");
     }
 }
 
@@ -151,7 +151,7 @@ SINGLE_BATTLE_TEST("Teatime does not affect Pokémon in the semi-invulnerable tu
         MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TEATIME) "!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_TEATIME, player);
-            MESSAGE("Using Liechi Berry, the Attack of Foe Wobbuffet rose!");
+            MESSAGE("Using Liechi Berry, the Attack of Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " rose!");
         }
     }
 }
@@ -188,7 +188,7 @@ SINGLE_BATTLE_TEST("Teatime triggers Volt Absorb if it has been affected by Elec
             NOT ABILITY_POPUP(player, ABILITY_VOLT_ABSORB);
             MESSAGE("Using Liechi Berry, the Attack of Jolteon rose!");
         }
-        MESSAGE("Using Liechi Berry, the Attack of Foe Wobbuffet rose!");
+        MESSAGE("Using Liechi Berry, the Attack of Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " rose!");
     }
 }
 
@@ -227,7 +227,7 @@ SINGLE_BATTLE_TEST("Teatime triggers Lightning Rod if it has been affected by El
             }
             MESSAGE("Using Liechi Berry, the Attack of Pikachu rose!");
         }
-        MESSAGE("Using Liechi Berry, the Attack of Foe Wobbuffet rose!");
+        MESSAGE("Using Liechi Berry, the Attack of Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " rose!");
     }
 }
 
@@ -267,6 +267,6 @@ SINGLE_BATTLE_TEST("Teatime triggers Motor Drive if it has been affected by Elec
             }
             MESSAGE("Using Liechi Berry, the Attack of Electivire rose!");
         }
-        MESSAGE("Using Liechi Berry, the Attack of Foe Wobbuffet rose!");
+        MESSAGE("Using Liechi Berry, the Attack of Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " rose!");
     }
 }

--- a/test/battle/move_effect/teleport.c
+++ b/test/battle/move_effect/teleport.c
@@ -41,7 +41,7 @@ SINGLE_BATTLE_TEST("Teleport forces the pokemon to switch out")
         TURN { MOVE(opponent, MOVE_TELEPORT); SEND_OUT(opponent, 1); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TELEPORT, opponent);
-        MESSAGE("2 sent out Wynaut!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WYNAUT) "!");
     }
 }
 
@@ -56,6 +56,6 @@ SINGLE_BATTLE_TEST("Teleport does not fail if the user is trapped")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_FIRE_SPIN, player);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TELEPORT, opponent);
-        MESSAGE("2 sent out Wynaut!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WYNAUT) "!");
     }
 }

--- a/test/battle/move_effect/thunder.c
+++ b/test/battle/move_effect/thunder.c
@@ -29,6 +29,6 @@ SINGLE_BATTLE_TEST("Thunder bypasses accuracy checks in Rain")
     } WHEN {
         TURN { MOVE(opponent, MOVE_RAIN_DANCE); MOVE(player, MOVE_THUNDER); }
     } SCENE {
-        NONE_OF { MESSAGE("Wobbuffet's attack missed!"); }
+        NONE_OF { MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) "'s attack missed!"); }
     }
 }

--- a/test/battle/move_effect/torment.c
+++ b/test/battle/move_effect/torment.c
@@ -16,7 +16,7 @@ SINGLE_BATTLE_TEST("Torment prevents consecutive move uses")
         TURN { MOVE(opponent, MOVE_SPLASH, allowed: FALSE); MOVE(opponent, MOVE_CELEBRATE); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TORMENT, player);
-        MESSAGE("Foe Wobbuffet was subjected to torment!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " was subjected to torment!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SPLASH, opponent);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
     }

--- a/test/battle/move_effect/toxic_spikes.c
+++ b/test/battle/move_effect/toxic_spikes.c
@@ -64,7 +64,7 @@ SINGLE_BATTLE_TEST("Toxic Spikes fails after 2 layers")
         MESSAGE("Poison Spikes were scattered all around the opposing team's feet!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TOXIC_SPIKES, player);
         MESSAGE("Poison Spikes were scattered all around the opposing team's feet!");
-        MESSAGE("Wobbuffet used Toxic Spikes!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TOXIC_SPIKES) "!");
         MESSAGE("But it failed!");
         MESSAGE("2 sent out Wynaut!");
         ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
@@ -222,7 +222,7 @@ SINGLE_BATTLE_TEST("Toxic Spikes inflicts poison on switch in after Primal Rever
         TURN { SWITCH(player, 1); }
         TURN { MOVE(player, MOVE_MEMENTO); SEND_OUT(player, 2); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used Toxic Spikes!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TOXIC_SPIKES) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TOXIC_SPIKES, opponent);
         MESSAGE("Poison Spikes were scattered all around your team's feet!");
         // Switch in
@@ -232,7 +232,7 @@ SINGLE_BATTLE_TEST("Toxic Spikes inflicts poison on switch in after Primal Rever
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_PRIMAL_REVERSION, player);
         MESSAGE("Groudon's Primal Reversion! It reverted to its primal form!");
         // Memento
-        MESSAGE("Groudon used Memento!");
+        MESSAGE("Groudon used " MOVE_NAME(MOVE_MEMENTO) "!");
         MESSAGE("Groudon fainted!");
         // 2nd switch-in
         MESSAGE("Go! Wynaut!");

--- a/test/battle/move_effect/toxic_spikes.c
+++ b/test/battle/move_effect/toxic_spikes.c
@@ -19,7 +19,7 @@ SINGLE_BATTLE_TEST("Toxic Spikes inflicts poison on switch in")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TOXIC_SPIKES, player);
         MESSAGE("Poison Spikes were scattered all around the opposing team's feet!");
-        MESSAGE("2 sent out Wynaut!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WYNAUT) "!");
         ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
         STATUS_ICON(opponent, poison: TRUE);
     }
@@ -41,7 +41,7 @@ SINGLE_BATTLE_TEST("Toxic Spikes inflicts bad poison on switch in")
         MESSAGE("Poison Spikes were scattered all around the opposing team's feet!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TOXIC_SPIKES, player);
         MESSAGE("Poison Spikes were scattered all around the opposing team's feet!");
-        MESSAGE("2 sent out Wynaut!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WYNAUT) "!");
         ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
         STATUS_ICON(opponent, badPoison: TRUE);
     }
@@ -64,9 +64,9 @@ SINGLE_BATTLE_TEST("Toxic Spikes fails after 2 layers")
         MESSAGE("Poison Spikes were scattered all around the opposing team's feet!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TOXIC_SPIKES, player);
         MESSAGE("Poison Spikes were scattered all around the opposing team's feet!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TOXIC_SPIKES) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TOXIC_SPIKES) "!");
         MESSAGE("But it failed!");
-        MESSAGE("2 sent out Wynaut!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WYNAUT) "!");
         ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
         STATUS_ICON(opponent, badPoison: TRUE);
     }
@@ -84,7 +84,7 @@ SINGLE_BATTLE_TEST("Toxic Spikes inflicts poison on subsequent switch ins")
         TURN { SWITCH(opponent, 0); }
         TURN {}
     } SCENE {
-        MESSAGE("2 sent out Wynaut!");
+        MESSAGE("2 sent out " SPECIES_NAME(SPECIES_WYNAUT) "!");
         STATUS_ICON(opponent, poison: TRUE);
     }
 }
@@ -222,20 +222,20 @@ SINGLE_BATTLE_TEST("Toxic Spikes inflicts poison on switch in after Primal Rever
         TURN { SWITCH(player, 1); }
         TURN { MOVE(player, MOVE_MEMENTO); SEND_OUT(player, 2); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_TOXIC_SPIKES) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TOXIC_SPIKES) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TOXIC_SPIKES, opponent);
         MESSAGE("Poison Spikes were scattered all around your team's feet!");
         // Switch in
-        MESSAGE("Go! Groudon!");
+        MESSAGE("Go! " SPECIES_NAME(SPECIES_GROUDON) "!");
         ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, player);
         STATUS_ICON(player, poison: TRUE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_PRIMAL_REVERSION, player);
-        MESSAGE("Groudon's Primal Reversion! It reverted to its primal form!");
+        MESSAGE(SPECIES_NAME(SPECIES_GROUDON) "'s Primal Reversion! It reverted to its primal form!");
         // Memento
-        MESSAGE("Groudon used " MOVE_NAME(MOVE_MEMENTO) "!");
-        MESSAGE("Groudon fainted!");
+        MESSAGE(SPECIES_NAME(SPECIES_GROUDON) " used " MOVE_NAME(MOVE_MEMENTO) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_GROUDON) " fainted!");
         // 2nd switch-in
-        MESSAGE("Go! Wynaut!");
+        MESSAGE("Go! " SPECIES_NAME(SPECIES_WYNAUT) "!");
         ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, player);
         STATUS_ICON(player, poison: TRUE);
     }

--- a/test/battle/move_effect/triple_arrows.c
+++ b/test/battle/move_effect/triple_arrows.c
@@ -25,7 +25,7 @@ SINGLE_BATTLE_TEST("Triple Arrows may lower Defense by one stage")
     }
 }
 
-SINGLE_BATTLE_TEST("Triple Arrows makes the foe flinch 30% of the time")
+SINGLE_BATTLE_TEST("Triple Arrows makes the Foe " SPECIES_NAME(SPECIES_FLINCH) " 30% of the time")
 {
     u32 ability;
     u32 chance;
@@ -39,7 +39,7 @@ SINGLE_BATTLE_TEST("Triple Arrows makes the foe flinch 30% of the time")
         TURN { MOVE(player, MOVE_TRIPLE_ARROWS); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TRIPLE_ARROWS, player);
-        MESSAGE("Foe Wobbuffet flinched!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " flinched!");
     }
 }
 
@@ -70,7 +70,7 @@ SINGLE_BATTLE_TEST("Triple Arrows can lower Defense and cause flinch at the time
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TRIPLE_ARROWS, player);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
         MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Defense fell!");
-        MESSAGE("Foe Wobbuffet flinched!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " flinched!");
     }
 }
 
@@ -85,7 +85,7 @@ SINGLE_BATTLE_TEST("Triple Arrows's flinching is prevented by Inner Focus")
         }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TRIPLE_ARROWS, player);
-        NONE_OF { MESSAGE("Foe Wobbuffet flinched!"); }
+        NONE_OF { MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " flinched!"); }
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
     }
 }

--- a/test/battle/move_effect/triple_arrows.c
+++ b/test/battle/move_effect/triple_arrows.c
@@ -21,7 +21,7 @@ SINGLE_BATTLE_TEST("Triple Arrows may lower Defense by one stage")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TRIPLE_ARROWS, player);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-        MESSAGE("Foe Wobbuffet's Defense fell!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Defense fell!");
     }
 }
 
@@ -69,7 +69,7 @@ SINGLE_BATTLE_TEST("Triple Arrows can lower Defense and cause flinch at the time
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TRIPLE_ARROWS, player);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-        MESSAGE("Foe Wobbuffet's Defense fell!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s Defense fell!");
         MESSAGE("Foe Wobbuffet flinched!");
     }
 }

--- a/test/battle/move_flags/powder.c
+++ b/test/battle/move_flags/powder.c
@@ -12,6 +12,6 @@ SINGLE_BATTLE_TEST("Powder moves are blocked by Grass-type Pokémon")
         TURN { MOVE(player, MOVE_STUN_SPORE); }
     } SCENE {
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_STUN_SPORE, player);
-        MESSAGE("It doesn't affect Foe Oddish…");
+        MESSAGE("It doesn't affect Foe " SPECIES_NAME(SPECIES_ODDISH) "…");
     }
 }

--- a/test/battle/status1/freeze.c
+++ b/test/battle/status1/freeze.c
@@ -23,7 +23,7 @@ SINGLE_BATTLE_TEST("Freeze is thawed by opponent's Fire-type attacks")
     } WHEN {
         TURN { MOVE(opponent, MOVE_EMBER); MOVE(player, MOVE_CELEBRATE); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used Ember!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_EMBER) "!");
         MESSAGE("Wobbuffet was defrosted!");
         STATUS_ICON(player, none: TRUE);
     }
@@ -40,6 +40,6 @@ SINGLE_BATTLE_TEST("Freeze is thawed by user's Flame Wheel")
     } SCENE {
         MESSAGE("Wobbuffet was defrosted by Flame Wheel!");
         STATUS_ICON(player, none: TRUE);
-        MESSAGE("Wobbuffet used Flame Wheel!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FLAME_WHEEL) "!");
     }
 }

--- a/test/battle/status1/freeze.c
+++ b/test/battle/status1/freeze.c
@@ -23,8 +23,8 @@ SINGLE_BATTLE_TEST("Freeze is thawed by opponent's Fire-type attacks")
     } WHEN {
         TURN { MOVE(opponent, MOVE_EMBER); MOVE(player, MOVE_CELEBRATE); }
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_EMBER) "!");
-        MESSAGE("Wobbuffet was defrosted!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_EMBER) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was defrosted!");
         STATUS_ICON(player, none: TRUE);
     }
 }
@@ -38,8 +38,8 @@ SINGLE_BATTLE_TEST("Freeze is thawed by user's Flame Wheel")
     } WHEN {
         TURN { MOVE(player, MOVE_FLAME_WHEEL); }
     } SCENE {
-        MESSAGE("Wobbuffet was defrosted by Flame Wheel!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " was defrosted by Flame Wheel!");
         STATUS_ICON(player, none: TRUE);
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_FLAME_WHEEL) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_FLAME_WHEEL) "!");
     }
 }

--- a/test/battle/status1/frostbite.c
+++ b/test/battle/status1/frostbite.c
@@ -32,7 +32,7 @@ SINGLE_BATTLE_TEST("Frostbite deals 1/16 damage to effected pokemon")
     } WHEN {
         TURN {}
     } SCENE {
-        MESSAGE("Foe Wobbuffet is hurt by its frostbite!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is hurt by its frostbite!");
         ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_FRZ, opponent);
         HP_BAR(opponent, captureDamage: &frostbiteDamage);
    } THEN { EXPECT_EQ(frostbiteDamage, opponent->maxHP / 16); }
@@ -57,10 +57,10 @@ SINGLE_BATTLE_TEST("Frostbite is healed if hit with a thawing move")
         ANIMATION(ANIM_TYPE_MOVE, move, player);
         if (move == MOVE_EMBER) {
             NONE_OF {
-                MESSAGE("Foe Wobbuffet's frostbite was healed!");
+                MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s frostbite was healed!");
             }
         } else {
-            MESSAGE("Foe Wobbuffet's frostbite was healed!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) "'s frostbite was healed!");
         }
    }
 }
@@ -84,11 +84,11 @@ SINGLE_BATTLE_TEST("Frostbite is healed when the user uses a thawing move")
         ANIMATION(ANIM_TYPE_MOVE, move, player);
         HP_BAR(opponent);
         if (move == MOVE_EMBER) {
-            MESSAGE("Wobbuffet is hurt by its frostbite!");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is hurt by its frostbite!");
             ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_FRZ, player);
         } else {
             NONE_OF {
-                MESSAGE("Wobbuffet is hurt by its frostbite!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is hurt by its frostbite!");
                 ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_FRZ, player);
             }
         }

--- a/test/battle/status1/paralysis.c
+++ b/test/battle/status1/paralysis.c
@@ -16,14 +16,14 @@ SINGLE_BATTLE_TEST("Paralysis reduces Speed by 50%")
     } SCENE {
         if (playerFirst) {
             ONE_OF {
-                MESSAGE("Wobbuffet used Celebrate!");
+                MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
                 MESSAGE("Wobbuffet is paralyzed! It can't move!");
             }
-            MESSAGE("Foe Wobbuffet used Celebrate!");
+            MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
         } else {
-            MESSAGE("Foe Wobbuffet used Celebrate!");
+            MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
             ONE_OF {
-                MESSAGE("Wobbuffet used Celebrate!");
+                MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
                 MESSAGE("Wobbuffet is paralyzed! It can't move!");
             }
         }

--- a/test/battle/status1/paralysis.c
+++ b/test/battle/status1/paralysis.c
@@ -16,15 +16,15 @@ SINGLE_BATTLE_TEST("Paralysis reduces Speed by 50%")
     } SCENE {
         if (playerFirst) {
             ONE_OF {
-                MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
-                MESSAGE("Wobbuffet is paralyzed! It can't move!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is paralyzed! It can't move!");
             }
-            MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
         } else {
-            MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+            MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
             ONE_OF {
-                MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
-                MESSAGE("Wobbuffet is paralyzed! It can't move!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+                MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is paralyzed! It can't move!");
             }
         }
     }
@@ -39,6 +39,6 @@ SINGLE_BATTLE_TEST("Paralysis has a 25% chance of skipping the turn")
     } WHEN {
         TURN { MOVE(player, MOVE_CELEBRATE); }
     } SCENE {
-        MESSAGE("Wobbuffet is paralyzed! It can't move!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is paralyzed! It can't move!");
     }
 }

--- a/test/battle/status1/sleep.c
+++ b/test/battle/status1/sleep.c
@@ -16,7 +16,7 @@ SINGLE_BATTLE_TEST("Sleep prevents the battler from using a move")
     } SCENE {
         for (j = 0; j < turns - 1; j++)
             MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is fast asleep.");
-        MESSAGE("Wobbuffet woke up!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " woke up!");
         STATUS_ICON(player, none: TRUE);
         MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
     }

--- a/test/battle/status1/sleep.c
+++ b/test/battle/status1/sleep.c
@@ -18,6 +18,6 @@ SINGLE_BATTLE_TEST("Sleep prevents the battler from using a move")
             MESSAGE("Wobbuffet is fast asleep.");
         MESSAGE("Wobbuffet woke up!");
         STATUS_ICON(player, none: TRUE);
-        MESSAGE("Wobbuffet used Celebrate!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
     }
 }

--- a/test/battle/status1/sleep.c
+++ b/test/battle/status1/sleep.c
@@ -15,9 +15,9 @@ SINGLE_BATTLE_TEST("Sleep prevents the battler from using a move")
             TURN { MOVE(player, MOVE_CELEBRATE); }
     } SCENE {
         for (j = 0; j < turns - 1; j++)
-            MESSAGE("Wobbuffet is fast asleep.");
+            MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is fast asleep.");
         MESSAGE("Wobbuffet woke up!");
         STATUS_ICON(player, none: TRUE);
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
     }
 }

--- a/test/battle/terrain/electric.c
+++ b/test/battle/terrain/electric.c
@@ -14,7 +14,7 @@ SINGLE_BATTLE_TEST("Electric Terrain protects grounded battlers from falling asl
         MESSAGE("Foe " SPECIES_NAME(SPECIES_CLAYDOL) " used " MOVE_NAME(MOVE_SPORE) "!");
         MESSAGE("Wobbuffet surrounds itself with electrified terrain!");
         MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SPORE) "!");
-        MESSAGE("Foe Claydol fell asleep!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_CLAYDOL) " fell asleep!");
         STATUS_ICON(opponent, sleep: TRUE);
     }
 }

--- a/test/battle/terrain/electric.c
+++ b/test/battle/terrain/electric.c
@@ -10,10 +10,10 @@ SINGLE_BATTLE_TEST("Electric Terrain protects grounded battlers from falling asl
         TURN { MOVE(player, MOVE_ELECTRIC_TERRAIN); MOVE(opponent, MOVE_SPORE); }
         TURN { MOVE(player, MOVE_SPORE); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_ELECTRIC_TERRAIN) "!");
-        MESSAGE("Foe Claydol used " MOVE_NAME(MOVE_SPORE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_ELECTRIC_TERRAIN) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_CLAYDOL) " used " MOVE_NAME(MOVE_SPORE) "!");
         MESSAGE("Wobbuffet surrounds itself with electrified terrain!");
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SPORE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_SPORE) "!");
         MESSAGE("Foe Claydol fell asleep!");
         STATUS_ICON(opponent, sleep: TRUE);
     }
@@ -33,7 +33,7 @@ SINGLE_BATTLE_TEST("Electric Terrain activates Electric Seed and Mimicry")
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
         MESSAGE("Using Electric Seed, the Defense of Wobbuffet rose!");
         ABILITY_POPUP(opponent);
-        MESSAGE("Foe Stunfisk's type changed to Electr!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_STUNFISK) "'s type changed to Electr!");
     } THEN {
         EXPECT_EQ(gBattleMons[B_POSITION_OPPONENT_LEFT].type1, TYPE_ELECTRIC);
     }
@@ -52,7 +52,7 @@ SINGLE_BATTLE_TEST("Electric Terrain increases power of Electric-type moves by 3
             TURN { MOVE(player, MOVE_ELECTRIC_TERRAIN); }
         TURN { MOVE(player, MOVE_THUNDER_SHOCK); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_THUNDER_SHOCK) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_THUNDER_SHOCK) "!");
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
         if (B_TERRAIN_TYPE_BOOST >= GEN_8)
@@ -74,18 +74,18 @@ SINGLE_BATTLE_TEST("Electric Terrain lasts for 5 turns")
         TURN {}
         TURN {}
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ELECTRIC_TERRAIN, player);
         MESSAGE("An electric current runs across the battlefield!");
 
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
 
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
 
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
 
         MESSAGE("The electricity disappeared from the battlefield.");
     }

--- a/test/battle/terrain/electric.c
+++ b/test/battle/terrain/electric.c
@@ -10,10 +10,10 @@ SINGLE_BATTLE_TEST("Electric Terrain protects grounded battlers from falling asl
         TURN { MOVE(player, MOVE_ELECTRIC_TERRAIN); MOVE(opponent, MOVE_SPORE); }
         TURN { MOVE(player, MOVE_SPORE); }
     } SCENE {
-        MESSAGE("Wobbuffet used ElctrcTrrain!");
-        MESSAGE("Foe Claydol used Spore!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_ELECTRIC_TERRAIN) "!");
+        MESSAGE("Foe Claydol used " MOVE_NAME(MOVE_SPORE) "!");
         MESSAGE("Wobbuffet surrounds itself with electrified terrain!");
-        MESSAGE("Wobbuffet used Spore!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_SPORE) "!");
         MESSAGE("Foe Claydol fell asleep!");
         STATUS_ICON(opponent, sleep: TRUE);
     }
@@ -52,7 +52,7 @@ SINGLE_BATTLE_TEST("Electric Terrain increases power of Electric-type moves by 3
             TURN { MOVE(player, MOVE_ELECTRIC_TERRAIN); }
         TURN { MOVE(player, MOVE_THUNDER_SHOCK); }
     } SCENE {
-        MESSAGE("Wobbuffet used ThunderShock!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_THUNDER_SHOCK) "!");
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
         if (B_TERRAIN_TYPE_BOOST >= GEN_8)
@@ -74,18 +74,18 @@ SINGLE_BATTLE_TEST("Electric Terrain lasts for 5 turns")
         TURN {}
         TURN {}
     } SCENE {
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ELECTRIC_TERRAIN, player);
         MESSAGE("An electric current runs across the battlefield!");
 
-        MESSAGE("Wobbuffet used Celebrate!");
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
 
-        MESSAGE("Wobbuffet used Celebrate!");
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
 
-        MESSAGE("Wobbuffet used Celebrate!");
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
 
         MESSAGE("The electricity disappeared from the battlefield.");
     }

--- a/test/battle/terrain/grassy.c
+++ b/test/battle/terrain/grassy.c
@@ -48,7 +48,7 @@ SINGLE_BATTLE_TEST("Grassy Terrain increases power of Grass-type moves by 30/50 
             TURN { MOVE(player, MOVE_GRASSY_TERRAIN); }
         TURN { MOVE(player, MOVE_ABSORB); }
     } SCENE {
-        MESSAGE("Wobbuffet used Absorb!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_ABSORB) "!");
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
         if (B_TERRAIN_TYPE_BOOST >= GEN_8)
@@ -97,18 +97,18 @@ SINGLE_BATTLE_TEST("Grassy Terrain lasts for 5 turns")
         TURN {}
         TURN {}
     } SCENE {
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_GRASSY_TERRAIN, player);
         MESSAGE("Grass grew to cover the battlefield!");
 
-        MESSAGE("Wobbuffet used Celebrate!");
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
 
-        MESSAGE("Wobbuffet used Celebrate!");
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
 
-        MESSAGE("Wobbuffet used Celebrate!");
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
 
         MESSAGE("The grass disappeared from the battlefield.");
     }

--- a/test/battle/terrain/grassy.c
+++ b/test/battle/terrain/grassy.c
@@ -10,7 +10,7 @@ SINGLE_BATTLE_TEST("Grassy Terrain recovers 1/16th HP at end of turn")
         TURN { MOVE(player, MOVE_GRASSY_TERRAIN); }
     } SCENE {
         s32 maxHP = GetMonData(&PLAYER_PARTY[0], MON_DATA_MAX_HP);
-        MESSAGE("Wobbuffet is healed by the grassy terrain!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " is healed by the grassy terrain!");
         HP_BAR(player, damage: -maxHP / 16);
     }
 }
@@ -29,7 +29,7 @@ SINGLE_BATTLE_TEST("Grassy Terrain activates Grassy Seed and Mimicry")
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
         MESSAGE("Using Grassy Seed, the Defense of Wobbuffet rose!");
         ABILITY_POPUP(opponent);
-        MESSAGE("Foe Stunfisk's type changed to Grass!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_STUNFISK) "'s type changed to Grass!");
     } THEN {
         EXPECT_EQ(gBattleMons[B_POSITION_OPPONENT_LEFT].type1, TYPE_GRASS);
     }
@@ -48,7 +48,7 @@ SINGLE_BATTLE_TEST("Grassy Terrain increases power of Grass-type moves by 30/50 
             TURN { MOVE(player, MOVE_GRASSY_TERRAIN); }
         TURN { MOVE(player, MOVE_ABSORB); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_ABSORB) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_ABSORB) "!");
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
         if (B_TERRAIN_TYPE_BOOST >= GEN_8)
@@ -97,18 +97,18 @@ SINGLE_BATTLE_TEST("Grassy Terrain lasts for 5 turns")
         TURN {}
         TURN {}
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_GRASSY_TERRAIN, player);
         MESSAGE("Grass grew to cover the battlefield!");
 
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
 
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
 
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
 
         MESSAGE("The grass disappeared from the battlefield.");
     }

--- a/test/battle/terrain/misty.c
+++ b/test/battle/terrain/misty.c
@@ -10,11 +10,11 @@ SINGLE_BATTLE_TEST("Misty Terrain protects grounded battlers from non-volatile s
         TURN { MOVE(player, MOVE_MISTY_TERRAIN); MOVE(opponent, MOVE_TOXIC); }
         TURN { MOVE(player, MOVE_TOXIC); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_MISTY_TERRAIN) "!");
-        MESSAGE("Foe Claydol used " MOVE_NAME(MOVE_TOXIC) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_MISTY_TERRAIN) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_CLAYDOL) " used " MOVE_NAME(MOVE_TOXIC) "!");
         MESSAGE("Wobbuffet surrounds itself with a protective mist!");
         NOT { STATUS_ICON(opponent, badPoison: TRUE); }
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TOXIC) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_TOXIC) "!");
         STATUS_ICON(opponent, badPoison: TRUE);
     }
 }
@@ -33,7 +33,7 @@ SINGLE_BATTLE_TEST("Misty Terrain activates Misty Seed and Mimicry")
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
         MESSAGE("Using Misty Seed, the Sp. Def of Wobbuffet rose!");
         ABILITY_POPUP(opponent);
-        MESSAGE("Foe Stunfisk's type changed to Fairy!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_STUNFISK) "'s type changed to Fairy!");
     } THEN {
         EXPECT_EQ(gBattleMons[B_POSITION_OPPONENT_LEFT].type1, TYPE_FAIRY);
     }
@@ -52,7 +52,7 @@ SINGLE_BATTLE_TEST("Misty Terrain does not increase the power of Fairy-type move
             TURN { MOVE(player, MOVE_MISTY_TERRAIN); }
         TURN { MOVE(player, MOVE_MOONBLAST); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_MOONBLAST) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_MOONBLAST) "!");
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
         EXPECT_EQ(results[0].damage, results[1].damage);
@@ -72,7 +72,7 @@ SINGLE_BATTLE_TEST("Misty Terrain decreases power of Dragon-type moves by 50 per
             TURN { MOVE(player, MOVE_MISTY_TERRAIN); }
         TURN { MOVE(player, MOVE_DRAGON_CLAW); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_DRAGON_CLAW) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_DRAGON_CLAW) "!");
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
         EXPECT_MUL_EQ(results[0].damage, Q_4_12(0.5), results[1].damage);
@@ -91,18 +91,18 @@ SINGLE_BATTLE_TEST("Misty Terrain lasts for 5 turns")
         TURN {}
         TURN {}
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_MISTY_TERRAIN, player);
         MESSAGE("Mist swirled about the battlefield!");
 
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
 
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
 
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
 
         MESSAGE("The mist disappeared from the battlefield.");
     }

--- a/test/battle/terrain/misty.c
+++ b/test/battle/terrain/misty.c
@@ -10,11 +10,11 @@ SINGLE_BATTLE_TEST("Misty Terrain protects grounded battlers from non-volatile s
         TURN { MOVE(player, MOVE_MISTY_TERRAIN); MOVE(opponent, MOVE_TOXIC); }
         TURN { MOVE(player, MOVE_TOXIC); }
     } SCENE {
-        MESSAGE("Wobbuffet used MistyTerrain!");
-        MESSAGE("Foe Claydol used Toxic!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_MISTY_TERRAIN) "!");
+        MESSAGE("Foe Claydol used " MOVE_NAME(MOVE_TOXIC) "!");
         MESSAGE("Wobbuffet surrounds itself with a protective mist!");
         NOT { STATUS_ICON(opponent, badPoison: TRUE); }
-        MESSAGE("Wobbuffet used Toxic!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_TOXIC) "!");
         STATUS_ICON(opponent, badPoison: TRUE);
     }
 }
@@ -52,7 +52,7 @@ SINGLE_BATTLE_TEST("Misty Terrain does not increase the power of Fairy-type move
             TURN { MOVE(player, MOVE_MISTY_TERRAIN); }
         TURN { MOVE(player, MOVE_MOONBLAST); }
     } SCENE {
-        MESSAGE("Wobbuffet used Moonblast!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_MOONBLAST) "!");
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
         EXPECT_EQ(results[0].damage, results[1].damage);
@@ -72,7 +72,7 @@ SINGLE_BATTLE_TEST("Misty Terrain decreases power of Dragon-type moves by 50 per
             TURN { MOVE(player, MOVE_MISTY_TERRAIN); }
         TURN { MOVE(player, MOVE_DRAGON_CLAW); }
     } SCENE {
-        MESSAGE("Wobbuffet used Dragon Claw!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_DRAGON_CLAW) "!");
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
         EXPECT_MUL_EQ(results[0].damage, Q_4_12(0.5), results[1].damage);
@@ -91,18 +91,18 @@ SINGLE_BATTLE_TEST("Misty Terrain lasts for 5 turns")
         TURN {}
         TURN {}
     } SCENE {
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_MISTY_TERRAIN, player);
         MESSAGE("Mist swirled about the battlefield!");
 
-        MESSAGE("Wobbuffet used Celebrate!");
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
 
-        MESSAGE("Wobbuffet used Celebrate!");
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
 
-        MESSAGE("Wobbuffet used Celebrate!");
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
 
         MESSAGE("The mist disappeared from the battlefield.");
     }

--- a/test/battle/terrain/psychic.c
+++ b/test/battle/terrain/psychic.c
@@ -10,10 +10,10 @@ SINGLE_BATTLE_TEST("Psychic Terrain protects grounded battlers from priority mov
         TURN { MOVE(player, MOVE_PSYCHIC_TERRAIN); }
         TURN { MOVE(player, MOVE_QUICK_ATTACK); MOVE(opponent, MOVE_QUICK_ATTACK); }
     } SCENE {
-        MESSAGE("Claydol used " MOVE_NAME(MOVE_PSYCHIC_TERRAIN) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_CLAYDOL) " used " MOVE_NAME(MOVE_PSYCHIC_TERRAIN) "!");
         MESSAGE("Claydol cannot use Quick Attack!");
         NOT { HP_BAR(opponent); }
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_QUICK_ATTACK) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_QUICK_ATTACK) "!");
         HP_BAR(player);
     }
 }
@@ -32,7 +32,7 @@ SINGLE_BATTLE_TEST("Psychic Terrain activates Psychic Seed and Mimicry")
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
         MESSAGE("Using Psychic Seed, the Sp. Def of Wobbuffet rose!");
         ABILITY_POPUP(opponent);
-        MESSAGE("Foe Stunfisk's type changed to Psychc!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_STUNFISK) "'s type changed to Psychc!");
     } THEN {
         EXPECT_EQ(gBattleMons[B_POSITION_OPPONENT_LEFT].type1, TYPE_PSYCHIC);
     }
@@ -51,7 +51,7 @@ SINGLE_BATTLE_TEST("Psychic Terrain increases power of Psychic-type moves by 30/
             TURN { MOVE(player, MOVE_PSYCHIC_TERRAIN); }
         TURN { MOVE(player, MOVE_CONFUSION); }
     } SCENE {
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CONFUSION) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CONFUSION) "!");
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
         if (B_TERRAIN_TYPE_BOOST >= GEN_8)
@@ -70,8 +70,8 @@ SINGLE_BATTLE_TEST("Psychic Terrain doesn't block priority moves that target the
         TURN { MOVE(player, MOVE_PSYCHIC_TERRAIN); }
         TURN { MOVE(player, MOVE_RECOVER); }
     } SCENE {
-        MESSAGE("Sableye used " MOVE_NAME(MOVE_PSYCHIC_TERRAIN) "!");
-        MESSAGE("Sableye used " MOVE_NAME(MOVE_RECOVER) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_SABLEYE) " used " MOVE_NAME(MOVE_PSYCHIC_TERRAIN) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_SABLEYE) " used " MOVE_NAME(MOVE_RECOVER) "!");
         HP_BAR(player);
     }
 }
@@ -85,8 +85,8 @@ SINGLE_BATTLE_TEST("Psychic Terrain doesn't block priority moves that target all
         TURN { MOVE(player, MOVE_PSYCHIC_TERRAIN); }
         TURN { MOVE(player, MOVE_HAZE); }
     } SCENE {
-        MESSAGE("Sableye used " MOVE_NAME(MOVE_PSYCHIC_TERRAIN) "!");
-        MESSAGE("Sableye used " MOVE_NAME(MOVE_HAZE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_SABLEYE) " used " MOVE_NAME(MOVE_PSYCHIC_TERRAIN) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_SABLEYE) " used " MOVE_NAME(MOVE_HAZE) "!");
     }
 }
 
@@ -99,8 +99,8 @@ SINGLE_BATTLE_TEST("Psychic Terrain doesn't block priority moves that target all
         TURN { MOVE(player, MOVE_PSYCHIC_TERRAIN); }
         TURN { MOVE(player, MOVE_SPIKES); }
     } SCENE {
-        MESSAGE("Sableye used " MOVE_NAME(MOVE_PSYCHIC_TERRAIN) "!");
-        MESSAGE("Sableye used " MOVE_NAME(MOVE_SPIKES) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_SABLEYE) " used " MOVE_NAME(MOVE_PSYCHIC_TERRAIN) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_SABLEYE) " used " MOVE_NAME(MOVE_SPIKES) "!");
     }
 }
 
@@ -115,8 +115,8 @@ DOUBLE_BATTLE_TEST("Psychic Terrain doesn't block priority moves that target all
         TURN { MOVE(playerLeft, MOVE_PSYCHIC_TERRAIN); }
         TURN { MOVE(playerLeft, MOVE_HEAL_PULSE, target: playerRight); }
     } SCENE {
-        MESSAGE("Sableye used " MOVE_NAME(MOVE_PSYCHIC_TERRAIN) "!");
-        MESSAGE("Sableye used " MOVE_NAME(MOVE_HEAL_PULSE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_SABLEYE) " used " MOVE_NAME(MOVE_PSYCHIC_TERRAIN) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_SABLEYE) " used " MOVE_NAME(MOVE_HEAL_PULSE) "!");
     }
 }
 
@@ -129,8 +129,8 @@ SINGLE_BATTLE_TEST("Psychic Terrain doesn't block priority field moves")
         TURN { MOVE(player, MOVE_PSYCHIC_TERRAIN); }
         TURN { MOVE(player, MOVE_SUNNY_DAY); }
     } SCENE {
-        MESSAGE("Sableye used " MOVE_NAME(MOVE_PSYCHIC_TERRAIN) "!");
-        MESSAGE("Sableye used " MOVE_NAME(MOVE_SUNNY_DAY) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_SABLEYE) " used " MOVE_NAME(MOVE_PSYCHIC_TERRAIN) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_SABLEYE) " used " MOVE_NAME(MOVE_SUNNY_DAY) "!");
     }
 }
 
@@ -146,18 +146,18 @@ SINGLE_BATTLE_TEST("Psychic Terrain lasts for 5 turns")
         TURN {}
         TURN {}
     } SCENE {
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_PSYCHIC_TERRAIN, player);
         MESSAGE("The battlefield got weird!");
 
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
 
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
 
-        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
-        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE(SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " used " MOVE_NAME(MOVE_CELEBRATE) "!");
 
         MESSAGE("The weirdness disappeared from the battlefield.");
     }

--- a/test/battle/terrain/psychic.c
+++ b/test/battle/terrain/psychic.c
@@ -10,10 +10,10 @@ SINGLE_BATTLE_TEST("Psychic Terrain protects grounded battlers from priority mov
         TURN { MOVE(player, MOVE_PSYCHIC_TERRAIN); }
         TURN { MOVE(player, MOVE_QUICK_ATTACK); MOVE(opponent, MOVE_QUICK_ATTACK); }
     } SCENE {
-        MESSAGE("Claydol used PsychcTrrain!");
+        MESSAGE("Claydol used " MOVE_NAME(MOVE_PSYCHIC_TERRAIN) "!");
         MESSAGE("Claydol cannot use Quick Attack!");
         NOT { HP_BAR(opponent); }
-        MESSAGE("Foe Wobbuffet used Quick Attack!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_QUICK_ATTACK) "!");
         HP_BAR(player);
     }
 }
@@ -51,7 +51,7 @@ SINGLE_BATTLE_TEST("Psychic Terrain increases power of Psychic-type moves by 30/
             TURN { MOVE(player, MOVE_PSYCHIC_TERRAIN); }
         TURN { MOVE(player, MOVE_CONFUSION); }
     } SCENE {
-        MESSAGE("Wobbuffet used Confusion!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CONFUSION) "!");
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
         if (B_TERRAIN_TYPE_BOOST >= GEN_8)
@@ -70,8 +70,8 @@ SINGLE_BATTLE_TEST("Psychic Terrain doesn't block priority moves that target the
         TURN { MOVE(player, MOVE_PSYCHIC_TERRAIN); }
         TURN { MOVE(player, MOVE_RECOVER); }
     } SCENE {
-        MESSAGE("Sableye used PsychcTrrain!");
-        MESSAGE("Sableye used Recover!");
+        MESSAGE("Sableye used " MOVE_NAME(MOVE_PSYCHIC_TERRAIN) "!");
+        MESSAGE("Sableye used " MOVE_NAME(MOVE_RECOVER) "!");
         HP_BAR(player);
     }
 }
@@ -85,8 +85,8 @@ SINGLE_BATTLE_TEST("Psychic Terrain doesn't block priority moves that target all
         TURN { MOVE(player, MOVE_PSYCHIC_TERRAIN); }
         TURN { MOVE(player, MOVE_HAZE); }
     } SCENE {
-        MESSAGE("Sableye used PsychcTrrain!");
-        MESSAGE("Sableye used Haze!");
+        MESSAGE("Sableye used " MOVE_NAME(MOVE_PSYCHIC_TERRAIN) "!");
+        MESSAGE("Sableye used " MOVE_NAME(MOVE_HAZE) "!");
     }
 }
 
@@ -99,8 +99,8 @@ SINGLE_BATTLE_TEST("Psychic Terrain doesn't block priority moves that target all
         TURN { MOVE(player, MOVE_PSYCHIC_TERRAIN); }
         TURN { MOVE(player, MOVE_SPIKES); }
     } SCENE {
-        MESSAGE("Sableye used PsychcTrrain!");
-        MESSAGE("Sableye used Spikes!");
+        MESSAGE("Sableye used " MOVE_NAME(MOVE_PSYCHIC_TERRAIN) "!");
+        MESSAGE("Sableye used " MOVE_NAME(MOVE_SPIKES) "!");
     }
 }
 
@@ -115,8 +115,8 @@ DOUBLE_BATTLE_TEST("Psychic Terrain doesn't block priority moves that target all
         TURN { MOVE(playerLeft, MOVE_PSYCHIC_TERRAIN); }
         TURN { MOVE(playerLeft, MOVE_HEAL_PULSE, target: playerRight); }
     } SCENE {
-        MESSAGE("Sableye used PsychcTrrain!");
-        MESSAGE("Sableye used Heal Pulse!");
+        MESSAGE("Sableye used " MOVE_NAME(MOVE_PSYCHIC_TERRAIN) "!");
+        MESSAGE("Sableye used " MOVE_NAME(MOVE_HEAL_PULSE) "!");
     }
 }
 
@@ -129,8 +129,8 @@ SINGLE_BATTLE_TEST("Psychic Terrain doesn't block priority field moves")
         TURN { MOVE(player, MOVE_PSYCHIC_TERRAIN); }
         TURN { MOVE(player, MOVE_SUNNY_DAY); }
     } SCENE {
-        MESSAGE("Sableye used PsychcTrrain!");
-        MESSAGE("Sableye used Sunny Day!");
+        MESSAGE("Sableye used " MOVE_NAME(MOVE_PSYCHIC_TERRAIN) "!");
+        MESSAGE("Sableye used " MOVE_NAME(MOVE_SUNNY_DAY) "!");
     }
 }
 
@@ -146,18 +146,18 @@ SINGLE_BATTLE_TEST("Psychic Terrain lasts for 5 turns")
         TURN {}
         TURN {}
     } SCENE {
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_PSYCHIC_TERRAIN, player);
         MESSAGE("The battlefield got weird!");
 
-        MESSAGE("Wobbuffet used Celebrate!");
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
 
-        MESSAGE("Wobbuffet used Celebrate!");
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
 
-        MESSAGE("Wobbuffet used Celebrate!");
-        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
+        MESSAGE("Foe Wobbuffet used " MOVE_NAME(MOVE_CELEBRATE) "!");
 
         MESSAGE("The weirdness disappeared from the battlefield.");
     }

--- a/test/battle/weather/hail.c
+++ b/test/battle/weather/hail.c
@@ -12,7 +12,7 @@ SINGLE_BATTLE_TEST("Hail deals 1/16 damage per turn")
     } WHEN {
         TURN {MOVE(player, MOVE_HAIL);}
     } SCENE {
-        MESSAGE("Foe Wobbuffet is pelted by HAIL!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is pelted by HAIL!");
         HP_BAR(opponent, captureDamage: &hailDamage);
    } THEN { EXPECT_EQ(hailDamage, opponent->maxHP / 16); }
 }
@@ -26,6 +26,6 @@ SINGLE_BATTLE_TEST("Hail damage does not affect Ice-type Pokémon")
     } WHEN {
         TURN {MOVE(player, MOVE_HAIL);}
     } SCENE {
-        NOT MESSAGE("Foe Glalie is pelted by HAIL!");
+        NOT MESSAGE("Foe " SPECIES_NAME(SPECIES_GLALIE) " is pelted by HAIL!");
     }
 }

--- a/test/battle/weather/sandstorm.c
+++ b/test/battle/weather/sandstorm.c
@@ -12,7 +12,7 @@ SINGLE_BATTLE_TEST("Sandstorm deals 1/16 damage per turn")
     } WHEN {
         TURN {MOVE(player, MOVE_SANDSTORM);}
     } SCENE {
-        MESSAGE("Foe Wobbuffet is buffeted by the sandstorm!");
+        MESSAGE("Foe " SPECIES_NAME(SPECIES_WOBBUFFET) " is buffeted by the sandstorm!");
         HP_BAR(opponent, captureDamage: &sandstormDamage);
    } THEN { EXPECT_EQ(sandstormDamage, opponent->maxHP / 16); }
 }
@@ -53,13 +53,13 @@ SINGLE_BATTLE_TEST("Sandstorm damage does not hurt Ground, Rock, and Steel-type 
         switch (mon)
         {
         case SPECIES_SANDSLASH:
-            NOT MESSAGE("Foe Sandslash is buffeted by the sandstorm!");
+            NOT MESSAGE("Foe " SPECIES_NAME(SPECIES_SANDSLASH) " is buffeted by the sandstorm!");
             break;
         case SPECIES_NOSEPASS:
-            NOT MESSAGE("Foe Nosepass is buffeted by the sandstorm!");
+            NOT MESSAGE("Foe " SPECIES_NAME(SPECIES_NOSEPASS) " is buffeted by the sandstorm!");
             break;
         case SPECIES_REGISTEEL:
-            NOT MESSAGE("Foe Registeel is buffeted by the sandstorm!");
+            NOT MESSAGE("Foe " SPECIES_NAME(SPECIES_REGISTEEL) " is buffeted by the sandstorm!");
             break;
         }
     }

--- a/test/test_runner_battle.c
+++ b/test/test_runner_battle.c
@@ -766,6 +766,12 @@ static s32 TryMessage(s32 i, s32 n, const u8 *string)
                 case CHAR_A: // A for ability
                     refString = gAbilityNames[refID];
                     break;
+                case CHAR_S: // S for species
+                    refString = gSpeciesNames[refID];
+                    break;
+                case CHAR_I: // I for item
+                    refString = gItems[refID].name;
+                    break;
                 }
                 for (l = 0; refString[l] != EOS; l++)
                 {


### PR DESCRIPTION
Move, species, ability and item names used to be hardcoded in test messages, resulting in issues when toggling expanded move names (or when anyone would change any move name for whatever reason). This PR adds the possibility to buffer move, ability, species and item names directly into test messages.

I more than likely missed occurrences of any of the four categories above (I did use a regex to convert everything), so feel free to point those out.

## **Discord contact info**
bassoonian