### PR TITLE
Reordered Debug_EventScript_InflictStatus1

### DIFF
--- a/data/scripts/debug.inc
+++ b/data/scripts/debug.inc
@@ -297,21 +297,6 @@ Debug_EventScript_InflictStatus1_Close:
 	releaseall
 	end
 
-.endif
-
-Debug_FlagsAndVarNotSetBattleConfigMessage::
-	lockall
-	message Debug_FlagsAndVarNotSetBattleConfigMessage_Text
-	waitmessage
-	waitbuttonpress
-	releaseall
-	end
-
-Debug_FlagsAndVarNotSetBattleConfigMessage_Text:
-	.string "Feature unavailable! Please define a\n"
-	.string "usable flag and a usable var in:\l"
-	.string "'include/config/battle.h'!$"
-
 Debug_EventScript_InflictStatus1_Single:
 	special ChoosePartyMon
 	waitstate
@@ -337,6 +322,42 @@ Debug_EventScript_InflictStatus1_Single:
 	case MULTI_B_PRESSED, Debug_EventScript_InflictStatus1_Close
 	releaseall
 	end
+
+Debug_EventScript_InflictStatus1_Party:
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Poison, 0
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Paralysis, 1
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Sleep, 2
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Burn, 3
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Freeze, 4
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Frostbite, 5
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Close, 6
+	dynmultistack 0, 0, FALSE, 7, FALSE, 0, NULL
+	switch VAR_RESULT
+	case 0, Debug_EventScript_InflictStatus1_Party_Poison
+	case 1, Debug_EventScript_InflictStatus1_Party_Paralysis
+	case 2, Debug_EventScript_InflictStatus1_Party_Sleep
+	case 3, Debug_EventScript_InflictStatus1_Party_Burn
+	case 4, Debug_EventScript_InflictStatus1_Party_Freeze
+	case 5, Debug_EventScript_InflictStatus1_Party_Frostbite
+	case 6, Debug_EventScript_InflictStatus1_Close
+	case MULTI_B_PRESSED, Debug_EventScript_InflictStatus1_Close
+	releaseall
+	end
+
+.endif
+
+Debug_FlagsAndVarNotSetBattleConfigMessage::
+	lockall
+	message Debug_FlagsAndVarNotSetBattleConfigMessage_Text
+	waitmessage
+	waitbuttonpress
+	releaseall
+	end
+
+Debug_FlagsAndVarNotSetBattleConfigMessage_Text:
+	.string "Feature unavailable! Please define a\n"
+	.string "usable flag and a usable var in:\l"
+	.string "'include/config/battle.h'!$"
 
 Debug_EventScript_InflictStatus1_Single_Poison:
 	setstatus1 STATUS1_POISON, VAR_0x8004
@@ -365,27 +386,6 @@ Debug_EventScript_InflictStatus1_Single_Freeze:
 
 Debug_EventScript_InflictStatus1_Single_Frostbite:
 	setstatus1 STATUS1_FROSTBITE, VAR_0x8004
-	releaseall
-	end
-
-Debug_EventScript_InflictStatus1_Party:
-	dynmultipush Debug_EventScript_InflictStatus1_Text_Poison, 0
-	dynmultipush Debug_EventScript_InflictStatus1_Text_Paralysis, 1
-	dynmultipush Debug_EventScript_InflictStatus1_Text_Sleep, 2
-	dynmultipush Debug_EventScript_InflictStatus1_Text_Burn, 3
-	dynmultipush Debug_EventScript_InflictStatus1_Text_Freeze, 4
-	dynmultipush Debug_EventScript_InflictStatus1_Text_Frostbite, 5
-	dynmultipush Debug_EventScript_InflictStatus1_Text_Close, 6
-	dynmultistack 0, 0, FALSE, 7, FALSE, 0, NULL
-	switch VAR_RESULT
-	case 0, Debug_EventScript_InflictStatus1_Party_Poison
-	case 1, Debug_EventScript_InflictStatus1_Party_Paralysis
-	case 2, Debug_EventScript_InflictStatus1_Party_Sleep
-	case 3, Debug_EventScript_InflictStatus1_Party_Burn
-	case 4, Debug_EventScript_InflictStatus1_Party_Freeze
-	case 5, Debug_EventScript_InflictStatus1_Party_Frostbite
-	case 6, Debug_EventScript_InflictStatus1_Close
-	case MULTI_B_PRESSED, Debug_EventScript_InflictStatus1_Close
 	releaseall
 	end
 

