### PR TITLE
Fixed graphics bug with Steven double battle

### DIFF
--- a/src/battle_controller_player_partner.c
+++ b/src/battle_controller_player_partner.c
@@ -440,7 +440,7 @@ static void PlayerPartnerHandleIntroTrainerBallThrow(u32 battler)
     const u32 *trainerPal;
 
     if (gPartnerTrainerId == TRAINER_STEVEN_PARTNER)
-        trainerPal = gTrainerBackPicPaletteTable[TRAINER_STEVEN_PARTNER].data;
+        trainerPal = gTrainerBackPicPaletteTable[TRAINER_BACK_PIC_STEVEN].data;
     else if (gPartnerTrainerId >= TRAINER_CUSTOM_PARTNER) // Custom multi battle.
         trainerPal = gTrainerBackPicPaletteTable[gPartnerSpriteId].data;
     else if (IsAiVsAiBattle())


### PR DESCRIPTION
Fixed a bug that caused the wrong palette to be used during Steven's ball throw animation in the Mossdeep Space Center fight.

## Description
Fixed a bug that caused the wrong palette to be used during Steven's ball throw animation in the Mossdeep Space Center fight.
I'm not sure if it is a known bug.

## Images
Issue that has been fixed:
![2024-01-2714-17-33-Trim-ezgif com-crop](https://github.com/rh-hideout/pokeemerald-expansion/assets/151456919/6e7c58a5-5ca0-4581-b494-dfc3961a07e2)

## **Discord contact info**
jojoo0
