### PR TITLE
Fixed Egg's summary screen softlock

### DIFF
--- a/gflib/string_util.c
+++ b/gflib/string_util.c
@@ -823,7 +823,7 @@ void ConvertInternationalString(u8 *s, u8 language)
 
         i--;
 
-        while (i != (u8)-1)
+        while (i != -1)
         {
             s[i + 2] = s[i];
             i--;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A loop in `ConvertInternationalString` after an intentional underflow by GF caused it to loop until the end of time. This affected Pokémon with Japanese language and Eggs, which have their language set to Japanese until they hatch.

## Issue(s) that this PR fixes
Fixes #4300 

## **People who collaborated with me in this PR**
@DizzyEggg, who recommended to remove the casting entirely instead of upgrading it to `u32`.

## **Discord contact info**
AsparagusEduardo
