### PR TITLE
Fixed Disguise not ending the battle in the correct form

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1213,6 +1213,7 @@ static bool32 NoTargetPresent(u8 battler, u32 move)
     return FALSE;
 }
 
+// TODO: Convert this to a proper FORM_CHANGE type.
 static bool32 TryAegiFormChange(void)
 {
     // Only Aegislash with Stance Change can transform, transformed mons cannot.
@@ -2315,6 +2316,7 @@ static void Cmd_datahpupdate(void)
         }
         else if (DoesDisguiseBlockMove(gBattlerAttacker, battler, gCurrentMove))
         {
+            // TODO: Convert this to a proper FORM_CHANGE type.
             u32 side = GetBattlerSide(battler);
             if (gBattleStruct->changedSpecies[side][gBattlerPartyIndexes[battler]] == SPECIES_NONE)
                 gBattleStruct->changedSpecies[side][gBattlerPartyIndexes[battler]] = gBattleMons[battler].species;
@@ -2494,6 +2496,7 @@ static void Cmd_resultmessage(void)
     if (gBattleControllerExecFlags)
         return;
 
+    // TODO: Convert this to a proper FORM_CHANGE type.
     // Do Ice Face form change which was set up in Cmd_adjustdamage.
     if (gBattleResources->flags->flags[gBattlerTarget] & RESOURCE_FLAG_ICE_FACE)
     {
@@ -10116,6 +10119,7 @@ static void Cmd_various(void)
         }
         return;
     }
+    // TODO: Convert this to a proper FORM_CHANGE type.
     case VARIOUS_TRY_ACTIVATE_BATTLE_BOND:
     {
         VARIOUS_ARGS();
@@ -16234,6 +16238,7 @@ void BS_SetGlaiveRush(void)
     gBattlescriptCurrInstr = cmd->nextInstr;
 }
 
+// TODO: Convert this to a proper FORM_CHANGE type.
 void BS_TryRelicSong(void)
 {
     NATIVE_ARGS();

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2315,6 +2315,9 @@ static void Cmd_datahpupdate(void)
         }
         else if (DoesDisguiseBlockMove(gBattlerAttacker, battler, gCurrentMove))
         {
+            u32 side = GetBattlerSide(battler);
+            if (gBattleStruct->changedSpecies[side][gBattlerPartyIndexes[battler]] == SPECIES_NONE)
+                gBattleStruct->changedSpecies[side][gBattlerPartyIndexes[battler]] = gBattleMons[battler].species;
             gBattleMons[battler].species = SPECIES_MIMIKYU_BUSTED;
             BattleScriptPush(cmd->nextInstr);
             gBattlescriptCurrInstr = BattleScript_TargetFormChange;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -5667,6 +5667,7 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
              && TARGET_TURN_DAMAGED
              && IsBattlerAlive(battler))
             {
+                // TODO: Convert this to a proper FORM_CHANGE type.
                 if (gBattleMons[gBattlerTarget].species == SPECIES_CRAMORANT_GORGING)
                 {
                     gBattleMons[gBattlerTarget].species = SPECIES_CRAMORANT;
@@ -6109,6 +6110,7 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
              && !(gBattleMons[battler].status2 & STATUS2_TRANSFORMED)
              && gBattleStruct->allowedToChangeFormInWeather[gBattlerPartyIndexes[battler]][GetBattlerSide(battler)])
             {
+                // TODO: Convert this to a proper FORM_CHANGE type.
                 gBattleStruct->allowedToChangeFormInWeather[gBattlerPartyIndexes[battler]][GetBattlerSide(battler)] = FALSE;
                 gBattleMons[battler].species = SPECIES_EISCUE_ICE_FACE;
                 BattleScriptPushCursorAndCallback(BattleScript_BattlerFormChangeWithStringEnd3);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Disguise wasn't registering `changedSpecies` for the original form, causing issues when the battle ended.

## Images
Before
![mGBA_hWJX1Kfxo2](https://github.com/rh-hideout/pokeemerald-expansion/assets/2904965/c0989bfa-cda9-49aa-84be-8488dd1ed04f)

After
![mGBA_m0OYRqsy4j](https://github.com/rh-hideout/pokeemerald-expansion/assets/2904965/09d36613-a20e-4f40-914f-afa5b24ca4ec)

## Issue(s) that this PR fixes
Fixes #4131.

## Feature(s) this PR does NOT handle:
- Minior scenario described in the issue is vanilla behavior. While you catch Minior in its Meteor form, it stays in Core form outside of battle, becoming Meteor form once a new battle starts.
- Other non form change table form changes may be affected by this situation as well. For now, this PR only fixes Disguise, but I added comments to convert the form changes to the new table.

## **Discord contact info**
AsparagusEduardo
