### PR TITLE
Added pre-1.6.2 changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 # Pokeemerald-Expansion Changelogs
 
 ## 1.8.x
-- ### [Version 1.8.0](docs/changelogs/1.8.0.md) - Feature Release
+- ### [Version 1.8.0](docs/changelogs/1.8.0.md) - Feature Release ✨
 
 ## 1.7.x
 - ### [Version 1.7.4](docs/changelogs/1.7.4.md) - Bugfix Release 🧹
 - ### [Version 1.7.3](docs/changelogs/1.7.3.md) - Bugfix Release 🧹
 - ### [Version 1.7.2](docs/changelogs/1.7.2.md) - Bugfix Release 🧹
 - ### [Version 1.7.1](docs/changelogs/1.7.1.md) - Bugfix Release 🧹
-- ### [Version 1.7.0](docs/changelogs/1.7.0.md) - Feature Release
+- ### [Version 1.7.0](docs/changelogs/1.7.0.md) - Feature Release ✨
 
 ## 1.6.x
 - ### [Version 1.6.2](docs/changelogs/1.6.2.md) - Bugfix Release 🧹

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,44 @@
 # Pokeemerald-Expansion Changelogs
 
-## Version 1.8.x
-### [Version 1.8.0](docs/changelogs/1.8.0.md) - Feature Release
+## 1.8.x
+- ### [Version 1.8.0](docs/changelogs/1.8.0.md) - Feature Release
 
-## Version 1.7.x
-### [Version 1.7.4](docs/changelogs/1.7.4.md) - Bugfix Release
-### [Version 1.7.3](docs/changelogs/1.7.3.md) - Bugfix Release
-### [Version 1.7.2](docs/changelogs/1.7.2.md) - Bugfix Release
-### [Version 1.7.1](docs/changelogs/1.7.1.md) - Bugfix Release
-### [Version 1.7.0](docs/changelogs/1.7.0.md) - Feature Release
+## 1.7.x
+- ### [Version 1.7.4](docs/changelogs/1.7.4.md) - Bugfix Release 🧹
+- ### [Version 1.7.3](docs/changelogs/1.7.3.md) - Bugfix Release 🧹
+- ### [Version 1.7.2](docs/changelogs/1.7.2.md) - Bugfix Release 🧹
+- ### [Version 1.7.1](docs/changelogs/1.7.1.md) - Bugfix Release 🧹
+- ### [Version 1.7.0](docs/changelogs/1.7.0.md) - Feature Release
 
-## Version 1.6.x
-### [Version 1.6.2](docs/changelogs/1.6.2.md) - Bugfix Release
+## 1.6.x
+- ### [Version 1.6.2](docs/changelogs/1.6.2.md) - Bugfix Release 🧹
+- ### [Version 1.6.1](docs/changelogs/1.6.1.md) - HOTFIX Release 🔥
+- ### [Version 1.6.0](docs/changelogs/1.6.0.md) - Feature Release ✨
+
+## 1.5.x
+- ### [Version 1.5.3](docs/changelogs/1.5.3.md) - HOTFIX Release 🔥
+- ### [Version 1.5.2](docs/changelogs/1.5.2.md) - Bugfix Release 🧹
+- ### [Version 1.5.1](docs/changelogs/1.5.1.md) - Bugfix Release 🧹
+- ### [Version 1.5.0](docs/changelogs/1.5.0.md) - Feature Release ✨
+
+## 1.4.x
+- ### [Version 1.4.3](docs/changelogs/1.4.3.md) - Bugfix Release 🧹
+- ### [Version 1.4.2](docs/changelogs/1.4.2.md) - Bugfix Release 🧹
+- ### [Version 1.4.1](docs/changelogs/1.4.1.md) - HOTFIX Release 🔥
+- ### [Version 1.4.0](docs/changelogs/1.4.0.md) - Feature Release ✨
+
+## 1.3.x
+- ### [Version 1.3.0](docs/changelogs/1.3.0.md) - Feature Release ✨
+
+## 1.2.x
+- ### [Version 1.2.0](docs/changelogs/1.2.0.md) - Feature Release ✨
+
+## 1.1.x
+- ### [Version 1.1.1](docs/changelogs/1.1.1.md) - Bugfix Release 🧹
+- ### [Version 1.1.0](docs/changelogs/1.1.0.md) - Feature Release ✨
+
+## 1.0.x
+- ### [Version 1.0.0](docs/changelogs/1.0.0.md) - Feature Release ✨
+
+## Pre-1.0.x:
+- ### [Version 0.9.0](docs/changelogs/0.9.0.md) - Retroactive Version 🦕

