### PR TITLE
Removed redundant '#if P_ALOLAN_FORMS' for Raticate and fixed Veluza's stat spacing

### DIFF
--- a/src/data/pokemon/level_up_learnsets.h
+++ b/src/data/pokemon/level_up_learnsets.h
@@ -383,9 +383,7 @@ static const struct LevelUpMove sRattataAlolanLevelUpLearnset[] = {
     LEVEL_UP_MOVE(34, MOVE_ENDEAVOR),
     LEVEL_UP_END
 };
-#endif //P_ALOLAN_FORMS
 
-#if P_ALOLAN_FORMS
 static const struct LevelUpMove sRaticateAlolanLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 0, MOVE_SCARY_FACE),
     LEVEL_UP_MOVE( 1, MOVE_SCARY_FACE),

--- a/src/data/pokemon/species_info.h
+++ b/src/data/pokemon/species_info.h
@@ -57593,12 +57593,12 @@ const struct SpeciesInfo gSpeciesInfo[] =
 #if P_FAMILY_VELUZA
     [SPECIES_VELUZA] =
     {
-        .baseHP        =      90,
-        .baseAttack    =  102,
+        .baseHP        = 90,
+        .baseAttack    = 102,
         .baseDefense   = 73,
-        .baseSpeed     =   70,
-        .baseSpAttack  =   78,
-        .baseSpDefense =   65,
+        .baseSpeed     = 70,
+        .baseSpAttack  = 78,
+        .baseSpDefense = 65,
         .types = { TYPE_WATER, TYPE_PSYCHIC },
         .catchRate = 100,
         .expYield = 167,


### PR DESCRIPTION
## Description
Both Alolan Rattata and Alolan Raticate have "#if P_ALOLAN_FORMS" before their level up learnsets even though all other Alolan forms (including Rattata/Raticate in other files) only have the if statement once per line. This PR removes that and also standarizes the spacing in Veluza's stats

## **Discord contact info**
Frankfurter0