### PR TITLE
Add configuration to prevent permanent item theft (Covet / Thief) from NPCs

### DIFF
--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -152,7 +152,7 @@
 #define B_X_ITEMS_BUFF              GEN_LATEST // In Gen7+, the X Items raise a stat by 2 stages instead of 1.
 #define B_MENTAL_HERB               GEN_LATEST // In Gen5+, the Mental Herb cures Taunt, Encore, Torment, Heal Block, and Disable in addition to Infatuation from before.
 #define B_TRAINERS_KNOCK_OFF_ITEMS  TRUE       // If TRUE, trainers can steal/swap your items (non-berries are restored after battle). In vanilla games trainers cannot steal items.
-#define B_PREVENT_TRAINER_ITEM_LOSS GEN_LATEST // In Gen5+, Thief and Covet do not steal items from trainers.
+#define B_NO_TRAINER_ITEM_STEALING  GEN_LATEST // In Gen5+, Thief and Covet do not steal items from trainers.
 #define B_RESTORE_HELD_BATTLE_ITEMS GEN_LATEST // In Gen9, all non-berry items are restored after battle.
 #define B_SOUL_DEW_BOOST            GEN_LATEST // In Gens3-6, Soul Dew boosts Latis' Sp. Atk and Sp. Def. In Gen7+ it boosts the power of their Psychic and Dragon type moves instead.
 #define B_NET_BALL_MODIFIER         GEN_LATEST // In Gen7+, Net Ball's catch multiplier is x5 instead of x3.

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -152,6 +152,7 @@
 #define B_X_ITEMS_BUFF              GEN_LATEST // In Gen7+, the X Items raise a stat by 2 stages instead of 1.
 #define B_MENTAL_HERB               GEN_LATEST // In Gen5+, the Mental Herb cures Taunt, Encore, Torment, Heal Block, and Disable in addition to Infatuation from before.
 #define B_TRAINERS_KNOCK_OFF_ITEMS  TRUE       // If TRUE, trainers can steal/swap your items (non-berries are restored after battle). In vanilla games trainers cannot steal items.
+#define B_PREVENT_TRAINER_ITEM_LOSS GEN_LATEST // In Gen5+, Thief and Covet do not steal items from trainers.
 #define B_RESTORE_HELD_BATTLE_ITEMS GEN_LATEST // In Gen9, all non-berry items are restored after battle.
 #define B_SOUL_DEW_BOOST            GEN_LATEST // In Gens3-6, Soul Dew boosts Latis' Sp. Atk and Sp. Def. In Gen7+ it boosts the power of their Psychic and Dragon type moves instead.
 #define B_NET_BALL_MODIFIER         GEN_LATEST // In Gen7+, Net Ball's catch multiplier is x5 instead of x3.

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -152,7 +152,7 @@
 #define B_X_ITEMS_BUFF              GEN_LATEST // In Gen7+, the X Items raise a stat by 2 stages instead of 1.
 #define B_MENTAL_HERB               GEN_LATEST // In Gen5+, the Mental Herb cures Taunt, Encore, Torment, Heal Block, and Disable in addition to Infatuation from before.
 #define B_TRAINERS_KNOCK_OFF_ITEMS  TRUE       // If TRUE, trainers can steal/swap your items (non-berries are restored after battle). In vanilla games trainers cannot steal items.
-#define B_NO_TRAINER_ITEM_STEALING  GEN_LATEST // In Gen5+, Thief and Covet do not steal items from trainers.
+#define B_RETURN_STOLEN_NPC_ITEMS   GEN_LATEST // In Gen5+, Thief and Covet do not steal items from trainers.
 #define B_RESTORE_HELD_BATTLE_ITEMS GEN_LATEST // In Gen9, all non-berry items are restored after battle.
 #define B_SOUL_DEW_BOOST            GEN_LATEST // In Gens3-6, Soul Dew boosts Latis' Sp. Atk and Sp. Def. In Gen7+ it boosts the power of their Psychic and Dragon type moves instead.
 #define B_NET_BALL_MODIFIER         GEN_LATEST // In Gen7+, Net Ball's catch multiplier is x5 instead of x3.

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -10854,7 +10854,6 @@ void SortBattlersBySpeed(u8 *battlers, bool32 slowToFast)
 void TryRestoreHeldItems(void)
 {
     u32 i;
-    u16 lostItem = ITEM_NONE;
     bool32 returnNPCItems = B_RETURN_STOLEN_NPC_ITEMS >= GEN_5 && gBattleTypeFlags & BATTLE_TYPE_TRAINER;
     
     for (i = 0; i < PARTY_SIZE; i++)
@@ -10862,14 +10861,15 @@ void TryRestoreHeldItems(void)
         // Check if held items should be restored after battle based on generation
         if (B_RESTORE_HELD_BATTLE_ITEMS >= GEN_9 || gBattleStruct->itemLost[i].stolen || returnNPCItems)
         {
-            lostItem = gBattleStruct->itemLost[i].originalItem;
+            u16 lostItem = gBattleStruct->itemLost[i].originalItem;
+
+            // Check if the lost item is a berry and the mon is not holding it
+            if (ItemId_GetPocket(lostItem) == POCKET_BERRIES && GetMonData(&gPlayerParty[i], MON_DATA_HELD_ITEM) != lostItem) lostItem = ITEM_NONE;
 
             // Check if the lost item should be restored
-            if ((lostItem != ITEM_NONE || returnNPCItems)
-                && ItemId_GetPocket(lostItem) != POCKET_BERRIES)
-            {
+            if ((lostItem != ITEM_NONE || returnNPCItems) && ItemId_GetPocket(lostItem) != POCKET_BERRIES) 
                 SetMonData(&gPlayerParty[i], MON_DATA_HELD_ITEM, &lostItem);
-            }
+            
         }
     }
 }

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -10864,7 +10864,7 @@ void TryRestoreHeldItems(void)
             lostItem = gBattleStruct->itemLost[i].originalItem;
 
             // Check if the lost item should be restored
