### PR TITLE
Added B_FAST_EXP_GROW / Updated MoveBattleBar to use a more applicable denominator

### DIFF
--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -206,7 +206,8 @@
 // Interface settings
 #define B_ABILITY_POP_UP            TRUE  // In Gen5+, the Pokémon abilities are displayed in a pop-up, when they activate in battle.
 #define B_FAST_INTRO                TRUE  // If set to TRUE, battle intro texts print at the same time as animation of a Pokémon, as opposing to waiting for the animation to end.
-#define B_FAST_HP_DRAIN             TRUE  // If set to TRUE, HP bars will move faster to accomodate higher max HP amounts.
+#define B_FAST_HP_DRAIN             TRUE  // If set to TRUE, HP bars will move faster.
+#define B_FAST_EXP_GROW             TRUE  // If set to TRUE, EXP bars will move faster.
 #define B_SHOW_TARGETS              TRUE  // If set to TRUE, all available targets, for moves hitting 2 or 3 Pokémon, will be shown before selecting a move.
 #define B_SHOW_CATEGORY_ICON        TRUE  // If set to TRUE, it will show an icon in the summary showing the move's category.
 #define B_HIDE_HEALTHBOX_IN_ANIMS   TRUE  // If set to TRUE, hides healthboxes during move animations.

--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -2615,7 +2615,7 @@ s32 MoveBattleBar(u8 battlerId, u8 healthboxSpriteId, u8 whichBar, u8 unused)
 
     if (whichBar == HEALTH_BAR) // health bar
     {
-        u16 hpFraction = B_FAST_HP_DRAIN == FALSE ? 1 : max(gBattleSpritesDataPtr->battleBars[battlerId].maxValue / B_HEALTHBAR_PIXELS, 1);
+        u16 hpFraction = B_FAST_HP_DRAIN == FALSE ? 1 : max(gBattleSpritesDataPtr->battleBars[battlerId].maxValue / (B_HEALTHBAR_PIXELS / 2), 1);
         currentBarValue = CalcNewBarValue(gBattleSpritesDataPtr->battleBars[battlerId].maxValue,
                     gBattleSpritesDataPtr->battleBars[battlerId].oldValue,
                     gBattleSpritesDataPtr->battleBars[battlerId].receivedValue,
@@ -2838,7 +2838,7 @@ static u8 GetScaledExpFraction(s32 oldValue, s32 receivedValue, s32 maxValue, u8
     s32 newVal, result;
     s8 oldToMax, newToMax;
 
-    scale *= 8;
+    scale *= (B_FAST_EXP_GROW) ? 2 : 8;
     newVal = oldValue - receivedValue;
 
     if (newVal < 0)


### PR DESCRIPTION
## Description

### HP Fix

In `MoveBattlerBar`, when `B_FAST_HP_DRAIN` is enabled, `hpFraction` gets the maximum amount of the relevant mon's HP and divides it by `B_HEALTHBAR_PIXELS`. After some [manual testing](https://docs.google.com/spreadsheets/d/1aIt5ybfxz-9kTux6mF178sr7KT7wHIgKq5am_wg8cNo/edit?usp=sharing) and conversations with @SonikkuA-DatH (who helped with the original implementation, [7ca07527faeb5d8f3c5aae355ecfd33a554acca6](https://github.com/PokemonSanFran/pokeemerald-expansion/commit/7ca07527faeb5d8f3c5aae355ecfd33a554acca6)), I've realized:

* `B_HEALTHBAR_PIXELS` should actually be divided by 2 here to provide a greater benefit to Pokémon of varying HP.
    * The current implementation is slightly _slower_ for Pokémon with less HP, while the newly proposed one benefits all to a greater extent.

### EXP Addition

* Using similar logic to the aforementioned fix, when a developer enables `B_FAST_EXP_GROW`, `GetScaledExpFraction` will calculate `scale` by multiplying by 2 instead of 8.

## Even Faster?

* If `hPFraction` is calculated by divided `maxValue` by 8 instead 32, even greater performance jumps can be gained.
* If `GetScaledExpFraction` calculates `scale` by multiplying by 0 instead of 8, even greater performance jumps can be gained.

In both cases, these changes _extremely_ fast, and do not seem to be inline with Game Freak's overall design philosophy. As such, I have opted for what I believe to be more sane values. 

## Images

| | Proposed | Current Fast | Vanilla Emerald | Even Faster |
|---|---|---|---|---|
|  | ![newHPnewEXP](https://github.com/rh-hideout/pokeemerald-expansion/assets/77138753/49747750-94ca-47cb-b43a-cd19897224d8) | ![exHPexEXP](https://github.com/rh-hideout/pokeemerald-expansion/assets/77138753/12516f63-cd45-48ce-9b13-c9059ff3c8b6) | ![vanillaHPvanillaEXP](https://github.com/rh-hideout/pokeemerald-expansion/assets/77138753/cce564a5-1127-483d-a478-74a2ff440adc) | ![sonic](https://github.com/rh-hideout/pokeemerald-expansion/assets/77138753/cfa655f2-eee0-43c0-930d-3b9398365341) | 

## Testing

```diff
// src/data/trainer_parties.h
static const struct TrainerMon sParty_Rick[] = {
+    {
+    .lvl = 24,
+    .species = SPECIES_BLISSEY,
+    .iv = TRAINER_PARTY_IVS(31, 31, 31, 31, 31, 31),
+    .moves = {MOVE_SPLASH, MOVE_NONE, MOVE_NONE, MOVE_NONE}
+    },
+    /*
    {
    .lvl = 4,
    .species = SPECIES_WURMPLE,
    },
    {
    .lvl = 4,
    .species = SPECIES_WURMPLE,
    },
+    */
};

// data/scripts/debug.inc
Debug_EventScript_Script_1::
+	setflag FLAG_BADGE01_GET
+	setflag FLAG_BADGE02_GET
+	setflag FLAG_BADGE03_GET
+	setflag FLAG_BADGE04_GET
+	setflag FLAG_BADGE05_GET
+	setflag FLAG_BADGE06_GET
+	setflag FLAG_BADGE07_GET
+	setflag FLAG_BADGE08_GET
+    givemon species=SPECIES_MACHAMP,level=30,move1=MOVE_FISSURE,abilityNum=1,isShiny=FALSE
+    trainerbattle_single TRAINER_RICK, Debug_BoxFilledMessage_Text, Debug_BoxFilledMessage_Text
	end

```

1. Enable debug mode in include/config.h.
2. Start a new save file.
3. Open the Debug menu using R + Start.
4. Select Script 1.
5. Once in battle, use Fissure. Observe faster bar movement.

## **People who collaborated with me in this PR**
@SonikkuA-DatH

## **Discord contact info**
I am pkmnsnfrn on Discord. I have not started a discussion thread.