### PR TITLE
AI PR 4036 follow up

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -3846,7 +3846,7 @@ static u32 AI_CalcMoveScore(u32 battlerAtk, u32 battlerDef, u32 move)
     case EFFECT_FIRST_TURN_ONLY:
         if (ShouldFakeOut(battlerAtk, battlerDef, move))
             ADJUST_SCORE(GOOD_EFFECT);
-        else if (gMovesInfo[move].priority >= 1 && gDisableStructs[battlerAtk].isFirstTurn && GetBestDmgMoveFromBattler(battlerAtk, battlerDef) == move)
+        else if (gMovesInfo[move].argument == MOVE_FIRST_IMPRESSION && gDisableStructs[battlerAtk].isFirstTurn && GetBestDmgMoveFromBattler(battlerAtk, battlerDef) == move)
             ADJUST_SCORE(BEST_EFFECT);
         break;
     case EFFECT_STOCKPILE:

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -3297,7 +3297,7 @@ void IncreaseStatUpScore(u32 battlerAtk, u32 battlerDef, u32 statId, s32 *score)
         return;
 
     // Don't set up if AI is dead to residual damage from weather
-    if (BattlerWillFaintFromWeather(battlerAtk, AI_DATA->abilities[battlerAtk]))
+    if (GetBattlerSecondaryDamage(battlerAtk) >= gBattleMons[battlerAtk].hp)
         return;
 
     // Don't increase stats if opposing battler has Opportunist
@@ -3312,10 +3312,15 @@ void IncreaseStatUpScore(u32 battlerAtk, u32 battlerDef, u32 statId, s32 *score)
         break;
     case STAT_CHANGE_DEF:
         if (HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_PHYSICAL) || !HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_SPECIAL))
-            ADJUST_SCORE_PTR(DECENT_EFFECT);
+        {
+            if (AI_THINKING_STRUCT->aiFlags[battlerAtk] & AI_FLAG_STALL)
+                ADJUST_SCORE_PTR(DECENT_EFFECT);
+            else
+                ADJUST_SCORE_PTR(WEAK_EFFECT);
+        }
         break;
     case STAT_CHANGE_SPEED:
-        if ((noOfHitsToFaint >= 3 && !aiIsFaster) || noOfHitsToFaint == 0)
+        if ((noOfHitsToFaint >= 3 && !aiIsFaster) || noOfHitsToFaint == UNKNOWN_NO_OF_HITS)
             ADJUST_SCORE_PTR(DECENT_EFFECT);
         break;
     case STAT_CHANGE_SPATK:
@@ -3324,7 +3329,12 @@ void IncreaseStatUpScore(u32 battlerAtk, u32 battlerDef, u32 statId, s32 *score)
         break;
     case STAT_CHANGE_SPDEF:
         if (HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_SPECIAL) || !HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_PHYSICAL))
-            ADJUST_SCORE_PTR(DECENT_EFFECT);
+        {
+            if (AI_THINKING_STRUCT->aiFlags[battlerAtk] & AI_FLAG_STALL)
+                ADJUST_SCORE_PTR(DECENT_EFFECT);
+            else
+                ADJUST_SCORE_PTR(WEAK_EFFECT);
+        }
         break;
     case STAT_CHANGE_ATK_2:
         if (HasMoveWithCategory(battlerAtk, DAMAGE_CATEGORY_PHYSICAL) && shouldSetUp)
@@ -3332,10 +3342,15 @@ void IncreaseStatUpScore(u32 battlerAtk, u32 battlerDef, u32 statId, s32 *score)
         break;
     case STAT_CHANGE_DEF_2:
         if (HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_PHYSICAL) || !HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_SPECIAL))
-            ADJUST_SCORE_PTR(GOOD_EFFECT);
+        {
+            if (AI_THINKING_STRUCT->aiFlags[battlerAtk] & AI_FLAG_STALL)
+                ADJUST_SCORE_PTR(GOOD_EFFECT);
+            else
+                ADJUST_SCORE_PTR(DECENT_EFFECT);
+        }
         break;
     case STAT_CHANGE_SPEED_2:
-        if ((noOfHitsToFaint >= 3 && !aiIsFaster) || noOfHitsToFaint == 0)
+        if ((noOfHitsToFaint >= 3 && !aiIsFaster) || noOfHitsToFaint == UNKNOWN_NO_OF_HITS)
             ADJUST_SCORE_PTR(GOOD_EFFECT);
         break;
     case STAT_CHANGE_SPATK_2:
@@ -3344,14 +3359,19 @@ void IncreaseStatUpScore(u32 battlerAtk, u32 battlerDef, u32 statId, s32 *score)
         break;
     case STAT_CHANGE_SPDEF_2:
         if (HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_SPECIAL) || !HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_PHYSICAL))
-            ADJUST_SCORE_PTR(GOOD_EFFECT);
+        {
+            if (AI_THINKING_STRUCT->aiFlags[battlerAtk] & AI_FLAG_STALL)
+                ADJUST_SCORE_PTR(GOOD_EFFECT);
+            else
+                ADJUST_SCORE_PTR(DECENT_EFFECT);
+        }
         break;
     case STAT_CHANGE_ACC:
         if (gBattleMons[battlerAtk].statStages[STAT_ACC] <= 3) // Increase only if necessary
             ADJUST_SCORE_PTR(DECENT_EFFECT);
         break;
     case STAT_CHANGE_EVASION:
-        if (GetBattlerSecondaryDamage(battlerAtk) && ((noOfHitsToFaint > 3) || noOfHitsToFaint == 0))
+        if (noOfHitsToFaint > 3 || noOfHitsToFaint == UNKNOWN_NO_OF_HITS)
             ADJUST_SCORE_PTR(GOOD_EFFECT);
         else
             ADJUST_SCORE_PTR(DECENT_EFFECT);

--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -15021,6 +15021,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .target = MOVE_TARGET_SELECTED,
         .priority = 2,
         .category = DAMAGE_CATEGORY_PHYSICAL,
+        .argument = MOVE_FIRST_IMPRESSION,
         .makesContact = TRUE,
         .contestEffect = CONTEST_EFFECT_BETTER_IF_FIRST,
         .contestCategory = CONTEST_CATEGORY_COOL,


### PR DESCRIPTION
In PR #4036 ghoul recommended to use `GetBattlerSecondaryDamage` instead of `BattlerWillFaintFromWeather` in the function `IncreaseStatUpScore` which makes sense since the checks cover much more then just weather.

Also some minor corrections. First Impression needs an argument because checking for priority made no sense since both `first turn only moves` are priority moves. Also defense boosts are useless a lot of times, especially if they increase the stat only by one so I included a `AI_FLAG_STALL` check. 
