### PR TITLE
healBlockBanned -> healingMove

### DIFF
--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -451,7 +451,7 @@ struct BattleMove
     u32 forcePressure:1;
     u32 cantUseTwice:1;
     u32 gravityBanned:1;
-    u32 healBlockBanned:1;
+    u32 healingMove:1;
     u32 meFirstBanned:1;
     u32 mimicBanned:1;
     u32 metronomeBanned:1;

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -2024,7 +2024,7 @@ bool32 HasSleepMoveWithLowAccuracy(u32 battlerAtk, u32 battlerDef)
 
 bool32 IsHealingMove(u32 move)
 {
-    return gBattleMoves[move].healBlockBanned;
+    return gBattleMoves[move].healingMove;
 }
 
 bool32 HasHealingEffect(u32 battlerId)

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -1498,7 +1498,7 @@ bool32 IsHealBlockPreventingMove(u32 battler, u32 move)
     if (!(gStatuses3[battler] & STATUS3_HEAL_BLOCK))
         return FALSE;
 
-    return gBattleMoves[move].healBlockBanned;
+    return gBattleMoves[move].healingMove;
 }
 
 static bool32 IsBelchPreventingMove(u32 battler, u32 move)

--- a/src/data/battle_moves.h
+++ b/src/data/battle_moves.h
@@ -1256,7 +1256,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .split = SPLIT_SPECIAL,
         .zMoveEffect = Z_EFFECT_NONE,
         .ignoresKingsRock = B_UPDATED_MOVE_FLAGS < GEN_5, // && B_UPDATED_MOVE_FLAGS > GEN_2
-        .healBlockBanned = B_HEAL_BLOCKING >= GEN_6,
+        .healingMove = B_HEAL_BLOCKING >= GEN_6,
     },
 
     [MOVE_MEGA_DRAIN] =
@@ -1276,7 +1276,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .split = SPLIT_SPECIAL,
         .zMoveEffect = Z_EFFECT_NONE,
         .ignoresKingsRock = B_UPDATED_MOVE_FLAGS < GEN_5, // && B_UPDATED_MOVE_FLAGS > GEN_2
-        .healBlockBanned = B_HEAL_BLOCKING >= GEN_6,
+        .healingMove = B_HEAL_BLOCKING >= GEN_6,
     },
 
     [MOVE_LEECH_SEED] =
@@ -1857,7 +1857,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .zMoveEffect = Z_EFFECT_RESET_STATS,
         .ignoresProtect = TRUE,
         .mirrorMoveBanned = TRUE,
-        .healBlockBanned = TRUE,
+        .healingMove = TRUE,
         .snatchAffected = TRUE,
     },
 
@@ -2393,7 +2393,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .priority = 0,
         .split = SPLIT_STATUS,
         .zMoveEffect = Z_EFFECT_RESET_STATS,
-        .healBlockBanned = TRUE,
+        .healingMove = TRUE,
         .ignoresProtect = TRUE,
         .mirrorMoveBanned = TRUE,
         .snatchAffected = TRUE,
@@ -2456,7 +2456,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .priority = 0,
         .split = SPLIT_SPECIAL,
         .zMoveEffect = Z_EFFECT_NONE,
-        .healBlockBanned = B_HEAL_BLOCKING >= GEN_6,
+        .healingMove = B_HEAL_BLOCKING >= GEN_6,
     },
 
     [MOVE_POISON_GAS] =
@@ -2516,7 +2516,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .zMoveEffect = Z_EFFECT_NONE,
         .makesContact = TRUE,
         .ignoresKingsRock = B_UPDATED_MOVE_FLAGS < GEN_5, // && B_UPDATED_MOVE_FLAGS > GEN_2
-        .healBlockBanned = B_HEAL_BLOCKING >= GEN_6,
+        .healingMove = B_HEAL_BLOCKING >= GEN_6,
     },
 
     [MOVE_LOVELY_KISS] =
@@ -2790,7 +2790,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .snatchAffected = TRUE,
         .ignoresProtect = TRUE,
         .mirrorMoveBanned = TRUE,
-        .healBlockBanned = TRUE,
+        .healingMove = TRUE,
     },
 
     [MOVE_ROCK_SLIDE] =
@@ -3648,7 +3648,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .split = SPLIT_SPECIAL,
         .zMoveEffect = Z_EFFECT_NONE,
         .ignoresKingsRock = B_UPDATED_MOVE_FLAGS < GEN_5, // && B_UPDATED_MOVE_FLAGS > GEN_2
-        .healBlockBanned = B_HEAL_BLOCKING >= GEN_6,
+        .healingMove = B_HEAL_BLOCKING >= GEN_6,
     },
 
     [MOVE_ENDURE] =
@@ -3761,7 +3761,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .priority = 0,
         .split = SPLIT_STATUS,
         .zMoveEffect = Z_EFFECT_RESET_STATS,
-        .healBlockBanned = TRUE,
+        .healingMove = TRUE,
         .snatchAffected = TRUE,
         .ignoresProtect = TRUE,
         .mirrorMoveBanned = TRUE,
