### PR TITLE
Updated Knock Off

### DIFF
--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -118,6 +118,7 @@
 #define B_IMPRISON                  GEN_LATEST // In Gen5+, Imprison doesn't fail if opposing pokemon don't have any moves the user knows.
 #define B_ALLY_SWITCH_FAIL_CHANCE   GEN_LATEST // In Gen9, using Ally Switch consecutively decreases the chance of success for each consecutive use.
 #define B_SKETCH_BANS               GEN_LATEST // In Gen9+, Sketch is unable to copy more moves than in previous generations.
+#define B_KNOCK_OFF_REMOVAL         GEN_LATEST // In Gen5+, Knock Off removes the foe's item instead of rendering it unusable.
 
 // Ability settings
 #define B_EXPANDED_ABILITY_NAMES    TRUE       // If TRUE, ability names are increased from 12 characters to 16 characters.

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -5341,8 +5341,18 @@ static bool32 TryKnockOffBattleScript(u32 battlerDef)
             gBattleMons[battlerDef].item = 0;
             if (gBattleMons[battlerDef].ability != ABILITY_GORILLA_TACTICS)
                 gBattleStruct->choicedMove[battlerDef] = 0;
-            gWishFutureKnock.knockedOffMons[side] |= gBitTable[gBattlerPartyIndexes[battlerDef]];
             CheckSetUnburden(battlerDef);
+
+            // In Gen 5+, Knock Off removes the target's item rather than rendering it unusable.
+            if (B_KNOCK_OFF_REMOVAL >= GEN_5)
+            {
+                BtlController_EmitSetMonData(battlerDef, BUFFER_A, REQUEST_HELDITEM_BATTLE, 0, sizeof(gBattleMons[battlerDef].item), &gBattleMons[battlerDef].item);
+                MarkBattlerForControllerExec(battlerDef);
+            }
+            else
+            {
+                gWishFutureKnock.knockedOffMons[side] |= gBitTable[gBattlerPartyIndexes[battlerDef]];
+            }
 
             BattleScriptPushCursor();
             gBattlescriptCurrInstr = BattleScript_KnockedOff;

--- a/test/battle/move_effect/knock_off.c
+++ b/test/battle/move_effect/knock_off.c
@@ -21,6 +21,8 @@ SINGLE_BATTLE_TEST("Knock Off knocks a healing berry before it has the chance to
         }
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ITEM_KNOCKOFF);
         MESSAGE("Wobbuffet knocked off Foe Wobbuffet's Sitrus Berry!");
+    } THEN {
+        opponent->item == ITEM_NONE;
     }
 }
 
@@ -49,6 +51,8 @@ SINGLE_BATTLE_TEST("Knock Off activates after Rocky Helmet and Weakness Policy")
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ITEM_KNOCKOFF);
             MESSAGE("Wobbuffet knocked off Foe Wobbuffet's Rocky Helmet!");
         }
+    } THEN {
+        opponent->item == ITEM_NONE;
     }
 }
 
@@ -74,6 +78,8 @@ SINGLE_BATTLE_TEST("Knock Off deals additional damage to opponents holding an it
             EXPECT_MUL_EQ(results[0].damage, UQ_4_12(1.5), results[1].damage);
         else
             EXPECT_EQ(results[0].damage, results[1].damage);
+    } THEN {
+        opponent->item == ITEM_NONE;
     }
 }
 
@@ -89,6 +95,8 @@ SINGLE_BATTLE_TEST("Knock Off does not remove items through Substitute")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_KNOCK_OFF, player);
         NOT { ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ITEM_KNOCKOFF); }
+    } THEN {
+        opponent->item == ITEM_LEFTOVERS;
     }
 }
 
@@ -107,6 +115,8 @@ SINGLE_BATTLE_TEST("Recycle cannot recover an item removed by Knock Off")
         
         MESSAGE("Foe Wobbuffet used Recycle!");
         MESSAGE("But it failed!");
+    } THEN {
+        opponent->item == ITEM_NONE;
     }
 }
 
@@ -132,6 +142,11 @@ SINGLE_BATTLE_TEST("Knock Off does not prevent targets from receiving another it
             NOT { ANIMATION(ANIM_TYPE_MOVE, MOVE_BESTOW, player); }
             MESSAGE("But it failed!");
         }
+    } THEN {
+        if (B_KNOCK_OFF_REMOVAL >= GEN_5)
+            opponent->item == ITEM_LEFTOVERS;
+        else
+            opponent->item == ITEM_NONE;
     }
 }
 
@@ -152,6 +167,8 @@ SINGLE_BATTLE_TEST("Knock Off triggers Unburden")
         // turn 2
         MESSAGE("Foe Wobbuffet used Celebrate!");
         MESSAGE("Wobbuffet used Celebrate!");
+    } THEN {
+        opponent->item == ITEM_NONE;
     }
 }
 
