### PR TITLE
[Critical fix] Backported gHeap alignment fix from upstream pret

### DIFF
--- a/ld_script_modern.ld
+++ b/ld_script_modern.ld
@@ -15,6 +15,11 @@ SECTIONS {
     ewram 0x2000000 (NOLOAD) :
     ALIGN(4)
     {
+        /* 
+           We link malloc.o here to prevent `gHeap` from landing in the middle of EWRAM.
+           Otherwise this causes corruption issues on some ld versions
+        */
+        gflib/malloc.o(ewram_data);
         src/*.o(ewram_data);
         gflib/*.o(ewram_data);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Backported @SBird1337's [fix to pret's pokeemerald](https://github.com/pret/pokeemerald/pull/1976/files).

Normally, this would wait until next pret merge, but it fixes an ugly bug that manifests in 1.7.0-1.7.2, so it takes priority.

## Issue(s) that this PR fixes
Fixes #4077.

## **Discord contact info**
AsparagusEduardo
