### PR TITLE
Clear Dynamax data when a battler faints 

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3716,6 +3716,10 @@ const u8* FaintClearSetData(u32 battler)
     gBattleStruct->zmove.active = FALSE;
     gBattleStruct->zmove.toBeUsed[battler] = MOVE_NONE;
     gBattleStruct->zmove.effect = EFFECT_HIT;
+	
+    // Clear Dynamax data
+    gBattleStruct->dynamax.dynamaxed[battler] = FALSE;
+    gBattleStruct->dynamax.dynamaxTurns[battler] = 0;
     return result;
 }
 

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3718,8 +3718,7 @@ const u8* FaintClearSetData(u32 battler)
     gBattleStruct->zmove.effect = EFFECT_HIT;
 	
     // Clear Dynamax data
-    gBattleStruct->dynamax.dynamaxed[battler] = FALSE;
-    gBattleStruct->dynamax.dynamaxTurns[battler] = 0;
+    UndoDynamax(battler);
     return result;
 }
 

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3716,9 +3716,9 @@ const u8* FaintClearSetData(u32 battler)
     gBattleStruct->zmove.active = FALSE;
     gBattleStruct->zmove.toBeUsed[battler] = MOVE_NONE;
     gBattleStruct->zmove.effect = EFFECT_HIT;
-	
     // Clear Dynamax data
     UndoDynamax(battler);
+    
     return result;
 }
 


### PR DESCRIPTION
## Description
Updates `FaintClearSetData` in `battle_main.c` to clear Dynamax data when a battler faints.

## Issue(s) that this PR fixes
Fixes #4484 

## **Discord contact info**
Special K#8400
