### PR TITLE
Update battle_scripts_1.s

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -8568,7 +8568,7 @@ BattleScript_FriskMsg::
 BattleScript_FriskActivates::
 	saveattacker
 	copybyte gBattlerAttacker, sBATTLER
-	tryfriskmsg BS_ATTACKER
+	tryfriskmsg BS_SCRIPTING
 	restoreattacker
 	end3
 


### PR DESCRIPTION
#4061 changed `ABILITY_FRISK` to use `gBattleScripting.battler` but the script wasn't fully updated. It needes `BS_SCRIPTING` as an argument now. 
