### PR TITLE
Renames evolution methods the were labeled as evo level

### DIFF
--- a/docs/changelogs/1.8.x/1.8.0.md
+++ b/docs/changelogs/1.8.x/1.8.0.md
@@ -362,7 +362,7 @@
     * `EVO_USE_MOVE_TWENTY_TIMES`:
         * Stantler can now evolve into Wyrdeer by using Psyshield Bash 20 times.
         * Primeape can now evolve into Annihilape by using Rage Fist 20 times.
-    * `EVO_LEVEL_RECOIL_DAMAGE_MALE`/`EVO_LEVEL_RECOIL_DAMAGE_FEMALE`
+    * `EVO_RECOIL_DAMAGE_MALE`/`EVO_RECOIL_DAMAGE_FEMALE`
         * White-Striped Basculin can now evolve into Basculegion when leveling up after receiving 294HP of recoil damage and being the corresponding gender.
 * Added missing Paldean Wooper icon by @kittenchilly in https://github.com/rh-hideout/pokeemerald-expansion/pull/4260
 * Added missing data for placeholder Pokémon by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/4281

--- a/docs/changelogs/1.8.x/1.8.0.md
+++ b/docs/changelogs/1.8.x/1.8.0.md
@@ -359,7 +359,7 @@
 * Added missing `P_UPDATED_EVS` config that allows setting the EV yield changes across generations by @Bassoonian in https://github.com/rh-hideout/pokeemerald-expansion/pull/3993
 * Added missing `P_UPDATED_EXP_YIELDS` config that allows setting the Experience yield changes across generations by @Bassoonian in https://github.com/rh-hideout/pokeemerald-expansion/pull/3995
 * Added evolution methods that require custom trackers (`MON_DATA_EVOLUTION_TRACKER`) by @Bassoonian in https://github.com/rh-hideout/pokeemerald-expansion/pull/4087
-    * `EVO_LEVEL_MOVE_TWENTY_TIMES`:
+    * `EVO_USE_MOVE_TWENTY_TIMES`:
         * Stantler can now evolve into Wyrdeer by using Psyshield Bash 20 times.
         * Primeape can now evolve into Annihilape by using Rage Fist 20 times.
     * `EVO_LEVEL_RECOIL_DAMAGE_MALE`/`EVO_LEVEL_RECOIL_DAMAGE_FEMALE`
@@ -495,7 +495,7 @@
     * Aeroblast: Added Wind Move flag.
 * Ivy Cudgel's type now changes based on Ogerpon's form rather than held item by @kittenchilly in https://github.com/rh-hideout/pokeemerald-expansion/pull/3865
 * Renamed `healBlockBanned` flag to `healingMove` by @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3981
-* Removed some hardcoded move IDs 
+* Removed some hardcoded move IDs
     * By @AsparagusEduardo in https://github.com/rh-hideout/pokeemerald-expansion/pull/3982
         * `MOVE_EXPLOSION`, `MOVE_SELF_DESTRUCT`, `MOVE_FRUSTRATION`, `MOVE_AURA_WHEEL`, `MOVE_PRESENT`, `MOVE_BLIZZARD`.
     * By @ZnogyroP in https://github.com/rh-hideout/pokeemerald-expansion/pull/4085

--- a/docs/changelogs/1.8.x/1.8.3.md
+++ b/docs/changelogs/1.8.x/1.8.3.md
@@ -23,7 +23,7 @@
     * Fixed Exp. Candies ignoring hard caps.
     * Fixed Pokémon gaining 1 experience if they are at the level cap.
 * Fixed evolution tracker issues by @cawtds in https://github.com/rh-hideout/pokeemerald-expansion/pull/4503
-    * `EVO_LEVEL_MOVE_TWENTY_TIMES` no longer increases with every move.
+    * `EVO_USE_MOVE_TWENTY_TIMES` no longer increases with every move.
     * `EVO_LEVEL_RECOIL_DAMAGE_MALE/FEMALE` is no longer updated twice than intended.
 
 ## ✨ Feature Branches ✨

--- a/docs/changelogs/1.8.x/1.8.3.md
+++ b/docs/changelogs/1.8.x/1.8.3.md
@@ -24,7 +24,7 @@
     * Fixed Pokémon gaining 1 experience if they are at the level cap.
 * Fixed evolution tracker issues by @cawtds in https://github.com/rh-hideout/pokeemerald-expansion/pull/4503
     * `EVO_USE_MOVE_TWENTY_TIMES` no longer increases with every move.
