### PR TITLE
Updated OW_SYNCHRONIZE_NATURE statement in ScriptGiveMonParameterized

### DIFF
--- a/src/script_pokemon_util.c
+++ b/src/script_pokemon_util.c
@@ -299,10 +299,14 @@ u32 ScriptGiveMonParameterized(u16 species, u8 level, u16 item, u8 ball, u8 natu
     u16 targetSpecies;
 
     // check whether to use a specific nature or a random one
-    if (OW_SYNCHRONIZE_NATURE >= GEN_6 && (gSpeciesInfo[species].eggGroups[0] == EGG_GROUP_NO_EGGS_DISCOVERED || OW_SYNCHRONIZE_NATURE == GEN_7))
-        nature = PickWildMonNature();
-    else if (nature >= NUM_NATURES)
-        nature = Random() % NUM_NATURES;
+    if (nature >= NUM_NATURES)
+    {
+        if (OW_SYNCHRONIZE_NATURE >= GEN_6
+         && (gSpeciesInfo[species].eggGroups[0] == EGG_GROUP_NO_EGGS_DISCOVERED || OW_SYNCHRONIZE_NATURE == GEN_7))
+            nature = PickWildMonNature();
+        else
+            nature = Random() % NUM_NATURES;
+    }
 
     // create a Pokémon with basic data
     if ((gender == MON_MALE && genderRatio != MON_FEMALE && genderRatio != MON_GENDERLESS)


### PR DESCRIPTION
## Description
Fixes an issue where the nature of a Deoxys would be randomized even if one was set at the time of calling givemon or the functions related to it.
This was happening because when the code executed `ScriptGiveMonParameterized`, the conditions of the `if (OW_SYNCHRONIZE_NATURE >= GEN_6 && (gSpeciesInfo[species].eggGroups[0] == EGG_GROUP_NO_EGGS_DISCOVERED || OW_SYNCHRONIZE_NATURE == GEN_7))` statement were met, prompting the function to set a random nature.

## Images
![mGBA_20240311_142241525](https://github.com/rh-hideout/pokeemerald-expansion/assets/4485172/30ab9b21-966a-4100-b296-3861a3c7db6b)

## Issue(s) that this PR fixes
#4263 

## **Discord contact info**
lunos4026