### PR TITLE
Update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,9 @@
 <!-- Format: "Fixes #2345, fixes #4523, fixes #2222." -->
 <!-- If it doesn't apply, feel free to remove this section. -->
 
+## Issue(s) that this PR introduces
+<!-- If your PR contains any unfinished features that are not considered merge-blocking, please list them here for clarity so no one can forget. -->
+
 ## **Discord contact info**
 <!--- formatted as name#numbers, e.g. Lunos#4026 -->
 <!--- Contributors must join https://discord.gg/6CzjAG6GZk -->


### PR DESCRIPTION
Adds a field for PRs where one can specify which features are still missing (if they're considered non-blocking) that is. This way, maintainers have a clear idea of which issues to open when approving the PR.

Discord conversation: https://discord.com/channels/419213663107416084/1077168246555430962/1181936838869524531

## **Discord contact info**
bassoonian