### PR TITLE
Re-Enabled Z-Move Usage in Battle Frontier

### DIFF
--- a/src/battle_z_move.c
+++ b/src/battle_z_move.c
@@ -171,7 +171,8 @@ bool32 IsViableZMove(u8 battler, u16 move)
     if (gBattleStruct->zmove.used[battler])
         return FALSE;
 
-    if (gBattleTypeFlags & (BATTLE_TYPE_SAFARI | BATTLE_TYPE_WALLY_TUTORIAL | BATTLE_TYPE_FRONTIER))
+    // Add '| BATTLE_TYPE_FRONTIER' to below if issues occur
+    if (gBattleTypeFlags & (BATTLE_TYPE_SAFARI | BATTLE_TYPE_WALLY_TUTORIAL))
         return FALSE;
 
     if ((GetBattlerPosition(battler) == B_POSITION_PLAYER_LEFT || (!(gBattleTypeFlags & BATTLE_TYPE_MULTI) && GetBattlerPosition(battler) == B_POSITION_PLAYER_RIGHT)) && !CheckBagHasItem(ITEM_Z_POWER_RING, 1))


### PR DESCRIPTION
## Description
In the issue linked below, it was reported that Z-Moves are broken in the Battle Frontier, and this appears to be the reason for why they were disabled. However, after performing some testing in different scenarios I have been unable to reproduce any errors which occur from using Z-Moves in the battle frontier. Please see below for a video demonstration of this feature working.

I'd imagine whatever was causing crashes with Z-Moves in the Battle Frontier may have inadvertently been fixed by another change, and it has not been tested since then until now. Please let me know if there are any concerns or questions ^

## Images
No images, however youtube demonstration of Z-Moves working can be seen [here](https://youtu.be/ubI8Q0PFoq0)

## Issue(s) that this PR fixes
Fixed [#3334](https://github.com/rh-hideout/pokeemerald-expansion/issues/3334)

## Feature(s) this PR does NOT handle:
No other changes

## **Discord contact info**
SirScrubbington#0322