### PR TITLE
Consistent BENCHMARK timing (master)

### DIFF
--- a/include/test/test.h
+++ b/include/test/test.h
@@ -165,6 +165,9 @@ struct Benchmark { s32 ticks; };
 static inline void BenchmarkStart(void)
 {
     gTestRunnerState.inBenchmark = TRUE;
+    // Wait for a v-blank so that comparing two benchmarks is not affected
+    // by the v-count (different numbers of IRQs may run).
+    VBlankIntrWait();
     REG_TM3CNT = (TIMER_ENABLE | TIMER_64CLK) << 16;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -23,6 +23,7 @@
 #include "intro.h"
 #include "main.h"
 #include "trainer_hill.h"
+#include "test_runner.h"
 #include "constants/rgb.h"
 
 static void VBlankIntr(void);
@@ -372,7 +373,7 @@ static void VBlankIntr(void)
     m4aSoundMain();
     TryReceiveLinkBattleData();
 
-    if (!gMain.inBattle || !(gBattleTypeFlags & (BATTLE_TYPE_LINK | BATTLE_TYPE_FRONTIER | BATTLE_TYPE_RECORDED)))
+    if (!gTestRunnerEnabled && (!gMain.inBattle || !(gBattleTypeFlags & (BATTLE_TYPE_LINK | BATTLE_TYPE_FRONTIER | BATTLE_TYPE_RECORDED))))
         Random();
 
     UpdateWirelessStatusIndicatorSprite();


### PR DESCRIPTION
#3866, but targeting `master` since it has the same bug (it's just that I don't think we've run into it due to sheer luck).