### PR TITLE
Ability flags update

### DIFF
--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -223,7 +223,6 @@ bool32 IsAlly(u32 battlerAtk, u32 battlerDef);
 bool32 IsGen6ExpShareEnabled(void);
 
 // Ability checks
-bool32 IsSkillSwapBannedAbility(u16 ability);
 bool32 IsRolePlayDoodleBannedAbility(u16 ability);
 bool32 IsRolePlayDoodleBannedAbilityAttacker(u16 ability);
 

--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -226,11 +226,8 @@ bool32 IsGen6ExpShareEnabled(void);
 bool32 IsSkillSwapBannedAbility(u16 ability);
 bool32 IsRolePlayDoodleBannedAbility(u16 ability);
 bool32 IsRolePlayDoodleBannedAbilityAttacker(u16 ability);
-bool32 IsWorrySeedBannedAbility(u16 ability);
-bool32 IsGastroAcidBannedAbility(u16 ability);
 bool32 IsEntrainmentBannedAbility(u16 ability);
 bool32 IsEntrainmentBannedAbilityAttacker(u16 ability);
-bool32 IsSimpleBeamBannedAbility(u16 ability);
 
 bool32 CanSleep(u32 battler);
 bool32 CanBePoisoned(u32 battlerAttacker, u32 battlerTarget);

--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -226,8 +226,6 @@ bool32 IsGen6ExpShareEnabled(void);
 bool32 IsSkillSwapBannedAbility(u16 ability);
 bool32 IsRolePlayDoodleBannedAbility(u16 ability);
 bool32 IsRolePlayDoodleBannedAbilityAttacker(u16 ability);
-bool32 IsEntrainmentBannedAbility(u16 ability);
-bool32 IsEntrainmentBannedAbilityAttacker(u16 ability);
 
 bool32 CanSleep(u32 battler);
 bool32 CanBePoisoned(u32 battlerAttacker, u32 battlerTarget);

--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -222,10 +222,6 @@ void RecalcBattlerStats(u32 battler, struct Pokemon *mon);
 bool32 IsAlly(u32 battlerAtk, u32 battlerDef);
 bool32 IsGen6ExpShareEnabled(void);
 
-// Ability checks
-bool32 IsRolePlayDoodleBannedAbility(u16 ability);
-bool32 IsRolePlayDoodleBannedAbilityAttacker(u16 ability);
-
 bool32 CanSleep(u32 battler);
 bool32 CanBePoisoned(u32 battlerAttacker, u32 battlerTarget);
 bool32 CanBeBurned(u32 battler);

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -71,6 +71,9 @@
 #define B_PP_REDUCED_BY_SPITE       GEN_LATEST // In Gen4+, Spite reduces the foe's last move's PP by 4, instead of 2 to 5.
 #define B_EXTRAPOLATED_MOVE_FLAGS   TRUE       // Adds move flags to moves that they don't officially have but would likely have if they were in the latest core series game.
 
+// Ability data settings
+#define B_UPDATED_ABILITY_DATA      GEN_LATEST // Affects flags
+
 // Move accuracy settings
 #define B_TOXIC_NEVER_MISS          GEN_LATEST // In Gen6+, if Toxic is used by a Poison-type Pokémon, it will never miss.
 #define B_MINIMIZE_DMG_ACC          GEN_LATEST // In Gen6+, moves that causes double damage to minimized Pokémon will also skip accuracy checks.

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -518,7 +518,7 @@ struct Ability
     u8 cantBeTransferred:1; // cannot be swapped with Skill Swap or Wandering Spirit
     u8 cantBeTraced:1; // cannot be copied by Trace - same as cantBeCopied except for Wonder Guard
     u8 cantBeSuppressed:1; // cannot be negated by Gastro Acid or Neutralizing Gas
-    u8 cantBeOverwritten:1; // cannot be overwritten by Entrainment, Worry Seed or Simple Beam - same as cantBeSuppressed except for Truant
+    u8 cantBeOverwritten:1; // cannot be overwritten by Entrainment, Worry Seed or Simple Beam (but can be by Mummy) - same as cantBeSuppressed except for Truant
     u8 canBeIgnored:1; // can be bypassed by Mold Breaker and clones
     u8 failsOnImposter:1; // doesn't work on an Imposter mon; when can we actually use this?
 };

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -514,13 +514,13 @@ struct Ability
     u8 name[ABILITY_NAME_LENGTH + 1];
     const u8 *description;
     s8 aiRating;
-    u8 cantBeCopied:1;
-    u8 cantBeTransferred:1;
-    u8 cantBeTraced:1;
-    u8 cantBeSuppressed:1;
-    u8 cantBeOverwritten:1;
-    u8 canBeIgnored:1;
-    u8 failsOnImposter:1;
+    u8 cantBeCopied:1; // cannot be copied by Role Play or Doodle
+    u8 cantBeTransferred:1; // cannot be swapped with Skill Swap or Wandering Spirit
+    u8 cantBeTraced:1; // cannot be copied by Trace - same as cantBeCopied except for Wonder Guard
+    u8 cantBeSuppressed:1; // cannot be negated by Gastro Acid or Neutralizing Gas
+    u8 cantBeOverwritten:1; // cannot be overwritten by Entrainment, Worry Seed or Simple Beam - same as cantBeSuppressed except for Truant
+    u8 canBeIgnored:1; // can be bypassed by Mold Breaker and clones
+    u8 failsOnImposter:1; // doesn't work on an Imposter mon; when can we actually use this?
 };
 
 #define SPINDA_SPOT_WIDTH 16

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -514,6 +514,11 @@ struct Ability
     u8 name[ABILITY_NAME_LENGTH + 1];
     const u8 *description;
     s8 aiRating;
+    u8 cantBeTransferred:1;
+    u8 cantBeTraced:1;
+    u8 cantBeSuppressed:1;
+    u8 canBeIgnored:1;
+    u8 failsOnImposter:1;
 };
 
 #define SPINDA_SPOT_WIDTH 16

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -515,11 +515,11 @@ struct Ability
     const u8 *description;
     s8 aiRating;
     u8 cantBeCopied:1; // cannot be copied by Role Play or Doodle
-    u8 cantBeTransferred:1; // cannot be swapped with Skill Swap or Wandering Spirit
+    u8 cantBeSwapped:1; // cannot be swapped with Skill Swap or Wandering Spirit
     u8 cantBeTraced:1; // cannot be copied by Trace - same as cantBeCopied except for Wonder Guard
     u8 cantBeSuppressed:1; // cannot be negated by Gastro Acid or Neutralizing Gas
     u8 cantBeOverwritten:1; // cannot be overwritten by Entrainment, Worry Seed or Simple Beam (but can be by Mummy) - same as cantBeSuppressed except for Truant
-    u8 canBeIgnored:1; // can be bypassed by Mold Breaker and clones
+    u8 breakable:1; // can be bypassed by Mold Breaker and clones
     u8 failsOnImposter:1; // doesn't work on an Imposter mon; when can we actually use this?
 };
 

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -514,9 +514,11 @@ struct Ability
     u8 name[ABILITY_NAME_LENGTH + 1];
     const u8 *description;
     s8 aiRating;
+    u8 cantBeCopied:1;
     u8 cantBeTransferred:1;
     u8 cantBeTraced:1;
     u8 cantBeSuppressed:1;
+    u8 cantBeOverwritten:1;
     u8 canBeIgnored:1;
     u8 failsOnImposter:1;
 };

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -2189,13 +2189,13 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             break;
         case EFFECT_WORRY_SEED:
             if (aiData->abilities[battlerDef] == ABILITY_INSOMNIA
-              || IsWorrySeedBannedAbility(aiData->abilities[battlerDef])
+              || gAbilities[aiData->abilities[battlerDef]].cantBeOverwritten
               || aiData->holdEffects[battlerDef] == HOLD_EFFECT_ABILITY_SHIELD)
                 ADJUST_SCORE(-10);
             break;
         case EFFECT_GASTRO_ACID:
             if (gStatuses3[battlerDef] & STATUS3_GASTRO_ACID
-              || IsGastroAcidBannedAbility(aiData->abilities[battlerDef]))
+              || gAbilities[aiData->abilities[battlerDef]].cantBeSuppressed)
                 ADJUST_SCORE(-10);
             break;
         case EFFECT_ENTRAINMENT:
@@ -2209,7 +2209,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             break;
         case EFFECT_SIMPLE_BEAM:
             if (aiData->abilities[battlerDef] == ABILITY_SIMPLE
-              || IsSimpleBeamBannedAbility(aiData->abilities[battlerDef])
+              || gAbilities[aiData->abilities[battlerDef]].cantBeOverwritten
               || aiData->holdEffects[battlerDef] == HOLD_EFFECT_ABILITY_SHIELD)
                 ADJUST_SCORE(-10);
             break;

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -2153,8 +2153,8 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
         case EFFECT_ROLE_PLAY:
             if (aiData->abilities[battlerAtk] == aiData->abilities[battlerDef]
               || aiData->abilities[battlerDef] == ABILITY_NONE
-              || IsRolePlayDoodleBannedAbilityAttacker(aiData->abilities[battlerAtk])
-              || IsRolePlayDoodleBannedAbility(aiData->abilities[battlerDef]))
+              || gAbilities[aiData->abilities[battlerAtk]].cantBeSuppressed
+              || gAbilities[aiData->abilities[battlerDef]].cantBeCopied)
                 ADJUST_SCORE(-10);
             else if (IsAbilityOfRating(aiData->abilities[battlerAtk], 5))
                 ADJUST_SCORE(-4);
@@ -4378,8 +4378,8 @@ static s32 AI_CheckViability(u32 battlerAtk, u32 battlerDef, u32 move, s32 score
         }
         break;
     case EFFECT_ROLE_PLAY:
