### PR TITLE
Update IsDamageMoveUsable to check for Steel Roller viability

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -366,7 +366,7 @@ static inline s32 LowestRollDmg(s32 dmg)
     return dmg;
 }
 
-bool32 IsDamageMoveUsable(u32 move, u32 battlerAtk, u32 battlerDef)
+bool32 IsDamageMoveUnusable(u32 move, u32 battlerAtk, u32 battlerDef)
 {
     s32 moveType;
     struct AiLogicData *aiData = AI_DATA;
@@ -439,10 +439,11 @@ bool32 IsDamageMoveUsable(u32 move, u32 battlerAtk, u32 battlerDef)
             return TRUE;
         break;
     case EFFECT_HIT_SET_REMOVE_TERRAIN:
-	if (!(gFieldStatuses & (STATUS_FIELD_MISTY_TERRAIN | STATUS_FIELD_ELECTRIC_TERRAIN | STATUS_FIELD_GRASSY_TERRAIN | STATUS_FIELD_PSYCHIC_TERRAIN)))
+	if (!(gFieldStatuses & STATUS_FIELD_TERRAIN_ANY))
 	    return TRUE;
 	break;
     }
+
     return FALSE;
 }
 
@@ -475,7 +476,7 @@ s32 AI_CalcDamage(u32 move, u32 battlerAtk, u32 battlerDef, u8 *typeEffectivenes
     GET_MOVE_TYPE(move, moveType);
 
     if (gMovesInfo[move].power)
-        isDamageMoveUnusable = IsDamageMoveUsable(move, battlerAtk, battlerDef);
+        isDamageMoveUnusable = IsDamageMoveUnusable(move, battlerAtk, battlerDef);
 
     effectivenessMultiplier = CalcTypeEffectivenessMultiplier(move, moveType, battlerAtk, battlerDef, aiData->abilities[battlerDef], FALSE);
     if (gMovesInfo[move].power && !isDamageMoveUnusable)

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -438,8 +438,11 @@ bool32 IsDamageMoveUsable(u32 move, u32 battlerAtk, u32 battlerDef)
         if (!IS_BATTLER_OF_TYPE(battlerAtk, gMovesInfo[move].argument))
             return TRUE;
         break;
+    case EFFECT_HIT_SET_REMOVE_TERRAIN:
+	if (!(gFieldStatuses & (STATUS_FIELD_MISTY_TERRAIN | STATUS_FIELD_ELECTRIC_TERRAIN | STATUS_FIELD_GRASSY_TERRAIN | STATUS_FIELD_PSYCHIC_TERRAIN)))
+	    return TRUE;
+	break;
     }
-
     return FALSE;
 }
 


### PR DESCRIPTION
## Description
Added a case in `IsDamageMoveUsable` to see if any terrain is up. If not, the function returns `TRUE`, so the AI should realize that Steel Roller (and moves with the same effect) will not succeed.

Additionally, `IsDamageMoveUsable` was renamed to `IsDamageMoveUnusable` to better reflect the returned boolean value.

## **People who collaborated with me in this PR**
Alex, for pointing out where the missing check was.

## **Discord contact info**
Special K#8400
