### PR TITLE
Fix clangorous soulblaze boosting itself twice in doubles

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -5301,6 +5301,8 @@ BattleScript_EffectSpecialAttackUpHit::
 	goto BattleScript_EffectHit
 
 BattleScript_EffectAllStatsUpHit::
+	@ Handle clangorous soulblaze boosting itself twice in doubles
+	jumpifword CMP_NO_COMMON_BITS, gHitMarker, HITMARKER_NO_ATTACKSTRING | HITMARKER_NO_PPDEDUCT, BattleScript_NoMoveEffect
 	setmoveeffect MOVE_EFFECT_ALL_STATS_UP | MOVE_EFFECT_AFFECTS_USER
 	goto BattleScript_EffectHit
 


### PR DESCRIPTION
Very simple change to stop Clangorous Soulblaze boosting itself twice (once after each hit) in doubles

## Feature(s) this PR does NOT handle:
Target still needs to be selected in doubles, which is redundant but I assume part of how Z-Moves are implemented

## **Discord contact info**
SirScrubbington#0322
