### PR TITLE
Removed sGigantaxFactorLockedSpecies to instead check for mythicals

### DIFF
--- a/src/script_pokemon_util.c
+++ b/src/script_pokemon_util.c
@@ -310,9 +310,7 @@ void HasGigantamaxFactor(struct ScriptContext *ctx)
 
 void ToggleGigantamaxFactor(struct ScriptContext *ctx)
 {
-    u32 i;
     u32 partyIndex = VarGet(ScriptReadHalfword(ctx));
-    u32 species;
 
     gSpecialVar_Result = FALSE;
 
@@ -320,8 +318,7 @@ void ToggleGigantamaxFactor(struct ScriptContext *ctx)
     {
         bool32 gigantamaxFactor;
 
-        species = SanitizeSpeciesId(GetMonData(&gPlayerParty[partyIndex], MON_DATA_SPECIES));
-        if (gSpeciesInfo[species].isMythical)
+        if (gSpeciesInfo[SanitizeSpeciesId(GetMonData(&gPlayerParty[partyIndex], MON_DATA_SPECIES))].isMythical)
             return;
 
         gigantamaxFactor = GetMonData(&gPlayerParty[partyIndex], MON_DATA_GIGANTAMAX_FACTOR);

--- a/src/script_pokemon_util.c
+++ b/src/script_pokemon_util.c
@@ -308,11 +308,6 @@ void HasGigantamaxFactor(struct ScriptContext *ctx)
         gSpecialVar_Result = FALSE;
 }
 
-static const u16 sGigantaxFactorLockedSpecies[] =
-{
-    SPECIES_MELMETAL,
-};
-
 void ToggleGigantamaxFactor(struct ScriptContext *ctx)
 {
     u32 i;
@@ -325,12 +320,9 @@ void ToggleGigantamaxFactor(struct ScriptContext *ctx)
     {
         bool32 gigantamaxFactor;
 
-        species = GetMonData(&gPlayerParty[partyIndex], MON_DATA_SPECIES);
-        for (i = 0; i < ARRAY_COUNT(sGigantaxFactorLockedSpecies); i++)
-        {
-            if (species == sGigantaxFactorLockedSpecies[i])
-                return;
-        }
+        species = SanitizeSpeciesId(GetMonData(&gPlayerParty[partyIndex], MON_DATA_SPECIES));
+        if (gSpeciesInfo[species].isMythical)
+            return;
 
         gigantamaxFactor = GetMonData(&gPlayerParty[partyIndex], MON_DATA_GIGANTAMAX_FACTOR);
         gigantamaxFactor = !gigantamaxFactor;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Melmetal is the only Mythical with a GMax form and also the only one whose GMax form can't be toggled with Max Soup.
Therefore, it's safe to assume that for the sake of extrapolation, Mythicals are excluded from the Max Soup effect.

## **Discord contact info**
AsparagusEduardo
