### PR TITLE
Add on release item config

### DIFF
--- a/include/config/overworld.h
+++ b/include/config/overworld.h
@@ -19,6 +19,7 @@
 #define OW_PC_JAPAN_WALDA_ICONS     TRUE       // In the US release of Emerald, the Cross, Bolt, and Plusle icons for Walda's wallpapers were left blank from the Japan release. Setting this to TRUE will restore them.
 #define OW_PC_HEAL                  GEN_LATEST // In Gen8+, Pokémon are not healed when deposited in the PC.
 #define OW_PC_MOVE_ORDER            GEN_LATEST // Starting in Gen4, the order of options in the PC menu change.
+#define OW_PC_RELEASE_ITEM          GEN_LATEST // In Gen8+, Pokémon that get released with a held item return it to the bag.
 
 #define OW_BERRY_MUTATIONS             FALSE      // If enabled, Berry plants can mutate based on berries planted next to them.
 #define OW_BERRY_MUTATION_CHANCE       25         // Determines the % chance of a mutation.

--- a/src/pokemon_storage_system.c
+++ b/src/pokemon_storage_system.c
@@ -6438,10 +6438,23 @@ static void SetPlacedMonData(u8 boxId, u8 position)
 
 static void PurgeMonOrBoxMon(u8 boxId, u8 position)
 {
+    u16 item = ITEM_NONE;
+
     if (boxId == TOTAL_BOXES_COUNT)
+    {
+        if (OW_PC_RELEASE_ITEM >= GEN_8)
+            item = GetMonData(&gPlayerParty[position], MON_DATA_HELD_ITEM);
         ZeroMonData(&gPlayerParty[position]);
+    }
     else
+    {
+        if (OW_PC_RELEASE_ITEM >= GEN_8)
+            item = GetBoxMonDataAt(boxId, position, MON_DATA_HELD_ITEM);
         ZeroBoxMonAt(boxId, position);
+    }
+
+    if (item != ITEM_NONE)
+        AddBagItem(item, 1);
 }
 
 static void SetShiftedMonData(u8 boxId, u8 position)


### PR DESCRIPTION
Adds a config that makes released mons put their held item in the bag first, as is the case in Gen8+

## Issue(s) that this PR fixes
Fixes #3703 

## Feature(s) this PR does NOT handle:
If the bag is full, the item is still lost. Need to check in Gen8+ what happens if you eg release a mon holding a Poké Ball with maxed out Poké Balls in the bag

## **Discord contact info**
bassoonian