-        if (!IsRolePlayDoodleBannedAbilityAttacker(aiData->abilities[battlerAtk])
-          && !IsRolePlayDoodleBannedAbility(aiData->abilities[battlerDef])
+        if (!gAbilities[aiData->abilities[battlerAtk]].cantBeSuppressed
+          && !gAbilities[aiData->abilities[battlerDef]].cantBeCopied
           && !IsAbilityOfRating(aiData->abilities[battlerAtk], 5)
           && IsAbilityOfRating(aiData->abilities[battlerDef], 5))
             ADJUST_SCORE(2);

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -2183,7 +2183,8 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             break;
         case EFFECT_SKILL_SWAP:
             if (aiData->abilities[battlerAtk] == ABILITY_NONE || aiData->abilities[battlerDef] == ABILITY_NONE
-              || IsSkillSwapBannedAbility(aiData->abilities[battlerAtk]) || IsSkillSwapBannedAbility(aiData->abilities[battlerDef])
+              || gAbilities[aiData->abilities[battlerAtk]].cantBeTransferred
+              || gAbilities[aiData->abilities[battlerDef]].cantBeTransferred
               || aiData->holdEffects[battlerDef] == HOLD_EFFECT_ABILITY_SHIELD)
                 ADJUST_SCORE(-10);
             break;

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -2200,8 +2200,8 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             break;
         case EFFECT_ENTRAINMENT:
             if (aiData->abilities[battlerAtk] == ABILITY_NONE
-              || IsEntrainmentBannedAbilityAttacker(aiData->abilities[battlerAtk])
-              || IsEntrainmentBannedAbility(aiData->abilities[battlerDef])
+              || gAbilities[aiData->abilities[battlerAtk]].cantBeCopied
+              || gAbilities[aiData->abilities[battlerDef]].cantBeOverwritten
               || aiData->holdEffects[battlerAtk] == HOLD_EFFECT_ABILITY_SHIELD)
                 ADJUST_SCORE(-10);
             break;

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -2183,8 +2183,8 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             break;
         case EFFECT_SKILL_SWAP:
             if (aiData->abilities[battlerAtk] == ABILITY_NONE || aiData->abilities[battlerDef] == ABILITY_NONE
-              || gAbilities[aiData->abilities[battlerAtk]].cantBeTransferred
-              || gAbilities[aiData->abilities[battlerDef]].cantBeTransferred
+              || gAbilities[aiData->abilities[battlerAtk]].cantBeSwapped
+              || gAbilities[aiData->abilities[battlerDef]].cantBeSwapped
               || aiData->holdEffects[battlerDef] == HOLD_EFFECT_ABILITY_SHIELD)
                 ADJUST_SCORE(-10);
             break;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -14129,8 +14129,8 @@ static void Cmd_tryswapabilities(void)
 {
     CMD_ARGS(const u8 *failInstr);
 
-    if (IsSkillSwapBannedAbility(gBattleMons[gBattlerAttacker].ability)
-      || IsSkillSwapBannedAbility(gBattleMons[gBattlerTarget].ability))
+    if (gAbilities[gBattleMons[gBattlerAttacker].ability].cantBeTransferred
+      || gAbilities[gBattleMons[gBattlerTarget].ability].cantBeTransferred)
     {
         RecordAbilityBattle(gBattlerTarget, gBattleMons[gBattlerTarget].ability);
         gBattlescriptCurrInstr = cmd->failInstr;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -13951,9 +13951,9 @@ static void Cmd_trycopyability(void)
 
     if (gBattleMons[battler].ability == defAbility
       || defAbility == ABILITY_NONE
-      || IsRolePlayDoodleBannedAbilityAttacker(gBattleMons[battler].ability)
-      || IsRolePlayDoodleBannedAbilityAttacker(gBattleMons[BATTLE_PARTNER(battler)].ability)
-      || IsRolePlayDoodleBannedAbility(defAbility))
+      || gAbilities[gBattleMons[battler].ability].cantBeSuppressed
+      || gAbilities[gBattleMons[BATTLE_PARTNER(battler)].ability].cantBeSuppressed
+      || gAbilities[defAbility].cantBeCopied)
     {
         gBattlescriptCurrInstr = cmd->failInstr;
     }

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -9329,7 +9329,7 @@ static void Cmd_various(void)
     case VARIOUS_SET_SIMPLE_BEAM:
     {
         VARIOUS_ARGS(const u8 *failInstr);
-        if (IsSimpleBeamBannedAbility(gBattleMons[gBattlerTarget].ability)
+        if (gAbilities[gBattleMons[gBattlerTarget].ability].cantBeOverwritten
             || gBattleMons[gBattlerTarget].ability == ABILITY_SIMPLE)
         {
             RecordAbilityBattle(gBattlerTarget, gBattleMons[gBattlerTarget].ability);
@@ -14029,7 +14029,7 @@ static void Cmd_setgastroacid(void)
 {
     CMD_ARGS(const u8 *failInstr);
 
-    if (IsGastroAcidBannedAbility(gBattleMons[gBattlerTarget].ability))
+    if (gAbilities[gBattleMons[gBattlerTarget].ability].cantBeSuppressed)
     {
         gBattlescriptCurrInstr = cmd->failInstr;
     }
@@ -15489,7 +15489,8 @@ static void Cmd_tryworryseed(void)
 {
     CMD_ARGS(const u8 *failInstr);
 
-    if (IsWorrySeedBannedAbility(gBattleMons[gBattlerTarget].ability))
+    if (gAbilities[gBattleMons[gBattlerTarget].ability].cantBeOverwritten
+      || gBattleMons[gBattlerTarget].ability == ABILITY_INSOMNIA)
     {
         RecordAbilityBattle(gBattlerTarget, gBattleMons[gBattlerTarget].ability);
         gBattlescriptCurrInstr = T1_READ_PTR(gBattlescriptCurrInstr + 1);

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -9353,8 +9353,8 @@ static void Cmd_various(void)
     case VARIOUS_TRY_ENTRAINMENT:
     {
         VARIOUS_ARGS(const u8 *failInstr);
-        if (IsEntrainmentBannedAbilityAttacker(gBattleMons[gBattlerAttacker].ability)
-          || IsEntrainmentBannedAbility(gBattleMons[gBattlerTarget].ability))
+        if (gAbilities[gBattleMons[gBattlerAttacker].ability].cantBeCopied
+          || gAbilities[gBattleMons[gBattlerTarget].ability].cantBeOverwritten)
         {
             RecordAbilityBattle(gBattlerTarget, gBattleMons[gBattlerTarget].ability);
             gBattlescriptCurrInstr = cmd->failInstr;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -14129,8 +14129,8 @@ static void Cmd_tryswapabilities(void)
 {
     CMD_ARGS(const u8 *failInstr);
 
-    if (gAbilities[gBattleMons[gBattlerAttacker].ability].cantBeTransferred
-      || gAbilities[gBattleMons[gBattlerTarget].ability].cantBeTransferred)
+    if (gAbilities[gBattleMons[gBattlerAttacker].ability].cantBeSwapped
+      || gAbilities[gBattleMons[gBattlerTarget].ability].cantBeSwapped)
     {
         RecordAbilityBattle(gBattlerTarget, gBattleMons[gBattlerTarget].ability);
         gBattlescriptCurrInstr = cmd->failInstr;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -985,114 +985,6 @@ void HandleAction_ActionFinished(void)
     }
 }
 
-static const u8 sAbilitiesAffectedByMoldBreaker[] =
-{
-    [ABILITY_BATTLE_ARMOR] = 1,
-    [ABILITY_CLEAR_BODY] = 1,
-    [ABILITY_DAMP] = 1,
-    [ABILITY_DRY_SKIN] = 1,
-    [ABILITY_FILTER] = 1,
-    [ABILITY_FLASH_FIRE] = 1,
-    [ABILITY_FLOWER_GIFT] = 1,
-    [ABILITY_HEATPROOF] = 1,
-    [ABILITY_HYPER_CUTTER] = 1,
-    [ABILITY_IMMUNITY] = 1,
-    [ABILITY_INNER_FOCUS] = 1,
-    [ABILITY_INSOMNIA] = 1,
-    [ABILITY_KEEN_EYE] = 1,
-    [ABILITY_LEAF_GUARD] = 1,
-    [ABILITY_LEVITATE] = 1,
-    [ABILITY_LIGHTNING_ROD] = 1,
-    [ABILITY_LIMBER] = 1,
-    [ABILITY_MAGMA_ARMOR] = 1,
-    [ABILITY_MARVEL_SCALE] = 1,
-    [ABILITY_MOTOR_DRIVE] = 1,
-    [ABILITY_OBLIVIOUS] = 1,
-    [ABILITY_OWN_TEMPO] = 1,
-    [ABILITY_SAND_VEIL] = 1,
-    [ABILITY_SHELL_ARMOR] = 1,
-    [ABILITY_SHIELD_DUST] = 1,
-    [ABILITY_SIMPLE] = 1,
-    [ABILITY_SNOW_CLOAK] = 1,
-    [ABILITY_SOLID_ROCK] = 1,
-    [ABILITY_SOUNDPROOF] = 1,
-    [ABILITY_STICKY_HOLD] = 1,
-    [ABILITY_STORM_DRAIN] = 1,
-    [ABILITY_STURDY] = 1,
-    [ABILITY_SUCTION_CUPS] = 1,
-    [ABILITY_TANGLED_FEET] = 1,
-    [ABILITY_THICK_FAT] = 1,
-    [ABILITY_UNAWARE] = 1,
-    [ABILITY_VITAL_SPIRIT] = 1,
-    [ABILITY_VOLT_ABSORB] = 1,
-    [ABILITY_WATER_ABSORB] = 1,
-    [ABILITY_WATER_VEIL] = 1,
-    [ABILITY_WHITE_SMOKE] = 1,
-    [ABILITY_WONDER_GUARD] = 1,
-    [ABILITY_BIG_PECKS] = 1,
-    [ABILITY_CONTRARY] = 1,
-    [ABILITY_FRIEND_GUARD] = 1,
-    [ABILITY_HEAVY_METAL] = 1,
-    [ABILITY_LIGHT_METAL] = 1,
-    [ABILITY_MAGIC_BOUNCE] = 1,
-    [ABILITY_MULTISCALE] = 1,
-    [ABILITY_SAP_SIPPER] = 1,
-    [ABILITY_TELEPATHY] = 1,
-    [ABILITY_WONDER_SKIN] = 1,
-    [ABILITY_AROMA_VEIL] = 1,
-    [ABILITY_BULLETPROOF] = 1,
-    [ABILITY_FLOWER_VEIL] = 1,
-    [ABILITY_FUR_COAT] = 1,
-    [ABILITY_OVERCOAT] = 1,
-    [ABILITY_SWEET_VEIL] = 1,
-    [ABILITY_DAZZLING] = 1,
-    [ABILITY_DISGUISE] = 1,
-    [ABILITY_FLUFFY] = 1,
-    [ABILITY_QUEENLY_MAJESTY] = 1,
-    [ABILITY_WATER_BUBBLE] = 1,
-    [ABILITY_MIRROR_ARMOR] = 1,
-    [ABILITY_PUNK_ROCK] = 1,
-    [ABILITY_ICE_SCALES] = 1,
-    [ABILITY_ICE_FACE] = 1,
-    [ABILITY_PASTEL_VEIL] = 1,
-    [ABILITY_ARMOR_TAIL] = 1,
-    [ABILITY_EARTH_EATER] = 1,
-    [ABILITY_GOOD_AS_GOLD] = 1,
-    [ABILITY_PURIFYING_SALT] = 1,
-    [ABILITY_WELL_BAKED_BODY] = 1,
-    [ABILITY_MINDS_EYE] = 1,
-    [ABILITY_ILLUMINATE] = 1,
-};
-
-static const u8 sAbilitiesNotTraced[ABILITIES_COUNT] =
-{
-    [ABILITY_AS_ONE_ICE_RIDER] = 1,
-    [ABILITY_AS_ONE_SHADOW_RIDER] = 1,
-    [ABILITY_BATTLE_BOND] = 1,
-    [ABILITY_COMATOSE] = 1,
-    [ABILITY_DISGUISE] = 1,
-    [ABILITY_FLOWER_GIFT] = 1,
-    [ABILITY_FORECAST] = 1,
-    [ABILITY_GULP_MISSILE] = 1,
-    [ABILITY_HUNGER_SWITCH] = 1,
-    [ABILITY_ICE_FACE] = 1,
-    [ABILITY_ILLUSION] = 1,
-    [ABILITY_IMPOSTER] = 1,
-    [ABILITY_MULTITYPE] = 1,
-    [ABILITY_NEUTRALIZING_GAS] = 1,
-    [ABILITY_NONE] = 1,
-    [ABILITY_POWER_CONSTRUCT] = 1,
-    [ABILITY_POWER_OF_ALCHEMY] = 1,
-    [ABILITY_RECEIVER] = 1,
-    [ABILITY_RKS_SYSTEM] = 1,
-    [ABILITY_SCHOOLING] = 1,
-    [ABILITY_SHIELDS_DOWN] = 1,
-    [ABILITY_STANCE_CHANGE] = 1,
-    [ABILITY_TRACE] = 1,
-    [ABILITY_ZEN_MODE] = 1,
-    [ABILITY_ZERO_TO_HERO] = 1,
-};
-
 static const u8 sHoldEffectToType[][2] =
 {
     {HOLD_EFFECT_BUG_POWER, TYPE_BUG},
@@ -6152,17 +6044,17 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
 
                 if (gBattleTypeFlags & BATTLE_TYPE_DOUBLE)
                 {
-                    if (!sAbilitiesNotTraced[gBattleMons[target1].ability] && gBattleMons[target1].hp != 0
-                     && !sAbilitiesNotTraced[gBattleMons[target2].ability] && gBattleMons[target2].hp != 0)
+                    if (!gAbilities[gBattleMons[target1].ability].cantBeTraced && gBattleMons[target1].hp != 0
+                     && !gAbilities[gBattleMons[target2].ability].cantBeTraced && gBattleMons[target2].hp != 0)
                         chosenTarget = GetBattlerAtPosition((RandomPercentage(RNG_TRACE, 50) * 2) | side), effect++;
-                    else if (!sAbilitiesNotTraced[gBattleMons[target1].ability] && gBattleMons[target1].hp != 0)
+                    else if (!gAbilities[gBattleMons[target1].ability].cantBeTraced && gBattleMons[target1].hp != 0)
                         chosenTarget = target1, effect++;
-                    else if (!sAbilitiesNotTraced[gBattleMons[target2].ability] && gBattleMons[target2].hp != 0)
+                    else if (!gAbilities[gBattleMons[target2].ability].cantBeTraced && gBattleMons[target2].hp != 0)
                         chosenTarget = target2, effect++;
                 }
                 else
                 {
-                    if (!sAbilitiesNotTraced[gBattleMons[target1].ability] && gBattleMons[target1].hp != 0)
+                    if (!gAbilities[gBattleMons[target1].ability].cantBeTraced && gBattleMons[target1].hp != 0)
                         chosenTarget = target1, effect++;
                 }
 
@@ -6398,7 +6290,7 @@ u32 GetBattlerAbility(u32 battler)
     if (((IsMoldBreakerTypeAbility(gBattleMons[gBattlerAttacker].ability)
             && !(gStatuses3[gBattlerAttacker] & STATUS3_GASTRO_ACID))
             || gBattleMoves[gCurrentMove].ignoresTargetAbility)
-            && sAbilitiesAffectedByMoldBreaker[gBattleMons[battler].ability]
+            && gAbilities[gBattleMons[battler].ability].canBeIgnored
             && gBattlerByTurnOrder[gCurrentTurnActionNumber] == gBattlerAttacker
             && gActionsByTurnOrder[gBattlerByTurnOrder[gBattlerAttacker]] == B_ACTION_USE_MOVE
             && gCurrentTurnActionNumber < gBattlersCount)

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -180,64 +180,6 @@ static const u16 sRolePlayDoodleBannedAttackerAbilities[] =
     ABILITY_ZERO_TO_HERO,
 };
 
-static const u16 sEntrainmentBannedAbilities[] =
-{
-    ABILITY_AS_ONE_ICE_RIDER,
-    ABILITY_AS_ONE_SHADOW_RIDER,
-    ABILITY_BATTLE_BOND,
-    ABILITY_COMATOSE,
-    ABILITY_COMMANDER,
-    ABILITY_DISGUISE,
-    ABILITY_GULP_MISSILE,
-    ABILITY_HADRON_ENGINE,
-    ABILITY_ICE_FACE,
-    ABILITY_MULTITYPE,
-    ABILITY_ORICHALCUM_PULSE,
-    ABILITY_POWER_CONSTRUCT,
-    ABILITY_PROTOSYNTHESIS,
-    ABILITY_QUARK_DRIVE,
-    ABILITY_RKS_SYSTEM,
-    ABILITY_SCHOOLING,
-    ABILITY_SHIELDS_DOWN,
-    ABILITY_STANCE_CHANGE,
-    ABILITY_TRUANT,
-    ABILITY_ZEN_MODE,
-    ABILITY_ZERO_TO_HERO,
-};
-
-static const u16 sEntrainmentBannedAttackerAbilities[] =
-{
-    ABILITY_AS_ONE_ICE_RIDER,
-    ABILITY_AS_ONE_SHADOW_RIDER,
-    ABILITY_BATTLE_BOND,
-    ABILITY_COMATOSE,
-    ABILITY_COMMANDER,
-    ABILITY_DISGUISE,
-    ABILITY_FLOWER_GIFT,
-    ABILITY_FORECAST,
-    ABILITY_GULP_MISSILE,
-    ABILITY_HADRON_ENGINE,
-    ABILITY_HUNGER_SWITCH,
-    ABILITY_ICE_FACE,
-    ABILITY_ILLUSION,
-    ABILITY_IMPOSTER,
-    ABILITY_MULTITYPE,
-    ABILITY_NEUTRALIZING_GAS,
-    ABILITY_ORICHALCUM_PULSE,
-    ABILITY_POWER_CONSTRUCT,
-    ABILITY_POWER_OF_ALCHEMY,
-    ABILITY_PROTOSYNTHESIS,
-    ABILITY_QUARK_DRIVE,
-    ABILITY_RECEIVER,
-    ABILITY_RKS_SYSTEM,
-    ABILITY_SCHOOLING,
-    ABILITY_SHIELDS_DOWN,
-    ABILITY_STANCE_CHANGE,
-    ABILITY_TRACE,
-    ABILITY_ZEN_MODE,
-    ABILITY_ZERO_TO_HERO,
-};
-
 static u8 CalcBeatUpPower(void)
 {
     u8 basePower;
@@ -10800,28 +10742,6 @@ bool32 IsRolePlayDoodleBannedAbilityAttacker(u16 ability)
     for (i = 0; i < ARRAY_COUNT(sRolePlayDoodleBannedAttackerAbilities); i++)
     {
         if (ability == sRolePlayDoodleBannedAttackerAbilities[i])
-            return TRUE;
-    }
-    return FALSE;
-}
-
-bool32 IsEntrainmentBannedAbility(u16 ability)
-{
-    u32 i;
-    for (i = 0; i < ARRAY_COUNT(sEntrainmentBannedAbilities); i++)
-    {
-        if (ability == sEntrainmentBannedAbilities[i])
-            return TRUE;
-    }
-    return FALSE;
-}
-
-bool32 IsEntrainmentBannedAbilityAttacker(u16 ability)
-{
-    u32 i;
-    for (i = 0; i < ARRAY_COUNT(sEntrainmentBannedAttackerAbilities); i++)
-    {
-        if (ability == sEntrainmentBannedAttackerAbilities[i])
             return TRUE;
     }
     return FALSE;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -5157,7 +5157,7 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
              && TARGET_TURN_DAMAGED
              && IsMoveMakingContact(move, gBattlerAttacker)
              && !IsDynamaxed(gBattlerTarget)
-             && !gAbilities[gBattleMons[gBattlerAttacker].ability].cantBeTransferred)
+             && !gAbilities[gBattleMons[gBattlerAttacker].ability].cantBeSwapped)
             {
                 if (GetBattlerHoldEffect(gBattlerAttacker, TRUE) == HOLD_EFFECT_ABILITY_SHIELD)
                 {
@@ -6016,7 +6016,7 @@ u32 GetBattlerAbility(u32 battler)
     if (((IsMoldBreakerTypeAbility(gBattleMons[gBattlerAttacker].ability)
             && !(gStatuses3[gBattlerAttacker] & STATUS3_GASTRO_ACID))
             || gBattleMoves[gCurrentMove].ignoresTargetAbility)
-            && gAbilities[gBattleMons[battler].ability].canBeIgnored
+            && gAbilities[gBattleMons[battler].ability].breakable
             && gBattlerByTurnOrder[gCurrentTurnActionNumber] == gBattlerAttacker
             && gActionsByTurnOrder[gBattlerByTurnOrder[gBattlerAttacker]] == B_ACTION_USE_MOVE
             && gCurrentTurnActionNumber < gBattlersCount)

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -94,64 +94,6 @@ static const u8 sPkblToEscapeFactor[][3] = {
 static const u8 sGoNearCounterToCatchFactor[] = {4, 3, 2, 1};
 static const u8 sGoNearCounterToEscapeFactor[] = {4, 4, 4, 4};
 
-static const u16 sRolePlayDoodleBannedAbilities[] =
-{
-    ABILITY_AS_ONE_ICE_RIDER,
-    ABILITY_AS_ONE_SHADOW_RIDER,
-    ABILITY_BATTLE_BOND,
-    ABILITY_COMATOSE,
-    ABILITY_COMMANDER,
-    ABILITY_DISGUISE,
-    ABILITY_FLOWER_GIFT,
-    ABILITY_FORECAST,
-    ABILITY_GULP_MISSILE,
-    ABILITY_HADRON_ENGINE,
-    ABILITY_HUNGER_SWITCH,
-    ABILITY_ICE_FACE,
-    ABILITY_ILLUSION,
-    ABILITY_IMPOSTER,
-    ABILITY_MULTITYPE,
-    ABILITY_NEUTRALIZING_GAS,
-    ABILITY_ORICHALCUM_PULSE,
-    ABILITY_POWER_CONSTRUCT,
-    ABILITY_POWER_OF_ALCHEMY,
-    ABILITY_PROTOSYNTHESIS,
-    ABILITY_QUARK_DRIVE,
-    ABILITY_RECEIVER,
-    ABILITY_RKS_SYSTEM,
-    ABILITY_SCHOOLING,
-    ABILITY_SHIELDS_DOWN,
-    ABILITY_STANCE_CHANGE,
-    ABILITY_TRACE,
-    ABILITY_WONDER_GUARD,
-    ABILITY_ZEN_MODE,
-    ABILITY_ZERO_TO_HERO,
-};
-
-static const u16 sRolePlayDoodleBannedAttackerAbilities[] =
-{
-    ABILITY_AS_ONE_ICE_RIDER,
-    ABILITY_AS_ONE_SHADOW_RIDER,
-    ABILITY_BATTLE_BOND,
-    ABILITY_COMATOSE,
-    ABILITY_COMMANDER,
-    ABILITY_DISGUISE,
-    ABILITY_GULP_MISSILE,
-    ABILITY_HADRON_ENGINE,
-    ABILITY_ICE_FACE,
-    ABILITY_MULTITYPE,
-    ABILITY_ORICHALCUM_PULSE,
-    ABILITY_POWER_CONSTRUCT,
-    ABILITY_PROTOSYNTHESIS,
-    ABILITY_QUARK_DRIVE,
-    ABILITY_RKS_SYSTEM,
-    ABILITY_SCHOOLING,
-    ABILITY_SHIELDS_DOWN,
-    ABILITY_STANCE_CHANGE,
-    ABILITY_ZEN_MODE,
-    ABILITY_ZERO_TO_HERO,
-};
-
 static u8 CalcBeatUpPower(void)
 {
     u8 basePower;
@@ -10683,29 +10625,6 @@ bool32 CanFling(u32 battler)
         return FALSE;
 
     return TRUE;
-}
-
-// Ability checks
-bool32 IsRolePlayDoodleBannedAbility(u16 ability)
-{
-    u32 i;
-    for (i = 0; i < ARRAY_COUNT(sRolePlayDoodleBannedAbilities); i++)
-    {
-        if (ability == sRolePlayDoodleBannedAbilities[i])
-            return TRUE;
-    }
-    return FALSE;
-}
-
-bool32 IsRolePlayDoodleBannedAbilityAttacker(u16 ability)
-{
-    u32 i;
-    for (i = 0; i < ARRAY_COUNT(sRolePlayDoodleBannedAttackerAbilities); i++)
-    {
-        if (ability == sRolePlayDoodleBannedAttackerAbilities[i])
-            return TRUE;
-    }
-    return FALSE;
 }
 
 // Sort an array of battlers by speed

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -5133,34 +5133,22 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
              && IsBattlerAlive(gBattlerAttacker)
              && TARGET_TURN_DAMAGED
              && IsMoveMakingContact(move, gBattlerAttacker)
-             && gBattleStruct->overwrittenAbilities[gBattlerAttacker] != GetBattlerAbility(gBattlerTarget))
+             && gBattleStruct->overwrittenAbilities[gBattlerAttacker] != GetBattlerAbility(gBattlerTarget)
+             && gBattleMons[gBattlerTarget].ability != ABILITY_MUMMY
+             && gBattleMons[gBattlerTarget].ability != ABILITY_LINGERING_AROMA
+             && !gAbilities[gBattleMons[gBattlerTarget].ability].cantBeSuppressed)
             {
-                switch (gBattleMons[gBattlerAttacker].ability)
+                if (GetBattlerHoldEffect(gBattlerAttacker, TRUE) == HOLD_EFFECT_ABILITY_SHIELD)
                 {
-                case ABILITY_MUMMY:
-                case ABILITY_BATTLE_BOND:
-                case ABILITY_COMATOSE:
-                case ABILITY_DISGUISE:
-                case ABILITY_MULTITYPE:
-                case ABILITY_POWER_CONSTRUCT:
-                case ABILITY_RKS_SYSTEM:
-                case ABILITY_SCHOOLING:
-                case ABILITY_SHIELDS_DOWN:
-                case ABILITY_STANCE_CHANGE:
-                    break;
-                default:
-                    if (GetBattlerHoldEffect(gBattlerAttacker, TRUE) == HOLD_EFFECT_ABILITY_SHIELD)
-                    {
-                        RecordItemEffectBattle(gBattlerAttacker, HOLD_EFFECT_ABILITY_SHIELD);
-                        break;
-                    }
-
-                    gLastUsedAbility = gBattleMons[gBattlerAttacker].ability = gBattleStruct->overwrittenAbilities[gBattlerAttacker] = gBattleMons[gBattlerTarget].ability;
-                    BattleScriptPushCursor();
-                    gBattlescriptCurrInstr = BattleScript_MummyActivates;
-                    effect++;
+                    RecordItemEffectBattle(gBattlerAttacker, HOLD_EFFECT_ABILITY_SHIELD);
                     break;
                 }
+
+                gLastUsedAbility = gBattleMons[gBattlerAttacker].ability = gBattleStruct->overwrittenAbilities[gBattlerAttacker] = gBattleMons[gBattlerTarget].ability;
+                BattleScriptPushCursor();
+                gBattlescriptCurrInstr = BattleScript_MummyActivates;
+                effect++;
+                break;
             }
             break;
         case ABILITY_WANDERING_SPIRIT:
@@ -5168,40 +5156,22 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
              && IsBattlerAlive(gBattlerAttacker)
              && TARGET_TURN_DAMAGED
              && IsMoveMakingContact(move, gBattlerAttacker)
-             && !IsDynamaxed(gBattlerTarget))
+             && !IsDynamaxed(gBattlerTarget)
+             && !gAbilities[gBattleMons[gBattlerAttacker].ability].cantBeTransferred)
             {
-                switch (gBattleMons[gBattlerAttacker].ability)
+                if (GetBattlerHoldEffect(gBattlerAttacker, TRUE) == HOLD_EFFECT_ABILITY_SHIELD)
                 {
-                case ABILITY_DISGUISE:
-                case ABILITY_FLOWER_GIFT:
-                case ABILITY_GULP_MISSILE:
-                case ABILITY_HUNGER_SWITCH:
-                case ABILITY_ICE_FACE:
-                case ABILITY_ILLUSION:
-                case ABILITY_IMPOSTER:
-                case ABILITY_RECEIVER:
-                case ABILITY_RKS_SYSTEM:
-                case ABILITY_SCHOOLING:
-                case ABILITY_STANCE_CHANGE:
-                case ABILITY_WONDER_GUARD:
-                case ABILITY_ZEN_MODE:
-                case ABILITY_ZERO_TO_HERO:
-                    break;
-                default:
-                    if (GetBattlerHoldEffect(gBattlerAttacker, TRUE) == HOLD_EFFECT_ABILITY_SHIELD)
-                    {
-                        RecordItemEffectBattle(gBattlerAttacker, HOLD_EFFECT_ABILITY_SHIELD);
-                        break;
-                    }
-
-                    gLastUsedAbility = gBattleMons[gBattlerAttacker].ability;
-                    gBattleMons[gBattlerAttacker].ability = gBattleStruct->overwrittenAbilities[gBattlerAttacker] = gBattleMons[gBattlerTarget].ability;
-                    gBattleMons[gBattlerTarget].ability = gBattleStruct->overwrittenAbilities[gBattlerTarget] = gLastUsedAbility;
-                    BattleScriptPushCursor();
-                    gBattlescriptCurrInstr = BattleScript_WanderingSpiritActivates;
-                    effect++;
+                    RecordItemEffectBattle(gBattlerAttacker, HOLD_EFFECT_ABILITY_SHIELD);
                     break;
                 }
+
+                gLastUsedAbility = gBattleMons[gBattlerAttacker].ability;
+                gBattleMons[gBattlerAttacker].ability = gBattleStruct->overwrittenAbilities[gBattlerAttacker] = gBattleMons[gBattlerTarget].ability;
+                gBattleMons[gBattlerTarget].ability = gBattleStruct->overwrittenAbilities[gBattlerTarget] = gLastUsedAbility;
+                BattleScriptPushCursor();
+                gBattlescriptCurrInstr = BattleScript_WanderingSpiritActivates;
+                effect++;
+                break;
             }
             break;
         case ABILITY_ANGER_POINT:
@@ -5998,35 +5968,6 @@ bool32 TryPrimalReversion(u32 battler)
     return FALSE;
 }
 
-static const u16 sNeutralizingGasBannedAbilities[] =
-{
-    ABILITY_AS_ONE_ICE_RIDER,
-    ABILITY_AS_ONE_SHADOW_RIDER,
-    ABILITY_COMATOSE,
-    ABILITY_DISGUISE,
-    ABILITY_GULP_MISSILE,
-    ABILITY_ICE_FACE,
-    ABILITY_MULTITYPE,
-    ABILITY_POWER_CONSTRUCT,
-    ABILITY_RKS_SYSTEM,
-    ABILITY_SCHOOLING,
-    ABILITY_SHIELDS_DOWN,
-    ABILITY_STANCE_CHANGE,
-    ABILITY_ZEN_MODE,
-    ABILITY_ZERO_TO_HERO,
-};
-
-bool32 IsNeutralizingGasBannedAbility(u16 ability)
-{
-    u32 i;
-    for (i = 0; i < ARRAY_COUNT(sNeutralizingGasBannedAbilities); i++)
-    {
-        if (ability == sNeutralizingGasBannedAbilities[i])
-            return TRUE;
-    }
-    return FALSE;
-}
-
 bool32 IsNeutralizingGasOnField(void)
 {
     u32 i;
@@ -6060,10 +6001,13 @@ bool32 IsMoldBreakerTypeAbility(u32 ability)
 
 u32 GetBattlerAbility(u32 battler)
 {
+    if (gAbilities[gBattleMons[battler].ability].cantBeSuppressed)
+        return gBattleMons[battler].ability;
+
     if (gStatuses3[battler] & STATUS3_GASTRO_ACID)
         return ABILITY_NONE;
 
-    if (IsNeutralizingGasOnField() && !IsNeutralizingGasBannedAbility(gBattleMons[battler].ability))
+    if (IsNeutralizingGasOnField() && gBattleMons[battler].ability != ABILITY_NEUTRALIZING_GAS)
         return ABILITY_NONE;
 
     if (IsMyceliumMightOnField())

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -94,34 +94,6 @@ static const u8 sPkblToEscapeFactor[][3] = {
 static const u8 sGoNearCounterToCatchFactor[] = {4, 3, 2, 1};
 static const u8 sGoNearCounterToEscapeFactor[] = {4, 4, 4, 4};
 
-static const u16 sSkillSwapBannedAbilities[] =
-{
-    ABILITY_AS_ONE_ICE_RIDER,
-    ABILITY_AS_ONE_SHADOW_RIDER,
-    ABILITY_BATTLE_BOND,
-    ABILITY_COMATOSE,
-    ABILITY_COMMANDER,
-    ABILITY_DISGUISE,
-    ABILITY_GULP_MISSILE,
-    ABILITY_HADRON_ENGINE,
-    ABILITY_HUNGER_SWITCH,
-    ABILITY_ICE_FACE,
-    ABILITY_ILLUSION,
-    ABILITY_MULTITYPE,
-    ABILITY_NEUTRALIZING_GAS,
-    ABILITY_ORICHALCUM_PULSE,
-    ABILITY_POWER_CONSTRUCT,
-    ABILITY_PROTOSYNTHESIS,
-    ABILITY_QUARK_DRIVE,
-    ABILITY_RKS_SYSTEM,
-    ABILITY_SCHOOLING,
-    ABILITY_SHIELDS_DOWN,
-    ABILITY_STANCE_CHANGE,
-    ABILITY_WONDER_GUARD,
-    ABILITY_ZEN_MODE,
-    ABILITY_ZERO_TO_HERO,
-};
-
 static const u16 sRolePlayDoodleBannedAbilities[] =
 {
     ABILITY_AS_ONE_ICE_RIDER,
@@ -10714,17 +10686,6 @@ bool32 CanFling(u32 battler)
 }
 
 // Ability checks
-bool32 IsSkillSwapBannedAbility(u16 ability)
-{
-    u32 i;
-    for (i = 0; i < ARRAY_COUNT(sSkillSwapBannedAbilities); i++)
-    {
-        if (ability == sSkillSwapBannedAbilities[i])
-            return TRUE;
-    }
-    return FALSE;
-}
-
 bool32 IsRolePlayDoodleBannedAbility(u16 ability)
 {
     u32 i;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -180,54 +180,6 @@ static const u16 sRolePlayDoodleBannedAttackerAbilities[] =
     ABILITY_ZERO_TO_HERO,
 };
 
-static const u16 sWorrySeedBannedAbilities[] =
-{
-    ABILITY_AS_ONE_ICE_RIDER,
-    ABILITY_AS_ONE_SHADOW_RIDER,
-    ABILITY_BATTLE_BOND,
-    ABILITY_COMATOSE,
-    ABILITY_COMMANDER,
-    ABILITY_DISGUISE,
-    ABILITY_GULP_MISSILE,
-    ABILITY_HADRON_ENGINE,
-    ABILITY_ICE_FACE,
-    ABILITY_INSOMNIA,
-    ABILITY_MULTITYPE,
-    ABILITY_ORICHALCUM_PULSE,
-    ABILITY_POWER_CONSTRUCT,
-    ABILITY_PROTOSYNTHESIS,
-    ABILITY_QUARK_DRIVE,
-    ABILITY_RKS_SYSTEM,
-    ABILITY_SCHOOLING,
-    ABILITY_SHIELDS_DOWN,
-    ABILITY_STANCE_CHANGE,
-    ABILITY_TRUANT,
-    ABILITY_ZEN_MODE,
-    ABILITY_ZERO_TO_HERO,
-};
-
-static const u16 sGastroAcidBannedAbilities[] =
-{
-    ABILITY_AS_ONE_ICE_RIDER,
-    ABILITY_AS_ONE_SHADOW_RIDER,
-    ABILITY_BATTLE_BOND,
-    ABILITY_COMATOSE,
-    ABILITY_COMMANDER,
-    ABILITY_DISGUISE,
-    ABILITY_GULP_MISSILE,
-    ABILITY_HADRON_ENGINE,
-    ABILITY_ICE_FACE,
-    ABILITY_MULTITYPE,
-    ABILITY_ORICHALCUM_PULSE,
-    ABILITY_POWER_CONSTRUCT,
-    ABILITY_RKS_SYSTEM,
-    ABILITY_SCHOOLING,
-    ABILITY_SHIELDS_DOWN,
-    ABILITY_STANCE_CHANGE,
-    ABILITY_ZEN_MODE,
-    ABILITY_ZERO_TO_HERO,
-};
-
 static const u16 sEntrainmentBannedAbilities[] =
 {
     ABILITY_AS_ONE_ICE_RIDER,
@@ -282,32 +234,6 @@ static const u16 sEntrainmentBannedAttackerAbilities[] =
     ABILITY_SHIELDS_DOWN,
     ABILITY_STANCE_CHANGE,
     ABILITY_TRACE,
-    ABILITY_ZEN_MODE,
-    ABILITY_ZERO_TO_HERO,
-};
-
-static const u16 sSimpleBeamBannedAbilities[] =
-{
-    ABILITY_AS_ONE_ICE_RIDER,
-    ABILITY_AS_ONE_SHADOW_RIDER,
-    ABILITY_BATTLE_BOND,
-    ABILITY_COMATOSE,
-    ABILITY_COMMANDER,
-    ABILITY_DISGUISE,
-    ABILITY_GULP_MISSILE,
-    ABILITY_HADRON_ENGINE,
-    ABILITY_ICE_FACE,
-    ABILITY_MULTITYPE,
-    ABILITY_ORICHALCUM_PULSE,
-    ABILITY_POWER_CONSTRUCT,
-    ABILITY_PROTOSYNTHESIS,
-    ABILITY_QUARK_DRIVE,
-    ABILITY_RKS_SYSTEM,
-    ABILITY_SCHOOLING,
-    ABILITY_SHIELDS_DOWN,
-    ABILITY_SIMPLE,
-    ABILITY_STANCE_CHANGE,
-    ABILITY_TRUANT,
     ABILITY_ZEN_MODE,
     ABILITY_ZERO_TO_HERO,
 };
@@ -10879,28 +10805,6 @@ bool32 IsRolePlayDoodleBannedAbilityAttacker(u16 ability)
     return FALSE;
 }
 
-bool32 IsWorrySeedBannedAbility(u16 ability)
-{
-    u32 i;
-    for (i = 0; i < ARRAY_COUNT(sWorrySeedBannedAbilities); i++)
-    {
-        if (ability == sWorrySeedBannedAbilities[i])
-            return TRUE;
-    }
-    return FALSE;
-}
-
-bool32 IsGastroAcidBannedAbility(u16 ability)
-{
-    u32 i;
-    for (i = 0; i < ARRAY_COUNT(sGastroAcidBannedAbilities); i++)
-    {
-        if (ability == sGastroAcidBannedAbilities[i])
-            return TRUE;
-    }
-    return FALSE;
-}
-
 bool32 IsEntrainmentBannedAbility(u16 ability)
 {
     u32 i;
@@ -10918,17 +10822,6 @@ bool32 IsEntrainmentBannedAbilityAttacker(u16 ability)
     for (i = 0; i < ARRAY_COUNT(sEntrainmentBannedAttackerAbilities); i++)
     {
         if (ability == sEntrainmentBannedAttackerAbilities[i])
-            return TRUE;
-    }
-    return FALSE;
-}
-
-bool32 IsSimpleBeamBannedAbility(u16 ability)
-{
-    u32 i;
-    for (i = 0; i < ARRAY_COUNT(sSimpleBeamBannedAbilities); i++)
-    {
-        if (ability == sSimpleBeamBannedAbilities[i])
             return TRUE;
     }
     return FALSE;

--- a/src/data/abilities.h
+++ b/src/data/abilities.h
@@ -5,7 +5,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("-------"),
         .description = COMPOUND_STRING("No special ability."),
         .aiRating = 0,
-        .cantBeTransferred = TRUE,
+        .cantBeSwapped = TRUE,
         .cantBeTraced = TRUE,
     },
 
@@ -35,7 +35,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Battle Armor"),
         .description = COMPOUND_STRING("Blocks critical hits."),
         .aiRating = 2,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_STURDY] =
@@ -43,7 +43,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Sturdy"),
         .description = COMPOUND_STRING("Negates 1-hit KO attacks."),
         .aiRating = 6,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_DAMP] =
@@ -51,7 +51,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Damp"),
         .description = COMPOUND_STRING("Prevents self-destruction."),
         .aiRating = 2,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_LIMBER] =
@@ -59,7 +59,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Limber"),
         .description = COMPOUND_STRING("Prevents paralysis."),
         .aiRating = 3,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_SAND_VEIL] =
@@ -67,7 +67,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Sand Veil"),
         .description = COMPOUND_STRING("Ups evasion in a sandstorm."),
         .aiRating = 3,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_STATIC] =
@@ -82,7 +82,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Volt Absorb"),
         .description = COMPOUND_STRING("Turns electricity into HP."),
         .aiRating = 7,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_WATER_ABSORB] =
@@ -90,7 +90,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Water Absorb"),
         .description = COMPOUND_STRING("Changes water into HP."),
         .aiRating = 7,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_OBLIVIOUS] =
@@ -98,7 +98,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Oblivious"),
         .description = COMPOUND_STRING("Prevents attraction."),
         .aiRating = 2,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_CLOUD_NINE] =
@@ -124,7 +124,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Insomnia"),
         .description = COMPOUND_STRING("Prevents sleep."),
         .aiRating = 4,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_COLOR_CHANGE] =
