### PR TITLE
AI_CalcPartyMonDamage set saved flag for SetBattlerData

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -3288,12 +3288,16 @@ s32 AI_CalcPartyMonDamage(u32 move, u32 battlerAtk, u32 battlerDef, struct Battl
     if (isPartyMonAttacker)
     {
         gBattleMons[battlerAtk] = switchinCandidate;
+        AI_THINKING_STRUCT->saved[battlerDef].saved = TRUE;
         SetBattlerData(battlerDef); // set known opposing battler data
+        AI_THINKING_STRUCT->saved[battlerDef].saved = FALSE;
     }
     else
     {
         gBattleMons[battlerDef] = switchinCandidate;
+        AI_THINKING_STRUCT->saved[battlerAtk].saved = TRUE;
         SetBattlerData(battlerAtk); // set known opposing battler data
+        AI_THINKING_STRUCT->saved[battlerAtk].saved = FALSE;
     }
     
     dmg = AI_CalcDamage(move, battlerAtk, battlerDef, &effectiveness, FALSE, AI_GetWeather(AI_DATA));


### PR DESCRIPTION
Fixes call to SetBattlerData in `AI_CalcPartyMonDamage` needing the `saved` flag set. Temporarily set and then cleared afterwards