-    * `EVO_LEVEL_RECOIL_DAMAGE_MALE/FEMALE` is no longer updated twice than intended.
+    * `EVO_RECOIL_DAMAGE_MALE/FEMALE` is no longer updated twice than intended.
 
 ## ✨ Feature Branches ✨
 ### ***TheXaman's HGSS Pokédex Plus***:

--- a/include/constants/pokemon.h
+++ b/include/constants/pokemon.h
@@ -295,7 +295,7 @@
 #define EVO_USE_MOVE_TWENTY_TIMES         47     // Pokémon levels up after having used a move for at least 20 times
 #define EVO_RECOIL_DAMAGE_MALE            48     // Pokémon levels up after having suffered specified amount of non-fainting recoil damage as a male
 #define EVO_RECOIL_DAMAGE_FEMALE          49     // Pokémon levels up after having suffered specified amount of non-fainting recoil damage as a female
-#define EVO_LEVEL_ITEM_COUNT_999          50     // Pokémon levels up after trainer has collected 999 of a specific item
+#define EVO_ITEM_COUNT_999                50     // Pokémon levels up after trainer has collected 999 of a specific item
 
 // Evolution 'modes,' for GetEvolutionTargetSpecies
 #define EVO_MODE_NORMAL            0

--- a/include/constants/pokemon.h
+++ b/include/constants/pokemon.h
@@ -292,7 +292,7 @@
 #define EVO_MOVE_THREE_SEGMENT            44     // Pokémon levels up, knows specified move, has a personality value with a modulus of 1-99
 #define EVO_LEVEL_FAMILY_OF_THREE         45     // Pokémon reaches the specified level with a personality value with a modulus of 0
 #define EVO_LEVEL_FAMILY_OF_FOUR          46     // Pokémon reaches the specified level with a personality value with a modulus of 1-99
-#define EVO_LEVEL_MOVE_TWENTY_TIMES       47     // Pokémon levels up after having used a move for at least 20 times
+#define EVO_USE_MOVE_TWENTY_TIMES       47     // Pokémon levels up after having used a move for at least 20 times
 #define EVO_LEVEL_RECOIL_DAMAGE_MALE      48     // Pokémon levels up after having suffered specified amount of non-fainting recoil damage as a male
 #define EVO_LEVEL_RECOIL_DAMAGE_FEMALE    49     // Pokémon levels up after having suffered specified amount of non-fainting recoil damage as a female
 #define EVO_LEVEL_ITEM_COUNT_999          50     // Pokémon levels up after trainer has collected 999 of a specific item

--- a/include/constants/pokemon.h
+++ b/include/constants/pokemon.h
@@ -292,9 +292,9 @@
 #define EVO_MOVE_THREE_SEGMENT            44     // Pokémon levels up, knows specified move, has a personality value with a modulus of 1-99
 #define EVO_LEVEL_FAMILY_OF_THREE         45     // Pokémon reaches the specified level with a personality value with a modulus of 0
 #define EVO_LEVEL_FAMILY_OF_FOUR          46     // Pokémon reaches the specified level with a personality value with a modulus of 1-99
