### PR TITLE
fix and tweak level cap code

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -4431,15 +4431,19 @@ static void Cmd_getexp(void)
                         gBattleMoveDamage += GetSoftLevelCapExpValue(gPlayerParty[*expMonId].level, gBattleStruct->expShareExpValue);;
                     }
 
-                    if (EXP_CAP_HARD && gBattleMoveDamage != 0)
+                    ApplyExperienceMultipliers(&gBattleMoveDamage, *expMonId, gBattlerFainted);
+
+                    if (B_EXP_CAP_TYPE == EXP_CAP_HARD && gBattleMoveDamage != 0)
                     {
                         u32 growthRate = gSpeciesInfo[GetMonData(&gPlayerParty[*expMonId], MON_DATA_SPECIES)].growthRate;
-                        if (gExperienceTables[growthRate][GetCurrentLevelCap()] < gExperienceTables[growthRate][GetMonData(&gPlayerParty[*expMonId], MON_DATA_LEVEL)] + gBattleMoveDamage)
-                            gBattleMoveDamage = gExperienceTables[growthRate][GetCurrentLevelCap()];
-                    }
+                        u32 currentExp = GetMonData(&gPlayerParty[*expMonId], MON_DATA_EXP);
+                        u32 levelCap = GetCurrentLevelCap();
 
-                    if (!EXP_CAP_HARD || gBattleMoveDamage != 0) // Edge case for hard level caps. Prevents mons from getting 1 exp
-                        ApplyExperienceMultipliers(&gBattleMoveDamage, *expMonId, gBattlerFainted);
+                        if (GetMonData(&gPlayerParty[*expMonId], MON_DATA_LEVEL) >= levelCap)
+                            gBattleMoveDamage = 0;
+                        else if (gExperienceTables[growthRate][levelCap] < currentExp + gBattleMoveDamage)
+                            gBattleMoveDamage = gExperienceTables[growthRate][levelCap] - currentExp;
+                    }
 
                     if (IsTradedMon(&gPlayerParty[*expMonId]))
                     {

--- a/src/level_caps.c
+++ b/src/level_caps.c
@@ -49,15 +49,26 @@ u32 GetSoftLevelCapExpValue(u32 level, u32 expValue)
     if (B_EXP_CAP_TYPE == EXP_CAP_NONE)
         return expValue;
 
-    if (B_LEVEL_CAP_EXP_UP && level < currentLevelCap)
+    if (level < currentLevelCap)
     {
-        levelDifference = currentLevelCap - level;
-        if (levelDifference > ARRAY_COUNT(sExpScalingDown))
-            return expValue + (expValue / sExpScalingUp[ARRAY_COUNT(sExpScalingDown) - 1]);
+        if (B_LEVEL_CAP_EXP_UP)
+        {
+            levelDifference = currentLevelCap - level;
+            if (levelDifference > ARRAY_COUNT(sExpScalingUp))
+                return expValue + (expValue / sExpScalingUp[ARRAY_COUNT(sExpScalingUp) - 1]);
+            else
+                return expValue + (expValue / sExpScalingUp[levelDifference]);
+        }
         else
-            return expValue + (expValue / sExpScalingUp[levelDifference]);
+        {
+            return expValue;
+        }
     }
-    else if (B_EXP_CAP_TYPE == EXP_CAP_SOFT && level >= currentLevelCap)
+    else if (B_EXP_CAP_TYPE == EXP_CAP_HARD)
+    {
+        return 0;
+    }
+    else if (B_EXP_CAP_TYPE == EXP_CAP_SOFT)
     {
         levelDifference = level - currentLevelCap;
         if (levelDifference > ARRAY_COUNT(sExpScalingDown))
@@ -65,13 +76,8 @@ u32 GetSoftLevelCapExpValue(u32 level, u32 expValue)
         else
             return expValue / sExpScalingDown[levelDifference];
     }
-    else if (level < currentLevelCap)
+    else
     {
        return expValue;
     }
-    else
-    {
-        return 0;
-    }
-
 }

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -3531,7 +3531,7 @@ bool8 PokemonUseItemEffects(struct Pokemon *mon, u16 item, u8 partyIndex, u8 mov
                     u16 species = GetMonData(mon, MON_DATA_SPECIES, NULL);
                     dataUnsigned = sExpCandyExperienceTable[param - 1] + GetMonData(mon, MON_DATA_EXP, NULL);
 
-                    if (B_RARE_CANDY_CAP && EXP_CAP_HARD)
+                    if (B_RARE_CANDY_CAP && B_EXP_CAP_TYPE == EXP_CAP_HARD)
                     {
                         u32 currentLevelCap = GetCurrentLevelCap();
                         if (dataUnsigned > gExperienceTables[gSpeciesInfo[species].growthRate][currentLevelCap])


### PR DESCRIPTION
Fixed an absurd amount of experience points being gained.

## Description
Changed the checks order in GetSoftLevelCapExpValue for better clarity.
Fixed parts where EXP_CAP_HARD settings were not properly checked (should have been B_EXP_CAP_TYPE == EXP_CAP_HARD).
Fixed wrong assignment of gBattleMoveDamage to a gExperienceTables value (see picture below).

## Images
![image](https://github.com/rh-hideout/pokeemerald-expansion/assets/140268269/f7677f1a-af7f-44c4-aa8e-a3fe03fa2989)


## Issue(s) that this PR fixes
None opened

## **People who collaborated with me in this PR**
Duke on discord

## **Discord contact info**
Nopinou#8678
