### PR TITLE
Added a GetSpeciesPreEvolution function and updated the value of EVO_…

### DIFF
--- a/include/constants/pokemon.h
+++ b/include/constants/pokemon.h
@@ -253,7 +253,8 @@
 #define F_SUMMARY_SCREEN_FLIP_SPRITE 0x80
 
 // Evolution types
-#define EVO_NONE                          0xffff // Not an actual evolution, used to generate offspring that can't evolve into the specified species, like regional forms.
+#define EVOLUTIONS_END                    0xFFFF
+#define EVO_NONE                          0xFFFE // Not an actual evolution, used to generate offspring that can't evolve into the specified species, like regional forms.
 #define EVO_FRIENDSHIP                    1      // Pokémon levels up with friendship ≥ 220
 #define EVO_FRIENDSHIP_DAY                2      // Pokémon levels up during the day with friendship ≥ 220
 #define EVO_FRIENDSHIP_NIGHT              3      // Pokémon levels up at night with friendship ≥ 220
@@ -300,8 +301,6 @@
 #define EVO_MOVE_THREE_SEGMENT            44     // Pokémon levels up, knows specified move, has a personality value with a modulus of 1-99
 #define EVO_LEVEL_FAMILY_OF_THREE         45     // Pokémon reaches the specified level with a personality value with a modulus of 0
 #define EVO_LEVEL_FAMILY_OF_FOUR          46     // Pokémon reaches the specified level with a personality value with a modulus of 1-99
-
-#define EVOLUTIONS_END 0xFFFF
 
 // Evolution 'modes,' for GetEvolutionTargetSpecies
 #define EVO_MODE_NORMAL            0

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -709,5 +709,6 @@ u8 CalculatePartyCount(struct Pokemon *party);
 u16 SanitizeSpeciesId(u16 species);
 bool32 IsSpeciesEnabled(u16 species);
 u16 GetCryIdBySpecies(u16 species);
+u16 GetSpeciesPreEvolution(u16 species);
 
 #endif // GUARD_POKEMON_H

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -6092,3 +6092,22 @@ u16 GetCryIdBySpecies(u16 species)
         return 0;
     return gSpeciesInfo[species].cryId;
 }
+
+u16 GetSpeciesPreEvolution(u16 species)
+{
+    int i, j;
+
+    for (i = SPECIES_BULBASAUR; i < NUM_SPECIES; i++)
+    {
+        const struct Evolution *evolutions = GetSpeciesEvolutions(i);
+        if (evolutions == NULL)
+            continue;
+        for (j = 0; evolutions[j].method != EVOLUTIONS_END; j++)
+        {
+            if (SanitizeSpeciesId(evolutions[j].targetSpecies) == species)
+                return i;
+        }
+    }
+
+    return SPECIES_NONE;
+}


### PR DESCRIPTION
## Description
After a conversation in RHH's Discord server's Species Simplifier thread, we kinda sorta somewhat decided to add a function to use by the people who use the Pokeemerald-expansion at their own convenience.
This function makes it easier to get the pre-evolution of X or Y species, which can be benefitial to certain feature branches.

## **Discord contact info**
lunos4026