--- a/data/scripts/debug.inc
+++ b/data/scripts/debug.inc
@@ -344,21 +344,6 @@ Debug_EventScript_InflictStatus1_Party:
 	releaseall
 	end
 
-.endif
-
-Debug_FlagsAndVarNotSetBattleConfigMessage::
-	lockall
-	message Debug_FlagsAndVarNotSetBattleConfigMessage_Text
-	waitmessage
-	waitbuttonpress
-	releaseall
-	end
-
-Debug_FlagsAndVarNotSetBattleConfigMessage_Text:
-	.string "Feature unavailable! Please define a\n"
-	.string "usable flag and a usable var in:\l"
-	.string "'include/config/battle.h'!$"
-
 Debug_EventScript_InflictStatus1_Single_Poison:
 	setstatus1 STATUS1_POISON, VAR_0x8004
 	releaseall
@@ -445,3 +430,18 @@ Debug_EventScript_InflictStatus1_Text_Freeze:
 
 Debug_EventScript_InflictStatus1_Text_Frostbite:
 	.string "Frostbite$"
+
+.endif
+
+Debug_FlagsAndVarNotSetBattleConfigMessage::
+	lockall
+	message Debug_FlagsAndVarNotSetBattleConfigMessage_Text
+	waitmessage
+	waitbuttonpress
+	releaseall
+	end
+
+Debug_FlagsAndVarNotSetBattleConfigMessage_Text:
+	.string "Feature unavailable! Please define a\n"
+	.string "usable flag and a usable var in:\l"
+	.string "'include/config/battle.h'!$"

--- a/data/scripts/debug.inc
+++ b/data/scripts/debug.inc
@@ -281,21 +281,6 @@ DebugText_BerryWeedsDisabled:
 	.string "OW_BERRY_WEEDS is disabled.\n"
 	.string "Unable to force weeds onto berry trees.$"
 
-.endif
-
-Debug_FlagsAndVarNotSetBattleConfigMessage::
-	lockall
-	message Debug_FlagsAndVarNotSetBattleConfigMessage_Text
-	waitmessage
-	waitbuttonpress
-	releaseall
-	end
-
-Debug_FlagsAndVarNotSetBattleConfigMessage_Text:
-	.string "Feature unavailable! Please define a\n"
-	.string "usable flag and a usable var in:\l"
-	.string "'include/config/battle.h'!$"
-
 Debug_EventScript_InflictStatus1::
 	lockall
 	getpartysize
@@ -311,6 +296,21 @@ Debug_EventScript_InflictStatus1::
 Debug_EventScript_InflictStatus1_Close:
 	releaseall
 	end
+
+.endif
+
+Debug_FlagsAndVarNotSetBattleConfigMessage::
+	lockall
+	message Debug_FlagsAndVarNotSetBattleConfigMessage_Text
+	waitmessage
+	waitbuttonpress
+	releaseall
+	end
+
+Debug_FlagsAndVarNotSetBattleConfigMessage_Text:
+	.string "Feature unavailable! Please define a\n"
+	.string "usable flag and a usable var in:\l"
+	.string "'include/config/battle.h'!$"
 
 Debug_EventScript_InflictStatus1_Single:
 	special ChoosePartyMon


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Reordered Debug_EventScript_InflictStatus1 to within the 'DEBUG_OVERWORLD_MENU == TRUE' .if block, as it relies on 'Debug_NoPokemon' which is not defined outside of it.

## Issue(s) that this PR fixes
[Discord Message](https://discord.com/channels/419213663107416084/1077168246555430962/1219230896075309097)

## **People who collaborated with me in this PR**
[MrGriffin, for suggesting the fix](https://discord.com/channels/419213663107416084/1077168246555430962/1219233509567365140)

## **Discord contact info**
sirscrubbington