@@ -4197,7 +4197,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .priority = 0,
         .split = SPLIT_STATUS,
         .zMoveEffect = Z_EFFECT_RESET_STATS,
-        .healBlockBanned = TRUE,
+        .healingMove = TRUE,
         .snatchAffected = TRUE,
         .ignoresProtect = TRUE,
         .mirrorMoveBanned = TRUE,
@@ -4215,7 +4215,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .priority = 0,
         .split = SPLIT_STATUS,
         .zMoveEffect = Z_EFFECT_RESET_STATS,
-        .healBlockBanned = TRUE,
+        .healingMove = TRUE,
         .snatchAffected = TRUE,
         .ignoresProtect = TRUE,
         .mirrorMoveBanned = TRUE,
@@ -4237,7 +4237,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .priority = 0,
         .split = SPLIT_STATUS,
         .zMoveEffect = Z_EFFECT_RESET_STATS,
-        .healBlockBanned = TRUE,
+        .healingMove = TRUE,
         .snatchAffected = TRUE,
         .ignoresProtect = TRUE,
         .mirrorMoveBanned = TRUE,
@@ -4613,7 +4613,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .priority = 0,
         .split = SPLIT_STATUS,
         .zMoveEffect = Z_EFFECT_RESET_STATS,
-        .healBlockBanned = TRUE,
+        .healingMove = TRUE,
         .snatchAffected = TRUE,
         .ignoresProtect = TRUE,
         .mirrorMoveBanned = TRUE,
@@ -4923,7 +4923,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .priority = 0,
         .split = SPLIT_STATUS,
         .zMoveEffect = Z_EFFECT_SPDEF_UP_1,
-        .healBlockBanned = TRUE,
+        .healingMove = TRUE,
         .snatchAffected = B_UPDATED_MOVE_FLAGS >= GEN_5,
         .ignoresProtect = TRUE,
         .mirrorMoveBanned = TRUE,
@@ -5439,7 +5439,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .priority = 0,
         .split = SPLIT_STATUS,
         .zMoveEffect = Z_EFFECT_RESET_STATS,
-        .healBlockBanned = TRUE,
+        .healingMove = TRUE,
         .snatchAffected = TRUE,
         .ignoresProtect = TRUE,
         .mirrorMoveBanned = TRUE,
@@ -6361,7 +6361,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .priority = 0,
         .split = SPLIT_STATUS,
         .zMoveEffect = Z_EFFECT_RESET_STATS,
-        .healBlockBanned = TRUE,
+        .healingMove = TRUE,
         .snatchAffected = TRUE,
         .ignoresProtect = TRUE,
         .mirrorMoveBanned = TRUE,
@@ -6464,7 +6464,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .priority = 0,
         .split = SPLIT_STATUS,
         .zMoveEffect = Z_EFFECT_NONE,
-        .healBlockBanned = TRUE,
+        .healingMove = TRUE,
         .snatchAffected = B_UPDATED_MOVE_FLAGS >= GEN_5,
         .ignoresProtect = TRUE,
         .mirrorMoveBanned = TRUE,
@@ -7285,7 +7285,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .zMoveEffect = Z_EFFECT_NONE,
         .makesContact = TRUE,
         .punchingMove = TRUE,
-        .healBlockBanned = B_HEAL_BLOCKING >= GEN_6,
+        .healingMove = B_HEAL_BLOCKING >= GEN_6,
     },
 
     [MOVE_VACUUM_WAVE] =
@@ -8056,7 +8056,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .priority = 0,
         .split = SPLIT_STATUS,
         .zMoveEffect = Z_EFFECT_RESET_STATS,
-        .healBlockBanned = TRUE,
+        .healingMove = TRUE,
         .snatchAffected = TRUE,
         .ignoresProtect = TRUE,
         .mirrorMoveBanned = TRUE,
@@ -8137,7 +8137,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .snatchAffected = B_UPDATED_MOVE_FLAGS >= GEN_5,
         .ignoresProtect = TRUE,
         .mirrorMoveBanned = TRUE,
-        .healBlockBanned = TRUE,
+        .healingMove = TRUE,
         .danceMove = TRUE,
     },
 
@@ -8884,7 +8884,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .zMoveEffect = Z_EFFECT_RESET_STATS,
         .magicCoatAffected = TRUE,
         .mirrorMoveBanned = TRUE,
-        .healBlockBanned = TRUE,
+        .healingMove = TRUE,
         .pulseMove = TRUE,
     },
 
@@ -9338,7 +9338,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .split = SPLIT_PHYSICAL,
         .zMoveEffect = Z_EFFECT_NONE,
         .makesContact = TRUE,
-        .healBlockBanned = B_HEAL_BLOCKING >= GEN_6,
+        .healingMove = B_HEAL_BLOCKING >= GEN_6,
     },
 
     [MOVE_SACRED_SWORD] =
@@ -9999,7 +9999,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .priority = 0,
         .split = SPLIT_SPECIAL,
         .zMoveEffect = Z_EFFECT_NONE,
