### PR TITLE
Fix GetBoxMonData for evolution tracker if compiled with agbcc

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -2537,6 +2537,7 @@ u32 GetBoxMonData3(struct BoxPokemon *boxMon, s32 field, u8 *data)
         case MON_DATA_EVOLUTION_TRACKER:
             evoTracker.asField.a = substruct1->evolutionTracker1;
             evoTracker.asField.b = substruct1->evolutionTracker2;
+            evoTracker.asField.unused = 0;
             retVal = evoTracker.value;
             break;
         default:


### PR DESCRIPTION
## Description
Issue: If compiled with agbcc ```evoTracker.asField.unused``` is not initialized(?) and ``` evoTracker.value ``` reads 7 bits of garbage.
Solution: Initialize ``` evoTracker.asField.unused``` with 0

## Images
before-after comparison:
![image](https://github.com/rh-hideout/pokeemerald-expansion/assets/38510667/ae8bf583-5c02-4543-99b3-b2ca0435b0f2)
asField.a (5 bit) -> 0 or 00000 in binary
asField.b (4 bit) -> 0 or 0000 in binary
asField.unused -> 41 or 101001
value -> 20992 or   101001 | 0000 | 00000 (unused | b | a) in binary

## **Discord contact info**
.cawt
