### PR TITLE
Clean up space/tabs difference

### DIFF
--- a/data/battle_anim_scripts.s
+++ b/data/battle_anim_scripts.s
@@ -9541,7 +9541,7 @@ Move_EERIE_IMPULSE::
 	createsprite gZapCannonSparkSpriteTemplate, ANIM_TARGET, 4, 10, 0, 32, 30, 0, 40, 0
 	createsprite gZapCannonSparkSpriteTemplate, ANIM_TARGET, 4, 10, 0, 32, 30, 0, 40, 1
 	createsprite gZapCannonSparkSpriteTemplate, ANIM_TARGET, 4, 10, 0, 32, 30, 0, 40, 0
- 	createsprite gZapCannonSparkSpriteTemplate, ANIM_TARGET, 4, 10, 0, 32, 30, 0, 40, 2
+	createsprite gZapCannonSparkSpriteTemplate, ANIM_TARGET, 4, 10, 0, 32, 30, 0, 40, 2
 	createsprite gZapCannonSparkSpriteTemplate, ANIM_TARGET, 4, 10, 0, 48, 30, 0, 40, 0
 	createsprite gZapCannonSparkSpriteTemplate, ANIM_TARGET, 4, 10, 0, 48, 30, 0, 40, 1
 	createsprite gZapCannonSparkSpriteTemplate, ANIM_TARGET, 4, 10, 0, 48, 30, 0, 40, 0
@@ -10206,7 +10206,7 @@ Move_THOUSAND_WAVES::
 	waitforvisualfinish
 	clearmonbg ANIM_ATK_PARTNER            @I placed this one here, because it ruins the teleport animation
 	loopsewithpan SE_M_COMET_PUNCH, SOUND_PAN_TARGET, 0x3, 0x15
- 	call ThousandWavesRecover
+	call ThousandWavesRecover
 	createsprite gThousandWavesGreenRecoverTemplate, ANIM_ATTACKER, 2, 0x28, 0xfff6, 0xd
 	delay 0x3
 	createsprite gThousandWavesGreenRecoverTemplate, ANIM_ATTACKER, 2, 0xffdd, 0x8, 0xd
@@ -10434,7 +10434,7 @@ Move_ORIGIN_PULSE::
 	delay 0x10
 	createsprite gOriginPulseRingTemplate, ANIM_ATTACKER, 3, 0x0, 0x0, 0x0, 0x0, 0x1F, 0x8
 	playsewithpan SE_INTRO_BLAST, SOUND_PAN_ATTACKER
- 	waitforvisualfinish
+	waitforvisualfinish
 	createsprite gOriginPulseOrbTemplate, ANIM_ATTACKER, 2, 0x0
 	createsprite gOriginPulseOrbTemplate, ANIM_ATTACKER, 2, 0x2b
 	createsprite gOriginPulseOrbTemplate, ANIM_ATTACKER, 2, 0x55
@@ -12017,7 +12017,7 @@ Move_CORE_ENFORCER::
 	delay 0x1
 	createsprite gCoreEnforcerImpactTemplate, ANIM_TARGET, 3, 0xfffa, 0xffe2, 0x1, 0x3
 	delay 0x1
- 	createsprite gCoreEnforcerImpactTemplate, ANIM_TARGET, 3, 0xffff, 0xffe2, 0x1, 0x3
+	createsprite gCoreEnforcerImpactTemplate, ANIM_TARGET, 3, 0xffff, 0xffe2, 0x1, 0x3
 	delay 0x1
 	createsprite gCoreEnforcerImpactTemplate, ANIM_TARGET, 3, 0x5, 0xffe2, 0x1, 0x3
 	delay 0x1
@@ -12060,7 +12060,7 @@ Move_CORE_ENFORCER::
 	createsprite gCoreEnforcerBeamTemplate, ANIM_TARGET, 3, 0xf, 0x0, 0x14, 0x5
 	createsprite gCoreEnforcerImpactTemplate, ANIM_TARGET, 3, 0x7, 0x3, 0x1, 0x3
 	delay 0x1
