### PR TITLE
Add check for Magic Guard to avoid taking recoil damage

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -7467,6 +7467,7 @@ BattleScript_MoveEffectConfusion::
 BattleScript_MoveEffectRecoil::
 	jumpifmove MOVE_STRUGGLE, BattleScript_DoRecoil
 	jumpifability BS_ATTACKER, ABILITY_ROCK_HEAD, BattleScript_RecoilEnd
+	jumpifability BS_ATTACKER, ABILITY_MAGIC_GUARD, BattleScript_RecoilEnd
 BattleScript_DoRecoil::
 	orword gHitMarker, HITMARKER_IGNORE_SUBSTITUTE | HITMARKER_PASSIVE_DAMAGE | HITMARKER_IGNORE_DISGUISE
 	healthbarupdate BS_ATTACKER

--- a/test/battle/ability/magic_guard.c
+++ b/test/battle/ability/magic_guard.c
@@ -1,0 +1,16 @@
+#include "global.h"
+#include "test/battle.h"
+
+SINGLE_BATTLE_TEST("Magic Guard prevents recoil damage to the user")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_DOUBLE_EDGE].recoil == 33);
+        PLAYER(SPECIES_CLEFABLE) { Ability(ABILITY_MAGIC_GUARD); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_DOUBLE_EDGE); }
+    } SCENE {
+        NOT HP_BAR(player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DOUBLE_EDGE, player);
+    } 
+}

--- a/test/battle/ability/magic_guard.c
+++ b/test/battle/ability/magic_guard.c
@@ -10,7 +10,8 @@ SINGLE_BATTLE_TEST("Magic Guard prevents recoil damage to the user")
     } WHEN {
         TURN { MOVE(player, MOVE_DOUBLE_EDGE); }
     } SCENE {
-        NOT HP_BAR(player);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DOUBLE_EDGE, player);
+        HP_BAR(opponent);
+        NOT HP_BAR(player);
     } 
 }

--- a/test/battle/move_effect/max_hp_50_recoil.c
+++ b/test/battle/move_effect/max_hp_50_recoil.c
@@ -91,8 +91,9 @@ SINGLE_BATTLE_TEST("Steel Beam hp loss is prevented by Magic Guard")
     } WHEN {
         TURN { MOVE(player, MOVE_STEEL_BEAM); }
     } SCENE {
-        NOT HP_BAR(player);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_STEEL_BEAM, player);
+        HP_BAR(opponent);
+        NOT HP_BAR(player);
     }
 }
 

--- a/test/battle/move_effect/mind_blown.c
+++ b/test/battle/move_effect/mind_blown.c
@@ -114,8 +114,9 @@ SINGLE_BATTLE_TEST("Mind Blown hp loss is prevented by Magic Guard")
     } WHEN {
         TURN { MOVE(player, MOVE_MIND_BLOWN); }
     } SCENE {
-        NOT HP_BAR(player);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_MIND_BLOWN, player);
+        HP_BAR(opponent);
+        NOT HP_BAR(player);
     }
 }
 


### PR DESCRIPTION
## Description
Pokemon with Magic Guard shouldn't take damage from recoil from moves like Double-edge. I think the only normal in game situation where this can occur is Clefable with Magic Guard getting access to the move Double-edge. In that case, Clefable should not take damage from recoil. 

I didn't see a set of tests that exists where something like this should be added. Didn't see any tests for Rock Head or Magic Guard, and the tests in the recoil.c file don't look to account for abilities such as these.


## Images
Before fix:
![magicguardrecoil](https://github.com/rh-hideout/pokeemerald-expansion/assets/40581123/2bc653b3-f6aa-40b9-aabe-ff641097a74f)

After fix:
![magicguardfixed](https://github.com/rh-hideout/pokeemerald-expansion/assets/40581123/a024aad3-6906-427d-8ce5-ae77d0cb5f6f)


^ sorry it's not Clefable but this Delphox has magic guard and I gave it double-edge so i think it will do


## **Discord contact info**
iriv24
