### PR TITLE
Fixes Seedot and Lotad House

### DIFF
--- a/data/maps/SootopolisCity_LotadAndSeedotHouse/scripts.inc
+++ b/data/maps/SootopolisCity_LotadAndSeedotHouse/scripts.inc
@@ -116,7 +116,7 @@ SootopolisCity_LotadAndSeedotHouse_Text_PleaseShowMeBigSeedot:
 	.string "P-p-please, show me!$"
 
 SootopolisCity_LotadAndSeedotHouse_Text_GoshMightBeBiggerThanLotad:
-	.string "{STR_VAR_2} inches!\n"
+	.string "{STR_VAR_2}!\n"
 	.string "Oh, my gosh, this is a big one!\p"
 	.string "It might even beat the big LOTAD\n"
 	.string "my younger brother saw!\p"
@@ -132,7 +132,7 @@ SootopolisCity_LotadAndSeedotHouse_Text_BagCrammedFull1:
 	.string "Your BAG is crammed full.$"
 
 SootopolisCity_LotadAndSeedotHouse_Text_SeenBiggerSeedot:
-	.string "{STR_VAR_2} inches, is it?\p"
+	.string "{STR_VAR_2}, is it?\p"
 	.string "Hmm… I've seen a bigger SEEDOT\n"
 	.string "than this one.$"
 
@@ -148,7 +148,7 @@ SootopolisCity_LotadAndSeedotHouse_Text_DontHaveBigSeedot:
 
 SootopolisCity_LotadAndSeedotHouse_Text_BiggestSeedotInHistory:
 	.string "The biggest SEEDOT in history!\n"
-	.string "{STR_VAR_2}'s {STR_VAR_3}-inch giant!\p"
+	.string "{STR_VAR_2}'s {STR_VAR_3} giant!\p"
 	.string "A SEEDOT bigger than a LOTAD\n"
 	.string "always wanted!$"
 
@@ -164,7 +164,7 @@ SootopolisCity_LotadAndSeedotHouse_Text_PleaseShowMeBigLotad:
 	.string "P-p-please show me!$"
 
 SootopolisCity_LotadAndSeedotHouse_Text_WowMightBeBiggerThanSeedot:
-	.string "{STR_VAR_2} inches!\n"
+	.string "{STR_VAR_2}!\n"
 	.string "Wow, that is big!\p"
 	.string "It might be even bigger than the huge\n"
 	.string "SEEDOT my big brother saw.\p"
@@ -180,7 +180,7 @@ SootopolisCity_LotadAndSeedotHouse_Text_BagCrammedFull2:
 	.string "Your BAG is crammed full.$"
 
 SootopolisCity_LotadAndSeedotHouse_Text_SeenBiggerLotad:
-	.string "{STR_VAR_2} inches?\p"
+	.string "{STR_VAR_2}?\p"
 	.string "Hmm… I've seen a bigger LOTAD\n"
 	.string "than this one here.$"
 
@@ -196,7 +196,7 @@ SootopolisCity_LotadAndSeedotHouse_Text_DontHaveBigLotad:
 
 SootopolisCity_LotadAndSeedotHouse_Text_BiggestLotadInHistory:
 	.string "The biggest LOTAD in history!\n"
-	.string "{STR_VAR_2}'s {STR_VAR_3}-inch colossus!\p"
+	.string "{STR_VAR_2}'s {STR_VAR_3} colossus!\p"
 	.string "A LOTAD bigger than a SEEDOT\n"
 	.string "always wanted!$"
 

--- a/include/pokedex.h
+++ b/include/pokedex.h
@@ -30,5 +30,7 @@ void ResetPokedexScrollPositions(void);
 bool16 HasAllMons(void);
 void CB2_OpenPokedex(void);
 void PrintMonMeasurements(u16 species, u32 owned);
+u8* ConvertMonHeightToString(u32 height);
+u8* ConvertMonWeightToString(u32 weight);
 
 #endif // GUARD_POKEDEX_H

--- a/src/pokedex.c
+++ b/src/pokedex.c
@@ -286,7 +286,7 @@ static u8* ConvertMonHeightToImperialString(u32 height);
 static u8* ConvertMonHeightToMetricString(u32 height);
 static u8* ConvertMonWeightToImperialString(u32 weight);
 static u8* ConvertMonWeightToMetricString(u32 weight);
-static u8* ConvertMeasurementToMetricString(u16 num, u32* index);
+static u8* ConvertMeasurementToMetricString(u32 num, u32* index);
 static void ResetOtherVideoRegisters(u16);
 static u8 PrintCryScreenSpeciesName(u8, u16, u8, u8);
 static void PrintDecimalNum(u8 windowId, u16 num, u8 left, u8 top);
