### PR TITLE
Make overworld weather-based terrain setting effects use B_MSG_TERRAIN_SET constants for intro text

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4276,7 +4276,7 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
         {
             // overworld weather started rain, so just do electric terrain anim
             gFieldStatuses = (STATUS_FIELD_ELECTRIC_TERRAIN | STATUS_FIELD_TERRAIN_PERMANENT);
-            gBattleCommunication[MULTISTRING_CHOOSER] = 2;
+            gBattleCommunication[MULTISTRING_CHOOSER] = B_MSG_TERRAIN_SET_ELECTRIC;
             BattleScriptPushCursorAndCallback(BattleScript_OverworldTerrain);
             effect++;
         }
@@ -4285,7 +4285,7 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
             && !(gFieldStatuses & STATUS_FIELD_MISTY_TERRAIN))
         {
             gFieldStatuses = (STATUS_FIELD_MISTY_TERRAIN | STATUS_FIELD_TERRAIN_PERMANENT);
-            gBattleCommunication[MULTISTRING_CHOOSER] = 0;
+            gBattleCommunication[MULTISTRING_CHOOSER] = B_MSG_TERRAIN_SET_MISTY;
             BattleScriptPushCursorAndCallback(BattleScript_OverworldTerrain);
             effect++;
         }


### PR DESCRIPTION
## Description
Overworld weather-based terrain setting effects were previously using hard-coded numbers for their intro text, which is causing incorrect text to display for electric terrain created by thunderstorms. I changed them to instead reference their respective B_MSG_TERRAIN_SET constants.

I made the change for both electric and misty terrain, though the constant has been unchanged so far for misty terrain, so the text wasn't bugged.

## Images
Gif of the issue before being fixed:
![Gif of the electric terrain issue](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExYXMyNHR1encxaGp2enhnenBiZmI2cDV4MTg3cXp4YjM4dXV3NG0zayZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/CRuMwEdS7O1gpqn7r4/giphy.gif)

## **Discord contact info**
User: ravepossum
