### PR TITLE
Changed item descriptions to prevent text overflowing into scroll menus

### DIFF
--- a/src/data/items.h
+++ b/src/data/items.h
@@ -3682,7 +3682,7 @@ const struct Item gItemsInfo[] =
         .name = _("Dubious Disc"),
         .price = (I_PRICE >= GEN_7) ? 2000 * TREASURE_FACTOR : 2100,
         .description = COMPOUND_STRING(
-            "A transparent device\n"
+            "A clear device\n"
             "overflowing with\n"
             "dubious data."),
         .pocket = POCKET_ITEMS,

--- a/src/data/items.h
+++ b/src/data/items.h
@@ -9413,7 +9413,7 @@ const struct Item gItemsInfo[] =
             "Fires an icy cold\n"
             "beam that may\n"
         #if B_USE_FROSTBITE == TRUE
-            "give the foe frostbite."),
+            "inflict frostbite."),
         #else
             "freeze the foe."),
         #endif
@@ -9429,11 +9429,13 @@ const struct Item gItemsInfo[] =
         .name = _("TM14"),
         .price = 5500,
         .description = COMPOUND_STRING(
+        #if B_USE_FROSTBITE == TRUE
+            "A snow-and-wind\n"
+            "attack that may\n"
+            "inflict frostbite."),
+        #else
             "A brutal snow-and-\n"
             "wind attack that\n"
-        #if B_USE_FROSTBITE == TRUE
-            "may give the foe frostbite."),
-        #else
             "may freeze the foe."),
         #endif
         .importance = I_REUSABLE_TMS,


### PR DESCRIPTION
## Description
The first line of the Dubious Disc description was too long. A few letters would escape the box in the Bag and in Marts. This brings them in line.

Additionally, when the Freeze Status is replaced with Frostbite, the descriptions of the Ice Beam and Blizzard TMs are too long, so I altered those as well.

## Images
Dubious Disc Post-fix:
![image](https://github.com/rh-hideout/pokeemerald-expansion/assets/57021938/e8871cb6-69cc-4f45-8ae8-8bbd9698b5cb)

Should've taken a screenshot before the fix, but with "transparent" instead of "clear," the last "e" in "device" was well into the scroll menu.

Blizzard TM Pre-fix:
![image](https://github.com/rh-hideout/pokeemerald-expansion/assets/57021938/fda33feb-b33b-4a43-984c-becd641024de)

Blizzard TM Post-fix:
![image](https://github.com/rh-hideout/pokeemerald-expansion/assets/57021938/88de6f1a-6981-4b8b-a506-ef1b90a25560)

## **Discord contact info**
Special K#8400
