### PR TITLE
Adjust description of FREE_MATCH_CALL

### DIFF
--- a/include/config/save.h
+++ b/include/config/save.h
@@ -5,7 +5,7 @@
 #define FREE_EXTRA_SEEN_FLAGS_SAVEBLOCK1    FALSE   // Free up unused Pokédex seen flags (52 bytes).
 #define FREE_TRAINER_HILL                   FALSE   // Frees up Trainer Hill data (28 bytes).
 #define FREE_MYSTERY_EVENT_BUFFERS          FALSE   // Frees up ramScript (1104 bytes).
-#define FREE_MATCH_CALL                     FALSE   // Frees up match call and rematch data. (104 bytes).
+#define FREE_MATCH_CALL                     FALSE   // Frees up match call and rematch data. Still needed to use the VS Seeker even if the Pokénav's "Match Call" isn't being used (104 bytes).
 #define FREE_UNION_ROOM_CHAT                FALSE   // Frees up union room chat (212 bytes).
 #define FREE_ENIGMA_BERRY                   FALSE   // Frees up E-Reader Enigma Berry data (52 bytes).
 #define FREE_LINK_BATTLE_RECORDS            FALSE   // Frees up link battle record data (88 bytes).

--- a/include/config/save.h
+++ b/include/config/save.h
@@ -5,7 +5,7 @@
 #define FREE_EXTRA_SEEN_FLAGS_SAVEBLOCK1    FALSE   // Free up unused Pokédex seen flags (52 bytes).
 #define FREE_TRAINER_HILL                   FALSE   // Frees up Trainer Hill data (28 bytes).
 #define FREE_MYSTERY_EVENT_BUFFERS          FALSE   // Frees up ramScript (1104 bytes).
-#define FREE_MATCH_CALL                     FALSE   // Frees up match call and rematch data. Still needed to use the VS Seeker even if the Pokénav's "Match Call" isn't being used (104 bytes).
+#define FREE_MATCH_CALL                     FALSE   // Frees up match call and rematch / VS Seeker data. (104 bytes).
 #define FREE_UNION_ROOM_CHAT                FALSE   // Frees up union room chat (212 bytes).
 #define FREE_ENIGMA_BERRY                   FALSE   // Frees up E-Reader Enigma Berry data (52 bytes).
 #define FREE_LINK_BATTLE_RECORDS            FALSE   // Frees up link battle record data (88 bytes).


### PR DESCRIPTION
## Description
I've disabled the Pokenav / match call behaviour because I use psf's Jaizu's VS Seeker, so when I got the save control defines merged I figured awesome more save space I can turn this off, I'm not using match call. This is the description next to that define:

```
#define FREE_MATCH_CALL                     FALSE   // Frees up match call and rematch data
```
It became apparent after the VS Seeker broke that this is needed for that also. I brought this up in Discord and psf suggested I PR a clarification to the comment. I've changed it to:

```
#define FREE_MATCH_CALL                     FALSE   // Frees up match call and rematch data. Still needed to use the VS Seeker even if the Pokénav's "Match Call" isn't being used (104 bytes).
```
I'm a fan of detailed clarity above brevity where misinterpretation is possible, but feel free to go with something shorter if you prefer. Just making a PR as requested. :)


## **Discord contact info**
@pawkkie
