### PR TITLE
Fixes Eject Items causing wrong pokemon to take damage from entry hazards

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -6281,6 +6281,21 @@ BattleScript_DmgHazardsOnTargetFainted::
 	moveendall
 	goto BattleScript_HandleFaintedMon
 
+BattleScript_DmgHazardsOnBattlerScripting::
+	orword gHitMarker, HITMARKER_IGNORE_SUBSTITUTE | HITMARKER_PASSIVE_DAMAGE
+	healthbarupdate BS_SCRIPTING
+	datahpupdate BS_SCRIPTING
+	call BattleScript_PrintHurtByDmgHazards
+	tryfaintmon BS_SCRIPTING
+	tryfaintmon_spikes BS_SCRIPTING, BattleScript_DmgHazardsOnBattlerScriptingFainted
+	return
+
+BattleScript_DmgHazardsOnBattlerScriptingFainted::
+	setbyte sGIVEEXP_STATE, 0
+	getexp BS_SCRIPTING
+	moveendall
+	goto BattleScript_HandleFaintedMon
+
 BattleScript_DmgHazardsOnFaintedBattler::
 	orword gHitMarker, HITMARKER_IGNORE_SUBSTITUTE | HITMARKER_PASSIVE_DAMAGE
 	healthbarupdate BS_FAINTED

--- a/include/battle_scripts.h
+++ b/include/battle_scripts.h
@@ -77,6 +77,7 @@ extern const u8 BattleScript_EncoredNoMore[];
 extern const u8 BattleScript_DestinyBondTakesLife[];
 extern const u8 BattleScript_DmgHazardsOnAttacker[];
 extern const u8 BattleScript_DmgHazardsOnTarget[];
+extern const u8 BattleScript_DmgHazardsOnBattlerScripting[];
 extern const u8 BattleScript_DmgHazardsOnFaintedBattler[];
 extern const u8 BattleScript_PerishSongTakesLife[];
 extern const u8 BattleScript_PerishSongCountGoesDown[];

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -7040,6 +7040,8 @@ static void SetDmgHazardsBattlescript(u8 battler, u8 multistringId)
         gBattlescriptCurrInstr = BattleScript_DmgHazardsOnTarget;
     else if (gBattlescriptCurrInstr[1] == BS_ATTACKER)
         gBattlescriptCurrInstr = BattleScript_DmgHazardsOnAttacker;
+    else if (gBattlescriptCurrInstr[1] == BS_SCRIPTING)
+        gBattlescriptCurrInstr = BattleScript_DmgHazardsOnBattlerScripting;
     else
         gBattlescriptCurrInstr = BattleScript_DmgHazardsOnFaintedBattler;
 }

--- a/test/battle/move_effect/stealth_rock.c
+++ b/test/battle/move_effect/stealth_rock.c
@@ -52,3 +52,24 @@ SINGLE_BATTLE_TEST("Stealth Rock damages the correct pokemon when Eject Button i
         EXPECT_EQ(opponent->hp, opponent->maxHP);
     }
 }
+
+DOUBLE_BATTLE_TEST("Stealth Rock damages the correct pokemon when Eject Button is triggered in double battle")
+{
+    GIVEN {
+        PLAYER(SPECIES_METAPOD) { Item(ITEM_EJECT_BUTTON); }
+        PLAYER(SPECIES_METAPOD) { Item(ITEM_EJECT_BUTTON); }
+        PLAYER(SPECIES_METAPOD);
+        OPPONENT(SPECIES_JOLTEON);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponentLeft, MOVE_STEALTH_ROCK); MOVE(opponentRight, MOVE_TACKLE, target: playerLeft); SEND_OUT(playerLeft, 2); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_STEALTH_ROCK, opponentLeft);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentRight);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, playerLeft);
+        MESSAGE("Go! Metapod!");
+        HP_BAR(playerLeft);
+    } THEN {
+        EXPECT_EQ(opponentLeft->hp, opponentLeft->maxHP);
+    }
+}

--- a/test/battle/move_effect/stealth_rock.c
+++ b/test/battle/move_effect/stealth_rock.c
@@ -30,3 +30,25 @@ SINGLE_BATTLE_TEST("Stealth Rock damage on switch in based on typing")
         HP_BAR(opponent, damage: maxHP / divisor);
     }
 }
+
+SINGLE_BATTLE_TEST("Stealth Rock damages the correct pokemon when Eject Button is triggered")
+{
+    GIVEN {
+        PLAYER(SPECIES_METAPOD) { Item(ITEM_EJECT_BUTTON); }
+        PLAYER(SPECIES_METAPOD);
+        OPPONENT(SPECIES_JOLTEON);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_STEALTH_ROCK); MOVE(player, MOVE_HARDEN); }
+        TURN { MOVE(opponent, MOVE_QUICK_ATTACK); MOVE(player, MOVE_HARDEN); SEND_OUT(player, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_STEALTH_ROCK, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_HARDEN, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_QUICK_ATTACK, opponent);
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_HARDEN, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+        MESSAGE("Go! Metapod!");
+        HP_BAR(player);
+    } THEN {
+        EXPECT_EQ(opponent->hp, opponent->maxHP);
+    }
+}


### PR DESCRIPTION
## Description
Fixes Eject Items causing gBattlerFainted to take entry hazard damage instead of the pokemon switching in, since SetDmgHazardsBattlescript did not account for calls with BS_SCRIPTING. This PR handles that.

## Issue(s) that this PR fixes
Fixes #4457

## **Discord contact info**
PhallenTree