### PR TITLE
Upgrading the debug menu's 'Poison Party'

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -2164,3 +2164,11 @@
 		setvar VAR_RESULT, TRUE
 	2:
 	.endm
+
+	@ Inflicts \status1 to the Pokémon in \slot.
+	@ If \slot is greater or equal than PARTY_SIZE, the status is inflicted on each of the Player's Pokémon.
+	.macro setstatus1 status1:req, slot:req
+	callnative Script_SetStatus1
+	.2byte \status1
+	.2byte \slot
+	.endm

--- a/data/scripts/debug.inc
+++ b/data/scripts/debug.inc
@@ -98,7 +98,7 @@ Debug_BoxFilledMessage_Text:
 Debug_EventScript_CheckEV::
 	lockall
 	getpartysize
-	goto_if_eq VAR_RESULT, 0, Debug_HatchAnEgg_NoPokemon
+	goto_if_eq VAR_RESULT, 0, Debug_NoPokemon
 	special ChoosePartyMon
 	waitstate
 	goto_if_ge VAR_0x8004, PARTY_SIZE, Debug_EventScript_CheckEV_End
@@ -119,7 +119,7 @@ Debug_EventScript_Text_DefensiveEV:
 Debug_EventScript_CheckIV::
 	lockall
 	getpartysize
-	goto_if_eq VAR_RESULT, 0, Debug_HatchAnEgg_NoPokemon
+	goto_if_eq VAR_RESULT, 0, Debug_NoPokemon
 	special ChoosePartyMon
 	waitstate
 	goto_if_ge VAR_0x8004, PARTY_SIZE, Debug_EventScript_CheckIV_End
@@ -202,7 +202,7 @@ Debug_ROMSize::
 Debug_HatchAnEgg::
 	lockall
 	getpartysize
-	goto_if_eq VAR_RESULT, 0, Debug_HatchAnEgg_NoPokemon
+	goto_if_eq VAR_RESULT, 0, Debug_NoPokemon
 	special ChoosePartyMon
 	waitstate
 	goto_if_ge VAR_0x8004, PARTY_SIZE, Debug_HatchAnEgg_End
@@ -214,7 +214,7 @@ Debug_HatchAnEgg_End::
 	releaseall
 	end
 
-Debug_HatchAnEgg_NoPokemon::
+Debug_NoPokemon::
 	msgbox DebugScript_Text_EmptyParty, MSGBOX_DEFAULT
 	releaseall
 	end
@@ -299,7 +299,7 @@ Debug_FlagsAndVarNotSetBattleConfigMessage_Text:
 Debug_EventScript_InflictStatus1::
 	lockall
 	getpartysize
-	goto_if_eq VAR_RESULT, 0, Debug_EventScript_InflictStatus1_NoPokemon
+	goto_if_eq VAR_RESULT, 0, Debug_NoPokemon
 	dynmultipush Debug_EventScript_InflictStatus1_Text_Single, 0
 	dynmultipush Debug_EventScript_InflictStatus1_Text_PartyWide, 1
 	dynmultipush Debug_EventScript_InflictStatus1_Text_Close, 2
@@ -309,11 +309,6 @@ Debug_EventScript_InflictStatus1::
 	case 1, Debug_EventScript_InflictStatus1_Party
 	case 2, Debug_EventScript_InflictStatus1_Close
 Debug_EventScript_InflictStatus1_Close:
-	releaseall
-	end
-
-Debug_EventScript_InflictStatus1_NoPokemon:
-	msgbox DebugScript_Text_EmptyParty, MSGBOX_DEFAULT
 	releaseall
 	end
 

--- a/data/scripts/debug.inc
+++ b/data/scripts/debug.inc
@@ -215,7 +215,7 @@ Debug_HatchAnEgg_End::
 	end
 
 Debug_HatchAnEgg_NoPokemon::