- 	createsprite gCoreEnforcerImpactTemplate, ANIM_TARGET, 3, 0xC, 0x3, 0x1, 0x3
+	createsprite gCoreEnforcerImpactTemplate, ANIM_TARGET, 3, 0xC, 0x3, 0x1, 0x3
 	delay 0x1
 	createsprite gCoreEnforcerImpactTemplate, ANIM_TARGET, 3, 0x11, 0x3, 0x1, 0x3
 	delay 0x1
@@ -13501,7 +13501,7 @@ Move_PHOTON_GEYSER::
 	unloadspritegfx ANIM_TAG_YELLOW_BALL @confuse ray (for zap cannon)
 	unloadspritegfx ANIM_TAG_BLACK_BALL_2 @zap cannon
 	unloadspritegfx ANIM_TAG_AIR_WAVE_2 @white/gray color
-    @Shoot beam to the sky
+	@Shoot beam to the sky
 	loadspritegfx ANIM_TAG_STRAIGHT_BEAM
 	createvisualtask AnimTask_BlendBattleAnimPal, 0xa, F_PAL_TARGET, 0x6, 0x0, 0x10, 0x43FF  @Light yellow
 	createvisualtask AnimTask_ShakeMon, 2, ANIM_TARGET, 4, 0, 96, 1
@@ -13623,7 +13623,7 @@ Move_SNIPE_SHOT::
 	loadspritegfx ANIM_TAG_LEER
 	createvisualtask AnimTask_BlendBattleAnimPal, 10, F_PAL_BG, 0, 0, 16, 0 @;Black
 	waitforvisualfinish
- 	createsprite gLeerSpriteTemplate, ANIM_TARGET, 2, 0x18, -12
+	createsprite gLeerSpriteTemplate, ANIM_TARGET, 2, 0x18, -12
 	playsewithpan SE_M_DETECT, SOUND_PAN_ATTACKER
 	waitforvisualfinish
 	delay 0x20

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -779,7 +779,7 @@ BattleScript_EffectAttackUpUserAlly_TryAlly:
 BattleScript_EffectAttackUpUserAlly_End:
 	goto BattleScript_MoveEnd
 BattleScript_EffectAttackUpUserAlly_TryAlly_:
- 	jumpifability BS_ATTACKER_PARTNER, ABILITY_SOUNDPROOF, BattleScript_EffectAttackUpUserAlly_TryAllyBlocked
+	jumpifability BS_ATTACKER_PARTNER, ABILITY_SOUNDPROOF, BattleScript_EffectAttackUpUserAlly_TryAllyBlocked
 	setstatchanger STAT_ATK, 1, FALSE
 	statbuffchange STAT_CHANGE_ALLOW_PTR, BattleScript_EffectAttackUpUserAlly_End
 	jumpifbyte CMP_NOT_EQUAL, cMULTISTRING_CHOOSER, B_MSG_STAT_WONT_INCREASE, BattleScript_EffectAttackUpUserAlly_AllyAnim
@@ -2757,8 +2757,8 @@ BattleScript_EffectHealPulse:
 	attackcanceler
 	attackstring
 	ppreduce
-    jumpifstatus3 BS_ATTACKER, STATUS3_HEAL_BLOCK, BattleScript_MoveUsedHealBlockPrevents @ stops pollen puff
-    jumpifstatus3 BS_TARGET, STATUS3_HEAL_BLOCK, BattleScript_MoveUsedHealBlockPrevents
+	jumpifstatus3 BS_ATTACKER, STATUS3_HEAL_BLOCK, BattleScript_MoveUsedHealBlockPrevents @ stops pollen puff
+	jumpifstatus3 BS_TARGET, STATUS3_HEAL_BLOCK, BattleScript_MoveUsedHealBlockPrevents
 	accuracycheck BattleScript_ButItFailed, NO_ACC_CALC_CHECK_LOCK_ON
 	jumpifsubstituteblocks BattleScript_ButItFailed
 	tryhealpulse BattleScript_AlreadyAtFullHp
@@ -6020,7 +6020,7 @@ BattleScript_EffectYawn::
 	setyawn BattleScript_ButItFailed
 	attackanimation
 	waitanimation
