### PR TITLE
Intimidate and Super Sweet Sugar prints the right message and doesn't play animation when already at -6

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -7784,6 +7784,7 @@ BattleScript_IntimidateEffect:
 	statbuffchange STAT_CHANGE_NOT_PROTECT_AFFECTED | STAT_CHANGE_ALLOW_PTR, BattleScript_IntimidateLoopIncrement
 	setgraphicalstatchangevalues
 	jumpifability BS_TARGET, ABILITY_CONTRARY, BattleScript_IntimidateContrary
+	jumpifbyte CMP_EQUAL, cMULTISTRING_CHOOSER, B_MSG_STAT_WONT_DECREASE, BattleScript_IntimidateWontDecrease
 	playanimation BS_TARGET, B_ANIM_STATS_CHANGE, sB_ANIM_ARG1
 	printstring STRINGID_PKMNCUTSATTACKWITH
 BattleScript_IntimidateEffect_WaitString:
@@ -7799,6 +7800,10 @@ BattleScript_IntimidateEnd:
 	copybyte gBattlerTarget, sSAVED_BATTLER
 	pause B_WAIT_TIME_MED
 	end3
+
+BattleScript_IntimidateWontDecrease:
+	printstring STRINGID_STATSWONTDECREASE
+	goto BattleScript_IntimidateEffect_WaitString
 
 BattleScript_IntimidateContrary:
 	call BattleScript_AbilityPopUpTarget
@@ -7839,6 +7844,7 @@ BattleScript_SupersweetSyrupEffect:
 	statbuffchange STAT_CHANGE_NOT_PROTECT_AFFECTED | STAT_CHANGE_ALLOW_PTR, BattleScript_SupersweetSyrupLoopIncrement
 	setgraphicalstatchangevalues
 	jumpifability BS_TARGET, ABILITY_CONTRARY, BattleScript_SupersweetSyrupContrary
+	jumpifbyte CMP_EQUAL, cMULTISTRING_CHOOSER, B_MSG_STAT_WONT_DECREASE, BattleScript_SupersweetSyrupWontDecrease
 	playanimation BS_TARGET, B_ANIM_STATS_CHANGE, sB_ANIM_ARG1
 	printfromtable gStatDownStringIds
 BattleScript_SupersweetSyrupEffect_WaitString:
@@ -7854,6 +7860,10 @@ BattleScript_SupersweetSyrupEnd:
  	copybyte gBattlerTarget, sSAVED_BATTLER
 	pause B_WAIT_TIME_MED
 	end3
+
+BattleScript_SupersweetSyrupWontDecrease:
+	printstring STRINGID_STATSWONTDECREASE
+	goto BattleScript_SupersweetSyrupEffect_WaitString
 
 BattleScript_SupersweetSyrupContrary:
 	call BattleScript_AbilityPopUpTarget

--- a/test/battle/ability/intimidate.c
+++ b/test/battle/ability/intimidate.c
@@ -184,3 +184,29 @@ DOUBLE_BATTLE_TEST("Intimidate activates immediately after the mon was switched 
         EXPECT_EQ(playerLeft->statStages[STAT_DEF], DEFAULT_STAT_STAGE + 1);
     }
 }
+
+SINGLE_BATTLE_TEST("Intimidate can not further lower opponents Atk stat if it is at minimum stages")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_ARBOK) { Ability(ABILITY_INTIMIDATE); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_CHARM); }
+        TURN { MOVE(opponent, MOVE_CHARM); }
+        TURN { MOVE(opponent, MOVE_CHARM); }
+        TURN { SWITCH(opponent, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CHARM, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CHARM, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CHARM, opponent);
+        ABILITY_POPUP(opponent, ABILITY_INTIMIDATE);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+            MESSAGE("Foe Arbok's Intimidate cuts Wobbuffet's attack!");
+        }
+        MESSAGE("Wobbuffet's Attack won't go lower!");
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_ATK], MIN_STAT_STAGE);
+    }
+}

--- a/test/battle/ability/supersweet_syrup.c
+++ b/test/battle/ability/supersweet_syrup.c
@@ -45,3 +45,29 @@ DOUBLE_BATTLE_TEST("Supersweet Syrup lowers evasion of both opposing mon's in ba
         EXPECT_EQ(playerRight->statStages[STAT_EVASION], DEFAULT_STAT_STAGE - 1);
     }
 }
+
+SINGLE_BATTLE_TEST("Supersweet Syrum can not further lower opponents evasion if it is at minimum stages")
+{
+    GIVEN {
+        PLAYER(SPECIES_ODDISH);
+        OPPONENT(SPECIES_ODDISH);
+        OPPONENT(SPECIES_HYDRAPPLE) { Ability(ABILITY_SUPERSWEET_SYRUP); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SWEET_SCENT); }
+        TURN { MOVE(opponent, MOVE_SWEET_SCENT); }
+        TURN { MOVE(opponent, MOVE_SWEET_SCENT); }
+        TURN { SWITCH(opponent, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SWEET_SCENT, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SWEET_SCENT, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SWEET_SCENT, opponent);
+        ABILITY_POPUP(opponent, ABILITY_SUPERSWEET_SYRUP);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+            MESSAGE("Oddish's evasiveness fell!");
+        }
+        MESSAGE("Oddish's evasiveness won't go lower!");
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_EVASION], MIN_STAT_STAGE);
+    }
+}

--- a/test/battle/ability/supersweet_syrup.c
+++ b/test/battle/ability/supersweet_syrup.c
@@ -46,7 +46,7 @@ DOUBLE_BATTLE_TEST("Supersweet Syrup lowers evasion of both opposing mon's in ba
     }
 }
 
-SINGLE_BATTLE_TEST("Supersweet Syrum can not further lower opponents evasion if it is at minimum stages")
+SINGLE_BATTLE_TEST("Supersweet Syrup can not further lower opponents evasion if it is at minimum stages")
 {
     GIVEN {
         PLAYER(SPECIES_ODDISH);


### PR DESCRIPTION
## Description
When attack or evasion can't be further reduced by these abilities, it now prints "Pokemon's stat won't go lower!"

Tests by @AlexOn1ine 

## Issue(s) that this PR fixes
Fixes #4401


## **Discord contact info**
duke5614
