### PR TITLE
Fixes Future Sight freeze/weird behavior

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -2973,6 +2973,15 @@ bool32 HandleWishPerishSongOnTurnEnd(void)
             {
                 struct Pokemon *party;
 
+                if (gWishFutureKnock.futureSightCounter[battler] == 0
+                 && gWishFutureKnock.futureSightCounter[BATTLE_PARTNER(battler)] == 0)
+                {
+                    gSideStatuses[GetBattlerSide(battler)] &= ~SIDE_STATUS_FUTUREATTACK;
+                }
+
+                if (!IsBattlerAlive(battler))
+                    continue;
+
                 if (gWishFutureKnock.futureSightMove[battler] == MOVE_FUTURE_SIGHT)
                     gBattleCommunication[MULTISTRING_CHOOSER] = B_MSG_FUTURE_SIGHT;
                 else
@@ -2990,12 +2999,6 @@ bool32 HandleWishPerishSongOnTurnEnd(void)
                     SetTypeBeforeUsingMove(gCurrentMove, gBattlerAttacker);
 
                 BattleScriptExecute(BattleScript_MonTookFutureAttack);
-
-                if (gWishFutureKnock.futureSightCounter[battler] == 0
-                 && gWishFutureKnock.futureSightCounter[BATTLE_PARTNER(battler)] == 0)
-                {
-                    gSideStatuses[GetBattlerSide(gBattlerTarget)] &= ~SIDE_STATUS_FUTUREATTACK;
-                }
 
                 return TRUE;
             }

--- a/test/battle/move_effect/future_sight.c
+++ b/test/battle/move_effect/future_sight.c
@@ -132,3 +132,24 @@ SINGLE_BATTLE_TEST("Future Sight will miss timing if target faints before it is 
         NOT MESSAGE("Foe Wynaut took the Future Sight attack!");
     }
 }
+
+SINGLE_BATTLE_TEST("Future Sight will miss timing if target faints by residual damage")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { HP(10); }
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN { MOVE(player, MOVE_FUTURE_SIGHT); }
+        TURN { MOVE(player, MOVE_CELEBRATE); }
+        TURN { MOVE(player, MOVE_WRAP); SEND_OUT(opponent, 1); }
+        TURN { }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FUTURE_SIGHT, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_WRAP, player);
+        MESSAGE("Foe Wobbuffet fainted!");
+        MESSAGE("2 sent out Wynaut!");
+        NOT MESSAGE("Foe Wynaut took the Future Sight attack!");
+    }
+}


### PR DESCRIPTION
Fixes #4542

Fixes freeze/weird behavior if a mon was killed by residual damage while a future sight attack attempted to strike. 