@@ -139,7 +139,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Immunity"),
         .description = COMPOUND_STRING("Prevents poisoning."),
         .aiRating = 4,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_FLASH_FIRE] =
@@ -147,7 +147,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Flash Fire"),
         .description = COMPOUND_STRING("Powers up if hit by fire."),
         .aiRating = 6,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_SHIELD_DUST] =
@@ -155,7 +155,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Shield Dust"),
         .description = COMPOUND_STRING("Prevents added effects."),
         .aiRating = 5,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_OWN_TEMPO] =
@@ -163,7 +163,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Own Tempo"),
         .description = COMPOUND_STRING("Prevents confusion."),
         .aiRating = 3,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_SUCTION_CUPS] =
@@ -171,7 +171,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Suction Cups"),
         .description = COMPOUND_STRING("Firmly anchors the body."),
         .aiRating = 2,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_INTIMIDATE] =
@@ -201,8 +201,8 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .description = COMPOUND_STRING("“Supereffective” hits."),
         .aiRating = 10,
         .cantBeCopied = TRUE,
-        .cantBeTransferred = TRUE,
-        .canBeIgnored = TRUE,
+        .cantBeSwapped = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_LEVITATE] =
@@ -210,7 +210,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Levitate"),
         .description = COMPOUND_STRING("Not hit by Ground attacks."),
         .aiRating = 7,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_EFFECT_SPORE] =
