### PR TITLE
Ally Switch Handle Shadows, Fix Opponent Anim

### DIFF
--- a/include/battle_gfx_sfx_util.h
+++ b/include/battle_gfx_sfx_util.h
@@ -31,6 +31,7 @@ void BattleStopLowHpSound(void);
 u8 GetMonHPBarLevel(struct Pokemon *mon);
 void HandleBattleLowHpMusicChange(void);
 void SetBattlerSpriteAffineMode(u8 affineMode);
+void CreateEnemyShadowSprite(u32 battler);
 void LoadAndCreateEnemyShadowSprites(void);
 void SpriteCB_SetInvisible(struct Sprite *sprite);
 void SetBattlerShadowSpriteCallback(u8 battler, u16 species);

--- a/src/battle_anim_effects_1.c
+++ b/src/battle_anim_effects_1.c
@@ -6523,6 +6523,11 @@ void PrepareDoubleTeamAnim(u32 taskId, u32 animBattler, bool32 forAllySwitch)
             gSprites[spriteId].sBattlerFlank = (animBattler != ANIM_ATTACKER);
         else
             gSprites[spriteId].sBattlerFlank = (animBattler == ANIM_ATTACKER);
+        
+        // correct direction on opponent side
+        if (GetBattlerSide(gBattleAnimAttacker) == B_SIDE_OPPONENT)
+            gSprites[spriteId].sBattlerFlank ^= 1;
+        
         gSprites[spriteId].callback = AnimDoubleTeam;
         task->tBlendSpritesCount++;
     }
@@ -6548,11 +6553,21 @@ static inline void SwapStructData(void *s1, void *s2, void *data, u32 size)
 
 static void ReloadBattlerSprites(u32 battler, struct Pokemon *party)
 {
-    BattleLoadMonSpriteGfx(&party[gBattlerPartyIndexes[battler]], battler);
+    struct Pokemon *mon = &party[gBattlerPartyIndexes[battler]];
+    BattleLoadMonSpriteGfx(mon, battler);
     CreateBattlerSprite(battler);
-    UpdateHealthboxAttribute(gHealthboxSpriteIds[battler], &party[gBattlerPartyIndexes[battler]], HEALTHBOX_ALL);
+    UpdateHealthboxAttribute(gHealthboxSpriteIds[battler], mon, HEALTHBOX_ALL);
     // If battler is mega evolved / primal reversed, hide the sprite until the move animation finishes.
     MegaIndicator_SetVisibilities(gHealthboxSpriteIds[battler], TRUE);
+    
+    // Try to recreate shadow sprite
+    if (gBattleSpritesDataPtr->healthBoxesData[battler].shadowSpriteId < MAX_SPRITES)
+    {
+        DestroySprite(&gSprites[gBattleSpritesDataPtr->healthBoxesData[battler].shadowSpriteId]);
+        gBattleSpritesDataPtr->healthBoxesData[battler].shadowSpriteId = MAX_SPRITES;
+        CreateEnemyShadowSprite(battler);
+        SetBattlerShadowSpriteCallback(battler, GetMonData(mon, MON_DATA_SPECIES));
+    }
 }
 
 static void AnimTask_AllySwitchDataSwap(u8 taskId)

--- a/src/battle_gfx_sfx_util.c
+++ b/src/battle_gfx_sfx_util.c
@@ -1108,27 +1108,36 @@ void SetBattlerSpriteAffineMode(u8 affineMode)
 
 #define tBattlerId data[0]
 
-void LoadAndCreateEnemyShadowSprites(void)
+void CreateEnemyShadowSprite(u32 battler)
 {
-    u8 battler;
-
-    LoadCompressedSpriteSheet(&gSpriteSheet_EnemyShadow);
-
-    battler = GetBattlerAtPosition(B_POSITION_OPPONENT_LEFT);
     gBattleSpritesDataPtr->healthBoxesData[battler].shadowSpriteId = CreateSprite(&gSpriteTemplate_EnemyShadow,
                                                                                     GetBattlerSpriteCoord(battler, BATTLER_COORD_X),
                                                                                     GetBattlerSpriteCoord(battler, BATTLER_COORD_Y) + 29,
                                                                                     0xC8);
-    gSprites[gBattleSpritesDataPtr->healthBoxesData[battler].shadowSpriteId].data[0] = battler;
+    if (gBattleSpritesDataPtr->healthBoxesData[battler].shadowSpriteId < MAX_SPRITES)
+        gSprites[gBattleSpritesDataPtr->healthBoxesData[battler].shadowSpriteId].data[0] = battler;
+}
 
+void LoadAndCreateEnemyShadowSprites(void)
+{
+    u8 battler;
+    u32 i;
+
+    LoadCompressedSpriteSheet(&gSpriteSheet_EnemyShadow);
+    
+    // initialize shadow sprite ids
+    for (i = 0; i < gBattlersCount; i++)
+    {
+        gBattleSpritesDataPtr->healthBoxesData[i].shadowSpriteId = MAX_SPRITES;
+    }
+
+    battler = GetBattlerAtPosition(B_POSITION_OPPONENT_LEFT);
+    CreateEnemyShadowSprite(battler);
+    
     if (IsDoubleBattle())
     {
         battler = GetBattlerAtPosition(B_POSITION_OPPONENT_RIGHT);
-        gBattleSpritesDataPtr->healthBoxesData[battler].shadowSpriteId = CreateSprite(&gSpriteTemplate_EnemyShadow,
-                                                                                        GetBattlerSpriteCoord(battler, BATTLER_COORD_X),
-                                                                                        GetBattlerSpriteCoord(battler, BATTLER_COORD_Y) + 29,
-                                                                                        0xC8);
-        gSprites[gBattleSpritesDataPtr->healthBoxesData[battler].shadowSpriteId].data[0] = battler;
+        CreateEnemyShadowSprite(battler);
     }
 }
 
@@ -1168,6 +1177,8 @@ void SetBattlerShadowSpriteCallback(u8 battler, u16 species)
 {
     // The player's shadow is never seen.
     if (GetBattlerSide(battler) == B_SIDE_PLAYER || gBattleScripting.monCaught)
+        return;
+    if (gBattleSpritesDataPtr->healthBoxesData[battler].shadowSpriteId >= MAX_SPRITES)
         return;
 
     if (gBattleSpritesDataPtr->battlerData[battler].transformSpecies != SPECIES_NONE)


### PR DESCRIPTION
- Ally Switch handles elevation shadows
- Ally switch fix direction of animation for opponents
- Also add some safety checks into shadow sprite id

Before:
![allyswitch_old](https://github.com/rh-hideout/pokeemerald-expansion/assets/41651341/133cfd65-9d76-4c22-88e2-fe0eac7d7508)

After:
![allyswitch_fix](https://github.com/rh-hideout/pokeemerald-expansion/assets/41651341/022fd9ec-5e97-43ab-82a9-91ca1826e83f)
