### PR TITLE
Add configuration to prevent permanent item theft (Covet / Thief) from NPCs

### DIFF
--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -154,6 +154,7 @@
 #define B_X_ITEMS_BUFF              GEN_LATEST // In Gen7+, the X Items raise a stat by 2 stages instead of 1.
 #define B_MENTAL_HERB               GEN_LATEST // In Gen5+, the Mental Herb cures Taunt, Encore, Torment, Heal Block, and Disable in addition to Infatuation from before.
 #define B_TRAINERS_KNOCK_OFF_ITEMS  TRUE       // If TRUE, trainers can steal/swap your items (non-berries are restored after battle). In vanilla games trainers cannot steal items.
+#define B_RETURN_STOLEN_NPC_ITEMS   GEN_LATEST // In Gen5+, Thief and Covet no longer steal items from NPCs.
 #define B_RESTORE_HELD_BATTLE_ITEMS GEN_LATEST // In Gen9, all non-berry items are restored after battle.
 #define B_SOUL_DEW_BOOST            GEN_LATEST // In Gens3-6, Soul Dew boosts Latis' Sp. Atk and Sp. Def. In Gen7+ it boosts the power of their Psychic and Dragon type moves instead.
 #define B_NET_BALL_MODIFIER         GEN_LATEST // In Gen7+, Net Ball's catch multiplier is x5 instead of x3.

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -10988,23 +10988,25 @@ void SortBattlersBySpeed(u8 *battlers, bool32 slowToFast)
     }
 }
 
+#define RETURN_NPC_ITEMS B_RETURN_STOLEN_NPC_ITEMS >= GEN_5 && gBattleTypeFlags & BATTLE_TYPE_TRAINER
+
 void TryRestoreHeldItems(void)
 {
     u32 i;
-    bool32 returnNPCItems = B_RETURN_STOLEN_NPC_ITEMS >= GEN_5 && gBattleTypeFlags & BATTLE_TYPE_TRAINER;
-    
+
     for (i = 0; i < PARTY_SIZE; i++)
     {
         // Check if held items should be restored after battle based on generation
-        if (B_RESTORE_HELD_BATTLE_ITEMS >= GEN_9 || gBattleStruct->itemLost[i].stolen || returnNPCItems)
+        if (B_RESTORE_HELD_BATTLE_ITEMS >= GEN_9 || gBattleStruct->itemLost[i].stolen || RETURN_NPC_ITEMS)
         {
             u16 lostItem = gBattleStruct->itemLost[i].originalItem;
 
             // Check if the lost item is a berry and the mon is not holding it
-            if (ItemId_GetPocket(lostItem) == POCKET_BERRIES && GetMonData(&gPlayerParty[i], MON_DATA_HELD_ITEM) != lostItem) lostItem = ITEM_NONE;
+            if (ItemId_GetPocket(lostItem) == POCKET_BERRIES && GetMonData(&gPlayerParty[i], MON_DATA_HELD_ITEM) != lostItem) 
+                lostItem = ITEM_NONE;
 
             // Check if the lost item should be restored
-            if ((lostItem != ITEM_NONE || returnNPCItems) && ItemId_GetPocket(lostItem) != POCKET_BERRIES) 
+            if ((lostItem != ITEM_NONE || RETURN_NPC_ITEMS) && ItemId_GetPocket(lostItem) != POCKET_BERRIES) 
                 SetMonData(&gPlayerParty[i], MON_DATA_HELD_ITEM, &lostItem);
             
         }

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -10988,25 +10988,23 @@ void SortBattlersBySpeed(u8 *battlers, bool32 slowToFast)
     }
 }
 
