### PR TITLE
Fix Full Restore / Antidote not reseting Toxic Counter

### DIFF
--- a/asm/macros/battle_script.inc
+++ b/asm/macros/battle_script.inc
@@ -1332,12 +1332,14 @@
 	.4byte \jumpInstr
 	.endm
 
-	.macro itemrestorehp
+	.macro itemrestorehp jumpInstr:req
 	callnative BS_ItemRestoreHP
+	.4byte \jumpInstr
 	.endm
 
-	.macro itemcurestatus
+	.macro itemcurestatus jumpInstr:req
 	callnative BS_ItemCureStatus
+	.4byte \jumpInstr
 	.endm
 
 	.macro itemincreasestat

--- a/data/battle_scripts_2.s
+++ b/data/battle_scripts_2.s
@@ -47,13 +47,13 @@ BattleScript_UseItemMessage:
     return
 	
 BattleScript_ItemRestoreHPRet:
-	bichalfword gMoveResultFlags, MOVE_RESULT_NO_EFFECT
+    bichalfword gMoveResultFlags, MOVE_RESULT_NO_EFFECT
     orword gHitMarker, HITMARKER_IGNORE_SUBSTITUTE
     healthbarupdate BS_SCRIPTING
     datahpupdate BS_SCRIPTING
     printstring STRINGID_ITEMRESTOREDSPECIESHEALTH
     waitmessage B_WAIT_TIME_LONG
-	return
+    return
 
 BattleScript_ItemRestoreHP::
     call BattleScript_UseItemMessage
@@ -88,8 +88,8 @@ BattleScript_ItemCureStatusEnd:
 BattleScript_ItemHealAndCureStatus::
     call BattleScript_UseItemMessage
     itemrestorehp BattleScript_ItemCureStatusAfterItemMsg
-	call BattleScript_ItemRestoreHPRet
-	goto BattleScript_ItemCureStatusAfterItemMsg
+    call BattleScript_ItemRestoreHPRet
+    goto BattleScript_ItemCureStatusAfterItemMsg
 
 BattleScript_ItemIncreaseStat::
     call BattleScript_UseItemMessage
@@ -116,7 +116,7 @@ BattleScript_ItemSetFocusEnergy::
     setfocusenergy
     playmoveanimation BS_ATTACKER, MOVE_FOCUS_ENERGY
     waitanimation
-	copybyte sBATTLER, gBattlerAttacker
+    copybyte sBATTLER, gBattlerAttacker
     printstring STRINGID_PKMNUSEDXTOGETPUMPED
     waitmessage B_WAIT_TIME_LONG
     end

--- a/data/battle_scripts_2.s
+++ b/data/battle_scripts_2.s
@@ -45,16 +45,21 @@ BattleScript_UseItemMessage:
     printfromtable gTrainerUsedItemStringIds
     waitmessage B_WAIT_TIME_LONG
     return
-
-BattleScript_ItemRestoreHP::
-    call BattleScript_UseItemMessage
-    itemrestorehp
-    bichalfword gMoveResultFlags, MOVE_RESULT_NO_EFFECT
+	
+BattleScript_ItemRestoreHPRet:
+	bichalfword gMoveResultFlags, MOVE_RESULT_NO_EFFECT
     orword gHitMarker, HITMARKER_IGNORE_SUBSTITUTE
     healthbarupdate BS_SCRIPTING
     datahpupdate BS_SCRIPTING
     printstring STRINGID_ITEMRESTOREDSPECIESHEALTH
     waitmessage B_WAIT_TIME_LONG
+	return
+
+BattleScript_ItemRestoreHP::
+    call BattleScript_UseItemMessage
+    itemrestorehp BattleScript_ItemRestoreHPEnd
+    call BattleScript_ItemRestoreHPRet
+BattleScript_ItemRestoreHPEnd:
     end
 
 BattleScript_ItemRestoreHP_Party::
@@ -72,26 +77,19 @@ BattleScript_ItemRestoreHP_SendOutRevivedBattler:
 
 BattleScript_ItemCureStatus::
     call BattleScript_UseItemMessage
-    itemcurestatus
+BattleScript_ItemCureStatusAfterItemMsg:
+    itemcurestatus BattleScript_ItemCureStatusEnd
     updatestatusicon BS_SCRIPTING
     printstring STRINGID_ITEMCUREDSPECIESSTATUS
     waitmessage B_WAIT_TIME_LONG
+BattleScript_ItemCureStatusEnd:
     end
 
 BattleScript_ItemHealAndCureStatus::
     call BattleScript_UseItemMessage
-    itemrestorehp
-    itemcurestatus
-    printstring STRINGID_ITEMRESTOREDSPECIESHEALTH
-    waitmessage B_WAIT_TIME_LONG
-    bichalfword gMoveResultFlags, MOVE_RESULT_NO_EFFECT
-    orword gHitMarker, HITMARKER_IGNORE_SUBSTITUTE
-    healthbarupdate BS_SCRIPTING
-    datahpupdate BS_SCRIPTING
-    updatestatusicon BS_SCRIPTING
-    printstring STRINGID_ITEMRESTOREDSPECIESHEALTH
-    waitmessage B_WAIT_TIME_LONG
-    end
+    itemrestorehp BattleScript_ItemCureStatusAfterItemMsg
+	call BattleScript_ItemRestoreHPRet
+	goto BattleScript_ItemCureStatusAfterItemMsg
 
 BattleScript_ItemIncreaseStat::
     call BattleScript_UseItemMessage

--- a/src/item.c
+++ b/src/item.c
@@ -974,11 +974,11 @@ u32 GetItemStatus1Mask(u16 itemId)
         case ITEM3_BURN:
             return STATUS1_BURN;
         case ITEM3_POISON:
