### PR TITLE
Updated the way in which ScriptGiveMonParameterized and ScrCmd_givemon chooe a default ability

### DIFF
--- a/include/constants/pokemon.h
+++ b/include/constants/pokemon.h
@@ -323,6 +323,9 @@
 #define NUM_NORMAL_ABILITY_SLOTS 2
 #define NUM_HIDDEN_ABILITY_SLOTS 1
 
+// Used as a signal for givemon to generate a default ability in the vanilla Pokémon Emerald way.
+#define NUM_ABILITY_VANILLA 0xFF
+
 #define LEGENDARY_PERFECT_IV_COUNT 3
 
 #endif // GUARD_CONSTANTS_POKEMON_H

--- a/src/script_pokemon_util.c
+++ b/src/script_pokemon_util.c
@@ -345,7 +345,13 @@ u32 ScriptGiveMonParameterized(u16 species, u8 level, u16 item, u8 ball, u8 natu
     }
 
     // ability
-    if (abilityNum >= NUM_ABILITY_SLOTS || GetAbilityBySpecies(species, abilityNum) == ABILITY_NONE)
+    if (abilityNum == NUM_ABILITY_VANILLA)
+    {
+        abilityNum = 0;
+        SetMonData(&mon, MON_DATA_ABILITY_NUM, &abilityNum);
+        abilityNum = GetMonData(&mon, MON_DATA_PERSONALITY) & 1;
+    }
+    else if (abilityNum > NUM_NORMAL_ABILITY_SLOTS || GetAbilityBySpecies(species, abilityNum) == ABILITY_NONE)
     {
         do {
             abilityNum = Random() % NUM_ABILITY_SLOTS; // includes hidden abilities
@@ -410,7 +416,7 @@ u32 ScriptGiveMon(u16 species, u8 level, u16 item)
                                 MAX_PER_STAT_IVS + 1, MAX_PER_STAT_IVS + 1, MAX_PER_STAT_IVS + 1};  // ScriptGiveMonParameterized won't touch the stats' IV.
     u16 moves[MAX_MON_MOVES] = {MOVE_NONE, MOVE_NONE, MOVE_NONE, MOVE_NONE};
 
-    return ScriptGiveMonParameterized(species, level, item, ITEM_POKE_BALL, NUM_NATURES, NUM_ABILITY_SLOTS, MON_GENDERLESS, evs, ivs, moves, FALSE, FALSE, NUMBER_OF_MON_TYPES);
+    return ScriptGiveMonParameterized(species, level, item, ITEM_POKE_BALL, NUM_NATURES, NUM_ABILITY_VANILLA, MON_GENDERLESS, evs, ivs, moves, FALSE, FALSE, NUMBER_OF_MON_TYPES);
 }
 
 #define PARSE_FLAG(n, default_) (flags & (1 << (n))) ? VarGet(ScriptReadHalfword(ctx)) : (default_)
@@ -424,7 +430,7 @@ void ScrCmd_givemon(struct ScriptContext *ctx)
     u16 item          = PARSE_FLAG(0, ITEM_NONE);
     u8 ball           = PARSE_FLAG(1, ITEM_POKE_BALL);
     u8 nature         = PARSE_FLAG(2, NUM_NATURES);
-    u8 abilityNum     = PARSE_FLAG(3, NUM_ABILITY_SLOTS);
+    u8 abilityNum     = PARSE_FLAG(3, NUM_ABILITY_VANILLA);
     u8 gender         = PARSE_FLAG(4, MON_GENDERLESS); // TODO: Find a better way to assign a random gender.
     u8 hpEv           = PARSE_FLAG(5, 0);
     u8 atkEv          = PARSE_FLAG(6, 0);

--- a/src/script_pokemon_util.c
+++ b/src/script_pokemon_util.c
@@ -347,8 +347,6 @@ u32 ScriptGiveMonParameterized(u16 species, u8 level, u16 item, u8 ball, u8 natu
     // ability
     if (abilityNum == NUM_ABILITY_VANILLA)
     {
-        abilityNum = 0;
-        SetMonData(&mon, MON_DATA_ABILITY_NUM, &abilityNum);
         abilityNum = GetMonData(&mon, MON_DATA_PERSONALITY) & 1;
     }
     else if (abilityNum > NUM_NORMAL_ABILITY_SLOTS || GetAbilityBySpecies(species, abilityNum) == ABILITY_NONE)


### PR DESCRIPTION
## Description
Closes #4186.

`ScriptGiveMonParameterized`, `ScriptGiveMon` and `ScrCmd_givemon` will now generate an ability for a Pokémon in the vanilla way when `NUM_ABILITY_VANILLA` is passed through their `abilityNum` parameter, that is, by defaulting to the 1st ability and then tweaking it based on the least relevant bit of the personality of the Pokémon they generate.

I also wrote the `if` statement that tries to generate a valid random ability at `ScriptGiveMonParameterized` differently due to popular demand.

## **Discord contact info**
lunos4026