### PR TITLE
Fix teachable learnsets crashing in some environments

### DIFF
--- a/tools/learnset_helpers/teachable.py
+++ b/tools/learnset_helpers/teachable.py
@@ -5,14 +5,14 @@ import os
 
 # before all else, abort if the config is off
 with open("./include/config/pokemon.h", "r") as file:
-    learnset_config = re.findall("#define P_LEARNSET_HELPER_TEACHABLE *([^ ]*)", file.read())
+    learnset_config = re.findall(r"#define P_LEARNSET_HELPER_TEACHABLE *([^ ]*)", file.read())
     if len(learnset_config) != 1:
         quit()
     if learnset_config[0] != "TRUE":
         quit()
 
 def parse_mon_name(name):
-    return re.sub('(?!^)([A-Z]+)', r'_\1', name).upper()
+    return re.sub(r'(?!^)([A-Z]+)', r'_\1', name).upper()
     
 tm_moves = []
 tutor_moves = []
@@ -28,20 +28,20 @@ for file in incs_to_check:
     with open(file, 'r') as f2:
         raw = f2.read()
     if 'special ChooseMonForMoveTutor' in raw:
-        for x in re.findall('setvar VAR_0x8005, (MOVE_.*)', raw):
+        for x in re.findall(r'setvar VAR_0x8005, (MOVE_.*)', raw):
             if not x in tutor_moves:
                 tutor_moves.append(x)
 
 # scan TMs and HMs
 with open("./include/constants/tms_hms.h", 'r') as file:
-    for x in re.findall('F\((.*)\)', file.read()):
+    for x in re.findall(r'F\((.*)\)', file.read()):
         if not 'MOVE_' + x in tm_moves:
             tm_moves.append('MOVE_' + x)
 
 # look up universal moves to exclude them
 universal_moves = []
 with open("./src/pokemon.c", "r") as file:
-    for x in re.findall("static const u16 sUniversalMoves\[\] =(.|\n)*?{((.|\n)*?)};", file.read())[0]:
+    for x in re.findall(r"static const u16 sUniversalMoves\[\] =(.|\n)*?{((.|\n)*?)};", file.read())[0]:
         x = x.replace("\n", "")
         for y in x.split(","):
             y = y.strip()
@@ -79,7 +79,7 @@ def construct_compatibility_dict(force_custom_check):
         raw = file.read()
         if not "// DO NOT MODIFY THIS FILE!" in raw and force_custom_check == True:
             custom_teachable_compatibilities = {}
-            for entry in re.findall("static const u16 s(.*)TeachableLearnset\[\] = {\n((.|\n)*?)\n};", raw):
+            for entry in re.findall(r"static const u16 s(.*)TeachableLearnset\[\] = {\n((.|\n)*?)\n};", raw):
                 monname = parse_mon_name(entry[0])
                 if monname == "NONE":
                     continue
@@ -128,7 +128,7 @@ compatibility_dict = construct_compatibility_dict(True)
 # actually prepare the file
 with open("./src/data/pokemon/teachable_learnsets.h", 'r') as file:
     out = file.read()
-    list_of_mons = re.findall('static const u16 s(.*)TeachableLearnset', out)
+    list_of_mons = re.findall(r'static const u16 s(.*)TeachableLearnset', out)
 for mon in list_of_mons:
     mon_parsed = parse_mon_name(mon)
     tm_learnset = []
@@ -161,7 +161,7 @@ for mon in list_of_mons:
     if len(tm_learnset) > 0:
         repl += ",\n    ".join(tm_learnset) + ",\n    "
     repl += "MOVE_UNAVAILABLE,\n};"
-    newout = re.sub('static const u16 s%sTeachableLearnset\[\] = {[\s\S]*?};' % mon, repl, out)
+    newout = re.sub(r'static const u16 s%sTeachableLearnset\[\] = {[\s\S]*?};' % mon, repl, out)
     if newout != out:
         out = newout
         print("Updated %s" % mon)
@@ -208,7 +208,7 @@ header += "// " + longest_move_name * "*" + " //\n\n"
 if not "// DO NOT MODIFY THIS FILE!" in out:
     out = header + out
 else:
-    out = re.sub("\/\/\n\/\/ DO NOT MODIFY THIS FILE!(.|\n)*\* \/\/\n\n", header, out)
+    out = re.sub(r"\/\/\n\/\/ DO NOT MODIFY THIS FILE!(.|\n)*\* \/\/\n\n", header, out)
 
 with open("./src/data/pokemon/teachable_learnsets.h", 'w') as file:
     file.write(out)


### PR DESCRIPTION
In some environments (not actually Windows as previously thought), or alternatively in some versions of Python, the teachable learnset helper would fail to work. This PR changes all regex strings to be considered raw by Python, so this should fix it (it fixed it for psf). Confirmed to work on my OSX environment, preferably tested by the reviewer also.

## Issue(s) that this PR fixes
Fixes #4321 

## **People who collaborated with me in this PR**
Fixed thanks to a suggestion by @mrgriffin 

## **Discord contact info**
bassoonian
