### PR TITLE
Fix move descriptions for Feint and Feint Attack

### DIFF
--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -4530,7 +4530,9 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
     [MOVE_FEINT_ATTACK] =
     {
         .name = COMPOUND_STRING("Feint Attack"),
-        .description = sFeintDescription,
+        .description = COMPOUND_STRING(
+            "Draws the foe close, then\n"
+            "strikes without fail."),
         .effect = EFFECT_HIT,
         .power = 60,
         .type = TYPE_DARK,
@@ -8808,9 +8810,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
     [MOVE_FEINT] =
     {
         .name = COMPOUND_STRING("Feint"),
-        .description = COMPOUND_STRING(
-            "An attack that hits foes\n"
-            "using moves like Protect."),
+        .description = sFeintDescription,
         .effect = EFFECT_HIT,
         .power = B_UPDATED_MOVE_DATA >= GEN_5 ? 30 : 50,
         .type = TYPE_NORMAL,


### PR DESCRIPTION
Fixes the descriptions for Feint and Feint Attack.

## Description
Feint utilized a custom description, despite intention to share a description with Mighty Cleave. Feint Attack also had the wrong description. The description in this PR is taken from [`pokeemerald`](https://github.com/pret/pokeemerald/blob/18f84b78f2d1a8669753fa586836fca06036c790/src/data/text/move_descriptions.h#L740).

## Images
![pokeemerald-0](https://github.com/rh-hideout/pokeemerald-expansion/assets/118140365/41596ba4-c147-45fe-9319-a7202554cbb8)
![pokeemerald-1](https://github.com/rh-hideout/pokeemerald-expansion/assets/118140365/835f928e-a54f-4cd4-bff7-ca024e49a1f4)


## **Discord contact info**
@lhea
