### PR TITLE
Fix daycare move transferring between evolved mons and allow sharing moves between different forms of the same species

### DIFF
--- a/include/daycare.h
+++ b/include/daycare.h
@@ -32,7 +32,7 @@ void SetDaycareCompatibilityString(void);
 bool8 NameHasGenderSymbol(const u8 *name, u8 genderRatio);
 void ShowDaycareLevelMenu(void);
 void ChooseSendDaycareMon(void);
-u8 GetEggMovesSpecies(u16 species, u16 *eggMoves);
+u8 GetEggMovesBySpecies(u16 species, u16 *eggMoves);
 bool8 SpeciesCanLearnEggMove(u16 species, u16 move);
 
 #endif // GUARD_DAYCARE_H

--- a/src/daycare.c
+++ b/src/daycare.c
@@ -202,7 +202,7 @@ static void TransferEggMoves(void)
         if (!GetBoxMonData(&gSaveBlock1Ptr->daycare.mons[i].mon, MON_DATA_SANITY_HAS_SPECIES))
             continue;
 
-        // Make sure Snorlax gets Snorlax's egg moves instead of Munchlax's
+        // Prevent non-baby species from learning incense baby egg moves
         if (eggSpecies != moveLearnerSpecies && P_INCENSE_BREEDING < GEN_9)
         {
             for (j = 0; j < ARRAY_COUNT(sIncenseBabyTable); j++)

--- a/src/daycare.c
+++ b/src/daycare.c
@@ -203,7 +203,7 @@ static void TransferEggMoves(void)
             continue;
 
         // Prevent non-baby species from learning incense baby egg moves
-        if (eggSpecies != moveLearnerSpecies && P_INCENSE_BREEDING < GEN_9)
+        if (P_INCENSE_BREEDING < GEN_9 && eggSpecies != moveLearnerSpecies)
         {
             for (j = 0; j < ARRAY_COUNT(sIncenseBabyTable); j++)
             {

--- a/src/daycare.c
+++ b/src/daycare.c
@@ -216,7 +216,7 @@ static void TransferEggMoves(void)
         }
 
         ClearHatchedEggMoves();
-        numEggMoves = GetEggMovesSpecies(eggSpecies, sHatchedEggEggMoves);
+        numEggMoves = GetEggMovesBySpecies(eggSpecies, sHatchedEggEggMoves);
         for (j = 0; j < numEggMoves; j++)
         {
             // Go through other Daycare mons
@@ -805,7 +805,7 @@ static u8 GetEggMoves(struct Pokemon *pokemon, u16 *eggMoves)
     return numEggMoves;
 }
 
-u8 GetEggMovesSpecies(u16 species, u16 *eggMoves)
+u8 GetEggMovesBySpecies(u16 species, u16 *eggMoves)
 {
     u16 eggMoveIdx;
     u16 numEggMoves;

--- a/src/daycare.c
+++ b/src/daycare.c
@@ -989,7 +989,6 @@ void RejectEggFromDayCare(void)
     RemoveEggFromDayCare(&gSaveBlock1Ptr->daycare);
 }
 
-#if P_INCENSE_BREEDING < GEN_9
 static void AlterEggSpeciesWithIncenseItem(u16 *species, struct DayCare *daycare)
 {
     u32 i;
@@ -1006,7 +1005,6 @@ static void AlterEggSpeciesWithIncenseItem(u16 *species, struct DayCare *daycare
         }
     }
 }
-#endif
 
 static const struct {
   u16 offspring;
@@ -1099,9 +1097,8 @@ static void _GiveEggFromDaycare(struct DayCare *daycare)
     bool8 isEgg;
 
     species = DetermineEggSpeciesAndParentSlots(daycare, parentSlots);
-#if P_INCENSE_BREEDING < GEN_9
-    AlterEggSpeciesWithIncenseItem(&species, daycare);
-#endif
+    if (P_INCENSE_BREEDING < GEN_9)
+        AlterEggSpeciesWithIncenseItem(&species, daycare);
     SetInitialEggData(&egg, species, daycare);
     InheritIVs(&egg, daycare);
     InheritPokeball(&egg, &daycare->mons[parentSlots[1]].mon, &daycare->mons[parentSlots[0]].mon);

--- a/src/daycare.c
+++ b/src/daycare.c
@@ -87,6 +87,24 @@ static const struct ListMenuTemplate sDaycareListMenuLevelTemplate =
     .cursorKind = CURSOR_BLACK_ARROW
 };
 
+static const struct {
+  u16 currSpecies;
+  u16 item;
+  u16 babySpecies;
+} sIncenseBabyTable[] =
+{
+    // Regular offspring,   Item,              Incense Offspring
+    { SPECIES_WOBBUFFET,    ITEM_LAX_INCENSE,  SPECIES_WYNAUT },
+    { SPECIES_MARILL,       ITEM_SEA_INCENSE,  SPECIES_AZURILL },
+    { SPECIES_SNORLAX,      ITEM_FULL_INCENSE, SPECIES_MUNCHLAX },
+    { SPECIES_CHANSEY,      ITEM_LUCK_INCENSE, SPECIES_HAPPINY },
+    { SPECIES_MR_MIME,      ITEM_ODD_INCENSE,  SPECIES_MIME_JR },
+    { SPECIES_CHIMECHO,     ITEM_PURE_INCENSE, SPECIES_CHINGLING },
+    { SPECIES_SUDOWOODO,    ITEM_ROCK_INCENSE, SPECIES_BONSLY },
+    { SPECIES_ROSELIA,      ITEM_ROSE_INCENSE, SPECIES_BUDEW },
+    { SPECIES_MANTINE,      ITEM_WAVE_INCENSE, SPECIES_MANTYKE },
+};
+
 static const u8 *const sCompatibilityMessages[] =
 {
     gDaycareText_GetAlongVeryWell,
@@ -175,18 +193,27 @@ static void TransferEggMoves(void)
 {
     u32 i, j, k, l;
     u16 numEggMoves;
-    struct Pokemon mon;
 
     for (i = 0; i < DAYCARE_MON_COUNT; i++)
     {
         u16 moveLearnerSpecies = GetBoxMonData(&gSaveBlock1Ptr->daycare.mons[i].mon, MON_DATA_SPECIES);
+        u16 eggSpecies = GetEggSpecies(moveLearnerSpecies);
 
         if (!GetBoxMonData(&gSaveBlock1Ptr->daycare.mons[i].mon, MON_DATA_SANITY_HAS_SPECIES))
             continue;
 
-        BoxMonToMon(&gSaveBlock1Ptr->daycare.mons[i].mon, &mon);
+        // Make sure Snorlax gets Snorlax's egg moves instead of Munchlax's
+        if (eggSpecies != moveLearnerSpecies)
+        {
+            for (j = 0; j < sizeof(sIncenseBabyTable) / sizeof(sIncenseBabyTable[0]); j++)
+                {
+                    if (sIncenseBabyTable[i].babySpecies == eggSpecies)
+                        eggSpecies = sIncenseBabyTable[i].currSpecies;
+                }
+        }
+
         ClearHatchedEggMoves();
-        numEggMoves = GetEggMovesSpecies(GetEggSpecies(moveLearnerSpecies), sHatchedEggEggMoves);
+        numEggMoves = GetEggMovesSpecies(eggSpecies, sHatchedEggEggMoves);
         for (j = 0; j < numEggMoves; j++)
         {
             // Go through other Daycare mons
@@ -958,25 +985,6 @@ void RejectEggFromDayCare(void)
 {
     RemoveEggFromDayCare(&gSaveBlock1Ptr->daycare);
 }
-
-
-static const struct {
-  u16 currSpecies;
-  u16 item;
-  u16 babySpecies;
-} sIncenseBabyTable[] =
-{
-    // Regular offspring,   Item,              Incense Offspring
-    { SPECIES_WOBBUFFET,    ITEM_LAX_INCENSE,  SPECIES_WYNAUT },
-    { SPECIES_MARILL,       ITEM_SEA_INCENSE,  SPECIES_AZURILL },
-    { SPECIES_SNORLAX,      ITEM_FULL_INCENSE, SPECIES_MUNCHLAX },
-    { SPECIES_CHANSEY,      ITEM_LUCK_INCENSE, SPECIES_HAPPINY },
-    { SPECIES_MR_MIME,      ITEM_ODD_INCENSE,  SPECIES_MIME_JR },
-    { SPECIES_CHIMECHO,     ITEM_PURE_INCENSE, SPECIES_CHINGLING },
-    { SPECIES_SUDOWOODO,    ITEM_ROCK_INCENSE, SPECIES_BONSLY },
-    { SPECIES_ROSELIA,      ITEM_ROSE_INCENSE, SPECIES_BUDEW },
-    { SPECIES_MANTINE,      ITEM_WAVE_INCENSE, SPECIES_MANTYKE },
-};
 
 #if P_INCENSE_BREEDING < GEN_9
 static void AlterEggSpeciesWithIncenseItem(u16 *species, struct DayCare *daycare)

--- a/src/daycare.c
+++ b/src/daycare.c
@@ -203,16 +203,16 @@ static void TransferEggMoves(void)
             continue;
 
         // Make sure Snorlax gets Snorlax's egg moves instead of Munchlax's
-        if (eggSpecies != moveLearnerSpecies)
+        if (eggSpecies != moveLearnerSpecies && P_INCENSE_BREEDING < GEN_9)
         {
             for (j = 0; j < ARRAY_COUNT(sIncenseBabyTable); j++)
+            {
+                if (sIncenseBabyTable[j].babySpecies == eggSpecies)
                 {
-                    if (sIncenseBabyTable[j].babySpecies == eggSpecies)
-                    {
-                        eggSpecies = sIncenseBabyTable[j].currSpecies;
-                        break;
-                    }
+                    eggSpecies = sIncenseBabyTable[j].currSpecies;
+                    break;
                 }
+            }
         }
 
         ClearHatchedEggMoves();

--- a/src/daycare.c
+++ b/src/daycare.c
@@ -225,7 +225,7 @@ static void TransferEggMoves(void)
                     continue;
 
                 // Check if you can inherit from them
-                if (GetFormSpeciesId(moveTeacherSpecies, 0) != GetFormSpeciesId(moveLearnerSpecies, 0)
+                if (GET_BASE_SPECIES_ID(moveTeacherSpecies) != GET_BASE_SPECIES_ID(moveLearnerSpecies)
                     && (P_EGG_MOVE_TRANSFER < GEN_9 || GetBoxMonData(&gSaveBlock1Ptr->daycare.mons[i].mon, MON_DATA_HELD_ITEM) != ITEM_MIRROR_HERB)
                 )
                     continue;

--- a/src/daycare.c
+++ b/src/daycare.c
@@ -34,6 +34,7 @@ static void SetInitialEggData(struct Pokemon *mon, u16 species, struct DayCare *
 static void DaycarePrintMonInfo(u8 windowId, u32 daycareSlotId, u8 y);
 static u8 ModifyBreedingScoreForOvalCharm(u8 score);
 static u8 GetEggMoves(struct Pokemon *pokemon, u16 *eggMoves);
+static u16 GetEggSpecies(u16 species);
 
 // RAM buffers used to assist with BuildEggMoveset()
 EWRAM_DATA static u16 sHatchedEggLevelUpMoves[EGG_LVL_UP_MOVES_ARRAY_COUNT] = {0};
@@ -178,22 +179,26 @@ static void TransferEggMoves(void)
 
     for (i = 0; i < DAYCARE_MON_COUNT; i++)
     {
+        u16 moveLearnerSpecies = GetBoxMonData(&gSaveBlock1Ptr->daycare.mons[i].mon, MON_DATA_SPECIES);
+
         if (!GetBoxMonData(&gSaveBlock1Ptr->daycare.mons[i].mon, MON_DATA_SANITY_HAS_SPECIES))
             continue;
 
         BoxMonToMon(&gSaveBlock1Ptr->daycare.mons[i].mon, &mon);
         ClearHatchedEggMoves();
-        numEggMoves = GetEggMoves(&mon, sHatchedEggEggMoves);
+        numEggMoves = GetEggMovesSpecies(GetEggSpecies(moveLearnerSpecies), sHatchedEggEggMoves);
         for (j = 0; j < numEggMoves; j++)
         {
             // Go through other Daycare mons
             for (k = 0; k < DAYCARE_MON_COUNT; k++)
             {
+                u16 moveTeacherSpecies = GetBoxMonData(&gSaveBlock1Ptr->daycare.mons[k].mon, MON_DATA_SPECIES);
+
                 if (k == i || !GetBoxMonData(&gSaveBlock1Ptr->daycare.mons[k].mon, MON_DATA_SANITY_HAS_SPECIES))
                     continue;
 
                 // Check if you can inherit from them
-                if (GetBoxMonData(&gSaveBlock1Ptr->daycare.mons[k].mon, MON_DATA_SPECIES) != GetBoxMonData(&gSaveBlock1Ptr->daycare.mons[i].mon, MON_DATA_SPECIES)
+                if (GetFormSpeciesId(moveTeacherSpecies, 0) != GetFormSpeciesId(moveLearnerSpecies, 0)
                     && (P_EGG_MOVE_TRANSFER < GEN_9 || GetBoxMonData(&gSaveBlock1Ptr->daycare.mons[i].mon, MON_DATA_HELD_ITEM) != ITEM_MIRROR_HERB)
                 )
                     continue;

--- a/src/daycare.c
+++ b/src/daycare.c
@@ -205,10 +205,13 @@ static void TransferEggMoves(void)
         // Make sure Snorlax gets Snorlax's egg moves instead of Munchlax's
         if (eggSpecies != moveLearnerSpecies)
         {
-            for (j = 0; j < sizeof(sIncenseBabyTable) / sizeof(sIncenseBabyTable[0]); j++)
+            for (j = 0; j < ARRAY_COUNT(sIncenseBabyTable); j++)
                 {
-                    if (sIncenseBabyTable[i].babySpecies == eggSpecies)
-                        eggSpecies = sIncenseBabyTable[i].currSpecies;
+                    if (sIncenseBabyTable[j].babySpecies == eggSpecies)
+                    {
+                        eggSpecies = sIncenseBabyTable[j].currSpecies;
+                        break;
+                    }
                 }
         }
 

--- a/src/pokedex_plus_hgss.c
+++ b/src/pokedex_plus_hgss.c
@@ -5128,7 +5128,7 @@ static bool8 CalculateMoves(void)
         species = GetFormSpeciesId(species, 0);
 
     //Calculate amount of Egg and LevelUp moves
-    numEggMoves = GetEggMovesSpecies(species, statsMovesEgg);
+    numEggMoves = GetEggMovesBySpecies(species, statsMovesEgg);
     numLevelUpMoves = GetLevelUpMovesBySpecies(species, statsMovesLevelUp);
 
     //Egg moves


### PR DESCRIPTION
## Issue(s) that this PR fixes
1. Evolved mons could not copy moves as they do not have their own egg move table.
2. Different forms of the same species could not copy  egg moves from each other.

Alternatively the first issue could be fixed by assigning egg moves to evolved mons.

## **Discord contact info**
duke5614
