### PR TITLE
Added missing Move Effect TODO tests - Volume A

### DIFF
--- a/test/battle/move_effect/absorb.c
+++ b/test/battle/move_effect/absorb.c
@@ -68,3 +68,6 @@ DOUBLE_BATTLE_TEST("Matcha Gatcha recovers 50% of the damage dealt from both tar
         EXPECT_MUL_EQ(damageRight, Q_4_12(-0.5), healedRight);
     }
 }
+
+TO_DO_BATTLE_TEST("Absorb recovers 50% of the damage dealt to a Substitute");
+TO_DO_BATTLE_TEST("Draining Kiss recovers 75% of the damage dealt"); // Tests .argument 's implementation

--- a/test/battle/move_effect/accuracy_down.c
+++ b/test/battle/move_effect/accuracy_down.c
@@ -6,7 +6,7 @@ ASSUMPTIONS
     ASSUME(gMovesInfo[MOVE_SAND_ATTACK].effect == EFFECT_ACCURACY_DOWN);
 }
 
-SINGLE_BATTLE_TEST("Sand Attack lowers Accuracy")
+SINGLE_BATTLE_TEST("Sand Attack lowers Accuracy by 1 stage")
 {
     ASSUME(gMovesInfo[MOVE_SCRATCH].accuracy == 100);
     PASSES_RANDOMLY(gMovesInfo[MOVE_SCRATCH].accuracy * 3 / 4, 100, RNG_ACCURACY);

--- a/test/battle/move_effect/accuracy_down_2.c
+++ b/test/battle/move_effect/accuracy_down_2.c
@@ -1,0 +1,4 @@
+#include "global.h"
+#include "test/battle.h"
+
+// There are no moves with EFFECT_ACCURACY_DOWN_2's effect ^^;

--- a/test/battle/move_effect/accuracy_up.c
+++ b/test/battle/move_effect/accuracy_up.c
@@ -1,0 +1,4 @@
+#include "global.h"
+#include "test/battle.h"
+
+// There are no moves with EFFECT_ACCURACY_UP's effect ^^;

--- a/test/battle/move_effect/accuracy_up_2.c
+++ b/test/battle/move_effect/accuracy_up_2.c
@@ -1,0 +1,4 @@
+#include "global.h"
+#include "test/battle.h"
+
+// There are no moves with EFFECT_ACCURACY_UP_2's effect ^^;

--- a/test/battle/move_effect/acrobatics.c
+++ b/test/battle/move_effect/acrobatics.c
@@ -1,0 +1,5 @@
+#include "global.h"
+#include "test/battle.h"
+
+TO_DO_BATTLE_TEST("Acrobatics doubles in power if the user has no held item");
+TO_DO_BATTLE_TEST("Acrobatics still doubles in power when Flying Gem is consumed");

--- a/test/battle/move_effect/acupressure.c
+++ b/test/battle/move_effect/acupressure.c
@@ -1,0 +1,59 @@
+#include "global.h"
+#include "test/battle.h"
+
+TO_DO_BATTLE_TEST("Acupressure increases one of two stats by 2 stages at random");
+TO_DO_BATTLE_TEST("Acupressure doesn't try to increase a stat that has been maximized");
+TO_DO_BATTLE_TEST("Acupressure fails on the user if all of its stats are maximized");
+TO_DO_BATTLE_TEST("Acupressure fails on the ally if all of its stats are maximized");
+TO_DO_BATTLE_TEST("Acupressure works on the user if it's behind a Substitute (Gen5+)");
+TO_DO_BATTLE_TEST("Acupressure fails on its ally if it's behind a Substitute");
+
+DOUBLE_BATTLE_TEST("Acupressure works on the ally if the user targeted itself but switched positions via Ally Switch")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_KADABRA);
+        OPPONENT(SPECIES_ABRA);
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_ALLY_SWITCH); MOVE(playerRight, MOVE_ACUPRESSURE, target:playerRight); }
+    } SCENE {
+        MESSAGE("Wobbuffet used Ally Switch!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ALLY_SWITCH, playerLeft);
+        MESSAGE("Wobbuffet and Wynaut switched places!");
+
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ACUPRESSURE);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerRight);
+        NOT MESSAGE("But it failed!");
+    }
+}
+
+DOUBLE_BATTLE_TEST("Acupressure fails on the user if it targeted its ally but switched positions via Ally Switch")
+{
+    KNOWN_FAILING; // Tested in Gen 5, Acupressure fails here
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_KADABRA);
+        OPPONENT(SPECIES_ABRA);
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_ALLY_SWITCH); MOVE(playerRight, MOVE_ACUPRESSURE, target:playerLeft); }
+    } SCENE {
+        MESSAGE("Wobbuffet used Ally Switch!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ALLY_SWITCH, playerLeft);
+        MESSAGE("Wobbuffet and Wynaut switched places!");
+
+        MESSAGE("But it failed!");
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_ACUPRESSURE);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
+        }
+    }
+}
+
+TO_DO_BATTLE_TEST("Acupressure works on the user if its side is protected by Crafty Shield");
+TO_DO_BATTLE_TEST("Acupressure fails on the ally if its side is protected by Crafty Shield");
+
+// Triple Battles required to test
+//TO_DO_BATTLE_TEST("Acupressure works on the ally if the user targeted itself but switched positions via Triple Battle shift before execution");
+//TO_DO_BATTLE_TEST("Acupressure fails on the user if it targeted its ally but switched positions via Triple Battle shift before execution");

