### PR TITLE
Fixes Item Metronome damage

### DIFF
--- a/include/constants/battle_script_commands.h
+++ b/include/constants/battle_script_commands.h
@@ -317,8 +317,9 @@
 #define MOVEEND_EMERGENCY_EXIT                    33
 #define MOVEEND_SYMBIOSIS                         34
 #define MOVEEND_OPPORTUNIST                       35    // Occurs after other stat change items/abilities to try and copy the boosts
-#define MOVEEND_CLEAR_BITS                        36
-#define MOVEEND_COUNT                             37
+#define MOVEEND_SAME_MOVE_TURNS                   36
+#define MOVEEND_CLEAR_BITS                        37
+#define MOVEEND_COUNT                             38
 
 // switch cases
 #define B_SWITCH_NORMAL     0

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1858,13 +1858,9 @@ static void Cmd_ppreduce(void)
     if (!(gHitMarker & (HITMARKER_NO_PPDEDUCT | HITMARKER_NO_ATTACKSTRING)) && gBattleMons[gBattlerAttacker].pp[gCurrMovePos])
     {
         gProtectStructs[gBattlerAttacker].notFirstStrike = TRUE;
+
         // For item Metronome, echoed voice
-        if (gCurrentMove == gLastResultingMoves[gBattlerAttacker]
-            && !(gMoveResultFlags & MOVE_RESULT_NO_EFFECT)
-            && !WasUnableToUseMove(gBattlerAttacker)
-            && gSpecialStatuses[gBattlerAttacker].parentalBondState != PARENTAL_BOND_1ST_HIT) // Don't increment counter on first hit
-                gBattleStruct->sameMoveTurns[gBattlerAttacker]++;
-        else
+        if (gCurrentMove != gLastResultingMoves[gBattlerAttacker] || WasUnableToUseMove(gBattlerAttacker))
             gBattleStruct->sameMoveTurns[gBattlerAttacker] = 0;
 
         if (gBattleMons[gBattlerAttacker].pp[gCurrMovePos] > ppToDeduct)
@@ -6077,6 +6073,13 @@ static void Cmd_moveend(void)
                     effect = TRUE;
                 }
             }
+            gBattleScripting.moveendState++;
+            break;
+        case MOVEEND_SAME_MOVE_TURNS:
+            if (gCurrentMove != gLastResultingMoves[gBattlerAttacker] || gMoveResultFlags & MOVE_RESULT_NO_EFFECT)
+                gBattleStruct->sameMoveTurns[gBattlerAttacker] = 0;
+            else if (gCurrentMove == gLastResultingMoves[gBattlerAttacker] && gSpecialStatuses[gBattlerAttacker].parentalBondState != PARENTAL_BOND_1ST_HIT)
+                gBattleStruct->sameMoveTurns[gBattlerAttacker]++;
             gBattleScripting.moveendState++;
             break;
         case MOVEEND_CLEAR_BITS: // Clear/Set bits for things like using a move for all targets and all hits.

--- a/test/battle/hold_effect/metronome.c
+++ b/test/battle/hold_effect/metronome.c
@@ -67,7 +67,6 @@ SINGLE_BATTLE_TEST("Metronome Item's boost is reset if the attacker uses a diffe
 SINGLE_BATTLE_TEST("Metronome Item's boost is reset if the move fails")
 {
     s16 damage[2];
-    KNOWN_FAILING; //https://github.com/rh-hideout/pokeemerald-expansion/issues/3251
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_METRONOME); }
         OPPONENT(SPECIES_WOBBUFFET);
@@ -110,7 +109,6 @@ SINGLE_BATTLE_TEST("Metronome Item counts charging turn of moves for its attacki
 {
     u32 item;
 
-    KNOWN_FAILING; // https://github.com/rh-hideout/pokeemerald-expansion/issues/3250
     PARAMETRIZE {item = ITEM_NONE; }
     PARAMETRIZE {item = ITEM_METRONOME; }
     GIVEN {


### PR DESCRIPTION
Fixes  #3251
Fixes #3250

I split up the logic so it is checked when a move ends. Checking it in ppreduce didn't cover everything.