### PR TITLE
Fixed Elixir only being useable if the first move was missing PP

### DIFF
--- a/src/item_use.c
+++ b/src/item_use.c
@@ -1254,11 +1254,11 @@ bool32 CannotUseItemsInBattle(u16 itemId, struct Pokemon *mon)
             cannotUse = TRUE;
         break;
     case EFFECT_ITEM_RESTORE_PP:
-        if (ItemId_GetEffect(itemId)[6] == ITEM4_HEAL_PP)
+        if (ItemId_GetEffect(itemId)[4] == ITEM4_HEAL_PP)
         {
             for (i = 0; i < MAX_MON_MOVES; i++)
             {
-                if (GetMonData(mon, MON_DATA_PP1 + i) < CalculatePPWithBonus(GetMonData(mon, MON_DATA_MOVE1 + i), GetMonData(mon, MON_DATA_PP_BONUSES), i));
+                if (GetMonData(mon, MON_DATA_PP1 + i) < CalculatePPWithBonus(GetMonData(mon, MON_DATA_MOVE1 + i), GetMonData(mon, MON_DATA_PP_BONUSES), i))
                     break;
             }
             if (i == MAX_MON_MOVES)

--- a/test/battle/item_effect/restore_pp.c
+++ b/test/battle/item_effect/restore_pp.c
@@ -66,3 +66,28 @@ SINGLE_BATTLE_TEST("Max Elixir restores the PP of all of a battler's moves fully
 }
 
 TO_DO_BATTLE_TEST("Ether won't work if the selected move has all its PP")
+
+SINGLE_BATTLE_TEST("Elixir can be used if at least one move is missing PP in any slot") // As it works right now, this test can't test what it's suppossed to, since the relevant check doesn't run in the testing system.
+{
+    u8 move1PP;
+    u8 move2PP;
+    u8 move3PP;
+    u8 move4PP;
+    PARAMETRIZE { move1PP = 30; move2PP = 30; move3PP = 20; move4PP = 10; }
+    PARAMETRIZE { move1PP = 40; move2PP = 20; move3PP = 20; move4PP = 10; }
+    PARAMETRIZE { move1PP = 40; move2PP = 30; move3PP = 10; move4PP = 10; }
+    PARAMETRIZE { move1PP = 40; move2PP = 30; move3PP = 20; move4PP = 0; }
+    GIVEN {
+        ASSUME(gItemsInfo[ITEM_ELIXIR].battleUsage == EFFECT_ITEM_RESTORE_PP);
+        ASSUME(gItemsInfo[ITEM_ELIXIR].type == ITEM_USE_PARTY_MENU);
+        PLAYER(SPECIES_WOBBUFFET) { MovesWithPP({MOVE_MEDITATE, move1PP}, {MOVE_AGILITY, move2PP}, {MOVE_PSYBEAM, move3PP}, {MOVE_TRICK, move4PP}); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { USE_ITEM(player, ITEM_ELIXIR, partyIndex: 0); }
+    } THEN {
+        EXPECT_EQ(player->pp[0], 40);
+        EXPECT_EQ(player->pp[1], 30);
+        EXPECT_EQ(player->pp[2], 20);
+        EXPECT_EQ(player->pp[3], 10);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Elixirs could only be used if the move in the first move slot was missing PP, while correct behavior would be to allow it's use as long as any move was missing PP.
This fixes that

## Description
<!--- Describe your changes in detail -->
`case EFFECT_ITEM_RESTORE_PP:` of `CannotUseItemsInBattle` was checking the wrong item effect, therefore the `else` branch was always run therefore only checking the first move when using an Elixir.
Changing which item effect it checks fixes the issue.

## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, fixes #2222." -->
<!-- If it doesn't apply, feel free to remove this section. -->
Fixes #4593 

## Feature(s) this PR does NOT handle:
<!-- If your PR contains any unfinished features that are not considered merge-blocking, please list them here for clarity so no one can forget. -->
<!-- If it doesn't apply, feel free to remove this section. -->
Integrating the check for if items can be used into the testing system, currently the check for if Elixir's and possibly other items can actually be used is not run in tests, items are simply activated.

## **Discord contact info**
<!--- formatted as name#numbers, e.g. Lunos#4026 -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara