### PR TITLE
Allocate initialized sections for EWRAM and IWRAM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -473,7 +473,7 @@ endif
 $(OBJ_DIR)/ld_script.ld: $(LD_SCRIPT) $(LD_SCRIPT_DEPS)
 	cd $(OBJ_DIR) && sed "s#tools/#../../tools/#g" ../../$(LD_SCRIPT) > ld_script.ld
 
-LDFLAGS = -Map ../../$(MAP)
+LDFLAGS = -Map ../../$(MAP) --no-warn-rwx-segments
 $(ELF): $(OBJ_DIR)/ld_script.ld $(OBJS) libagbsyscall
 	@echo "cd $(OBJ_DIR) && $(LD) $(LDFLAGS) -T ld_script.ld -o ../../$@ <objects> <lib>"
 	@cd $(OBJ_DIR) && $(LD) $(LDFLAGS) -T ld_script.ld --print-memory-usage -o ../../$@ $(OBJS_REL) $(LIB) | cat

--- a/include/crt0.h
+++ b/include/crt0.h
@@ -3,4 +3,6 @@
 
 extern u32 IntrMain[];
 
+extern void ReInitializeEWRAM();
+
 #endif //GUARD_CRT0_H

--- a/include/gba/defines.h
+++ b/include/gba/defines.h
@@ -6,8 +6,10 @@
 #define TRUE  1
 #define FALSE 0
 
-#define IWRAM_DATA __attribute__((section("iwram_data")))
-#define EWRAM_DATA __attribute__((section("ewram_data")))
+#define IWRAM_DATA __attribute__((section(".bss")))
+#define EWRAM_DATA __attribute__((section(".sbss")))
+#define IWRAM_INIT __attribute__((section(".iwram")))
+#define EWRAM_INIT __attribute__((section(".ewram")))
 #define UNUSED __attribute__((unused))
 
 #if MODERN

