### PR TITLE
Status2/3/4 refactoring

### DIFF
--- a/asm/macros/battle_script.inc
+++ b/asm/macros/battle_script.inc
@@ -148,18 +148,23 @@
 	.byte \battler
 	.endm
 
-	.macro jumpifstatus battler:req, flags:req, jumpInstr:req
+	.macro jumpifstatus battler:req, status:req, jumpInstr:req, isVolatile=FALSE
 	.byte 0x1c
 	.byte \battler
-	.4byte \flags
+	.4byte \status
 	.4byte \jumpInstr
+	.byte \isVolatile
 	.endm
 
-	.macro jumpifvolatilestatus battler:req, flags:req, jumpInstr:req
+	.macro jumpifvolatilestatus battler:req, volatileStatus:req, jumpInstr:req
+	jumpifstatus \battler, \volatileStatus, \jumpInstr, TRUE
+	.endm
+
+	.macro setvolatilestatusorfail battler:req, status:req, failInstr:req
 	.byte 0x1d
 	.byte \battler
-	.4byte \flags
-	.4byte \jumpInstr
+	.4byte \status
+	.4byte \failInstr
 	.endm
 
 	.macro jumpifability battler:req, ability:req, jumpInstr:req
@@ -182,14 +187,6 @@
 	.byte \comparison
 	.byte \stat
 	.byte \value
-	.4byte \jumpInstr
-	.endm
-
-	.macro jumpifstatus3condition battler:req, flags:req, jumpIfTrue:req, jumpInstr:req
-	.byte 0x21
-	.byte \battler
-	.4byte \flags
-	.byte \jumpIfTrue
 	.4byte \jumpInstr
 	.endm
 
@@ -1175,12 +1172,6 @@
 
 	.macro setstealthrock failInstr:req
 	.byte 0xdc
-	.4byte \failInstr
-	.endm
-
-	.macro setuserstatus3 flags:req, failInstr:req
-	.byte 0xdd
-	.4byte \flags
 	.4byte \failInstr
 	.endm
 
@@ -2310,14 +2301,6 @@
 
 	.macro jumpifnotchosenmove move:req, jumpInstr:req
 	jumpifhalfword CMP_NOT_EQUAL, gChosenMove, \move, \jumpInstr
-	.endm
-
-	.macro jumpifstatus3 battler:req, flags:req, jumpInstr:req
-	jumpifstatus3condition \battler, \flags, FALSE, \jumpInstr
-	.endm
-
-	.macro jumpifnostatus3 battler:req, flags:req, jumpInstr:req
-	jumpifstatus3condition \battler, \flags, TRUE, \jumpInstr
 	.endm
 
 	.macro jumpifmovehadnoeffect jumpInstr:req

--- a/asm/macros/battle_script.inc
+++ b/asm/macros/battle_script.inc
@@ -155,7 +155,7 @@
 	.4byte \jumpInstr
 	.endm
 
-	.macro jumpifstatus2 battler:req, flags:req, jumpInstr:req
+	.macro jumpifvolatilestatus battler:req, flags:req, jumpInstr:req
 	.byte 0x1d
 	.byte \battler
 	.4byte \flags
@@ -855,8 +855,10 @@
 	.byte 0x99
 	.endm
 
-	.macro setfocusenergy
+	.macro setfocusenergyorfail battler:req, failInstr:req
 	.byte 0x9a
+	.byte \battler
+	.4byte \failInstr
 	.endm
 
 	.macro transformdataexecution
@@ -1938,16 +1940,18 @@
 	.4byte \failInstr
 	.endm
 
-	.macro setpowder battler:req
-	various \battler, VARIOUS_SET_POWDER
+	.macro setpowderorfail battler:req, failInstr:req
+	various \battler, VARIOUS_SET_POWDER_OR_FAIL
+	.4byte \failInstr
 	.endm
 
 	.macro spectralthiefprintstats
 	various BS_ATTACKER, VARIOUS_SPECTRAL_THIEF
 	.endm
 
-	.macro bringdownairbornebattler battler:req
+	.macro bringdownairbornebattlerorend battler:req, endInstr:req
 	various \battler, VARIOUS_GRAVITY_ON_AIRBORNE_MONS
+	.4byte \endInstr
 	.endm
 
 	.macro checkgrassyterrainheal battler:req, failInstr:req
@@ -2424,8 +2428,8 @@
 	.endm
 
 	@ Accounts for if the target of Sky Drop was in confuse_lock when the attacker falls asleep due to Yawn.
-	.macro skydropyawn
-	various 0, VARIOUS_SKY_DROP_YAWN
+	.macro skydropyawn battler:req
+	various \battler, VARIOUS_SKY_DROP_YAWN
 	.endm
 
 	@ Tries to increase or decrease a battler's stat's stat stage by a specified amount. If impossible, jumps to \script.

--- a/asm/macros/battle_script.inc
+++ b/asm/macros/battle_script.inc
@@ -592,22 +592,15 @@
 	.byte \notChosenMove
 	.endm
 
-	.macro statusanimation battler:req
+	.macro statusanimation battler:req, isVolatile=FALSE, volatileStatus=0
 	.byte 0x64
 	.byte \battler
+	.byte \isVolatile
+	.byte \volatileStatus
 	.endm
 
-	.macro status2animation battler:req, status2:req
-	.byte 0x65
-	.byte \battler
-	.4byte \status2
-	.endm
-
-	.macro chosenstatusanimation battler:req, isStatus2:req, status:req
-	.byte 0x66
-	.byte \battler
-	.byte \isStatus2
-	.4byte \status
+	.macro volatilestatusanimation battler:req, volatileStatus:req
+	statusanimation \battler, TRUE, \volatileStatus
 	.endm
 
 	.macro yesnobox
@@ -2273,14 +2266,6 @@
 	.macro setmoveeffect effect:req
 	sethword sMOVE_EFFECT, \effect
 	sethword sSAVED_MOVE_EFFECT, \effect
-	.endm
-
-	.macro chosenstatus1animation battler:req, status:req
-	chosenstatusanimation \battler, 0x0, \status
-	.endm
-
-	.macro chosenstatus2animation battler:req, status:req
-	chosenstatusanimation \battler, 0x1, \status
 	.endm
 
 	.macro sethword dst:req, value:req

--- a/data/battle_anim_scripts.s
+++ b/data/battle_anim_scripts.s
@@ -979,7 +979,6 @@ gBattleAnims_StatusConditions::
 	.4byte Status_Freeze                    @ B_ANIM_STATUS_FRZ
 	.4byte Status_Curse                     @ B_ANIM_STATUS_CURSED
 	.4byte Status_Nightmare                 @ B_ANIM_STATUS_NIGHTMARE
-	.4byte Status_Powder
 
 	.align 2
 gBattleAnims_General::
@@ -27782,9 +27781,6 @@ Status_Nightmare:
 	createvisualtask AnimTask_ShakeMon2, 2, ANIM_TARGET, 2, 0, 14, 1
 	waitforvisualfinish
 	clearmonbg ANIM_DEF_PARTNER
-	end
-
-Status_Powder:
 	end
 
 General_StatsChange:

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -4334,7 +4334,7 @@ BattleScript_TryDestinyKnotTarget:
 	infatuatewithbattler BS_TARGET, BS_ATTACKER
 	playanimation BS_ATTACKER, B_ANIM_HELD_ITEM_EFFECT
 	waitanimation
-	status2animation BS_TARGET, STATUS2_INFATUATION
+	volatilestatusanimation BS_TARGET, ENUM_VOLATILE_STATUS_INFATUATION
 	waitanimation
 	printstring STRINGID_DESTINYKNOTACTIVATES
 	waitmessage B_WAIT_TIME_LONG
