### PR TITLE
Fix Dugtrio's footprint and formSpeciedIdTable.

### DIFF
--- a/src/data/pokemon/species_info/gen_1.h
+++ b/src/data/pokemon/species_info/gen_1.h
@@ -3723,19 +3723,21 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .formSpeciesIdTable = sDiglettFormSpeciesIdTable,   \
         DIGLETT_FAMILY_MISC_INFO
 
-#define DUGTRIO_MISC_INFO                   \
-        .catchRate = 50,                    \
-        .expYield = 149,                    \
-        .evYield_Speed = 2,                 \
-        .speciesName = _("Dugtrio"),        \
-        .cryId = CRY_DUGTRIO,               \
-        .natDexNum = NATIONAL_DEX_DUGTRIO,  \
-        .categoryName = _("Mole"),          \
-        .height = 7,                        \
-        .pokemonScale = 406,                \
-        .pokemonOffset = 18,                \
-        .trainerScale = 256,                \
-        .trainerOffset = 0,                 \
+#define DUGTRIO_MISC_INFO                                   \
+        .catchRate = 50,                                    \
+        .expYield = 149,                                    \
+        .evYield_Speed = 2,                                 \
+        .speciesName = _("Dugtrio"),                        \
+        .cryId = CRY_DUGTRIO,                               \
+        .natDexNum = NATIONAL_DEX_DUGTRIO,                  \
+        .categoryName = _("Mole"),                          \
+        .height = 7,                                        \
+        .pokemonScale = 406,                                \
+        .pokemonOffset = 18,                                \
+        .trainerScale = 256,                                \
+        .trainerOffset = 0,                                 \
+        .footprint = gMonFootprint_Dugtrio,                 \
+        .formSpeciesIdTable = sDugtrioFormSpeciesIdTable,   \
         DIGLETT_FAMILY_MISC_INFO
 
 #define DUGTRIO_ATTACK (P_UPDATED_STATS >= GEN_7 ? 100 : 80)


### PR DESCRIPTION
## Description
Dugtrio's species info was missing its footprint and formSpeciesIdTable for some reason. Just happened to notice it. Don't know if there are more cases.
I added it and fixed the indentation.

## **Discord contact info**
mauro58
