### PR TITLE
Fix stat drop in doubles for single target moves

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -3192,13 +3192,15 @@ void SetMoveEffect(bool32 primary, bool32 certain)
                 if (GetBattlerSide(gBattlerAttacker) == B_SIDE_PLAYER && gSpecialStatuses[gBattlerAttacker].parentalBondState!= PARENTAL_BOND_2ND_HIT)
                 {
                     u16 payday = gPaydayMoney;
+                    u16 moveTarget = GetBattlerMoveTargetType(gBattlerAttacker, gCurrentMove);
                     gPaydayMoney += (gBattleMons[gBattlerAttacker].level * 5);
                     if (payday > gPaydayMoney)
                         gPaydayMoney = 0xFFFF;
 
                     // For a move that hits multiple targets (i.e. Make it Rain)
                     // we only want to print the message on the final hit
-                    if (GetNextTarget(gBattleMoves[gCurrentMove].target, TRUE) == MAX_BATTLERS_COUNT)
+                    if (!((moveTarget == MOVE_TARGET_BOTH || moveTarget == MOVE_TARGET_FOES_AND_ALLY)
+                        && GetNextTarget(moveTarget, TRUE) != MAX_BATTLERS_COUNT))
                     {
                         BattleScriptPush(gBattlescriptCurrInstr + 1);
                         gBattlescriptCurrInstr = BattleScript_MoveEffectPayDay;
@@ -3807,6 +3809,7 @@ static void Cmd_setadditionaleffects(void)
         if (gBattleMoves[gCurrentMove].numAdditionalEffects > gBattleStruct->additionalEffectsCounter)
         {
             u32 percentChance;
+            u16 moveTarget = GetBattlerMoveTargetType(gBattlerAttacker, gCurrentMove);
             const u8 *currentPtr = gBattlescriptCurrInstr;
             const struct AdditionalEffect *additionalEffect = &gBattleMoves[gCurrentMove].additionalEffects[gBattleStruct->additionalEffectsCounter];
 
@@ -3814,7 +3817,8 @@ static void Cmd_setadditionaleffects(void)
             // self-targeting move effects cannot occur multiple times per turn
             // only occur on the last setmoveeffect when there are multiple targets
             if (!(gBattleMoves[gCurrentMove].additionalEffects[gBattleStruct->additionalEffectsCounter].self
-                && GetNextTarget(gBattleMoves[gCurrentMove].target, TRUE) != MAX_BATTLERS_COUNT)
+                && (moveTarget == MOVE_TARGET_BOTH || moveTarget == MOVE_TARGET_FOES_AND_ALLY)
+                && GetNextTarget(moveTarget, TRUE) != MAX_BATTLERS_COUNT)
               && !(additionalEffect->onlyIfTargetRaisedStats && !gProtectStructs[gBattlerTarget].statRaised)
               && additionalEffect->onChargeTurnOnly == gProtectStructs[gBattlerAttacker].chargingTurn)
             {

--- a/test/battle/move_effect/pay_day.c
+++ b/test/battle/move_effect/pay_day.c
@@ -1,0 +1,37 @@
+#include "global.h"
+#include "test/battle.h"
+
+ASSUMPTIONS
+{
+    ASSUME(MoveHasMoveEffect(MOVE_PAY_DAY, MOVE_EFFECT_PAYDAY));
+}
+
+SINGLE_BATTLE_TEST("Single Battle: Pay Day Scatters coins around after it hits")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET)
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_PAY_DAY); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_PAY_DAY, player);
+        HP_BAR(opponent);
+        MESSAGE("Coins scattered everywhere!");
+    }
+}
+
+DOUBLE_BATTLE_TEST("Double Battle: Pay Day Scatters coins around after it hits")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET)
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_PAY_DAY, target: opponentLeft); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_PAY_DAY, playerLeft);
+        HP_BAR(opponentLeft);
+        MESSAGE("Coins scattered everywhere!");
+    }
+}

--- a/test/battle/move_effect/pay_day.c
+++ b/test/battle/move_effect/pay_day.c
@@ -20,7 +20,7 @@ SINGLE_BATTLE_TEST("Pay Day Scatters coins around after it hits - singles")
     }
 }
 
-DOUBLE_BATTLE_TEST("Double Battle: Pay Day Scatters coins around after it hits")
+DOUBLE_BATTLE_TEST("Pay Day Scatters coins around after it hits - doubles")
 {
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET)

--- a/test/battle/move_effect/pay_day.c
+++ b/test/battle/move_effect/pay_day.c
@@ -6,7 +6,7 @@ ASSUMPTIONS
     ASSUME(MoveHasMoveEffect(MOVE_PAY_DAY, MOVE_EFFECT_PAYDAY));
 }
 
-SINGLE_BATTLE_TEST("Single Battle: Pay Day Scatters coins around after it hits")
+SINGLE_BATTLE_TEST("Pay Day Scatters coins around after it hits - singles")
 {
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET)

--- a/test/battle/move_effect/sp_atk_two_down.c
+++ b/test/battle/move_effect/sp_atk_two_down.c
@@ -6,7 +6,7 @@ ASSUMPTIONS
     ASSUME(MoveHasMoveEffectSelf(MOVE_OVERHEAT, MOVE_EFFECT_SP_ATK_TWO_DOWN));
 }
 
-SINGLE_BATTLE_TEST("Single Battle: Overheat drops Sp. Atk by 2 stages")
+SINGLE_BATTLE_TEST("Overheat drops Sp. Atk by 2 stages - singles")
 {
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET)

--- a/test/battle/move_effect/sp_atk_two_down.c
+++ b/test/battle/move_effect/sp_atk_two_down.c
@@ -1,0 +1,43 @@
+#include "global.h"
+#include "test/battle.h"
+
+ASSUMPTIONS
+{
+    ASSUME(MoveHasMoveEffectSelf(MOVE_OVERHEAT, MOVE_EFFECT_SP_ATK_TWO_DOWN));
+}
+
+SINGLE_BATTLE_TEST("Single Battle: Overheat drops Sp. Atk by 2 stages")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET)
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_OVERHEAT); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_OVERHEAT, player);
+        HP_BAR(opponent);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        MESSAGE("Wobbuffet's Sp. Atk harshly fell!");
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_SPATK], DEFAULT_STAT_STAGE - 2);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Double Battle: Overheat drops Sp. Atk by 2 stages")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET)
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_OVERHEAT, target: opponentLeft); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_OVERHEAT, playerLeft);
+        HP_BAR(opponentLeft);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
+        MESSAGE("Wobbuffet's Sp. Atk harshly fell!");
+    } THEN {
+        EXPECT_EQ(playerLeft->statStages[STAT_SPATK], DEFAULT_STAT_STAGE - 2);
+    }
+}

--- a/test/battle/move_effect/sp_atk_two_down.c
+++ b/test/battle/move_effect/sp_atk_two_down.c
@@ -23,7 +23,7 @@ SINGLE_BATTLE_TEST("Overheat drops Sp. Atk by 2 stages - singles")
     }
 }
 
-DOUBLE_BATTLE_TEST("Double Battle: Overheat drops Sp. Atk by 2 stages")
+DOUBLE_BATTLE_TEST("Overheat drops Sp. Atk by 2 stages - doubles")
 {
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET)


### PR DESCRIPTION
Fixes #4002

Technically both the single and double battle test check the same thing but since this was a bug I wrote them for both. 