### PR TITLE
Fix height call

### DIFF
--- a/src/pokemon_size_record.c
+++ b/src/pokemon_size_record.c
@@ -84,7 +84,7 @@ static u32 GetMonSize(u16 species, u16 b)
     u32 height;
     u32 var;
 
-    height = GetSpeciesWeight(species);
+    height = GetSpeciesHeight(species);
     var = TranslateBigMonSizeTableIndex(b);
     unk0 = sBigMonSizeTable[var].unk0;
     unk2 = sBigMonSizeTable[var].unk2;


### PR DESCRIPTION
A typo that slipped in during Species Refactor work meant that GetMonSize was using weight rather than height.

## **Discord contact info**
bassoonian