-#define RETURN_NPC_ITEMS (B_RETURN_STOLEN_NPC_ITEMS >= GEN_5 && gBattleTypeFlags & BATTLE_TYPE_TRAINER)
-
 void TryRestoreHeldItems(void)
 {
     u32 i;
+    bool32 returnNPCItems = B_RETURN_STOLEN_NPC_ITEMS >= GEN_5 && gBattleTypeFlags & BATTLE_TYPE_TRAINER;
 
     for (i = 0; i < PARTY_SIZE; i++)
     {
         // Check if held items should be restored after battle based on generation
-        if (B_RESTORE_HELD_BATTLE_ITEMS >= GEN_9 || gBattleStruct->itemLost[i].stolen || RETURN_NPC_ITEMS)
+        if (B_RESTORE_HELD_BATTLE_ITEMS >= GEN_9 || gBattleStruct->itemLost[i].stolen || returnNPCItems)
         {
             u16 lostItem = gBattleStruct->itemLost[i].originalItem;
 
             // Check if the lost item is a berry and the mon is not holding it
-            if (ItemId_GetPocket(lostItem) == POCKET_BERRIES && GetMonData(&gPlayerParty[i], MON_DATA_HELD_ITEM) != lostItem) 
-                lostItem = ITEM_NONE;
+            if (ItemId_GetPocket(lostItem) == POCKET_BERRIES && GetMonData(&gPlayerParty[i], MON_DATA_HELD_ITEM) != lostItem) lostItem = ITEM_NONE;
 
             // Check if the lost item should be restored
-            if ((lostItem != ITEM_NONE || RETURN_NPC_ITEMS) && ItemId_GetPocket(lostItem) != POCKET_BERRIES) 
+            if ((lostItem != ITEM_NONE || returnNPCItems) && ItemId_GetPocket(lostItem) != POCKET_BERRIES) 
                 SetMonData(&gPlayerParty[i], MON_DATA_HELD_ITEM, &lostItem);
             
         }

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -11001,7 +11001,8 @@ void TryRestoreHeldItems(void)
             u16 lostItem = gBattleStruct->itemLost[i].originalItem;
 
             // Check if the lost item is a berry and the mon is not holding it
-            if (ItemId_GetPocket(lostItem) == POCKET_BERRIES && GetMonData(&gPlayerParty[i], MON_DATA_HELD_ITEM) != lostItem) lostItem = ITEM_NONE;
+            if (ItemId_GetPocket(lostItem) == POCKET_BERRIES && GetMonData(&gPlayerParty[i], MON_DATA_HELD_ITEM) != lostItem) 
+                lostItem = ITEM_NONE;
 
             // Check if the lost item should be restored
             if ((lostItem != ITEM_NONE || returnNPCItems) && ItemId_GetPocket(lostItem) != POCKET_BERRIES) 

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -10991,15 +10991,22 @@ void SortBattlersBySpeed(u8 *battlers, bool32 slowToFast)
 void TryRestoreHeldItems(void)
 {
     u32 i;
-    u16 lostItem = ITEM_NONE;
-
+    bool32 returnNPCItems = B_RETURN_STOLEN_NPC_ITEMS >= GEN_5 && gBattleTypeFlags & BATTLE_TYPE_TRAINER;
+    
     for (i = 0; i < PARTY_SIZE; i++)
     {
-        if (B_RESTORE_HELD_BATTLE_ITEMS >= GEN_9 || gBattleStruct->itemLost[i].stolen)
+        // Check if held items should be restored after battle based on generation
+        if (B_RESTORE_HELD_BATTLE_ITEMS >= GEN_9 || gBattleStruct->itemLost[i].stolen || returnNPCItems)
         {
-            lostItem = gBattleStruct->itemLost[i].originalItem;
-            if (lostItem != ITEM_NONE && ItemId_GetPocket(lostItem) != POCKET_BERRIES)
-                SetMonData(&gPlayerParty[i], MON_DATA_HELD_ITEM, &lostItem);  // Restore stolen non-berry items
+            u16 lostItem = gBattleStruct->itemLost[i].originalItem;
+
+            // Check if the lost item is a berry and the mon is not holding it
+            if (ItemId_GetPocket(lostItem) == POCKET_BERRIES && GetMonData(&gPlayerParty[i], MON_DATA_HELD_ITEM) != lostItem) lostItem = ITEM_NONE;
+
+            // Check if the lost item should be restored
+            if ((lostItem != ITEM_NONE || returnNPCItems) && ItemId_GetPocket(lostItem) != POCKET_BERRIES) 
+                SetMonData(&gPlayerParty[i], MON_DATA_HELD_ITEM, &lostItem);
+            
         }
     }
 }

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -10988,7 +10988,7 @@ void SortBattlersBySpeed(u8 *battlers, bool32 slowToFast)
     }
 }
 
-#define RETURN_NPC_ITEMS B_RETURN_STOLEN_NPC_ITEMS >= GEN_5 && gBattleTypeFlags & BATTLE_TYPE_TRAINER
+#define RETURN_NPC_ITEMS (B_RETURN_STOLEN_NPC_ITEMS >= GEN_5 && gBattleTypeFlags & BATTLE_TYPE_TRAINER)
 
 void TryRestoreHeldItems(void)
 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In Generation 5 onward, Thief and Covet no longer _permanently_ steal items from trainers. From Bulbapedia:

> Covet no longer steals a Trainer's Pokémon's items permanently; however, a wild Pokémon's item is still permanently stolen by the player. 

> Thief no longer steals a Trainer's Pokémon's items permanently; however, a wild Pokémon's item is still permanently stolen by the player. 

However, as it currently stands, this updated behavior was not implemented. As such, this PR implements the following:

- The addition of a variable `B_RETURN_STOLEN_NPC_ITEMS` in `battle.h` that rudimentarily handles generation-based logic for Thief/Covet against NPCs;
- A refactor of the `TryRestoreHeldItem` function that includes the above variable. Individuals can now choose whether or not trainer NPCs are able to have their items be stolen permanently with Covet/Thief, or not.
- The player still keeps all items obtained through Covet/Thief from Wild Pokemon regardless of variable states.
- When a Pokemon holds a berry and consumes it, and steals an item with Covet/Thief from a trainer NPC after, it will either keep or discard the item depending on which generation `B_RETURN_STOLEN_NPC_ITEMS` is set to.

Fixes #1778 

## **People who collaborated with me in this PR**
- Duke ( @Sneed69 ) for some help with the logic

## **Discord contact info**
'viridian.' (including the dot)
