### PR TITLE
Reset atkCancellerTracker for disobedience + random move

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -8216,6 +8216,7 @@ u8 IsMonDisobedient(void)
             } while (gBitTable[gCurrMovePos] & calc);
 
             gCalledMove = gBattleMons[gBattlerAttacker].moves[gCurrMovePos];
+            gBattleStruct->atkCancellerTracker = 0;
             gBattlescriptCurrInstr = BattleScript_IgnoresAndUsesRandomMove;
             gBattlerTarget = GetMoveTarget(gCalledMove, NO_TARGET_OVERRIDE);
             gHitMarker |= HITMARKER_DISOBEDIENT_MOVE;


### PR DESCRIPTION
Bug: if disobedient and used a multi-strike move, the randomly-chosen move will still have gMultiHitCounter set. This fixes that