### PR TITLE
Fix form change table pointer defines

### DIFF
--- a/src/data/pokemon/form_change_table_pointers.h
+++ b/src/data/pokemon/form_change_table_pointers.h
@@ -1,24 +1,36 @@
 const struct Fusion *const gFusionTablePointers[NUM_SPECIES] =
 {
-#if P_GEN_5_POKEMON == TRUE
+#if P_FAMILY_KYUREM
     [SPECIES_KYUREM] = sKyuremFusionTable,
-    [SPECIES_KYUREM_BLACK] = sKyuremFusionTable,
+#if P_FAMILY_RESHIRAM
     [SPECIES_KYUREM_WHITE] = sKyuremFusionTable,
     [SPECIES_RESHIRAM] = sKyuremFusionTable,
+#endif //P_FAMILY_RESHIRAM
+#if P_FAMILY_ZEKROM
+    [SPECIES_KYUREM_BLACK] = sKyuremFusionTable,
     [SPECIES_ZEKROM] = sKyuremFusionTable,
-#endif
-#if P_GEN_7_POKEMON == TRUE
+#endif //P_FAMILY_ZEKROM
+#endif //P_FAMILY_KYUREM
+#if P_FAMILY_NECROZMA
     [SPECIES_NECROZMA] = sNecrozmaFusionTable,
+#if P_FAMILY_SOLGALEO
     [SPECIES_NECROZMA_DAWN_WINGS] = sNecrozmaFusionTable,
-    [SPECIES_NECROZMA_DUSK_MANE] = sNecrozmaFusionTable,
     [SPECIES_SOLGALEO] = sNecrozmaFusionTable,
+#endif //P_FAMILY_SOLGALEO
+#if P_FAMILY_LUNALA
+    [SPECIES_NECROZMA_DUSK_MANE] = sNecrozmaFusionTable,
     [SPECIES_LUNALA] = sNecrozmaFusionTable,
-#endif
-#if P_GEN_8_POKEMON == TRUE
+#endif //P_FAMILY_LUNALA
+#endif //P_FAMILY_NECROZMA
+#if P_FAMILY_CALYREX
     [SPECIES_CALYREX] = sCalyrexFusionTable,
-    [SPECIES_CALYREX_ICE_RIDER] = sCalyrexFusionTable,
+#if P_FAMILY_SPECTRIER
     [SPECIES_CALYREX_SHADOW_RIDER] = sCalyrexFusionTable,
     [SPECIES_SPECTRIER] = sCalyrexFusionTable,
+#endif //P_FAMILY_SPECTRIER
+#if P_FAMILY_GLASTRIER
+    [SPECIES_CALYREX_ICE_RIDER] = sCalyrexFusionTable,
     [SPECIES_GLASTRIER] = sCalyrexFusionTable,
-#endif
+#endif //P_FAMILY_GLASTRIER
+#endif //P_FAMILY_CALYREX
 };


### PR DESCRIPTION
Replaces the generational defines in the form change table pointer defines with family-based defines. I don't think I currently have the ideal solution since this is all rather finicky, and we should probably include `P_FUSION_FORMS` in here too, but it quickly turns into a config fest. Thoughts are very welcome!

## Issue(s) that this PR fixes
Fixed #3691 

## **Discord contact info**
bassoonian