### PR TITLE
Fix P_FAMILY #if blocks for Regigigas and Giratina in front_pic_anims.h

### DIFF
--- a/src/data/pokemon_graphics/front_pic_anims.h
+++ b/src/data/pokemon_graphics/front_pic_anims.h
@@ -6127,7 +6127,9 @@ static const union AnimCmd sAnim_Regigigas_1[] =
     ANIMCMD_FRAME(0, 5),
     ANIMCMD_END,
 };
+#endif //P_FAMILY_REGIGIGAS
 
+#if P_FAMILY_GIRATINA
 static const union AnimCmd sAnim_GiratinaAltered_1[] =
 {
     ANIMCMD_FRAME(0, 12),
@@ -6145,7 +6147,7 @@ static const union AnimCmd sAnim_GiratinaOrigin_1[] =
     ANIMCMD_FRAME(0, 10),
     ANIMCMD_END,
 };
-#endif //P_FAMILY_REGIGIGAS
+#endif //P_FAMILY_GIRATINA
 
 #if P_FAMILY_CRESSELIA
 static const union AnimCmd sAnim_Cresselia_1[] =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

I spotted that the first #if block for `P_FAMILY_REGIGIGAS` in `front_pic_anims.h` covers the AnimCmd array declarations for both Regigigas and Giratina.

## **Discord contact info**
<!--- formatted as name#numbers, e.g. Lunos#4026 -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
`gamebriel#4784`
