### PR TITLE
Pre-1.8 tweaks

### DIFF
--- a/data/scripts/debug.inc
+++ b/data/scripts/debug.inc
@@ -95,47 +95,47 @@ Debug_BoxFilledMessage::
 Debug_BoxFilledMessage_Text:
 	.string "Storage boxes filled!$"
 
-Debug_EventScript_CheckEV::
+Debug_EventScript_CheckEVs::
 	lockall
 	getpartysize
 	goto_if_eq VAR_RESULT, 0, Debug_NoPokemon
 	special ChoosePartyMon
 	waitstate
-	goto_if_ge VAR_0x8004, PARTY_SIZE, Debug_EventScript_CheckEV_End
-	callnative Script_GetChosenMonOffensiveEV
-	msgbox Debug_EventScript_Text_OffensiveEV, MSGBOX_DEFAULT
-	callnative Script_GetChosenMonDefensiveEV
-	msgbox Debug_EventScript_Text_DefensiveEV, MSGBOX_DEFAULT
-Debug_EventScript_CheckEV_End::
+	goto_if_ge VAR_0x8004, PARTY_SIZE, Debug_EventScript_CheckEVs_End
+	callnative Script_GetChosenMonOffensiveEVs
+	msgbox Debug_EventScript_Text_OffensiveEVs, MSGBOX_DEFAULT
+	callnative Script_GetChosenMonDefensiveEVs
+	msgbox Debug_EventScript_Text_DefensiveEVs, MSGBOX_DEFAULT
+Debug_EventScript_CheckEVs_End::
 	releaseall
 	end
 
-Debug_EventScript_Text_OffensiveEV:
-	.string "ATK EV: {STR_VAR_1}, SPATK EV: {STR_VAR_2}, SPEED EV: {STR_VAR_3}$"
+Debug_EventScript_Text_OffensiveEVs:
+	.string "ATK EVs: {STR_VAR_1}, SPATK EVs: {STR_VAR_2}, SPEED EVs: {STR_VAR_3}$"
 
-Debug_EventScript_Text_DefensiveEV:
-	.string "HP EV: {STR_VAR_1}, DEF EV: {STR_VAR_2}, SPDEF EV: {STR_VAR_3}$"
+Debug_EventScript_Text_DefensiveEVs:
+	.string "HP EVs: {STR_VAR_1}, DEF EVs: {STR_VAR_2}, SPDEF EVs: {STR_VAR_3}$"
 
-Debug_EventScript_CheckIV::
+Debug_EventScript_CheckIVs::
 	lockall
 	getpartysize
 	goto_if_eq VAR_RESULT, 0, Debug_NoPokemon
 	special ChoosePartyMon
 	waitstate
-	goto_if_ge VAR_0x8004, PARTY_SIZE, Debug_EventScript_CheckIV_End
-	callnative Script_GetChosenMonOffensiveIV
-	msgbox Debug_EventScript_Text_OffensiveIV, MSGBOX_DEFAULT
-	callnative Script_GetChosenMonDefensiveIV
-	msgbox Debug_EventScript_Text_DefensiveIV, MSGBOX_DEFAULT
-Debug_EventScript_CheckIV_End::
+	goto_if_ge VAR_0x8004, PARTY_SIZE, Debug_EventScript_CheckIVs_End
+	callnative Script_GetChosenMonOffensiveIVs
+	msgbox Debug_EventScript_Text_OffensiveIVs, MSGBOX_DEFAULT
+	callnative Script_GetChosenMonDefensiveIVs
+	msgbox Debug_EventScript_Text_DefensiveIVs, MSGBOX_DEFAULT
+Debug_EventScript_CheckIVs_End::
 	releaseall
 	end
 
-Debug_EventScript_Text_OffensiveIV:
-	.string "ATK IV: {STR_VAR_1}, SPATK IV: {STR_VAR_2}, SPEED IV: {STR_VAR_3}$"
+Debug_EventScript_Text_OffensiveIVs:
+	.string "ATK IVs: {STR_VAR_1}, SPATK IVs: {STR_VAR_2}, SPEED IVs: {STR_VAR_3}$"
 
