### PR TITLE
Add tests to complement PR 4500

### DIFF
--- a/test/battle/ability/beads_of_ruin.c
+++ b/test/battle/ability/beads_of_ruin.c
@@ -29,3 +29,47 @@ SINGLE_BATTLE_TEST("Beads of Ruin reduces Sp. Def if opposing mon's ability does
         EXPECT_MUL_EQ(damage[1], Q_4_12(1.33), damage[0]);
     }
 }
+
+SINGLE_BATTLE_TEST("Beads of Ruin's message displays correctly after all battlers fainted - Player")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_EXPLOSION].effect == EFFECT_EXPLOSION);
+        PLAYER(SPECIES_WOBBUFFET) { HP(1);}
+        PLAYER(SPECIES_CHI_YU);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_EXPLOSION); SEND_OUT(player, 1); SEND_OUT(opponent, 1); }
+        TURN { MOVE(player, MOVE_TACKLE); MOVE(opponent, MOVE_RUINATION); }
+    } SCENE {
+        HP_BAR(opponent, hp: 0);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, opponent);
+        // Everyone faints.
+        MESSAGE("Go! Chi-Yu!");
+        ABILITY_POPUP(player, ABILITY_BEADS_OF_RUIN);
+        MESSAGE("Chi-Yu's Beads of Ruin weakened the Sp. Def of all surrounding Pokémon!");
+        MESSAGE("2 sent out Wobbuffet!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Beads of Ruin's message displays correctly after all battlers fainted - Opponent")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_EXPLOSION].effect == EFFECT_EXPLOSION);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { HP(1);}
+        OPPONENT(SPECIES_CHI_YU);
+    } WHEN {
+        TURN { MOVE(player, MOVE_EXPLOSION); SEND_OUT(player, 1); SEND_OUT(opponent, 1); }
+        TURN { MOVE(player, MOVE_RUINATION); MOVE(opponent, MOVE_TACKLE); }
+    } SCENE {
+        HP_BAR(player, hp: 0);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, player);
+        // Everyone faints.
+        MESSAGE("Go! Wobbuffet!");
+        MESSAGE("2 sent out Chi-Yu!");
+        ABILITY_POPUP(opponent, ABILITY_BEADS_OF_RUIN);
+        MESSAGE("Foe Chi-Yu's Beads of Ruin weakened the Sp. Def of all surrounding Pokémon!");
+    }
+}

--- a/test/battle/ability/costar.c
+++ b/test/battle/ability/costar.c
@@ -1,0 +1,8 @@
+#include "global.h"
+#include "test/battle.h"
+
+TO_DO_BATTLE_TEST("Costar copies an ally's stat stages upon entering battle");
+
+// Copy from Ruin ability tests
+TO_DO_BATTLE_TEST("Costar's message displays correctly after all battlers fainted - Player");
+TO_DO_BATTLE_TEST("Costar's message displays correctly after all battlers fainted - Opponent");

--- a/test/battle/ability/supreme_overlord.c
+++ b/test/battle/ability/supreme_overlord.c
@@ -1,7 +1,7 @@
 #include "global.h"
 #include "test/battle.h"
 
