### PR TITLE
Fix lingering long ability popup names

### DIFF
--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -3114,6 +3114,7 @@ static void PrintBattlerOnAbilityPopUp(u8 battlerId, u8 spriteId1, u8 spriteId2)
 
 static void PrintAbilityOnAbilityPopUp(u32 ability, u8 spriteId1, u8 spriteId2)
 {
+    ClearAbilityName(spriteId1, spriteId2);
     PrintOnAbilityPopUp(gAbilitiesInfo[ability].name,
                         (void*)(OBJ_VRAM0) + (gSprites[spriteId1].oam.tileNum * 32) + 256,
                         (void*)(OBJ_VRAM0) + (gSprites[spriteId2].oam.tileNum * 32) + 256,
@@ -3320,7 +3321,6 @@ void UpdateAbilityPopup(u8 battlerId)
     u8 spriteId2 = gBattleStruct->abilityPopUpSpriteIds[battlerId][1];
     u16 ability = (gBattleScripting.abilityPopupOverwrite != 0) ? gBattleScripting.abilityPopupOverwrite : gBattleMons[battlerId].ability;
 
-    ClearAbilityName(spriteId1, spriteId2);
     PrintAbilityOnAbilityPopUp(ability, spriteId1, spriteId2);
     RestoreOverwrittenPixels((void*)(OBJ_VRAM0) + (gSprites[spriteId1].oam.tileNum * 32));
 }


### PR DESCRIPTION
## Issue(s) that this PR fixes
Hard to describe, if two ability popus happen on the same battle step and the second one has a short ability name the popup displays some leftover text.
Before:

https://github.com/rh-hideout/pokeemerald-expansion/assets/56992013/d67c0325-acd8-41dc-844f-d7c630e7cb3a



After:

https://github.com/rh-hideout/pokeemerald-expansion/assets/56992013/a16e90c0-3747-4322-9c3a-a7e7a5f105aa




## **Discord contact info**
duke5614