- BattleScript_EffectYawnSuccess::
+BattleScript_EffectYawnSuccess::
 	printstring STRINGID_PKMNWASMADEDROWSY
 	waitmessage B_WAIT_TIME_LONG
 	goto BattleScript_MoveEnd
@@ -8669,7 +8669,7 @@ BattleScript_TryAdrenalineOrbRet:
 
 BattleScript_IntimidateActivates::
 	showabilitypopup BS_ATTACKER
- 	copybyte sSAVED_BATTLER, gBattlerTarget
+	copybyte sSAVED_BATTLER, gBattlerTarget
 	pause B_WAIT_TIME_LONG
 	destroyabilitypopup
 	setbyte gBattlerTarget, 0
@@ -8697,7 +8697,7 @@ BattleScript_IntimidateLoopIncrement:
 BattleScript_IntimidateEnd:
 	copybyte sBATTLER, gBattlerAttacker
 	destroyabilitypopup
- 	copybyte gBattlerTarget, sSAVED_BATTLER
+	copybyte gBattlerTarget, sSAVED_BATTLER
 	pause B_WAIT_TIME_MED
 	end3
 

--- a/data/battle_scripts_2.s
+++ b/data/battle_scripts_2.s
@@ -6,260 +6,260 @@
 #include "constants/moves.h"
 #include "constants/songs.h"
 #include "constants/game_stat.h"
-    .include "asm/macros.inc"
-    .include "asm/macros/battle_script.inc"
-    .include "constants/constants.inc"
+	.include "asm/macros.inc"
+	.include "asm/macros/battle_script.inc"
+	.include "constants/constants.inc"
 
-    .section script_data, "aw", %progbits
+	.section script_data, "aw", %progbits
 
-    .align 2
+	.align 2
 gBattlescriptsForUsingItem::
-    .4byte BattleScript_ItemRestoreHP                @ EFFECT_ITEM_RESTORE_HP
-    .4byte BattleScript_ItemCureStatus               @ EFFECT_ITEM_CURE_STATUS
-    .4byte BattleScript_ItemHealAndCureStatus        @ EFFECT_ITEM_HEAL_AND_CURE_STATUS
-    .4byte BattleScript_ItemIncreaseStat             @ EFFECT_ITEM_INCREASE_STAT
-    .4byte BattleScript_ItemSetMist                  @ EFFECT_ITEM_SET_MIST
-    .4byte BattleScript_ItemSetFocusEnergy           @ EFFECT_ITEM_SET_FOCUS_ENERGY
-    .4byte BattleScript_RunByUsingItem               @ EFFECT_ITEM_ESCAPE
-    .4byte BattleScript_BallThrow                    @ EFFECT_ITEM_THROW_BALL
-    .4byte BattleScript_ItemRestoreHP                @ EFFECT_ITEM_REVIVE
-    .4byte BattleScript_ItemRestorePP                @ EFFECT_ITEM_RESTORE_PP
-    .4byte BattleScript_ItemIncreaseAllStats         @ EFFECT_ITEM_INCREASE_ALL_STATS
+	.4byte BattleScript_ItemRestoreHP                @ EFFECT_ITEM_RESTORE_HP
+	.4byte BattleScript_ItemCureStatus               @ EFFECT_ITEM_CURE_STATUS
+	.4byte BattleScript_ItemHealAndCureStatus        @ EFFECT_ITEM_HEAL_AND_CURE_STATUS
+	.4byte BattleScript_ItemIncreaseStat             @ EFFECT_ITEM_INCREASE_STAT
+	.4byte BattleScript_ItemSetMist                  @ EFFECT_ITEM_SET_MIST
+	.4byte BattleScript_ItemSetFocusEnergy           @ EFFECT_ITEM_SET_FOCUS_ENERGY
+	.4byte BattleScript_RunByUsingItem               @ EFFECT_ITEM_ESCAPE
+	.4byte BattleScript_BallThrow                    @ EFFECT_ITEM_THROW_BALL
+	.4byte BattleScript_ItemRestoreHP                @ EFFECT_ITEM_REVIVE
+	.4byte BattleScript_ItemRestorePP                @ EFFECT_ITEM_RESTORE_PP
+	.4byte BattleScript_ItemIncreaseAllStats         @ EFFECT_ITEM_INCREASE_ALL_STATS
 