@@ -4289,13 +4289,18 @@ static void PrintOwnedMonHeight(u16 species)
     u32 x = GetMeasurementTextPositions(DEX_MEASUREMENT_X);
     u32 yTop = GetMeasurementTextPositions(DEX_Y_TOP);
 
-    if (UNITS == UNITS_IMPERIAL)
-        heightString = ConvertMonHeightToImperialString(height);
-    else
-        heightString = ConvertMonHeightToMetricString(height);
+    heightString = ConvertMonHeightToString(height);
 
     PrintInfoScreenText(heightString, x, yTop);
     Free(heightString);
+}
+
+u8* ConvertMonHeightToString(u32 height)
+{
+    if (UNITS == UNITS_IMPERIAL)
+        return ConvertMonHeightToImperialString(height);
+    else
+        return ConvertMonHeightToMetricString(height);
 }
 
 static void PrintOwnedMonWeight(u16 species)
@@ -4305,13 +4310,18 @@ static void PrintOwnedMonWeight(u16 species)
     u32 x = GetMeasurementTextPositions(DEX_MEASUREMENT_X);
     u32 yBottom = GetMeasurementTextPositions(DEX_Y_BOTTOM);
 
-    if (UNITS == UNITS_IMPERIAL)
-        weightString = ConvertMonWeightToImperialString(weight);
-    else
-        weightString = ConvertMonWeightToMetricString(weight);
+    weightString = ConvertMonWeightToString(weight);
 
     PrintInfoScreenText(weightString, x, yBottom);
     Free(weightString);
+}
+
+u8* ConvertMonWeightToString(u32 weight)
+{
+    if (UNITS == UNITS_IMPERIAL)
+        return ConvertMonWeightToImperialString(weight);
+    else
+        return ConvertMonWeightToMetricString(weight);
 }
 
 static u8* ConvertMonHeightToImperialString(u32 height)
@@ -4425,7 +4435,7 @@ static u8* ConvertMonWeightToMetricString(u32 weight)
     return weightString;
 }
 
