### PR TITLE
Two turn moves tweaks

### DIFF
--- a/asm/macros/battle_script.inc
+++ b/asm/macros/battle_script.inc
@@ -1061,7 +1061,7 @@
 	setsemiinvulnerablebit TRUE
 	.endm
 
-	.macro tryfiretwoturnmovenowcheckeffects battler:req, checkChargeTurnEffects:req, jumpInstr:req
+	.macro tryfiretwoturnmovenowbyeffect battler:req, checkChargeTurnEffects:req, jumpInstr:req
 	.byte 0xc6
 	.byte \battler
 	.byte \checkChargeTurnEffects
@@ -1069,11 +1069,11 @@
 	.endm
 
 	.macro tryfiretwoturnmovewithoutcharging battler:req, jumpInstr:req
-	tryfiretwoturnmovenowcheckeffects \battler, TRUE, \jumpInstr
+	tryfiretwoturnmovenowbyeffect \battler, TRUE, \jumpInstr
 	.endm
 
 	.macro tryfiretwoturnmoveaftercharging battler:req, jumpInstr:req
-	tryfiretwoturnmovenowcheckeffects \battler, FALSE, \jumpInstr
+	tryfiretwoturnmovenowbyeffect \battler, FALSE, \jumpInstr
 	.endm
 
 	.macro setminimize

--- a/asm/macros/battle_script.inc
+++ b/asm/macros/battle_script.inc
@@ -1061,11 +1061,19 @@
 	setsemiinvulnerablebit TRUE
 	.endm
 
-	.macro jumpifweathercheckchargeeffects battler:req, checkChargeTurnEffects:req, jumpInstr:req
+	.macro tryfiretwoturnmovenowcheckeffects battler:req, checkChargeTurnEffects:req, jumpInstr:req
 	.byte 0xc6
 	.byte \battler
 	.byte \checkChargeTurnEffects
 	.4byte \jumpInstr
+	.endm
+
+	.macro tryfiretwoturnmovewithoutcharging battler:req, jumpInstr:req
+	tryfiretwoturnmovenowcheckeffects \battler, TRUE, \jumpInstr
+	.endm
+
+	.macro tryfiretwoturnmoveaftercharging battler:req, jumpInstr:req
+	tryfiretwoturnmovenowcheckeffects \battler, FALSE, \jumpInstr
 	.endm
 
 	.macro setminimize

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -3718,9 +3718,9 @@ BattleScript_PowerHerbActivation:
 BattleScript_EffectTwoTurnsAttack::
 	jumpifstatus2 BS_ATTACKER, STATUS2_MULTIPLETURNS, BattleScript_TwoTurnMovesSecondTurn
 	jumpifword CMP_COMMON_BITS, gHitMarker, HITMARKER_NO_ATTACKSTRING, BattleScript_TwoTurnMovesSecondTurn
-	jumpifweathercheckchargeeffects BS_ATTACKER, TRUE, BattleScript_EffectHit
+	tryfiretwoturnmovewithoutcharging BS_ATTACKER, BattleScript_EffectHit @ e.g. Solar Beam
 	call BattleScript_FirstChargingTurn
-	jumpifweathercheckchargeeffects BS_ATTACKER, FALSE, BattleScript_TwoTurnMovesSecondTurn
+	tryfiretwoturnmoveaftercharging BS_ATTACKER, BattleScript_TwoTurnMovesSecondTurn @ e.g. Electro Shot
 	jumpifholdeffect BS_ATTACKER, HOLD_EFFECT_POWER_HERB, BattleScript_TwoTurnMovesSecondPowerHerbActivates
 	goto BattleScript_MoveEnd
 
@@ -3766,7 +3766,8 @@ BattleScript_GeomancyEnd::
 
 BattleScript_FirstChargingTurn::
 	attackcanceler
-.if B_UPDATED_MOVE_DATA >= GEN_5 @ before Gen 5, charge moves did not print an attack string on the charge turn
+@ before Gen 5, charge moves did not print an attack string on the charge turn
+.if B_UPDATED_MOVE_DATA >= GEN_5
 	flushtextbox
 	attackstring
 	waitmessage B_WAIT_TIME_LONG
@@ -3784,7 +3785,8 @@ BattleScript_TwoTurnMovesSecondPowerHerbActivates:
 	call BattleScript_PowerHerbActivation
 	call BattleScript_TwoTurnMovesSecondTurnRet
 	accuracycheck BattleScript_PrintMoveMissed, ACC_CURR_MOVE
-.if B_UPDATED_MOVE_DATA < GEN_5 @ before Gen 5, charge moves did not print an attack string on the charge turn
+@ before Gen 5, charge moves did not print an attack string on the charge turn
+.if B_UPDATED_MOVE_DATA < GEN_5
 	attackstring
 .endif
 	goto BattleScript_HitFromCritCalc

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -556,7 +556,7 @@ static void Cmd_selectfirstvalidtarget(void);
 static void Cmd_trysetfutureattack(void);
 static void Cmd_trydobeatup(void);
 static void Cmd_setsemiinvulnerablebit(void);
