### PR TITLE
Made ScriptGiveMonParameterized recognize the state of P_FLAG_FORCE_SHINY and P_FLAG_FORCE_NO_SHINY

### DIFF
--- a/src/script_pokemon_util.c
+++ b/src/script_pokemon_util.c
@@ -313,6 +313,8 @@ u32 ScriptGiveMonParameterized(u16 species, u8 level, u16 item, u8 ball, u8 natu
         CreateMonWithNature(&mon, species, level, 32, nature);
 
     // shininess
+    if (P_FLAG_FORCE_SHINY != 0 && FlagGet(P_FLAG_FORCE_SHINY))
+        isShiny = TRUE;
     SetMonData(&mon, MON_DATA_IS_SHINY, &isShiny);
 
     // gigantamax factor

--- a/src/script_pokemon_util.c
+++ b/src/script_pokemon_util.c
@@ -315,6 +315,8 @@ u32 ScriptGiveMonParameterized(u16 species, u8 level, u16 item, u8 ball, u8 natu
     // shininess
     if (P_FLAG_FORCE_SHINY != 0 && FlagGet(P_FLAG_FORCE_SHINY))
         isShiny = TRUE;
+    else if (P_FLAG_FORCE_NO_SHINY != 0 && FlagGet(P_FLAG_FORCE_NO_SHINY))
+        isShiny = FALSE;
     SetMonData(&mon, MON_DATA_IS_SHINY, &isShiny);
 
     // gigantamax factor


### PR DESCRIPTION
## Description
Fixes an oversight of mine from #3924.
The new `givemon` wasn't properly respecting the value of the `P_FLAG_FORCE_SHINY`, causing certain Pokémon such as the starters not to be generated as shinies even if said flag was set.

## **Discord contact info**
lunos4026