@@ -4346,7 +4346,7 @@ BattleScript_TryDestinyKnotAttacker:
 	infatuatewithbattler BS_ATTACKER, BS_TARGET
 	playanimation BS_TARGET, B_ANIM_HELD_ITEM_EFFECT
 	waitanimation
-	status2animation BS_ATTACKER, STATUS2_INFATUATION
+	volatilestatusanimation BS_ATTACKER, ENUM_VOLATILE_STATUS_INFATUATION
 	waitanimation
 	printstring STRINGID_DESTINYKNOTACTIVATES
 	waitmessage B_WAIT_TIME_LONG
@@ -7319,7 +7319,7 @@ BattleScript_PrintUproarOverTurns::
 	end2
 
 BattleScript_ThrashConfuses::
-	chosenstatus2animation BS_ATTACKER, STATUS2_CONFUSION
+	volatilestatusanimation BS_ATTACKER, ENUM_VOLATILE_STATUS_CONFUSION
 	printstring STRINGID_PKMNFATIGUECONFUSION
 	waitmessage B_WAIT_TIME_LONG
 	end2
@@ -7327,7 +7327,7 @@ BattleScript_ThrashConfuses::
 BattleScript_MoveUsedIsConfused::
 	printstring STRINGID_PKMNISCONFUSED
 	waitmessage B_WAIT_TIME_LONG
-	status2animation BS_ATTACKER, STATUS2_CONFUSION
+	volatilestatusanimation BS_ATTACKER, ENUM_VOLATILE_STATUS_CONFUSION
 	jumpifbyte CMP_EQUAL, cMULTISTRING_CHOOSER, FALSE, BattleScript_MoveUsedIsConfusedRet
 BattleScript_DoSelfConfusionDmg::
 	cancelmultiturnmoves BS_ATTACKER
@@ -7353,7 +7353,6 @@ BattleScript_MoveUsedPowder::
 	ppreduce
 	pause B_WAIT_TIME_SHORT
 	cancelmultiturnmoves BS_ATTACKER
-	status2animation BS_ATTACKER, STATUS2_POWDER
 	waitanimation
 	effectivenesssound
 	hitanimation BS_ATTACKER
@@ -7391,7 +7390,7 @@ BattleScript_WrapEnds::
 BattleScript_MoveUsedIsInLove::
 	printstring STRINGID_PKMNINLOVE
 	waitmessage B_WAIT_TIME_LONG
-	status2animation BS_ATTACKER, STATUS2_INFATUATION
+	volatilestatusanimation BS_ATTACKER, ENUM_VOLATILE_STATUS_INFATUATION
 	return
 
 BattleScript_MoveUsedIsInLoveCantAttack::
@@ -7402,13 +7401,13 @@ BattleScript_MoveUsedIsInLoveCantAttack::
 BattleScript_NightmareTurnDmg::
 	printstring STRINGID_PKMNLOCKEDINNIGHTMARE
 	waitmessage B_WAIT_TIME_LONG
-	status2animation BS_ATTACKER, STATUS2_NIGHTMARE
+	volatilestatusanimation BS_ATTACKER, ENUM_VOLATILE_STATUS_NIGHTMARE
 	goto BattleScript_DoTurnDmg
 
 BattleScript_CurseTurnDmg::
 	printstring STRINGID_PKMNAFFLICTEDBYCURSE
 	waitmessage B_WAIT_TIME_LONG
-	status2animation BS_ATTACKER, STATUS2_CURSED
+	volatilestatusanimation BS_ATTACKER, ENUM_VOLATILE_STATUS_CURSED
 	goto BattleScript_DoTurnDmg
 
 BattleScript_TargetPRLZHeal::
@@ -7528,7 +7527,7 @@ BattleScript_MoveEffectWrap::
 	return
 
 BattleScript_MoveEffectConfusion::
-	chosenstatus2animation BS_EFFECT_BATTLER, STATUS2_CONFUSION
+	volatilestatusanimation BS_EFFECT_BATTLER, ENUM_VOLATILE_STATUS_CONFUSION
 	printstring STRINGID_PKMNWASCONFUSED
 	waitmessage B_WAIT_TIME_LONG
 	return
@@ -8553,7 +8552,7 @@ BattleScript_BanefulBunkerEffect::
 
 BattleScript_CuteCharmActivates::
 	call BattleScript_AbilityPopUp
-	status2animation BS_ATTACKER, STATUS2_INFATUATION
+	volatilestatusanimation BS_ATTACKER, ENUM_VOLATILE_STATUS_INFATUATION
 	printstring STRINGID_PKMNSXINFATUATEDY
 	waitmessage B_WAIT_TIME_LONG
 	call BattleScript_TryDestinyKnotTarget
@@ -9757,11 +9756,11 @@ BattleScript_Status2FoesEnd:
 	goto BattleScript_MoveEnd
 
 BattleScript_DoConfuseAnim:
-	status2animation BS_EFFECT_BATTLER, STATUS2_CONFUSION
+	volatilestatusanimation BS_EFFECT_BATTLER, ENUM_VOLATILE_STATUS_CONFUSION
 	goto BattleScript_Status2FoesPrintMessage
 
 BattleScript_DoInfatuationAnim:
-	status2animation BS_EFFECT_BATTLER, STATUS2_INFATUATION
+	volatilestatusanimation BS_EFFECT_BATTLER, ENUM_VOLATILE_STATUS_INFATUATION
 	goto BattleScript_Status2FoesPrintMessage
 
 BattleScript_PrintCoinsScattered:

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -1197,7 +1197,7 @@ BattleScript_EffectLaserFocus::
 	attackcanceler
 	attackstring
 	ppreduce
-	setuserstatus3 STATUS3_LASER_FOCUS, BattleScript_ButItFailed
+	setvolatilestatusorfail BS_ATTACKER, ENUM_VOLATILE_STATUS_LASER_FOCUS, BattleScript_ButItFailed
 	attackanimation
 	waitanimation
 	printstring STRINGID_LASERFOCUS
@@ -2517,7 +2517,7 @@ BattleScript_EffectMagnetRise::
 	attackcanceler
 	attackstring
 	ppreduce
-	setuserstatus3 STATUS3_MAGNET_RISE, BattleScript_ButItFailed
+	setvolatilestatusorfail BS_ATTACKER, ENUM_VOLATILE_STATUS_MAGNET_RISE, BattleScript_ButItFailed
 	attackanimation
 	waitanimation
 	printstring STRINGID_PKMNLEVITATEDONELECTROMAGNETISM
@@ -2561,7 +2561,7 @@ BattleScript_EffectAquaRing::
 	attackcanceler
 	attackstring
 	ppreduce
-	setuserstatus3 STATUS3_AQUA_RING, BattleScript_ButItFailed
+	setvolatilestatusorfail BS_ATTACKER, ENUM_VOLATILE_STATUS_AQUA_RING, BattleScript_ButItFailed
 	attackanimation
 	waitanimation
 	printstring STRINGID_PKMNSURROUNDEDWITHVEILOFWATER
@@ -5081,7 +5081,7 @@ BattleScript_EffectIngrain::
 	attackcanceler
 	attackstring
 	ppreduce
-	setuserstatus3 STATUS3_ROOTED, BattleScript_ButItFailed
+	setvolatilestatusorfail BS_ATTACKER, ENUM_VOLATILE_STATUS_ROOTED, BattleScript_ButItFailed
 	attackanimation
 	waitanimation
 	printstring STRINGID_PKMNPLANTEDROOTS
@@ -5236,7 +5236,7 @@ BattleScript_EffectGrudge::
 	attackcanceler
 	attackstring
 	ppreduce
