### PR TITLE
Fixes Dancer triggering if the move's user didn't act

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -6260,7 +6260,16 @@ static void Cmd_moveend(void)
             if (gMovesInfo[gCurrentMove].danceMove)
             {
                 u8 battler, nextDancer = 0;
+                bool8 turnOnHitmarker = FALSE;
 
+                for (battler = 0; battler < MAX_BATTLERS_COUNT; battler++)
+                    if (gSpecialStatuses[battler].dancerUsedMove)
+                    {
+                        // in case a battler fails to act on a Dancer proc
+                        turnOnHitmarker = TRUE;
+                        break;
+                    }
+                
                 if (!(gBattleStruct->lastMoveFailed & gBitTable[gBattlerAttacker]
                     || (!gSpecialStatuses[gBattlerAttacker].dancerUsedMove
                         && gBattleStruct->bouncedMoveIsUsed)))
@@ -6276,6 +6285,8 @@ static void Cmd_moveend(void)
                     {
                         if (GetBattlerAbility(battler) == ABILITY_DANCER && !gSpecialStatuses[battler].dancerUsedMove)
                         {
+                            if (turnOnHitmarker)
+                                gHitMarker |= HITMARKER_ATTACKSTRING_PRINTED;
                             if (!nextDancer || (gBattleMons[battler].speed < gBattleMons[nextDancer & 0x3].speed))
                                 nextDancer = battler | 0x4;
                         }

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -6259,16 +6259,18 @@ static void Cmd_moveend(void)
         case MOVEEND_DANCER: // Special case because it's so annoying
             if (gMovesInfo[gCurrentMove].danceMove)
             {
-                u8 battler, nextDancer = 0;
-                bool8 turnOnHitmarker = FALSE;
+                u32 battler, nextDancer = 0;
+                bool32 turnOnHitmarker = FALSE;
 
                 for (battler = 0; battler < MAX_BATTLERS_COUNT; battler++)
+                {
                     if (gSpecialStatuses[battler].dancerUsedMove)
                     {
-                        // in case a battler fails to act on a Dancer proc
+                        // in case a battler fails to act on a Dancer-called move
                         turnOnHitmarker = TRUE;
                         break;
                     }
+                }
                 
                 if (!(gBattleStruct->lastMoveFailed & gBitTable[gBattlerAttacker]
                     || (!gSpecialStatuses[gBattlerAttacker].dancerUsedMove

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -5754,6 +5754,7 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
             if (IsBattlerAlive(battler)
              && (gMovesInfo[gCurrentMove].danceMove)
              && !gSpecialStatuses[battler].dancerUsedMove
+             && (gHitMarker & HITMARKER_ATTACKSTRING_PRINTED)
              && gBattlerAttacker != battler)
             {
                 // Set bit and save Dancer mon's original target

--- a/test/battle/ability/dancer.c
+++ b/test/battle/ability/dancer.c
@@ -114,10 +114,12 @@ DOUBLE_BATTLE_TEST("Dancer still triggers if another dancer flinches")
         ABILITY_POPUP(playerLeft, ABILITY_DANCER);
         MESSAGE("Wobbuffet flinched!");
         NONE_OF {
+            MESSAGE("Wobbuffet used Dragon Dance!");
             ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DANCE, playerLeft);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
         }
         ABILITY_POPUP(opponentLeft, ABILITY_DANCER);
+        MESSAGE("Foe Oricorio used Dragon Dance!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DANCE, opponentLeft);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
     }

--- a/test/battle/ability/dancer.c
+++ b/test/battle/ability/dancer.c
@@ -82,6 +82,7 @@ DOUBLE_BATTLE_TEST("Dancer triggers from slowest to fastest")
 SINGLE_BATTLE_TEST("Dancer doesn't trigger if the original user flinches")
 {
     GIVEN {
+        ASSUME(MoveHasAdditionalEffectWithChance(MOVE_FAKE_OUT, MOVE_EFFECT_FLINCH, 100));
         ASSUME(gMovesInfo[MOVE_DRAGON_DANCE].danceMove == TRUE);
         PLAYER(SPECIES_WOBBUFFET)
         OPPONENT(SPECIES_ORICORIO) { Ability(ABILITY_DANCER); }
@@ -100,6 +101,7 @@ SINGLE_BATTLE_TEST("Dancer doesn't trigger if the original user flinches")
 DOUBLE_BATTLE_TEST("Dancer still triggers if another dancer flinches")
 {
     GIVEN {
+        ASSUME(MoveHasAdditionalEffectWithChance(MOVE_FAKE_OUT, MOVE_EFFECT_FLINCH, 100));
         ASSUME(gMovesInfo[MOVE_DRAGON_DANCE].danceMove == TRUE);
         PLAYER(SPECIES_WOBBUFFET) { Ability(ABILITY_DANCER); Speed(10); }
         PLAYER(SPECIES_WYNAUT) { Speed(5); }

--- a/test/battle/ability/dancer.c
+++ b/test/battle/ability/dancer.c
@@ -53,3 +53,72 @@ DOUBLE_BATTLE_TEST("Dancer can copy Teeter Dance and confuse both opposing targe
         MESSAGE("Wynaut became confused!");
     }
 }
+
+DOUBLE_BATTLE_TEST("Dancer triggers from slowest to fastest")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_DRAGON_DANCE].danceMove == TRUE);
+        PLAYER(SPECIES_WOBBUFFET) { Ability(ABILITY_DANCER); Speed(10); }
+        PLAYER(SPECIES_WYNAUT) { Speed(50); }
+        OPPONENT(SPECIES_ORICORIO) { Ability(ABILITY_DANCER); Speed(20); }
+        OPPONENT(SPECIES_WOBBUFFET) { Ability(ABILITY_DANCER); Speed(3); }
+    } WHEN {
+        TURN { MOVE(playerRight, MOVE_DRAGON_DANCE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DANCE, playerRight);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerRight);
+        ABILITY_POPUP(opponentRight, ABILITY_DANCER);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DANCE, opponentRight);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);
+        ABILITY_POPUP(playerLeft, ABILITY_DANCER);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DANCE, playerLeft);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
+        ABILITY_POPUP(opponentLeft, ABILITY_DANCER);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DANCE, opponentLeft);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
+    }
+}
+
+SINGLE_BATTLE_TEST("Dancer doesn't trigger if the original user flinches")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_DRAGON_DANCE].danceMove == TRUE);
+        PLAYER(SPECIES_WOBBUFFET)
+        OPPONENT(SPECIES_ORICORIO) { Ability(ABILITY_DANCER); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_FAKE_OUT); MOVE(player, MOVE_DRAGON_DANCE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FAKE_OUT, opponent);
+        MESSAGE("Wobbuffet flinched!");
+        NONE_OF {
+            ABILITY_POPUP(opponent, ABILITY_DANCER);
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DANCE, opponent);
+        }
+    }
+}
+
+DOUBLE_BATTLE_TEST("Dancer still triggers if another dancer flinches")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_DRAGON_DANCE].danceMove == TRUE);
+        PLAYER(SPECIES_WOBBUFFET) { Ability(ABILITY_DANCER); Speed(10); }
+        PLAYER(SPECIES_WYNAUT) { Speed(5); }
+        OPPONENT(SPECIES_ORICORIO) { Ability(ABILITY_DANCER); Speed(20); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(3); }
+    } WHEN {
+        TURN { MOVE(opponentLeft, MOVE_FAKE_OUT, target: playerLeft); MOVE(playerRight, MOVE_DRAGON_DANCE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FAKE_OUT, opponentLeft);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DANCE, playerRight);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerRight);
+        ABILITY_POPUP(playerLeft, ABILITY_DANCER);
+        MESSAGE("Wobbuffet flinched!");
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DANCE, playerLeft);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
+        }
+        ABILITY_POPUP(opponentLeft, ABILITY_DANCER);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DANCE, opponentLeft);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
+    }
+}


### PR DESCRIPTION
Fixes Dancer triggering if the original user of the move flinched, was paralyzed or frozen. Added tests for this and for checking if the order of Dancer triggering is correct (slowest to fastest).

## Issue(s) that this PR fixes
Fixes #4495 

## Feature(s) this PR does NOT handle:
I'm not sure if Dancer still triggers every time it should, specifically if there are cases where it should trigger but gHitmarker doesn't include HITMARKER_ATTACKSTRING_PRINTED

## **Discord contact info**
PhallenTree