@@ -172,5 +189,7 @@ DOUBLE_BATTLE_TEST("Knock Off does not trigger the opposing ally's Symbiosis")
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT);
             MESSAGE("Wobbuffet's Leftovers restored health!");
         }
+    } THEN {
+        playerLeft->item == ITEM_NONE;
     }
 }

--- a/test/battle/move_effect/knock_off.c
+++ b/test/battle/move_effect/knock_off.c
@@ -22,7 +22,7 @@ SINGLE_BATTLE_TEST("Knock Off knocks a healing berry before it has the chance to
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ITEM_KNOCKOFF);
         MESSAGE("Wobbuffet knocked off Foe Wobbuffet's Sitrus Berry!");
     } THEN {
-        opponent->item == ITEM_NONE;
+        EXPECT(opponent->item == ITEM_NONE);
     }
 }
 
@@ -52,7 +52,7 @@ SINGLE_BATTLE_TEST("Knock Off activates after Rocky Helmet and Weakness Policy")
             MESSAGE("Wobbuffet knocked off Foe Wobbuffet's Rocky Helmet!");
         }
     } THEN {
-        opponent->item == ITEM_NONE;
+        EXPECT(opponent->item == ITEM_NONE);
     }
 }
 
@@ -79,7 +79,7 @@ SINGLE_BATTLE_TEST("Knock Off deals additional damage to opponents holding an it
         else
             EXPECT_EQ(results[0].damage, results[1].damage);
     } THEN {
-        opponent->item == ITEM_NONE;
+        EXPECT(opponent->item == ITEM_NONE);
     }
 }
 
@@ -96,7 +96,7 @@ SINGLE_BATTLE_TEST("Knock Off does not remove items through Substitute")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_KNOCK_OFF, player);
         NOT { ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ITEM_KNOCKOFF); }
     } THEN {
-        opponent->item == ITEM_LEFTOVERS;
+        EXPECT(opponent->item == ITEM_NONE);
     }
 }
 
@@ -116,7 +116,7 @@ SINGLE_BATTLE_TEST("Recycle cannot recover an item removed by Knock Off")
         MESSAGE("Foe Wobbuffet used Recycle!");
         MESSAGE("But it failed!");
     } THEN {
-        opponent->item == ITEM_NONE;
+        EXPECT(opponent->item == ITEM_NONE);
     }
 }
 
@@ -144,9 +144,9 @@ SINGLE_BATTLE_TEST("Knock Off does not prevent targets from receiving another it
         }
     } THEN {
         if (B_KNOCK_OFF_REMOVAL >= GEN_5)
-            opponent->item == ITEM_LEFTOVERS;
+            EXPECT(opponent->item == ITEM_LEFTOVERS);
         else
-            opponent->item == ITEM_NONE;
+            EXPECT(opponent->item == ITEM_NONE);
     }
 }
 
@@ -168,7 +168,7 @@ SINGLE_BATTLE_TEST("Knock Off triggers Unburden")
         MESSAGE("Foe Wobbuffet used Celebrate!");
         MESSAGE("Wobbuffet used Celebrate!");
     } THEN {
-        opponent->item == ITEM_NONE;
+        EXPECT(opponent->item == ITEM_NONE);
     }
 }
 
@@ -190,6 +190,6 @@ DOUBLE_BATTLE_TEST("Knock Off does not trigger the opposing ally's Symbiosis")
             MESSAGE("Wobbuffet's Leftovers restored health!");
         }
     } THEN {
-        playerLeft->item == ITEM_NONE;
+        EXPECT(playerLeft->item == ITEM_NONE);
     }
 }

--- a/test/battle/move_effect/knock_off.c
+++ b/test/battle/move_effect/knock_off.c
@@ -51,3 +51,125 @@ SINGLE_BATTLE_TEST("Knock Off activates after Rocky Helmet and Weakness Policy")
         }
     }
 }
