### PR TITLE
Revert Dynamax HP on fainting

### DIFF
--- a/src/battle_dynamax.c
+++ b/src/battle_dynamax.c
@@ -207,6 +207,7 @@ void UndoDynamax(u16 battlerId)
         u16 mult = UQ_4_12(1.0/1.5); // placeholder
         gBattleMons[battlerId].hp = UQ_4_12_TO_INT((GetMonData(mon, MON_DATA_HP) * mult + 1) + UQ_4_12_ROUND); // round up
         SetMonData(mon, MON_DATA_HP, &gBattleMons[battlerId].hp);
+        CalculateMonStats(mon);
     }
 
     // Makes sure there are no Dynamax flags set, including on switch / faint.

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3677,7 +3677,6 @@ const u8* FaintClearSetData(u32 battler)
     gBattleStruct->zmove.active = FALSE;
     gBattleStruct->zmove.toBeUsed[battler] = MOVE_NONE;
     gBattleStruct->zmove.effect = EFFECT_HIT;
-	
     // Clear Dynamax data
     UndoDynamax(battler);	
 	

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3677,6 +3677,10 @@ const u8* FaintClearSetData(u32 battler)
     gBattleStruct->zmove.active = FALSE;
     gBattleStruct->zmove.toBeUsed[battler] = MOVE_NONE;
     gBattleStruct->zmove.effect = EFFECT_HIT;
+	
+    // Clear Dynamax data
+    UndoDynamax(battler);	
+	
     return result;
 }
 


### PR DESCRIPTION
## Description
In `FaintClearSetData` in `battle_main.c`, calls `UndoDynamax` whenever a mon faints to ensure that its HP is reverted and the relevant data is cleared. Updates `UndoDynamax` in `battle_dynamax.c` to `CalculateMonStats` after applying the HP reversion to prevent fainted mons from retaining their boosted Max HP until the end of the battle.

## Issue(s) that this PR fixes
Fixes #4484 

## **Discord contact info**
Special K#8400
