### PR TITLE
Add NixOS install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -475,6 +475,13 @@ devkitARM is now installed.
 
 Then proceed to [Choosing where to store pokeemerald Expansion (Linux)](#choosing-where-to-store-pokeemerald-expansion-linux).
 
+### NixOS
+Run the following command to start an interactive shell with the necessary packages:
+```bash
+nix-shell -p pkgsCross.arm-embedded.stdenv.cc git pkg-config libpng
+```
+Then proceed to [Choosing where to store pokeemerald Expansion (Linux)](#choosing-where-to-store-pokeemerald-expansion-linux).
+
 ### Other distributions
 _(Specific instructions for other distributions would be greatly appreciated!)_
 

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ MODERN_ELF_NAME := $(MODERN_ROM_NAME:.gba=.elf)
 MODERN_MAP_NAME := $(MODERN_ROM_NAME:.gba=.map)
 MODERN_OBJ_DIR_NAME := build/modern
 
-SHELL := /bin/bash -o pipefail
+SHELL := bash -o pipefail
 
 ELF = $(ROM:.gba=.elf)
 MAP = $(ROM:.gba=.map)

--- a/asmdiff.sh
+++ b/asmdiff.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ -d "$DEVKITARM/bin/" ]]; then
     OBJDUMP_BIN="$DEVKITARM/bin/arm-none-eabi-objdump"

--- a/check_history.sh
+++ b/check_history.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -e .histignore ]
 then


### PR DESCRIPTION
Add instructions for NixOS to INSTALL.md.

## Description
This adds instructions for NixOS (and technically any distribution with Nix installed) using `nix-shell` to INSTALL.md, and also fixes a build issue on that platform. 

## Feature(s) this PR does NOT handle:
This does not include instructions for installing devkitARM on NixOS. To my knowledge, this is impossible without hacks that devkitPro almost certainly would not consider supported. Docker can be used as a workaround if needed.

## **Discord contact info**
leo60228