-	setuserstatus3 STATUS3_GRUDGE, BattleScript_ButItFailed
+	setvolatilestatusorfail BS_ATTACKER, ENUM_VOLATILE_STATUS_GRUDGE, BattleScript_ButItFailed
 	attackanimation
 	waitanimation
 	printstring STRINGID_PKMNWANTSGRUDGE

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -30,7 +30,7 @@ BattleScript_EffectShedTail::
 	attackstring
 	ppreduce
 	waitstate
-	jumpifstatus2 BS_ATTACKER, STATUS2_SUBSTITUTE, BattleScript_AlreadyHasSubstitute
+	jumpifvolatilestatus BS_ATTACKER, ENUM_VOLATILE_STATUS_SUBSTITUTE, BattleScript_AlreadyHasSubstitute
 	jumpifbattletype BATTLE_TYPE_ARENA, BattleScript_ButItFailed
 	jumpifcantswitch SWITCH_IGNORE_ESCAPE_PREVENTION | BS_ATTACKER, BattleScript_ButItFailed
 	setsubstitute
@@ -587,7 +587,7 @@ BattleScript_BeakBlastBurn::
 
 BattleScript_EffectSkyDrop::
 	attackcanceler
-	jumpifstatus2 BS_ATTACKER, STATUS2_MULTIPLETURNS, BattleScript_SkyDropTurn2
+	jumpifvolatilestatus BS_ATTACKER, ENUM_VOLATILE_STATUS_MULTIPLETURNS, BattleScript_SkyDropTurn2
 	ppreduce
 	accuracycheck BattleScript_PrintMoveMissed, ACC_CURR_MOVE
 	attackstring
@@ -614,8 +614,8 @@ BattleScript_SkyDropFlyingType:
 	printstring STRINGID_ITDOESNTAFFECT
 	waitmessage B_WAIT_TIME_LONG
 	makevisible BS_ATTACKER
-	jumpifstatus2 BS_TARGET, STATUS2_CONFUSION, BattleScript_SkyDropFlyingAlreadyConfused
-	jumpifstatus2 BS_TARGET, STATUS2_LOCK_CONFUSE, BattleScript_SkyDropFlyingConfuseLock
+	jumpifvolatilestatus BS_TARGET, ENUM_VOLATILE_STATUS_CONFUSION, BattleScript_SkyDropFlyingAlreadyConfused
+	jumpifvolatilestatus BS_TARGET, ENUM_VOLATILE_STATUS_LOCK_CONFUSE, BattleScript_SkyDropFlyingConfuseLock
 	goto BattleScript_MoveEnd
 BattleScript_SkyDropChangedTarget:
 	pause B_WAIT_TIME_SHORT
@@ -629,7 +629,7 @@ BattleScript_SkyDropFlyingConfuseLock:
 	seteffectprimary MOVE_EFFECT_CONFUSION
 BattleScript_SkyDropFlyingAlreadyConfused:
 	clearstatusfromeffect BS_TARGET, MOVE_EFFECT_THRASH
-	jumpifstatus2 BS_TARGET, STATUS2_CONFUSION, BattleScript_MoveEnd
+	jumpifvolatilestatus BS_TARGET, ENUM_VOLATILE_STATUS_CONFUSION, BattleScript_MoveEnd
 	setbyte BS_ATTACKER, BS_TARGET
 	goto BattleScript_ThrashConfuses
 
@@ -824,7 +824,7 @@ BattleScript_EffectNoRetreat::
 	attackanimation
 	waitanimation
 	call BattleScript_AllStatsUp
-	jumpifstatus2 BS_TARGET, STATUS2_ESCAPE_PREVENTION, BattleScript_MoveEnd
+	jumpifvolatilestatus BS_TARGET, ENUM_VOLATILE_STATUS_ESCAPE_PREVENTION, BattleScript_MoveEnd
 	seteffectprimary MOVE_EFFECT_PREVENT_ESCAPE | MOVE_EFFECT_AFFECTS_USER
 	printstring STRINGID_CANTESCAPEDUETOUSEDMOVE
 	waitmessage B_WAIT_TIME_LONG
@@ -885,7 +885,7 @@ BattleScript_EffectFreezyFrost::
 	goto BattleScript_MoveEnd
 
 BattleScript_EffectSappySeed::
-	jumpifstatus3 BS_TARGET, STATUS3_LEECHSEED, BattleScript_EffectHit
+	jumpifvolatilestatus BS_TARGET, ENUM_VOLATILE_STATUS_LEECHSEED, BattleScript_EffectHit
 	call BattleScript_EffectHit_Ret
 	tryfaintmon BS_TARGET
 	jumpifhasnohp BS_TARGET, BattleScript_MoveEnd
@@ -1137,7 +1137,7 @@ BattleScript_StrengthSapTryHp:
 	waitanimation
 BattleScript_StrengthSapHp:
 	jumpifability BS_TARGET, ABILITY_LIQUID_OOZE, BattleScript_StrengthSapManipulateDmg
-	jumpifstatus3 BS_ATTACKER, STATUS3_HEAL_BLOCK, BattleScript_MoveEnd
+	jumpifvolatilestatus BS_ATTACKER, ENUM_VOLATILE_STATUS_HEAL_BLOCK, BattleScript_MoveEnd
 	jumpiffullhp BS_ATTACKER, BattleScript_MoveEnd
 BattleScript_StrengthSapManipulateDmg:
 	manipulatedamage DMG_BIG_ROOT
@@ -1273,8 +1273,7 @@ BattleScript_EffectPowder::
 	accuracycheck BattleScript_PrintMoveMissed, NO_ACC_CALC_CHECK_LOCK_ON
 	attackstring
 	ppreduce
-	jumpifstatus2 BS_TARGET, STATUS2_POWDER, BattleScript_ButItFailed
-	setpowder BS_TARGET
+	setpowderorfail BS_TARGET, BattleScript_ButItFailed
 	attackanimation
 	waitanimation
 	printstring STRINGID_COVEREDINPOWDER
@@ -1387,7 +1386,7 @@ BattleScript_EffectGearUpEnd:
 BattleScript_EffectAcupressure::
 	attackcanceler
 	jumpifbyteequal gBattlerTarget, gBattlerAttacker, BattleScript_EffectAcupressureTry
-	jumpifstatus2 BS_TARGET, STATUS2_SUBSTITUTE, BattleScript_PrintMoveMissed
+	jumpifvolatilestatus BS_TARGET, ENUM_VOLATILE_STATUS_SUBSTITUTE, BattleScript_PrintMoveMissed
 BattleScript_EffectAcupressureTry:
 	attackstring
 	ppreduce
@@ -1743,7 +1742,7 @@ BattleScript_EffectHitSwitchTarget::
 	tryfaintmon BS_TARGET
 	jumpiffainted BS_TARGET, TRUE, BattleScript_MoveEnd
 	jumpifability BS_TARGET, ABILITY_SUCTION_CUPS, BattleScript_AbilityPreventsPhasingOut
-	jumpifstatus3 BS_TARGET, STATUS3_ROOTED, BattleScript_PrintMonIsRooted
+	jumpifvolatilestatus BS_TARGET, ENUM_VOLATILE_STATUS_ROOTED, BattleScript_PrintMonIsRooted
 	jumpiftargetdynamaxed BattleScript_HitSwitchTargetDynamaxed
 	tryhitswitchtarget BattleScript_MoveEnd
 	forcerandomswitch BattleScript_HitSwitchTargetForceRandomSwitchFailed
@@ -2232,8 +2231,8 @@ BattleScript_EffectHealPulse::
 	attackcanceler
 	attackstring
 	ppreduce
