### PR TITLE
Fixed some moves' on-hit effects bypassing Substitutes where they shouldn't and some other things discovered along the way

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -288,6 +288,7 @@ BattleScript_EffectSaltCure::
 	call BattleScript_EffectHit_Ret
 	tryfaintmon BS_TARGET
 	jumpiffainted BS_TARGET, TRUE, BattleScript_EffectSaltCure_End
+	jumpifsubstituteblocks BattleScript_EffectSaltCure_End
 	applysaltcure BS_TARGET
 	printstring STRINGID_TARGETISBEINGSALTCURED
 	waitmessage B_WAIT_TIME_LONG

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -5670,8 +5670,8 @@ static void Cmd_moveend(void)
                 break;
             case MOVE_EFFECT_REMOVE_STATUS: // Smelling salts, Wake-Up Slap, Sparkling Aria
                 if ((gBattleMons[gBattlerTarget].status1 & gMovesInfo[gCurrentMove].argument)
-                        && IsBattlerAlive(gBattlerTarget)
-                        && !DoesSubstituteBlockMove(gBattlerAttacker, gBattlerTarget, gCurrentMove))
+                 && IsBattlerAlive(gBattlerTarget)
+                 && !DoesSubstituteBlockMove(gBattlerAttacker, gBattlerTarget, gCurrentMove))
                 {
                     gBattleMons[gBattlerTarget].status1 &= ~(gMovesInfo[gCurrentMove].argument);
 

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -5397,6 +5397,7 @@ static void Cmd_moveend(void)
     u16 *choicedMoveAtk = NULL;
     u32 endMode, endState;
     u32 originallyUsedMove;
+    u8 currBattler, liveBattlerCount;
 
     if (gChosenMove == MOVE_UNAVAILABLE)
         originallyUsedMove = MOVE_NONE;
@@ -5690,8 +5691,8 @@ static void Cmd_moveend(void)
                         // Checks to see if Sparkling Aria should cure a Shield Dust pokemon
                         if (gBattleMons[gBattlerTarget].ability == ABILITY_SHIELD_DUST || gBattleMons[gBattlerTarget].item == ITEM_COVERT_CLOAK)
                         {
-                            u8 liveBattlerCount = 0;
-                            for (u8 currBattler = 0; currBattler < gBattlersCount; currBattler++)
+                            liveBattlerCount = 0;
+                            for (currBattler = 0; currBattler < gBattlersCount; currBattler++)
                             {
                                 if (gBattleMons[currBattler].hp != 0)
                                 {
@@ -5701,12 +5702,8 @@ static void Cmd_moveend(void)
                             if (liveBattlerCount > 2)
                             {
                                 gBattlescriptCurrInstr = BattleScript_TargetBurnHeal;
-                                break;
                             }
-                            else
-                            {
-                                break;
-                            }
+                            break;
                         }
                         else
                         {

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -5658,8 +5658,8 @@ static void Cmd_moveend(void)
                 break;
             case MOVE_EFFECT_SMACK_DOWN:
                 if (!IsBattlerGrounded(gBattlerTarget)
-                        && IsBattlerAlive(gBattlerTarget)
-                        && !DoesSubstituteBlockMove(gBattlerAttacker, gBattlerTarget, gCurrentMove))
+                 && IsBattlerAlive(gBattlerTarget)
+                 && !DoesSubstituteBlockMove(gBattlerAttacker, gBattlerTarget, gCurrentMove))
                 {
                     gStatuses3[gBattlerTarget] |= STATUS3_SMACKED_DOWN;
                     gStatuses3[gBattlerTarget] &= ~(STATUS3_MAGNET_RISE | STATUS3_TELEKINESIS | STATUS3_ON_AIR);

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -8616,7 +8616,10 @@ static inline u32 CalcMoveBasePower(u32 move, u32 battlerAtk, u32 battlerDef, u3
     case EFFECT_DOUBLE_POWER_ON_ARG_STATUS:
         // Comatose targets treated as if asleep
         if ((gBattleMons[battlerDef].status1 | (STATUS1_SLEEP * (abilityDef == ABILITY_COMATOSE))) & gMovesInfo[move].argument)
-            basePower *= 2;
+            if (!((gMovesInfo[move].additionalEffects->moveEffect == MOVE_EFFECT_REMOVE_STATUS) && DoesSubstituteBlockMove(battlerAtk, battlerDef, move)))
+            {
+                basePower *= 2;
+            }
         break;
     case EFFECT_VARY_POWER_BASED_ON_HP:
         basePower = gMovesInfo[move].argument * gBattleMons[battlerDef].hp / gBattleMons[battlerDef].maxHP;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -8616,8 +8616,7 @@ static inline u32 CalcMoveBasePower(u32 move, u32 battlerAtk, u32 battlerDef, u3
     case EFFECT_DOUBLE_POWER_ON_ARG_STATUS:
         // Comatose targets treated as if asleep
         if ((gBattleMons[battlerDef].status1 | (STATUS1_SLEEP * (abilityDef == ABILITY_COMATOSE))) & gMovesInfo[move].argument
-                && !((gMovesInfo[move].additionalEffects->moveEffect == MOVE_EFFECT_REMOVE_STATUS)
-                    && DoesSubstituteBlockMove(battlerAtk, battlerDef, move)))
+         && !((gMovesInfo[move].additionalEffects->moveEffect == MOVE_EFFECT_REMOVE_STATUS) && DoesSubstituteBlockMove(battlerAtk, battlerDef, move)))
         {
             basePower *= 2;
         }

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -8615,11 +8615,12 @@ static inline u32 CalcMoveBasePower(u32 move, u32 battlerAtk, u32 battlerDef, u3
         break;
     case EFFECT_DOUBLE_POWER_ON_ARG_STATUS:
         // Comatose targets treated as if asleep
-        if ((gBattleMons[battlerDef].status1 | (STATUS1_SLEEP * (abilityDef == ABILITY_COMATOSE))) & gMovesInfo[move].argument)
-            if (!((gMovesInfo[move].additionalEffects->moveEffect == MOVE_EFFECT_REMOVE_STATUS) && DoesSubstituteBlockMove(battlerAtk, battlerDef, move)))
-            {
-                basePower *= 2;
-            }
+        if ((gBattleMons[battlerDef].status1 | (STATUS1_SLEEP * (abilityDef == ABILITY_COMATOSE))) & gMovesInfo[move].argument
+                && !((gMovesInfo[move].additionalEffects->moveEffect == MOVE_EFFECT_REMOVE_STATUS)
+                    && DoesSubstituteBlockMove(battlerAtk, battlerDef, move)))
+        {
+            basePower *= 2;
+        }
         break;
     case EFFECT_VARY_POWER_BASED_ON_HP:
         basePower = gMovesInfo[move].argument * gBattleMons[battlerDef].hp / gBattleMons[battlerDef].maxHP;

--- a/test/battle/ability/shield_dust.c
+++ b/test/battle/ability/shield_dust.c
@@ -135,13 +135,10 @@ DOUBLE_BATTLE_TEST("Shield Dust does or does not block Sparkling Aria depending 
         TURN { MOVE(playerRight, moveToUse, target: opponentRight); MOVE(playerLeft, MOVE_SPARKLING_ARIA); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SPARKLING_ARIA, playerLeft);
-        if (moveToUse == MOVE_TACKLE)
-        {
+        if (moveToUse == MOVE_TACKLE) {
             MESSAGE("Foe Vivillon's burn was healed.");
             STATUS_ICON(opponentLeft, none: TRUE);
-        }
-        else
-        {
+        } else {
             NONE_OF {
                 MESSAGE("Foe Vivillon's burn was healed.");
                 STATUS_ICON(opponentLeft, none: TRUE);

--- a/test/battle/item_effect/covert_cloak.c
+++ b/test/battle/item_effect/covert_cloak.c
@@ -1,7 +1,7 @@
 #include "global.h"
 #include "test/battle.h"
 
-SINGLE_BATTLE_TEST("Shield Dust blocks secondary effects")
+SINGLE_BATTLE_TEST("Covert Cloak blocks secondary effects")
 {
     u16 move;
     PARAMETRIZE { move = MOVE_NUZZLE; }
@@ -21,26 +21,26 @@ SINGLE_BATTLE_TEST("Shield Dust blocks secondary effects")
         ASSUME(MoveHasAdditionalEffectWithChance(MOVE_SPIRIT_SHACKLE, MOVE_EFFECT_PREVENT_ESCAPE, 100) == TRUE);
         ASSUME(MoveHasAdditionalEffectWithChance(MOVE_PSYCHIC_NOISE, MOVE_EFFECT_PSYCHIC_NOISE, 100) == TRUE);
         PLAYER(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_VIVILLON) { Ability(ABILITY_SHIELD_DUST); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_COVERT_CLOAK); }
     } WHEN {
         TURN { MOVE(player, move); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, move, player);
         HP_BAR(opponent);
         NONE_OF {
-            MESSAGE("Foe Vivillon is paralyzed! It may be unable to move!");
-            MESSAGE("Foe Vivillon was burned!");
-            MESSAGE("Foe Vivillon was poisoned!");
-            MESSAGE("Foe Vivillon flinched!");
+            MESSAGE("Foe Wobbuffet is paralyzed! It may be unable to move!");
+            MESSAGE("Foe Wobbuffet was burned!");
+            MESSAGE("Foe Wobbuffet was poisoned!");
+            MESSAGE("Foe Wobbuffet flinched!");
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-            MESSAGE("Foe Vivillon was prevented from healing!");
+            MESSAGE("Foe Wobbuffet was prevented from healing!");
         }
     } THEN { // Can't find good way to test trapping
         EXPECT(!(opponent->status2 & STATUS2_ESCAPE_PREVENTION));
     }
 }
 
-SINGLE_BATTLE_TEST("Shield Dust does not block primary effects")
+SINGLE_BATTLE_TEST("Covert Cloak does not block primary effects")
 {
     u16 move;
     PARAMETRIZE { move = MOVE_INFESTATION; }
@@ -55,7 +55,7 @@ SINGLE_BATTLE_TEST("Shield Dust does not block primary effects")
         ASSUME(MoveHasAdditionalEffectWithChance(MOVE_PAY_DAY, MOVE_EFFECT_PAYDAY, 0) == TRUE);
         ASSUME(MoveHasAdditionalEffectWithChance(MOVE_SMACK_DOWN, MOVE_EFFECT_SMACK_DOWN, 0) == TRUE);
         PLAYER(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_VIVILLON) { Ability(ABILITY_SHIELD_DUST); }
+        OPPONENT(SPECIES_SKARMORY) { Item(ITEM_COVERT_CLOAK); }
     } WHEN {
         TURN { MOVE(player, move); }
     } SCENE {
@@ -64,10 +64,10 @@ SINGLE_BATTLE_TEST("Shield Dust does not block primary effects")
         switch (move)
         {
             case MOVE_INFESTATION:
-                MESSAGE("Foe Vivillon has been afflicted with an infestation by Wobbuffet!");
+                MESSAGE("Foe Skarmory has been afflicted with an infestation by Wobbuffet!");
                 break;
             case MOVE_THOUSAND_ARROWS:
-                MESSAGE("Foe Vivillon fell straight down!");
+                MESSAGE("Foe Skarmory fell straight down!");
                 break;
             case MOVE_JAW_LOCK:
                 MESSAGE("Neither Pokémon can run away!");
@@ -84,7 +84,7 @@ SINGLE_BATTLE_TEST("Shield Dust does not block primary effects")
     }
 }
 
-SINGLE_BATTLE_TEST("Shield Dust does not block self-targeting effects, primary or secondary")
+SINGLE_BATTLE_TEST("Covert Cloak does not block self-targeting effects, primary or secondary")
 {
     u16 move;
     PARAMETRIZE { move = MOVE_POWER_UP_PUNCH; }
@@ -98,7 +98,7 @@ SINGLE_BATTLE_TEST("Shield Dust does not block self-targeting effects, primary o
         ASSUME(MoveHasAdditionalEffectSelf(MOVE_LEAF_STORM, MOVE_EFFECT_SP_ATK_TWO_DOWN) == TRUE);
         ASSUME(MoveHasAdditionalEffectSelf(MOVE_METEOR_ASSAULT, MOVE_EFFECT_RECHARGE) == TRUE);
         PLAYER(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_VIVILLON) { Ability(ABILITY_SHIELD_DUST); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_COVERT_CLOAK); }
     } WHEN {
         TURN { MOVE(player, move); }
         if (move == MOVE_METEOR_ASSAULT) {
@@ -121,7 +121,7 @@ SINGLE_BATTLE_TEST("Shield Dust does not block self-targeting effects, primary o
     }
 }
 
-DOUBLE_BATTLE_TEST("Shield Dust does or does not block Sparkling Aria depending on number of targets hit")
+DOUBLE_BATTLE_TEST("Covert Cloak does or does not block Sparkling Aria depending on number of targets hit")
 {
     u32 moveToUse;
     PARAMETRIZE { moveToUse = MOVE_FINAL_GAMBIT; }
@@ -129,7 +129,7 @@ DOUBLE_BATTLE_TEST("Shield Dust does or does not block Sparkling Aria depending 
     GIVEN {
         PLAYER(SPECIES_WYNAUT);
         PLAYER(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_VIVILLON) { Ability(ABILITY_SHIELD_DUST); Status1(STATUS1_BURN); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_COVERT_CLOAK); Status1(STATUS1_BURN); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
         TURN { MOVE(playerRight, moveToUse, target: opponentRight); MOVE(playerLeft, MOVE_SPARKLING_ARIA); }
@@ -137,30 +137,30 @@ DOUBLE_BATTLE_TEST("Shield Dust does or does not block Sparkling Aria depending 
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SPARKLING_ARIA, playerLeft);
         if (moveToUse == MOVE_TACKLE)
         {
-            MESSAGE("Foe Vivillon's burn was healed.");
+            MESSAGE("Foe Wobbuffet's burn was healed.");
             STATUS_ICON(opponentLeft, none: TRUE);
         }
         else
         {
             NONE_OF {
-                MESSAGE("Foe Vivillon's burn was healed.");
+                MESSAGE("Foe Wobbuffet's burn was healed.");
                 STATUS_ICON(opponentLeft, none: TRUE);
             }
         }
     }
 }
 
-SINGLE_BATTLE_TEST("Shield Dust blocks Sparkling Aria in singles")
+SINGLE_BATTLE_TEST("Covert Cloak blocks Sparkling Aria in singles")
 {
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_VIVILLON) { Ability(ABILITY_SHIELD_DUST); Status1(STATUS1_BURN); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_COVERT_CLOAK); Status1(STATUS1_BURN); }
     } WHEN {
         TURN { MOVE(player, MOVE_SPARKLING_ARIA); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SPARKLING_ARIA, player);
         NONE_OF {
-            MESSAGE("Foe Vivillon's burn was healed.");
+            MESSAGE("Foe Wobbuffet's burn was healed.");
             STATUS_ICON(opponent, none: TRUE);
         }
     }

--- a/test/battle/item_effect/covert_cloak.c
+++ b/test/battle/item_effect/covert_cloak.c
@@ -106,8 +106,7 @@ SINGLE_BATTLE_TEST("Covert Cloak does not block self-targeting effects, primary 
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, move, player);
         HP_BAR(opponent);
-        switch (move)
-        {
+        switch (move) {
             case MOVE_POWER_UP_PUNCH:
             case MOVE_RAPID_SPIN:
             case MOVE_LEAF_STORM:

--- a/test/battle/item_effect/covert_cloak.c
+++ b/test/battle/item_effect/covert_cloak.c
@@ -61,8 +61,7 @@ SINGLE_BATTLE_TEST("Covert Cloak does not block primary effects")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, move, player);
         HP_BAR(opponent);
-        switch (move)
-        {
+        switch (move) {
             case MOVE_INFESTATION:
                 MESSAGE("Foe Skarmory has been afflicted with an infestation by Wobbuffet!");
                 break;

--- a/test/battle/item_effect/covert_cloak.c
+++ b/test/battle/item_effect/covert_cloak.c
@@ -133,13 +133,10 @@ DOUBLE_BATTLE_TEST("Covert Cloak does or does not block Sparkling Aria depending
         TURN { MOVE(playerRight, moveToUse, target: opponentRight); MOVE(playerLeft, MOVE_SPARKLING_ARIA); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SPARKLING_ARIA, playerLeft);
-        if (moveToUse == MOVE_TACKLE)
-        {
+        if (moveToUse == MOVE_TACKLE) {
             MESSAGE("Foe Wobbuffet's burn was healed.");
             STATUS_ICON(opponentLeft, none: TRUE);
-        }
-        else
-        {
+        } else {
             NONE_OF {
                 MESSAGE("Foe Wobbuffet's burn was healed.");
                 STATUS_ICON(opponentLeft, none: TRUE);

--- a/test/battle/move_effect/knock_off.c
+++ b/test/battle/move_effect/knock_off.c
@@ -51,3 +51,15 @@ SINGLE_BATTLE_TEST("Knock Off activates after Rocky Helmet and Weakness Policy")
         }
     }
 }
+
+SINGLE_BATTLE_TEST("Knock Off doesn't knock off items from Pokemon behind substitutes")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_POKE_BALL); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SUBSTITUTE); MOVE(player, MOVE_KNOCK_OFF); }
+    } SCENE {
+        NOT MESSAGE("Wobbuffet knocked off Foe Wobbuffet's Poké Ball");
+    }
+}

--- a/test/battle/move_effect/salt_cure.c
+++ b/test/battle/move_effect/salt_cure.c
@@ -85,3 +85,17 @@ SINGLE_BATTLE_TEST("If Salt Cure faints the target no status will be applied")
         MESSAGE("Foe Wobbuffet fainted!");
     }
 }
+
+SINGLE_BATTLE_TEST("Salt Cure does not get applied if hitting a Substitute")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SUBSTITUTE); MOVE(player, MOVE_SALT_CURE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SALT_CURE, player);
+        MESSAGE("The SUBSTITUTE took damage for Foe Wobbuffet!");
+        NOT MESSAGE("Foe Wobbuffet is being salt cured!");
+    }
+}

--- a/test/battle/move_effect/smack_down.c
+++ b/test/battle/move_effect/smack_down.c
@@ -1,0 +1,19 @@
+#include "global.h"
+#include "test/battle.h"
+
+ASSUMPTIONS
+{
+    ASSUME(gMovesInfo[MOVE_SMACK_DOWN].additionalEffects->moveEffect == MOVE_EFFECT_SMACK_DOWN);
+}
+
+SINGLE_BATTLE_TEST("Smack Down does not ground mons behind substitutes")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_SKARMORY);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SUBSTITUTE); MOVE(player, MOVE_SMACK_DOWN); }
+    } SCENE {
+        NOT MESSAGE("Foe Skarmory fell straight down!");
+    }
+}