-            if ((lostItem != ITEM_NONE || (B_PREVENT_TRAINER_ITEM_LOSS >= GEN_5 && gBattleTypeFlags & BATTLE_TYPE_TRAINER))
+            if ((lostItem != ITEM_NONE || (B_NO_TRAINER_ITEM_STEALING >= GEN_5 && gBattleTypeFlags & BATTLE_TYPE_TRAINER))
                 && ItemId_GetPocket(lostItem) != POCKET_BERRIES)
             {
                 SetMonData(&gPlayerParty[i], MON_DATA_HELD_ITEM, &lostItem);

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -10864,10 +10864,8 @@ void TryRestoreHeldItems(void)
             lostItem = gBattleStruct->itemLost[i].originalItem;
 
             // Check if the lost item should be restored
-            bool shouldRestore = (lostItem != ITEM_NONE || (B_PREVENT_TRAINER_ITEM_LOSS >= GEN_5 && gBattleTypeFlags & BATTLE_TYPE_TRAINER))
-                && ItemId_GetPocket(lostItem) != POCKET_BERRIES;
-
-            if (shouldRestore)
+            if ((lostItem != ITEM_NONE || (B_PREVENT_TRAINER_ITEM_LOSS >= GEN_5 && gBattleTypeFlags & BATTLE_TYPE_TRAINER))
+                && ItemId_GetPocket(lostItem) != POCKET_BERRIES)
             {
                 SetMonData(&gPlayerParty[i], MON_DATA_HELD_ITEM, &lostItem);
             }

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -10855,14 +10855,22 @@ void TryRestoreHeldItems(void)
 {
     u32 i;
     u16 lostItem = ITEM_NONE;
-
+    
     for (i = 0; i < PARTY_SIZE; i++)
     {
+        // Check if held items should be restored after battle based on generation
         if (B_RESTORE_HELD_BATTLE_ITEMS >= GEN_9 || gBattleStruct->itemLost[i].stolen)
         {
             lostItem = gBattleStruct->itemLost[i].originalItem;
-            if (lostItem != ITEM_NONE && ItemId_GetPocket(lostItem) != POCKET_BERRIES)
-                SetMonData(&gPlayerParty[i], MON_DATA_HELD_ITEM, &lostItem);  // Restore stolen non-berry items
+
+            // Check if the lost item should be restored
+            bool shouldRestore = (lostItem != ITEM_NONE || (B_PREVENT_TRAINER_ITEM_LOSS >= GEN_5 && gBattleTypeFlags & BATTLE_TYPE_TRAINER))
+                && ItemId_GetPocket(lostItem) != POCKET_BERRIES;
+
+            if (shouldRestore)
+            {
+                SetMonData(&gPlayerParty[i], MON_DATA_HELD_ITEM, &lostItem);
+            }
         }
     }
 }

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -10855,16 +10855,17 @@ void TryRestoreHeldItems(void)
 {
     u32 i;
     u16 lostItem = ITEM_NONE;
+    bool32 returnNPCItems = B_RETURN_STOLEN_NPC_ITEMS >= GEN_5 && gBattleTypeFlags & BATTLE_TYPE_TRAINER;
     
     for (i = 0; i < PARTY_SIZE; i++)
     {
         // Check if held items should be restored after battle based on generation
-        if (B_RESTORE_HELD_BATTLE_ITEMS >= GEN_9 || gBattleStruct->itemLost[i].stolen)
+        if (B_RESTORE_HELD_BATTLE_ITEMS >= GEN_9 || gBattleStruct->itemLost[i].stolen || returnNPCItems)
         {
             lostItem = gBattleStruct->itemLost[i].originalItem;
 
             // Check if the lost item should be restored
-            if ((lostItem != ITEM_NONE || (B_NO_TRAINER_ITEM_STEALING >= GEN_5 && gBattleTypeFlags & BATTLE_TYPE_TRAINER))
+            if ((lostItem != ITEM_NONE || returnNPCItems)
                 && ItemId_GetPocket(lostItem) != POCKET_BERRIES)
             {
                 SetMonData(&gPlayerParty[i], MON_DATA_HELD_ITEM, &lostItem);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In Generation 5 onward, Thief and Covet no longer _permanently_ steal items from trainers. From Bulbapedia:

> Covet no longer steals a Trainer's Pokémon's items permanently; however, a wild Pokémon's item is still permanently stolen by the player. 

> Thief no longer steals a Trainer's Pokémon's items permanently; however, a wild Pokémon's item is still permanently stolen by the player. 

However, as it currently stands, this updated behavior was not implemented. As such, this PR implements the following:

- The addition of a variable `B_RETURN_STOLEN_NPC_ITEMS` in `battle.h` that rudimentarily handles generation-based logic for Thief/Covet against NPCs;
- A refactor of the `TryRestoreHeldItem` function that includes the above variable. Individuals can now choose whether or not trainer NPCs are able to have their items be stolen permanently with Covet/Thief, or not.
- The player still keeps all items obtained through Covet/Thief from Wild Pokemon regardless of variable states.

## **People who collaborated with me in this PR**
- Duke ( @Sneed69 ) for some help with the logic

## **Discord contact info**
'viridian.' (including the dot)
