### PR TITLE
Pokedex plus expYield matches SpeciesInfo type

### DIFF
--- a/src/pokedex_plus_hgss.c
+++ b/src/pokedex_plus_hgss.c
@@ -385,7 +385,7 @@ struct PokemonStats
     u8  eggGroup1;
     u8  eggGroup2;
     u8  eggCycles;
-    u8  expYield;
+    u16  expYield;
     u8  friendship;
     u16 ability0;
     u16 ability1;


### PR DESCRIPTION
Changed PokemonStats.expYield to u16 so that pokedex plus works with the expansion's updated experience yield feature.

## Issue(s) that this PR fixes
Wrong display of experience yield in pokedex plus due to overflow

duke5614