--- a/test/battle/move_effect/after_you.c
+++ b/test/battle/move_effect/after_you.c
@@ -51,3 +51,6 @@ DOUBLE_BATTLE_TEST("After You does nothing if the target has already moved")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, playerRight);
     }
 }
+
+TO_DO_BATTLE_TEST("After You doesn't fail if the turner remains the same after After You (Gen8+)");
+TO_DO_BATTLE_TEST("After You ignores the effects of Quash");

--- a/test/battle/move_effect/ally_switch.c
+++ b/test/battle/move_effect/ally_switch.c
@@ -115,7 +115,7 @@ DOUBLE_BATTLE_TEST("Ally Switch does not redirect moves done by pokemon with Sta
     }
 }
 
-DOUBLE_BATTLE_TEST("Ally Switch has no effect on parnter's chosen move")
+DOUBLE_BATTLE_TEST("Ally Switch has no effect on partner's chosen move")
 {
     u16 chosenMove;
     struct BattlePokemon *chosenTarget = NULL;
@@ -167,32 +167,6 @@ DOUBLE_BATTLE_TEST("Ally Switch - move fails if the target was ally which change
     }
 }
 
-// Verified on Showdown, even though Bulbapedia says otherwise.
-DOUBLE_BATTLE_TEST("Acupressure works after ally used Ally Switch")
-{
-    struct BattlePokemon *battlerTarget = NULL;
-
-    PARAMETRIZE { battlerTarget = playerLeft; }
-    PARAMETRIZE { battlerTarget = playerRight; }
-
-    GIVEN {
-        PLAYER(SPECIES_WOBBUFFET);
-        PLAYER(SPECIES_WYNAUT);
-        OPPONENT(SPECIES_KADABRA);
-        OPPONENT(SPECIES_ABRA);
-    } WHEN {
-        TURN { MOVE(playerLeft, MOVE_ALLY_SWITCH); MOVE(playerRight, MOVE_ACUPRESSURE, target:battlerTarget); }
-    } SCENE {
-        MESSAGE("Wobbuffet used Ally Switch!");
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_ALLY_SWITCH, playerLeft);
-        MESSAGE("Wobbuffet and Wynaut switched places!");
-
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_ACUPRESSURE);
-        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, battlerTarget);
-        NOT MESSAGE("But it failed!");
-    }
-}
-
 DOUBLE_BATTLE_TEST("Ally Switch increases the Protect-like moves counter")
 {
     GIVEN {
@@ -228,3 +202,6 @@ DOUBLE_BATTLE_TEST("Ally Switch works if ally used two-turn move like Dig")
         HP_BAR(opponentRight);
     }
 }
+
+// Triple Battles required to test
+//TO_DO_BATTLE_TEST("Ally Switch fails if the user is in the middle of the field in a Triple Battle");

--- a/test/battle/move_effect/aqua_ring.c
+++ b/test/battle/move_effect/aqua_ring.c
@@ -1,0 +1,6 @@
+#include "global.h"
+#include "test/battle.h"
+
+TO_DO_BATTLE_TEST("Aqua Ring recovers 1/16th HP at end of turn");
+TO_DO_BATTLE_TEST("Aqua Ring can be used under Heal Block but will not heal the user");
+TO_DO_BATTLE_TEST("Aqua Ring can be Baton Passed");

