### PR TITLE
Combine AI smart switching with smart mon choices automatically and disable smart mon choices in double battles.

### DIFF
--- a/include/constants/battle_ai.h
+++ b/include/constants/battle_ai.h
@@ -42,7 +42,7 @@
 #define AI_FLAG_HELP_PARTNER          (1 << 12)  // AI can try to help partner. If not set, will tend not to target partner
 #define AI_FLAG_PREFER_STATUS_MOVES   (1 << 13)  // AI gets a score bonus for status moves. Should be combined with AI_FLAG_CHECK_BAD_MOVE to prevent using only status moves
 #define AI_FLAG_STALL                 (1 << 14)  // AI stalls battle and prefers secondary damage/trapping/etc. TODO not finished
-#define AI_FLAG_SMART_SWITCHING       (1 << 15)  // AI includes a lot more switching checks
+#define AI_FLAG_SMART_SWITCHING       (1 << 15)  // AI includes a lot more switching checks. Automatically includes AI_FLAG_SMART_MON_CHOICES for better results.
 #define AI_FLAG_ACE_POKEMON           (1 << 16)  // AI has an Ace Pokemon. The last Pokemon in the party will not be used until it's the last one remaining.
 #define AI_FLAG_OMNISCIENT            (1 << 17)  // AI has full knowledge of player moves, abilities, hold items
 #define AI_FLAG_SMART_MON_CHOICES     (1 << 18)  // AI will make smarter decisions when choosing which mon to send out mid-battle and after a KO, which are separate decisions. Pairs very well with AI_FLAG_SMART_SWITCHING.

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -175,6 +175,10 @@ static u32 GetAiFlags(u16 trainerId)
         flags |= AI_FLAG_DOUBLE_BATTLE;
     }
 
+    // Automatically add smart choice flag to smart switching to greatly improve its behavior
+    if (flags & AI_FLAG_SMART_SWITCHING)
+        flags |= AI_FLAG_SMART_MON_CHOICES;
+
     return flags;
 }
 

--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -1943,7 +1943,7 @@ u8 GetMostSuitableMonToSwitchInto(u32 battler, bool32 switchAfterMonKOd)
 
     // Split ideal mon decision between after previous mon KO'd (prioritize offensive options) and after switching active mon out (prioritize defensive options), and expand the scope of both.
     // Only use better mon selection if AI_FLAG_SMART_MON_CHOICES is set for the trainer.
-    if (AI_THINKING_STRUCT->aiFlags[battler] & AI_FLAG_SMART_MON_CHOICES)
+    if (AI_THINKING_STRUCT->aiFlags[battler] & AI_FLAG_SMART_MON_CHOICES && !(gBattleTypeFlags & BATTLE_TYPE_DOUBLE)) // Won't bother configuring this for double battles
     {
         bestMonId = GetBestMonIntegrated(party, firstId, lastId, battler, opposingBattler, battlerIn1, battlerIn2, switchAfterMonKOd);
         return bestMonId;


### PR DESCRIPTION
AI_FLAG_SMART_SWITCHING also sets AI_FLAG_SMART_MON_CHOICES automatically for greatly improved switching behavior.
Through doing this I accidentally discovered that AI_FLAG_SMART_MON_CHOICES may cause softlocks in double battles thus this PR disables it for double battles for now.

## Description
When used on its own AI_FLAG_SMART_SWITCHING causes the AI to perform extremely questionable switches as it doesn't know which Pokemon effectively counters the enemy, arguably making it dumber instead of smarter.
Combined with AI_FLAG_SMART_MON_CHOICES it produces very satisfying and logical results, but simply merging them into one is not necessarily desirable as AI_FLAG_SMART_MON_CHOICES works perfectly on its own to make enemies switch into favorable matchups after a faint.

## Issues fixed by this PR:
Smart mon choices cause the AI to choose the same pokemon for both battler slots, causing a softlock.

https://github.com/rh-hideout/pokeemerald-expansion/assets/56992013/e28c298f-dcab-47c7-89ec-49bc4767741d


Not sure if this counts as an issue, but it should also be fixed by this PR:
In the video below "smart"  switching Roxanne keeps swapping from Geodude to Geodude because both of them cause an unfavorable matchup for her.

https://github.com/rh-hideout/pokeemerald-expansion/assets/56992013/5f8c98bf-c34f-4b78-baf3-41c96ef28b3a

## **Discord contact info**
duke5614