### PR TITLE
Adds a check for EFFECT_MULTI_HIT moves in IsMoveAffectedByParentalBond

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -15778,7 +15778,8 @@ bool32 IsMoveAffectedByParentalBond(u32 move, u32 battler)
     if (move != MOVE_NONE && move != MOVE_UNAVAILABLE && move != MOVE_STRUGGLE
         && !gMovesInfo[move].parentalBondBanned
         && gMovesInfo[move].category != DAMAGE_CATEGORY_STATUS
-        && gMovesInfo[move].strikeCount < 2)
+        && gMovesInfo[move].strikeCount < 2
+        && gMovesInfo[move].effect != EFFECT_MULTI_HIT)
     {
         if (gBattleTypeFlags & BATTLE_TYPE_DOUBLE)
         {


### PR DESCRIPTION
## Description
The ability Parental Bond should not affect multi-hit moves in any way. To give an example (in fact, the only example that exists under normal conditions), Mega-Kangaskhan can have the move Comet Punch. Comet Punch has `.effect = EFFECT_MULTI_HIT` and can hit from 2-5 times. Mega-Kangaskhan's ability, Parental Bond, should be ignored for this move, but it currently is not. 

So let's say Parental Bond is configured to have the 2nd hit do 25% damage. The behavior that is currently seen is that Comet Punch will hit once for normal damage, then a 2nd time 25 % damage as Parental Bond's 2nd hit, then Comet Punch will end. It can only hit a maximum of twice, with the 2nd hit only hitting for 25% (or 50% depending on configuration) damage. 

While this is the only interaction that occurs in the game naturally, this issue would manifest for any mon with Parental Bond using any move with `EFFECT_MULTI_HIT` that isn't ruled out by something else in `IsMoveAffectedByParentalBond`, which could happen if someone made randomizers based off expansion, which I'm sure has happened.

![pbondcometpunch](https://github.com/rh-hideout/pokeemerald-expansion/assets/40581123/258f490b-00ee-476a-ace7-c916137365c1)

^ this GIF also coincidentally captures a visual bug of the Shadow Sneak animation hitting both in doubles, but that issue exists somewhere else i think

## Issue(s) that this PR fixes
I haven't submitted an issue as I think the fix for this is just this one line. Can submit one if desired.

## **Discord contact info**
iriv24#8479