-        .healBlockBanned = B_HEAL_BLOCKING >= GEN_6,
+        .healingMove = B_HEAL_BLOCKING >= GEN_6,
     },
 
     [MOVE_FORESTS_CURSE] =
@@ -10114,7 +10114,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .argument = 75, // restores 75% HP instead of 50% HP
         .zMoveEffect = Z_EFFECT_NONE,
         .makesContact = TRUE,
-        .healBlockBanned = B_HEAL_BLOCKING >= GEN_6,
+        .healingMove = B_HEAL_BLOCKING >= GEN_6,
     },
 
     [MOVE_CRAFTY_SHIELD] =
@@ -10726,7 +10726,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .split = SPLIT_SPECIAL,
         .argument = 75, // restores 75% HP instead of 50% HP
         .zMoveEffect = Z_EFFECT_NONE,
-        .healBlockBanned = B_HEAL_BLOCKING >= GEN_6,
+        .healingMove = B_HEAL_BLOCKING >= GEN_6,
     },
 
     [MOVE_THOUSAND_ARROWS] =
@@ -10873,7 +10873,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .priority = 0,
         .split = SPLIT_STATUS,
         .zMoveEffect = Z_EFFECT_RESET_STATS,
-        .healBlockBanned = TRUE,
+        .healingMove = TRUE,
         .snatchAffected = TRUE,
         .ignoresProtect = TRUE,
         .mirrorMoveBanned = TRUE,
@@ -10993,7 +10993,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .zMoveEffect = Z_EFFECT_RESET_STATS,
         .argument = MOVE_EFFECT_FLORAL_HEALING,
         .mirrorMoveBanned = TRUE,
-        .healBlockBanned = TRUE,
+        .healingMove = TRUE,
         .magicCoatAffected = TRUE,
     },
 
@@ -11025,7 +11025,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .split = SPLIT_STATUS,
         .zMoveEffect = Z_EFFECT_DEF_UP_1,
         .magicCoatAffected = TRUE,
-        .healBlockBanned = B_HEAL_BLOCKING >= GEN_6,
+        .healingMove = B_HEAL_BLOCKING >= GEN_6,
     },
 
     [MOVE_SOLAR_BLADE] =
@@ -11298,7 +11298,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .split = SPLIT_STATUS,
         .zMoveEffect = Z_EFFECT_ALL_STATS_UP_1,
         .mirrorMoveBanned = TRUE,
-        .healBlockBanned = TRUE,
+        .healingMove = TRUE,
         .magicCoatAffected = TRUE,
     },
 
@@ -11838,7 +11838,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .zMoveEffect = Z_EFFECT_NONE,
         .mirrorMoveBanned = B_UPDATED_MOVE_FLAGS < GEN_8,
         .metronomeBanned = TRUE,
-        .healBlockBanned = B_HEAL_BLOCKING >= GEN_6,
+        .healingMove = B_HEAL_BLOCKING >= GEN_6,
     },
 
     [MOVE_BUZZY_BUZZ] =
@@ -12534,7 +12534,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .ignoresProtect = TRUE,
         .ignoresSubstitute = TRUE,
         .mirrorMoveBanned = TRUE,
-        .healBlockBanned = TRUE,
+        .healingMove = TRUE,
         .metronomeBanned = TRUE,
     },
 
@@ -12929,7 +12929,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .ignoresProtect = TRUE,
         .ignoresSubstitute = TRUE,
         .mirrorMoveBanned = TRUE,
-        .healBlockBanned = TRUE,
+        .healingMove = TRUE,
         .metronomeBanned = TRUE,
     },
 
@@ -13531,7 +13531,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .snatchAffected = TRUE,
         .ignoresProtect = TRUE,
         .mirrorMoveBanned = TRUE,
-        .healBlockBanned = TRUE,
+        .healingMove = TRUE,
     },
 
     [MOVE_TAKE_HEART] =
@@ -13764,7 +13764,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .ignoresProtect = TRUE,
         .mirrorMoveBanned = TRUE,
         .metronomeBanned = TRUE,
-        .healBlockBanned = TRUE,
+        .healingMove = TRUE,
         .sketchBanned = (B_SKETCH_BANS >= GEN_9),
     },
 
@@ -14187,7 +14187,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .zMoveEffect = Z_EFFECT_NONE,
         .makesContact = TRUE,
         .slicingMove = TRUE,
-        .healBlockBanned = TRUE,
+        .healingMove = B_HEAL_BLOCKING >= GEN_6,
     },
 
     [MOVE_DOUBLE_SHOCK] =
@@ -14439,7 +14439,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT_DYNAMAX] =
         .zMoveEffect = Z_EFFECT_NONE,
         .thawsUser = TRUE,
         .metronomeBanned = TRUE,
-        .healBlockBanned = TRUE,
+        .healingMove = B_HEAL_BLOCKING >= GEN_6,
     },
 
     [MOVE_SYRUP_BOMB] =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Renames healBlockBanned flag to healingMove, since its used for more than just heal block.
Also made it so Bitter Blade and Matcha Gotcha only have the flag if B_HEAL_BLOCKING is GEN_6 or greater.

## **Discord contact info**
kittenchilly