### PR TITLE
Added CONFIG_BY_DEFINE/CONFIG_BY_GEN_DEFINE macros

### DIFF
--- a/include/global.h
+++ b/include/global.h
@@ -180,9 +180,6 @@ Input must be of the form (upper << lower) where upper can be up to 3, lower up 
 #define NUM_FLAG_BYTES ROUND_BITS_TO_BYTES(FLAGS_COUNT)
 #define NUM_TRENDY_SAYING_BYTES ROUND_BITS_TO_BYTES(NUM_TRENDY_SAYINGS)
 
-// Converts a string to a compound literal, essentially making it a pointer to const u8
-#define COMPOUND_STRING(str) (const u8[]) _(str)
-
 // This produces an error at compile-time if expr is zero.
 // It looks like file.c:line: size of array `id' is negative
 #define STATIC_ASSERT(expr, id) typedef char id[(expr) ? 1 : -1];

--- a/include/metaprogram.h
+++ b/include/metaprogram.h
@@ -17,7 +17,10 @@
 #define STR(...) STR_(__VA_ARGS__)
 #define STR_(...) #__VA_ARGS__
 
-/* Expands to the first/second/third/fourth argument. */
+/* Converts a string to a compound literal, essentially making it a pointer to const u8 */
+#define COMPOUND_STRING(str) (const u8[]) _(str)
+
+/* Expands to the first/second/third/fourth argument (if it exists) */
 #define FIRST(a, ...) a
 #define SECOND(a, ...) __VA_OPT__(FIRST(__VA_ARGS__))
 #define THIRD(a, ...) __VA_OPT__(SECOND(__VA_ARGS__))
@@ -29,13 +32,20 @@
 #define EXCEPT_3(a, ...) __VA_OPT__(EXCEPT_2(__VA_ARGS__))
 #define EXCEPT_4(a, ...) __VA_OPT__(EXCEPT_3(__VA_ARGS__))
 
+/* Picks the xth VA_ARG if it exists, otherwise returns a default value */
+#define DEFAULT(_default, ...) FIRST(__VA_OPT__(__VA_ARGS__, ) _default)
+#define DEFAULT_2(_default, ...) DEFAULT(_default __VA_OPT__(, SECOND(__VA_ARGS__)))
+#define DEFAULT_3(_default, ...) DEFAULT(_default __VA_OPT__(, THIRD(__VA_ARGS__)))
+#define DEFAULT_4(_default, ...) DEFAULT(_default __VA_OPT__(, FOURTH(__VA_ARGS__)))
+
 /* 'UNPACK (x, y, z)' expands to 'x, y, z'.
  * Useful for passing arguments which may contain commas into a macro. */
 #define UNPACK(...) __VA_ARGS__
 
 /* Expands to 'macro(...args, ...)'. */
-#define INVOKE_WITH(macro, args, ...) INVOKE_WITH_(macro, UNPACK args __VA_OPT__(, __VA_ARGS__))
-#define INVOKE_WITH_(macro, ...) macro(__VA_ARGS__)
+#define INVOKE_WITH(macro, args, ...) INVOKE(macro, UNPACK args __VA_OPT__(, __VA_ARGS__))
+#define INVOKE(macro, ...) macro(__VA_ARGS__)
+#define INVOKE_() INVOKE
 
 /* Recursive macros.
  * Based on https://www.scs.stanford.edu/~dm/blog/va-opt.html
@@ -66,11 +76,130 @@
 #define R_FOR_EACH_WITH_(macro, args, a, ...) INVOKE_WITH(macro, args, a) __VA_OPT__(R_FOR_EACH_WITH_P PARENS (macro, args, __VA_ARGS__))
 #define R_FOR_EACH_WITH_P() R_FOR_EACH_WITH_
 
-/* Picks the xth VA_ARG if it exists, otherwise returns a default value */
-#define DEFAULT(_default, ...) FIRST(__VA_OPT__(__VA_ARGS__, ) _default)
-#define DEFAULT_2(_default, ...) DEFAULT(_default __VA_OPT__(, SECOND(__VA_ARGS__)))
-#define DEFAULT_3(_default, ...) DEFAULT(_default __VA_OPT__(, THIRD(__VA_ARGS__)))
-#define DEFAULT_4(_default, ...) DEFAULT(_default __VA_OPT__(, FOURTH(__VA_ARGS__)))
+/* current gen = 1*/
+#define CONFIG_BY_DEFINE_0_GTOE_0(a, b) a
+#define CONFIG_BY_DEFINE_0_GTOE_1(a, b) b
+#define CONFIG_BY_DEFINE_0_GTOE_2(a, b) b
+#define CONFIG_BY_DEFINE_0_GTOE_3(a, b) b
+#define CONFIG_BY_DEFINE_0_GTOE_4(a, b) b
+#define CONFIG_BY_DEFINE_0_GTOE_5(a, b) b
+#define CONFIG_BY_DEFINE_0_GTOE_6(a, b) b
+#define CONFIG_BY_DEFINE_0_GTOE_7(a, b) b
+#define CONFIG_BY_DEFINE_0_GTOE_8(a, b) b
+
+/* current gen = 2 */
+#define CONFIG_BY_DEFINE_1_GTOE_0(a, b) a
+#define CONFIG_BY_DEFINE_1_GTOE_1(a, b) a
+#define CONFIG_BY_DEFINE_1_GTOE_2(a, b) b
+#define CONFIG_BY_DEFINE_1_GTOE_3(a, b) b
+#define CONFIG_BY_DEFINE_1_GTOE_4(a, b) b
+#define CONFIG_BY_DEFINE_1_GTOE_5(a, b) b
+#define CONFIG_BY_DEFINE_1_GTOE_6(a, b) b
+#define CONFIG_BY_DEFINE_1_GTOE_7(a, b) b
+#define CONFIG_BY_DEFINE_1_GTOE_8(a, b) b
+
+/* current gen = 3 */
+#define CONFIG_BY_DEFINE_2_GTOE_0(a, b) a
+#define CONFIG_BY_DEFINE_2_GTOE_1(a, b) a
+#define CONFIG_BY_DEFINE_2_GTOE_2(a, b) a
+#define CONFIG_BY_DEFINE_2_GTOE_3(a, b) b
+#define CONFIG_BY_DEFINE_2_GTOE_4(a, b) b
+#define CONFIG_BY_DEFINE_2_GTOE_5(a, b) b
+#define CONFIG_BY_DEFINE_2_GTOE_6(a, b) b
+#define CONFIG_BY_DEFINE_2_GTOE_7(a, b) b
+#define CONFIG_BY_DEFINE_2_GTOE_8(a, b) b
+
+/* current gen = 4 */
+#define CONFIG_BY_DEFINE_3_GTOE_0(a, b) a
+#define CONFIG_BY_DEFINE_3_GTOE_1(a, b) a
+#define CONFIG_BY_DEFINE_3_GTOE_2(a, b) a
+#define CONFIG_BY_DEFINE_3_GTOE_3(a, b) a
+#define CONFIG_BY_DEFINE_3_GTOE_4(a, b) b
+#define CONFIG_BY_DEFINE_3_GTOE_5(a, b) b
+#define CONFIG_BY_DEFINE_3_GTOE_6(a, b) b
+#define CONFIG_BY_DEFINE_3_GTOE_7(a, b) b
+#define CONFIG_BY_DEFINE_3_GTOE_8(a, b) b
+
+/* current gen = 5 */
+#define CONFIG_BY_DEFINE_4_GTOE_0(a, b) a
+#define CONFIG_BY_DEFINE_4_GTOE_1(a, b) a
+#define CONFIG_BY_DEFINE_4_GTOE_2(a, b) a
+#define CONFIG_BY_DEFINE_4_GTOE_3(a, b) a
+#define CONFIG_BY_DEFINE_4_GTOE_4(a, b) a
+#define CONFIG_BY_DEFINE_4_GTOE_5(a, b) b
+#define CONFIG_BY_DEFINE_4_GTOE_6(a, b) b
+#define CONFIG_BY_DEFINE_4_GTOE_7(a, b) b
+#define CONFIG_BY_DEFINE_4_GTOE_8(a, b) b
+
+/* current gen = 6 */
+#define CONFIG_BY_DEFINE_5_GTOE_0(a, b) a
+#define CONFIG_BY_DEFINE_5_GTOE_1(a, b) a
+#define CONFIG_BY_DEFINE_5_GTOE_2(a, b) a
+#define CONFIG_BY_DEFINE_5_GTOE_3(a, b) a
+#define CONFIG_BY_DEFINE_5_GTOE_4(a, b) a
+#define CONFIG_BY_DEFINE_5_GTOE_5(a, b) a
+#define CONFIG_BY_DEFINE_5_GTOE_6(a, b) b
+#define CONFIG_BY_DEFINE_5_GTOE_7(a, b) b
+#define CONFIG_BY_DEFINE_5_GTOE_8(a, b) b
+
+/* current gen = 7 */
+#define CONFIG_BY_DEFINE_6_GTOE_0(a, b) a
+#define CONFIG_BY_DEFINE_6_GTOE_1(a, b) a
+#define CONFIG_BY_DEFINE_6_GTOE_2(a, b) a
+#define CONFIG_BY_DEFINE_6_GTOE_3(a, b) a
+#define CONFIG_BY_DEFINE_6_GTOE_4(a, b) a
+#define CONFIG_BY_DEFINE_6_GTOE_5(a, b) a
+#define CONFIG_BY_DEFINE_6_GTOE_6(a, b) a
+#define CONFIG_BY_DEFINE_6_GTOE_7(a, b) b
+#define CONFIG_BY_DEFINE_6_GTOE_8(a, b) b
+
+/* current gen = 8 */
+#define CONFIG_BY_DEFINE_7_GTOE_0(a, b) a
+#define CONFIG_BY_DEFINE_7_GTOE_1(a, b) a
+#define CONFIG_BY_DEFINE_7_GTOE_2(a, b) a
+#define CONFIG_BY_DEFINE_7_GTOE_3(a, b) a
+#define CONFIG_BY_DEFINE_7_GTOE_4(a, b) a
+#define CONFIG_BY_DEFINE_7_GTOE_5(a, b) a
+#define CONFIG_BY_DEFINE_7_GTOE_6(a, b) a
+#define CONFIG_BY_DEFINE_7_GTOE_7(a, b) a
+#define CONFIG_BY_DEFINE_7_GTOE_8(a, b) b
+
+/* current gen = 9 */
+#define CONFIG_BY_DEFINE_8_GTOE_0(a, b) a
+#define CONFIG_BY_DEFINE_8_GTOE_1(a, b) a
+#define CONFIG_BY_DEFINE_8_GTOE_2(a, b) a
+#define CONFIG_BY_DEFINE_8_GTOE_3(a, b) a
+#define CONFIG_BY_DEFINE_8_GTOE_4(a, b) a
+#define CONFIG_BY_DEFINE_8_GTOE_5(a, b) a
+#define CONFIG_BY_DEFINE_8_GTOE_6(a, b) a
+#define CONFIG_BY_DEFINE_8_GTOE_7(a, b) a
+#define CONFIG_BY_DEFINE_8_GTOE_8(a, b) a
+
+/* A "simple" macro that lets you define values by a config where a ternary wouldn't work
+Can be read from left to right as (define >= target ? val : val2)
+Define and target are compared on a "greater than or equal" (GTOE) basis and no other */
+#define CONFIG_BY_DEFINE(define, target, val1, val2) CONFIG_BY_DEFINE_(define, target)(val1, val2)
+#define CONFIG_BY_DEFINE_(define, target) CONFIG_BY_DEFINE_ ## define ## _GTOE_ ## target
+
+/* Similar but check for TRUE or FALSE - only works for booleans */
+#define CONFIG_BY_DEFINE_TRUE(define, val1, val2) CONFIG_BY_DEFINE_EQ_(define, 1)(val1, val2)
+#define CONFIG_BY_DEFINE_FALSE(define, val1, val2) CONFIG_BY_DEFINE_EQ_(define, 0)(val1, val2)
+#define CONFIG_BY_DEFINE_EQ_(define, target) CONFIG_BY_DEFINE_ ## define ## _EQ_ ## target
+#define CONFIG_BY_DEFINE_1_EQ_0(a, b) b
+#define CONFIG_BY_DEFINE_1_EQ_1(a, b) a
+#define CONFIG_BY_DEFINE_0_EQ_0(a, b) a
+#define CONFIG_BY_DEFINE_0_EQ_1(a, b) b
+
+/* Lets you define values that vary across generations without needing a ternary
+You should use it by defining CONFIG_BY_GEN in each file where you want to use it
+along with the relevant constant e.g. for moves_info.h:
+#define CONFIG_BY_GEN(...) CONFIG_BY_GEN_DEFINE(B_UPDATED_MOVE_DATA, __VA_ARGS__) */
+#define CONFIG_BY_GEN_DEFINE(define, ...) VARARG_8(CONFIG_BY_GEN_DEFINE_, define, __VA_ARGS__)
+#define CONFIG_BY_GEN_DEFINE_3(define, base, tuple) INVOKE(CONFIG_BY_DEFINE, define, UNPACK tuple, base)
+#define CONFIG_BY_GEN_DEFINE_4(define, base, tuple1, tuple2) INVOKE(CONFIG_BY_GEN_DEFINE_4_UNPACKED, define, base, UNPACK tuple1, UNPACK tuple2)
+#define CONFIG_BY_GEN_DEFINE_4_UNPACKED(define, base, target1, value1, target2, value2) CONFIG_BY_DEFINE_(define, target1)(CONFIG_BY_DEFINE_(define, target2)(value2, value1), base)
+#define CONFIG_BY_GEN_DEFINE_5(define, base, tuple1, tuple2, tuple3) INVOKE(CONFIG_BY_GEN_DEFINE_5_UNPACKED, define, base, UNPACK tuple1, UNPACK tuple2, UNPACK tuple3)
+#define CONFIG_BY_GEN_DEFINE_5_UNPACKED(define, base, target1, value1, target2, value2, target3, value3) CONFIG_BY_DEFINE_(define, target1)(CONFIG_BY_DEFINE_(define, target2)(CONFIG_BY_DEFINE_(define, target3)(value3, value2), value1), base)
 
 /* (Credit to MGriffin) A rather monstrous way of finding the set bit in a word.
 Invalid input causes a compiler error. Sample: https://cexplore.karathan.at/z/x1hm7B */

