### PR TITLE
Fix debug action SelectShiny tInput value toggle

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -3200,7 +3200,7 @@ static void DebugAction_Give_Pokemon_SelectShiny(u8 taskId)
     if (JOY_NEW(DPAD_ANY))
     {
         PlaySE(SE_SELECT);
-        gTasks[taskId].tInput ^= JOY_NEW(DPAD_UP | DPAD_DOWN);
+        gTasks[taskId].tInput ^= JOY_NEW(DPAD_UP | DPAD_DOWN) > 0;
         txtStr = (gTasks[taskId].tInput == TRUE) ? sDebugText_True : sDebugText_False;
         StringCopyPadded(gStringVar2, txtStr, CHAR_SPACE, 15);
         ConvertIntToDecimalStringN(gStringVar3, gTasks[taskId].tInput, STR_CONV_MODE_LEADING_ZEROS, 0);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
#3566 introduced a bug to `upcoming` where you can't toggle the "Shiny" value when using the "Give Pokemon (Complex)" action in the debug menu.
The code assumes that the value of `JOY_NEW(DPAD_UP | DPAD_DOWN)` will be 1 or 0.

## Images
<!-- Please provide with relevant GIFs or images to make it easier for reviewers to accept your PR quicker.-->
<!-- If it doesn't apply, feel free to remove this section. -->
![pokeemerald-0](https://github.com/rh-hideout/pokeemerald-expansion/assets/6616877/dc00a987-036a-4b82-b330-3c503679df81)

## **Discord contact info**
<!--- formatted as name#numbers, e.g. Lunos#4026 -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
`gamebriel#4784`