-    .align 2
+	.align 2
 gBattlescriptsForSafariActions::
-    .4byte BattleScript_ActionWatchesCarefully
-    .4byte BattleScript_ActionGetNear
-    .4byte BattleScript_ActionThrowPokeblock
-    .4byte BattleScript_ActionWallyThrow
+	.4byte BattleScript_ActionWatchesCarefully
+	.4byte BattleScript_ActionGetNear
+	.4byte BattleScript_ActionThrowPokeblock
+	.4byte BattleScript_ActionWallyThrow
 
 BattleScript_ItemEnd:
-    end
+	end
 
 BattleScript_UseItemMessage:
-    printstring STRINGID_EMPTYSTRING3
-    pause B_WAIT_TIME_MED
-    playse SE_USE_ITEM
-    getbattlerside BS_ATTACKER
-    copybyte cMULTISTRING_CHOOSER, gBattleCommunication
-    printfromtable gTrainerUsedItemStringIds
-    waitmessage B_WAIT_TIME_LONG
-    return
+	printstring STRINGID_EMPTYSTRING3
+	pause B_WAIT_TIME_MED
+	playse SE_USE_ITEM
+	getbattlerside BS_ATTACKER
+	copybyte cMULTISTRING_CHOOSER, gBattleCommunication
+	printfromtable gTrainerUsedItemStringIds
+	waitmessage B_WAIT_TIME_LONG
+	return
 	
 BattleScript_ItemRestoreHPRet:
-    bichalfword gMoveResultFlags, MOVE_RESULT_NO_EFFECT
-    orword gHitMarker, HITMARKER_IGNORE_SUBSTITUTE
-    healthbarupdate BS_SCRIPTING
-    datahpupdate BS_SCRIPTING
-    printstring STRINGID_ITEMRESTOREDSPECIESHEALTH
-    waitmessage B_WAIT_TIME_LONG
-    return
+	bichalfword gMoveResultFlags, MOVE_RESULT_NO_EFFECT
+	orword gHitMarker, HITMARKER_IGNORE_SUBSTITUTE
+	healthbarupdate BS_SCRIPTING
+	datahpupdate BS_SCRIPTING
+	printstring STRINGID_ITEMRESTOREDSPECIESHEALTH
+	waitmessage B_WAIT_TIME_LONG
+	return
 
 BattleScript_ItemRestoreHP::
-    call BattleScript_UseItemMessage
-    itemrestorehp BattleScript_ItemRestoreHPEnd
-    call BattleScript_ItemRestoreHPRet
+	call BattleScript_UseItemMessage
+	itemrestorehp BattleScript_ItemRestoreHPEnd
+	call BattleScript_ItemRestoreHPRet
 BattleScript_ItemRestoreHPEnd:
-    end
+	end
 
 BattleScript_ItemRestoreHP_Party::
-    jumpifbyte CMP_EQUAL, gBattleCommunication, TRUE, BattleScript_ItemRestoreHP_SendOutRevivedBattler
-    bichalfword gMoveResultFlags, MOVE_RESULT_NO_EFFECT
-    printstring STRINGID_ITEMRESTOREDSPECIESHEALTH
-    waitmessage B_WAIT_TIME_LONG
-    end
+	jumpifbyte CMP_EQUAL, gBattleCommunication, TRUE, BattleScript_ItemRestoreHP_SendOutRevivedBattler
+	bichalfword gMoveResultFlags, MOVE_RESULT_NO_EFFECT
+	printstring STRINGID_ITEMRESTOREDSPECIESHEALTH
+	waitmessage B_WAIT_TIME_LONG
+	end
 
 BattleScript_ItemRestoreHP_SendOutRevivedBattler:
