### PR TITLE
Fix fusions

### DIFF
--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -5876,6 +5876,8 @@ u8 IsFusionMon(u16 species)
 {
     u16 i;
     const struct Fusion *itemFusion = gFusionTablePointers[species];
+    if (itemFusion == NULL)
+        return FALSE;
     for (i = 0; itemFusion[i].fusionStorageIndex != FUSION_TERMINATOR; i++)
     {
         if (itemFusion[i].fusingIntoMon == species)
@@ -6157,7 +6159,7 @@ void ItemUseCB_Fusion(u8 taskId, TaskFunc taskFunc)
             {
                 if (gPokemonStoragePtr->fusions[itemFusion[i].fusionStorageIndex].level != 0)
                     continue;
-                if (itemFusion[i].itemId == gSpecialVar_ItemId && itemFusion[i].targetSpecies1 == task->firstFusion)
+                if (itemFusion[i].itemId == gSpecialVar_ItemId && itemFusion[i].targetSpecies1 == task->firstFusion && itemFusion[i].targetSpecies2 == species)
                 {
                     task->storageIndex = itemFusion[i].fusionStorageIndex;
                     task->fusionResult = itemFusion[i].fusingIntoMon;


### PR DESCRIPTION
Fixes two oddities in the fusion system:
- Selecting an incompatible species at any point froze the game (because it didn't check if said species had any fusion data at all, so we're lucky it didn't just outright crash!)
- The second species was not taken into account, leading to fusions of Kyurem and Zekrom into White Kyurem.

## Issue(s) that this PR fixes
Fixes #3601 (that disppeared mysteriously)

## **Discord contact info**
bassoonian