### PR TITLE
Allow being spotted by two trainers with one mon in party

### DIFF
--- a/include/config/overworld.h
+++ b/include/config/overworld.h
@@ -5,8 +5,9 @@
 #define OW_RUNNING_INDOORS          GEN_LATEST  // In Gen4+, players are allowed to run indoors.
 
 // Other settings
-#define OW_POISON_DAMAGE            GEN_LATEST // In Gen4, Pokémon no longer faint from Poison in the overworld. In Gen5+, they no longer take damage at all.
-#define OW_TIMES_OF_DAY             GEN_LATEST // Different generations have the times of day change at different times
+#define OW_POISON_DAMAGE                GEN_LATEST // In Gen4, Pokémon no longer faint from Poison in the overworld. In Gen5+, they no longer take damage at all.
+#define OW_TIMES_OF_DAY                 GEN_LATEST // Different generations have the times of day change at different times.
+#define OW_DOUBLE_APPROACH_WITH_ONE_MON FALSE      // If enabled, you can be spotted by two trainers at the same time even if you only have one eligible Pokémon in your party.
 
 // PC settings
 #define OW_PC_PRESS_B               GEN_LATEST // In Gen4, pressing B when holding a Pokémon is equivalent to placing it. In Gen3, it gives the "You're holding a Pokémon!" error.

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -3080,6 +3080,9 @@ u8 GetMonsStateToDoubles_2(void)
     s32 aliveCount = 0;
     s32 i;
 
+    if (OW_DOUBLE_APPROACH_WITH_ONE_MON)
+        return PLAYER_HAS_TWO_USABLE_MONS;
+
     for (i = 0; i < PARTY_SIZE; i++)
     {
         u32 species = GetMonData(&gPlayerParty[i], MON_DATA_SPECIES_OR_EGG, NULL);


### PR DESCRIPTION
By default, you can be seen by two different trainers at the same time and engage in a 1v2 multi battle with them on the condition you have at least two eligible Pokémon in your party. The added config allows you to override said check and get spotted by two trainers at the same time, even if you only have one eligible Pokémon.

## Issue(s) that this PR fixes
Fixes #3951

## **Discord contact info**
bassoonian