-            return STATUS1_POISON | STATUS1_TOXIC_POISON;
+            return STATUS1_PSN_ANY | STATUS1_TOXIC_COUNTER;
         case ITEM3_SLEEP:
             return STATUS1_SLEEP;
         case ITEM3_STATUS_ALL:
-            return STATUS1_ANY;
+            return STATUS1_ANY | STATUS1_TOXIC_COUNTER;
     }
     return 0;
 }

--- a/test/battle/item_effect/cure_status.c
+++ b/test/battle/item_effect/cure_status.c
@@ -46,6 +46,24 @@ SINGLE_BATTLE_TEST("Antidote heals a battler from being badly poisoned")
     }
 }
 
+SINGLE_BATTLE_TEST("Antidote resets Toxic Counter")
+{
+    GIVEN {
+        ASSUME(gItems[ITEM_ANTIDOTE].battleUsage == EFFECT_ITEM_CURE_STATUS);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_TOXIC); }
+        TURN { ; }
+        TURN { USE_ITEM(player, ITEM_ANTIDOTE, partyIndex: 0); }
+    } SCENE {
+        MESSAGE("Foe Wobbuffet used Toxic!");
+        MESSAGE("Wobbuffet had its status healed!");
+    } THEN {
+        EXPECT_EQ(player->status1, STATUS1_NONE);
+    }
+}
+
 SINGLE_BATTLE_TEST("Awakening heals a battler from being asleep")
 {
     GIVEN {

--- a/test/battle/item_effect/heal_and_cure_status.c
+++ b/test/battle/item_effect/heal_and_cure_status.c
@@ -1,6 +1,11 @@
 #include "global.h"
 #include "test/battle.h"
 
+ASSUMPTIONS
+{
+    ASSUME(gItems[ITEM_FULL_RESTORE].battleUsage == EFFECT_ITEM_HEAL_AND_CURE_STATUS);
+}
+
 SINGLE_BATTLE_TEST("Full Restore restores a battler's HP and cures any primary status")
 {
     u16 status;
@@ -10,16 +15,41 @@ SINGLE_BATTLE_TEST("Full Restore restores a battler's HP and cures any primary s
     PARAMETRIZE{ status = STATUS1_POISON; }
     PARAMETRIZE{ status = STATUS1_TOXIC_POISON; }
     PARAMETRIZE{ status = STATUS1_SLEEP; }
+    PARAMETRIZE{ status = STATUS1_NONE; }
     GIVEN {
-        ASSUME(gItems[ITEM_FULL_RESTORE].battleUsage == EFFECT_ITEM_HEAL_AND_CURE_STATUS);
         PLAYER(SPECIES_WOBBUFFET) { HP(1); MaxHP(300); Status1(status); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
         TURN{ USE_ITEM(player, ITEM_FULL_RESTORE, partyIndex: 0); }
     } SCENE {
         MESSAGE("Wobbuffet had its HP restored!");
+        if (status != STATUS1_NONE) {
+            MESSAGE("Wobbuffet had its status healed!"); // The message is not printed if status wasn't healed.
+        }
     } THEN {
         EXPECT_EQ(player->hp, player->maxHP);
+        EXPECT_EQ(player->status1, STATUS1_NONE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Full Restore heals a battler from any primary status")
+{
+    u16 status;
+    PARAMETRIZE{ status = STATUS1_BURN; }
+    PARAMETRIZE{ status = STATUS1_FREEZE; }
+    PARAMETRIZE{ status = STATUS1_PARALYSIS; }
+    PARAMETRIZE{ status = STATUS1_POISON; }
+    PARAMETRIZE{ status = STATUS1_TOXIC_POISON; }
+    PARAMETRIZE{ status = STATUS1_SLEEP; }
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Status1(status); }
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN { USE_ITEM(player, ITEM_FULL_RESTORE, partyIndex: 0); }
+    } SCENE {
+        NOT MESSAGE("Wobbuffet had its HP restored!"); // The message is not printed if mon has max HP.
+        MESSAGE("Wobbuffet had its status healed!");
+    } THEN {
         EXPECT_EQ(player->status1, STATUS1_NONE);
     }
 }
@@ -27,7 +57,6 @@ SINGLE_BATTLE_TEST("Full Restore restores a battler's HP and cures any primary s
 SINGLE_BATTLE_TEST("Full Restore restores a battler's HP and cures confusion")
 {
     GIVEN {
-        ASSUME(gItems[ITEM_FULL_RESTORE].battleUsage == EFFECT_ITEM_HEAL_AND_CURE_STATUS);
         PLAYER(SPECIES_WOBBUFFET) { HP(1); MaxHP(300); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
@@ -39,5 +68,23 @@ SINGLE_BATTLE_TEST("Full Restore restores a battler's HP and cures confusion")
         NONE_OF { MESSAGE("Wobbuffet is confused!"); }
     } THEN {
         EXPECT_EQ(player->hp, player->maxHP);
+    }
+}
+
+SINGLE_BATTLE_TEST("Full Restore resets Toxic Counter")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_TOXIC); }
+        TURN { ; }
+        TURN { USE_ITEM(player, ITEM_FULL_RESTORE, partyIndex: 0); }
+    } SCENE {
+        MESSAGE("Foe Wobbuffet used Toxic!");
+        MESSAGE("Wobbuffet had its HP restored!");
+        MESSAGE("Wobbuffet had its status healed!");
+    } THEN {
+        EXPECT_EQ(player->status1, STATUS1_NONE);
     }
 }


### PR DESCRIPTION
Fixes #4099

With tests.

Also, I modified the Full Restore's battlescript so it only prints 'healed HP' / 'healed Status' messages if they're actually cleared and not always(this was bugged before anyway, because it was printing the HP message twice).