### PR TITLE
Removed footprint field when P_FOOTPRINTS is FALSE

### DIFF
--- a/include/pokedex.h
+++ b/include/pokedex.h
@@ -23,6 +23,7 @@ u16 GetNationalPokedexCount(u8);
 u16 GetHoennPokedexCount(u8);
 u8 DisplayCaughtMonDexPage(u16 species, bool32 isShiny, u32 personality);
 s8 GetSetPokedexFlag(u16 nationalNum, u8 caseId);
+void DrawFootprint(u8 windowId, u16 species);
 u16 CreateMonSpriteFromNationalDexNumber(u16, s16, s16, u16);
 bool16 HasAllHoennMons(void);
 void ResetPokedexScrollPositions(void);

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -403,7 +403,9 @@ struct SpeciesInfo /*0x8C*/
  /* 0x64 */ const u32 *shinyPaletteFemale;
  /* 0x68 */ const u8 *iconSprite;
  /* 0x6C */ const u8 *iconSpriteFemale;
+#if P_FOOTPRINTS
  /* 0x70 */ const u8 *footprint;
+#endif
             // All Pokémon pics are 64x64, but this data table defines where in this 64x64 frame the sprite's non-transparent pixels actually are.
  /* 0x74 */ u8 frontPicSize; // The dimensions of this drawn pixel area.
  /* 0x74 */ u8 frontPicSizeFemale; // The dimensions of this drawn pixel area.

--- a/src/data/pokemon/species_info.h
+++ b/src/data/pokemon/species_info.h
@@ -218,9 +218,9 @@ const u8 gOgerponCornerstoneMaskPokedexText[] = _(
         .teachableLearnset = s ## learn##TeachableLearnset
 
 #if P_FOOTPRINTS
-#define FOOTPRINT(sprite) .footprint = gMonFootprint_## sprite
+#define FOOTPRINT(sprite) .footprint = gMonFootprint_## sprite,
 #else
-#define FOOTPRINT(sprite) .footprint = NULL
+#define FOOTPRINT(sprite)
 #endif
 
 // Maximum value for a female Pokémon is 254 (MON_FEMALE) which is 100% female.
@@ -336,7 +336,7 @@ const struct SpeciesInfo gSpeciesInfo[] =
         //PALETTE_FEMALE(CircledQuestionMark),
         ICON(QuestionMark, 0),
         //ICON_FEMALE(QuestionMark, 1),
-        //FOOTPRINT(None),
+        //FOOTPRINT(None)
         LEARNSETS(None),
         .evolutions = EVOLUTION({EVO_LEVEL, 100, SPECIES_NONE},
                                 {EVO_ITEM, ITEM_MOOMOO_MILK, SPECIES_NONE}),

--- a/src/data/pokemon/species_info/gen_1.h
+++ b/src/data/pokemon/species_info/gen_1.h
@@ -47,7 +47,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Bulbasaur),
         ICON(Bulbasaur, 4),
-        FOOTPRINT(Bulbasaur),
+        FOOTPRINT(Bulbasaur)
         LEARNSETS(Bulbasaur),
         .evolutions = EVOLUTION({EVO_LEVEL, 16, SPECIES_IVYSAUR}),
     },
@@ -96,7 +96,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Ivysaur),
         ICON(Ivysaur, 4),
-        FOOTPRINT(Ivysaur),
+        FOOTPRINT(Ivysaur)
         LEARNSETS(Ivysaur),
         .evolutions = EVOLUTION({EVO_LEVEL, 32, SPECIES_VENUSAUR}),
     },
@@ -115,7 +115,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .speciesName = _("Venusaur"),                                       \
         .natDexNum = NATIONAL_DEX_VENUSAUR,                                 \
         .categoryName = _("Seed"),                                          \
-        FOOTPRINT(Venusaur),                                                \
+        FOOTPRINT(Venusaur)                                                 \
         LEARNSETS(Venusaur),                                                \
         .formSpeciesIdTable = sVenusaurFormSpeciesIdTable,                  \
         .formChangeTable = sVenusaurFormChangeTable
@@ -274,7 +274,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Charmander),
         ICON(Charmander, 0),
-        FOOTPRINT(Charmander),
+        FOOTPRINT(Charmander)
         LEARNSETS(Charmander),
         .evolutions = EVOLUTION({EVO_LEVEL, 16, SPECIES_CHARMELEON}),
     },
@@ -323,7 +323,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Charmeleon),
         ICON(Charmeleon, 0),
-        FOOTPRINT(Charmeleon),
+        FOOTPRINT(Charmeleon)
         LEARNSETS(Charmeleon),
         .evolutions = EVOLUTION({EVO_LEVEL, 36, SPECIES_CHARIZARD}),
     },
@@ -339,7 +339,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .speciesName = _("Charizard"),                                  \
         .natDexNum = NATIONAL_DEX_CHARIZARD,                            \
         .categoryName = _("Flame"),                                     \
-        FOOTPRINT(Charizard),                                           \
+        FOOTPRINT(Charizard)                                            \
         LEARNSETS(Charizard),                                           \
         .formSpeciesIdTable = sCharizardFormSpeciesIdTable,             \
         .formChangeTable = sCharizardFormChangeTable
@@ -539,7 +539,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Squirtle),
         ICON(Squirtle, 0),
-        FOOTPRINT(Squirtle),
+        FOOTPRINT(Squirtle)
         LEARNSETS(Squirtle),
         .evolutions = EVOLUTION({EVO_LEVEL, 16, SPECIES_WARTORTLE}),
     },
@@ -588,7 +588,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Wartortle),
         ICON(Wartortle, 2),
-        FOOTPRINT(Wartortle),
+        FOOTPRINT(Wartortle)
         LEARNSETS(Wartortle),
         .evolutions = EVOLUTION({EVO_LEVEL, 36, SPECIES_BLASTOISE}),
     },
@@ -606,7 +606,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .speciesName = _("Blastoise"),                                  \
         .natDexNum = NATIONAL_DEX_BLASTOISE,                            \
         .categoryName = _("Shellfish"),                                 \
-        FOOTPRINT(Blastoise),                                           \
+        FOOTPRINT(Blastoise)                                            \
         LEARNSETS(Blastoise),                                           \
         .formSpeciesIdTable = sBlastoiseFormSpeciesIdTable,             \
         .formChangeTable = sBlastoiseFormChangeTable
@@ -765,7 +765,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Caterpie),
         ICON(Caterpie, 1),
-        FOOTPRINT(Caterpie),
+        FOOTPRINT(Caterpie)
         LEARNSETS(Caterpie),
         .evolutions = EVOLUTION({EVO_LEVEL, 7, SPECIES_METAPOD}),
     },
@@ -813,7 +813,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Metapod),
         ICON(Metapod, 1),
-        FOOTPRINT(Metapod),
+        FOOTPRINT(Metapod)
         LEARNSETS(Metapod),
         .evolutions = EVOLUTION({EVO_LEVEL, 10, SPECIES_BUTTERFREE}),
     },
@@ -842,7 +842,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .cryId = CRY_BUTTERFREE,                                                    \
         .natDexNum = NATIONAL_DEX_BUTTERFREE,                                       \
         .categoryName = _("Butterfly"),                                             \
-        FOOTPRINT(Butterfree),                                                      \
+        FOOTPRINT(Butterfree)                                                       \
         LEARNSETS(Butterfree),                                                      \
         .formSpeciesIdTable = sButterfreeFormSpeciesIdTable,                        \
         .formChangeTable = sButterfreeFormChangeTable
@@ -950,7 +950,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Weedle),
         ICON(Weedle, 2),
-        FOOTPRINT(Weedle),
+        FOOTPRINT(Weedle)
         LEARNSETS(Weedle),
         .evolutions = EVOLUTION({EVO_LEVEL, 7, SPECIES_KAKUNA}),
     },
@@ -999,7 +999,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Kakuna),
         ICON(Kakuna, 2),
-        FOOTPRINT(Kakuna),
+        FOOTPRINT(Kakuna)
         LEARNSETS(Kakuna),
         .evolutions = EVOLUTION({EVO_LEVEL, 10, SPECIES_BEEDRILL}),
     },
@@ -1021,7 +1021,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .speciesName = _("Beedrill"),                       \
         .natDexNum = NATIONAL_DEX_BEEDRILL,                 \
         .categoryName = _("Poison Bee"),                    \
-        FOOTPRINT(Beedrill),                                \
+        FOOTPRINT(Beedrill)                                 \
         LEARNSETS(Beedrill),                                \
         .formSpeciesIdTable = sBeedrillFormSpeciesIdTable,  \
         .formChangeTable = sBeedrillFormChangeTable
@@ -1144,7 +1144,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Pidgey),
         ICON(Pidgey, 0),
-        FOOTPRINT(Pidgey),
+        FOOTPRINT(Pidgey)
         LEARNSETS(Pidgey),
         .evolutions = EVOLUTION({EVO_LEVEL, 18, SPECIES_PIDGEOTTO}),
     },
@@ -1193,7 +1193,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Pidgeotto),
         ICON(Pidgeotto, 0),
-        FOOTPRINT(Pidgeotto),
+        FOOTPRINT(Pidgeotto)
         LEARNSETS(Pidgeotto),
         .evolutions = EVOLUTION({EVO_LEVEL, 36, SPECIES_PIDGEOT}),
     },
@@ -1213,7 +1213,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .speciesName = _("Pidgeot"),                        \
         .natDexNum = NATIONAL_DEX_PIDGEOT,                  \
         .categoryName = _("Bird"),                          \
-        FOOTPRINT(Pidgeot),                                 \
+        FOOTPRINT(Pidgeot)                                  \
         LEARNSETS(Pidgeot),                                 \
         .formSpeciesIdTable = sPidgeotFormSpeciesIdTable,   \
         .formChangeTable = sPidgeotFormChangeTable
@@ -1313,7 +1313,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .cryId = CRY_RATTATA,                               \
         .natDexNum = NATIONAL_DEX_RATTATA,                  \
         .categoryName = _("Mouse"),                         \
-        FOOTPRINT(Rattata),                                 \
+        FOOTPRINT(Rattata)                                  \
         .formSpeciesIdTable = sRattataFormSpeciesIdTable
 
 #define RATICATE_MISC_INFO                  \
@@ -1325,7 +1325,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .natDexNum = NATIONAL_DEX_RATICATE, \
         .categoryName = _("Mouse"),         \
         .height = 7,                        \
-        FOOTPRINT(Raticate),                \
+        FOOTPRINT(Raticate)                 \
         .formSpeciesIdTable = sRaticateFormSpeciesIdTable
 
     [SPECIES_RATTATA] =
@@ -1516,7 +1516,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Spearow),
         ICON(Spearow, 0),
-        FOOTPRINT(Spearow),
+        FOOTPRINT(Spearow)
         LEARNSETS(Spearow),
         .evolutions = EVOLUTION({EVO_LEVEL, 20, SPECIES_FEAROW}),
     },
@@ -1567,7 +1567,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Fearow),
         ICON(Fearow, 0),
-        FOOTPRINT(Fearow),
+        FOOTPRINT(Fearow)
         LEARNSETS(Fearow),
     },
 #endif //P_FAMILY_SPEAROW
@@ -1617,7 +1617,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Ekans),
         ICON(Ekans, 2),
-        FOOTPRINT(Ekans),
+        FOOTPRINT(Ekans)
         LEARNSETS(Ekans),
         .evolutions = EVOLUTION({EVO_LEVEL, 22, SPECIES_ARBOK}),
     },
@@ -1665,7 +1665,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Arbok),
         ICON(Arbok, 2),
-        FOOTPRINT(Arbok),
+        FOOTPRINT(Arbok)
         LEARNSETS(Arbok),
     },
 #endif //P_FAMILY_EKANS
@@ -1701,7 +1701,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .pokemonOffset = 20,                                                            \
         .trainerScale = 256,                                                            \
         .trainerOffset = 0,                                                             \
-        FOOTPRINT(Pichu),                                                               \
+        FOOTPRINT(Pichu)                                                                \
         LEARNSETS(Pichu),                                                               \
         .formSpeciesIdTable = sPichuFormSpeciesIdTable
 
@@ -1757,7 +1757,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .cryId = CRY_PIKACHU,                                                   \
         .natDexNum = NATIONAL_DEX_PIKACHU,                                      \
         .categoryName = _("Mouse"),                                             \
-        FOOTPRINT(Pikachu),                                                     \
+        FOOTPRINT(Pikachu)                                                      \
         LEARNSETS(Pikachu),                                                     \
         .formSpeciesIdTable = sPikachuFormSpeciesIdTable
 
@@ -2102,7 +2102,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .cryId = CRY_RAICHU,                                \
         .natDexNum = NATIONAL_DEX_RAICHU,                   \
         .categoryName = _("Mouse"),                         \
-        FOOTPRINT(Raichu),                                  \
+        FOOTPRINT(Raichu)                                   \
         .formSpeciesIdTable = sRaichuFormSpeciesIdTable
 
     [SPECIES_RAICHU] =
@@ -2198,7 +2198,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .cryId = CRY_SANDSHREW,                             \
         .natDexNum = NATIONAL_DEX_SANDSHREW,                \
         .categoryName = _("Mouse"),                         \
-        FOOTPRINT(Sandshrew),                               \
+        FOOTPRINT(Sandshrew)                                \
         .formSpeciesIdTable = sSandshrewFormSpeciesIdTable, \
         SANDSHREW_FAMILY_MISC_INFO
 
@@ -2210,7 +2210,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .cryId = CRY_SANDSLASH,                             \
         .natDexNum = NATIONAL_DEX_SANDSLASH,                \
         .categoryName = _("Mouse"),                         \
-        FOOTPRINT(Sandslash),                               \
+        FOOTPRINT(Sandslash)                                \
         .formSpeciesIdTable = sSandslashFormSpeciesIdTable, \
         SANDSHREW_FAMILY_MISC_INFO
 
@@ -2406,7 +2406,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(NidoranF),
         ICON(NidoranF, 0),
-        FOOTPRINT(NidoranF),
+        FOOTPRINT(NidoranF)
         LEARNSETS(NidoranF),
         .evolutions = EVOLUTION({EVO_LEVEL, 16, SPECIES_NIDORINA}),
     },
@@ -2454,7 +2454,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Nidorina),
         ICON(Nidorina, 0),
-        FOOTPRINT(Nidorina),
+        FOOTPRINT(Nidorina)
         LEARNSETS(Nidorina),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_MOON_STONE, SPECIES_NIDOQUEEN}),
     },
@@ -2502,7 +2502,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Nidoqueen),
         ICON(Nidoqueen, 2),
-        FOOTPRINT(Nidoqueen),
+        FOOTPRINT(Nidoqueen)
         LEARNSETS(Nidoqueen),
     },
 
@@ -2549,7 +2549,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(NidoranM),
         ICON(NidoranM, 2),
-        FOOTPRINT(NidoranM),
+        FOOTPRINT(NidoranM)
         LEARNSETS(NidoranM),
         .evolutions = EVOLUTION({EVO_LEVEL, 16, SPECIES_NIDORINO}),
     },
@@ -2597,7 +2597,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Nidorino),
         ICON(Nidorino, 2),
-        FOOTPRINT(Nidorino),
+        FOOTPRINT(Nidorino)
         LEARNSETS(Nidorino),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_MOON_STONE, SPECIES_NIDOKING}),
     },
@@ -2646,7 +2646,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Nidoking),
         ICON(Nidoking, 2),
-        FOOTPRINT(Nidoking),
+        FOOTPRINT(Nidoking)
         LEARNSETS(Nidoking),
     },
 #endif //P_FAMILY_NIDORAN
@@ -2704,7 +2704,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Cleffa),
         ICON(Cleffa, 0),
-        FOOTPRINT(Cleffa),
+        FOOTPRINT(Cleffa)
         LEARNSETS(Cleffa),
         .evolutions = EVOLUTION({EVO_FRIENDSHIP, 0, SPECIES_CLEFAIRY}),
     },
@@ -2755,7 +2755,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Clefairy),
         ICON(Clefairy, 0),
-        FOOTPRINT(Clefairy),
+        FOOTPRINT(Clefairy)
         LEARNSETS(Clefairy),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_MOON_STONE, SPECIES_CLEFABLE}),
     },
@@ -2805,7 +2805,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Clefable),
         ICON(Clefable, 0),
-        FOOTPRINT(Clefable),
+        FOOTPRINT(Clefable)
         LEARNSETS(Clefable),
     },
 #endif //P_FAMILY_CLEFAIRY
@@ -2838,7 +2838,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .pokemonOffset = 19,                            \
         .trainerScale = 256,                            \
         .trainerOffset = 0,                             \
-        FOOTPRINT(Vulpix),                              \
+        FOOTPRINT(Vulpix)                               \
         .formSpeciesIdTable = sVulpixFormSpeciesIdTable,\
         VULPIX_FAMILY_MISC_INFO
 
@@ -2857,7 +2857,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .pokemonOffset = 10,                                \
         .trainerScale = 256,                                \
         .trainerOffset = 0,                                 \
-        FOOTPRINT(Ninetales),                               \
+        FOOTPRINT(Ninetales)                                \
         .formSpeciesIdTable = sNinetalesFormSpeciesIdTable, \
         VULPIX_FAMILY_MISC_INFO
 
@@ -3028,7 +3028,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Igglybuff),
         ICON(Igglybuff, 1),
-        FOOTPRINT(Igglybuff),
+        FOOTPRINT(Igglybuff)
         LEARNSETS(Igglybuff),
         .evolutions = EVOLUTION({EVO_FRIENDSHIP, 0, SPECIES_JIGGLYPUFF}),
     },
@@ -3079,7 +3079,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Jigglypuff),
         ICON(Jigglypuff, 0),
-        FOOTPRINT(Jigglypuff),
+        FOOTPRINT(Jigglypuff)
         LEARNSETS(Jigglypuff),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_MOON_STONE, SPECIES_WIGGLYTUFF}),
     },
@@ -3129,7 +3129,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_GROW,
         PALETTES(Wigglytuff),
         ICON(Wigglytuff, 0),
-        FOOTPRINT(Wigglytuff),
+        FOOTPRINT(Wigglytuff)
         LEARNSETS(Wigglytuff),
     },
 #endif //P_FAMILY_JIGGLYPUFF
@@ -3181,7 +3181,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Zubat),
         ICON(Zubat, 2),
-        FOOTPRINT(Zubat),
+        FOOTPRINT(Zubat)
         LEARNSETS(Zubat),
         .evolutions = EVOLUTION({EVO_LEVEL, 22, SPECIES_GOLBAT}),
     },
@@ -3232,7 +3232,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Golbat),
         ICON(Golbat, 2),
-        FOOTPRINT(Golbat),
+        FOOTPRINT(Golbat)
         LEARNSETS(Golbat),
         .evolutions = EVOLUTION({EVO_FRIENDSHIP, 0, SPECIES_CROBAT}),
     },
@@ -3282,7 +3282,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Crobat),
         ICON(Crobat, 2),
-        FOOTPRINT(Crobat),
+        FOOTPRINT(Crobat)
         LEARNSETS(Crobat),
     },
 #endif //P_GEN_2_CROSS_EVOS
@@ -3333,7 +3333,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Oddish),
         ICON(Oddish, 4),
-        FOOTPRINT(Oddish),
+        FOOTPRINT(Oddish)
         LEARNSETS(Oddish),
         .evolutions = EVOLUTION({EVO_LEVEL, 21, SPECIES_GLOOM}),
     },
@@ -3384,7 +3384,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Gloom),
         ICON(Gloom, 0),
-        FOOTPRINT(Gloom),
+        FOOTPRINT(Gloom)
         LEARNSETS(Gloom),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_LEAF_STONE, SPECIES_VILEPLUME},
                                 {EVO_ITEM, ITEM_SUN_STONE, SPECIES_BELLOSSOM}),
@@ -3436,7 +3436,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,
         PALETTES(Vileplume),
         ICON(Vileplume, 0),
-        FOOTPRINT(Vileplume),
+        FOOTPRINT(Vileplume)
         LEARNSETS(Vileplume),
     },
 
@@ -3485,7 +3485,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Bellossom),
         ICON(Bellossom, 1),
-        FOOTPRINT(Bellossom),
+        FOOTPRINT(Bellossom)
         LEARNSETS(Bellossom),
     },
 #endif //P_GEN_2_CROSS_EVOS
@@ -3538,7 +3538,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Paras),
         ICON(Paras, 0),
-        FOOTPRINT(Paras),
+        FOOTPRINT(Paras)
         LEARNSETS(Paras),
         .evolutions = EVOLUTION({EVO_LEVEL, 24, SPECIES_PARASECT}),
     },
@@ -3590,7 +3590,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_H_SHAKE,
         PALETTES(Parasect),
         ICON(Parasect, 0),
-        FOOTPRINT(Parasect),
+        FOOTPRINT(Parasect)
         LEARNSETS(Parasect),
     },
 #endif //P_FAMILY_PARAS
@@ -3640,7 +3640,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_V_SHAKE_H_SLIDE,
         PALETTES(Venonat),
         ICON(Venonat, 2),
-        FOOTPRINT(Venonat),
+        FOOTPRINT(Venonat)
         LEARNSETS(Venonat),
         .evolutions = EVOLUTION({EVO_LEVEL, 31, SPECIES_VENOMOTH}),
     },
@@ -3691,7 +3691,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Venomoth),
         ICON(Venomoth, 2),
-        FOOTPRINT(Venomoth),
+        FOOTPRINT(Venomoth)
         LEARNSETS(Venomoth),
     },
 #endif //P_FAMILY_VENONAT
@@ -3719,7 +3719,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .pokemonOffset = 25,                                \
         .trainerScale = 256,                                \
         .trainerOffset = 0,                                 \
-        FOOTPRINT(Diglett),                                 \
+        FOOTPRINT(Diglett)                                  \
         .formSpeciesIdTable = sDiglettFormSpeciesIdTable,   \
         DIGLETT_FAMILY_MISC_INFO
 
@@ -3879,7 +3879,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .cryId = CRY_MEOWTH,                                                \
         .natDexNum = NATIONAL_DEX_MEOWTH,                                   \
         .categoryName = _("Scratch Cat"),                                   \
-        FOOTPRINT(Meowth),                                                  \
+        FOOTPRINT(Meowth)                                                   \
         .formSpeciesIdTable = sMeowthFormSpeciesIdTable
 
 #define PERSIAN_MISC_INFO                                   \
@@ -3896,7 +3896,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .cryId = CRY_PERSIAN,                               \
         .natDexNum = NATIONAL_DEX_PERSIAN,                  \
         .categoryName = _("Classy Cat"),                    \
-        FOOTPRINT(Persian),                                 \
+        FOOTPRINT(Persian)                                  \
         .formSpeciesIdTable = sPersianFormSpeciesIdTable
 
     [SPECIES_MEOWTH] =
@@ -4133,7 +4133,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Perrserker),
         ICON(Perrserker, 2),
-        FOOTPRINT(Perrserker),
+        FOOTPRINT(Perrserker)
         LEARNSETS(Perrserker),
     },
 #endif //P_GALARIAN_FORMS
@@ -4224,7 +4224,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Psyduck),
         ICON(Psyduck, 1),
-        FOOTPRINT(Psyduck),
+        FOOTPRINT(Psyduck)
         LEARNSETS(Psyduck),
         .evolutions = EVOLUTION({EVO_LEVEL, 33, SPECIES_GOLDUCK}),
     },
@@ -4272,7 +4272,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,
         PALETTES(Golduck),
         ICON(Golduck, 0),
-        FOOTPRINT(Golduck),
+        FOOTPRINT(Golduck)
         LEARNSETS(Golduck),
     },
 #endif //P_FAMILY_PSYDUCK
@@ -4322,7 +4322,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_LARGE,
         PALETTES(Mankey),
         ICON(Mankey, 1),
-        FOOTPRINT(Mankey),
+        FOOTPRINT(Mankey)
         LEARNSETS(Mankey),
         .evolutions = EVOLUTION({EVO_LEVEL, 28, SPECIES_PRIMEAPE}),
     },
@@ -4370,7 +4370,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_LARGE,
         PALETTES(Primeape),
         ICON(Primeape, 2),
-        FOOTPRINT(Primeape),
+        FOOTPRINT(Primeape)
         LEARNSETS(Primeape),
         .evolutions = EVOLUTION({EVO_MOVE, MOVE_RAGE_FIST, SPECIES_ANNIHILAPE}),
     },
@@ -4419,7 +4419,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Annihilape),
         ICON(Annihilape, 0),
-        //FOOTPRINT(Annihilape),
+        //FOOTPRINT(Annihilape)
         LEARNSETS(Annihilape),
     },
 #endif //P_GEN_9_CROSS_EVOS
@@ -4441,7 +4441,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .speciesName = _("Growlithe"),                      \
         .cryId = CRY_GROWLITHE,                             \
         .natDexNum = NATIONAL_DEX_GROWLITHE,                \
-        FOOTPRINT(Growlithe),                               \
+        FOOTPRINT(Growlithe)                                \
         .formSpeciesIdTable = sGrowlitheFormSpeciesIdTable, \
         GROWLITHE_FAMILY_MISC_INFO
 
@@ -4453,7 +4453,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .cryId = CRY_ARCANINE,                              \
         .natDexNum = NATIONAL_DEX_ARCANINE,                 \
         .categoryName = _("Legendary"),                     \
-        FOOTPRINT(Arcanine),                                \
+        FOOTPRINT(Arcanine)                                 \
         .formSpeciesIdTable = sArcanineFormSpeciesIdTable,  \
         GROWLITHE_FAMILY_MISC_INFO
 
@@ -4649,7 +4649,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Poliwag),
         ICON(Poliwag, 0),
-        FOOTPRINT(Poliwag),
+        FOOTPRINT(Poliwag)
         LEARNSETS(Poliwag),
         .evolutions = EVOLUTION({EVO_LEVEL, 25, SPECIES_POLIWHIRL}),
     },
@@ -4700,7 +4700,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Poliwhirl),
         ICON(Poliwhirl, 0),
-        FOOTPRINT(Poliwhirl),
+        FOOTPRINT(Poliwhirl)
         LEARNSETS(Poliwhirl),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_WATER_STONE, SPECIES_POLIWRATH},
                                 {EVO_TRADE_ITEM, ITEM_KINGS_ROCK, SPECIES_POLITOED},
@@ -4752,7 +4752,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_V_SHAKE_LOW,
         PALETTES(Poliwrath),
         ICON(Poliwrath, 0),
-        FOOTPRINT(Poliwrath),
+        FOOTPRINT(Poliwrath)
         LEARNSETS(Poliwrath),
     },
 
@@ -4805,7 +4805,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_LARGE,
         PALETTES(Politoed),
         ICON(Politoed, 1),
-        FOOTPRINT(Politoed),
+        FOOTPRINT(Politoed)
         LEARNSETS(Politoed),
     },
 #endif //P_GEN_2_CROSS_EVOS
@@ -4856,7 +4856,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,
         PALETTES(Abra),
         ICON(Abra, 2),
-        FOOTPRINT(Abra),
+        FOOTPRINT(Abra)
         LEARNSETS(Abra),
         .evolutions = EVOLUTION({EVO_LEVEL, 16, SPECIES_KADABRA}),
     },
@@ -4908,7 +4908,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,
         PALETTES(Kadabra),
         ICON(Kadabra, 2),
-        FOOTPRINT(Kadabra),
+        FOOTPRINT(Kadabra)
         LEARNSETS(Kadabra),
         .evolutions = EVOLUTION({EVO_TRADE, 0, SPECIES_ALAKAZAM},
                                 {EVO_ITEM, ITEM_LINKING_CORD, SPECIES_ALAKAZAM}),
@@ -4930,7 +4930,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .speciesName = _("Alakazam"),                               \
         .natDexNum = NATIONAL_DEX_ALAKAZAM,                         \
         .categoryName = _("Psi"),                                   \
-        FOOTPRINT(Alakazam),                                        \
+        FOOTPRINT(Alakazam)                                         \
         LEARNSETS(Alakazam),                                        \
         .formSpeciesIdTable = sAlakazamFormSpeciesIdTable,          \
         .formChangeTable = sAlakazamFormChangeTable
@@ -5054,7 +5054,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Machop),
         ICON(Machop, 0),
-        FOOTPRINT(Machop),
+        FOOTPRINT(Machop)
         LEARNSETS(Machop),
         .evolutions = EVOLUTION({EVO_LEVEL, 28, SPECIES_MACHOKE}),
     },
@@ -5104,7 +5104,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Machoke),
         ICON(Machoke, 2),
-        FOOTPRINT(Machoke),
+        FOOTPRINT(Machoke)
         LEARNSETS(Machoke),
         .evolutions = EVOLUTION({EVO_TRADE, 0, SPECIES_MACHAMP},
                                 {EVO_ITEM, ITEM_LINKING_CORD, SPECIES_MACHAMP}),
@@ -5133,7 +5133,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .cryId = CRY_MACHAMP,                                               \
         .natDexNum = NATIONAL_DEX_MACHAMP,                                  \
         .categoryName = _("Superpower"),                                    \
-        FOOTPRINT(Machamp),                                                 \
+        FOOTPRINT(Machamp)                                                  \
         LEARNSETS(Machamp),                                                 \
         .formSpeciesIdTable = sMachampFormSpeciesIdTable,                   \
         .formChangeTable = sMachampFormChangeTable
@@ -5236,7 +5236,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_V_STRETCH,
         PALETTES(Bellsprout),
         ICON(Bellsprout, 1),
-        FOOTPRINT(Bellsprout),
+        FOOTPRINT(Bellsprout)
         LEARNSETS(Bellsprout),
         .evolutions = EVOLUTION({EVO_LEVEL, 21, SPECIES_WEEPINBELL}),
     },
@@ -5285,7 +5285,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_V_STRETCH,
         PALETTES(Weepinbell),
         ICON(Weepinbell, 1),
-        FOOTPRINT(Weepinbell),
+        FOOTPRINT(Weepinbell)
         LEARNSETS(Weepinbell),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_LEAF_STONE, SPECIES_VICTREEBEL}),
     },
@@ -5333,7 +5333,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_V_STRETCH,
         PALETTES(Victreebel),
         ICON(Victreebel, 1),
-        FOOTPRINT(Victreebel),
+        FOOTPRINT(Victreebel)
         LEARNSETS(Victreebel),
     },
 #endif //P_FAMILY_BELLSPROUT
@@ -5383,7 +5383,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Tentacool),
         ICON(Tentacool, 0),
-        FOOTPRINT(Tentacool),
+        FOOTPRINT(Tentacool)
         LEARNSETS(Tentacool),
         .evolutions = EVOLUTION({EVO_LEVEL, 30, SPECIES_TENTACRUEL}),
     },
@@ -5432,7 +5432,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Tentacruel),
         ICON(Tentacruel, 0),
-        FOOTPRINT(Tentacruel),
+        FOOTPRINT(Tentacruel)
         LEARNSETS(Tentacruel),
     },
 #endif //P_FAMILY_TENTACOOL
@@ -5470,7 +5470,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .pokemonOffset = 18,                                \
         .trainerScale = 256,                                \
         .trainerOffset = 0,                                 \
-        FOOTPRINT(Geodude),                                 \
+        FOOTPRINT(Geodude)                                  \
         .formSpeciesIdTable = sGeodudeFormSpeciesIdTable,   \
         GEODUDE_FAMILY_MISC_INFO
 
@@ -5493,7 +5493,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .pokemonOffset = 2,                                 \
         .trainerScale = 256,                                \
         .trainerOffset = 0,                                 \
-        FOOTPRINT(Graveler),                                \
+        FOOTPRINT(Graveler)                                 \
         .formSpeciesIdTable = sGravelerFormSpeciesIdTable,  \
         GEODUDE_FAMILY_MISC_INFO
 
@@ -5513,7 +5513,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .cryId = CRY_GOLEM,                             \
         .natDexNum = NATIONAL_DEX_GOLEM,                \
         .categoryName = _("Megaton"),                   \
-        FOOTPRINT(Golem),                               \
+        FOOTPRINT(Golem)                                \
         .formSpeciesIdTable = sGolemFormSpeciesIdTable, \
         GEODUDE_FAMILY_MISC_INFO
 
@@ -5704,7 +5704,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .speciesName = _("Ponyta"),                     \
         .cryId = CRY_PONYTA,                            \
         .natDexNum = NATIONAL_DEX_PONYTA,               \
-        FOOTPRINT(Ponyta),                              \
+        FOOTPRINT(Ponyta)                               \
         .formSpeciesIdTable = sPonytaFormSpeciesIdTable,\
         PONYTA_FAMILY_MISC_INFO
 
@@ -5726,7 +5726,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .pokemonOffset = 0,                                 \
         .trainerScale = 289,                                \
         .trainerOffset = 1,                                 \
-        FOOTPRINT(Rapidash),                                \
+        FOOTPRINT(Rapidash)                                 \
         .formSpeciesIdTable = sRapidashFormSpeciesIdTable,  \
         PONYTA_FAMILY_MISC_INFO
 
@@ -5871,7 +5871,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .pokemonOffset = 10,                                    \
         .trainerScale = 256,                                    \
         .trainerOffset = 0,                                     \
-        FOOTPRINT(Slowpoke),                                    \
+        FOOTPRINT(Slowpoke)                                     \
         .formSpeciesIdTable = sSlowpokeFormSpeciesIdTable
 
 #define SLOWBRO_MISC_INFO                                       \
@@ -5887,7 +5887,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .cryId = CRY_SLOWBRO,                                   \
         .natDexNum = NATIONAL_DEX_SLOWBRO,                      \
         .categoryName = _("Hermit Crab"),                       \
-        FOOTPRINT(Slowbro),                                     \
+        FOOTPRINT(Slowbro)                                      \
         .formSpeciesIdTable = sSlowbroFormSpeciesIdTable
 
 #define SLOWKING_MISC_INFO                                      \
@@ -5903,7 +5903,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .cryId = CRY_SLOWKING,                                  \
         .natDexNum = NATIONAL_DEX_SLOWKING,                     \
         .weight = 795,                                          \
-        FOOTPRINT(Slowking),                                    \
+        FOOTPRINT(Slowking)                                     \
         .formSpeciesIdTable = sSlowkingFormSpeciesIdTable
 
     [SPECIES_SLOWPOKE] =
@@ -6198,7 +6198,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Magnemite),
         ICON(Magnemite, 0),
-        FOOTPRINT(Magnemite),
+        FOOTPRINT(Magnemite)
         LEARNSETS(Magnemite),
         .evolutions = EVOLUTION({EVO_LEVEL, 30, SPECIES_MAGNETON}),
     },
@@ -6248,7 +6248,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Magneton),
         ICON(Magneton, 0),
-        FOOTPRINT(Magneton),
+        FOOTPRINT(Magneton)
         LEARNSETS(Magneton),
         .evolutions = EVOLUTION({EVO_MAPSEC, MAPSEC_NEW_MAUVILLE, SPECIES_MAGNEZONE},
                                 {EVO_ITEM, ITEM_THUNDER_STONE, SPECIES_MAGNEZONE}),
@@ -6300,7 +6300,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Magnezone),
         ICON(Magnezone, 0),
-        FOOTPRINT(Magnezone),
+        FOOTPRINT(Magnezone)
         LEARNSETS(Magnezone),
     },
 #endif //P_GEN_4_CROSS_EVOS
@@ -6323,7 +6323,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .cryId = CRY_FARFETCHD,                             \
         .natDexNum = NATIONAL_DEX_FARFETCHD,                \
         .categoryName = _("Wild Duck"),                     \
-        FOOTPRINT(Farfetchd),                               \
+        FOOTPRINT(Farfetchd)                                \
         .formSpeciesIdTable = sFarfetchdFormSpeciesIdTable
 
     [SPECIES_FARFETCHD] =
@@ -6443,7 +6443,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Sirfetchd),
         ICON(Sirfetchd, 1),
-        FOOTPRINT(Sirfetchd),
+        FOOTPRINT(Sirfetchd)
         LEARNSETS(Sirfetchd),
     },
 #endif //P_GALARIAN_FORMS
@@ -6496,7 +6496,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Doduo),
         ICON(Doduo, 2),
-        FOOTPRINT(Doduo),
+        FOOTPRINT(Doduo)
         LEARNSETS(Doduo),
         .evolutions = EVOLUTION({EVO_LEVEL, 31, SPECIES_DODRIO}),
     },
@@ -6547,7 +6547,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Dodrio),
         ICON(Dodrio, 2),
-        FOOTPRINT(Dodrio),
+        FOOTPRINT(Dodrio)
         LEARNSETS(Dodrio),
     },
 #endif //P_FAMILY_DODUO
@@ -6596,7 +6596,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Seel),
         ICON(Seel, 0),
-        FOOTPRINT(Seel),
+        FOOTPRINT(Seel)
         LEARNSETS(Seel),
         .evolutions = EVOLUTION({EVO_LEVEL, 34, SPECIES_DEWGONG}),
     },
@@ -6644,7 +6644,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Dewgong),
         ICON(Dewgong, 2),
-        FOOTPRINT(Dewgong),
+        FOOTPRINT(Dewgong)
         LEARNSETS(Dewgong),
     },
 #endif //P_FAMILY_SEEL
@@ -6672,7 +6672,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .cryId = CRY_GRIMER,                            \
         .natDexNum = NATIONAL_DEX_GRIMER,               \
         .categoryName = _("Sludge"),                    \
-        FOOTPRINT(Grimer),                              \
+        FOOTPRINT(Grimer)                               \
         .formSpeciesIdTable = sGrimerFormSpeciesIdTable,\
         GRIMER_FAMILY_MISC_INFO
 
@@ -6691,7 +6691,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .cryId = CRY_MUK,                               \
         .natDexNum = NATIONAL_DEX_MUK,                  \
         .categoryName = _("Sludge"),                    \
-        FOOTPRINT(Muk),                                 \
+        FOOTPRINT(Muk)                                  \
         .formSpeciesIdTable = sMukFormSpeciesIdTable,   \
         GRIMER_FAMILY_MISC_INFO
 
@@ -6868,7 +6868,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Shellder),
         ICON(Shellder, 2),
-        FOOTPRINT(Shellder),
+        FOOTPRINT(Shellder)
         LEARNSETS(Shellder),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_WATER_STONE, SPECIES_CLOYSTER}),
     },
@@ -6918,7 +6918,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Cloyster),
         ICON(Cloyster, 2),
-        FOOTPRINT(Cloyster),
+        FOOTPRINT(Cloyster)
         LEARNSETS(Cloyster),
     },
 #endif //P_FAMILY_SHELLDER
@@ -6968,7 +6968,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_H_VIBRATE,
         PALETTES(Gastly),
         ICON(Gastly, 2),
-        FOOTPRINT(Gastly),
+        FOOTPRINT(Gastly)
         LEARNSETS(Gastly),
         .evolutions = EVOLUTION({EVO_LEVEL, 25, SPECIES_HAUNTER}),
     },
@@ -7018,7 +7018,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_H_VIBRATE,
         PALETTES(Haunter),
         ICON(Haunter, 2),
-        FOOTPRINT(Haunter),
+        FOOTPRINT(Haunter)
         LEARNSETS(Haunter),
         .evolutions = EVOLUTION({EVO_TRADE, 0, SPECIES_GENGAR},
                                 {EVO_ITEM, ITEM_LINKING_CORD, SPECIES_GENGAR}),
@@ -7043,7 +7043,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .speciesName = _("Gengar"),                                 \
         .natDexNum = NATIONAL_DEX_GENGAR,                           \
         .categoryName = _("Shadow"),                                \
-        FOOTPRINT(Gengar),                                          \
+        FOOTPRINT(Gengar)                                           \
         LEARNSETS(Gengar),                                          \
         .formSpeciesIdTable = sGengarFormSpeciesIdTable,            \
         .formChangeTable = sGengarFormChangeTable
@@ -7198,7 +7198,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Onix),
         ICON(Onix, 2),
-        FOOTPRINT(Onix),
+        FOOTPRINT(Onix)
         LEARNSETS(Onix),
         .evolutions = EVOLUTION({EVO_TRADE_ITEM, ITEM_METAL_COAT, SPECIES_STEELIX},
                                 {EVO_ITEM, ITEM_METAL_COAT, SPECIES_STEELIX}),
@@ -7219,7 +7219,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .speciesName = _("Steelix"),                            \
         .natDexNum = NATIONAL_DEX_STEELIX,                      \
         .categoryName = _("Iron Snake"),                        \
-        FOOTPRINT(Steelix),                                     \
+        FOOTPRINT(Steelix)                                      \
         LEARNSETS(Steelix),                                     \
         .formSpeciesIdTable = sSteelixFormSpeciesIdTable,       \
         .formChangeTable = sSteelixFormChangeTable
@@ -7345,7 +7345,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Drowzee),
         ICON(Drowzee, 2),
-        FOOTPRINT(Drowzee),
+        FOOTPRINT(Drowzee)
         LEARNSETS(Drowzee),
         .evolutions = EVOLUTION({EVO_LEVEL, 26, SPECIES_HYPNO}),
     },
@@ -7396,7 +7396,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,
         PALETTES(Hypno),
         ICON(Hypno, 2),
-        FOOTPRINT(Hypno),
+        FOOTPRINT(Hypno)
         LEARNSETS(Hypno),
     },
 #endif //P_FAMILY_DROWZEE
@@ -7445,7 +7445,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_V_SHAKE_H_SLIDE,
         PALETTES(Krabby),
         ICON(Krabby, 0),
-        FOOTPRINT(Krabby),
+        FOOTPRINT(Krabby)
         LEARNSETS(Krabby),
         .evolutions = EVOLUTION({EVO_LEVEL, 28, SPECIES_KINGLER}),
     },
@@ -7473,7 +7473,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .cryId = CRY_KINGLER,                                                           \
         .natDexNum = NATIONAL_DEX_KINGLER,                                              \
         .categoryName = _("Pincer"),                                                    \
-        FOOTPRINT(Kingler),                                                             \
+        FOOTPRINT(Kingler)                                                              \
         LEARNSETS(Kingler),                                                             \
         .formSpeciesIdTable = sKinglerFormSpeciesIdTable,                               \
         .formChangeTable = sKinglerFormChangeTable
@@ -7561,7 +7561,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .pokemonOffset = -8,                                \
         .trainerScale = 256,                                \
         .trainerOffset = 0,                                 \
-        FOOTPRINT(Voltorb),                                 \
+        FOOTPRINT(Voltorb)                                  \
         .formSpeciesIdTable = sVoltorbFormSpeciesIdTable,   \
         VOLTORB_FAMILY_MISC_INFO
 
@@ -7583,7 +7583,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .pokemonOffset = 0,                                     \
         .trainerScale = 256,                                    \
         .trainerOffset = 0,                                     \
-        FOOTPRINT(Electrode),                                   \
+        FOOTPRINT(Electrode)                                    \
         .formSpeciesIdTable = sElectrodeFormSpeciesIdTable,     \
         VOLTORB_FAMILY_MISC_INFO
 
@@ -7731,7 +7731,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Exeggcute),
         ICON(Exeggcute, 0),
-        FOOTPRINT(Exeggcute),
+        FOOTPRINT(Exeggcute)
         LEARNSETS(Exeggcute),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_LEAF_STONE, SPECIES_EXEGGUTOR},
                                 {EVO_NONE, 0, SPECIES_EXEGGUTOR_ALOLAN}),
@@ -7751,7 +7751,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .cryId = CRY_EXEGGUTOR,                             \
         .natDexNum = NATIONAL_DEX_EXEGGUTOR,                \
         .categoryName = _("Coconut"),                       \
-        FOOTPRINT(Exeggutor),                               \
+        FOOTPRINT(Exeggutor)                                \
         .formSpeciesIdTable = sExeggutorFormSpeciesIdTable
 
 #define EXEGGUTOR_SP_DEF (P_UPDATED_STATS >= GEN_7 ? 75 : 65)
@@ -7874,7 +7874,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Cubone),
         ICON(Cubone, 2),
-        FOOTPRINT(Cubone),
+        FOOTPRINT(Cubone)
         LEARNSETS(Cubone),
         .evolutions = EVOLUTION({EVO_LEVEL, 28, SPECIES_MAROWAK},
                                 {EVO_NONE, 0, SPECIES_MAROWAK_ALOLAN}),
@@ -7905,7 +7905,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .pokemonOffset = 12,                                    \
         .trainerScale = 256,                                    \
         .trainerOffset = 0,                                     \
-        FOOTPRINT(Marowak),                                     \
+        FOOTPRINT(Marowak)                                      \
         .formSpeciesIdTable = sMarowakFormSpeciesIdTable
 
     [SPECIES_MAROWAK] =
@@ -8005,7 +8005,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Tyrogue),
         ICON(Tyrogue, 2),
-        FOOTPRINT(Tyrogue),
+        FOOTPRINT(Tyrogue)
         LEARNSETS(Tyrogue),
         .evolutions = EVOLUTION({EVO_LEVEL_ATK_LT_DEF, 20, SPECIES_HITMONCHAN},
                                 {EVO_LEVEL_ATK_GT_DEF, 20, SPECIES_HITMONLEE},
@@ -8056,7 +8056,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Hitmonlee),
         ICON(Hitmonlee, 2),
-        FOOTPRINT(Hitmonlee),
+        FOOTPRINT(Hitmonlee)
         LEARNSETS(Hitmonlee),
     },
 
@@ -8103,7 +8103,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Hitmonchan),
         ICON(Hitmonchan, 2),
-        FOOTPRINT(Hitmonchan),
+        FOOTPRINT(Hitmonchan)
         LEARNSETS(Hitmonchan),
     },
 
@@ -8151,7 +8151,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_CIRCLE_COUNTERCLOCKWISE,
         PALETTES(Hitmontop),
         ICON(Hitmontop, 2),
-        FOOTPRINT(Hitmontop),
+        FOOTPRINT(Hitmontop)
         LEARNSETS(Hitmontop),
     },
 #endif //P_GEN_2_CROSS_EVOS
@@ -8202,7 +8202,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Lickitung),
         ICON(Lickitung, 0),
-        FOOTPRINT(Lickitung),
+        FOOTPRINT(Lickitung)
         LEARNSETS(Lickitung),
         .evolutions = EVOLUTION({EVO_MOVE, MOVE_ROLLOUT, SPECIES_LICKILICKY}),
     },
@@ -8252,7 +8252,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Lickilicky),
         ICON(Lickilicky, 1),
-        FOOTPRINT(Lickilicky),
+        FOOTPRINT(Lickilicky)
         LEARNSETS(Lickilicky),
     },
 #endif //P_GEN_4_CROSS_EVOS
@@ -8308,7 +8308,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_GROW,
         PALETTES(Koffing),
         ICON(Koffing, 2),
-        FOOTPRINT(Koffing),
+        FOOTPRINT(Koffing)
         LEARNSETS(Koffing),
         .evolutions = EVOLUTION({EVO_LEVEL, 35, SPECIES_WEEZING},
                                 {EVO_NONE, 0, SPECIES_WEEZING_GALARIAN}),
@@ -8334,7 +8334,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .cryId = CRY_WEEZING,                                       \
         .natDexNum = NATIONAL_DEX_WEEZING,                          \
         .categoryName = _("Poison Gas"),                            \
-        FOOTPRINT(Weezing),                                         \
+        FOOTPRINT(Weezing)                                          \
         .formSpeciesIdTable = sWeezingFormSpeciesIdTable
 
     [SPECIES_WEEZING] =
@@ -8453,7 +8453,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_V_SHAKE_LOW,
         PALETTES(Rhyhorn),
         ICON(Rhyhorn, 1),
-        FOOTPRINT(Rhyhorn),
+        FOOTPRINT(Rhyhorn)
         LEARNSETS(Rhyhorn),
         .evolutions = EVOLUTION({EVO_LEVEL, 42, SPECIES_RHYDON}),
     },
@@ -8503,7 +8503,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_V_SHAKE_LOW,
         PALETTES(Rhydon),
         ICON(Rhydon, 1),
-        FOOTPRINT(Rhydon),
+        FOOTPRINT(Rhydon)
         LEARNSETS(Rhydon),
         .evolutions = EVOLUTION({EVO_TRADE_ITEM, ITEM_PROTECTOR, SPECIES_RHYPERIOR},
                                 {EVO_ITEM, ITEM_PROTECTOR, SPECIES_RHYPERIOR}),
@@ -8555,7 +8555,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Rhyperior),
         ICON(Rhyperior, 0),
-        FOOTPRINT(Rhyperior),
+        FOOTPRINT(Rhyperior)
         LEARNSETS(Rhyperior),
     },
 #endif //P_GEN_4_CROSS_EVOS
@@ -8607,7 +8607,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Happiny),
         ICON(Happiny, 0),
-        FOOTPRINT(Happiny),
+        FOOTPRINT(Happiny)
         LEARNSETS(Happiny),
         .evolutions = EVOLUTION({EVO_ITEM_HOLD_DAY, ITEM_OVAL_STONE, SPECIES_CHANSEY},
                                 {EVO_ITEM_DAY, ITEM_OVAL_STONE, SPECIES_CHANSEY}),
@@ -8658,7 +8658,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Chansey),
         ICON(Chansey, 0),
-        FOOTPRINT(Chansey),
+        FOOTPRINT(Chansey)
         LEARNSETS(Chansey),
         .evolutions = EVOLUTION({EVO_FRIENDSHIP, 0, SPECIES_BLISSEY}),
     },
@@ -8708,7 +8708,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Blissey),
         ICON(Blissey, 0),
-        FOOTPRINT(Blissey),
+        FOOTPRINT(Blissey)
         LEARNSETS(Blissey),
     },
 #endif //P_GEN_2_CROSS_EVOS
@@ -8758,7 +8758,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_V_STRETCH,
         PALETTES(Tangela),
         ICON(Tangela, 0),
-        FOOTPRINT(Tangela),
+        FOOTPRINT(Tangela)
         LEARNSETS(Tangela),
         .evolutions = EVOLUTION({EVO_MOVE, MOVE_ANCIENT_POWER, SPECIES_TANGROWTH}),
     },
@@ -8808,7 +8808,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_GROW,
         PALETTES(Tangrowth),
         ICON(Tangrowth, 0),
-        FOOTPRINT(Tangrowth),
+        FOOTPRINT(Tangrowth)
         LEARNSETS(Tangrowth),
     },
 #endif //P_GEN_4_CROSS_EVOS
@@ -8833,7 +8833,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .pokemonOffset = 0,                                     \
         .trainerScale = 387,                                    \
         .trainerOffset = 8,                                     \
-        FOOTPRINT(Kangaskhan),                                  \
+        FOOTPRINT(Kangaskhan)                                   \
         LEARNSETS(Kangaskhan),                                  \
         .formSpeciesIdTable = sKangaskhanFormSpeciesIdTable,    \
         .formChangeTable = sKangaskhanFormChangeTable
@@ -8945,7 +8945,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Horsea),
         ICON(Horsea, 0),
-        FOOTPRINT(Horsea),
+        FOOTPRINT(Horsea)
         LEARNSETS(Horsea),
         .evolutions = EVOLUTION({EVO_LEVEL, 32, SPECIES_SEADRA}),
     },
@@ -8995,7 +8995,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Seadra),
         ICON(Seadra, 0),
-        FOOTPRINT(Seadra),
+        FOOTPRINT(Seadra)
         LEARNSETS(Seadra),
         .evolutions = EVOLUTION({EVO_TRADE_ITEM, ITEM_DRAGON_SCALE, SPECIES_KINGDRA},
                                 {EVO_ITEM, ITEM_DRAGON_SCALE, SPECIES_KINGDRA}),
@@ -9048,7 +9048,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_SHAKE_GLOW_BLUE,
         PALETTES(Kingdra),
         ICON(Kingdra, 0),
-        FOOTPRINT(Kingdra),
+        FOOTPRINT(Kingdra)
         LEARNSETS(Kingdra),
     },
 #endif //P_GEN_2_CROSS_EVOS
@@ -9101,7 +9101,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Goldeen),
         ICON(Goldeen, 0),
-        FOOTPRINT(Goldeen),
+        FOOTPRINT(Goldeen)
         LEARNSETS(Goldeen),
         .evolutions = EVOLUTION({EVO_LEVEL, 33, SPECIES_SEAKING}),
     },
@@ -9152,7 +9152,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Seaking),
         ICON(Seaking, 0),
-        FOOTPRINT(Seaking),
+        FOOTPRINT(Seaking)
         LEARNSETS(Seaking),
     },
 #endif //P_FAMILY_GOLDEEN
@@ -9204,7 +9204,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Staryu),
         ICON(Staryu, 2),
-        FOOTPRINT(Staryu),
+        FOOTPRINT(Staryu)
         LEARNSETS(Staryu),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_WATER_STONE, SPECIES_STARMIE}),
     },
@@ -9254,7 +9254,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_SHAKE_GLOW_BLUE,
         PALETTES(Starmie),
         ICON(Starmie, 2),
-        FOOTPRINT(Starmie),
+        FOOTPRINT(Starmie)
         LEARNSETS(Starmie),
     },
 #endif //P_FAMILY_STARYU
@@ -9308,7 +9308,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_LARGE,
         PALETTES(MimeJr),
         ICON(MimeJr, 0),
-        FOOTPRINT(MimeJr),
+        FOOTPRINT(MimeJr)
         LEARNSETS(MimeJr),
         .evolutions = EVOLUTION({EVO_MOVE, MOVE_MIMIC, SPECIES_MR_MIME},
                                 {EVO_NONE, 0, SPECIES_MR_MIME_GALARIAN}),
@@ -9326,7 +9326,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .speciesName = _("Mr. Mime"),                               \
         .cryId = CRY_MR_MIME,                                       \
         .natDexNum = NATIONAL_DEX_MR_MIME,                          \
-        FOOTPRINT(MrMime),                                          \
+        FOOTPRINT(MrMime)                                           \
         .formSpeciesIdTable = sMrMimeFormSpeciesIdTable
 
     [SPECIES_MR_MIME] =
@@ -9452,7 +9452,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(MrRime),
         ICON(MrRime, 0),
-        FOOTPRINT(MrRime),
+        FOOTPRINT(MrRime)
         LEARNSETS(MrRime),
     },
 #endif //P_GALARIAN_FORMS
@@ -9504,7 +9504,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Scyther),
         ICON(Scyther, 1),
-        FOOTPRINT(Scyther),
+        FOOTPRINT(Scyther)
         LEARNSETS(Scyther),
         .evolutions = EVOLUTION({EVO_TRADE_ITEM, ITEM_METAL_COAT, SPECIES_SCIZOR},
                                 {EVO_ITEM, ITEM_BLACK_AUGURITE, SPECIES_KLEAVOR},
@@ -9525,7 +9525,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .speciesName = _("Scizor"),                     \
         .natDexNum = NATIONAL_DEX_SCIZOR,               \
         .categoryName = _("Pincer"),                    \
-        FOOTPRINT(Scizor),                              \
+        FOOTPRINT(Scizor)                               \
         LEARNSETS(Scizor),                              \
         .formSpeciesIdTable = sScizorFormSpeciesIdTable,\
         .formChangeTable = sScizorFormChangeTable
@@ -9648,7 +9648,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Kleavor),
         ICON(Kleavor, 2),
-        //FOOTPRINT(Kleavor),
+        //FOOTPRINT(Kleavor)
         LEARNSETS(Kleavor),
     },
 #endif //P_GEN_8_CROSS_EVOS
@@ -9700,7 +9700,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Smoochum),
         ICON(Smoochum, 1),
-        FOOTPRINT(Smoochum),
+        FOOTPRINT(Smoochum)
         LEARNSETS(Smoochum),
         .evolutions = EVOLUTION({EVO_LEVEL, 30, SPECIES_JYNX}),
     },
@@ -9749,7 +9749,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Jynx),
         ICON(Jynx, 2),
-        FOOTPRINT(Jynx),
+        FOOTPRINT(Jynx)
         LEARNSETS(Jynx),
     },
 #endif //P_FAMILY_JYNX
@@ -9801,7 +9801,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_H_SHAKE,
         PALETTES(Elekid),
         ICON(Elekid, 1),
-        FOOTPRINT(Elekid),
+        FOOTPRINT(Elekid)
         LEARNSETS(Elekid),
         .evolutions = EVOLUTION({EVO_LEVEL, 30, SPECIES_ELECTABUZZ}),
     },
@@ -9852,7 +9852,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_SHAKE_FLASH_YELLOW,
         PALETTES(Electabuzz),
         ICON(Electabuzz, 1),
-        FOOTPRINT(Electabuzz),
+        FOOTPRINT(Electabuzz)
         LEARNSETS(Electabuzz),
         .evolutions = EVOLUTION({EVO_TRADE_ITEM, ITEM_ELECTIRIZER, SPECIES_ELECTIVIRE},
                                 {EVO_ITEM, ITEM_ELECTIRIZER, SPECIES_ELECTIVIRE}),
@@ -9903,7 +9903,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_SHAKE_FLASH_YELLOW,
         PALETTES(Electivire),
         ICON(Electivire, 1),
-        FOOTPRINT(Electivire),
+        FOOTPRINT(Electivire)
         LEARNSETS(Electivire),
     },
 #endif //P_GEN_4_CROSS_EVOS
@@ -9956,7 +9956,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_SHAKE_GLOW_RED,
         PALETTES(Magby),
         ICON(Magby, 0),
-        FOOTPRINT(Magby),
+        FOOTPRINT(Magby)
         LEARNSETS(Magby),
         .evolutions = EVOLUTION({EVO_LEVEL, 30, SPECIES_MAGMAR}),
     },
@@ -10006,7 +10006,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_SHAKE_GLOW_RED,
         PALETTES(Magmar),
         ICON(Magmar, 0),
-        FOOTPRINT(Magmar),
+        FOOTPRINT(Magmar)
         LEARNSETS(Magmar),
         .evolutions = EVOLUTION({EVO_TRADE_ITEM, ITEM_MAGMARIZER, SPECIES_MAGMORTAR},
                                 {EVO_ITEM, ITEM_MAGMARIZER, SPECIES_MAGMORTAR}),
@@ -10058,7 +10058,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_SHAKE_GLOW_RED,
         PALETTES(Magmortar),
         ICON(Magmortar, 0),
-        FOOTPRINT(Magmortar),
+        FOOTPRINT(Magmortar)
         LEARNSETS(Magmortar),
     },
 #endif //P_GEN_4_CROSS_EVOS
@@ -10077,7 +10077,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .speciesName = _("Pinsir"),                     \
         .natDexNum = NATIONAL_DEX_PINSIR,               \
         .categoryName = _("Stag Beetle"),               \
-        FOOTPRINT(Pinsir),                              \
+        FOOTPRINT(Pinsir)                               \
         LEARNSETS(Pinsir),                              \
         .formSpeciesIdTable = sPinsirFormSpeciesIdTable,\
         .formChangeTable = sPinsirFormChangeTable
@@ -10181,7 +10181,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .pokemonOffset = 0,                                 \
         .trainerScale = 256,                                \
         .trainerOffset = 0,                                 \
-        FOOTPRINT(Tauros),                                  \
+        FOOTPRINT(Tauros)                                   \
         .formSpeciesIdTable = sTaurosFormSpeciesIdTable
 
     [SPECIES_TAUROS] =
@@ -10338,7 +10338,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_LARGE,
         PALETTES(Magikarp),
         ICON(Magikarp, 0),
-        FOOTPRINT(Magikarp),
+        FOOTPRINT(Magikarp)
         LEARNSETS(Magikarp),
         .evolutions = EVOLUTION({EVO_LEVEL, 20, SPECIES_GYARADOS}),
     },
@@ -10360,7 +10360,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .pokemonOffset = 6,                                 \
         .trainerScale = 481,                                \
         .trainerOffset = 13,                                \
-        FOOTPRINT(Gyarados),                                \
+        FOOTPRINT(Gyarados)                                 \
         LEARNSETS(Gyarados),                                \
         .formSpeciesIdTable = sGyaradosFormSpeciesIdTable,  \
         .formChangeTable = sGyaradosFormChangeTable
@@ -10457,7 +10457,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .cryId = CRY_LAPRAS,                                                            \
         .natDexNum = NATIONAL_DEX_LAPRAS,                                               \
         .categoryName = _("Transport"),                                                 \
-        FOOTPRINT(Lapras),                                                              \
+        FOOTPRINT(Lapras)                                                               \
         LEARNSETS(Lapras),                                                              \
         .formSpeciesIdTable = sLaprasFormSpeciesIdTable,                                \
         .formChangeTable = sLaprasFormChangeTable
@@ -10562,7 +10562,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW,
         PALETTES(Ditto),
         ICON(Ditto, 2),
-        FOOTPRINT(Ditto),
+        FOOTPRINT(Ditto)
         LEARNSETS(Ditto),
     },
 #endif //P_FAMILY_DITTO
@@ -10590,7 +10590,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .cryId = CRY_EEVEE,                                                             \
         .natDexNum = NATIONAL_DEX_EEVEE,                                                \
         .categoryName = _("Evolution"),                                                 \
-        FOOTPRINT(Eevee),                                                               \
+        FOOTPRINT(Eevee)                                                                \
         LEARNSETS(Eevee),                                                               \
         .formSpeciesIdTable = sEeveeFormSpeciesIdTable,                                 \
         .formChangeTable = sEeveeFormChangeTable
@@ -10703,7 +10703,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_SHAKE_GLOW_BLUE,
         PALETTES(Vaporeon),
         ICON(Vaporeon, 0),
-        FOOTPRINT(Vaporeon),
+        FOOTPRINT(Vaporeon)
         LEARNSETS(Vaporeon),
     },
 
@@ -10750,7 +10750,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_SHAKE_FLASH_YELLOW,
         PALETTES(Jolteon),
         ICON(Jolteon, 2),
-        FOOTPRINT(Jolteon),
+        FOOTPRINT(Jolteon)
         LEARNSETS(Jolteon),
     },
 
@@ -10797,7 +10797,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_SHAKE_GLOW_RED,
         PALETTES(Flareon),
         ICON(Flareon, 3),
-        FOOTPRINT(Flareon),
+        FOOTPRINT(Flareon)
         LEARNSETS(Flareon),
     },
 
@@ -10845,7 +10845,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,
         PALETTES(Espeon),
         ICON(Espeon, 2),
-        FOOTPRINT(Espeon),
+        FOOTPRINT(Espeon)
         LEARNSETS(Espeon),
     },
 
@@ -10892,7 +10892,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,
         PALETTES(Umbreon),
         ICON(Umbreon, 0),
-        FOOTPRINT(Umbreon),
+        FOOTPRINT(Umbreon)
         LEARNSETS(Umbreon),
     },
 #endif //P_GEN_2_CROSS_EVOS
@@ -10941,7 +10941,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,
         PALETTES(Leafeon),
         ICON(Leafeon, 1),
-        FOOTPRINT(Leafeon),
+        FOOTPRINT(Leafeon)
         LEARNSETS(Leafeon),
     },
 
@@ -10988,7 +10988,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,
         PALETTES(Glaceon),
         ICON(Glaceon, 0),
-        FOOTPRINT(Glaceon),
+        FOOTPRINT(Glaceon)
         LEARNSETS(Glaceon),
     },
 #endif //P_GEN_4_CROSS_EVOS
@@ -11038,7 +11038,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,
         PALETTES(Sylveon),
         ICON(Sylveon, 0),
-        FOOTPRINT(Sylveon),
+        FOOTPRINT(Sylveon)
         LEARNSETS(Sylveon),
     },
 #endif //P_GEN_6_CROSS_EVOS
@@ -11088,7 +11088,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_H_VIBRATE,
         PALETTES(Porygon),
         ICON(Porygon, 0),
-        FOOTPRINT(Porygon),
+        FOOTPRINT(Porygon)
         LEARNSETS(Porygon),
         .evolutions = EVOLUTION({EVO_TRADE_ITEM, ITEM_UPGRADE, SPECIES_PORYGON2},
                                 {EVO_ITEM, ITEM_UPGRADE, SPECIES_PORYGON2}),
@@ -11139,7 +11139,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_H_VIBRATE,
         PALETTES(Porygon2),
         ICON(Porygon2, 0),
-        FOOTPRINT(Porygon2),
+        FOOTPRINT(Porygon2)
         LEARNSETS(Porygon2),
         .evolutions = EVOLUTION({EVO_TRADE_ITEM, ITEM_DUBIOUS_DISC, SPECIES_PORYGON_Z},
                                 {EVO_ITEM, ITEM_DUBIOUS_DISC, SPECIES_PORYGON_Z}),
@@ -11190,7 +11190,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_H_VIBRATE,
         PALETTES(PorygonZ),
         ICON(PorygonZ, 0),
-        FOOTPRINT(PorygonZ),
+        FOOTPRINT(PorygonZ)
         LEARNSETS(PorygonZ),
     },
 #endif //P_GEN_4_CROSS_EVOS
@@ -11241,7 +11241,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Omanyte),
         ICON(Omanyte, 0),
-        FOOTPRINT(Omanyte),
+        FOOTPRINT(Omanyte)
         LEARNSETS(Omanyte),
         .evolutions = EVOLUTION({EVO_LEVEL, 40, SPECIES_OMASTAR}),
     },
@@ -11289,7 +11289,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Omastar),
         ICON(Omastar, 0),
-        FOOTPRINT(Omastar),
+        FOOTPRINT(Omastar)
         LEARNSETS(Omastar),
     },
 #endif //P_FAMILY_OMANYTE
@@ -11338,7 +11338,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Kabuto),
         ICON(Kabuto, 2),
-        FOOTPRINT(Kabuto),
+        FOOTPRINT(Kabuto)
         LEARNSETS(Kabuto),
         .evolutions = EVOLUTION({EVO_LEVEL, 40, SPECIES_KABUTOPS}),
     },
@@ -11386,7 +11386,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Kabutops),
         ICON(Kabutops, 2),
-        FOOTPRINT(Kabutops),
+        FOOTPRINT(Kabutops)
         LEARNSETS(Kabutops),
     },
 #endif //P_FAMILY_KABUTO
@@ -11405,7 +11405,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .speciesName = _("Aerodactyl"),                     \
         .natDexNum = NATIONAL_DEX_AERODACTYL,               \
         .categoryName = _("Fossil"),                        \
-        FOOTPRINT(Aerodactyl),                              \
+        FOOTPRINT(Aerodactyl)                               \
         LEARNSETS(Aerodactyl),                              \
         .formSpeciesIdTable = sAerodactylFormSpeciesIdTable,\
         .formChangeTable = sAerodactylFormChangeTable
@@ -11530,7 +11530,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_GROW,
         PALETTES(Munchlax),
         ICON(Munchlax, 3),
-        FOOTPRINT(Munchlax),
+        FOOTPRINT(Munchlax)
         LEARNSETS(Munchlax),
         .evolutions = EVOLUTION({EVO_FRIENDSHIP, 0, SPECIES_SNORLAX}),
     },
@@ -11560,7 +11560,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .cryId = CRY_SNORLAX,                                                   \
         .natDexNum = NATIONAL_DEX_SNORLAX,                                      \
         .categoryName = _("Sleeping"),                                          \
-        FOOTPRINT(Snorlax),                                                     \
+        FOOTPRINT(Snorlax)                                                      \
         LEARNSETS(Snorlax),                                                     \
         .formSpeciesIdTable = sSnorlaxFormSpeciesIdTable,                       \
         .formChangeTable = sSnorlaxFormChangeTable
@@ -11634,7 +11634,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .pokemonOffset = 0,                                             \
         .trainerScale = 309,                                            \
         .trainerOffset = 2,                                             \
-        FOOTPRINT(Articuno),                                            \
+        FOOTPRINT(Articuno)                                             \
         .formSpeciesIdTable = sArticunoFormSpeciesIdTable,              \
         .isLegendary = TRUE
 
@@ -11727,7 +11727,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .pokemonOffset = 0,                                             \
         .trainerScale = 318,                                            \
         .trainerOffset = 3,                                             \
-        FOOTPRINT(Zapdos),                                              \
+        FOOTPRINT(Zapdos)                                               \
         .formSpeciesIdTable = sZapdosFormSpeciesIdTable,                \
         .isLegendary = TRUE
 
@@ -11821,7 +11821,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .pokemonOffset = 0,                                             \
         .trainerScale = 387,                                            \
         .trainerOffset = 8,                                             \
-        FOOTPRINT(Moltres),                                             \
+        FOOTPRINT(Moltres)                                              \
         .formSpeciesIdTable = sMoltresFormSpeciesIdTable,               \
         .isLegendary = TRUE
 
@@ -11942,7 +11942,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Dratini),
         ICON(Dratini, 0),
-        FOOTPRINT(Dratini),
+        FOOTPRINT(Dratini)
         LEARNSETS(Dratini),
         .evolutions = EVOLUTION({EVO_LEVEL, 30, SPECIES_DRAGONAIR}),
     },
@@ -11991,7 +11991,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Dragonair),
         ICON(Dragonair, 0),
-        FOOTPRINT(Dragonair),
+        FOOTPRINT(Dragonair)
         LEARNSETS(Dragonair),
         .evolutions = EVOLUTION({EVO_LEVEL, 55, SPECIES_DRAGONITE}),
     },
@@ -12040,7 +12040,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Dragonite),
         ICON(Dragonite, 2),
-        FOOTPRINT(Dragonite),
+        FOOTPRINT(Dragonite)
         LEARNSETS(Dragonite),
     },
 #endif //P_FAMILY_DRATINI
@@ -12058,7 +12058,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .speciesName = _("Mewtwo"),                                     \
         .natDexNum = NATIONAL_DEX_MEWTWO,                               \
         .categoryName = _("Genetic"),                                   \
-        FOOTPRINT(Mewtwo),                                              \
+        FOOTPRINT(Mewtwo)                                               \
         LEARNSETS(Mewtwo),                                              \
         .formSpeciesIdTable = sMewtwoFormSpeciesIdTable,                \
         .formChangeTable = sMewtwoFormChangeTable,                      \
@@ -12223,7 +12223,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Mew),
         ICON(Mew, 0),
-        FOOTPRINT(Mew),
+        FOOTPRINT(Mew)
         LEARNSETS(Mew),
     },
 #endif //P_FAMILY_MEW

--- a/src/data/pokemon/species_info/gen_2.h
+++ b/src/data/pokemon/species_info/gen_2.h
@@ -47,7 +47,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Chikorita),
         ICON(Chikorita, 1),
-        FOOTPRINT(Chikorita),
+        FOOTPRINT(Chikorita)
         LEARNSETS(Chikorita),
         .evolutions = EVOLUTION({EVO_LEVEL, 16, SPECIES_BAYLEEF}),
     },
@@ -96,7 +96,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Bayleef),
         ICON(Bayleef, 1),
-        FOOTPRINT(Bayleef),
+        FOOTPRINT(Bayleef)
         LEARNSETS(Bayleef),
         .evolutions = EVOLUTION({EVO_LEVEL, 32, SPECIES_MEGANIUM}),
     },
@@ -147,7 +147,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Meganium),
         ICON(Meganium, 1),
-        FOOTPRINT(Meganium),
+        FOOTPRINT(Meganium)
         LEARNSETS(Meganium),
     },
 #endif //P_FAMILY_CHIKORITA
@@ -196,7 +196,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Cyndaquil),
         ICON(Cyndaquil, 3),
-        FOOTPRINT(Cyndaquil),
+        FOOTPRINT(Cyndaquil)
         LEARNSETS(Cyndaquil),
         .evolutions = EVOLUTION({EVO_LEVEL, 14, SPECIES_QUILAVA}),
     },
@@ -245,7 +245,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Quilava),
         ICON(Quilava, 3),
-        FOOTPRINT(Quilava),
+        FOOTPRINT(Quilava)
         LEARNSETS(Quilava),
         .evolutions = EVOLUTION({EVO_LEVEL, 36, SPECIES_TYPHLOSION},
                                 {EVO_NONE, 0, SPECIES_TYPHLOSION_HISUIAN}),
@@ -264,7 +264,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .speciesName = _("Typhlosion"),                                 \
         .cryId = CRY_TYPHLOSION,                                        \
         .natDexNum = NATIONAL_DEX_TYPHLOSION,                           \
-        FOOTPRINT(Typhlosion),                                          \
+        FOOTPRINT(Typhlosion)                                           \
         .formSpeciesIdTable = sTyphlosionFormSpeciesIdTable
 
     [SPECIES_TYPHLOSION] =
@@ -386,7 +386,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Totodile),
         ICON(Totodile, 0),
-        FOOTPRINT(Totodile),
+        FOOTPRINT(Totodile)
         LEARNSETS(Totodile),
         .evolutions = EVOLUTION({EVO_LEVEL, 18, SPECIES_CROCONAW}),
     },
@@ -436,7 +436,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Croconaw),
         ICON(Croconaw, 0),
-        FOOTPRINT(Croconaw),
+        FOOTPRINT(Croconaw)
         LEARNSETS(Croconaw),
         .evolutions = EVOLUTION({EVO_LEVEL, 30, SPECIES_FERALIGATR}),
     },
@@ -486,7 +486,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Feraligatr),
         ICON(Feraligatr, 0),
-        FOOTPRINT(Feraligatr),
+        FOOTPRINT(Feraligatr)
         LEARNSETS(Feraligatr),
     },
 #endif //P_FAMILY_TOTODILE
@@ -535,7 +535,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Sentret),
         ICON(Sentret, 2),
-        FOOTPRINT(Sentret),
+        FOOTPRINT(Sentret)
         LEARNSETS(Sentret),
         .evolutions = EVOLUTION({EVO_LEVEL, 15, SPECIES_FURRET}),
     },
@@ -583,7 +583,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_LARGE,
         PALETTES(Furret),
         ICON(Furret, 2),
-        FOOTPRINT(Furret),
+        FOOTPRINT(Furret)
         LEARNSETS(Furret),
     },
 #endif //P_FAMILY_SENTRET
@@ -632,7 +632,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Hoothoot),
         ICON(Hoothoot, 2),
-        FOOTPRINT(Hoothoot),
+        FOOTPRINT(Hoothoot)
         LEARNSETS(Hoothoot),
         .evolutions = EVOLUTION({EVO_LEVEL, 20, SPECIES_NOCTOWL}),
     },
@@ -680,7 +680,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Noctowl),
         ICON(Noctowl, 2),
-        FOOTPRINT(Noctowl),
+        FOOTPRINT(Noctowl)
         LEARNSETS(Noctowl),
     },
 #endif //P_FAMILY_HOOTHOOT
@@ -731,7 +731,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_V_SHAKE_H_SLIDE,
         PALETTES(Ledyba),
         ICON(Ledyba, 0),
-        FOOTPRINT(Ledyba),
+        FOOTPRINT(Ledyba)
         LEARNSETS(Ledyba),
         .evolutions = EVOLUTION({EVO_LEVEL, 18, SPECIES_LEDIAN}),
     },
@@ -782,7 +782,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Ledian),
         ICON(Ledian, 0),
-        FOOTPRINT(Ledian),
+        FOOTPRINT(Ledian)
         LEARNSETS(Ledian),
     },
 #endif //P_FAMILY_LEDYBA
@@ -831,7 +831,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_V_SHAKE_H_SLIDE,
         PALETTES(Spinarak),
         ICON(Spinarak, 1),
-        FOOTPRINT(Spinarak),
+        FOOTPRINT(Spinarak)
         LEARNSETS(Spinarak),
         .evolutions = EVOLUTION({EVO_LEVEL, 22, SPECIES_ARIADOS}),
     },
@@ -879,7 +879,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Ariados),
         ICON(Ariados, 0),
-        FOOTPRINT(Ariados),
+        FOOTPRINT(Ariados)
         LEARNSETS(Ariados),
     },
 #endif //P_FAMILY_SPINARAK
@@ -929,7 +929,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_V_STRETCH,
         PALETTES(Chinchou),
         ICON(Chinchou, 2),
-        FOOTPRINT(Chinchou),
+        FOOTPRINT(Chinchou)
         LEARNSETS(Chinchou),
         .evolutions = EVOLUTION({EVO_LEVEL, 27, SPECIES_LANTURN}),
     },
@@ -978,7 +978,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_SHAKE_FLASH_YELLOW,
         PALETTES(Lanturn),
         ICON(Lanturn, 0),
-        FOOTPRINT(Lanturn),
+        FOOTPRINT(Lanturn)
         LEARNSETS(Lanturn),
     },
 #endif //P_FAMILY_CHINCHOU
@@ -1029,7 +1029,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Togepi),
         ICON(Togepi, 0),
-        FOOTPRINT(Togepi),
+        FOOTPRINT(Togepi)
         LEARNSETS(Togepi),
         .evolutions = EVOLUTION({EVO_FRIENDSHIP, 0, SPECIES_TOGETIC}),
     },
@@ -1077,7 +1077,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Togetic),
         ICON(Togetic, 0),
-        FOOTPRINT(Togetic),
+        FOOTPRINT(Togetic)
         LEARNSETS(Togetic),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_SHINY_STONE, SPECIES_TOGEKISS}),
     },
@@ -1133,7 +1133,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_LARGE,
         PALETTES(Togekiss),
         ICON(Togekiss, 2),
-        FOOTPRINT(Togekiss),
+        FOOTPRINT(Togekiss)
         LEARNSETS(Togekiss),
     },
 #endif //P_GEN_4_CROSS_EVOS
@@ -1184,7 +1184,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Natu),
         ICON(Natu, 1),
-        FOOTPRINT(Natu),
+        FOOTPRINT(Natu)
         LEARNSETS(Natu),
         .evolutions = EVOLUTION({EVO_LEVEL, 25, SPECIES_XATU}),
     },
@@ -1234,7 +1234,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,
         PALETTES(Xatu),
         ICON(Xatu, 1),
-        FOOTPRINT(Xatu),
+        FOOTPRINT(Xatu)
         LEARNSETS(Xatu),
     },
 #endif //P_FAMILY_NATU
@@ -1284,7 +1284,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Mareep),
         ICON(Mareep, 0),
-        FOOTPRINT(Mareep),
+        FOOTPRINT(Mareep)
         LEARNSETS(Mareep),
         .evolutions = EVOLUTION({EVO_LEVEL, 15, SPECIES_FLAAFFY}),
     },
@@ -1332,7 +1332,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Flaaffy),
         ICON(Flaaffy, 0),
-        FOOTPRINT(Flaaffy),
+        FOOTPRINT(Flaaffy)
         LEARNSETS(Flaaffy),
         .evolutions = EVOLUTION({EVO_LEVEL, 30, SPECIES_AMPHAROS}),
     },
@@ -1355,7 +1355,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .pokemonOffset = 4,                                 \
         .trainerScale = 256,                                \
         .trainerOffset = 0,                                 \
-        FOOTPRINT(Ampharos),                                \
+        FOOTPRINT(Ampharos)                                 \
         LEARNSETS(Ampharos),                                \
         .formSpeciesIdTable = sAmpharosFormSpeciesIdTable,  \
         .formChangeTable = sAmpharosFormChangeTable
@@ -1474,7 +1474,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_LARGE,
         PALETTES(Azurill),
         ICON(Azurill, 0),
-        FOOTPRINT(Azurill),
+        FOOTPRINT(Azurill)
         LEARNSETS(Azurill),
         .evolutions = EVOLUTION({EVO_FRIENDSHIP, 0, SPECIES_MARILL}),
     },
@@ -1527,7 +1527,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Marill),
         ICON(Marill, 0),
-        FOOTPRINT(Marill),
+        FOOTPRINT(Marill)
         LEARNSETS(Marill),
         .evolutions = EVOLUTION({EVO_LEVEL, 18, SPECIES_AZUMARILL}),
     },
@@ -1579,7 +1579,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Azumarill),
         ICON(Azumarill, 0),
-        FOOTPRINT(Azumarill),
+        FOOTPRINT(Azumarill)
         LEARNSETS(Azumarill),
     },
 #endif //P_FAMILY_MARILL
@@ -1629,7 +1629,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_H_VIBRATE,
         PALETTES(Bonsly),
         ICON(Bonsly, 1),
-        FOOTPRINT(Bonsly),
+        FOOTPRINT(Bonsly)
         LEARNSETS(Bonsly),
         .evolutions = EVOLUTION({EVO_MOVE, MOVE_MIMIC, SPECIES_SUDOWOODO}),
     },
@@ -1680,7 +1680,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Sudowoodo),
         ICON(Sudowoodo, 1),
-        FOOTPRINT(Sudowoodo),
+        FOOTPRINT(Sudowoodo)
         LEARNSETS(Sudowoodo),
     },
 #endif //P_FAMILY_SUDOWOODO
@@ -1730,7 +1730,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Hoppip),
         ICON(Hoppip, 1),
-        FOOTPRINT(Hoppip),
+        FOOTPRINT(Hoppip)
         LEARNSETS(Hoppip),
         .evolutions = EVOLUTION({EVO_LEVEL, 18, SPECIES_SKIPLOOM}),
     },
@@ -1779,7 +1779,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Skiploom),
         ICON(Skiploom, 1),
-        FOOTPRINT(Skiploom),
+        FOOTPRINT(Skiploom)
         LEARNSETS(Skiploom),
         .evolutions = EVOLUTION({EVO_LEVEL, 27, SPECIES_JUMPLUFF}),
     },
@@ -1828,7 +1828,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Jumpluff),
         ICON(Jumpluff, 2),
-        FOOTPRINT(Jumpluff),
+        FOOTPRINT(Jumpluff)
         LEARNSETS(Jumpluff),
     },
 #endif //P_FAMILY_HOPPIP
@@ -1879,7 +1879,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_LARGE,
         PALETTES(Aipom),
         ICON(Aipom, 2),
-        FOOTPRINT(Aipom),
+        FOOTPRINT(Aipom)
         LEARNSETS(Aipom),
         .evolutions = EVOLUTION({EVO_MOVE, MOVE_DOUBLE_HIT, SPECIES_AMBIPOM}),
     },
@@ -1930,7 +1930,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_LARGE,
         PALETTES(Ambipom),
         ICON(Ambipom, 2),
-        FOOTPRINT(Ambipom),
+        FOOTPRINT(Ambipom)
         LEARNSETS(Ambipom),
     },
 #endif //P_GEN_4_CROSS_EVOS
@@ -1980,7 +1980,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Sunkern),
         ICON(Sunkern, 1),
-        FOOTPRINT(Sunkern),
+        FOOTPRINT(Sunkern)
         LEARNSETS(Sunkern),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_SUN_STONE, SPECIES_SUNFLORA}),
     },
@@ -2028,7 +2028,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Sunflora),
         ICON(Sunflora, 1),
-        FOOTPRINT(Sunflora),
+        FOOTPRINT(Sunflora)
         LEARNSETS(Sunflora),
     },
 #endif //P_FAMILY_SUNKERN
@@ -2079,7 +2079,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Yanma),
         ICON(Yanma, 1),
-        FOOTPRINT(Yanma),
+        FOOTPRINT(Yanma)
         LEARNSETS(Yanma),
         .evolutions = EVOLUTION({EVO_MOVE, MOVE_ANCIENT_POWER, SPECIES_YANMEGA}),
     },
@@ -2130,7 +2130,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_H_VIBRATE,
         PALETTES(Yanmega),
         ICON(Yanmega, 1),
-        FOOTPRINT(Yanmega),
+        FOOTPRINT(Yanmega)
         LEARNSETS(Yanmega),
     },
 #endif //P_GEN_4_CROSS_EVOS
@@ -2160,7 +2160,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .pokemonOffset = 21,                                                    \
         .trainerScale = 256,                                                    \
         .trainerOffset = 0,                                                     \
-        FOOTPRINT(Wooper),                                                      \
+        FOOTPRINT(Wooper)                                                       \
         .formSpeciesIdTable = sWooperFormSpeciesIdTable
 
     [SPECIES_WOOPER] =
@@ -2236,7 +2236,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Quagsire),
         ICON(Quagsire, 0),
-        FOOTPRINT(Quagsire),
+        FOOTPRINT(Quagsire)
         LEARNSETS(Quagsire),
     },
 
@@ -2311,7 +2311,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Clodsire),
         ICON(Clodsire, 2),
-        //FOOTPRINT(Clodsire),
+        //FOOTPRINT(Clodsire)
         LEARNSETS(Clodsire),
     },
 #endif //P_PALDEAN_FORMS
@@ -2364,7 +2364,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Murkrow),
         ICON(Murkrow, 2),
-        FOOTPRINT(Murkrow),
+        FOOTPRINT(Murkrow)
         LEARNSETS(Murkrow),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_DUSK_STONE, SPECIES_HONCHKROW}),
     },
@@ -2413,7 +2413,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_H_STRETCH,
         PALETTES(Honchkrow),
         ICON(Honchkrow, 2),
-        FOOTPRINT(Honchkrow),
+        FOOTPRINT(Honchkrow)
         LEARNSETS(Honchkrow),
     },
 #endif //P_GEN_4_CROSS_EVOS
@@ -2464,7 +2464,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_H_VIBRATE,
         PALETTES(Misdreavus),
         ICON(Misdreavus, 0),
-        FOOTPRINT(Misdreavus),
+        FOOTPRINT(Misdreavus)
         LEARNSETS(Misdreavus),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_DUSK_STONE, SPECIES_MISMAGIUS}),
     },
@@ -2515,7 +2515,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Mismagius),
         ICON(Mismagius, 2),
-        FOOTPRINT(Mismagius),
+        FOOTPRINT(Mismagius)
         LEARNSETS(Mismagius),
     },
 #endif //P_GEN_4_CROSS_EVOS
@@ -2559,7 +2559,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,                    \
         PALETTES(Unown),                                                \
         ICON(Unown ##letter, 0),                                        \
-        FOOTPRINT(Unown),                                               \
+        FOOTPRINT(Unown)                                                \
         LEARNSETS(Unown),                                               \
         .formSpeciesIdTable = sUnownFormSpeciesIdTable
 
@@ -2852,7 +2852,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Wynaut),
         ICON(Wynaut, 0),
-        FOOTPRINT(Wynaut),
+        FOOTPRINT(Wynaut)
         LEARNSETS(Wynaut),
         .evolutions = EVOLUTION({EVO_LEVEL, 15, SPECIES_WOBBUFFET}),
     },
@@ -2906,7 +2906,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
     #if P_CUSTOM_GENDER_DIFF_ICONS == TRUE
         ICON_FEMALE(Wobbuffet, 0),
     #endif
-        FOOTPRINT(Wobbuffet),
+        FOOTPRINT(Wobbuffet)
         LEARNSETS(Wobbuffet),
     },
 #endif //P_FAMILY_WOBBUFFET
@@ -2957,7 +2957,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,
         PALETTES(Girafarig),
         ICON(Girafarig, 1),
-        FOOTPRINT(Girafarig),
+        FOOTPRINT(Girafarig)
         LEARNSETS(Girafarig),
         .evolutions = EVOLUTION({EVO_MOVE, MOVE_TWIN_BEAM, SPECIES_FARIGIRAF}),
     },
@@ -3006,7 +3006,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Farigiraf),
         ICON(Farigiraf, 0),
-        //FOOTPRINT(Farigiraf),
+        //FOOTPRINT(Farigiraf)
         LEARNSETS(Farigiraf),
     },
 #endif //P_GEN_9_CROSS_EVOS
@@ -3056,7 +3056,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_H_SHAKE,
         PALETTES(Pineco),
         ICON(Pineco, 0),
-        FOOTPRINT(Pineco),
+        FOOTPRINT(Pineco)
         LEARNSETS(Pineco),
         .evolutions = EVOLUTION({EVO_LEVEL, 31, SPECIES_FORRETRESS}),
     },
@@ -3104,7 +3104,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Forretress),
         ICON(Forretress, 2),
-        FOOTPRINT(Forretress),
+        FOOTPRINT(Forretress)
         LEARNSETS(Forretress),
     },
 #endif //P_FAMILY_PINECO
@@ -3154,7 +3154,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Dunsparce),
         ICON(Dunsparce, 0),
-        FOOTPRINT(Dunsparce),
+        FOOTPRINT(Dunsparce)
         LEARNSETS(Dunsparce),
         .evolutions = EVOLUTION({EVO_MOVE_TWO_SEGMENT, MOVE_HYPER_DRILL, SPECIES_DUDUNSPARCE_TWO_SEGMENT},
                                 {EVO_MOVE_THREE_SEGMENT, MOVE_HYPER_DRILL, SPECIES_DUDUNSPARCE_THREE_SEGMENT}),
@@ -3198,7 +3198,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .formSpeciesIdTable = sDudunsparceFormSpeciesIdTable
         //.frontAnimId = ANIM_V_SQUISH_AND_BOUNCE,
         //.backAnimId = BACK_ANIM_NONE,
-        //FOOTPRINT(Dudunsparce),
+        //FOOTPRINT(Dudunsparce)
 
     [SPECIES_DUDUNSPARCE_TWO_SEGMENT] =
     {
@@ -3273,7 +3273,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW,
         PALETTES(Gligar),
         ICON(Gligar, 0),
-        FOOTPRINT(Gligar),
+        FOOTPRINT(Gligar)
         LEARNSETS(Gligar),
         .evolutions = EVOLUTION({EVO_ITEM_HOLD_NIGHT, ITEM_RAZOR_FANG, SPECIES_GLISCOR},
                                 {EVO_ITEM_NIGHT, ITEM_RAZOR_FANG, SPECIES_GLISCOR}),
@@ -3324,7 +3324,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_V_STRETCH,
         PALETTES(Gliscor),
         ICON(Gliscor, 2),
-        FOOTPRINT(Gliscor),
+        FOOTPRINT(Gliscor)
         LEARNSETS(Gliscor),
     },
 #endif //P_GEN_4_CROSS_EVOS
@@ -3378,7 +3378,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Snubbull),
         ICON(Snubbull, 0),
-        FOOTPRINT(Snubbull),
+        FOOTPRINT(Snubbull)
         LEARNSETS(Snubbull),
         .evolutions = EVOLUTION({EVO_LEVEL, 23, SPECIES_GRANBULL}),
     },
@@ -3430,7 +3430,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Granbull),
         ICON(Granbull, 2),
-        FOOTPRINT(Granbull),
+        FOOTPRINT(Granbull)
         LEARNSETS(Granbull),
     },
 #endif //P_FAMILY_SNUBBULL
@@ -3463,7 +3463,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .pokemonOffset = 0,                                                             \
         .trainerScale = 256,                                                            \
         .trainerOffset = 0,                                                             \
-        FOOTPRINT(Qwilfish),                                                            \
+        FOOTPRINT(Qwilfish)                                                             \
         .formSpeciesIdTable = sQwilfishFormSpeciesIdTable
 
     [SPECIES_QWILFISH] =
@@ -3558,7 +3558,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Overqwil),
         ICON(Overqwil, 2),
-        //FOOTPRINT(Overqwil),
+        //FOOTPRINT(Overqwil)
         LEARNSETS(Overqwil),
     },
 #endif //P_HISUIAN_FORMS
@@ -3611,7 +3611,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Shuckle),
         ICON(Shuckle, 1),
-        FOOTPRINT(Shuckle),
+        FOOTPRINT(Shuckle)
         LEARNSETS(Shuckle),
     },
 #endif //P_FAMILY_SHUCKLE
@@ -3630,7 +3630,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .speciesName = _("Heracross"),                      \
         .natDexNum = NATIONAL_DEX_HERACROSS,                \
         .categoryName = _("Single Horn"),                   \
-        FOOTPRINT(Heracross),                               \
+        FOOTPRINT(Heracross)                                \
         LEARNSETS(Heracross),                               \
         .formSpeciesIdTable = sHeracrossFormSpeciesIdTable, \
         .formChangeTable = sHeracrossFormChangeTable
@@ -3736,7 +3736,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .pokemonOffset = -3,                                \
         .trainerScale = 256,                                \
         .trainerOffset = 0,                                 \
-        FOOTPRINT(Sneasel),                                 \
+        FOOTPRINT(Sneasel)                                  \
         .formSpeciesIdTable = sSneaselFormSpeciesIdTable
 
     [SPECIES_SNEASEL] =
@@ -3815,7 +3815,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Weavile),
         ICON(Weavile, 0),
-        FOOTPRINT(Weavile),
+        FOOTPRINT(Weavile)
         LEARNSETS(Weavile),
     },
 #endif //P_GEN_4_CROSS_EVOS
@@ -3893,7 +3893,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Sneasler),
         ICON(Sneasler, 2),
-        //FOOTPRINT(Sneasler),
+        //FOOTPRINT(Sneasler)
         LEARNSETS(Sneasler),
     },
 #endif //P_HISUIAN_FORMS
@@ -3944,7 +3944,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Teddiursa),
         ICON(Teddiursa, 0),
-        FOOTPRINT(Teddiursa),
+        FOOTPRINT(Teddiursa)
         LEARNSETS(Teddiursa),
         .evolutions = EVOLUTION({EVO_LEVEL, 30, SPECIES_URSARING}),
     },
@@ -3994,7 +3994,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Ursaring),
         ICON(Ursaring, 2),
-        FOOTPRINT(Ursaring),
+        FOOTPRINT(Ursaring)
         LEARNSETS(Ursaring),
         .evolutions = EVOLUTION({EVO_ITEM_NIGHT, ITEM_PEAT_BLOCK, SPECIES_URSALUNA},
                                 {EVO_NONE, 0, SPECIES_URSALUNA_BLOODMOON}),
@@ -4047,7 +4047,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Ursaluna),
         ICON(Ursaluna, 2),
-        //FOOTPRINT(Ursaluna),
+        //FOOTPRINT(Ursaluna)
         LEARNSETS(Ursaluna),
     },
 
@@ -4084,7 +4084,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(UrsalunaBloodmoon),
         //ICON(UrsalunaBloodmoon, 0),
-        //FOOTPRINT(UrsalunaBloodmoon),
+        //FOOTPRINT(UrsalunaBloodmoon)
         LEARNSETS(UrsalunaBloodmoon),
     },
 #endif //P_GEN_8_CROSS_EVOS
@@ -4134,7 +4134,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_SHAKE_GLOW_RED,
         PALETTES(Slugma),
         ICON(Slugma, 0),
-        FOOTPRINT(Slugma),
+        FOOTPRINT(Slugma)
         LEARNSETS(Slugma),
         .evolutions = EVOLUTION({EVO_LEVEL, 38, SPECIES_MAGCARGO}),
     },
@@ -4183,7 +4183,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_SHAKE_GLOW_RED,
         PALETTES(Magcargo),
         ICON(Magcargo, 0),
-        FOOTPRINT(Magcargo),
+        FOOTPRINT(Magcargo)
         LEARNSETS(Magcargo),
     },
 #endif //P_FAMILY_SLUGMA
@@ -4232,7 +4232,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_V_SHAKE_H_SLIDE,
         PALETTES(Swinub),
         ICON(Swinub, 2),
-        FOOTPRINT(Swinub),
+        FOOTPRINT(Swinub)
         LEARNSETS(Swinub),
         .evolutions = EVOLUTION({EVO_LEVEL, 33, SPECIES_PILOSWINE}),
     },
@@ -4283,7 +4283,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_H_SHAKE,
         PALETTES(Piloswine),
         ICON(Piloswine, 2),
-        FOOTPRINT(Piloswine),
+        FOOTPRINT(Piloswine)
         LEARNSETS(Piloswine),
         .evolutions = EVOLUTION({EVO_MOVE, MOVE_ANCIENT_POWER, SPECIES_MAMOSWINE}),
     },
@@ -4333,7 +4333,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_V_SHAKE_LOW,
         PALETTES(Mamoswine),
         ICON(Mamoswine, 2),
-        FOOTPRINT(Mamoswine),
+        FOOTPRINT(Mamoswine)
         LEARNSETS(Mamoswine),
     },
 #endif //P_GEN_4_CROSS_EVOS
@@ -4361,7 +4361,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .pokemonOffset = 15,                                    \
         .trainerScale = 256,                                    \
         .trainerOffset = 0,                                     \
-        FOOTPRINT(Corsola),                                     \
+        FOOTPRINT(Corsola)                                      \
         .formSpeciesIdTable = sCorsolaFormSpeciesIdTable
 
     [SPECIES_CORSOLA] =
@@ -4472,7 +4472,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Cursola),
         ICON(Cursola, 0),
-        FOOTPRINT(Cursola),
+        FOOTPRINT(Cursola)
         LEARNSETS(Cursola),
     },
 #endif //P_GALARIAN_FORMS
@@ -4522,7 +4522,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Remoraid),
         ICON(Remoraid, 0),
-        FOOTPRINT(Remoraid),
+        FOOTPRINT(Remoraid)
         LEARNSETS(Remoraid),
         .evolutions = EVOLUTION({EVO_LEVEL, 25, SPECIES_OCTILLERY}),
     },
@@ -4574,7 +4574,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW,
         PALETTES(Octillery),
         ICON(Octillery, 0),
-        FOOTPRINT(Octillery),
+        FOOTPRINT(Octillery)
         LEARNSETS(Octillery),
     },
 #endif //P_FAMILY_REMORAID
@@ -4623,7 +4623,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Delibird),
         ICON(Delibird, 1),
-        FOOTPRINT(Delibird),
+        FOOTPRINT(Delibird)
         LEARNSETS(Delibird),
     },
 #endif //P_FAMILY_DELIBIRD
@@ -4673,7 +4673,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Mantyke),
         ICON(Mantyke, 0),
-        FOOTPRINT(Mantyke),
+        FOOTPRINT(Mantyke)
         LEARNSETS(Mantyke),
         .evolutions = EVOLUTION({EVO_SPECIFIC_MON_IN_PARTY, SPECIES_REMORAID, SPECIES_MANTINE}),
     },
@@ -4723,7 +4723,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Mantine),
         ICON(Mantine, 2),
-        FOOTPRINT(Mantine),
+        FOOTPRINT(Mantine)
         LEARNSETS(Mantine),
     },
 #endif //P_FAMILY_MANTINE
@@ -4773,7 +4773,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Skarmory),
         ICON(Skarmory, 0),
-        FOOTPRINT(Skarmory),
+        FOOTPRINT(Skarmory)
         LEARNSETS(Skarmory),
     },
 #endif //P_FAMILY_SKARMORY
@@ -4822,7 +4822,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Houndour),
         ICON(Houndour, 0),
-        FOOTPRINT(Houndour),
+        FOOTPRINT(Houndour)
         LEARNSETS(Houndour),
         .evolutions = EVOLUTION({EVO_LEVEL, 24, SPECIES_HOUNDOOM}),
     },
@@ -4840,7 +4840,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .speciesName = _("Houndoom"),                       \
         .natDexNum = NATIONAL_DEX_HOUNDOOM,                 \
         .categoryName = _("Dark"),                          \
-        FOOTPRINT(Houndoom),                                \
+        FOOTPRINT(Houndoom)                                 \
         LEARNSETS(Houndoom),                                \
         .formSpeciesIdTable = sHoundoomFormSpeciesIdTable,  \
         .formChangeTable = sHoundoomFormChangeTable
@@ -4962,7 +4962,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Phanpy),
         ICON(Phanpy, 0),
-        FOOTPRINT(Phanpy),
+        FOOTPRINT(Phanpy)
         LEARNSETS(Phanpy),
         .evolutions = EVOLUTION({EVO_LEVEL, 25, SPECIES_DONPHAN}),
     },
@@ -5013,7 +5013,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_V_SHAKE_LOW,
         PALETTES(Donphan),
         ICON(Donphan, 0),
-        FOOTPRINT(Donphan),
+        FOOTPRINT(Donphan)
         LEARNSETS(Donphan),
     },
 #endif //P_FAMILY_PHANPY
@@ -5062,7 +5062,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Stantler),
         ICON(Stantler, 2),
-        FOOTPRINT(Stantler),
+        FOOTPRINT(Stantler)
         LEARNSETS(Stantler),
         .evolutions = EVOLUTION({EVO_MOVE, MOVE_PSYSHIELD_BASH, SPECIES_WYRDEER}),
     },
@@ -5112,7 +5112,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Wyrdeer),
         ICON(Wyrdeer, 2),
-        //FOOTPRINT(Wyrdeer),
+        //FOOTPRINT(Wyrdeer)
         LEARNSETS(Wyrdeer),
     },
 #endif //P_GEN_8_CROSS_EVOS
@@ -5162,7 +5162,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Smeargle),
         ICON(Smeargle, 1),
-        FOOTPRINT(Smeargle),
+        FOOTPRINT(Smeargle)
         LEARNSETS(Smeargle),
     },
 #endif //P_FAMILY_SMEARGLE
@@ -5213,7 +5213,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Miltank),
         ICON(Miltank, 0),
-        FOOTPRINT(Miltank),
+        FOOTPRINT(Miltank)
         LEARNSETS(Miltank),
     },
 #endif //P_FAMILY_MILTANK
@@ -5268,7 +5268,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_SHAKE_FLASH_YELLOW,
         PALETTES(Raikou),
         ICON(Raikou, 2),
-        FOOTPRINT(Raikou),
+        FOOTPRINT(Raikou)
         LEARNSETS(Raikou),
     },
 #endif //P_FAMILY_RAIKOU
@@ -5323,7 +5323,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_SHAKE_GLOW_RED,
         PALETTES(Entei),
         ICON(Entei, 2),
-        FOOTPRINT(Entei),
+        FOOTPRINT(Entei)
         LEARNSETS(Entei),
     },
 #endif //P_FAMILY_ENTEI
@@ -5378,7 +5378,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_SHAKE_GLOW_BLUE,
         PALETTES(Suicune),
         ICON(Suicune, 2),
-        FOOTPRINT(Suicune),
+        FOOTPRINT(Suicune)
         LEARNSETS(Suicune),
     },
 #endif //P_FAMILY_SUICUNE
@@ -5427,7 +5427,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_V_SHAKE_LOW,
         PALETTES(Larvitar),
         ICON(Larvitar, 1),
-        FOOTPRINT(Larvitar),
+        FOOTPRINT(Larvitar)
         LEARNSETS(Larvitar),
         .evolutions = EVOLUTION({EVO_LEVEL, 30, SPECIES_PUPITAR}),
     },
@@ -5475,7 +5475,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Pupitar),
         ICON(Pupitar, 2),
-        FOOTPRINT(Pupitar),
+        FOOTPRINT(Pupitar)
         LEARNSETS(Pupitar),
         .evolutions = EVOLUTION({EVO_LEVEL, 55, SPECIES_TYRANITAR}),
     },
@@ -5493,7 +5493,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .speciesName = _("Tyranitar"),                          \
         .natDexNum = NATIONAL_DEX_TYRANITAR,                    \
         .categoryName = _("Armor"),                             \
-        FOOTPRINT(Tyranitar),                                   \
+        FOOTPRINT(Tyranitar)                                    \
         LEARNSETS(Tyranitar),                                   \
         .formSpeciesIdTable = sTyranitarFormSpeciesIdTable,     \
         .formChangeTable = sTyranitarFormChangeTable
@@ -5618,7 +5618,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_SHAKE_GLOW_BLUE,
         PALETTES(Lugia),
         ICON(Lugia, 0),
-        FOOTPRINT(Lugia),
+        FOOTPRINT(Lugia)
         LEARNSETS(Lugia),
     },
 #endif //P_FAMILY_LUGIA
@@ -5671,7 +5671,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_SHAKE_GLOW_RED,
         PALETTES(HoOh),
         ICON(HoOh, 1),
-        FOOTPRINT(HoOh),
+        FOOTPRINT(HoOh)
         LEARNSETS(HoOh),
     },
 #endif //P_FAMILY_HO_OH
@@ -5724,7 +5724,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .backAnimId = BACK_ANIM_SHAKE_GLOW_GREEN,
         PALETTES(Celebi),
         ICON(Celebi, 1),
-        FOOTPRINT(Celebi),
+        FOOTPRINT(Celebi)
         LEARNSETS(Celebi),
     },
 #endif //P_FAMILY_CELEBI

--- a/src/data/pokemon/species_info/gen_3.h
+++ b/src/data/pokemon/species_info/gen_3.h
@@ -47,7 +47,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_LARGE,
         PALETTES(Treecko),
         ICON(Treecko, 1),
-        FOOTPRINT(Treecko),
+        FOOTPRINT(Treecko)
         LEARNSETS(Treecko),
         .evolutions = EVOLUTION({EVO_LEVEL, 16, SPECIES_GROVYLE}),
     },
@@ -95,7 +95,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Grovyle),
         ICON(Grovyle, 1),
-        FOOTPRINT(Grovyle),
+        FOOTPRINT(Grovyle)
         LEARNSETS(Grovyle),
         .evolutions = EVOLUTION({EVO_LEVEL, 36, SPECIES_SCEPTILE}),
     },
@@ -112,7 +112,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .speciesName = _("Sceptile"),                       \
         .natDexNum = NATIONAL_DEX_SCEPTILE,                 \
         .categoryName = _("Forest"),                        \
-        FOOTPRINT(Sceptile),                                \
+        FOOTPRINT(Sceptile)                                 \
         LEARNSETS(Sceptile),                                \
         .formSpeciesIdTable = sSceptileFormSpeciesIdTable,  \
         .formChangeTable = sSceptileFormChangeTable
@@ -236,7 +236,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Torchic),
         ICON(Torchic, 0),
-        FOOTPRINT(Torchic),
+        FOOTPRINT(Torchic)
         LEARNSETS(Torchic),
         .evolutions = EVOLUTION({EVO_LEVEL, 16, SPECIES_COMBUSKEN}),
     },
@@ -287,7 +287,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_LARGE,
         PALETTES(Combusken),
         ICON(Combusken, 0),
-        FOOTPRINT(Combusken),
+        FOOTPRINT(Combusken)
         LEARNSETS(Combusken),
         .evolutions = EVOLUTION({EVO_LEVEL, 36, SPECIES_BLAZIKEN}),
     },
@@ -311,7 +311,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .pokemonOffset = 0,                                 \
         .trainerScale = 301,                                \
         .trainerOffset = 4,                                 \
-        FOOTPRINT(Blaziken),                                \
+        FOOTPRINT(Blaziken)                                 \
         LEARNSETS(Blaziken),                                \
         .formSpeciesIdTable = sBlazikenFormSpeciesIdTable,  \
         .formChangeTable = sBlazikenFormChangeTable
@@ -422,7 +422,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Mudkip),
         ICON(Mudkip, 0),
-        FOOTPRINT(Mudkip),
+        FOOTPRINT(Mudkip)
         LEARNSETS(Mudkip),
         .evolutions = EVOLUTION({EVO_LEVEL, 16, SPECIES_MARSHTOMP}),
     },
@@ -470,7 +470,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Marshtomp),
         ICON(Marshtomp, 0),
-        FOOTPRINT(Marshtomp),
+        FOOTPRINT(Marshtomp)
         LEARNSETS(Marshtomp),
         .evolutions = EVOLUTION({EVO_LEVEL, 36, SPECIES_SWAMPERT}),
     },
@@ -488,7 +488,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .speciesName = _("Swampert"),                           \
         .natDexNum = NATIONAL_DEX_SWAMPERT,                     \
         .categoryName = _("Mud Fish"),                          \
-        FOOTPRINT(Swampert),                                    \
+        FOOTPRINT(Swampert)                                     \
         LEARNSETS(Swampert),                                    \
         .formSpeciesIdTable = sSwampertFormSpeciesIdTable,      \
         .formChangeTable = sSwampertFormChangeTable
@@ -609,7 +609,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Poochyena),
         ICON(Poochyena, 2),
-        FOOTPRINT(Poochyena),
+        FOOTPRINT(Poochyena)
         LEARNSETS(Poochyena),
         .evolutions = EVOLUTION({EVO_LEVEL, 18, SPECIES_MIGHTYENA}),
     },
@@ -657,7 +657,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_H_SHAKE,
         PALETTES(Mightyena),
         ICON(Mightyena, 2),
-        FOOTPRINT(Mightyena),
+        FOOTPRINT(Mightyena)
         LEARNSETS(Mightyena),
     },
 #endif //P_FAMILY_POOCHYENA
@@ -689,7 +689,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .pokemonOffset = 22,                                                    \
         .trainerScale = 256,                                                    \
         .trainerOffset = 0,                                                     \
-        FOOTPRINT(Zigzagoon),                                                   \
+        FOOTPRINT(Zigzagoon)                                                    \
         .formSpeciesIdTable = sZigzagoonFormSpeciesIdTable
 
 #define LINOONE_MISC_INFO                                                       \
@@ -719,7 +719,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .pokemonOffset = 7,                                                     \
         .trainerScale = 256,                                                    \
         .trainerOffset = 0,                                                     \
-        FOOTPRINT(Linoone),                                                     \
+        FOOTPRINT(Linoone)                                                      \
         .formSpeciesIdTable = sLinooneFormSpeciesIdTable
 
     [SPECIES_ZIGZAGOON] =
@@ -861,7 +861,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Obstagoon),
         ICON(Obstagoon, 0),
-        FOOTPRINT(Obstagoon),
+        FOOTPRINT(Obstagoon)
         LEARNSETS(Obstagoon),
     },
 #endif //P_GALARIAN_FORMS
@@ -913,7 +913,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_V_STRETCH,
         PALETTES(Wurmple),
         ICON(Wurmple, 0),
-        FOOTPRINT(Wurmple),
+        FOOTPRINT(Wurmple)
         LEARNSETS(Wurmple),
         .evolutions = EVOLUTION({EVO_LEVEL_SILCOON, 7, SPECIES_SILCOON},
                                 {EVO_LEVEL_CASCOON, 7, SPECIES_CASCOON}),
@@ -962,7 +962,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_H_SHAKE,
         PALETTES(Silcoon),
         ICON(Silcoon, 2),
-        FOOTPRINT(Silcoon),
+        FOOTPRINT(Silcoon)
         LEARNSETS(Silcoon),
         .evolutions = EVOLUTION({EVO_LEVEL, 10, SPECIES_BEAUTIFLY}),
     },
@@ -1014,7 +1014,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Beautifly),
         ICON(Beautifly, 0),
-        FOOTPRINT(Beautifly),
+        FOOTPRINT(Beautifly)
         LEARNSETS(Beautifly),
     },
 
@@ -1061,7 +1061,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_H_SHAKE,
         PALETTES(Cascoon),
         ICON(Cascoon, 2),
-        FOOTPRINT(Cascoon),
+        FOOTPRINT(Cascoon)
         LEARNSETS(Cascoon),
         .evolutions = EVOLUTION({EVO_LEVEL, 10, SPECIES_DUSTOX}),
     },
@@ -1113,7 +1113,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Dustox),
         ICON(Dustox, 5),
-        FOOTPRINT(Dustox),
+        FOOTPRINT(Dustox)
         LEARNSETS(Dustox),
     },
 #endif //P_FAMILY_WURMPLE
@@ -1163,7 +1163,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Lotad),
         ICON(Lotad, 4),
-        FOOTPRINT(Lotad),
+        FOOTPRINT(Lotad)
         LEARNSETS(Lotad),
         .evolutions = EVOLUTION({EVO_LEVEL, 14, SPECIES_LOMBRE}),
     },
@@ -1212,7 +1212,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_LARGE,
         PALETTES(Lombre),
         ICON(Lombre, 1),
-        FOOTPRINT(Lombre),
+        FOOTPRINT(Lombre)
         LEARNSETS(Lombre),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_WATER_STONE, SPECIES_LUDICOLO}),
     },
@@ -1263,7 +1263,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_LARGE,
         PALETTES(Ludicolo),
         ICON(Ludicolo, 1),
-        FOOTPRINT(Ludicolo),
+        FOOTPRINT(Ludicolo)
         LEARNSETS(Ludicolo),
     },
 #endif //P_FAMILY_LOTAD
@@ -1313,7 +1313,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Seedot),
         ICON(Seedot, 2),
-        FOOTPRINT(Seedot),
+        FOOTPRINT(Seedot)
         LEARNSETS(Seedot),
         .evolutions = EVOLUTION({EVO_LEVEL, 14, SPECIES_NUZLEAF}),
     },
@@ -1364,7 +1364,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Nuzleaf),
         ICON(Nuzleaf, 1),
-        FOOTPRINT(Nuzleaf),
+        FOOTPRINT(Nuzleaf)
         LEARNSETS(Nuzleaf),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_LEAF_STONE, SPECIES_SHIFTRY}),
     },
@@ -1419,7 +1419,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,
         PALETTES(Shiftry),
         ICON(Shiftry, 5),
-        FOOTPRINT(Shiftry),
+        FOOTPRINT(Shiftry)
         LEARNSETS(Shiftry),
     },
 #endif //P_FAMILY_SEEDOT
@@ -1468,7 +1468,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Taillow),
         ICON(Taillow, 2),
-        FOOTPRINT(Taillow),
+        FOOTPRINT(Taillow)
         LEARNSETS(Taillow),
         .evolutions = EVOLUTION({EVO_LEVEL, 22, SPECIES_SWELLOW}),
     },
@@ -1516,7 +1516,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Swellow),
         ICON(Swellow, 2),
-        FOOTPRINT(Swellow),
+        FOOTPRINT(Swellow)
         LEARNSETS(Swellow),
     },
 #endif //P_FAMILY_TAILLOW
@@ -1567,7 +1567,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Wingull),
         ICON(Wingull, 0),
-        FOOTPRINT(Wingull),
+        FOOTPRINT(Wingull)
         LEARNSETS(Wingull),
         .evolutions = EVOLUTION({EVO_LEVEL, 25, SPECIES_PELIPPER}),
     },
@@ -1617,7 +1617,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Pelipper),
         ICON(Pelipper, 2),
-        FOOTPRINT(Pelipper),
+        FOOTPRINT(Pelipper)
         LEARNSETS(Pelipper),
     },
 #endif //P_FAMILY_WINGULL
@@ -1674,7 +1674,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,
         PALETTES(Ralts),
         ICON(Ralts, 1),
-        FOOTPRINT(Ralts),
+        FOOTPRINT(Ralts)
         LEARNSETS(Ralts),
         .evolutions = EVOLUTION({EVO_LEVEL, 20, SPECIES_KIRLIA}),
     },
@@ -1722,7 +1722,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,
         PALETTES(Kirlia),
         ICON(Kirlia, 1),
-        FOOTPRINT(Kirlia),
+        FOOTPRINT(Kirlia)
         LEARNSETS(Kirlia),
         .evolutions = EVOLUTION({EVO_LEVEL, 30, SPECIES_GARDEVOIR},
                                 {EVO_ITEM_MALE, ITEM_DAWN_STONE, SPECIES_GALLADE}),
@@ -1747,7 +1747,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .pokemonOffset = 0,                                 \
         .trainerScale = 256,                                \
         .trainerOffset = 0,                                 \
-        FOOTPRINT(Gardevoir),                               \
+        FOOTPRINT(Gardevoir)                                \
         LEARNSETS(Gardevoir),                               \
         .formSpeciesIdTable = sGardevoirFormSpeciesIdTable, \
         .formChangeTable = sGardevoirFormChangeTable
@@ -1830,7 +1830,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .pokemonOffset = 1,                                 \
         .trainerScale = 296,                                \
         .trainerOffset = 1,                                 \
-        FOOTPRINT(Gallade),                                 \
+        FOOTPRINT(Gallade)                                  \
         LEARNSETS(Gallade),                                 \
         .formSpeciesIdTable = sGalladeFormSpeciesIdTable,   \
         .formChangeTable = sGalladeFormChangeTable
@@ -1947,7 +1947,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_H_SPRING,
         PALETTES(Surskit),
         ICON(Surskit, 0),
-        FOOTPRINT(Surskit),
+        FOOTPRINT(Surskit)
         LEARNSETS(Surskit),
         .evolutions = EVOLUTION({EVO_LEVEL, 22, SPECIES_MASQUERAIN}),
     },
@@ -2003,7 +2003,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Masquerain),
         ICON(Masquerain, 0),
-        FOOTPRINT(Masquerain),
+        FOOTPRINT(Masquerain)
         LEARNSETS(Masquerain),
     },
 #endif //P_FAMILY_SURSKIT
@@ -2054,7 +2054,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Shroomish),
         ICON(Shroomish, 1),
-        FOOTPRINT(Shroomish),
+        FOOTPRINT(Shroomish)
         LEARNSETS(Shroomish),
         .evolutions = EVOLUTION({EVO_LEVEL, 23, SPECIES_BRELOOM}),
     },
@@ -2104,7 +2104,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Breloom),
         ICON(Breloom, 1),
-        FOOTPRINT(Breloom),
+        FOOTPRINT(Breloom)
         LEARNSETS(Breloom),
     },
 #endif //P_FAMILY_SHROOMISH
@@ -2153,7 +2153,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Slakoth),
         ICON(Slakoth, 2),
-        FOOTPRINT(Slakoth),
+        FOOTPRINT(Slakoth)
         LEARNSETS(Slakoth),
         .evolutions = EVOLUTION({EVO_LEVEL, 18, SPECIES_VIGOROTH}),
     },
@@ -2201,7 +2201,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_LARGE,
         PALETTES(Vigoroth),
         ICON(Vigoroth, 2),
-        FOOTPRINT(Vigoroth),
+        FOOTPRINT(Vigoroth)
         LEARNSETS(Vigoroth),
         .evolutions = EVOLUTION({EVO_LEVEL, 36, SPECIES_SLAKING}),
     },
@@ -2249,7 +2249,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_H_SHAKE,
         PALETTES(Slaking),
         ICON(Slaking, 2),
-        FOOTPRINT(Slaking),
+        FOOTPRINT(Slaking)
         LEARNSETS(Slaking),
     },
 #endif //P_FAMILY_SLAKOTH
@@ -2299,7 +2299,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_V_SHAKE_H_SLIDE,
         PALETTES(Nincada),
         ICON(Nincada, 1),
-        FOOTPRINT(Nincada),
+        FOOTPRINT(Nincada)
         LEARNSETS(Nincada),
         .evolutions = EVOLUTION({EVO_LEVEL_NINJASK, 20, SPECIES_NINJASK},
                                 {EVO_LEVEL_SHEDINJA, 20, SPECIES_SHEDINJA}),
@@ -2349,7 +2349,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_H_VIBRATE,
         PALETTES(Ninjask),
         ICON(Ninjask, 1),
-        FOOTPRINT(Ninjask),
+        FOOTPRINT(Ninjask)
         LEARNSETS(Ninjask),
     },
 
@@ -2397,7 +2397,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,
         PALETTES(Shedinja),
         ICON(Shedinja, 1),
-        FOOTPRINT(Shedinja),
+        FOOTPRINT(Shedinja)
         LEARNSETS(Shedinja),
     },
 #endif //P_FAMILY_NINCADA
@@ -2446,7 +2446,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Whismur),
         ICON(Whismur, 1),
-        FOOTPRINT(Whismur),
+        FOOTPRINT(Whismur)
         LEARNSETS(Whismur),
         .evolutions = EVOLUTION({EVO_LEVEL, 20, SPECIES_LOUDRED}),
     },
@@ -2494,7 +2494,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Loudred),
         ICON(Loudred, 2),
-        FOOTPRINT(Loudred),
+        FOOTPRINT(Loudred)
         LEARNSETS(Loudred),
         .evolutions = EVOLUTION({EVO_LEVEL, 40, SPECIES_EXPLOUD}),
     },
@@ -2542,7 +2542,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_GROW_STUTTER,
         PALETTES(Exploud),
         ICON(Exploud, 2),
-        FOOTPRINT(Exploud),
+        FOOTPRINT(Exploud)
         LEARNSETS(Exploud),
     },
 #endif //P_FAMILY_WHISMUR
@@ -2592,7 +2592,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_V_SHAKE_LOW,
         PALETTES(Makuhita),
         ICON(Makuhita, 1),
-        FOOTPRINT(Makuhita),
+        FOOTPRINT(Makuhita)
         LEARNSETS(Makuhita),
         .evolutions = EVOLUTION({EVO_LEVEL, 24, SPECIES_HARIYAMA}),
     },
@@ -2641,7 +2641,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_V_SHAKE_LOW,
         PALETTES(Hariyama),
         ICON(Hariyama, 2),
-        FOOTPRINT(Hariyama),
+        FOOTPRINT(Hariyama)
         LEARNSETS(Hariyama),
     },
 #endif //P_FAMILY_MAKUHITA
@@ -2691,7 +2691,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_V_SHAKE_LOW,
         PALETTES(Nosepass),
         ICON(Nosepass, 0),
-        FOOTPRINT(Nosepass),
+        FOOTPRINT(Nosepass)
         LEARNSETS(Nosepass),
         .evolutions = EVOLUTION({EVO_MAPSEC, MAPSEC_NEW_MAUVILLE, SPECIES_PROBOPASS},
                                 {EVO_ITEM, ITEM_THUNDER_STONE, SPECIES_PROBOPASS}),
@@ -2744,7 +2744,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_V_SHAKE_H_SLIDE,
         PALETTES(Probopass),
         ICON(Probopass, 0),
-        FOOTPRINT(Probopass),
+        FOOTPRINT(Probopass)
         LEARNSETS(Probopass),
     },
 #endif //P_GEN_4_CROSS_EVOS
@@ -2794,7 +2794,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Skitty),
         ICON(Skitty, 0),
-        FOOTPRINT(Skitty),
+        FOOTPRINT(Skitty)
         LEARNSETS(Skitty),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_MOON_STONE, SPECIES_DELCATTY}),
     },
@@ -2843,7 +2843,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Delcatty),
         ICON(Delcatty, 2),
-        FOOTPRINT(Delcatty),
+        FOOTPRINT(Delcatty)
         LEARNSETS(Delcatty),
     },
 #endif //P_FAMILY_SKITTY
@@ -2864,7 +2864,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .natDexNum = NATIONAL_DEX_SABLEYE,                          \
         .categoryName = _("Darkness"),                              \
         .height = 5,                                                \
-        FOOTPRINT(Sableye),                                         \
+        FOOTPRINT(Sableye)                                          \
         LEARNSETS(Sableye),                                         \
         .formSpeciesIdTable = sSableyeFormSpeciesIdTable,           \
         .formChangeTable = sSableyeFormChangeTable
@@ -2960,7 +2960,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .speciesName = _("Mawile"),                         \
         .natDexNum = NATIONAL_DEX_MAWILE,                   \
         .categoryName = _("Deceiver"),                      \
-        FOOTPRINT(Mawile),                                  \
+        FOOTPRINT(Mawile)                                   \
         LEARNSETS(Mawile),                                  \
         .formSpeciesIdTable = sMawileFormSpeciesIdTable,    \
         .formChangeTable = sMawileFormChangeTable
@@ -3083,7 +3083,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Aron),
         ICON(Aron, 2),
-        FOOTPRINT(Aron),
+        FOOTPRINT(Aron)
         LEARNSETS(Aron),
         .evolutions = EVOLUTION({EVO_LEVEL, 32, SPECIES_LAIRON}),
     },
@@ -3132,7 +3132,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Lairon),
         ICON(Lairon, 2),
-        FOOTPRINT(Lairon),
+        FOOTPRINT(Lairon)
         LEARNSETS(Lairon),
         .evolutions = EVOLUTION({EVO_LEVEL, 42, SPECIES_AGGRON}),
     },
@@ -3150,7 +3150,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .speciesName = _("Aggron"),                             \
         .natDexNum = NATIONAL_DEX_AGGRON,                       \
         .categoryName = _("Iron Armor"),                        \
-        FOOTPRINT(Aggron),                                      \
+        FOOTPRINT(Aggron)                                       \
         LEARNSETS(Aggron),                                      \
         .formSpeciesIdTable = sAggronFormSpeciesIdTable,        \
         .formChangeTable = sAggronFormChangeTable
@@ -3275,7 +3275,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,
         PALETTES(Meditite),
         ICON(Meditite, 0),
-        FOOTPRINT(Meditite),
+        FOOTPRINT(Meditite)
         LEARNSETS(Meditite),
         .evolutions = EVOLUTION({EVO_LEVEL, 37, SPECIES_MEDICHAM}),
     },
@@ -3299,7 +3299,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .pokemonOffset = 5,                                         \
         .trainerScale = 256,                                        \
         .trainerOffset = 0,                                         \
-        FOOTPRINT(Medicham),                                        \
+        FOOTPRINT(Medicham)                                         \
         LEARNSETS(Medicham),                                        \
         .formSpeciesIdTable = sMedichamFormSpeciesIdTable,          \
         .formChangeTable = sMedichamFormChangeTable
@@ -3410,7 +3410,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Electrike),
         ICON(Electrike, 1),
-        FOOTPRINT(Electrike),
+        FOOTPRINT(Electrike)
         LEARNSETS(Electrike),
         .evolutions = EVOLUTION({EVO_LEVEL, 26, SPECIES_MANECTRIC}),
     },
@@ -3428,7 +3428,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .speciesName = _("Manectric"),                      \
         .natDexNum = NATIONAL_DEX_MANECTRIC,                \
         .categoryName = _("Discharge"),                     \
-        FOOTPRINT(Manectric),                               \
+        FOOTPRINT(Manectric)                                \
         LEARNSETS(Manectric),                               \
         .formSpeciesIdTable = sManectricFormSpeciesIdTable, \
         .formChangeTable = sManectricFormChangeTable
@@ -3549,7 +3549,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Plusle),
         ICON(Plusle, 0),
-        FOOTPRINT(Plusle),
+        FOOTPRINT(Plusle)
         LEARNSETS(Plusle),
     },
 #endif //P_FAMILY_PLUSLE
@@ -3599,7 +3599,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Minun),
         ICON(Minun, 0),
-        FOOTPRINT(Minun),
+        FOOTPRINT(Minun)
         LEARNSETS(Minun),
     },
 #endif //P_FAMILY_MINUN
@@ -3654,7 +3654,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Volbeat),
         ICON(Volbeat, 0),
-        FOOTPRINT(Volbeat),
+        FOOTPRINT(Volbeat)
         LEARNSETS(Volbeat),
     },
 
@@ -3707,7 +3707,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Illumise),
         ICON(Illumise, 2),
-        FOOTPRINT(Illumise),
+        FOOTPRINT(Illumise)
         LEARNSETS(Illumise),
     },
 #endif //P_FAMILY_VOLBEAT_ILLUMISE
@@ -3759,7 +3759,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Budew),
         ICON(Budew, 1),
-        FOOTPRINT(Budew),
+        FOOTPRINT(Budew)
         LEARNSETS(Budew),
         .evolutions = EVOLUTION({EVO_FRIENDSHIP_DAY, 0, SPECIES_ROSELIA}),
     },
@@ -3812,7 +3812,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_SHAKE_GLOW_GREEN,
         PALETTES(Roselia),
         ICON(Roselia, 4),
-        FOOTPRINT(Roselia),
+        FOOTPRINT(Roselia)
         LEARNSETS(Roselia),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_SHINY_STONE, SPECIES_ROSERADE}),
     },
@@ -3865,7 +3865,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,
         PALETTES(Roserade),
         ICON(Roserade, 0),
-        FOOTPRINT(Roserade),
+        FOOTPRINT(Roserade)
         LEARNSETS(Roserade),
     },
 #endif //P_GEN_4_CROSS_EVOS
@@ -3919,7 +3919,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_V_STRETCH,
         PALETTES(Gulpin),
         ICON(Gulpin, 1),
-        FOOTPRINT(Gulpin),
+        FOOTPRINT(Gulpin)
         LEARNSETS(Gulpin),
         .evolutions = EVOLUTION({EVO_LEVEL, 26, SPECIES_SWALOT}),
     },
@@ -3971,7 +3971,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_V_STRETCH,
         PALETTES(Swalot),
         ICON(Swalot, 2),
-        FOOTPRINT(Swalot),
+        FOOTPRINT(Swalot)
         LEARNSETS(Swalot),
     },
 #endif //P_FAMILY_GULPIN
@@ -4021,7 +4021,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_H_SPRING_REPEATED,
         PALETTES(Carvanha),
         ICON(Carvanha, 0),
-        FOOTPRINT(Carvanha),
+        FOOTPRINT(Carvanha)
         LEARNSETS(Carvanha),
         .evolutions = EVOLUTION({EVO_LEVEL, 30, SPECIES_SHARPEDO}),
     },
@@ -4040,7 +4040,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .speciesName = _("Sharpedo"),                           \
         .natDexNum = NATIONAL_DEX_SHARPEDO,                     \
         .categoryName = _("Brutal"),                            \
-        FOOTPRINT(Sharpedo),                                    \
+        FOOTPRINT(Sharpedo)                                     \
         LEARNSETS(Sharpedo),                                    \
         .formSpeciesIdTable = sSharpedoFormSpeciesIdTable,      \
         .formChangeTable = sSharpedoFormChangeTable
@@ -4162,7 +4162,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_SHAKE_GLOW_BLUE,
         PALETTES(Wailmer),
         ICON(Wailmer, 2),
-        FOOTPRINT(Wailmer),
+        FOOTPRINT(Wailmer)
         LEARNSETS(Wailmer),
         .evolutions = EVOLUTION({EVO_LEVEL, 40, SPECIES_WAILORD}),
     },
@@ -4211,7 +4211,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_SHAKE_GLOW_BLUE,
         PALETTES(Wailord),
         ICON(Wailord, 0),
-        FOOTPRINT(Wailord),
+        FOOTPRINT(Wailord)
         LEARNSETS(Wailord),
     },
 #endif //P_FAMILY_WAILMER
@@ -4262,7 +4262,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_V_SHAKE_LOW,
         PALETTES(Numel),
         ICON(Numel, 1),
-        FOOTPRINT(Numel),
+        FOOTPRINT(Numel)
         LEARNSETS(Numel),
         .evolutions = EVOLUTION({EVO_LEVEL, 33, SPECIES_CAMERUPT}),
     },
@@ -4281,7 +4281,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .speciesName = _("Camerupt"),                       \
         .natDexNum = NATIONAL_DEX_CAMERUPT,                 \
         .categoryName = _("Eruption"),                      \
-        FOOTPRINT(Camerupt),                                \
+        FOOTPRINT(Camerupt)                                 \
         LEARNSETS(Camerupt),                                \
         .formSpeciesIdTable = sCameruptFormSpeciesIdTable,  \
         .formChangeTable = sCameruptFormChangeTable
@@ -4405,7 +4405,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_SHAKE_GLOW_RED,
         PALETTES(Torkoal),
         ICON(Torkoal, 2),
-        FOOTPRINT(Torkoal),
+        FOOTPRINT(Torkoal)
         LEARNSETS(Torkoal),
     },
 #endif //P_FAMILY_TORKOAL
@@ -4454,7 +4454,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_LARGE,
         PALETTES(Spoink),
         ICON(Spoink, 0),
-        FOOTPRINT(Spoink),
+        FOOTPRINT(Spoink)
         LEARNSETS(Spoink),
         .evolutions = EVOLUTION({EVO_LEVEL, 32, SPECIES_GRUMPIG}),
     },
@@ -4503,7 +4503,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,
         PALETTES(Grumpig),
         ICON(Grumpig, 2),
-        FOOTPRINT(Grumpig),
+        FOOTPRINT(Grumpig)
         LEARNSETS(Grumpig),
     },
 #endif //P_FAMILY_SPOINK
@@ -4553,7 +4553,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_CIRCLE_COUNTERCLOCKWISE,
         PALETTES(Spinda),
         ICON(Spinda, 1),
-        FOOTPRINT(Spinda),
+        FOOTPRINT(Spinda)
         LEARNSETS(Spinda),
     },
 #endif //P_FAMILY_SPINDA
@@ -4607,7 +4607,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Trapinch),
         ICON(Trapinch, 0),
-        FOOTPRINT(Trapinch),
+        FOOTPRINT(Trapinch)
         LEARNSETS(Trapinch),
         .evolutions = EVOLUTION({EVO_LEVEL, 35, SPECIES_VIBRAVA}),
     },
@@ -4660,7 +4660,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_H_VIBRATE,
         PALETTES(Vibrava),
         ICON(Vibrava, 1),
-        FOOTPRINT(Vibrava),
+        FOOTPRINT(Vibrava)
         LEARNSETS(Vibrava),
         .evolutions = EVOLUTION({EVO_LEVEL, 45, SPECIES_FLYGON}),
     },
@@ -4714,7 +4714,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Flygon),
         ICON(Flygon, 1),
-        FOOTPRINT(Flygon),
+        FOOTPRINT(Flygon)
         LEARNSETS(Flygon),
     },
 #endif //P_FAMILY_TRAPINCH
@@ -4764,7 +4764,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_V_SHAKE_H_SLIDE,
         PALETTES(Cacnea),
         ICON(Cacnea, 1),
-        FOOTPRINT(Cacnea),
+        FOOTPRINT(Cacnea)
         LEARNSETS(Cacnea),
         .evolutions = EVOLUTION({EVO_LEVEL, 32, SPECIES_CACTURNE}),
     },
@@ -4815,7 +4815,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_H_SHAKE,
         PALETTES(Cacturne),
         ICON(Cacturne, 1),
-        FOOTPRINT(Cacturne),
+        FOOTPRINT(Cacturne)
         LEARNSETS(Cacturne),
     },
 #endif //P_FAMILY_CACNEA
@@ -4864,7 +4864,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Swablu),
         ICON(Swablu, 0),
-        FOOTPRINT(Swablu),
+        FOOTPRINT(Swablu)
         LEARNSETS(Swablu),
         .evolutions = EVOLUTION({EVO_LEVEL, 35, SPECIES_ALTARIA}),
     },
@@ -4881,7 +4881,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .speciesName = _("Altaria"),                        \
         .natDexNum = NATIONAL_DEX_ALTARIA,                  \
         .categoryName = _("Humming"),                       \
-        FOOTPRINT(Altaria),                                 \
+        FOOTPRINT(Altaria)                                  \
         LEARNSETS(Altaria),                                 \
         .formSpeciesIdTable = sAltariaFormSpeciesIdTable,   \
         .formChangeTable = sAltariaFormChangeTable
@@ -5007,7 +5007,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Zangoose),
         ICON(Zangoose, 0),
-        FOOTPRINT(Zangoose),
+        FOOTPRINT(Zangoose)
         LEARNSETS(Zangoose),
     },
 #endif //P_FAMILY_ZANGOOSE
@@ -5059,7 +5059,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_V_STRETCH,
         PALETTES(Seviper),
         ICON(Seviper, 2),
-        FOOTPRINT(Seviper),
+        FOOTPRINT(Seviper)
         LEARNSETS(Seviper),
     },
 #endif //P_FAMILY_SEVIPER
@@ -5111,7 +5111,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Lunatone),
         ICON(Lunatone, 1),
-        FOOTPRINT(Lunatone),
+        FOOTPRINT(Lunatone)
         LEARNSETS(Lunatone),
     },
 #endif //P_FAMILY_LUNATONE
@@ -5163,7 +5163,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Solrock),
         ICON(Solrock, 0),
-        FOOTPRINT(Solrock),
+        FOOTPRINT(Solrock)
         LEARNSETS(Solrock),
     },
 #endif //P_FAMILY_SOLROCK
@@ -5213,7 +5213,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_V_STRETCH,
         PALETTES(Barboach),
         ICON(Barboach, 0),
-        FOOTPRINT(Barboach),
+        FOOTPRINT(Barboach)
         LEARNSETS(Barboach),
         .evolutions = EVOLUTION({EVO_LEVEL, 30, SPECIES_WHISCASH}),
     },
@@ -5261,7 +5261,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Whiscash),
         ICON(Whiscash, 0),
-        FOOTPRINT(Whiscash),
+        FOOTPRINT(Whiscash)
         LEARNSETS(Whiscash),
     },
 #endif //P_FAMILY_BARBOACH
@@ -5310,7 +5310,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Corphish),
         ICON(Corphish, 0),
-        FOOTPRINT(Corphish),
+        FOOTPRINT(Corphish)
         LEARNSETS(Corphish),
         .evolutions = EVOLUTION({EVO_LEVEL, 30, SPECIES_CRAWDAUNT}),
     },
@@ -5358,7 +5358,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Crawdaunt),
         ICON(Crawdaunt, 0),
-        FOOTPRINT(Crawdaunt),
+        FOOTPRINT(Crawdaunt)
         LEARNSETS(Crawdaunt),
     },
 #endif //P_FAMILY_CORPHISH
@@ -5409,7 +5409,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Baltoy),
         ICON(Baltoy, 2),
-        FOOTPRINT(Baltoy),
+        FOOTPRINT(Baltoy)
         LEARNSETS(Baltoy),
         .evolutions = EVOLUTION({EVO_LEVEL, 36, SPECIES_CLAYDOL}),
     },
@@ -5459,7 +5459,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,
         PALETTES(Claydol),
         ICON(Claydol, 0),
-        FOOTPRINT(Claydol),
+        FOOTPRINT(Claydol)
         LEARNSETS(Claydol),
     },
 #endif //P_FAMILY_BALTOY
@@ -5509,7 +5509,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_H_STRETCH,
         PALETTES(Lileep),
         ICON(Lileep, 2),
-        FOOTPRINT(Lileep),
+        FOOTPRINT(Lileep)
         LEARNSETS(Lileep),
         .evolutions = EVOLUTION({EVO_LEVEL, 40, SPECIES_CRADILY}),
     },
@@ -5558,7 +5558,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_V_STRETCH,
         PALETTES(Cradily),
         ICON(Cradily, 1),
-        FOOTPRINT(Cradily),
+        FOOTPRINT(Cradily)
         LEARNSETS(Cradily),
     },
 #endif //P_FAMILY_LILEEP
@@ -5607,7 +5607,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Anorith),
         ICON(Anorith, 0),
-        FOOTPRINT(Anorith),
+        FOOTPRINT(Anorith)
         LEARNSETS(Anorith),
         .evolutions = EVOLUTION({EVO_LEVEL, 40, SPECIES_ARMALDO}),
     },
@@ -5655,7 +5655,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Armaldo),
         ICON(Armaldo, 2),
-        FOOTPRINT(Armaldo),
+        FOOTPRINT(Armaldo)
         LEARNSETS(Armaldo),
     },
 #endif //P_FAMILY_ANORITH
@@ -5704,7 +5704,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_H_SPRING,
         PALETTES(Feebas),
         ICON(Feebas, 2),
-        FOOTPRINT(Feebas),
+        FOOTPRINT(Feebas)
         LEARNSETS(Feebas),
         .evolutions = EVOLUTION({EVO_BEAUTY, 170, SPECIES_MILOTIC},
                                 {EVO_TRADE_ITEM, ITEM_PRISM_SCALE, SPECIES_MILOTIC},
@@ -5757,7 +5757,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_SHAKE_GLOW_BLUE,
         PALETTES(Milotic),
         ICON(Milotic, 2),
-        FOOTPRINT(Milotic),
+        FOOTPRINT(Milotic)
         LEARNSETS(Milotic),
     },
 #endif //P_FAMILY_FEEBAS
@@ -5791,7 +5791,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .pokemonOffset = -5,                                    \
         .trainerScale = 256,                                    \
         .trainerOffset = 0,                                     \
-        FOOTPRINT(Castform),                                    \
+        FOOTPRINT(Castform)                                     \
         LEARNSETS(Castform),                                    \
         .formSpeciesIdTable = sCastformFormSpeciesIdTable,      \
         .formChangeTable = sCastformFormChangeTable
@@ -5930,7 +5930,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_H_VIBRATE,
         PALETTES(Kecleon),
         ICON(Kecleon, 1),
-        FOOTPRINT(Kecleon),
+        FOOTPRINT(Kecleon)
         LEARNSETS(Kecleon),
     },
 #endif //P_FAMILY_KECLEON
@@ -5981,7 +5981,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_H_VIBRATE,
         PALETTES(Shuppet),
         ICON(Shuppet, 0),
-        FOOTPRINT(Shuppet),
+        FOOTPRINT(Shuppet)
         LEARNSETS(Shuppet),
         .evolutions = EVOLUTION({EVO_LEVEL, 37, SPECIES_BANETTE}),
     },
@@ -6000,7 +6000,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .speciesName = _("Banette"),                                \
         .natDexNum = NATIONAL_DEX_BANETTE,                          \
         .categoryName = _("Marionette"),                            \
-        FOOTPRINT(Banette),                                         \
+        FOOTPRINT(Banette)                                          \
         LEARNSETS(Banette),                                         \
         .formSpeciesIdTable = sBanetteFormSpeciesIdTable,           \
         .formChangeTable = sBanetteFormChangeTable
@@ -6123,7 +6123,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_H_VIBRATE,
         PALETTES(Duskull),
         ICON(Duskull, 0),
-        FOOTPRINT(Duskull),
+        FOOTPRINT(Duskull)
         LEARNSETS(Duskull),
         .evolutions = EVOLUTION({EVO_LEVEL, 37, SPECIES_DUSCLOPS}),
     },
@@ -6174,7 +6174,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_H_VIBRATE,
         PALETTES(Dusclops),
         ICON(Dusclops, 0),
-        FOOTPRINT(Dusclops),
+        FOOTPRINT(Dusclops)
         LEARNSETS(Dusclops),
         .evolutions = EVOLUTION({EVO_TRADE_ITEM, ITEM_REAPER_CLOTH, SPECIES_DUSKNOIR},
                                 {EVO_ITEM, ITEM_REAPER_CLOTH, SPECIES_DUSKNOIR}),
@@ -6227,7 +6227,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,
         PALETTES(Dusknoir),
         ICON(Dusknoir, 2),
-        FOOTPRINT(Dusknoir),
+        FOOTPRINT(Dusknoir)
         LEARNSETS(Dusknoir),
     },
 #endif //P_GEN_4_CROSS_EVOS
@@ -6277,7 +6277,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_V_SHAKE_LOW,
         PALETTES(Tropius),
         ICON(Tropius, 1),
-        FOOTPRINT(Tropius),
+        FOOTPRINT(Tropius)
         LEARNSETS(Tropius),
     },
 #endif //P_FAMILY_TROPIUS
@@ -6328,7 +6328,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Chingling),
         ICON(Chingling, 1),
-        FOOTPRINT(Chingling),
+        FOOTPRINT(Chingling)
         LEARNSETS(Chingling),
         .evolutions = EVOLUTION({EVO_FRIENDSHIP_NIGHT, 0, SPECIES_CHIMECHO}),
     },
@@ -6386,7 +6386,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Chimecho),
         ICON(Chimecho, 0),
-        FOOTPRINT(Chimecho),
+        FOOTPRINT(Chimecho)
         LEARNSETS(Chimecho),
     },
 #endif //P_FAMILY_CHIMECHO
@@ -6411,7 +6411,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .pokemonOffset = 3,                                 \
         .trainerScale = 256,                                \
         .trainerOffset = 0,                                 \
-        FOOTPRINT(Absol),                                   \
+        FOOTPRINT(Absol)                                    \
         LEARNSETS(Absol),                                   \
         .formSpeciesIdTable = sAbsolFormSpeciesIdTable,     \
         .formChangeTable = sAbsolFormChangeTable
@@ -6525,7 +6525,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Snorunt),
         ICON(Snorunt, 2),
-        FOOTPRINT(Snorunt),
+        FOOTPRINT(Snorunt)
         LEARNSETS(Snorunt),
         .evolutions = EVOLUTION({EVO_LEVEL, 42, SPECIES_GLALIE},
                                 {EVO_ITEM_FEMALE, ITEM_DAWN_STONE, SPECIES_FROSLASS}),
@@ -6544,7 +6544,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .speciesName = _("Glalie"),                         \
         .natDexNum = NATIONAL_DEX_GLALIE,                   \
         .categoryName = _("Face"),                          \
-        FOOTPRINT(Glalie),                                  \
+        FOOTPRINT(Glalie)                                   \
         LEARNSETS(Glalie),                                  \
         .formSpeciesIdTable = sGlalieFormSpeciesIdTable,    \
         .formChangeTable = sGlalieFormChangeTable
@@ -6666,7 +6666,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Froslass),
         ICON(Froslass, 0),
-        FOOTPRINT(Froslass),
+        FOOTPRINT(Froslass)
         LEARNSETS(Froslass),
     },
 #endif //P_GEN_4_CROSS_EVOS
@@ -6717,7 +6717,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Spheal),
         ICON(Spheal, 2),
-        FOOTPRINT(Spheal),
+        FOOTPRINT(Spheal)
         LEARNSETS(Spheal),
         .evolutions = EVOLUTION({EVO_LEVEL, 32, SPECIES_SEALEO}),
     },
@@ -6765,7 +6765,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Sealeo),
         ICON(Sealeo, 2),
-        FOOTPRINT(Sealeo),
+        FOOTPRINT(Sealeo)
         LEARNSETS(Sealeo),
         .evolutions = EVOLUTION({EVO_LEVEL, 44, SPECIES_WALREIN}),
     },
@@ -6813,7 +6813,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Walrein),
         ICON(Walrein, 0),
-        FOOTPRINT(Walrein),
+        FOOTPRINT(Walrein)
         LEARNSETS(Walrein),
     },
 #endif //P_FAMILY_SPHEAL
@@ -6864,7 +6864,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Clamperl),
         ICON(Clamperl, 0),
-        FOOTPRINT(Clamperl),
+        FOOTPRINT(Clamperl)
         LEARNSETS(Clamperl),
         .evolutions = EVOLUTION({EVO_TRADE_ITEM, ITEM_DEEP_SEA_TOOTH, SPECIES_HUNTAIL},
                                 {EVO_TRADE_ITEM, ITEM_DEEP_SEA_SCALE, SPECIES_GOREBYSS},
@@ -6917,7 +6917,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Huntail),
         ICON(Huntail, 0),
-        FOOTPRINT(Huntail),
+        FOOTPRINT(Huntail)
         LEARNSETS(Huntail),
     },
 
@@ -6965,7 +6965,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Gorebyss),
         ICON(Gorebyss, 0),
-        FOOTPRINT(Gorebyss),
+        FOOTPRINT(Gorebyss)
         LEARNSETS(Gorebyss),
     },
 #endif //P_FAMILY_CLAMPERL
@@ -7018,7 +7018,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Relicanth),
         ICON(Relicanth, 2),
-        FOOTPRINT(Relicanth),
+        FOOTPRINT(Relicanth)
         LEARNSETS(Relicanth),
     },
 #endif //P_FAMILY_RELICANTH
@@ -7068,7 +7068,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_H_SPRING_REPEATED,
         PALETTES(Luvdisc),
         ICON(Luvdisc, 0),
-        FOOTPRINT(Luvdisc),
+        FOOTPRINT(Luvdisc)
         LEARNSETS(Luvdisc),
     },
 #endif //P_FAMILY_LUVDISC
@@ -7118,7 +7118,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Bagon),
         ICON(Bagon, 0),
-        FOOTPRINT(Bagon),
+        FOOTPRINT(Bagon)
         LEARNSETS(Bagon),
         .evolutions = EVOLUTION({EVO_LEVEL, 30, SPECIES_SHELGON}),
     },
@@ -7167,7 +7167,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Shelgon),
         ICON(Shelgon, 2),
-        FOOTPRINT(Shelgon),
+        FOOTPRINT(Shelgon)
         LEARNSETS(Shelgon),
         .evolutions = EVOLUTION({EVO_LEVEL, 50, SPECIES_SALAMENCE}),
     },
@@ -7186,7 +7186,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .speciesName = _("Salamence"),                      \
         .natDexNum = NATIONAL_DEX_SALAMENCE,                \
         .categoryName = _("Dragon"),                        \
-        FOOTPRINT(Salamence),                               \
+        FOOTPRINT(Salamence)                                \
         LEARNSETS(Salamence),                               \
         .formSpeciesIdTable = sSalamenceFormSpeciesIdTable, \
         .formChangeTable = sSalamenceFormChangeTable
@@ -7310,7 +7310,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Beldum),
         ICON(Beldum, 0),
-        FOOTPRINT(Beldum),
+        FOOTPRINT(Beldum)
         LEARNSETS(Beldum),
         .evolutions = EVOLUTION({EVO_LEVEL, 20, SPECIES_METANG}),
     },
@@ -7359,7 +7359,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Metang),
         ICON(Metang, 0),
-        FOOTPRINT(Metang),
+        FOOTPRINT(Metang)
         LEARNSETS(Metang),
         .evolutions = EVOLUTION({EVO_LEVEL, 45, SPECIES_METAGROSS}),
     },
@@ -7378,7 +7378,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .speciesName = _("Metagross"),                          \
         .natDexNum = NATIONAL_DEX_METAGROSS,                    \
         .categoryName = _("Iron Leg"),                          \
-        FOOTPRINT(Metagross),                                   \
+        FOOTPRINT(Metagross)                                    \
         LEARNSETS(Metagross),                                   \
         .formSpeciesIdTable = sMetagrossFormSpeciesIdTable,     \
         .formChangeTable = sMetagrossFormChangeTable
@@ -7501,7 +7501,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Regirock),
         ICON(Regirock, 2),
-        FOOTPRINT(Regirock),
+        FOOTPRINT(Regirock)
         LEARNSETS(Regirock),
     },
 #endif //P_FAMILY_REGIROCK
@@ -7551,7 +7551,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Regice),
         ICON(Regice, 0),
-        FOOTPRINT(Regice),
+        FOOTPRINT(Regice)
         LEARNSETS(Regice),
     },
 #endif //P_FAMILY_REGICE
@@ -7602,7 +7602,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Registeel),
         ICON(Registeel, 2),
-        FOOTPRINT(Registeel),
+        FOOTPRINT(Registeel)
         LEARNSETS(Registeel),
     },
 #endif //P_FAMILY_REGISTEEL
@@ -7620,7 +7620,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .speciesName = _("Latias"),                                     \
         .natDexNum = NATIONAL_DEX_LATIAS,                               \
         .categoryName = _("Eon"),                                       \
-        FOOTPRINT(Latias),                                              \
+        FOOTPRINT(Latias)                                               \
         LEARNSETS(Latias),                                              \
         .formSpeciesIdTable = sLatiasFormSpeciesIdTable,                \
         .formChangeTable = sLatiasFormChangeTable,                      \
@@ -7716,7 +7716,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .speciesName = _("Latios"),                                     \
         .natDexNum = NATIONAL_DEX_LATIOS,                               \
         .categoryName = _("Eon"),                                       \
-        FOOTPRINT(Latios),                                              \
+        FOOTPRINT(Latios)                                               \
         LEARNSETS(Latios),                                              \
         .formSpeciesIdTable = sLatiosFormSpeciesIdTable,                \
         .formChangeTable = sLatiosFormChangeTable
@@ -7813,7 +7813,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .speciesName = _("Kyogre"),                                     \
         .natDexNum = NATIONAL_DEX_KYOGRE,                               \
         .categoryName = _("Sea Basin"),                                 \
-        FOOTPRINT(Kyogre),                                              \
+        FOOTPRINT(Kyogre)                                               \
         LEARNSETS(Kyogre),                                              \
         .formSpeciesIdTable = sKyogreFormSpeciesIdTable,                \
         .formChangeTable = sKyogreFormChangeTable
@@ -7904,7 +7904,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .cryId = CRY_GROUDON,                                           \
         .natDexNum = NATIONAL_DEX_GROUDON,                              \
         .categoryName = _("Continent"),                                 \
-        FOOTPRINT(Groudon),                                             \
+        FOOTPRINT(Groudon)                                              \
         LEARNSETS(Groudon),                                             \
         .formSpeciesIdTable = sGroudonFormSpeciesIdTable,               \
         .formChangeTable = sGroudonFormChangeTable
@@ -7997,7 +7997,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .cryId = CRY_RAYQUAZA,                                          \
         .natDexNum = NATIONAL_DEX_RAYQUAZA,                             \
         .categoryName = _("Sky High"),                                  \
-        FOOTPRINT(Rayquaza),                                            \
+        FOOTPRINT(Rayquaza)                                             \
         LEARNSETS(Rayquaza),                                            \
         .formSpeciesIdTable = sRayquazaFormSpeciesIdTable,              \
         .formChangeTable = sRayquazaFormChangeTable,                    \
@@ -8122,7 +8122,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Jirachi),
         ICON(Jirachi, 0),
-        FOOTPRINT(Jirachi),
+        FOOTPRINT(Jirachi)
         LEARNSETS(Jirachi),
     },
 #endif //P_FAMILY_JIRACHI
@@ -8151,7 +8151,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .pokemonOffset = 0,                                             \
         .trainerScale = 290,                                            \
         .trainerOffset = 2,                                             \
-        FOOTPRINT(Deoxys),                                              \
+        FOOTPRINT(Deoxys)                                               \
         .formSpeciesIdTable = sDeoxysFormSpeciesIdTable
 
     [SPECIES_DEOXYS_NORMAL] =

--- a/src/data/pokemon/species_info/gen_4.h
+++ b/src/data/pokemon/species_info/gen_4.h
@@ -47,7 +47,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Turtwig),
         ICON(Turtwig, 1),
-        FOOTPRINT(Turtwig),
+        FOOTPRINT(Turtwig)
         LEARNSETS(Turtwig),
         .evolutions = EVOLUTION({EVO_LEVEL, 18, SPECIES_GROTLE}),
     },
@@ -96,7 +96,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Grotle),
         ICON(Grotle, 1),
-        FOOTPRINT(Grotle),
+        FOOTPRINT(Grotle)
         LEARNSETS(Grotle),
         .evolutions = EVOLUTION({EVO_LEVEL, 32, SPECIES_TORTERRA}),
     },
@@ -146,7 +146,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_SHAKE_GLOW_GREEN,
         PALETTES(Torterra),
         ICON(Torterra, 1),
-        FOOTPRINT(Torterra),
+        FOOTPRINT(Torterra)
         LEARNSETS(Torterra),
     },
 #endif //P_FAMILY_TURTWIG
@@ -196,7 +196,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Chimchar),
         ICON(Chimchar, 1),
-        FOOTPRINT(Chimchar),
+        FOOTPRINT(Chimchar)
         LEARNSETS(Chimchar),
         .evolutions = EVOLUTION({EVO_LEVEL, 14, SPECIES_MONFERNO}),
     },
@@ -246,7 +246,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Monferno),
         ICON(Monferno, 0),
-        FOOTPRINT(Monferno),
+        FOOTPRINT(Monferno)
         LEARNSETS(Monferno),
         .evolutions = EVOLUTION({EVO_LEVEL, 36, SPECIES_INFERNAPE}),
     },
@@ -296,7 +296,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_SHAKE_GLOW_RED,
         PALETTES(Infernape),
         ICON(Infernape, 0),
-        FOOTPRINT(Infernape),
+        FOOTPRINT(Infernape)
         LEARNSETS(Infernape),
     },
 #endif //P_FAMILY_CHIMCHAR
@@ -349,7 +349,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Piplup),
         ICON(Piplup, 0),
-        FOOTPRINT(Piplup),
+        FOOTPRINT(Piplup)
         LEARNSETS(Piplup),
         .evolutions = EVOLUTION({EVO_LEVEL, 16, SPECIES_PRINPLUP}),
     },
@@ -401,7 +401,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_V_STRETCH,
         PALETTES(Prinplup),
         ICON(Prinplup, 0),
-        FOOTPRINT(Prinplup),
+        FOOTPRINT(Prinplup)
         LEARNSETS(Prinplup),
         .evolutions = EVOLUTION({EVO_LEVEL, 36, SPECIES_EMPOLEON}),
     },
@@ -453,7 +453,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_SHAKE_GLOW_BLUE,
         PALETTES(Empoleon),
         ICON(Empoleon, 0),
-        FOOTPRINT(Empoleon),
+        FOOTPRINT(Empoleon)
         LEARNSETS(Empoleon),
     },
 #endif //P_FAMILY_PIPLUP
@@ -504,7 +504,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Starly),
         ICON(Starly, 0),
-        FOOTPRINT(Starly),
+        FOOTPRINT(Starly)
         LEARNSETS(Starly),
         .evolutions = EVOLUTION({EVO_LEVEL, 14, SPECIES_STARAVIA}),
     },
@@ -554,7 +554,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Staravia),
         ICON(Staravia, 0),
-        FOOTPRINT(Staravia),
+        FOOTPRINT(Staravia)
         LEARNSETS(Staravia),
         .evolutions = EVOLUTION({EVO_LEVEL, 34, SPECIES_STARAPTOR}),
     },
@@ -603,7 +603,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Staraptor),
         ICON(Staraptor, 0),
-        FOOTPRINT(Staraptor),
+        FOOTPRINT(Staraptor)
         LEARNSETS(Staraptor),
     },
 #endif //P_FAMILY_STARLY
@@ -654,7 +654,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_V_SHAKE_H_SLIDE,
         PALETTES(Bidoof),
         ICON(Bidoof, 2),
-        FOOTPRINT(Bidoof),
+        FOOTPRINT(Bidoof)
         LEARNSETS(Bidoof),
         .evolutions = EVOLUTION({EVO_LEVEL, 15, SPECIES_BIBAREL}),
     },
@@ -703,7 +703,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Bibarel),
         ICON(Bibarel, 2),
-        FOOTPRINT(Bibarel),
+        FOOTPRINT(Bibarel)
         LEARNSETS(Bibarel),
     },
 #endif //P_FAMILY_BIDOOF
@@ -755,7 +755,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Kricketot),
         ICON(Kricketot, 2),
-        FOOTPRINT(Kricketot),
+        FOOTPRINT(Kricketot)
         LEARNSETS(Kricketot),
         .evolutions = EVOLUTION({EVO_LEVEL, 10, SPECIES_KRICKETUNE}),
     },
@@ -806,7 +806,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_H_VIBRATE,
         PALETTES(Kricketune),
         ICON(Kricketune, 2),
-        FOOTPRINT(Kricketune),
+        FOOTPRINT(Kricketune)
         LEARNSETS(Kricketune),
     },
 #endif //P_FAMILY_KRICKETOT
@@ -857,7 +857,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Shinx),
         ICON(Shinx, 0),
-        FOOTPRINT(Shinx),
+        FOOTPRINT(Shinx)
         LEARNSETS(Shinx),
         .evolutions = EVOLUTION({EVO_LEVEL, 15, SPECIES_LUXIO}),
     },
@@ -907,7 +907,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Luxio),
         ICON(Luxio, 0),
-        FOOTPRINT(Luxio),
+        FOOTPRINT(Luxio)
         LEARNSETS(Luxio),
         .evolutions = EVOLUTION({EVO_LEVEL, 30, SPECIES_LUXRAY}),
     },
@@ -957,7 +957,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,
         PALETTES(Luxray),
         ICON(Luxray, 0),
-        FOOTPRINT(Luxray),
+        FOOTPRINT(Luxray)
         LEARNSETS(Luxray),
     },
 #endif //P_FAMILY_SHINX
@@ -1006,7 +1006,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Cranidos),
         ICON(Cranidos, 0),
-        FOOTPRINT(Cranidos),
+        FOOTPRINT(Cranidos)
         LEARNSETS(Cranidos),
         .evolutions = EVOLUTION({EVO_LEVEL, 30, SPECIES_RAMPARDOS}),
     },
@@ -1054,7 +1054,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_V_SHAKE_LOW,
         PALETTES(Rampardos),
         ICON(Rampardos, 0),
-        FOOTPRINT(Rampardos),
+        FOOTPRINT(Rampardos)
         LEARNSETS(Rampardos),
     },
 #endif //P_FAMILY_CRANIDOS
@@ -1103,7 +1103,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Shieldon),
         ICON(Shieldon, 1),
-        FOOTPRINT(Shieldon),
+        FOOTPRINT(Shieldon)
         LEARNSETS(Shieldon),
         .evolutions = EVOLUTION({EVO_LEVEL, 30, SPECIES_BASTIODON}),
     },
@@ -1151,7 +1151,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_V_SHAKE_LOW,
         PALETTES(Bastiodon),
         ICON(Bastiodon, 1),
-        FOOTPRINT(Bastiodon),
+        FOOTPRINT(Bastiodon)
         LEARNSETS(Bastiodon),
     },
 #endif //P_FAMILY_SHIELDON
@@ -1188,7 +1188,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .frontAnimId = ANIM_V_STRETCH,                                      \
         .enemyMonElevation = 10,                                            \
         .backAnimId = BACK_ANIM_H_SHAKE,                                    \
-        FOOTPRINT(Burmy),                                                   \
+        FOOTPRINT(Burmy)                                                    \
         LEARNSETS(Burmy),                                                   \
         .formSpeciesIdTable = sBurmyFormSpeciesIdTable,                     \
         .formChangeTable = sBurmyFormChangeTable
@@ -1276,7 +1276,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .enemyMonElevation = 8,                                                 \
         .backPicYOffset = 2,                                                    \
         .backAnimId = BACK_ANIM_V_SHAKE,                                        \
-        FOOTPRINT(Wormadam),                                                    \
+        FOOTPRINT(Wormadam)                                                     \
         .formSpeciesIdTable = sWormadamFormSpeciesIdTable
 
     [SPECIES_WORMADAM_PLANT_CLOAK] =
@@ -1398,7 +1398,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_H_SHAKE,
         PALETTES(Mothim),
         ICON(Mothim, 0),
-        FOOTPRINT(Mothim),
+        FOOTPRINT(Mothim)
         LEARNSETS(Mothim),
     },
 #endif //P_FAMILY_BURMY
@@ -1450,7 +1450,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         PALETTES(Combee),
         PALETTE_FEMALE(Combee),
         ICON(Combee, 0),
-        FOOTPRINT(Combee),
+        FOOTPRINT(Combee)
         LEARNSETS(Combee),
         .evolutions = EVOLUTION({EVO_LEVEL_FEMALE, 21, SPECIES_VESPIQUEN}),
     },
@@ -1501,7 +1501,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_CIRCLE_COUNTERCLOCKWISE,
         PALETTES(Vespiquen),
         ICON(Vespiquen, 0),
-        FOOTPRINT(Vespiquen),
+        FOOTPRINT(Vespiquen)
         LEARNSETS(Vespiquen),
     },
 #endif //P_FAMILY_COMBEE
@@ -1551,7 +1551,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_SHAKE_FLASH_YELLOW,
         PALETTES(Pachirisu),
         ICON(Pachirisu, 0),
-        FOOTPRINT(Pachirisu),
+        FOOTPRINT(Pachirisu)
         LEARNSETS(Pachirisu),
     },
 #endif //P_FAMILY_PACHIRISU
@@ -1601,7 +1601,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Buizel),
         ICON(Buizel, 0),
-        FOOTPRINT(Buizel),
+        FOOTPRINT(Buizel)
         LEARNSETS(Buizel),
         .evolutions = EVOLUTION({EVO_LEVEL, 26, SPECIES_FLOATZEL}),
     },
@@ -1650,7 +1650,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_V_STRETCH,
         PALETTES(Floatzel),
         ICON(Floatzel, 0),
-        FOOTPRINT(Floatzel),
+        FOOTPRINT(Floatzel)
         LEARNSETS(Floatzel),
     },
 #endif //P_FAMILY_BUIZEL
@@ -1700,7 +1700,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Cherubi),
         ICON(Cherubi, 1),
-        FOOTPRINT(Cherubi),
+        FOOTPRINT(Cherubi)
         LEARNSETS(Cherubi),
         .evolutions = EVOLUTION({EVO_LEVEL, 25, SPECIES_CHERRIM_OVERCAST}),
     },
@@ -1733,7 +1733,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .pokemonOffset = 13,                                \
         .trainerScale = 256,                                \
         .trainerOffset = 0,                                 \
-        FOOTPRINT(Cherrim),                                 \
+        FOOTPRINT(Cherrim)                                  \
         LEARNSETS(Cherrim),                                 \
         .formSpeciesIdTable = sCherrimFormSpeciesIdTable,   \
         .formChangeTable = sCherrimFormChangeTable
@@ -1811,7 +1811,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .frontAnimId = ANIM_V_STRETCH,                                                  \
         .backPicYOffset = 8,                                                            \
         .backAnimId = BACK_ANIM_H_SPRING,                                               \
-        FOOTPRINT(Shellos),                                                             \
+        FOOTPRINT(Shellos)                                                              \
         LEARNSETS(Shellos),                                                             \
         .formSpeciesIdTable = sShellosFormSpeciesIdTable
 
@@ -1881,7 +1881,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .frontAnimId = ANIM_CIRCULAR_STRETCH_TWICE,                                     \
         .backPicYOffset = 3,                                                            \
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,                                    \
-        FOOTPRINT(Gastrodon),                                                           \
+        FOOTPRINT(Gastrodon)                                                            \
         LEARNSETS(Gastrodon),                                                           \
         .formSpeciesIdTable = sGastrodonFormSpeciesIdTable
 
@@ -1961,7 +1961,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Drifloon),
         ICON(Drifloon, 2),
-        FOOTPRINT(Drifloon),
+        FOOTPRINT(Drifloon)
         LEARNSETS(Drifloon),
         .evolutions = EVOLUTION({EVO_LEVEL, 28, SPECIES_DRIFBLIM}),
     },
@@ -2010,7 +2010,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Drifblim),
         ICON(Drifblim, 2),
-        FOOTPRINT(Drifblim),
+        FOOTPRINT(Drifblim)
         LEARNSETS(Drifblim),
     },
 #endif //P_FAMILY_DRIFLOON
@@ -2059,7 +2059,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Buneary),
         ICON(Buneary, 2),
-        FOOTPRINT(Buneary),
+        FOOTPRINT(Buneary)
         LEARNSETS(Buneary),
         .evolutions = EVOLUTION({EVO_FRIENDSHIP, 0, SPECIES_LOPUNNY}),
     },
@@ -2076,7 +2076,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .speciesName = _("Lopunny"),                            \
         .natDexNum = NATIONAL_DEX_LOPUNNY,                      \
         .categoryName = _("Rabbit"),                            \
-        FOOTPRINT(Lopunny),                                     \
+        FOOTPRINT(Lopunny)                                      \
         LEARNSETS(Lopunny),                                     \
         .formSpeciesIdTable = sLopunnyFormSpeciesIdTable,       \
         .formChangeTable = sLopunnyFormChangeTable
@@ -2199,7 +2199,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW,
         PALETTES(Glameow),
         ICON(Glameow, 0),
-        FOOTPRINT(Glameow),
+        FOOTPRINT(Glameow)
         LEARNSETS(Glameow),
         .evolutions = EVOLUTION({EVO_LEVEL, 38, SPECIES_PURUGLY}),
     },
@@ -2247,7 +2247,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_GROW_STUTTER,
         PALETTES(Purugly),
         ICON(Purugly, 0),
-        FOOTPRINT(Purugly),
+        FOOTPRINT(Purugly)
         LEARNSETS(Purugly),
     },
 #endif //P_FAMILY_GLAMEOW
@@ -2296,7 +2296,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Stunky),
         ICON(Stunky, 2),
-        FOOTPRINT(Stunky),
+        FOOTPRINT(Stunky)
         LEARNSETS(Stunky),
         .evolutions = EVOLUTION({EVO_LEVEL, 34, SPECIES_SKUNTANK}),
     },
@@ -2344,7 +2344,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_H_STRETCH,
         PALETTES(Skuntank),
         ICON(Skuntank, 2),
-        FOOTPRINT(Skuntank),
+        FOOTPRINT(Skuntank)
         LEARNSETS(Skuntank),
     },
 #endif //P_FAMILY_STUNKY
@@ -2395,7 +2395,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Bronzor),
         ICON(Bronzor, 0),
-        FOOTPRINT(Bronzor),
+        FOOTPRINT(Bronzor)
         LEARNSETS(Bronzor),
         .evolutions = EVOLUTION({EVO_LEVEL, 33, SPECIES_BRONZONG}),
     },
@@ -2446,7 +2446,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_V_SHAKE_LOW,
         PALETTES(Bronzong),
         ICON(Bronzong, 0),
-        FOOTPRINT(Bronzong),
+        FOOTPRINT(Bronzong)
         LEARNSETS(Bronzong),
     },
 #endif //P_FAMILY_BRONZOR
@@ -2496,7 +2496,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_V_STRETCH,
         PALETTES(Chatot),
         ICON(Chatot, 0),
-        FOOTPRINT(Chatot),
+        FOOTPRINT(Chatot)
         LEARNSETS(Chatot),
     },
 #endif //P_FAMILY_CHATOT
@@ -2546,7 +2546,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,
         PALETTES(Spiritomb),
         ICON(Spiritomb, 5),
-        FOOTPRINT(Spiritomb),
+        FOOTPRINT(Spiritomb)
         LEARNSETS(Spiritomb),
     },
 #endif //P_FAMILY_SPIRITOMB
@@ -2597,7 +2597,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_H_SHAKE,
         PALETTES(Gible),
         ICON(Gible, 0),
-        FOOTPRINT(Gible),
+        FOOTPRINT(Gible)
         LEARNSETS(Gible),
         .evolutions = EVOLUTION({EVO_LEVEL, 24, SPECIES_GABITE}),
     },
@@ -2647,7 +2647,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Gabite),
         ICON(Gabite, 0),
-        FOOTPRINT(Gabite),
+        FOOTPRINT(Gabite)
         LEARNSETS(Gabite),
         .evolutions = EVOLUTION({EVO_LEVEL, 48, SPECIES_GARCHOMP}),
     },
@@ -2671,7 +2671,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .pokemonOffset = 1,                                     \
         .trainerScale = 326,                                    \
         .trainerOffset = 4,                                     \
-        FOOTPRINT(Garchomp),                                    \
+        FOOTPRINT(Garchomp)                                     \
         LEARNSETS(Garchomp),                                    \
         .formSpeciesIdTable = sGarchompFormSpeciesIdTable,      \
         .formChangeTable = sGarchompFormChangeTable
@@ -2781,7 +2781,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_LARGE,
         PALETTES(Riolu),
         ICON(Riolu, 2),
-        FOOTPRINT(Riolu),
+        FOOTPRINT(Riolu)
         LEARNSETS(Riolu),
         .evolutions = EVOLUTION({EVO_FRIENDSHIP_DAY, 0, SPECIES_LUCARIO}),
     },
@@ -2800,7 +2800,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .speciesName = _("Lucario"),                            \
         .natDexNum = NATIONAL_DEX_LUCARIO,                      \
         .categoryName = _("Aura"),                              \
-        FOOTPRINT(Lucario),                                     \
+        FOOTPRINT(Lucario)                                      \
         LEARNSETS(Lucario),                                     \
         .formSpeciesIdTable = sLucarioFormSpeciesIdTable,       \
         .formChangeTable = sLucarioFormChangeTable
@@ -2925,7 +2925,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
     #if P_CUSTOM_GENDER_DIFF_ICONS == TRUE
         ICON_FEMALE(Hippopotas, 1),
     #endif
-        FOOTPRINT(Hippopotas),
+        FOOTPRINT(Hippopotas)
         LEARNSETS(Hippopotas),
         .evolutions = EVOLUTION({EVO_LEVEL, 34, SPECIES_HIPPOWDON}),
     },
@@ -2977,7 +2977,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
     #if P_CUSTOM_GENDER_DIFF_ICONS == TRUE
         ICON_FEMALE(Hippowdon, 1),
     #endif
-        FOOTPRINT(Hippowdon),
+        FOOTPRINT(Hippowdon)
         LEARNSETS(Hippowdon),
     },
 #endif //P_FAMILY_HIPPOPOTAS
@@ -3027,7 +3027,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Skorupi),
         ICON(Skorupi, 0),
-        FOOTPRINT(Skorupi),
+        FOOTPRINT(Skorupi)
         LEARNSETS(Skorupi),
         .evolutions = EVOLUTION({EVO_LEVEL, 40, SPECIES_DRAPION}),
     },
@@ -3076,7 +3076,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_V_SHAKE_H_SLIDE,
         PALETTES(Drapion),
         ICON(Drapion, 2),
-        FOOTPRINT(Drapion),
+        FOOTPRINT(Drapion)
         LEARNSETS(Drapion),
     },
 #endif //P_FAMILY_SKORUPI
@@ -3128,7 +3128,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_GROW,
         PALETTES(Croagunk),
         ICON(Croagunk, 0),
-        FOOTPRINT(Croagunk),
+        FOOTPRINT(Croagunk)
         LEARNSETS(Croagunk),
         .evolutions = EVOLUTION({EVO_LEVEL, 37, SPECIES_TOXICROAK}),
     },
@@ -3179,7 +3179,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_V_SHAKE_H_SLIDE,
         PALETTES(Toxicroak),
         ICON(Toxicroak, 0),
-        FOOTPRINT(Toxicroak),
+        FOOTPRINT(Toxicroak)
         LEARNSETS(Toxicroak),
     },
 #endif //P_FAMILY_CROAGUNK
@@ -3229,7 +3229,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,
         PALETTES(Carnivine),
         ICON(Carnivine, 1),
-        FOOTPRINT(Carnivine),
+        FOOTPRINT(Carnivine)
         LEARNSETS(Carnivine),
     },
 #endif //P_FAMILY_CARNIVINE
@@ -3280,7 +3280,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Finneon),
         ICON(Finneon, 0),
-        FOOTPRINT(Finneon),
+        FOOTPRINT(Finneon)
         LEARNSETS(Finneon),
         .evolutions = EVOLUTION({EVO_LEVEL, 31, SPECIES_LUMINEON}),
     },
@@ -3330,7 +3330,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Lumineon),
         ICON(Lumineon, 0),
-        FOOTPRINT(Lumineon),
+        FOOTPRINT(Lumineon)
         LEARNSETS(Lumineon),
     },
 #endif //P_FAMILY_FINNEON
@@ -3382,7 +3382,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_V_STRETCH,
         PALETTES(Snover),
         ICON(Snover, 1),
-        FOOTPRINT(Snover),
+        FOOTPRINT(Snover)
         LEARNSETS(Snover),
         .evolutions = EVOLUTION({EVO_LEVEL, 40, SPECIES_ABOMASNOW}),
     },
@@ -3402,7 +3402,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .speciesName = _("Abomasnow"),                      \
         .natDexNum = NATIONAL_DEX_ABOMASNOW,                \
         .categoryName = _("Frost Tree"),                    \
-        FOOTPRINT(Abomasnow),                               \
+        FOOTPRINT(Abomasnow)                                \
         LEARNSETS(Abomasnow),                               \
         .formSpeciesIdTable = sAbomasnowFormSpeciesIdTable, \
         .formChangeTable = sAbomasnowFormChangeTable
@@ -3502,7 +3502,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .pokemonOffset = 13,                                        \
         .trainerScale = 256,                                        \
         .trainerOffset = 0,                                         \
-        FOOTPRINT(Rotom),                                           \
+        FOOTPRINT(Rotom)                                            \
         LEARNSETS(Rotom),                                           \
         .formSpeciesIdTable = sRotomFormSpeciesIdTable,             \
         .formChangeTable = sRotomFormChangeTable
@@ -3704,7 +3704,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Uxie),
         ICON(Uxie, 0),
-        FOOTPRINT(Uxie),
+        FOOTPRINT(Uxie)
         LEARNSETS(Uxie),
     },
 #endif //P_FAMILY_UXIE
@@ -3757,7 +3757,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Mesprit),
         ICON(Mesprit, 0),
-        FOOTPRINT(Mesprit),
+        FOOTPRINT(Mesprit)
         LEARNSETS(Mesprit),
     },
 #endif //P_FAMILY_MESPRIT
@@ -3809,7 +3809,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Azelf),
         ICON(Azelf, 0),
-        FOOTPRINT(Azelf),
+        FOOTPRINT(Azelf)
         LEARNSETS(Azelf),
     },
 #endif //P_FAMILY_AZELF
@@ -3831,7 +3831,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .cryId = CRY_DIALGA,                                                            \
         .natDexNum = NATIONAL_DEX_DIALGA,                                               \
         .categoryName = _("Temporal"),                                                  \
-        FOOTPRINT(Dialga),                                                              \
+        FOOTPRINT(Dialga)                                                               \
         LEARNSETS(Dialga),                                                              \
         .formSpeciesIdTable = sDialgaFormSpeciesIdTable,                                \
         .formChangeTable = sDialgaFormChangeTable,                                      \
@@ -3917,7 +3917,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .cryId = CRY_PALKIA,                                                            \
         .natDexNum = NATIONAL_DEX_PALKIA,                                               \
         .categoryName = _("Spatial"),                                                   \
-        FOOTPRINT(Palkia),                                                              \
+        FOOTPRINT(Palkia)                                                               \
         LEARNSETS(Palkia),                                                              \
         .formSpeciesIdTable = sPalkiaFormSpeciesIdTable,                                \
         .formChangeTable = sPalkiaFormChangeTable,                                      \
@@ -4031,7 +4031,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_SHAKE_GLOW_RED,
         PALETTES(Heatran),
         ICON(Heatran, 0),
-        FOOTPRINT(Heatran),
+        FOOTPRINT(Heatran)
         LEARNSETS(Heatran),
     },
 #endif //P_FAMILY_HEATRAN
@@ -4081,7 +4081,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_V_SHAKE_LOW,
         PALETTES(Regigigas),
         ICON(Regigigas, 0),
-        FOOTPRINT(Regigigas),
+        FOOTPRINT(Regigigas)
         LEARNSETS(Regigigas),
     },
 #endif //P_FAMILY_REGIGIGAS
@@ -4102,7 +4102,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .cryId = CRY_GIRATINA,                                                          \
         .natDexNum = NATIONAL_DEX_GIRATINA,                                             \
         .categoryName = _("Renegade"),                                                  \
-        FOOTPRINT(Giratina),                                                            \
+        FOOTPRINT(Giratina)                                                             \
         LEARNSETS(Giratina),                                                            \
         .formSpeciesIdTable = sGiratinaFormSpeciesIdTable,                              \
         .formChangeTable = sGiratinaFormChangeTable,                                    \
@@ -4220,7 +4220,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Cresselia),
         ICON(Cresselia, 0),
-        FOOTPRINT(Cresselia),
+        FOOTPRINT(Cresselia)
         LEARNSETS(Cresselia),
     },
 #endif //P_FAMILY_CRESSELIA
@@ -4271,7 +4271,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Phione),
         ICON(Phione, 0),
-        FOOTPRINT(Phione),
+        FOOTPRINT(Phione)
         LEARNSETS(Phione),
     },
 
@@ -4320,7 +4320,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Manaphy),
         ICON(Manaphy, 0),
-        FOOTPRINT(Manaphy),
+        FOOTPRINT(Manaphy)
         LEARNSETS(Manaphy),
     },
 #endif //P_FAMILY_MANAPHY
@@ -4372,7 +4372,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,
         PALETTES(Darkrai),
         ICON(Darkrai, 0),
-        FOOTPRINT(Darkrai),
+        FOOTPRINT(Darkrai)
         LEARNSETS(Darkrai),
     },
 #endif //P_FAMILY_DARKRAI
@@ -4393,7 +4393,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .speciesName = _("Shaymin"),                                                    \
         .natDexNum = NATIONAL_DEX_SHAYMIN,                                              \
         .categoryName = _("Gratitude"),                                                 \
-        FOOTPRINT(Shaymin),                                                             \
+        FOOTPRINT(Shaymin)                                                              \
         .formSpeciesIdTable = sShayminFormSpeciesIdTable,                               \
         .formChangeTable = sShayminFormChangeTable,                                     \
         .isMythical = TRUE
@@ -4510,7 +4510,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .backAnimId = BACK_ANIM_GROW_STUTTER,                                           \
         PALETTES(Arceus ##typeName),                                                    \
         ICON(Arceus, 1),                                                                \
-        FOOTPRINT(Arceus),                                                              \
+        FOOTPRINT(Arceus)                                                               \
         LEARNSETS(Arceus),                                                              \
         .formSpeciesIdTable = sArceusFormSpeciesIdTable,                                \
         .formChangeTable = sArceusFormChangeTable,                                      \

--- a/src/data/pokemon/species_info/gen_5.h
+++ b/src/data/pokemon/species_info/gen_5.h
@@ -48,7 +48,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_SHAKE,
         PALETTES(Victini),
         ICON(Victini, 0),
-        FOOTPRINT(Victini),
+        FOOTPRINT(Victini)
         LEARNSETS(Victini),
     },
 #endif //P_FAMILY_VICTINI
@@ -97,7 +97,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Snivy),
         ICON(Snivy, 1),
-        FOOTPRINT(Snivy),
+        FOOTPRINT(Snivy)
         LEARNSETS(Snivy),
         .evolutions = EVOLUTION({EVO_LEVEL, 17, SPECIES_SERVINE}),
     },
@@ -145,7 +145,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Servine),
         ICON(Servine, 1),
-        FOOTPRINT(Servine),
+        FOOTPRINT(Servine)
         LEARNSETS(Servine),
         .evolutions = EVOLUTION({EVO_LEVEL, 36, SPECIES_SERPERIOR}),
     },
@@ -193,7 +193,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_STRETCH,
         PALETTES(Serperior),
         ICON(Serperior, 1),
-        FOOTPRINT(Serperior),
+        FOOTPRINT(Serperior)
         LEARNSETS(Serperior),
     },
 #endif //P_FAMILY_SNIVY
@@ -242,7 +242,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Tepig),
         ICON(Tepig, 0),
-        FOOTPRINT(Tepig),
+        FOOTPRINT(Tepig)
         LEARNSETS(Tepig),
         .evolutions = EVOLUTION({EVO_LEVEL, 17, SPECIES_PIGNITE}),
     },
@@ -290,7 +290,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_GROW_STUTTER,
         PALETTES(Pignite),
         ICON(Pignite, 0),
-        FOOTPRINT(Pignite),
+        FOOTPRINT(Pignite)
         LEARNSETS(Pignite),
         .evolutions = EVOLUTION({EVO_LEVEL, 36, SPECIES_EMBOAR}),
     },
@@ -339,7 +339,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_SHAKE_GLOW_RED,
         PALETTES(Emboar),
         ICON(Emboar, 0),
-        FOOTPRINT(Emboar),
+        FOOTPRINT(Emboar)
         LEARNSETS(Emboar),
     },
 #endif //P_FAMILY_TEPIG
@@ -388,7 +388,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Oshawott),
         ICON(Oshawott, 0),
-        FOOTPRINT(Oshawott),
+        FOOTPRINT(Oshawott)
         LEARNSETS(Oshawott),
         .evolutions = EVOLUTION({EVO_LEVEL, 17, SPECIES_DEWOTT}),
     },
@@ -436,7 +436,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_LARGE,
         PALETTES(Dewott),
         ICON(Dewott, 0),
-        FOOTPRINT(Dewott),
+        FOOTPRINT(Dewott)
         LEARNSETS(Dewott),
         .evolutions = EVOLUTION({EVO_LEVEL, 36, SPECIES_SAMUROTT},
                                 {EVO_NONE, 0, SPECIES_SAMUROTT_HISUIAN}),
@@ -460,7 +460,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .pokemonOffset = 2,                                                 \
         .trainerScale = 271,                                                \
         .trainerOffset = 0,                                                 \
-        FOOTPRINT(Samurott),                                                \
+        FOOTPRINT(Samurott)                                                 \
         .formSpeciesIdTable = sSamurottFormSpeciesIdTable
 
     [SPECIES_SAMUROTT] =
@@ -571,7 +571,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Patrat),
         ICON(Patrat, 2),
-        FOOTPRINT(Patrat),
+        FOOTPRINT(Patrat)
         LEARNSETS(Patrat),
         .evolutions = EVOLUTION({EVO_LEVEL, 20, SPECIES_WATCHOG}),
     },
@@ -619,7 +619,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Watchog),
         ICON(Watchog, 2),
-        FOOTPRINT(Watchog),
+        FOOTPRINT(Watchog)
         LEARNSETS(Watchog),
     },
 #endif //P_FAMILY_PATRAT
@@ -668,7 +668,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Lillipup),
         ICON(Lillipup, 2),
-        FOOTPRINT(Lillipup),
+        FOOTPRINT(Lillipup)
         LEARNSETS(Lillipup),
         .evolutions = EVOLUTION({EVO_LEVEL, 16, SPECIES_HERDIER}),
     },
@@ -716,7 +716,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_SHAKE,
         PALETTES(Herdier),
         ICON(Herdier, 2),
-        FOOTPRINT(Herdier),
+        FOOTPRINT(Herdier)
         LEARNSETS(Herdier),
         .evolutions = EVOLUTION({EVO_LEVEL, 32, SPECIES_STOUTLAND}),
     },
@@ -764,7 +764,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_STRETCH,
         PALETTES(Stoutland),
         ICON(Stoutland, 2),
-        FOOTPRINT(Stoutland),
+        FOOTPRINT(Stoutland)
         LEARNSETS(Stoutland),
     },
 #endif //P_FAMILY_LILLIPUP
@@ -813,7 +813,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_STRETCH,
         PALETTES(Purrloin),
         ICON(Purrloin, 0),
-        FOOTPRINT(Purrloin),
+        FOOTPRINT(Purrloin)
         LEARNSETS(Purrloin),
         .evolutions = EVOLUTION({EVO_LEVEL, 20, SPECIES_LIEPARD}),
     },
@@ -861,7 +861,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_STRETCH,
         PALETTES(Liepard),
         ICON(Liepard, 0),
-        FOOTPRINT(Liepard),
+        FOOTPRINT(Liepard)
         LEARNSETS(Liepard),
     },
 #endif //P_FAMILY_PURRLOIN
@@ -910,7 +910,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_LARGE,
         PALETTES(Pansage),
         ICON(Pansage, 1),
-        FOOTPRINT(Pansage),
+        FOOTPRINT(Pansage)
         LEARNSETS(Pansage),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_LEAF_STONE, SPECIES_SIMISAGE}),
     },
@@ -958,7 +958,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_SHAKE_H_SLIDE,
         PALETTES(Simisage),
         ICON(Simisage, 1),
-        FOOTPRINT(Simisage),
+        FOOTPRINT(Simisage)
         LEARNSETS(Simisage),
     },
 #endif //P_FAMILY_PANSAGE
@@ -1008,7 +1008,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_LARGE,
         PALETTES(Pansear),
         ICON(Pansear, 2),
-        FOOTPRINT(Pansear),
+        FOOTPRINT(Pansear)
         LEARNSETS(Pansear),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_FIRE_STONE, SPECIES_SIMISEAR}),
     },
@@ -1057,7 +1057,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_SHAKE_H_SLIDE,
         PALETTES(Simisear),
         ICON(Simisear, 2),
-        FOOTPRINT(Simisear),
+        FOOTPRINT(Simisear)
         LEARNSETS(Simisear),
     },
 #endif //P_FAMILY_PANSEAR
@@ -1106,7 +1106,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_LARGE,
         PALETTES(Panpour),
         ICON(Panpour, 2),
-        FOOTPRINT(Panpour),
+        FOOTPRINT(Panpour)
         LEARNSETS(Panpour),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_WATER_STONE, SPECIES_SIMIPOUR}),
     },
@@ -1154,7 +1154,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_SHAKE_H_SLIDE,
         PALETTES(Simipour),
         ICON(Simipour, 2),
-        FOOTPRINT(Simipour),
+        FOOTPRINT(Simipour)
         LEARNSETS(Simipour),
     },
 #endif //P_FAMILY_PANPOUR
@@ -1204,7 +1204,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW,
         PALETTES(Munna),
         ICON(Munna, 0),
-        FOOTPRINT(Munna),
+        FOOTPRINT(Munna)
         LEARNSETS(Munna),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_MOON_STONE, SPECIES_MUSHARNA}),
     },
@@ -1253,7 +1253,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_GROW,
         PALETTES(Musharna),
         ICON(Musharna, 0),
-        FOOTPRINT(Musharna),
+        FOOTPRINT(Musharna)
         LEARNSETS(Musharna),
     },
 #endif //P_FAMILY_MUNNA
@@ -1302,7 +1302,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Pidove),
         ICON(Pidove, 0),
-        FOOTPRINT(Pidove),
+        FOOTPRINT(Pidove)
         LEARNSETS(Pidove),
         .evolutions = EVOLUTION({EVO_LEVEL, 21, SPECIES_TRANQUILL}),
     },
@@ -1350,7 +1350,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Tranquill),
         ICON(Tranquill, 0),
-        FOOTPRINT(Tranquill),
+        FOOTPRINT(Tranquill)
         LEARNSETS(Tranquill),
         .evolutions = EVOLUTION({EVO_LEVEL, 32, SPECIES_UNFEZANT}),
     },
@@ -1402,7 +1402,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         PALETTE_FEMALE(Unfezant),
         ICON(Unfezant, 1),
         ICON_FEMALE(Unfezant, 1),
-        FOOTPRINT(Unfezant),
+        FOOTPRINT(Unfezant)
         LEARNSETS(Unfezant),
     },
 #endif //P_FAMILY_PIDOVE
@@ -1451,7 +1451,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Blitzle),
         ICON(Blitzle, 2),
-        FOOTPRINT(Blitzle),
+        FOOTPRINT(Blitzle)
         LEARNSETS(Blitzle),
         .evolutions = EVOLUTION({EVO_LEVEL, 27, SPECIES_ZEBSTRIKA}),
     },
@@ -1499,7 +1499,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_SHAKE_FLASH_YELLOW,
         PALETTES(Zebstrika),
         ICON(Zebstrika, 2),
-        FOOTPRINT(Zebstrika),
+        FOOTPRINT(Zebstrika)
         LEARNSETS(Zebstrika),
     },
 #endif //P_FAMILY_BLITZLE
@@ -1550,7 +1550,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Roggenrola),
         ICON(Roggenrola, 2),
-        FOOTPRINT(Roggenrola),
+        FOOTPRINT(Roggenrola)
         LEARNSETS(Roggenrola),
         .evolutions = EVOLUTION({EVO_LEVEL, 25, SPECIES_BOLDORE}),
     },
@@ -1601,7 +1601,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_SHAKE,
         PALETTES(Boldore),
         ICON(Boldore, 0),
-        FOOTPRINT(Boldore),
+        FOOTPRINT(Boldore)
         LEARNSETS(Boldore),
         .evolutions = EVOLUTION({EVO_TRADE, 0, SPECIES_GIGALITH},
                                 {EVO_ITEM, ITEM_LINKING_CORD, SPECIES_GIGALITH}),
@@ -1652,7 +1652,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_SHAKE_LOW,
         PALETTES(Gigalith),
         ICON(Gigalith, 0),
-        FOOTPRINT(Gigalith),
+        FOOTPRINT(Gigalith)
         LEARNSETS(Gigalith),
     },
 #endif //P_FAMILY_ROGGENROLA
@@ -1702,7 +1702,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Woobat),
         ICON(Woobat, 0),
-        FOOTPRINT(Woobat),
+        FOOTPRINT(Woobat)
         LEARNSETS(Woobat),
         .evolutions = EVOLUTION({EVO_FRIENDSHIP, 0, SPECIES_SWOOBAT}),
     },
@@ -1751,7 +1751,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_STRETCH,
         PALETTES(Swoobat),
         ICON(Swoobat, 0),
-        FOOTPRINT(Swoobat),
+        FOOTPRINT(Swoobat)
         LEARNSETS(Swoobat),
     },
 #endif //P_FAMILY_WOOBAT
@@ -1801,7 +1801,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Drilbur),
         ICON(Drilbur, 0),
-        FOOTPRINT(Drilbur),
+        FOOTPRINT(Drilbur)
         LEARNSETS(Drilbur),
         .evolutions = EVOLUTION({EVO_LEVEL, 31, SPECIES_EXCADRILL}),
     },
@@ -1850,7 +1850,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_SHAKE_LOW,
         PALETTES(Excadrill),
         ICON(Excadrill, 0),
-        FOOTPRINT(Excadrill),
+        FOOTPRINT(Excadrill)
         LEARNSETS(Excadrill),
     },
 #endif //P_FAMILY_DRILBUR
@@ -1868,7 +1868,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .speciesName = _("Audino"),                         \
         .natDexNum = NATIONAL_DEX_AUDINO,                   \
         .categoryName = _("Hearing"),                       \
-        FOOTPRINT(Audino),                                  \
+        FOOTPRINT(Audino)                                   \
         LEARNSETS(Audino),                                  \
         .formSpeciesIdTable = sAudinoFormSpeciesIdTable,    \
         .formChangeTable = sAudinoFormChangeTable
@@ -1994,7 +1994,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Timburr),
         ICON(Timburr, 1),
-        FOOTPRINT(Timburr),
+        FOOTPRINT(Timburr)
         LEARNSETS(Timburr),
         .evolutions = EVOLUTION({EVO_LEVEL, 25, SPECIES_GURDURR}),
     },
@@ -2042,7 +2042,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Gurdurr),
         ICON(Gurdurr, 1),
-        FOOTPRINT(Gurdurr),
+        FOOTPRINT(Gurdurr)
         LEARNSETS(Gurdurr),
         .evolutions = EVOLUTION({EVO_TRADE, 0, SPECIES_CONKELDURR},
                                 {EVO_ITEM, ITEM_LINKING_CORD, SPECIES_CONKELDURR}),
@@ -2091,7 +2091,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_SHAKE_H_SLIDE,
         PALETTES(Conkeldurr),
         ICON(Conkeldurr, 1),
-        FOOTPRINT(Conkeldurr),
+        FOOTPRINT(Conkeldurr)
         LEARNSETS(Conkeldurr),
     },
 #endif //P_FAMILY_TIMBURR
@@ -2140,7 +2140,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_SPRING,
         PALETTES(Tympole),
         ICON(Tympole, 2),
-        FOOTPRINT(Tympole),
+        FOOTPRINT(Tympole)
         LEARNSETS(Tympole),
         .evolutions = EVOLUTION({EVO_LEVEL, 25, SPECIES_PALPITOAD}),
     },
@@ -2188,7 +2188,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_VIBRATE,
         PALETTES(Palpitoad),
         ICON(Palpitoad, 2),
-        FOOTPRINT(Palpitoad),
+        FOOTPRINT(Palpitoad)
         LEARNSETS(Palpitoad),
         .evolutions = EVOLUTION({EVO_LEVEL, 36, SPECIES_SEISMITOAD}),
     },
@@ -2236,7 +2236,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_SHAKE_H_SLIDE,
         PALETTES(Seismitoad),
         ICON(Seismitoad, 0),
-        FOOTPRINT(Seismitoad),
+        FOOTPRINT(Seismitoad)
         LEARNSETS(Seismitoad),
     },
 #endif //P_FAMILY_TYMPOLE
@@ -2286,7 +2286,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_SHAKE_LOW,
         PALETTES(Throh),
         ICON(Throh, 0),
-        FOOTPRINT(Throh),
+        FOOTPRINT(Throh)
         LEARNSETS(Throh),
     },
 #endif //P_FAMILY_THROH
@@ -2337,7 +2337,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_STRETCH,
         PALETTES(Sawk),
         ICON(Sawk, 0),
-        FOOTPRINT(Sawk),
+        FOOTPRINT(Sawk)
         LEARNSETS(Sawk),
     },
 #endif //P_FAMILY_SAWK
@@ -2387,7 +2387,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Sewaddle),
         ICON(Sewaddle, 1),
-        FOOTPRINT(Sewaddle),
+        FOOTPRINT(Sewaddle)
         LEARNSETS(Sewaddle),
         .evolutions = EVOLUTION({EVO_LEVEL, 20, SPECIES_SWADLOON}),
     },
@@ -2436,7 +2436,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_VIBRATE,
         PALETTES(Swadloon),
         ICON(Swadloon, 1),
-        FOOTPRINT(Swadloon),
+        FOOTPRINT(Swadloon)
         LEARNSETS(Swadloon),
         .evolutions = EVOLUTION({EVO_FRIENDSHIP, 0, SPECIES_LEAVANNY}),
     },
@@ -2485,7 +2485,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_GROW_STUTTER,
         PALETTES(Leavanny),
         ICON(Leavanny, 1),
-        FOOTPRINT(Leavanny),
+        FOOTPRINT(Leavanny)
         LEARNSETS(Leavanny),
     },
 #endif //P_FAMILY_SEWADDLE
@@ -2539,7 +2539,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_VIBRATE,
         PALETTES(Venipede),
         ICON(Venipede, 1),
-        FOOTPRINT(Venipede),
+        FOOTPRINT(Venipede)
         LEARNSETS(Venipede),
         .evolutions = EVOLUTION({EVO_LEVEL, 22, SPECIES_WHIRLIPEDE}),
     },
@@ -2592,7 +2592,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Whirlipede),
         ICON(Whirlipede, 2),
-        FOOTPRINT(Whirlipede),
+        FOOTPRINT(Whirlipede)
         LEARNSETS(Whirlipede),
         .evolutions = EVOLUTION({EVO_LEVEL, 30, SPECIES_SCOLIPEDE}),
     },
@@ -2645,7 +2645,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_SHAKE_LOW,
         PALETTES(Scolipede),
         ICON(Scolipede, 2),
-        FOOTPRINT(Scolipede),
+        FOOTPRINT(Scolipede)
         LEARNSETS(Scolipede),
     },
 #endif //P_FAMILY_VENIPEDE
@@ -2701,7 +2701,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Cottonee),
         ICON(Cottonee, 1),
-        FOOTPRINT(Cottonee),
+        FOOTPRINT(Cottonee)
         LEARNSETS(Cottonee),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_SUN_STONE, SPECIES_WHIMSICOTT}),
     },
@@ -2750,7 +2750,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_LARGE,
         PALETTES(Whimsicott),
         ICON(Whimsicott, 1),
-        FOOTPRINT(Whimsicott),
+        FOOTPRINT(Whimsicott)
         LEARNSETS(Whimsicott),
     },
 #endif //P_FAMILY_COTTONEE
@@ -2801,7 +2801,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_STRETCH,
         PALETTES(Petilil),
         ICON(Petilil, 1),
-        FOOTPRINT(Petilil),
+        FOOTPRINT(Petilil)
         LEARNSETS(Petilil),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_SUN_STONE, SPECIES_LILLIGANT},
                                 {EVO_NONE, 0, SPECIES_LILLIGANT_HISUIAN}),
@@ -2821,7 +2821,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .speciesName = _("Lilligant"),                      \
         .cryId = CRY_LILLIGANT,                             \
         .natDexNum = NATIONAL_DEX_LILLIGANT,                \
-        FOOTPRINT(Lilligant),                               \
+        FOOTPRINT(Lilligant)                                \
         .formSpeciesIdTable = sLilligantFormSpeciesIdTable
 
     [SPECIES_LILLIGANT] =
@@ -2929,7 +2929,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .trainerScale = 257,                                    \
         .trainerOffset = 0,                                     \
         .enemyMonElevation = 6,                                 \
-        FOOTPRINT(Basculin),                                    \
+        FOOTPRINT(Basculin)                                     \
         .formSpeciesIdTable = sBasculinFormSpeciesIdTable
 
     [SPECIES_BASCULIN_RED_STRIPED] =
@@ -3033,7 +3033,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .formSpeciesIdTable = sBasculegionFormSpeciesIdTable
         //.frontAnimId = ANIM_V_SQUISH_AND_BOUNCE,
         //.backAnimId = BACK_ANIM_NONE,
-        //FOOTPRINT(Basculegion),
+        //FOOTPRINT(Basculegion)
 
     [SPECIES_BASCULEGION_MALE] =
     {
@@ -3123,7 +3123,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Sandile),
         ICON(Sandile, 1),
-        FOOTPRINT(Sandile),
+        FOOTPRINT(Sandile)
         LEARNSETS(Sandile),
         .evolutions = EVOLUTION({EVO_LEVEL, 29, SPECIES_KROKOROK}),
     },
@@ -3172,7 +3172,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_STRETCH,
         PALETTES(Krokorok),
         ICON(Krokorok, 1),
-        FOOTPRINT(Krokorok),
+        FOOTPRINT(Krokorok)
         LEARNSETS(Krokorok),
         .evolutions = EVOLUTION({EVO_LEVEL, 40, SPECIES_KROOKODILE}),
     },
@@ -3221,7 +3221,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_SHAKE_LOW,
         PALETTES(Krookodile),
         ICON(Krookodile, 0),
-        FOOTPRINT(Krookodile),
+        FOOTPRINT(Krookodile)
         LEARNSETS(Krookodile),
     },
 #endif //P_FAMILY_SANDILE
@@ -3247,7 +3247,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .cryId = CRY_DARUMAKA,                                              \
         .natDexNum = NATIONAL_DEX_DARUMAKA,                                 \
         .categoryName = _("Zen Charm"),                                     \
-        FOOTPRINT(Darumaka),                                                \
+        FOOTPRINT(Darumaka)                                                 \
         .formSpeciesIdTable = sDarumakaFormSpeciesIdTable
 
     [SPECIES_DARUMAKA] =
@@ -3289,7 +3289,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .speciesName = _("Darmanitan"),                     \
         .cryId = CRY_DARMANITAN,                            \
         .natDexNum = NATIONAL_DEX_DARMANITAN,               \
-        FOOTPRINT(Darmanitan),                              \
+        FOOTPRINT(Darmanitan)                               \
         .formSpeciesIdTable = sDarmanitanFormSpeciesIdTable
 
 #define DARMANITAN_STANDARD_MISC_INFO   \
@@ -3510,7 +3510,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_LARGE,
         PALETTES(Maractus),
         ICON(Maractus, 1),
-        FOOTPRINT(Maractus),
+        FOOTPRINT(Maractus)
         LEARNSETS(Maractus),
     },
 #endif //P_FAMILY_MARACTUS
@@ -3560,7 +3560,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Dwebble),
         ICON(Dwebble, 0),
-        FOOTPRINT(Dwebble),
+        FOOTPRINT(Dwebble)
         LEARNSETS(Dwebble),
         .evolutions = EVOLUTION({EVO_LEVEL, 34, SPECIES_CRUSTLE}),
     },
@@ -3609,7 +3609,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_SHAKE_LOW,
         PALETTES(Crustle),
         ICON(Crustle, 2),
-        FOOTPRINT(Crustle),
+        FOOTPRINT(Crustle)
         LEARNSETS(Crustle),
     },
 #endif //P_FAMILY_DWEBBLE
@@ -3659,7 +3659,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_LARGE,
         PALETTES(Scraggy),
         ICON(Scraggy, 2),
-        FOOTPRINT(Scraggy),
+        FOOTPRINT(Scraggy)
         LEARNSETS(Scraggy),
         .evolutions = EVOLUTION({EVO_LEVEL, 39, SPECIES_SCRAFTY}),
     },
@@ -3709,7 +3709,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_GROW,
         PALETTES(Scrafty),
         ICON(Scrafty, 0),
-        FOOTPRINT(Scrafty),
+        FOOTPRINT(Scrafty)
         LEARNSETS(Scrafty),
     },
 #endif //P_FAMILY_SCRAGGY
@@ -3759,7 +3759,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Sigilyph),
         ICON(Sigilyph, 0),
-        FOOTPRINT(Sigilyph),
+        FOOTPRINT(Sigilyph)
         LEARNSETS(Sigilyph),
     },
 #endif //P_FAMILY_SIGILYPH
@@ -3785,7 +3785,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .pokemonOffset = 13,                                        \
         .trainerScale = 256,                                        \
         .trainerOffset = 0,                                         \
-        FOOTPRINT(Yamask),                                          \
+        FOOTPRINT(Yamask)                                           \
         .formSpeciesIdTable = sYamaskFormSpeciesIdTable
 
     [SPECIES_YAMASK] =
@@ -3863,7 +3863,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_SHAKE_H_SLIDE,
         PALETTES(Cofagrigus),
         ICON(Cofagrigus, 0),
-        FOOTPRINT(Cofagrigus),
+        FOOTPRINT(Cofagrigus)
         LEARNSETS(Cofagrigus),
     },
 
@@ -3942,7 +3942,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Runerigus),
         ICON(Runerigus, 2),
-        FOOTPRINT(Runerigus),
+        FOOTPRINT(Runerigus)
         LEARNSETS(Runerigus),
     },
 #endif //P_GALARIAN_FORMS
@@ -3992,7 +3992,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Tirtouga),
         ICON(Tirtouga, 2),
-        FOOTPRINT(Tirtouga),
+        FOOTPRINT(Tirtouga)
         LEARNSETS(Tirtouga),
         .evolutions = EVOLUTION({EVO_LEVEL, 37, SPECIES_CARRACOSTA}),
     },
@@ -4040,7 +4040,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_SHAKE_LOW,
         PALETTES(Carracosta),
         ICON(Carracosta, 2),
-        FOOTPRINT(Carracosta),
+        FOOTPRINT(Carracosta)
         LEARNSETS(Carracosta),
     },
 #endif //P_FAMILY_TIRTOUGA
@@ -4089,7 +4089,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Archen),
         ICON(Archen, 0),
-        FOOTPRINT(Archen),
+        FOOTPRINT(Archen)
         LEARNSETS(Archen),
         .evolutions = EVOLUTION({EVO_LEVEL, 37, SPECIES_ARCHEOPS}),
     },
@@ -4138,7 +4138,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_STRETCH,
         PALETTES(Archeops),
         ICON(Archeops, 0),
-        FOOTPRINT(Archeops),
+        FOOTPRINT(Archeops)
         LEARNSETS(Archeops),
     },
 #endif //P_FAMILY_ARCHEN
@@ -4188,7 +4188,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW,
         PALETTES(Trubbish),
         ICON(Trubbish, 1),
-        FOOTPRINT(Trubbish),
+        FOOTPRINT(Trubbish)
         LEARNSETS(Trubbish),
         .evolutions = EVOLUTION({EVO_LEVEL, 36, SPECIES_GARBODOR}),
     },
@@ -4218,7 +4218,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .cryId = CRY_GARBODOR,                                                  \
         .natDexNum = NATIONAL_DEX_GARBODOR,                                     \
         .categoryName = _("Trash Heap"),                                        \
-        FOOTPRINT(Garbodor),                                                    \
+        FOOTPRINT(Garbodor)                                                     \
         LEARNSETS(Garbodor),                                                    \
         .formSpeciesIdTable = sGarbodorFormSpeciesIdTable,                      \
         .formChangeTable = sGarbodorFormChangeTable
@@ -4298,7 +4298,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .pokemonOffset = 12,                                \
         .trainerScale = 256,                                \
         .trainerOffset = 0,                                 \
-        FOOTPRINT(Zorua),                                   \
+        FOOTPRINT(Zorua)                                    \
         .formSpeciesIdTable = sZoruaFormSpeciesIdTable
 
 #define ZOROARK_MISC_INFO                                   \
@@ -4320,7 +4320,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .pokemonOffset = 1,                                 \
         .trainerScale = 296,                                \
         .trainerOffset = 1,                                 \
-        FOOTPRINT(Zoroark),                                 \
+        FOOTPRINT(Zoroark)                                  \
         .formSpeciesIdTable = sZoroarkFormSpeciesIdTable
 
     [SPECIES_ZORUA] =
@@ -4488,7 +4488,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Minccino),
         ICON(Minccino, 0),
-        FOOTPRINT(Minccino),
+        FOOTPRINT(Minccino)
         LEARNSETS(Minccino),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_SHINY_STONE, SPECIES_CINCCINO}),
     },
@@ -4537,7 +4537,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_LARGE,
         PALETTES(Cinccino),
         ICON(Cinccino, 0),
-        FOOTPRINT(Cinccino),
+        FOOTPRINT(Cinccino)
         LEARNSETS(Cinccino),
     },
 #endif //P_FAMILY_MINCCINO
@@ -4586,7 +4586,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Gothita),
         ICON(Gothita, 2),
-        FOOTPRINT(Gothita),
+        FOOTPRINT(Gothita)
         LEARNSETS(Gothita),
         .evolutions = EVOLUTION({EVO_LEVEL, 32, SPECIES_GOTHORITA}),
     },
@@ -4634,7 +4634,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Gothorita),
         ICON(Gothorita, 2),
-        FOOTPRINT(Gothorita),
+        FOOTPRINT(Gothorita)
         LEARNSETS(Gothorita),
         .evolutions = EVOLUTION({EVO_LEVEL, 41, SPECIES_GOTHITELLE}),
     },
@@ -4682,7 +4682,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_STRETCH,
         PALETTES(Gothitelle),
         ICON(Gothitelle, 2),
-        FOOTPRINT(Gothitelle),
+        FOOTPRINT(Gothitelle)
         LEARNSETS(Gothitelle),
     },
 #endif //P_FAMILY_GOTHITA
@@ -4733,7 +4733,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW,
         PALETTES(Solosis),
         ICON(Solosis, 1),
-        FOOTPRINT(Solosis),
+        FOOTPRINT(Solosis)
         LEARNSETS(Solosis),
         .evolutions = EVOLUTION({EVO_LEVEL, 32, SPECIES_DUOSION}),
     },
@@ -4782,7 +4782,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_GROW,
         PALETTES(Duosion),
         ICON(Duosion, 1),
-        FOOTPRINT(Duosion),
+        FOOTPRINT(Duosion)
         LEARNSETS(Duosion),
         .evolutions = EVOLUTION({EVO_LEVEL, 41, SPECIES_REUNICLUS}),
     },
@@ -4831,7 +4831,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,
         PALETTES(Reuniclus),
         ICON(Reuniclus, 1),
-        FOOTPRINT(Reuniclus),
+        FOOTPRINT(Reuniclus)
         LEARNSETS(Reuniclus),
     },
 #endif //P_FAMILY_SOLOSIS
@@ -4880,7 +4880,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Ducklett),
         ICON(Ducklett, 0),
-        FOOTPRINT(Ducklett),
+        FOOTPRINT(Ducklett)
         LEARNSETS(Ducklett),
         .evolutions = EVOLUTION({EVO_LEVEL, 35, SPECIES_SWANNA}),
     },
@@ -4928,7 +4928,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_STRETCH,
         PALETTES(Swanna),
         ICON(Swanna, 2),
-        FOOTPRINT(Swanna),
+        FOOTPRINT(Swanna)
         LEARNSETS(Swanna),
     },
 #endif //P_FAMILY_DUCKLETT
@@ -4978,7 +4978,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Vanillite),
         ICON(Vanillite, 0),
-        FOOTPRINT(Vanillite),
+        FOOTPRINT(Vanillite)
         LEARNSETS(Vanillite),
         .evolutions = EVOLUTION({EVO_LEVEL, 35, SPECIES_VANILLISH}),
     },
@@ -5027,7 +5027,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Vanillish),
         ICON(Vanillish, 2),
-        FOOTPRINT(Vanillish),
+        FOOTPRINT(Vanillish)
         LEARNSETS(Vanillish),
         .evolutions = EVOLUTION({EVO_LEVEL, 47, SPECIES_VANILLUXE}),
     },
@@ -5076,7 +5076,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_SHAKE,
         PALETTES(Vanilluxe),
         ICON(Vanilluxe, 2),
-        FOOTPRINT(Vanilluxe),
+        FOOTPRINT(Vanilluxe)
         LEARNSETS(Vanilluxe),
     },
 #endif //P_FAMILY_VANILLITE
@@ -5116,7 +5116,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         BACK_PIC(Deerling, 48, 56),                                                     \
         .backPicYOffset = 9,                                                            \
         .backAnimId = BACK_ANIM_H_SLIDE,                                                \
-        FOOTPRINT(Deerling),                                                            \
+        FOOTPRINT(Deerling)                                                             \
         LEARNSETS(Deerling),                                                            \
         .formSpeciesIdTable = sDeerlingFormSpeciesIdTable
 
@@ -5206,7 +5206,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .frontAnimId = ANIM_V_SQUISH_AND_BOUNCE,                                        \
         .backPicYOffset = 5,                                                            \
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,                                         \
-        FOOTPRINT(Sawsbuck),                                                            \
+        FOOTPRINT(Sawsbuck)                                                             \
         LEARNSETS(Sawsbuck),                                                            \
         .formSpeciesIdTable = sSawsbuckFormSpeciesIdTable
 
@@ -5313,7 +5313,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Emolga),
         ICON(Emolga, 2),
-        FOOTPRINT(Emolga),
+        FOOTPRINT(Emolga)
         LEARNSETS(Emolga),
     },
 #endif //P_FAMILY_EMOLGA
@@ -5362,7 +5362,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_LARGE,
         PALETTES(Karrablast),
         ICON(Karrablast, 0),
-        FOOTPRINT(Karrablast),
+        FOOTPRINT(Karrablast)
         LEARNSETS(Karrablast),
         .evolutions = EVOLUTION({EVO_TRADE_SPECIFIC_MON, SPECIES_SHELMET, SPECIES_ESCAVALIER}),
     },
@@ -5410,7 +5410,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Escavalier),
         ICON(Escavalier, 0),
-        FOOTPRINT(Escavalier),
+        FOOTPRINT(Escavalier)
         LEARNSETS(Escavalier),
     },
 #endif //P_FAMILY_KARRABLAST
@@ -5461,7 +5461,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW,
         PALETTES(Foongus),
         ICON(Foongus, 0),
-        FOOTPRINT(Foongus),
+        FOOTPRINT(Foongus)
         LEARNSETS(Foongus),
         .evolutions = EVOLUTION({EVO_LEVEL, 39, SPECIES_AMOONGUSS}),
     },
@@ -5512,7 +5512,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_GROW_STUTTER,
         PALETTES(Amoonguss),
         ICON(Amoonguss, 1),
-        FOOTPRINT(Amoonguss),
+        FOOTPRINT(Amoonguss)
         LEARNSETS(Amoonguss),
     },
 #endif //P_FAMILY_FOONGUS
@@ -5565,7 +5565,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         PALETTE_FEMALE(Frillish),
         ICON(Frillish, 0),
         ICON_FEMALE(Frillish, 1),
-        FOOTPRINT(Frillish),
+        FOOTPRINT(Frillish)
         LEARNSETS(Frillish),
         .evolutions = EVOLUTION({EVO_LEVEL, 40, SPECIES_JELLICENT}),
     },
@@ -5617,7 +5617,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         PALETTE_FEMALE(Jellicent),
         ICON(Jellicent, 0),
         ICON_FEMALE(Jellicent, 1),
-        FOOTPRINT(Jellicent),
+        FOOTPRINT(Jellicent)
         LEARNSETS(Jellicent),
     },
 #endif //P_FAMILY_FRILLISH
@@ -5666,7 +5666,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Alomomola),
         ICON(Alomomola, 0),
-        FOOTPRINT(Alomomola),
+        FOOTPRINT(Alomomola)
         LEARNSETS(Alomomola),
     },
 #endif //P_FAMILY_ALOMOMOLA
@@ -5715,7 +5715,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Joltik),
         ICON(Joltik, 0),
-        FOOTPRINT(Joltik),
+        FOOTPRINT(Joltik)
         LEARNSETS(Joltik),
         .evolutions = EVOLUTION({EVO_LEVEL, 36, SPECIES_GALVANTULA}),
     },
@@ -5763,7 +5763,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_SHAKE_FLASH_YELLOW,
         PALETTES(Galvantula),
         ICON(Galvantula, 2),
-        FOOTPRINT(Galvantula),
+        FOOTPRINT(Galvantula)
         LEARNSETS(Galvantula),
     },
 #endif //P_FAMILY_JOLTIK
@@ -5813,7 +5813,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_SHAKE,
         PALETTES(Ferroseed),
         ICON(Ferroseed, 1),
-        FOOTPRINT(Ferroseed),
+        FOOTPRINT(Ferroseed)
         LEARNSETS(Ferroseed),
         .evolutions = EVOLUTION({EVO_LEVEL, 40, SPECIES_FERROTHORN}),
     },
@@ -5863,7 +5863,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_SHAKE_LOW,
         PALETTES(Ferrothorn),
         ICON(Ferrothorn, 1),
-        FOOTPRINT(Ferrothorn),
+        FOOTPRINT(Ferrothorn)
         LEARNSETS(Ferrothorn),
     },
 #endif //P_FAMILY_FERROSEED
@@ -5914,7 +5914,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Klink),
         ICON(Klink, 0),
-        FOOTPRINT(Klink),
+        FOOTPRINT(Klink)
         LEARNSETS(Klink),
         .evolutions = EVOLUTION({EVO_LEVEL, 38, SPECIES_KLANG}),
     },
@@ -5964,7 +5964,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Klang),
         ICON(Klang, 0),
-        FOOTPRINT(Klang),
+        FOOTPRINT(Klang)
         LEARNSETS(Klang),
         .evolutions = EVOLUTION({EVO_LEVEL, 49, SPECIES_KLINKLANG}),
     },
@@ -6014,7 +6014,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_CIRCLE_COUNTERCLOCKWISE,
         PALETTES(Klinklang),
         ICON(Klinklang, 0),
-        FOOTPRINT(Klinklang),
+        FOOTPRINT(Klinklang)
         LEARNSETS(Klinklang),
     },
 #endif //P_FAMILY_KLINK
@@ -6064,7 +6064,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Tynamo),
         ICON(Tynamo, 0),
-        FOOTPRINT(Tynamo),
+        FOOTPRINT(Tynamo)
         LEARNSETS(Tynamo),
         .evolutions = EVOLUTION({EVO_LEVEL, 39, SPECIES_EELEKTRIK}),
     },
@@ -6113,7 +6113,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW,
         PALETTES(Eelektrik),
         ICON(Eelektrik, 0),
-        FOOTPRINT(Eelektrik),
+        FOOTPRINT(Eelektrik)
         LEARNSETS(Eelektrik),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_THUNDER_STONE, SPECIES_EELEKTROSS}),
     },
@@ -6162,7 +6162,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_SHAKE_FLASH_YELLOW,
         PALETTES(Eelektross),
         ICON(Eelektross, 0),
-        FOOTPRINT(Eelektross),
+        FOOTPRINT(Eelektross)
         LEARNSETS(Eelektross),
     },
 #endif //P_FAMILY_TYNAMO
@@ -6211,7 +6211,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW,
         PALETTES(Elgyem),
         ICON(Elgyem, 0),
-        FOOTPRINT(Elgyem),
+        FOOTPRINT(Elgyem)
         LEARNSETS(Elgyem),
         .evolutions = EVOLUTION({EVO_LEVEL, 42, SPECIES_BEHEEYEM}),
     },
@@ -6259,7 +6259,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_SHAKE,
         PALETTES(Beheeyem),
         ICON(Beheeyem, 2),
-        FOOTPRINT(Beheeyem),
+        FOOTPRINT(Beheeyem)
         LEARNSETS(Beheeyem),
     },
 #endif //P_FAMILY_ELGYEM
@@ -6313,7 +6313,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW,
         PALETTES(Litwick),
         ICON(Litwick, 2),
-        FOOTPRINT(Litwick),
+        FOOTPRINT(Litwick)
         LEARNSETS(Litwick),
         .evolutions = EVOLUTION({EVO_LEVEL, 41, SPECIES_LAMPENT}),
     },
@@ -6366,7 +6366,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Lampent),
         ICON(Lampent, 2),
-        FOOTPRINT(Lampent),
+        FOOTPRINT(Lampent)
         LEARNSETS(Lampent),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_DUSK_STONE, SPECIES_CHANDELURE}),
     },
@@ -6419,7 +6419,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Chandelure),
         ICON(Chandelure, 2),
-        FOOTPRINT(Chandelure),
+        FOOTPRINT(Chandelure)
         LEARNSETS(Chandelure),
     },
 #endif //P_FAMILY_LITWICK
@@ -6468,7 +6468,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Axew),
         ICON(Axew, 1),
-        FOOTPRINT(Axew),
+        FOOTPRINT(Axew)
         LEARNSETS(Axew),
         .evolutions = EVOLUTION({EVO_LEVEL, 38, SPECIES_FRAXURE}),
     },
@@ -6516,7 +6516,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_SHAKE_H_SLIDE,
         PALETTES(Fraxure),
         ICON(Fraxure, 1),
-        FOOTPRINT(Fraxure),
+        FOOTPRINT(Fraxure)
         LEARNSETS(Fraxure),
         .evolutions = EVOLUTION({EVO_LEVEL, 48, SPECIES_HAXORUS}),
     },
@@ -6564,7 +6564,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_SHAKE_LOW,
         PALETTES(Haxorus),
         ICON(Haxorus, 2),
-        FOOTPRINT(Haxorus),
+        FOOTPRINT(Haxorus)
         LEARNSETS(Haxorus),
     },
 #endif //P_FAMILY_AXEW
@@ -6613,7 +6613,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Cubchoo),
         ICON(Cubchoo, 0),
-        FOOTPRINT(Cubchoo),
+        FOOTPRINT(Cubchoo)
         LEARNSETS(Cubchoo),
         .evolutions = EVOLUTION({EVO_LEVEL, 37, SPECIES_BEARTIC}),
     },
@@ -6661,7 +6661,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_SHAKE_H_SLIDE,
         PALETTES(Beartic),
         ICON(Beartic, 0),
-        FOOTPRINT(Beartic),
+        FOOTPRINT(Beartic)
         LEARNSETS(Beartic),
     },
 #endif //P_FAMILY_CUBCHOO
@@ -6717,7 +6717,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_VIBRATE,
         PALETTES(Cryogonal),
         ICON(Cryogonal, 0),
-        FOOTPRINT(Cryogonal),
+        FOOTPRINT(Cryogonal)
         LEARNSETS(Cryogonal),
     },
 #endif //P_FAMILY_CRYOGONAL
@@ -6766,7 +6766,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Shelmet),
         ICON(Shelmet, 1),
-        FOOTPRINT(Shelmet),
+        FOOTPRINT(Shelmet)
         LEARNSETS(Shelmet),
         .evolutions = EVOLUTION({EVO_TRADE_SPECIFIC_MON, SPECIES_KARRABLAST, SPECIES_ACCELGOR}),
     },
@@ -6814,7 +6814,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_SPRING_REPEATED,
         PALETTES(Accelgor),
         ICON(Accelgor, 1),
-        FOOTPRINT(Accelgor),
+        FOOTPRINT(Accelgor)
         LEARNSETS(Accelgor),
     },
 #endif //P_FAMILY_SHELMET
@@ -6837,7 +6837,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .pokemonOffset = 14,                                        \
         .trainerScale = 256,                                        \
         .trainerOffset = 0,                                         \
-        FOOTPRINT(Stunfisk),                                        \
+        FOOTPRINT(Stunfisk)                                         \
         .formSpeciesIdTable = sStunfiskFormSpeciesIdTable
 
     [SPECIES_STUNFISK] =
@@ -6951,7 +6951,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_LARGE,
         PALETTES(Mienfoo),
         ICON(Mienfoo, 1),
-        FOOTPRINT(Mienfoo),
+        FOOTPRINT(Mienfoo)
         LEARNSETS(Mienfoo),
         .evolutions = EVOLUTION({EVO_LEVEL, 50, SPECIES_MIENSHAO}),
     },
@@ -6999,7 +6999,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_STRETCH,
         PALETTES(Mienshao),
         ICON(Mienshao, 2),
-        FOOTPRINT(Mienshao),
+        FOOTPRINT(Mienshao)
         LEARNSETS(Mienshao),
     },
 #endif //P_FAMILY_MIENFOO
@@ -7049,7 +7049,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_SHAKE_LOW,
         PALETTES(Druddigon),
         ICON(Druddigon, 0),
-        FOOTPRINT(Druddigon),
+        FOOTPRINT(Druddigon)
         LEARNSETS(Druddigon),
     },
 #endif //P_FAMILY_DRUDDIGON
@@ -7100,7 +7100,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Golett),
         ICON(Golett, 0),
-        FOOTPRINT(Golett),
+        FOOTPRINT(Golett)
         LEARNSETS(Golett),
         .evolutions = EVOLUTION({EVO_LEVEL, 43, SPECIES_GOLURK}),
     },
@@ -7150,7 +7150,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Golurk),
         ICON(Golurk, 0),
-        FOOTPRINT(Golurk),
+        FOOTPRINT(Golurk)
         LEARNSETS(Golurk),
     },
 #endif //P_FAMILY_GOLETT
@@ -7199,7 +7199,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Pawniard),
         ICON(Pawniard, 0),
-        FOOTPRINT(Pawniard),
+        FOOTPRINT(Pawniard)
         LEARNSETS(Pawniard),
         .evolutions = EVOLUTION({EVO_LEVEL, 52, SPECIES_BISHARP}),
     },
@@ -7247,7 +7247,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_GROW_STUTTER,
         PALETTES(Bisharp),
         ICON(Bisharp, 0),
-        FOOTPRINT(Bisharp),
+        FOOTPRINT(Bisharp)
         LEARNSETS(Bisharp),
         .evolutions = EVOLUTION({EVO_NONE, 0, SPECIES_KINGAMBIT}),
     },
@@ -7296,7 +7296,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Kingambit),
         ICON(Kingambit, 3),
-        //FOOTPRINT(Kingambit),
+        //FOOTPRINT(Kingambit)
         LEARNSETS(Kingambit),
     },
 #endif //P_GEN_9_CROSS_EVOS
@@ -7346,7 +7346,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_SHAKE_LOW,
         PALETTES(Bouffalant),
         ICON(Bouffalant, 2),
-        FOOTPRINT(Bouffalant),
+        FOOTPRINT(Bouffalant)
         LEARNSETS(Bouffalant),
     },
 #endif //P_FAMILY_BOUFFALANT
@@ -7395,7 +7395,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Rufflet),
         ICON(Rufflet, 2),
-        FOOTPRINT(Rufflet),
+        FOOTPRINT(Rufflet)
         LEARNSETS(Rufflet),
         .evolutions = EVOLUTION({EVO_LEVEL, 54, SPECIES_BRAVIARY},
                                 {EVO_NONE, 0, SPECIES_BRAVIARY_HISUIAN}),
@@ -7412,7 +7412,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .speciesName = _("Braviary"),                           \
         .cryId = CRY_BRAVIARY,                                  \
         .natDexNum = NATIONAL_DEX_BRAVIARY,                     \
-        FOOTPRINT(Braviary),                                    \
+        FOOTPRINT(Braviary)                                     \
         .formSpeciesIdTable = sBraviaryFormSpeciesIdTable
 
     [SPECIES_BRAVIARY] =
@@ -7538,7 +7538,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Vullaby),
         ICON(Vullaby, 0),
-        FOOTPRINT(Vullaby),
+        FOOTPRINT(Vullaby)
         LEARNSETS(Vullaby),
         .evolutions = EVOLUTION({EVO_LEVEL, 54, SPECIES_MANDIBUZZ}),
     },
@@ -7586,7 +7586,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Mandibuzz),
         ICON(Mandibuzz, 1),
-        FOOTPRINT(Mandibuzz),
+        FOOTPRINT(Mandibuzz)
         LEARNSETS(Mandibuzz),
     },
 #endif //P_FAMILY_VULLABY
@@ -7635,7 +7635,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Heatmor),
         ICON(Heatmor, 2),
-        FOOTPRINT(Heatmor),
+        FOOTPRINT(Heatmor)
         LEARNSETS(Heatmor),
     },
 #endif //P_FAMILY_HEATMOR
@@ -7684,7 +7684,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_VIBRATE,
         PALETTES(Durant),
         ICON(Durant, 0),
-        FOOTPRINT(Durant),
+        FOOTPRINT(Durant)
         LEARNSETS(Durant),
     },
 #endif //P_FAMILY_DURANT
@@ -7733,7 +7733,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Deino),
         ICON(Deino, 2),
-        FOOTPRINT(Deino),
+        FOOTPRINT(Deino)
         LEARNSETS(Deino),
         .evolutions = EVOLUTION({EVO_LEVEL, 50, SPECIES_ZWEILOUS}),
     },
@@ -7781,7 +7781,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_SHAKE,
         PALETTES(Zweilous),
         ICON(Zweilous, 2),
-        FOOTPRINT(Zweilous),
+        FOOTPRINT(Zweilous)
         LEARNSETS(Zweilous),
         .evolutions = EVOLUTION({EVO_LEVEL, 64, SPECIES_HYDREIGON}),
     },
@@ -7830,7 +7830,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_GROW_STUTTER,
         PALETTES(Hydreigon),
         ICON(Hydreigon, 2),
-        FOOTPRINT(Hydreigon),
+        FOOTPRINT(Hydreigon)
         LEARNSETS(Hydreigon),
     },
 #endif //P_FAMILY_DEINO
@@ -7879,7 +7879,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Larvesta),
         ICON(Larvesta, 0),
-        FOOTPRINT(Larvesta),
+        FOOTPRINT(Larvesta)
         LEARNSETS(Larvesta),
         .evolutions = EVOLUTION({EVO_LEVEL, 59, SPECIES_VOLCARONA}),
     },
@@ -7930,7 +7930,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_SHAKE_GLOW_RED,
         PALETTES(Volcarona),
         ICON(Volcarona, 0),
-        FOOTPRINT(Volcarona),
+        FOOTPRINT(Volcarona)
         LEARNSETS(Volcarona),
     },
 #endif //P_FAMILY_LARVESTA
@@ -7980,7 +7980,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_STRETCH,
         PALETTES(Cobalion),
         ICON(Cobalion, 0),
-        FOOTPRINT(Cobalion),
+        FOOTPRINT(Cobalion)
         LEARNSETS(Cobalion),
     },
 #endif //P_FAMILY_COBALION
@@ -8030,7 +8030,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_V_SHAKE_LOW,
         PALETTES(Terrakion),
         ICON(Terrakion, 2),
-        FOOTPRINT(Terrakion),
+        FOOTPRINT(Terrakion)
         LEARNSETS(Terrakion),
     },
 #endif //P_FAMILY_TERRAKION
@@ -8080,7 +8080,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_H_SHAKE,
         PALETTES(Virizion),
         ICON(Virizion, 1),
-        FOOTPRINT(Virizion),
+        FOOTPRINT(Virizion)
         LEARNSETS(Virizion),
     },
 #endif //P_FAMILY_VIRIZION
@@ -8102,7 +8102,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .natDexNum = NATIONAL_DEX_TORNADUS,                                             \
         .categoryName = _("Cyclone"),                                                   \
         .weight = 630,                                                                  \
-        FOOTPRINT(Tornadus),                                                            \
+        FOOTPRINT(Tornadus)                                                             \
         LEARNSETS(Tornadus),                                                            \
         .formSpeciesIdTable = sTornadusFormSpeciesIdTable,                              \
         .formChangeTable = sTornadusFormChangeTable
@@ -8189,7 +8189,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .natDexNum = NATIONAL_DEX_THUNDURUS,                                            \
         .categoryName = _("Bolt Strike"),                                               \
         .weight = 610,                                                                  \
-        FOOTPRINT(Thundurus),                                                           \
+        FOOTPRINT(Thundurus)                                                            \
         LEARNSETS(Thundurus),                                                           \
         .formSpeciesIdTable = sThundurusFormSpeciesIdTable,                             \
         .formChangeTable = sThundurusFormChangeTable
@@ -8308,7 +8308,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_SHAKE_GLOW_RED,
         PALETTES(Reshiram),
         ICON(Reshiram, 0),
-        FOOTPRINT(Reshiram),
+        FOOTPRINT(Reshiram)
         LEARNSETS(Reshiram),
     },
 #endif //P_FAMILY_RESHIRAM
@@ -8358,7 +8358,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_SHAKE_GLOW_BLUE,
         PALETTES(Zekrom),
         ICON(Zekrom, 2),
-        FOOTPRINT(Zekrom),
+        FOOTPRINT(Zekrom)
         LEARNSETS(Zekrom),
     },
 #endif //P_FAMILY_ZEKROM
@@ -8379,7 +8379,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .natDexNum = NATIONAL_DEX_LANDORUS,                                             \
         .categoryName = _("Abundance"),                                                 \
         .weight = 680,                                                                  \
-        FOOTPRINT(Landorus),                                                            \
+        FOOTPRINT(Landorus)                                                             \
         LEARNSETS(Landorus),                                                            \
         .formSpeciesIdTable = sLandorusFormSpeciesIdTable,                              \
         .formChangeTable = sLandorusFormChangeTable
@@ -8467,7 +8467,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .natDexNum = NATIONAL_DEX_KYUREM,                                               \
         .categoryName = _("Boundary"),                                                  \
         .weight = 3250,                                                                 \
-        FOOTPRINT(Kyurem),                                                              \
+        FOOTPRINT(Kyurem)                                                               \
         .formSpeciesIdTable = sKyuremFormSpeciesIdTable,                                \
         .isLegendary = TRUE
 
@@ -8615,7 +8615,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .pokemonOffset = 2,                                                             \
         .trainerScale = 262,                                                            \
         .trainerOffset = 0,                                                             \
-        FOOTPRINT(Keldeo),                                                              \
+        FOOTPRINT(Keldeo)                                                               \
         LEARNSETS(Keldeo),                                                              \
         .formSpeciesIdTable = sKeldeoFormSpeciesIdTable,                                \
         .formChangeTable = sKeldeoFormChangeTable
@@ -8686,7 +8686,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .pokemonOffset = 12,                                                            \
         .trainerScale = 256,                                                            \
         .trainerOffset = 0,                                                             \
-        FOOTPRINT(Meloetta),                                                            \
+        FOOTPRINT(Meloetta)                                                             \
         LEARNSETS(Meloetta),                                                            \
         .formSpeciesIdTable = sMeloettaFormSpeciesIdTable,                              \
         .formChangeTable = sMeloettaFormChangeTable
@@ -8789,7 +8789,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .backAnimId = BACK_ANIM_CIRCLE_COUNTERCLOCKWISE,                                \
         PALETTES(form),                                                                 \
         ICON(Genesect, 2),                                                              \
-        FOOTPRINT(Genesect),                                                            \
+        FOOTPRINT(Genesect)                                                             \
         LEARNSETS(Genesect),                                                            \
         .formSpeciesIdTable = sGenesectFormSpeciesIdTable,                              \
         .formChangeTable = sGenesectFormChangeTable,                                    \

--- a/src/data/pokemon/species_info/gen_6.h
+++ b/src/data/pokemon/species_info/gen_6.h
@@ -47,7 +47,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Chespin),
         ICON(Chespin, 1),
-        FOOTPRINT(Chespin),
+        FOOTPRINT(Chespin)
         LEARNSETS(Chespin),
         .evolutions = EVOLUTION({EVO_LEVEL, 16, SPECIES_QUILLADIN}),
     },
@@ -95,7 +95,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_GROW,
         PALETTES(Quilladin),
         ICON(Quilladin, 1),
-        FOOTPRINT(Quilladin),
+        FOOTPRINT(Quilladin)
         LEARNSETS(Quilladin),
         .evolutions = EVOLUTION({EVO_LEVEL, 36, SPECIES_CHESNAUGHT}),
     },
@@ -143,7 +143,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_V_SHAKE_LOW,
         PALETTES(Chesnaught),
         ICON(Chesnaught, 1),
-        FOOTPRINT(Chesnaught),
+        FOOTPRINT(Chesnaught)
         LEARNSETS(Chesnaught),
     },
 #endif //P_FAMILY_CHESPIN
@@ -192,7 +192,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Fennekin),
         ICON(Fennekin, 0),
-        FOOTPRINT(Fennekin),
+        FOOTPRINT(Fennekin)
         LEARNSETS(Fennekin),
         .evolutions = EVOLUTION({EVO_LEVEL, 16, SPECIES_BRAIXEN}),
     },
@@ -240,7 +240,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_LARGE,
         PALETTES(Braixen),
         ICON(Braixen, 0),
-        FOOTPRINT(Braixen),
+        FOOTPRINT(Braixen)
         LEARNSETS(Braixen),
         .evolutions = EVOLUTION({EVO_LEVEL, 36, SPECIES_DELPHOX}),
     },
@@ -288,7 +288,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_GROW_STUTTER,
         PALETTES(Delphox),
         ICON(Delphox, 0),
-        FOOTPRINT(Delphox),
+        FOOTPRINT(Delphox)
         LEARNSETS(Delphox),
     },
 #endif //P_FAMILY_FENNEKIN
@@ -337,7 +337,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW,
         PALETTES(Froakie),
         ICON(Froakie, 0),
-        FOOTPRINT(Froakie),
+        FOOTPRINT(Froakie)
         LEARNSETS(Froakie),
         .evolutions = EVOLUTION({EVO_LEVEL, 16, SPECIES_FROGADIER}),
     },
@@ -385,7 +385,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_GROW_STUTTER,
         PALETTES(Frogadier),
         ICON(Frogadier, 0),
-        FOOTPRINT(Frogadier),
+        FOOTPRINT(Frogadier)
         LEARNSETS(Frogadier),
         .evolutions = EVOLUTION({EVO_LEVEL, 36, SPECIES_GRENINJA}),
     },
@@ -426,7 +426,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .pokemonOffset = 2,                             \
         .trainerScale = 271,                            \
         .trainerOffset = 0,                             \
-        FOOTPRINT(Greninja),                            \
+        FOOTPRINT(Greninja)                             \
         LEARNSETS(Greninja),                            \
         .formSpeciesIdTable = sGreninjaFormSpeciesIdTable
 
@@ -528,7 +528,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_V_STRETCH,
         PALETTES(Bunnelby),
         ICON(Bunnelby, 2),
-        FOOTPRINT(Bunnelby),
+        FOOTPRINT(Bunnelby)
         LEARNSETS(Bunnelby),
         .evolutions = EVOLUTION({EVO_LEVEL, 20, SPECIES_DIGGERSBY}),
     },
@@ -576,7 +576,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_V_SHAKE_H_SLIDE,
         PALETTES(Diggersby),
         ICON(Diggersby, 2),
-        FOOTPRINT(Diggersby),
+        FOOTPRINT(Diggersby)
         LEARNSETS(Diggersby),
     },
 #endif //P_FAMILY_BUNNELBY
@@ -625,7 +625,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Fletchling),
         ICON(Fletchling, 2),
-        FOOTPRINT(Fletchling),
+        FOOTPRINT(Fletchling)
         LEARNSETS(Fletchling),
         .evolutions = EVOLUTION({EVO_LEVEL, 17, SPECIES_FLETCHINDER}),
     },
@@ -674,7 +674,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Fletchinder),
         ICON(Fletchinder, 2),
-        FOOTPRINT(Fletchinder),
+        FOOTPRINT(Fletchinder)
         LEARNSETS(Fletchinder),
         .evolutions = EVOLUTION({EVO_LEVEL, 35, SPECIES_TALONFLAME}),
     },
@@ -723,7 +723,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,
         PALETTES(Talonflame),
         ICON(Talonflame, 2),
-        FOOTPRINT(Talonflame),
+        FOOTPRINT(Talonflame)
         LEARNSETS(Talonflame),
     },
 #endif //P_FAMILY_FLETCHLING
@@ -772,7 +772,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Scatterbug),
         ICON(Scatterbug, 1),
-        FOOTPRINT(Scatterbug),
+        FOOTPRINT(Scatterbug)
         LEARNSETS(Scatterbug),
         .evolutions = EVOLUTION({EVO_LEVEL, 9, SPECIES_SPEWPA}),
     },
@@ -820,7 +820,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_H_VIBRATE,
         PALETTES(Spewpa),
         ICON(Spewpa, 1),
-        FOOTPRINT(Spewpa),
+        FOOTPRINT(Spewpa)
         LEARNSETS(Spewpa),
         .evolutions = EVOLUTION({EVO_LEVEL, 12, SPECIES_VIVILLON_ICY_SNOW}),
     },
@@ -865,7 +865,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_CIRCLE_COUNTERCLOCKWISE,                                    \
         PALETTES(Vivillon ##form),                                                          \
         ICON(Vivillon ##form, iconPal),                                                     \
-        FOOTPRINT(Vivillon),                                                                \
+        FOOTPRINT(Vivillon)                                                                 \
         LEARNSETS(Vivillon),                                                                \
         .formSpeciesIdTable = sVivillonFormSpeciesIdTable
 
@@ -1095,7 +1095,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Litleo),
         ICON(Litleo, 2),
-        FOOTPRINT(Litleo),
+        FOOTPRINT(Litleo)
         LEARNSETS(Litleo),
         .evolutions = EVOLUTION({EVO_LEVEL, 35, SPECIES_PYROAR}),
     },
@@ -1146,7 +1146,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         PALETTES(Pyroar),
         ICON(Pyroar, 2),
         ICON_FEMALE(Pyroar, 2),
-        FOOTPRINT(Pyroar),
+        FOOTPRINT(Pyroar)
         LEARNSETS(Pyroar),
     },
 #endif //P_FAMILY_LITLEO
@@ -1190,7 +1190,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,                              \
         PALETTES(Flabebe##Form##Flower),                                        \
         ICON(Flabebe##Form##Flower, iconPal),                                   \
-        FOOTPRINT(Flabebe),                                                     \
+        FOOTPRINT(Flabebe)                                                      \
         LEARNSETS(Flabebe),                                                     \
         .formSpeciesIdTable = sFlabebeFormSpeciesIdTable,                       \
         .evolutions = EVOLUTION({EVO_LEVEL, 19, SPECIES_FLOETTE_ ##FORM##_FLOWER})
@@ -1265,7 +1265,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,                              \
         PALETTES(Floette ##form##Flower),                                       \
         ICON(Floette##form##Flower, iconPal),                                   \
-        FOOTPRINT(Floette),                                                     \
+        FOOTPRINT(Floette)                                                      \
         .formSpeciesIdTable = sFloetteFormSpeciesIdTable
 
 #define FLOETTE_NORMAL_INFO(form, FORM, iconPal)                                                \
@@ -1394,7 +1394,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,                            \
         PALETTES(Florges##Form##Flower),                                        \
         ICON(Florges##Form##Flower, iconPal),                                   \
-        FOOTPRINT(Florges),                                                     \
+        FOOTPRINT(Florges)                                                      \
         LEARNSETS(Florges),                                                     \
         .formSpeciesIdTable = sFlorgesFormSpeciesIdTable
 
@@ -1488,7 +1488,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Skiddo),
         ICON(Skiddo, 1),
-        FOOTPRINT(Skiddo),
+        FOOTPRINT(Skiddo)
         LEARNSETS(Skiddo),
         .evolutions = EVOLUTION({EVO_LEVEL, 32, SPECIES_GOGOAT}),
     },
@@ -1536,7 +1536,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_DIP_RIGHT_SIDE,
         PALETTES(Gogoat),
         ICON(Gogoat, 1),
-        FOOTPRINT(Gogoat),
+        FOOTPRINT(Gogoat)
         LEARNSETS(Gogoat),
     },
 #endif //P_FAMILY_SKIDDO
@@ -1586,7 +1586,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_CIRCLE_COUNTERCLOCKWISE,
         PALETTES(Pancham),
         ICON(Pancham, 1),
-        FOOTPRINT(Pancham),
+        FOOTPRINT(Pancham)
         LEARNSETS(Pancham),
         .evolutions = EVOLUTION({EVO_LEVEL_DARK_TYPE_MON_IN_PARTY, 32, SPECIES_PANGORO}),
     },
@@ -1635,7 +1635,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_V_SHAKE_LOW,
         PALETTES(Pangoro),
         ICON(Pangoro, 1),
-        FOOTPRINT(Pangoro),
+        FOOTPRINT(Pangoro)
         LEARNSETS(Pangoro),
     },
 #endif //P_FAMILY_PANCHAM
@@ -1673,7 +1673,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .frontAnimFrames = sAnims_Furfrou,                  \
         .frontAnimId = ANIM_H_SLIDE,                        \
         .backAnimId = BACK_ANIM_V_STRETCH,                  \
-        FOOTPRINT(Furfrou),                                 \
+        FOOTPRINT(Furfrou)                                  \
         LEARNSETS(Furfrou),                                 \
         .formSpeciesIdTable = sFurfrouFormSpeciesIdTable
 
@@ -1824,7 +1824,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Espurr),
         ICON(Espurr, 2),
-        FOOTPRINT(Espurr),
+        FOOTPRINT(Espurr)
         LEARNSETS(Espurr),
         .evolutions = EVOLUTION({EVO_LEVEL_MALE, 25, SPECIES_MEOWSTIC_MALE},
                                 {EVO_LEVEL_FEMALE, 25, SPECIES_MEOWSTIC_FEMALE}),
@@ -1859,7 +1859,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .frontAnimId = ANIM_GROW_VIBRATE,                   \
         .backPicYOffset = 9,                                \
         .backAnimId = BACK_ANIM_CONCAVE_ARC_LARGE,          \
-        FOOTPRINT(Meowstic),                                \
+        FOOTPRINT(Meowstic)                                 \
         .formSpeciesIdTable = sMeowsticFormSpeciesIdTable
 
     [SPECIES_MEOWSTIC_MALE] =
@@ -1946,7 +1946,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Honedge),
         ICON(Honedge, 2),
-        FOOTPRINT(Honedge),
+        FOOTPRINT(Honedge)
         LEARNSETS(Honedge),
         .evolutions = EVOLUTION({EVO_LEVEL, 35, SPECIES_DOUBLADE}),
     },
@@ -1995,7 +1995,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_H_SHAKE,
         PALETTES(Doublade),
         ICON(Doublade, 2),
-        FOOTPRINT(Doublade),
+        FOOTPRINT(Doublade)
         LEARNSETS(Doublade),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_DUSK_STONE, SPECIES_AEGISLASH_SHIELD}),
     },
@@ -2021,7 +2021,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .pokemonOffset = 0,                                     \
         .trainerScale = 290,                                    \
         .trainerOffset = 1,                                     \
-        FOOTPRINT(Aegislash),                                   \
+        FOOTPRINT(Aegislash)                                    \
         LEARNSETS(Aegislash),                                   \
         .formSpeciesIdTable = sAegislashFormSpeciesIdTable,     \
         .formChangeTable = sAegislashFormChangeTable
@@ -2130,7 +2130,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Spritzee),
         ICON(Spritzee, 0),
-        FOOTPRINT(Spritzee),
+        FOOTPRINT(Spritzee)
         LEARNSETS(Spritzee),
         .evolutions = EVOLUTION({EVO_TRADE_ITEM, ITEM_SACHET, SPECIES_AROMATISSE},
                                 {EVO_ITEM, ITEM_SACHET, SPECIES_AROMATISSE}),
@@ -2179,7 +2179,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Aromatisse),
         ICON(Aromatisse, 0),
-        FOOTPRINT(Aromatisse),
+        FOOTPRINT(Aromatisse)
         LEARNSETS(Aromatisse),
     },
 #endif //P_FAMILY_SPRITZEE
@@ -2228,7 +2228,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_H_SPRING,
         PALETTES(Swirlix),
         ICON(Swirlix, 1),
-        FOOTPRINT(Swirlix),
+        FOOTPRINT(Swirlix)
         LEARNSETS(Swirlix),
         .evolutions = EVOLUTION({EVO_TRADE_ITEM, ITEM_WHIPPED_DREAM, SPECIES_SLURPUFF},
                                 {EVO_ITEM, ITEM_WHIPPED_DREAM, SPECIES_SLURPUFF}),
@@ -2277,7 +2277,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_V_SHAKE_H_SLIDE,
         PALETTES(Slurpuff),
         ICON(Slurpuff, 1),
-        FOOTPRINT(Slurpuff),
+        FOOTPRINT(Slurpuff)
         LEARNSETS(Slurpuff),
     },
 #endif //P_FAMILY_SWIRLIX
@@ -2327,7 +2327,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW,
         PALETTES(Inkay),
         ICON(Inkay, 0),
-        FOOTPRINT(Inkay),
+        FOOTPRINT(Inkay)
         LEARNSETS(Inkay),
         .evolutions = EVOLUTION({EVO_LEVEL, 30, SPECIES_MALAMAR}),
     },
@@ -2375,7 +2375,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_V_STRETCH,
         PALETTES(Malamar),
         ICON(Malamar, 2),
-        FOOTPRINT(Malamar),
+        FOOTPRINT(Malamar)
         LEARNSETS(Malamar),
     },
 #endif //P_FAMILY_INKAY
@@ -2424,7 +2424,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Binacle),
         ICON(Binacle, 2),
-        FOOTPRINT(Binacle),
+        FOOTPRINT(Binacle)
         LEARNSETS(Binacle),
         .evolutions = EVOLUTION({EVO_LEVEL, 39, SPECIES_BARBARACLE}),
     },
@@ -2473,7 +2473,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_V_SHAKE_H_SLIDE,
         PALETTES(Barbaracle),
         ICON(Barbaracle, 2),
-        FOOTPRINT(Barbaracle),
+        FOOTPRINT(Barbaracle)
         LEARNSETS(Barbaracle),
     },
 #endif //P_FAMILY_BINACLE
@@ -2522,7 +2522,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_V_STRETCH,
         PALETTES(Skrelp),
         ICON(Skrelp, 2),
-        FOOTPRINT(Skrelp),
+        FOOTPRINT(Skrelp)
         LEARNSETS(Skrelp),
         .evolutions = EVOLUTION({EVO_LEVEL, 48, SPECIES_DRAGALGE}),
     },
@@ -2570,7 +2570,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_H_STRETCH,
         PALETTES(Dragalge),
         ICON(Dragalge, 5),
-        FOOTPRINT(Dragalge),
+        FOOTPRINT(Dragalge)
         LEARNSETS(Dragalge),
     },
 #endif //P_FAMILY_SKRELP
@@ -2620,7 +2620,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Clauncher),
         ICON(Clauncher, 0),
-        FOOTPRINT(Clauncher),
+        FOOTPRINT(Clauncher)
         LEARNSETS(Clauncher),
         .evolutions = EVOLUTION({EVO_LEVEL, 37, SPECIES_CLAWITZER}),
     },
@@ -2669,7 +2669,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_V_SHAKE,
         PALETTES(Clawitzer),
         ICON(Clawitzer, 0),
-        FOOTPRINT(Clawitzer),
+        FOOTPRINT(Clawitzer)
         LEARNSETS(Clawitzer),
     },
 #endif //P_FAMILY_CLAUNCHER
@@ -2718,7 +2718,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Helioptile),
         ICON(Helioptile, 2),
-        FOOTPRINT(Helioptile),
+        FOOTPRINT(Helioptile)
         LEARNSETS(Helioptile),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_SUN_STONE, SPECIES_HELIOLISK}),
     },
@@ -2767,7 +2767,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_SHAKE_FLASH_YELLOW,
         PALETTES(Heliolisk),
         ICON(Heliolisk, 2),
-        FOOTPRINT(Heliolisk),
+        FOOTPRINT(Heliolisk)
         LEARNSETS(Heliolisk),
     },
 #endif //P_FAMILY_HELIOPTILE
@@ -2816,7 +2816,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_H_SHAKE,
         PALETTES(Tyrunt),
         ICON(Tyrunt, 2),
-        FOOTPRINT(Tyrunt),
+        FOOTPRINT(Tyrunt)
         LEARNSETS(Tyrunt),
         .evolutions = EVOLUTION({EVO_LEVEL_DAY, 39, SPECIES_TYRANTRUM}),
     },
@@ -2864,7 +2864,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_V_SHAKE_H_SLIDE,
         PALETTES(Tyrantrum),
         ICON(Tyrantrum, 0),
-        FOOTPRINT(Tyrantrum),
+        FOOTPRINT(Tyrantrum)
         LEARNSETS(Tyrantrum),
     },
 #endif //P_FAMILY_TYRUNT
@@ -2913,7 +2913,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Amaura),
         ICON(Amaura, 0),
-        FOOTPRINT(Amaura),
+        FOOTPRINT(Amaura)
         LEARNSETS(Amaura),
         .evolutions = EVOLUTION({EVO_LEVEL_NIGHT, 39, SPECIES_AURORUS}),
     },
@@ -2961,7 +2961,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,
         PALETTES(Aurorus),
         ICON(Aurorus, 0),
-        FOOTPRINT(Aurorus),
+        FOOTPRINT(Aurorus)
         LEARNSETS(Aurorus),
     },
 #endif //P_FAMILY_AMAURA
@@ -3015,7 +3015,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_GROW_STUTTER,
         PALETTES(Hawlucha),
         ICON(Hawlucha, 0),
-        FOOTPRINT(Hawlucha),
+        FOOTPRINT(Hawlucha)
         LEARNSETS(Hawlucha),
     },
 #endif //P_FAMILY_HAWLUCHA
@@ -3064,7 +3064,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_SHAKE_FLASH_YELLOW,
         PALETTES(Dedenne),
         ICON(Dedenne, 0),
-        FOOTPRINT(Dedenne),
+        FOOTPRINT(Dedenne)
         LEARNSETS(Dedenne),
     },
 #endif //P_FAMILY_DEDENNE
@@ -3115,7 +3115,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_H_VIBRATE,
         PALETTES(Carbink),
         ICON(Carbink, 2),
-        FOOTPRINT(Carbink),
+        FOOTPRINT(Carbink)
         LEARNSETS(Carbink),
     },
 #endif //P_FAMILY_CARBINK
@@ -3165,7 +3165,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_H_SPRING,
         PALETTES(Goomy),
         ICON(Goomy, 5),
-        FOOTPRINT(Goomy),
+        FOOTPRINT(Goomy)
         LEARNSETS(Goomy),
         .evolutions = EVOLUTION({EVO_LEVEL, 40, SPECIES_SLIGGOO},
                                 {EVO_NONE, 0, SPECIES_SLIGGOO_HISUIAN}),
@@ -3185,7 +3185,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .speciesName = _("Sliggoo"),                            \
         .cryId = CRY_SLIGGOO,                                   \
         .natDexNum = NATIONAL_DEX_SLIGGOO,                      \
-        FOOTPRINT(Sliggoo),                                     \
+        FOOTPRINT(Sliggoo)                                      \
         .formSpeciesIdTable = sSliggooFormSpeciesIdTable
 
     [SPECIES_SLIGGOO] =
@@ -3238,7 +3238,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .speciesName = _("Goodra"),                             \
         .cryId = CRY_GOODRA,                                    \
         .natDexNum = NATIONAL_DEX_GOODRA,                       \
-        FOOTPRINT(Goodra),                                      \
+        FOOTPRINT(Goodra)                                       \
         .formSpeciesIdTable = sGoodraFormSpeciesIdTable
 
     [SPECIES_GOODRA] =
@@ -3399,7 +3399,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Klefki),
         ICON(Klefki, 0),
-        FOOTPRINT(Klefki),
+        FOOTPRINT(Klefki)
         LEARNSETS(Klefki),
     },
 #endif //P_FAMILY_KLEFKI
@@ -3449,7 +3449,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_CIRCLE_COUNTERCLOCKWISE,
         PALETTES(Phantump),
         ICON(Phantump, 1),
-        FOOTPRINT(Phantump),
+        FOOTPRINT(Phantump)
         LEARNSETS(Phantump),
         .evolutions = EVOLUTION({EVO_TRADE, 0, SPECIES_TREVENANT},
                                 {EVO_ITEM, ITEM_LINKING_CORD, SPECIES_TREVENANT}),
@@ -3498,7 +3498,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_V_SHAKE_LOW,
         PALETTES(Trevenant),
         ICON(Trevenant, 1),
-        FOOTPRINT(Trevenant),
+        FOOTPRINT(Trevenant)
         LEARNSETS(Trevenant),
     },
 #endif //P_FAMILY_PHANTUMP
@@ -3524,7 +3524,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,                              \
         PALETTES(Pumpkaboo),                                                \
         ICON(Pumpkaboo, 2),                                                 \
-        FOOTPRINT(Pumpkaboo),                                               \
+        FOOTPRINT(Pumpkaboo)                                                \
         LEARNSETS(Pumpkaboo),                                               \
         .formSpeciesIdTable = sPumpkabooFormSpeciesIdTable
 
@@ -3663,7 +3663,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_V_STRETCH,                                  \
         PALETTES(Gourgeist),                                                \
         ICON(Gourgeist, 2),                                                 \
-        FOOTPRINT(Gourgeist),                                               \
+        FOOTPRINT(Gourgeist)                                                \
         LEARNSETS(Gourgeist),                                               \
         .formSpeciesIdTable = sGourgeistFormSpeciesIdTable
 
@@ -3828,7 +3828,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_H_SHAKE,
         PALETTES(Bergmite),
         ICON(Bergmite, 0),
-        FOOTPRINT(Bergmite),
+        FOOTPRINT(Bergmite)
         LEARNSETS(Bergmite),
         .evolutions = EVOLUTION({EVO_LEVEL, 37, SPECIES_AVALUGG},
                                 {EVO_NONE, 0, SPECIES_AVALUGG_HISUIAN}),
@@ -3848,7 +3848,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .cryId = CRY_AVALUGG,                           \
         .natDexNum = NATIONAL_DEX_AVALUGG,              \
         .categoryName = _("Iceberg"),                   \
-        FOOTPRINT(Avalugg),                             \
+        FOOTPRINT(Avalugg)                              \
         .formSpeciesIdTable = sAvaluggFormSpeciesIdTable
 
     [SPECIES_AVALUGG] =
@@ -3972,7 +3972,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_TRIANGLE_DOWN,
         PALETTES(Noibat),
         ICON(Noibat, 2),
-        FOOTPRINT(Noibat),
+        FOOTPRINT(Noibat)
         LEARNSETS(Noibat),
         .evolutions = EVOLUTION({EVO_LEVEL, 48, SPECIES_NOIVERN}),
     },
@@ -4024,7 +4024,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_JOLT_RIGHT,
         PALETTES(Noivern),
         ICON(Noivern, 2),
-        FOOTPRINT(Noivern),
+        FOOTPRINT(Noivern)
         LEARNSETS(Noivern),
     },
 #endif //P_FAMILY_NOIBAT
@@ -4069,7 +4069,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_SHAKE_GLOW_BLUE,                                        \
         PALETTES(Xerneas##Form),                                                        \
         ICON(Xerneas##Form, 0),                                                         \
-        FOOTPRINT(Xerneas),                                                             \
+        FOOTPRINT(Xerneas)                                                              \
         LEARNSETS(Xerneas),                                                             \
         .formSpeciesIdTable = sXerneasFormSpeciesIdTable,                               \
         .formChangeTable = sXerneasFormChangeTable,                                     \
@@ -4126,7 +4126,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_SHAKE_GLOW_RED,
         PALETTES(Yveltal),
         ICON(Yveltal, 0),
-        FOOTPRINT(Yveltal),
+        FOOTPRINT(Yveltal)
         LEARNSETS(Yveltal),
     },
 #endif //P_FAMILY_YVELTAL
@@ -4146,7 +4146,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .speciesName = _("Zygarde"),                                                    \
         .natDexNum = NATIONAL_DEX_ZYGARDE,                                              \
         .categoryName = _("Order"),                                                     \
-        FOOTPRINT(Zygarde),                                                             \
+        FOOTPRINT(Zygarde)                                                              \
         LEARNSETS(Zygarde),                                                             \
         .formSpeciesIdTable = sZygardeFormSpeciesIdTable,                               \
         .isLegendary = TRUE
@@ -4276,7 +4276,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .speciesName = _("Diancie"),                                                    \
         .natDexNum = NATIONAL_DEX_DIANCIE,                                              \
         .categoryName = _("Jewel"),                                                     \
-        FOOTPRINT(Diancie),                                                             \
+        FOOTPRINT(Diancie)                                                              \
         LEARNSETS(Diancie),                                                             \
         .formSpeciesIdTable = sDiancieFormSpeciesIdTable,                               \
         .formChangeTable = sDiancieFormChangeTable,                                     \
@@ -4364,7 +4364,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .bodyColor = BODY_COLOR_PURPLE,                                                 \
         .speciesName = _("Hoopa"),                                                      \
         .natDexNum = NATIONAL_DEX_HOOPA,                                                \
-        FOOTPRINT(Hoopa),                                                               \
+        FOOTPRINT(Hoopa)                                                                \
         .formSpeciesIdTable = sHoopaFormSpeciesIdTable,                                 \
         .formChangeTable = sHoopaFormChangeTable,                                       \
         .isMythical = TRUE
@@ -4486,7 +4486,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .backAnimId = BACK_ANIM_SHAKE_GLOW_RED,
         PALETTES(Volcanion),
         ICON(Volcanion, 0),
-        FOOTPRINT(Volcanion),
+        FOOTPRINT(Volcanion)
         LEARNSETS(Volcanion),
     },
 #endif //P_FAMILY_VOLCANION

--- a/src/data/pokemon/species_info/gen_7.h
+++ b/src/data/pokemon/species_info/gen_7.h
@@ -47,7 +47,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_SMALL,
         PALETTES(Rowlet),
         ICON(Rowlet, 0),
-        FOOTPRINT(Rowlet),
+        FOOTPRINT(Rowlet)
         LEARNSETS(Rowlet),
         .evolutions = EVOLUTION({EVO_LEVEL, 17, SPECIES_DARTRIX}),
     },
@@ -96,7 +96,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .backAnimId = BACK_ANIM_V_STRETCH,
         PALETTES(Dartrix),
         ICON(Dartrix, 1),
-        FOOTPRINT(Dartrix),
+        FOOTPRINT(Dartrix)
         LEARNSETS(Dartrix),
         .evolutions = EVOLUTION({EVO_LEVEL, 34, SPECIES_DECIDUEYE},
                                 {EVO_NONE, 0, SPECIES_DECIDUEYE_HISUIAN}),
@@ -121,7 +121,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .pokemonOffset = 1,                                     \
         .trainerScale = 296,                                    \
         .trainerOffset = 1,                                     \
-        FOOTPRINT(Decidueye),                                   \
+        FOOTPRINT(Decidueye)                                    \
         .formSpeciesIdTable = sDecidueyeFormSpeciesIdTable
 
     [SPECIES_DECIDUEYE] =
@@ -230,7 +230,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Litten),
         ICON(Litten, 0),
-        FOOTPRINT(Litten),
+        FOOTPRINT(Litten)
         LEARNSETS(Litten),
         .evolutions = EVOLUTION({EVO_LEVEL, 17, SPECIES_TORRACAT}),
     },
@@ -278,7 +278,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Torracat),
         ICON(Torracat, 0),
-        FOOTPRINT(Torracat),
+        FOOTPRINT(Torracat)
         LEARNSETS(Torracat),
         .evolutions = EVOLUTION({EVO_LEVEL, 34, SPECIES_INCINEROAR}),
     },
@@ -326,7 +326,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Incineroar),
         ICON(Incineroar, 0),
-        FOOTPRINT(Incineroar),
+        FOOTPRINT(Incineroar)
         LEARNSETS(Incineroar),
     },
 #endif //P_FAMILY_LITTEN
@@ -375,7 +375,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Popplio),
         ICON(Popplio, 0),
-        FOOTPRINT(Popplio),
+        FOOTPRINT(Popplio)
         LEARNSETS(Popplio),
         .evolutions = EVOLUTION({EVO_LEVEL, 17, SPECIES_BRIONNE}),
     },
@@ -423,7 +423,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Brionne),
         ICON(Brionne, 0),
-        FOOTPRINT(Brionne),
+        FOOTPRINT(Brionne)
         LEARNSETS(Brionne),
         .evolutions = EVOLUTION({EVO_LEVEL, 34, SPECIES_PRIMARINA}),
     },
@@ -471,7 +471,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Primarina),
         ICON(Primarina, 0),
-        FOOTPRINT(Primarina),
+        FOOTPRINT(Primarina)
         LEARNSETS(Primarina),
     },
 #endif //P_FAMILY_POPPLIO
@@ -521,7 +521,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW,
         PALETTES(Pikipek),
         ICON(Pikipek, 2),
-        FOOTPRINT(Pikipek),
+        FOOTPRINT(Pikipek)
         LEARNSETS(Pikipek),
         .evolutions = EVOLUTION({EVO_LEVEL, 14, SPECIES_TRUMBEAK}),
     },
@@ -570,7 +570,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .backAnimId = BACK_ANIM_H_STRETCH,
         PALETTES(Trumbeak),
         ICON(Trumbeak, 0),
-        FOOTPRINT(Trumbeak),
+        FOOTPRINT(Trumbeak)
         LEARNSETS(Trumbeak),
         .evolutions = EVOLUTION({EVO_LEVEL, 28, SPECIES_TOUCANNON}),
     },
@@ -619,7 +619,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,
         PALETTES(Toucannon),
         ICON(Toucannon, 0),
-        FOOTPRINT(Toucannon),
+        FOOTPRINT(Toucannon)
         LEARNSETS(Toucannon),
     },
 #endif //P_FAMILY_PIKIPEK
@@ -669,7 +669,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Yungoos),
         ICON(Yungoos, 2),
-        FOOTPRINT(Yungoos),
+        FOOTPRINT(Yungoos)
         LEARNSETS(Yungoos),
         .evolutions = EVOLUTION({EVO_LEVEL_DAY, 20, SPECIES_GUMSHOOS}),
     },
@@ -718,7 +718,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Gumshoos),
         ICON(Gumshoos, 2),
-        FOOTPRINT(Gumshoos),
+        FOOTPRINT(Gumshoos)
         LEARNSETS(Gumshoos),
     },
 #endif //P_FAMILY_YUNGOOS
@@ -767,7 +767,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Grubbin),
         ICON(Grubbin, 0),
-        FOOTPRINT(Grubbin),
+        FOOTPRINT(Grubbin)
         LEARNSETS(Grubbin),
         .evolutions = EVOLUTION({EVO_LEVEL, 20, SPECIES_CHARJABUG}),
     },
@@ -816,7 +816,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Charjabug),
         ICON(Charjabug, 1),
-        FOOTPRINT(Charjabug),
+        FOOTPRINT(Charjabug)
         LEARNSETS(Charjabug),
         .evolutions = EVOLUTION({EVO_MAPSEC, MAPSEC_NEW_MAUVILLE, SPECIES_VIKAVOLT},
                                 {EVO_ITEM, ITEM_THUNDER_STONE, SPECIES_VIKAVOLT}),
@@ -866,7 +866,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Vikavolt),
         ICON(Vikavolt, 0),
-        FOOTPRINT(Vikavolt),
+        FOOTPRINT(Vikavolt)
         LEARNSETS(Vikavolt),
     },
 #endif //P_FAMILY_GRUBBIN
@@ -916,7 +916,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Crabrawler),
         ICON(Crabrawler, 2),
-        FOOTPRINT(Crabrawler),
+        FOOTPRINT(Crabrawler)
         LEARNSETS(Crabrawler),
         .evolutions = EVOLUTION({EVO_SPECIFIC_MAP, MAP_SHOAL_CAVE_LOW_TIDE_ICE_ROOM, SPECIES_CRABOMINABLE},
                                 {EVO_ITEM, ITEM_ICE_STONE, SPECIES_CRABOMINABLE}),
@@ -966,7 +966,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Crabominable),
         ICON(Crabominable, 2),
-        FOOTPRINT(Crabominable),
+        FOOTPRINT(Crabominable)
         LEARNSETS(Crabominable),
     },
 #endif //P_FAMILY_CRABRAWLER
@@ -1000,7 +1000,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .trainerOffset = 0,                                     \
         .frontAnimFrames = sAnims_Oricorio,                     \
         .backPicYOffset = 0,                                    \
-        FOOTPRINT(Oricorio),                                    \
+        FOOTPRINT(Oricorio)                                     \
         LEARNSETS(Oricorio),                                    \
         .formSpeciesIdTable = sOricorioFormSpeciesIdTable,      \
         .formChangeTable = sOricorioFormChangeTable
@@ -1133,7 +1133,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .backAnimId = BACK_ANIM_CONCAVE_ARC_LARGE,
         PALETTES(Cutiefly),
         ICON(Cutiefly, 2),
-        FOOTPRINT(Cutiefly),
+        FOOTPRINT(Cutiefly)
         LEARNSETS(Cutiefly),
         .evolutions = EVOLUTION({EVO_LEVEL, 25, SPECIES_RIBOMBEE}),
     },
@@ -1183,7 +1183,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .backAnimId = BACK_ANIM_CONVEX_DOUBLE_ARC,
         PALETTES(Ribombee),
         ICON(Ribombee, 2),
-        FOOTPRINT(Ribombee),
+        FOOTPRINT(Ribombee)
         LEARNSETS(Ribombee),
     },
 #endif //P_FAMILY_CUTIEFLY
@@ -1223,7 +1223,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .backPicYOffset = 7,                                    \
         PALETTES(Rockruff),                                     \
         ICON(Rockruff, 2),                                      \
-        FOOTPRINT(Rockruff),                                    \
+        FOOTPRINT(Rockruff)                                     \
         LEARNSETS(Rockruff),                                    \
         .formSpeciesIdTable = sRockruffFormSpeciesIdTable
 
@@ -1267,7 +1267,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .trainerScale = 257,                                \
         .trainerOffset = 0,                                 \
         BACK_PIC(LycanrocMidday, 64, 56),                   \
-        FOOTPRINT(Lycanroc),                                \
+        FOOTPRINT(Lycanroc)                                 \
         .formSpeciesIdTable = sLycanrocFormSpeciesIdTable
 
     [SPECIES_LYCANROC_MIDDAY] =
@@ -1378,7 +1378,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .pokemonOffset = 24,                                    \
         .trainerScale = 256,                                    \
         .trainerOffset = 0,                                     \
-        FOOTPRINT(Wishiwashi),                                  \
+        FOOTPRINT(Wishiwashi)                                   \
         LEARNSETS(Wishiwashi),                                  \
         .formSpeciesIdTable = sWishiwashiFormSpeciesIdTable,    \
         .formChangeTable = sWishiwashiFormChangeTable
@@ -1486,7 +1486,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Mareanie),
         ICON(Mareanie, 2),
-        FOOTPRINT(Mareanie),
+        FOOTPRINT(Mareanie)
         LEARNSETS(Mareanie),
         .evolutions = EVOLUTION({EVO_LEVEL, 38, SPECIES_TOXAPEX}),
     },
@@ -1535,7 +1535,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Toxapex),
         ICON(Toxapex, 0),
-        FOOTPRINT(Toxapex),
+        FOOTPRINT(Toxapex)
         LEARNSETS(Toxapex),
     },
 #endif //P_FAMILY_MAREANIE
@@ -1585,7 +1585,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Mudbray),
         ICON(Mudbray, 2),
-        FOOTPRINT(Mudbray),
+        FOOTPRINT(Mudbray)
         LEARNSETS(Mudbray),
         .evolutions = EVOLUTION({EVO_LEVEL, 30, SPECIES_MUDSDALE}),
     },
@@ -1634,7 +1634,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Mudsdale),
         ICON(Mudsdale, 0),
-        FOOTPRINT(Mudsdale),
+        FOOTPRINT(Mudsdale)
         LEARNSETS(Mudsdale),
     },
 #endif //P_FAMILY_MUDBRAY
@@ -1684,7 +1684,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Dewpider),
         ICON(Dewpider, 0),
-        FOOTPRINT(Dewpider),
+        FOOTPRINT(Dewpider)
         LEARNSETS(Dewpider),
         .evolutions = EVOLUTION({EVO_LEVEL, 22, SPECIES_ARAQUANID}),
     },
@@ -1733,7 +1733,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Araquanid),
         ICON(Araquanid, 2),
-        FOOTPRINT(Araquanid),
+        FOOTPRINT(Araquanid)
         LEARNSETS(Araquanid),
     },
 #endif //P_FAMILY_DEWPIDER
@@ -1783,7 +1783,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Fomantis),
         ICON(Fomantis, 1),
-        FOOTPRINT(Fomantis),
+        FOOTPRINT(Fomantis)
         LEARNSETS(Fomantis),
         .evolutions = EVOLUTION({EVO_LEVEL_DAY, 34, SPECIES_LURANTIS}),
     },
@@ -1832,7 +1832,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Lurantis),
         ICON(Lurantis, 1),
-        FOOTPRINT(Lurantis),
+        FOOTPRINT(Lurantis)
         LEARNSETS(Lurantis),
     },
 #endif //P_FAMILY_FOMANTIS
@@ -1883,7 +1883,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Morelull),
         ICON(Morelull, 0),
-        FOOTPRINT(Morelull),
+        FOOTPRINT(Morelull)
         LEARNSETS(Morelull),
         .evolutions = EVOLUTION({EVO_LEVEL, 24, SPECIES_SHIINOTIC}),
     },
@@ -1933,7 +1933,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Shiinotic),
         ICON(Shiinotic, 1),
-        FOOTPRINT(Shiinotic),
+        FOOTPRINT(Shiinotic)
         LEARNSETS(Shiinotic),
     },
 #endif //P_FAMILY_MORELULL
@@ -1983,7 +1983,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Salandit),
         ICON(Salandit, 2),
-        FOOTPRINT(Salandit),
+        FOOTPRINT(Salandit)
         LEARNSETS(Salandit),
         .evolutions = EVOLUTION({EVO_LEVEL_FEMALE, 33, SPECIES_SALAZZLE}),
     },
@@ -2032,7 +2032,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Salazzle),
         ICON(Salazzle, 0),
-        FOOTPRINT(Salazzle),
+        FOOTPRINT(Salazzle)
         LEARNSETS(Salazzle),
     },
 #endif //P_FAMILY_SALANDIT
@@ -2081,7 +2081,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Stufful),
         ICON(Stufful, 0),
-        FOOTPRINT(Stufful),
+        FOOTPRINT(Stufful)
         LEARNSETS(Stufful),
         .evolutions = EVOLUTION({EVO_LEVEL, 27, SPECIES_BEWEAR}),
     },
@@ -2129,7 +2129,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Bewear),
         ICON(Bewear, 0),
-        FOOTPRINT(Bewear),
+        FOOTPRINT(Bewear)
         LEARNSETS(Bewear),
     },
 #endif //P_FAMILY_STUFFUL
@@ -2179,7 +2179,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Bounsweet),
         ICON(Bounsweet, 1),
-        FOOTPRINT(Bounsweet),
+        FOOTPRINT(Bounsweet)
         LEARNSETS(Bounsweet),
         .evolutions = EVOLUTION({EVO_LEVEL, 18, SPECIES_STEENEE}),
     },
@@ -2229,7 +2229,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Steenee),
         ICON(Steenee, 1),
-        FOOTPRINT(Steenee),
+        FOOTPRINT(Steenee)
         LEARNSETS(Steenee),
         .evolutions = EVOLUTION({EVO_MOVE, MOVE_STOMP, SPECIES_TSAREENA}),
     },
@@ -2279,7 +2279,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Tsareena),
         ICON(Tsareena, 1),
-        FOOTPRINT(Tsareena),
+        FOOTPRINT(Tsareena)
         LEARNSETS(Tsareena),
     },
 #endif //P_FAMILY_BOUNSWEET
@@ -2331,7 +2331,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Comfey),
         ICON(Comfey, 1),
-        FOOTPRINT(Comfey),
+        FOOTPRINT(Comfey)
         LEARNSETS(Comfey),
     },
 #endif //P_FAMILY_COMFEY
@@ -2380,7 +2380,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Oranguru),
         ICON(Oranguru, 0),
-        FOOTPRINT(Oranguru),
+        FOOTPRINT(Oranguru)
         LEARNSETS(Oranguru),
     },
 #endif //P_FAMILY_ORANGURU
@@ -2429,7 +2429,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .backAnimId = BACK_ANIM_H_SHAKE,
         PALETTES(Passimian),
         ICON(Passimian, 1),
-        FOOTPRINT(Passimian),
+        FOOTPRINT(Passimian)
         LEARNSETS(Passimian),
     },
 #endif //P_FAMILY_PASSIMIAN
@@ -2478,7 +2478,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Wimpod),
         ICON(Wimpod, 2),
-        FOOTPRINT(Wimpod),
+        FOOTPRINT(Wimpod)
         LEARNSETS(Wimpod),
         .evolutions = EVOLUTION({EVO_LEVEL, 30, SPECIES_GOLISOPOD}),
     },
@@ -2526,7 +2526,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Golisopod),
         ICON(Golisopod, 2),
-        FOOTPRINT(Golisopod),
+        FOOTPRINT(Golisopod)
         LEARNSETS(Golisopod),
     },
 #endif //P_FAMILY_WIMPOD
@@ -2576,7 +2576,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Sandygast),
         ICON(Sandygast, 1),
-        FOOTPRINT(Sandygast),
+        FOOTPRINT(Sandygast)
         LEARNSETS(Sandygast),
         .evolutions = EVOLUTION({EVO_LEVEL, 42, SPECIES_PALOSSAND}),
     },
@@ -2625,7 +2625,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Palossand),
         ICON(Palossand, 2),
-        FOOTPRINT(Palossand),
+        FOOTPRINT(Palossand)
         LEARNSETS(Palossand),
     },
 #endif //P_FAMILY_SANDYGAST
@@ -2674,7 +2674,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Pyukumuku),
         ICON(Pyukumuku, 0),
-        FOOTPRINT(Pyukumuku),
+        FOOTPRINT(Pyukumuku)
         LEARNSETS(Pyukumuku),
     },
 #endif //P_FAMILY_PYUKUMUKU
@@ -2724,7 +2724,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(TypeNull),
         ICON(TypeNull, 0),
-        FOOTPRINT(Type_Null),
+        FOOTPRINT(Type_Null)
         LEARNSETS(TypeNull),
         .evolutions = EVOLUTION({EVO_FRIENDSHIP, 0, SPECIES_SILVALLY_NORMAL}),
     },
@@ -2770,7 +2770,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .backPicYOffset = 0,                                                            \
         PALETTES(palette),                                                              \
         ICON(Silvally, 0),                                                              \
-        FOOTPRINT(Silvally),                                                            \
+        FOOTPRINT(Silvally)                                                             \
         LEARNSETS(Silvally),                                                            \
         .formSpeciesIdTable = sSilvallyFormSpeciesIdTable,                              \
         .formChangeTable = sSilvallyFormChangeTable,                                    \
@@ -2822,7 +2822,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .pokemonOffset = 13,                                    \
         .trainerScale = 256,                                    \
         .trainerOffset = 0,                                     \
-        FOOTPRINT(Minior),                                      \
+        FOOTPRINT(Minior)                                       \
         LEARNSETS(Minior),                                      \
         .formSpeciesIdTable = sMiniorFormSpeciesIdTable
 
@@ -2934,7 +2934,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Komala),
         ICON(Komala, 2),
-        FOOTPRINT(Komala),
+        FOOTPRINT(Komala)
         LEARNSETS(Komala),
     },
 #endif //P_FAMILY_KOMALA
@@ -2984,7 +2984,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Turtonator),
         ICON(Turtonator, 0),
-        FOOTPRINT(Turtonator),
+        FOOTPRINT(Turtonator)
         LEARNSETS(Turtonator),
     },
 #endif //P_FAMILY_TURTONATOR
@@ -3034,7 +3034,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .backAnimId = BACK_ANIM_GROW_STUTTER,
         PALETTES(Togedemaru),
         ICON(Togedemaru, 2),
-        FOOTPRINT(Togedemaru),
+        FOOTPRINT(Togedemaru)
         LEARNSETS(Togedemaru),
     },
 #endif //P_FAMILY_TOGEDEMARU
@@ -3069,7 +3069,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .pokemonOffset = 24,                                        \
         .trainerScale = 256,                                        \
         .trainerOffset = 0,                                         \
-        FOOTPRINT(Mimikyu),                                         \
+        FOOTPRINT(Mimikyu)                                          \
         LEARNSETS(Mimikyu),                                         \
         .formSpeciesIdTable = sMimikyuFormSpeciesIdTable,           \
         .formChangeTable = sMimikyuFormChangeTable
@@ -3158,7 +3158,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Bruxish),
         ICON(Bruxish, 0),
-        FOOTPRINT(Bruxish),
+        FOOTPRINT(Bruxish)
         LEARNSETS(Bruxish),
     },
 #endif //P_FAMILY_BRUXISH
@@ -3208,7 +3208,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .backAnimId = BACK_ANIM_H_SLIDE,
         PALETTES(Drampa),
         ICON(Drampa, 0),
-        FOOTPRINT(Drampa),
+        FOOTPRINT(Drampa)
         LEARNSETS(Drampa),
     },
 #endif //P_FAMILY_DRAMPA
@@ -3259,7 +3259,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Dhelmise),
         ICON(Dhelmise, 1),
-        FOOTPRINT(Dhelmise),
+        FOOTPRINT(Dhelmise)
         LEARNSETS(Dhelmise),
     },
 #endif //P_FAMILY_DHELMISE
@@ -3309,7 +3309,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .backAnimId = BACK_ANIM_GROW_STUTTER,
         PALETTES(JangmoO),
         ICON(JangmoO, 2),
-        FOOTPRINT(JangmoO),
+        FOOTPRINT(JangmoO)
         LEARNSETS(JangmoO),
         .evolutions = EVOLUTION({EVO_LEVEL, 35, SPECIES_HAKAMO_O}),
     },
@@ -3358,7 +3358,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .backAnimId = BACK_ANIM_H_STRETCH,
         PALETTES(HakamoO),
         ICON(HakamoO, 2),
-        FOOTPRINT(HakamoO),
+        FOOTPRINT(HakamoO)
         LEARNSETS(HakamoO),
         .evolutions = EVOLUTION({EVO_LEVEL, 45, SPECIES_KOMMO_O}),
     },
@@ -3407,7 +3407,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .backAnimId = BACK_ANIM_SHRINK_GROW_VIBRATE,
         PALETTES(KommoO),
         ICON(KommoO, 2),
-        FOOTPRINT(KommoO),
+        FOOTPRINT(KommoO)
         LEARNSETS(KommoO),
     },
 #endif //P_FAMILY_JANGMO_O
@@ -3458,7 +3458,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(TapuKoko),
         ICON(TapuKoko, 0),
-        FOOTPRINT(Tapu_Koko),
+        FOOTPRINT(Tapu_Koko)
         LEARNSETS(TapuKoko),
     },
 #endif //P_FAMILY_TAPU_KOKO
@@ -3509,7 +3509,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(TapuLele),
         ICON(TapuLele, 0),
-        FOOTPRINT(Tapu_Lele),
+        FOOTPRINT(Tapu_Lele)
         LEARNSETS(TapuLele),
     },
 #endif //P_FAMILY_TAPU_LELE
@@ -3560,7 +3560,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(TapuBulu),
         ICON(TapuBulu, 2),
-        FOOTPRINT(Tapu_Bulu),
+        FOOTPRINT(Tapu_Bulu)
         LEARNSETS(TapuBulu),
     },
 #endif //P_FAMILY_TAPU_BULU
@@ -3612,7 +3612,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(TapuFini),
         ICON(TapuFini, 0),
-        FOOTPRINT(Tapu_Fini),
+        FOOTPRINT(Tapu_Fini)
         LEARNSETS(TapuFini),
     },
 #endif //P_FAMILY_TAPU_FINI
@@ -3663,7 +3663,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Cosmog),
         ICON(Cosmog, 2),
-        FOOTPRINT(Cosmog),
+        FOOTPRINT(Cosmog)
         LEARNSETS(Cosmog),
         .evolutions = EVOLUTION({EVO_LEVEL, 43, SPECIES_COSMOEM}),
     },
@@ -3714,7 +3714,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Cosmoem),
         ICON(Cosmoem, 0),
-        FOOTPRINT(Cosmoem),
+        FOOTPRINT(Cosmoem)
         LEARNSETS(Cosmoem),
         .evolutions = EVOLUTION({EVO_LEVEL_DAY, 53, SPECIES_SOLGALEO},
                                 {EVO_LEVEL_NIGHT, 53, SPECIES_LUNALA}),
@@ -3764,7 +3764,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Solgaleo),
         ICON(Solgaleo, 0),
-        FOOTPRINT(Solgaleo),
+        FOOTPRINT(Solgaleo)
         LEARNSETS(Solgaleo),
     },
 
@@ -3813,7 +3813,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Lunala),
         ICON(Lunala, 2),
-        FOOTPRINT(Lunala),
+        FOOTPRINT(Lunala)
         LEARNSETS(Lunala),
     },
 #endif //P_FAMILY_COSMOG
@@ -3864,7 +3864,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Nihilego),
         ICON(Nihilego, 0),
-        FOOTPRINT(Nihilego),
+        FOOTPRINT(Nihilego)
         LEARNSETS(Nihilego),
     },
 #endif //P_FAMILY_NIHILEGO
@@ -3915,7 +3915,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Buzzwole),
         ICON(Buzzwole, 0),
-        FOOTPRINT(Buzzwole),
+        FOOTPRINT(Buzzwole)
         LEARNSETS(Buzzwole),
     },
 #endif //P_FAMILY_BUZZWOLE
@@ -3965,7 +3965,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Pheromosa),
         ICON(Pheromosa, 2),
-        FOOTPRINT(Pheromosa),
+        FOOTPRINT(Pheromosa)
         LEARNSETS(Pheromosa),
     },
 #endif //P_FAMILY_PHEROMOSA
@@ -4015,7 +4015,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Xurkitree),
         ICON(Xurkitree, 0),
-        FOOTPRINT(Xurkitree),
+        FOOTPRINT(Xurkitree)
         LEARNSETS(Xurkitree),
     },
 #endif //P_FAMILY_XURKITREE
@@ -4067,7 +4067,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Celesteela),
         ICON(Celesteela, 0),
-        FOOTPRINT(Celesteela),
+        FOOTPRINT(Celesteela)
         LEARNSETS(Celesteela),
     },
 #endif //P_FAMILY_CELESTEELA
@@ -4118,7 +4118,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Kartana),
         ICON(Kartana, 0),
-        FOOTPRINT(Kartana),
+        FOOTPRINT(Kartana)
         LEARNSETS(Kartana),
     },
 #endif //P_FAMILY_KARTANA
@@ -4168,7 +4168,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Guzzlord),
         ICON(Guzzlord, 0),
-        FOOTPRINT(Guzzlord),
+        FOOTPRINT(Guzzlord)
         LEARNSETS(Guzzlord),
     },
 #endif //P_FAMILY_GUZZLORD
@@ -4188,7 +4188,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .pokemonOffset = 3,                                                             \
         .trainerScale = 369,                                                            \
         .trainerOffset = 7,                                                             \
-        FOOTPRINT(Necrozma),                                                            \
+        FOOTPRINT(Necrozma)                                                             \
         LEARNSETS(Necrozma),                                                            \
         .formSpeciesIdTable = sNecrozmaFormSpeciesIdTable,                              \
         .isLegendary = TRUE
@@ -4382,7 +4382,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .backPicYOffset = 4,                                                            \
         PALETTES(Form),                                                                 \
         ICON(Form, 0),                                                                  \
-        FOOTPRINT(Magearna),                                                            \
+        FOOTPRINT(Magearna)                                                             \
         LEARNSETS(Magearna),                                                            \
         .formSpeciesIdTable = sMagearnaFormSpeciesIdTable,                              \
         .isMythical = TRUE
@@ -4456,7 +4456,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Marshadow),
         ICON(Marshadow, 0),
-        FOOTPRINT(Marshadow),
+        FOOTPRINT(Marshadow)
         LEARNSETS(Marshadow),
         .isMythical = TRUE,
     },
@@ -4507,7 +4507,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Poipole),
         ICON(Poipole, 0),
-        FOOTPRINT(Poipole),
+        FOOTPRINT(Poipole)
         LEARNSETS(Poipole),
         .evolutions = EVOLUTION({EVO_MOVE, MOVE_DRAGON_PULSE, SPECIES_NAGANADEL}),
     },
@@ -4556,7 +4556,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Naganadel),
         ICON(Naganadel, 0),
-        FOOTPRINT(Naganadel),
+        FOOTPRINT(Naganadel)
         LEARNSETS(Naganadel),
     },
 #endif //P_FAMILY_POIPOLE
@@ -4606,7 +4606,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Stakataka),
         ICON(Stakataka, 0),
-        FOOTPRINT(Stakataka),
+        FOOTPRINT(Stakataka)
         LEARNSETS(Stakataka),
     },
 #endif //P_FAMILY_STAKATAKA
@@ -4656,7 +4656,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Blacephalon),
         ICON(Blacephalon, 0),
-        FOOTPRINT(Blacephalon),
+        FOOTPRINT(Blacephalon)
         LEARNSETS(Blacephalon),
     },
 #endif //P_FAMILY_BLACEPHALON
@@ -4705,7 +4705,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Zeraora),
         ICON(Zeraora, 0),
-        FOOTPRINT(Zeraora),
+        FOOTPRINT(Zeraora)
         LEARNSETS(Zeraora),
     },
 #endif //P_FAMILY_ZERAORA
@@ -4754,7 +4754,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Meltan),
         ICON(Meltan, 2),
-        FOOTPRINT(Meltan),
+        FOOTPRINT(Meltan)
         LEARNSETS(Meltan),
     },
 
@@ -4784,7 +4784,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .pokemonOffset = 10,                                                            \
         .trainerScale = 423,                                                            \
         .trainerOffset = 8,                                                             \
-        FOOTPRINT(Melmetal),                                                            \
+        FOOTPRINT(Melmetal)                                                             \
         LEARNSETS(Melmetal),                                                            \
         .formSpeciesIdTable = sMelmetalFormSpeciesIdTable,                              \
         .formChangeTable = sMelmetalFormChangeTable,                                    \

--- a/src/data/pokemon/species_info/gen_8.h
+++ b/src/data/pokemon/species_info/gen_8.h
@@ -47,7 +47,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Grookey),
         ICON(Grookey, 1),
-        FOOTPRINT(Grookey),
+        FOOTPRINT(Grookey)
         LEARNSETS(Grookey),
         .evolutions = EVOLUTION({EVO_LEVEL, 16, SPECIES_THWACKEY}),
     },
@@ -94,7 +94,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Thwackey),
         ICON(Thwackey, 1),
-        FOOTPRINT(Thwackey),
+        FOOTPRINT(Thwackey)
         LEARNSETS(Thwackey),
         .evolutions = EVOLUTION({EVO_LEVEL, 35, SPECIES_RILLABOOM}),
     },
@@ -121,7 +121,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         .cryId = CRY_RILLABOOM,                                                 \
         .natDexNum = NATIONAL_DEX_RILLABOOM,                                    \
         .categoryName = _("Drummer"),                                           \
-        FOOTPRINT(Rillaboom),                                                   \
+        FOOTPRINT(Rillaboom)                                                    \
         LEARNSETS(Rillaboom),                                                   \
         .formSpeciesIdTable = sRillaboomFormSpeciesIdTable,                     \
         .formChangeTable = sRillaboomFormChangeTable
@@ -222,7 +222,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Scorbunny),
         ICON(Scorbunny, 0),
-        FOOTPRINT(Scorbunny),
+        FOOTPRINT(Scorbunny)
         LEARNSETS(Scorbunny),
         .evolutions = EVOLUTION({EVO_LEVEL, 16, SPECIES_RABOOT}),
     },
@@ -269,7 +269,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Raboot),
         ICON(Raboot, 0),
-        FOOTPRINT(Raboot),
+        FOOTPRINT(Raboot)
         LEARNSETS(Raboot),
         .evolutions = EVOLUTION({EVO_LEVEL, 35, SPECIES_CINDERACE}),
     },
@@ -296,7 +296,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         .cryId = CRY_CINDERACE,                                         \
         .natDexNum = NATIONAL_DEX_CINDERACE,                            \
         .categoryName = _("Striker"),                                   \
-        FOOTPRINT(Cinderace),                                           \
+        FOOTPRINT(Cinderace)                                            \
         LEARNSETS(Cinderace),                                           \
         .formSpeciesIdTable = sCinderaceFormSpeciesIdTable,             \
         .formChangeTable = sCinderaceFormChangeTable
@@ -400,7 +400,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Sobble),
         ICON(Sobble, 2),
-        FOOTPRINT(Sobble),
+        FOOTPRINT(Sobble)
         LEARNSETS(Sobble),
         .evolutions = EVOLUTION({EVO_LEVEL, 16, SPECIES_DRIZZILE}),
     },
@@ -447,7 +447,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Drizzile),
         ICON(Drizzile, 2),
-        FOOTPRINT(Drizzile),
+        FOOTPRINT(Drizzile)
         LEARNSETS(Drizzile),
         .evolutions = EVOLUTION({EVO_LEVEL, 35, SPECIES_INTELEON}),
     },
@@ -474,7 +474,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         .cryId = CRY_INTELEON,                                          \
         .natDexNum = NATIONAL_DEX_INTELEON,                             \
         .categoryName = _("Secret Agent"),                              \
-        FOOTPRINT(Inteleon),                                            \
+        FOOTPRINT(Inteleon)                                             \
         LEARNSETS(Inteleon),                                            \
         .formSpeciesIdTable = sInteleonFormSpeciesIdTable,              \
         .formChangeTable = sInteleonFormChangeTable
@@ -577,7 +577,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Skwovet),
         ICON(Skwovet, 2),
-        FOOTPRINT(Skwovet),
+        FOOTPRINT(Skwovet)
         LEARNSETS(Skwovet),
         .evolutions = EVOLUTION({EVO_LEVEL, 24, SPECIES_GREEDENT}),
     },
@@ -626,7 +626,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Greedent),
         ICON(Greedent, 0),
-        FOOTPRINT(Greedent),
+        FOOTPRINT(Greedent)
         LEARNSETS(Greedent),
     },
 #endif //P_FAMILY_SKWOVET
@@ -675,7 +675,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Rookidee),
         ICON(Rookidee, 0),
-        FOOTPRINT(Rookidee),
+        FOOTPRINT(Rookidee)
         LEARNSETS(Rookidee),
         .evolutions = EVOLUTION({EVO_LEVEL, 18, SPECIES_CORVISQUIRE}),
     },
@@ -724,7 +724,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Corvisquire),
         ICON(Corvisquire, 0),
-        FOOTPRINT(Corvisquire),
+        FOOTPRINT(Corvisquire)
         LEARNSETS(Corvisquire),
         .evolutions = EVOLUTION({EVO_LEVEL, 38, SPECIES_CORVIKNIGHT}),
     },
@@ -751,7 +751,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         .cryId = CRY_CORVIKNIGHT,                                                   \
         .natDexNum = NATIONAL_DEX_CORVIKNIGHT,                                      \
         .categoryName = _("Raven"),                                                 \
-        FOOTPRINT(Corviknight),                                                     \
+        FOOTPRINT(Corviknight)                                                      \
         LEARNSETS(Corviknight),                                                     \
         .formSpeciesIdTable = sCorviknightFormSpeciesIdTable,                       \
         .formChangeTable = sCorviknightFormChangeTable
@@ -853,7 +853,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Blipbug),
         ICON(Blipbug, 0),
-        FOOTPRINT(Blipbug),
+        FOOTPRINT(Blipbug)
         LEARNSETS(Blipbug),
         .evolutions = EVOLUTION({EVO_LEVEL, 10, SPECIES_DOTTLER}),
     },
@@ -902,7 +902,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Dottler),
         ICON(Dottler, 2),
-        FOOTPRINT(Dottler),
+        FOOTPRINT(Dottler)
         LEARNSETS(Dottler),
         .evolutions = EVOLUTION({EVO_LEVEL, 30, SPECIES_ORBEETLE}),
     },
@@ -930,7 +930,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         .cryId = CRY_ORBEETLE,                                              \
         .natDexNum = NATIONAL_DEX_ORBEETLE,                                 \
         .categoryName = _("Seven Spot"),                                    \
-        FOOTPRINT(Orbeetle),                                                \
+        FOOTPRINT(Orbeetle)                                                 \
         LEARNSETS(Orbeetle),                                                \
         .formSpeciesIdTable = sOrbeetleFormSpeciesIdTable,                  \
         .formChangeTable = sOrbeetleFormChangeTable
@@ -1034,7 +1034,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Nickit),
         ICON(Nickit, 2),
-        FOOTPRINT(Nickit),
+        FOOTPRINT(Nickit)
         LEARNSETS(Nickit),
         .evolutions = EVOLUTION({EVO_LEVEL, 18, SPECIES_THIEVUL}),
     },
@@ -1082,7 +1082,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Thievul),
         ICON(Thievul, 2),
-        FOOTPRINT(Thievul),
+        FOOTPRINT(Thievul)
         LEARNSETS(Thievul),
     },
 #endif //P_FAMILY_NICKIT
@@ -1131,7 +1131,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Gossifleur),
         ICON(Gossifleur, 1),
-        FOOTPRINT(Gossifleur),
+        FOOTPRINT(Gossifleur)
         LEARNSETS(Gossifleur),
         .evolutions = EVOLUTION({EVO_LEVEL, 20, SPECIES_ELDEGOSS}),
     },
@@ -1179,7 +1179,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Eldegoss),
         ICON(Eldegoss, 1),
-        FOOTPRINT(Eldegoss),
+        FOOTPRINT(Eldegoss)
         LEARNSETS(Eldegoss),
     },
 #endif //P_FAMILY_GOSSIFLEUR
@@ -1228,7 +1228,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Wooloo),
         ICON(Wooloo, 0),
-        FOOTPRINT(Wooloo),
+        FOOTPRINT(Wooloo)
         LEARNSETS(Wooloo),
         .evolutions = EVOLUTION({EVO_LEVEL, 24, SPECIES_DUBWOOL}),
     },
@@ -1276,7 +1276,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Dubwool),
         ICON(Dubwool, 2),
-        FOOTPRINT(Dubwool),
+        FOOTPRINT(Dubwool)
         LEARNSETS(Dubwool),
     },
 #endif //P_FAMILY_WOOLOO
@@ -1324,7 +1324,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Chewtle),
         ICON(Chewtle, 0),
-        FOOTPRINT(Chewtle),
+        FOOTPRINT(Chewtle)
         LEARNSETS(Chewtle),
         .evolutions = EVOLUTION({EVO_LEVEL, 22, SPECIES_DREDNAW}),
     },
@@ -1351,7 +1351,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         .cryId = CRY_DREDNAW,                                                           \
         .natDexNum = NATIONAL_DEX_DREDNAW,                                              \
         .categoryName = _("Bite"),                                                      \
-        FOOTPRINT(Drednaw),                                                             \
+        FOOTPRINT(Drednaw)                                                              \
         LEARNSETS(Drednaw),                                                             \
         .formSpeciesIdTable = sDrednawFormSpeciesIdTable,                               \
         .formChangeTable = sDrednawFormChangeTable
@@ -1453,7 +1453,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Yamper),
         ICON(Yamper, 1),
-        FOOTPRINT(Yamper),
+        FOOTPRINT(Yamper)
         LEARNSETS(Yamper),
         .evolutions = EVOLUTION({EVO_LEVEL, 25, SPECIES_BOLTUND}),
     },
@@ -1501,7 +1501,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Boltund),
         ICON(Boltund, 1),
-        FOOTPRINT(Boltund),
+        FOOTPRINT(Boltund)
         LEARNSETS(Boltund),
     },
 #endif //P_FAMILY_YAMPER
@@ -1550,7 +1550,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Rolycoly),
         ICON(Rolycoly, 0),
-        FOOTPRINT(Rolycoly),
+        FOOTPRINT(Rolycoly)
         LEARNSETS(Rolycoly),
         .evolutions = EVOLUTION({EVO_LEVEL, 18, SPECIES_CARKOL}),
     },
@@ -1597,7 +1597,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Carkol),
         ICON(Carkol, 0),
-        FOOTPRINT(Carkol),
+        FOOTPRINT(Carkol)
         LEARNSETS(Carkol),
         .evolutions = EVOLUTION({EVO_LEVEL, 34, SPECIES_COALOSSAL}),
     },
@@ -1624,7 +1624,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         .cryId = CRY_COALOSSAL,                                                         \
         .natDexNum = NATIONAL_DEX_COALOSSAL,                                            \
         .categoryName = _("Coal"),                                                      \
-        FOOTPRINT(Coalossal),                                                           \
+        FOOTPRINT(Coalossal)                                                            \
         LEARNSETS(Coalossal),                                                           \
         .formSpeciesIdTable = sCoalossalFormSpeciesIdTable,                             \
         .formChangeTable = sCoalossalFormChangeTable
@@ -1727,7 +1727,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Applin),
         ICON(Applin, 1),
-        FOOTPRINT(Applin),
+        FOOTPRINT(Applin)
         LEARNSETS(Applin),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_TART_APPLE, SPECIES_FLAPPLE},
                                 {EVO_ITEM, ITEM_SWEET_APPLE, SPECIES_APPLETUN},
@@ -1756,7 +1756,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         .cryId = CRY_FLAPPLE,                                               \
         .natDexNum = NATIONAL_DEX_FLAPPLE,                                  \
         .categoryName = _("Apple Wing"),                                    \
-        FOOTPRINT(Flapple),                                                 \
+        FOOTPRINT(Flapple)                                                  \
         LEARNSETS(Flapple),                                                 \
         .formSpeciesIdTable = sFlappleFormSpeciesIdTable,                   \
         .formChangeTable = sFlappleFormChangeTable
@@ -1836,7 +1836,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         .cryId = CRY_APPLETUN,                                                  \
         .natDexNum = NATIONAL_DEX_APPLETUN,                                     \
         .categoryName = _("Apple Nectar"),                                      \
-        FOOTPRINT(Appletun),                                                    \
+        FOOTPRINT(Appletun)                                                     \
         LEARNSETS(Appletun),                                                    \
         .formSpeciesIdTable = sAppletunFormSpeciesIdTable,                      \
         .formChangeTable = sAppletunFormChangeTable
@@ -1936,7 +1936,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Dipplin),
         ICON(Dipplin, 1),
-        //FOOTPRINT(Dipplin),
+        //FOOTPRINT(Dipplin)
         LEARNSETS(Dipplin),
         .evolutions = EVOLUTION({EVO_MOVE, MOVE_DRAGON_CHEER, SPECIES_HYDRAPPLE}),
     },
@@ -1984,7 +1984,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         //PALETTES(Hydrapple),
         //ICON(Hydrapple, 0),
-        //FOOTPRINT(Hydrapple),
+        //FOOTPRINT(Hydrapple)
         LEARNSETS(Hydrapple),
     },
 #endif //P_GEN_9_CROSS_EVOS
@@ -2033,7 +2033,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Silicobra),
         ICON(Silicobra, 1),
-        FOOTPRINT(Silicobra),
+        FOOTPRINT(Silicobra)
         LEARNSETS(Silicobra),
         .evolutions = EVOLUTION({EVO_LEVEL, 36, SPECIES_SANDACONDA}),
     },
@@ -2060,7 +2060,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         .cryId = CRY_SANDACONDA,                                                    \
         .natDexNum = NATIONAL_DEX_SANDACONDA,                                       \
         .categoryName = _("Sand Snake"),                                            \
-        FOOTPRINT(Sandaconda),                                                      \
+        FOOTPRINT(Sandaconda)                                                       \
         LEARNSETS(Sandaconda),                                                      \
         .formSpeciesIdTable = sSandacondaFormSpeciesIdTable,                        \
         .formChangeTable = sSandacondaFormChangeTable
@@ -2146,7 +2146,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         .pokemonOffset = 7,                                     \
         .trainerScale = 257,                                    \
         .trainerOffset = 0,                                     \
-        FOOTPRINT(Cramorant),                                   \
+        FOOTPRINT(Cramorant)                                    \
         LEARNSETS(Cramorant),                                   \
         .formSpeciesIdTable = sCramorantFormSpeciesIdTable,     \
         .formChangeTable = sCramorantFormChangeTable
@@ -2252,7 +2252,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Arrokuda),
         ICON(Arrokuda, 2),
-        FOOTPRINT(Arrokuda),
+        FOOTPRINT(Arrokuda)
         LEARNSETS(Arrokuda),
         .evolutions = EVOLUTION({EVO_LEVEL, 26, SPECIES_BARRASKEWDA}),
     },
@@ -2300,7 +2300,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Barraskewda),
         ICON(Barraskewda, 2),
-        FOOTPRINT(Barraskewda),
+        FOOTPRINT(Barraskewda)
         LEARNSETS(Barraskewda),
     },
 #endif //P_FAMILY_ARROKUDA
@@ -2349,7 +2349,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Toxel),
         ICON(Toxel, 2),
-        FOOTPRINT(Toxel),
+        FOOTPRINT(Toxel)
         LEARNSETS(Toxel),
         .evolutions = EVOLUTION({EVO_LEVEL_NATURE_AMPED, 30, SPECIES_TOXTRICITY_AMPED},
                                 {EVO_LEVEL_NATURE_LOW_KEY, 30, SPECIES_TOXTRICITY_LOW_KEY}),
@@ -2403,7 +2403,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(ToxtricityAmped),
         ICON(ToxtricityAmped, 2),
-        FOOTPRINT(Toxtricity),
+        FOOTPRINT(Toxtricity)
         LEARNSETS(ToxtricityAmped),
 
     },
@@ -2430,7 +2430,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(ToxtricityGigantamax),
         ICON(ToxtricityGigantamax, 0),
-        FOOTPRINT(Toxtricity),
+        FOOTPRINT(Toxtricity)
         LEARNSETS(ToxtricityAmped),
         .isGigantamax = TRUE,
     },
@@ -2460,7 +2460,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(ToxtricityLowKey),
         ICON(ToxtricityLowKey, 2),
-        FOOTPRINT(Toxtricity),
+        FOOTPRINT(Toxtricity)
         LEARNSETS(ToxtricityLowKey),
     },
 
@@ -2486,7 +2486,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(ToxtricityGigantamax),
         ICON(ToxtricityGigantamax, 0),
-        FOOTPRINT(Toxtricity),
+        FOOTPRINT(Toxtricity)
         LEARNSETS(ToxtricityLowKey),
         .isGigantamax = TRUE,
     },
@@ -2536,7 +2536,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Sizzlipede),
         ICON(Sizzlipede, 0),
-        FOOTPRINT(Sizzlipede),
+        FOOTPRINT(Sizzlipede)
         LEARNSETS(Sizzlipede),
         .evolutions = EVOLUTION({EVO_LEVEL, 28, SPECIES_CENTISKORCH}),
     },
@@ -2563,7 +2563,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         .cryId = CRY_CENTISKORCH,                                                       \
         .natDexNum = NATIONAL_DEX_CENTISKORCH,                                          \
         .categoryName = _("Radiator"),                                                  \
-        FOOTPRINT(Centiskorch),                                                         \
+        FOOTPRINT(Centiskorch)                                                          \
         LEARNSETS(Centiskorch),                                                         \
         .formSpeciesIdTable = sCentiskorchFormSpeciesIdTable,                           \
         .formChangeTable = sCentiskorchFormChangeTable
@@ -2666,7 +2666,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Clobbopus),
         ICON(Clobbopus, 0),
-        FOOTPRINT(Clobbopus),
+        FOOTPRINT(Clobbopus)
         LEARNSETS(Clobbopus),
         .evolutions = EVOLUTION({EVO_MOVE, MOVE_TAUNT, SPECIES_GRAPPLOCT}),
     },
@@ -2713,7 +2713,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Grapploct),
         ICON(Grapploct, 2),
-        FOOTPRINT(Grapploct),
+        FOOTPRINT(Grapploct)
         LEARNSETS(Grapploct),
     },
 #endif //P_FAMILY_CLOBBOPUS
@@ -2754,7 +2754,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         .backPicYOffset = 16,                                                   \
         PALETTES(Sinistea),                                                     \
         ICON(Sinistea, 2),                                                      \
-        FOOTPRINT(Sinistea),                                                    \
+        FOOTPRINT(Sinistea)                                                     \
         LEARNSETS(Sinistea),                                                    \
         .formSpeciesIdTable = sSinisteaFormSpeciesIdTable
         //.frontAnimId = ANIM_V_SQUISH_AND_BOUNCE,
@@ -2818,7 +2818,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         .backPicYOffset = 13,                                                   \
         PALETTES(Polteageist),                                                  \
         ICON(Polteageist, 2),                                                   \
-        FOOTPRINT(Polteageist),                                                 \
+        FOOTPRINT(Polteageist)                                                  \
         LEARNSETS(Polteageist),                                                 \
         .formSpeciesIdTable = sPolteageistFormSpeciesIdTable
         //.frontAnimId = ANIM_V_SQUISH_AND_BOUNCE,
@@ -2890,7 +2890,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Hatenna),
         ICON(Hatenna, 0),
-        FOOTPRINT(Hatenna),
+        FOOTPRINT(Hatenna)
         LEARNSETS(Hatenna),
         .evolutions = EVOLUTION({EVO_LEVEL, 32, SPECIES_HATTREM}),
     },
@@ -2937,7 +2937,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Hattrem),
         ICON(Hattrem, 0),
-        FOOTPRINT(Hattrem),
+        FOOTPRINT(Hattrem)
         LEARNSETS(Hattrem),
         .evolutions = EVOLUTION({EVO_LEVEL, 42, SPECIES_HATTERENE}),
     },
@@ -2964,7 +2964,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         .cryId = CRY_HATTERENE,                                                         \
         .natDexNum = NATIONAL_DEX_HATTERENE,                                            \
         .categoryName = _("Silent"),                                                    \
-        FOOTPRINT(Hatterene),                                                           \
+        FOOTPRINT(Hatterene)                                                            \
         LEARNSETS(Hatterene),                                                           \
         .formSpeciesIdTable = sHattereneFormSpeciesIdTable,                             \
         .formChangeTable = sHattereneFormChangeTable
@@ -3066,7 +3066,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Impidimp),
         ICON(Impidimp, 0),
-        FOOTPRINT(Impidimp),
+        FOOTPRINT(Impidimp)
         LEARNSETS(Impidimp),
         .evolutions = EVOLUTION({EVO_LEVEL, 32, SPECIES_MORGREM}),
     },
@@ -3114,7 +3114,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Morgrem),
         ICON(Morgrem, 0),
-        FOOTPRINT(Morgrem),
+        FOOTPRINT(Morgrem)
         LEARNSETS(Morgrem),
         .evolutions = EVOLUTION({EVO_LEVEL, 42, SPECIES_GRIMMSNARL}),
     },
@@ -3141,7 +3141,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         .cryId = CRY_GRIMMSNARL,                                                \
         .natDexNum = NATIONAL_DEX_GRIMMSNARL,                                   \
         .categoryName = _("Bulk Up"),                                           \
-        FOOTPRINT(Grimmsnarl),                                                  \
+        FOOTPRINT(Grimmsnarl)                                                   \
         LEARNSETS(Grimmsnarl),                                                  \
         .formSpeciesIdTable = sGrimmsnarlFormSpeciesIdTable,                    \
         .formChangeTable = sGrimmsnarlFormChangeTable
@@ -3243,7 +3243,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Milcery),
         ICON(Milcery, 1),
-        FOOTPRINT(Milcery),
+        FOOTPRINT(Milcery)
         LEARNSETS(Milcery),
         .evolutions = EVOLUTION({EVO_LEVEL, 0, SPECIES_ALCREMIE_STRAWBERRY_VANILLA_CREAM},
                                 {EVO_LEVEL, 0, SPECIES_ALCREMIE_STRAWBERRY_RUBY_CREAM},
@@ -3297,7 +3297,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         .palette = gMonPalette_Alcremie ##sweet##cream,     \
         .shinyPalette = gMonShinyPalette_Alcremie ##sweet,  \
         ICON(AlcremieStrawberryVanillaCream, 1),            \
-        FOOTPRINT(Alcremie),                                \
+        FOOTPRINT(Alcremie)                                 \
         LEARNSETS(Alcremie),                                \
         .formSpeciesIdTable = sAlcremieFormSpeciesIdTable,  \
         .formChangeTable = sAlcremieFormChangeTable,        \
@@ -3398,7 +3398,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(AlcremieGigantamax),
         ICON(AlcremieGigantamax, 1),
-        FOOTPRINT(Alcremie),
+        FOOTPRINT(Alcremie)
         LEARNSETS(Alcremie),
         .formSpeciesIdTable = sAlcremieFormSpeciesIdTable,
         .formChangeTable = sAlcremieFormChangeTable,
@@ -3449,7 +3449,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Falinks),
         ICON(Falinks, 0),
-        FOOTPRINT(Falinks),
+        FOOTPRINT(Falinks)
         LEARNSETS(Falinks),
     },
 #endif //P_FAMILY_FALINKS
@@ -3497,7 +3497,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Pincurchin),
         ICON(Pincurchin, 0),
-        FOOTPRINT(Pincurchin),
+        FOOTPRINT(Pincurchin)
         LEARNSETS(Pincurchin),
     },
 #endif //P_FAMILY_PINCURCHIN
@@ -3547,7 +3547,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Snom),
         ICON(Snom, 0),
-        FOOTPRINT(Snom),
+        FOOTPRINT(Snom)
         LEARNSETS(Snom),
         .evolutions = EVOLUTION({EVO_FRIENDSHIP_NIGHT, 0, SPECIES_FROSMOTH}),
     },
@@ -3596,7 +3596,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Frosmoth),
         ICON(Frosmoth, 0),
-        FOOTPRINT(Frosmoth),
+        FOOTPRINT(Frosmoth)
         LEARNSETS(Frosmoth),
     },
 #endif //P_FAMILY_SNOM
@@ -3645,7 +3645,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Stonjourner),
         ICON(Stonjourner, 2),
-        FOOTPRINT(Stonjourner),
+        FOOTPRINT(Stonjourner)
         LEARNSETS(Stonjourner),
     },
 #endif //P_FAMILY_STONJOURNER
@@ -3672,7 +3672,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         .pokemonOffset = 2,                                     \
         .trainerScale = 262,                                    \
         .trainerOffset = 0,                                     \
-        FOOTPRINT(Eiscue),                                      \
+        FOOTPRINT(Eiscue)                                       \
         LEARNSETS(Eiscue),                                      \
         .formSpeciesIdTable = sEiscueFormSpeciesIdTable,        \
         .formChangeTable = sEiscueFormChangeTable
@@ -3749,7 +3749,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         .pokemonOffset = 8,                                 \
         .trainerScale = 256,                                \
         .trainerOffset = 0,                                 \
-        FOOTPRINT(Indeedee),                                \
+        FOOTPRINT(Indeedee)                                 \
         .formSpeciesIdTable = sIndeedeeFormSpeciesIdTable
 
     [SPECIES_INDEEDEE_MALE] =
@@ -3841,7 +3841,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         .pokemonOffset = 13,                                    \
         .trainerScale = 256,                                    \
         .trainerOffset = 0,                                     \
-        FOOTPRINT(Morpeko),                                     \
+        FOOTPRINT(Morpeko)                                      \
         LEARNSETS(Morpeko),                                     \
         .formSpeciesIdTable = sMorpekoFormSpeciesIdTable,       \
         .formChangeTable = sMorpekoFormChangeTable
@@ -3932,7 +3932,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Cufant),
         ICON(Cufant, 0),
-        FOOTPRINT(Cufant),
+        FOOTPRINT(Cufant)
         LEARNSETS(Cufant),
         .evolutions = EVOLUTION({EVO_LEVEL, 34, SPECIES_COPPERAJAH}),
     },
@@ -3960,7 +3960,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         .cryId = CRY_COPPERAJAH,                                                    \
         .natDexNum = NATIONAL_DEX_COPPERAJAH,                                       \
         .categoryName = _("Copperderm"),                                            \
-        FOOTPRINT(Copperajah),                                                      \
+        FOOTPRINT(Copperajah)                                                       \
         LEARNSETS(Copperajah),                                                      \
         .formSpeciesIdTable = sCopperajahFormSpeciesIdTable,                        \
         .formChangeTable = sCopperajahFormChangeTable
@@ -4062,7 +4062,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Dracozolt),
         ICON(Dracozolt, 1),
-        FOOTPRINT(Dracozolt),
+        FOOTPRINT(Dracozolt)
         LEARNSETS(Dracozolt),
     },
 #endif //P_FAMILY_DRACOZOLT
@@ -4110,7 +4110,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Arctozolt),
         ICON(Arctozolt, 2),
-        FOOTPRINT(Arctozolt),
+        FOOTPRINT(Arctozolt)
         LEARNSETS(Arctozolt),
     },
 #endif //P_FAMILY_ARCTOZOLT
@@ -4159,7 +4159,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Dracovish),
         ICON(Dracovish, 0),
-        FOOTPRINT(Dracovish),
+        FOOTPRINT(Dracovish)
         LEARNSETS(Dracovish),
     },
 #endif //P_FAMILY_DRACOVISH
@@ -4208,7 +4208,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Arctovish),
         ICON(Arctovish, 0),
-        FOOTPRINT(Arctovish),
+        FOOTPRINT(Arctovish)
         LEARNSETS(Arctovish),
     },
 #endif //P_FAMILY_ARCTOVISH
@@ -4236,7 +4236,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         .cryId = CRY_DURALUDON,                                                         \
         .natDexNum = NATIONAL_DEX_DURALUDON,                                            \
         .categoryName = _("Alloy"),                                                     \
-        FOOTPRINT(Duraludon),                                                           \
+        FOOTPRINT(Duraludon)                                                            \
         LEARNSETS(Duraludon),                                                           \
         .formSpeciesIdTable = sDuraludonFormSpeciesIdTable,                             \
         .formChangeTable = sDuraludonFormChangeTable
@@ -4338,7 +4338,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         //PALETTES(Archaludon),
         //ICON(Archaludon, 0),
-        //FOOTPRINT(Archaludon),
+        //FOOTPRINT(Archaludon)
         LEARNSETS(Archaludon),
     },
 #endif //P_GEN_9_CROSS_EVOS
@@ -4389,7 +4389,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Dreepy),
         ICON(Dreepy, 0),
-        FOOTPRINT(Dreepy),
+        FOOTPRINT(Dreepy)
         LEARNSETS(Dreepy),
         .evolutions = EVOLUTION({EVO_LEVEL, 50, SPECIES_DRAKLOAK}),
     },
@@ -4437,7 +4437,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Drakloak),
         ICON(Drakloak, 0),
-        FOOTPRINT(Drakloak),
+        FOOTPRINT(Drakloak)
         LEARNSETS(Drakloak),
         .evolutions = EVOLUTION({EVO_LEVEL, 60, SPECIES_DRAGAPULT}),
     },
@@ -4486,7 +4486,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Dragapult),
         ICON(Dragapult, 0),
-        FOOTPRINT(Dragapult),
+        FOOTPRINT(Dragapult)
         LEARNSETS(Dragapult),
     },
 #endif //P_FAMILY_DREEPY
@@ -4511,7 +4511,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         .pokemonOffset = 7,                                                             \
         .trainerScale = 256,                                                            \
         .trainerOffset = 0,                                                             \
-        FOOTPRINT(Zacian),                                                              \
+        FOOTPRINT(Zacian)                                                               \
         LEARNSETS(Zacian),                                                              \
         .formSpeciesIdTable = sZacianFormSpeciesIdTable,                                \
         .formChangeTable = sZacianFormChangeTable
@@ -4594,7 +4594,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         .pokemonOffset = 7,                                                             \
         .trainerScale = 256,                                                            \
         .trainerOffset = 0,                                                             \
-        FOOTPRINT(Zamazenta),                                                           \
+        FOOTPRINT(Zamazenta)                                                            \
         LEARNSETS(Zamazenta),                                                           \
         .formSpeciesIdTable = sZamazentaFormSpeciesIdTable,                             \
         .formChangeTable = sZamazentaFormChangeTable
@@ -4674,7 +4674,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         .speciesName = _("Eternatus"),                                                  \
         .natDexNum = NATIONAL_DEX_ETERNATUS,                                            \
         .categoryName = _("Gigantic"),                                                  \
-        FOOTPRINT(Eternatus),                                                           \
+        FOOTPRINT(Eternatus)                                                            \
         LEARNSETS(Eternatus),                                                           \
         .formSpeciesIdTable = sEternatusFormSpeciesIdTable
 
@@ -4791,7 +4791,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Kubfu),
         ICON(Kubfu, 1),
-        FOOTPRINT(Kubfu),
+        FOOTPRINT(Kubfu)
         LEARNSETS(Kubfu),
         .evolutions = EVOLUTION({EVO_DARK_SCROLL, 0, SPECIES_URSHIFU_SINGLE_STRIKE_STYLE},
                                 {EVO_ITEM, ITEM_SCROLL_OF_DARKNESS, SPECIES_URSHIFU_SINGLE_STRIKE_STYLE},
@@ -4820,7 +4820,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         .speciesName = _("Urshifu"),                                                    \
         .natDexNum = NATIONAL_DEX_URSHIFU,                                              \
         .categoryName = _("Wushu"),                                                     \
-        FOOTPRINT(Urshifu),                                                             \
+        FOOTPRINT(Urshifu)                                                              \
         .formSpeciesIdTable = sUrshifuFormSpeciesIdTable
 
 #define URSHIFU_SINGLE_STRIKE_STYLE_MISC_INFO       \
@@ -4975,7 +4975,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         .pokemonOffset = 2,                                                             \
         .trainerScale = 286,                                                            \
         .trainerOffset = 1,                                                             \
-        FOOTPRINT(Zarude),                                                              \
+        FOOTPRINT(Zarude)                                                               \
         LEARNSETS(Zarude),                                                              \
         .formSpeciesIdTable = sZarudeFormSpeciesIdTable
 
@@ -5062,7 +5062,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Regieleki),
         ICON(Regieleki, 0),
-        FOOTPRINT(Regieleki),
+        FOOTPRINT(Regieleki)
         LEARNSETS(Regieleki),
         .isLegendary = TRUE,
     },
@@ -5114,7 +5114,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Regidrago),
         ICON(Regidrago, 0),
-        FOOTPRINT(Regidrago),
+        FOOTPRINT(Regidrago)
         LEARNSETS(Regidrago),
     },
 #endif //P_FAMILY_REGIDRAGO
@@ -5163,7 +5163,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Glastrier),
         ICON(Glastrier, 0),
-        FOOTPRINT(Glastrier),
+        FOOTPRINT(Glastrier)
         LEARNSETS(Glastrier),
     },
 #endif //P_FAMILY_GLASTRIER
@@ -5213,7 +5213,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Spectrier),
         ICON(Spectrier, 0),
-        FOOTPRINT(Spectrier),
+        FOOTPRINT(Spectrier)
         LEARNSETS(Spectrier),
     },
 #endif //P_FAMILY_SPECTRIER
@@ -5221,7 +5221,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
 #define CALYREX_MISC_INFO                                   \
         .speciesName = _("Calyrex"),                        \
         .natDexNum = NATIONAL_DEX_CALYREX,                  \
-        FOOTPRINT(Calyrex),                                 \
+        FOOTPRINT(Calyrex)                                  \
         .formSpeciesIdTable = sCalyrexFormSpeciesIdTable,   \
         .isLegendary = TRUE
 
@@ -5417,7 +5417,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(EnamorusIncarnate),
         ICON(EnamorusIncarnate, 1),
-        //FOOTPRINT(EnamorusIncarnate),
+        //FOOTPRINT(EnamorusIncarnate)
     },
 
     [SPECIES_ENAMORUS_THERIAN] =
@@ -5445,7 +5445,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(EnamorusTherian),
         ICON(EnamorusTherian, 1),
-        //FOOTPRINT(Enamorus),
+        //FOOTPRINT(Enamorus)
     },
 #endif //P_FAMILY_ENAMORUS
 

--- a/src/data/pokemon/species_info/gen_9.h
+++ b/src/data/pokemon/species_info/gen_9.h
@@ -47,7 +47,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Sprigatito),
         ICON(Sprigatito, 4),
-        //FOOTPRINT(Sprigatito),
+        //FOOTPRINT(Sprigatito)
         LEARNSETS(Sprigatito),
         .evolutions = EVOLUTION({EVO_LEVEL, 16, SPECIES_FLORAGATO}),
     },
@@ -95,7 +95,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Floragato),
         ICON(Floragato, 1),
-        //FOOTPRINT(Floragato),
+        //FOOTPRINT(Floragato)
         LEARNSETS(Floragato),
         .evolutions = EVOLUTION({EVO_LEVEL, 36, SPECIES_MEOWSCARADA}),
     },
@@ -143,7 +143,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Meowscarada),
         ICON(Meowscarada, 1),
-        //FOOTPRINT(Meowscarada),
+        //FOOTPRINT(Meowscarada)
         LEARNSETS(Meowscarada),
     },
 #endif //P_FAMILY_SPRIGATITO
@@ -192,7 +192,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Fuecoco),
         ICON(Fuecoco, 0),
-        //FOOTPRINT(Fuecoco),
+        //FOOTPRINT(Fuecoco)
         LEARNSETS(Fuecoco),
         .evolutions = EVOLUTION({EVO_LEVEL, 16, SPECIES_CROCALOR}),
     },
@@ -240,7 +240,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Crocalor),
         ICON(Crocalor, 0),
-        //FOOTPRINT(Crocalor),
+        //FOOTPRINT(Crocalor)
         LEARNSETS(Crocalor),
         .evolutions = EVOLUTION({EVO_LEVEL, 36, SPECIES_SKELEDIRGE}),
     },
@@ -288,7 +288,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Skeledirge),
         ICON(Skeledirge, 0),
-        //FOOTPRINT(Skeledirge),
+        //FOOTPRINT(Skeledirge)
         LEARNSETS(Skeledirge),
     },
 #endif //P_FAMILY_FUECOCO
@@ -337,7 +337,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Quaxly),
         ICON(Quaxly, 2),
-        //FOOTPRINT(Quaxly),
+        //FOOTPRINT(Quaxly)
         LEARNSETS(Quaxly),
         .evolutions = EVOLUTION({EVO_LEVEL, 16, SPECIES_QUAXWELL}),
     },
@@ -385,7 +385,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Quaxwell),
         ICON(Quaxwell, 0),
-        //FOOTPRINT(Quaxwell),
+        //FOOTPRINT(Quaxwell)
         LEARNSETS(Quaxwell),
         .evolutions = EVOLUTION({EVO_LEVEL, 36, SPECIES_QUAQUAVAL}),
     },
@@ -433,7 +433,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Quaquaval),
         ICON(Quaquaval, 0),
-        //FOOTPRINT(Quaquaval),
+        //FOOTPRINT(Quaquaval)
         LEARNSETS(Quaquaval),
     },
 #endif //P_FAMILY_QUAXLY
@@ -482,7 +482,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Lechonk),
         ICON(Lechonk, 1),
-        //FOOTPRINT(Lechonk),
+        //FOOTPRINT(Lechonk)
         LEARNSETS(Lechonk),
         .evolutions = EVOLUTION({EVO_LEVEL_MALE, 18, SPECIES_OINKOLOGNE_MALE},
                                 {EVO_LEVEL_FEMALE, 18, SPECIES_OINKOLOGNE_FEMALE}),
@@ -534,7 +534,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(OinkologneMale),
         ICON(OinkologneMale, 1),
-        //FOOTPRINT(Oinkologne),
+        //FOOTPRINT(Oinkologne)
         LEARNSETS(OinkologneMale),
 
     },
@@ -565,7 +565,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(OinkologneFemale),
         ICON(OinkologneFemale, 2),
-        //FOOTPRINT(Oinkologne),
+        //FOOTPRINT(Oinkologne)
         LEARNSETS(OinkologneFemale),
     },
 #endif //P_FAMILY_LECHONK
@@ -614,7 +614,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Tarountula),
         ICON(Tarountula, 1),
-        //FOOTPRINT(Tarountula),
+        //FOOTPRINT(Tarountula)
         LEARNSETS(Tarountula),
         .evolutions = EVOLUTION({EVO_LEVEL, 15, SPECIES_SPIDOPS}),
     },
@@ -662,7 +662,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Spidops),
         ICON(Spidops, 1),
-        //FOOTPRINT(Spidops),
+        //FOOTPRINT(Spidops)
         LEARNSETS(Spidops),
     },
 #endif //P_FAMILY_TAROUNTULA
@@ -711,7 +711,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Nymble),
         ICON(Nymble, 0),
-        //FOOTPRINT(Nymble),
+        //FOOTPRINT(Nymble)
         LEARNSETS(Nymble),
         .evolutions = EVOLUTION({EVO_LEVEL, 24, SPECIES_LOKIX}),
     },
@@ -759,7 +759,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Lokix),
         ICON(Lokix, 0),
-        //FOOTPRINT(Lokix),
+        //FOOTPRINT(Lokix)
         LEARNSETS(Lokix),
     },
 #endif //P_FAMILY_NYMBLE
@@ -808,7 +808,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Pawmi),
         ICON(Pawmi, 3),
-        //FOOTPRINT(Pawmi),
+        //FOOTPRINT(Pawmi)
         LEARNSETS(Pawmi),
         .evolutions = EVOLUTION({EVO_LEVEL, 18, SPECIES_PAWMO}),
     },
@@ -856,7 +856,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Pawmo),
         ICON(Pawmo, 3),
-        //FOOTPRINT(Pawmo),
+        //FOOTPRINT(Pawmo)
         LEARNSETS(Pawmo),
         .evolutions = EVOLUTION({EVO_NONE, 0, SPECIES_PAWMOT}),
     },
@@ -904,7 +904,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Pawmot),
         ICON(Pawmot, 3),
-        //FOOTPRINT(Pawmot),
+        //FOOTPRINT(Pawmot)
         LEARNSETS(Pawmot),
     },
 #endif //P_FAMILY_PAWMI
@@ -953,7 +953,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Tandemaus),
         ICON(Tandemaus, 0),
-        //FOOTPRINT(Tandemaus),
+        //FOOTPRINT(Tandemaus)
         LEARNSETS(Tandemaus),
         .evolutions = EVOLUTION({EVO_LEVEL_FAMILY_OF_FOUR, 25, SPECIES_MAUSHOLD_FAMILY_OF_FOUR},
                                 {EVO_LEVEL_FAMILY_OF_THREE, 25, SPECIES_MAUSHOLD_FAMILY_OF_THREE}),
@@ -993,7 +993,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         .formSpeciesIdTable = sMausholdFormSpeciesIdTable
         //.frontAnimId = ANIM_V_SQUISH_AND_BOUNCE,
         //.backAnimId = BACK_ANIM_NONE,
-        //FOOTPRINT(Maushold),
+        //FOOTPRINT(Maushold)
 
     [SPECIES_MAUSHOLD_FAMILY_OF_THREE] =
     {
@@ -1069,7 +1069,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Fidough),
         ICON(Fidough, 1),
-        //FOOTPRINT(Fidough),
+        //FOOTPRINT(Fidough)
         LEARNSETS(Fidough),
         .evolutions = EVOLUTION({EVO_LEVEL, 26, SPECIES_DACHSBUN}),
     },
@@ -1117,7 +1117,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Dachsbun),
         ICON(Dachsbun, 0), // TODO
-        //FOOTPRINT(Dachsbun),
+        //FOOTPRINT(Dachsbun)
         LEARNSETS(Dachsbun),
     },
 #endif //P_FAMILY_FIDOUGH
@@ -1166,7 +1166,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Smoliv),
         ICON(Smoliv, 1),
-        //FOOTPRINT(Smoliv),
+        //FOOTPRINT(Smoliv)
         LEARNSETS(Smoliv),
         .evolutions = EVOLUTION({EVO_LEVEL, 25, SPECIES_DOLLIV}),
     },
@@ -1214,7 +1214,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Dolliv),
         ICON(Dolliv, 1),
-        //FOOTPRINT(Dolliv),
+        //FOOTPRINT(Dolliv)
         LEARNSETS(Dolliv),
         .evolutions = EVOLUTION({EVO_LEVEL, 35, SPECIES_ARBOLIVA}),
     },
@@ -1262,7 +1262,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Arboliva),
         ICON(Arboliva, 5),
-        //FOOTPRINT(Arboliva),
+        //FOOTPRINT(Arboliva)
         LEARNSETS(Arboliva),
     },
 #endif //P_FAMILY_SMOLIV
@@ -1303,7 +1303,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         .formSpeciesIdTable = sSquawkabillyFormSpeciesIdTable
         //.frontAnimId = ANIM_V_SQUISH_AND_BOUNCE,
         //.backAnimId = BACK_ANIM_NONE,
-        //FOOTPRINT(Squawkabilly),
+        //FOOTPRINT(Squawkabilly)
 
     [SPECIES_SQUAWKABILLY_GREEN_PLUMAGE] =
     {
@@ -1406,7 +1406,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Nacli),
         ICON(Nacli, 2),
-        //FOOTPRINT(Nacli),
+        //FOOTPRINT(Nacli)
         LEARNSETS(Nacli),
         .evolutions = EVOLUTION({EVO_LEVEL, 24, SPECIES_NACLSTACK}),
     },
@@ -1454,7 +1454,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Naclstack),
         ICON(Naclstack, 2), // TODO: recolor
-        //FOOTPRINT(Naclstack),
+        //FOOTPRINT(Naclstack)
         LEARNSETS(Naclstack),
         .evolutions = EVOLUTION({EVO_LEVEL, 38, SPECIES_GARGANACL}),
     },
@@ -1502,7 +1502,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Garganacl),
         ICON(Garganacl, 2),
-        //FOOTPRINT(Garganacl),
+        //FOOTPRINT(Garganacl)
         LEARNSETS(Garganacl),
     },
 #endif //P_FAMILY_NACLI
@@ -1551,7 +1551,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Charcadet),
         ICON(Charcadet, 1),
-        //FOOTPRINT(Charcadet),
+        //FOOTPRINT(Charcadet)
         LEARNSETS(Charcadet),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_AUSPICIOUS_ARMOR, SPECIES_ARMAROUGE},
                                 {EVO_ITEM, ITEM_MALICIOUS_ARMOR, SPECIES_CERULEDGE}),
@@ -1600,7 +1600,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Armarouge),
         ICON(Armarouge, 0),
-        //FOOTPRINT(Armarouge),
+        //FOOTPRINT(Armarouge)
         LEARNSETS(Armarouge),
     },
 
@@ -1647,7 +1647,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Ceruledge),
         ICON(Ceruledge, 2),
-        //FOOTPRINT(Ceruledge),
+        //FOOTPRINT(Ceruledge)
         LEARNSETS(Ceruledge),
     },
 #endif //P_FAMILY_CHARCADET
@@ -1697,7 +1697,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Tadbulb),
         ICON(Tadbulb, 5), // TODO: Redo to 0
-        //FOOTPRINT(Tadbulb),
+        //FOOTPRINT(Tadbulb)
         LEARNSETS(Tadbulb),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_THUNDER_STONE, SPECIES_BELLIBOLT}),
     },
@@ -1745,7 +1745,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Bellibolt),
         ICON(Bellibolt, 0),
-        //FOOTPRINT(Bellibolt),
+        //FOOTPRINT(Bellibolt)
         LEARNSETS(Bellibolt),
     },
 #endif //P_FAMILY_TADBULB
@@ -1794,7 +1794,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Wattrel),
         ICON(Wattrel, 3),
-        //FOOTPRINT(Wattrel),
+        //FOOTPRINT(Wattrel)
         LEARNSETS(Wattrel),
         .evolutions = EVOLUTION({EVO_LEVEL, 25, SPECIES_KILOWATTREL}),
     },
@@ -1842,7 +1842,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Kilowattrel),
         ICON(Kilowattrel, 3),
-        //FOOTPRINT(Kilowattrel),
+        //FOOTPRINT(Kilowattrel)
         LEARNSETS(Kilowattrel),
     },
 #endif //P_FAMILY_WATTREL
@@ -1891,7 +1891,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Maschiff),
         ICON(Maschiff, 3),
-        //FOOTPRINT(Maschiff),
+        //FOOTPRINT(Maschiff)
         LEARNSETS(Maschiff),
         .evolutions = EVOLUTION({EVO_LEVEL, 30, SPECIES_MABOSSTIFF}),
     },
@@ -1939,7 +1939,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Mabosstiff),
         ICON(Mabosstiff, 5),
-        //FOOTPRINT(Mabosstiff),
+        //FOOTPRINT(Mabosstiff)
         LEARNSETS(Mabosstiff),
     },
 #endif //P_FAMILY_MASCHIFF
@@ -1988,7 +1988,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Shroodle),
         ICON(Shroodle, 0),
-        //FOOTPRINT(Shroodle),
+        //FOOTPRINT(Shroodle)
         LEARNSETS(Shroodle),
         .evolutions = EVOLUTION({EVO_LEVEL, 28, SPECIES_GRAFAIAI}),
     },
@@ -2036,7 +2036,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Grafaiai),
         ICON(Grafaiai, 0),
-        //FOOTPRINT(Grafaiai),
+        //FOOTPRINT(Grafaiai)
         LEARNSETS(Grafaiai),
     },
 #endif //P_FAMILY_SHROODLE
@@ -2085,7 +2085,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Bramblin),
         ICON(Bramblin, 3),
-        //FOOTPRINT(Bramblin),
+        //FOOTPRINT(Bramblin)
         LEARNSETS(Bramblin),
         .evolutions = EVOLUTION({EVO_NONE, 0, SPECIES_BRAMBLEGHAST}),
     },
@@ -2133,7 +2133,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Brambleghast),
         ICON(Brambleghast, 5),
-        //FOOTPRINT(Brambleghast),
+        //FOOTPRINT(Brambleghast)
         LEARNSETS(Brambleghast),
     },
 #endif //P_FAMILY_BRAMBLIN
@@ -2182,7 +2182,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Toedscool),
         ICON(Toedscool, 0),
-        //FOOTPRINT(Toedscool),
+        //FOOTPRINT(Toedscool)
         LEARNSETS(Toedscool),
         .evolutions = EVOLUTION({EVO_LEVEL, 30, SPECIES_TOEDSCRUEL}),
     },
@@ -2230,7 +2230,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Toedscruel),
         ICON(Toedscruel, 0),
-        //FOOTPRINT(Toedscruel),
+        //FOOTPRINT(Toedscruel)
         LEARNSETS(Toedscruel),
     },
 #endif //P_FAMILY_TOEDSCOOL
@@ -2279,7 +2279,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Klawf),
         ICON(Klawf, 0),
-        //FOOTPRINT(Klawf),
+        //FOOTPRINT(Klawf)
         LEARNSETS(Klawf),
     },
 #endif //P_FAMILY_KLAWF
@@ -2328,7 +2328,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Capsakid),
         ICON(Capsakid, 1),
-        //FOOTPRINT(Capsakid),
+        //FOOTPRINT(Capsakid)
         LEARNSETS(Capsakid),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_FIRE_STONE, SPECIES_SCOVILLAIN}),
     },
@@ -2376,7 +2376,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Scovillain),
         ICON(Scovillain, 1),
-        //FOOTPRINT(Scovillain),
+        //FOOTPRINT(Scovillain)
         LEARNSETS(Scovillain),
     },
 #endif //P_FAMILY_CAPSAKID
@@ -2425,7 +2425,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Rellor),
         ICON(Rellor, 5),
-        //FOOTPRINT(Rellor),
+        //FOOTPRINT(Rellor)
         LEARNSETS(Rellor),
         .evolutions = EVOLUTION({EVO_NONE, 0, SPECIES_RABSCA}),
     },
@@ -2473,7 +2473,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Rabsca),
         ICON(Rabsca, 0),
-        //FOOTPRINT(Rabsca),
+        //FOOTPRINT(Rabsca)
         LEARNSETS(Rabsca),
     },
 #endif //P_FAMILY_RELLOR
@@ -2522,7 +2522,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Flittle),
         ICON(Flittle, 3),
-        //FOOTPRINT(Flittle),
+        //FOOTPRINT(Flittle)
         LEARNSETS(Flittle),
         .evolutions = EVOLUTION({EVO_LEVEL, 35, SPECIES_ESPATHRA}),
     },
@@ -2570,7 +2570,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Espathra),
         ICON(Espathra, 5),
-        //FOOTPRINT(Espathra),
+        //FOOTPRINT(Espathra)
         LEARNSETS(Espathra),
     },
 #endif //P_FAMILY_FLITTLE
@@ -2619,7 +2619,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Tinkatink),
         ICON(Tinkatink, 1),
-        //FOOTPRINT(Tinkatink),
+        //FOOTPRINT(Tinkatink)
         LEARNSETS(Tinkatink),
         .evolutions = EVOLUTION({EVO_LEVEL, 24, SPECIES_TINKATUFF}),
     },
@@ -2667,7 +2667,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Tinkatuff),
         ICON(Tinkatuff, 4),
-        //FOOTPRINT(Tinkatuff),
+        //FOOTPRINT(Tinkatuff)
         LEARNSETS(Tinkatuff),
         .evolutions = EVOLUTION({EVO_LEVEL, 38, SPECIES_TINKATON}),
     },
@@ -2715,7 +2715,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Tinkaton),
         ICON(Tinkaton, 4),
-        //FOOTPRINT(Tinkaton),
+        //FOOTPRINT(Tinkaton)
         LEARNSETS(Tinkaton),
     },
 #endif //P_FAMILY_TINKATINK
@@ -2763,7 +2763,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Wiglett),
         ICON(Wiglett, 0),
-        //FOOTPRINT(Wiglett),
+        //FOOTPRINT(Wiglett)
         LEARNSETS(Wiglett),
         .evolutions = EVOLUTION({EVO_LEVEL, 26, SPECIES_WUGTRIO}),
     },
@@ -2810,7 +2810,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Wugtrio),
         ICON(Wugtrio, 0),
-        //FOOTPRINT(Wugtrio),
+        //FOOTPRINT(Wugtrio)
         LEARNSETS(Wugtrio),
     },
 #endif //P_FAMILY_WIGLETT
@@ -2860,7 +2860,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Bombirdier),
         ICON(Bombirdier, 0),
-        //FOOTPRINT(Bombirdier),
+        //FOOTPRINT(Bombirdier)
         LEARNSETS(Bombirdier),
     },
 #endif //P_FAMILY_BOMBIRDIER
@@ -2908,7 +2908,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Finizen),
         ICON(Finizen, 0),
-        //FOOTPRINT(Finizen),
+        //FOOTPRINT(Finizen)
         LEARNSETS(Finizen),
         .evolutions = EVOLUTION({EVO_LEVEL, 38, SPECIES_PALAFIN_ZERO}),
     },
@@ -2935,7 +2935,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         .formSpeciesIdTable = sPalafinFormSpeciesIdTable,       \
         .formChangeTable = sPalafinZeroFormChangeTable
         //.frontAnimId = ANIM_V_SQUISH_AND_BOUNCE,
-        //FOOTPRINT(Palafin),
+        //FOOTPRINT(Palafin)
 
     [SPECIES_PALAFIN_ZERO] =
     {
@@ -3038,7 +3038,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Varoom),
         ICON(Varoom, 5),
-        //FOOTPRINT(Varoom),
+        //FOOTPRINT(Varoom)
         LEARNSETS(Varoom),
         .evolutions = EVOLUTION({EVO_LEVEL, 40, SPECIES_REVAVROOM}),
     },
@@ -3086,7 +3086,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Revavroom),
         ICON(Revavroom, 5),
-        //FOOTPRINT(Revavroom),
+        //FOOTPRINT(Revavroom)
         LEARNSETS(Revavroom),
     },
 #endif //P_FAMILY_VAROOM
@@ -3135,7 +3135,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Cyclizar),
         ICON(Cyclizar, 1),
-        //FOOTPRINT(Cyclizar),
+        //FOOTPRINT(Cyclizar)
         LEARNSETS(Cyclizar),
     },
 #endif //P_FAMILY_CYCLIZAR
@@ -3184,7 +3184,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Orthworm),
         ICON(Orthworm, 4),
-        //FOOTPRINT(Orthworm),
+        //FOOTPRINT(Orthworm)
         LEARNSETS(Orthworm),
     },
 #endif //P_FAMILY_ORTHWORM
@@ -3234,7 +3234,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Glimmet),
         ICON(Glimmet, 0),
-        //FOOTPRINT(Glimmet),
+        //FOOTPRINT(Glimmet)
         LEARNSETS(Glimmet),
         .evolutions = EVOLUTION({EVO_LEVEL, 35, SPECIES_GLIMMORA}),
     },
@@ -3283,7 +3283,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Glimmora),
         ICON(Glimmora, 0),
-        //FOOTPRINT(Glimmora),
+        //FOOTPRINT(Glimmora)
         LEARNSETS(Glimmora),
     },
 #endif //P_FAMILY_GLIMMET
@@ -3332,7 +3332,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Greavard),
         ICON(Greavard, 2),
-        //FOOTPRINT(Greavard),
+        //FOOTPRINT(Greavard)
         LEARNSETS(Greavard),
         .evolutions = EVOLUTION({EVO_LEVEL_NIGHT, 30, SPECIES_HOUNDSTONE}),
     },
@@ -3380,7 +3380,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Houndstone),
         ICON(Houndstone, 5),
-        //FOOTPRINT(Houndstone),
+        //FOOTPRINT(Houndstone)
         LEARNSETS(Houndstone),
     },
 #endif //P_FAMILY_GREAVARD
@@ -3429,7 +3429,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Flamigo),
         ICON(Flamigo, 4),
-        //FOOTPRINT(Flamigo),
+        //FOOTPRINT(Flamigo)
         LEARNSETS(Flamigo),
     },
 #endif //P_FAMILY_FLAMIGO
@@ -3478,7 +3478,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Cetoddle),
         ICON(Cetoddle, 0),
-        //FOOTPRINT(Cetoddle),
+        //FOOTPRINT(Cetoddle)
         LEARNSETS(Cetoddle),
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_ICE_STONE, SPECIES_CETITAN}),
     },
@@ -3526,7 +3526,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Cetitan),
         ICON(Cetitan, 0),
-        //FOOTPRINT(Cetitan),
+        //FOOTPRINT(Cetitan)
         LEARNSETS(Cetitan),
     },
 #endif //P_FAMILY_CETODDLE
@@ -3576,7 +3576,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Veluza),
         ICON(Veluza, 4),
-        //FOOTPRINT(Veluza),
+        //FOOTPRINT(Veluza)
         LEARNSETS(Veluza),
     },
 #endif //P_FAMILY_VELUZA
@@ -3626,7 +3626,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Dondozo),
         ICON(Dondozo, 0),
-        //FOOTPRINT(Dondozo),
+        //FOOTPRINT(Dondozo)
         LEARNSETS(Dondozo),
     },
 #endif //P_FAMILY_DONDOZO
@@ -3665,7 +3665,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         .formSpeciesIdTable = sTatsugiriFormSpeciesIdTable
         //.frontAnimId = ANIM_V_SQUISH_AND_BOUNCE,
         //.backAnimId = BACK_ANIM_NONE,
-        //FOOTPRINT(Tatsugiri),
+        //FOOTPRINT(Tatsugiri)
 
     [SPECIES_TATSUGIRI_CURLY] =
     {
@@ -3759,7 +3759,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(GreatTusk),
         ICON(GreatTusk, 0),
-        //FOOTPRINT(GreatTusk),
+        //FOOTPRINT(GreatTusk)
         LEARNSETS(GreatTusk),
     },
 #endif //P_FAMILY_GREAT_TUSK
@@ -3809,7 +3809,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(ScreamTail),
         ICON(ScreamTail, 0),
-        //FOOTPRINT(ScreamTail),
+        //FOOTPRINT(ScreamTail)
         LEARNSETS(ScreamTail),
     },
 #endif //P_FAMILY_SCREAM_TAIL
@@ -3859,7 +3859,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(BruteBonnet),
         ICON(BruteBonnet, 1),
-        //FOOTPRINT(BruteBonnet),
+        //FOOTPRINT(BruteBonnet)
         LEARNSETS(BruteBonnet),
     },
 #endif //P_FAMILY_BRUTE_BONNET
@@ -3912,7 +3912,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(FlutterMane),
         ICON(FlutterMane, 4),
-        //FOOTPRINT(FlutterMane),
+        //FOOTPRINT(FlutterMane)
         LEARNSETS(FlutterMane),
     },
 #endif //P_FAMILY_FLUTTER_MANE
@@ -3961,7 +3961,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(SlitherWing),
         ICON(SlitherWing, 3),
-        //FOOTPRINT(SlitherWing),
+        //FOOTPRINT(SlitherWing)
         LEARNSETS(SlitherWing),
     },
 #endif //P_FAMILY_SLITHER_WING
@@ -4011,7 +4011,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(SandyShocks),
         ICON(SandyShocks, 0),
-        //FOOTPRINT(SandyShocks),
+        //FOOTPRINT(SandyShocks)
         LEARNSETS(SandyShocks),
     },
 #endif //P_FAMILY_SANDY_SHOCKS
@@ -4061,7 +4061,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(IronTreads),
         ICON(IronTreads, 0),
-        //FOOTPRINT(IronTreads),
+        //FOOTPRINT(IronTreads)
         LEARNSETS(IronTreads),
     },
 #endif //P_FAMILY_IRON_TREADS
@@ -4111,7 +4111,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(IronBundle),
         ICON(IronBundle, 0),
-        //FOOTPRINT(IronBundle),
+        //FOOTPRINT(IronBundle)
         LEARNSETS(IronBundle),
     },
 #endif //P_FAMILY_IRON_BUNDLE
@@ -4161,7 +4161,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(IronHands),
         ICON(IronHands, 0),
-        //FOOTPRINT(IronHands),
+        //FOOTPRINT(IronHands)
         LEARNSETS(IronHands),
     },
 #endif //P_FAMILY_IRON_HANDS
@@ -4212,7 +4212,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(IronJugulis),
         ICON(IronJugulis, 2),
-        //FOOTPRINT(IronJugulis),
+        //FOOTPRINT(IronJugulis)
         LEARNSETS(IronJugulis),
     },
 #endif //P_FAMILY_IRON_JUGULIS
@@ -4263,7 +4263,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(IronMoth),
         ICON(IronMoth, 3),
-        //FOOTPRINT(IronMoth),
+        //FOOTPRINT(IronMoth)
         LEARNSETS(IronMoth),
     },
 #endif //P_FAMILY_IRON_MOTH
@@ -4313,7 +4313,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(IronThorns),
         ICON(IronThorns, 1),
-        //FOOTPRINT(IronThorns),
+        //FOOTPRINT(IronThorns)
         LEARNSETS(IronThorns),
     },
 #endif //P_FAMILY_IRON_THORNS
@@ -4362,7 +4362,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Frigibax),
         ICON(Frigibax, 3),
-        //FOOTPRINT(Frigibax),
+        //FOOTPRINT(Frigibax)
         LEARNSETS(Frigibax),
         .evolutions = EVOLUTION({EVO_LEVEL, 35, SPECIES_ARCTIBAX}),
     },
@@ -4410,7 +4410,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Arctibax),
         ICON(Arctibax, 0),
-        //FOOTPRINT(Arctibax),
+        //FOOTPRINT(Arctibax)
         LEARNSETS(Arctibax),
         .evolutions = EVOLUTION({EVO_LEVEL, 54, SPECIES_BAXCALIBUR}),
     },
@@ -4458,7 +4458,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Baxcalibur),
         ICON(Baxcalibur, 0),
-        //FOOTPRINT(Baxcalibur),
+        //FOOTPRINT(Baxcalibur)
         LEARNSETS(Baxcalibur),
     },
 #endif //P_FAMILY_FRIGIBAX
@@ -4483,7 +4483,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         .evolutions = EVOLUTION({EVO_NONE, 0, SPECIES_GHOLDENGO})
         //.frontAnimId = ANIM_V_SQUISH_AND_BOUNCE,
         //.backAnimId = BACK_ANIM_NONE,
-        //FOOTPRINT(Gimmighoul),
+        //FOOTPRINT(Gimmighoul)
 
     [SPECIES_GIMMIGHOUL_CHEST] =
     {
@@ -4590,7 +4590,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Gholdengo),
         ICON(Gholdengo, 0),
-        //FOOTPRINT(Gholdengo),
+        //FOOTPRINT(Gholdengo)
         LEARNSETS(Gholdengo),
     },
 #endif //P_FAMILY_GIMMIGHOUL
@@ -4640,7 +4640,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(WoChien),
         ICON(WoChien, 5),
-        //FOOTPRINT(WoChien),
+        //FOOTPRINT(WoChien)
         LEARNSETS(WoChien),
     },
 #endif //P_FAMILY_WO_CHIEN
@@ -4690,7 +4690,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(ChienPao),
         ICON(ChienPao, 0),
-        //FOOTPRINT(ChienPao),
+        //FOOTPRINT(ChienPao)
         LEARNSETS(ChienPao),
     },
 #endif //P_FAMILY_CHIEN_PAO
@@ -4740,7 +4740,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(TingLu),
         ICON(TingLu, 0),
-        //FOOTPRINT(TingLu),
+        //FOOTPRINT(TingLu)
         LEARNSETS(TingLu),
     },
 #endif //P_FAMILY_TING_LU
@@ -4791,7 +4791,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(ChiYu),
         ICON(ChiYu, 0),
-        //FOOTPRINT(ChiYu),
+        //FOOTPRINT(ChiYu)
         LEARNSETS(ChiYu),
     },
 #endif //P_FAMILY_CHI_YU
@@ -4842,7 +4842,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(RoaringMoon),
         ICON(RoaringMoon, 3),
-        //FOOTPRINT(RoaringMoon),
+        //FOOTPRINT(RoaringMoon)
         LEARNSETS(RoaringMoon),
     },
 #endif //P_FAMILY_ROARING_MOON
@@ -4891,7 +4891,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(IronValiant),
         ICON(IronValiant, 4),
-        //FOOTPRINT(IronValiant),
+        //FOOTPRINT(IronValiant)
         LEARNSETS(IronValiant),
     },
 #endif //P_FAMILY_IRON_VALIANT
@@ -4942,7 +4942,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Koraidon),
         ICON(Koraidon, 0),
-        //FOOTPRINT(Koraidon),
+        //FOOTPRINT(Koraidon)
         LEARNSETS(Koraidon),
     },
 #endif //P_FAMILY_KORAIDON
@@ -4993,7 +4993,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Miraidon),
         ICON(Miraidon, 2),
-        //FOOTPRINT(Miraidon),
+        //FOOTPRINT(Miraidon)
         LEARNSETS(Miraidon),
     },
 #endif //P_FAMILY_MIRAIDON
@@ -5042,7 +5042,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(WalkingWake),
         ICON(WalkingWake, 2),
-        //FOOTPRINT(WalkingWake),
+        //FOOTPRINT(WalkingWake)
         LEARNSETS(WalkingWake),
     },
 #endif //P_FAMILY_WALKING_WAKE
@@ -5091,7 +5091,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(IronLeaves),
         ICON(IronLeaves, 1),
-        //FOOTPRINT(IronLeaves),
+        //FOOTPRINT(IronLeaves)
         LEARNSETS(IronLeaves),
     },
 #endif //P_FAMILY_IRON_LEAVES
@@ -5136,7 +5136,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         LEARNSETS(Poltchageist)
         //.frontAnimId = ANIM_V_SQUISH_AND_BOUNCE,
         //.backAnimId = BACK_ANIM_NONE,
-        //FOOTPRINT(Poltchageist),
+        //FOOTPRINT(Poltchageist)
 
     [SPECIES_POLTCHAGEIST_COUNTERFEIT] =
     {
@@ -5198,7 +5198,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         LEARNSETS(Sinistcha)
         //.frontAnimId = ANIM_V_SQUISH_AND_BOUNCE,
         //.backAnimId = BACK_ANIM_NONE,
-        //FOOTPRINT(Sinistcha),
+        //FOOTPRINT(Sinistcha)
 
     [SPECIES_SINISTCHA_UNREMARKABLE] =
     {
@@ -5264,7 +5264,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Okidogi),
         ICON(Okidogi, 1),
-        //FOOTPRINT(Okidogi),
+        //FOOTPRINT(Okidogi)
         LEARNSETS(Okidogi),
         .isLegendary = TRUE,
     },
@@ -5315,7 +5315,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Munkidori),
         ICON(Munkidori, 0),
-        //FOOTPRINT(Munkidori),
+        //FOOTPRINT(Munkidori)
         LEARNSETS(Munkidori),
     },
 #endif //P_FAMILY_MUNKIDORI
@@ -5365,7 +5365,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         PALETTES(Fezandipiti),
         ICON(Fezandipiti, 0),
-        //FOOTPRINT(Fezandipiti),
+        //FOOTPRINT(Fezandipiti)
         LEARNSETS(Fezandipiti),
     },
 #endif //P_FAMILY_FEZANDIPITI
@@ -5417,7 +5417,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         //.shinyPalette = gMonShinyPalette_OgerponTealMask,
         //ICON(Ogerpon##Form##, 1),
-        //FOOTPRINT(Ogerpon),
+        //FOOTPRINT(Ogerpon)
 
     [SPECIES_OGERPON_TEAL_MASK]             = OGERPON_SPECIES_INFO(TealMask,        TYPE_GRASS, ABILITY_DEFIANT,                   BODY_COLOR_GREEN, FALSE),
     [SPECIES_OGERPON_WELLSPRING_MASK]       = OGERPON_SPECIES_INFO(WellspringMask,  TYPE_WATER, ABILITY_WATER_ABSORB,              BODY_COLOR_BLUE, FALSE),
@@ -5477,7 +5477,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         //PALETTES(GougingFire),
         //ICON(GougingFire, 0),
-        //FOOTPRINT(GougingFire),
+        //FOOTPRINT(GougingFire)
         LEARNSETS(GougingFire),
     },
 #endif //P_FAMILY_GOUGING_FIRE
@@ -5527,7 +5527,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         //PALETTES(RagingBolt),
         //ICON(RagingBolt, 0),
-        //FOOTPRINT(RagingBolt),
+        //FOOTPRINT(RagingBolt)
         LEARNSETS(RagingBolt),
     },
 #endif //P_FAMILY_RAGING_BOLT
@@ -5576,7 +5576,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         //PALETTES(IronBoulder),
         //ICON(IronBoulder, 0),
-        //FOOTPRINT(IronBoulder),
+        //FOOTPRINT(IronBoulder)
         LEARNSETS(IronBoulder),
     },
 #endif //P_FAMILY_IRON_BOULDER
@@ -5626,7 +5626,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         //PALETTES(IronCrown),
         //ICON(IronCrown, 0),
-        //FOOTPRINT(IronCrown),
+        //FOOTPRINT(IronCrown)
         LEARNSETS(IronCrown),
     },
 #endif //P_FAMILY_IRON_CROWN
@@ -5650,7 +5650,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         .formChangeTable = sTerapagosFormChangeTable,                                   \
         .isLegendary = TRUE
         //.cryId = CRY_TERAPAGOS,
-        //FOOTPRINT(Terapagos),
+        //FOOTPRINT(Terapagos)
 
     [SPECIES_TERAPAGOS_NORMAL] =
     {
@@ -5797,7 +5797,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         //.backAnimId = BACK_ANIM_NONE,
         //PALETTES(Pecharunt),
         //ICON(Pecharunt, 0),
-        //FOOTPRINT(Pecharunt),
+        //FOOTPRINT(Pecharunt)
         LEARNSETS(Pecharunt),
     },
 #endif //P_FAMILY_PECHARUNT

--- a/src/pokedex.c
+++ b/src/pokedex.c
@@ -279,7 +279,6 @@ static void PrintMonWeight(u16 weight, u8 left, u8 top);
 static void ResetOtherVideoRegisters(u16);
 static u8 PrintCryScreenSpeciesName(u8, u16, u8, u8);
 static void PrintDecimalNum(u8 windowId, u16 num, u8 left, u8 top);
-static void DrawFootprint(u8 windowId, u16 dexNum);
 static u16 GetPokemonScaleFromNationalDexNumber(u16 nationalNum);
 static u16 GetPokemonOffsetFromNationalDexNumber(u16 nationalNum);
 static u16 GetTrainerScaleFromNationalDexNumber(u16 nationalNum);
@@ -3291,7 +3290,7 @@ static void Task_LoadInfoScreen(u8 taskId)
         FillWindowPixelBuffer(WIN_INFO, PIXEL_FILL(0));
         PutWindowTilemap(WIN_INFO);
         PutWindowTilemap(WIN_FOOTPRINT);
-        DrawFootprint(WIN_FOOTPRINT, sPokedexListItem->dexNum);
+        DrawFootprint(WIN_FOOTPRINT, NationalPokedexNumToSpecies(sPokedexListItem->dexNum));
         CopyWindowToVram(WIN_FOOTPRINT, COPYWIN_GFX);
         gMain.state++;
         break;
@@ -4020,7 +4019,7 @@ static void Task_DisplayCaughtMonDexPage(u8 taskId)
         FillWindowPixelBuffer(WIN_INFO, PIXEL_FILL(0));
         PutWindowTilemap(WIN_INFO);
         PutWindowTilemap(WIN_FOOTPRINT);
-        DrawFootprint(WIN_FOOTPRINT, dexNum);
+        DrawFootprint(WIN_FOOTPRINT, NationalPokedexNumToSpecies(dexNum));
         CopyWindowToVram(WIN_FOOTPRINT, COPYWIN_GFX);
         ResetPaletteFade();
         LoadPokedexBgPalette(FALSE);
@@ -4561,14 +4560,17 @@ static void UNUSED PrintDecimalNum(u8 windowId, u16 num, u8 left, u8 top)
 
 #define NUM_FOOTPRINT_TILES  4
 
-static void DrawFootprint(u8 windowId, u16 dexNum)
+void DrawFootprint(u8 windowId, u16 species)
 {
     u8 ALIGNED(4) footprint4bpp[TILE_SIZE_4BPP * NUM_FOOTPRINT_TILES];
-    const u8 *footprintGfx = gSpeciesInfo[NationalPokedexNumToSpecies(dexNum)].footprint;
+    const u8 *footprintGfx = NULL;
     u32 i, j, tileIdx = 0;
 
-    if (P_FOOTPRINTS == FALSE)
-        return;
+#if P_FOOTPRINTS
+    footprintGfx = gSpeciesInfo[SanitizeSpeciesId(species)].footprint;
+#else
+    return;
+#endif
 
     if (footprintGfx != NULL)
     {

--- a/src/pokedex_plus_hgss.c
+++ b/src/pokedex_plus_hgss.c
@@ -539,7 +539,6 @@ static void PrintMonWeight(u16 weight, u8 left, u8 top);
 static void ResetOtherVideoRegisters(u16);
 static u8 PrintCryScreenSpeciesName(u8, u16, u8, u8);
 static void PrintDecimalNum(u8 windowId, u16 num, u8 left, u8 top);
-static void DrawFootprint(u8 windowId, u16 species);
 static u16 CreateMonSpriteFromNationalDexNumberHGSS(u16 nationalNum, s16 x, s16 y, u16 paletteSlot);
 static u16 CreateSizeScreenTrainerPic(u16, s16, s16, s8);
 static u16 GetNextPosition(u8, u16, u16, u16);
@@ -4643,49 +4642,6 @@ static void UNUSED PrintDecimalNum(u8 windowId, u16 num, u8 left, u8 top)
     str[4] = CHAR_0 + ((num % 1000) % 100) % 10;
     str[5] = EOS;
     PrintInfoSubMenuText(windowId, str, left, top);
-}
-
-// The footprints are drawn on WIN_FOOTPRINT, which uses BG palette 15 (loaded with graphics/text_window/message_box.gbapal)
-// The footprint pixels are stored as 1BPP, and set to the below color index in this palette when converted to 4BPP.
-#define FOOTPRINT_COLOR_IDX  2
-
-#define NUM_FOOTPRINT_TILES  4
-
-static void DrawFootprint(u8 windowId, u16 species)
-{
-    u8 ALIGNED(4) footprint4bpp[TILE_SIZE_4BPP * NUM_FOOTPRINT_TILES];
-    const u8 *footprintGfx = gSpeciesInfo[SanitizeSpeciesId(species)].footprint;
-    u32 i, j, tileIdx = 0;
-
-    if (P_FOOTPRINTS == FALSE)
-        return;
-
-    if (footprintGfx != NULL)
-    {
-        for (i = 0; i < TILE_SIZE_1BPP * NUM_FOOTPRINT_TILES; i++)
-        {
-            u8 footprint1bpp = footprintGfx[i];
-
-            // Convert the 8 pixels in the above 1BPP byte to 4BPP.
-            // Each iteration creates one 4BPP byte (2 pixels),
-            // so we need 4 iterations to do all 8 pixels.
-            for (j = 0; j < 4; j++)
-            {
-                u8 tile = 0;
-                if (footprint1bpp & (1 << (2 * j)))
-                    tile |= FOOTPRINT_COLOR_IDX; // Set pixel
-                if (footprint1bpp & (2 << (2 * j)))
-                    tile |= FOOTPRINT_COLOR_IDX << 4; // Set pixel
-                footprint4bpp[tileIdx] = tile;
-                tileIdx++;
-            }
-        }
-    }
-    else
-    {
-        CpuFastFill(0, footprint4bpp, sizeof(footprint4bpp));
-    }
-    CopyToWindowPixelBuffer(windowId, footprint4bpp, sizeof(footprint4bpp), 0);
 }
 
 static void PrintInfoSubMenuText(u8 windowId, const u8 *str, u8 left, u8 top)

--- a/src/pokemon_debug.c
+++ b/src/pokemon_debug.c
@@ -803,34 +803,6 @@ static void LoadAndCreateEnemyShadowSpriteCustom(struct PokemonDebugMenu *data, 
     gSprites[data->frontShadowSpriteId].invisible = invisible;
 }
 
-//Tile functions (footprints)
-static void DrawFootprintCustom(u8 windowId, u16 species)
-{
-    u8 footprint[32 * 4] = {0};
-    const u8 *footprintGfx = gSpeciesInfo[species].footprint;
-    u32 i, j, tileIdx = 0;
-
-    if (P_FOOTPRINTS == FALSE)
-        return;
-
-    if (footprintGfx != NULL)
-    {
-        for (i = 0; i < 32; i++)
-        {
-            u8 tile = footprintGfx[i];
-            for (j = 0; j < 4; j++)
-            {
-                u8 value = ((tile >> (2 * j)) & 1 ? 2 : 0);
-                if (tile & (2 << (2 * j)))
-                    value |= 0x20;
-                footprint[tileIdx] = value;
-                tileIdx++;
-            }
-        }
-    }
-    CopyToWindowPixelBuffer(windowId, footprint, sizeof(footprint), 0);
-}
-
 //Battle background functions
 static void LoadBattleBg(u8 battleBgType, u8 battleTerrain)
 {
@@ -1189,7 +1161,7 @@ void CB2_Debug_Pokemon(void)
             PrintBattleBgName(taskId);
 
             //Footprint
-            DrawFootprintCustom(WIN_FOOTPRINT, species);
+            DrawFootprint(WIN_FOOTPRINT, species);
             CopyWindowToVram(WIN_FOOTPRINT, COPYWIN_GFX);
 
             gMain.state++;
@@ -1740,7 +1712,7 @@ static void ReloadPokemonSprites(struct PokemonDebugMenu *data)
     SetArrowInvisibility(data);
 
     //Footprint
-    DrawFootprintCustom(WIN_FOOTPRINT, species);
+    DrawFootprint(WIN_FOOTPRINT, species);
     CopyWindowToVram(WIN_FOOTPRINT, COPYWIN_GFX);
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Saves an additional 6376 bytes on top of the other 29096 bytes that the original change did.

Also, unified Footprint functions into a single one.
