### PR TITLE
Adds missing Doodle tests and fix

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -13886,6 +13886,7 @@ static void Cmd_trycopyability(void)
     if (gBattleMons[battler].ability == defAbility
       || defAbility == ABILITY_NONE
       || IsRolePlayDoodleBannedAbilityAttacker(gBattleMons[battler].ability)
+      || IsRolePlayDoodleBannedAbilityAttacker(gBattleMons[BATTLE_PARTNER(battler)].ability)
       || IsRolePlayDoodleBannedAbility(defAbility))
     {
         gBattlescriptCurrInstr = cmd->failInstr;

--- a/test/battle/move_effect/doodle.c
+++ b/test/battle/move_effect/doodle.c
@@ -11,16 +11,73 @@ DOUBLE_BATTLE_TEST("Doodle gives the target's ability to user and ally")
     GIVEN {
         PLAYER(SPECIES_WYNAUT);
         PLAYER(SPECIES_WYNAUT);
-        OPPONENT(SPECIES_WOBBUFFET) { Ability(ABILITY_STENCH); }
+        OPPONENT(SPECIES_TORCHIC) { Ability(ABILITY_BLAZE); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
         TURN { MOVE(playerLeft, MOVE_DOODLE, target: opponentLeft);  }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DOODLE, playerLeft);
-        MESSAGE("Wynaut copied Foe Wobbuffet's Stench!");
-        MESSAGE("Wynaut copied Foe Wobbuffet's Stench!");
+        MESSAGE("Wynaut copied Foe Torchic's Blaze!");
+        MESSAGE("Wynaut copied Foe Torchic's Blaze!");
     } THEN {
-        EXPECT(playerLeft->ability == ABILITY_STENCH);
-        EXPECT(playerRight->ability == ABILITY_STENCH);
+        EXPECT(playerLeft->ability == ABILITY_BLAZE);
+        EXPECT(playerRight->ability == ABILITY_BLAZE);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Doodle can't copy a banned ability")
+{
+    GIVEN {
+        PLAYER(SPECIES_WYNAUT);
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_GREAT_TUSK) { Ability(ABILITY_PROTOSYNTHESIS); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_DOODLE, target: opponentLeft);  }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DOODLE, playerLeft);
+        NONE_OF {
+            MESSAGE("Wynaut copied Foe Great Tusk's Protosynthesis!");
+            MESSAGE("Wynaut copied Foe Great Tusk's Protosynthesis!");
+        }
+    } THEN {
+        EXPECT(playerLeft->ability != ABILITY_PROTOSYNTHESIS);
+        EXPECT(playerRight->ability != ABILITY_PROTOSYNTHESIS);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Doodle fails if user has a banned Ability")
+{
+    GIVEN {
+        PLAYER(SPECIES_GREAT_TUSK) { Ability(ABILITY_PROTOSYNTHESIS); }
+        PLAYER(SPECIES_WYNAUT) { Ability(ABILITY_SHADOW_TAG); }
+        OPPONENT(SPECIES_TORCHIC) { Ability(ABILITY_BLAZE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_DOODLE, target: opponentLeft);  }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DOODLE, playerLeft);
+        MESSAGE("But it failed!");
+    } THEN {
+        EXPECT(playerLeft->ability == ABILITY_PROTOSYNTHESIS);
+        EXPECT(playerRight->ability == ABILITY_SHADOW_TAG);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Doodle fails if partner has a banned Ability")
+{
+    GIVEN {
+        PLAYER(SPECIES_WYNAUT) { Ability(ABILITY_SHADOW_TAG); }
+        PLAYER(SPECIES_GREAT_TUSK) { Ability(ABILITY_PROTOSYNTHESIS); }
+        OPPONENT(SPECIES_TORCHIC) { Ability(ABILITY_BLAZE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_DOODLE, target: opponentLeft);  }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DOODLE, playerLeft);
+        MESSAGE("But it failed!");
+    } THEN {
+        EXPECT(playerLeft->ability == ABILITY_SHADOW_TAG);
+        EXPECT(playerRight->ability == ABILITY_PROTOSYNTHESIS);
     }
 }


### PR DESCRIPTION
Follow up on PR #2498

According to a [smogon forum post](https://www.smogon.com/forums/threads/incorrect-sv-smogon-pokedex-doodle-ability-description.3711874/) the move fails if either user or target have a banned ability. 