### PR TITLE
Use the same relative gBattleTextBuff3 declaration in both definitions.

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -976,7 +976,7 @@ extern u16 gBattle_WIN1V;
 extern u8 gDisplayedStringBattle[425];
 extern u8 gBattleTextBuff1[TEXT_BUFF_ARRAY_COUNT];
 extern u8 gBattleTextBuff2[TEXT_BUFF_ARRAY_COUNT];
-extern u8 gBattleTextBuff3[30]; //to handle stupidly large z move names
+extern u8 gBattleTextBuff3[TEXT_BUFF_ARRAY_COUNT + 13]; //to handle stupidly large z move names
 extern u32 gBattleTypeFlags;
 extern u8 gBattleTerrain;
 extern u32 gUnusedFirstBattleVar1;


### PR DESCRIPTION
Compare against https://github.com/rh-hideout/pokeemerald-expansion/blob/upcoming/src/battle_main.c#L135.

## **Discord contact info**
graiondilach