@@ -232,7 +232,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Clear Body"),
         .description = COMPOUND_STRING("Prevents ability reduction."),
         .aiRating = 4,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_NATURAL_CURE] =
@@ -251,7 +251,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Draws electrical moves."),
         .aiRating = 7,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_SERENE_GRACE] =
@@ -280,7 +280,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Illuminate"),
         .description = COMPOUND_STRING("Encounter rate increases."),
         .aiRating = 0,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_TRACE] =
@@ -311,7 +311,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Inner Focus"),
         .description = COMPOUND_STRING("Prevents flinching."),
         .aiRating = 2,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_MAGMA_ARMOR] =
@@ -319,7 +319,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Magma Armor"),
         .description = COMPOUND_STRING("Prevents freezing."),
         .aiRating = 1,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_WATER_VEIL] =
@@ -327,7 +327,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Water Veil"),
         .description = COMPOUND_STRING("Prevents burns."),
         .aiRating = 4,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_MAGNET_PULL] =
@@ -342,7 +342,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Soundproof"),
         .description = COMPOUND_STRING("Avoids sound-based moves."),
         .aiRating = 4,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_RAIN_DISH] =
@@ -371,7 +371,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Thick Fat"),
         .description = COMPOUND_STRING("Heat-and-cold protection."),
         .aiRating = 7,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_EARLY_BIRD] =
@@ -400,7 +400,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Keen Eye"),
         .description = COMPOUND_STRING("Prevents loss of accuracy."),
         .aiRating = 1,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_HYPER_CUTTER] =
@@ -408,7 +408,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Hyper Cutter"),
         .description = COMPOUND_STRING("Prevents Attack reduction."),
         .aiRating = 3,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_PICKUP] =
@@ -468,7 +468,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Sticky Hold"),
         .description = COMPOUND_STRING("Prevents item theft."),
         .aiRating = 3,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_SHED_SKIN] =
@@ -490,7 +490,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Marvel Scale"),
         .description = COMPOUND_STRING("Ups Defense if suffering."),
         .aiRating = 5,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_LIQUID_OOZE] =
@@ -554,7 +554,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Vital Spirit"),
         .description = COMPOUND_STRING("Prevents sleep."),
         .aiRating = 4,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_WHITE_SMOKE] =
@@ -562,7 +562,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("White Smoke"),
         .description = COMPOUND_STRING("Prevents ability reduction."),
         .aiRating = 4,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_PURE_POWER] =