--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -10,17 +10,8 @@
 
 // The Gen. 4+ contest data comes from urpg's contest movedex.
 
-#if B_EXPANDED_MOVE_NAMES == TRUE
-#define HANDLE_EXPANDED_MOVE_NAME(_name, ...) COMPOUND_STRING(DEFAULT(_name, __VA_ARGS__))
-#else
-#define HANDLE_EXPANDED_MOVE_NAME(_name, ...) COMPOUND_STRING(_name)
-#endif
-
-#if B_BINDING_TURNS >= GEN_5
-#define BINDING_TURNS "4 or 5"
-#else
-#define BINDING_TURNS "2 to 5"
-#endif
+#define CONFIG_BY_GEN(...) CONFIG_BY_GEN_DEFINE(B_UPDATED_MOVE_DATA, __VA_ARGS__)
+#define HANDLE_EXPANDED_MOVE_NAME(_name, ...) COMPOUND_STRING(CONFIG_BY_DEFINE_TRUE(B_EXPANDED_MOVE_NAMES, DEFAULT(_name, __VA_ARGS__), _name))
 
 /* First arg is the charge turn string id, second arg depends on effect
 EFFECT_SEMI_INVULNERABLE/EFFECT_SKY_DROP: semi-invulnerable STATUS3 to apply to battler
@@ -298,11 +289,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("Ice Punch"),
         .description = COMPOUND_STRING(
             "An icy punch that may\n"
-        #if B_USE_FROSTBITE == TRUE
-            "leave the foe with frostbite."),
-        #else
-            "freeze the foe."),
-        #endif
+            CONFIG_BY_DEFINE_TRUE(B_USE_FROSTBITE, "leave the foe with frostbite.", "freeze the foe.")),
         .effect = EFFECT_HIT,
         .power = 75,
         .type = TYPE_ICE,
@@ -450,7 +437,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .power = 0,
         .type = TYPE_NORMAL,
         .accuracy = 0,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_6 ? 20 : 30,
+        .pp = CONFIG_BY_GEN(30, (GEN_6, 20)),
         .target = MOVE_TARGET_USER,
         .priority = 0,
         .category = DAMAGE_CATEGORY_STATUS,
@@ -538,7 +525,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .effect = EFFECT_ROAR,
         .power = 0,
         .type = TYPE_NORMAL,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_6 ? 0 : 100,
+        .accuracy = CONFIG_BY_GEN(100, (GEN_6, 0)),
         .pp = 20,
         .target = MOVE_TARGET_SELECTED,
         .priority = -6,
@@ -563,7 +550,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Flies up on the first turn,\n"
             "then strikes the next turn."),
         .effect = EFFECT_SEMI_INVULNERABLE,
-        .power = B_UPDATED_MOVE_DATA >= GEN_4 ? 90 : 70,
+        .power = CONFIG_BY_GEN(70, (GEN_4, 90)),
         .type = TYPE_FLYING,
         .accuracy = 95,
         .pp = 15,
@@ -588,11 +575,11 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("Bind"),
         .description = COMPOUND_STRING(
             "Binds and squeezes the foe\n"
-            "for "BINDING_TURNS" turns."),
+            "for " CONFIG_BY_GEN("2 to 5", (GEN_5, "4 or 5")) " turns."),
         .effect = EFFECT_HIT,
         .power = 15,
         .type = TYPE_NORMAL,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_5 ? 85 : 75,
+        .accuracy = CONFIG_BY_GEN(75, (GEN_5, 85)),
         .pp = 20,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -636,15 +623,9 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .description = COMPOUND_STRING(
             "Strikes the foe with\n"
             "slender, whiplike vines."),
-        #if B_UPDATED_MOVE_DATA >= GEN_6
-            .pp = 25,
-        #elif B_UPDATED_MOVE_DATA >= GEN_4
-            .pp = 15,
-        #else
-            .pp = 10,
-        #endif
+        .pp = CONFIG_BY_GEN(10, (GEN_4, 15), (GEN_6, 25)),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 45 : 35,
+        .power = CONFIG_BY_GEN(35, (GEN_6, 45)),
         .type = TYPE_GRASS,
         .accuracy = 100,
         .target = MOVE_TARGET_SELECTED,
@@ -734,17 +715,11 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .description = COMPOUND_STRING(
             "A strong jumping kick. May\n"
             "miss and hurt the kicker."),
-        #if B_UPDATED_MOVE_DATA >= GEN_5
-            .power = 100,
-        #elif B_UPDATED_MOVE_DATA >= GEN_4
-            .power = 85,
-        #else
-            .power = 70,
-        #endif
+        .power = CONFIG_BY_GEN(70, (GEN_4, 85), (GEN_5, 100)),
         .effect = EFFECT_RECOIL_IF_MISS,
         .type = TYPE_FIGHTING,
         .accuracy = 95,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_5 ? 10 : 25,
+        .pp = CONFIG_BY_GEN(25, (GEN_5, 10)),
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
         .category = DAMAGE_CATEGORY_PHYSICAL,
@@ -900,16 +875,10 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .description = COMPOUND_STRING(
             "Charges the foe with a full-\n"
             "body tackle."),
-        #if B_UPDATED_MOVE_DATA >= GEN_7
-            .power = 40,
-        #elif B_UPDATED_MOVE_DATA >= GEN_5
-            .power = 50,
-        #else
-            .power = 35,
-        #endif
+        .power = CONFIG_BY_GEN(35, (GEN_5, 50), (GEN_7, 40)),
         .effect = EFFECT_HIT,
         .type = TYPE_NORMAL,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_5 ? 100 : 95,
+        .accuracy = CONFIG_BY_GEN(95, (GEN_5, 100)),
         .pp = 35,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -954,11 +923,11 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("Wrap"),
         .description = COMPOUND_STRING(
             "Wraps and squeezes the foe\n"
-            BINDING_TURNS" times with vines, etc."),
+            CONFIG_BY_GEN("2 to 5", (GEN_5, "4 or 5")) " times with vines, etc."),
         .effect = EFFECT_HIT,
         .power = 15,
         .type = TYPE_NORMAL,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_5 ? 90 : 85,
+        .accuracy = CONFIG_BY_GEN(85, (GEN_5, 90)),
         .pp = 20,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -1002,10 +971,10 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "A rampage of 2 to 3 turns\n"
             "that confuses the user."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_5 ? 120 : 90,
+        .power = CONFIG_BY_GEN(90, (GEN_5, 120)),
         .type = TYPE_NORMAL,
         .accuracy = 100,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_5 ? 10 : 20,
+        .pp = CONFIG_BY_GEN(20, (GEN_5, 10)),
         .target = MOVE_TARGET_RANDOM,
         .priority = 0,
         .category = DAMAGE_CATEGORY_PHYSICAL,
@@ -1124,9 +1093,9 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Sharp pins are fired to\n"
             "strike 2 to 5 times."),
         .effect = EFFECT_MULTI_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 25 : 14,
+        .power = CONFIG_BY_GEN(14, (GEN_6, 25)),
         .type = TYPE_BUG,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_6 ? 95 : 85,
+        .accuracy = CONFIG_BY_GEN(85, (GEN_6, 95)),
         .pp = 20,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -1219,7 +1188,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .effect = EFFECT_ROAR,
         .power = 0,
         .type = TYPE_NORMAL,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_6 ? 0 : 100,
+        .accuracy = CONFIG_BY_GEN(100, (GEN_6, 0)),
         .pp = 20,
         .target = MOVE_TARGET_SELECTED,
         .priority = -6,
@@ -1312,13 +1281,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .description = COMPOUND_STRING(
             "Psychically disables one of\n"
             "the foe's moves."),
-        #if B_UPDATED_MOVE_DATA >= GEN_5
-            .accuracy = 100,
-        #elif B_UPDATED_MOVE_DATA == GEN_4
-            .accuracy = 80,
-        #else
-            .accuracy = 55,
-        #endif
+        .accuracy = CONFIG_BY_GEN(55, (GEN_4, 80), (GEN_5, 100)),
         .effect = EFFECT_DISABLE,
         .power = 0,
         .type = TYPE_NORMAL,
@@ -1340,11 +1303,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("Acid"),
         .description = COMPOUND_STRING(
             "Sprays a hide-melting acid.\n"
-        #if B_UPDATED_MOVE_DATA >= GEN_4
-            "May lower Sp. Def."),
-        #else
-            "May lower Defense."),
-        #endif
+            "May lower " CONFIG_BY_GEN("Defense.", (GEN_4, "Sp. Def."))),
         .effect = EFFECT_HIT,
         .power = 40,
         .type = TYPE_POISON,
@@ -1355,7 +1314,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .category = DAMAGE_CATEGORY_SPECIAL,
         .sheerForceBoost = TRUE,
             .additionalEffects = ADDITIONAL_EFFECTS({
-            .moveEffect = B_UPDATED_MOVE_DATA >= GEN_4 ? MOVE_EFFECT_SP_DEF_MINUS_1 : MOVE_EFFECT_DEF_MINUS_1,
+            .moveEffect = CONFIG_BY_GEN(MOVE_EFFECT_DEF_MINUS_1, (GEN_4, MOVE_EFFECT_SP_DEF_MINUS_1)),
             .chance = 10,
         }),
         .contestEffect = CONTEST_EFFECT_BADLY_STARTLE_FRONT_MON,
@@ -1396,7 +1355,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "A powerful fire attack that\n"
             "may inflict a burn."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 90 : 95,
+        .power = CONFIG_BY_GEN(95, (GEN_6, 90)),
         .type = TYPE_FIRE,
         .accuracy = 100,
         .pp = 15,
@@ -1465,7 +1424,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Blasts water at high power\n"
             "to strike the foe."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 110 : 120,
+        .power = CONFIG_BY_GEN(120, (GEN_6, 110)),
         .type = TYPE_WATER,
         .accuracy = 80,
         .pp = 5,
@@ -1485,11 +1444,11 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Creates a huge wave, then\n"
             "crashes it down on the foe."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 90 : 95,
+        .power = CONFIG_BY_GEN(95, (GEN_6, 90)),
         .type = TYPE_WATER,
         .accuracy = 100,
         .pp = 15,
-        .target = B_UPDATED_MOVE_DATA >= GEN_4 ? MOVE_TARGET_FOES_AND_ALLY : MOVE_TARGET_BOTH,
+        .target = CONFIG_BY_GEN(MOVE_TARGET_BOTH, (GEN_4, MOVE_TARGET_FOES_AND_ALLY)),
         .priority = 0,
         .category = DAMAGE_CATEGORY_SPECIAL,
         .damagesUnderwater = TRUE,
@@ -1505,13 +1464,9 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("Ice Beam"),
         .description = COMPOUND_STRING(
             "Blasts the foe with an icy\n"
-        #if B_USE_FROSTBITE == TRUE
-            "beam. May cause frostbite."),
-        #else
-            "beam that may freeze it."),
-        #endif
+            CONFIG_BY_DEFINE_TRUE(B_USE_FROSTBITE, "beam. May cause frostbite.", "beam that may freeze it.")),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 90 : 95,
+        .power = CONFIG_BY_GEN(95, (GEN_6, 90)),
         .type = TYPE_ICE,
         .accuracy = 100,
         .pp = 10,
@@ -1536,13 +1491,9 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("Blizzard"),
         .description = COMPOUND_STRING(
             "Hits the foe with an icy\n"
-        #if B_USE_FROSTBITE == TRUE
-            "storm. May cause frostbite."),
-        #else
-            "storm that may freeze it."),
-        #endif
-        .effect = B_BLIZZARD_HAIL >= GEN_4 ? EFFECT_BLIZZARD : EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 110 : 120,
+            CONFIG_BY_DEFINE_TRUE(B_USE_FROSTBITE, "storm. May cause frostbite.", "storm that may freeze it.")),
+        .effect = CONFIG_BY_DEFINE(B_BLIZZARD_HAIL, GEN_4, EFFECT_BLIZZARD, EFFECT_HIT),
+        .power = CONFIG_BY_GEN(120, (GEN_6, 110)),
         .type = TYPE_ICE,
         .accuracy = 70,
         .pp = 5,
@@ -1711,7 +1662,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .power = 80,
         .type = TYPE_FIGHTING,
         .accuracy = 80,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_6 ? 20 : 25,
+        .pp = CONFIG_BY_GEN(25, (GEN_6, 20)),
         .recoil = 25,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -1823,7 +1774,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .power = 20,
         .type = TYPE_GRASS,
         .accuracy = 100,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_4 ? 25 : 20,
+        .pp = CONFIG_BY_GEN(20, (GEN_4, 25)),
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
         .category = DAMAGE_CATEGORY_SPECIAL,
@@ -1843,7 +1794,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .power = 40,
         .type = TYPE_GRASS,
         .accuracy = 100,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_4 ? 15 : 10,
+        .pp = CONFIG_BY_GEN(10, (GEN_4, 15)),
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
         .category = DAMAGE_CATEGORY_SPECIAL,
@@ -1883,11 +1834,11 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .description = COMPOUND_STRING(
             "Forces the body to grow\n"
             "and heightens Sp. Atk."),
-        .effect = B_GROWTH_STAT_RAISE >= GEN_5 ? EFFECT_GROWTH : EFFECT_SPECIAL_ATTACK_UP,
+        .effect = CONFIG_BY_DEFINE(B_GROWTH_STAT_RAISE, GEN_5, EFFECT_GROWTH, EFFECT_SPECIAL_ATTACK_UP),
         .power = 0,
         .type = TYPE_NORMAL,
         .accuracy = 0,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_6 ? 20 : 40,
+        .pp = CONFIG_BY_GEN(40, (GEN_6, 20)),
         .target = MOVE_TARGET_USER,
         .priority = 0,
         .category = DAMAGE_CATEGORY_STATUS,
@@ -2022,17 +1973,11 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .description = COMPOUND_STRING(
             "A rampage of 2 to 3 turns\n"
             "that confuses the user."),
-        #if B_UPDATED_MOVE_DATA >= GEN_5
-            .power = 120,
-        #elif B_UPDATED_MOVE_DATA == GEN_4
-            .power = 90,
-        #else
-            .power = 70,
-        #endif
+        .power = CONFIG_BY_GEN(70, (GEN_4, 90), (GEN_5, 120)),
         .effect = EFFECT_HIT,
         .type = TYPE_GRASS,
         .accuracy = 100,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_5 ? 10 : 20,
+        .pp = CONFIG_BY_GEN(20, (GEN_5, 10)),
         .target = MOVE_TARGET_RANDOM,
         .priority = 0,
         .category = DAMAGE_CATEGORY_SPECIAL,
@@ -2055,7 +2000,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .description = COMPOUND_STRING(
             "Binds the foe with string\n"
             "to reduce its Speed."),
-        .effect = B_UPDATED_MOVE_DATA >= GEN_6 ? EFFECT_SPEED_DOWN_2 : EFFECT_SPEED_DOWN,
+        .effect = CONFIG_BY_GEN(EFFECT_SPEED_DOWN, (GEN_6, EFFECT_SPEED_DOWN_2)),
         .power = 0,
         .type = TYPE_BUG,
         .accuracy = 95,
@@ -2098,11 +2043,11 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("Fire Spin"),
         .description = COMPOUND_STRING(
             "Traps the foe in a ring of\n"
-            "fire for "BINDING_TURNS" turns."),
+            "fire for " CONFIG_BY_GEN("2 to 5", (GEN_5, "4 or 5")) " turns."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_5 ? 35 : 15,
+        .power = CONFIG_BY_GEN(15, (GEN_5, 35)),
         .type = TYPE_FIRE,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_5 ? 85 : 70,
+        .accuracy = CONFIG_BY_GEN(70, (GEN_5, 85)),
         .pp = 15,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -2149,7 +2094,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "A strong electrical attack\n"
             "that may paralyze the foe."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 90 : 95,
+        .power = CONFIG_BY_GEN(95, (GEN_6, 90)),
         .type = TYPE_ELECTRIC,
         .accuracy = 100,
         .pp = 15,
@@ -2176,7 +2121,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .effect = EFFECT_PARALYZE,
         .power = 0,
         .type = TYPE_ELECTRIC,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_7 ? 90 : 100,
+        .accuracy = CONFIG_BY_GEN(100, (GEN_7, 90)),
         .pp = 20,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -2196,7 +2141,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "A lightning attack that may\n"
             "cause paralysis."),
         .effect = EFFECT_THUNDER,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 110 : 120,
+        .power = CONFIG_BY_GEN(120, (GEN_6, 110)),
         .type = TYPE_ELECTRIC,
         .accuracy = 70,
         .pp = 10,
@@ -2287,7 +2232,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Digs underground the first\n"
             "turn and strikes next turn."),
         .effect = EFFECT_SEMI_INVULNERABLE,
-        .power = B_UPDATED_MOVE_DATA >= GEN_4 ? 80 : 60,
+        .power = CONFIG_BY_GEN(60, (GEN_4, 80)),
         .type = TYPE_GROUND,
         .accuracy = 100,
         .pp = 10,
@@ -2316,7 +2261,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .effect = EFFECT_TOXIC,
         .power = 0,
         .type = TYPE_POISON,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_5 ? 90 : 85,
+        .accuracy = CONFIG_BY_GEN(85, (GEN_5, 90)),
         .pp = 10,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -2617,13 +2562,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .description = COMPOUND_STRING(
             "Recovers up to half the\n"
             "user's maximum HP."),
-        #if B_UPDATED_MOVE_DATA >= GEN_9
-            .pp = 5,
-        #elif B_UPDATED_MOVE_DATA >= GEN_4
-            .pp = 10,
-        #else
-            .pp = 20,
-        #endif
+        .pp = CONFIG_BY_GEN(20, (GEN_4, 10), (GEN_9, 5)),
         .effect = EFFECT_RESTORE_HP,
         .power = 0,
         .type = TYPE_NORMAL,
@@ -2676,7 +2615,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .power = 0,
         .type = TYPE_NORMAL,
         .accuracy = 0,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_6 ? 10 : 20,
+        .pp = CONFIG_BY_GEN(20, (GEN_6, 10)),
         .target = MOVE_TARGET_USER,
         .priority = 0,
         .category = DAMAGE_CATEGORY_STATUS,
@@ -2792,7 +2731,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .power = 0,
         .type = TYPE_PSYCHIC,
         .accuracy = 0,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_6 ? 20 : 30,
+        .pp = CONFIG_BY_GEN(30, (GEN_6, 20)),
         .target = MOVE_TARGET_USER,
         .priority = 0,
         .category = DAMAGE_CATEGORY_STATUS,
@@ -2912,10 +2851,10 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .effect = EFFECT_BIDE,
         .power = 1,
         .type = TYPE_NORMAL,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_4 ? 0 : 100,
+        .accuracy = CONFIG_BY_GEN(100, (GEN_4, 0)),
         .pp = 10,
         .target = MOVE_TARGET_USER,
-        .priority = B_UPDATED_MOVE_DATA >= GEN_4 ? 1 : 0,
+        .priority = CONFIG_BY_GEN(0, (GEN_4, 1)),
         .category = DAMAGE_CATEGORY_PHYSICAL,
         .makesContact = TRUE,
         .sleepTalkBanned = TRUE,
@@ -3033,7 +2972,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Licks with a long tongue to\n"
             "injure. May also paralyze."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 30 : 20,
+        .power = CONFIG_BY_GEN(20, (GEN_6, 30)),
         .type = TYPE_GHOST,
         .accuracy = 100,
         .pp = 30,
@@ -3059,7 +2998,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "An exhaust-gas attack\n"
             "that may also poison."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 30 : 20,
+        .power = CONFIG_BY_GEN(20, (GEN_6, 30)),
         .type = TYPE_POISON,
         .accuracy = 70,
         .pp = 20,
@@ -3134,7 +3073,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Incinerates everything it\n"
             "strikes. May cause a burn."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 110 : 120,
+        .power = CONFIG_BY_GEN(120, (GEN_6, 110)),
         .type = TYPE_FIRE,
         .accuracy = 85,
         .pp = 5,
@@ -3185,12 +3124,12 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("Clamp"),
         .description = COMPOUND_STRING(
             "Traps and squeezes the\n"
-            "foe for "BINDING_TURNS" turns."),
+            "foe for " CONFIG_BY_GEN("2 to 5", (GEN_5, "4 or 5")) " turns."),
         .effect = EFFECT_HIT,
         .power = 35,
         .type = TYPE_WATER,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_5 ? 85 : 75,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_5 ? 15 : 10,
+        .accuracy = CONFIG_BY_GEN(75, (GEN_5, 85)),
+        .pp = CONFIG_BY_GEN(10, (GEN_5, 15)),
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
         .category = DAMAGE_CATEGORY_PHYSICAL,
@@ -3232,10 +3171,10 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Tucks in the head, then\n"
             "attacks on the next turn."),
         .effect = EFFECT_TWO_TURNS_ATTACK,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 130 : 100,
+        .power = CONFIG_BY_GEN(100, (GEN_6, 130)),
         .type = TYPE_NORMAL,
         .accuracy = 100,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_6 ? 10 : 15,
+        .pp = CONFIG_BY_GEN(15, (GEN_6, 10)),
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
         .category = DAMAGE_CATEGORY_PHYSICAL,
@@ -3357,7 +3296,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .power = 0,
         .type = TYPE_NORMAL,
         .accuracy = 100,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_9 ? 5 : 10,
+        .pp = CONFIG_BY_GEN(10, (GEN_9, 5)),
         .target = MOVE_TARGET_USER,
         .priority = 0,
         .category = DAMAGE_CATEGORY_STATUS,
@@ -3378,17 +3317,11 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .description = COMPOUND_STRING(
             "A jumping knee kick. If it\n"
             "misses, the user is hurt."),
-        #if B_UPDATED_MOVE_DATA >= GEN_5
-            .power = 130,
-        #elif B_UPDATED_MOVE_DATA == GEN_4
-            .power = 100,
-        #else
-            .power = 85,
-        #endif
+        .power = CONFIG_BY_GEN(85, (GEN_4, 100), (GEN_5, 130)),
         .effect = EFFECT_RECOIL_IF_MISS,
         .type = TYPE_FIGHTING,
         .accuracy = 90,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_5 ? 10 : 20,
+        .pp = CONFIG_BY_GEN(20, (GEN_5, 10)),
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
         .category = DAMAGE_CATEGORY_PHYSICAL,
@@ -3406,13 +3339,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .description = COMPOUND_STRING(
             "Intimidates and frightens\n"
             "the foe into paralysis."),
-        #if B_UPDATED_MOVE_DATA >= GEN_6
-            .accuracy = 100,
-        #elif B_UPDATED_MOVE_DATA == GEN_5
-            .accuracy = 90,
-        #else
-            .accuracy = 75,
-        #endif
+        .accuracy = CONFIG_BY_GEN(75, (GEN_5, 90), (GEN_6, 100)),
         .effect = EFFECT_PARALYZE,
         .power = 0,
         .type = TYPE_NORMAL,
@@ -3455,18 +3382,12 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .description = COMPOUND_STRING(
             "Envelops the foe in a toxic\n"
             "gas that may poison."),
-        #if B_UPDATED_MOVE_DATA >= GEN_6
-            .accuracy = 90,
-        #elif B_UPDATED_MOVE_DATA >= GEN_5
-            .accuracy = 80,
-        #else
-            .accuracy = 55,
-        #endif
+        .accuracy = CONFIG_BY_GEN(55, (GEN_5, 80), (GEN_6, 90)),
         .effect = EFFECT_POISON,
         .power = 0,
         .type = TYPE_POISON,
         .pp = 40,
-        .target = B_UPDATED_MOVE_DATA >= GEN_5 ? MOVE_TARGET_BOTH : MOVE_TARGET_SELECTED,
+        .target = CONFIG_BY_GEN(MOVE_TARGET_SELECTED, (GEN_5, MOVE_TARGET_BOTH)),
         .priority = 0,
         .category = DAMAGE_CATEGORY_STATUS,
         .zMove = { .effect = Z_EFFECT_DEF_UP_1 },
@@ -3505,10 +3426,10 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "An attack that steals half\n"
             "the damage inflicted."),
         .effect = EFFECT_ABSORB,
-        .power = B_UPDATED_MOVE_DATA >= GEN_7 ? 80 : 20,
+        .power = CONFIG_BY_GEN(20, (GEN_7, 80)),
         .type = TYPE_BUG,
         .accuracy = 100,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_7 ? 10 : 15,
+        .pp = CONFIG_BY_GEN(15, (GEN_7, 10)),
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
         .category = DAMAGE_CATEGORY_PHYSICAL,
@@ -3611,7 +3532,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "An attack using bubbles.\n"
             "May lower the foe's Speed."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 40 : 20,
+        .power = CONFIG_BY_GEN(20, (GEN_6, 40)),
         .type = TYPE_WATER,
         .accuracy = 100,
         .pp = 30,
@@ -3688,7 +3609,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .effect = EFFECT_ACCURACY_DOWN,
         .power = 0,
         .type = TYPE_NORMAL,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_4 ? 100 : 70,
+        .accuracy = CONFIG_BY_GEN(70, (GEN_4, 100)),
         .pp = 20,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -3710,7 +3631,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .effect = EFFECT_PSYWAVE,
         .power = 1,
         .type = TYPE_PSYCHIC,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_6 ? 100 : 80,
+        .accuracy = CONFIG_BY_GEN(80, (GEN_6, 100)),
         .pp = 15,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -3755,7 +3676,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .power = 0,
         .type = TYPE_POISON,
         .accuracy = 0,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_6 ? 20 : 40,
+        .pp = CONFIG_BY_GEN(40, (GEN_6, 20)),
         .target = MOVE_TARGET_USER,
         .priority = 0,
         .category = DAMAGE_CATEGORY_STATUS,
@@ -3776,9 +3697,9 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Hammers with a pincer. Has a\n"
             "high critical-hit ratio."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 100 : 90,
+        .power = CONFIG_BY_GEN(90, (GEN_6, 100)),
         .type = TYPE_WATER,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_5 ? 90 : 85,
+        .accuracy = CONFIG_BY_GEN(85, (GEN_5, 90)),
         .criticalHitStage = 1,
         .pp = 10,
         .target = MOVE_TARGET_SELECTED,
@@ -3864,7 +3785,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .power = 0,
         .type = TYPE_PSYCHIC,
         .accuracy = 0,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_9 ? 5 : 10,
+        .pp = CONFIG_BY_GEN(10, (GEN_9, 5)),
         .target = MOVE_TARGET_USER,
         .priority = 0,
         .category = DAMAGE_CATEGORY_STATUS,
@@ -4080,19 +4001,19 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .description = COMPOUND_STRING(
             "Used only if all PP are gone.\n"
             "Also hurts the user a little."),
-        #if B_UPDATED_MOVE_DATA >= GEN_4
-            .effect = EFFECT_RECOIL_HP_25,
-            .accuracy = 0,
-            .mirrorMoveBanned = TRUE,
-            .additionalEffects = ADDITIONAL_EFFECTS({
-                .moveEffect = MOVE_EFFECT_RECOIL_HP_25,
-                .self = TRUE,
-            }),
-        #else
-            .effect = EFFECT_HIT,
-            .accuracy = 100,
-            .recoil = 25,
-        #endif
+    #if B_UPDATED_MOVE_DATA >= GEN_4
+        .effect = EFFECT_RECOIL_HP_25,
+        .accuracy = 0,
+        .mirrorMoveBanned = TRUE,
+        .additionalEffects = ADDITIONAL_EFFECTS({
+            .moveEffect = MOVE_EFFECT_RECOIL_HP_25,
+            .self = TRUE,
+        }),
+    #else
+        .effect = EFFECT_HIT,
+        .accuracy = 100,
+        .recoil = 25,
+    #endif
         .power = 50,
         .type = TYPE_NORMAL,
         .pp = 1,
@@ -4172,10 +4093,10 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "While attacking, it may\n"
             "steal the foe's held item."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 60 : 40,
+        .power = CONFIG_BY_GEN(40, (GEN_6, 60)),
         .type = TYPE_DARK,
         .accuracy = 100,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_6 ? 25 : 10,
+        .pp = CONFIG_BY_GEN(10, (GEN_6, 25)),
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
         .category = DAMAGE_CATEGORY_PHYSICAL,
@@ -4226,7 +4147,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .effect = EFFECT_LOCK_ON,
         .power = 0,
         .type = TYPE_NORMAL,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_4 ? 0 : 100,
+        .accuracy = CONFIG_BY_GEN(100, (GEN_4, 0)),
         .pp = 5,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -4247,7 +4168,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .effect = EFFECT_NIGHTMARE,
         .power = 0,
         .type = TYPE_GHOST,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_4 ? 100 : 0,
+        .accuracy = CONFIG_BY_GEN(0, (GEN_4, 100)),
         .pp = 15,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -4294,7 +4215,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "A loud attack that can be\n"
             "used only while asleep."),
         .effect = EFFECT_SNORE,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 50 : 40,
+        .power = CONFIG_BY_GEN(40, (GEN_6, 50)),
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .pp = 15,
@@ -4323,7 +4244,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "differently for GHOSTS."),
         .effect = EFFECT_CURSE,
         .power = 0,
-        .type = B_UPDATED_MOVE_TYPES >= GEN_5 ? TYPE_GHOST : TYPE_MYSTERY,
+        .type = CONFIG_BY_DEFINE(B_UPDATED_MOVE_TYPES, GEN_5, TYPE_GHOST, TYPE_MYSTERY),
         .accuracy = 0,
         .pp = 10,
         .target = MOVE_TARGET_SELECTED,
@@ -4415,9 +4336,9 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .effect = EFFECT_SPEED_DOWN_2,
         .power = 0,
         .type = TYPE_GRASS,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_5 ? 100 : 85,
+        .accuracy = CONFIG_BY_GEN(85, (GEN_5, 100)),
         .pp = 40,
-        .target = B_UPDATED_MOVE_DATA >= GEN_6 ? MOVE_TARGET_BOTH : MOVE_TARGET_SELECTED,
+        .target = CONFIG_BY_GEN(MOVE_TARGET_SELECTED, (GEN_6, MOVE_TARGET_BOTH)),
         .priority = 0,
         .category = DAMAGE_CATEGORY_STATUS,
         .zMove = { .effect = Z_EFFECT_RESET_STATS },
@@ -4510,7 +4431,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .accuracy = 0,
         .pp = 10,
         .target = MOVE_TARGET_USER,
-        .priority = B_UPDATED_MOVE_DATA >= GEN_5 ? 4 : 3,
+        .priority = CONFIG_BY_GEN(3, (GEN_5, 4)),
         .category = DAMAGE_CATEGORY_STATUS,
         .zMove = { .effect = Z_EFFECT_RESET_STATS },
         .protectionMove = TRUE,
@@ -4554,7 +4475,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .effect = EFFECT_SPEED_DOWN_2,
         .power = 0,
         .type = TYPE_NORMAL,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_5 ? 100 : 90,
+        .accuracy = CONFIG_BY_GEN(90, (GEN_5, 100)),
         .pp = 10,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -4594,7 +4515,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "look. May cause confusion."),
         .effect = EFFECT_CONFUSE,
         .power = 0,
-        .type = B_UPDATED_MOVE_TYPES >= GEN_6 ? TYPE_FAIRY : TYPE_NORMAL,
+        .type = CONFIG_BY_DEFINE(B_UPDATED_MOVE_TYPES, GEN_6, TYPE_FAIRY, TYPE_NORMAL),
         .accuracy = 75,
         .pp = 10,
         .target = MOVE_TARGET_SELECTED,
@@ -4742,7 +4663,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Powerful and sure to cause\n"
             "paralysis, but inaccurate."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_4 ? 120 : 100,
+        .power = CONFIG_BY_GEN(100, (GEN_4, 120)),
         .type = TYPE_ELECTRIC,
         .accuracy = 50,
         .pp = 5,
@@ -4770,7 +4691,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .effect = EFFECT_FORESIGHT,
         .power = 0,
         .type = TYPE_NORMAL,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_5 ? 0 : 100,
+        .accuracy = CONFIG_BY_GEN(100, (GEN_5, 0)),
         .pp = 40,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -4874,7 +4795,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .accuracy = 0,
         .pp = 5,
         .target = MOVE_TARGET_USER,
-        .priority = B_UPDATED_MOVE_DATA >= GEN_5 ? 4 : 3,
+        .priority = CONFIG_BY_GEN(3, (GEN_5, 4)),
         .category = DAMAGE_CATEGORY_STATUS,
         .zMove = { .effect = Z_EFFECT_EVSN_UP_1 },
         .ignoresProtect = TRUE,
@@ -4898,7 +4819,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .effect = EFFECT_MULTI_HIT,
         .power = 25,
         .type = TYPE_GROUND,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_5 ? 90 : 80,
+        .accuracy = CONFIG_BY_GEN(80, (GEN_5, 90)),
         .pp = 10,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -4918,7 +4839,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .effect = EFFECT_LOCK_ON,
         .power = 0,
         .type = TYPE_NORMAL,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_4 ? 0 : 100,
+        .accuracy = CONFIG_BY_GEN(100, (GEN_4, 0)),
         .pp = 5,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -4937,10 +4858,10 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "A rampage of 2 to 3 turns\n"
             "that confuses the user."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_4 ? 120 : 90,
+        .power = CONFIG_BY_GEN(90, (GEN_4, 120)),
         .type = TYPE_DRAGON,
         .accuracy = 100,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_5 ? 10 : 15,
+        .pp = CONFIG_BY_GEN(15, (GEN_5, 10)),
         .target = MOVE_TARGET_RANDOM,
         .priority = 0,
         .category = DAMAGE_CATEGORY_PHYSICAL,
@@ -4987,10 +4908,10 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "An attack that steals half\n"
             "the damage inflicted."),
         .effect = EFFECT_ABSORB,
-        .power = B_UPDATED_MOVE_DATA >= GEN_5 ? 75 : 60,
+        .power = CONFIG_BY_GEN(60, (GEN_5, 75)),
         .type = TYPE_GRASS,
         .accuracy = 100,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_4 ? 10 : 5,
+        .pp = CONFIG_BY_GEN(5, (GEN_4, 10)),
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
         .category = DAMAGE_CATEGORY_SPECIAL,
@@ -5014,7 +4935,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .accuracy = 0,
         .pp = 10,
         .target = MOVE_TARGET_USER,
-        .priority = B_UPDATED_MOVE_DATA >= GEN_5 ? 4 : 3,
+        .priority = CONFIG_BY_GEN(3, (GEN_5, 4)),
         .category = DAMAGE_CATEGORY_STATUS,
         .zMove = { .effect = Z_EFFECT_RESET_STATS },
         .ignoresProtect = TRUE,
@@ -5037,7 +4958,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "reduces its Attack."),
         .effect = EFFECT_ATTACK_DOWN_2,
         .power = 0,
-        .type = B_UPDATED_MOVE_TYPES >= GEN_6 ? TYPE_FAIRY : TYPE_NORMAL,
+        .type = CONFIG_BY_DEFINE(B_UPDATED_MOVE_TYPES, GEN_6, TYPE_FAIRY, TYPE_NORMAL),
         .accuracy = 100,
         .pp = 20,
         .target = MOVE_TARGET_SELECTED,
@@ -5102,7 +5023,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .effect = EFFECT_SWAGGER,
         .power = 0,
         .type = TYPE_NORMAL,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_7 ? 85 : 90,
+        .accuracy = CONFIG_BY_GEN(90, (GEN_7, 85)),
         .pp = 15,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -5125,7 +5046,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .power = 0,
         .type = TYPE_NORMAL,
         .accuracy = 0,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_9 ? 5 : 10,
+        .pp = CONFIG_BY_GEN(10, (GEN_9, 5)),
         .target = MOVE_TARGET_USER,
         .priority = 0,
         .category = DAMAGE_CATEGORY_STATUS,
@@ -5172,13 +5093,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .description = COMPOUND_STRING(
             "An attack that intensifies\n"
             "on each successive hit."),
-        #if B_UPDATED_MOVE_DATA >= GEN_6
-            .power = 40,
-        #elif B_UPDATED_MOVE_DATA >= GEN_5
-            .power = 20,
-        #else
-            .power = 10,
-        #endif
+        .power = CONFIG_BY_GEN(10, (GEN_5, 20), (GEN_6, 40)),
         .effect = EFFECT_FURY_CUTTER,
         .type = TYPE_BUG,
         .accuracy = 95,
@@ -5629,7 +5544,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Spins the body at high\n"
             "speed to strike the foe."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_8 ? 50 : 20,
+        .power = CONFIG_BY_GEN(20, (GEN_8, 50)),
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .pp = 40,
@@ -5661,7 +5576,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .description = COMPOUND_STRING(
             "Allures the foe to reduce\n"
             "evasiveness."),
-        .effect = B_UPDATED_MOVE_DATA >= GEN_6 ? EFFECT_EVASION_DOWN_2 : EFFECT_EVASION_DOWN,
+        .effect = CONFIG_BY_GEN(EFFECT_EVASION_DOWN, (GEN_6, EFFECT_EVASION_DOWN_2)),
         .power = 0,
         .type = TYPE_NORMAL,
         .accuracy = 100,
@@ -5809,7 +5724,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "varies with the weather."),
         .effect = EFFECT_MOONLIGHT,
         .power = 0,
-        .type = B_UPDATED_MOVE_TYPES >= GEN_6 ? TYPE_FAIRY : TYPE_NORMAL,
+        .type = CONFIG_BY_DEFINE(B_UPDATED_MOVE_TYPES, GEN_6, TYPE_FAIRY, TYPE_NORMAL),
         .accuracy = 0,
         .pp = 5,
         .target = MOVE_TARGET_USER,
@@ -5832,7 +5747,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .description = COMPOUND_STRING(
             "The effectiveness varies\n"
             "with the user."),
-        .power = B_HIDDEN_POWER_DMG >= GEN_6 ? 60 : 1,
+        .power = CONFIG_BY_DEFINE(B_HIDDEN_POWER_DMG, GEN_6, 60, 1),
         .effect = EFFECT_HIDDEN_POWER,
         .type = TYPE_NORMAL,
         .accuracy = 100,
@@ -5946,11 +5861,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("Crunch"),
         .description = COMPOUND_STRING(
             "Crunches with sharp fangs.\n"
-        #if B_UPDATED_MOVE_DATA >= GEN_4
-            "May lower Defense."),
-        #else
-            "May lower Sp. Def."),
-        #endif
+            "May lower " CONFIG_BY_GEN("Sp. Def.", (GEN_4, "Defense."))),
         .effect = EFFECT_HIT,
         .power = 80,
         .type = TYPE_DARK,
@@ -5962,12 +5873,8 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .makesContact = TRUE,
         .sheerForceBoost = TRUE,
         .bitingMove = TRUE,
-            .additionalEffects = ADDITIONAL_EFFECTS({
-        #if B_UPDATED_MOVE_DATA >= GEN_4
-            .moveEffect = MOVE_EFFECT_DEF_MINUS_1,
-        #else
-            .moveEffect = MOVE_EFFECT_SP_DEF_MINUS_1,
-        #endif
+        .additionalEffects = ADDITIONAL_EFFECTS({
+            .moveEffect = CONFIG_BY_GEN(MOVE_EFFECT_DEF_MINUS_1, (GEN_4, MOVE_EFFECT_SP_DEF_MINUS_1)),
             .chance = 20,
         }),
         .contestEffect = CONTEST_EFFECT_BADLY_STARTLE_FRONT_MON,
@@ -6037,7 +5944,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .accuracy = 100,
         .pp = 5,
         .target = MOVE_TARGET_SELECTED,
-        .priority = B_UPDATED_MOVE_DATA >= GEN_5 ? 2 : 1,
+        .priority = CONFIG_BY_GEN(1, (GEN_5, 2)),
         .category = DAMAGE_CATEGORY_PHYSICAL,
         .makesContact = TRUE,
         .contestEffect = CONTEST_EFFECT_NEXT_APPEAL_EARLIER,
@@ -6105,17 +6012,11 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .description = COMPOUND_STRING(
             "Heightens inner power to\n"
             "strike 2 turns later."),
-        #if B_UPDATED_MOVE_DATA >= GEN_6
-            .power = 120,
-        #elif B_UPDATED_MOVE_DATA >= GEN_5
-            .power = 100,
-        #else
-            .power = 80,
-        #endif
+        .power = CONFIG_BY_GEN(80, (GEN_5, 100), (GEN_6, 120)),
         .effect = EFFECT_FUTURE_SIGHT,
         .type = TYPE_PSYCHIC,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_5 ? 100 : 90,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_5 ? 10 : 15,
+        .accuracy = CONFIG_BY_GEN(90, (GEN_5, 100)),
+        .pp = CONFIG_BY_GEN(15, (GEN_5, 10)),
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
         .category = DAMAGE_CATEGORY_SPECIAL,
@@ -6134,7 +6035,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "A rock-crushing attack\n"
             "that may lower Defense."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_4 ? 40 : 20,
+        .power = CONFIG_BY_GEN(20, (GEN_4, 40)),
         .type = TYPE_FIGHTING,
         .accuracy = 100,
         .pp = 15,
@@ -6158,11 +6059,11 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("Whirlpool"),
         .description = COMPOUND_STRING(
             "Traps and hurts the foe in\n"
-            "a whirlpool for "BINDING_TURNS" turns."),
+            "a whirlpool for " CONFIG_BY_GEN("2 to 5", (GEN_5, "4 or 5")) " turns."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_5 ? 35 : 15,
+        .power = CONFIG_BY_GEN(15, (GEN_5, 35)),
         .type = TYPE_WATER,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_5 ? 85 : 70,
+        .accuracy = CONFIG_BY_GEN(70, (GEN_5, 85)),
         .pp = 15,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -6184,7 +6085,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Summons party Pokémon to\n"
             "join in the attack."),
         .effect = EFFECT_BEAT_UP,
-        .power = B_UPDATED_MOVE_DATA >= GEN_5 ? 1 : 10,
+        .power = CONFIG_BY_GEN(10, (GEN_5, 1)),
         .type = TYPE_DARK,
         .accuracy = 100,
         .pp = 10,
@@ -6203,7 +6104,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .description = COMPOUND_STRING(
             "A 1st-turn, 1st-strike move\n"
             "that causes flinching."),
-        .priority = B_UPDATED_MOVE_DATA >= GEN_5 ? 3 : 1,
+        .priority = CONFIG_BY_GEN(1, (GEN_5, 3)),
         .makesContact = B_UPDATED_MOVE_DATA >= GEN_4,
         .effect = EFFECT_FIRST_TURN_ONLY,
         .power = 40,
@@ -6227,14 +6128,10 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
     {
         .name = COMPOUND_STRING("Uproar"),
         .description = COMPOUND_STRING(
-                                    #if B_UPROAR_TURNS >= GEN_5
-                                       "Causes an uproar for 2 to 5\n"
-                                    #else
-                                       "Causes an uproar for 3\n"
-                                    #endif
-                                       "turns and prevents sleep."),
+            "Causes an uproar for " CONFIG_BY_GEN("3\n", (GEN_5, "2 to 5\n"))
+            "turns and prevents sleep."),
         .effect = EFFECT_UPROAR,
-        .power = B_UPDATED_MOVE_DATA >= GEN_5 ? 90 : 50,
+        .power = CONFIG_BY_GEN(50, (GEN_5, 90)),
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .pp = 10,
@@ -6265,7 +6162,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .power = 0,
         .type = TYPE_NORMAL,
         .accuracy = 0,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_4 ? 20 : 10,
+        .pp = CONFIG_BY_GEN(10, (GEN_4, 20)),
         .target = MOVE_TARGET_USER,
         .priority = 0,
         .category = DAMAGE_CATEGORY_STATUS,
@@ -6286,7 +6183,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Releases stockpiled power\n"
             "(the more the better)."),
         .effect = EFFECT_SPIT_UP,
-        .power = B_UPDATED_MOVE_DATA >= GEN_4 ? 1 : 100,
+        .power = CONFIG_BY_GEN(100, (GEN_4, 1)),
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .pp = 10,
@@ -6332,7 +6229,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Exhales a hot breath on the\n"
             "foe. May inflict a burn."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 95 : 100,
+        .power = CONFIG_BY_GEN(100, (GEN_6, 95)),
         .type = TYPE_FIRE,
         .accuracy = 90,
         .pp = 10,
@@ -6427,7 +6324,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .effect = EFFECT_WILL_O_WISP,
         .power = 0,
         .type = TYPE_FIRE,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_6 ? 85 : 75,
+        .accuracy = CONFIG_BY_GEN(75, (GEN_6, 85)),
         .pp = 15,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -6518,7 +6415,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Powerful against paralyzed\n"
             "foes, but also heals them."),
         .effect = EFFECT_DOUBLE_POWER_ON_ARG_STATUS,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 70 : 60,
+        .power = CONFIG_BY_GEN(60, (GEN_6, 70)),
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .pp = 10,
@@ -6548,7 +6445,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .accuracy = 100,
         .pp = 20,
         .target = MOVE_TARGET_USER,
-        .priority = B_UPDATED_MOVE_DATA >= GEN_6 ? 2 : 3,
+        .priority = CONFIG_BY_GEN(3, (GEN_6, 2)),
         .category = DAMAGE_CATEGORY_STATUS,
         .zMove = { .effect = Z_EFFECT_RESET_STATS },
         .ignoresProtect = TRUE,
@@ -6647,7 +6544,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .pp = 20,
-        .target = B_UPDATED_MOVE_DATA >= GEN_4 ? MOVE_TARGET_ALLY : MOVE_TARGET_USER,
+        .target = CONFIG_BY_GEN(MOVE_TARGET_USER, (GEN_4, MOVE_TARGET_ALLY)),
         .priority = 5,
         .category = DAMAGE_CATEGORY_STATUS,
         .zMove = { .effect = Z_EFFECT_RESET_STATS },
@@ -6931,7 +6828,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Knocks down the foe's held\n"
             "item to prevent its use."),
         .effect = EFFECT_KNOCK_OFF,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 65 : 20,
+        .power = CONFIG_BY_GEN(20, (GEN_6, 65)),
         .type = TYPE_DARK,
         .accuracy = 100,
         .pp = 20,
@@ -7144,7 +7041,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Dives underwater the first\n"
             "turn and strikes next turn."),
         .effect = EFFECT_SEMI_INVULNERABLE,
-        .power = B_UPDATED_MOVE_DATA >= GEN_4 ? 80 : 60,
+        .power = CONFIG_BY_GEN(60, (GEN_4, 80)),
         .type = TYPE_WATER,
         .accuracy = 100,
         .pp = 10,
@@ -7215,7 +7112,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .description = COMPOUND_STRING(
             "Flashes a light that sharply\n"
             "raises Sp. Atk."),
-        .effect = B_UPDATED_MOVE_DATA >= GEN_5 ? EFFECT_SPECIAL_ATTACK_UP_3 : EFFECT_SPECIAL_ATTACK_UP_2,
+        .effect = CONFIG_BY_GEN(EFFECT_SPECIAL_ATTACK_UP_2, (GEN_5, EFFECT_SPECIAL_ATTACK_UP_3)),
         .power = 0,
         .type = TYPE_BUG,
         .accuracy = 0,
@@ -7240,7 +7137,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Attacks with a burst of\n"
             "light. May lower Sp. Def."),
         .effect = EFFECT_HIT,
-        .power = (B_UPDATED_MOVE_DATA >= GEN_9) ? 95 : 70,
+        .power = CONFIG_BY_GEN(70, (GEN_9, 95)),
         .type = TYPE_PSYCHIC,
         .accuracy = 100,
         .pp = 5,
@@ -7265,7 +7162,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Attacks with a flurry of\n"
             "down. May lower Sp. Atk."),
         .effect = EFFECT_HIT,
-        .power = (B_UPDATED_MOVE_DATA >= GEN_9) ? 95 : 70,
+        .power = CONFIG_BY_GEN(70, (GEN_9, 95)),
         .type = TYPE_PSYCHIC,
         .accuracy = 100,
         .pp = 5,
@@ -7442,7 +7339,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .power = 0,
         .type = TYPE_NORMAL,
         .accuracy = 100,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_9 ? 5 : 10,
+        .pp = CONFIG_BY_GEN(10, (GEN_9, 5)),
         .target = MOVE_TARGET_USER,
         .priority = 0,
         .category = DAMAGE_CATEGORY_STATUS,
@@ -7498,7 +7395,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .bitingMove = TRUE,
         .additionalEffects = ADDITIONAL_EFFECTS({
             .moveEffect = MOVE_EFFECT_TOXIC,
-            .chance = B_UPDATED_MOVE_DATA >= GEN_6 ? 50 : 30,
+            .chance = CONFIG_BY_GEN(30, (GEN_6, 50)),
         }),
         .contestEffect = CONTEST_EFFECT_WORSEN_CONDITION_OF_PREV_MONS,
         .contestCategory = CONTEST_CATEGORY_SMART,
@@ -7587,9 +7484,9 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Fires a meteor-like punch.\n"
             "May raise Attack."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 90 : 100,
+        .power = CONFIG_BY_GEN(100, (GEN_6, 90)),
         .type = TYPE_STEEL,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_6 ? 90 : 85,
+        .accuracy = CONFIG_BY_GEN(85, (GEN_6, 90)),
         .pp = 10,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -7709,7 +7606,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Hacks with razorlike wind.\n"
             "High critical-hit ratio."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 60 : 55,
+        .power = CONFIG_BY_GEN(55, (GEN_6, 60)),
         .type = TYPE_FLYING,
         .accuracy = 95,
         .criticalHitStage = 1,
@@ -7732,7 +7629,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Allows a full-power attack,\n"
             "but sharply lowers Sp. Atk."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 130 : 140,
+        .power = CONFIG_BY_GEN(140, (GEN_6, 130)),
         .type = TYPE_FIRE,
         .accuracy = 90,
         .pp = 5,
@@ -7759,7 +7656,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .effect = EFFECT_FORESIGHT,
         .power = 0,
         .type = TYPE_NORMAL,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_4 ? 0 : 100,
+        .accuracy = CONFIG_BY_GEN(100, (GEN_4, 0)),
         .pp = 40,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -7780,10 +7677,10 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Stops the foe from moving\n"
             "with rocks and cuts Speed."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 60 : 50,
+        .power = CONFIG_BY_GEN(50, (GEN_6, 60)),
         .type = TYPE_ROCK,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_6 ? 95 : 80,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_6 ? 15 : 10,
+        .accuracy = CONFIG_BY_GEN(80, (GEN_6, 95)),
+        .pp = CONFIG_BY_GEN(10, (GEN_6, 15)),
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
         .category = DAMAGE_CATEGORY_PHYSICAL,
@@ -7996,7 +7893,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .power = 80,
         .type = TYPE_PSYCHIC,
         .accuracy = 100,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_6 ? 20 : 30,
+        .pp = CONFIG_BY_GEN(30, (GEN_6, 20)),
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
         .category = DAMAGE_CATEGORY_SPECIAL,
@@ -8040,11 +7937,11 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("Sand Tomb"),
         .description = COMPOUND_STRING(
             "Traps and hurts the foe in\n"
-            "quicksand for "BINDING_TURNS" turns."),
+            "quicksand for " CONFIG_BY_GEN("2 to 5", (GEN_5, "4 or 5")) " turns."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_5 ? 35 : 15,
+        .power = CONFIG_BY_GEN(15, (GEN_5, 35)),
         .type = TYPE_GROUND,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_5 ? 85 : 70,
+        .accuracy = CONFIG_BY_GEN(70, (GEN_5, 85)),
         .pp = 15,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -8085,7 +7982,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Attacks with muddy water.\n"
             "May lower accuracy."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 90 : 95,
+        .power = CONFIG_BY_GEN(95, (GEN_6, 90)),
         .type = TYPE_WATER,
         .accuracy = 85,
         .pp = 10,
@@ -8111,7 +8008,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Shoots 2 to 5 seeds in a row\n"
             "to strike the foe."),
         .effect = EFFECT_MULTI_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_5 ? 25 : 10,
+        .power = CONFIG_BY_GEN(10, (GEN_5, 25)),
         .type = TYPE_GRASS,
         .accuracy = 100,
         .pp = 30,
@@ -8154,7 +8051,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Attacks the foe by firing\n"
             "2 to 5 icicles in a row."),
         .effect = EFFECT_MULTI_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_5 ? 25 : 10,
+        .power = CONFIG_BY_GEN(10, (GEN_5, 25)),
         .type = TYPE_ICE,
         .accuracy = 100,
         .pp = 30,
@@ -8221,7 +8118,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Howls to raise the spirit\n"
             "and boosts Attack."),
         .power = 0,
-        .effect = B_UPDATED_MOVE_DATA >= GEN_8 ? EFFECT_ATTACK_UP_USER_ALLY : EFFECT_ATTACK_UP,
+        .effect = CONFIG_BY_GEN(EFFECT_ATTACK_UP, (GEN_8, EFFECT_ATTACK_UP_USER_ALLY)),
         .type = TYPE_NORMAL,
         .accuracy = 0,
         .pp = 40,
@@ -8400,10 +8297,10 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Cutely begs to obtain an\n"
             "item held by the foe."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_5 ? 60 : 40,
+        .power = CONFIG_BY_GEN(40, (GEN_5, 60)),
         .type = TYPE_NORMAL,
         .accuracy = 100,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_6 ? 25 : 40,
+        .pp = CONFIG_BY_GEN(40, (GEN_6, 25)),
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
         .category = DAMAGE_CATEGORY_PHYSICAL,
@@ -8525,7 +8422,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Slashes with a sharp leaf.\n"
             "High critical-hit ratio."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_4 ? 90 : 70,
+        .power = CONFIG_BY_GEN(70, (GEN_4, 90)),
         .type = TYPE_GRASS,
         .accuracy = 100,
         .criticalHitStage = 1,
@@ -8575,7 +8472,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .effect = EFFECT_MULTI_HIT,
         .power = 25,
         .type = TYPE_ROCK,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_5 ? 90 : 80,
+        .accuracy = CONFIG_BY_GEN(80, (GEN_5, 90)),
         .pp = 10,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -8640,9 +8537,9 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Summons strong sunlight to\n"
             "attack 2 turns later."),
         .effect = EFFECT_FUTURE_SIGHT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_5 ? 140 : 120,
+        .power = CONFIG_BY_GEN(120, (GEN_5, 140)),
         .type = TYPE_STEEL,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_5 ? 100 : 85,
+        .accuracy = CONFIG_BY_GEN(85, (GEN_5, 100)),
         .pp = 5,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -8689,7 +8586,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .power = 0,
         .type = TYPE_FLYING,
         .accuracy = 0,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_9 ? 5 : 10,
+        .pp = CONFIG_BY_GEN(10, (GEN_9, 5)),
         .target = MOVE_TARGET_USER,
         .priority = 0,
         .category = DAMAGE_CATEGORY_STATUS,
@@ -8758,7 +8655,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Powerful against sleeping\n"
             "foes, but also heals them."),
         .effect = EFFECT_DOUBLE_POWER_ON_ARG_STATUS,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 70 : 60,
+        .power = CONFIG_BY_GEN(60, (GEN_6, 70)),
         .type = TYPE_FIGHTING,
         .accuracy = 100,
         .pp = 10,
@@ -8893,7 +8790,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "An attack that hits foes\n"
             "using moves like Protect."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_5 ? 30 : 50,
+        .power = CONFIG_BY_GEN(50, (GEN_5, 30)),
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .pp = 10,
@@ -8946,7 +8843,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .power = 0,
         .type = TYPE_FLYING,
         .accuracy = 0,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_6 ? 15 : 30,
+        .pp = CONFIG_BY_GEN(30, (GEN_6, 15)),
         .target = MOVE_TARGET_USER,
         .priority = 0,
         .category = DAMAGE_CATEGORY_STATUS,
@@ -9076,7 +8973,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "An attack that gains power\n"
             "if the foe has been hurt."),
         .effect = EFFECT_ASSURANCE,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 60 : 50,
+        .power = CONFIG_BY_GEN(50, (GEN_6, 60)),
         .type = TYPE_DARK,
         .accuracy = 100,
         .pp = 10,
@@ -9142,7 +9039,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .effect = EFFECT_PSYCHO_SHIFT,
         .power = 0,
         .type = TYPE_PSYCHIC,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_6 ? 100 : 90,
+        .accuracy = CONFIG_BY_GEN(90, (GEN_6, 100)),
         .pp = 10,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -9419,7 +9316,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Can only be used if every\n"
             "other move has been used."),
         .effect = EFFECT_LAST_RESORT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_5 ? 140 : 130,
+        .power = CONFIG_BY_GEN(130, (GEN_5, 140)),
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .pp = 5,
@@ -9460,7 +9357,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("Sucker Punch"),
         .description = sSuckerPunchDescription,
         .effect = EFFECT_SUCKER_PUNCH,
-        .power = B_UPDATED_MOVE_DATA >= GEN_7 ? 70 : 80,
+        .power = CONFIG_BY_GEN(80, (GEN_7, 70)),
         .type = TYPE_DARK,
         .accuracy = 100,
         .pp = 5,
@@ -9633,7 +9530,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Attacks with an aura blast\n"
             "that cannot be evaded."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 80 : 90,
+        .power = CONFIG_BY_GEN(90, (GEN_6, 80)),
         .type = TYPE_FIGHTING,
         .accuracy = 0,
         .pp = 20,
@@ -9799,7 +9696,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .power = 75,
         .type = TYPE_FLYING,
         .accuracy = 95,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_6 ? 15 : 20,
+        .pp = CONFIG_BY_GEN(20, (GEN_6, 15)),
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
         .category = DAMAGE_CATEGORY_SPECIAL,
@@ -9871,7 +9768,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Generates a shock wave to\n"
             "damage the foe."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 85 : 90,
+        .power = CONFIG_BY_GEN(90, (GEN_6, 85)),
         .type = TYPE_DRAGON,
         .accuracy = 100,
         .pp = 10,
@@ -9919,7 +9816,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Attacks with rays of light\n"
             "that sparkle like diamonds."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 80 : 70,
+        .power = CONFIG_BY_GEN(70, (GEN_6, 80)),
         .type = TYPE_ROCK,
         .accuracy = 100,
         .pp = 20,
@@ -9937,10 +9834,10 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("Drain Punch"),
         .description = sMegaDrainDescription,
         .effect = EFFECT_ABSORB,
-        .power = B_UPDATED_MOVE_DATA >= GEN_5 ? 75 : 60,
+        .power = CONFIG_BY_GEN(60, (GEN_5, 75)),
         .type = TYPE_FIGHTING,
         .accuracy = 100,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_5 ? 10 : 5,
+        .pp = CONFIG_BY_GEN(5, (GEN_5, 10)),
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
         .category = DAMAGE_CATEGORY_PHYSICAL,
@@ -10006,7 +9903,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Draws power from nature to\n"
             "attack. May lower Sp. Def."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 90 : 80,
+        .power = CONFIG_BY_GEN(80, (GEN_6, 90)),
         .type = TYPE_GRASS,
         .accuracy = 100,
         .pp = 10,
@@ -10545,7 +10442,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Casts comets onto the foe.\n"
             "Harshly lowers the Sp. Atk."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 130 : 140,
+        .power = CONFIG_BY_GEN(140, (GEN_6, 130)),
         .type = TYPE_DRAGON,
         .accuracy = 90,
         .pp = 5,
@@ -10617,7 +10514,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Whips up a storm of leaves.\n"
             "Harshly lowers the Sp. Atk."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 130 : 140,
+        .power = CONFIG_BY_GEN(140, (GEN_6, 130)),
         .type = TYPE_GRASS,
         .accuracy = 90,
         .pp = 5,
@@ -10715,7 +10612,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .effect = EFFECT_HIT,
         .power = 120,
         .type = TYPE_POISON,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_6 ? 80 : 70,
+        .accuracy = CONFIG_BY_GEN(70, (GEN_6, 80)),
         .pp = 5,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -10875,7 +10772,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Attacks with a sound wave\n"
             "that causes confusion."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 65 : 60,
+        .power = CONFIG_BY_GEN(60, (GEN_6, 65)),
         .type = TYPE_FLYING,
         .accuracy = 100,
         .pp = 20,
@@ -10894,13 +10791,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .assistBanned = TRUE,
         .additionalEffects = ADDITIONAL_EFFECTS({
             .moveEffect = MOVE_EFFECT_CONFUSION,
-        #if B_UPDATED_MOVE_DATA >= GEN_6
-            .chance = 100,
-        #elif B_UPDATED_MOVE_DATA >= GEN_5
-            .chance = 10,
-        #else
-            .chance = 31,
-        #endif
+            .chance = CONFIG_BY_GEN(31, (GEN_5, 10), (GEN_6, 100)),
         }),
         .contestEffect = CONTEST_EFFECT_SCRAMBLE_NEXT_TURN_ORDER,
         .contestCategory = CONTEST_CATEGORY_SMART,
@@ -11226,11 +11117,11 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("Magma Storm"),
         .description = COMPOUND_STRING(
             "Traps the foe in a vortex\n"
-            "of fire for "BINDING_TURNS" turns."),
+            "of fire for " CONFIG_BY_GEN("2 to 5", (GEN_5, "4 or 5")) " turns."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 100 : 120,
+        .power = CONFIG_BY_GEN(120, (GEN_6, 100)),
         .type = TYPE_FIRE,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_5 ? 75 : 70,
+        .accuracy = CONFIG_BY_GEN(70, (GEN_5, 75)),
         .pp = 5,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -11253,7 +11144,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .effect = EFFECT_DARK_VOID,
         .power = 0,
         .type = TYPE_DARK,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_7 ? 50 : 80,
+        .accuracy = CONFIG_BY_GEN(80, (GEN_7, 50)),
         .pp = 10,
         .target = MOVE_TARGET_BOTH,
         .priority = 0,
@@ -11455,7 +11346,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .accuracy = 0,
         .pp = 10,
         .target = MOVE_TARGET_ALL_BATTLERS,
-        .priority = B_UPDATED_MOVE_DATA >= GEN_6 ? 0 : -7,
+        .priority = CONFIG_BY_GEN(-7, (GEN_6, 0)),
         .category = DAMAGE_CATEGORY_STATUS,
         .zMove = { .effect = Z_EFFECT_SPDEF_UP_1 },
         .ignoresProtect = TRUE,
@@ -11540,7 +11431,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .accuracy = 0,
         .pp = 20,
         .target = MOVE_TARGET_USER,
-        .priority = B_UPDATED_MOVE_DATA >= GEN_6 ? 2 : 3,
+        .priority = CONFIG_BY_GEN(3, (GEN_6, 2)),
         .category = DAMAGE_CATEGORY_STATUS,
         .zMove = { .effect = Z_EFFECT_RESET_STATS },
         .powderMove = TRUE,
@@ -11590,7 +11481,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .accuracy = 0,
         .pp = 10,
         .target = MOVE_TARGET_ALL_BATTLERS,
-        .priority = B_UPDATED_MOVE_DATA >= GEN_6 ? 0 : -7,
+        .priority = CONFIG_BY_GEN(-7, (GEN_6, 0)),
         .category = DAMAGE_CATEGORY_STATUS,
         .zMove = { .effect = Z_EFFECT_SPDEF_UP_1 },
         .ignoresProtect = TRUE,
@@ -11630,7 +11521,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("Storm Throw"),
         .description = sStormThrowDescription,
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 60 : 40,
+        .power = CONFIG_BY_GEN(40, (GEN_6, 60)),
         .type = TYPE_FIGHTING,
         .accuracy = 100,
         .pp = 10,
@@ -11747,10 +11638,10 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "An odd shock wave that only\n"
             "damages same-type foes."),
         .effect = EFFECT_SYNCHRONOISE,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 120 : 70,
+        .power = CONFIG_BY_GEN(70, (GEN_6, 120)),
         .type = TYPE_PSYCHIC,
         .accuracy = 100,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_6 ? 10 : 15,
+        .pp = CONFIG_BY_GEN(15, (GEN_6, 10)),
         .target = MOVE_TARGET_FOES_AND_ALLY,
         .priority = 0,
         .category = DAMAGE_CATEGORY_SPECIAL,
@@ -11861,7 +11752,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Attacks the foe's legs\n"
             "lowering its Speed."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 65 : 60,
+        .power = CONFIG_BY_GEN(60, (GEN_6, 65)),
         .type = TYPE_FIGHTING,
         .accuracy = 100,
         .pp = 20,
@@ -12145,7 +12036,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .accuracy = 0,
         .pp = 15,
         .target = MOVE_TARGET_USER,
-        .priority = B_UPDATED_MOVE_DATA >= GEN_7 ? 2 : 1,
+        .priority = CONFIG_BY_GEN(1, (GEN_7, 2)),
         .category = DAMAGE_CATEGORY_STATUS,
         .zMove = { .effect = Z_EFFECT_SPD_UP_2 },
         .ignoresProtect = TRUE,
@@ -12238,7 +12129,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Does double damage if the\n"
             "foe has a status problem."),
         .effect = EFFECT_DOUBLE_POWER_ON_ARG_STATUS,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 65 : 50,
+        .power = CONFIG_BY_GEN(50, (GEN_6, 65)),
         .type = TYPE_GHOST,
         .accuracy = 100,
         .pp = 10,
@@ -12331,7 +12222,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Burns up Berries and Gems\n"
             "preventing their use."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 60 : 30,
+        .power = CONFIG_BY_GEN(30, (GEN_6, 60)),
         .type = TYPE_FIRE,
         .accuracy = 100,
         .pp = 15,
@@ -12514,7 +12405,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Attacks with a column of\n"
             "water. May make a rainbow."),
         .effect = EFFECT_PLEDGE,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 80 : 50,
+        .power = CONFIG_BY_GEN(50, (GEN_6, 80)),
         .type = TYPE_WATER,
         .accuracy = 100,
         .pp = 10,
@@ -12535,7 +12426,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Attacks with a column of\n"
             "fire. May burn the grass."),
         .effect = EFFECT_PLEDGE,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 80 : 50,
+        .power = CONFIG_BY_GEN(50, (GEN_6, 80)),
         .type = TYPE_FIRE,
         .accuracy = 100,
         .pp = 10,
@@ -12556,7 +12447,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Attacks with a column of\n"
             "grass. May create a swamp."),
         .effect = EFFECT_PLEDGE,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 80 : 50,
+        .power = CONFIG_BY_GEN(50, (GEN_6, 80)),
         .type = TYPE_GRASS,
         .accuracy = 100,
         .pp = 10,
@@ -12595,7 +12486,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Resisting, the user attacks\n"
             "the foe. Lowers Sp. Atk."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 50 : 30,
+        .power = CONFIG_BY_GEN(30, (GEN_6, 50)),
         .type = TYPE_BUG,
         .accuracy = 100,
         .pp = 20,
@@ -12644,7 +12535,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("Frost Breath"),
         .description = sStormThrowDescription,
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 60 : 40,
+        .power = CONFIG_BY_GEN(40, (GEN_6, 60)),
         .type = TYPE_ICE,
         .accuracy = 90,
         .pp = 10,
@@ -12848,7 +12739,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .power = 90,
         .type = TYPE_FIGHTING,
         .accuracy = 100,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_6 ? 15 : 20,
+        .pp = CONFIG_BY_GEN(20, (GEN_6, 15)),
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
         .category = DAMAGE_CATEGORY_PHYSICAL,
@@ -13056,7 +12947,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Traps the foe in a fierce\n"
             "wind. May cause confusion."),
         .effect = EFFECT_THUNDER,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 110 : 120,
+        .power = CONFIG_BY_GEN(120, (GEN_6, 110)),
         .type = TYPE_FLYING,
         .accuracy = 70,
         .pp = 10,
@@ -13151,7 +13042,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "The type varies with the\n"
             "kind of Drive held."),
         .effect = EFFECT_CHANGE_TYPE_ON_ITEM,
-        .power = B_UPDATED_MOVE_DATA >= GEN_6 ? 120 : 85,
+        .power = CONFIG_BY_GEN(85, (GEN_6, 120)),
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .pp = 5,
@@ -13507,7 +13398,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "This attack does Fighting\n"
             "and Flying-type damage."),
         .effect = EFFECT_TWO_TYPED_MOVE,
-        .power = B_UPDATED_MOVE_DATA >= GEN_7 ? 100 : 80,
+        .power = CONFIG_BY_GEN(80, (GEN_7, 100)),
         .type = TYPE_FIGHTING,
         .accuracy = 95,
         .pp = 10,
@@ -13638,7 +13529,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "If it knocks out a foe\n"
             "the Attack stat is raised."),
         .effect = EFFECT_FELL_STINGER,
-        .power = B_UPDATED_MOVE_DATA >= GEN_7 ? 50 : 30,
+        .power = CONFIG_BY_GEN(30, (GEN_7, 50)),
         .type = TYPE_BUG,
         .accuracy = 100,
         .pp = 25,
@@ -13758,7 +13649,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Damages adjacent Pokémon and\n"
             "heals up by half of it."),
         .effect = EFFECT_ABSORB,
-        .power = B_UPDATED_MOVE_DATA >= GEN_7 ? 65 : 50,
+        .power = CONFIG_BY_GEN(50, (GEN_7, 65)),
         .type = TYPE_ELECTRIC,
         .accuracy = 100,
         .pp = 20,
@@ -13896,7 +13787,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .effect = EFFECT_TOPSY_TURVY,
         .power = 0,
         .type = TYPE_DARK,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_7 ? 0 : 100,
+        .accuracy = CONFIG_BY_GEN(100, (GEN_7, 0)),
         .pp = 20,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -14257,7 +14148,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .sheerForceBoost = TRUE,
         .metronomeBanned = TRUE,
         .additionalEffects = ADDITIONAL_EFFECTS({
-            .moveEffect = B_UPDATED_MOVE_DATA >= GEN_7 ? MOVE_EFFECT_DEF_PLUS_2:  MOVE_EFFECT_DEF_PLUS_1,
+            .moveEffect = CONFIG_BY_GEN(MOVE_EFFECT_DEF_PLUS_1, (GEN_7, MOVE_EFFECT_DEF_PLUS_2)),
             .chance = 50,
         }),
         .contestEffect = CONTEST_EFFECT_USER_MORE_EASILY_STARTLED,
@@ -14330,7 +14221,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .pp = 20,
         .target = MOVE_TARGET_SELECTED,
         .priority = 1,
-        .category = B_UPDATED_MOVE_DATA >= GEN_7 ? DAMAGE_CATEGORY_SPECIAL : DAMAGE_CATEGORY_PHYSICAL,
+        .category = CONFIG_BY_GEN(DAMAGE_CATEGORY_PHYSICAL, (GEN_7, DAMAGE_CATEGORY_SPECIAL)),
         .contestEffect = CONTEST_EFFECT_STARTLE_MONS_SAME_TYPE_APPEAL,
         .contestCategory = CONTEST_CATEGORY_BEAUTY,
         .contestComboStarterId = 0,
@@ -14344,7 +14235,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Breathes a special, hot\n"
             "fire. Lowers Sp. Atk."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_7 ? 75 : 65,
+        .power = CONFIG_BY_GEN(65, (GEN_7, 75)),
         .type = TYPE_FIRE,
         .accuracy = 100,
         .pp = 10,
@@ -14728,7 +14619,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("Infestation"),
         .description = COMPOUND_STRING(
             "The foe is infested and\n"
-            "attacked for "BINDING_TURNS" turns."),
+            "attacked for " CONFIG_BY_GEN("2 to 5", (GEN_5, "4 or 5")) " turns."),
         .effect = EFFECT_HIT,
         .power = 20,
         .type = TYPE_BUG,
@@ -14991,7 +14882,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .power = 0,
         .type = TYPE_GROUND,
         .accuracy = 0,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_9 ? 5 : 10,
+        .pp = CONFIG_BY_GEN(10, (GEN_9, 5)),
         .target = MOVE_TARGET_USER,
         .priority = 0,
         .category = DAMAGE_CATEGORY_STATUS,
@@ -16184,7 +16075,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "An attack that changes\n"
             "with Memories."),
         .effect = EFFECT_CHANGE_TYPE_ON_ITEM,
-        .power = B_UPDATED_MOVE_DATA >= GEN_8 ? 120 : 90,
+        .power = CONFIG_BY_GEN(90, (GEN_8, 120)),
         .type = TYPE_NORMAL,
         .accuracy = 100,
         .pp = 10,
@@ -16272,10 +16163,10 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Electric bursts always go\n"
             "first and land a critical hit."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_8 ? 80 : 50,
+        .power = CONFIG_BY_GEN(50, (GEN_8, 80)),
         .type = TYPE_ELECTRIC,
         .accuracy = 100,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_8 ? 10 : 15,
+        .pp = CONFIG_BY_GEN(15, (GEN_8, 10)),
         .target = MOVE_TARGET_SELECTED,
         .priority = 2,
         .category = DAMAGE_CATEGORY_PHYSICAL,
@@ -16363,20 +16254,16 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = HANDLE_EXPANDED_MOVE_NAME("BouncyBubble", "Bouncy Bubble"),
         .description = COMPOUND_STRING(
             "An attack that absorbs\n"
-        #if B_UPDATED_MOVE_DATA >= GEN_8
-            "all the damage inflicted."),
-        #else
-            "half the damage inflicted."),
-        #endif
+            CONFIG_BY_GEN("half", (GEN_8, "all")) " the damage inflicted."),
         .effect = EFFECT_ABSORB,
-        .power = B_UPDATED_MOVE_DATA >= GEN_8 ? 60 : 90,
+        .power = CONFIG_BY_GEN(90, (GEN_8, 60)),
         .type = TYPE_WATER,
         .accuracy = 100,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_8 ? 20 : 15,
+        .pp = CONFIG_BY_GEN(15, (GEN_8, 20)),
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
         .category = DAMAGE_CATEGORY_SPECIAL,
-        .argument = B_UPDATED_MOVE_DATA >= GEN_8 ? 100 : 50, // restores 100% HP instead of 50% HP
+        .argument = CONFIG_BY_GEN(50, (GEN_8, 100)), // restores 100% HP instead of 50% HP
         .mirrorMoveBanned = B_UPDATED_MOVE_FLAGS < GEN_8,
         .metronomeBanned = TRUE,
         .healingMove = B_HEAL_BLOCKING >= GEN_6,
@@ -16389,10 +16276,10 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Shoots a jolt of electricity\n"
             "that always paralyzes."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_8 ? 60 : 90,
+        .power = CONFIG_BY_GEN(90, (GEN_8, 60)),
         .type = TYPE_ELECTRIC,
         .accuracy = 100,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_8 ? 20 : 15,
+        .pp = CONFIG_BY_GEN(15, (GEN_8, 20)),
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
         .category = DAMAGE_CATEGORY_SPECIAL,
@@ -16411,10 +16298,10 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "User cloaked in fire charges.\n"
             "Leaves the foe with a burn."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_8 ? 60 : 90,
+        .power = CONFIG_BY_GEN(90, (GEN_8, 60)),
         .type = TYPE_FIRE,
         .accuracy = 100,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_8 ? 20 : 15,
+        .pp = CONFIG_BY_GEN(15, (GEN_8, 20)),
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
         .category = DAMAGE_CATEGORY_PHYSICAL,
@@ -16435,9 +16322,9 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Telekinetic force that sets\n"
             "wall, lowering Sp. Atk damage."),
         .effect = EFFECT_GLITZY_GLOW,
-        .power = B_UPDATED_MOVE_DATA >= GEN_8 ? 80 : 90,
+        .power = CONFIG_BY_GEN(90, (GEN_8, 80)),
         .type = TYPE_PSYCHIC,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_8 ? 95 : 100,
+        .accuracy = CONFIG_BY_GEN(100, (GEN_8, 95)),
         .pp = 15,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -16453,9 +16340,9 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Acting badly, attacks. Sets\n"
             "wall, lowering Attack damage."),
         .effect = EFFECT_BADDY_BAD,
-        .power = B_UPDATED_MOVE_DATA >= GEN_8 ? 80 : 90,
+        .power = CONFIG_BY_GEN(90, (GEN_8, 80)),
         .type = TYPE_DARK,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_8 ? 95 : 100,
+        .accuracy = CONFIG_BY_GEN(100, (GEN_8, 95)),
         .pp = 15,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -16471,10 +16358,10 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Giant stalk scatters seeds\n"
             "that drain HP every turn."),
         .effect = EFFECT_SAPPY_SEED,
-        .power = B_UPDATED_MOVE_DATA >= GEN_8 ? 100 : 90,
+        .power = CONFIG_BY_GEN(90, (GEN_8, 100)),
         .type = TYPE_GRASS,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_8 ? 90 : 100,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_8 ? 10 : 15,
+        .accuracy = CONFIG_BY_GEN(100, (GEN_8, 90)),
+        .pp = CONFIG_BY_GEN(15, (GEN_8, 10)),
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
         .category = DAMAGE_CATEGORY_PHYSICAL,
@@ -16490,10 +16377,10 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Crystal from cold haze hits.\n"
             "Eliminates all stat changes."),
         .effect = EFFECT_FREEZY_FROST,
-        .power = B_UPDATED_MOVE_DATA >= GEN_8 ? 100 : 90,
+        .power = CONFIG_BY_GEN(90, (GEN_8, 100)),
         .type = TYPE_ICE,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_8 ? 90 : 100,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_8 ? 10 : 15,
+        .accuracy = CONFIG_BY_GEN(100, (GEN_8, 90)),
+        .pp = CONFIG_BY_GEN(15, (GEN_8, 10)),
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
         .category = DAMAGE_CATEGORY_SPECIAL,
@@ -16508,10 +16395,10 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Wrap foe with whirlwind of\n"
             "scent. Heals party's status."),
         .effect = EFFECT_SPARKLY_SWIRL,
-        .power = B_UPDATED_MOVE_DATA >= GEN_8 ? 120 : 90,
+        .power = CONFIG_BY_GEN(90, (GEN_8, 120)),
         .type = TYPE_FAIRY,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_8 ? 85 : 100,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_8 ? 5 : 15,
+        .accuracy = CONFIG_BY_GEN(100, (GEN_8, 85)),
+        .pp = CONFIG_BY_GEN(15, (GEN_8, 5)),
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
         .category = DAMAGE_CATEGORY_SPECIAL,
@@ -17558,7 +17445,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Gliding on ground, hits. Goes\n"
             "first on Grassy Terrain."),
         .effect = EFFECT_GRASSY_GLIDE,
-        .power = B_UPDATED_MOVE_DATA >= GEN_9 ? 55 : 70,
+        .power = CONFIG_BY_GEN(70, (GEN_9, 55)),
         .type = TYPE_GRASS,
         .accuracy = 100,
         .pp = 20,
@@ -17874,7 +17761,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Mastering the Dark style,\n"
             "strikes with a critical hit."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_9 ? 75 : 80,
+        .power = CONFIG_BY_GEN(80, (GEN_9, 75)),
         .type = TYPE_DARK,
         .accuracy = 100,
         .pp = 5,
@@ -17921,7 +17808,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("Thunder Cage"),
         .description = COMPOUND_STRING(
             "Traps the foe in a cage of\n"
-            "electricity for "BINDING_TURNS" turns."),
+            "electricity for " CONFIG_BY_GEN("2 to 5", (GEN_5, "4 or 5")) " turns."),
         .effect = EFFECT_HIT,
         .power = 80,
         .type = TYPE_ELECTRIC,
@@ -17966,11 +17853,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = HANDLE_EXPANDED_MOVE_NAME("FreezngGlare", "Freezing Glare"),
         .description = COMPOUND_STRING(
             "Shoots psychic power from\n"
-        #if B_USE_FROSTBITE == TRUE
-            "the eyes. May frostbite."),
-        #else
-            "the eyes. May freeze the foe."),
-        #endif
+            "the eyes. May " CONFIG_BY_DEFINE_TRUE(B_USE_FROSTBITE, "frostbite.", "freeze the foe.")),
         .power = 90,
         .effect = EFFECT_HIT,
         .type = TYPE_PSYCHIC,
@@ -18050,7 +17933,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Strikes by hurling a blizzard-\n"
             "cloaked icicle lance at foes."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_9 ? 120 : 130,
+        .power = CONFIG_BY_GEN(130, (GEN_9, 120)),
         .type = TYPE_ICE,
         .accuracy = 100,
         .pp = 5,
@@ -18115,7 +17998,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "High critical hit chance. May\n"
             "paralyze, poison or drowse."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_9 ? 80 : 60,
+        .power = CONFIG_BY_GEN(60, (GEN_9, 80)),
         .type = TYPE_POISON,
         .accuracy = 100,
         .pp = 15,
@@ -18203,7 +18086,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Wraps a foe in fierce winds.\n"
             "Varies with the user's form."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_9 ? 100 : 95,
+        .power = CONFIG_BY_GEN(95, (GEN_9, 100)),
         .type = TYPE_FAIRY,
         .accuracy = 80,
         .pp = 5,
@@ -18248,7 +18131,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "A rampage of 2 to 3 turns\n"
             "that confuses the user."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_9 ? 120 : 90,
+        .power = CONFIG_BY_GEN(90, (GEN_9, 120)),
         .type = TYPE_FIRE,
         .accuracy = 100,
         .pp = 10,
@@ -18269,7 +18152,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "A slam shrouded in water.\n"
             "It also hurts the user."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_9 ? 120 : 75,
+        .power = CONFIG_BY_GEN(75, (GEN_9, 120)),
         .type = TYPE_WATER,
         .accuracy = 100,
         .recoil = 33,
@@ -18288,7 +18171,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "A user-hurting blast of\n"
             "amassed chlorophyll."),
         .effect = EFFECT_MAX_HP_50_RECOIL,
-        .power = B_UPDATED_MOVE_DATA >= GEN_9 ? 150 : 120,
+        .power = CONFIG_BY_GEN(120, (GEN_9, 150)),
         .type = TYPE_GRASS,
         .accuracy = 95,
         .pp = 5,
@@ -18345,7 +18228,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Hits with a full-body tackle.\n"
             "Lowers the users's defenses."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_9 ? 120 : 100,
+        .power = CONFIG_BY_GEN(100, (GEN_9, 120)),
         .type = TYPE_GROUND,
         .accuracy = 100,
         .pp = 5,
@@ -18370,7 +18253,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .power = 60,
         .type = TYPE_POISON,
         .accuracy = 100,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_9 ? 10 : 15,
+        .pp = CONFIG_BY_GEN(15, (GEN_9, 10)),
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
         .category = DAMAGE_CATEGORY_PHYSICAL,
@@ -18389,9 +18272,9 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "High critical hit ratio.\n"
             "Ups the user's Speed."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_9 ? 80 : 75,
+        .power = CONFIG_BY_GEN(75, (GEN_9, 80)),
         .type = TYPE_PSYCHIC,
-        .accuracy = B_UPDATED_MOVE_DATA >= GEN_9 ? 100 : 90,
+        .accuracy = CONFIG_BY_GEN(90, (GEN_9, 100)),
         .criticalHitStage = 1,
         .pp = 10,
         .target = MOVE_TARGET_SELECTED,
@@ -18412,7 +18295,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "A spine-chilling resentment.\n"
             "May lower the foe's Attack."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_9 ? 75 : 60,
+        .power = CONFIG_BY_GEN(60, (GEN_9, 75)),
         .type = TYPE_GHOST,
         .accuracy = 100,
         .pp = 15,
@@ -18452,10 +18335,10 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "High critical hit ratio.\n"
             "May lower Defense or flinch."),
         .effect = EFFECT_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_9 ? 90 : 50,
+        .power = CONFIG_BY_GEN(50, (GEN_9, 90)),
         .type = TYPE_FIGHTING,
         .accuracy = 100,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_9 ? 10 : 15,
+        .pp = CONFIG_BY_GEN(15, (GEN_9, 10)),
         .criticalHitStage = 1,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
@@ -18523,10 +18406,10 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Hits with brutal, cold winds.\n"
             "May lower the foe's Speed."),
         .effect = EFFECT_RAIN_ALWAYS_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_9 ? 100 : 95,
+        .power = CONFIG_BY_GEN(95, (GEN_9, 100)),
         .type = TYPE_FLYING,
         .accuracy = 80,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_9 ? 10 : 5,
+        .pp = CONFIG_BY_GEN(5, (GEN_9, 10)),
         .target = MOVE_TARGET_BOTH,
         .priority = 0,
         .category = DAMAGE_CATEGORY_SPECIAL,
@@ -18545,10 +18428,10 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Hits with a brutal tempest.\n"
             "May inflict paralysis."),
         .effect = EFFECT_RAIN_ALWAYS_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_9 ? 100 : 95,
+        .power = CONFIG_BY_GEN(95, (GEN_9, 100)),
         .type = TYPE_ELECTRIC,
         .accuracy = 80,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_9 ? 10 : 5,
+        .pp = CONFIG_BY_GEN(5, (GEN_9, 10)),
         .target = MOVE_TARGET_BOTH,
         .priority = 0,
         .category = DAMAGE_CATEGORY_SPECIAL,
@@ -18567,10 +18450,10 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
             "Hits with brutally hot sand.\n"
             "May inflict a burn."),
         .effect = EFFECT_RAIN_ALWAYS_HIT,
-        .power = B_UPDATED_MOVE_DATA >= GEN_9 ? 100 : 95,
+        .power = CONFIG_BY_GEN(95, (GEN_9, 100)),
         .type = TYPE_GROUND,
         .accuracy = 80,
-        .pp = B_UPDATED_MOVE_DATA >= GEN_9 ? 10 : 5,
+        .pp = CONFIG_BY_GEN(5, (GEN_9, 10)),
         .target = MOVE_TARGET_BOTH,
         .priority = 0,
         .category = DAMAGE_CATEGORY_SPECIAL,


### PR DESCRIPTION
## Description
Allows for neater setting of values that vary across generation, especially ones that vary across multiple generations. Replaced ternaries and #if #else statements in moves.info as a demonstration.

## Images
Allows for up to four values across generations - returns the actual value without the developer needing to check the values of the relevant defines or work out a ternary:
![image](https://github.com/rh-hideout/pokeemerald-expansion/assets/22523466/c2f1a3bb-5793-4879-a0d4-6354bf0757ec)

It also works where ternaries don't:
<img width="465" alt="image" src="https://github.com/rh-hideout/pokeemerald-expansion/assets/22523466/4471770e-31be-43fd-8884-45dbe8c0da71">

## Feature(s) this PR does NOT handle:
Does not apply the macro to anywhere other than moves_info.h.

## **Discord contact info**
The Cancer Fairy/thechurchofcage
