### PR TITLE
Remove temp scores in AI_CalcMoveEffectScores

### DIFF
--- a/include/battle_ai_main.h
+++ b/include/battle_ai_main.h
@@ -32,17 +32,11 @@
 #define BEST_DAMAGE_MOVE     1  // Move with the most amount of hits with the best accuracy/effect
 #define POWERFUL_STATUS_MOVE 10 // Moves with this score will be chosen over a move that faints target
 
-// Temporary scores that are added together to determine a final score at the end of AI_CalcMoveEffectScore
+// Scores given in AI_CalcMoveEffectScore
 #define WEAK_EFFECT      1
 #define DECENT_EFFECT    2
-#define GOOD_EFFECT      4
-#define BEST_EFFECT      6
-
-// AI_CalcMoveEffectScore final score
-#define NOT_GOOD_ENOUGH           0 // Not worth using over a damaging move
-#define GOOD_MOVE_EFFECTS         2 // Worth using over a damaging move
-#define PREFERRED_MOVE_EFFECTS    3 // Worth using over a damagin move and is better then DECENT_EFFECT
-#define BEST_MOVE_EFFECTS         4 // Best possible move effects. E.g. stat boosting moves that boost multiply moves
+#define GOOD_EFFECT      3
+#define BEST_EFFECT      4
 
 // AI_TryToFaint
 #define FAST_KILL      6 // AI is faster and faints target

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -1435,7 +1435,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             if (IsBattlerIncapacitated(battlerDef, aiData->abilities[battlerDef]) || gBattleMons[battlerDef].status2 & (STATUS2_INFATUATION | STATUS2_CONFUSION))
                 ADJUST_SCORE(-1);
             if ((predictedMove == MOVE_NONE || GetBattleMoveCategory(predictedMove) == DAMAGE_CATEGORY_STATUS
-              || DoesSubstituteBlockMove(battlerAtk, BATTLE_PARTNER(battlerDef), predictedMove)) 
+              || DoesSubstituteBlockMove(battlerAtk, BATTLE_PARTNER(battlerDef), predictedMove))
               && !(predictedMove == MOVE_NONE && (AI_THINKING_STRUCT->aiFlags[battlerAtk] & AI_FLAG_RISKY))) // Let Risky AI predict blindly based on stats
                 ADJUST_SCORE(-10);
             break;
@@ -4722,14 +4722,7 @@ static u32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move)
         }
     }
 
-    if (score <= 1)
-        return NOT_GOOD_ENOUGH;
-    else if (score <= 3)
-        return GOOD_MOVE_EFFECTS;
-    else if (score <= 5)
-        return PREFERRED_MOVE_EFFECTS;
-    else
-        return BEST_MOVE_EFFECTS;
+    return score;
 }
 
 // AI_FLAG_CHECK_VIABILITY - Chooses best possible move to hit player


### PR DESCRIPTION
I've added Temporarily scores in #3984 but since then I've realized that they are convoluted for no reason. This PR reverts that part and adjusts the scores accordingly.  