### PR TITLE
Made competitive party syntax no longer print the contents of PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -339,7 +339,7 @@ $(CRY_SUBDIR)/uncomp_%.bin: $(CRY_SUBDIR)/uncomp_%.aif ; $(AIF) $< $@
 $(CRY_SUBDIR)/%.bin: $(CRY_SUBDIR)/%.aif ; $(AIF) $< $@ --compress
 sound/%.bin: sound/%.aif ; $(AIF) $< $@
 
-COMPETITIVE_PARTY_SYNTAX := $(shell PATH=$(PATH); echo 'COMPETITIVE_PARTY_SYNTAX' | $(CPP) $(CPPFLAGS) -imacros include/global.h | tail -n1)
+COMPETITIVE_PARTY_SYNTAX := $(shell PATH="$(PATH)"; echo 'COMPETITIVE_PARTY_SYNTAX' | $(CPP) $(CPPFLAGS) -imacros include/global.h | tail -n1)
 ifeq ($(COMPETITIVE_PARTY_SYNTAX),1)
 %.h: %.party tools ; $(CPP) $(CPPFLAGS) - < $< | sed '/#[^p]/d' | $(TRAINERPROC) -o $@ -i $< -
 endif


### PR DESCRIPTION
## Description
I'm PR'ing this on behalf of @mrgriffin.
Me and RavePossum noticed that while trying to build a ROM or tests using the upcoming branch, the contents of our Windows installations' PATH variable were being printed on the terminal.
This PR fixes that.

## **Discord contact info**
lunos4026