### PR TITLE
Add recorded battle version field

### DIFF
--- a/include/recorded_battle.h
+++ b/include/recorded_battle.h
@@ -5,6 +5,7 @@
 #include "random.h"
 
 #define BATTLER_RECORD_SIZE 664
+#define RECORDED_BATTLE_VERSION 1
 
 struct RecordedBattleSave
 {
@@ -34,6 +35,7 @@ struct RecordedBattleSave
     u8 recordMixFriendLanguage;
     u8 apprenticeLanguage;
     u8 battleRecord[MAX_BATTLERS_COUNT][BATTLER_RECORD_SIZE];
+    u16 version;
     u32 checksum;
 };
 

--- a/src/recorded_battle.c
+++ b/src/recorded_battle.c
@@ -262,7 +262,7 @@ bool32 CanCopyRecordedBattleSaveData(void)
     return ret;
 }
 
-static inline RecordedBattleHash(const u8* data, const u32 size)
+static inline u32 RecordedBattleHash(const u8* data, const u32 size)
 {
     u32 hash;
     u32 i;

--- a/src/recorded_battle.c
+++ b/src/recorded_battle.c
@@ -274,9 +274,6 @@ static inline u32 RecordedBattleHash(const u8* data, const u32 size)
 
 static bool32 IsRecordedBattleSaveValid(struct RecordedBattleSave *save)
 {
-    u32 hash;
-    u32 i;
-    u8 *const saveArray = (u8 *)save;
     if (save->battleFlags == 0)
         return FALSE;
     if (save->battleFlags & BATTLE_TYPE_RECORDED_INVALID)

--- a/src/recorded_battle.c
+++ b/src/recorded_battle.c
@@ -288,7 +288,6 @@ static bool32 IsRecordedBattleSaveValid(struct RecordedBattleSave *save)
 
 static bool32 RecordedBattleToSave(struct RecordedBattleSave *battleSave, struct RecordedBattleSave *saveSector)
 {
-    u32 hash;
     memset(saveSector, 0, SECTOR_SIZE);
     memcpy(saveSector, battleSave, sizeof(*battleSave));
 


### PR DESCRIPTION
The intent is that this field will be updated every time there is a change to the battle system so major that there is no way old recorded battles would continue to work.
Also change the checksum calculation to the djb2 hash to ensure that old battles are invalid.

<!--- Provide a general summary of your changes in the Title above -->

## **Discord contact info**
tertu
