### PR TITLE
Fix style of some bit definitions

### DIFF
--- a/include/data.h
+++ b/include/data.h
@@ -65,13 +65,13 @@ struct TrainerMon
     u8 lvl;
     u8 ball;
     u8 friendship;
-    u8 nature : 5;
-    bool8 gender : 2;
-    bool8 isShiny : 1;
-    u8 dynamaxLevel : 4;
-    bool8 gigantamaxFactor : 1;
-    bool8 shouldDynamax : 1;
-    bool8 shouldTerastal : 1;
+    u8 nature:5;
+    bool8 gender:2;
+    bool8 isShiny:1;
+    u8 dynamaxLevel:4;
+    bool8 gigantamaxFactor:1;
+    bool8 shouldDynamax:1;
+    bool8 shouldTerastal:1;
 };
 
 #define TRAINER_PARTY(partyArray) partyArray, .partySize = ARRAY_COUNT(partyArray)

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -389,9 +389,9 @@ struct SpeciesInfo /*0x8C*/
  /* 0x38 */ u16 trainerScale;
  /* 0x3A */ u16 trainerOffset;
  /* 0x3C */ const u8 *description;
- /* 0x40 */ u8 bodyColor : 7;
+ /* 0x40 */ u8 bodyColor:7;
             // Graphical Data
-            u8 noFlip : 1;
+            u8 noFlip:1;
  /* 0x41 */ u8 frontAnimDelay;
  /* 0x42 */ u8 frontAnimId;
  /* 0x43 */ u8 backAnimId;


### PR DESCRIPTION
A few structs surrounded used `field : bits;` rather than `field:bits;`. This PR brings them in line with the rest of the repo

## **Discord contact info**
bassoonian