@@ -577,7 +577,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Shell Armor"),
         .description = COMPOUND_STRING("Blocks critical hits."),
         .aiRating = 2,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_AIR_LOCK] =
@@ -592,7 +592,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Tangled Feet"),
         .description = COMPOUND_STRING("Ups evasion if confused."),
         .aiRating = 2,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_MOTOR_DRIVE] =
@@ -600,7 +600,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Motor Drive"),
         .description = COMPOUND_STRING("Electricity raises Speed."),
         .aiRating = 6,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_RIVALRY] =
@@ -622,7 +622,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Snow Cloak"),
         .description = COMPOUND_STRING("Ups evasion in Hail or Snow."),
         .aiRating = 3,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_GLUTTONY] =
@@ -651,7 +651,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Heatproof"),
         .description = COMPOUND_STRING("Heat and burn protection."),
         .aiRating = 5,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_SIMPLE] =
@@ -659,7 +659,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Simple"),
         .description = COMPOUND_STRING("Prone to wild stat changes."),
         .aiRating = 8,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_DRY_SKIN] =
@@ -667,7 +667,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Dry Skin"),
         .description = COMPOUND_STRING("Prefers moisture to heat."),
         .aiRating = 6,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_DOWNLOAD] =
@@ -773,7 +773,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Leaf Guard"),
         .description = COMPOUND_STRING("Blocks status in sunshine."),
         .aiRating = 2,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_KLUTZ] =
@@ -823,7 +823,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Unaware"),
         .description = COMPOUND_STRING("Ignores stat changes."),
         .aiRating = 6,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_TINTED_LENS] =
@@ -838,7 +838,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Filter"),
         .description = COMPOUND_STRING("Weakens “supereffective”."),
         .aiRating = 6,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_SLOW_START] =
@@ -860,7 +860,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Storm Drain"),
         .description = COMPOUND_STRING("Draws in Water moves."),
         .aiRating = 7,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_ICE_BODY] =
@@ -875,7 +875,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Solid Rock"),
         .description = COMPOUND_STRING("Weakens “supereffective”."),
         .aiRating = 6,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_SNOW_WARNING] =
@@ -912,7 +912,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .description = COMPOUND_STRING("Changes type to its Plate."),
         .aiRating = 8,
         .cantBeCopied = TRUE,
-        .cantBeTransferred = TRUE,
+        .cantBeSwapped = TRUE,
         .cantBeTraced = TRUE,
         .cantBeSuppressed = TRUE,
         .cantBeOverwritten = TRUE,
@@ -925,7 +925,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .aiRating = 4,
         .cantBeCopied = TRUE,
         .cantBeTraced = TRUE,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_BAD_DREAMS] =
@@ -954,7 +954,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Contrary"),
         .description = COMPOUND_STRING("Inverts stat changes."),
         .aiRating = 8,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_UNNERVE] =
@@ -997,7 +997,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Friend Guard"),
         .description = COMPOUND_STRING("Lowers damage to partner."),
         .aiRating = 0,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_WEAK_ARMOR] =
@@ -1012,7 +1012,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Heavy Metal"),
         .description = COMPOUND_STRING("Doubles weight."),
         .aiRating = -1,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_LIGHT_METAL] =
@@ -1020,7 +1020,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Light Metal"),
         .description = COMPOUND_STRING("Halves weight."),
         .aiRating = 2,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_MULTISCALE] =
@@ -1028,7 +1028,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Multiscale"),
         .description = COMPOUND_STRING("Halves damage at full HP."),
         .aiRating = 8,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_TOXIC_BOOST] =
@@ -1057,7 +1057,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Telepathy"),
         .description = COMPOUND_STRING("Can't be damaged by an ally."),
         .aiRating = 0,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_MOODY] =
@@ -1072,7 +1072,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Overcoat"),
         .description = COMPOUND_STRING("Blocks weather and powder."),
         .aiRating = 5,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_POISON_TOUCH] =
@@ -1094,7 +1094,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Big Pecks"),
         .description = COMPOUND_STRING("Prevents Defense loss."),
         .aiRating = 1,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_SAND_RUSH] =
@@ -1109,7 +1109,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Wonder Skin"),
         .description = COMPOUND_STRING("May avoid status problems."),
         .aiRating = 4,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_ANALYTIC] =
@@ -1125,7 +1125,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .description = COMPOUND_STRING("Appears as a partner."),
         .aiRating = 8,
         .cantBeCopied = TRUE,
-        .cantBeTransferred = TRUE,
+        .cantBeSwapped = TRUE,
         .cantBeTraced = TRUE,
     },
 
@@ -1178,7 +1178,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Magic Bounce"),
         .description = COMPOUND_STRING("Reflects status moves."),
         .aiRating = 9,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_SAP_SIPPER] =
@@ -1186,7 +1186,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Sap Sipper"),
         .description = COMPOUND_STRING("Grass increases Attack."),
         .aiRating = 7,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_PRANKSTER] =
@@ -1216,7 +1216,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .description = COMPOUND_STRING("Transforms at half HP."),
         .aiRating = -1,
         .cantBeCopied = TRUE,
-        .cantBeTransferred = TRUE,
+        .cantBeSwapped = TRUE,
         .cantBeTraced = TRUE,
         .cantBeSuppressed = B_UPDATED_ABILITY_DATA >= GEN_7,
     },
@@ -1247,7 +1247,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Aroma Veil"),
         .description = COMPOUND_STRING("Prevents limiting of moves."),
         .aiRating = 3,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_FLOWER_VEIL] =
@@ -1318,7 +1318,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Sweet Veil"),
         .description = COMPOUND_STRING("Prevents party from sleep."),
         .aiRating = 4,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_STANCE_CHANGE] =
@@ -1331,7 +1331,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .description = COMPOUND_STRING("Transforms as it battles."),
         .aiRating = 10,
         .cantBeCopied = TRUE,
-        .cantBeTransferred = TRUE,
+        .cantBeSwapped = TRUE,
         .cantBeTraced = TRUE,
         .cantBeSuppressed = TRUE,
         .cantBeOverwritten = TRUE,
@@ -1360,7 +1360,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Grass Pelt"),
         .description = COMPOUND_STRING("Ups Defense in grass."),
         .aiRating = 2,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_SYMBIOSIS] =
@@ -1508,7 +1508,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .description = COMPOUND_STRING("Shell breaks at half HP."),
         .aiRating = 6,
         .cantBeCopied = TRUE,
-        .cantBeTransferred = TRUE,
+        .cantBeSwapped = TRUE,
         .cantBeTraced = TRUE,
         .cantBeSuppressed = TRUE,
         .cantBeOverwritten = TRUE,
@@ -1590,7 +1590,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .description = COMPOUND_STRING("Forms a school when strong."),
         .aiRating = 6,
         .cantBeCopied = TRUE,
-        .cantBeTransferred = TRUE,
+        .cantBeSwapped = TRUE,
         .cantBeTraced = TRUE,
         .cantBeSuppressed = TRUE,
         .cantBeOverwritten = TRUE,
@@ -1602,7 +1602,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .description = COMPOUND_STRING("Decoy protects it once."),
         .aiRating = 8,
         .cantBeCopied = TRUE,
-        .cantBeTransferred = TRUE,
+        .cantBeSwapped = TRUE,
         .cantBeTraced = TRUE,
         .cantBeSuppressed = TRUE,
         .cantBeOverwritten = TRUE,
@@ -1615,7 +1615,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .description = COMPOUND_STRING("Changes form after a KO."),
         .aiRating = 6,
         .cantBeCopied = TRUE,
-        .cantBeTransferred = TRUE,
+        .cantBeSwapped = TRUE,
         .cantBeTraced = TRUE,
         .cantBeSuppressed = TRUE,
         .cantBeOverwritten = TRUE,
@@ -1631,7 +1631,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .description = COMPOUND_STRING("Cells aid it when weakened."),
         .aiRating = 10,
         .cantBeCopied = TRUE,
-        .cantBeTransferred = TRUE,
+        .cantBeSwapped = TRUE,
         .cantBeTraced = TRUE,
         .cantBeSuppressed = TRUE,
         .cantBeOverwritten = TRUE,
@@ -1650,7 +1650,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .description = COMPOUND_STRING("Always drowsing."),
         .aiRating = 6,
         .cantBeCopied = TRUE,
-        .cantBeTransferred = TRUE,
+        .cantBeSwapped = TRUE,
         .cantBeTraced = TRUE,
         .cantBeSuppressed = TRUE,
         .cantBeOverwritten = TRUE,
@@ -1665,7 +1665,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Protects from priority."),
         .aiRating = 6,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_INNARDS_OUT] =
@@ -1694,7 +1694,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Fluffy"),
         .description = COMPOUND_STRING("Tougher but flammable."),
         .aiRating = 5,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_DAZZLING] =
@@ -1702,7 +1702,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Dazzling"),
         .description = COMPOUND_STRING("Protects from priority."),
         .aiRating = 5,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_SOUL_HEART] =
@@ -1758,7 +1758,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .description = COMPOUND_STRING("Memories change its type."),
         .aiRating = 8,
         .cantBeCopied = TRUE,
-        .cantBeTransferred = TRUE,
+        .cantBeSwapped = TRUE,
         .cantBeTraced = TRUE,
         .cantBeSuppressed = TRUE,
         .cantBeOverwritten = TRUE,
@@ -1894,7 +1894,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Mirror Armor"),
         .description = COMPOUND_STRING("Reflect stat decreases."),
         .aiRating = 6,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_GULP_MISSILE] =
@@ -1926,7 +1926,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Punk Rock"),
         .description = COMPOUND_STRING("Ups and resists sound."),
         .aiRating = 2,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_SAND_SPIT] =
@@ -1941,7 +1941,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Ice Scales"),
         .description = COMPOUND_STRING("Halves special damage."),
         .aiRating = 7,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_RIPEN] =
@@ -1957,11 +1957,11 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .description = COMPOUND_STRING("Hail or Snow renew free hit."),
         .aiRating = 4,
         .cantBeCopied = TRUE,
-        .cantBeTransferred = TRUE,
+        .cantBeSwapped = TRUE,
         .cantBeTraced = TRUE,
         .cantBeSuppressed = TRUE,
         .cantBeOverwritten = TRUE,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
         .failsOnImposter = TRUE,
     },
 
@@ -2040,7 +2040,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .description = COMPOUND_STRING("All Abilities are nullified."),
         .aiRating = 5,
         .cantBeCopied = TRUE,
-        .cantBeTransferred = TRUE,
+        .cantBeSwapped = TRUE,
         .cantBeTraced = TRUE,
         .failsOnImposter = TRUE,
     },
@@ -2050,7 +2050,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Pastel Veil"),
         .description = COMPOUND_STRING("Protects team from poison."),
         .aiRating = 4,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_HUNGER_SWITCH] =
@@ -2063,7 +2063,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .description = COMPOUND_STRING("Changes form each turn."),
         .aiRating = 2,
         .cantBeCopied = TRUE,
-        .cantBeTransferred = TRUE,
+        .cantBeSwapped = TRUE,
         .cantBeTraced = TRUE,
         .failsOnImposter = TRUE,
     },
@@ -2131,7 +2131,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .description = COMPOUND_STRING("Unnerve and Chilling Neigh."),
         .aiRating = 10,
         .cantBeCopied = TRUE,
-        .cantBeTransferred = TRUE,
+        .cantBeSwapped = TRUE,
         .cantBeTraced = TRUE,
         .cantBeSuppressed = TRUE,
         .cantBeOverwritten = TRUE,
@@ -2143,7 +2143,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .description = COMPOUND_STRING("Unnerve and Grim Neigh."),
         .aiRating = 10,
         .cantBeCopied = TRUE,
-        .cantBeTransferred = TRUE,
+        .cantBeSwapped = TRUE,
         .cantBeTraced = TRUE,
         .cantBeSuppressed = TRUE,
         .cantBeOverwritten = TRUE,
@@ -2176,7 +2176,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Fire hits up Attack."),
         .aiRating = 4,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_ANGER_SHELL] =
@@ -2195,7 +2195,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Protected by pure salts."),
         .aiRating = 6,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_WELL_BAKED_BODY] =
@@ -2207,7 +2207,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Strengthened by Fire."),
         .aiRating = 5,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_WIND_RIDER] =
@@ -2215,7 +2215,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Wind Rider"),
         .description = COMPOUND_STRING("Ups Attack if hit by wind."),
         .aiRating = 4,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_GUARD_DOG] =
@@ -2223,7 +2223,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Guard Dog"),
         .description = COMPOUND_STRING("Cannot be intimidated."),
         .aiRating = 5,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_ROCKY_PAYLOAD] =
@@ -2250,7 +2250,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .description = COMPOUND_STRING("Changes form on switch out."),
         .aiRating = 10,
         .cantBeCopied = TRUE,
-        .cantBeTransferred = TRUE,
+        .cantBeSwapped = TRUE,
         .cantBeTraced = TRUE,
         .cantBeSuppressed = TRUE,
         .cantBeOverwritten = TRUE,
@@ -2263,7 +2263,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .description = COMPOUND_STRING("Commands from Dondozo."),
         .aiRating = 10,
         .cantBeCopied = TRUE,
-        .cantBeTransferred = TRUE,
+        .cantBeSwapped = TRUE,
         .cantBeTraced = TRUE,
     },
 
@@ -2288,7 +2288,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .description = COMPOUND_STRING("Sun boosts best stat."),
         .aiRating = 7,
         .cantBeCopied = TRUE,
-        .cantBeTransferred = TRUE,
+        .cantBeSwapped = TRUE,
         .cantBeTraced = TRUE,
         .failsOnImposter = TRUE,
     },
@@ -2299,7 +2299,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .description = COMPOUND_STRING("Elec. field ups best stat."),
         .aiRating = 7,
         .cantBeCopied = TRUE,
