### PR TITLE
fix non expanded types names macro

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -298,7 +298,7 @@ static const s8 sCenterToCornerVecXs[8] ={-32, -16, -16, -32, -32};
 #if B_EXPANDED_TYPE_NAMES == TRUE
 #define HANDLE_EXPANDED_TYPE_NAME(_name, ...) _(DEFAULT(_name, __VA_ARGS__))
 #else
-#define HANDLE_EXPANDED_TYPE_NAME(_name) _(_name)
+#define HANDLE_EXPANDED_TYPE_NAME(_name, ...) _(_name)
 #endif
 
 // .generic is large enough that the text for TYPE_ELECTRIC will exceed TEXT_BUFF_ARRAY_COUNT.


### PR DESCRIPTION
Fix HANDLE_EXPANDED_TYPE_NAMES producing errors when setting B_EXPANDED_TYPE_NAMES to FALSE

## Description
Modified the macro arguments

## **People who collaborated with me in this PR**
MGriffin on discord

## **Discord contact info**
Nopinou#8678
