### PR TITLE
Add LocalRandomSeed

### DIFF
--- a/include/random.h
+++ b/include/random.h
@@ -17,7 +17,7 @@
 * LocalRandom(*val) allows you to have local random states that are the same
 * type as the global states regardless of HQ_RANDOM setting, which is useful
 * if you want to be able to set them from or assign them to gRngValue.
-* SeedLocalRandom(*val, u32) properly seeds a local random state.
+* LocalRandomSeed(u32) returns a properly seeded rng_value_t.
 *
 * Random2_32() was added to HQ_RANDOM because the output of the generator is
 * always 32 bits and Random()/Random2() are just wrappers in that mode. It is
@@ -62,7 +62,7 @@ static inline u16 Random(void)
 
 void SeedRng(u32 seed);
 void SeedRng2(u32 seed);
-void SeedLocalRandom(rng_value_t *val, u32 seed);
+rng_value_t LocalRandomSeed(u32 seed);
 
 static inline u16 Random2(void)
 {
@@ -98,9 +98,9 @@ static inline void AdvanceRandom(void)
     Random();
 }
 
-static inline void SeedLocalRandom(rng_value_t *val, u32 seed)
+static inline rng_value_t LocalRandomSeed(u32 seed)
 {
-    *val = seed;
+    return seed;
 }
 
 #endif

--- a/include/random.h
+++ b/include/random.h
@@ -17,6 +17,7 @@
 * LocalRandom(*val) allows you to have local random states that are the same
 * type as the global states regardless of HQ_RANDOM setting, which is useful
 * if you want to be able to set them from or assign them to gRngValue.
+* SeedLocalRandom(*val, u32) properly seeds a local random state.
 *
 * Random2_32() was added to HQ_RANDOM because the output of the generator is
 * always 32 bits and Random()/Random2() are just wrappers in that mode. It is
@@ -61,6 +62,7 @@ static inline u16 Random(void)
 
 void SeedRng(u32 seed);
 void SeedRng2(u32 seed);
+void SeedLocalRandom(rng_value_t *val, u32 seed);
 
 static inline u16 Random2(void)
 {
@@ -94,6 +96,11 @@ static inline u16 LocalRandom(rng_value_t *val)
 static inline void AdvanceRandom(void)
 {
     Random();
+}
+
+static inline void SeedLocalRandom(rng_value_t *val, u32 seed)
+{
+    *val = seed;
 }
 
 #endif

--- a/src/random.c
+++ b/src/random.c
@@ -91,9 +91,11 @@ void SeedRng2(u32 seed)
     SFC32_Seed(&gRng2Value, seed, STREAM2);
 }
 
-void SeedLocalRandom(rng_value_t *val, u32 seed)
+rng_value_t LocalRandomSeed(u32 seed)
 {
-    SFC32_Seed(val, seed, STREAM1);
+    rng_value_t result;
+    SFC32_Seed(&result, seed, STREAM1);
+    return result;
 }
 
 void AdvanceRandom(void)

--- a/src/random.c
+++ b/src/random.c
@@ -91,6 +91,11 @@ void SeedRng2(u32 seed)
     SFC32_Seed(&gRng2Value, seed, STREAM2);
 }
 
+void SeedLocalRandom(rng_value_t *val, u32 seed)
+{
+    SFC32_Seed(val, seed, STREAM1);
+}
+
 void AdvanceRandom(void)
 {
     if (sRngLoopUnlocked == TRUE)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a function `rng_value_t LocalRandomSeed(u32)` that returns a properly seeded `rng_value_t` regardless of `HQ_RANDOM` status. I realized this was missing. In LCG mode, it simply returns its argument, and in SFC32 mode it calls the internal SFC32 seed function and returns that.

## **Discord contact info**
tertu