-DOUBLE_BATTLE_TEST("Supreme Overlord boosts Attack by an additive 10% per fainted mon on the side", s16 damage)
+DOUBLE_BATTLE_TEST("Supreme Overlord boosts Attack by an additive 10% per fainted mon on its side upon switch in", s16 damage)
 {
     bool32 switchMon = 0;
     PARAMETRIZE { switchMon = FALSE; }
@@ -21,6 +21,10 @@ DOUBLE_BATTLE_TEST("Supreme Overlord boosts Attack by an additive 10% per fainte
             TURN { SWITCH(playerLeft, 0); }
         TURN { MOVE(playerLeft, MOVE_TACKLE, target: opponentLeft); }
     } SCENE {
+        if (switchMon) {
+            ABILITY_POPUP(playerLeft, ABILITY_SUPREME_OVERLORD);
+            MESSAGE("Kingambit gained strength from the fallen!");
+        }
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, playerLeft);
         HP_BAR(opponentLeft, captureDamage: &results[i].damage);
     } FINALLY {
@@ -51,6 +55,8 @@ DOUBLE_BATTLE_TEST("Supreme Overlord's boost caps at a 1.5x multipler", s16 dama
         TURN { SWITCH(playerRight, 3); }
         TURN { MOVE(playerRight, MOVE_TACKLE, target: opponentLeft); }
     } SCENE {
+        ABILITY_POPUP(playerRight, ABILITY_SUPREME_OVERLORD);
+        MESSAGE("Kingambit gained strength from the fallen!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, playerRight);
         HP_BAR(opponentLeft, captureDamage: &results[i].damage);
     } FINALLY {
@@ -83,5 +89,54 @@ SINGLE_BATTLE_TEST("Supreme Overlord does not boost attack if party members are 
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
         EXPECT_EQ(results[0].damage, results[1].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Supreme Overlord's message displays correctly after all battlers fainted - Player")
+{
+    // For some reason the Ability Pop Up fails to appear after Explosion.
+    KNOWN_FAILING;
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_EXPLOSION].effect == EFFECT_EXPLOSION);
+        PLAYER(SPECIES_WOBBUFFET) { HP(1);}
+        PLAYER(SPECIES_KINGAMBIT);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_EXPLOSION); SEND_OUT(player, 1); SEND_OUT(opponent, 1); }
+        TURN { MOVE(player, MOVE_TACKLE); MOVE(opponent, MOVE_KOWTOW_CLEAVE); }
+    } SCENE {
+        HP_BAR(opponent, hp: 0);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, opponent);
+        // Everyone faints.
+        MESSAGE("Go! Kingambit!");
+        ABILITY_POPUP(player, ABILITY_SUPREME_OVERLORD);
+        MESSAGE("Kingambit gained strength from the fallen!");
+        MESSAGE("2 sent out Wobbuffet!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Supreme Overlord's message displays correctly after all battlers fainted - Opponent")
+{
+    // For some reason the Ability Pop Up fails to appear after Explosion.
+    KNOWN_FAILING;
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_EXPLOSION].effect == EFFECT_EXPLOSION);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { HP(1);}
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_KINGAMBIT);
+    } WHEN {
+        TURN { MOVE(player, MOVE_EXPLOSION); SEND_OUT(player, 1); SEND_OUT(opponent, 1); }
+        TURN { SWITCH(opponent, 2); MOVE(player, MOVE_TACKLE); }
+    } SCENE {
+        HP_BAR(player, hp: 0);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, player);
+        // Everyone faints.
+        MESSAGE("Go! Wobbuffet!");
+        MESSAGE("2 sent out Kingambit!");
+        ABILITY_POPUP(opponent, ABILITY_SUPREME_OVERLORD);
+        MESSAGE("Foe Kingambit gained strength from the fallen!");
     }
 }

--- a/test/battle/ability/sword_of_ruin.c
+++ b/test/battle/ability/sword_of_ruin.c
@@ -29,3 +29,47 @@ SINGLE_BATTLE_TEST("Sword of Ruin reduces Defense if opposing mon's ability does
         EXPECT_MUL_EQ(damage[1], Q_4_12(1.33), damage[0]);
     }
 }
+
+SINGLE_BATTLE_TEST("Sword of Ruin's message displays correctly after all battlers fainted - Player")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_EXPLOSION].effect == EFFECT_EXPLOSION);
+        PLAYER(SPECIES_WOBBUFFET) { HP(1);}
+        PLAYER(SPECIES_CHIEN_PAO);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_EXPLOSION); SEND_OUT(player, 1); SEND_OUT(opponent, 1); }
+        TURN { MOVE(player, MOVE_TACKLE); MOVE(opponent, MOVE_RUINATION); }
+    } SCENE {
+        HP_BAR(opponent, hp: 0);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, opponent);
+        // Everyone faints.
+        MESSAGE("Go! Chien-Pao!");
+        ABILITY_POPUP(player, ABILITY_SWORD_OF_RUIN);
+        MESSAGE("Chien-Pao's Sword of Ruin weakened the Defense of all surrounding Pokémon!");
+        MESSAGE("2 sent out Wobbuffet!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Sword of Ruin's message displays correctly after all battlers fainted - Opponent")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_EXPLOSION].effect == EFFECT_EXPLOSION);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { HP(1);}
+        OPPONENT(SPECIES_CHIEN_PAO);
+    } WHEN {
+        TURN { MOVE(player, MOVE_EXPLOSION); SEND_OUT(player, 1); SEND_OUT(opponent, 1); }
+        TURN { MOVE(player, MOVE_RUINATION); MOVE(opponent, MOVE_TACKLE); }
+    } SCENE {
+        HP_BAR(player, hp: 0);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, player);
+        // Everyone faints.
+        MESSAGE("Go! Wobbuffet!");
+        MESSAGE("2 sent out Chien-Pao!");
+        ABILITY_POPUP(opponent, ABILITY_SWORD_OF_RUIN);
+        MESSAGE("Foe Chien-Pao's Sword of Ruin weakened the Defense of all surrounding Pokémon!");
+    }
+}

