### PR TITLE
[battle_controller_player.c] refactor  and fix buffer overread

### DIFF
--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -225,16 +225,16 @@ static u16 GetPrevBall(u16 ballId)
     return gBagPockets[BALLS_POCKET].itemSlots[i].itemId;
 }
 
-static u16 GetNextBall(u16 ballId)
+static u32 GetNextBall(u32 ballId)
 {
-    u16 ballNext = 0;
+    u32 ballNext = ITEM_NONE;
     s32 i;
     CompactItemsInBagPocket(&gBagPockets[BALLS_POCKET]);
-    for (i = 0; i < gBagPockets[BALLS_POCKET].capacity; i++)
+    for (i = 1; i < gBagPockets[BALLS_POCKET].capacity; i++)
     {
-        if (ballId == gBagPockets[BALLS_POCKET].itemSlots[i].itemId)
+        if (ballId == gBagPockets[BALLS_POCKET].itemSlots[i-1].itemId)
         {
-            ballNext = gBagPockets[BALLS_POCKET].itemSlots[i+1].itemId;
+            ballNext = gBagPockets[BALLS_POCKET].itemSlots[i].itemId;
             break;
         }
     }


### PR DESCRIPTION
Fixes a buffer overread in `GetNextBall`.

## Description
When `i` is indexing the last item in the bag pocket reading `i+1` overflowed into the next pocket (TMs), this fixes the issue.

## Issue(s) that this PR fixes
resolves #3790

## **Discord contact info**
karathan
