### PR TITLE
Fixes cries in move animations ignoring Illusion

### DIFF
--- a/src/battle_anim_sound_tasks.c
+++ b/src/battle_anim_sound_tasks.c
@@ -5,6 +5,7 @@
 #include "m4a.h"
 #include "sound.h"
 #include "task.h"
+#include "constants/abilities.h"
 #include "constants/battle_anim.h"
 
 extern struct MusicPlayerInfo gMPlayInfo_SE1;
@@ -167,10 +168,7 @@ void SoundTask_PlayCryHighPitch(u8 taskId)
             return;
         }
 
-        if (GetBattlerSide(battlerId) != B_SIDE_PLAYER)
-            species = GetMonData(&gEnemyParty[gBattlerPartyIndexes[battlerId]], MON_DATA_SPECIES);
-        else
-            species = GetMonData(&gPlayerParty[gBattlerPartyIndexes[battlerId]], MON_DATA_SPECIES);
+        species = (GetBattlerAbility(battlerId) == ABILITY_ILLUSION && gBattleStruct->illusion[battlerId].on) ? GetIllusionMonSpecies(battlerId) : gAnimBattlerSpecies[battlerId];
     }
 
     if (species != SPECIES_NONE)
@@ -215,10 +213,7 @@ void SoundTask_PlayDoubleCry(u8 taskId)
             return;
         }
 
-        if (GetBattlerSide(battlerId) != B_SIDE_PLAYER)
-            species = GetMonData(&gEnemyParty[gBattlerPartyIndexes[battlerId]], MON_DATA_SPECIES);
-        else
-            species = GetMonData(&gPlayerParty[gBattlerPartyIndexes[battlerId]], MON_DATA_SPECIES);
+        species = (GetBattlerAbility(battlerId) == ABILITY_ILLUSION && gBattleStruct->illusion[battlerId].on) ? GetIllusionMonSpecies(battlerId) : gAnimBattlerSpecies[battlerId];
     }
 
     gTasks[taskId].data[0] = gBattleAnimArgs[1];
@@ -285,7 +280,8 @@ void SoundTask_WaitForCry(u8 taskId)
 
 void SoundTask_PlayNormalCry(u8 taskId)
 {
-    PlayCry_ByMode(gBattleMons[gBattleAnimAttacker].species, BattleAnimAdjustPanning(SOUND_PAN_ATTACKER), CRY_MODE_NORMAL);
+    u16 species = (GetBattlerAbility(gBattleAnimAttacker) == ABILITY_ILLUSION && gBattleStruct->illusion[gBattleAnimAttacker].on) ? GetIllusionMonSpecies(gBattleAnimAttacker) : gAnimBattlerSpecies[gBattleAnimAttacker];
+    PlayCry_ByMode(species, BattleAnimAdjustPanning(SOUND_PAN_ATTACKER), CRY_MODE_NORMAL);
     gTasks[taskId].func = SoundTask_WaitForCry;
 }
 
@@ -305,7 +301,7 @@ void SoundTask_PlayCryWithEcho(u8 taskId)
     if (IsContest())
         species = gContestResources->moveAnim->species;
     else
-        species = gAnimBattlerSpecies[gBattleAnimAttacker];
+        species = (GetBattlerAbility(gBattleAnimAttacker) == ABILITY_ILLUSION && gBattleStruct->illusion[gBattleAnimAttacker].on) ? GetIllusionMonSpecies(gBattleAnimAttacker) : gAnimBattlerSpecies[gBattleAnimAttacker];
 
     gTasks[taskId].tSpecies = species;
     gTasks[taskId].tPan = pan;

--- a/src/battle_anim_sound_tasks.c
+++ b/src/battle_anim_sound_tasks.c
@@ -5,7 +5,6 @@
 #include "m4a.h"
 #include "sound.h"
 #include "task.h"
-#include "constants/abilities.h"
 #include "constants/battle_anim.h"
 
 extern struct MusicPlayerInfo gMPlayInfo_SE1;
@@ -168,7 +167,7 @@ void SoundTask_PlayCryHighPitch(u8 taskId)
             return;
         }
 
-        species = (GetBattlerAbility(battlerId) == ABILITY_ILLUSION && gBattleStruct->illusion[battlerId].on) ? GetIllusionMonSpecies(battlerId) : gAnimBattlerSpecies[battlerId];
+        species = (GetIllusionMonSpecies(battlerId) != SPECIES_NONE) ? GetIllusionMonSpecies(battlerId) : gAnimBattlerSpecies[battlerId];
     }
 
     if (species != SPECIES_NONE)
@@ -213,7 +212,7 @@ void SoundTask_PlayDoubleCry(u8 taskId)
             return;
         }
 
-        species = (GetBattlerAbility(battlerId) == ABILITY_ILLUSION && gBattleStruct->illusion[battlerId].on) ? GetIllusionMonSpecies(battlerId) : gAnimBattlerSpecies[battlerId];
+        species = (GetIllusionMonSpecies(battlerId) != SPECIES_NONE) ? GetIllusionMonSpecies(battlerId) : gAnimBattlerSpecies[battlerId];
     }
 
     gTasks[taskId].data[0] = gBattleAnimArgs[1];
@@ -280,7 +279,7 @@ void SoundTask_WaitForCry(u8 taskId)
 
 void SoundTask_PlayNormalCry(u8 taskId)
 {
-    u16 species = (GetBattlerAbility(gBattleAnimAttacker) == ABILITY_ILLUSION && gBattleStruct->illusion[gBattleAnimAttacker].on) ? GetIllusionMonSpecies(gBattleAnimAttacker) : gAnimBattlerSpecies[gBattleAnimAttacker];
+    u16 species = (GetIllusionMonSpecies(gBattleAnimAttacker) != SPECIES_NONE) ? GetIllusionMonSpecies(gBattleAnimAttacker) : gAnimBattlerSpecies[gBattleAnimAttacker];
     PlayCry_ByMode(species, BattleAnimAdjustPanning(SOUND_PAN_ATTACKER), CRY_MODE_NORMAL);
     gTasks[taskId].func = SoundTask_WaitForCry;
 }
@@ -301,7 +300,7 @@ void SoundTask_PlayCryWithEcho(u8 taskId)
     if (IsContest())
         species = gContestResources->moveAnim->species;
     else
-        species = (GetBattlerAbility(gBattleAnimAttacker) == ABILITY_ILLUSION && gBattleStruct->illusion[gBattleAnimAttacker].on) ? GetIllusionMonSpecies(gBattleAnimAttacker) : gAnimBattlerSpecies[gBattleAnimAttacker];
+        species = (GetIllusionMonSpecies(gBattleAnimAttacker) != SPECIES_NONE) ? GetIllusionMonSpecies(gBattleAnimAttacker) : gAnimBattlerSpecies[gBattleAnimAttacker];
 
     gTasks[taskId].tSpecies = species;
     gTasks[taskId].tPan = pan;


### PR DESCRIPTION
## Description
Currently if a Pokemon is disguised by Illusion and uses a move that plays a cry, it will always play the cry of the Pokemon with the ability instead of using the Pokemon it appears as (this makes it a lot more obvious that it's an Illusion).

I also made the method of obtaining the species to use for the cry consistent.

## Images
Before the fix:

https://github.com/rh-hideout/pokeemerald-expansion/assets/168426989/c36e0b50-4f75-4c52-bf69-bcf63a75e693

After the fix:

https://github.com/rh-hideout/pokeemerald-expansion/assets/168426989/b1bd8ef6-9eea-4669-b967-7afdcb02319a

## **Discord contact info**
PhallenTree
