### PR TITLE
Actually remove unused STATUS3_CANT_SCORE_A_CRIT

### DIFF
--- a/include/constants/battle.h
+++ b/include/constants/battle.h
@@ -167,7 +167,7 @@
 #define STATUS3_YAWN_TURN(num)          (((num) << 11) & STATUS3_YAWN)
 #define STATUS3_IMPRISONED_OTHERS       (1 << 13)
 #define STATUS3_GRUDGE                  (1 << 14)
-#define STATUS3_CANT_SCORE_A_CRIT       (1 << 15)
+#define STATUS3___UNUSED                (1 << 15)
 #define STATUS3_GASTRO_ACID             (1 << 16)
 #define STATUS3_EMBARGO                 (1 << 17)
 #define STATUS3_UNDERWATER              (1 << 18)

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1893,7 +1893,7 @@ s32 CalcCritChanceStageArgs(u32 battlerAtk, u32 battlerDef, u32 move, bool32 rec
 {
     s32 critChance = 0;
 
-    if (gSideStatuses[battlerDef] & SIDE_STATUS_LUCKY_CHANT || gStatuses3[battlerAtk] & STATUS3_CANT_SCORE_A_CRIT
+    if (gSideStatuses[battlerDef] & SIDE_STATUS_LUCKY_CHANT
         || abilityDef == ABILITY_BATTLE_ARMOR || abilityDef == ABILITY_SHELL_ARMOR)
     {
         critChance = -1;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
#3377 mentioned that the status was removed when it wasn't. This PR fixes that.

## **Discord contact info**
AsparagusEduardo