--- a/test/battle/move_effect/smelling_salts.c
+++ b/test/battle/move_effect/smelling_salts.c
@@ -37,3 +37,27 @@ SINGLE_BATTLE_TEST("Smelling Salts does not cure paralyzed pokemons behind subst
         }
     }
 }
+
+SINGLE_BATTLE_TEST("Smelling Salts get incread power vs. paralyzed targets")
+{
+    u32 status1;
+    PARAMETRIZE { status1 = STATUS1_PARALYSIS; }
+    PARAMETRIZE { status1 = STATUS1_NONE; }
+    GIVEN {
+        PLAYER(SPECIES_CROBAT);
+        OPPONENT(SPECIES_LOTAD) { Status1(status1); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SMELLING_SALTS); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SMELLING_SALTS, player);
+        if (status1 == STATUS1_PARALYSIS)
+        {
+            MESSAGE("Foe Lotad fainted!");
+        }
+        else
+        {
+            NOT MESSAGE("Foe Lotad fainted!");
+            MESSAGE("Foe Lotad used Celebrate!");
+        }
+    }
+}

--- a/test/battle/move_effect/smelling_salts.c
+++ b/test/battle/move_effect/smelling_salts.c
@@ -32,8 +32,8 @@ SINGLE_BATTLE_TEST("Smelling Salts does not cure paralyzed pokemons behind subst
         }
         else
         {
-                MESSAGE("Foe Seismitoad was healed of paralysis!");
-                STATUS_ICON(opponent, none: TRUE);
+            MESSAGE("Foe Seismitoad was healed of paralysis!");
+            STATUS_ICON(opponent, none: TRUE);
         }
     }
 }