--- a/test/battle/move_effect/aromatic_mist.c
+++ b/test/battle/move_effect/aromatic_mist.c
@@ -1,0 +1,5 @@
+#include "global.h"
+#include "test/battle.h"
+
+TO_DO_BATTLE_TEST("Aromatic Mist raises Sp. Defense of a target ally by 1 stage");
+TO_DO_BATTLE_TEST("Aromatic Mist fails in Single Battles");

--- a/test/battle/move_effect/assist.c
+++ b/test/battle/move_effect/assist.c
@@ -6,6 +6,18 @@ ASSUMPTIONS
     ASSUME(gMovesInfo[MOVE_ASSIST].effect == EFFECT_ASSIST);
 }
 
+TO_DO_BATTLE_TEST("Assist randomly calls a move from any party member");
+TO_DO_BATTLE_TEST("Assist counts all instances of the same move as separate");
+TO_DO_BATTLE_TEST("Assist can call moves with no PP left");
+TO_DO_BATTLE_TEST("Assist can call moves from a fainted party member");
+TO_DO_BATTLE_TEST("Assist can call moves that are blocked to its partners"); // Eg. double battle parter blocked by Disable
+TO_DO_BATTLE_TEST("Assist can only call the original moves of a Transformed partner (Gen4 only)");
+TO_DO_BATTLE_TEST("Assist can only call the current moves of a Transformed partner (Gen5+)");
+TO_DO_BATTLE_TEST("Assist cannot call a Mimicked move (Gen4 only)");
+TO_DO_BATTLE_TEST("Assist can call a Mimicked move but not the original Mimic (Gen5+)");
+TO_DO_BATTLE_TEST("Assist can call moves in unhatched Eggs (Gen5 only)");
+TO_DO_BATTLE_TEST("Assist can be used by wild Pokémon in Wild Double Battles, even if the partner faints");
+
 SINGLE_BATTLE_TEST("Assist fails if there are no valid moves to choose from")
 {
     GIVEN {

--- a/test/battle/move_effect/assurance.c
+++ b/test/battle/move_effect/assurance.c
@@ -1,0 +1,8 @@
+#include "global.h"
+#include "test/battle.h"
+
+TO_DO_BATTLE_TEST("Assurance doubles in power if the target has been damaged in the same turn - Recoil");
+TO_DO_BATTLE_TEST("Assurance doubles in power if the target has been damaged in the same turn - Life Orb");
+TO_DO_BATTLE_TEST("Assurance doubles in power if the target has been damaged in the same turn - Crash");
+TO_DO_BATTLE_TEST("Assurance doubles in power if the target has been damaged in the same turn - Confusion");
+TO_DO_BATTLE_TEST("Assurance doubles in power if the target has been damaged in the same turn - Rocky Helmet");

--- a/test/battle/move_effect/attack_accuracy_up.c
+++ b/test/battle/move_effect/attack_accuracy_up.c
@@ -1,0 +1,4 @@
+#include "global.h"
+#include "test/battle.h"
+
+TO_DO_BATTLE_TEST("Hone Claws increases Attack and Accuracy by one stage each");

--- a/test/battle/move_effect/attack_down_2.c
+++ b/test/battle/move_effect/attack_down_2.c
@@ -3,10 +3,10 @@
 
 ASSUMPTIONS
 {
-    ASSUME(gMovesInfo[MOVE_GROWL].effect == EFFECT_ATTACK_DOWN);
+    ASSUME(gMovesInfo[MOVE_CHARM].effect == EFFECT_ATTACK_DOWN_2);
 }
 
-SINGLE_BATTLE_TEST("Growl lowers Attack by 1 stage", s16 damage)
+SINGLE_BATTLE_TEST("Charm lowers Attack by 2 stages", s16 damage)
 {
     bool32 lowerAttack;
     PARAMETRIZE { lowerAttack = FALSE; }
@@ -16,17 +16,17 @@ SINGLE_BATTLE_TEST("Growl lowers Attack by 1 stage", s16 damage)
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
-        if (lowerAttack) TURN { MOVE(player, MOVE_GROWL); }
+        if (lowerAttack) TURN { MOVE(player, MOVE_CHARM); }
         TURN { MOVE(opponent, MOVE_TACKLE); }
     } SCENE {
         if (lowerAttack) {
-            ANIMATION(ANIM_TYPE_MOVE, MOVE_GROWL, player);
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_CHARM, player);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-            MESSAGE("Foe Wobbuffet's Attack fell!");
+            MESSAGE("Foe Wobbuffet's Attack harshly fell!");
         }
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
         HP_BAR(player, captureDamage: &results[i].damage);
     } FINALLY {
-        EXPECT_MUL_EQ(results[1].damage, Q_4_12(1.5), results[0].damage);
+        EXPECT_MUL_EQ(results[1].damage, Q_4_12(2.0), results[0].damage);
     }
 }

