### PR TITLE
Fixed silent Klefki cry

### DIFF
--- a/include/config/species_enabled.h
+++ b/include/config/species_enabled.h
@@ -1,6 +1,9 @@
 #ifndef GUARD_CONFIG_SPECIES_ENABLED_H
 #define GUARD_CONFIG_SPECIES_ENABLED_H
 
+// WARNING: For some reason, using 1/0 instead of TRUE/FALSE causes cry IDs to be shifted.
+// Please use TRUE/FALSE when using the family toggles.
+
 // Modifying the latest generation WILL change the saveblock due to Dex flags and will require a new save file.
 // Generations of Pokémon are defined by the first member introduced,
 // so Pikachu depends on the Gen 1 setting despite Pichu being the lowest member of the evolution tree.

--- a/sound/cry_tables.inc
+++ b/sound/cry_tables.inc
@@ -1707,7 +1707,7 @@ gCryTable::
 	cry Cry_Goodra
 .endif @ P_FAMILY_GOOMY
 .if P_FAMILY_KLEFKI == TRUE
-	cry Cry_Klefki
+	cry_uncomp Cry_Klefki @ Cannot be heard unless we use cry_uncomp here.
 .endif @ P_FAMILY_KLEFKI
 .if P_FAMILY_PHANTUMP == TRUE
 	cry Cry_Phantump
@@ -4133,7 +4133,7 @@ gCryTable_Reverse::
 	cry_reverse Cry_Goodra
 .endif @ P_FAMILY_GOOMY
 .if P_FAMILY_KLEFKI == TRUE
-	cry_reverse Cry_Klefki
+	cry_reverse_uncomp Cry_Klefki @ Cannot be heard unless we use cry_reverse_uncomp here.
 .endif @ P_FAMILY_KLEFKI
 .if P_FAMILY_PHANTUMP == TRUE
 	cry_reverse Cry_Phantump


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes regression from #3562.

It also adds a warning to `include/config/species_enabled.h`, since for some reason using `1` and `0` instead of `TRUE` and `FALSE` causes cry ID's enum to not be properly updated.

## Images
https://github.com/rh-hideout/pokeemerald-expansion/assets/2904965/484fe57c-d891-408c-89e1-9d50006e4264

## Issue(s) that this PR fixes
Fixes #4388 

## Feature(s) this PR does NOT handle:
Tried to update `include\constants\cries.h` to use `== TRUE`, but didn't work.

## **Discord contact info**
AsparagusEduardo