### PR TITLE
Fix possible multi battle bug

### DIFF
--- a/src/data.c
+++ b/src/data.c
@@ -222,6 +222,7 @@ const union AnimCmd *const gAnims_MonPic[MAX_MON_PIC_FRAMES] =
 
 const union AnimCmd *const sAnims_Trainer[] ={
     sAnim_GeneralFrame0,
+    sAnim_GeneralFrame0,
 };
 
 #include "data/trainer_parties.h"


### PR DESCRIPTION
Fixes an issue when an ai vs ai battle or a partner multi battle would crash/freeze/break during the intro throw animation, because the front opponent sprites, when used as back sprites, do not have second frames.