-    switchinanim BS_SCRIPTING, FALSE
-    waitstate
-    switchineffects BS_SCRIPTING
-    end
+	switchinanim BS_SCRIPTING, FALSE
+	waitstate
+	switchineffects BS_SCRIPTING
+	end
 
 BattleScript_ItemCureStatus::
-    call BattleScript_UseItemMessage
+	call BattleScript_UseItemMessage
 BattleScript_ItemCureStatusAfterItemMsg:
-    itemcurestatus BattleScript_ItemCureStatusEnd
-    updatestatusicon BS_SCRIPTING
-    printstring STRINGID_ITEMCUREDSPECIESSTATUS
-    waitmessage B_WAIT_TIME_LONG
+	itemcurestatus BattleScript_ItemCureStatusEnd
+	updatestatusicon BS_SCRIPTING
+	printstring STRINGID_ITEMCUREDSPECIESSTATUS
+	waitmessage B_WAIT_TIME_LONG
 BattleScript_ItemCureStatusEnd:
-    end
+	end
 
 BattleScript_ItemHealAndCureStatus::
-    call BattleScript_UseItemMessage
-    itemrestorehp BattleScript_ItemCureStatusAfterItemMsg
-    call BattleScript_ItemRestoreHPRet
-    goto BattleScript_ItemCureStatusAfterItemMsg
+	call BattleScript_UseItemMessage
+	itemrestorehp BattleScript_ItemCureStatusAfterItemMsg
+	call BattleScript_ItemRestoreHPRet
+	goto BattleScript_ItemCureStatusAfterItemMsg
 
 BattleScript_ItemIncreaseStat::
-    call BattleScript_UseItemMessage
-    itemincreasestat
-    statbuffchange MOVE_EFFECT_AFFECTS_USER | STAT_CHANGE_NOT_PROTECT_AFFECTED | STAT_CHANGE_ALLOW_PTR, BattleScript_ItemEnd
-    setgraphicalstatchangevalues
-    playanimation BS_ATTACKER, B_ANIM_STATS_CHANGE, sB_ANIM_ARG1
-    printfromtable gStatUpStringIds
-    waitmessage B_WAIT_TIME_LONG
-    end
+	call BattleScript_UseItemMessage
+	itemincreasestat
+	statbuffchange MOVE_EFFECT_AFFECTS_USER | STAT_CHANGE_NOT_PROTECT_AFFECTED | STAT_CHANGE_ALLOW_PTR, BattleScript_ItemEnd
+	setgraphicalstatchangevalues
+	playanimation BS_ATTACKER, B_ANIM_STATS_CHANGE, sB_ANIM_ARG1
+	printfromtable gStatUpStringIds
+	waitmessage B_WAIT_TIME_LONG
+	end
 
 BattleScript_ItemSetMist::
-    call BattleScript_UseItemMessage
-    setmist
-    playmoveanimation BS_ATTACKER, MOVE_MIST
-    waitanimation
-    printfromtable gMistUsedStringIds
-    waitmessage B_WAIT_TIME_LONG
-    end
+	call BattleScript_UseItemMessage
+	setmist
+	playmoveanimation BS_ATTACKER, MOVE_MIST
+	waitanimation
+	printfromtable gMistUsedStringIds
+	waitmessage B_WAIT_TIME_LONG
+	end
 
 BattleScript_ItemSetFocusEnergy::
-    call BattleScript_UseItemMessage
-    jumpifstatus2 BS_ATTACKER, STATUS2_FOCUS_ENERGY, BattleScript_ButItFailed
-    setfocusenergy
-    playmoveanimation BS_ATTACKER, MOVE_FOCUS_ENERGY
-    waitanimation
-    copybyte sBATTLER, gBattlerAttacker
-    printstring STRINGID_PKMNUSEDXTOGETPUMPED
-    waitmessage B_WAIT_TIME_LONG
-    end
+	call BattleScript_UseItemMessage
+	jumpifstatus2 BS_ATTACKER, STATUS2_FOCUS_ENERGY, BattleScript_ButItFailed
+	setfocusenergy
+	playmoveanimation BS_ATTACKER, MOVE_FOCUS_ENERGY
+	waitanimation
+	copybyte sBATTLER, gBattlerAttacker
+	printstring STRINGID_PKMNUSEDXTOGETPUMPED
+	waitmessage B_WAIT_TIME_LONG
+	end
 
 BattleScript_ItemRestorePP::
