### PR TITLE
Fix YIELD_RATE (berryexpansion fix)

### DIFF
--- a/src/berry.c
+++ b/src/berry.c
@@ -50,7 +50,7 @@ static void AddTreeBonus(struct BerryTree *tree, u8 bonus);
 #endif
 
 #define GROWTH_DURATION(g3, g4, g5, xy, oras, g7) OW_BERRY_GROWTH_RATE == GEN_3 ? g3 : OW_BERRY_GROWTH_RATE == GEN_4 ? g4 : OW_BERRY_GROWTH_RATE == GEN_5 ? g5 : OW_BERRY_GROWTH_RATE == GEN_6_XY ? xy : OW_BERRY_GROWTH_RATE == GEN_6_ORAS ? oras : g7
-#define YIELD_RATE(g3, g4, xy, oras) GROWTH_DURATION(g3, g4, 0, xy, oras, 0)
+#define YIELD_RATE(g3, g4, xy, oras) OW_BERRY_YIELD_RATE == GEN_3 ? g3 : OW_BERRY_YIELD_RATE == GEN_4 ? g4 : OW_BERRY_YIELD_RATE == GEN_6_XY ? xy : oras
 
 const struct Berry gBerries[] =
 {


### PR DESCRIPTION
As found by @fdeblasio, YIELD_RATE was an oversight because of laziness. This PR fixes that

## **Discord contact info**
bassoonian