-	msgbox DebugScript_HatchAnEgg_Text_EmptyParty, MSGBOX_DEFAULT
+	msgbox DebugScript_Text_EmptyParty, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -224,7 +224,7 @@ DebugScript_HatchAnEgg_CantForceHatch::
 	releaseall
 	end
 
-DebugScript_HatchAnEgg_Text_EmptyParty::
+DebugScript_Text_EmptyParty::
 	.string "You have no Pokémon nor Eggs.$"
 
 DebugScript_HatchAnEgg_Text_NotAnEgg::
@@ -295,3 +295,141 @@ Debug_FlagsAndVarNotSetBattleConfigMessage_Text:
 	.string "Feature unavailable! Please define a\n"
 	.string "usable flag and a usable var in:\l"
 	.string "'include/config/battle.h'!$"
+
+Debug_EventScript_InflictStatus1::
+	lockall
+	getpartysize
+	goto_if_eq VAR_RESULT, 0, Debug_EventScript_InflictStatus1_NoPokemon
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Single, 0
+	dynmultipush Debug_EventScript_InflictStatus1_Text_PartyWide, 1
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Close, 2
+	dynmultistack 0, 0, FALSE, 3 FALSE, 0, NULL
+	switch VAR_RESULT
+	case 0, Debug_EventScript_InflictStatus1_Single
+	case 1, Debug_EventScript_InflictStatus1_Party
+	case 2, Debug_EventScript_InflictStatus1_Close
+Debug_EventScript_InflictStatus1_Close:
+	releaseall
+	end
+
+Debug_EventScript_InflictStatus1_NoPokemon:
+	msgbox DebugScript_Text_EmptyParty, MSGBOX_DEFAULT
+	releaseall
+	end
+
+Debug_EventScript_InflictStatus1_Single:
+	special ChoosePartyMon
+	waitstate
+	goto_if_ge VAR_0x8004, PARTY_SIZE, Debug_EventScript_InflictStatus1_Close
+	specialvar VAR_RESULT, ScriptGetPartyMonSpecies
+	goto_if_eq VAR_RESULT, SPECIES_EGG, Debug_EventScript_InflictStatus1_Close
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Poison, 0
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Paralysis, 1
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Sleep, 2
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Burn, 3
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Freeze, 4
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Close, 5
+	dynmultistack 0, 0, FALSE, 6, FALSE, 0, NULL
+	switch VAR_RESULT
+	case 0, Debug_EventScript_InflictStatus1_Single_Poison
+	case 1, Debug_EventScript_InflictStatus1_Single_Paralysis
+	case 2, Debug_EventScript_InflictStatus1_Single_Sleep
+	case 3, Debug_EventScript_InflictStatus1_Single_Burn
+	case 4, Debug_EventScript_InflictStatus1_Single_Freeze
+	case 5, Debug_EventScript_InflictStatus1_Close
+	case MULTI_B_PRESSED, Debug_EventScript_InflictStatus1_Close
+	releaseall
+	end
+
+Debug_EventScript_InflictStatus1_Single_Poison:
+	setstatus1 STATUS1_POISON, VAR_0x8004
+	releaseall
+	end
+
+Debug_EventScript_InflictStatus1_Single_Paralysis:
+	setstatus1 STATUS1_PARALYSIS, VAR_0x8004
+	releaseall
+	end
+
+Debug_EventScript_InflictStatus1_Single_Sleep:
+	setstatus1 STATUS1_SLEEP, VAR_0x8004
+	releaseall
+	end
+
+Debug_EventScript_InflictStatus1_Single_Burn:
+	setstatus1 STATUS1_BURN, VAR_0x8004
+	releaseall
+	end
+
+Debug_EventScript_InflictStatus1_Single_Freeze:
+	setstatus1 STATUS1_FREEZE, VAR_0x8004
+	releaseall
+	end
+
+Debug_EventScript_InflictStatus1_Party:
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Poison, 0
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Paralysis, 1
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Sleep, 2
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Burn, 3
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Freeze, 4
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Close, 5
+	dynmultistack 0, 0, FALSE, 6, FALSE, 0, NULL
+	switch VAR_RESULT
+	case 0, Debug_EventScript_InflictStatus1_Party_Poison
+	case 1, Debug_EventScript_InflictStatus1_Party_Paralysis
+	case 2, Debug_EventScript_InflictStatus1_Party_Sleep
+	case 3, Debug_EventScript_InflictStatus1_Party_Burn
+	case 4, Debug_EventScript_InflictStatus1_Party_Freeze
+	case 5, Debug_EventScript_InflictStatus1_Close
+	case MULTI_B_PRESSED, Debug_EventScript_InflictStatus1_Close
+	releaseall
+	end
+
+Debug_EventScript_InflictStatus1_Party_Poison:
+	setstatus1 STATUS1_POISON, PARTY_SIZE
+	releaseall
+	end
+
+Debug_EventScript_InflictStatus1_Party_Paralysis:
+	setstatus1 STATUS1_PARALYSIS, PARTY_SIZE
+	releaseall
+	end
+
+Debug_EventScript_InflictStatus1_Party_Sleep:
+	setstatus1 STATUS1_SLEEP, PARTY_SIZE
+	releaseall
+	end
+
+Debug_EventScript_InflictStatus1_Party_Burn:
+	setstatus1 STATUS1_BURN, PARTY_SIZE
+	releaseall
+	end
+
+Debug_EventScript_InflictStatus1_Party_Freeze:
+	setstatus1 STATUS1_FREEZE, PARTY_SIZE
+	releaseall
+	end
+
+Debug_EventScript_InflictStatus1_Text_Single:
+	.string "Single$"
+
+Debug_EventScript_InflictStatus1_Text_PartyWide:
+	.string "Party-wide$"
+
+Debug_EventScript_InflictStatus1_Text_Close:
+	.string "Close$"
+
+Debug_EventScript_InflictStatus1_Text_Poison:
+	.string "Poison$"
+
+Debug_EventScript_InflictStatus1_Text_Paralysis:
+	.string "Paralysis$"
+
+Debug_EventScript_InflictStatus1_Text_Sleep:
+	.string "Sleep$"
+
+Debug_EventScript_InflictStatus1_Text_Burn:
+	.string "Burn$"
+
+Debug_EventScript_InflictStatus1_Text_Freeze:
+	.string "Freeze$"

