### PR TITLE
EXPECT_MUL_EQ thresholds are always at least ±1

### DIFF
--- a/include/test/battle.h
+++ b/include/test/battle.h
@@ -1063,7 +1063,7 @@ void ValidateFinally(u32 sourceLine);
     { \
         s32 _a = (a), _m = (m), _b = (b); \
         s32 _am = Q_4_12_TO_INT(_a * _m); \
-        s32 _t = Q_4_12_TO_INT(abs(_m) + Q_4_12_ROUND); \
+        s32 _t = max(Q_4_12_TO_INT(abs(_m) + Q_4_12_ROUND), 1); \
         if (abs(_am-_b) > _t) \
             Test_ExitWithResult(TEST_RESULT_FAIL, "%s:%d: EXPECT_MUL_EQ(%d, %q, %d) failed: %d not in [%d..%d]", gTestRunnerState.test->filename, __LINE__, _a, _m, _b, _am, _b-_t, _b+_t); \
     } while (0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Makes the EXPECT_MUL_EQ threshold always ±1 no matter how small it is. This leaves room for any rounding errors at smaller multiples.

## **Discord contact info**
kittenchilly
