### PR TITLE
Fixes Copycat issues with Z-Moves and 2 turn moves

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -1684,6 +1684,8 @@ BattleScript_EffectCopycat::
 	trycopycat BattleScript_CopycatFail
 	attackanimation
 	waitanimation
+	setbyte sB_ANIM_TURN, 0
+	setbyte sB_ANIM_TARGETS_HIT, 0
 	jumptocalledmove TRUE
 BattleScript_CopycatFail:
 	ppreduce

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -16650,7 +16650,7 @@ void BS_TryCopycat(void)
 {
     NATIVE_ARGS(const u8 *failInstr);
 
-    if (gLastUsedMove == MOVE_NONE || gLastUsedMove == MOVE_UNAVAILABLE || gMovesInfo[gLastUsedMove].copycatBanned)
+    if (gLastUsedMove == MOVE_NONE || gLastUsedMove == MOVE_UNAVAILABLE || gMovesInfo[gLastUsedMove].copycatBanned || IsZMove(gLastUsedMove))
     {
         gBattlescriptCurrInstr = cmd->failInstr;
     }


### PR DESCRIPTION
## Description
Fixes Copycat being able to call Z-Moves (should fail) and fixes Copycat-called 2 turn moves (like Fly, Ice Burn, ...) having the second turn's animation play on both turns.

## Issue(s) that this PR fixes
Fixes #4490 

## **Discord contact info**
PhallenTree
