### PR TITLE
Make filepath links in readme relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Based off RHH's pokeemerald-expansion v1.8.0 https://github.com/rh-hideout/pokee
 
 ## What features are included?
 - ***IMPORTANT*❗❗ Read through these to learn what features you can toggle**:
-    - [Battle configurations](/include/config/battle.h)
-    - [Pokémon configurations](/include/config/pokemon.h)
-    - [Item configurations](/include/config/item.h)
-    - [Overworld configurations](/include/config/overworld.h)
-    - [Debug configurations](/include/config/debug.h)
+    - [Battle configurations](include/config/battle.h)
+    - [Pokémon configurations](include/config/pokemon.h)
+    - [Item configurations](include/config/item.h)
+    - [Overworld configurations](include/config/overworld.h)
+    - [Debug configurations](include/config/debug.h)
 - ***Upgraded battle engine.***
     - Gen5+ damage calculation.
     - 2v2 Wild battles support.
@@ -62,7 +62,7 @@ Based off RHH's pokeemerald-expansion v1.8.0 https://github.com/rh-hideout/pokee
     - Recalculating stats at the end of every battle.
     - Level 100 Pokémon can earn EVs.
     - Inverse battle support.
-    - TONS of other features listed [here](/include/config/battle.h).
+    - TONS of other features listed [here](include/config/battle.h).
 - ***Full Trainer customization***
     - Nickname, EVs, IVs, moves, ability, ball, friendship, nature, gender, shininess.
     - Custom tag battle support (teaming up an NPC in a double battle).
@@ -94,7 +94,7 @@ Based off RHH's pokeemerald-expansion v1.8.0 https://github.com/rh-hideout/pokee
     - All gender differences.
         - Custom female icons for female Hippopotas Hippowdon, Pikachu and Wobbufett
     - 3 Perfect IVs on Legendaries, Mythicals and Ultra Beasts.
-- ***Customizable form change tables. Full list of methods [here](/include/constants/form_change_types.h).***
+- ***Customizable form change tables. Full list of methods [here](include/constants/form_change_types.h).***
     - Item holding (eg. Giratina/Arceus)
     - Item using (eg. Oricorio)
         - Time of day option for Shaymin
@@ -115,7 +115,7 @@ Based off RHH's pokeemerald-expansion v1.8.0 https://github.com/rh-hideout/pokee
     - Egg Move Transfer, including Mirror Herb (configurable).
     - Nature inheriting 100% of the time with Everstone (configurable)
     - Gen6+ Ability inheriting (configurable).
-- ***Items from newer Generations. Full list [here](/include/constants/items.h).***
+- ***Items from newer Generations. Full list [here](include/constants/items.h).***
     - ***Gen 6+ Exp. Share*** (configurable)
     - Berserk Gene
     - Most battle items from Gen 4+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This allows programs like emacs to open the proper file when clicking them.  Previously doing so would lead to a different (probably nonexistant) file because they would be interpreted as relative to the filesystem root instead of being relative to the current directory.

Absolute filepaths only work on GitHub because GitHub-flavored markdown does some non-standard magic with them specifically, instead of following the relative URL specification.

## Feature(s) this PR does NOT handle:
Comb through any other markdown files in the repo to update them accordingly.
