### PR TITLE
Fix RHH rom header section

### DIFF
--- a/src/rom_header_rhh.c
+++ b/src/rom_header_rhh.c
@@ -23,6 +23,7 @@ struct RHHRomHeader
     /*0x18*/ const struct Ability *abilities;
 };
 
+__attribute__((section(".text.consts")))
 static const struct RHHRomHeader sRHHRomHeader =
 {
     .rhh_magic = { 'R', 'H', 'H', 'E', 'X', 'P' },


### PR DESCRIPTION
RHH rom header was not in the correct section

(Compare https://github.com/rh-hideout/pokeemerald-expansion/blob/upcoming/src/rom_header_gf.c#L98 / https://github.com/rh-hideout/pokeemerald-expansion/blob/upcoming/src/rom_header_rhh.c#L26 )


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Images
Old:
![image](https://github.com/rh-hideout/pokeemerald-expansion/assets/65647523/a794deea-3166-479c-8f10-17b9207bcee8)
New:
![image](https://github.com/rh-hideout/pokeemerald-expansion/assets/65647523/ad2b068d-c1d1-42e2-8f26-2afaeed19f9e)


## **Discord contact info**
ninjdai
