### PR TITLE
Belch AI Scoring Fix

### DIFF
--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -202,6 +202,7 @@ u8 GetBattleMoveCategory(u32 moveId);
 bool32 CanFling(u32 battler);
 bool32 IsTelekinesisBannedSpecies(u16 species);
 bool32 IsHealBlockPreventingMove(u32 battler, u32 move);
+bool32 IsBelchPreventingMove(u32 battler, u32 move);
 bool32 HasEnoughHpToEatBerry(u32 battler, u32 hpFraction, u32 itemId);
 bool32 IsPartnerMonFromSameTrainer(u32 battler);
 u8 GetCategoryBasedOnStats(u32 battler);

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -426,7 +426,7 @@ bool32 IsDamageMoveUnusable(u32 move, u32 battlerAtk, u32 battlerDef)
             return TRUE;
         break;
     case EFFECT_BELCH:
-        if (ItemId_GetPocket(GetUsedHeldItem(battlerAtk)) != POCKET_BERRIES)
+        if (IsBelchPreventingMove(battlerAtk, move))
             return TRUE;
         break;
     case EFFECT_LAST_RESORT:

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2186,6 +2186,7 @@ static void Cmd_multihitresultmessage(void)
     if (gSpecialStatuses[gBattlerTarget].berryReduced
         && !(gMoveResultFlags & MOVE_RESULT_NO_EFFECT))
     {
+        gBattleStruct->ateBerry[gBattlerTarget & BIT_SIDE] |= gBitTable[gBattlerPartyIndexes[gBattlerTarget]];
         gSpecialStatuses[gBattlerTarget].berryReduced = FALSE;
         BattleScriptPushCursor();
         gBattlescriptCurrInstr = BattleScript_PrintBerryReduceString;
@@ -2646,6 +2647,7 @@ static void Cmd_resultmessage(void)
     if (gSpecialStatuses[gBattlerTarget].berryReduced
         && !(gMoveResultFlags & MOVE_RESULT_NO_EFFECT))
     {
+        gBattleStruct->ateBerry[gBattlerTarget & BIT_SIDE] |= gBitTable[gBattlerPartyIndexes[gBattlerTarget]];
         gSpecialStatuses[gBattlerTarget].berryReduced = FALSE;
         BattleScriptPushCursor();
         gBattlescriptCurrInstr = BattleScript_PrintBerryReduceString;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -1266,7 +1266,7 @@ bool32 IsBelchPreventingMove(u32 battler, u32 move)
 {
     if (gMovesInfo[move].effect != EFFECT_BELCH)
         return FALSE;
- 
+
     return !(gBattleStruct->ateBerry[battler & BIT_SIDE] & gBitTable[gBattlerPartyIndexes[battler]]);
 }
 

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -1262,7 +1262,7 @@ bool32 IsHealBlockPreventingMove(u32 battler, u32 move)
     return gMovesInfo[move].healingMove;
 }
 
-static bool32 IsBelchPreventingMove(u32 battler, u32 move)
+bool32 IsBelchPreventingMove(u32 battler, u32 move)
 {
     if (gMovesInfo[move].effect != EFFECT_BELCH)
         return FALSE;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -1267,7 +1267,10 @@ static bool32 IsBelchPreventingMove(u32 battler, u32 move)
     if (gMovesInfo[move].effect != EFFECT_BELCH)
         return FALSE;
 
-    return !(gBattleStruct->ateBerry[battler & BIT_SIDE] & gBitTable[gBattlerPartyIndexes[battler]]);
+    if (ItemId_GetPocket(GetUsedHeldItem(battler)) != POCKET_BERRIES)
+        return TRUE;
+    else
+        return FALSE;
 }
 
 // Dynamax bypasses all selection prevention except Taunt and Assault Vest.

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -1266,11 +1266,8 @@ bool32 IsBelchPreventingMove(u32 battler, u32 move)
 {
     if (gMovesInfo[move].effect != EFFECT_BELCH)
         return FALSE;
-
-    if (ItemId_GetPocket(GetUsedHeldItem(battler)) != POCKET_BERRIES)
-        return TRUE;
-    else
-        return FALSE;
+        
+    return !(gBattleStruct->ateBerry[battler & BIT_SIDE] & gBitTable[gBattlerPartyIndexes[battler]]);
 }
 
 // Dynamax bypasses all selection prevention except Taunt and Assault Vest.

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -1266,7 +1266,7 @@ bool32 IsBelchPreventingMove(u32 battler, u32 move)
 {
     if (gMovesInfo[move].effect != EFFECT_BELCH)
         return FALSE;
-        
+ 
     return !(gBattleStruct->ateBerry[battler & BIT_SIDE] & gBitTable[gBattlerPartyIndexes[battler]]);
 }
 

--- a/test/battle/move_effect/belch.c
+++ b/test/battle/move_effect/belch.c
@@ -7,6 +7,8 @@ ASSUMPTIONS
     ASSUME(gMovesInfo[MOVE_MUD_SHOT].type == TYPE_GROUND);
     ASSUME(gItemsInfo[ITEM_SHUCA_BERRY].holdEffect == HOLD_EFFECT_RESIST_BERRY);
     ASSUME(gItemsInfo[ITEM_SHUCA_BERRY].holdEffectParam == TYPE_GROUND);
+    ASSUME(gItemsInfo[ITEM_SHUCA_BERRY].pocket == POCKET_BERRIES);
+    ASSUME(gItemsInfo[ITEM_ORAN_BERRY].pocket == POCKET_BERRIES);
 }
 
 SINGLE_BATTLE_TEST("AI: Belch has nonzero score after eating a berry")

