### PR TITLE
Refactored SetMoveEffect Inner Focus Case

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -3128,20 +3128,25 @@ void SetMoveEffect(bool32 primary, u32 certain)
                 }
                 break;
             case MOVE_EFFECT_FLINCH:
-                if (battlerAbility == ABILITY_INNER_FOCUS
-                    && (primary == TRUE || certain == MOVE_EFFECT_CERTAIN))
+                if (battlerAbility == ABILITY_INNER_FOCUS)
                 {
-                    gLastUsedAbility = ABILITY_INNER_FOCUS;
-                    gBattlerAbility = gEffectBattler;
-                    RecordAbilityBattle(gEffectBattler, ABILITY_INNER_FOCUS);
-                    gBattlescriptCurrInstr = BattleScript_FlinchPrevention;
+                    if (primary == TRUE || certain == MOVE_EFFECT_CERTAIN)
+                    {
+                        gLastUsedAbility = ABILITY_INNER_FOCUS;
+                        gBattlerAbility = gEffectBattler;
+                        RecordAbilityBattle(gEffectBattler, ABILITY_INNER_FOCUS);
+                        gBattlescriptCurrInstr = BattleScript_FlinchPrevention;
+                    } else 
+                    {
+                        gBattlescriptCurrInstr++;
+                    }
                 }
-                else if (GetBattlerTurnOrderNum(gEffectBattler) > gCurrentTurnActionNumber
-                         && !IsDynamaxed(gEffectBattler))
-                {
-                    gBattleMons[gEffectBattler].status2 |= sStatusFlagsForMoveEffects[gBattleScripting.moveEffect];
+                else {
+                    if (GetBattlerTurnOrderNum(gEffectBattler) > gCurrentTurnActionNumber
+                        && !IsDynamaxed(gEffectBattler))
+                        gBattleMons[gEffectBattler].status2 |= sStatusFlagsForMoveEffects[gBattleScripting.moveEffect]; 
+                    gBattlescriptCurrInstr++;
                 }
-                gBattlescriptCurrInstr++;
                 break;
             case MOVE_EFFECT_UPROAR:
                 if (!(gBattleMons[gEffectBattler].status2 & STATUS2_UPROAR))

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -3141,10 +3141,10 @@ void SetMoveEffect(bool32 primary, u32 certain)
                         gBattlescriptCurrInstr++;
                     }
                 }
-                else {
-                    if (GetBattlerTurnOrderNum(gEffectBattler) > gCurrentTurnActionNumber
+                else if (GetBattlerTurnOrderNum(gEffectBattler) > gCurrentTurnActionNumber
                         && !IsDynamaxed(gEffectBattler))
-                        gBattleMons[gEffectBattler].status2 |= sStatusFlagsForMoveEffects[gBattleScripting.moveEffect]; 
+                {
+                    gBattleMons[gEffectBattler].status2 |= sStatusFlagsForMoveEffects[gBattleScripting.moveEffect]; 
                     gBattlescriptCurrInstr++;
                 }
                 break;


### PR DESCRIPTION
## Description
This fixes an issue where changing `B_WAIT_TIME_MULTIPLIER` to a value other than 16 (we tried 8) would break the inner focus case of SetMoveEffect. The default value of 16 "magically" ends up in the right string to print (use gdb debugger), as `gBattlescriptCurrInstr++` ends up using (16 * 2 = 0x20) as the mapped function from `gBattleScriptingCommandsTable`.


## **Discord contact info**
poetahto
me: accelgor