### PR TITLE
Add missing shouldDynamax

### DIFF
--- a/test/battle/trainer_control.h
+++ b/test/battle/trainer_control.h
@@ -52,6 +52,7 @@
             .isShiny = TRUE,
 #line 18
             .dynamaxLevel = 5,
+            .shouldDynamax = TRUE,
             .moves = {
 #line 19
                 MOVE_AIR_SLASH,


### PR DESCRIPTION
This gets added whenever `trainerproc` runs, due to #4431, so I'm committing it to stop it showing up in some random PR in the future.