### PR TITLE
Prevents Terastallization UI from making part of the Safari Zone battle UI invisible

### DIFF
--- a/src/battle_terastal.c
+++ b/src/battle_terastal.c
@@ -8,6 +8,7 @@
 #include "item.h"
 #include "palette.h"
 #include "pokemon.h"
+#include "safari_zone.h"
 #include "sprite.h"
 #include "util.h"
 #include "constants/abilities.h"
@@ -721,6 +722,9 @@ void TeraIndicator_SetVisibilities(u32 healthboxId, bool32 invisible)
 {
     u8 spriteId = TeraIndicator_GetSpriteId(healthboxId);
     u32 battler = gSprites[healthboxId].hMain_Battler;
+	
+	if (GetSafariZoneFlag())
+        return;
 
     if (invisible == TRUE)
         gSprites[spriteId].invisible = TRUE;

--- a/src/battle_terastal.c
+++ b/src/battle_terastal.c
@@ -722,8 +722,8 @@ void TeraIndicator_SetVisibilities(u32 healthboxId, bool32 invisible)
 {
     u8 spriteId = TeraIndicator_GetSpriteId(healthboxId);
     u32 battler = gSprites[healthboxId].hMain_Battler;
-	
-	if (GetSafariZoneFlag())
+
+    if (GetSafariZoneFlag())
         return;
 
     if (invisible == TRUE)


### PR DESCRIPTION
Checks if the Safari Zone flag is set to avoid making part of the battle UI invisible.

## Images
Before fix:
![image](https://github.com/rh-hideout/pokeemerald-expansion/assets/57021938/93a14eb6-1b1b-4f68-a228-19b4b546ee51)

After fix:
![image](https://github.com/rh-hideout/pokeemerald-expansion/assets/57021938/15ccd0cb-7f8b-466e-8268-baedd960004f)


## **People who collaborated with me in this PR**
This is Jasper's fix, I'm just making the PR.

## **Discord contact info**
Special K#8400
