### PR TITLE
Fix Innards Out doing dmg after Gastro Acid / vs Magic Guard

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -7932,12 +7932,14 @@ BattleScript_AnticipationActivates::
 BattleScript_AftermathDmg::
 	pause B_WAIT_TIME_SHORT
 	call BattleScript_AbilityPopUp
+	jumpifability BS_ATTACKER, ABILITY_MAGIC_GUARD, BattleScript_AftermathDmgRet
 	orword gHitMarker, HITMARKER_IGNORE_SUBSTITUTE | HITMARKER_PASSIVE_DAMAGE
 	healthbarupdate BS_ATTACKER
 	datahpupdate BS_ATTACKER
 	printstring STRINGID_AFTERMATHDMG
 	waitmessage B_WAIT_TIME_LONG
 	tryfaintmon BS_ATTACKER
+BattleScript_AftermathDmgRet:
 	return
 
 BattleScript_DampPreventsAftermath::

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3262,7 +3262,7 @@ void FaintClearSetData(u32 battler)
         gBattleMons[battler].statStages[i] = DEFAULT_STAT_STAGE;
 
     gBattleMons[battler].status2 = 0;
-    gStatuses3[battler] = 0;
+    gStatuses3[battler] &= STATUS3_GASTRO_ACID; // Edge case: Keep Gastro Acid if pokemon's ability can have effect after fainting, for example Innards Out.
     gStatuses4[battler] = 0;
 
     for (i = 0; i < gBattlersCount; i++)

--- a/test/battle/ability/innards_out.c
+++ b/test/battle/ability/innards_out.c
@@ -1,0 +1,48 @@
+#include "global.h"
+#include "test/battle.h"
+
+SINGLE_BATTLE_TEST("Innards Out deal dmg on fainting equal to the amount of dmg inflicted on the Innards Out mon")
+{
+    u16 hp = 0;
+    PARAMETRIZE { hp = 5; }
+    PARAMETRIZE { hp = 15; }
+    PARAMETRIZE { hp = 50; }
+    PARAMETRIZE { hp = 100; } // This takes out Wobbuffet.
+
+    GIVEN {
+        PLAYER(SPECIES_PYUKUMUKU) { HP(hp); Ability(ABILITY_INNARDS_OUT); }
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { HP(70); SpAttack(1000); }
+        OPPONENT(SPECIES_WOBBUFFET);
+        ASSUME(gBattleMoves[MOVE_PSYCHIC].power != 0);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_PSYCHIC); SEND_OUT(player, 1); if (hp == 100) { SEND_OUT(opponent, 1); } }
+    } SCENE {
+        MESSAGE("Foe Wobbuffet used Psychic!");
+        HP_BAR(player, hp);
+        ABILITY_POPUP(player, ABILITY_INNARDS_OUT);
+        HP_BAR(opponent, hp);
+    }
+}
+
+SINGLE_BATTLE_TEST("Innards Out does not trigger after Gastro Acid has been used")
+{
+    GIVEN {
+        PLAYER(SPECIES_PYUKUMUKU) { HP(1); Ability(ABILITY_INNARDS_OUT); }
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+        ASSUME(gBattleMoves[MOVE_PSYCHIC].power != 0);
+        ASSUME(gBattleMoves[MOVE_GASTRO_ACID].effect == EFFECT_GASTRO_ACID);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_GASTRO_ACID); }
+        TURN { MOVE(opponent, MOVE_PSYCHIC); SEND_OUT(player, 1); }
+    } SCENE {
+        MESSAGE("Foe Wobbuffet used Gastro Acid!");
+        MESSAGE("Foe Wobbuffet used Psychic!");
+        HP_BAR(player);
+        NONE_OF {
+            ABILITY_POPUP(player, ABILITY_INNARDS_OUT);
+            HP_BAR(opponent);
+        }
+    }
+}

--- a/test/battle/ability/innards_out.c
+++ b/test/battle/ability/innards_out.c
@@ -46,3 +46,21 @@ SINGLE_BATTLE_TEST("Innards Out does not trigger after Gastro Acid has been used
         }
     }
 }
+
+// According to Showdown Innards Out triggers, but does nothing.
+SINGLE_BATTLE_TEST("Innards Out does not damage Magic Guard Pokemon")
+{
+    GIVEN {
+        PLAYER(SPECIES_PYUKUMUKU) { HP(1); Ability(ABILITY_INNARDS_OUT); }
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_CLEFABLE) { Ability(ABILITY_MAGIC_GUARD); }
+        ASSUME(gBattleMoves[MOVE_PSYCHIC].power != 0);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_PSYCHIC); SEND_OUT(player, 1); }
+    } SCENE {
+        MESSAGE("Foe Clefable used Psychic!");
+        HP_BAR(player);
+        ABILITY_POPUP(player, ABILITY_INNARDS_OUT);
+        NOT HP_BAR(opponent);
+    }
+}


### PR DESCRIPTION
Fixes #3658 

Tests included.

Note: For Innards Out on Magic Guard I used Showdown's behavior. If someone wants to, they could check if it's the same in the games, but imo it's fine the way it is.