--- a/test/battle/move_effect/attack_spatk_up.c
+++ b/test/battle/move_effect/attack_spatk_up.c
@@ -1,0 +1,39 @@
+#include "global.h"
+#include "test/battle.h"
+
+
+ASSUMPTIONS
+{
+    ASSUME(gMovesInfo[MOVE_WORK_UP].effect == EFFECT_ATTACK_SPATK_UP);
+}
+
+SINGLE_BATTLE_TEST("Work Up raises Attack and Sp. Attack by 1 stage each", s16 damage)
+{
+    bool32 raiseStats;
+    u32 move;
+    PARAMETRIZE { raiseStats = FALSE; move = MOVE_TACKLE; }
+    PARAMETRIZE { raiseStats = TRUE;  move = MOVE_TACKLE; }
+    PARAMETRIZE { raiseStats = FALSE; move = MOVE_SWIFT; }
+    PARAMETRIZE { raiseStats = TRUE;  move = MOVE_SWIFT; }
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_TACKLE].category == DAMAGE_CATEGORY_PHYSICAL);
+        ASSUME(gMovesInfo[MOVE_SWIFT].category == DAMAGE_CATEGORY_SPECIAL);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        if (raiseStats) TURN { MOVE(player, MOVE_WORK_UP); }
+        TURN { MOVE(player, move); }
+    } SCENE {
+        if (raiseStats) {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_WORK_UP, player);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+            MESSAGE("Wobbuffet's Attack rose!");
+            MESSAGE("Wobbuffet's Sp. Atk rose!");
+        }
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.5), results[1].damage);
+        EXPECT_MUL_EQ(results[2].damage, Q_4_12(1.5), results[3].damage);
+    }
+}

--- a/test/battle/move_effect/attack_up_2.c
+++ b/test/battle/move_effect/attack_up_2.c
@@ -3,10 +3,10 @@
 
 ASSUMPTIONS
 {
-    ASSUME(gMovesInfo[MOVE_MEDITATE].effect == EFFECT_ATTACK_UP);
+    ASSUME(gMovesInfo[MOVE_SWORDS_DANCE].effect == EFFECT_ATTACK_UP_2);
 }
 
-SINGLE_BATTLE_TEST("Meditate raises Attack by 1 stage", s16 damage)
+SINGLE_BATTLE_TEST("Swords Dance raises Attack by 2 stages", s16 damage)
 {
     bool32 raiseAttack;
     PARAMETRIZE { raiseAttack = FALSE; }
@@ -16,17 +16,17 @@ SINGLE_BATTLE_TEST("Meditate raises Attack by 1 stage", s16 damage)
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
-        if (raiseAttack) TURN { MOVE(player, MOVE_MEDITATE); }
+        if (raiseAttack) TURN { MOVE(player, MOVE_SWORDS_DANCE); }
         TURN { MOVE(player, MOVE_TACKLE); }
     } SCENE {
         if (raiseAttack) {
-            ANIMATION(ANIM_TYPE_MOVE, MOVE_MEDITATE, player);
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_SWORDS_DANCE, player);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-            MESSAGE("Wobbuffet's Attack rose!");
+            MESSAGE("Wobbuffet's Attack sharply rose!");
         }
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, player);
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
-        EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.5), results[1].damage);
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(2.0), results[1].damage);
     }
 }

--- a/test/battle/move_effect/attack_up_user_ally.c
+++ b/test/battle/move_effect/attack_up_user_ally.c
@@ -6,7 +6,7 @@ ASSUMPTIONS
     ASSUME(gMovesInfo[MOVE_HOWL].effect == EFFECT_ATTACK_UP_USER_ALLY);
 }
 
