### PR TITLE
Add shouldDynamax & shouldTerastal bits to TrainerMon for better trainer control

### DIFF
--- a/include/data.h
+++ b/include/data.h
@@ -71,6 +71,8 @@ struct TrainerMon
     bool8 isShiny : 1;
     u8 dynamaxLevel : 4;
     bool8 gigantamaxFactor : 1;
+    bool8 shouldDynamax : 1;
+    bool8 shouldTerastal : 1;
 };
 
 #define TRAINER_PARTY(partyArray) partyArray, .partySize = ARRAY_COUNT(partyArray)

--- a/src/battle_controller_opponent.c
+++ b/src/battle_controller_opponent.c
@@ -547,6 +547,9 @@ static void OpponentHandleChooseMove(u32 battler)
             default:
                 {
                     u16 chosenMove = moveInfo->moves[chosenMoveId];
+                    bool32 isSecondTrainer = (GetBattlerPosition(battler) == B_POSITION_OPPONENT_RIGHT) && (gBattleTypeFlags & BATTLE_TYPE_TWO_OPPONENTS) && !BATTLE_TWO_VS_ONE_OPPONENT;
+                    u16 trainerId = isSecondTrainer ? gTrainerBattleOpponent_B : gTrainerBattleOpponent_A;
+                    const struct TrainerMon *party = gTrainers[trainerId].party;
 
                     if (GetBattlerMoveTargetType(battler, chosenMove) & (MOVE_TARGET_USER_OR_SELECTED | MOVE_TARGET_USER))
                         gBattlerTarget = battler;
@@ -564,8 +567,8 @@ static void OpponentHandleChooseMove(u32 battler)
                     // If opponent can Ultra Burst, do it.
                     else if (CanUltraBurst(battler))
                         BtlController_EmitTwoReturnValues(battler, BUFFER_B, 10, (chosenMoveId) | (RET_ULTRA_BURST) | (gBattlerTarget << 8));
-                    // If opponent can Dynamax and is on final Pokemon, do it.
-                    else if (CanDynamax(battler) && CountAIAliveNonEggMonsExcept(gBattlerPartyIndexes[battler]) == 0)
+                    // If opponent can Dynamax and is allowed in the partydata, do it.
+                    else if (CanDynamax(battler) && party[isSecondTrainer ? gBattlerPartyIndexes[battler] - MULTI_PARTY_SIZE : gBattlerPartyIndexes[battler]].shouldDynamax)
                         BtlController_EmitTwoReturnValues(battler, BUFFER_B, 10, (chosenMoveId) | (RET_DYNAMAX) | (gBattlerTarget << 8));
                     else
                         BtlController_EmitTwoReturnValues(battler, BUFFER_B, 10, (chosenMoveId) | (gBattlerTarget << 8));


### PR DESCRIPTION
Add 2 new bits to the TrainerMon struct to allow for which Pokémon will Dynamax or Terastallize.

## Description
These new bits have to be set in src/data/trainer_parties.h.
For example, add ".shouldDynamax = TRUE," to the first party entry of sParty_Steven to have its skarmory to dynamax. 

The only other change is the condition to Dynamax in src/battle_controller_opponent.c which checks the TrainerMon data.
The trainerId is correctly recovered mid-battle even for two-opponents battles. 

Cases tested:
- Single opponent, first Pokémon
- Single opponent, second Pokémon
- Two opponents, first Pokémon of opponentA
- Two opponents, first Pokémon of opponentB
- Two opponents, secondPokémon of opponentB

## Issue(s) that this PR fixes
None opened

## Feature(s) this PR does NOT handle:
These changes currently only allow to trigger the Dynamax of a selected Pokemon. Even though the bit has also been added for Terastallization, the Terastallization feature is not incorporated in this PR.

## **Discord contact info**
Nopinou#8678