+
+SINGLE_BATTLE_TEST("Knock Off deals additional damage to opponents holding an item in Gen 6+", s16 damage)
+{
+    u16 item;
+    PARAMETRIZE { item = ITEM_NONE; }
+    PARAMETRIZE { item = ITEM_LEFTOVERS; }
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { Item(item); };
+    } WHEN {
+        TURN { MOVE(player, MOVE_KNOCK_OFF); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_KNOCK_OFF, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+        if (item != ITEM_NONE)
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ITEM_KNOCKOFF);
+    } FINALLY {
+        if (B_KNOCK_OFF_DMG >= GEN_6)
+            EXPECT_MUL_EQ(results[0].damage, UQ_4_12(1.5), results[1].damage);
+        else
+            EXPECT_EQ(results[0].damage, results[1].damage);
+    }
+}
+
+
+SINGLE_BATTLE_TEST("Knock Off does not remove items through Substitute")
+{
+    u16 item;
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_LEFTOVERS); };
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SUBSTITUTE); 
+               MOVE(player, MOVE_KNOCK_OFF); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_KNOCK_OFF, player);
+        NOT { ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ITEM_KNOCKOFF); }
+    }
+}
+
+SINGLE_BATTLE_TEST("Recycle cannot recover an item removed by Knock Off")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_LEFTOVERS); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_KNOCK_OFF);
+               MOVE(opponent, MOVE_RECYCLE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_KNOCK_OFF, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ITEM_KNOCKOFF);
+        MESSAGE("Wobbuffet knocked off Foe Wobbuffet's Leftovers!");
+        
+        MESSAGE("Foe Wobbuffet used Recycle!");
+        MESSAGE("But it failed!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Knock Off does not prevent targets from receiving another item in Gen 5+")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_LEFTOVERS); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_LEFTOVERS); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_KNOCK_OFF); }
+        TURN { MOVE(player, MOVE_BESTOW); }
+    } SCENE {
+        // turn 1
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_KNOCK_OFF, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ITEM_KNOCKOFF);
+        MESSAGE("Wobbuffet knocked off Foe Wobbuffet's Leftovers!");
+        // turn 2
+        if (B_KNOCK_OFF_REMOVAL >= GEN_5) {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_BESTOW, player);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT);
+            MESSAGE("Foe Wobbuffet's Leftovers restored its HP a little!");
+        } else {
+            NOT { ANIMATION(ANIM_TYPE_MOVE, MOVE_BESTOW, player); }
+            MESSAGE("But it failed!");
+        }
+    }
+}
+
+// Knock Off triggers Unburden regardless of whether the item is fully removed (Gen 5+) or not.
+SINGLE_BATTLE_TEST("Knock Off triggers Unburden")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Speed(60); }
+        OPPONENT(SPECIES_WOBBUFFET) { Ability(ABILITY_UNBURDEN); Item(ITEM_LEFTOVERS); Speed(50); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_KNOCK_OFF); }
+        TURN { MOVE(player, MOVE_CELEBRATE); }
+    } SCENE {
+        // turn 1
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_KNOCK_OFF, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ITEM_KNOCKOFF);
+        MESSAGE("Wobbuffet knocked off Foe Wobbuffet's Leftovers!");
+        // turn 2
+        MESSAGE("Foe Wobbuffet used Celebrate!");
+        MESSAGE("Wobbuffet used Celebrate!");
+    }
+}
+
+DOUBLE_BATTLE_TEST("Knock Off does not trigger the opposing ally's Symbiosis")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_LEFTOVERS); }
+        PLAYER(SPECIES_FLORGES) { Item(ITEM_LEFTOVERS); }
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponentLeft, MOVE_KNOCK_OFF, target: playerLeft); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_KNOCK_OFF, opponentLeft);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ITEM_KNOCKOFF);
+        MESSAGE("Foe Wobbuffet knocked off Wobbuffet's Leftovers!");
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT);
+            MESSAGE("Wobbuffet's Leftovers restored health!");
+        }
+    }
+}

--- a/test/battle/move_effect/knock_off.c
+++ b/test/battle/move_effect/knock_off.c
@@ -54,9 +54,11 @@ SINGLE_BATTLE_TEST("Knock Off activates after Rocky Helmet and Weakness Policy")
 
 SINGLE_BATTLE_TEST("Knock Off deals additional damage to opponents holding an item in Gen 6+", s16 damage)
 {
-    u16 item;
+    u16 item = 0;
+
     PARAMETRIZE { item = ITEM_NONE; }
     PARAMETRIZE { item = ITEM_LEFTOVERS; }
+
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET) { Item(item); };
@@ -78,7 +80,6 @@ SINGLE_BATTLE_TEST("Knock Off deals additional damage to opponents holding an it
 
 SINGLE_BATTLE_TEST("Knock Off does not remove items through Substitute")
 {
-    u16 item;
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_LEFTOVERS); };


### PR DESCRIPTION
## Description
In Gen 5+, Knock Off removes the item from the target altogether, as opposed to making it unusable. This updated behavior allows for Knocked Off targets to gain another item later in the battle. Otherwise, it is almost entirely aesthetic as other edge cases seem unaffected: Unburden seems to trigger from Knock Off in Gen 4 and Symbiosis never triggers after Knock Off.

This PR adds more tests for Knock Off's basic interactions, this updated behavior, and some other small edge cases.

## Images
**Gen 3 and 4:**
https://github.com/rh-hideout/pokeemerald-expansion/assets/103095241/02afedb3-6c3a-4694-ac75-9ad16b905769

**Gen 5+:**
https://github.com/rh-hideout/pokeemerald-expansion/assets/103095241/787e48ae-305b-4efe-a380-83ece229565e

## Issue(s) that this PR fixes
Fixes #1903 (wow that's old)

## **People who collaborated with me in this PR**
Thanks @AlexOn1ine and @Bassoonian for reminding me to update my old PR.

## **Discord contact info**
agustingdlv