-Debug_EventScript_Text_DefensiveIV:
-	.string "HP IV: {STR_VAR_1}, DEF IV: {STR_VAR_2}, SPDEF IV: {STR_VAR_3}$"
+Debug_EventScript_Text_DefensiveIVs:
+	.string "HP IVs: {STR_VAR_1}, DEF IVs: {STR_VAR_2}, SPDEF IVs: {STR_VAR_3}$"
 
 Debug_EventScript_Script_1::
 	end

--- a/data/specials.inc
+++ b/data/specials.inc
@@ -550,7 +550,7 @@ gSpecials::
 	def_special ObjectEventInteractionBerryHasWeed
 	def_special ObjectEventInteractionBerryHasPests
 	def_special CanWaterBerryPlot
-	def_special Script_GetChosenMonOffensiveEV
-	def_special Script_GetChosenMonDefensiveEV
-	def_special Script_GetChosenMonOffensiveIV
-	def_special Script_GetChosenMonDefensiveIV
+	def_special Script_GetChosenMonOffensiveEVs
+	def_special Script_GetChosenMonDefensiveEVs
+	def_special Script_GetChosenMonOffensiveIVs
+	def_special Script_GetChosenMonDefensiveIVs

--- a/include/config/decap.h
+++ b/include/config/decap.h
@@ -11,7 +11,7 @@ Exceptions:
 - ASM strings that use `.fixstr`
 - If mirroring enabled, string addresses passed through MirrorPtr
 */
-#define DECAP_ENABLED TRUE
+#define DECAP_ENABLED FALSE
 // Enables signaling that a string's case should be preserved
 // by *mirroring* its address: i.e 08xxxxxx to 0Axxxxxx
 // Unless you are targeting a different platform than the GBA,

--- a/include/config/level_caps.h
+++ b/include/config/level_caps.h
@@ -1,0 +1,21 @@
+#ifndef GUARD_CONFIG_LEVEL_CAP_H
+#define GUARD_CONFIG_LEVEL_CAP_H
+
+// Constants
+#define EXP_CAP_NONE                    0 // Regular behavior, no level caps are applied
+#define EXP_CAP_HARD                    1 // Pokémon with a level >= the level cap cannot gain any experience
+#define EXP_CAP_SOFT                    2 // Pokémon with a level >= the level cap will gain reduced experience
+
+#define LEVEL_CAP_NONE                  0 // No level cap, only applicable if B_EXP_CAP_TYPE is EXP_CAP_NONE
+#define LEVEL_CAP_FLAG_LIST             1 // Level cap is chosen according to the first unset flag in `sLevelCapFlagMap`
+#define LEVEL_CAP_VARIABLE              2 // Level cap is chosen according to the contents of the event variable specified by B_LEVEL_CAP_VARIABLE
+
+// Configs
+#define B_EXP_CAP_TYPE                  EXP_CAP_NONE   // [EXP_CAP_NONE, EXP_CAP_HARD, EXP_CAP_SOFT] choose the type of level cap to apply
+#define B_LEVEL_CAP_TYPE                LEVEL_CAP_NONE // [LEVEL_CAP_NONE, LEVEL_CAP_FLAG_LIST, LEVEL_CAP_VARIABLE] choose the method to derive the level cap
+#define B_LEVEL_CAP_VARIABLE            0 // event variable used to derive level cap if B_LEVEL_CAP_TYPE is set to LEVEL_CAP_VARIABLE
+
+#define B_RARE_CANDY_CAP                FALSE // If set to true, Rare Candies can't be used to go over the level cap
+#define B_LEVEL_CAP_EXP_UP              FALSE // If set to true, mons under level cap will receive more experience
+
+#endif /* GUARD_CONFIG_LEVEL_CAP_H */