-static void Cmd_jumpifweathercheckchargeeffects(void);
+static void Cmd_tryfiretwoturnmovenowcheckeffects(void);
 static void Cmd_setminimize(void);
 static void Cmd_sethail(void);
 static void Cmd_trymemento(void);
@@ -815,7 +815,7 @@ void (* const gBattleScriptingCommandsTable[])(void) =
     Cmd_trysetfutureattack,                      //0xC3
     Cmd_trydobeatup,                             //0xC4
     Cmd_setsemiinvulnerablebit,                  //0xC5
-    Cmd_jumpifweathercheckchargeeffects,         //0xC6
+    Cmd_tryfiretwoturnmovenowcheckeffects,       //0xC6
     Cmd_setminimize,                             //0xC7
     Cmd_sethail,                                 //0xC8
     Cmd_trymemento,                              //0xC9
@@ -13668,16 +13668,31 @@ static void Cmd_setsemiinvulnerablebit(void)
     gBattlescriptCurrInstr = cmd->nextInstr;
 }
 
-static void Cmd_jumpifweathercheckchargeeffects(void)
+static bool32 CheckIfCanFireTwoTurnMoveNow(u8 battler, bool8 checkChargeTurnEffects)
+{
+    // Semi-invulnerable moves cannot skip their charge turn (except with Power Herb)
+    if (gBattleMoveEffects[gMovesInfo[gCurrentMove].effect].semiInvulnerableEffect == TRUE)
+        return FALSE;
+
+    // If this move has charge turn effects, it must charge, activate them, then try to fire
+    if (checkChargeTurnEffects && MoveHasChargeTurnMoveEffect(gCurrentMove))
+        return FALSE;
+
+    // Insert custom conditions here
+
+    // Certain two-turn moves may fire on the first turn in the right weather (Solar Beam, Electro Shot)
+    // By default, all two-turn moves have the option of adding weather to their argument
+    if (IsBattlerWeatherAffected(battler, HIHALF(gMovesInfo[gCurrentMove].argument)))
+        return TRUE;
+
+    return FALSE;
+}
+
+static void Cmd_tryfiretwoturnmovenowcheckeffects(void)
 {
     CMD_ARGS(u8 battler, bool8 checkChargeTurnEffects, const u8 *jumpInstr);
 
-    /* If this is NOT semi-invulnerable move and we don't have charge turn effects
-    yet to fire, we can fire the move right away so long as the weather matches
-    the argument and the battler is affected by it (not blocked by Cloud Nine etc) */
-    if (gBattleMoveEffects[gMovesInfo[gCurrentMove].effect].semiInvulnerableEffect == FALSE
-      && !(cmd->checkChargeTurnEffects && MoveHasChargeTurnMoveEffect(gCurrentMove))
-      && IsBattlerWeatherAffected(cmd->battler, HIHALF(gMovesInfo[gCurrentMove].argument)))
+    if (CheckIfCanFireTwoTurnMoveNow(cmd->battler, cmd->checkChargeTurnEffects) == TRUE)
     {
         gBattleScripting.animTurn = 1;
         gBattlescriptCurrInstr = cmd->jumpInstr;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -556,7 +556,7 @@ static void Cmd_selectfirstvalidtarget(void);
 static void Cmd_trysetfutureattack(void);
 static void Cmd_trydobeatup(void);
 static void Cmd_setsemiinvulnerablebit(void);
-static void Cmd_tryfiretwoturnmovenowcheckeffects(void);
+static void Cmd_tryfiretwoturnmovenowbyeffect(void);
 static void Cmd_setminimize(void);
 static void Cmd_sethail(void);
 static void Cmd_trymemento(void);
@@ -815,7 +815,7 @@ void (* const gBattleScriptingCommandsTable[])(void) =
     Cmd_trysetfutureattack,                      //0xC3
     Cmd_trydobeatup,                             //0xC4
     Cmd_setsemiinvulnerablebit,                  //0xC5
-    Cmd_tryfiretwoturnmovenowcheckeffects,       //0xC6
+    Cmd_tryfiretwoturnmovenowbyeffect,           //0xC6
     Cmd_setminimize,                             //0xC7
     Cmd_sethail,                                 //0xC8
     Cmd_trymemento,                              //0xC9
@@ -13688,7 +13688,7 @@ static bool32 CheckIfCanFireTwoTurnMoveNow(u8 battler, bool8 checkChargeTurnEffe
     return FALSE;
 }
 
-static void Cmd_tryfiretwoturnmovenowcheckeffects(void)
+static void Cmd_tryfiretwoturnmovenowbyeffect(void)
 {
     CMD_ARGS(u8 battler, bool8 checkChargeTurnEffects, const u8 *jumpInstr);
 


### PR DESCRIPTION
## Description
Minor adjustments that do ~~two~~ three things:

- fix a bug caused by a comment (of all things) in `battle_scripts_1.s` causing the attackstring/charge animation/charge string sequence of two-turn moves to fall out of order (thanks to Alex for discovering that)
- made a separate, more easily modifiable function for checking conditions for a charge move to fire in one turn (thanks to Jasper/Bassoonian's comments)
- make macros/commands a little easier to understand

That's all, folks

## **Discord contact info**
The Cancer Fairy/thechurchofcage
