### PR TITLE
Dynamic regional dex rating

### DIFF
--- a/include/birch_pc.h
+++ b/include/birch_pc.h
@@ -1,0 +1,6 @@
+#ifndef GUARD_BIRCH_PC_H
+#define GUARD_BIRCH_PC_H
+
+const u8 *GetPokedexRatingText(u16 count);
+
+#endif // GUARD_BIRCH_PC_H

--- a/src/birch_pc.c
+++ b/src/birch_pc.c
@@ -20,66 +20,52 @@ bool16 ScriptGetPokedexInfo(void)
     return IsNationalPokedexEnabled();
 }
 
+// Species in this array are ignored in the progress towards a full regional dex
+static const u16 sRegionalNotCountedList[] = {
+    SPECIES_JIRACHI,
+    SPECIES_DEOXYS,
+    SPECIES_NONE
+};
+
+#define BIRCH_DEX_STRINGS 21
+
+static const u8 *const sBirchDexRatingTexts[BIRCH_DEX_STRINGS] =
+{
+    gBirchDexRatingText_LessThan10,
+    gBirchDexRatingText_LessThan20,
+    gBirchDexRatingText_LessThan30,
+    gBirchDexRatingText_LessThan40,
+    gBirchDexRatingText_LessThan50,
+    gBirchDexRatingText_LessThan60,
+    gBirchDexRatingText_LessThan70,
+    gBirchDexRatingText_LessThan80,
+    gBirchDexRatingText_LessThan90,
+    gBirchDexRatingText_LessThan100,
+    gBirchDexRatingText_LessThan110,
+    gBirchDexRatingText_LessThan120,
+    gBirchDexRatingText_LessThan130,
+    gBirchDexRatingText_LessThan140,
+    gBirchDexRatingText_LessThan150,
+    gBirchDexRatingText_LessThan160,
+    gBirchDexRatingText_LessThan170,
+    gBirchDexRatingText_LessThan180,
+    gBirchDexRatingText_LessThan190,
+    gBirchDexRatingText_LessThan200,
+    gBirchDexRatingText_DexCompleted,
+};
+
 // This shows your Hoenn Pokedex rating and not your National Dex.
 const u8 *GetPokedexRatingText(u16 count)
 {
-    if (count < 10)
-        return gBirchDexRatingText_LessThan10;
-    if (count < 20)
-        return gBirchDexRatingText_LessThan20;
-    if (count < 30)
-        return gBirchDexRatingText_LessThan30;
-    if (count < 40)
-        return gBirchDexRatingText_LessThan40;
-    if (count < 50)
-        return gBirchDexRatingText_LessThan50;
-    if (count < 60)
-        return gBirchDexRatingText_LessThan60;
-    if (count < 70)
-        return gBirchDexRatingText_LessThan70;
-    if (count < 80)
-        return gBirchDexRatingText_LessThan80;
-    if (count < 90)
-        return gBirchDexRatingText_LessThan90;
-    if (count < 100)
-        return gBirchDexRatingText_LessThan100;
-    if (count < 110)
-        return gBirchDexRatingText_LessThan110;
-    if (count < 120)
-        return gBirchDexRatingText_LessThan120;
-    if (count < 130)
-        return gBirchDexRatingText_LessThan130;
-    if (count < 140)
-        return gBirchDexRatingText_LessThan140;
-    if (count < 150)
-        return gBirchDexRatingText_LessThan150;
-    if (count < 160)
-        return gBirchDexRatingText_LessThan160;
-    if (count < 170)
-        return gBirchDexRatingText_LessThan170;
-    if (count < 180)
-        return gBirchDexRatingText_LessThan180;
-    if (count < 190)
-        return gBirchDexRatingText_LessThan190;
-    if (count < 200)
-        return gBirchDexRatingText_LessThan200;
-    if (count == 200)
+    u32 i;
+    u16 maxDex = HOENN_DEX_COUNT - 1;
+    for(i = 0; sRegionalNotCountedList[i] != SPECIES_NONE; i++)
     {
-        if (GetSetPokedexFlag(SpeciesToNationalPokedexNum(SPECIES_JIRACHI), FLAG_GET_CAUGHT)
-         || GetSetPokedexFlag(SpeciesToNationalPokedexNum(SPECIES_DEOXYS), FLAG_GET_CAUGHT)) // Jirachi or Deoxys is not counted towards the dex completion. If either of these flags are enabled, it means the actual count is less than 200.
-            return gBirchDexRatingText_LessThan200;
-        return gBirchDexRatingText_DexCompleted;
+        if (GetSetPokedexFlag(SpeciesToNationalPokedexNum(sRegionalNotCountedList[i]), FLAG_GET_CAUGHT))
+            count--;
+        maxDex--;
     }
-    if (count == HOENN_DEX_COUNT - 1)
-    {
-        if (GetSetPokedexFlag(SpeciesToNationalPokedexNum(SPECIES_JIRACHI), FLAG_GET_CAUGHT)
-         && GetSetPokedexFlag(SpeciesToNationalPokedexNum(SPECIES_DEOXYS), FLAG_GET_CAUGHT)) // If both of these flags are enabled, it means the actual count is less than 200.
-            return gBirchDexRatingText_LessThan200;
-        return gBirchDexRatingText_DexCompleted;
-    }
-    if (count == HOENN_DEX_COUNT)
-        return gBirchDexRatingText_DexCompleted;
-    return gBirchDexRatingText_LessThan10;
+    return sBirchDexRatingTexts[(count * (BIRCH_DEX_STRINGS - 1)) / maxDex];
 }
 
 void ShowPokedexRatingMessage(void)

