### PR TITLE
Reverted bad implementation of Sparkling Aria+Covert Cloak/Shield Dust

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -7357,6 +7357,12 @@ BattleScript_TargetBurnHeal::
 	updatestatusicon BS_TARGET
 	return
 
+BattleScript_TargetPoisonHealed::
+	printstring STRINGID_PASTELVEILENTERS
+	waitmessage B_WAIT_TIME_LONG
+	updatestatusicon BS_TARGET
+	return
+
 BattleScript_MoveEffectSleep::
 	statusanimation BS_EFFECT_BATTLER
 	printfromtable gFellAsleepStringIds

--- a/include/battle_scripts.h
+++ b/include/battle_scripts.h
@@ -139,6 +139,7 @@ extern const u8 BattleScript_CurseTurnDmg[];
 extern const u8 BattleScript_TargetPRLZHeal[];
 extern const u8 BattleScript_TargetWokeUp[];
 extern const u8 BattleScript_TargetBurnHeal[];
+extern const u8 BattleScript_TargetPoisonHealed[];
 extern const u8 BattleScript_MoveEffectSleep[];
 extern const u8 BattleScript_YawnMakesAsleep[];
 extern const u8 BattleScript_MoveEffectPoison[];

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -5406,7 +5406,6 @@ static void Cmd_moveend(void)
     u16 *choicedMoveAtk = NULL;
     u32 endMode, endState;
     u32 originallyUsedMove;
-    u8 currBattler, liveBattlerCount;
 
     if (gChosenMove == MOVE_UNAVAILABLE)
         originallyUsedMove = MOVE_NONE;
@@ -5717,28 +5716,19 @@ static void Cmd_moveend(void)
                         gBattlescriptCurrInstr = BattleScript_TargetWokeUp;
                         break;
                     case STATUS1_BURN:
-                        // Checks to see if Sparkling Aria should cure a Shield Dust pokemon
-                        if (gBattleMons[gBattlerTarget].ability == ABILITY_SHIELD_DUST || gBattleMons[gBattlerTarget].item == ITEM_COVERT_CLOAK)
-                        {
-                            liveBattlerCount = 0;
-                            for (currBattler = 0; currBattler < gBattlersCount; currBattler++)
-                            {
-                                if (gBattleMons[currBattler].hp != 0)
-                                {
-                                    liveBattlerCount++;
-                                }
-                            }
-                            if (liveBattlerCount > 2)
-                            {
-                                gBattlescriptCurrInstr = BattleScript_TargetBurnHeal;
-                            }
-                            break;
-                        }
-                        else
-                        {
-                            gBattlescriptCurrInstr = BattleScript_TargetBurnHeal;
-                            break;
-                        }
+                        gBattlescriptCurrInstr = BattleScript_TargetBurnHeal;
+                        break;
+                    case STATUS1_FREEZE:
+                        gBattlescriptCurrInstr = BattleScript_FrostbiteHealedViaFireMove;
+                        break;
+                    case STATUS1_FROSTBITE:
+                        gBattlescriptCurrInstr = BattleScript_DefrostedViaFireMove;
+                        break;
+                    case STATUS1_POISON:
+                    case STATUS1_TOXIC_POISON:
+                    case STATUS1_PSN_ANY:
+                        gBattlescriptCurrInstr = BattleScript_TargetPoisonHealed;
+                        break;
                     }
                 }
                 break; // MOVE_EFFECT_REMOVE_STATUS

--- a/test/battle/ability/shield_dust.c
+++ b/test/battle/ability/shield_dust.c
@@ -124,6 +124,7 @@ SINGLE_BATTLE_TEST("Shield Dust does not block self-targeting effects, primary o
 DOUBLE_BATTLE_TEST("Shield Dust does or does not block Sparkling Aria depending on number of targets hit")
 {
     u32 moveToUse;
+    KNOWN_FAILING;
     PARAMETRIZE { moveToUse = MOVE_FINAL_GAMBIT; }
     PARAMETRIZE { moveToUse = MOVE_TACKLE; }
     GIVEN {
@@ -149,6 +150,7 @@ DOUBLE_BATTLE_TEST("Shield Dust does or does not block Sparkling Aria depending 
 
 SINGLE_BATTLE_TEST("Shield Dust blocks Sparkling Aria in singles")
 {
+    KNOWN_FAILING;
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_VIVILLON) { Ability(ABILITY_SHIELD_DUST); Status1(STATUS1_BURN); }

--- a/test/battle/item_effect/covert_cloak.c
+++ b/test/battle/item_effect/covert_cloak.c
@@ -122,6 +122,7 @@ SINGLE_BATTLE_TEST("Covert Cloak does not block self-targeting effects, primary 
 DOUBLE_BATTLE_TEST("Covert Cloak does or does not block Sparkling Aria depending on number of targets hit")
 {
     u32 moveToUse;
+    KNOWN_FAILING;
     PARAMETRIZE { moveToUse = MOVE_FINAL_GAMBIT; }
     PARAMETRIZE { moveToUse = MOVE_TACKLE; }
     GIVEN {
@@ -147,6 +148,7 @@ DOUBLE_BATTLE_TEST("Covert Cloak does or does not block Sparkling Aria depending
 
 SINGLE_BATTLE_TEST("Covert Cloak blocks Sparkling Aria in singles")
 {
+    KNOWN_FAILING;
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_COVERT_CLOAK); Status1(STATUS1_BURN); }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
#4558 introduced a rough version of Sparkling Aria + Shield Dust edge case, but it was just preventing messages and icons from playing and updating, meaning that tests were being masked into passing.

Reverting this change showed that Covert Cloak/Shield Dust also wasn't protecting from Sparkling Aria even in singles, so all of them have been marked as `KNOWN_FAILING`.

Also, added failsafes in case `MOVE_EFFECT_REMOVE_STATUS` is used with other Status1

## **Discord contact info**
AsparagusEduardo
