### PR TITLE
Faster code for forcing shiny personality

### DIFF
--- a/include/config/pokemon.h
+++ b/include/config/pokemon.h
@@ -39,6 +39,8 @@
 #define P_FLAG_FORCE_SHINY      0     // If this flag is set, all wild and gift Pokémon will forced into being Shiny.
 #define P_FLAG_FORCE_NO_SHINY   0     // If this flag is set, all wild and gift Pokémon will forced into NOT being Shiny.
 
+#define FAST_FORCE_SHINY        1     // Enables faster code to force Pokémon to be shiny. May not work if SHINY_ODDS is changed.
+
 // Go here if you want to disable specific families of Pokémon.
 #include "config/species_enabled.h"
 

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -809,7 +809,7 @@ void CreateBoxMon(struct BoxPokemon *boxMon, u16 species, u8 level, u8 fixedIV, 
             #if FAST_FORCE_SHINY != 0
                 personality = GenerateShinyPersonality(value);
             #else
-            while (GET_SHINY_VALUE(value, personality) > SHINY_ODDS)
+            while (GET_SHINY_VALUE(value, personality) >= SHINY_ODDS)
                 personality = Random32();
             #endif
         }

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -742,7 +742,7 @@ static u32 GenerateShinyPersonality(const u32 otPart)
     const u32 random_bits = Random32();
     const u16 random_part = random_bits >> 16;
     const u16 check_value = HIHALF(otPart) ^ LOHALF(otPart) ^ random_part;
-    const u16 chosen_part = (~(check_value >> SHINY_BITS) << SHINY_BITS) | (random_bits & SHINY_MASK);
+    const u16 chosen_part = ((check_value >> SHINY_BITS) << SHINY_BITS) | (random_bits & SHINY_MASK);
     if ((random_bits >> 15) & 1)
         return ((u32)random_part << 16) | chosen_part;
     else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds code that can generate a personality that is guaranteed to be shiny in one step, versus the current code which one would expect to take a Very Long Time because it just tries to generate personalities until it gets one which is shiny.

It does this by randomly picking half of the personality and setting the high bits of the other half of the personality to a value that will be 0 when XORed with the OT ID, secret ID, and randomly chosen personality half. The remaining 3 bits, and which half of the personality is which, are also chosen randomly, so every shiny personality that could be possible should be assuming a perfect random number generator.

## **Discord contact info**
tertu