--- a/test/battle/move_effect/smelling_salts.c
+++ b/test/battle/move_effect/smelling_salts.c
@@ -1,0 +1,39 @@
+#include "global.h"
+#include "test/battle.h"
+
+ASSUMPTIONS
+{
+    ASSUME(gMovesInfo[MOVE_SMELLING_SALTS].additionalEffects->moveEffect == MOVE_EFFECT_REMOVE_STATUS);
+    ASSUME(gMovesInfo[MOVE_SMELLING_SALTS].argument == STATUS1_PARALYSIS);
+}
+
+SINGLE_BATTLE_TEST("Smelling Salts does not cure paralyzed pokemons behind substitutes or get increased power")
+{
+    u32 ability;
+    PARAMETRIZE { ability = ABILITY_INNER_FOCUS; }
+    PARAMETRIZE { ability = ABILITY_INFILTRATOR; }
+    GIVEN {
+        PLAYER(SPECIES_CROBAT) { Ability(ability); }
+        OPPONENT(SPECIES_SEISMITOAD) { Status1(STATUS1_PARALYSIS); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SUBSTITUTE); MOVE(player, MOVE_CELEBRATE); }
+        TURN { MOVE(opponent, MOVE_CELEBRATE); MOVE(player, MOVE_SMELLING_SALTS); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SMELLING_SALTS, player);
+        if (ability == ABILITY_INNER_FOCUS)
+        {
+            MESSAGE("The SUBSTITUTE took damage for Foe Seismitoad!");
+            NONE_OF
+            {
+                MESSAGE("Foe Seismitoad's SUBSTITUTE faded!"); // Smelling Salts does 86 damage, the sub has 122 HP, if hitting a sub it shouldn't get boosted damage.
+                MESSAGE("Foe Seismitoad was healed of paralysis!");
+                STATUS_ICON(opponent, none: TRUE);
+            }
+        }
+        else
+        {
+                MESSAGE("Foe Seismitoad was healed of paralysis!");
+                STATUS_ICON(opponent, none: TRUE);
+        }
+    }
+}