--- a/test/battle/move_effect/belch.c
+++ b/test/battle/move_effect/belch.c
@@ -1,0 +1,49 @@
+#include "global.h"
+#include "test/battle.h"
+
+ASSUMPTIONS
+{
+    ASSUME(gMovesInfo[MOVE_BELCH].effect == EFFECT_BELCH);
+    ASSUME(gMovesInfo[MOVE_MUD_SHOT].type == TYPE_GROUND);
+    ASSUME(gItemsInfo[ITEM_SHUCA_BERRY].holdEffect == HOLD_EFFECT_RESIST_BERRY);
+    ASSUME(gItemsInfo[ITEM_SHUCA_BERRY].holdEffectParam == TYPE_GROUND);
+}
+
+SINGLE_BATTLE_TEST("AI: Belch has nonzero score after eating a berry")
+{
+    GIVEN {
+        PLAYER(SPECIES_BAYLEEF) { Level(18); Moves(MOVE_MUD_SHOT, MOVE_TACKLE); }
+        OPPONENT(SPECIES_PIKACHU) { Level(15); Item(ITEM_SHUCA_BERRY); Moves(MOVE_BELCH, MOVE_EXTREME_SPEED); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_MUD_SHOT); MOVE(opponent, MOVE_EXTREME_SPEED); }
+        TURN { MOVE(player, MOVE_TACKLE); MOVE(opponent, MOVE_BELCH);}
+    } SCENE {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_BELCH, opponent);
+    }
+}
+
+SINGLE_BATTLE_TEST("Belch cannot be used if the user has not eaten a berry")
+{
+    u16 item = 0;
+    PARAMETRIZE { item = ITEM_NONE; }
+    PARAMETRIZE { item = ITEM_ORAN_BERRY; }
+    GIVEN {
+        PLAYER(SPECIES_SKWOVET) { Item(item); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        if (item == ITEM_NONE)
+            TURN { MOVE(player, MOVE_BELCH, allowed: FALSE); MOVE(player, MOVE_CELEBRATE); }
+        else {
+            TURN { MOVE(player, MOVE_STUFF_CHEEKS); }
+            TURN { MOVE(player, MOVE_BELCH); }
+        }
+    } SCENE {
+        if (item == ITEM_NONE) {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
+        }
+        else {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_STUFF_CHEEKS, player);
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_BELCH, player);
+        }
+    }
+}

--- a/test/battle/move_effect/belch.c
+++ b/test/battle/move_effect/belch.c
@@ -11,14 +11,15 @@ ASSUMPTIONS
     ASSUME(gItemsInfo[ITEM_ORAN_BERRY].pocket == POCKET_BERRIES);
 }
 
