### PR TITLE
Fix to issue with party menu field moves

### DIFF
--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -2787,7 +2787,7 @@ static void SetPartyMonFieldSelectionActions(struct Pokemon *mons, u8 slotId)
     // Add field moves to action list
     for (i = 0; i < MAX_MON_MOVES; i++)
     {
-        for (j = 0; sFieldMoves[j] != FIELD_MOVES_COUNT; j++)
+        for (j = 0; j != FIELD_MOVES_COUNT; j++)
         {
             if (GetMonData(&mons[slotId], i + MON_DATA_MOVE1) == sFieldMoves[j])
             {


### PR DESCRIPTION
Issue: After adding a new field move, no field moves will be displayed in the party menu screen at all. This fixes this issue.

## Description
When adding a new field move to the party menu options (e.g. adding FIELD_MOVE_HEADBUTT in the appropriate spots in party_menu.c and party_menu.h), no field moves will be displayed in the party menu screen at all for any Pokémon.
This one-line change fixes that.

## **Discord contact info**
jojoo0