### PR TITLE
Small test runner improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -495,7 +495,7 @@ $(OBJ_DIR)/ld_script_test.ld: $(LD_SCRIPT_TEST) $(LD_SCRIPT_DEPS)
 $(TESTELF): $(OBJ_DIR)/ld_script_test.ld $(OBJS) $(TEST_OBJS) libagbsyscall tools check-tools
 	@echo "cd $(OBJ_DIR) && $(LD) -T ld_script_test.ld -o ../../$@ <objects> <test-objects> <lib>"
 	@cd $(OBJ_DIR) && $(LD) $(TESTLDFLAGS) -T ld_script_test.ld -o ../../$@ $(OBJS_REL) $(TEST_OBJS_REL) $(LIB)
-	$(FIX) $@ -t"$(TITLE)" -c$(GAME_CODE) -m$(MAKER_CODE) -r$(REVISION) --silent
+	$(FIX) $@ -t"$(TITLE)" -c$(GAME_CODE) -m$(MAKER_CODE) -r$(REVISION) -d0 --silent
 	$(PATCHELF) $(TESTELF) gTestRunnerArgv "$(TESTS)\0"
 
 ifeq ($(GITHUB_REPOSITORY_OWNER),rh-hideout)

--- a/include/test/test.h
+++ b/include/test/test.h
@@ -59,8 +59,8 @@ extern const struct TestRunner gAssumptionsRunner;
 
 struct FunctionTestRunnerState
 {
-    u8 parameters;
-    u8 runParameter;
+    u16 parameters;
+    u16 runParameter;
 };
 
 extern const struct TestRunner gFunctionTestRunner;

--- a/ld_script_test.ld
+++ b/ld_script_test.ld
@@ -109,6 +109,12 @@ SECTIONS {
 
     __rom_end = .;
 
+    dacs 0x9FFC000 :
+    ALIGN(4)
+    {
+        test/*.o(.dacs);
+    } > ROM =0
+
     /* DWARF debug sections.
        Symbols in the DWARF debugging sections are relative to the beginning
        of the section so we begin them at 0.  */

--- a/test/species.c
+++ b/test/species.c
@@ -34,6 +34,8 @@ TEST("Form change tables contain only forms in the form species ID table")
 
     for (i = 0; formChangeTable[i].method != FORM_CHANGE_TERMINATOR; i++)
     {
+        if (formChangeTable[i].targetSpecies == SPECIES_NONE)
+            continue;
         for (j = 0; formSpeciesIdTable[j] != FORM_SPECIES_END; j++)
         {
             if (formChangeTable[i].targetSpecies == formSpeciesIdTable[j])

--- a/test/test_runner.c
+++ b/test/test_runner.c
@@ -106,6 +106,8 @@ static u32 AssignCostToRunner(void)
 
 void CB2_TestRunner(void)
 {
+top:
+
     switch (gTestRunnerState.state)
     {
     case STATE_INIT:
@@ -361,6 +363,9 @@ void CB2_TestRunner(void)
         MgbaExit_(gTestRunnerState.exitCode);
         break;
     }
+
+    if (gMain.callback2 == CB2_TestRunner)
+        goto top;
 }
 
 void Test_ExpectedResult(enum TestResult result)


### PR DESCRIPTION
- Supports `u16` `PARAMETRIZE`s in the non-battle tests.
- Speeds up `CB2_TestRunner` with a `goto` (saves several frames per skipped test which is valuable when using `TESTS=`).
- Uses DACS to set the test state to `CRASH` if an illegal instruction is encountered. This greatly speeds up test failures when branching into memory that does not contain code. Previously we'd have to wait ~60s (headless!) for `mgba-rom-test` to report a `TIMEOUT`. mgba's 0.10.2 release does not support DACS in its HLE BIOS, but it's on `master` and hopefully the next release will support it. When unsupported, DACS is harmless.

[merrp uses DACS in her crash handler](<https://discord.com/channels/442462691542695948/442465020291317760/1179672160088883280>) (with a different ROM offset).