--- a/data/scripts/debug.inc
+++ b/data/scripts/debug.inc
@@ -323,15 +323,17 @@ Debug_EventScript_InflictStatus1_Single:
 	dynmultipush Debug_EventScript_InflictStatus1_Text_Sleep, 2
 	dynmultipush Debug_EventScript_InflictStatus1_Text_Burn, 3
 	dynmultipush Debug_EventScript_InflictStatus1_Text_Freeze, 4
-	dynmultipush Debug_EventScript_InflictStatus1_Text_Close, 5
-	dynmultistack 0, 0, FALSE, 6, FALSE, 0, NULL
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Frostbite, 5
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Close, 6
+	dynmultistack 0, 0, FALSE, 7, FALSE, 0, NULL
 	switch VAR_RESULT
 	case 0, Debug_EventScript_InflictStatus1_Single_Poison
 	case 1, Debug_EventScript_InflictStatus1_Single_Paralysis
 	case 2, Debug_EventScript_InflictStatus1_Single_Sleep
 	case 3, Debug_EventScript_InflictStatus1_Single_Burn
 	case 4, Debug_EventScript_InflictStatus1_Single_Freeze
-	case 5, Debug_EventScript_InflictStatus1_Close
+	case 5, Debug_EventScript_InflictStatus1_Single_Frostbite
+	case 6, Debug_EventScript_InflictStatus1_Close
 	case MULTI_B_PRESSED, Debug_EventScript_InflictStatus1_Close
 	releaseall
 	end
@@ -361,21 +363,28 @@ Debug_EventScript_InflictStatus1_Single_Freeze:
 	releaseall
 	end
 
