### PR TITLE
Fix exp gain when defeating two opponents at once

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3338,7 +3338,8 @@ bool32 HandleFaintedMonActions(void)
                 && gCurrentTurnActionNumber != gBattlersCount)
             {
                 gAbsentBattlerFlags |= gBitTable[gBattlerFainted];
-                return FALSE;
+                if (gBattleStruct->faintedActionsState != 1)
+                    return FALSE;
             }
             break;
         case 3:


### PR DESCRIPTION
When defeating two opponents simultaneously, the second exp gain wasn't occurring until the subsequent action was performed
![exp](https://github.com/rh-hideout/pokeemerald-expansion/assets/41651341/da676dc1-2379-468f-8f49-b8768cb4bf20)


This was due to a premature `return FALSE;` in `HandleFaintedMonActions`. The fix:
![exp_fix](https://github.com/rh-hideout/pokeemerald-expansion/assets/41651341/c3635e0d-aaf8-4ae2-bc1c-cefcce588478)