-#define EVO_USE_MOVE_TWENTY_TIMES       47     // Pokémon levels up after having used a move for at least 20 times
-#define EVO_LEVEL_RECOIL_DAMAGE_MALE      48     // Pokémon levels up after having suffered specified amount of non-fainting recoil damage as a male
-#define EVO_LEVEL_RECOIL_DAMAGE_FEMALE    49     // Pokémon levels up after having suffered specified amount of non-fainting recoil damage as a female
+#define EVO_USE_MOVE_TWENTY_TIMES         47     // Pokémon levels up after having used a move for at least 20 times
+#define EVO_RECOIL_DAMAGE_MALE            48     // Pokémon levels up after having suffered specified amount of non-fainting recoil damage as a male
+#define EVO_RECOIL_DAMAGE_FEMALE          49     // Pokémon levels up after having suffered specified amount of non-fainting recoil damage as a female
 #define EVO_LEVEL_ITEM_COUNT_999          50     // Pokémon levels up after trainer has collected 999 of a specific item
 
 // Evolution 'modes,' for GetEvolutionTargetSpecies

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -16786,8 +16786,8 @@ static void TryUpdateEvolutionTracker(u32 evolutionMethod, u32 upAmount, u16 use
                         if (evolutions[i].param == usedMove)
                             SetMonData(&gPlayerParty[gBattlerPartyIndexes[gBattlerAttacker]], MON_DATA_EVOLUTION_TRACKER, &val);
                         break;
-                    case EVO_LEVEL_RECOIL_DAMAGE_MALE:
-                    case EVO_LEVEL_RECOIL_DAMAGE_FEMALE:
+                    case EVO_RECOIL_DAMAGE_MALE:
+                    case EVO_RECOIL_DAMAGE_FEMALE:
                         if (gBattleMons[gBattlerAttacker].hp == 0)
                             val = 0;
                         SetMonData(&gPlayerParty[gBattlerPartyIndexes[gBattlerAttacker]], MON_DATA_EVOLUTION_TRACKER, &val);
@@ -16807,10 +16807,10 @@ void BS_TryUpdateRecoilTracker(void)
     switch(gender)
     {
         case MON_MALE:
-            TryUpdateEvolutionTracker(EVO_LEVEL_RECOIL_DAMAGE_MALE, gBattleMoveDamage, MOVE_NONE);
+            TryUpdateEvolutionTracker(EVO_RECOIL_DAMAGE_MALE, gBattleMoveDamage, MOVE_NONE);
             break;
         case MON_FEMALE:
-            TryUpdateEvolutionTracker(EVO_LEVEL_RECOIL_DAMAGE_FEMALE, gBattleMoveDamage, MOVE_NONE);
+            TryUpdateEvolutionTracker(EVO_RECOIL_DAMAGE_FEMALE, gBattleMoveDamage, MOVE_NONE);
             break;
     }
 

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -6290,7 +6290,7 @@ static void Cmd_moveend(void)
         case MOVEEND_SET_EVOLUTION_TRACKER:
             // If the Pokémon needs to keep track of move usage for its evolutions, do it
             if (originallyUsedMove != MOVE_NONE)
-                TryUpdateEvolutionTracker(EVO_LEVEL_MOVE_TWENTY_TIMES, 1, originallyUsedMove);
+                TryUpdateEvolutionTracker(EVO_USE_MOVE_TWENTY_TIMES, 1, originallyUsedMove);
             gBattleScripting.moveendState++;
             break;
         case MOVEEND_CLEAR_BITS: // Clear/Set bits for things like using a move for all targets and all hits.
@@ -16782,7 +16782,7 @@ static void TryUpdateEvolutionTracker(u32 evolutionMethod, u32 upAmount, u16 use
                 // Reset progress if you faint for the recoil method.
                 switch (evolutionMethod)
                 {
-                    case EVO_LEVEL_MOVE_TWENTY_TIMES:
+                    case EVO_USE_MOVE_TWENTY_TIMES:
                         if (evolutions[i].param == usedMove)
                             SetMonData(&gPlayerParty[gBattlerPartyIndexes[gBattlerAttacker]], MON_DATA_EVOLUTION_TRACKER, &val);
                         break;

--- a/src/data/pokemon/species_info/gen_1_families.h
+++ b/src/data/pokemon/species_info/gen_1_families.h
@@ -5957,7 +5957,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         FOOTPRINT(Primeape)
         .levelUpLearnset = sPrimeapeLevelUpLearnset,
         .teachableLearnset = sPrimeapeTeachableLearnset,
-        .evolutions = EVOLUTION({EVO_LEVEL_MOVE_TWENTY_TIMES, MOVE_RAGE_FIST, SPECIES_ANNIHILAPE}),
+        .evolutions = EVOLUTION({EVO_USE_MOVE_TWENTY_TIMES, MOVE_RAGE_FIST, SPECIES_ANNIHILAPE}),
     },
 
 #if P_GEN_9_CROSS_EVOS

--- a/src/data/pokemon/species_info/gen_2_families.h
+++ b/src/data/pokemon/species_info/gen_2_families.h
@@ -5719,7 +5719,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .levelUpLearnset = sStantlerLevelUpLearnset,
         .teachableLearnset = sStantlerTeachableLearnset,
         .eggMoveLearnset = sStantlerEggMoveLearnset,
-        .evolutions = EVOLUTION({EVO_LEVEL_MOVE_TWENTY_TIMES, MOVE_PSYSHIELD_BASH, SPECIES_WYRDEER}),
+        .evolutions = EVOLUTION({EVO_USE_MOVE_TWENTY_TIMES, MOVE_PSYSHIELD_BASH, SPECIES_WYRDEER}),
     },
 
 #if P_GEN_8_CROSS_EVOS

--- a/src/data/pokemon/species_info/gen_5_families.h
+++ b/src/data/pokemon/species_info/gen_5_families.h
@@ -3465,8 +3465,8 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .levelUpLearnset = sBasculinWhiteStripedLevelUpLearnset,
         .teachableLearnset = sBasculinWhiteStripedTeachableLearnset,
         .formSpeciesIdTable = sBasculinFormSpeciesIdTable,
-        .evolutions = EVOLUTION({EVO_LEVEL_RECOIL_DAMAGE_MALE, 294, SPECIES_BASCULEGION_MALE},
-                                {EVO_LEVEL_RECOIL_DAMAGE_FEMALE, 294, SPECIES_BASCULEGION_FEMALE}),
+        .evolutions = EVOLUTION({EVO_RECOIL_DAMAGE_MALE, 294, SPECIES_BASCULEGION_MALE},
+                                {EVO_RECOIL_DAMAGE_FEMALE, 294, SPECIES_BASCULEGION_FEMALE}),
     },
 
     [SPECIES_BASCULEGION_MALE] =