+Debug_EventScript_InflictStatus1_Single_Frostbite:
+	setstatus1 STATUS1_FROSTBITE, VAR_0x8004
+	releaseall
+	end
+
 Debug_EventScript_InflictStatus1_Party:
 	dynmultipush Debug_EventScript_InflictStatus1_Text_Poison, 0
 	dynmultipush Debug_EventScript_InflictStatus1_Text_Paralysis, 1
 	dynmultipush Debug_EventScript_InflictStatus1_Text_Sleep, 2
 	dynmultipush Debug_EventScript_InflictStatus1_Text_Burn, 3
 	dynmultipush Debug_EventScript_InflictStatus1_Text_Freeze, 4
-	dynmultipush Debug_EventScript_InflictStatus1_Text_Close, 5
-	dynmultistack 0, 0, FALSE, 6, FALSE, 0, NULL
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Frostbite, 5
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Close, 6
+	dynmultistack 0, 0, FALSE, 7, FALSE, 0, NULL
 	switch VAR_RESULT
 	case 0, Debug_EventScript_InflictStatus1_Party_Poison
 	case 1, Debug_EventScript_InflictStatus1_Party_Paralysis
 	case 2, Debug_EventScript_InflictStatus1_Party_Sleep
 	case 3, Debug_EventScript_InflictStatus1_Party_Burn
 	case 4, Debug_EventScript_InflictStatus1_Party_Freeze
-	case 5, Debug_EventScript_InflictStatus1_Close
+	case 5, Debug_EventScript_InflictStatus1_Party_Frostbite
+	case 6, Debug_EventScript_InflictStatus1_Close
 	case MULTI_B_PRESSED, Debug_EventScript_InflictStatus1_Close
 	releaseall
 	end
@@ -405,6 +414,11 @@ Debug_EventScript_InflictStatus1_Party_Freeze:
 	releaseall
 	end
 
+Debug_EventScript_InflictStatus1_Party_Frostbite:
+	setstatus1 STATUS1_FROSTBITE, PARTY_SIZE
+	releaseall
+	end
+
 Debug_EventScript_InflictStatus1_Text_Single:
 	.string "Single$"
 
@@ -428,3 +442,6 @@ Debug_EventScript_InflictStatus1_Text_Burn:
 
 Debug_EventScript_InflictStatus1_Text_Freeze:
 	.string "Freeze$"
+
+Debug_EventScript_InflictStatus1_Text_Frostbite:
+	.string "Frostbite$"

--- a/src/debug.c
+++ b/src/debug.c
@@ -126,7 +126,7 @@ enum PartyDebugMenu
     DEBUG_PARTY_MENU_ITEM_MOVE_REMINDER,
     DEBUG_PARTY_MENU_ITEM_HATCH_AN_EGG,
     DEBUG_PARTY_MENU_ITEM_HEAL_PARTY,
-    DEBUG_PARTY_MENU_ITEM_POISON_MONS,
+    DEBUG_PARTY_MENU_ITEM_INFLICT_STATUS1,
     DEBUG_PARTY_MENU_ITEM_CHECK_EV,
     DEBUG_PARTY_MENU_ITEM_CHECK_IV,
     DEBUG_PARTY_MENU_ITEM_CLEAR_PARTY,
@@ -391,7 +391,7 @@ static void DebugAction_PCBag_ClearBoxes(u8 taskId);
 static void DebugAction_Party_MoveReminder(u8 taskId);
 static void DebugAction_Party_HatchAnEgg(u8 taskId);
 static void DebugAction_Party_HealParty(u8 taskId);
-static void DebugAction_Party_PoisonMons(u8 taskId);
+static void DebugAction_Party_InflictStatus1(u8 taskId);
 static void DebugAction_Party_CheckEV(u8 taskId);
 static void DebugAction_Party_CheckIV(u8 taskId);
 static void DebugAction_Party_ClearParty(u8 taskId);
