### PR TITLE
Fixed LastUsedBall not being saved and DisplayBall not being shown

### DIFF
--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -3470,7 +3470,10 @@ void TryAddLastUsedBallItemSprites(void)
         // we're out of the last used ball, so just set it to the first ball in the bag
         // we have to compact the bag first bc it is typically only compacted when you open it
         CompactItemsInBagPocket(&gBagPockets[BALLS_POCKET]);
-        gBallToDisplay = gBagPockets[BALLS_POCKET].itemSlots[0].itemId;
+
+        u16 firstBall = gBagPockets[BALLS_POCKET].itemSlots[0].itemId;
+        if (firstBall > ITEM_NONE)
+            gBallToDisplay = gBagPockets[BALLS_POCKET].itemSlots[0].itemId;
     }
 
     if (!CanThrowLastUsedBall())

--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -3467,11 +3467,12 @@ void TryAddLastUsedBallItemSprites(void)
     if (gLastThrownBall == 0
       || (gLastThrownBall != 0 && !CheckBagHasItem(gLastThrownBall, 1)))
     {
+        u16 firstBall = ITEM_NONE;
         // we're out of the last used ball, so just set it to the first ball in the bag
         // we have to compact the bag first bc it is typically only compacted when you open it
         CompactItemsInBagPocket(&gBagPockets[BALLS_POCKET]);
 
-        u16 firstBall = gBagPockets[BALLS_POCKET].itemSlots[0].itemId;
+        firstBall = gBagPockets[BALLS_POCKET].itemSlots[0].itemId;
         if (firstBall > ITEM_NONE)
             gBallToDisplay = gBagPockets[BALLS_POCKET].itemSlots[0].itemId;
     }

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4980,7 +4980,7 @@ static void TurnValuesCleanUp(bool8 var0)
         else
         {
             memset(&gProtectStructs[i], 0, sizeof(struct ProtectStruct));
-            memset(&gQueuedStatBoosts[i], 0, sizeof(gQueuedStatBoosts));
+            memset(&gQueuedStatBoosts[i], 0, sizeof(struct QueuedStatBoost));
 
             if (gDisableStructs[i].isFirstTurn)
                 gDisableStructs[i].isFirstTurn--;


### PR DESCRIPTION
## Description
In #4168 b7d77099b524c818619e8a7e6f4432b93381109a a memset was added but this causes the issue #4200. The sizeof was done on the variable instead of the struct. This caused other variables in EWRAM to loose their value. I have no idea if this fix breaks what was intented to do in #4168.

Also fixed the issue reported in my comment. When you run out of balls gLastThrownBall has a value, but you enter the if statement because you have no more balls. There the next in line ball is set to display but if there are non there is nothing to display. Afterwards when you get a new ball, you do not enter the if statement to update the gBallToDisplay because the ball is in the bag and gLastThrownBall is still set to not 0. Then it's checked if the bag has gBallToDisplay which does not point to a ball and therefor nothing is shown. Now we only update gBallToDisplay if there is actually a ball to display.

## Images
![mGBA_6cjaSzsuzC](https://github.com/rh-hideout/pokeemerald-expansion/assets/34153881/fa29faa0-a5a2-40d6-b9c0-c09ab9528b55)


## Issue(s) that this PR fixes
#4200

## **Discord contact info**
Wesmaster#3404
