### PR TITLE
Fixed Egg graphical data not being properly read

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -5985,7 +5985,7 @@ u16 SanitizeSpeciesId(u16 species)
 
 bool32 IsSpeciesEnabled(u16 species)
 {
-    return gSpeciesInfo[species].baseHP > 0;
+    return gSpeciesInfo[species].baseHP > 0 || species == SPECIES_EGG;
 }
 
 void TryToSetBattleFormChangeMoves(struct Pokemon *mon, u16 method)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`IsSpeciesEnabled` wasn't accounting for Eggs, since they don't have they HP stat set.

## Images
![image](https://github.com/rh-hideout/pokeemerald-expansion/assets/2904965/3413d6b8-7d2a-4657-aa58-df835cbec71c)

## Issue(s) that this PR fixes
#3775 

## **Discord contact info**
AsparagusEduardo