--- a/test/battle/move_effect/sparkling_aria.c
+++ b/test/battle/move_effect/sparkling_aria.c
@@ -1,0 +1,25 @@
+#include "global.h"
+#include "test/battle.h"
+
+ASSUMPTIONS
+{
+    ASSUME(gMovesInfo[MOVE_SPARKLING_ARIA].additionalEffects->moveEffect == MOVE_EFFECT_REMOVE_STATUS);
+    ASSUME(gMovesInfo[MOVE_SPARKLING_ARIA].argument == STATUS1_BURN);
+    ASSUME(gMovesInfo[MOVE_SPARKLING_ARIA].soundMove == TRUE);
+}
+
+DOUBLE_BATTLE_TEST("Sparkling Aria cures burns from all Pokemon on the field and behind substitutes")
+{
+    GIVEN {
+        PLAYER(SPECIES_PRIMARINA);
+        PLAYER(SPECIES_WOBBUFFET) { Status1(STATUS1_BURN); }
+        OPPONENT(SPECIES_WOBBUFFET) { Status1(STATUS1_BURN); }
+        OPPONENT(SPECIES_WYNAUT) { Status1(STATUS1_BURN); }
+    } WHEN {
+        TURN { MOVE(opponentLeft, MOVE_SUBSTITUTE); MOVE(opponentRight, MOVE_CELEBRATE); MOVE(playerRight, MOVE_CELEBRATE); MOVE(playerLeft, MOVE_SPARKLING_ARIA); }
+    } SCENE {
+        MESSAGE("Foe Wobbuffet's burn was healed.");
+        MESSAGE("Wobbuffet's burn was healed.");
+        MESSAGE("Foe Wynaut's burn was healed.");
+    }
+}

