### PR TITLE
Fixed printing HP restore message twice

### DIFF
--- a/data/battle_scripts_2.s
+++ b/data/battle_scripts_2.s
@@ -82,8 +82,6 @@ BattleScript_ItemHealAndCureStatus::
     call BattleScript_UseItemMessage
     itemrestorehp
     itemcurestatus
-    printstring STRINGID_ITEMRESTOREDSPECIESHEALTH
-    waitmessage B_WAIT_TIME_LONG
     bichalfword gMoveResultFlags, MOVE_RESULT_NO_EFFECT
     orword gHitMarker, HITMARKER_IGNORE_SUBSTITUTE
     healthbarupdate BS_SCRIPTING


### PR DESCRIPTION
If the player or opponent uses a Full Restore on their mon, the "... had its HP restored" message is printed twice.

## Description
If the player or opponent uses a Full Restore on their mon, the "... had its HP restored" message is printed twice, once before and once after the health bar moves. I removed the first message.

## Issue(s) that this PR fixes
Unsure if it is a known bug, I found this while playtesting.

## **Discord contact info**
jojoo0