--- a/ld_script.ld
+++ b/ld_script.ld
@@ -13,19 +13,35 @@ MEMORY
 
 SECTIONS {
 
-    ewram 0x2000000 (NOLOAD) :
+    .ewram ORIGIN(EWRAM) : AT (__ewram_lma)
+    ALIGN(4)
+    {
+        __ewram_start = .;
+        *(.ewram*)
+        __ewram_end = .;
+    } > EWRAM
+
+    .ewram.sbss (NOLOAD) :
     ALIGN(4)
     {
         INCLUDE "sym_ewram.ld"
-        src/*.o(ewram_data);
-        gflib/*.o(ewram_data);
+        src/*.o(.sbss);
+        gflib/*.o(.sbss);
 
         *libc.a:impure.o(.data);
         *libc.a:locale.o(.data);
         *libc.a:mallocr.o(.data);
     } > EWRAM
 
-    iwram 0x3000000 (NOLOAD) :
+    .iwram ORIGIN(IWRAM) : AT (__iwram_lma)
+    ALIGN(4)
+    {
+        __iwram_start = .;
+        *(.iwram*);
+        __iwram_end = .;
+    } > IWRAM
+
+    .iwram.bss (NOLOAD) :
     ALIGN(4)
     {
         /* .bss starts at 0x3000000 */
@@ -1322,6 +1338,20 @@ SECTIONS {
         src/*.o(.rodata);
         gflib/*.o(.rodata);
         data/*.o(.rodata);
+    } > ROM = 0
+
+    .data.iwram :
+    ALIGN(4)
+    {
+        __iwram_lma = .;
+        . = . + (__iwram_end - __iwram_start);
+    } > ROM = 0
+
+    .data.ewram :
+    ALIGN(4)
+    {
+        __ewram_lma = .;
+        . = . + (__ewram_end - __ewram_start);
     } > ROM = 0
 
     __rom_end = .;

--- a/ld_script_modern.ld
+++ b/ld_script_modern.ld
@@ -12,15 +12,32 @@ MEMORY
 }
 
 SECTIONS {
-    ewram 0x2000000 (NOLOAD) :
+
+
+    .ewram ORIGIN(EWRAM) : AT (__ewram_lma)
     ALIGN(4)
     {
-        src/*.o(ewram_data);
-        gflib/*.o(ewram_data);
-
+        __ewram_start = .;
+        *(.ewram*)
+        __ewram_end = .;
     } > EWRAM
 
-    iwram 0x3000000 (NOLOAD) :
+    .ewram.sbss (NOLOAD) :
+    ALIGN(4)
+    {
+        src/*.o(.sbss);
+        gflib/*.o(.sbss);
+    } > EWRAM
+
+    .iwram ORIGIN(IWRAM) : AT (__iwram_lma)
+    ALIGN(4)
+    {
+        __iwram_start = .;
+        *(.iwram*);
+        __iwram_end = .;
+    } > IWRAM
+
+    .iwram.bss (NOLOAD) :
     ALIGN(4)
     {
         src/*.o(.bss);
@@ -38,9 +55,8 @@ SECTIONS {
     } > IWRAM
 
     /* BEGIN ROM DATA */
-    . = 0x8000000;
 
-    .text :
+    .text ORIGIN(ROM) :
     ALIGN(4)
     {
         src/rom_header.o(.text*);
@@ -124,6 +140,20 @@ SECTIONS {
     {
         src/graphics.o(.rodata);
     } > ROM =0
+
+    .data.iwram :
+    ALIGN(4)
+    {
+        __iwram_lma = .;
+        . = . + (__iwram_end - __iwram_start);
+    } > ROM = 0
+
+    .data.ewram :
+    ALIGN(4)
+    {
+        __ewram_lma = .;
+        . = . + (__ewram_end - __ewram_start);
+    } > ROM = 0
 
     __rom_end = .;
 

--- a/ld_script_test.ld
+++ b/ld_script_test.ld
@@ -12,15 +12,32 @@ MEMORY
 }
 
 SECTIONS {
-    ewram 0x2000000 (NOLOAD) :
+
+    .ewram ORIGIN(EWRAM) : AT (__ewram_lma)
     ALIGN(4)
     {
-        src/*.o(ewram_data);
-        gflib/*.o(ewram_data);
-        test/*.o(ewram_data);
+        __ewram_start = .;
+        *(.ewram*)
+        __ewram_end = .;
     } > EWRAM
 
-    iwram 0x3000000 (NOLOAD) :
+    .ewram.sbss (NOLOAD) :
+    ALIGN(4)
+    {
+        src/*.o(.sbss);
+        gflib/*.o(.sbss);
+        test/*.o(.sbss);
+    } > EWRAM
+
+    .iwram ORIGIN(IWRAM) : AT (__iwram_lma)
+    ALIGN(4)
+    {
+        __iwram_start = .;
+        *(.iwram*);
+        __iwram_end = .;
+    } > IWRAM
+
+    .iwram.sbss (NOLOAD) :
     ALIGN(4)
     {
         src/*.o(.bss);
@@ -96,6 +113,20 @@ SECTIONS {
         *libc.a:*.o(.data*);
         src/libisagbprn.o(.rodata);
     } > ROM =0
+
+    .data.iwram :
+    ALIGN(4)
+    {
+        __iwram_lma = .;
+        . = . + (__iwram_end - __iwram_start);
+    } > ROM = 0
+
+    .data.ewram :
+    ALIGN(4)
+    {
+        __ewram_lma = .;
+        . = . + (__ewram_end - __ewram_start);
+    } > ROM = 0
 
     tests :
     ALIGN(4)

--- a/src/main.c
+++ b/src/main.c
@@ -93,11 +93,6 @@ void EnableVCountIntrAtLine150(void);
 
 void AgbMain()
 {
-    // Modern compilers are liberal with the stack on entry to this function,
-    // so RegisterRamReset may crash if it resets IWRAM.
-#if !MODERN
-    RegisterRamReset(RESET_ALL);
-#endif //MODERN
     *(vu16 *)BG_PLTT = RGB_WHITE; // Set the backdrop to white on startup
     InitGpuRegManager();
     REG_WAITCNT = WAITCNT_PREFETCH_ENABLE | WAITCNT_WS0_S_1 | WAITCNT_WS0_N_3;

--- a/src/reload_save.c
+++ b/src/reload_save.c
@@ -1,5 +1,6 @@
 #include "global.h"
 #include "main.h"
+#include "crt0.h"
 #include "gpu_regs.h"
 #include "m4a.h"
 #include "load_save.h"
@@ -15,6 +16,7 @@ void ReloadSave(void)
     u16 imeBackup = REG_IME;
     REG_IME = 0;
     RegisterRamReset(RESET_EWRAM);
+    ReInitializeEWRAM();
     ClearGpuRegBits(REG_OFFSET_DISPCNT, DISPCNT_FORCED_BLANK);
     REG_IME = imeBackup;
     gMain.inBattle = FALSE;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Copied from #3877 due to my mistake picking the wrong branch to merge into (master vs upcoming)

## Description
<!--- Describe your changes in detail -->
I understand there is occasionally a need to allocate data or code within EWRAM or IWRAM sections that are initialized when the crt0.s codepath starts the game.

I have implemented LD script and assembly changes that create (currently unused) sections for EWRAM and IWRAM data that will be initialized from LMA areas towards the end of the ROM. These LMA areas will not be created if the sections are unused.

I also renamed the existing IWRAM and EWRAM sections to have names more appropriate for their purpose.

## **Discord contact info**
`luigi___`
<!--- formatted as name#numbers, e.g. Lunos#4026 -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