--- a/test/battle/move_effect/thousand_arrows.c
+++ b/test/battle/move_effect/thousand_arrows.c
@@ -32,13 +32,10 @@ SINGLE_BATTLE_TEST("Thousand Arrows does neutral damage to non-grounded Flying t
         TURN { MOVE(player, MOVE_THOUSAND_ARROWS); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_THOUSAND_ARROWS, player);
-        if (pokemon == SPECIES_SKARMORY)
-        {
+        if (pokemon == SPECIES_SKARMORY) {
             MESSAGE("Foe Skarmory fell straight down!");
             MESSAGE("Foe Skarmory used Celebrate!");
-        }
-        else
-        {
+        } else {
             MESSAGE("Foe Scyther fell straight down!");
             MESSAGE("Foe Scyther used Celebrate!");
         }

--- a/test/battle/move_effect/thousand_arrows.c
+++ b/test/battle/move_effect/thousand_arrows.c
@@ -1,0 +1,19 @@
+#include "global.h"
+#include "test/battle.h"
+
+ASSUMPTIONS
+{
+    ASSUME(gMovesInfo[MOVE_THOUSAND_ARROWS].additionalEffects->moveEffect == MOVE_EFFECT_SMACK_DOWN);
+}
+
+SINGLE_BATTLE_TEST("Thousand Arrows does not ground mons behind substitutes")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_SKARMORY);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SUBSTITUTE); MOVE(player, MOVE_THOUSAND_ARROWS); }
+    } SCENE {
+        NOT MESSAGE("Foe Skarmory fell straight down!");
+    }
+}