@@ -454,6 +454,7 @@ extern const u8 Debug_FlagsNotSetBattleConfigMessage[];
 extern const u8 Debug_FlagsAndVarNotSetBattleConfigMessage[];
 extern const u8 Debug_EventScript_CheckEV[];
 extern const u8 Debug_EventScript_CheckIV[];
+extern const u8 Debug_EventScript_InflictStatus1[];
 extern const u8 Debug_EventScript_Script_1[];
 extern const u8 Debug_EventScript_Script_2[];
 extern const u8 Debug_EventScript_Script_3[];
@@ -548,7 +549,7 @@ static const u8 sDebugText_PCBag_ClearBoxes[] =              _("Clear Storage Bo
 static const u8 sDebugText_Party_MoveReminder[] =            _("Move Reminder");
 static const u8 sDebugText_Party_HatchAnEgg[] =              _("Hatch an Egg");
 static const u8 sDebugText_Party_HealParty[] =               _("Heal party");
-static const u8 sDebugText_Party_PoisonParty[] =             _("Poison party");
+static const u8 sDebugText_Party_InflictStatus1[] =          _("Inflict Status1");
 static const u8 sDebugText_Party_CheckEV[] =                 _("Check EV");
 static const u8 sDebugText_Party_CheckIV[] =                 _("Check IV");
 static const u8 sDebugText_Party_ClearParty[] =              _("Clear Party");
@@ -743,13 +744,13 @@ static const struct ListMenuItem sDebugMenu_Items_PCBag_Fill[] =
 
 static const struct ListMenuItem sDebugMenu_Items_Party[] =
 {
-    [DEBUG_PARTY_MENU_ITEM_MOVE_REMINDER]  = {sDebugText_Party_MoveReminder,   DEBUG_PARTY_MENU_ITEM_MOVE_REMINDER},
-    [DEBUG_PARTY_MENU_ITEM_HATCH_AN_EGG]   = {sDebugText_Party_HatchAnEgg,     DEBUG_PARTY_MENU_ITEM_HATCH_AN_EGG},
-    [DEBUG_PARTY_MENU_ITEM_HEAL_PARTY]     = {sDebugText_Party_HealParty,      DEBUG_PARTY_MENU_ITEM_HEAL_PARTY},
-    [DEBUG_PARTY_MENU_ITEM_POISON_MONS]    = {sDebugText_Party_PoisonParty,    DEBUG_PARTY_MENU_ITEM_POISON_MONS},
-    [DEBUG_PARTY_MENU_ITEM_CHECK_EV]       = {sDebugText_Party_CheckEV,        DEBUG_PARTY_MENU_ITEM_CHECK_EV},
-    [DEBUG_PARTY_MENU_ITEM_CHECK_IV]       = {sDebugText_Party_CheckIV,        DEBUG_PARTY_MENU_ITEM_CHECK_IV},
-    [DEBUG_PARTY_MENU_ITEM_CLEAR_PARTY]    = {sDebugText_Party_ClearParty,     DEBUG_PARTY_MENU_ITEM_CLEAR_PARTY},
+    [DEBUG_PARTY_MENU_ITEM_MOVE_REMINDER]   = {sDebugText_Party_MoveReminder,   DEBUG_PARTY_MENU_ITEM_MOVE_REMINDER},
+    [DEBUG_PARTY_MENU_ITEM_HATCH_AN_EGG]    = {sDebugText_Party_HatchAnEgg,     DEBUG_PARTY_MENU_ITEM_HATCH_AN_EGG},
+    [DEBUG_PARTY_MENU_ITEM_HEAL_PARTY]      = {sDebugText_Party_HealParty,      DEBUG_PARTY_MENU_ITEM_HEAL_PARTY},
+    [DEBUG_PARTY_MENU_ITEM_INFLICT_STATUS1] = {sDebugText_Party_InflictStatus1, DEBUG_PARTY_MENU_ITEM_INFLICT_STATUS1},
+    [DEBUG_PARTY_MENU_ITEM_CHECK_EV]        = {sDebugText_Party_CheckEV,        DEBUG_PARTY_MENU_ITEM_CHECK_EV},
+    [DEBUG_PARTY_MENU_ITEM_CHECK_IV]        = {sDebugText_Party_CheckIV,        DEBUG_PARTY_MENU_ITEM_CHECK_IV},
+    [DEBUG_PARTY_MENU_ITEM_CLEAR_PARTY]     = {sDebugText_Party_ClearParty,     DEBUG_PARTY_MENU_ITEM_CLEAR_PARTY},
 };
 
 static const struct ListMenuItem sDebugMenu_Items_Scripts[] =
@@ -912,13 +913,13 @@ static void (*const sDebugMenu_Actions_PCBag_Fill[])(u8) =
 
 static void (*const sDebugMenu_Actions_Party[])(u8) =
 {
-    [DEBUG_PARTY_MENU_ITEM_MOVE_REMINDER] = DebugAction_Party_MoveReminder,
-    [DEBUG_PARTY_MENU_ITEM_HATCH_AN_EGG]  = DebugAction_Party_HatchAnEgg,
-    [DEBUG_PARTY_MENU_ITEM_HEAL_PARTY]    = DebugAction_Party_HealParty,
-    [DEBUG_PARTY_MENU_ITEM_POISON_MONS]   = DebugAction_Party_PoisonMons,
-    [DEBUG_PARTY_MENU_ITEM_CHECK_EV]      = DebugAction_Party_CheckEV,
-    [DEBUG_PARTY_MENU_ITEM_CHECK_IV]      = DebugAction_Party_CheckIV,
-    [DEBUG_PARTY_MENU_ITEM_CLEAR_PARTY]   = DebugAction_Party_ClearParty,
+    [DEBUG_PARTY_MENU_ITEM_MOVE_REMINDER]   = DebugAction_Party_MoveReminder,
+    [DEBUG_PARTY_MENU_ITEM_HATCH_AN_EGG]    = DebugAction_Party_HatchAnEgg,
+    [DEBUG_PARTY_MENU_ITEM_HEAL_PARTY]      = DebugAction_Party_HealParty,
+    [DEBUG_PARTY_MENU_ITEM_INFLICT_STATUS1] = DebugAction_Party_InflictStatus1,
+    [DEBUG_PARTY_MENU_ITEM_CHECK_EV]        = DebugAction_Party_CheckEV,
+    [DEBUG_PARTY_MENU_ITEM_CHECK_IV]        = DebugAction_Party_CheckIV,
+    [DEBUG_PARTY_MENU_ITEM_CLEAR_PARTY]     = DebugAction_Party_ClearParty,
 };
 
 static void (*const sDebugMenu_Actions_Scripts[])(u8) =
@@ -5084,22 +5085,9 @@ static void DebugAction_Party_HealParty(u8 taskId)
     Debug_DestroyMenu_Full(taskId);
 }
 
