### PR TITLE
Move SOLAR_POWER_HP_DROP label

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4903,10 +4903,10 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
                 BattleScriptPushCursorAndCallback(BattleScript_BadDreamsActivates);
                 effect++;
                 break;
-            SOLAR_POWER_HP_DROP:
             case ABILITY_SOLAR_POWER:
                 if (IsBattlerWeatherAffected(battler, B_WEATHER_SUN))
                 {
+                SOLAR_POWER_HP_DROP:
                     BattleScriptPushCursorAndCallback(BattleScript_SolarPowerActivates);
                     gBattleMoveDamage = GetNonDynamaxMaxHP(battler) / 8;
                     if (gBattleMoveDamage == 0)


### PR DESCRIPTION
## Description
Moved this label to prevent `IsBattlerWeatherAffected(battler, B_WEATHER_SUN)` from being checked twice in a row by Dry Skin code.

## **Discord contact info**
duke5614