--- a/test/battle/move_effect/thousand_arrows.c
+++ b/test/battle/move_effect/thousand_arrows.c
@@ -4,6 +4,7 @@
 ASSUMPTIONS
 {
     ASSUME(gMovesInfo[MOVE_THOUSAND_ARROWS].additionalEffects->moveEffect == MOVE_EFFECT_SMACK_DOWN);
+    ASSUME(gMovesInfo[MOVE_THOUSAND_ARROWS].ignoreTypeIfFlyingAndUngrounded == TRUE);
 }
 
 SINGLE_BATTLE_TEST("Thousand Arrows does not ground mons behind substitutes")
@@ -15,5 +16,43 @@ SINGLE_BATTLE_TEST("Thousand Arrows does not ground mons behind substitutes")
         TURN { MOVE(opponent, MOVE_SUBSTITUTE); MOVE(player, MOVE_THOUSAND_ARROWS); }
     } SCENE {
         NOT MESSAGE("Foe Skarmory fell straight down!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Thousand Arrows does neutral damage to non-grounded Flying types regardless of other typings")
+{
+    u32 pokemon;
+    PARAMETRIZE { pokemon = SPECIES_SKARMORY; }
+    PARAMETRIZE { pokemon = SPECIES_SCYTHER; }
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(pokemon);
+    } WHEN {
+        TURN { MOVE(player, MOVE_THOUSAND_ARROWS); }
+        TURN { MOVE(player, MOVE_THOUSAND_ARROWS); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_THOUSAND_ARROWS, player);
+        if (pokemon == SPECIES_SKARMORY)
+        {
+            MESSAGE("Foe Skarmory fell straight down!");
+            MESSAGE("Foe Skarmory used Celebrate!");
+        }
+        else
+        {
+            MESSAGE("Foe Scyther fell straight down!");
+            MESSAGE("Foe Scyther used Celebrate!");
+        }
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
+        MESSAGE("Congratulations, 1!");
+        MESSAGE("Wobbuffet used ThousndArrws!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_THOUSAND_ARROWS, player);
+        if (pokemon == SPECIES_SKARMORY)
+        {
+            MESSAGE("It's super effective!");
+        }
+        else
+        {
+            MESSAGE("It's not very effective…");
+        }
     }
 }

--- a/test/battle/move_effect/wake_up_slap.c
+++ b/test/battle/move_effect/wake_up_slap.c
@@ -1,0 +1,39 @@
+#include "global.h"
+#include "test/battle.h"
+
+ASSUMPTIONS
+{
+    ASSUME(gMovesInfo[MOVE_WAKE_UP_SLAP].additionalEffects->moveEffect == MOVE_EFFECT_REMOVE_STATUS);
+    ASSUME(gMovesInfo[MOVE_WAKE_UP_SLAP].argument == STATUS1_SLEEP);
+}
+
+SINGLE_BATTLE_TEST("Wake-Up Slap does not cure paralyzed pokemons behind substitutes or get increased power")
+{
+    u32 ability;
+    PARAMETRIZE { ability = ABILITY_INNER_FOCUS; }
+    PARAMETRIZE { ability = ABILITY_INFILTRATOR; }
+    GIVEN {
+        PLAYER(SPECIES_CROBAT) { Ability(ability); }
+        OPPONENT(SPECIES_SEISMITOAD);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SUBSTITUTE); MOVE(player, MOVE_SING); }
+        TURN { MOVE(opponent, MOVE_CELEBRATE); MOVE(player, MOVE_WAKE_UP_SLAP); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_WAKE_UP_SLAP, player);
+        if (ability == ABILITY_INNER_FOCUS)
+        {
+            MESSAGE("The SUBSTITUTE took damage for Foe Seismitoad!");
+            NONE_OF
+            {
+                MESSAGE("Foe Seismitoad's SUBSTITUTE faded!"); // Smelling Salts does 86 damage, the sub has 122 HP, if hitting a sub it shouldn't get boosted damage.
+                MESSAGE("Foe Seismitoad woke up!");
+                STATUS_ICON(opponent, none: TRUE);
+            }
+        }
+        else
+        {
+                MESSAGE("Foe Seismitoad woke up!");
+                STATUS_ICON(opponent, none: TRUE);
+        }
+    }
+}

