### PR TITLE
[Rebase of #4286] Reordered Debug_EventScript_InflictStatus1 

### DIFF
--- a/data/event_scripts.s
+++ b/data/event_scripts.s
@@ -579,6 +579,7 @@ gStdScripts_End::
 	.include "data/scripts/new_game.inc"
 	.include "data/scripts/hall_of_fame.inc"
 
+	.include "data/scripts/config.inc"
 	.include "data/scripts/debug.inc"
 
 EventScript_WhiteOut::

--- a/data/scripts/config.inc
+++ b/data/scripts/config.inc
@@ -1,0 +1,12 @@
+Debug_FlagsAndVarNotSetBattleConfigMessage::
+	lockall
+	message Debug_FlagsAndVarNotSetBattleConfigMessage_Text
+	waitmessage
+	waitbuttonpress
+	releaseall
+	end
+
+Debug_FlagsAndVarNotSetBattleConfigMessage_Text:
+	.string "Feature unavailable! Please define a\n"
+	.string "usable flag and a usable var in:\l"
+	.string "'include/config/battle.h'!$"

--- a/data/scripts/debug.inc
+++ b/data/scripts/debug.inc
@@ -323,27 +323,6 @@ Debug_EventScript_InflictStatus1_Single:
 	releaseall
 	end
 
-Debug_EventScript_InflictStatus1_Party:
-	dynmultipush Debug_EventScript_InflictStatus1_Text_Poison, 0
-	dynmultipush Debug_EventScript_InflictStatus1_Text_Paralysis, 1
-	dynmultipush Debug_EventScript_InflictStatus1_Text_Sleep, 2
-	dynmultipush Debug_EventScript_InflictStatus1_Text_Burn, 3
-	dynmultipush Debug_EventScript_InflictStatus1_Text_Freeze, 4
-	dynmultipush Debug_EventScript_InflictStatus1_Text_Frostbite, 5
-	dynmultipush Debug_EventScript_InflictStatus1_Text_Close, 6
-	dynmultistack 0, 0, FALSE, 7, FALSE, 0, NULL
-	switch VAR_RESULT
-	case 0, Debug_EventScript_InflictStatus1_Party_Poison
-	case 1, Debug_EventScript_InflictStatus1_Party_Paralysis
-	case 2, Debug_EventScript_InflictStatus1_Party_Sleep
-	case 3, Debug_EventScript_InflictStatus1_Party_Burn
-	case 4, Debug_EventScript_InflictStatus1_Party_Freeze
-	case 5, Debug_EventScript_InflictStatus1_Party_Frostbite
-	case 6, Debug_EventScript_InflictStatus1_Close
-	case MULTI_B_PRESSED, Debug_EventScript_InflictStatus1_Close
-	releaseall
-	end
-
 Debug_EventScript_InflictStatus1_Single_Poison:
 	setstatus1 STATUS1_POISON, VAR_0x8004
 	releaseall
@@ -401,6 +380,27 @@ Debug_EventScript_InflictStatus1_Party_Freeze:
 
 Debug_EventScript_InflictStatus1_Party_Frostbite:
 	setstatus1 STATUS1_FROSTBITE, PARTY_SIZE
+	releaseall
+	end
+
+Debug_EventScript_InflictStatus1_Party:
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Poison, 0
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Paralysis, 1
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Sleep, 2
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Burn, 3
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Freeze, 4
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Frostbite, 5
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Close, 6
+	dynmultistack 0, 0, FALSE, 7, FALSE, 0, NULL
+	switch VAR_RESULT
+	case 0, Debug_EventScript_InflictStatus1_Party_Poison
+	case 1, Debug_EventScript_InflictStatus1_Party_Paralysis
+	case 2, Debug_EventScript_InflictStatus1_Party_Sleep
+	case 3, Debug_EventScript_InflictStatus1_Party_Burn
+	case 4, Debug_EventScript_InflictStatus1_Party_Freeze
+	case 5, Debug_EventScript_InflictStatus1_Party_Frostbite
+	case 6, Debug_EventScript_InflictStatus1_Close
+	case MULTI_B_PRESSED, Debug_EventScript_InflictStatus1_Close
 	releaseall
 	end
 

--- a/data/scripts/debug.inc
+++ b/data/scripts/debug.inc
@@ -353,6 +353,27 @@ Debug_EventScript_InflictStatus1_Single_Frostbite:
 	releaseall
 	end
 
+Debug_EventScript_InflictStatus1_Party:
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Poison, 0
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Paralysis, 1
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Sleep, 2
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Burn, 3
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Freeze, 4
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Frostbite, 5
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Close, 6
+	dynmultistack 0, 0, FALSE, 7, FALSE, 0, NULL
+	switch VAR_RESULT
+	case 0, Debug_EventScript_InflictStatus1_Party_Poison
+	case 1, Debug_EventScript_InflictStatus1_Party_Paralysis
+	case 2, Debug_EventScript_InflictStatus1_Party_Sleep
+	case 3, Debug_EventScript_InflictStatus1_Party_Burn
+	case 4, Debug_EventScript_InflictStatus1_Party_Freeze
+	case 5, Debug_EventScript_InflictStatus1_Party_Frostbite
+	case 6, Debug_EventScript_InflictStatus1_Close
+	case MULTI_B_PRESSED, Debug_EventScript_InflictStatus1_Close
+	releaseall
+	end
+
 Debug_EventScript_InflictStatus1_Party_Poison:
 	setstatus1 STATUS1_POISON, PARTY_SIZE
 	releaseall
@@ -380,27 +401,6 @@ Debug_EventScript_InflictStatus1_Party_Freeze:
 
 Debug_EventScript_InflictStatus1_Party_Frostbite:
 	setstatus1 STATUS1_FROSTBITE, PARTY_SIZE
-	releaseall
-	end
-
-Debug_EventScript_InflictStatus1_Party:
-	dynmultipush Debug_EventScript_InflictStatus1_Text_Poison, 0
-	dynmultipush Debug_EventScript_InflictStatus1_Text_Paralysis, 1
-	dynmultipush Debug_EventScript_InflictStatus1_Text_Sleep, 2
-	dynmultipush Debug_EventScript_InflictStatus1_Text_Burn, 3
-	dynmultipush Debug_EventScript_InflictStatus1_Text_Freeze, 4
-	dynmultipush Debug_EventScript_InflictStatus1_Text_Frostbite, 5
-	dynmultipush Debug_EventScript_InflictStatus1_Text_Close, 6
-	dynmultistack 0, 0, FALSE, 7, FALSE, 0, NULL
-	switch VAR_RESULT
-	case 0, Debug_EventScript_InflictStatus1_Party_Poison
-	case 1, Debug_EventScript_InflictStatus1_Party_Paralysis
-	case 2, Debug_EventScript_InflictStatus1_Party_Sleep
-	case 3, Debug_EventScript_InflictStatus1_Party_Burn
-	case 4, Debug_EventScript_InflictStatus1_Party_Freeze
-	case 5, Debug_EventScript_InflictStatus1_Party_Frostbite
-	case 6, Debug_EventScript_InflictStatus1_Close
-	case MULTI_B_PRESSED, Debug_EventScript_InflictStatus1_Close
 	releaseall
 	end
 

--- a/data/scripts/debug.inc
+++ b/data/scripts/debug.inc
@@ -281,21 +281,6 @@ DebugText_BerryWeedsDisabled:
 	.string "OW_BERRY_WEEDS is disabled.\n"
 	.string "Unable to force weeds onto berry trees.$"
 
-.endif
-
-Debug_FlagsAndVarNotSetBattleConfigMessage::
-	lockall
-	message Debug_FlagsAndVarNotSetBattleConfigMessage_Text
-	waitmessage
-	waitbuttonpress
-	releaseall
-	end
-
-Debug_FlagsAndVarNotSetBattleConfigMessage_Text:
-	.string "Feature unavailable! Please define a\n"
-	.string "usable flag and a usable var in:\l"
-	.string "'include/config/battle.h'!$"
-
 Debug_EventScript_InflictStatus1::
 	lockall
 	getpartysize
@@ -338,6 +323,27 @@ Debug_EventScript_InflictStatus1_Single:
 	releaseall
 	end
 
+Debug_EventScript_InflictStatus1_Party:
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Poison, 0
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Paralysis, 1
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Sleep, 2
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Burn, 3
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Freeze, 4
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Frostbite, 5
+	dynmultipush Debug_EventScript_InflictStatus1_Text_Close, 6
+	dynmultistack 0, 0, FALSE, 7, FALSE, 0, NULL
+	switch VAR_RESULT
+	case 0, Debug_EventScript_InflictStatus1_Party_Poison
+	case 1, Debug_EventScript_InflictStatus1_Party_Paralysis
+	case 2, Debug_EventScript_InflictStatus1_Party_Sleep
+	case 3, Debug_EventScript_InflictStatus1_Party_Burn
+	case 4, Debug_EventScript_InflictStatus1_Party_Freeze
+	case 5, Debug_EventScript_InflictStatus1_Party_Frostbite
+	case 6, Debug_EventScript_InflictStatus1_Close
+	case MULTI_B_PRESSED, Debug_EventScript_InflictStatus1_Close
+	releaseall
+	end
+
 Debug_EventScript_InflictStatus1_Single_Poison:
 	setstatus1 STATUS1_POISON, VAR_0x8004
 	releaseall
@@ -365,27 +371,6 @@ Debug_EventScript_InflictStatus1_Single_Freeze:
 
 Debug_EventScript_InflictStatus1_Single_Frostbite:
 	setstatus1 STATUS1_FROSTBITE, VAR_0x8004
-	releaseall
-	end
-
-Debug_EventScript_InflictStatus1_Party:
-	dynmultipush Debug_EventScript_InflictStatus1_Text_Poison, 0
-	dynmultipush Debug_EventScript_InflictStatus1_Text_Paralysis, 1
-	dynmultipush Debug_EventScript_InflictStatus1_Text_Sleep, 2
-	dynmultipush Debug_EventScript_InflictStatus1_Text_Burn, 3
-	dynmultipush Debug_EventScript_InflictStatus1_Text_Freeze, 4
-	dynmultipush Debug_EventScript_InflictStatus1_Text_Frostbite, 5
-	dynmultipush Debug_EventScript_InflictStatus1_Text_Close, 6
-	dynmultistack 0, 0, FALSE, 7, FALSE, 0, NULL
-	switch VAR_RESULT
-	case 0, Debug_EventScript_InflictStatus1_Party_Poison
-	case 1, Debug_EventScript_InflictStatus1_Party_Paralysis
-	case 2, Debug_EventScript_InflictStatus1_Party_Sleep
-	case 3, Debug_EventScript_InflictStatus1_Party_Burn
-	case 4, Debug_EventScript_InflictStatus1_Party_Freeze
-	case 5, Debug_EventScript_InflictStatus1_Party_Frostbite
-	case 6, Debug_EventScript_InflictStatus1_Close
-	case MULTI_B_PRESSED, Debug_EventScript_InflictStatus1_Close
 	releaseall
 	end
 
@@ -445,3 +430,18 @@ Debug_EventScript_InflictStatus1_Text_Freeze:
 
 Debug_EventScript_InflictStatus1_Text_Frostbite:
 	.string "Frostbite$"
+
+.endif
+
+Debug_FlagsAndVarNotSetBattleConfigMessage::
+	lockall
+	message Debug_FlagsAndVarNotSetBattleConfigMessage_Text
+	waitmessage
+	waitbuttonpress
+	releaseall
+	end
+
+Debug_FlagsAndVarNotSetBattleConfigMessage_Text:
+	.string "Feature unavailable! Please define a\n"
+	.string "usable flag and a usable var in:\l"
+	.string "'include/config/battle.h'!$"

--- a/data/scripts/debug.inc
+++ b/data/scripts/debug.inc
@@ -432,16 +432,3 @@ Debug_EventScript_InflictStatus1_Text_Frostbite:
 	.string "Frostbite$"
 
 .endif
-
-Debug_FlagsAndVarNotSetBattleConfigMessage::
-	lockall
-	message Debug_FlagsAndVarNotSetBattleConfigMessage_Text
-	waitmessage
-	waitbuttonpress
-	releaseall
-	end
-
-Debug_FlagsAndVarNotSetBattleConfigMessage_Text:
-	.string "Feature unavailable! Please define a\n"
-	.string "usable flag and a usable var in:\l"
-	.string "'include/config/battle.h'!$"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Previous Pull Request:
https://github.com/rh-hideout/pokeemerald-expansion/pull/4286

This has been rebased for the master branch, and updated as per feedback

Tested and working on my system

## Description
Reordered Debug_EventScript_InflictStatus1 to within the 'DEBUG_OVERWORLD_MENU == TRUE' .if block, as it relies on 'Debug_NoPokemon' which is not defined outside of it.

## Issue(s) that this PR fixes
[Discord Message](https://discord.com/channels/419213663107416084/1077168246555430962/1219230896075309097)

## **People who collaborated with me in this PR**
[MrGriffin, for suggesting the fix](https://discord.com/channels/419213663107416084/1077168246555430962/1219233509567365140)

AsparagusEduardo, for suggesting the second refractor to remove unused functions in release builds

## **Discord contact info**
sirscrubbington
