### PR TITLE
Fixed moves with HP cost triggering effects where they shouldn't

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -52,6 +52,7 @@ BattleScript_EffectShedTail::
 	jumpifcantswitch SWITCH_IGNORE_ESCAPE_PREVENTION | BS_ATTACKER, BattleScript_ButItFailed
 	setsubstitute
 	jumpifbyte CMP_EQUAL, cMULTISTRING_CHOOSER, B_MSG_SUBSTITUTE_FAILED, BattleScript_SubstituteString
+        orword gHitMarker, HITMARKER_PASSIVE_DAMAGE
 	attackanimation
 	waitanimation
 	healthbarupdate BS_ATTACKER
@@ -76,7 +77,7 @@ BattleScript_EffectFilletAway::
 	jumpifstat BS_ATTACKER, CMP_EQUAL, STAT_SPEED, MAX_STAT_STAGE, BattleScript_ButItFailed
 BattleScript_FilletAwayTryAttack::
 	halvehp BattleScript_ButItFailed
-	orword gHitMarker, HITMARKER_IGNORE_SUBSTITUTE
+	orword gHitMarker, HITMARKER_IGNORE_SUBSTITUTE | HITMARKER_PASSIVE_DAMAGE
 	attackanimation
 	waitanimation
 	setbyte sSTAT_ANIM_PLAYED, FALSE
@@ -3834,6 +3835,7 @@ BattleScript_EffectSubstitute::
 	jumpifstatus2 BS_ATTACKER, STATUS2_SUBSTITUTE, BattleScript_AlreadyHasSubstitute
 	setsubstitute
 	jumpifbyte CMP_EQUAL, cMULTISTRING_CHOOSER, B_MSG_SUBSTITUTE_FAILED, BattleScript_SubstituteString
+        orword gHitMarker, HITMARKER_PASSIVE_DAMAGE
 	attackanimation
 	waitanimation
 	healthbarupdate BS_ATTACKER
@@ -4568,7 +4570,7 @@ BattleScript_EffectBellyDrum::
 	ppreduce
 	jumpifstat BS_ATTACKER, CMP_EQUAL, STAT_ATK, MAX_STAT_STAGE, BattleScript_ButItFailed
 	halvehp BattleScript_ButItFailed
-	orword gHitMarker, HITMARKER_IGNORE_SUBSTITUTE
+	orword gHitMarker, HITMARKER_IGNORE_SUBSTITUTE | HITMARKER_PASSIVE_DAMAGE
 	attackanimation
 	waitanimation
 	healthbarupdate BS_ATTACKER

--- a/test/battle/move_effect/belly_drum.c
+++ b/test/battle/move_effect/belly_drum.c
@@ -90,3 +90,17 @@ SINGLE_BATTLE_TEST("Belly Drum fails if the user's Attack is already at +6")
         }
     }
 }
+
+SINGLE_BATTLE_TEST("Belly Drum's HP cost doesn't trigger effects that trigger on damage taken")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_AIR_BALLOON); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_BELLY_DRUM); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BELLY_DRUM, player);
+        MESSAGE("Wobbuffet cut its own HP and maximized ATTACK!");
+        NOT MESSAGE("Wobbuffet's Air Balloon popped!");
+    }
+}

--- a/test/battle/move_effect/fillet_away.c
+++ b/test/battle/move_effect/fillet_away.c
@@ -56,3 +56,19 @@ SINGLE_BATTLE_TEST("Fillet Away fails if user's current HP is half or less than 
         }
     }
 }
+
+SINGLE_BATTLE_TEST("Fillet Away's HP cost doesn't trigger effects that trigger on damage taken")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_AIR_BALLOON); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_FILLET_AWAY); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FILLET_AWAY, player);
+        MESSAGE("Wobbuffet's Attack sharply rose!");
+        MESSAGE("Wobbuffet's Sp. Atk sharply rose!");
+        MESSAGE("Wobbuffet's Speed sharply rose!");
+        NOT MESSAGE("Wobbuffet's Air Balloon popped!");
+    }
+}

--- a/test/battle/move_effect/shed_tail.c
+++ b/test/battle/move_effect/shed_tail.c
@@ -70,3 +70,18 @@ SINGLE_BATTLE_TEST("Shed Tail fails if there are no usable pokemon left")
         MESSAGE("But it failed!");
     }
 }
+
+SINGLE_BATTLE_TEST("Shed Tail's HP cost doesn't trigger effects that trigger on damage taken")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_AIR_BALLOON); }
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_SHED_TAIL); SEND_OUT(player, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SHED_TAIL, player);
+        MESSAGE("Wobbuffet shed its tail to create a decoy!");
+        NOT MESSAGE("Wobbuffet's Air Balloon popped!");
+    }
+}

--- a/test/battle/move_effect/substitute.c
+++ b/test/battle/move_effect/substitute.c
@@ -54,3 +54,17 @@ SINGLE_BATTLE_TEST("Substitute's HP cost can trigger a berry")
         MESSAGE("Wobbuffet's Sitrus Berry restored health!");
     }
 }
+
+SINGLE_BATTLE_TEST("Substitute's HP cost doesn't trigger effects that trigger on damage taken")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_AIR_BALLOON); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_SUBSTITUTE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SUBSTITUTE, player);
+        MESSAGE("Wobbuffet made a SUBSTITUTE!");
+        NOT MESSAGE("Wobbuffet's Air Balloon popped!");
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Marked the damage taken from using those moves as "passive damage" so that they don't trigger on-hit effects.

## Description
<!--- Describe your changes in detail -->
Added `HITMARKER_PASSIVE_DAMAGE` to moves that costs HP to use and erroneously triggered on-hit effects. Substitute, Belly Drum, Fillet Away and Shed Tail were the moves exhibited this behavior.
Wrote tests to check if said moves trigger on-hit effects.

## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, fixes #2222." -->
<!-- If it doesn't apply, feel free to remove this section. -->
Fixes #4527 



## **Discord contact info**
<!--- formatted as name#numbers, e.g. Lunos#4026 -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara
