### PR TITLE
Adds support for shouldDynamax and shouldTerastal in trainer parties

### DIFF
--- a/tools/trainerproc/main.c
+++ b/tools/trainerproc/main.c
@@ -1822,12 +1822,18 @@ static void fprint_trainers(const char *output_path, FILE *f, struct Parsed *par
                 fprintf(f, ",\n");
             }
 
+            if (pokemon->dynamax_level_line || pokemon->gigantamax_factor_line)
+            {
+                fprintf(f, "            .shouldDynamax = TRUE,\n");
+            }
+
             if (pokemon->tera_type_line)
             {
                 fprintf(f, "#line %d\n", pokemon->tera_type_line);
                 fprintf(f, "            .teraType = ");
                 fprint_constant(f, "TYPE", pokemon->tera_type);
                 fprintf(f, ",\n");
+                fprintf(f, "            .shouldTerastal = TRUE,\n");
             }
 
             if (pokemon->moves_n > 0)


### PR DESCRIPTION
Adds missing support for dynamax and terastal in trainer parties. Without it trainer mons aren't able to use those gimmicks. The flags are added automatically if a tera type is given or dynamax level/factor specified.  