### PR TITLE
Revert Dynamaxed Pokemon's HP upon fainting

### DIFF
--- a/src/battle_dynamax.c
+++ b/src/battle_dynamax.c
@@ -207,6 +207,7 @@ void UndoDynamax(u16 battlerId)
         u16 mult = UQ_4_12(1.0/1.5); // placeholder
         gBattleMons[battlerId].hp = UQ_4_12_TO_INT((GetMonData(mon, MON_DATA_HP) * mult + 1) + UQ_4_12_ROUND); // round up
         SetMonData(mon, MON_DATA_HP, &gBattleMons[battlerId].hp);
+        CalculateMonStats(mon);
     }
 
     // Makes sure there are no Dynamax flags set, including on switch / faint.

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3716,6 +3716,10 @@ const u8* FaintClearSetData(u32 battler)
     gBattleStruct->zmove.active = FALSE;
     gBattleStruct->zmove.toBeUsed[battler] = MOVE_NONE;
     gBattleStruct->zmove.effect = EFFECT_HIT;
+	
+    // Clear Dynamax data
+    gBattleStruct->dynamax.dynamaxed[battler] = FALSE;
+    gBattleStruct->dynamax.dynamaxTurns[battler] = 0;
     return result;
 }
 

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3718,8 +3718,7 @@ const u8* FaintClearSetData(u32 battler)
     gBattleStruct->zmove.effect = EFFECT_HIT;
 	
     // Clear Dynamax data
-    gBattleStruct->dynamax.dynamaxed[battler] = FALSE;
-    gBattleStruct->dynamax.dynamaxTurns[battler] = 0;
+    UndoDynamax(battler);
     return result;
 }
 

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3716,9 +3716,9 @@ const u8* FaintClearSetData(u32 battler)
     gBattleStruct->zmove.active = FALSE;
     gBattleStruct->zmove.toBeUsed[battler] = MOVE_NONE;
     gBattleStruct->zmove.effect = EFFECT_HIT;
-	
     // Clear Dynamax data
     UndoDynamax(battler);
+    
     return result;
 }
 


### PR DESCRIPTION
## Description
Adds a `CalculateMonStats` call to `UndoDynamax` in `battle_dynamax.c` to revert the Max HP increase before the battle ends.

## **Discord contact info**
Special K#8400