-    call BattleScript_UseItemMessage
-    itemrestorepp
-    printstring STRINGID_ITEMRESTOREDSPECIESPP
-    waitmessage B_WAIT_TIME_LONG
-    end
+	call BattleScript_UseItemMessage
+	itemrestorepp
+	printstring STRINGID_ITEMRESTOREDSPECIESPP
+	waitmessage B_WAIT_TIME_LONG
+	end
 
 BattleScript_ItemIncreaseAllStats::
-    call BattleScript_UseItemMessage
-    call BattleScript_AllStatsUp
-    end
+	call BattleScript_UseItemMessage
+	call BattleScript_AllStatsUp
+	end
 
 BattleScript_BallThrow::
-    jumpifword CMP_COMMON_BITS, gBattleTypeFlags, BATTLE_TYPE_WALLY_TUTORIAL, BattleScript_BallThrowByWally
-    printstring STRINGID_PLAYERUSEDITEM
-    handleballthrow
+	jumpifword CMP_COMMON_BITS, gBattleTypeFlags, BATTLE_TYPE_WALLY_TUTORIAL, BattleScript_BallThrowByWally
+	printstring STRINGID_PLAYERUSEDITEM
+	handleballthrow
 
 BattleScript_BallThrowByWally::
-    printstring STRINGID_WALLYUSEDITEM
-    handleballthrow
+	printstring STRINGID_WALLYUSEDITEM
+	handleballthrow
 
 BattleScript_SafariBallThrow::
-    printstring STRINGID_PLAYERUSEDITEM
-    updatestatusicon BS_ATTACKER
-    handleballthrow
+	printstring STRINGID_PLAYERUSEDITEM
+	updatestatusicon BS_ATTACKER
+	handleballthrow
 
 BattleScript_SuccessBallThrow::
-    setbyte sMON_CAUGHT, TRUE
-    incrementgamestat GAME_STAT_POKEMON_CAPTURES
+	setbyte sMON_CAUGHT, TRUE
+	incrementgamestat GAME_STAT_POKEMON_CAPTURES
 BattleScript_PrintCaughtMonInfo::
-    printstring STRINGID_GOTCHAPKMNCAUGHTPLAYER
-    jumpifbyte CMP_NOT_EQUAL, sEXP_CATCH, TRUE, BattleScript_TryPrintCaughtMonInfo
-    setbyte sGIVEEXP_STATE, 0
-    getexp BS_TARGET
-    sethword gBattle_BG2_X, 0
+	printstring STRINGID_GOTCHAPKMNCAUGHTPLAYER
+	jumpifbyte CMP_NOT_EQUAL, sEXP_CATCH, TRUE, BattleScript_TryPrintCaughtMonInfo
+	setbyte sGIVEEXP_STATE, 0
+	getexp BS_TARGET
+	sethword gBattle_BG2_X, 0
 BattleScript_TryPrintCaughtMonInfo:
-    jumpifbattletype BATTLE_TYPE_RECORDED, BattleScript_GiveCaughtMonEnd
-    trysetcaughtmondexflags BattleScript_TryNicknameCaughtMon
-    printstring STRINGID_PKMNDATAADDEDTODEX
-    waitstate
-    setbyte gBattleCommunication, 0
-    displaydexinfo
+	jumpifbattletype BATTLE_TYPE_RECORDED, BattleScript_GiveCaughtMonEnd
+	trysetcaughtmondexflags BattleScript_TryNicknameCaughtMon
+	printstring STRINGID_PKMNDATAADDEDTODEX
+	waitstate
+	setbyte gBattleCommunication, 0
+	displaydexinfo
 BattleScript_TryNicknameCaughtMon::