--- a/src/match_call.c
+++ b/src/match_call.c
@@ -3,6 +3,7 @@
 #include "battle.h"
 #include "battle_setup.h"
 #include "bg.h"
+#include "birch_pc.h"
 #include "data.h"
 #include "event_data.h"
 #include "event_object_movement.h"
@@ -1965,90 +1966,10 @@ static u16 GetFrontierStreakInfo(u16 facilityId, u32 *topicTextId)
     return streak;
 }
 
-static u8 GetPokedexRatingLevel(u16 numSeen)
-{
-    if (numSeen < 10)
-        return 0;
-    if (numSeen < 20)
-        return 1;
-    if (numSeen < 30)
-        return 2;
-    if (numSeen < 40)
-        return 3;
-    if (numSeen < 50)
-        return 4;
-    if (numSeen < 60)
-        return 5;
-    if (numSeen < 70)
-        return 6;
-    if (numSeen < 80)
-        return 7;
-    if (numSeen < 90)
-        return 8;
-    if (numSeen < 100)
-        return 9;
-    if (numSeen < 110)
-        return 10;
-    if (numSeen < 120)
-        return 11;
-    if (numSeen < 130)
-        return 12;
-    if (numSeen < 140)
-        return 13;
-    if (numSeen < 150)
-        return 14;
-    if (numSeen < 160)
-        return 15;
-    if (numSeen < 170)
-        return 16;
-    if (numSeen < 180)
-        return 17;
-    if (numSeen < 190)
-        return 18;
-    if (numSeen < 200)
-        return 19;
-
-    if (GetSetPokedexFlag(SpeciesToNationalPokedexNum(SPECIES_DEOXYS), FLAG_GET_CAUGHT))
-        numSeen--;
-    if (GetSetPokedexFlag(SpeciesToNationalPokedexNum(SPECIES_JIRACHI), FLAG_GET_CAUGHT))
-        numSeen--;
-
-    if (numSeen < 200)
-        return 19;
-    else
-        return 20;
-}
-
-static const u8 *const sBirchDexRatingTexts[] =
-{
-    gBirchDexRatingText_LessThan10,
-    gBirchDexRatingText_LessThan20,
-    gBirchDexRatingText_LessThan30,
-    gBirchDexRatingText_LessThan40,
-    gBirchDexRatingText_LessThan50,
-    gBirchDexRatingText_LessThan60,
-    gBirchDexRatingText_LessThan70,
-    gBirchDexRatingText_LessThan80,
-    gBirchDexRatingText_LessThan90,
-    gBirchDexRatingText_LessThan100,
-    gBirchDexRatingText_LessThan110,
-    gBirchDexRatingText_LessThan120,
-    gBirchDexRatingText_LessThan130,
-    gBirchDexRatingText_LessThan140,
-    gBirchDexRatingText_LessThan150,
-    gBirchDexRatingText_LessThan160,
-    gBirchDexRatingText_LessThan170,
-    gBirchDexRatingText_LessThan180,
-    gBirchDexRatingText_LessThan190,
-    gBirchDexRatingText_LessThan200,
-    gBirchDexRatingText_DexCompleted,
-};
-
 void BufferPokedexRatingForMatchCall(u8 *destStr)
 {
     int numSeen, numCaught;
     u8 *str;
-    u8 dexRatingLevel;
 
     u8 *buffer = Alloc(sizeof(gStringVar4));
     if (!buffer)
@@ -2061,12 +1982,11 @@ void BufferPokedexRatingForMatchCall(u8 *destStr)
     numCaught = GetHoennPokedexCount(FLAG_GET_CAUGHT);
     ConvertIntToDecimalStringN(gStringVar1, numSeen, STR_CONV_MODE_LEFT_ALIGN, 3);
     ConvertIntToDecimalStringN(gStringVar2, numCaught, STR_CONV_MODE_LEFT_ALIGN, 3);
-    dexRatingLevel = GetPokedexRatingLevel(numCaught);
     str = StringCopy(buffer, gBirchDexRatingText_AreYouCurious);
     *(str++) = CHAR_PROMPT_CLEAR;
     str = StringCopy(str, gBirchDexRatingText_SoYouveSeenAndCaught);
     *(str++) = CHAR_PROMPT_CLEAR;
-    StringCopy(str, sBirchDexRatingTexts[dexRatingLevel]);
+    StringCopy(str, GetPokedexRatingText(numCaught));
     str = StringExpandPlaceholders(destStr, buffer);
 
     if (IsNationalPokedexEnabled())


### PR DESCRIPTION
This PR completely overhauls the regional dex rating. Features:
- There no longer is a hardcoded limit of 200 in the rating. Instead, it dynamically adapts to the amount of species in the regional dex and the amount of quotes Birch has, evenly distributing them across the size of the regional dex.
- The two different functions in Match Call and actually talking to Birch have been condensed into a single function.
- Rather than hardcoding Jirachi and Deoxys (and how they affect what counts as a complete dex), there is now a static array that consists of species that are ignored for regional dex rating purposes. They are taken into account for the formulas mentioned above.
- This also saves a whopping 496 bytes!

This is currently based on master since it's a bugfix (imo), but can be rebased to upcoming if considered too invasive for master.

## Issue(s) that this PR fixes
Fixes #3874 

## **Discord contact info**
bassoonian
