### PR TITLE
Fixes Stench ability triggering on non-damaging attacks

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -5804,7 +5804,7 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
              && gBattleMons[gBattlerTarget].hp != 0
              && !gProtectStructs[gBattlerAttacker].confusionSelfDmg
              && RandomWeighted(RNG_STENCH, 9, 1)
-             && !IS_MOVE_STATUS(move)
+             && TARGET_TURN_DAMAGED
              && gBattleMoves[gCurrentMove].effect != EFFECT_FLINCH_HIT
              && gBattleMoves[gCurrentMove].effect != EFFECT_FLINCH_STATUS
              && gBattleMoves[gCurrentMove].effect != EFFECT_TRIPLE_ARROWS)

--- a/test/battle/ability/stench.c
+++ b/test/battle/ability/stench.c
@@ -31,4 +31,27 @@ SINGLE_BATTLE_TEST("Stench does not stack with King's Rock")
     }
 }
 
+DOUBLE_BATTLE_TEST("Stench only triggers if target takes damage")
+{
+    GIVEN {
+        ASSUME(gBattleMoves[MOVE_TACKLE].power > 0);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_GRIMER) { Ability(ABILITY_STENCH); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN {
+            MOVE(playerLeft, MOVE_FAKE_OUT, target: opponentLeft);
+            MOVE(opponentLeft, MOVE_TACKLE, WITH_RNG(RNG_STENCH, TRUE),  target: playerRight);
+            MOVE(playerRight, MOVE_TACKLE, target: opponentRight);
+        }
+        TURN {
+            MOVE(opponentLeft, MOVE_SCARY_FACE, WITH_RNG(RNG_STENCH, TRUE),  target: playerRight);
+            MOVE(playerRight, MOVE_TACKLE, target: opponentRight);
+        }
+    } SCENE {
+        NONE_OF { MESSAGE("Wynaut flinched!"); }
+    }
+}
+
 // TODO: Test against interaction with multi hits

--- a/test/battle/ability/stench.c
+++ b/test/battle/ability/stench.c
@@ -35,6 +35,7 @@ DOUBLE_BATTLE_TEST("Stench only triggers if target takes damage")
 {
     GIVEN {
         ASSUME(gBattleMoves[MOVE_TACKLE].power > 0);
+        ASSUME(gBattleMoves[MOVE_FAKE_OUT].effect == EFFECT_FAKE_OUT);
         PLAYER(SPECIES_WOBBUFFET);
         PLAYER(SPECIES_WYNAUT);
         OPPONENT(SPECIES_GRIMER) { Ability(ABILITY_STENCH); }
@@ -51,6 +52,30 @@ DOUBLE_BATTLE_TEST("Stench only triggers if target takes damage")
         }
     } SCENE {
         NONE_OF { MESSAGE("Wynaut flinched!"); }
+    }
+}
+
+DOUBLE_BATTLE_TEST("Stench doesn't trigger if partner uses a move")
+{
+    GIVEN {
+        ASSUME(gBattleMoves[MOVE_TACKLE].power > 0);
+        ASSUME(gBattleMoves[MOVE_FAKE_OUT].effect == EFFECT_FAKE_OUT);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(20); }
+        PLAYER(SPECIES_WYNAUT) { Speed(10); }
+        OPPONENT(SPECIES_GRIMER) { Speed(100); Ability(ABILITY_STENCH); }
+        OPPONENT(SPECIES_WOBBUFFET) {Speed(50); }
+    } WHEN {
+        TURN {
+            MOVE(playerLeft, MOVE_FAKE_OUT, target: opponentLeft);
+            MOVE(opponentRight, MOVE_TACKLE, target: playerRight);
+            MOVE(playerRight, MOVE_TACKLE, target: opponentRight);
+        }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FAKE_OUT, playerLeft);
+        MESSAGE("Foe Grimer flinched!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentRight);
+        NOT MESSAGE("Wynaut flinched!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, playerRight);
     }
 }
 


### PR DESCRIPTION
## Description
Pokemon would still be able to proc Stench even if they were flinched with Fake Out and their move didn't damage the opponent. Changed Stench to check if the target was damaged, instead of checking if a non-status move was used.

## Images
Broken Stench: 
#4158 

Fixed Stench:

https://github.com/rh-hideout/pokeemerald-expansion/assets/81360291/4c490027-2a35-4208-ae62-a2bde4871ee4

## Issue(s) that this PR fixes
Fixes #4158 

## **Discord contact info**
hungry_pickle
