### PR TITLE
fixed oversight causing chosen fossil to be lost if bag is full

### DIFF
--- a/data/maps/DesertUnderpass/scripts.inc
+++ b/data/maps/DesertUnderpass/scripts.inc
@@ -18,12 +18,14 @@ DesertUnderpass_EventScript_Fossil::
 
 DesertUnderpass_EventScript_GiveClawFossil::
 	giveitem ITEM_CLAW_FOSSIL
+	goto_if_eq VAR_RESULT, FALSE, Common_EventScript_ShowBagIsFull
 	removeobject LOCALID_FOSSIL
 	release
 	end
 
 DesertUnderpass_EventScript_GiveRootFossil::
 	giveitem ITEM_ROOT_FOSSIL
+	goto_if_eq VAR_RESULT, FALSE, Common_EventScript_ShowBagIsFull
 	removeobject LOCALID_FOSSIL
 	release
 	end

--- a/data/maps/MirageTower_4F/scripts.inc
+++ b/data/maps/MirageTower_4F/scripts.inc
@@ -10,6 +10,9 @@ MirageTower_4F_EventScript_RootFossil::
 	msgbox MirageTower_4F_Text_TakeRootFossil, MSGBOX_YESNO
 	goto_if_eq VAR_RESULT, NO, MirageTower_4F_EventScript_LeaveRootFossil
 	giveitem ITEM_ROOT_FOSSIL
+.if I_KEY_FOSSILS
+	goto_if_eq VAR_RESULT, FALSE, Common_EventScript_ShowBagIsFull
+.endif
 	closemessage
 	setflag FLAG_HIDE_MIRAGE_TOWER_ROOT_FOSSIL
 	setflag FLAG_HIDE_MIRAGE_TOWER_CLAW_FOSSIL
@@ -30,6 +33,9 @@ MirageTower_4F_EventScript_ClawFossil::
 	msgbox MirageTower_4F_Text_TakeClawFossil, MSGBOX_YESNO
 	goto_if_eq VAR_RESULT, NO, MirageTower_4F_EventScript_LeaveClawFossil
 	giveitem ITEM_CLAW_FOSSIL
+.if I_KEY_FOSSILS
+	goto_if_eq VAR_RESULT, FALSE, Common_EventScript_ShowBagIsFull
+.endif
 	closemessage
 	setflag FLAG_HIDE_MIRAGE_TOWER_CLAW_FOSSIL
 	setflag FLAG_HIDE_MIRAGE_TOWER_ROOT_FOSSIL

--- a/data/maps/MirageTower_4F/scripts.inc
+++ b/data/maps/MirageTower_4F/scripts.inc
@@ -10,7 +10,7 @@ MirageTower_4F_EventScript_RootFossil::
 	msgbox MirageTower_4F_Text_TakeRootFossil, MSGBOX_YESNO
 	goto_if_eq VAR_RESULT, NO, MirageTower_4F_EventScript_LeaveRootFossil
 	giveitem ITEM_ROOT_FOSSIL
-.if I_KEY_FOSSILS
+.if I_KEY_FOSSILS >= GEN_4
 	goto_if_eq VAR_RESULT, FALSE, Common_EventScript_ShowBagIsFull
 .endif
 	closemessage
@@ -33,7 +33,7 @@ MirageTower_4F_EventScript_ClawFossil::
 	msgbox MirageTower_4F_Text_TakeClawFossil, MSGBOX_YESNO
 	goto_if_eq VAR_RESULT, NO, MirageTower_4F_EventScript_LeaveClawFossil
 	giveitem ITEM_CLAW_FOSSIL
-.if I_KEY_FOSSILS
+.if I_KEY_FOSSILS >= GEN_4
 	goto_if_eq VAR_RESULT, FALSE, Common_EventScript_ShowBagIsFull
 .endif
 	closemessage

--- a/data/maps/MirageTower_4F/scripts.inc
+++ b/data/maps/MirageTower_4F/scripts.inc
@@ -10,9 +10,7 @@ MirageTower_4F_EventScript_RootFossil::
 	msgbox MirageTower_4F_Text_TakeRootFossil, MSGBOX_YESNO
 	goto_if_eq VAR_RESULT, NO, MirageTower_4F_EventScript_LeaveRootFossil
 	giveitem ITEM_ROOT_FOSSIL
-.if I_KEY_FOSSILS >= GEN_4
 	goto_if_eq VAR_RESULT, FALSE, Common_EventScript_ShowBagIsFull
-.endif
 	closemessage
 	setflag FLAG_HIDE_MIRAGE_TOWER_ROOT_FOSSIL
 	setflag FLAG_HIDE_MIRAGE_TOWER_CLAW_FOSSIL
@@ -33,9 +31,7 @@ MirageTower_4F_EventScript_ClawFossil::
 	msgbox MirageTower_4F_Text_TakeClawFossil, MSGBOX_YESNO
 	goto_if_eq VAR_RESULT, NO, MirageTower_4F_EventScript_LeaveClawFossil
 	giveitem ITEM_CLAW_FOSSIL
-.if I_KEY_FOSSILS >= GEN_4
 	goto_if_eq VAR_RESULT, FALSE, Common_EventScript_ShowBagIsFull
-.endif
 	closemessage
 	setflag FLAG_HIDE_MIRAGE_TOWER_CLAW_FOSSIL
 	setflag FLAG_HIDE_MIRAGE_TOWER_ROOT_FOSSIL


### PR DESCRIPTION
## Description
If bag is full and expansion configs are set as default, the chosen fossil will be lost upon selecting it, as there is no check to ensure it went into your regular items pocket.

## **Discord contact info**
Zatsoo
