### PR TITLE
Fixed trainerproc skipping numbers when writing species IDs

### DIFF
--- a/tools/trainerproc/main.c
+++ b/tools/trainerproc/main.c
@@ -1528,7 +1528,7 @@ static void fprint_species(FILE *f, const char *prefix, struct String s)
         for (int i = 0; i < s.string_n; i++)
         {
             unsigned char c = s.string[i];
-            if ('A' <= c && c <= 'Z')
+            if (('A' <= c && c <= 'Z') || ('0' <= c && c <= '9'))
             {
                 if (underscore)
                     fputc('_', f);


### PR DESCRIPTION
## Description
Porygon2 was being interpreted as just Porygon, for example.

## Issue(s) that this PR fixes
Fixes #4365 

## **People who collaborated with me in this PR**
Credit to @agsmgmaster64 for finding the issue and to @mrgriffin for the fix itself.

## **Discord contact info**
AsparagusEduardo
