### PR TITLE
Move from slow DMA to fast CpuSet in CRT0

### DIFF
--- a/ld_script.ld
+++ b/ld_script.ld
@@ -59,9 +59,8 @@ SECTIONS {
     } > IWRAM
 
     /* BEGIN ROM DATA */
-    . = 0x8000000;
 
-    .text :
+    .text ORIGIN(ROM) :
     ALIGN(4)
     {
         src/rom_header.o(.text);

--- a/ld_script_modern.ld
+++ b/ld_script_modern.ld
@@ -13,7 +13,6 @@ MEMORY
 
 SECTIONS {
 
-
     .ewram ORIGIN(EWRAM) : AT (__ewram_lma)
     ALIGN(4)
     {

--- a/ld_script_test.ld
+++ b/ld_script_test.ld
@@ -64,9 +64,8 @@ SECTIONS {
     } > IWRAM
 
     /* BEGIN ROM DATA */
-    . = 0x8000000;
 
-    .text :
+    .text ORIGIN(ROM) :
     ALIGN(4)
     {
         src/rom_header.o(.text);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
After consulting with experts in the GBADEV Discord server, I've learned that DMA block transfers are slower on the GBA compared to using `CpuSet`.

> DMA for setting data is quite slow except for DSi
> which has a special fill mode
> otherwise it will do a bunch of non sequential accesses

I offer this change to use `CpuSet` instead of DMA for the initial load of EWRAM and IWRAM initialized data.

Tested in a manner similar to #3892 and #3877 by marking `InitIntrHandlers` to be in EWRAM and ensuring the game booted.

I also cleaned up some changes I didn't standardize between all three linker scripts in my previous PR.

I'm not using the excitingly-named `CpuSetFast` as it has a known bug on some platforms that makes it slow.

## **Discord contact info**
`luigi___`
<!--- formatted as name#numbers, e.g. Lunos#4026 -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
