### PR TITLE
Fix static variable names

### DIFF
--- a/gflib/sprite.c
+++ b/gflib/sprite.c
@@ -281,7 +281,7 @@ EWRAM_DATA static bool8 sShouldProcessSpriteCopyRequests = 0;
 EWRAM_DATA static u8 sSpriteCopyRequestCount = 0;
 EWRAM_DATA static struct SpriteCopyRequest sSpriteCopyRequests[MAX_SPRITES] = {0};
 EWRAM_DATA u8 gOamLimit = 0;
-static EWRAM_DATA u8 gOamDummyIndex = 0;
+static EWRAM_DATA u8 sOamDummyIndex = 0;
 EWRAM_DATA u16 gReservedSpriteTileCount = 0;
 EWRAM_DATA static u8 sSpriteTileAllocBitmap[128] = {0};
 EWRAM_DATA s16 gSpriteCoordOffsetX = 0;
@@ -292,7 +292,7 @@ EWRAM_DATA bool8 gAffineAnimsDisabled = FALSE;
 void ResetSpriteData(void)
 {
     ResetOamRange(0, 128);
-    gOamDummyIndex = 0;
+    sOamDummyIndex = 0;
     ResetAllSprites();
     ClearSpriteCopyRequests();
     ResetAffineAnimData();
@@ -405,9 +405,9 @@ void BuildOamBuffer(void)
             break;
     }
 
-    for (i = oamIndex; i < gOamDummyIndex; i++)
+    for (i = oamIndex; i < sOamDummyIndex; i++)
         gMain.oamBuffer[i] = gDummyOamData;
-    gOamDummyIndex = oamIndex;
+    sOamDummyIndex = oamIndex;
 
     for (i = 0; matrices != 0; i++, matrices >>= 1)
     {

--- a/src/battle_anim_new.c
+++ b/src/battle_anim_new.c
@@ -5680,13 +5680,13 @@ const struct SpriteTemplate gBlackHoleEclipseRedRingInwardsSpriteTemplate =
     .affineAnims = gThinRingShrinkingAffineAnimTable,
     .callback = AnimSpriteOnMonPos
 };