-        .cantBeTransferred = TRUE,
+        .cantBeSwapped = TRUE,
         .cantBeTraced = TRUE,
         .failsOnImposter = TRUE,
     },
@@ -2309,7 +2309,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Good as Gold"),
         .description = COMPOUND_STRING("Avoids status problems."),
         .aiRating = 8,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_VESSEL_OF_RUIN] =
@@ -2321,7 +2321,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Lowers foes' sp. damage."),
         .aiRating = 5,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_SWORD_OF_RUIN] =
@@ -2333,7 +2333,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Lowers foes' Defense."),
         .aiRating = 5,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_TABLETS_OF_RUIN] =
@@ -2345,7 +2345,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Lowers foes' damage."),
         .aiRating = 5,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_BEADS_OF_RUIN] =
@@ -2357,7 +2357,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Lowers foes' Sp. Defense."),
         .aiRating = 5,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_ORICHALCUM_PULSE] =
@@ -2433,7 +2433,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Armor Tail"),
         .description = COMPOUND_STRING("Protects from priority."),
         .aiRating = 5,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_EARTH_EATER] =
@@ -2441,7 +2441,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Earth Eater"),
         .description = COMPOUND_STRING("Eats ground to heal HP."),
         .aiRating = 7,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_MYCELIUM_MIGHT] =
@@ -2467,7 +2467,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Mind's Eye"),
         .description = COMPOUND_STRING("Keen Eye and Scrappy."),
         .aiRating = 8,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_EMBODY_ASPECT_TEAL] =
@@ -2480,7 +2480,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .description = COMPOUND_STRING("Raises Speed."),
         .aiRating = 6,
         .cantBeCopied = TRUE,
-        .cantBeTransferred = TRUE,
+        .cantBeSwapped = TRUE,
         .cantBeTraced = TRUE,
         .failsOnImposter = TRUE,
     },
@@ -2495,7 +2495,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .description = COMPOUND_STRING("Raises Attack."),
         .aiRating = 6,
         .cantBeCopied = TRUE,
-        .cantBeTransferred = TRUE,
+        .cantBeSwapped = TRUE,
         .cantBeTraced = TRUE,
         .failsOnImposter = TRUE,
     },
@@ -2510,7 +2510,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .description = COMPOUND_STRING("Raises Sp. Def."),
         .aiRating = 6,
         .cantBeCopied = TRUE,
-        .cantBeTransferred = TRUE,
+        .cantBeSwapped = TRUE,
         .cantBeTraced = TRUE,
         .failsOnImposter = TRUE,
     },
@@ -2525,7 +2525,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .description = COMPOUND_STRING("Raises Defense."),
         .aiRating = 6,
         .cantBeCopied = TRUE,
-        .cantBeTransferred = TRUE,
+        .cantBeSwapped = TRUE,
         .cantBeTraced = TRUE,
         .failsOnImposter = TRUE,
     },
@@ -2554,7 +2554,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .description = COMPOUND_STRING("Terasteralizes upon entry."),
         .aiRating = 10,
         .cantBeCopied = TRUE,
-        .cantBeTransferred = TRUE,
+        .cantBeSwapped = TRUE,
         .cantBeTraced = TRUE,
         .cantBeSuppressed = TRUE,
         .cantBeOverwritten = TRUE,
@@ -2567,9 +2567,9 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .description = COMPOUND_STRING("Resistant to types at full HP."),
         .aiRating = 10,
         .cantBeCopied = TRUE,
-        .cantBeTransferred = TRUE,
+        .cantBeSwapped = TRUE,
         .cantBeTraced = TRUE,
-        .canBeIgnored = TRUE,
+        .breakable = TRUE,
     },
 
     [ABILITY_TERAFORM_ZERO] =
@@ -2582,7 +2582,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .description = COMPOUND_STRING("Removes weather and terrain."),
         .aiRating = 10,
         .cantBeCopied = TRUE,
-        .cantBeTransferred = TRUE,
+        .cantBeSwapped = TRUE,
         .cantBeTraced = TRUE,
     },
 
@@ -2596,7 +2596,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .description = COMPOUND_STRING("Confuses poisoned foes."),
         .aiRating = 8,
         .cantBeCopied = TRUE,
-        .cantBeTransferred = TRUE,
+        .cantBeSwapped = TRUE,
         .cantBeTraced = TRUE,
     },
 };

--- a/src/data/abilities.h
+++ b/src/data/abilities.h
@@ -5,6 +5,8 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("-------"),
         .description = COMPOUND_STRING("No special ability."),
         .aiRating = 0,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
     },
 
     [ABILITY_STENCH] =
@@ -198,6 +200,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Wonder Guard"),
         .description = COMPOUND_STRING("“Supereffective” hits."),
         .aiRating = 10,
+        .cantBeCopied = TRUE,
         .cantBeTransferred = TRUE,
         .canBeIgnored = TRUE,
     },
@@ -285,7 +288,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Trace"),
         .description = COMPOUND_STRING("Copies special ability."),
         .aiRating = 6,
-        .cantBeTransferred = TRUE,
+        .cantBeCopied = TRUE,
         .cantBeTraced = TRUE,
     },
 
@@ -420,6 +423,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Truant"),
         .description = COMPOUND_STRING("Moves only every two turns."),
         .aiRating = -2,
+        .cantBeOverwritten = TRUE,
     },
 
     [ABILITY_HUSTLE] =
@@ -455,7 +459,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Forecast"),
         .description = COMPOUND_STRING("Changes with the weather."),
         .aiRating = 6,
-        .cantBeTransferred = TRUE,
+        .cantBeCopied = TRUE,
         .cantBeTraced = TRUE,
     },
 
@@ -907,9 +911,11 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Multitype"),
         .description = COMPOUND_STRING("Changes type to its Plate."),
         .aiRating = 8,
+        .cantBeCopied = TRUE,
         .cantBeTransferred = TRUE,
         .cantBeTraced = TRUE,
         .cantBeSuppressed = TRUE,
+        .cantBeOverwritten = TRUE,
     },
 
     [ABILITY_FLOWER_GIFT] =
@@ -917,7 +923,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Flower Gift"),
         .description = COMPOUND_STRING("Allies power up in sunshine."),
         .aiRating = 4,
-        .cantBeTransferred = TRUE,
+        .cantBeCopied = TRUE,
         .cantBeTraced = TRUE,
         .canBeIgnored = TRUE,
     },
@@ -1118,6 +1124,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Illusion"),
         .description = COMPOUND_STRING("Appears as a partner."),
         .aiRating = 8,
+        .cantBeCopied = TRUE,
         .cantBeTransferred = TRUE,
         .cantBeTraced = TRUE,
     },
@@ -1127,7 +1134,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Imposter"),
         .description = COMPOUND_STRING("Transforms into the foe."),
         .aiRating = 9,
-        .cantBeTransferred = TRUE,
+        .cantBeCopied = TRUE,
         .cantBeTraced = TRUE,
     },
 
@@ -1208,6 +1215,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Zen Mode"),
         .description = COMPOUND_STRING("Transforms at half HP."),
         .aiRating = -1,
+        .cantBeCopied = TRUE,
         .cantBeTransferred = TRUE,
         .cantBeTraced = TRUE,
         .cantBeSuppressed = B_UPDATED_ABILITY_DATA >= GEN_7,
@@ -1322,9 +1330,11 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Transforms as it battles."),
         .aiRating = 10,
+        .cantBeCopied = TRUE,
         .cantBeTransferred = TRUE,
         .cantBeTraced = TRUE,
         .cantBeSuppressed = TRUE,
+        .cantBeOverwritten = TRUE,
     },
 
     [ABILITY_GALE_WINGS] =
@@ -1497,9 +1507,11 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Shields Down"),
         .description = COMPOUND_STRING("Shell breaks at half HP."),
         .aiRating = 6,
+        .cantBeCopied = TRUE,
         .cantBeTransferred = TRUE,
         .cantBeTraced = TRUE,
         .cantBeSuppressed = TRUE,
+        .cantBeOverwritten = TRUE,
     },
 
     [ABILITY_STAKEOUT] =
@@ -1577,9 +1589,11 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Schooling"),
         .description = COMPOUND_STRING("Forms a school when strong."),
         .aiRating = 6,
+        .cantBeCopied = TRUE,
         .cantBeTransferred = TRUE,
         .cantBeTraced = TRUE,
         .cantBeSuppressed = TRUE,
+        .cantBeOverwritten = TRUE,
     },
 
     [ABILITY_DISGUISE] =
@@ -1587,9 +1601,11 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Disguise"),
         .description = COMPOUND_STRING("Decoy protects it once."),
         .aiRating = 8,
+        .cantBeCopied = TRUE,
         .cantBeTransferred = TRUE,
         .cantBeTraced = TRUE,
         .cantBeSuppressed = TRUE,
+        .cantBeOverwritten = TRUE,
         .failsOnImposter = TRUE,
     },
 
@@ -1598,9 +1614,11 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Battle Bond"),
         .description = COMPOUND_STRING("Changes form after a KO."),
         .aiRating = 6,
+        .cantBeCopied = TRUE,
         .cantBeTransferred = TRUE,
         .cantBeTraced = TRUE,
         .cantBeSuppressed = TRUE,
+        .cantBeOverwritten = TRUE,
     },
 
     [ABILITY_POWER_CONSTRUCT] =
@@ -1612,9 +1630,11 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Cells aid it when weakened."),
         .aiRating = 10,
+        .cantBeCopied = TRUE,
         .cantBeTransferred = TRUE,
         .cantBeTraced = TRUE,
         .cantBeSuppressed = TRUE,
+        .cantBeOverwritten = TRUE,
     },
 
     [ABILITY_CORROSION] =
@@ -1629,9 +1649,11 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Comatose"),
         .description = COMPOUND_STRING("Always drowsing."),
         .aiRating = 6,
+        .cantBeCopied = TRUE,
         .cantBeTransferred = TRUE,
         .cantBeTraced = TRUE,
         .cantBeSuppressed = TRUE,
+        .cantBeOverwritten = TRUE,
     },
 
     [ABILITY_QUEENLY_MAJESTY] =
@@ -1706,7 +1728,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Receiver"),
         .description = COMPOUND_STRING("Copies ally's ability."),
         .aiRating = 0,
-        .cantBeTransferred = TRUE,
+        .cantBeCopied = TRUE,
         .cantBeTraced = TRUE,
     },
 
@@ -1719,7 +1741,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Copies ally's ability."),
         .aiRating = 0,
-        .cantBeTransferred = TRUE,
+        .cantBeCopied = TRUE,
         .cantBeTraced = TRUE,
     },
 
@@ -1735,9 +1757,11 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("RKS System"),
         .description = COMPOUND_STRING("Memories change its type."),
         .aiRating = 8,
+        .cantBeCopied = TRUE,
         .cantBeTransferred = TRUE,
         .cantBeTraced = TRUE,
         .cantBeSuppressed = TRUE,
+        .cantBeOverwritten = TRUE,
     },
 
     [ABILITY_ELECTRIC_SURGE] =
@@ -1879,6 +1903,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .description = COMPOUND_STRING("If hit, spits prey from sea."),
         .aiRating = 3,
         .cantBeSuppressed = TRUE,
+        .cantBeOverwritten = TRUE,
         .failsOnImposter = TRUE,
     },
 
@@ -1931,9 +1956,11 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Ice Face"),
         .description = COMPOUND_STRING("Hail or Snow renew free hit."),
         .aiRating = 4,
+        .cantBeCopied = TRUE,
         .cantBeTransferred = TRUE,
         .cantBeTraced = TRUE,
         .cantBeSuppressed = TRUE,
+        .cantBeOverwritten = TRUE,
         .canBeIgnored = TRUE,
         .failsOnImposter = TRUE,
     },
@@ -2012,6 +2039,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("All Abilities are nullified."),
         .aiRating = 5,
+        .cantBeCopied = TRUE,
         .cantBeTransferred = TRUE,
         .cantBeTraced = TRUE,
         .failsOnImposter = TRUE,
@@ -2034,6 +2062,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Changes form each turn."),
         .aiRating = 2,
+        .cantBeCopied = TRUE,
         .cantBeTransferred = TRUE,
         .cantBeTraced = TRUE,
         .failsOnImposter = TRUE,
@@ -2101,9 +2130,11 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("As One"),
         .description = COMPOUND_STRING("Unnerve and Chilling Neigh."),
         .aiRating = 10,
+        .cantBeCopied = TRUE,
         .cantBeTransferred = TRUE,
         .cantBeTraced = TRUE,
         .cantBeSuppressed = TRUE,
+        .cantBeOverwritten = TRUE,
     },
 
     [ABILITY_AS_ONE_SHADOW_RIDER] =
@@ -2111,9 +2142,11 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("As One"),
         .description = COMPOUND_STRING("Unnerve and Grim Neigh."),
         .aiRating = 10,
+        .cantBeCopied = TRUE,
         .cantBeTransferred = TRUE,
         .cantBeTraced = TRUE,
         .cantBeSuppressed = TRUE,
+        .cantBeOverwritten = TRUE,
     },
 
     [ABILITY_LINGERING_AROMA] =
@@ -2216,9 +2249,11 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Zero to Hero"),
         .description = COMPOUND_STRING("Changes form on switch out."),
         .aiRating = 10,
+        .cantBeCopied = TRUE,
         .cantBeTransferred = TRUE,
         .cantBeTraced = TRUE,
         .cantBeSuppressed = TRUE,
+        .cantBeOverwritten = TRUE,
         .failsOnImposter = TRUE,
     },
 
@@ -2227,6 +2262,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Commander"),
         .description = COMPOUND_STRING("Commands from Dondozo."),
         .aiRating = 10,
+        .cantBeCopied = TRUE,
         .cantBeTransferred = TRUE,
         .cantBeTraced = TRUE,
     },
@@ -2251,6 +2287,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Sun boosts best stat."),
         .aiRating = 7,
+        .cantBeCopied = TRUE,
         .cantBeTransferred = TRUE,
         .cantBeTraced = TRUE,
         .failsOnImposter = TRUE,
