### PR TITLE
Fixed Kingra's learnset gen

### DIFF
--- a/src/data/pokemon/level_up_learnsets.h
+++ b/src/data/pokemon/level_up_learnsets.h
@@ -3479,7 +3479,7 @@ static const struct LevelUpMove sSeadraLevelUpLearnset[] = {
     LEVEL_UP_END
 };
 
-#if P_GEN_4_CROSS_EVOS
+#if P_GEN_2_CROSS_EVOS
 static const struct LevelUpMove sKingdraLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_HYDRO_PUMP),
     LEVEL_UP_MOVE( 1, MOVE_YAWN),


### PR DESCRIPTION
## Description
In level_up_learnsets.h, Kingdra's learnset was inside a check for P_GEN_4_CROSS_EVOS. As a Gen 2 Pokemon, this has been updated to check for P_GEN_2_CROSS_EVOS instead.

## **Discord contact info**
.skyeward