-SINGLE_BATTLE_TEST("Howl raises user's Attack", s16 damage)
+SINGLE_BATTLE_TEST("Howl raises user's Attack by 1 stage", s16 damage)
 {
     bool32 raiseAttack;
     PARAMETRIZE { raiseAttack = FALSE; }
@@ -31,7 +31,7 @@ SINGLE_BATTLE_TEST("Howl raises user's Attack", s16 damage)
     }
 }
 
-DOUBLE_BATTLE_TEST("Howl raises user's and partner's Attack", s16 damageLeft, s16 damageRight)
+DOUBLE_BATTLE_TEST("Howl raises user's and partner's Attack by 1 stage", s16 damageLeft, s16 damageRight)
 {
     bool32 raiseAttack;
     PARAMETRIZE { raiseAttack = FALSE; }

--- a/test/battle/move_effect/attract.c
+++ b/test/battle/move_effect/attract.c
@@ -1,0 +1,7 @@
+#include "global.h"
+#include "test/battle.h"
+
+TO_DO_BATTLE_TEST("Attract causes the target to become infatuated with the user if they have opposite genders");
+TO_DO_BATTLE_TEST("Attract ignores type immunity");
+TO_DO_BATTLE_TEST("Attract bypasses Substitute");
+TO_DO_BATTLE_TEST("Attract fails if the target is already infatuated");

--- a/test/battle/move_effect/aura_wheel.c
+++ b/test/battle/move_effect/aura_wheel.c
@@ -49,3 +49,5 @@ SINGLE_BATTLE_TEST("Aura Wheel changes type depending on Morpeko's form")
         MESSAGE("It's super effective!");
     }
 }
+
+TO_DO_BATTLE_TEST("Aura Wheel can be used by Pokémon transformed into Morpeko");

--- a/test/battle/move_effect/autotomize.c
+++ b/test/battle/move_effect/autotomize.c
@@ -1,0 +1,12 @@
+#include "global.h"
+#include "test/battle.h"
+
+TO_DO_BATTLE_TEST("Autotomize increases speed by 2 stages");
+TO_DO_BATTLE_TEST("Autotomize decreases weight by 100kg (220 lbs.)");
+TO_DO_BATTLE_TEST("Autotomize can be used multiple times to decrease weight each time");
+TO_DO_BATTLE_TEST("Autotomize cannot decrease weight below 0.1kg (0.2 lbs)");
+TO_DO_BATTLE_TEST("Autotomize's weight reduction cannot be Baton Passed");
+TO_DO_BATTLE_TEST("Autotomize's weight reduction cannot be removed by Haze");
+TO_DO_BATTLE_TEST("Autotomize's weight reduction is reset upon form change (Gen6+)");
+TO_DO_BATTLE_TEST("Autotomize's weight reduction is reset upon switch");
+TO_DO_BATTLE_TEST("Autotomize's weight reduction is reset upon fainting");

--- a/test/battle/move_effect/autotomize.c
+++ b/test/battle/move_effect/autotomize.c
@@ -1,7 +1,7 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("Autotomize increases speed by 2 stages");
+TO_DO_BATTLE_TEST("Autotomize increases Speed by 2 stages");
 TO_DO_BATTLE_TEST("Autotomize decreases weight by 100kg (220 lbs.)");
 TO_DO_BATTLE_TEST("Autotomize can be used multiple times to decrease weight each time");
 TO_DO_BATTLE_TEST("Autotomize cannot decrease weight below 0.1kg (0.2 lbs)");


### PR DESCRIPTION
## Description
First part of a long-term goal of adding all missing TODO tests to the repository.

Also:
- Split Acupressure + Ally Switch test into 2 separate tests to account for #4565.
- Added tests for: `EFFECT_ATTACK_DOWN_2`, `EFFECT_ATTACK_SPATK_UP` and `EFFECT_ATTACK_UP_2` based on existing tests.
- Adjsuted test names for `EFFECT_ACCURACY_DOWN`, `EFFECT_ATTACK_DOWN`, `EFFECT_ATTACK_UP` and `EFFECT_ATTACK_UP_USER_ALLY`.

## Feature(s) this PR does NOT handle:
The plan is just to mainly just add TODO tests, so that they can eventually be filled properly.

## **Discord contact info**
AsparagusEduardo