-static void DebugAction_Party_PoisonMons(u8 taskId)
+static void DebugAction_Party_InflictStatus1(u8 taskId)
 {
-    int i;
-    for (i = 0; i < PARTY_SIZE; i++)
-    {
-        if (GetMonData(&gPlayerParty[i], MON_DATA_SPECIES, 0)
-            && GetMonData(&gPlayerParty[i], MON_DATA_SPECIES_OR_EGG) != SPECIES_NONE
-            && GetMonData(&gPlayerParty[i], MON_DATA_SPECIES_OR_EGG) != SPECIES_EGG)
-        {
-            u32 curStatus = STATUS1_POISON;
-            SetMonData(&gPlayerParty[i], MON_DATA_STATUS, &curStatus);
-        }
-    }
-    PlaySE(SE_FIELD_POISON);
-    ScriptContext_Enable();
-    Debug_DestroyMenu_Full(taskId);
+    Debug_DestroyMenu_Full_Script(taskId, Debug_EventScript_InflictStatus1);
 }
 
 static void DebugAction_Party_CheckEV(u8 taskId)

--- a/src/script_pokemon_util.c
+++ b/src/script_pokemon_util.c
@@ -494,10 +494,13 @@ void Script_SetStatus1(struct ScriptContext *ctx)
 
     if (slot >= PARTY_SIZE)
     {
+        u16 species;
+
         for (slot = 0; slot < PARTY_SIZE; slot++)
         {
-            if (GetMonData(&gPlayerParty[slot], MON_DATA_SPECIES) != SPECIES_NONE
-             && GetMonData(&gPlayerParty[slot], MON_DATA_SPECIES) != SPECIES_EGG
+            species = GetMonData(&gPlayerParty[slot], MON_DATA_SPECIES);
+            if (species != SPECIES_NONE
+             && species != SPECIES_EGG
              && GetMonData(&gPlayerParty[slot], MON_DATA_HP) != 0)
                 SetMonData(&gPlayerParty[slot], MON_DATA_STATUS, &status1);
         }

--- a/src/script_pokemon_util.c
+++ b/src/script_pokemon_util.c
@@ -486,3 +486,24 @@ void Script_GetChosenMonDefensiveIV(void)
     ConvertIntToDecimalStringN(gStringVar2, GetMonData(&gPlayerParty[gSpecialVar_0x8004], MON_DATA_DEF_IV), STR_CONV_MODE_LEFT_ALIGN, 3);
     ConvertIntToDecimalStringN(gStringVar3, GetMonData(&gPlayerParty[gSpecialVar_0x8004], MON_DATA_SPDEF_IV), STR_CONV_MODE_LEFT_ALIGN, 3);
 }
+
+void Script_SetStatus1(struct ScriptContext *ctx)
+{
+    u32 status1 = VarGet(ScriptReadHalfword(ctx));
+    u32 slot = VarGet(ScriptReadHalfword(ctx));
+
+    if (slot >= PARTY_SIZE)
+    {
+        for (slot = 0; slot < PARTY_SIZE; slot++)
+        {
+            if (GetMonData(&gPlayerParty[slot], MON_DATA_SPECIES) != SPECIES_NONE
+             && GetMonData(&gPlayerParty[slot], MON_DATA_SPECIES) != SPECIES_EGG
+             && GetMonData(&gPlayerParty[slot], MON_DATA_HP) != 0)
+                SetMonData(&gPlayerParty[slot], MON_DATA_STATUS, &status1);
+        }
+    }
+    else
+    {        
+        SetMonData(&gPlayerParty[slot], MON_DATA_STATUS, &status1);
+    }
+}


### PR DESCRIPTION
## Description
So, earlier, we were kinda talking inside RHH's Discord server about how it'd be cool to provide examples of how to use the dynamic multichoice feature designed by @SBird1337 which was merged in #3826.

Josh asked why didn't we feature one such example as a part of the debug menu.
As soon as they said that, a light bulb went on in my head.
We have this not-very-convenient option to poison all the Pokémon in the party, yeah?
Why not turn it into something more useful with the power of ~~science~~ the dynamic multichoices?

Thus, I wrote a debug overworld script to inflict a non-volatile status ailment aka status1 at will.
I also added a choice for the scope of the feature while I was at it, which means you can now burn to a crisp that detestable Pikachu in your party without ever damaging your precious Magikarp!

This PR introduces a new overworld scripting command to inflict a status1 on individual Pokémon of the Player's party, or all of them.
*I wonder why. Where is it used? I guess we will never know the answer.*

## Images
![](https://media.discordapp.net/attachments/774393519569502268/1212497471733768222/mGBA_20240228_173045557.gif?ex=65f20d44&is=65df9844&hm=3fa3cbd95138d65461247e842602272b3930a8314d76f00152cdf9c34d960202&=) ![](https://media.discordapp.net/attachments/774393519569502268/1212507345536548894/mGBA_20240228_181001536.gif?ex=65f21676&is=65dfa176&hm=ad11780a6c6bd42f57c2d02ac32f6d213cb95d25c5f5e8c2fed33b8fbf3710ab&=)

## **Discord contact info**
lunos4026