### PR TITLE
Fixes givemon moves not defaulting to none

### DIFF
--- a/src/script_pokemon_util.c
+++ b/src/script_pokemon_util.c
@@ -347,7 +347,9 @@ u32 ScriptGiveMonParameterized(u16 species, u8 level, u16 item, u8 ball, u8 natu
     // moves
     for (i = 0; i < MAX_MON_MOVES; i++)
     {
-        if (moves[i] == MOVE_NONE || moves[i] >= MOVES_COUNT)
+        if (moves[0] == MOVE_NONE)
+            break;
+        if (moves[i] >= MOVES_COUNT)
             continue;
         SetMonMoveSlot(&mon, moves[i], i);
     }
@@ -400,7 +402,7 @@ u32 ScriptGiveMonParameterized(u16 species, u8 level, u16 item, u8 ball, u8 natu
     }
 
     // set pokédex flags
-    nationalDexNum = SpeciesToNationalPokedexNum(species); 
+    nationalDexNum = SpeciesToNationalPokedexNum(species);
     switch (sentToPc)
     {
     case MON_GIVEN_TO_PARTY:
@@ -514,7 +516,7 @@ void Script_SetStatus1(struct ScriptContext *ctx)
         }
     }
     else
-    {        
+    {
         SetMonData(&gPlayerParty[slot], MON_DATA_STATUS, &status1);
     }
 }

--- a/test/pokemon.c
+++ b/test/pokemon.c
@@ -193,6 +193,22 @@ TEST("givemon [simple]")
     EXPECT_EQ(GetMonData(&gPlayerParty[0], MON_DATA_LEVEL), 100);
 }
 
+TEST("givemon [moves]")
+{
+    ZeroPlayerPartyMons();
+
+    RUN_OVERWORLD_SCRIPT(
+        givemon SPECIES_WOBBUFFET, 100, move1=MOVE_TACKLE, move2=MOVE_SPLASH, move3=MOVE_NONE, move4=MOVE_NONE;
+    );
+
+    EXPECT_EQ(GetMonData(&gPlayerParty[0], MON_DATA_SPECIES), SPECIES_WOBBUFFET);
+    EXPECT_EQ(GetMonData(&gPlayerParty[0], MON_DATA_LEVEL), 100);
+    EXPECT_EQ(GetMonData(&gPlayerParty[0], MON_DATA_MOVE1), MOVE_TACKLE);
+    EXPECT_EQ(GetMonData(&gPlayerParty[0], MON_DATA_MOVE2), MOVE_SPLASH);
+    EXPECT_EQ(GetMonData(&gPlayerParty[0], MON_DATA_MOVE3), MOVE_NONE);
+    EXPECT_EQ(GetMonData(&gPlayerParty[0], MON_DATA_MOVE4), MOVE_NONE);
+}
+
 TEST("givemon [all]")
 {
     ZeroPlayerPartyMons();


### PR DESCRIPTION
Fixes #4262

With the PR moves are now filled with level up learnsets only if none are given at all. 
![pokeemerald-1](https://github.com/rh-hideout/pokeemerald-expansion/assets/93446519/6b29e87f-3b43-4e25-a6f9-81bb4de82cd9)
