### PR TITLE
feat: check if inside of git repository before building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ MAKEFLAGS += --no-print-directory
 # Secondary expansion is required for dependency variables in object rules.
 .SECONDEXPANSION:
 
-.PHONY: all rom clean compare tidy tools check-tools mostlyclean clean-tools clean-check-tools $(TOOLDIRS) $(CHECKTOOLDIRS) libagbsyscall agbcc modern tidymodern tidynonmodern check
+.PHONY: all rom clean compare tidy tools check-tools mostlyclean clean-tools clean-check-tools $(TOOLDIRS) $(CHECKTOOLDIRS) libagbsyscall agbcc modern tidymodern tidynonmodern check history
 
 infoshell = $(foreach line, $(shell $1 | sed "s/ /__SPACE__/g"), $(info $(subst __SPACE__, ,$(line))))
 
@@ -254,7 +254,10 @@ endif
 
 AUTO_GEN_TARGETS :=
 
-all: rom
+all: history rom
+
+history:
+	@bash ./check_history.sh
 
 tools: $(TOOLDIRS)
 

--- a/check_history.sh
+++ b/check_history.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+if [ -e .histignore ]
+then
+    exit 0
+fi
+
+if [ $GITHUB_ACTION ]
+then
+    exit 0
+fi
+
+has_hist=false
+has_git=1
+if which git >/dev/null
+then
+    has_hist="$(git rev-parse --is-inside-work-tree 2>/dev/null)"
+else
+    has_git=0
+fi
+
+if [ $has_git -ne 1 ]
+then
+    echo -e "\033[0;31mfatal: \033[0m\033[1;33mgit was not found. You will be unable to use version control, update pokemon_expansion, or use feature branches. To use version control, install \`git\` and clone the repository instead of using \"Download Zip\" on GitHub. Run \`touch .histignore\` to ignore this and continue anyways.\033[0m"
+    exit 1
+fi
+
+if [ "$has_hist" ]
+then
+   exit 0
+else
+   echo -e "\033[0;31mfatal: \033[0m\033[1;33mno git history found. You will be unable to use version control, update pokemon_expansion, or use feature branches. To use version control, use \`git\` to clone the repository instead of using \"Download Zip\" on GitHub. Run \`touch .histignore\` to ignore this and continue anyways.\033[0m"
+   exit 1
+fi
+

--- a/check_history.sh
+++ b/check_history.sh
@@ -21,7 +21,7 @@ fi
 
 if [ $has_git -ne 1 ]
 then
-    echo -e "\033[0;31mfatal: \033[0m\033[1;33mgit was not found. You will be unable to use version control, update pokemon_expansion, or use feature branches. To use version control, install \`git\` and clone the repository instead of using \"Download Zip\" on GitHub. Run \`touch .histignore\` to ignore this and continue anyways.\033[0m"
+    echo -e "\033[0;31mfatal: \033[0m\033[1;33mgit was not found. You will be unable to use version control, update pokeemerald-expansion, or use feature branches. To use version control, install \`git\` and clone the repository instead of using \"Download Zip\" on GitHub. Run \`touch .histignore\` to ignore this and continue anyways.\033[0m"
     exit 1
 fi
 
@@ -29,7 +29,7 @@ if [ "$has_hist" ]
 then
    exit 0
 else
-   echo -e "\033[0;31mfatal: \033[0m\033[1;33mno git history found. You will be unable to use version control, update pokemon_expansion, or use feature branches. To use version control, use \`git\` to clone the repository instead of using \"Download Zip\" on GitHub. Run \`touch .histignore\` to ignore this and continue anyways.\033[0m"
+   echo -e "\033[0;31mfatal: \033[0m\033[1;33mno git history found. You will be unable to use version control, update pokeemerald-expansion, or use feature branches. To use version control, use \`git\` to clone the repository instead of using \"Download Zip\" on GitHub. Run \`touch .histignore\` to ignore this and continue anyways.\033[0m"
    exit 1
 fi
 


### PR DESCRIPTION
Requires active confirmation to build the repository without a valid `git` repository or installed `git` software.

## Description
Prints a scary error when someone tries to build without a git repository in order to avoid a potential footgun of not being able to merge release updates or use feature branches.

## Images

![image](https://github.com/rh-hideout/pokeemerald-expansion/assets/3799173/6616828b-533a-4e49-817d-3507cf23772a)


## **People who collaborated with me in this PR**
@SBird1337 

## **Discord contact info**
karathan