-    jumpifstatus3 BS_ATTACKER, STATUS3_HEAL_BLOCK, BattleScript_MoveUsedHealBlockPrevents @ stops pollen puff
-    jumpifstatus3 BS_TARGET, STATUS3_HEAL_BLOCK, BattleScript_MoveUsedHealBlockPrevents
+    jumpifvolatilestatus BS_ATTACKER, ENUM_VOLATILE_STATUS_HEAL_BLOCK, BattleScript_MoveUsedHealBlockPrevents @ stops pollen puff
+    jumpifvolatilestatus BS_TARGET, ENUM_VOLATILE_STATUS_HEAL_BLOCK, BattleScript_MoveUsedHealBlockPrevents
 	accuracycheck BattleScript_ButItFailed, NO_ACC_CALC_CHECK_LOCK_ON
 	jumpifsubstituteblocks BattleScript_ButItFailed
 	tryhealpulse BattleScript_AlreadyAtFullHp
@@ -2640,10 +2639,7 @@ BattleScript_EffectGravitySuccess::
 	selectfirstvalidtarget
 BattleScript_GravityLoop:
 	movevaluescleanup
-	jumpifstatus3 BS_TARGET, STATUS3_ON_AIR | STATUS3_MAGNET_RISE | STATUS3_TELEKINESIS, BattleScript_GravityLoopDrop
-	goto BattleScript_GravityLoopEnd
-BattleScript_GravityLoopDrop:
-	bringdownairbornebattler BS_TARGET
+	bringdownairbornebattlerorend BS_TARGET, BattleScript_GravityLoopEnd
 	printstring STRINGID_GRAVITYGROUNDING
 	waitmessage B_WAIT_TIME_LONG
 BattleScript_GravityLoopEnd:
@@ -2756,7 +2752,7 @@ BattleScript_EffectNaturalGift::
 	jumpifnotberry BS_ATTACKER, BattleScript_ButItFailed
 	jumpifword CMP_COMMON_BITS, gFieldStatuses, STATUS_FIELD_MAGIC_ROOM, BattleScript_ButItFailed
 	jumpifability BS_ATTACKER, ABILITY_KLUTZ, BattleScript_ButItFailed
-	jumpifstatus3 BS_ATTACKER, STATUS3_EMBARGO, BattleScript_ButItFailed
+	jumpifvolatilestatus BS_ATTACKER, ENUM_VOLATILE_STATUS_EMBARGO, BattleScript_ButItFailed
 	accuracycheck BattleScript_MoveMissedPause, ACC_CURR_MOVE
 	call BattleScript_EffectHit_RetFromCritCalc
 	jumpifmovehadnoeffect BattleScript_EffectNaturalGiftEnd
@@ -2921,7 +2917,7 @@ BattleScript_CantMakeAsleep::
 
 BattleScript_EffectAbsorb::
 	call BattleScript_EffectHit_Ret
-	jumpifstatus3 BS_ATTACKER, STATUS3_HEAL_BLOCK, BattleScript_AbsorbHealBlock
+	jumpifvolatilestatus BS_ATTACKER, ENUM_VOLATILE_STATUS_HEAL_BLOCK, BattleScript_AbsorbHealBlock
 	setdrainedhp
 	manipulatedamage DMG_BIG_ROOT
 	orword gHitMarker, HITMARKER_IGNORE_SUBSTITUTE | HITMARKER_IGNORE_DISGUISE
@@ -3052,7 +3048,7 @@ BattleScript_DreamEaterWorked:
 	waitmessage B_WAIT_TIME_LONG
 	resultmessage
 	waitmessage B_WAIT_TIME_LONG
-	jumpifstatus3 BS_ATTACKER, STATUS3_HEAL_BLOCK, BattleScript_DreamEaterTryFaintEnd
+	jumpifvolatilestatus BS_ATTACKER, ENUM_VOLATILE_STATUS_HEAL_BLOCK, BattleScript_DreamEaterTryFaintEnd
 	setdrainedhp
 	manipulatedamage DMG_BIG_ROOT
 	orword gHitMarker, HITMARKER_IGNORE_SUBSTITUTE
@@ -3241,7 +3237,7 @@ BattleScript_EffectRoar::
 	jumpifroarfails BattleScript_ButItFailed
 	jumpifability BS_TARGET, ABILITY_GUARD_DOG, BattleScript_ButItFailed
 	jumpifability BS_TARGET, ABILITY_SUCTION_CUPS, BattleScript_AbilityPreventsPhasingOut
-	jumpifstatus3 BS_TARGET, STATUS3_ROOTED, BattleScript_PrintMonIsRooted
+	jumpifvolatilestatus BS_TARGET, ENUM_VOLATILE_STATUS_ROOTED, BattleScript_PrintMonIsRooted
 	jumpiftargetdynamaxed BattleScript_RoarBlockedByDynamax
 	accuracycheck BattleScript_ButItFailed, NO_ACC_CALC_CHECK_LOCK_ON
 	accuracycheck BattleScript_MoveMissedPause, ACC_CURR_MOVE
@@ -3513,8 +3509,7 @@ BattleScript_EffectFocusEnergy::
 	attackcanceler
 	attackstring
 	ppreduce
-	jumpifstatus2 BS_ATTACKER, STATUS2_FOCUS_ENERGY_ANY, BattleScript_ButItFailed
-	setfocusenergy
+	setfocusenergyorfail BS_ATTACKER, BattleScript_ButItFailed
 	attackanimation
 	waitanimation
 	printfromtable gFocusEnergyUsedStringIds
@@ -3527,7 +3522,7 @@ BattleScript_EffectConfuse::
 	ppreduce
 	jumpifability BS_TARGET, ABILITY_OWN_TEMPO, BattleScript_OwnTempoPrevents
 	jumpifsubstituteblocks BattleScript_ButItFailed
-	jumpifstatus2 BS_TARGET, STATUS2_CONFUSION, BattleScript_AlreadyConfused
+	jumpifvolatilestatus BS_TARGET, ENUM_VOLATILE_STATUS_CONFUSION, BattleScript_AlreadyConfused
 	jumpifterrainaffected BS_TARGET, STATUS_FIELD_MISTY_TERRAIN, BattleScript_MistyTerrainPrevents
 	accuracycheck BattleScript_ButItFailed, ACC_CURR_MOVE
 	jumpifsafeguard BattleScript_SafeguardProtected
@@ -3716,7 +3711,7 @@ BattleScript_PowerHerbActivation:
 	return
 
 BattleScript_EffectTwoTurnsAttack::
-	jumpifstatus2 BS_ATTACKER, STATUS2_MULTIPLETURNS, BattleScript_TwoTurnMovesSecondTurn
+	jumpifvolatilestatus BS_ATTACKER, ENUM_VOLATILE_STATUS_MULTIPLETURNS, BattleScript_TwoTurnMovesSecondTurn
 	jumpifword CMP_COMMON_BITS, gHitMarker, HITMARKER_NO_ATTACKSTRING, BattleScript_TwoTurnMovesSecondTurn
 	tryfiretwoturnmovewithoutcharging BS_ATTACKER, BattleScript_EffectHit @ e.g. Solar Beam
 	call BattleScript_FirstChargingTurn
@@ -3725,7 +3720,7 @@ BattleScript_EffectTwoTurnsAttack::
 	goto BattleScript_MoveEnd
 
 BattleScript_EffectGeomancy::
