### PR TITLE
Fixed softlock w/ weather-triggered form changes & Cloud Nine

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -10454,7 +10454,8 @@ u16 GetBattleFormChangeTargetSpecies(u32 battler, u16 method)
                         targetSpecies = formChanges[i].targetSpecies;
                     }
                     // Otherwise, just check for a match between the weather and the form change table.
-                    else if (gBattleWeather & formChanges[i].param1
+                    // Added a check for whether the weather is in effect to prevent end-of-turn soft locks with Cloud Nine / Air Lock
+                    else if (((gBattleWeather & formChanges[i].param1) && WEATHER_HAS_EFFECT)
                         || (gBattleWeather == B_WEATHER_NONE && formChanges[i].param1 == B_WEATHER_NONE))
                     {
                         targetSpecies = formChanges[i].targetSpecies;

--- a/test/battle/ability/forecast.c
+++ b/test/battle/ability/forecast.c
@@ -266,7 +266,6 @@ SINGLE_BATTLE_TEST("Forecast transforms Castform back to normal when Sandstorm i
 
 SINGLE_BATTLE_TEST("Forecast transforms Castform back to normal under Air Lock")
 {
-    KNOWN_FAILING;
     GIVEN {
         PLAYER(SPECIES_CASTFORM_NORMAL) { Ability(ABILITY_FORECAST); }
         OPPONENT(SPECIES_WOBBUFFET);


### PR DESCRIPTION
## Description
**Before**: At end-of-turn, if a Pokémon with a weather-triggered form change is on the field, and the weather effects are suppressed by Cloud Nine or Air Lock, an infinite loop ensues in which the Pokémon continually swaps between its weather-specific form and its base form. This may depend on specifically which slots the battlers with weather suppression and form changes occupy. In my case, Cloud Nine Golduck was in slot `B_POSITION_PLAYER_LEFT` and Flower Gift Cherrim was in `B_POSITION_OPPONENT_RIGHT` during a Double Battle.

**After**: A simple check of `WEATHER_HAS_EFFECT` to prevent execution of the change back to the weather-specific form prevents the loop and resolves the issue.

## **Discord contact info**
Skolgrahd#6928