--- a/test/battle/ability/tablets_of_ruin.c
+++ b/test/battle/ability/tablets_of_ruin.c
@@ -29,3 +29,47 @@ SINGLE_BATTLE_TEST("Tablets of Ruin reduces Attack if opposing mon's ability doe
         EXPECT_MUL_EQ(damage[0], Q_4_12(1.33), damage[1]);
     }
 }
+
+SINGLE_BATTLE_TEST("Tablets of Ruin's message displays correctly after all battlers fainted - Player")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_EXPLOSION].effect == EFFECT_EXPLOSION);
+        PLAYER(SPECIES_WOBBUFFET) { HP(1);}
+        PLAYER(SPECIES_WO_CHIEN);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_EXPLOSION); SEND_OUT(player, 1); SEND_OUT(opponent, 1); }
+        TURN { MOVE(player, MOVE_TACKLE); MOVE(opponent, MOVE_RUINATION); }
+    } SCENE {
+        HP_BAR(opponent, hp: 0);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, opponent);
+        // Everyone faints.
+        MESSAGE("Go! Wo-Chien!");
+        ABILITY_POPUP(player, ABILITY_TABLETS_OF_RUIN);
+        MESSAGE("Wo-Chien's Tablets of Ruin weakened the Attack of all surrounding Pokémon!");
+        MESSAGE("2 sent out Wobbuffet!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Tablets of Ruin's message displays correctly after all battlers fainted - Opponent")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_EXPLOSION].effect == EFFECT_EXPLOSION);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { HP(1);}
+        OPPONENT(SPECIES_WO_CHIEN);
+    } WHEN {
+        TURN { MOVE(player, MOVE_EXPLOSION); SEND_OUT(player, 1); SEND_OUT(opponent, 1); }
+        TURN { MOVE(player, MOVE_RUINATION); MOVE(opponent, MOVE_TACKLE); }
+    } SCENE {
+        HP_BAR(player, hp: 0);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, player);
+        // Everyone faints.
+        MESSAGE("Go! Wobbuffet!");
+        MESSAGE("2 sent out Wo-Chien!");
+        ABILITY_POPUP(opponent, ABILITY_TABLETS_OF_RUIN);
+        MESSAGE("Foe Wo-Chien's Tablets of Ruin weakened the Attack of all surrounding Pokémon!");
+    }
+}

--- a/test/battle/ability/vessel_of_ruin.c
+++ b/test/battle/ability/vessel_of_ruin.c
@@ -29,3 +29,47 @@ SINGLE_BATTLE_TEST("Vessel of Ruin reduces Sp. Atk if opposing mon's ability doe
         EXPECT_MUL_EQ(damage[0], Q_4_12(1.33), damage[1]);
     }
 }
