### PR TITLE
randompercentage and randomelement Script Commands

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -2133,3 +2133,34 @@
 	callnative ToggleGigantamaxFactor
 	.2byte \slot
 	.endm
+
+	@ Sets VAR_RESULT to one of the arguments (via setorcopyvar).
+	.macro randomelement element:req, elements:vararg
+	.set _randomelement_n, 0
+	.irp el, \element, \elements
+	.set _randomelement_n, _randomelement_n + 1
+	.endr
+		random _randomelement_n
+
+	.set _randomelement_n, 0
+	.irp el, \element, \elements
+		goto_if_ne VAR_RESULT, _randomelement_n, 1f
+		setorcopyvar VAR_RESULT, \el
+		goto 2f
+	1:
+	.set _randomelement_n, _randomelement_n + 1
+	.endr
+	2:
+	.endm
+
+	@ Sets VAR_RESULT to TRUE with probability 'percent', and FALSE
+	@ with probability '100% - percent'.
+	.macro randompercentage percent:req
+		random 100
+		goto_if_lt VAR_RESULT, \percent, 1f
+		setvar VAR_RESULT, FALSE
+		goto 2f
+	1:
+		setvar VAR_RESULT, TRUE
+	2:
+	.endm


### PR DESCRIPTION
Inspired by [this Discord message](https://discord.com/channels/419213663107416084/774393519569502268/1207220602029744138).

Lets us do things like:
```
@ VAR_RESULT is one of Treecko, Torchic, or Mudkip
randomelement SPECIES_TREECKO, SPECIES_TORCHIC, SPECIES_MUDKIP

@ Gives a random one of Treecko, Torchic, or Mudkip.
givemon VAR_RESULT, 5
```

```
@ VAR_RESULT is TRUE 25% of the time, and FALSE 75% of the time.
randompercentage 25

@ Gives a Wobbuffet that is shiny 25% of the time.
givemon SPECIES_WOBBUFFET, 20, isShiny=VAR_RESULT
```

The implementations of these could be improved if there was some way to do indirection, but they're not any worse than what a user would roll by hand.

I think `randomelement` in particular is something that gets asked for relatively often.