### PR TITLE
Fix silent Oricorio Pom-Pom cry

### DIFF
--- a/sound/cry_tables.inc
+++ b/sound/cry_tables.inc
@@ -1786,7 +1786,7 @@ gCryTable::
 .endif @ P_FAMILY_CRABRAWLER
 .if P_FAMILY_ORICORIO == TRUE
 	cry Cry_OricorioBaile
-	cry_uncomp Cry_OricorioPomPom @ Cannot be heard unless we use cry_reverse_uncomp here.
+	cry_uncomp Cry_OricorioPomPom @ Cannot be heard unless we use cry_uncomp here.
 	cry Cry_OricorioPau
 	cry Cry_OricorioSensu
 .endif @ P_FAMILY_ORICORIO

--- a/sound/cry_tables.inc
+++ b/sound/cry_tables.inc
@@ -1786,7 +1786,7 @@ gCryTable::
 .endif @ P_FAMILY_CRABRAWLER
 .if P_FAMILY_ORICORIO == TRUE
 	cry Cry_OricorioBaile
-	cry Cry_OricorioPomPom
+	cry_uncomp Cry_OricorioPomPom @ Cannot be heard unless we use cry_reverse_uncomp here.
 	cry Cry_OricorioPau
 	cry Cry_OricorioSensu
 .endif @ P_FAMILY_ORICORIO
@@ -4212,7 +4212,7 @@ gCryTable_Reverse::
 .endif @ P_FAMILY_CRABRAWLER
 .if P_FAMILY_ORICORIO == TRUE
 	cry_reverse Cry_OricorioBaile
-	cry_reverse Cry_OricorioPomPom
+	cry_reverse_uncomp Cry_OricorioPomPom @ Cannot be heard unless we use cry_reverse_uncomp here.
 	cry_reverse Cry_OricorioPau
 	cry_reverse Cry_OricorioSensu
 .endif @ P_FAMILY_ORICORIO


### PR DESCRIPTION
This PR fixes Oricorio Pom-Pom silent cry.
It does the same thing as https://github.com/rh-hideout/pokeemerald-expansion/pull/4392 but with this guy.


## Images

https://github.com/rh-hideout/pokeemerald-expansion/assets/46283144/75f63388-236b-490c-9fb1-91dd24395647


https://github.com/rh-hideout/pokeemerald-expansion/assets/46283144/8c673577-1450-4f48-94a4-561c69779a6b



