### PR TITLE
Fixed unintended Pokédex form behavior

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -4554,7 +4554,7 @@ u16 NationalPokedexNumToSpecies(u16 nationalNum)
     if (species == NUM_SPECIES)
         return NATIONAL_DEX_NONE;
 
-    return species;
+    return GET_BASE_SPECIES_ID(species);
 }
 
 u16 NationalToHoennOrder(u16 nationalNum)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When implemented form tables were implemented, I had assumed that by changing the order of the forms in them (and therefore the "base form"), it would've been reflected in the Pokédex.
However, that was not the case, instead it was returning the first species that had the specific National Dex number (which was always the base form). This PR fixes that, so that you can do this to set the default species shown in the Pokédex:
```diff
static const u16 sRattataFormSpeciesIdTable[] = {
-   SPECIES_RATTATA,
    SPECIES_RATTATA_ALOLAN,
+   SPECIES_RATTATA,
    FORM_SPECIES_END,
};
```

## Images
![image](https://github.com/rh-hideout/pokeemerald-expansion/assets/2904965/19541012-46a9-446a-8d1d-271b91ef82b5)

## **People who collaborated with me in this PR**
Spirits Undead on Discord for letting me know about the issue.

## Feature(s) this PR does NOT handle:
I don't currently have thought on what to do about cases like Giratina, where `HOLD_EFFECT_GRISEOUS_ORB` checks for `SPECIES_GIRATINA` which is defined as `#define SPECIES_GIRATINA SPECIES_GIRATINA_ALTERED`.

## **Discord contact info**
AsparagusEduardo
