### PR TITLE
Fixes freeze on Galvanize Explosion against Volt Absorb

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -8097,7 +8097,6 @@ BattleScript_MoveStatDrain::
 .endif
 BattleScript_MoveStatDrain_Cont:
 	clearsemiinvulnerablebit
-	tryfaintmon BS_ATTACKER
 	goto BattleScript_MoveEnd
 
 BattleScript_MonMadeMoveUseless_PPLoss::
@@ -8108,7 +8107,6 @@ BattleScript_MonMadeMoveUseless::
 	call BattleScript_AbilityPopUp
 	printstring STRINGID_PKMNSXMADEYUSELESS
 	waitmessage B_WAIT_TIME_LONG
-	tryfaintmon BS_ATTACKER
 	orhalfword gMoveResultFlags, MOVE_RESULT_DOESNT_AFFECT_FOE
 	goto BattleScript_MoveEnd
 
@@ -8120,7 +8118,6 @@ BattleScript_FlashFireBoost::
 	call BattleScript_AbilityPopUp
 	printfromtable gFlashFireStringIds
 	waitmessage B_WAIT_TIME_LONG
-	tryfaintmon BS_ATTACKER
 	goto BattleScript_MoveEnd
 
 BattleScript_AbilityPreventsPhasingOut::

--- a/test/battle/move_effect/explosion.c
+++ b/test/battle/move_effect/explosion.c
@@ -123,3 +123,25 @@ SINGLE_BATTLE_TEST("Explosion does not trigger Destiny Bond")
         NOT HP_BAR(opponent);
     }
 }
+
+DOUBLE_BATTLE_TEST("Explosion boosted by Galvanize is correctly blocked by Volt Absorb")
+{
+    GIVEN {
+        PLAYER(SPECIES_GEODUDE_ALOLAN) { Ability(ABILITY_GALVANIZE); }
+        PLAYER(SPECIES_WYNAUT) { HP(1); }
+        OPPONENT(SPECIES_LANTURN) { Ability(ABILITY_VOLT_ABSORB); }
+        OPPONENT(SPECIES_WOBBUFFET) { HP(1); }
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_EXPLOSION); }
+    } SCENE {
+        MESSAGE("Geodude used Explosion!");
+        HP_BAR(playerLeft, hp: 0);
+        ABILITY_POPUP(opponentLeft, ABILITY_VOLT_ABSORB);
+        NOT HP_BAR(opponentLeft, hp: 0);
+        HP_BAR(playerRight, hp: 0);
+        MESSAGE("Wynaut fainted!");
+        HP_BAR(opponentRight, hp: 0);
+        MESSAGE("Foe Wobbuffet fainted!");
+        MESSAGE("Geodude fainted!");
+    }
+}


### PR DESCRIPTION
Fixes #4599

I couldn't find the PR that added `trytofaintmon` to all absorbing ability scripts (vanilla emerald doesn't have those) but judging by the comments in #1961 it was added to fix an explosion interaction. With #4516 this is not needed anymore and causes a bug instead. 