### PR TITLE
Restore specialTrainerBattleType in ClearSetBScriptingStruct

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3290,11 +3290,13 @@ static void ClearSetBScriptingStruct(void)
 {
     // windowsType is set up earlier in BattleInitBgsAndWindows, so we need to save the value
     u32 temp = gBattleScripting.windowsType;
+    u32 specialBattleType = gBattleScripting.specialTrainerBattleType;
     memset(&gBattleScripting, 0, sizeof(gBattleScripting));
 
     gBattleScripting.windowsType = temp;
     gBattleScripting.battleStyle = gSaveBlock2Ptr->optionsBattleStyle;
     gBattleScripting.expOnCatch = (B_EXP_CATCH >= GEN_6);
+    gBattleScripting.specialTrainerBattleType = specialBattleType;
 }
 
 static void BattleStartClearSetData(void)


### PR DESCRIPTION
`specialTrainerBattleType` gets reset in `ClearSetBScriptingStruct`, which is needed for `DoSpecialTrainerBattle`/`HandleSpecialTrainerBattleEnd`