@@ -2261,6 +2298,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Quark Drive"),
         .description = COMPOUND_STRING("Elec. field ups best stat."),
         .aiRating = 7,
+        .cantBeCopied = TRUE,
         .cantBeTransferred = TRUE,
         .cantBeTraced = TRUE,
         .failsOnImposter = TRUE,
@@ -2441,6 +2479,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Raises Speed."),
         .aiRating = 6,
+        .cantBeCopied = TRUE,
         .cantBeTransferred = TRUE,
         .cantBeTraced = TRUE,
         .failsOnImposter = TRUE,
@@ -2455,6 +2494,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Raises Attack."),
         .aiRating = 6,
+        .cantBeCopied = TRUE,
         .cantBeTransferred = TRUE,
         .cantBeTraced = TRUE,
         .failsOnImposter = TRUE,
@@ -2469,6 +2509,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Raises Sp. Def."),
         .aiRating = 6,
+        .cantBeCopied = TRUE,
         .cantBeTransferred = TRUE,
         .cantBeTraced = TRUE,
         .failsOnImposter = TRUE,
@@ -2483,6 +2524,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Raises Defense."),
         .aiRating = 6,
+        .cantBeCopied = TRUE,
         .cantBeTransferred = TRUE,
         .cantBeTraced = TRUE,
         .failsOnImposter = TRUE,
@@ -2511,9 +2553,11 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Tera Shift"),
         .description = COMPOUND_STRING("Terasteralizes upon entry."),
         .aiRating = 10,
+        .cantBeCopied = TRUE,
         .cantBeTransferred = TRUE,
         .cantBeTraced = TRUE,
         .cantBeSuppressed = TRUE,
+        .cantBeOverwritten = TRUE,
         .failsOnImposter = TRUE,
     },
 
@@ -2522,6 +2566,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Tera Shell"),
         .description = COMPOUND_STRING("Resistant to types at full HP."),
         .aiRating = 10,
+        .cantBeCopied = TRUE,
         .cantBeTransferred = TRUE,
         .cantBeTraced = TRUE,
         .canBeIgnored = TRUE,
@@ -2536,6 +2581,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Removes weather and terrain."),
         .aiRating = 10,
+        .cantBeCopied = TRUE,
         .cantBeTransferred = TRUE,
         .cantBeTraced = TRUE,
     },
@@ -2549,6 +2595,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Confuses poisoned foes."),
         .aiRating = 8,
+        .cantBeCopied = TRUE,
         .cantBeTransferred = TRUE,
         .cantBeTraced = TRUE,
     },

--- a/src/data/abilities.h
+++ b/src/data/abilities.h
@@ -33,6 +33,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Battle Armor"),
         .description = COMPOUND_STRING("Blocks critical hits."),
         .aiRating = 2,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_STURDY] =
@@ -40,6 +41,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Sturdy"),
         .description = COMPOUND_STRING("Negates 1-hit KO attacks."),
         .aiRating = 6,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_DAMP] =
@@ -47,6 +49,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Damp"),
         .description = COMPOUND_STRING("Prevents self-destruction."),
         .aiRating = 2,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_LIMBER] =
@@ -54,6 +57,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Limber"),
         .description = COMPOUND_STRING("Prevents paralysis."),
         .aiRating = 3,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_SAND_VEIL] =
@@ -61,6 +65,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Sand Veil"),
         .description = COMPOUND_STRING("Ups evasion in a sandstorm."),
         .aiRating = 3,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_STATIC] =
@@ -75,6 +80,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Volt Absorb"),
         .description = COMPOUND_STRING("Turns electricity into HP."),
         .aiRating = 7,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_WATER_ABSORB] =
@@ -82,6 +88,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Water Absorb"),
         .description = COMPOUND_STRING("Changes water into HP."),
         .aiRating = 7,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_OBLIVIOUS] =
@@ -89,6 +96,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Oblivious"),
         .description = COMPOUND_STRING("Prevents attraction."),
         .aiRating = 2,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_CLOUD_NINE] =
@@ -114,6 +122,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Insomnia"),
         .description = COMPOUND_STRING("Prevents sleep."),
         .aiRating = 4,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_COLOR_CHANGE] =
@@ -128,6 +137,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Immunity"),
         .description = COMPOUND_STRING("Prevents poisoning."),
         .aiRating = 4,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_FLASH_FIRE] =
@@ -135,6 +145,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Flash Fire"),
         .description = COMPOUND_STRING("Powers up if hit by fire."),
         .aiRating = 6,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_SHIELD_DUST] =
@@ -142,6 +153,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Shield Dust"),
         .description = COMPOUND_STRING("Prevents added effects."),
         .aiRating = 5,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_OWN_TEMPO] =
@@ -149,6 +161,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Own Tempo"),
         .description = COMPOUND_STRING("Prevents confusion."),
         .aiRating = 3,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_SUCTION_CUPS] =
@@ -156,6 +169,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Suction Cups"),
         .description = COMPOUND_STRING("Firmly anchors the body."),
         .aiRating = 2,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_INTIMIDATE] =
@@ -184,6 +198,8 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Wonder Guard"),
         .description = COMPOUND_STRING("“Supereffective” hits."),
         .aiRating = 10,
+        .cantBeTransferred = TRUE,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_LEVITATE] =
@@ -191,6 +207,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Levitate"),
         .description = COMPOUND_STRING("Not hit by Ground attacks."),
         .aiRating = 7,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_EFFECT_SPORE] =
@@ -212,6 +229,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Clear Body"),
         .description = COMPOUND_STRING("Prevents ability reduction."),
         .aiRating = 4,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_NATURAL_CURE] =
@@ -230,6 +248,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Draws electrical moves."),
         .aiRating = 7,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_SERENE_GRACE] =
@@ -258,6 +277,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Illuminate"),
         .description = COMPOUND_STRING("Encounter rate increases."),
         .aiRating = 0,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_TRACE] =
@@ -265,6 +285,8 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Trace"),
         .description = COMPOUND_STRING("Copies special ability."),
         .aiRating = 6,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
     },
 
     [ABILITY_HUGE_POWER] =
@@ -286,6 +308,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Inner Focus"),
         .description = COMPOUND_STRING("Prevents flinching."),
         .aiRating = 2,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_MAGMA_ARMOR] =
@@ -293,6 +316,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Magma Armor"),
         .description = COMPOUND_STRING("Prevents freezing."),
         .aiRating = 1,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_WATER_VEIL] =
@@ -300,6 +324,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Water Veil"),
         .description = COMPOUND_STRING("Prevents burns."),
         .aiRating = 4,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_MAGNET_PULL] =
@@ -314,6 +339,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Soundproof"),
         .description = COMPOUND_STRING("Avoids sound-based moves."),
         .aiRating = 4,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_RAIN_DISH] =
@@ -342,6 +368,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Thick Fat"),
         .description = COMPOUND_STRING("Heat-and-cold protection."),
         .aiRating = 7,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_EARLY_BIRD] =
@@ -370,6 +397,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Keen Eye"),
         .description = COMPOUND_STRING("Prevents loss of accuracy."),
         .aiRating = 1,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_HYPER_CUTTER] =
@@ -377,6 +405,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Hyper Cutter"),
         .description = COMPOUND_STRING("Prevents Attack reduction."),
         .aiRating = 3,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_PICKUP] =
@@ -426,6 +455,8 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Forecast"),
         .description = COMPOUND_STRING("Changes with the weather."),
         .aiRating = 6,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
     },
 
     [ABILITY_STICKY_HOLD] =
@@ -433,6 +464,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Sticky Hold"),
         .description = COMPOUND_STRING("Prevents item theft."),
         .aiRating = 3,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_SHED_SKIN] =
@@ -454,6 +486,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Marvel Scale"),
         .description = COMPOUND_STRING("Ups Defense if suffering."),
         .aiRating = 5,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_LIQUID_OOZE] =
@@ -517,6 +550,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Vital Spirit"),
         .description = COMPOUND_STRING("Prevents sleep."),
         .aiRating = 4,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_WHITE_SMOKE] =
@@ -524,6 +558,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("White Smoke"),
         .description = COMPOUND_STRING("Prevents ability reduction."),
         .aiRating = 4,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_PURE_POWER] =
@@ -538,6 +573,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Shell Armor"),
         .description = COMPOUND_STRING("Blocks critical hits."),
         .aiRating = 2,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_AIR_LOCK] =
@@ -552,6 +588,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Tangled Feet"),
         .description = COMPOUND_STRING("Ups evasion if confused."),
         .aiRating = 2,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_MOTOR_DRIVE] =
@@ -559,6 +596,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Motor Drive"),
         .description = COMPOUND_STRING("Electricity raises Speed."),
         .aiRating = 6,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_RIVALRY] =
@@ -580,6 +618,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Snow Cloak"),
         .description = COMPOUND_STRING("Ups evasion in Hail or Snow."),
         .aiRating = 3,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_GLUTTONY] =
@@ -608,6 +647,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Heatproof"),
         .description = COMPOUND_STRING("Heat and burn protection."),
         .aiRating = 5,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_SIMPLE] =
@@ -615,6 +655,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Simple"),
         .description = COMPOUND_STRING("Prone to wild stat changes."),
         .aiRating = 8,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_DRY_SKIN] =
@@ -622,6 +663,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Dry Skin"),
         .description = COMPOUND_STRING("Prefers moisture to heat."),
         .aiRating = 6,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_DOWNLOAD] =
@@ -727,6 +769,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Leaf Guard"),
         .description = COMPOUND_STRING("Blocks status in sunshine."),
         .aiRating = 2,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_KLUTZ] =
@@ -776,6 +819,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Unaware"),
         .description = COMPOUND_STRING("Ignores stat changes."),
         .aiRating = 6,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_TINTED_LENS] =
@@ -790,6 +834,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Filter"),
         .description = COMPOUND_STRING("Weakens “supereffective”."),
         .aiRating = 6,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_SLOW_START] =
@@ -811,6 +856,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Storm Drain"),
         .description = COMPOUND_STRING("Draws in Water moves."),
         .aiRating = 7,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_ICE_BODY] =
@@ -825,6 +871,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Solid Rock"),
         .description = COMPOUND_STRING("Weakens “supereffective”."),
         .aiRating = 6,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_SNOW_WARNING] =
@@ -860,6 +907,9 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Multitype"),
         .description = COMPOUND_STRING("Changes type to its Plate."),
         .aiRating = 8,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
+        .cantBeSuppressed = TRUE,
     },
 
     [ABILITY_FLOWER_GIFT] =
@@ -867,6 +917,9 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Flower Gift"),
         .description = COMPOUND_STRING("Allies power up in sunshine."),
         .aiRating = 4,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_BAD_DREAMS] =
@@ -895,6 +948,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Contrary"),
         .description = COMPOUND_STRING("Inverts stat changes."),
         .aiRating = 8,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_UNNERVE] =
@@ -937,6 +991,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Friend Guard"),
         .description = COMPOUND_STRING("Lowers damage to partner."),
         .aiRating = 0,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_WEAK_ARMOR] =
@@ -951,6 +1006,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Heavy Metal"),
         .description = COMPOUND_STRING("Doubles weight."),
         .aiRating = -1,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_LIGHT_METAL] =
@@ -958,6 +1014,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Light Metal"),
         .description = COMPOUND_STRING("Halves weight."),
         .aiRating = 2,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_MULTISCALE] =
@@ -965,6 +1022,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Multiscale"),
         .description = COMPOUND_STRING("Halves damage at full HP."),
         .aiRating = 8,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_TOXIC_BOOST] =
@@ -993,6 +1051,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Telepathy"),
         .description = COMPOUND_STRING("Can't be damaged by an ally."),
         .aiRating = 0,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_MOODY] =
@@ -1007,6 +1066,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Overcoat"),
         .description = COMPOUND_STRING("Blocks weather and powder."),
         .aiRating = 5,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_POISON_TOUCH] =
@@ -1028,6 +1088,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Big Pecks"),
         .description = COMPOUND_STRING("Prevents Defense loss."),
         .aiRating = 1,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_SAND_RUSH] =
@@ -1042,6 +1103,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Wonder Skin"),
         .description = COMPOUND_STRING("May avoid status problems."),
         .aiRating = 4,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_ANALYTIC] =
@@ -1056,6 +1118,8 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Illusion"),
         .description = COMPOUND_STRING("Appears as a partner."),
         .aiRating = 8,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
     },
 
     [ABILITY_IMPOSTER] =
@@ -1063,6 +1127,8 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Imposter"),
         .description = COMPOUND_STRING("Transforms into the foe."),
         .aiRating = 9,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
     },
 
     [ABILITY_INFILTRATOR] =
@@ -1105,6 +1171,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Magic Bounce"),
         .description = COMPOUND_STRING("Reflects status moves."),
         .aiRating = 9,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_SAP_SIPPER] =
@@ -1112,6 +1179,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Sap Sipper"),
         .description = COMPOUND_STRING("Grass increases Attack."),
         .aiRating = 7,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_PRANKSTER] =
@@ -1140,6 +1208,9 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Zen Mode"),
         .description = COMPOUND_STRING("Transforms at half HP."),
         .aiRating = -1,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
+        .cantBeSuppressed = B_UPDATED_ABILITY_DATA >= GEN_7,
     },
 
     [ABILITY_VICTORY_STAR] =
@@ -1168,6 +1239,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Aroma Veil"),
         .description = COMPOUND_STRING("Prevents limiting of moves."),
         .aiRating = 3,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_FLOWER_VEIL] =
@@ -1238,6 +1310,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Sweet Veil"),
         .description = COMPOUND_STRING("Prevents party from sleep."),
         .aiRating = 4,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_STANCE_CHANGE] =
@@ -1249,6 +1322,9 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Transforms as it battles."),
         .aiRating = 10,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
+        .cantBeSuppressed = TRUE,
     },
 
     [ABILITY_GALE_WINGS] =