-	jumpifstatus2 BS_ATTACKER, STATUS2_MULTIPLETURNS, BattleScript_GeomancySecondTurn
+	jumpifvolatilestatus BS_ATTACKER, ENUM_VOLATILE_STATUS_MULTIPLETURNS, BattleScript_GeomancySecondTurn
 	jumpifword CMP_COMMON_BITS, gHitMarker, HITMARKER_NO_ATTACKSTRING, BattleScript_GeomancySecondTurn
 	call BattleScript_FirstChargingTurn
 	jumpifnoholdeffect BS_ATTACKER, HOLD_EFFECT_POWER_HERB, BattleScript_MoveEnd
@@ -3808,7 +3803,7 @@ BattleScript_EffectSubstitute::
 	ppreduce
 	attackstring
 	waitstate
-	jumpifstatus2 BS_ATTACKER, STATUS2_SUBSTITUTE, BattleScript_AlreadyHasSubstitute
+	jumpifvolatilestatus BS_ATTACKER, ENUM_VOLATILE_STATUS_SUBSTITUTE, BattleScript_AlreadyHasSubstitute
 	setsubstitute
 	jumpifbyte CMP_EQUAL, cMULTISTRING_CHOOSER, B_MSG_SUBSTITUTE_FAILED, BattleScript_SubstituteString
 	attackanimation
@@ -4119,7 +4114,7 @@ BattleScript_EffectMeanLook::
 	attackstring
 	ppreduce
 	accuracycheck BattleScript_ButItFailed, NO_ACC_CALC_CHECK_LOCK_ON
-	jumpifstatus2 BS_TARGET, STATUS2_ESCAPE_PREVENTION, BattleScript_ButItFailed
+	jumpifvolatilestatus BS_TARGET, ENUM_VOLATILE_STATUS_ESCAPE_PREVENTION, BattleScript_ButItFailed
 	jumpifsubstituteblocks BattleScript_ButItFailed
 .if B_GHOSTS_ESCAPE >= GEN_6
 	jumpiftype BS_TARGET, TYPE_GHOST, BattleScript_ButItFailed
@@ -4136,7 +4131,7 @@ BattleScript_EffectNightmare::
 	attackstring
 	ppreduce
 	jumpifsubstituteblocks BattleScript_ButItFailed
-	jumpifstatus2 BS_TARGET, STATUS2_NIGHTMARE, BattleScript_ButItFailed
+	jumpifvolatilestatus BS_TARGET, ENUM_VOLATILE_STATUS_NIGHTMARE, BattleScript_ButItFailed
 	jumpifstatus BS_TARGET, STATUS1_SLEEP, BattleScript_NightmareWorked
 	jumpifability BS_TARGET, ABILITY_COMATOSE, BattleScript_NightmareWorked
 	goto BattleScript_ButItFailed
@@ -4241,7 +4236,7 @@ BattleScript_EffectForesight::
 	attackstring
 	ppreduce
 	accuracycheck BattleScript_ButItFailed, NO_ACC_CALC_CHECK_LOCK_ON
-	jumpifstatus2 BS_TARGET, STATUS2_FORESIGHT, BattleScript_ButItFailed
+	jumpifvolatilestatus BS_TARGET, ENUM_VOLATILE_STATUS_FORESIGHT, BattleScript_ButItFailed
 	setforesight
 BattleScript_IdentifiedFoe:
 	attackanimation
@@ -4290,7 +4285,7 @@ BattleScript_EffectSandstorm::
 BattleScript_EffectRollout::
 	attackcanceler
 	attackstring
-	jumpifstatus2 BS_ATTACKER, STATUS2_MULTIPLETURNS, BattleScript_RolloutCheckAccuracy
+	jumpifvolatilestatus BS_ATTACKER, ENUM_VOLATILE_STATUS_MULTIPLETURNS, BattleScript_RolloutCheckAccuracy
 	ppreduce
 BattleScript_RolloutCheckAccuracy::
 	accuracycheck BattleScript_RolloutHit, ACC_CURR_MOVE
@@ -4725,7 +4720,7 @@ BattleScript_EffectUproar::
 	attackcanceler
 	accuracycheck BattleScript_PrintMoveMissed, ACC_CURR_MOVE
 	attackstring
-	jumpifstatus2 BS_ATTACKER, STATUS2_MULTIPLETURNS, BattleScript_UproarHit
+	jumpifvolatilestatus BS_ATTACKER, ENUM_VOLATILE_STATUS_MULTIPLETURNS, BattleScript_UproarHit
 	ppreduce
 BattleScript_UproarHit::
 	goto BattleScript_HitFromCritCalc
@@ -5275,7 +5270,7 @@ BattleScript_TeeterDanceLoop::
 	jumpifbyteequal gBattlerAttacker, gBattlerTarget, BattleScript_TeeterDanceLoopIncrement
 	jumpifability BS_TARGET, ABILITY_OWN_TEMPO, BattleScript_TeeterDanceOwnTempoPrevents
 	jumpifsubstituteblocks BattleScript_TeeterDanceSubstitutePrevents
-	jumpifstatus2 BS_TARGET, STATUS2_CONFUSION, BattleScript_TeeterDanceAlreadyConfused
+	jumpifvolatilestatus BS_TARGET, ENUM_VOLATILE_STATUS_CONFUSION, BattleScript_TeeterDanceAlreadyConfused
 	jumpifhasnohp BS_TARGET, BattleScript_TeeterDanceLoopIncrement
 	accuracycheck BattleScript_TeeterDanceMissed, ACC_CURR_MOVE
 	jumpifsafeguard BattleScript_TeeterDanceSafeguardProtected
@@ -6077,7 +6072,7 @@ BattleScript_LeechSeedTurnDrain::
 	copyword gBattleMoveDamage, gHpDealt
 	jumpifability BS_ATTACKER, ABILITY_LIQUID_OOZE, BattleScript_LeechSeedTurnPrintLiquidOoze
 	setbyte cMULTISTRING_CHOOSER, B_MSG_LEECH_SEED_DRAIN
-	jumpifstatus3 BS_TARGET, STATUS3_HEAL_BLOCK, BattleScript_LeechSeedHealBlock
+	jumpifvolatilestatus BS_TARGET, ENUM_VOLATILE_STATUS_HEAL_BLOCK, BattleScript_LeechSeedHealBlock
 	manipulatedamage DMG_BIG_ROOT
 	goto BattleScript_LeechSeedTurnPrintAndUpdateHp
 BattleScript_LeechSeedTurnPrintLiquidOoze::
@@ -7451,10 +7446,7 @@ BattleScript_YawnMakesAsleep::
 	waitmessage B_WAIT_TIME_LONG
 	updatestatusicon BS_EFFECT_BATTLER
 	waitstate
-	jumpifstatus3 BS_EFFECT_BATTLER, STATUS3_SKY_DROPPED, BattleScript_YawnEnd
-	makevisible BS_EFFECT_BATTLER
-	skydropyawn
-BattleScript_YawnEnd:
+	skydropyawn BS_EFFECT_BATTLER
 	end2
 
 BattleScript_EmbargoEndTurn::
@@ -7789,7 +7781,7 @@ BattleScript_IntimidateLoop:
 	jumpifbyteequal gBattlerTarget, gBattlerAttacker, BattleScript_IntimidateLoopIncrement
 	jumpiftargetally BattleScript_IntimidateLoopIncrement
 	jumpifabsent BS_TARGET, BattleScript_IntimidateLoopIncrement
-	jumpifstatus2 BS_TARGET, STATUS2_SUBSTITUTE, BattleScript_IntimidateLoopIncrement
+	jumpifvolatilestatus BS_TARGET, ENUM_VOLATILE_STATUS_SUBSTITUTE, BattleScript_IntimidateLoopIncrement
 	jumpifability BS_TARGET, ABILITY_GUARD_DOG, BattleScript_IntimidateInReverse
 BattleScript_IntimidateEffect:
 	copybyte sBATTLER, gBattlerAttacker