-static u8* ConvertMeasurementToMetricString(u16 num, u32* index)
+static u8* ConvertMeasurementToMetricString(u32 num, u32* index)
 {
     u8* string = Alloc(WEIGHT_HEIGHT_STR_MEM);
     bool32 outputted = FALSE;

--- a/src/pokemon_size_record.c
+++ b/src/pokemon_size_record.c
@@ -8,6 +8,7 @@
 #include "text.h"
 
 #define DEFAULT_MAX_SIZE 0x8000 // was 0x8100 in Ruby/Sapphire
+static u8* ReturnHeightStringNoWhitespace(u32 size);
 
 struct UnknownStruct
 {
@@ -93,12 +94,24 @@ static u32 GetMonSize(u16 species, u16 b)
 
 static void FormatMonSizeRecord(u8 *string, u32 size)
 {
-    //Convert size from centimeters to inches
-	size = (f64)(size * 10) / (CM_PER_INCH * 10);
+    size = (f64)(size / 100);
+    StringCopy(string,ReturnHeightStringNoWhitespace(size));
+}
 
-    string = ConvertIntToDecimalStringN(string, size / 10, STR_CONV_MODE_LEFT_ALIGN, 8);
-    string = StringAppend(string, gText_DecimalPoint);
-    ConvertIntToDecimalStringN(string, size % 10, STR_CONV_MODE_LEFT_ALIGN, 1);
+static u8* ReturnHeightStringNoWhitespace(u32 size)
+{
+    u8* heightStr = ConvertMonHeightToString(size);
+    u32 length = StringLength(heightStr);
+    u32 i =  0, j =  0;
+
+    while (i < length && !(heightStr[i] >= CHAR_0 && heightStr[i] <= CHAR_9))
+        i++;
+
+    while (i < length)
+        heightStr[j++] = heightStr[i++];
+
+    heightStr[j] = EOS;
+    return heightStr;
 }
 
 static u8 CompareMonSize(u16 species, u16 *sizeRecord)


### PR DESCRIPTION
# Description

Solves https://github.com/rh-hideout/pokeemerald-expansion/issues/4188

![Screenshot of the player presenting a 200 inch Seedot to the Seedot NPC while units are metric, and separator is comma](https://github.com/rh-hideout/pokeemerald-expansion/assets/77138753/dd8b1ea7-0782-4f0f-86f8-425fba56d860)

- Fixes Seedot and Lotad House to give measurements based on the unit system and decimal seperator chosen by the developer.
- Created `ConvertMonHeightToString` and `ConvertMonWeightToString` for developers to use

## Details

### Usage
The scripts in the Lotad and Seedot house used to seperately convert a Seedot or Lotad's calculated size into inches (or presumably centimeters in non-imperial versions of the game.)

This logic has been removed and replaced with `ConvertMonHeightToString`, which was partially introduced in https://github.com/rh-hideout/pokeemerald-expansion/pull/4183. This means the NPCs will now output the same measurements as the Pokédex.

# Testing
## Clean Branch
You can recreate this branch by applying a patch or pulling the repo. From a clean version of expansion's upcoming, you can either:

### Patch
`wget https://raw.githubusercontent.com/PokemonSanFran/pokeemerald-expansion/pokemon_size_record_testing/patch-pokemon_size_record.patch -O pokemon_size_record.patch ; git apply pokemon_size_record.patch ; rm pokemon_size_record.patch`

### Repo
`git remote add psf-expansion https://github.com/PokemonSanFran/pokeemerald-expansion/ ; git pull psf-expansion pokemon_size_record`

## Manual Tests
After replicating the branch, to recreate my testing environment, you can either directly download the modified config and save file, or manually create the changes.

### Download

#### `UNITS_IMPERIAL` && `CHAR_COMMA` 
`wget https://github.com/PokemonSanFran/pokeemerald-expansion/raw/pokemon_size_record_testing/pokeemerald.sav ; wget https://raw.githubusercontent.com/PokemonSanFran/pokeemerald-expansion/measurement_config_testing/include/config_imperial_comma.h -O include/config.h`
#### `UNITS_IMPERIAL` && `CHAR_PERIOD` 
`wget https://github.com/PokemonSanFran/pokeemerald-expansion/raw/pokemon_size_record_testing/pokeemerald.sav ; wget https://raw.githubusercontent.com/PokemonSanFran/pokeemerald-expansion/measurement_config_testing/include/config_imperial_period.h -O include/config.h`
#### `UNITS_METRIC` && `CHAR_COMMA` 
`wget https://github.com/PokemonSanFran/pokeemerald-expansion/raw/pokemon_size_record_testing/pokeemerald.sav ; wget https://raw.githubusercontent.com/PokemonSanFran/pokeemerald-expansion/measurement_config_testing/include/config_metric_comma.h -O include/config.h`
#### `UNITS_METRIC` && `CHAR_PERIOD` 
`wget https://github.com/PokemonSanFran/pokeemerald-expansion/raw/pokemon_size_record_testing/pokeemerald.sav ; wget https://raw.githubusercontent.com/PokemonSanFran/pokeemerald-expansion/measurement_config_testing/include/config_metric_period.h -O include/config.h`

### Manual Testing
* Open [`include/config.h`](https://github.com/PokemonSanFran/pokeemerald-expansion/blob/pokemon_size_record/include/config.h) and change `UNITS` and `CHAR_DEC_SEPERATOR` to the desired values.
* Add the commands from `EventScript_Script_1` from the testing debug file [`data/scripts/debug.inc`](https://raw.githubusercontent.com/PokemonSanFran/pokeemerald-expansion/pokemon_size_record_testing/data/scripts/debug.inc)
* From overworld:
    * Press (R + START)
    * Scripts
    * Script 1
    * Talk to one of the NPCs, or the posters in the back

## Verified Scenarios
The columns in the below tables are different `CHAR_DEC_SEPERATOR` values. `The rows are different systems of measurements. 

| | `CHAR_COMMA` | `CHAR_PERIOD` |
|---|---|---|
| `UNITS_METRIC`   | ![Screenshot of the player presenting a 200 inch Seedot to the Seedot NPC while units are metric, and separator is comma](https://github.com/rh-hideout/pokeemerald-expansion/assets/77138753/dd8b1ea7-0782-4f0f-86f8-425fba56d860) | ![Screenshot of the player presenting a 200 inch Seedot to the Seedot NPC while units are metric, and separator is period](https://github.com/rh-hideout/pokeemerald-expansion/assets/77138753/ba5d8511-486e-4b5f-85da-6afe99bfdb6b) |
| `UNITS_IMPERIAL` | ![Screenshot of the player presenting a 200 inch Seedot to the Seedot NPC while units are imperial, and separator is comma](https://github.com/rh-hideout/pokeemerald-expansion/assets/77138753/5d083978-7c73-4bb0-bc10-5b7b3003f2da) | ![Screenshot of the player presenting a 200 inch Seedot to the Seedot NPC while units are imperial, and separator is period](https://github.com/rh-hideout/pokeemerald-expansion/assets/77138753/377052a2-2858-4586-8cb1-94602d890dc2) |

# Discord Contact Info

I am `pkmnsnfrn`. I have already started a [discussion thread](https://discord.com/channels/419213663107416084/1207049838189879358/1207049838189879358).