### PR TITLE
Fix Receiving Zero Exp When Below Level Cap

### DIFF
--- a/src/level_caps.c
+++ b/src/level_caps.c
@@ -70,6 +70,8 @@ u32 GetSoftLevelCapExpValue(u32 level, u32 expValue)
        return expValue;
     }
     else
+    {
         return 0;
+    }
 
 }

--- a/src/level_caps.c
+++ b/src/level_caps.c
@@ -65,6 +65,10 @@ u32 GetSoftLevelCapExpValue(u32 level, u32 expValue)
         else
             return expValue / sExpScalingDown[levelDifference];
     }
+    else if (level < currentLevelCap)
+    {
+       return expValue;
+    }
     else
         return 0;
 


### PR DESCRIPTION
## Description
This fixes the logic in `GetSoftLevelCapExpValue()` so that it properly calculates the exp you should receive when you are below the level cap. Previously it would always calculate to zero if you:
- Had a soft or hard level cap configured
- And were below the level cap 
- And left `B_LEVEL_CAP_EXP_UP = FALSE`

## Issue(s) that this PR fixes
- Receving zero exp when below the level cap when a level cap is configured with `B_LEVEL_CAP_EXP_UP = FALSE`

## **Discord contact info**
ravepossum