--- a/test/battle/move_effect/wake_up_slap.c
+++ b/test/battle/move_effect/wake_up_slap.c
@@ -20,8 +20,7 @@ SINGLE_BATTLE_TEST("Wake-Up Slap does not cure paralyzed pokemons behind substit
         TURN { MOVE(opponent, MOVE_CELEBRATE); MOVE(player, MOVE_WAKE_UP_SLAP); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_WAKE_UP_SLAP, player);
-        if (ability == ABILITY_INNER_FOCUS)
-        {
+        if (ability == ABILITY_INNER_FOCUS) {
             MESSAGE("The SUBSTITUTE took damage for Foe Seismitoad!");
             NONE_OF
             {
@@ -29,9 +28,7 @@ SINGLE_BATTLE_TEST("Wake-Up Slap does not cure paralyzed pokemons behind substit
                 MESSAGE("Foe Seismitoad woke up!");
                 STATUS_ICON(opponent, none: TRUE);
             }
-        }
-        else
-        {
+        } else {
             MESSAGE("Foe Seismitoad woke up!");
             STATUS_ICON(opponent, none: TRUE);
         }

--- a/test/battle/move_effect/wake_up_slap.c
+++ b/test/battle/move_effect/wake_up_slap.c
@@ -50,12 +50,9 @@ SINGLE_BATTLE_TEST("Wake-Up Slap get incread power vs. sleeping targets")
         TURN { MOVE(player, MOVE_WAKE_UP_SLAP); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_WAKE_UP_SLAP, player);
-        if (status1 == STATUS1_SLEEP)
-        {
+        if (status1 == STATUS1_SLEEP) {
             MESSAGE("Foe Lotad fainted!");
-        }
-        else
-        {
+        } else {
             NOT MESSAGE("Foe Lotad fainted!");
             MESSAGE("Foe Lotad used Celebrate!");
         }

--- a/test/battle/move_effect/wake_up_slap.c
+++ b/test/battle/move_effect/wake_up_slap.c
@@ -37,3 +37,27 @@ SINGLE_BATTLE_TEST("Wake-Up Slap does not cure paralyzed pokemons behind substit
         }
     }
 }
+
+SINGLE_BATTLE_TEST("Wake-Up Slap get incread power vs. sleeping targets")
+{
+    u32 status1;
+    PARAMETRIZE { status1 = STATUS1_SLEEP; }
+    PARAMETRIZE { status1 = STATUS1_NONE; }
+    GIVEN {
+        PLAYER(SPECIES_CROBAT);
+        OPPONENT(SPECIES_LOTAD) { Status1(status1); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_WAKE_UP_SLAP); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_WAKE_UP_SLAP, player);
+        if (status1 == STATUS1_SLEEP)
+        {
+            MESSAGE("Foe Lotad fainted!");
+        }
+        else
+        {
+            NOT MESSAGE("Foe Lotad fainted!");
+            MESSAGE("Foe Lotad used Celebrate!");
+        }
+    }
+}

--- a/test/battle/move_effect/wake_up_slap.c
+++ b/test/battle/move_effect/wake_up_slap.c
@@ -32,8 +32,8 @@ SINGLE_BATTLE_TEST("Wake-Up Slap does not cure paralyzed pokemons behind substit
         }
         else
         {
-                MESSAGE("Foe Seismitoad woke up!");
-                STATUS_ICON(opponent, none: TRUE);
+            MESSAGE("Foe Seismitoad woke up!");
+            STATUS_ICON(opponent, none: TRUE);
         }
     }
 }