--- a/include/config/overworld.h
+++ b/include/config/overworld.h
@@ -20,6 +20,7 @@
 #define GEN_6_ORAS GEN_LATEST + 1
 
 #define OW_BERRY_MUTATIONS             FALSE      // If enabled, Berry plants can mutate based on berries planted next to them.
+#define OW_BERRY_MUTATION_CHANCE       25         // Determines the % chance of a mutation.
 #define OW_BERRY_MOISTURE              FALSE      // If enabled, Berry watering is not a matter of watering it once per stage, but rather of keeping the soil moist.
 #define OW_BERRY_ALWAYS_WATERABLE      FALSE      // If OW_BERRY_MOISTURE is enabled, this setting allows the player to continuously water soil; dry soil will cause a decrease in Berry Yield (like Gen4). When off, soil can only be watered when dry and watering increases yield (like Gen6).
 #define OW_BERRY_MULCH_USAGE           FALSE      // If enabled, Mulch can be used on soil to fertilize it. Otherwise, it is considered unusable. Note that moisture effects only work with OW_BERRY_MOISTURE enabled!

--- a/include/constants/global.h
+++ b/include/constants/global.h
@@ -4,6 +4,7 @@
 #include "config/battle.h"
 #include "config/debug.h"
 #include "config/item.h"
+#include "config/level_caps.h"
 #include "config/pokemon.h"
 #include "config/overworld.h"
 #include "config/decap.h"

--- a/include/level_caps.h
+++ b/include/level_caps.h
@@ -1,23 +1,6 @@
 #ifndef GUARD_LEVEL_CAP_H
 #define GUARD_LEVEL_CAP_H
 
-// experience (soft-)caps
-
-#define EXP_CAP_NONE                    0 // Regular behavior, no level caps are applied
-#define EXP_CAP_HARD                    1 // Pokémon with a level >= the level cap cannot gain any experience
-#define EXP_CAP_SOFT                    2 // Pokémon with a level >= the level cap will gain reduced experience
-
-#define LEVEL_CAP_NONE                  0 // No level cap, only applicable if B_EXP_CAP_TYPE is EXP_CAP_NONE
-#define LEVEL_CAP_FLAG_LIST             1 // Level cap is chosen according to the first unset flag in `sLevelCapFlagMap`
-#define LEVEL_CAP_VARIABLE              2 // Level cap is chosen according to the contents of the event variable specified by B_LEVEL_CAP_VARIABLE
-
-#define B_EXP_CAP_TYPE                  EXP_CAP_NONE   // [EXP_CAP_NONE, EXP_CAP_HARD, EXP_CAP_SOFT] choose the type of level cap to apply
-#define B_LEVEL_CAP_TYPE                LEVEL_CAP_NONE // [LEVEL_CAP_NONE, LEVEL_CAP_FLAG_LIST, LEVEL_CAP_VARIABLE] choose the method to derive the level cap
-#define B_LEVEL_CAP_VARIABLE            0 // event variable used to derive level cap if B_LEVEL_CAP_TYPE is set to LEVEL_CAP_VARIABLE
-
-#define B_RARE_CANDY_CAP                FALSE // If set to true, Rare Candies can't be used to go over the level cap
-#define B_LEVEL_CAP_EXP_UP              FALSE // If set to true, mons under level cap will receive more experience
-
 #if B_EXP_CAP_TYPE != EXP_CAP_NONE && B_EXP_CAP_TYPE != EXP_CAP_HARD && B_EXP_CAP_TYPE != EXP_CAP_SOFT
 #error "Invalid choice for B_EXP_CAP_TYPE, must be of [EXP_CAP_NONE, EXP_CAP_HARD, EXP_CAP_SOFT]"
 #endif

--- a/include/script_pokemon_util.h
+++ b/include/script_pokemon_util.h
@@ -9,9 +9,9 @@ void CreateScriptedDoubleWildMon(u16, u8, u16, u16, u8, u16);
 void ScriptSetMonMoveSlot(u8, u16, u8);
 void ReducePlayerPartyToSelectedMons(void);
 void HealPlayerParty(void);