-    printstring STRINGID_GIVENICKNAMECAPTURED
-    waitstate
-    setbyte gBattleCommunication, 0
-    trygivecaughtmonnick BattleScript_GiveCaughtMonEnd
-    givecaughtmon
-    printfromtable gCaughtMonStringIds
-    waitmessage B_WAIT_TIME_LONG
-    goto BattleScript_SuccessBallThrowEnd
+	printstring STRINGID_GIVENICKNAMECAPTURED
+	waitstate
+	setbyte gBattleCommunication, 0
+	trygivecaughtmonnick BattleScript_GiveCaughtMonEnd
+	givecaughtmon
+	printfromtable gCaughtMonStringIds
+	waitmessage B_WAIT_TIME_LONG
+	goto BattleScript_SuccessBallThrowEnd
 BattleScript_GiveCaughtMonEnd::
-    givecaughtmon
+	givecaughtmon
 BattleScript_SuccessBallThrowEnd::
-    setbyte gBattleOutcome, B_OUTCOME_CAUGHT
-    finishturn
+	setbyte gBattleOutcome, B_OUTCOME_CAUGHT
+	finishturn
 
 BattleScript_WallyBallThrow::
-    printstring STRINGID_GOTCHAPKMNCAUGHTWALLY
-    setbyte gBattleOutcome, B_OUTCOME_CAUGHT
-    finishturn
+	printstring STRINGID_GOTCHAPKMNCAUGHTWALLY
+	setbyte gBattleOutcome, B_OUTCOME_CAUGHT
+	finishturn
 
 BattleScript_ShakeBallThrow::
-    printfromtable gBallEscapeStringIds
-    waitmessage B_WAIT_TIME_LONG
-    jumpifword CMP_NO_COMMON_BITS, gBattleTypeFlags, BATTLE_TYPE_SAFARI, BattleScript_ShakeBallThrowEnd
-    jumpifbyte CMP_NOT_EQUAL, gNumSafariBalls, 0, BattleScript_ShakeBallThrowEnd
-    printstring STRINGID_OUTOFSAFARIBALLS
-    waitmessage B_WAIT_TIME_LONG
-    setbyte gBattleOutcome, B_OUTCOME_NO_SAFARI_BALLS
+	printfromtable gBallEscapeStringIds
+	waitmessage B_WAIT_TIME_LONG
+	jumpifword CMP_NO_COMMON_BITS, gBattleTypeFlags, BATTLE_TYPE_SAFARI, BattleScript_ShakeBallThrowEnd
+	jumpifbyte CMP_NOT_EQUAL, gNumSafariBalls, 0, BattleScript_ShakeBallThrowEnd
+	printstring STRINGID_OUTOFSAFARIBALLS
+	waitmessage B_WAIT_TIME_LONG
+	setbyte gBattleOutcome, B_OUTCOME_NO_SAFARI_BALLS
 BattleScript_ShakeBallThrowEnd::
-    finishaction
+	finishaction
 
 BattleScript_TrainerBallBlock::
-    waitmessage B_WAIT_TIME_LONG
-    printstring STRINGID_TRAINERBLOCKEDBALL
-    waitmessage B_WAIT_TIME_LONG
-    printstring STRINGID_DONTBEATHIEF
-    waitmessage B_WAIT_TIME_LONG
-    finishaction
+	waitmessage B_WAIT_TIME_LONG
+	printstring STRINGID_TRAINERBLOCKEDBALL
+	waitmessage B_WAIT_TIME_LONG
+	printstring STRINGID_DONTBEATHIEF
+	waitmessage B_WAIT_TIME_LONG
+	finishaction
 
 BattleScript_RunByUsingItem::
-    playse SE_FLEE
-    setbyte gBattleOutcome, B_OUTCOME_RAN
-    finishturn
+	playse SE_FLEE
+	setbyte gBattleOutcome, B_OUTCOME_RAN
+	finishturn
 
 BattleScript_ActionWatchesCarefully:
-    printstring STRINGID_PKMNWATCHINGCAREFULLY
-    waitmessage B_WAIT_TIME_LONG
-    end2
+	printstring STRINGID_PKMNWATCHINGCAREFULLY
+	waitmessage B_WAIT_TIME_LONG
+	end2
 
 BattleScript_ActionGetNear:
