### PR TITLE
Fixes Diamond Storm and Mortal Spin's description

### DIFF
--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -14113,6 +14113,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .description = COMPOUND_STRING(
             "Whips up a storm of\n"
             "diamonds. May up Defense."),
+        .effect = EFFECT_HIT,
         .power = 100,
         .type = TYPE_ROCK,
         .accuracy = 95,
@@ -18721,7 +18722,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .name = COMPOUND_STRING("Mortal Spin"),
         .description = COMPOUND_STRING(
             "Erases trap moves and Leech\n"
-            "Seed. Poisons adjecent foes."),
+            "Seed. Poisons adjacent foes."),
         .effect = EFFECT_HIT,
         .power = 30,
         .type = TYPE_POISON,


### PR DESCRIPTION
## Description
Fixes a typo in the description of Mortal Spin and Diamond Storm having no effect.

## **Discord contact info**
PhallenTree