@@ -1274,6 +1350,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Grass Pelt"),
         .description = COMPOUND_STRING("Ups Defense in grass."),
         .aiRating = 2,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_SYMBIOSIS] =
@@ -1420,6 +1497,9 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Shields Down"),
         .description = COMPOUND_STRING("Shell breaks at half HP."),
         .aiRating = 6,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
+        .cantBeSuppressed = TRUE,
     },
 
     [ABILITY_STAKEOUT] =
@@ -1497,6 +1577,9 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Schooling"),
         .description = COMPOUND_STRING("Forms a school when strong."),
         .aiRating = 6,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
+        .cantBeSuppressed = TRUE,
     },
 
     [ABILITY_DISGUISE] =
@@ -1504,6 +1587,10 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Disguise"),
         .description = COMPOUND_STRING("Decoy protects it once."),
         .aiRating = 8,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
+        .cantBeSuppressed = TRUE,
+        .failsOnImposter = TRUE,
     },
 
     [ABILITY_BATTLE_BOND] =
@@ -1511,6 +1598,9 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Battle Bond"),
         .description = COMPOUND_STRING("Changes form after a KO."),
         .aiRating = 6,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
+        .cantBeSuppressed = TRUE,
     },
 
     [ABILITY_POWER_CONSTRUCT] =
@@ -1522,6 +1612,9 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Cells aid it when weakened."),
         .aiRating = 10,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
+        .cantBeSuppressed = TRUE,
     },
 
     [ABILITY_CORROSION] =
@@ -1536,6 +1629,9 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Comatose"),
         .description = COMPOUND_STRING("Always drowsing."),
         .aiRating = 6,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
+        .cantBeSuppressed = TRUE,
     },
 
     [ABILITY_QUEENLY_MAJESTY] =
@@ -1547,6 +1643,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Protects from priority."),
         .aiRating = 6,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_INNARDS_OUT] =
@@ -1575,6 +1672,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Fluffy"),
         .description = COMPOUND_STRING("Tougher but flammable."),
         .aiRating = 5,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_DAZZLING] =
@@ -1582,6 +1680,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Dazzling"),
         .description = COMPOUND_STRING("Protects from priority."),
         .aiRating = 5,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_SOUL_HEART] =
@@ -1607,6 +1706,8 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Receiver"),
         .description = COMPOUND_STRING("Copies ally's ability."),
         .aiRating = 0,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
     },
 
     [ABILITY_POWER_OF_ALCHEMY] =
@@ -1618,6 +1719,8 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Copies ally's ability."),
         .aiRating = 0,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
     },
 
     [ABILITY_BEAST_BOOST] =
@@ -1632,6 +1735,9 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("RKS System"),
         .description = COMPOUND_STRING("Memories change its type."),
         .aiRating = 8,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
+        .cantBeSuppressed = TRUE,
     },
 
     [ABILITY_ELECTRIC_SURGE] =
@@ -1764,6 +1870,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Mirror Armor"),
         .description = COMPOUND_STRING("Reflect stat decreases."),
         .aiRating = 6,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_GULP_MISSILE] =
@@ -1771,6 +1878,8 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Gulp Missile"),
         .description = COMPOUND_STRING("If hit, spits prey from sea."),
         .aiRating = 3,
+        .cantBeSuppressed = TRUE,
+        .failsOnImposter = TRUE,
     },
 
     [ABILITY_STALWART] =
@@ -1792,6 +1901,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Punk Rock"),
         .description = COMPOUND_STRING("Ups and resists sound."),
         .aiRating = 2,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_SAND_SPIT] =
@@ -1806,6 +1916,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Ice Scales"),
         .description = COMPOUND_STRING("Halves special damage."),
         .aiRating = 7,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_RIPEN] =
@@ -1820,6 +1931,11 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Ice Face"),
         .description = COMPOUND_STRING("Hail or Snow renew free hit."),
         .aiRating = 4,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
+        .cantBeSuppressed = TRUE,
+        .canBeIgnored = TRUE,
+        .failsOnImposter = TRUE,
     },
 
     [ABILITY_POWER_SPOT] =
@@ -1896,6 +2012,9 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("All Abilities are nullified."),
         .aiRating = 5,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
+        .failsOnImposter = TRUE,
     },
 
     [ABILITY_PASTEL_VEIL] =
@@ -1903,6 +2022,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Pastel Veil"),
         .description = COMPOUND_STRING("Protects team from poison."),
         .aiRating = 4,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_HUNGER_SWITCH] =
@@ -1914,6 +2034,9 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Changes form each turn."),
         .aiRating = 2,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
+        .failsOnImposter = TRUE,
     },
 
     [ABILITY_QUICK_DRAW] =
@@ -1978,6 +2101,9 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("As One"),
         .description = COMPOUND_STRING("Unnerve and Chilling Neigh."),
         .aiRating = 10,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
+        .cantBeSuppressed = TRUE,
     },
 
     [ABILITY_AS_ONE_SHADOW_RIDER] =
@@ -1985,6 +2111,9 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("As One"),
         .description = COMPOUND_STRING("Unnerve and Grim Neigh."),
         .aiRating = 10,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
+        .cantBeSuppressed = TRUE,
     },
 
     [ABILITY_LINGERING_AROMA] =
@@ -2014,6 +2143,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Fire hits up Attack."),
         .aiRating = 4,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_ANGER_SHELL] =
@@ -2032,6 +2162,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Protected by pure salts."),
         .aiRating = 6,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_WELL_BAKED_BODY] =
@@ -2043,6 +2174,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Strengthened by Fire."),
         .aiRating = 5,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_WIND_RIDER] =
@@ -2050,6 +2182,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Wind Rider"),
         .description = COMPOUND_STRING("Ups Attack if hit by wind."),
         .aiRating = 4,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_GUARD_DOG] =
@@ -2057,6 +2190,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Guard Dog"),
         .description = COMPOUND_STRING("Cannot be intimidated."),
         .aiRating = 5,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_ROCKY_PAYLOAD] =
@@ -2082,6 +2216,10 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Zero to Hero"),
         .description = COMPOUND_STRING("Changes form on switch out."),
         .aiRating = 10,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
+        .cantBeSuppressed = TRUE,
+        .failsOnImposter = TRUE,
     },
 
     [ABILITY_COMMANDER] =
@@ -2089,6 +2227,8 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Commander"),
         .description = COMPOUND_STRING("Commands from Dondozo."),
         .aiRating = 10,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
     },
 
     [ABILITY_ELECTROMORPHOSIS] =
@@ -2111,6 +2251,9 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Sun boosts best stat."),
         .aiRating = 7,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
+        .failsOnImposter = TRUE,
     },
 
     [ABILITY_QUARK_DRIVE] =
@@ -2118,6 +2261,9 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Quark Drive"),
         .description = COMPOUND_STRING("Elec. field ups best stat."),
         .aiRating = 7,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
+        .failsOnImposter = TRUE,
     },
 
     [ABILITY_GOOD_AS_GOLD] =
@@ -2125,6 +2271,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Good as Gold"),
         .description = COMPOUND_STRING("Avoids status problems."),
         .aiRating = 8,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_VESSEL_OF_RUIN] =
@@ -2136,6 +2283,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Lowers foes' sp. damage."),
         .aiRating = 5,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_SWORD_OF_RUIN] =
@@ -2147,6 +2295,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Lowers foes' Defense."),
         .aiRating = 5,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_TABLETS_OF_RUIN] =
@@ -2158,6 +2307,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Lowers foes' damage."),
         .aiRating = 5,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_BEADS_OF_RUIN] =
@@ -2169,6 +2319,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Lowers foes' Sp. Defense."),
         .aiRating = 5,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_ORICHALCUM_PULSE] =
@@ -2244,6 +2395,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Armor Tail"),
         .description = COMPOUND_STRING("Protects from priority."),
         .aiRating = 5,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_EARTH_EATER] =
@@ -2251,6 +2403,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Earth Eater"),
         .description = COMPOUND_STRING("Eats ground to heal HP."),
         .aiRating = 7,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_MYCELIUM_MIGHT] =
@@ -2276,6 +2429,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Mind's Eye"),
         .description = COMPOUND_STRING("Keen Eye and Scrappy."),
         .aiRating = 8,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_EMBODY_ASPECT_TEAL] =
@@ -2287,6 +2441,9 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Raises Speed."),
         .aiRating = 6,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
+        .failsOnImposter = TRUE,
     },
 
     [ABILITY_EMBODY_ASPECT_HEARTHFLAME] =
@@ -2298,6 +2455,9 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Raises Attack."),
         .aiRating = 6,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
+        .failsOnImposter = TRUE,
     },
 
     [ABILITY_EMBODY_ASPECT_WELLSPRING] =
@@ -2309,6 +2469,9 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Raises Sp. Def."),
         .aiRating = 6,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
+        .failsOnImposter = TRUE,
     },
 
     [ABILITY_EMBODY_ASPECT_CORNERSTONE] =
@@ -2320,6 +2483,9 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Raises Defense."),
         .aiRating = 6,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
+        .failsOnImposter = TRUE,
     },
 
     [ABILITY_TOXIC_CHAIN] =
@@ -2345,6 +2511,10 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Tera Shift"),
         .description = COMPOUND_STRING("Terasteralizes upon entry."),
         .aiRating = 10,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
+        .cantBeSuppressed = TRUE,
+        .failsOnImposter = TRUE,
     },
 
     [ABILITY_TERA_SHELL] =
@@ -2352,6 +2522,9 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
         .name = _("Tera Shell"),
         .description = COMPOUND_STRING("Resistant to types at full HP."),
         .aiRating = 10,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
+        .canBeIgnored = TRUE,
     },
 
     [ABILITY_TERAFORM_ZERO] =
@@ -2363,6 +2536,8 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Removes weather and terrain."),
         .aiRating = 10,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
     },
 
     [ABILITY_POISON_PUPPETEER] =
@@ -2374,5 +2549,7 @@ const struct Ability gAbilities[ABILITIES_COUNT] =
     #endif
         .description = COMPOUND_STRING("Confuses poisoned foes."),
         .aiRating = 8,
+        .cantBeTransferred = TRUE,
+        .cantBeTraced = TRUE,
     },
 };

--- a/test/battle/move_effect/doodle.c
+++ b/test/battle/move_effect/doodle.c
@@ -49,7 +49,7 @@ DOUBLE_BATTLE_TEST("Doodle can't copy a banned ability")
 DOUBLE_BATTLE_TEST("Doodle fails if user has a banned Ability")
 {
     GIVEN {
-        PLAYER(SPECIES_GREAT_TUSK) { Ability(ABILITY_PROTOSYNTHESIS); }
+        PLAYER(SPECIES_CRAMORANT) { Ability(ABILITY_GULP_MISSILE); }
         PLAYER(SPECIES_WYNAUT) { Ability(ABILITY_SHADOW_TAG); }
         OPPONENT(SPECIES_TORCHIC) { Ability(ABILITY_BLAZE); }
         OPPONENT(SPECIES_WOBBUFFET);
@@ -59,7 +59,7 @@ DOUBLE_BATTLE_TEST("Doodle fails if user has a banned Ability")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DOODLE, playerLeft);
         MESSAGE("But it failed!");
     } THEN {
-        EXPECT(playerLeft->ability == ABILITY_PROTOSYNTHESIS);
+        EXPECT(playerLeft->ability == ABILITY_GULP_MISSILE);
         EXPECT(playerRight->ability == ABILITY_SHADOW_TAG);
     }
 }
@@ -68,7 +68,7 @@ DOUBLE_BATTLE_TEST("Doodle fails if partner has a banned Ability")
 {
     GIVEN {
         PLAYER(SPECIES_WYNAUT) { Ability(ABILITY_SHADOW_TAG); }
-        PLAYER(SPECIES_GREAT_TUSK) { Ability(ABILITY_PROTOSYNTHESIS); }
+        PLAYER(SPECIES_CRAMORANT) { Ability(ABILITY_GULP_MISSILE); }
         OPPONENT(SPECIES_TORCHIC) { Ability(ABILITY_BLAZE); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
@@ -78,6 +78,6 @@ DOUBLE_BATTLE_TEST("Doodle fails if partner has a banned Ability")
         MESSAGE("But it failed!");
     } THEN {
         EXPECT(playerLeft->ability == ABILITY_SHADOW_TAG);
-        EXPECT(playerRight->ability == ABILITY_PROTOSYNTHESIS);
+        EXPECT(playerRight->ability == ABILITY_GULP_MISSILE);
     }
 }


### PR DESCRIPTION
Replaced cumbersome hardcoded arrays in battle_util.c with flags applied directly to abilities to mark what can be suppressed, copied, swapped etc.

## Description
As the title suggests, created the following flags for abilities:
```
u8 cantBeCopied:1; // cannot be copied by Role Play or Doodle
u8 cantBeSwapped:1; // cannot be swapped with Skill Swap or Wandering Spirit
u8 cantBeTraced:1; // cannot be copied by Trace - same as cantBeCopied except for Wonder Guard
u8 cantBeSuppressed:1; // cannot be negated by Gastro Acid or Neutralizing Gas
u8 cantBeOverwritten:1; // cannot be overwritten by Entrainment, Worry Seed or Simple Beam (but can be by Mummy) - same as cantBeSuppressed except for Truant
u8 breakable:1; // can be bypassed by Mold Breaker and clones
u8 failsOnImposter:1; // doesn't work on an Imposter mon; when can we actually use this?
```
And applied them to moves based on Gen 9 info obtained from a data mine summarised here: https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/page-49#post-9899064
(FailRolePlay, NoReceiver, NoEntrain are all represented by `cantBeCopied`; `cantBeOverwritten` is my own addition to avoid having to make a hardcoded exception for Truant when dealing with Entrainment, Worry Seed and Simple Beam. The rest should be fairly obvious but I gave them easier to understand names).

## **Discord contact info**
Cancer Fairy/thechurchofcage