-    printfromtable gSafariGetNearStringIds
-    waitmessage B_WAIT_TIME_LONG
-    end2
+	printfromtable gSafariGetNearStringIds
+	waitmessage B_WAIT_TIME_LONG
+	end2
 
 BattleScript_ActionThrowPokeblock:
-    printstring STRINGID_THREWPOKEBLOCKATPKMN
-    waitmessage B_WAIT_TIME_LONG
-    playanimation BS_ATTACKER, B_ANIM_POKEBLOCK_THROW, NULL
-    printfromtable gSafariPokeblockResultStringIds
-    waitmessage B_WAIT_TIME_LONG
-    end2
+	printstring STRINGID_THREWPOKEBLOCKATPKMN
+	waitmessage B_WAIT_TIME_LONG
+	playanimation BS_ATTACKER, B_ANIM_POKEBLOCK_THROW, NULL
+	printfromtable gSafariPokeblockResultStringIds
+	waitmessage B_WAIT_TIME_LONG
+	end2
 
 BattleScript_ActionWallyThrow:
-    printstring STRINGID_RETURNMON
-    waitmessage B_WAIT_TIME_LONG
-    returnatktoball
-    waitstate
-    trainerslidein BS_TARGET
-    waitstate
-    printstring STRINGID_YOUTHROWABALLNOWRIGHT
-    waitmessage B_WAIT_TIME_LONG
-    end2
+	printstring STRINGID_RETURNMON
+	waitmessage B_WAIT_TIME_LONG
+	returnatktoball
+	waitstate
+	trainerslidein BS_TARGET
+	waitstate
+	printstring STRINGID_YOUTHROWABALLNOWRIGHT
+	waitmessage B_WAIT_TIME_LONG
+	end2
 
 BattleScript_TrainerASlideMsgRet::
-    handletrainerslidemsg BS_SCRIPTING, 0
-    trainerslidein B_POSITION_OPPONENT_LEFT
-    handletrainerslidemsg BS_SCRIPTING, 1
-    waitstate
-    trainerslideout B_POSITION_OPPONENT_LEFT
-    waitstate
-    handletrainerslidemsg BS_SCRIPTING, 2
-    return
+	handletrainerslidemsg BS_SCRIPTING, 0
+	trainerslidein B_POSITION_OPPONENT_LEFT
+	handletrainerslidemsg BS_SCRIPTING, 1
+	waitstate
+	trainerslideout B_POSITION_OPPONENT_LEFT
+	waitstate
+	handletrainerslidemsg BS_SCRIPTING, 2
+	return
 
 BattleScript_TrainerASlideMsgEnd2::
-    call BattleScript_TrainerASlideMsgRet
-    end2
+	call BattleScript_TrainerASlideMsgRet
+	end2
 
 BattleScript_TrainerBSlideMsgRet::
-    handletrainerslidemsg BS_SCRIPTING, 0
-    trainerslidein B_POSITION_OPPONENT_RIGHT
-    handletrainerslidemsg BS_SCRIPTING, 1
-    waitstate
-    trainerslideout B_POSITION_OPPONENT_RIGHT
-    waitstate
-    handletrainerslidemsg BS_SCRIPTING, 2
-    return
+	handletrainerslidemsg BS_SCRIPTING, 0
+	trainerslidein B_POSITION_OPPONENT_RIGHT
+	handletrainerslidemsg BS_SCRIPTING, 1
+	waitstate
+	trainerslideout B_POSITION_OPPONENT_RIGHT
+	waitstate
+	handletrainerslidemsg BS_SCRIPTING, 2
+	return
 
 BattleScript_TrainerBSlideMsgEnd2::
-    call BattleScript_TrainerBSlideMsgRet
-    end2
+	call BattleScript_TrainerBSlideMsgRet
+	end2


### PR DESCRIPTION
For whatever obscure reason, `battle_scripts_2.s` switched to using spaces rather than tabs at some point, unlike `battle_scripts_1.s` and the counterpart of both files in pret. This PR switches it back to tabs and also cleans up some whitespace issues in other files to be consistent.

## **Discord contact info**
bassoonian