### PR DESCRIPTION
Fixed the effect of Knock Off, Salt Cure, Smack Down, Thousand Arrows, Wake-Up Slap and Smelling Salts not getting blocked by Substitutes where they should.
Fixed Sparkling Aria interaction with Shield Dust in Singles vs Doubles.
Fixed Wake-Up Slap and Smelling Salts getting boosted damage where they shouldn't vs Substitutes.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Encapsulated the calls to the effects of Knock Off, Salt Cure, Smack Down, Thousand Arrows, Wake-Up Slap and Smelling Salts in  `if (!DoesSubstituteBlockMove(...))` to check if they hit a Substitute or not.

Wrote a check for Sparkling Aria vs Shield Dust/Covert Cloak to implement the interaction where in doubles it can cure burns of supposedly protected Pokemon if Sparkling Aria hits more targets than the Shield Dust user. The check counts the number of Pokemon with more than 0 HP when it attempts to cure the Pokemon with Shield Dust, and if it's more than 2 it assumes that the condition to ignore Shield Dust has been met.

Encapsulated the damage multiplier for Wake-Up Slap and Smelling Salts in a `if (!DoesSubstituteBlockMove(...))`
 so that they don't get increased damage when hitting Substitutes.

Fixed broken doubles Shield Dust+Sparkling Aria test and extended it to cover the doubles case where all other Pokemon except Sparkling Aria user and Shield Dust user are fainted.
Wrote tests for all fixes and copied Shield Dust tests to Covert Cloak since they should always behave the same.

## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, fixes #2222." -->
<!-- If it doesn't apply, feel free to remove this section. -->
Fixes #4519

## Feature(s) this PR does NOT handle:
Edge case of the Sparkling Aria burn curing implementation where if the Shield Dust Pokemon is the last one in the effect trigger order and at least one other valid target faints from the Sparkling Aria. Currently it will get cured of the burn, but it shouldn't.

## **Discord contact info**
hedara
