### PR TITLE
Fixes Assist calling MOVE_NONE

### DIFF
--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -132,6 +132,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .metronomeBanned = TRUE,
         .mirrorMoveBanned = TRUE,
         .sketchBanned = TRUE,
+        .assistBanned = TRUE,
     },
 
     [MOVE_POUND] =


### PR DESCRIPTION
## Description
Fixes Assist calling MOVE_NONE. This would happen if there is a pokemon on the party that doesn't have a full moveset.
The original result of calling MOVE_NONE is shown in the video below (note that Phantom Force is banned by Assist).

https://github.com/rh-hideout/pokeemerald-expansion/assets/168426989/849618c5-7d48-4ff0-b37a-20278acd0a94

## **Discord contact info**
PhallenTree