-static const union AffineAnimCmd gGrowingBackHoleTargetAffineCmds[] = {
+static const union AffineAnimCmd sGrowingBackHoleTargetAffineCmds[] = {
     AFFINEANIMCMD_FRAME(0x100, 0x100, 0, 0),
     AFFINEANIMCMD_FRAME(0, 0, -10, 0x88),
     AFFINEANIMCMD_END,
 };
 static const union AffineAnimCmd *const gGrowingBlackHoleTargetAffineAnimTable[] = {
-    gGrowingBackHoleTargetAffineCmds,
+    sGrowingBackHoleTargetAffineCmds,
 };
 const struct SpriteTemplate gBlackHoleEclipseHoleSpriteTemplate =
 {
@@ -5698,13 +5698,13 @@ const struct SpriteTemplate gBlackHoleEclipseHoleSpriteTemplate =
     .affineAnims = gGrowingBlackHoleTargetAffineAnimTable,
     .callback = AnimSpriteOnMonPos
 };
-static const union AffineAnimCmd gShrinkingBlackHoleAffineCmds[] = {
+static const union AffineAnimCmd sShrinkingBlackHoleAffineCmds[] = {
     AFFINEANIMCMD_FRAME(0x100, 0x100, 0, 0),
     AFFINEANIMCMD_FRAME(-0x10, -0x10, 0xf6, 8),
     AFFINEANIMCMD_END_ALT(1),
 };
 static const union AffineAnimCmd *const gShrinkingBlackHoleAffineAnimTable[] = {
-    gShrinkingBlackHoleAffineCmds,
+    sShrinkingBlackHoleAffineCmds,
 };
 const struct SpriteTemplate gBlackHoleEclipseHoleShrinkSpriteTemplate =
 {
@@ -5716,13 +5716,13 @@ const struct SpriteTemplate gBlackHoleEclipseHoleShrinkSpriteTemplate =
     .affineAnims = gShrinkingBlackHoleAffineAnimTable,
     .callback = AnimSpriteOnMonPos
 };
-static const union AffineAnimCmd gGrowingBackHoleAffineCmds[] = {
+static const union AffineAnimCmd sGrowingBackHoleAffineCmds[] = {
     AFFINEANIMCMD_FRAME(0x100, 0x100, 0, 0),
     AFFINEANIMCMD_FRAME(0, 0, -10, 0x48),
     AFFINEANIMCMD_END,
 };
 static const union AffineAnimCmd *const gGrowingBlackHoleAffineAnimTable[] = {
-    gGrowingBackHoleAffineCmds,
+    sGrowingBackHoleAffineCmds,
 };
 const struct SpriteTemplate gBlackHoleEclipseHoleUserSpriteTemplate =
 {

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -62,7 +62,7 @@ static EWRAM_DATA u16 sMovingNpcMapNum = 0;
 static EWRAM_DATA u16 sFieldEffectScriptId = 0;
 
 static u8 sBrailleWindowId;
-static bool8 gIsScriptedWildDouble;
+static bool8 sIsScriptedWildDouble;
 
 extern const SpecialFunc gSpecials[];
 extern const u8 *gStdScripts[];
@@ -1879,12 +1879,12 @@ bool8 ScrCmd_setwildbattle(struct ScriptContext *ctx)
     if(species2 == SPECIES_NONE)
     {
         CreateScriptedWildMon(species, level, item);
-        gIsScriptedWildDouble = FALSE;
+        sIsScriptedWildDouble = FALSE;
     }
     else
     {
         CreateScriptedDoubleWildMon(species, level, item, species2, level2, item2);
-        gIsScriptedWildDouble = TRUE;
+        sIsScriptedWildDouble = TRUE;
     }
 
     return FALSE;
@@ -1892,7 +1892,7 @@ bool8 ScrCmd_setwildbattle(struct ScriptContext *ctx)
 
 bool8 ScrCmd_dowildbattle(struct ScriptContext *ctx)
 {
-    if (gIsScriptedWildDouble == FALSE)
+    if (sIsScriptedWildDouble == FALSE)
         BattleSetup_StartScriptedWildBattle();
     else
         BattleSetup_StartScriptedDoubleWildBattle();

--- a/src/start_menu.c
+++ b/src/start_menu.c
@@ -182,7 +182,7 @@ static const struct WindowTemplate sWindowTemplate_PyramidPeak = {
     .baseBlock = 0x8
 };
 
-static const u8 gText_MenuDebug[] = _("DEBUG");
+static const u8 sText_MenuDebug[] = _("DEBUG");
 
 static const struct MenuAction sStartMenuItems[] =
 {
@@ -199,7 +199,7 @@ static const struct MenuAction sStartMenuItems[] =
     [MENU_ACTION_REST_FRONTIER]   = {gText_MenuRest,    {.u8_void = StartMenuSaveCallback}},
     [MENU_ACTION_RETIRE_FRONTIER] = {gText_MenuRetire,  {.u8_void = StartMenuBattlePyramidRetireCallback}},
     [MENU_ACTION_PYRAMID_BAG]     = {gText_MenuBag,     {.u8_void = StartMenuBattlePyramidBagCallback}},
-    [MENU_ACTION_DEBUG]           = {gText_MenuDebug,   {.u8_void = StartMenuDebugCallback}},
+    [MENU_ACTION_DEBUG]           = {sText_MenuDebug,   {.u8_void = StartMenuDebugCallback}},
 };
 
 static const struct BgTemplate sBgTemplates_LinkBattleSave[] =


### PR DESCRIPTION
Fixes the name of some static variables that started with `g` to reflect their actual staticity.

## **Discord contact info**
bassoonian