### PR TITLE
Fixes Ability Shield, Neutralizing Gas interaction

### DIFF
--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -165,6 +165,8 @@ u32 SetRandomTarget(u32 battler);
 u32 GetMoveTarget(u16 move, u8 setTarget);
 u8 IsMonDisobedient(void);
 u32 GetBattlerHoldEffect(u32 battler, bool32 checkNegating);
+u32 GetBattlerHoldEffectIgnoreAbility(u32 battler, bool32 checkNegating);
+u32 GetBattlerHoldEffectInternal(u32 battler, bool32 checkNegating, bool32 checkAbility);
 u32 GetBattlerHoldEffectParam(u32 battler);
 bool32 IsMoveMakingContact(u32 move, u32 battlerAtk);
 bool32 IsBattlerGrounded(u32 battler);

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -6142,7 +6142,9 @@ u32 GetBattlerAbility(u32 battler)
     if (gStatuses3[battler] & STATUS3_GASTRO_ACID)
         return ABILITY_NONE;
 
-    if (IsNeutralizingGasOnField() && gBattleMons[battler].ability != ABILITY_NEUTRALIZING_GAS)
+    if (IsNeutralizingGasOnField()
+     && gBattleMons[battler].ability != ABILITY_NEUTRALIZING_GAS
+     && GetBattlerHoldEffectIgnoreAbility(battler, TRUE) != HOLD_EFFECT_ABILITY_SHIELD)
         return ABILITY_NONE;
 
     if (IsMyceliumMightOnField())
@@ -8166,13 +8168,23 @@ u8 IsMonDisobedient(void)
 
 u32 GetBattlerHoldEffect(u32 battler, bool32 checkNegating)
 {
+    return GetBattlerHoldEffectInternal(battler, checkNegating, TRUE);
+}
+
+u32 GetBattlerHoldEffectIgnoreAbility(u32 battler, bool32 checkNegating)
+{
+    return GetBattlerHoldEffectInternal(battler, checkNegating, FALSE);
+}
+
+u32 GetBattlerHoldEffectInternal(u32 battler, bool32 checkNegating, bool32 checkAbility)
+{
     if (checkNegating)
     {
         if (gStatuses3[battler] & STATUS3_EMBARGO)
             return HOLD_EFFECT_NONE;
         if (gFieldStatuses & STATUS_FIELD_MAGIC_ROOM)
             return HOLD_EFFECT_NONE;
-        if (GetBattlerAbility(battler) == ABILITY_KLUTZ)
+        if (checkAbility && GetBattlerAbility(battler) == ABILITY_KLUTZ)
             return HOLD_EFFECT_NONE;
     }
 

--- a/test/battle/hold_effect/ability_shield.c
+++ b/test/battle/hold_effect/ability_shield.c
@@ -1,0 +1,34 @@
+#include "global.h"
+#include "test/battle.h"
+
+ASSUMPTIONS
+{
+    ASSUME(gItemsInfo[ITEM_ABILITY_SHIELD].holdEffect == HOLD_EFFECT_ABILITY_SHIELD);
+}
+
+SINGLE_BATTLE_TEST("Ability Shield prevents Neutralizing Gas")
+{
+    u32 ability;
+
+    PARAMETRIZE { ability = ABILITY_DROUGHT; }
+    PARAMETRIZE { ability = ABILITY_WHITE_SMOKE; }
+
+    GIVEN {
+        PLAYER(SPECIES_TORKOAL) { Ability(ability); Item(ITEM_ABILITY_SHIELD); }
+        OPPONENT(SPECIES_KOFFING) { Ability(ABILITY_NEUTRALIZING_GAS); }
+    } WHEN {
+        TURN { }
+    } SCENE {
+        ABILITY_POPUP(opponent, ABILITY_NEUTRALIZING_GAS);
+        MESSAGE("Neutralizing Gas filled the area!");
+        if (ability == ABILITY_DROUGHT) {
+            ABILITY_POPUP(player, ability);
+            MESSAGE("Torkoal's Drought intensified the sun's rays!");
+        } else {
+            NONE_OF {
+                ABILITY_POPUP(player, ability);
+                MESSAGE("Torkoal's Drought intensified the sun's rays!");
+            }
+        }
+    }
+}

--- a/test/battle/hold_effect/ability_shield.c
+++ b/test/battle/hold_effect/ability_shield.c
@@ -8,25 +8,25 @@ ASSUMPTIONS
 
 SINGLE_BATTLE_TEST("Ability Shield prevents Neutralizing Gas")
 {
-    u32 ability;
+    u32 item;
 
-    PARAMETRIZE { ability = ABILITY_DROUGHT; }
-    PARAMETRIZE { ability = ABILITY_WHITE_SMOKE; }
+    PARAMETRIZE { item = ITEM_ABILITY_SHIELD; }
+    PARAMETRIZE { item = ITEM_NONE; }
 
     GIVEN {
-        PLAYER(SPECIES_TORKOAL) { Ability(ability); Item(ITEM_ABILITY_SHIELD); }
+        PLAYER(SPECIES_TORKOAL) { Ability(ABILITY_DROUGHT); Item(item); }
         OPPONENT(SPECIES_KOFFING) { Ability(ABILITY_NEUTRALIZING_GAS); }
     } WHEN {
         TURN { }
     } SCENE {
         ABILITY_POPUP(opponent, ABILITY_NEUTRALIZING_GAS);
         MESSAGE("Neutralizing Gas filled the area!");
-        if (ability == ABILITY_DROUGHT) {
-            ABILITY_POPUP(player, ability);
+        if (item == ITEM_ABILITY_SHIELD) {
+            ABILITY_POPUP(player, ABILITY_DROUGHT);
             MESSAGE("Torkoal's Drought intensified the sun's rays!");
         } else {
             NONE_OF {
-                ABILITY_POPUP(player, ability);
+                ABILITY_POPUP(player, ABILITY_DROUGHT);
                 MESSAGE("Torkoal's Drought intensified the sun's rays!");
             }
         }


### PR DESCRIPTION
Ability Shield should protect holder from Neutralizing Gas.

Bug found by @skolgrahd and fix provided by @AsparagusEduardo.  