-void Script_GetChosenMonOffensiveEV(void);
-void Script_GetChosenMonDefensiveEV(void);
-void Script_GetChosenMonOffensiveIV(void);
-void Script_GetChosenMonDefensiveIV(void);
+void Script_GetChosenMonOffensiveEVs(void);
+void Script_GetChosenMonDefensiveEVs(void);
+void Script_GetChosenMonOffensiveIVs(void);
+void Script_GetChosenMonDefensiveIVs(void);
 
 #endif // GUARD_SCRIPT_POKEMON_UTIL_H

--- a/src/berry.c
+++ b/src/berry.c
@@ -2295,8 +2295,6 @@ bool8 PlayerHasMulch(void)
 }
 
 #if OW_BERRY_MUTATIONS == TRUE
-#define BERRY_MUTATION_CHANCE 25
-
 static const u8 sBerryMutations[][3] = {
     {ITEM_TO_BERRY(ITEM_IAPAPA_BERRY), ITEM_TO_BERRY(ITEM_MAGO_BERRY),   ITEM_TO_BERRY(ITEM_POMEG_BERRY)},
     {ITEM_TO_BERRY(ITEM_CHESTO_BERRY), ITEM_TO_BERRY(ITEM_PERSIM_BERRY), ITEM_TO_BERRY(ITEM_KELPSY_BERRY)},
@@ -2353,7 +2351,7 @@ static u8 TryForMutation(u8 berryTreeId, u8 berry)
         {
             x2 = gObjectEvents[j].currentCoords.x;
             y2 = gObjectEvents[j].currentCoords.y;
-            if (Random() % 100 < (BERRY_MUTATION_CHANCE * (mulch == ITEM_TO_MULCH(ITEM_SURPRISE_MULCH) || mulch == ITEM_TO_MULCH(ITEM_AMAZE_MULCH))) && (
+            if (Random() % 100 < (OW_BERRY_MUTATION_CHANCE * (mulch == ITEM_TO_MULCH(ITEM_SURPRISE_MULCH) || mulch == ITEM_TO_MULCH(ITEM_AMAZE_MULCH))) && (
                 (x1 == x2 && y1 == y2 - 1) ||
                 (x1 == x2 && y1 == y2 + 1) ||
                 (x1 == x2 - 1 && y1 == y2) ||

--- a/src/debug.c
+++ b/src/debug.c
@@ -127,8 +127,8 @@ enum PartyDebugMenu
     DEBUG_PARTY_MENU_ITEM_HATCH_AN_EGG,
     DEBUG_PARTY_MENU_ITEM_HEAL_PARTY,
     DEBUG_PARTY_MENU_ITEM_INFLICT_STATUS1,
-    DEBUG_PARTY_MENU_ITEM_CHECK_EV,
-    DEBUG_PARTY_MENU_ITEM_CHECK_IV,
+    DEBUG_PARTY_MENU_ITEM_CHECK_EVS,
+    DEBUG_PARTY_MENU_ITEM_CHECK_IVS,
     DEBUG_PARTY_MENU_ITEM_CLEAR_PARTY,
 };
 
@@ -392,8 +392,8 @@ static void DebugAction_Party_MoveReminder(u8 taskId);
 static void DebugAction_Party_HatchAnEgg(u8 taskId);
 static void DebugAction_Party_HealParty(u8 taskId);
 static void DebugAction_Party_InflictStatus1(u8 taskId);
-static void DebugAction_Party_CheckEV(u8 taskId);
-static void DebugAction_Party_CheckIV(u8 taskId);
+static void DebugAction_Party_CheckEVs(u8 taskId);
+static void DebugAction_Party_CheckIVs(u8 taskId);
 static void DebugAction_Party_ClearParty(u8 taskId);
 
 static void DebugAction_FlagsVars_Flags(u8 taskId);
@@ -452,8 +452,8 @@ static void DebugAction_BerryFunctions_Weeds(u8 taskId);
 extern const u8 Debug_FlagsNotSetOverworldConfigMessage[];
 extern const u8 Debug_FlagsNotSetBattleConfigMessage[];
 extern const u8 Debug_FlagsAndVarNotSetBattleConfigMessage[];
-extern const u8 Debug_EventScript_CheckEV[];
-extern const u8 Debug_EventScript_CheckIV[];
+extern const u8 Debug_EventScript_CheckEVs[];
+extern const u8 Debug_EventScript_CheckIVs[];
 extern const u8 Debug_EventScript_InflictStatus1[];
 extern const u8 Debug_EventScript_Script_1[];
 extern const u8 Debug_EventScript_Script_2[];
@@ -550,8 +550,8 @@ static const u8 sDebugText_Party_MoveReminder[] =            _("Move Reminder");
 static const u8 sDebugText_Party_HatchAnEgg[] =              _("Hatch an Egg");
 static const u8 sDebugText_Party_HealParty[] =               _("Heal party");
 static const u8 sDebugText_Party_InflictStatus1[] =          _("Inflict Status1");
-static const u8 sDebugText_Party_CheckEV[] =                 _("Check EV");
-static const u8 sDebugText_Party_CheckIV[] =                 _("Check IV");
+static const u8 sDebugText_Party_CheckEVs[] =                _("Check EVs");
+static const u8 sDebugText_Party_CheckIVs[] =                _("Check IVs");
 static const u8 sDebugText_Party_ClearParty[] =              _("Clear Party");
 // Flags/Vars Menu
 static const u8 sDebugText_FlagsVars_Flags[] =               _("Set Flag XYZ…{CLEAR_TO 110}{RIGHT_ARROW}");
@@ -748,8 +748,8 @@ static const struct ListMenuItem sDebugMenu_Items_Party[] =
     [DEBUG_PARTY_MENU_ITEM_HATCH_AN_EGG]    = {sDebugText_Party_HatchAnEgg,     DEBUG_PARTY_MENU_ITEM_HATCH_AN_EGG},
     [DEBUG_PARTY_MENU_ITEM_HEAL_PARTY]      = {sDebugText_Party_HealParty,      DEBUG_PARTY_MENU_ITEM_HEAL_PARTY},
     [DEBUG_PARTY_MENU_ITEM_INFLICT_STATUS1] = {sDebugText_Party_InflictStatus1, DEBUG_PARTY_MENU_ITEM_INFLICT_STATUS1},
-    [DEBUG_PARTY_MENU_ITEM_CHECK_EV]        = {sDebugText_Party_CheckEV,        DEBUG_PARTY_MENU_ITEM_CHECK_EV},
-    [DEBUG_PARTY_MENU_ITEM_CHECK_IV]        = {sDebugText_Party_CheckIV,        DEBUG_PARTY_MENU_ITEM_CHECK_IV},
+    [DEBUG_PARTY_MENU_ITEM_CHECK_EVS]       = {sDebugText_Party_CheckEVs,       DEBUG_PARTY_MENU_ITEM_CHECK_EVS},
+    [DEBUG_PARTY_MENU_ITEM_CHECK_IVS]       = {sDebugText_Party_CheckIVs,       DEBUG_PARTY_MENU_ITEM_CHECK_IVS},
     [DEBUG_PARTY_MENU_ITEM_CLEAR_PARTY]     = {sDebugText_Party_ClearParty,     DEBUG_PARTY_MENU_ITEM_CLEAR_PARTY},
 };
 
@@ -917,8 +917,8 @@ static void (*const sDebugMenu_Actions_Party[])(u8) =
     [DEBUG_PARTY_MENU_ITEM_HATCH_AN_EGG]    = DebugAction_Party_HatchAnEgg,
     [DEBUG_PARTY_MENU_ITEM_HEAL_PARTY]      = DebugAction_Party_HealParty,
     [DEBUG_PARTY_MENU_ITEM_INFLICT_STATUS1] = DebugAction_Party_InflictStatus1,
-    [DEBUG_PARTY_MENU_ITEM_CHECK_EV]        = DebugAction_Party_CheckEV,
-    [DEBUG_PARTY_MENU_ITEM_CHECK_IV]        = DebugAction_Party_CheckIV,
+    [DEBUG_PARTY_MENU_ITEM_CHECK_EVS]       = DebugAction_Party_CheckEVs,
+    [DEBUG_PARTY_MENU_ITEM_CHECK_IVS]       = DebugAction_Party_CheckIVs,
     [DEBUG_PARTY_MENU_ITEM_CLEAR_PARTY]     = DebugAction_Party_ClearParty,
 };
 
@@ -5090,14 +5090,14 @@ static void DebugAction_Party_InflictStatus1(u8 taskId)
     Debug_DestroyMenu_Full_Script(taskId, Debug_EventScript_InflictStatus1);
 }
 
-static void DebugAction_Party_CheckEV(u8 taskId)
+static void DebugAction_Party_CheckEVs(u8 taskId)
 {
-    Debug_DestroyMenu_Full_Script(taskId, Debug_EventScript_CheckEV);
+    Debug_DestroyMenu_Full_Script(taskId, Debug_EventScript_CheckEVs);
 }
 
-static void DebugAction_Party_CheckIV(u8 taskId)
+static void DebugAction_Party_CheckIVs(u8 taskId)
 {
-    Debug_DestroyMenu_Full_Script(taskId, Debug_EventScript_CheckIV);
+    Debug_DestroyMenu_Full_Script(taskId, Debug_EventScript_CheckIVs);
 }
 
 static void DebugAction_Party_ClearParty(u8 taskId)

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -422,23 +422,23 @@ const s8 gNatureStatTable[NUM_NATURES][NUM_NATURE_STATS] =
 #include "data/pokemon/experience_tables.h"
 
 #if P_LVL_UP_LEARNSETS >= GEN_9
-#include "data/pokemon/level_up_learnsets/gen_9.h"
+#include "data/pokemon/level_up_learnsets/gen_9.h" // Scarlet/Violet
 #elif P_LVL_UP_LEARNSETS >= GEN_8
-#include "data/pokemon/level_up_learnsets/gen_8.h"
+#include "data/pokemon/level_up_learnsets/gen_8.h" // Sword/Shield
 #elif P_LVL_UP_LEARNSETS >= GEN_7
-#include "data/pokemon/level_up_learnsets/gen_7.h"
+#include "data/pokemon/level_up_learnsets/gen_7.h" // Ultra Sun/ Ultra Moon
 #elif P_LVL_UP_LEARNSETS >= GEN_6
-#include "data/pokemon/level_up_learnsets/gen_6.h"
+#include "data/pokemon/level_up_learnsets/gen_6.h" // Omega Ruby/Alpha Sapphire
 #elif P_LVL_UP_LEARNSETS >= GEN_5
-#include "data/pokemon/level_up_learnsets/gen_5.h"
+#include "data/pokemon/level_up_learnsets/gen_5.h" // Black 2/White 2
 #elif P_LVL_UP_LEARNSETS >= GEN_4
-#include "data/pokemon/level_up_learnsets/gen_4.h"
+#include "data/pokemon/level_up_learnsets/gen_4.h" // HeartGold/SoulSilver
 #elif P_LVL_UP_LEARNSETS >= GEN_3
-#include "data/pokemon/level_up_learnsets/gen_3.h"
+#include "data/pokemon/level_up_learnsets/gen_3.h" // Ruby/Sapphire/Emerald
 #elif P_LVL_UP_LEARNSETS >= GEN_2
-#include "data/pokemon/level_up_learnsets/gen_2.h"
+#include "data/pokemon/level_up_learnsets/gen_2.h" // Crystal
 #elif P_LVL_UP_LEARNSETS >= GEN_1
-#include "data/pokemon/level_up_learnsets/gen_1.h"
+#include "data/pokemon/level_up_learnsets/gen_1.h" // Yellow
 #endif
 
 #include "data/pokemon/teachable_learnsets.h"

--- a/src/script_pokemon_util.c
+++ b/src/script_pokemon_util.c
@@ -459,28 +459,28 @@ void ScrCmd_givemon(struct ScriptContext *ctx)
 
 #undef PARSE_FLAG
 
-void Script_GetChosenMonOffensiveEV(void)
+void Script_GetChosenMonOffensiveEVs(void)
 {
     ConvertIntToDecimalStringN(gStringVar1, GetMonData(&gPlayerParty[gSpecialVar_0x8004], MON_DATA_ATK_EV), STR_CONV_MODE_LEFT_ALIGN, 3);
     ConvertIntToDecimalStringN(gStringVar2, GetMonData(&gPlayerParty[gSpecialVar_0x8004], MON_DATA_SPATK_EV), STR_CONV_MODE_LEFT_ALIGN, 3);
     ConvertIntToDecimalStringN(gStringVar3, GetMonData(&gPlayerParty[gSpecialVar_0x8004], MON_DATA_SPEED_EV), STR_CONV_MODE_LEFT_ALIGN, 3);
 }
 
-void Script_GetChosenMonDefensiveEV(void)
+void Script_GetChosenMonDefensiveEVs(void)
 {
     ConvertIntToDecimalStringN(gStringVar1, GetMonData(&gPlayerParty[gSpecialVar_0x8004], MON_DATA_HP_EV), STR_CONV_MODE_LEFT_ALIGN, 3);
     ConvertIntToDecimalStringN(gStringVar2, GetMonData(&gPlayerParty[gSpecialVar_0x8004], MON_DATA_DEF_EV), STR_CONV_MODE_LEFT_ALIGN, 3);
     ConvertIntToDecimalStringN(gStringVar3, GetMonData(&gPlayerParty[gSpecialVar_0x8004], MON_DATA_SPDEF_EV), STR_CONV_MODE_LEFT_ALIGN, 3);
 }
 
-void Script_GetChosenMonOffensiveIV(void)
+void Script_GetChosenMonOffensiveIVs(void)
 {
     ConvertIntToDecimalStringN(gStringVar1, GetMonData(&gPlayerParty[gSpecialVar_0x8004], MON_DATA_ATK_IV), STR_CONV_MODE_LEFT_ALIGN, 3);
     ConvertIntToDecimalStringN(gStringVar2, GetMonData(&gPlayerParty[gSpecialVar_0x8004], MON_DATA_SPATK_IV), STR_CONV_MODE_LEFT_ALIGN, 3);
     ConvertIntToDecimalStringN(gStringVar3, GetMonData(&gPlayerParty[gSpecialVar_0x8004], MON_DATA_SPEED_IV), STR_CONV_MODE_LEFT_ALIGN, 3);
 }
 
-void Script_GetChosenMonDefensiveIV(void)
+void Script_GetChosenMonDefensiveIVs(void)
 {
     ConvertIntToDecimalStringN(gStringVar1, GetMonData(&gPlayerParty[gSpecialVar_0x8004], MON_DATA_HP_IV), STR_CONV_MODE_LEFT_ALIGN, 3);
     ConvertIntToDecimalStringN(gStringVar2, GetMonData(&gPlayerParty[gSpecialVar_0x8004], MON_DATA_DEF_IV), STR_CONV_MODE_LEFT_ALIGN, 3);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- [x] Move `BERRY_MUTATION_CHANCE` to `include/config/overworld.h` and renamed it to `OW_BERRY_MUTATION_CHANCE`
- [x] Move `include/level_caps.h` to `include/config/level_caps.h`.
- [x] Rename "Check EV" to "Check EVs".
- [x] Rename "Check IV" to "Check IVs".
- [x] Disable decaps by default (for now, to be reverted for 1.9).
- [x] Add comments to each #include "data/pokemon/level_up_learnsets/gen_x.h" to show what game they're from

## Feature(s) this PR does NOT handle:
#4274 #4230 already handle the rest of the things that I wanted to do.

## **Discord contact info**
AsparagusEduardo 