@@ -7842,7 +7834,7 @@ BattleScript_SupersweetSyrupLoop:
 	jumpifbyteequal gBattlerTarget, gBattlerAttacker, BattleScript_SupersweetSyrupLoopIncrement
 	jumpiftargetally BattleScript_SupersweetSyrupLoopIncrement
 	jumpifabsent BS_TARGET, BattleScript_SupersweetSyrupLoopIncrement
-	jumpifstatus2 BS_TARGET, STATUS2_SUBSTITUTE, BattleScript_SupersweetSyrupLoopIncrement
+	jumpifvolatilestatus BS_TARGET, ENUM_VOLATILE_STATUS_SUBSTITUTE, BattleScript_SupersweetSyrupLoopIncrement
 BattleScript_SupersweetSyrupEffect:
 	copybyte sBATTLER, gBattlerAttacker
 	setstatchanger STAT_EVASION, 1, TRUE
@@ -9454,7 +9446,7 @@ BattleScript_RedCardActivates::
 	printstring STRINGID_REDCARDACTIVATE
 	waitmessage B_WAIT_TIME_LONG
 	swapattackerwithtarget
-	jumpifstatus3 BS_EFFECT_BATTLER, STATUS3_ROOTED, BattleScript_RedCardIngrain
+	jumpifvolatilestatus BS_EFFECT_BATTLER, ENUM_VOLATILE_STATUS_ROOTED, BattleScript_RedCardIngrain
 	jumpifability BS_EFFECT_BATTLER, ABILITY_SUCTION_CUPS, BattleScript_RedCardSuctionCups
 	jumpiftargetdynamaxed BattleScript_RedCardDynamaxed
 	removeitem BS_SCRIPTING

--- a/data/battle_scripts_2.s
+++ b/data/battle_scripts_2.s
@@ -112,8 +112,7 @@ BattleScript_ItemSetMist::
 
 BattleScript_ItemSetFocusEnergy::
     call BattleScript_UseItemMessage
-    jumpifstatus2 BS_ATTACKER, STATUS2_FOCUS_ENERGY_ANY, BattleScript_ButItFailed
-    setfocusenergy
+    setfocusenergyorfail BS_ATTACKER, BattleScript_ButItFailed
     playmoveanimation BS_ATTACKER, MOVE_FOCUS_ENERGY
     waitanimation
     copybyte sBATTLER, gBattlerAttacker

--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -249,5 +249,6 @@ u8 GetBattlerType(u32 battler, u8 typeIndex);
 bool8 CanMonParticipateInSkyBattle(struct Pokemon *mon);
 bool8 IsMonBannedFromSkyBattles(u16 species);
 void RemoveBattlerType(u32 battler, u8 type);
+bool32 BattlerHasVolatileStatus(u32 battler, u32 volatileStatus);
 
 #endif // GUARD_BATTLE_UTIL_H

--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -249,6 +249,7 @@ u8 GetBattlerType(u32 battler, u8 typeIndex);
 bool8 CanMonParticipateInSkyBattle(struct Pokemon *mon);
 bool8 IsMonBannedFromSkyBattles(u16 species);
 void RemoveBattlerType(u32 battler, u8 type);
-bool32 BattlerHasVolatileStatus(u32 battler, u32 volatileStatus);
+bool32 SetBattlerVolatileStatus(u32 battler, u32 volatileStatus);
+bool32 CheckBattlerVolatileStatus(u32 battler, u32 volatileStatus);
 
 #endif // GUARD_BATTLE_UTIL_H

--- a/include/constants/battle.h
+++ b/include/constants/battle.h
@@ -208,6 +208,10 @@
 #define ENUM_VOLATILE_STATUS_EMBARGO            11
 #define ENUM_VOLATILE_STATUS_INFATUATION        12
 #define ENUM_VOLATILE_STATUS_CURSED             13
+#define ENUM_VOLATILE_STATUS_GRUDGE             14
+#define ENUM_VOLATILE_STATUS_MAGNET_RISE        15
+#define ENUM_VOLATILE_STATUS_AQUA_RING          16
+#define ENUM_VOLATILE_STATUS_LASER_FOCUS        17
 
 #define HITMARKER_WAKE_UP_CLEAR         (1 << 4) // Cleared when waking up. Never set or checked.
 #define HITMARKER_IGNORE_BIDE           (1 << 5)

--- a/include/constants/battle.h
+++ b/include/constants/battle.h
@@ -206,6 +206,8 @@
 #define ENUM_VOLATILE_STATUS_ROOTED             9
 #define ENUM_VOLATILE_STATUS_HEAL_BLOCK         10
 #define ENUM_VOLATILE_STATUS_EMBARGO            11
+#define ENUM_VOLATILE_STATUS_INFATUATION        12
+#define ENUM_VOLATILE_STATUS_CURSED             13
 
 #define HITMARKER_WAKE_UP_CLEAR         (1 << 4) // Cleared when waking up. Never set or checked.
 #define HITMARKER_IGNORE_BIDE           (1 << 5)

--- a/include/constants/battle.h
+++ b/include/constants/battle.h
@@ -194,6 +194,19 @@
 #define STATUS4_SYRUP_BOMB              (1 << 5)
 #define STATUS4_GLAIVE_RUSH             (1 << 6)
 
+// Enums for checking volatile statuses
+#define ENUM_VOLATILE_STATUS_CONFUSION          1
+#define ENUM_VOLATILE_STATUS_LOCK_CONFUSE       2
+#define ENUM_VOLATILE_STATUS_ESCAPE_PREVENTION  3
+#define ENUM_VOLATILE_STATUS_MULTIPLETURNS      4
+#define ENUM_VOLATILE_STATUS_FORESIGHT          5
+#define ENUM_VOLATILE_STATUS_NIGHTMARE          6
+#define ENUM_VOLATILE_STATUS_SUBSTITUTE         7
+#define ENUM_VOLATILE_STATUS_LEECHSEED          8
+#define ENUM_VOLATILE_STATUS_ROOTED             9
+#define ENUM_VOLATILE_STATUS_HEAL_BLOCK         10
+#define ENUM_VOLATILE_STATUS_EMBARGO            11
+
 #define HITMARKER_WAKE_UP_CLEAR         (1 << 4) // Cleared when waking up. Never set or checked.
 #define HITMARKER_IGNORE_BIDE           (1 << 5)
 #define HITMARKER_DESTINYBOND           (1 << 6)

--- a/include/constants/battle_script_commands.h
+++ b/include/constants/battle_script_commands.h
@@ -158,7 +158,7 @@
 #define VARIOUS_SET_AURORA_VEIL                      66
 #define VARIOUS_TRY_THIRD_TYPE                       67
 #define VARIOUS_ACUPRESSURE                          68
-#define VARIOUS_SET_POWDER                           69
+#define VARIOUS_SET_POWDER_OR_FAIL                   69
 #define VARIOUS_SPECTRAL_THIEF                       70
 #define VARIOUS_GRAVITY_ON_AIRBORNE_MONS             71
 #define VARIOUS_CHECK_IF_GRASSY_TERRAIN_HEALS        72

--- a/src/battle_controller_recorded_opponent.c
+++ b/src/battle_controller_recorded_opponent.c
@@ -44,7 +44,6 @@ static void RecordedOpponentHandleChooseItem(u32 battler);
 static void RecordedOpponentHandleChoosePokemon(u32 battler);
 static void RecordedOpponentHandleHealthBarUpdate(u32 battler);
 static void RecordedOpponentHandleStatusIconUpdate(u32 battler);
