### PR TITLE
Fix debug menu flags not redrawing correctly after PR 3796

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -1441,7 +1441,9 @@ static void DebugTask_HandleMenuInput_FlagsVars(u8 taskId)
             {
                 Debug_RedrawListMenu(taskId);
                 func(taskId);
-            } else {
+            }
+            else
+            {
                 func(taskId);
                 Debug_RedrawListMenu(taskId);
             }

--- a/src/debug.c
+++ b/src/debug.c
@@ -1437,8 +1437,14 @@ static void DebugTask_HandleMenuInput_FlagsVars(u8 taskId)
         PlaySE(SE_SELECT);
         if ((func = sDebugMenu_Actions_Flags[input]) != NULL)
         {
-            Debug_RedrawListMenu(taskId);
-            func(taskId);
+            if (input == DEBUG_FLAGVAR_MENU_ITEM_FLAGS || input == DEBUG_FLAGVAR_MENU_ITEM_VARS)
+            {
+                Debug_RedrawListMenu(taskId);
+                func(taskId);
+            } else {
+                func(taskId);
+                Debug_RedrawListMenu(taskId);
+            }
 
             // Remove TRUE/FALSE window for functions that haven't been assigned flags
             if (gTasks[taskId].tInput == 0xFF)


### PR DESCRIPTION
## Description
After PR 3796 was merged, now the flag toggles in the debug menu now no longer reflect the current state of the flag when you toggle them. Basically when you toggle a flag on, it doesn't update the color to reflect it and it ends up "flipped" from what it really should be, because it's getting redrawn before the function runs to toggle the flag.

This PR changes when the redraw happens relative to the function itself depending on which option is selected. This way the menu renders properly both when toggling a flag and viewing all the flags/vars in the debug menu.

This is kind of a silly fix, but it's the best way I could think of. Let me know if y'all have a better way to write this in mind.

## Images
No gif included because without inputs visible it doesn't make sense.

## **Discord contact info**
Discord user: ravepossum
