### PR TITLE
#4635 follow up. Missing test comments

### DIFF
--- a/test/battle/ability/armor_tail.c
+++ b/test/battle/ability/armor_tail.c
@@ -1,0 +1,4 @@
+#include "global.h"
+#include "test/battle.h"
+
+// Tests for Armor Tail are handled in test/battle/ability/dazzling.c

--- a/test/battle/ability/queenly_majesty.c
+++ b/test/battle/ability/queenly_majesty.c
@@ -1,0 +1,4 @@
+#include "global.h"
+#include "test/battle.h"
+
+// Tests for Queenly Majesty are handled in test/battle/ability/dazzling.c


### PR DESCRIPTION
PR #4635 combined Dazzling type tests. This PR adds empty test files with a comment referring to the `dazzling.c` file. 