-static void RecordedOpponentHandleStatusAnimation(u32 battler);
 static void RecordedOpponentHandleIntroTrainerBallThrow(u32 battler);
 static void RecordedOpponentHandleDrawPartyStatusSummary(u32 battler);
 static void RecordedOpponentHandleBattleAnimation(u32 battler);
@@ -83,7 +82,7 @@ static void (*const sRecordedOpponentBufferCommands[CONTROLLER_CMDS_COUNT])(u32 
     [CONTROLLER_HEALTHBARUPDATE]          = RecordedOpponentHandleHealthBarUpdate,
     [CONTROLLER_EXPUPDATE]                = BtlController_Empty,
     [CONTROLLER_STATUSICONUPDATE]         = RecordedOpponentHandleStatusIconUpdate,
-    [CONTROLLER_STATUSANIMATION]          = RecordedOpponentHandleStatusAnimation,
+    [CONTROLLER_STATUSANIMATION]          = BtlController_HandleStatusAnimation,
     [CONTROLLER_STATUSXOR]                = BtlController_Empty,
     [CONTROLLER_DATATRANSFER]             = BtlController_Empty,
     [CONTROLLER_DMA3TRANSFER]             = BtlController_Empty,
@@ -492,11 +491,6 @@ static void RecordedOpponentHandleStatusIconUpdate(u32 battler)
         if (gTestRunnerEnabled)
             TestRunner_Battle_RecordStatus1(battler, GetMonData(&gEnemyParty[gBattlerPartyIndexes[battler]], MON_DATA_STATUS));
     }
-}
-
-static void RecordedOpponentHandleStatusAnimation(u32 battler)
-{
-    BtlController_HandleStatusAnimation(battler);
 }
 
 static void RecordedOpponentHandleIntroTrainerBallThrow(u32 battler)

--- a/src/battle_controller_recorded_player.c
+++ b/src/battle_controller_recorded_player.c
@@ -41,7 +41,6 @@ static void RecordedPlayerHandleChooseItem(u32 battler);
 static void RecordedPlayerHandleChoosePokemon(u32 battler);
 static void RecordedPlayerHandleHealthBarUpdate(u32 battler);
 static void RecordedPlayerHandleStatusIconUpdate(u32 battler);
-static void RecordedPlayerHandleStatusAnimation(u32 battler);
 static void RecordedPlayerHandleIntroTrainerBallThrow(u32 battler);
 static void RecordedPlayerHandleDrawPartyStatusSummary(u32 battler);
 static void RecordedPlayerHandleBattleAnimation(u32 battler);
@@ -80,7 +79,7 @@ static void (*const sRecordedPlayerBufferCommands[CONTROLLER_CMDS_COUNT])(u32 ba
     [CONTROLLER_HEALTHBARUPDATE]          = RecordedPlayerHandleHealthBarUpdate,
     [CONTROLLER_EXPUPDATE]                = PlayerHandleExpUpdate,
     [CONTROLLER_STATUSICONUPDATE]         = RecordedPlayerHandleStatusIconUpdate,
-    [CONTROLLER_STATUSANIMATION]          = RecordedPlayerHandleStatusAnimation,
+    [CONTROLLER_STATUSANIMATION]          = BtlController_HandleStatusAnimation,
     [CONTROLLER_STATUSXOR]                = BtlController_Empty,
     [CONTROLLER_DATATRANSFER]             = BtlController_Empty,
     [CONTROLLER_DMA3TRANSFER]             = BtlController_Empty,
@@ -500,11 +499,6 @@ static void RecordedPlayerHandleStatusIconUpdate(u32 battler)
         if (gTestRunnerEnabled)
             TestRunner_Battle_RecordStatus1(battler, GetMonData(&gPlayerParty[gBattlerPartyIndexes[battler]], MON_DATA_STATUS));
     }
-}
-
-static void RecordedPlayerHandleStatusAnimation(u32 battler)
-{
-    BtlController_HandleStatusAnimation(battler);
 }
 
 static void RecordedPlayerHandleIntroTrainerBallThrow(u32 battler)

--- a/src/battle_gfx_sfx_util.c
+++ b/src/battle_gfx_sfx_util.c
@@ -439,18 +439,24 @@ void InitAndLaunchChosenStatusAnimation(u32 battler, bool32 isStatus2, u32 statu
     }
     else
     {
-        if (status & STATUS2_INFATUATION)
-            LaunchStatusAnimation(battler, B_ANIM_STATUS_INFATUATION);
-        else if (status & STATUS2_CONFUSION)
-            LaunchStatusAnimation(battler, B_ANIM_STATUS_CONFUSION);
-        else if (status & STATUS2_CURSED)
-            LaunchStatusAnimation(battler, B_ANIM_STATUS_CURSED);
-        else if (status & STATUS2_NIGHTMARE)
-            LaunchStatusAnimation(battler, B_ANIM_STATUS_NIGHTMARE);
-        else if (status & STATUS2_WRAPPED)
-            LaunchStatusAnimation(battler, B_ANIM_STATUS_WRAPPED); // this animation doesn't actually exist
-        else // no animation
-            gBattleSpritesDataPtr->healthBoxesData[battler].statusAnimActive = 0;
+        switch (status)
+        {
+            case ENUM_VOLATILE_STATUS_CONFUSION:
+                LaunchStatusAnimation(battler, B_ANIM_STATUS_CONFUSION);
+                break;
+            case ENUM_VOLATILE_STATUS_INFATUATION:
+                LaunchStatusAnimation(battler, B_ANIM_STATUS_INFATUATION);
+                break;
+            case ENUM_VOLATILE_STATUS_NIGHTMARE:
+                LaunchStatusAnimation(battler, B_ANIM_STATUS_NIGHTMARE);
+                break;
+            case ENUM_VOLATILE_STATUS_CURSED:
+                LaunchStatusAnimation(battler, B_ANIM_STATUS_CURSED);
+                break;
+            default: // no animation
+                gBattleSpritesDataPtr->healthBoxesData[battler].statusAnimActive = 0;
+                break;
+        }
     }
 }
 

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -11137,3 +11137,38 @@ void RemoveBattlerType(u32 battler, u8 type)
             *(u8 *)(&gBattleMons[battler].type1 + i) = TYPE_MYSTERY;
     }
 }
+
+bool32 BattlerHasVolatileStatus(u32 battler, u32 volatileStatus)
+{
+    switch (volatileStatus)
+    {
+        case ENUM_VOLATILE_STATUS_CONFUSION:
+            return (gBattleMons[battler].status2 & STATUS2_CONFUSION);
+        case ENUM_VOLATILE_STATUS_LOCK_CONFUSE:
+            return (gBattleMons[battler].status2 & STATUS2_LOCK_CONFUSE);
+        case ENUM_VOLATILE_STATUS_ESCAPE_PREVENTION:
+            return (gBattleMons[battler].status2 & STATUS2_ESCAPE_PREVENTION);
+        case ENUM_VOLATILE_STATUS_MULTIPLETURNS:
+            return (gBattleMons[battler].status2 & STATUS2_MULTIPLETURNS);
+        case ENUM_VOLATILE_STATUS_FORESIGHT:
+            return (gBattleMons[battler].status2 & STATUS2_FORESIGHT);
+        case ENUM_VOLATILE_STATUS_NIGHTMARE:
+            return (gBattleMons[battler].status2 & STATUS2_NIGHTMARE);
+        case ENUM_VOLATILE_STATUS_SUBSTITUTE:
+            return (gBattleMons[battler].status2 & STATUS2_SUBSTITUTE);
+        case ENUM_VOLATILE_STATUS_LEECHSEED:
+            return (gStatuses3[battler] & STATUS3_LEECHSEED);
+        case ENUM_VOLATILE_STATUS_ROOTED:
+            return (gStatuses3[battler] & STATUS3_ROOTED);
+        case ENUM_VOLATILE_STATUS_HEAL_BLOCK:
+            return (gStatuses3[battler] & STATUS3_HEAL_BLOCK);
+        case ENUM_VOLATILE_STATUS_EMBARGO:
+            return (gStatuses3[battler] & STATUS3_EMBARGO);
+        case ENUM_VOLATILE_STATUS_INFATUATION:
+            return (gBattleMons[battler].status2 & STATUS2_INFATUATION);
+        case ENUM_VOLATILE_STATUS_CURSED:
+            return (gBattleMons[battler].status2 & STATUS2_CURSED);
+    }
+
+    return FALSE;
+}

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -11138,37 +11138,72 @@ void RemoveBattlerType(u32 battler, u8 type)
     }
 }
 