--- a/docs/changelogs/0.9.0.md
+++ b/docs/changelogs/0.9.0.md
@@ -1,0 +1,97 @@
+# Version 0.9.0
+
+```md
+## How to update
+- If you haven't set up a remote, run the command `git remote add RHH https://github.com/rh-hideout/pokeemerald-expansion`.
+- Once you have your remote set up, run the command `git pull RHH expansion/0.9.0`.
+```
+
+## This version was labeled retroactively after our versioning scheme was decided, meaning the version number may be arbitrary.
+
+### ADDED
+* Support for double wild battles with a single opponent by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2238
+* Gen 8 EXP Candies by @AgustinGDLV in https://github.com/rh-hideout/pokeemerald-expansion/pull/2142
+* Affection/friendship battle mechanics by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2173
+### CHANGED
+* Moves with EFFECT_PLACEHOLDER can't be used anymore. by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2243
+* Modified HP display to support HP with 4 digits by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2256
+* Enable BUGFIX by default by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2258
+* Updated Fairy icon to better match the rest of them by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2269
+
+### FIXES
+* Gen5+ multihit odds. by @aarant in https://github.com/rh-hideout/pokeemerald-expansion/pull/2219
+* IsAbilityPreventingEscape message in party menu by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2125
+* ENDTURN_WISH not resetting gBattleStruct->turnSideTracker by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2236
+* Ability pop-up not displaying long abilities properly by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2234
+* Doubles 2 vs 1 interface by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2238
+* Fixed creation trio orbs not boosting power for non-base forms. by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2242
+* LoadSpecialPokePic now loads gender differences correctly by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2247
+* Fixed Net Ball Gen 7+ multiplier by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2259
+* Fix Escape Rope Message when on gen 8 mechanics by @ThirdLemon in https://github.com/rh-hideout/pokeemerald-expansion/pull/2263
+
+### PRET MERGES
+* Up to 578064d79966ebfcd0de8782f8b7294415fd6c87 by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2264
+
+### CLEANUP
+* Fix multiple pokemon icons & tidying pokemon graphic folders by @Blackforest92 in https://github.com/rh-hideout/pokeemerald-expansion/pull/2206
+* Get rid of garbage bytes in graphics.c by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2235
+* Fixed P_UPDATED_ABILITIES's comment by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2241
+* Fixed critical capture fields not using TRUE or FALSE by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2245
+* Reworked branch defines into single compatibility define by @gruxor in https://github.com/rh-hideout/pokeemerald-expansion/pull/2237
+* Removed unused local var in SetMonFormPSS by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2271
+
+## New Contributors
+* @ThirdLemon made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/2263
+
+**Full Changelog**: https://github.com/rh-hideout/pokeemerald-expansion/compare/expansion/0.8.0...expansion/0.9.0
+
+### BREAKING
+- Reworked TMHM into expandable list format by @gruxor in https://github.com/rh-hideout/pokeemerald-expansion/pull/2233
+  - Tutor moves and TM/HM moves have been combined into a single list of ***Teachable Moves***.
+  - With this change, it allows users to have official data for compatibility if they add their own TMs/HMs and Tutors.
+- Added Legends: Arceus species by @Blackforest92 in https://github.com/rh-hideout/pokeemerald-expansion/pull/2177
+- Fixed PokemonSubstruct3 alignment by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2265
+
+### ADDED
+- Added Legends: Arceus' move data by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2280
+- Inclusion of the TheXaman's Debug Menu by @TheXaman in https://github.com/rh-hideout/pokeemerald-expansion/pull/2277
+- Introduced FORM_BATTLE form changes by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2273
+  - Form changes for Zacian, Zamazenta and Xerneas before a battle's intro.
+  - Optional parameter to check for held item.
+    - Introduced `param3` to facilitate this and merging of FORM_ITEM_USE.
+
+### CHANGED
+- Merged FORM_ITEM_USE_TIME into FORM_ITEM_USE by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2304
+- Comatose prevents Battle Pike's status effects. by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2198
+- Updated Serene Grace checks in AI_CheckViability by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2218
+
+### FIXES
+- Fixed Quash's effect by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2239
+- Fixed pickup running when it shouldn't in some cases. by @StephenLynx in https://github.com/rh-hideout/pokeemerald-expansion/pull/2284
+- Dragon Tail Weak Armor fix by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2278
+- Fix Magic Bounce targets by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2260
+- Fixed ball multiplier fallthroughs by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2290
+- Weather forms fixes and config by @Sneed69 in https://github.com/rh-hideout/pokeemerald-expansion/pull/2150
+- Fixed compile error when using `GEN_3` setting for sport moves by @Yak-Attack-1012 in https://github.com/rh-hideout/pokeemerald-expansion/pull/2295
+
+### PRET MERGES
+- Up to 578064d (2022-08-26) by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2286
+
+### CLEANUP
+- Updated README.md to reflect the new workflow  by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2287
+- Updated README.md with credits and wiki links by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2299
+- Config refactor by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2297
+  - Refactored uses of configs to be exclusivetly handled by preproc, as an optimization such that we don't have stuff like (is 3 > 4?)
+  - Moved Gen definitions to `include/config.h`, to be used by all config files.
+  - Created `GEN_LATEST` as a way to avoid conflicts with users that modify the default configs and have a way for them to easily set everything to their prefered generation.
+- Tyding graphics
+  - Tidying Graphics/Battle_Anims by @Blackforest92 in https://github.com/rh-hideout/pokeemerald-expansion/pull/2289
+  - Acupressure by @Blackforest92 in https://github.com/rh-hideout/pokeemerald-expansion/pull/2301
+- Small syntax fix for CanLearnTeachableMove by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2302
+- Added missing constant in GetBattleMonMoveSlot by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2294
+
+## New Contributors
+- @StephenLynx made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/2284
+- @Yak-Attack-1012 made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/2295
+
+**Full Changelog**: https://github.com/rh-hideout/pokeemerald-expansion/compare/expansion/0.9.0...expansion/1.0.0

--- a/docs/changelogs/1.0.0.md
+++ b/docs/changelogs/1.0.0.md
@@ -1,0 +1,58 @@
+# Version 1.0.0
+
+```md
+## How to update
+- If you haven't set up a remote, run the command `git remote add RHH https://github.com/rh-hideout/pokeemerald-expansion`.
+- Once you have your remote set up, run the command `git pull RHH expansion/1.0.0`.
+```
+
+### BREAKING
+- Reworked TMHM into expandable list format by @gruxor in https://github.com/rh-hideout/pokeemerald-expansion/pull/2233
+  - Tutor moves and TM/HM moves have been combined into a single list of ***Teachable Moves***.
+  - With this change, it allows users to have official data for compatibility if they add their own TMs/HMs and Tutors.
+- Added Legends: Arceus species by @Blackforest92 in https://github.com/rh-hideout/pokeemerald-expansion/pull/2177
+- Fixed PokemonSubstruct3 alignment by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2265
+
+### ADDED
+- Added Legends: Arceus' move data by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2280
+- Inclusion of the TheXaman's Debug Menu by @TheXaman in https://github.com/rh-hideout/pokeemerald-expansion/pull/2277
+- Introduced FORM_BATTLE form changes by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2273
+  - Form changes for Zacian, Zamazenta and Xerneas before a battle's intro.
+  - Optional parameter to check for held item.
+    - Introduced `param3` to facilitate this and merging of FORM_ITEM_USE.
+
+### CHANGED
+- Merged FORM_ITEM_USE_TIME into FORM_ITEM_USE by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2304
+- Comatose prevents Battle Pike's status effects. by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2198
+- Updated Serene Grace checks in AI_CheckViability by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2218
+
+### FIXES
+- Fixed Quash's effect by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2239
+- Fixed pickup running when it shouldn't in some cases. by @StephenLynx in https://github.com/rh-hideout/pokeemerald-expansion/pull/2284
+- Dragon Tail Weak Armor fix by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2278
+- Fix Magic Bounce targets by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2260
+- Fixed ball multiplier fallthroughs by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2290
+- Weather forms fixes and config by @Sneed69 in https://github.com/rh-hideout/pokeemerald-expansion/pull/2150
+- Fixed compile error when using `GEN_3` setting for sport moves by @Yak-Attack-1012 in https://github.com/rh-hideout/pokeemerald-expansion/pull/2295
+
+### PRET MERGES
+- Up to 578064d (2022-08-26) by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2286
+
+### CLEANUP
+- Updated README.md to reflect the new workflow  by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2287
+- Updated README.md with credits and wiki links by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2299
+- Config refactor by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2297
+  - Refactored uses of configs to be exclusivetly handled by preproc, as an optimization such that we don't have stuff like (is 3 > 4?)
+  - Moved Gen definitions to `include/config.h`, to be used by all config files.
+  - Created `GEN_LATEST` as a way to avoid conflicts with users that modify the default configs and have a way for them to easily set everything to their prefered generation.
+- Tyding graphics
+  - Tidying Graphics/Battle_Anims by @Blackforest92 in https://github.com/rh-hideout/pokeemerald-expansion/pull/2289
+  - Acupressure by @Blackforest92 in https://github.com/rh-hideout/pokeemerald-expansion/pull/2301
+- Small syntax fix for CanLearnTeachableMove by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2302
+- Added missing constant in GetBattleMonMoveSlot by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2294
+
+## New Contributors
+- @StephenLynx made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/2284
+- @Yak-Attack-1012 made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/2295
+
+**Full Changelog**: https://github.com/rh-hideout/pokeemerald-expansion/compare/expansion/0.9.0...expansion/1.0.0

--- a/docs/changelogs/1.1.0.md
+++ b/docs/changelogs/1.1.0.md
@@ -1,0 +1,39 @@
+# Version 1.1.0
+
+```md
+## How to update
+- If you haven't set up a remote, run the command `git remote add RHH https://github.com/rh-hideout/pokeemerald-expansion`.
+- Once you have your remote set up, run the command `git pull RHH expansion/1.1.0`.
+```
+
+### Added
+* Option to change the weather from the Overworld Debug Menu by @TheXaman in https://github.com/rh-hideout/pokeemerald-expansion/pull/2315
+* Corner case logic for AI Switching. by @Porygon23 in https://github.com/rh-hideout/pokeemerald-expansion/pull/2226
+* Exp Candies now show the amount of experience gained by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2282
+* Config to limit the moves called by Metronome (by generation) by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2327
+
+### Changed
+* Changed Lure prices to the same standards as the default Repels by @Jaizu in https://github.com/rh-hideout/pokeemerald-expansion/pull/2309
+* Debug menu:
+  * The changeable flags now start at 1 (0 isnt a flag) by @TheXaman in https://github.com/rh-hideout/pokeemerald-expansion/pull/2315
+  * Object events now get frozen while the menu is open to avoid potential nasty effects by @TheXaman in https://github.com/rh-hideout/pokeemerald-expansion/pull/2315
+  * Automated creation of MAP_GROUP_COUNT for the debug menu by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2307
+  * Generating music names for the debug menu based on their labels by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2306
+
+### Fixed
+* Ability pop ups not appearing at all by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2314
+* Dauntless Shield's and Intrepid Sword's effects only triggering for mon on the left in double battle, even if the mon with the abilities are on the right by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2313
+* Flickering when switching menus in the Overworld Debug Menu @Jaizu in https://github.com/rh-hideout/pokeemerald-expansion/pull/2315
+* Missing uses of Fairy type for Union Room and Battle Factory by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2310
+* Tutors changing the level of the taught Pokémon to the level that the last mon that used a Exp Candy reached by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2282
+* Exp candies giving the wrong amount of experience by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2282
+* Exp Candy XL breaking experience points by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2282
+* Ai check for switching when the target is semi invulnerable by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2324
+
+### Pret merges
+* Up to (c1dfd3c9eca7d9dd73ac7dbaff0444d965758f4c) by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2308
+
+### Cleanup
+* Tidying graphics - Super Ancient Pokémon special weather by @Blackforest92 in https://github.com/rh-hideout/pokeemerald-expansion/pull/2303
+
+**Full Changelog**: https://github.com/rh-hideout/pokeemerald-expansion/compare/expansion/1.0.0...expansion/1.1.0

--- a/docs/changelogs/1.1.1.md
+++ b/docs/changelogs/1.1.1.md
@@ -1,0 +1,13 @@
+# Version 1.1.1
+
+```md
+## How to update
+- If you haven't set up a remote, run the command `git remote add RHH https://github.com/rh-hideout/pokeemerald-expansion`.
+- Once you have your remote set up, run the command `git pull RHH expansion/1.1.1`.
+```
+
+## What's Changed
+* Fixed battles breaking when ACE_POKEMON_FUNCTIONALITY was not set by @Porygon23 in https://github.com/rh-hideout/pokeemerald-expansion/pull/2334
+
+
+**Full Changelog**: https://github.com/rh-hideout/pokeemerald-expansion/compare/expansion/1.1.0...expansion/1.1.1

--- a/docs/changelogs/1.2.0.md
+++ b/docs/changelogs/1.2.0.md
@@ -1,0 +1,86 @@
+# Version 1.2.0
+
+```md
+## How to update
+- If you haven't set up a remote, run the command `git remote add RHH https://github.com/rh-hideout/pokeemerald-expansion`.
+- Once you have your remote set up, run the command `git pull RHH expansion/1.2.0`.
+```
+
+### Added
+* AI remembers Party mons - by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2230
+  * Takes in consideration overwritten abilities - by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2355
+* ABILITY_SYMBIOSIS - by @AgustinGDLV in https://github.com/rh-hideout/pokeemerald-expansion/pull/2117
+* Teleport's modern in-battle effect, with config - by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2121
+* "Access PC" option in debug menu now gives full access to both Item and Pokémon Storage - by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2356
+* Battle Arena's move Mind ratings now expands to all moves - by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2339 and https://github.com/rh-hideout/pokeemerald-expansion/pull/2365
+* 4 new species flags - by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2293
+  * `SPECIES_FLAG_ALL_PERFECT_IVS`
+  * `SPECIES_FLAG_SHINY_LOCKED`
+  * `SPECIES_FLAG_CANNOT_BE_TRADED`
+  * `SPECIES_FLAG_MEGA_EVOLUTION`
+* Config for Battle text pause times - by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2380
+
+### Changed
+* Updated move types now have their own separate config from `B_UPDATED_MOVE_DATA` - by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2361
+* Mew now has special handling for it's Teachable moveset by @AsparagusEduardo (it learns all moves minus certain exceptions) - in https://github.com/rh-hideout/pokeemerald-expansion/pull/2367
+* Changed ballMultiplier to account for future Hisuian ball multipliers - by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2376
+* `P_NEW_POKEMON` is now split by Generation - by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2283
+  * `HasAllMons` now accounts for all mon except mythicals.
+
+### Fixed
+* Natural Cure, Shed Skin and Early Bird check in ShouldSwitchIfGameStatePrompt - by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2336
+* Multi-fixed-wild partner not calculating damage - by @StubbornOne in https://github.com/rh-hideout/pokeemerald-expansion/pull/2343
+* Z-Power Ring check - by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2349
+* Crash during Light That Burns The Sky's animation - by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2350
+* Z-Moves not showing the correct type in battle if it's different from the base move's type - by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2353
+* Returning to the overworld after using the "Access PC" option in the debug menu makes option descriptions remain open - by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2356
+* Pokémon Debug isn't loading female icon palettes correctly - by @TheXaman in https://github.com/rh-hideout/pokeemerald-expansion/pull/2360
+* Multi battle interface displays incorrectly - by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2335
+* Multi battle party menu displays incorrectly - by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2335
+* AI doesn't track abilites when Traced - by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2364
+* Berserk doesn't activate if the mon falls to exactly half HP - by @StephenLynx in https://github.com/rh-hideout/pokeemerald-expansion/pull/2370
+* Triple Kick and Triple Axel doing too much damage - by @Sneed69 in https://github.com/rh-hideout/pokeemerald-expansion/pull/2141
+* Mega Evolved Pokémon are able to get Friendship effects in battle - by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2262
+
+### Cleanup
+* Fixed typo in BoxMonKnowsMove - by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2338
+* Renamed mislabeled labels in src/debug.c - by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2337 and https://github.com/rh-hideout/pokeemerald-expansion/pull/2340
+* Removed references to `ITEM_EXPANSION` after #2177 - by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2293
+
+### Pret merges
+* Up to 1ae5010233a07bbd4fbe80a340019e04215afb71 - by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2359
+* Up to bb2e64b3fc20f713356fb68326175871c8996331 - by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2379
+
+**Full Changelog**: https://github.com/rh-hideout/pokeemerald-expansion/compare/expansion/1.1.1...expansion/1.2.0
+
+### Added
+* Option to change the weather from the Overworld Debug Menu by @TheXaman in https://github.com/rh-hideout/pokeemerald-expansion/pull/2315
+* Corner case logic for AI Switching. by @Porygon23 in https://github.com/rh-hideout/pokeemerald-expansion/pull/2226
+* Exp Candies now show the amount of experience gained by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2282
+* Config to limit the moves called by Metronome (by generation) by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2327
+
+### Changed
+* Changed Lure prices to the same standards as the default Repels by @Jaizu in https://github.com/rh-hideout/pokeemerald-expansion/pull/2309
+* Debug menu:
+  * The changeable flags now start at 1 (0 isnt a flag) by @TheXaman in https://github.com/rh-hideout/pokeemerald-expansion/pull/2315
+  * Object events now get frozen while the menu is open to avoid potential nasty effects by @TheXaman in https://github.com/rh-hideout/pokeemerald-expansion/pull/2315
+  * Automated creation of MAP_GROUP_COUNT for the debug menu by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2307
+  * Generating music names for the debug menu based on their labels by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2306
+
+### Fixed
+* Ability pop ups not appearing at all by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2314
+* Dauntless Shield's and Intrepid Sword's effects only triggering for mon on the left in double battle, even if the mon with the abilities are on the right by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2313
+* Flickering when switching menus in the Overworld Debug Menu @Jaizu in https://github.com/rh-hideout/pokeemerald-expansion/pull/2315
+* Missing uses of Fairy type for Union Room and Battle Factory by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2310
+* Tutors changing the level of the taught Pokémon to the level that the last mon that used a Exp Candy reached by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2282
+* Exp candies giving the wrong amount of experience by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2282
+* Exp Candy XL breaking experience points by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2282
+* Ai check for switching when the target is semi invulnerable by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2324
+
+### Pret merges
+* Up to (c1dfd3c9eca7d9dd73ac7dbaff0444d965758f4c) by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2308
+
+### Cleanup
+* Tidying graphics - Super Ancient Pokémon special weather by @Blackforest92 in https://github.com/rh-hideout/pokeemerald-expansion/pull/2303
+
+**Full Changelog**: https://github.com/rh-hideout/pokeemerald-expansion/compare/expansion/1.1.0...expansion/1.2.0

--- a/docs/changelogs/1.3.0.md
+++ b/docs/changelogs/1.3.0.md
@@ -1,0 +1,53 @@
+# Version 1.3.0
+
+```md
+## How to update
+- If you haven't set up a remote, run the command `git remote add RHH https://github.com/rh-hideout/pokeemerald-expansion`.
+- Once you have your remote set up, run the command `git pull RHH expansion/1.3.0`.
+```
+
+### Added
+* Added class-based Poké Balls for trainers by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2385
+* Config for running indoors by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2388
+* Implemented Lures and Repel/Lure "use another" menu by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2319
+* Implemented Honey's Sweet Scent functionality by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2391
+* Implemented Parental Bond by @BuffelSaft in https://github.com/rh-hideout/pokeemerald-expansion/pull/1676
+* Implemented Beat Up Gen 5+ effect with config. by @BuffelSaft in https://github.com/rh-hideout/pokeemerald-expansion/pull/1676
+* Config for Dark Void being only usable by Darkrai by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2428
+
+### Changed
+* Improved Psycho Cut animation by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2390
+* Multi-hit logic refactor. by @BuffelSaft in https://github.com/rh-hideout/pokeemerald-expansion/pull/1676
+* Ported Gen 5 & 6 mon animations from Inclement Emerald + added most missing Gen 7 form animations by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/1927
+* Restored GF Header. by @tustin2121 in https://github.com/rh-hideout/pokeemerald-expansion/pull/2426
+
+### Fixed
+* Bug where badge boosts apply in all gens except gen 3. by @May8th1995 in https://github.com/rh-hideout/pokeemerald-expansion/pull/2383
+* AI issue giving decrementing score to confuse hit instead of confuse by @May8th1995 in https://github.com/rh-hideout/pokeemerald-expansion/pull/2384
+* Z-Move not being cleared if Pokémon faints by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2389
+* Integrated VBlank wait loop fix by @gruxor in https://github.com/rh-hideout/pokeemerald-expansion/pull/2392
+* Fling only working with items with Fling Power equal to 0. by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2408
+* Softlock when teaching a TM/HM after learning a move by level up. by @kaisermg5 in https://github.com/rh-hideout/pokeemerald-expansion/pull/2413
+* Battle Palace AI bug that caused multiple issues. by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2416
+* Abilities that raise target's stat after hit showing the wrong message. by @BuffelSaft in https://github.com/rh-hideout/pokeemerald-expansion/pull/2427
+* Fixed Bad Dream's ability popup message by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2430
+* Opponent's Teleport ending Trainer Battle if it only has one Pokémon. by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2420
+* Fixed Bug Bite deleting the user's item. by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2433, with cleanup by @eatthepear in https://github.com/rh-hideout/pokeemerald-expansion/pull/2451
+
+### Pret merges
+* Support for Porymap 5.0.0 (up to 9e24fe6ec8f23d042ba2b0fb2dd687ab82989c44 2022-11-08) by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2422
+
+### Cleanup
+* Uncommented evolution moves for each species by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2386
+* Uncommented Hisuian Pokémon level up moves by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2449
+* Removed worthless DEBUG_FLAG_PC_FROM_DEBUG_MENU config by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2423
+* Actually removed ItemId_GetId by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2424
+* Optimized Bad Dreams' code by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2434
+
+## New Contributors
+* @May8th1995 made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/2383
+* @kaisermg5 made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/2413
+* @tustin2121 made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/2426
+* @eatthepear made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/2451
+
+**Full Changelog**: https://github.com/rh-hideout/pokeemerald-expansion/compare/expansion/1.2.0...expansion/1.3.0

--- a/docs/changelogs/1.4.0.md
+++ b/docs/changelogs/1.4.0.md
@@ -1,0 +1,205 @@
+# Version 1.4.0
+
+```md
+## How to update
+- If you haven't set up a remote, run the command `git remote add RHH https://github.com/rh-hideout/pokeemerald-expansion`.
+- Once you have your remote set up, run the command `git pull RHH expansion/1.4.0`.
+```
+
+### Added
+#### General
+* Battle Auto-Tests by @mrgriffin in https://github.com/rh-hideout/pokeemerald-expansion/pull/2564
+    * Details of how they work and how to build them in `test\test_battle.h`.
+    * Add some tests for gen1-3 abilities by @SBird1337 in https://github.com/rh-hideout/pokeemerald-expansion/pull/2626
+* Implemented Xhyzi's RHH copyright intro by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2415
+    * There's a config to disable it, but we encourage keeping it :)
+    * Fixes by @SBird1337 and @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2665, https://github.com/rh-hideout/pokeemerald-expansion/pull/2687 and https://github.com/rh-hideout/pokeemerald-expansion/pull/2684
+* Config to restore Gen 3's damage reduction to multi target moves by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2542
+* Config to disable incense baby mechanic as of Gen 9 by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2531
+* Config for PLA+ obedience mechanics by @Bassoonian in https://github.com/rh-hideout/pokeemerald-expansion/pull/2569
+* Config for ball inheritence when breeding by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2566
+* Config to have Shuckle make Berry Juice from Oran Berries by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2331
+* Support for dynamic number of targets in move animations by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2649
+#### Moves
+* Generation IX Moves
+    * Base move data by @Bassoonian in https://github.com/rh-hideout/pokeemerald-expansion/pull/2467
+    * New moves with existing effects:
+        * Lumina Crash, Jet Punch, Ice Spinner, Triple Dive, Kowtow Cleave, Flower Trick, Torch Song, Aqua Step, Ruination, Pounce, Trailblaze, Chilling Water, Hyper Drill, Twin Beam, Armor Cannon, Bitter Blade, Comeuppance, Aqua Cutter, Blazing Torque, Noxious Torque, Combat Torque, Magical Torque
+    * New move effects:
+        * Wicked Torque (`EFFECT_SLEEP_HIT`)
+        * Double Shock (`EFFECT_DOUBLE_SHOCK`)
+        * Silk Trap (uses `EFFECT_PROTECT` but the condition to check the move in specific) by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2512 and https://github.com/rh-hideout/pokeemerald-expansion/pull/2610
+    * Missing move effects:
+        * Tera Blast, Axe Kick, Last Respects, Order Up, Spicy Extract, Spin Out, Population Bomb, Glaive Rush, Revival Blessing, Salt Cure, Mortal Spin, Doodle, Fillet Away, Raging Bull, Make It Rain, Collision Course, Electro Drift, Shed Tail, Chilly Reception, Tidy Up, Snowscape, Rage Fist, Gigaton Hammer
+* Updated Gen 1-8 move effects to Gen 9 standards: by @Bassoonian in https://github.com/rh-hideout/pokeemerald-expansion/pull/2467
+    * LA moves with existing effects
+        * Psyshield Bash, Raging Fury, Wave Crash, Chloroblast, Mountain Gale, Headlong Rush, Esper Wing, Shelter, Bitter Malice, Power Shift, Springtide Storm, Bleakwind Storm, Wildbolt Storm, Sandsear Storm
+    * LA moves with new move effects
+        * Mystical Power (`EFFECT_SPECIAL_ATTACK_UP_HIT`)
+        * Victory Dance (`EFFECT_VICTORY_DANCE`)
+    * PP adjustments.
+        * (5 -> 10) Bleakwind Storm, Wildbolt Storm, Sandsear Storm
+        * (10 -> 5) Recover, Soft-Boiled, Rest, Milk Drink, Slack Off, Roost, Shore Up
+    * Power adjustments
+        * (50 -> 90) Triple Arrows
+        * (90 -> 120) Raging Fury
+        * (120 -> 150) Wave Crash
+        * (60 -> 80) Dire Claw
+        * (100 -> 120) Headlong Rush
+        * (60 -> 75) Bitter Malice
+        * (75 -> 80) Esper Wing
+        * (95 -> 100) Springtide Storm, Bleakwind Storm, Wildbolt Storm, Sandsear Storm
+        * (80 -> 75) Wicked Blow
+        * (70 -> 60) Grassy Glide
+        * (130 -> 120) Glacial Lance
+* Implementing Teatime effect by @SonikkuA-DatH in https://github.com/rh-hideout/pokeemerald-expansion/pull/1956
+* Config for Gen 4's Roost pure-Flying behavior (`B_ROOST_PURE_FLYING`) by @mrgriffin in https://github.com/rh-hideout/pokeemerald-expansion/pull/2530
+* Config for Gen 8 Howl's effect by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2700
+    * AI check by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2703
+#### Abilities
+* Generation IX Abilities
+    * 28 of 31 abilities implemented by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2470
+        * Lingering Aroma, Seed Sower, Thermal Exchange, Anger Shell, Purifying Salt, Well-Baked Body, Wind Rider, Rocky Payload, Wind Power, Electromorphosis, Protosynthesis, Quark Drive, Good as Gold, Vessel of Ruin, Sword of Ruin, Tablets of Ruin, Beads of Ruin, Orichalcum Pulse, Hadron Engine, Cud Chew, Sharpness, Supreme Overlord, Costar, Toxic Debris, Armor Tail, Earth Eater, Guard Dog and Mycelium Might
+    * Not implemented yet:
+        * Commander
+        * Opportunist
+        * Zero to Hero
+* Implemented Ice Face by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2255
+#### Items
+* Generation IX Item Effects by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2471
+    * Ability Shield, Clear Amulet, Punching Glove, Covert Cloak and Loaded Dice
+    * Gen 9 item data except icons by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2595
+* Added Destiny Knot's breeding functionality by @Jaizu in https://github.com/rh-hideout/pokeemerald-expansion/pull/2616
+* Allow Lv100 Pokémon to access level based evos via Rare Candy by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2460
+
+### Changed
+#### Graphical changes
+* Remove usage of Sugimori Palettes for Pokémon sprites by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2318
+    * ***NOTICE***: These will be tweaked over time, due to the PR not utilizing official palettes. Generation 1 Pokémon have already been fixed by @Jaizu in https://github.com/rh-hideout/pokeemerald-expansion/pull/2593
+#### Refactors
+* Readable BattleScript command arguments by @mrgriffin in https://github.com/rh-hideout/pokeemerald-expansion/pull/2529
+* Add callnative battle script functions, as a way to convert the various macro to proper commands by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2464
+    * Converted Metal Burst damage calculation command by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2464
+* Removed `SPECIES_FLAG_SHINY_LOCKED` in favor of actual flags to control when to generate Shiny/Non-Shiny mon (`P_FLAG_FORCE_SHINY` and `P_FLAG_FORCE_NO_SHINY`) by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2453
+* Optimized Intimidate's code by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2452
+* Cleaned redundant `ENDTURN_PLASMA_FISTS` loop by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2520
+* Refactor sInverseTypeEffectivenessTable to implicit lookup by @SBird1337 in https://github.com/rh-hideout/pokeemerald-expansion/pull/2528
+* Reshape sBattlePointAwards to be easier to read by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2551
+* Adjusted AnimTask_PrimalReversion layout by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2446
+* Rolled `EFFECT_SCALD` into `EFFECT_BURN_HIT` with a config for its Gen6+ change by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2326
+* Refactored incense baby checks into table by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2531
+* Red Card and Eject Button effects check for `EFFECT_HIT_SWITCH_TARGET` instead of Dragon Tail and Circle Throw specifically by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2439
+#### Cleanup
+* Moved config files to their own folder (`include/constants/x_config.h → include/config/x.h`) by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2453
+* Fixed reference in INSTALL.md to pret's repo instead of the expansion's by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2468
+* Reorganized SpecialStatus struct to minimize padding. by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2511
+* Using decimal numbers for constants/battle.h by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2513
+* Updated SIDE constant usages by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2518
+* Removed repeated stat change defines by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2524
+* Cleanup HandleTerrainMove by @mrgriffin in https://github.com/rh-hideout/pokeemerald-expansion/pull/2527
+* Removed unread third `roostTypes` element by @mrgriffin in https://github.com/rh-hideout/pokeemerald-expansion/pull/2530
+* Renamed `CheckFocusPunch_ClearVarsBeforeTurnStarts` to `CheckChosenMoveForEffectsBeforeTurnStarts` because that function doesn't just check for Focus Punch anymore, and it doesn't clear any variables either. by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2544
+* Removed pointless timers from disable struct by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2647
+* Fixed `SpeciesInfo`(`BaseStats`) struct offset labels by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2666
+#### Other
+* Overworld Debug Menu now sets `FLAG_SYS_POKEMON_GET` giving yourself a Pokémon by @Bassoonian in https://github.com/rh-hideout/pokeemerald-expansion/pull/2475
+* Allow exiting the Battle Debug menu pressing B by @Jaizu in https://github.com/rh-hideout/pokeemerald-expansion/pull/2598
+
+### Fixed
+#### Softlocks
+* Fix Beat Up's battle script to avoid an out-of-bounds array access by @sphericalice in https://github.com/rh-hideout/pokeemerald-expansion/pull/2541
+
+#### Graphics
+* Fix Bastiodon's second icon frame by @cynderquil in https://github.com/rh-hideout/pokeemerald-expansion/pull/1589
+* Fixed Eggs sometimes reading garbage graphic data by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2539
+* Fix Transform's interaction with gender differences by @Jaizu in https://github.com/rh-hideout/pokeemerald-expansion/pull/2618
+* Fix buggy Pokémon animations with Illusion by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2639
+* Fixed potential graphical issues when calling `BattleScript_TrainerSlideMsgRet` by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2466
+* Fixed ability popup not showing all characters of Pokémon with full names by @Jaizu in https://github.com/rh-hideout/pokeemerald-expansion/pull/2586
+#### Battle Mechanics
+* General
+    * Fixed potential error in `TryChangeBattleTerrain` by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2469
+    * Fixed Ball throw handling in double wild battles by @walkingeyerobot in https://github.com/rh-hideout/pokeemerald-expansion/pull/2587
+    * Fixed 1v2 battles with eggs by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2658
+* Z-Moves
+    * Fixed Z-Moves being usable if the base move was out of PP by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2418
+    * Fixed switching Z-Moves when pressing SELECT in battle by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/2677
+    * Z-Move Indicator was wrongly displayed in double battles by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/2678
+    * Fixed UI PP colors for Z moves by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/2690
+* Move effects
+    * Fixed Speed Swap's effect by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2517
+    * Fixed Shell Trap being affected by Encore by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2544
+    * Fixed potential bug for moves that use `MOVE_EFFECT_FEINT` by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2516
+    * Fixed Beak Blast potentially not assigning its state to the proper battler by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2544
+    * Fixed Psycho Shift not buffering the string index for its printfromtable call by @TeamAquasHideout in https://github.com/rh-hideout/pokeemerald-expansion/pull/2588
+    * Fixed Flame Burst hitting semi-invulnerable partner by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2601
+    * Fixed Wood Hammer doing 1/4th recoil damage instead of 1/3rd by @TeamAquasHideout in https://github.com/rh-hideout/pokeemerald-expansion/pull/2603
+    * Fixed U-turn not switching out the user if the target's Emergendy Exit activates by @mrgriffin in https://github.com/rh-hideout/pokeemerald-expansion/pull/2605
+    * Fixed Encore not failing if the target hasn't moved yet in that turn by @mrgriffin in https://github.com/rh-hideout/pokeemerald-expansion/pull/2605
+    * Fixed Fling's berry check working backwards by @mrgriffin in https://github.com/rh-hideout/pokeemerald-expansion/pull/2607
+    * Fixed Jaw Lock's effect not leaving upon the user being KO'd by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2681
+    * Fixed Round's power calculation only taking the partner into account by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2602
+    * Fixed subsequent Round users not executing their move directly after the first user by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2602
+    * Fixed Follow Me working in singles by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2644
+    * Fixed Clanging Scales target and effect by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2691
+    * Fixed After You's effect being overritten by Gen 8+'s move action recalculation by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2646
+    * Fixes Heal Block only targeting a single battler by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2649
+    * Fixed Venom Drench not taking target positions into account by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2649
+* Ability effects
+    * Ability Pop-ups
+        * Fixed Insomnia not having an ability pop-up by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2643
+        * Fixed Shields Down Ability pop-up by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2692
+    * Fixed Pokémon with Clear Body-like abilities being immune to self-inflicted stat reductions (ie. Superpower, Shell Smash) by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2548
+    * Fixed Mimicry's implementation by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2473
+    * Fixed Intimidate activating after Explosion when it shouldn't by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2579
+    * Fixed Poison Point activating only if the Pokémon with Poison Point could be poisoned by the attacker by @mrgriffin in https://github.com/rh-hideout/pokeemerald-expansion/pull/2605
+    * Fixed Pastel Veil not granting Poison immunity @mrgriffin in https://github.com/rh-hideout/pokeemerald-expansion/pull/2605
+    * Fix Volt Absorb not activating with Thunder Wave by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2635
+    * Fixed Damp not showing ability pop-up when reacting with Aftermath by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2645
+    * Fixed Mirror Armor's effect against Clear Body by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2680
+    * Fixed Battle Bond activating multiple times in battle by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2689
+    * Fixed Grass-typed Pokémon being affected by powder moves reflected by Magic Bounce by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2633
+* Item effects
+    * Fixed a `HOLD_EFFECT_ZOOM_LENS` check that caused every move's attack to be increased by the hold effect parameter by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2557
+    * Fixed Flame Orb/Toxic Orb/Sticky Barb triggering when the holder is fainted by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2585
+#### Move Animations
+* Fixed Poison Gas animation for `MOVE_TARGET_BOTH` by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2608
+* Fixed Strange Steam's animation by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/2642
+* Fix Spacial Rend animation by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2671
+* Fixed Fiery Wrath's animation by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2649
+* Fixed Electroweb's animation by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2649
+#### Battle AI
+* Fix Helping Hand AI by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2533
+* Rewritten AI entry hazard checks to fix multiple issues by @Sneed69 in https://github.com/rh-hideout/pokeemerald-expansion/pull/2106
+    * Fixed Stealth Rock's AI check ignoring type effectiveness.
+    * Fixed Stealth Rock's AI check assuming that Levitate bypasses it.
+    * Fixed spike AI check that Stealth Rock may overlap.
+    * Fixed spike AI check ignoring the amount of spikes some spike immunities.
+    * Fixed AI not accounting for Stealth Rock and Spikes overlapping.
+* Fixed missic AI logic for Heal Pulse effects in double battles by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/2662
+* Fixes Pollen Puff AI issue #2611 by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/2648
+#### Other
+* Fixed cry table alignment that caused species from `SPECIES_KYUREM_WHITE` onward to play the wrong cries by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2462
+* Fixed right Frontier move tutor not loading their move list correctly. by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2525
+* Fixed reusable repels/lures function forcefully using items while menu config is on by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2561
+* Fixed Exp Candy S using the XS description by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2572
+* Fixed `B_DOUBLE_WILD_CHANCE` becoming 1% less than what's set by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2526
+
+
+### Pret merges
+* Gen 9 when? (Pret sync 2022/11/24) by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2456
+* I'll make your face the greatest in Hoenn! Or else you will DIE. (Pret merge 2022/12/16) by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2519
+* For me, it was tuesday. (pret merge 2023/01/03) by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2559
+* | || || |_ (pret merge 2023/01/20) by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2583
+* I like shorts, they're comfy and easy to wear! (pret merge 2023/01/25) by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2597
+* It's ya boi, pret merge! (pret merge 2023/02/16) by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2697
+
+## New Contributors
+* @cynderquil made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/1589
+* @Bassoonian made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/2467
+* @mrgriffin made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/2527
+* @TeamAquasHideout made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/2588
+* @walkingeyerobot made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/2587
+* @AlexOn1ine made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/2642
+
+**Full Changelog**: https://github.com/rh-hideout/pokeemerald-expansion/compare/expansion/1.3.0...expansion/1.4.0

--- a/docs/changelogs/1.4.1.md
+++ b/docs/changelogs/1.4.1.md
@@ -1,0 +1,12 @@
+# Version 1.4.1
+
+```md
+## How to update
+- If you haven't set up a remote, run the command `git remote add RHH https://github.com/rh-hideout/pokeemerald-expansion`.
+- Once you have your remote set up, run the command `git pull RHH expansion/1.4.1`.
+```
+
+### CRITICAL FIX, please update to avoid the issues detailed down below:
+- Fixed electricity move animations causing softlocks with weird graphical results by @DizzyEggg in #2785
+
+**Full Changelog**: https://github.com/rh-hideout/pokeemerald-expansion/compare/expansion/1.4.0...expansion/1.4.1

--- a/docs/changelogs/1.4.2.md
+++ b/docs/changelogs/1.4.2.md
@@ -1,0 +1,29 @@
+# Version 1.4.2
+
+```md
+## How to update
+- If you haven't set up a remote, run the command `git remote add RHH https://github.com/rh-hideout/pokeemerald-expansion`.
+- Once you have your remote set up, run the command `git pull RHH expansion/1.4.2`.
+```
+
+### Fixed
+#### General
+* Fixed overworld_config.h reference in the overworld debug by @Bassoonian in https://github.com/rh-hideout/pokeemerald-expansion/pull/2811
+#### Battle Mechanics
+* General
+    * Fixed long z-move names not showing properly on the battle textbox by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2789
+* Move effects
+    * Fixes certain moves preventing Z status moves. by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/2791
+    * Fixed Wring Out's power by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2824
+* Ability effects
+    * Fixed wrong Contrary message when affected by Intimidate by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2723
+#### Battle AI
+* Fixed uninitialized modifier variable in AI calc damage by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2731
+* Fixed AI mon getting lower score when it is faster by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/2740
+* Fixed status moves being considered for type effectiveness calculations by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/2743
+* Fixed AI not considering Nature Power in AI_CalcDamage by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/2776
+* Fixed Electrify check, as it workss on all move types, not just Normal by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/2817
+* Fixed score for Work up and Growth by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/2813
+* Fixed speed check on Electrify by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/2819
+
+**Full Changelog**: https://github.com/rh-hideout/pokeemerald-expansion/compare/expansion/1.4.1...expansion/1.4.2

--- a/docs/changelogs/1.4.3.md
+++ b/docs/changelogs/1.4.3.md
@@ -1,0 +1,27 @@
+# Version 1.4.3
+
+```md
+## How to update
+- If you haven't set up a remote, run the command `git remote add RHH https://github.com/rh-hideout/pokeemerald-expansion`.
+- Once you have your remote set up, run the command `git pull RHH expansion/1.4.3`.
+```
+
+### Changed
+#### Cleanup
+* Fixed instances of gSideTimers not using side constants by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2867
+
+### Fixed
+#### General
+* Fixed the Overworld debug menu not giving using the appropiate max item quantities by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2807
+* Fixed the Overworld debug menu map number display not correctly showing 3 digits by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2807
+* Fixed Budew's evolution method by @fdeblasio in https://github.com/rh-hideout/pokeemerald-expansion/pull/2928
+#### Battle Mechanics
+* General
+    * Fixed CanBeConfused not properly checking the battlerId passed into it by @AgustinGDLV in https://github.com/rh-hideout/pokeemerald-expansion/pull/2855
+* Move effects
+    * Fixed Knocked-Off Choice items resetting the choiced move despite the holder having Gorilla Tactics by @CallmeEchoo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2854
+    * Fixes Ominous Wind targeting by @Bassoonian in https://github.com/rh-hideout/pokeemerald-expansion/pull/2896
+* Item effects
+    * Fixed erroneous uses of non e-reader Enigma Berries by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2839
+
+**Full Changelog**: https://github.com/rh-hideout/pokeemerald-expansion/compare/expansion/1.4.2...expansion/1.4.3

--- a/docs/changelogs/1.5.0.md
+++ b/docs/changelogs/1.5.0.md
@@ -1,0 +1,269 @@
+# Version 1.5.0
+
+```md
+## How to update
+- If you haven't set up a remote, run the command `git remote add RHH https://github.com/rh-hideout/pokeemerald-expansion`.
+- Once you have your remote set up, run the command `git pull RHH expansion/1.5.0`.
+```
+
+### Added
+#### General
+* Mega Evolution and Primal Reversion now play the Pokémon's cry in its animation by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2805
+* Added Meltan and Melmetal teachable moves by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2732
+* Added option to clear PC boxes in Debug menu @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2814
+* Added missing Hisuian sprites and cries by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/2725 and https://github.com/rh-hideout/pokeemerald-expansion/pull/2829
+* Implement Customizable NPC Trainer Parties by @SBird1337 in https://github.com/rh-hideout/pokeemerald-expansion/pull/2733.
+    * Further fixes by
+        * @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/2862 and https://github.com/rh-hideout/pokeemerald-expansion/pull/2889
+        * @Jaizu in https://github.com/rh-hideout/pokeemerald-expansion/pull/2890
+    * Nickname, EVs, IVs, moves, species, held item, ability, level, ball, friendship, nature, gender and shininess can all be customized.
+    * ***IMPORTANT***: In a future version, we'll remove vanilla Trainer structs, so make sure to port your custom trainers to this system before then.
+* Overworld Poison configs by @Bassoonian in https://github.com/rh-hideout/pokeemerald-expansion/pull/2884
+    * Gen 3: Health gets depleted every couple of steps and can faint from it.
+    * Gen 4: Health gets depleted every couple of steps, but once it reaches 1 HP it disappears.
+    * Gen 5+: Health does not get depleted at all.
+* Reusable TMs by @Bassoonian in https://github.com/rh-hideout/pokeemerald-expansion/pull/2903 and https://github.com/rh-hideout/pokeemerald-expansion/pull/2930
+    * TMs are automatically counted as reusable when their importance is set to 1.
+    * Added config to toggle vanilla TMs' importance to 1.
+    * Shops will only allow to buy a reusable TM if the player doesn't already have one.
+* Added config for setting the max amount of EVs to Gen6+'s (252) by @citrusbolt in https://github.com/rh-hideout/pokeemerald-expansion/pull/2825
+* Added config for Gen 4's berry EV-stat lowering behavior by @citrusbolt in https://github.com/rh-hideout/pokeemerald-expansion/pull/2825
+* Added new conditions for the trainer slide-in system by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2713
+* Added config for Gen 4's transformed Pokémon using the opponent's palette instead of its own by @Ultimate-Bob in https://github.com/rh-hideout/pokeemerald-expansion/pull/2852
+* Breeding features by @Bassoonian in https://github.com/rh-hideout/pokeemerald-expansion/pull/2963
+    * Father TM Move inheritance (with config).
+    * Mother Egg Move inheritance (with config).
+    * Nature inheritance using an Everstone (with config).
+    * Ability inheritance (with config).
+    * Parent Egg Move transfer (with config).
+    * Power Item IV inheritance.
+* Added Ability Patch's Gen 9 functionality by @fdeblasio in https://github.com/rh-hideout/pokeemerald-expansion/pull/2989
+* Added Gen 4-6 Pokemon back animations by @SonikkuA-DatH in https://github.com/rh-hideout/pokeemerald-expansion/pull/2954
+#### Battle General
+* Support for multi battles where Trainer has only one mon by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2670
+* Added `B_RESTORE_HELD_BATTLE_ITEMS` that restore non-berry single-use items after a battle by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/2932
+* Added Frostbite status by @Bassoonian in https://github.com/rh-hideout/pokeemerald-expansion/pull/2942, with fix by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3019
+* Added Snow Battle Weather by @CallmeEchoo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2970
+* Added `B_DOUBLE_WILD_REQUIRE_2_MONS` config.
+    * Allows to trigger a double wild battle when only having a single Pokémon alive by @pkmnsnfrn in https://github.com/rh-hideout/pokeemerald-expansion/pull/2878
+#### Move Effects
+* Added Healing Wish's Gen 5+/8+ mechanics with config by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2708
+* Added Swallow/Spit Up's Gen 5+ mechanics with config by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2790
+* Added Shell Trap's effect by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2716
+* Added several Gen 9 Move effects:
+    * By @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2834
+        * Psyblade
+        * Hydro Steam
+    * By @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2534
+        * Stone Axe, with fix by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/2969
+        * Ceaseless Edge, with fix by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/2969
+        * Dire Claw
+        * Barb Barrage
+    * By @AgustinGDLV in https://github.com/rh-hideout/pokeemerald-expansion/pull/2883
+        * Revival Blessing, with fix by @AgustinGDLV in https://github.com/rh-hideout/pokeemerald-expansion/pull/3010
+#### Item Effects
+* Trade and Held Level up evolution items and can now be used to evolve the respective species by default like in Legends: Arceus by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/3009
+    * Eg. Magmarizer can be used from the Bag to evolve Magmar into Magmortar.
+    * Item usages can be turned off via config.
+* Added Legends: Arceus Evolution items by @AaghatIsLive in https://github.com/rh-hideout/pokeemerald-expansion/pull/2897
+    * Black Augurite
+    * Peat Block
+    * Linking Cord
+        * Existing no-item trade evolutions can now evolve by using this item from the bag.
+* Added Gen IX item data by @Bassoonian in https://github.com/rh-hideout/pokeemerald-expansion/pull/2838
+    * Mirror Herb
+        * Effect by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2873
+    * Scroll of Darkness
+    * Scroll of Waters
+    * Adamant Crystal
+    * Lustrous Globe
+    * Griseous Core
+    * Big Bamboo Shoot
+    * Tiny Bamboo Shoot
+    * No current effect
+        * Auspicious Armor
+        * Booster Energy
+        * Gimmighoul Coin
+        * Leader's Crest
+        * Malicious Armor
+        * Tera Orb
+        * Tera Shards
+* Max Mushrooms by @AgustinGDLV in https://github.com/rh-hideout/pokeemerald-expansion/pull/2902
+* Berserk Gene by @CallmeEchoo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2893
+#### Battle AI
+* Added `AI_FLAG_OMNISCIENT` flag by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2872
+    * It lets the AI know the entirety of the player's party.
+#### Tests
+* Automatic tests now have a summary to list the amount of tests passed, failed and more by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2722
+* To avoid tests failing when disabling new species, tests now use Gen 1-3 Pokémon when possible. Otherwise, they use ASSUMEs if the required species is disabled by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2818
+* Sped up tests by using structured RNG in `PASSES_RANDOMLY` by @mrgriffin in https://github.com/rh-hideout/pokeemerald-expansion/pull/2720
+    * RandomElement for structured RNG by @mrgriffin in https://github.com/rh-hideout/pokeemerald-expansion/pull/2868, with fix by @AgustinGDLV in https://github.com/rh-hideout/pokeemerald-expansion/pull/3013
+* Detect memory leaks in tests by @mrgriffin in https://github.com/rh-hideout/pokeemerald-expansion/pull/2698
+* Detect more invalid test cases by @mrgriffin in https://github.com/rh-hideout/pokeemerald-expansion/pull/2955
+* Tests now have their own build directory by @mrgriffin https://github.com/rh-hideout/pokeemerald-expansion/pull/3002
+* New `TESTING` define by @mrgriffin https://github.com/rh-hideout/pokeemerald-expansion/pull/3002
+
+### Changed
+#### General
+* Partially fix Dex size inconsistencies by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2799
+* Debug menu's Cheat Start now sets the Cable Club's tutorial as complete. by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2802
+* Debug menu to give items based on the respective max quantity by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2807
+* Debug menu's "Fill PC" option now adds one of each Pokémon instead of filling the boxes with Deoxys @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2814
+    * *Known Issue*: All Pokémon have the same personality/gender/stats/moves as the first Bulbasaur generated.
+    * It sets the Dex flags for each Pokémon as well.
+    * Enables `FLAG_SYS_POKEMON_GET`.
+* Debug menu's saveblock checks now use the proper max size of the saveblock instead of a hardcoded string value by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/3017
+* Disable Gen8+ Obedience Mechanics by default by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2980
+#### Graphical changes
+* Fixed Gen 2 Pokémon sprite palettes up to Ampharos included by @Jaizu in https://github.com/rh-hideout/pokeemerald-expansion/pull/2783
+* New move animations are set as default by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/2964
+#### Refactors
+* Battle Item Refactor by @AgustinGDLV in https://github.com/rh-hideout/pokeemerald-expansion/pull/2902
+    * Divorces in-battle effects from out-of-battle ones, such that they use battle scripts, making it easier to test and add new effects.
+    * Further fixes by
+        * @Jaizu in https://github.com/rh-hideout/pokeemerald-expansion/pull/2918
+        * @CallmeEchoo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2916, https://github.com/rh-hideout/pokeemerald-expansion/pull/2931 and https://github.com/rh-hideout/pokeemerald-expansion/pull/2940
+        * @AgustinGDLV in https://github.com/rh-hideout/pokeemerald-expansion/pull/2915 and https://github.com/rh-hideout/pokeemerald-expansion/pull/3022
+* Refactored most Battle Form changes into the form change tables by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2411
+    * This includes:
+        * Form changes upon fainting
+        * Form changes upon switching
+        * Form changes upon battle end.
+        * Mega Evolutions
+        * Primal Reversions
+        * Zacian/Zamazenta/Xerneas
+        * Burmy
+        * Zen Mode
+        * Power Construct
+        * Schooling
+        * Shields Down
+        * Forecast/Flower Gift, with fixes by @AgustinGDLV in https://github.com/rh-hideout/pokeemerald-expansion/pull/2978
+* Hydra improvements (for Battle Tests)
+    * Prints a summary of how many tests ran/passed.
+    * Makes the pokemerald-test.elf file depend on tools.
+    * Shows SKIP log line when ASSUMPTIONS fail.
+    * Prints any buffered output at exit.
+    * OSX support by @Bassoonian in https://github.com/rh-hideout/pokeemerald-expansion/pull/2975
+* Explosion looping is now handled by moveend instead of looping itself by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2688
+* Removed `zMovePower` field in `gBattleMoves` in favor of a function. by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2794
+* Removed `ITEM_HAS_EFFECT`, allowing for items in of any ID to have effects by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2840
+* Move direct statStage boosts to use statbuffchange by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/3000
+#### Cleanup
+* Removed unused single-frame front pics by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2793
+* Removed duplicated code in `Cmd_pickup` by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2705
+* Removed some unused Battle Test code.
+* Removed unused script `BattleScript_TargetAbilityStatRaiseOnMoveEnd` by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2727
+* Purged existing bKGD warnings from graphics by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2735
+* Use proper symbol name styles for Jangmo-o family by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2739
+* Removed trailing whitespaces by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2787
+* Debug Menu's "Feature unavailable" messages now properly point to the corresponding config file @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2814
+* Removed `assistPossibleMoves` from `BattleStruct` by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2816
+* Fixed instances of gSideTimers not using side constants by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2867
+* Fixed stat names not being properly capitalized by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/2927
+* Adds GetMovesArray in CanTargetFaintAi by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/2936
+* Add Thunder Cage case to trap anim IDs by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2941
+* GetSideParty/GetBattlerParty by @mrgriffin in https://github.com/rh-hideout/pokeemerald-expansion/pull/2910
+* Removed duplicate CanBePoisoned condition by @CallmeEchoo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2988
+* Convert a few various to callnatives by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2465
+* Changed 999999 in DebugAction_Give_MaxMoney to MAX_MONEY constant by @pkmnsnfrn in https://github.com/rh-hideout/pokeemerald-expansion/pull/3015
+* Optimized battle gender checks by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3020
+* Replace launchtemplate and launchtask in battle anims by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2640
+
+### Fixed
+#### General
+* Fixed Honey Gather in Battle Pyramid using an uninitialized `lvlDivBy10` value by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2705
+* Fixed B_FLAG_NO_CATCHING not working despite flag being defined @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2814
+* Fixed Budew evolution method by @fdeblasio in https://github.com/rh-hideout/pokeemerald-expansion/pull/2928
+* Fixed issue with Enamorus Therian cry define order that caused compile issue when Gen 7 and 8 species were disabled by @grunt-lucas in https://github.com/rh-hideout/pokeemerald-expansion/pull/2956
+* Fixed Zacian/Zamazenta's Iron Head PP not being calculated properly by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2411
+* Fixed ability select in Debug Menu's "Give mon" option by @Bassoonian in https://github.com/rh-hideout/pokeemerald-expansion/pull/2999
+* Fixed Esper Wing's accuracy if `B_UPDATED_MOVE_DATA` is set to Gen 9 by @fdeblasio in https://github.com/rh-hideout/pokeemerald-expansion/pull/3004
+* Fixed Hisuian Sneasel not having a way to evolve by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/3009
+* Fixed Throat Spray's description by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3027
+#### Graphics
+* Fixed Debug menu displaying 3-digit map numbers incorrectly by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2807
+* Properly aligned Pokémon icons up to gen V by @Jaizu in https://github.com/rh-hideout/pokeemerald-expansion/pull/2879
+* Fixed multiple Pokémon sprites by @Jaizu in https://github.com/rh-hideout/pokeemerald-expansion/pull/2926
+* Fixed form change animation properly loading the respective Pokémon palettes by @Ultimate-Bob in https://github.com/rh-hideout/pokeemerald-expansion/pull/2852
+* Fixed Illumise's pallete causing issues in PC boxes by @AaghatIsLive in https://github.com/rh-hideout/pokeemerald-expansion/pull/2995
+* Fixed for wrong mon positions for scripted wild double battles by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/2996
+* Fixed shiny animation not respecting Illusion mon target by @Ultimate-Bob in https://github.com/rh-hideout/pokeemerald-expansion/pull/2985
+#### Battle Mechanics
+* General
+    * Fixed Trainer slide-in not working properly on doubles by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2699
+    * Z-moves now properly bypass protection while doing 25% of the original damage by @AgustinGDLV in https://github.com/rh-hideout/pokeemerald-expansion/pull/2730
+    * Fixed Mega Evolution and Primal Reversion healthbox icons not hiding when they're supposed to by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2805, with further fix by @Jaizu in https://github.com/rh-hideout/pokeemerald-expansion/pull/2898
+    * Fixed potential issues with confusion checks by @AgustinGDLV in https://github.com/rh-hideout/pokeemerald-expansion/pull/2855
+    * Fixed an oversight that caused consecutive battles double battles by @SBird1337 in https://github.com/rh-hideout/pokeemerald-expansion/pull/2894
+    * Fixed status Z-Moves overwriting damage-dealing Z-Moves by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/2937
+    * Fixed Battle Vars and Flags not resetting after the player whites out by @pkmnsnfrn in https://github.com/rh-hideout/pokeemerald-expansion/pull/2875
+    * Fixed mons not disobeying with Gen8 mechanics disabled by @SubzeroEclipse in https://github.com/rh-hideout/pokeemerald-expansion/pull/2990
+    * Fixed turn order issues by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2810
+        * Mega Evolution not being based on turn order.
+        * Focus Punch/Beak Blast/Shell Trap messages not being based on turn order.
+    * Fixed Beak Blast's burn not showing up by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2810
+* Move effects
+    * Fixed Dragon Tail not activating Red Card if the target didn't switch by @mrgriffin in https://github.com/rh-hideout/pokeemerald-expansion/pull/2707
+    * Fixed Dragon Tail printing "But it failed!" if the target didn't switch by @mrgriffin in https://github.com/rh-hideout/pokeemerald-expansion/pull/2707
+    * Fixed Roar being not implemented with rejection sampling by @mrgriffin in https://github.com/rh-hideout/pokeemerald-expansion/pull/2707
+    * Fixed Mind Blown always fainting the user by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2688
+    * Fixed Defog showing improper battle strings by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2737
+    * Fixed Knock Off removing Choice Item restriction when the target has Gorilla Tactics as an ability by @CallmeEchoo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2854
+    * Fixed Ominous Wind's targeting by @Bassoonian in https://github.com/rh-hideout/pokeemerald-expansion/pull/2896
+    * Added missing forbidden Metronome move flags to LA and SV moves by @fdeblasio in https://github.com/rh-hideout/pokeemerald-expansion/pull/2949
+    * Fixed Anger Shell activating when fainted by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2945
+    * Fixed Burn Up/Double Shock being affected by the user's ability by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/2962
+    * Fixed Burn Up/Double Shock not removing their respective types if the target fainted by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/2962
+    * Fixed Triple Dive's effect by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/2947
+* Ability effects
+    * Fixed Volt Absorb stopping damage to other Pokémon from Explosion under the effect of Galvanize by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2688
+    * Fixed Intimidate's ability pop up showing the incorrect name by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2712
+    * Fixed switch-in abilities activating on an empty field by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2712
+    * Partially fixed Supreme Overlord's effect by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2809
+    * Fixed Intimidate targetting dead sides and false postpones by @May8th1995 in https://github.com/rh-hideout/pokeemerald-expansion/pull/2850
+    * Fixed switch-in abilities activating on terrain change by @AgustinGDLV in https://github.com/rh-hideout/pokeemerald-expansion/pull/2881
+    * Fixed Leaf Guard not preventing Rest by @ShaeTsuPog in https://github.com/rh-hideout/pokeemerald-expansion/pull/2957
+    * Fixed Plus/Minus working with all damage-dealing moves instead of only pecial moves by @Bassoonian in https://github.com/rh-hideout/pokeemerald-expansion/pull/2974
+    * Fixed Impostor's Popup showing the target's ability instead of Impostor by @Ultimate-Bob in https://github.com/rh-hideout/pokeemerald-expansion/pull/2985
+    * Fixed Illusion's working when it shouldn't if the Pokémon with it is the last one in the party by @Ultimate-Bob in https://github.com/rh-hideout/pokeemerald-expansion/pull/2985
+    * Fixed Mimikyu's Disguise not breaking by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3025
+* Item effects
+    * Fixed Eject Button interaction that forced incoming Pokémon with Intimidate to attack by @May8th1995 in https://github.com/rh-hideout/pokeemerald-expansion/pull/2846
+    * Fixed erroneous uses of non e-reader Enigma Berries by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2839
+#### Battle Animations
+* Fixed potential Ability Popup tile corruption due to missing Word-alignment by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2812
+* Fixed `GetBattleAnimMoveTargets` getting the wrong indices when the attacker is not the player by @ghoulslash in https://github.com/rh-hideout/
+* Fixed Ability Popup not disappearing when called by Wandering Spirit by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/2920pokeemerald-expansion/pull/2848
+* Added missing config to enable NEW_ROCKS_PARTICLE by @pkmnsnfrn in https://github.com/rh-hideout/pokeemerald-expansion/pull/2929
+* Fixed healthboxes reappearing in the Battle Tower by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2849
+* Fixes Speed Boost animation by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3033
+#### Battle AI
+* Fixed AI switching to an invalid party slot from Volt Switch/Roar when using the Ace Pokémon flag by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2660
+* Fixed AI not knowing how to handle Illusion by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2726
+    * Initially treats the initial Illusion species as the real species.
+    * If the type effectiveness doesn't match what it expects, or it uses a move that it cannot learn, the AI realises this and updates its data accordingly.
+* Fixed AI damage calculation incorrectly when it has Protean/Libero by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2714
+* Fix CalcMoveBasePower using battler addresses, which messed with AI calculations by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2858
+* Fixed Comatose AI checks by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2866
+* Fixed AI not considering Hidden Abilities in its team during switching logic by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2908
+* Fixed Z-Move and Triple Kick/Axel damage calculation by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/2983
+
+### Pret merges
+* Kept you waiting, huh? (pret sync 2023/03/03) by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2801
+* Palms are sweaty, arms are heavy, mom's spaghetti (pret merge 2023/03/19) by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2841
+* I get knocked down, but I get up again (pret merge 2023/04/13) by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2907
+* Pret merge Friday by @Bassoonian in https://github.com/rh-hideout/pokeemerald-expansion/pull/2998
+* One point five baby by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3044
+
+## New Contributors
+* @CallmeEchoo made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/2854
+* @pkmnsnfrn made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/2878
+* @AaghatIsLive made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/2897
+* @fdeblasio made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/2928
+* @citrusbolt made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/2825
+* @grunt-lucas made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/2956
+* @Ultimate-Bob made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/2852
+* @ShaeTsuPog made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/2957
+* @SubzeroEclipse made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/2990
+
+**Full Changelog**: https://github.com/rh-hideout/pokeemerald-expansion/compare/expansion/1.4.3...expansion/1.5.0

--- a/docs/changelogs/1.5.1.md
+++ b/docs/changelogs/1.5.1.md
@@ -1,0 +1,71 @@
+# Version 1.5.1
+
+```md
+## How to update
+- If you haven't set up a remote, run the command `git remote add RHH https://github.com/rh-hideout/pokeemerald-expansion`.
+- Once you have your remote set up, run the command `git pull RHH expansion/1.5.1`.
+```
+
+### Changed
+#### General
+* Easy Chat always shows words in uppercase by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3050
+
+### Fixed
+#### General
+* Fixed Hisuian mon not evolving by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3047
+* Fixed regional forms not breeding correctly by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3047
+* Fixed Sylveon's evolution method not requiring Friendship by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3048
+* Fixed being able to sell TMs set as reusable by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3049
+* Fixed shadows in Pokémon sprite viewer when toggling shininess by @gruxor in https://github.com/rh-hideout/pokeemerald-expansion/pull/3094
+#### Softlocks
+* Added safeguard for move animations to not create new sprites in case the maximum has been reached, which would lock the game by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3084
+	* Changed Mega indicator sprites from 3 per battler to 1 per battler by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3087
+* Fixed the debug menu not removing list menu task, causing eventual softlock if used too many times, like when giving items/Pokémon by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3088
+#### Graphics
+* Fixed Ball shortcut graphics moving offsync by @voloved in https://github.com/rh-hideout/pokeemerald-expansion/pull/3042
+#### Battle Mechanics
+* General
+	* Fixed disobedience not resetting move effects, causing the opponent getting stat changes originally for the player by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3089
+	* Fix graphical/exp bugs with 2 vs 1 trainer battles by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3105
+* Item effects
+	* Fixed Clear Amulet showing ability popup and message when nullifying stat reducing effects by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3074
+#### Battle AI
+* Fixed Baton Pass sending an invalid mon when Ace mon is the last one alive by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3067
+* Fixed overflow when AI chooses a new Pokemon to send out by @Pawkkie in https://github.com/rh-hideout/pokeemerald-expansion/pull/3068
+
+### Battle Tests
+#### Added
+* Test Runner support for illegal abilities by @AgustinGDLV in https://github.com/rh-hideout/pokeemerald-expansion/pull/3045
+	* This should ***NOT*** be used for test PRs unless the ability to test isn't available on any Pokémon.
+* Added tests for
+	* Items
+		* Air Balloon by @hetoord in https://github.com/rh-hideout/pokeemerald-expansion/pull/3071
+		* Clear Amulet by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3074
+	* Full ability tests for Scrappy, Own Tempo and Inner Focus by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3074
+	* Intimidate being blocked by Clear Body, Full Metal Body, Hyper Cutter and White Smoke by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3074
+#### Changed
+* Minor test changes by @mrgriffin in https://github.com/rh-hideout/pokeemerald-expansion/pull/3072
+    * Regularizes the whitespace.
+    * Removes unnecessary `;`s after `}`s.
+    * Parametrizes `item_effect_restore_hp.c` and uses `I_HEALTH_RECOVERY` everywhere.
+    * Inlines uses of macros where I think it makes the test easier to follow.
+    * Use 3-arg `PASSES_RANDOMLY` in the Snow + Blizzard test (improves performance).
+    * More conservative `unlink` error reporting. Ctrl-C in `make check` should not complain about being unable to unlink ROMs which weren't created yet.
+    * Better names for the ROMs in `/tmp`.
+    * Prints the test runner number in Hydra, making it easier to track down bugs involving state leaking from a test to the following tests.
+    * Simplify `TO_DO_BATTLE_TEST`'s implementation.
+    * Introduce a `TearDownBattle` function which was repeated twice.
+#### Fixed
+* Marks test as invalid if there's more than one PASSES_RANDOMLY in a single test by @mrgriffin in https://github.com/rh-hideout/pokeemerald-expansion/pull/3065
+* Fixed non-battle tests omitting errors when failing by @mrgriffin and @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3076
+* Fixed non-battle tests showing false positive memory leak errors due to the test failing for a different cause by @mrgriffin and @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3076
+* Fixed "Pastel Veil immediately cures Mold Breaker poison" test by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3074
+
+## Latest pret commit:
+https://github.com/pret/pokeemerald/commit/9c4a59f865360b7d6e0dede0e52812b897526588
+
+## New Contributors
+* @Pawkkie made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/3068
+* @voloved made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/3042
+
+**Full Changelog**: https://github.com/rh-hideout/pokeemerald-expansion/compare/expansion/1.5.0...expansion/1.5.1

--- a/docs/changelogs/1.5.2.md
+++ b/docs/changelogs/1.5.2.md
@@ -1,0 +1,96 @@
+# Version 1.5.2
+
+```md
+## How to update
+- If you haven't set up a remote, run the command `git remote add RHH https://github.com/rh-hideout/pokeemerald-expansion`.
+- Once you have your remote set up, run the command `git pull RHH expansion/1.5.2`.
+```
+
+## Changed
+### General
+* Added config for Gem boost multiplier by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3144
+### Refactors
+* Revamped GetTotalAccuracy by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/3182
+
+## Fixed
+### Softlocks
+* Fixed Z-Moves softlocking when their Z-Move effect failed to apply, by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3108
+### Graphics
+* Fixed ability pop-up not properly clearing the previous text, by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3107
+* Fixed wrong color in stat move animation by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3161
+* Fixed copyright screen not showing up on certain emulators by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/2664
+### Battle Mechanics
+* General
+    * Primal Reversion
+        * Fixed it not activating when switching in after a fainting by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3141
+        * Fixed it not activating when switching in after Eject Button by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3141
+    * Fixed enemy parties not reverting to their original form post-battle by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3150
+    * Fixed OTGender not being set in `FillPartnerParty`, by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3163
+    * Fixed missing use of `CustomTrainerPartyAssignMoves` in `FillPartnerParty`, by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3163
+    * Fixed trainer slide messages appearing for frontier trainers, by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3162
+    * Fixed `jumpifsideaffecting` potentially returning the wrong side by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/3200
+    * Fixed Trainer class balls not being assigned past the first Pokémon by @SubzeroEclipse in https://github.com/rh-hideout/pokeemerald-expansion/pull/3203
+* Move effects
+    * Fixed Multi-Hit moves only hitting once and powder moves affecting Grass types when called via Metronome or Mirror Move, by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3135
+    * Fixed Teleport ending trainer battles, by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3166
+* Ability effects
+    * Fixed multiple issues with Bad Dreams' ability pop-up, by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3131
+        * Fixed it activating even if there were no sleeping opponents.
+        * Fixed lag issue that caused it to not hide smoothly.
+        * Fixed it staying on screen if it fainted a target.
+    * Fixed Protosynthesis and Quark Drive boost amounts by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3139
+    * Fixed multiple issues with Primal Weather abilities by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3138
+        * Fixed printing "move missed" message for cancelled moves.
+        * Fixed 'move failed because of weather' printing twice if it were going to hit multiple targets (eg. Surf).
+        * Fixed 'move failed because of weather' printing if the mon was confused/paralyzed/asleep.
+        * Fixed 'move failed because of weather' printing when failing multiple times in a row.
+    * Fixed Sticky Web/Mirror Armor's interaction, by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3160
+* Item effects
+    * Fixed Gem boost only applying to the first hit of a Multi-Hit move by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3144
+    * Fixed Utility Umbrella damage calculations by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2835
+    * Fixed Ruin ability damage modifiers, by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3171
+### Battle AI
+* Fixed Rollout's and Fury Cutter's AI power calculation by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3110
+* Fixed how AI categorizes weak moves by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3109
+* AI now gives priority to moves that always hit if the opponent's evasion increases or the AI's accuracy is reduced by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3109
+
+## Pret merges:
+* 23-07-25 by @mrgriffin in https://github.com/rh-hideout/pokeemerald-expansion/pull/3176
+    * Remove unused macro to fix syntax highlights https://github.com/pret/pokeemerald/pull/1899
+    * Update msys2 instructions https://github.com/pret/pokeemerald/8ec0bff0342413ac4996b63382c8d03a3b532899
+    * Fix priortiy typos https://github.com/pret/pokeemerald/pull/1900
+    * Declarations for 2- and 3-argument GetMonData https://github.com/pret/pokeemerald/pull/1756
+    * Detect potential misalignment in modern https://github.com/pret/pokeemerald/pull/1901
+
+## Test Runner
+### Changed
+* Failed tests are now listed in the total, by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3073
+* Hydra now respects -jN by @mrgriffin in https://github.com/rh-hideout/pokeemerald-expansion/pull/3132
+* Test runner test runner crashes are now detected by @mrgriffin in https://github.com/rh-hideout/pokeemerald-expansion/pull/3129
+* Random functions that exclude elements based on conditions. Used by Metronome, multi-hit moves, and Loaded Dice by @mrgriffin in https://github.com/rh-hideout/pokeemerald-expansion/pull/3159
+### Fixed
+* Fixed fixedPopup not being cleared while gTestRunnerHeadless is active, which caused some tests to fail on CI but not locally by @mrgriffin in https://github.com/rh-hideout/pokeemerald-expansion/pull/3133
+### Tests added for:
+* General
+    * Primal Reversion, by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3141
+    * Rain weather, by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2835
+    * Sun weather, by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2835
+* Ability Effects
+    * Bad Dreams, by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3131
+    * Tablets of Ruin by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3171
+    * Swords of Ruin by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3171
+    * Vessel of Ruin by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3171
+    * Beads of Ruin by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3171
+    * Primordial Sea by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3138
+    * Desolate Land by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3138
+    * Mirror Armor by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3160
+* Move Effects
+    * Metronome, by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3135
+    * Mirror move, by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3135
+    * Hydro Steam, by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2835
+    * Sticky web by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3160
+    * Court Change by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3160
+* Item Effects
+    * Utility Umbrella, by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2835
+    
+**Full Changelog**: https://github.com/rh-hideout/pokeemerald-expansion/compare/expansion/1.5.1...expansion/1.5.2

--- a/docs/changelogs/1.5.3.md
+++ b/docs/changelogs/1.5.3.md
@@ -1,0 +1,36 @@
+# Version 1.5.3
+
+```md
+## How to update
+- If you haven't set up a remote, run the command `git remote add RHH https://github.com/rh-hideout/pokeemerald-expansion`.
+- Once you have your remote set up, run the command `git pull RHH expansion/1.5.3`.
+```
+
+## CRITICAL FIX, please update to avoid the issues detailed down below:
+- Fixed memory corruption when handling trigger sprites by @SBird1337 in https://github.com/rh-hideout/pokeemerald-expansion/pull/3238
+	- This had the posibility of manifesting in weird ways, like camera and music changes, NPC duplication and more. If you've had this issue in the past, we ***heavily*** recommend you update to this version of the expansion.
+	- Thank you @Bassoonian for helping us pinpointing the issue. 
+	
+![image](https://github.com/rh-hideout/pokeemerald-expansion/assets/2904965/26b9b984-c5db-4dac-85f7-5fc4e95a32ce) ![image](https://github.com/rh-hideout/pokeemerald-expansion/assets/2904965/d490eb30-ce54-4b90-bb2e-79c2e9bb50ac)
+
+
+
+## Fixed
+### Battle Mechanics
+* General
+	* Fixed wild double battles with an in-game partner using `multi_fixed_wild`, by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3210
+	* Corrected conditionals used for `B_SPEED_BUFFING_RAPID_SPIN` and `I_GEM_BOOST_POWER` by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/3232
+	* Fixed being unable to use a Z-Move when a previous mon in the player's team Mega Evolved, by @kittenchilly in https://github.com/rh-hideout/pokeemerald-expansion/pull/3233
+* Move effects
+	* Fixed Jump Kick's recoil happening before Spiky Shield's damage by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3208
+
+## Test Runner
+### Changed
+* Organized tests into subfolders by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2822
+### Fixed
+* Fixed certain tests failing when Inverse Battle battle flag was defined, by @mrgriffin in https://github.com/rh-hideout/pokeemerald-expansion/pull/3215
+
+## New Contributors
+* @kittenchilly made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/3233
+
+**Full Changelog**: https://github.com/rh-hideout/pokeemerald-expansion/compare/expansion/1.5.2...expansion/1.5.3

--- a/docs/changelogs/1.6.0.md
+++ b/docs/changelogs/1.6.0.md
@@ -1,0 +1,294 @@
+# Version 1.6.0
+
+```md
+## How to update
+- If you haven't set up a remote, run the command `git remote add RHH https://github.com/rh-hideout/pokeemerald-expansion`.
+- Once you have your remote set up, run the command `git pull RHH expansion/1.6.0`.
+```
+
+## Added
+### General
+* ***Ported TheXaman's latest changes to the Debug Menu*** by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2815
+    * Arrows and ellipsis to mark submenus.
+    * Added 9th scrolling option to occupy the whole screen height.
+    * Combine Flags and Vars into one submenu.
+        * Moved Running Shoes flag to this menu.
+        * Added new window to flags/vars showing the current state and added submenu indicator.
+        * Colored toggle options for specific flags that change upon toggling.
+        * Added option to reset Pokédex flags to whatever is in the party and boxes.
+    * New "Fill PC/Item Pocket" submenu for filling both PC and Bag Pockets.
+        * Option to generate Box Mon with their own personalities/IVs.
+    * Moved "CHEAT Start" option to the Utility Submenu"
+    * Fixes:
+        * By @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3223
+        * By @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3317
+* ***Allow Cycling Through Balls in the Last Ball Used Menu*** by @voloved in https://github.com/rh-hideout/pokeemerald-expansion/pull/3039
+    * Tweaks by @voloved in https://github.com/rh-hideout/pokeemerald-expansion/pull/3254
+* ***Implemented Ultra Burst*** by @kittenchilly in https://github.com/rh-hideout/pokeemerald-expansion/pull/3221
+* Config for LGPE friendship stat boost by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2257
+* Added a debug menu option to hatch eggs by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/3155
+* Option to run an AI vs AI battle by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3216
+    * With fixes by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3283
+* Added missing Evolution data by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3287
+    * Crabrawler can now evolve into Crabominable with an Ice Stone as of SV.
+    * Nosepass can now evolve into Probopass with a Thunder Stone as of LA.
+* Added Sliggoo's overworld fog evolution method by @kittenchilly in https://github.com/rh-hideout/pokeemerald-expansion/pull/3343
+* Overworld snow weather now summons Snow or Hail based on a config by @kittenchilly in https://github.com/rh-hideout/pokeemerald-expansion/pull/3241
+* Added unevolved Exp. multiplier by @kittenchilly in https://github.com/rh-hideout/pokeemerald-expansion/pull/3301
+* Added config to support placing Pokémon in the PC when pressing the B button by @Bassoonian in https://github.com/rh-hideout/pokeemerald-expansion/pull/3329
+* Added array shuffle implementation by @mrgriffin in https://github.com/rh-hideout/pokeemerald-expansion/pull/3097
+    * Fixes/improvements by @mrgriffin in https://github.com/rh-hideout/pokeemerald-expansion/pull/3128
+### Item Effects
+* ***Added Generation 6 Exp. Share*** by @pkmnsnfrn in https://github.com/rh-hideout/pokeemerald-expansion/pull/3276
+    * Cleanup
+        * By @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/3291
+        * By @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3339
+* Added Exp. Charm by @kittenchilly in https://github.com/rh-hideout/pokeemerald-expansion/pull/3301
+* Added Gen 4+'s Enigma Berry's hold effect by @kittenchilly in https://github.com/rh-hideout/pokeemerald-expansion/pull/3300
+* Added config for type-boosting held item power by @kittenchilly in https://github.com/rh-hideout/pokeemerald-expansion/pull/3326
+### Move Effects
+* By @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2870
+    * Triple Arrows
+    * Infernal Parade
+    * Lunar Blessing
+    * Take Heart
+    * Axe Kick
+* By @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3147
+    * Spin Out
+    * Make It Rain
+    * Collision Course/Electro Drift
+* By @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3178
+    * Mortal Spin
+    * Population Bomb
+* By @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3297
+    * Gigaton Hammer
+    * Salt Cure
+### Move Animations
+* By @Skeli789 and @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2861
+    * Spirit Break
+    * False Surrender
+    * Isle of Armor Moves
+        * Grassy Glide fix by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3092
+    * Crown Tundra Moves
+    * Legends: Arceus Moves
+* By @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3310
+    * Bitter Blade
+    * Double Shock by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3310
+### Graphics
+* ***Added all remaining gender differences sprites*** by @SubzeroEclipse and @CyanSMP64 in:
+    * https://github.com/rh-hideout/pokeemerald-expansion/pull/3070
+    * https://github.com/rh-hideout/pokeemerald-expansion/pull/3082
+    * https://github.com/rh-hideout/pokeemerald-expansion/pull/3095
+    * https://github.com/rh-hideout/pokeemerald-expansion/pull/3122
+    * https://github.com/rh-hideout/pokeemerald-expansion/pull/3149
+* Add new Substitute doll sprites by @kittenchilly in https://github.com/rh-hideout/pokeemerald-expansion/pull/3263
+* Added icon for Clear Amulet by @PacFire in https://github.com/rh-hideout/pokeemerald-expansion/pull/3078
+    * Palette fixes by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3086
+* Tera Shard icons by @AlexOn1ine @PacFire in https://github.com/rh-hideout/pokeemerald-expansion/pull/3307
+* A selection of mon animation frames by @Tacobell24 and @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3090
+    * Applin, Stufful, Chewtle, Rookidee, Rolycoly, Grubbin, Turtonator, Wimpod, Jangmo-O, Pyukumuku, Dewpider, Pincurchin, Sizzlipede, Salandit families and Alolan Exeggutor.
+* Multiple Graphical Tweaks by @SonikkuA-DatH in https://github.com/rh-hideout/pokeemerald-expansion/pull/3127
+    * Added 2nd frames to Castform, Spinda (with help by @shinydragonhunter) and Cherrim.
+    * Added Castform's Pokémon HOME shiny palettes.
+    * Adjusted Spheal's 2nd frame and restored vanilla Emerald's speen.
+
+## Changed
+### General
+* Set GEN_LATEST to GEN_9 by default by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3186
+* Make -fanalyzer optional by @SBird1337 in https://github.com/rh-hideout/pokeemerald-expansion/pull/3265
+* Updated Big Nugget's Fling power to Gen 8+ by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3296
+### Graphical changes
+* ***Adjusted Pokemon sprites and palettes - Part 1*** by @CyanSMP64 in https://github.com/rh-hideout/pokeemerald-expansion/pull/3235
+    * 0001 Bulbasaur to 0080 Slowbro
+### Refactors
+* Inlined fixed Point Math by @SBird1337 in https://github.com/rh-hideout/pokeemerald-expansion/pull/3115
+    * Refactors battle damage modifier calculations to use the new functions in order to improve readability and performance.
+    * Fixes by @SBird1337 in https://github.com/rh-hideout/pokeemerald-expansion/pull/3125
+* ***Refactored damage formula to match Gen5+*** by @SBird1337 in https://github.com/rh-hideout/pokeemerald-expansion/pull/3196
+    * Gamefreak often times rounds down on n.5 in their fixed point mathematics.
+    * Fixed point arithmetic (multiplication) is not associative, this changes the order of operations to match the original games.
+    * A lot of the damage calculation function was quite messy, some aspects were factored in at the wrong place.
+    * The main damage calculation should now be clearer to read.
+* ***Removed Vanilla trainer structs, converted trainer data to use the custom struct*** by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3114
+* ***Removed the sTMHMMoves array and made TMs/HMs read moves from their secondaryId item field*** by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/3243
+* ***Converted move flags and bans into GCC bitfields*** by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2952
+    * Fixes by by @PCG06 in https://github.com/rh-hideout/pokeemerald-expansion/pull/3229
+    * Added bitfields for moves that fail with Me First and Gravity.
+    * Inverted certain logic and flags, since there are more moves that are affected by them than not.
+        * Protect
+        * Mirror Move
+        * King's Rock
+    * Assist uses Copycat's flag + the 2 additional move effects banned by it.
+        * `EFFECT_SEMI_INVULNERABLE`
+        * `EFFECT_SKY_DROP`
+    * Made a separate config for move flag changes: `B_UPDATED_MOVE_FLAGS`.
+    * Adds `IS_MOVE_RECOIL` to help recoil move checks.
+    * Adds functions to account for the `flags` field being removed alongside `TestMoveFlags` and `TestMoveFlagsInMoveset`.
+    * Adds `sParentalBondBannedEffects` to streamline adding new moves.
+    * Unified multi-strike move flags by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3126
+* Some `gActiveBattler` fixes by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/3259
+* ***Got rid of the `gActiveBattler` variable by @DizzyEggg*** in https://github.com/rh-hideout/pokeemerald-expansion/pull/3262
+* Scale Shot now uses Multi-hit Moves' canceller  by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3290
+* Callnative functions now take ScriptContext arguments to allow using macros with .byte fields similar to vanilla battle script functions by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/3294
+* Converted some `VARIOUS`s to `callnative`s by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3269
+* Refactored battle terrain text string tables and removed `EFFECT_REMOVE_TERRAIN` by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/3247
+### Move animations
+* New Wood Hammer animation by @SBird1337 in https://github.com/rh-hideout/pokeemerald-expansion/pull/3192
+### Battle AI
+* Added AI delay timer by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3302
+* Fixed `AI_WhoStrikesFirst` considering status priority moves when it shouldn't by @Joggel19 in https://github.com/rh-hideout/pokeemerald-expansion/pull/3064
+* Fixed Beat Up Gen5+ AI damage calculation by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/3104
+* Improved AI switching, so it doesn't get killed on switch-in by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3146
+* Added missing absorbing abilities to `FindMonThatAbsorbsOpponentsMove` by @Pawkkie in https://github.com/rh-hideout/pokeemerald-expansion/pull/3218
+* Prevent certain status moves when item is known + Fake Out changes by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3219
+* Improve AI switching with bad moves by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3213
+* Fixed `CanTargetFaintAi` index issue by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3306
+* Transform updates `AI_PARTY` data by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/3295
+* Greatly reduce AI lag by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3308
+
+### Cleanup
+* ***Changed a lot of variables to `u32` in order to speed up processes and AI***
+* ***Simplify/Clean battle controllers code*** by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3202
+* ***Cleaned up remaining Castform hack code*** by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3063
+* ***Cleaned experience gain logic*** by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3339
+* Removed debug item effect override by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3106
+* By @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2952
+    * Removes unused `BattleScript_EffectStomp` and `EFFECT_FLINCH_MINIMIZE_HIT`.
+    * Removes unused `BattleScript_FlinchEffect`
+    * Removes reduntant `EFFECT_TWISTER` which was a copy of `EFFECT_FLINCH_HIT`.
+    * Fixes missing uses of `MOVE_UNAVAILABLE` in `battle_ai_util.c`.
+    * Removed `sMovesNotAffectedByStench` in favor of checking for moves with Flinch chance.
+    * Added `EFFECT_GEOMANCY` to `IsTwoTurnsMove`.
+* Animation script cleanup and fixes by @AsparagusEduardo in:
+    * https://github.com/rh-hideout/pokeemerald-expansion/pull/3185
+    * https://github.com/rh-hideout/pokeemerald-expansion/pull/3193
+* Reverted BattleMove power to u8 by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3187
+* Optimize sprite.c by @mrgriffin in https://github.com/rh-hideout/pokeemerald-expansion/pull/3175
+* Removed unused itemId field by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3293
+* Removed unused `EFFECT_UNUSED_125` by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3290
+* Removed redundant side macros/funcs by @gruxor and @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3299
+    * `GET_BATTLER_SIDE` (replaced by `GetBattlerSide`)
+    * `GET_BATTLER_SIDE2` (replaced by `GetBattlerSide`)
+    * `GetBattlerPosition` (replaced by direct call to `gBattlerPositions`)
+* Added missing return in `IsBattlerGrounded` by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3328
+* `GetBattlerHoldEffect` usage optimizations by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3330
+
+## Fixed
+### Softlocks
+* ***Disabled species now default their graphics to `SPECIES_NONE`, preventing softlocks when trying to load graphical data for disabled species*** by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3116
+* ***Fixed debug menu memory overflow when reducing `PC_ITEMS_COUNT` to a value below 19*** by @Bassoonian in https://github.com/rh-hideout/pokeemerald-expansion/pull/3154
+* ***Fixed Ice Spinner logic causing a softlock*** by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/3247
+* ***Fixed "Daycare Egg" debug option generating invalid eggs when parents in the Daycare aren't compatible or are missing*** by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3335
+### General
+* ***Fixed female Basculegion missing from the cry table*** by @Bassoonian in https://github.com/rh-hideout/pokeemerald-expansion/pull/3242
+* Fixed preproc config for Diamond Storm by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/3052
+* Fixed null dereferencing errors with -fanalyzer on modern by @gruxor in https://github.com/rh-hideout/pokeemerald-expansion/pull/3165
+* Fixed "Fill PC" debug option giving all mon Bulbasaur's moves by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2815
+* Fixed some Hisuian Pokémon abilities to Gen 9 data by @AaghatIsLive in https://github.com/rh-hideout/pokeemerald-expansion/pull/3292
+### Graphics
+* ***Killed the bKGD invalid index warnings and fixed the bit depth of the species sprites*** by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/3051
+    * Tweaks by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3205
+* Fixed item sprites with palette errors by @gruxor in https://github.com/rh-hideout/pokeemerald-expansion/pull/3222
+* Fixed Mega Venusaur icon to match regular Venusaur by @SubzeroEclipse in https://github.com/rh-hideout/pokeemerald-expansion/pull/3137
+* Fixed Wailord icon sprite by @SubzeroEclipse in https://github.com/rh-hideout/pokeemerald-expansion/pull/3183
+* Fixed overworld snow weather by @kittenchilly in https://github.com/rh-hideout/pokeemerald-expansion/pull/3241
+### Battle Mechanics
+* General
+    * By @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/2952
+        * Fixed Stench/King's Rock interaction.
+        * Fixed Wandering Spirit skipping contact checks.
+    * Reset all battler IDs at battle start by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/3111
+    * Fixed GetBattleAnimMoveTargets logic by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/3278
+    * Fixed Magnet Rise animation moving the partner in double battles by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3280
+    * Fixed Status Z-Moves' effect descriptions being cut off by @gabrielcowley in https://github.com/rh-hideout/pokeemerald-expansion/pull/3286
+    * By @kittenchilly in https://github.com/rh-hideout/pokeemerald-expansion/pull/3301
+        * Fixed traded Pokémon experience boost being applied twice.
+        * Fixed experience calculation inaccuracies.
+* Move effects
+    * Fixed `ABILITYEFFECT_ON_TERRAIN` setting `gBattlerAbility` incorrectly by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2796
+    * Fixed `TryChangeBattleTerrain` overwriting `gBattlerAttacker` by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2796
+    * Fixed Teatime skipping non-player Pokémon by @hetoord in https://github.com/rh-hideout/pokeemerald-expansion/pull/3096
+    * Fixed Pursuit commands check its move ID instead of its effect ID by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/3231
+    * Fixed Fling issues by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3191
+        * No longer consumes the item if user is fast asleep or paralyzed.
+        * When the user has no item, the "But it failed!" message no longer overwrites other messages like "X was fully paralyzed"
+        * Maranga and Kee Berries have their effects when being flung.
+    * Fixed Leppa Berry not recovering PP when being eaten by Bug Bite by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3282
+    * Fixed Seed Sower in Double Battles by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/2796
+    * Fixed Seed Sower changing move targets when triggered in double battles by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3341
+    * Fixed Protect issues by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3321
+        * Recoil moves no longer cause recoil damage if the target protected
+        * Fixed Multi-hit moves being able to hit a protected target past the first hit.
+        * Fixed Multi-hit moves decreasing speed on each hit when the target uses Silk Trap.
+* Ability effects
+    * Fixed potential bug with weather and terrain ABILITYEFFECT ids by @ghoulslash in https://github.com/rh-hideout/pokeemerald-expansion/pull/3083
+    * Fixed Battle bond not triggering when KOing an ally by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3279
+    * Fixed Toxic Debris issues that other effects to not trigger by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3306
+    * Fixed Toxic Debris not being able to set up 2 layers of Toxic Spikes by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3306
+    * Fixed Toxic Debris not triggering when user faints by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3323
+* Item effects
+    * Fixed Metronome's damage multiplier by @SBird1337 in https://github.com/rh-hideout/pokeemerald-expansion/pull/3246
+
+## Test Runner
+### General
+* Fixed tests breaking on modern by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3319
+### Tests added for:
+* Move Effects
+    * By @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/2870
+        * Axe Kick
+        * Infernal Parade
+        * Take Heart
+        * Triple Arrows
+    * Teatime by @hetoord in https://github.com/rh-hideout/pokeemerald-expansion/pull/3096
+    * By @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3147
+        * Spin Out
+        * Make It Rain
+        * Collision Course/Electro Drift
+    * By @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3178
+        * Mortal Spin
+        * Population Bomb
+    * Fling by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3191
+        * Leppa Berry interaction by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3282
+    * Bug Bite by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3282
+    * Multi-hit moves by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3290
+    * Protect by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3321
+        * Fixed Protect tests failing on `upcoming` by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3348
+* Item Effects
+    * Metronome by @SBird1337 in https://github.com/rh-hideout/pokeemerald-expansion/pull/3246
+    * Status-curing berries by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3289
+    * Gen 4+ Enigma Berry by @kittenchilly in https://github.com/rh-hideout/pokeemerald-expansion/pull/3300
+        * Fling/Bug Bite interaction by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3311
+* Ability Effects
+    * Battle bond by @DizzyEggg in https://github.com/rh-hideout/pokeemerald-expansion/pull/3279
+    * Toxic Debris by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3306
+        * Additional test by @AlexOn1ine in https://github.com/rh-hideout/pokeemerald-expansion/pull/3323
+
+## Pret merges:
+* Pret merge (2023/08/31) by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3268
+    * VAR_TEMP aliases
+    * ***TM and HM item constants by their move name without numbers***.
+    * Stat change documentation.
+    * Factory Menu + Dome Tourney documentation.
+    * Berry Fix Documentation.
+    * Missing uses of `DISPLAY_WIDTH` and `DISPLAY_HEIGHT`.
+    * Static assertion for Battle Palace Flags.
+    * Static assertion for Rotating Gates.
+    * Automatic increase of `TEXT_BUFF_ARRAY_COUNT` and `POKEMON_NAME_BUFFER_SIZE`.
+    * Proper `bravoTrainerTower` documentation.
+    * Birth Island Rock documentation.
+    * 6 new bugfixes.
+* Pret merge (2023/09/26) by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3347
+    * Add include guards for assembly constants files
+    * Add `blockBoxRS` field to `BoxPokemon` struct
+    * Bugfix for abilities affecting wild encounter tables
+        * Fixes a potential buffer overread in `TryGetAbilityInfluencedWildMonIndex`. The bug can occur if an electric type mon is in the first slots of a fishing encounter table and the player carries a mon with the `ABILITY_STATIC` ability. This never happens in the vanilla codebase.
+    * Add missing constant usage in `m4a_1`
+
+## New Contributors
+* @Joggel19 made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/3064
+* @PacFire made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/3078
+* @CyanSMP64 made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/3149
+* @PCG06 made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/3229
+* @gabrielcowley made their first contribution in https://github.com/rh-hideout/pokeemerald-expansion/pull/3286
+
+**Full Changelog**: https://github.com/rh-hideout/pokeemerald-expansion/compare/expansion/1.5.3...expansion/1.6.0

--- a/docs/changelogs/1.6.1.md
+++ b/docs/changelogs/1.6.1.md
@@ -1,0 +1,13 @@
+# Version 1.6.1
+
+```md
+## How to update
+- If you haven't set up a remote, run the command `git remote add RHH https://github.com/rh-hideout/pokeemerald-expansion`.
+- Once you have your remote set up, run the command `git pull RHH expansion/1.6.1`.
+```
+
+## CRITICAL FIX, please update to avoid the issues detailed down below:
+* Fixed deleting PC mon by placing another one on top with B by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3360
+  ![mGBA_xpFJ41LXqX](https://github.com/rh-hideout/pokeemerald-expansion/assets/2904965/8cac220a-ec9d-484e-b7ff-2ba5b5bd2d77)
+
+**Full Changelog**: https://github.com/rh-hideout/pokeemerald-expansion/compare/expansion/1.6.0...expansion/1.6.1

--- a/docs/changelogs/1.7.0.md
+++ b/docs/changelogs/1.7.0.md
@@ -143,12 +143,31 @@
 * Added `P_UPDATED_FRIENDSHIP` config that updates Pokémon base friendship to Gen 8+ standards by @kittenchilly in https://github.com/rh-hideout/pokeemerald-expansion/pull/3491
 ### Changed
 * ***Species Simplifier™*** (Parts [1](https://github.com/rh-hideout/pokeemerald-expansion/pull/3544), [2](https://github.com/rh-hideout/pokeemerald-expansion/pull/3546) and [3](https://github.com/rh-hideout/pokeemerald-expansion/pull/3562))
-    * **Moved most data to `gSpeciesInfo`**
-        * Species names
-        * Cries
-            * Refactored Cry tables to simplify the process of adding new cries. Now there's a single entry in the table per cry, and species are asigned cry IDs in `gSpeciesInfo`.
+    * **Moved most data from multiple arrays to new fields in `gSpeciesInfo`**
+        * `gSpeciesNames` array -> `speciesName` field.
+        * `gLevelUpLearnsets` array -> `levelUpLearnset` field.
+        * `gTeachableLearnsets` array -> `teachableLearnset` field.
+        * `gEvolutionTable` array -> `evolutions` field.
+            * Fix by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/3696
+        * `gFormSpeciesIdTables` array -> `formSpeciesIdTable` field.
+        * `gFormChangeTablePointers` array -> `formChangeTable` field.
+        * Refactored Cry tables to simplify the process of adding new cries.
+            * Now there's a single entry in the table per cry, and species are asigned cry IDs in `gSpeciesInfo`'s `cryId` field.
         * Graphical data now have their pointers in `gSpeciesInfo` (Sprites, palettes and animations)
             * Removed all files in `src/data/pokemon_graphics/` with the exception of `front_pic_anims.h`.
+                * `gMonBackPicCoords` array -> `backPicSize` field.
+                * `gMonBackPicTable` array -> `backPic` field.
+                    * `gMonBackPicTableFemale` array -> `backPicFemale` field.
+                * `gMonFrontPicCoords` array -> `frontPicSize` field.
+                * `gMonFrontPicTable` array -> `frontPic` field.
+                    * `gMonFrontPicTableFemale` array -> `frontPicFemale` field.
+                * `gMonPaletteTableFemale` array -> `palette` field.
+                    * `gMonPaletteTableFemale` array -> `paletteFemale` field.
+                * `gMonShinyPaletteTable` array -> `shinyPalette` field.
+                    * `gMonShinyPaletteTableFemale` array -> `shinyPaletteFemale` field.
+                * `gEnemyMonElevation` array -> `enemyMonElevation` field.
+                * `gMonIconPaletteIndices` array -> `iconPalIndex` field.
+                    * `gMonIconPaletteIndicesFemale` array -> `iconPalIndexFemale` field.
             * Removed unused 2nd animations.
         * Dex Entries
             * Individual form information is visible in the HGSS Pokédex (Vanilla Dex TBD)
@@ -157,10 +176,6 @@
                 * Pokédex size page proportions are also separate.
             * Pokédex descriptions are now saved as compound strings in `gSpeciesInfo` and differ by form. Shared entries are at the top of `src/data/pokemon/species_info.h`.
                 * Missing Pokédex texts for forms by @Bassoonian in https://github.com/rh-hideout/pokeemerald-expansion/pull/3708
-        * Level Up and Teachable learnset pointers are now stored in `gSpeciesInfo`.
-        * Evolutions are now stored as compound literals in `gSpeciesInfo`.
-            * Fix by @LOuroboros in https://github.com/rh-hideout/pokeemerald-expansion/pull/3696
-        * Form tables pointers are now stored in `gSpeciesInfo`.
     * **Added toggles to disable specific family groups of species**
         * Located in `include/config/species_enabled.h`.
             * Moved the original `P_GEN_x_POKEMON` configs to this file.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added all missing changelogs from pre-1.6.2 versions.
Also updated 1.7.0's changelog to better specify what tables were converted to what fields in `gSpeciesInfo`

## Feature(s) this PR does NOT handle:
Besides 1.7.0's changelog, I only updated the header to use the current instructions for pulling new versions.
If anyone wants to reorganize the changelogs to use the current categories, be my guest xD (though make sure to also update the GitHub releases pages.

## **Discord contact info**
AsparagusEduardo