--- a/src/data/pokemon/species_info/gen_9_families.h
+++ b/src/data/pokemon/species_info/gen_9_families.h
@@ -5260,7 +5260,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         .levelUpLearnset = sGimmighoulLevelUpLearnset,
         .teachableLearnset = sGimmighoulTeachableLearnset,
         .formSpeciesIdTable = sGimmighoulFormSpeciesIdTable,
-        .evolutions = EVOLUTION({EVO_LEVEL_ITEM_COUNT_999, ITEM_GIMMIGHOUL_COIN, SPECIES_GHOLDENGO}),
+        .evolutions = EVOLUTION({EVO_ITEM_COUNT_999, ITEM_GIMMIGHOUL_COIN, SPECIES_GHOLDENGO}),
     },
 
     [SPECIES_GIMMIGHOUL_ROAMING] =
@@ -5314,7 +5314,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         .levelUpLearnset = sGimmighoulLevelUpLearnset,
         .teachableLearnset = sGimmighoulTeachableLearnset,
         .formSpeciesIdTable = sGimmighoulFormSpeciesIdTable,
-        .evolutions = EVOLUTION({EVO_LEVEL_ITEM_COUNT_999, ITEM_GIMMIGHOUL_COIN, SPECIES_GHOLDENGO}),
+        .evolutions = EVOLUTION({EVO_ITEM_COUNT_999, ITEM_GIMMIGHOUL_COIN, SPECIES_GHOLDENGO}),
     },
 
     [SPECIES_GHOLDENGO] =

--- a/src/pokedex_plus_hgss.c
+++ b/src/pokedex_plus_hgss.c
@@ -244,7 +244,7 @@ static const u8 sText_EVO_WATER_SCROLL[] = _("ScrollOfWatrs is used");
 static const u8 sText_EVO_ITEM_NIGHT[] = _("{STR_VAR_2} is used, night");
 static const u8 sText_EVO_ITEM_DAY[] = _("{STR_VAR_2} is used, day");
 static const u8 sText_EVO_ITEM_HOLD[] = _("{LV}{UP_ARROW}, holds {STR_VAR_2}");
-static const u8 sText_EVO_LEVEL_MOVE_TWENTY_TIMES[] = _("{LV}{UP_ARROW} after 20x {STR_VAR_2}");
+static const u8 sText_EVO_USE_MOVE_TWENTY_TIMES[] = _("{LV}{UP_ARROW} after 20x {STR_VAR_2}");
 static const u8 sText_EVO_LEVEL_RECOIL_DAMAGE_MALE[] = _("{LV}{UP_ARROW} with {STR_VAR_2} recoil, male");
 static const u8 sText_EVO_LEVEL_RECOIL_DAMAGE_FEMALE[] = _("{LV}{UP_ARROW} with {STR_VAR_2} recoil, female");
 static const u8 sText_EVO_LEVEL_ITEM_COUNT_999[] = _("{LV}{UP_ARROW} with 999 {STR_VAR_2} in bag");
