### PR TITLE
HasBadOdds switch chance based on trainer class

### DIFF
--- a/include/data.h
+++ b/include/data.h
@@ -100,7 +100,7 @@ struct TrainerClass
     u8 name[13];
     u8 money;
     u16 ball;
-    u32 switchChance; // 0 - 100, percantage change to switch out if switching out is considered optimal
+    u32 switchChance; // 0 - 100, percantage chance to switch out if switching out is considered optimal
 };
 
 struct TypeInfo

--- a/include/data.h
+++ b/include/data.h
@@ -100,6 +100,7 @@ struct TrainerClass
     u8 name[13];
     u8 money;
     u16 ball;
+    u32 switchChance; // 0 - 100, percantage change to switch out if switching out is considered optimal
 };
 
 struct TypeInfo

--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -201,8 +201,8 @@ static bool32 HasBadOdds(u32 battler, bool32 emitResult)
             if (hasStatusMove)
                 return FALSE;
 
-            // 50% chance to stay in regardless
-            if (Random() % 2 == 0)
+            // Chance to stay in varies based on trainer class
+            if (Random() % 100 < gTrainerClasses[GetTrainerClassFromId(gTrainerBattleOpponent_A)].switchChance)
                 return FALSE;
 
             // Switch mon out

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -633,6 +633,7 @@ const struct TypeInfo gTypesInfo[NUMBER_OF_MON_TYPES] =
         .name = _(trainerName),                         \
         .money = DEFAULT(5, __VA_ARGS__),               \
         .ball = DEFAULT_2(ITEM_POKE_BALL, __VA_ARGS__), \
+        .switchChance = DEFAULT_3(50, __VA_ARGS__),     \
     }
 
 const struct TrainerClass gTrainerClasses[TRAINER_CLASS_COUNT] =


### PR DESCRIPTION
## Description
`HasBadOdds` is a function that, in general terms, prompts mid-battle switches when the AI does not have a good matchup and has a good switchin candidate in their party. This function has always had a hardcoded 50% chance to return FALSE to avoid excessive switching that can bog down gameplay.

I thought it would be fun to tie this switching chance to Trainer Class, so Jugglers could switch constantly if appropriate, Gym Leaders could switch more than the average trainer, and Youngsters could barely switch at all, with all of those switches still being sensible ones based on the `HasBadOdds` check.

It turns out this is really straightforward to implement after the Trainer Class refactor, so I thought I'd PR it. Feel free to close it if this is unpopular, I thought it was cool.

All of the trainer classes have been set to what was the hardcoded 50% chance by default.

## **Discord contact info**
@Pawkkie
