### PR TITLE
Added config for shiny chances

### DIFF
--- a/include/config/pokemon.h
+++ b/include/config/pokemon.h
@@ -30,6 +30,7 @@
 // Other settings
 #define P_CUSTOM_GENDER_DIFF_ICONS  TRUE        // If TRUE, will give more Pokémon custom icons for their female forms, i.e. Hippopotas and Hippowdon
 #define P_FOOTPRINTS                TRUE        // If TRUE, Pokémon will have footprints (as was the case up to Gen 5 and in BDSP). Disabling this saves some ROM space.
+#define P_SHINY_ODDS                GEN_LATEST  // Since Gen 6, the odds for a shiny Pokémon are 1/4096 instead of 1/8192.
 #define P_LEGENDARY_PERFECT_IVS     GEN_LATEST  // Since Gen 6, Legendaries, Mythicals and Ultra Beasts found in the wild or given through gifts have at least 3 perfect IVs.
 #define P_EV_CAP                    GEN_LATEST  // Since Gen 6, the max EVs per stat is 252 instead of 255.
 #define P_CATCH_CURVE               GEN_LATEST  // Since Gen 6, the capture rate curve was changed to make pokeballs more effective on lower level pokemon

--- a/include/constants/pokemon.h
+++ b/include/constants/pokemon.h
@@ -92,7 +92,12 @@
 #define MAX_STAT_STAGE    12
 
 // Shiny odds
-#define SHINY_ODDS 8 // Actual probability is SHINY_ODDS/65536
+// Actual probability is SHINY_ODDS/65536
+#if P_SHINY_ODDS >= GEN_6
+#define SHINY_ODDS 16
+#else
+#define SHINY_ODDS 8
+#endif
 
 // Ribbon IDs used by TV and Pokénav
 #define CHAMPION_RIBBON       0


### PR DESCRIPTION
## Description
This PR adds a config for the odds of a shiny Pokemon to match Gen 6+'s increased chances

## Issue(s) that this PR fixes
Fixes #3910 

## **Discord contact info**
Frankfurter0
