### PR TITLE
Fixes Fling damage calcs

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -904,8 +904,7 @@ BattleScript_EffectFling:
 	attackcanceler
 	jumpifcantfling BS_ATTACKER, BattleScript_FailedFromAtkString
 	setlastuseditem BS_ATTACKER
-	removeitem BS_ATTACKER
-	accuracycheck BattleScript_PrintMoveMissed, ACC_CURR_MOVE
+	accuracycheck BattleScript_FlingMissed, ACC_CURR_MOVE
 	attackstring
 	pause B_WAIT_TIME_SHORT
 	printstring STRINGID_PKMNFLUNG
@@ -914,6 +913,7 @@ BattleScript_EffectFling:
 	critcalc
 	damagecalc
 	adjustdamage
+	removeitem BS_ATTACKER
 	attackanimation
 	waitanimation
 	effectivenesssound
@@ -988,6 +988,12 @@ BattleScript_FlingWhiteHerb:
 	waitmessage B_WAIT_TIME_MED
 	swapattackerwithtarget
 	goto BattleScript_FlingEnd
+
+BattleScript_FlingMissed:
+	removeitem BS_ATTACKER
+	attackstring
+	ppreduce
+	goto BattleScript_MoveMissedPause
 
 BattleScript_EffectShellSideArm:
 	shellsidearmcheck

--- a/test/battle/move_effect/fling.c
+++ b/test/battle/move_effect/fling.c
@@ -273,7 +273,7 @@ SINGLE_BATTLE_TEST("Fling - thrown berry's effect activates for the target even 
     PARAMETRIZE { item = ITEM_SALAC_BERRY; effect = HOLD_EFFECT_SPEED_UP; statId = STAT_SPEED; }
 
     GIVEN {
-        PLAYER(SPECIES_WOBBUFFET) { Item(item); }
+        PLAYER(SPECIES_WOBBUFFET) { Item(item); Attack(1); }
         OPPONENT(SPECIES_WOBBUFFET) { Status1(status1); HP(399); MaxHP(400); MovesWithPP({MOVE_CELEBRATE, 35}); }
     } WHEN {
         TURN { MOVE(player, MOVE_FLING); }
@@ -346,3 +346,25 @@ SINGLE_BATTLE_TEST("Fling - thrown berry's effect activates for the target even 
     }
 }
 
+SINGLE_BATTLE_TEST("Fling deals damage based on items fling power")
+{
+    u16 item;
+    s16 damage[2];
+
+    GIVEN {
+        ASSUME(gBattleMoves[MOVE_CRUNCH].power == 80);
+        ASSUME(gItems[ITEM_VENUSAURITE].flingPower == 80);
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_VENUSAURITE); }
+        OPPONENT(SPECIES_REGIROCK);
+    } WHEN {
+        TURN { MOVE(player, MOVE_CRUNCH); }
+        TURN { MOVE(player, MOVE_FLING); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CRUNCH, player);
+        HP_BAR(opponent, captureDamage: &damage[0]);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FLING, player);
+        HP_BAR(opponent, captureDamage: &damage[1]);
+    } THEN {
+        EXPECT_EQ(damage[0], damage[1]);
+    }
+}


### PR DESCRIPTION
Fixes #3661

The test `Fling - thrown berry's effect activates for the target even if the trigger conditions are not met` was failing for `ITEM_ORAN_BERRY` because Fling did to much damage after the damage calcs were fixes so I just reduced the attack of Wobbuffet to 1. I don't think reducing it to 1 matters much because the damage isn't what the test is testing. 