-bool32 BattlerHasVolatileStatus(u32 battler, u32 volatileStatus)
+
+#define TRY_UPDATE_VOLATILE(field, status)  \
+if (set)                                    \
+{                                           \
+    if (field & status)                     \
+        return FALSE;                       \
+    field |= status;                        \
+}
+
+#define RETURN_CHECK_OR_UPDATE_VOLATILE(field, status)  \
+TRY_UPDATE_VOLATILE(field, status)                      \
+return (field & status)
+
+static bool32 CheckOrUpdateBattlerVolatileStatus(u32 battler, u32 volatileStatus, bool32 set)
 {
     switch (volatileStatus)
     {
         case ENUM_VOLATILE_STATUS_CONFUSION:
-            return (gBattleMons[battler].status2 & STATUS2_CONFUSION);
+            RETURN_CHECK_OR_UPDATE_VOLATILE(gBattleMons[battler].status2, STATUS2_CONFUSION);
         case ENUM_VOLATILE_STATUS_LOCK_CONFUSE:
-            return (gBattleMons[battler].status2 & STATUS2_LOCK_CONFUSE);
+            RETURN_CHECK_OR_UPDATE_VOLATILE(gBattleMons[battler].status2, STATUS2_LOCK_CONFUSE);
         case ENUM_VOLATILE_STATUS_ESCAPE_PREVENTION:
-            return (gBattleMons[battler].status2 & STATUS2_ESCAPE_PREVENTION);
+            RETURN_CHECK_OR_UPDATE_VOLATILE(gBattleMons[battler].status2, STATUS2_ESCAPE_PREVENTION);
         case ENUM_VOLATILE_STATUS_MULTIPLETURNS:
-            return (gBattleMons[battler].status2 & STATUS2_MULTIPLETURNS);
+            RETURN_CHECK_OR_UPDATE_VOLATILE(gBattleMons[battler].status2, STATUS2_MULTIPLETURNS);
         case ENUM_VOLATILE_STATUS_FORESIGHT:
-            return (gBattleMons[battler].status2 & STATUS2_FORESIGHT);
+            RETURN_CHECK_OR_UPDATE_VOLATILE(gBattleMons[battler].status2, STATUS2_FORESIGHT);
         case ENUM_VOLATILE_STATUS_NIGHTMARE:
-            return (gBattleMons[battler].status2 & STATUS2_NIGHTMARE);
+            RETURN_CHECK_OR_UPDATE_VOLATILE(gBattleMons[battler].status2, STATUS2_NIGHTMARE);
         case ENUM_VOLATILE_STATUS_SUBSTITUTE:
-            return (gBattleMons[battler].status2 & STATUS2_SUBSTITUTE);
+            RETURN_CHECK_OR_UPDATE_VOLATILE(gBattleMons[battler].status2, STATUS2_SUBSTITUTE);
         case ENUM_VOLATILE_STATUS_LEECHSEED:
-            return (gStatuses3[battler] & STATUS3_LEECHSEED);
+            RETURN_CHECK_OR_UPDATE_VOLATILE(gStatuses3[battler], STATUS3_LEECHSEED);
         case ENUM_VOLATILE_STATUS_ROOTED:
-            return (gStatuses3[battler] & STATUS3_ROOTED);
+            RETURN_CHECK_OR_UPDATE_VOLATILE(gStatuses3[battler], STATUS3_ROOTED);
         case ENUM_VOLATILE_STATUS_HEAL_BLOCK:
-            return (gStatuses3[battler] & STATUS3_HEAL_BLOCK);
+            RETURN_CHECK_OR_UPDATE_VOLATILE(gStatuses3[battler], STATUS3_HEAL_BLOCK);
         case ENUM_VOLATILE_STATUS_EMBARGO:
-            return (gStatuses3[battler] & STATUS3_EMBARGO);
+            RETURN_CHECK_OR_UPDATE_VOLATILE(gStatuses3[battler], STATUS3_EMBARGO);
         case ENUM_VOLATILE_STATUS_INFATUATION:
-            return (gBattleMons[battler].status2 & STATUS2_INFATUATION);
+            RETURN_CHECK_OR_UPDATE_VOLATILE(gBattleMons[battler].status2, STATUS2_INFATUATION);
         case ENUM_VOLATILE_STATUS_CURSED:
-            return (gBattleMons[battler].status2 & STATUS2_CURSED);
+            RETURN_CHECK_OR_UPDATE_VOLATILE(gBattleMons[battler].status2, STATUS2_CURSED);
+        case ENUM_VOLATILE_STATUS_GRUDGE:
+            RETURN_CHECK_OR_UPDATE_VOLATILE(gStatuses3[battler], STATUS3_GRUDGE);
+        case ENUM_VOLATILE_STATUS_MAGNET_RISE:
+            TRY_UPDATE_VOLATILE(gStatuses3[battler], STATUS3_MAGNET_RISE)
+            gDisableStructs[battler].magnetRiseTimer = 5;
+            return STATUS3_MAGNET_RISE;
+        case ENUM_VOLATILE_STATUS_AQUA_RING:
+            RETURN_CHECK_OR_UPDATE_VOLATILE(gStatuses3[battler], STATUS3_AQUA_RING);
+        case ENUM_VOLATILE_STATUS_LASER_FOCUS:
+            TRY_UPDATE_VOLATILE(gStatuses3[battler], STATUS3_LASER_FOCUS)
+            gDisableStructs[battler].laserFocusTimer = 2;
+            return STATUS3_LASER_FOCUS;
     }
 
     return FALSE;
+}
+
+bool32 SetBattlerVolatileStatus(u32 battler, u32 volatileStatus)
+{
+    return CheckOrUpdateBattlerVolatileStatus(battler, volatileStatus, TRUE);
+}
+
+bool32 CheckBattlerVolatileStatus(u32 battler, u32 volatileStatus)
+{
+    return CheckOrUpdateBattlerVolatileStatus(battler, volatileStatus, FALSE);
 }


### PR DESCRIPTION
## Description
Replaces statuses2/3/4 with a bitfield within `BattlePokemon`

- status2/3/4 bit flags removed
- status2/3/4 renamed to "volatile statuses" and all references thereto are renamed
- added "generic" functions for checking/applying volatiles statuses and for running associated animations

DRAWBACK
To add a volatile status to the "generic" function, it is necessary to define a corresponding enum in `include/constants/battle.h` of the form `ENUM_VOLATILE_STATUS_X` and add it to the switch case in `battle_util.c`.

## **People who collaborated with me in this PR**
<!-- Please credit everyone else that contributed to this PR, be it code and/or assets. -->
<!-- Use their GitHub tag if they have one. -->
<!-- If it doesn't apply, feel free to remove this section. -->

## Feature(s) this PR does NOT handle:
Does not merge anything else further into `BattlePokemon`

## **Discord contact info**
<!--- formatted as name#numbers, e.g. Lunos#4026 -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