+
+SINGLE_BATTLE_TEST("Vessel of Ruin's message displays correctly after all battlers fainted - Player")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_EXPLOSION].effect == EFFECT_EXPLOSION);
+        PLAYER(SPECIES_WOBBUFFET) { HP(1);}
+        PLAYER(SPECIES_TING_LU);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_EXPLOSION); SEND_OUT(player, 1); SEND_OUT(opponent, 1); }
+        TURN { MOVE(player, MOVE_TACKLE); MOVE(opponent, MOVE_RUINATION); }
+    } SCENE {
+        HP_BAR(opponent, hp: 0);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, opponent);
+        // Everyone faints.
+        MESSAGE("Go! Ting-Lu!");
+        ABILITY_POPUP(player, ABILITY_VESSEL_OF_RUIN);
+        MESSAGE("Ting-Lu's Vessel of Ruin weakened the Sp. Atk of all surrounding Pokémon!");
+        MESSAGE("2 sent out Wobbuffet!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Vessel of Ruin's message displays correctly after all battlers fainted - Opponent")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_EXPLOSION].effect == EFFECT_EXPLOSION);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { HP(1);}
+        OPPONENT(SPECIES_TING_LU);
+    } WHEN {
+        TURN { MOVE(player, MOVE_EXPLOSION); SEND_OUT(player, 1); SEND_OUT(opponent, 1); }
+        TURN { MOVE(player, MOVE_RUINATION); MOVE(opponent, MOVE_TACKLE); }
+    } SCENE {
+        HP_BAR(player, hp: 0);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, player);
+        // Everyone faints.
+        MESSAGE("Go! Wobbuffet!");
+        MESSAGE("2 sent out Ting-Lu!");
+        ABILITY_POPUP(opponent, ABILITY_VESSEL_OF_RUIN);
+        MESSAGE("Foe Ting-Lu's Vessel of Ruin weakened the Sp. Atk of all surrounding Pokémon!");
+    }
+}

--- a/test/battle/ability/zero_to_hero.c
+++ b/test/battle/ability/zero_to_hero.c
@@ -136,6 +136,52 @@ SINGLE_BATTLE_TEST("Imposter doesn't apply the heroic transformation message whe
     } THEN { EXPECT_EQ(player->species, SPECIES_PALAFIN_HERO); }
 }
 
+SINGLE_BATTLE_TEST("Zero to Hero's message displays correctly after all battlers fainted - Player")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_EXPLOSION].effect == EFFECT_EXPLOSION);
+        PLAYER(SPECIES_PALAFIN_ZERO);
+        PLAYER(SPECIES_WOBBUFFET) { HP(1);}
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_FLIP_TURN); SEND_OUT(player, 1); }
+        TURN { MOVE(opponent, MOVE_EXPLOSION); SEND_OUT(player, 0); SEND_OUT(opponent, 1); }
+        TURN { MOVE(player, MOVE_TACKLE); MOVE(opponent, MOVE_TACKLE); }
+    } SCENE {
+        HP_BAR(opponent, hp: 0);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, opponent);
+        // Everyone faints.
+        MESSAGE("Go! Palafin!");
+        ABILITY_POPUP(player, ABILITY_ZERO_TO_HERO);
+        MESSAGE("Palafin underwent a heroic transformation!");
+        MESSAGE("2 sent out Wobbuffet!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Zero to Hero's message displays correctly after all battlers fainted - Opponent")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_EXPLOSION].effect == EFFECT_EXPLOSION);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_PALAFIN_ZERO);
+        OPPONENT(SPECIES_WOBBUFFET) { HP(1);}
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_FLIP_TURN); SEND_OUT(opponent, 1); }
+        TURN { MOVE(opponent, MOVE_CELEBRATE); MOVE(player, MOVE_EXPLOSION); SEND_OUT(player, 1); SEND_OUT(opponent, 0); }
+        TURN { MOVE(opponent, MOVE_TACKLE); MOVE(player, MOVE_TACKLE); }
+    } SCENE {
+        HP_BAR(player, hp: 0);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, player);
+        // Everyone faints.
+        MESSAGE("Go! Wobbuffet!");
+        MESSAGE("2 sent out Palafin!");
+        ABILITY_POPUP(opponent, ABILITY_ZERO_TO_HERO);
+        MESSAGE("Foe Palafin underwent a heroic transformation!");
+    }
+}
+
 // Write Trace test and move this one to that file (including every other ability that can't be copied)
 SINGLE_BATTLE_TEST("Zero to Hero cannot be copied by Trace")
 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
#4500 fixed messaging certain abilities, but tests weren't added to complement this.
Confirmed that the test fails without the fix for the Ruin abilities and Zero to Hero, but I couldn't make Supreme Overlord trigger when using explosion, so I marked them as `KNOWN_FAILING`.

## Feature(s) this PR does NOT handle:
Costar didn't have a test, so for now I decided to leave it as a TODO test.

## **Discord contact info**
AsparagusEduardo