@@ -6650,9 +6650,9 @@ static u8 PrintEvolutionTargetSpeciesAndMethod(u8 taskId, u16 species, u8 depth,
             CopyItemName(item, gStringVar2);
             StringExpandPlaceholders(gStringVar4, sText_EVO_ITEM_HOLD );
             break;
-        case EVO_LEVEL_MOVE_TWENTY_TIMES:
+        case EVO_USE_MOVE_TWENTY_TIMES:
             StringCopy(gStringVar2, GetMoveName(evolutions[i].param));
-            StringExpandPlaceholders(gStringVar4, sText_EVO_LEVEL_MOVE_TWENTY_TIMES );
+            StringExpandPlaceholders(gStringVar4, sText_EVO_USE_MOVE_TWENTY_TIMES );
             break;
         case EVO_LEVEL_RECOIL_DAMAGE_MALE:
             ConvertIntToDecimalStringN(gStringVar2, evolutions[i].param, STR_CONV_MODE_LEADING_ZEROS, 3);

--- a/src/pokedex_plus_hgss.c
+++ b/src/pokedex_plus_hgss.c
@@ -245,8 +245,8 @@ static const u8 sText_EVO_ITEM_NIGHT[] = _("{STR_VAR_2} is used, night");
 static const u8 sText_EVO_ITEM_DAY[] = _("{STR_VAR_2} is used, day");
 static const u8 sText_EVO_ITEM_HOLD[] = _("{LV}{UP_ARROW}, holds {STR_VAR_2}");
 static const u8 sText_EVO_USE_MOVE_TWENTY_TIMES[] = _("{LV}{UP_ARROW} after 20x {STR_VAR_2}");
-static const u8 sText_EVO_LEVEL_RECOIL_DAMAGE_MALE[] = _("{LV}{UP_ARROW} with {STR_VAR_2} recoil, male");
-static const u8 sText_EVO_LEVEL_RECOIL_DAMAGE_FEMALE[] = _("{LV}{UP_ARROW} with {STR_VAR_2} recoil, female");
+static const u8 sText_EVO_RECOIL_DAMAGE_MALE[] = _("{LV}{UP_ARROW} with {STR_VAR_2} recoil, male");
+static const u8 sText_EVO_RECOIL_DAMAGE_FEMALE[] = _("{LV}{UP_ARROW} with {STR_VAR_2} recoil, female");
 static const u8 sText_EVO_LEVEL_ITEM_COUNT_999[] = _("{LV}{UP_ARROW} with 999 {STR_VAR_2} in bag");
 static const u8 sText_EVO_UNKNOWN[] = _("Method unknown");
 static const u8 sText_EVO_NONE[] = _("{STR_VAR_1} has no evolution.");
@@ -6654,13 +6654,13 @@ static u8 PrintEvolutionTargetSpeciesAndMethod(u8 taskId, u16 species, u8 depth,
             StringCopy(gStringVar2, GetMoveName(evolutions[i].param));
             StringExpandPlaceholders(gStringVar4, sText_EVO_USE_MOVE_TWENTY_TIMES );
             break;
-        case EVO_LEVEL_RECOIL_DAMAGE_MALE:
+        case EVO_RECOIL_DAMAGE_MALE:
             ConvertIntToDecimalStringN(gStringVar2, evolutions[i].param, STR_CONV_MODE_LEADING_ZEROS, 3);
-            StringExpandPlaceholders(gStringVar4, sText_EVO_LEVEL_RECOIL_DAMAGE_MALE);
+            StringExpandPlaceholders(gStringVar4, sText_EVO_RECOIL_DAMAGE_MALE);
             break;
-        case EVO_LEVEL_RECOIL_DAMAGE_FEMALE:
+        case EVO_RECOIL_DAMAGE_FEMALE:
             ConvertIntToDecimalStringN(gStringVar2, evolutions[i].param, STR_CONV_MODE_LEADING_ZEROS, 3);
-            StringExpandPlaceholders(gStringVar4, sText_EVO_LEVEL_RECOIL_DAMAGE_FEMALE);
+            StringExpandPlaceholders(gStringVar4, sText_EVO_RECOIL_DAMAGE_FEMALE);
             break;
         case EVO_LEVEL_ITEM_COUNT_999:
             item = evolutions[i].param;

--- a/src/pokedex_plus_hgss.c
+++ b/src/pokedex_plus_hgss.c
@@ -247,7 +247,7 @@ static const u8 sText_EVO_ITEM_HOLD[] = _("{LV}{UP_ARROW}, holds {STR_VAR_2}");
 static const u8 sText_EVO_USE_MOVE_TWENTY_TIMES[] = _("{LV}{UP_ARROW} after 20x {STR_VAR_2}");
 static const u8 sText_EVO_RECOIL_DAMAGE_MALE[] = _("{LV}{UP_ARROW} with {STR_VAR_2} recoil, male");
 static const u8 sText_EVO_RECOIL_DAMAGE_FEMALE[] = _("{LV}{UP_ARROW} with {STR_VAR_2} recoil, female");
-static const u8 sText_EVO_LEVEL_ITEM_COUNT_999[] = _("{LV}{UP_ARROW} with 999 {STR_VAR_2} in bag");
+static const u8 sText_EVO_ITEM_COUNT_999[] = _("{LV}{UP_ARROW} with 999 {STR_VAR_2} in bag");
 static const u8 sText_EVO_UNKNOWN[] = _("Method unknown");
 static const u8 sText_EVO_NONE[] = _("{STR_VAR_1} has no evolution.");
 
@@ -6662,10 +6662,10 @@ static u8 PrintEvolutionTargetSpeciesAndMethod(u8 taskId, u16 species, u8 depth,
             ConvertIntToDecimalStringN(gStringVar2, evolutions[i].param, STR_CONV_MODE_LEADING_ZEROS, 3);
             StringExpandPlaceholders(gStringVar4, sText_EVO_RECOIL_DAMAGE_FEMALE);
             break;
-        case EVO_LEVEL_ITEM_COUNT_999:
+        case EVO_ITEM_COUNT_999:
             item = evolutions[i].param;
             CopyItemName(item, gStringVar2);
-            StringExpandPlaceholders(gStringVar4, sText_EVO_LEVEL_ITEM_COUNT_999);
+            StringExpandPlaceholders(gStringVar4, sText_EVO_ITEM_COUNT_999);
             break;
         default:
             StringExpandPlaceholders(gStringVar4, sText_EVO_UNKNOWN );

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -4667,7 +4667,7 @@ u16 GetEvolutionTargetSpecies(struct Pokemon *mon, u8 mode, u16 evolutionItem, s
                     consumeItem = TRUE;
                 }
                 break;
-            case EVO_LEVEL_MOVE_TWENTY_TIMES:
+            case EVO_USE_MOVE_TWENTY_TIMES:
                 if (evolutionTracker >= 20)
                     targetSpecies = evolutions[i].targetSpecies;
                 break;

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -4671,11 +4671,11 @@ u16 GetEvolutionTargetSpecies(struct Pokemon *mon, u8 mode, u16 evolutionItem, s
                 if (evolutionTracker >= 20)
                     targetSpecies = evolutions[i].targetSpecies;
                 break;
-            case EVO_LEVEL_RECOIL_DAMAGE_MALE:
+            case EVO_RECOIL_DAMAGE_MALE:
                 if (evolutionTracker >= evolutions[i].param && GetMonGender(mon) == MON_MALE)
                     targetSpecies = evolutions[i].targetSpecies;
                 break;
-            case EVO_LEVEL_RECOIL_DAMAGE_FEMALE:
+            case EVO_RECOIL_DAMAGE_FEMALE:
                 if (evolutionTracker >= evolutions[i].param && GetMonGender(mon) == MON_FEMALE)
                     targetSpecies = evolutions[i].targetSpecies;
                 break;

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -4693,7 +4693,7 @@ u16 GetEvolutionTargetSpecies(struct Pokemon *mon, u8 mode, u16 evolutionItem, s
 
             switch (evolutions[i].method)
             {
-            case EVO_LEVEL_ITEM_COUNT_999:
+            case EVO_ITEM_COUNT_999:
                 if (CheckBagHasItem(evolutions[i].param, 999))
                 {
                     targetSpecies = evolutions[i].targetSpecies;


### PR DESCRIPTION
The reason for this change is that we usually don't name evolution methods with a `LEVEL` prefix unless it evolves with an explicit level.

Renames:
```
EVO_LEVEL_MOVE_TWENTY_TIMES -> EVO_USE_MOVE_TWENTY_TIMES
EVO_USE_MOVE_TWENTY_TIMES -> EVO_RECOIL_DAMAGE_MALE
EVO_RECOIL_DAMAGE_MALE -> EVO_RECOIL_DAMAGE_FEMALE
```