-SINGLE_BATTLE_TEST("AI: Belch has nonzero score after eating a berry")
+AI_SINGLE_BATTLE_TEST("AI: Belch has nonzero score after eating a berry")
 {
     GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT);
         PLAYER(SPECIES_BAYLEEF) { Level(18); Moves(MOVE_MUD_SHOT, MOVE_TACKLE); }
-        OPPONENT(SPECIES_PIKACHU) { Level(15); Item(ITEM_SHUCA_BERRY); Moves(MOVE_BELCH, MOVE_EXTREME_SPEED); }
+        OPPONENT(SPECIES_PIKACHU) { Level(15); Item(ITEM_SHUCA_BERRY); Moves(MOVE_BELCH, MOVE_TACKLE); }
     } WHEN {
-        TURN { MOVE(player, MOVE_MUD_SHOT); MOVE(opponent, MOVE_EXTREME_SPEED); }
-        TURN { MOVE(player, MOVE_TACKLE); MOVE(opponent, MOVE_BELCH);}
+        TURN { MOVE(player, MOVE_MUD_SHOT); EXPECT_MOVE(opponent, MOVE_TACKLE); }
+        TURN { MOVE(player, MOVE_TACKLE); EXPECT_MOVE(opponent, MOVE_BELCH);}
     } SCENE {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_BELCH, opponent);
     }

--- a/test/battle/move_effect/stuff_cheeks.c
+++ b/test/battle/move_effect/stuff_cheeks.c
@@ -103,29 +103,3 @@ SINGLE_BATTLE_TEST("Stuff Cheeks fails if the user's berry is removed before the
         MESSAGE("But it failed!");
     }
 }
-
-SINGLE_BATTLE_TEST("Belch cannot be used if the user has not eaten a berry")
-{
-    u16 item = 0;
-    PARAMETRIZE { item = ITEM_NONE; }
-    PARAMETRIZE { item = ITEM_ORAN_BERRY; }
-    GIVEN {
-        PLAYER(SPECIES_SKWOVET) { Item(item); }
-        OPPONENT(SPECIES_WOBBUFFET);
-    } WHEN {
-        if (item == ITEM_NONE)
-            TURN { MOVE(player, MOVE_BELCH, allowed: FALSE); MOVE(player, MOVE_CELEBRATE); }
-        else {
-            TURN { MOVE(player, MOVE_STUFF_CHEEKS); }
-            TURN { MOVE(player, MOVE_BELCH); }
-        }
-    } SCENE {
-        if (item == ITEM_NONE) {
-            ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
-        }
-        else {
-            ANIMATION(ANIM_TYPE_MOVE, MOVE_STUFF_CHEEKS, player);
-            ANIMATION(ANIM_TYPE_MOVE, MOVE_BELCH, player);
-        }
-    }
-}


### PR DESCRIPTION
## Description
@Kasen discovered today that Belch was being considered an invalid option (score and damage of 0) by the AI even after it had eaten a berry. While exploring the issue I discovered that the check used to determine whether a berry has been eaten was completely different in `IsDamageMoveUnusable` and `IsBelchPreventingMove`, with the latter implementation being significantly older. I updated it to match the newer implementation, and it fixed the issue.

I wrote a test that builds a situation in which the AI should use Belch, which fails on current master but passes with this PR. I also moved the only other Belch test I could find into its own file with this one as there are now two Belch tests, though one relates to the AI and the other was in with Stuff Cheeks so if you'd like a different organization let me know.

## Images
Sample scenario before this fix, from the turn after eating a berry:
![image](https://github.com/rh-hideout/pokeemerald-expansion/assets/61265402/34b8d7b2-b225-48ec-b504-3eff21e9c323)

Same scenario with this fix:
![image (1)](https://github.com/rh-hideout/pokeemerald-expansion/assets/61265402/d69696c6-5c00-485e-b4db-fd3634d65d72)


## **People who collaborated with me in this PR**
@Kasen found the issue, I've written the code!

## **Discord contact info**
@Pawkkie
