### PR TITLE
Dynamic Multichoice no longer plays sound on init

### DIFF
--- a/src/script_menu.c
+++ b/src/script_menu.c
@@ -329,7 +329,8 @@ void MultichoiceDynamic_DestroyStack(void)
 static void MultichoiceDynamic_MoveCursor(s32 itemIndex, bool8 onInit, struct ListMenu *list)
 {
     u8 taskId;
-    PlaySE(SE_SELECT);
+    if (!onInit)
+        PlaySE(SE_SELECT);
     taskId = FindTaskIdByFunc(Task_HandleScrollingMultichoiceInput);
     if (taskId != TASK_NONE)
     {


### PR DESCRIPTION
## Description
Dynamic Multichoice no longer plays SE_SELECT right after being created, matching the behavior of `multichoice` .

## **Discord contact info**
duke5416