### PR TITLE
Fix issues when building tests with agbcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,10 +86,13 @@ ELF = $(ROM:.gba=.elf)
 MAP = $(ROM:.gba=.map)
 SYM = $(ROM:.gba=.sym)
 
+TEST_OBJ_DIR_NAME_MODERN := build/modern-test
+TEST_OBJ_DIR_NAME_AGBCC := build/test
+
 ifeq ($(MODERN),0)
-TEST_OBJ_DIR_NAME := build/test
+TEST_OBJ_DIR_NAME := $(TEST_OBJ_DIR_NAME_AGBCC)
 else
-TEST_OBJ_DIR_NAME := build/modern-test
+TEST_OBJ_DIR_NAME := $(TEST_OBJ_DIR_NAME_MODERN)
 endif
 TESTELF = $(ROM:.gba=-test.elf)
 HEADLESSELF = $(ROM:.gba=-test-headless.elf)
@@ -309,7 +312,9 @@ tidymodern:
 
 tidycheck:
 	rm -f $(TESTELF) $(HEADLESSELF)
-	rm -rf $(TEST_OBJ_DIR_NAME)
+	rm -rf $(TEST_OBJ_DIR_NAME_MODERN)
+	rm -rf $(TEST_OBJ_DIR_NAME_AGBCC)
+
 
 ifneq ($(MODERN),0)
 $(C_BUILDDIR)/berry_crush.o: override CFLAGS += -Wno-address-of-packed-member

--- a/test/species.c
+++ b/test/species.c
@@ -6,12 +6,14 @@ TEST("Form species ID tables are shared between all forms")
 {
     u32 i;
     u32 species = SPECIES_NONE;
+    const u16 *formSpeciesIdTable;
+
     for (i = 0; i < NUM_SPECIES; i++)
     {
         if (gSpeciesInfo[i].formSpeciesIdTable) PARAMETRIZE { species = i; }
     }
 
-    const u16 *formSpeciesIdTable = gSpeciesInfo[species].formSpeciesIdTable;
+    formSpeciesIdTable = gSpeciesInfo[species].formSpeciesIdTable;
     for (i = 0; formSpeciesIdTable[i] != FORM_SPECIES_END; i++)
     {
         u32 formSpeciesId = formSpeciesIdTable[i];
@@ -23,13 +25,16 @@ TEST("Form change tables contain only forms in the form species ID table")
 {
     u32 i, j;
     u32 species = SPECIES_NONE;
+    const struct FormChange *formChangeTable;
+    const u16 *formSpeciesIdTable;
+
     for (i = 0; i < NUM_SPECIES; i++)
     {
         if (gSpeciesInfo[i].formChangeTable) PARAMETRIZE { species = i; }
     }
 
-    const struct FormChange *formChangeTable = gSpeciesInfo[species].formChangeTable;
-    const u16 *formSpeciesIdTable = gSpeciesInfo[species].formSpeciesIdTable;
+    formChangeTable = gSpeciesInfo[species].formChangeTable;
+    formSpeciesIdTable = gSpeciesInfo[species].formSpeciesIdTable;
     EXPECT(formSpeciesIdTable);
 
     for (i = 0; formChangeTable[i].method != FORM_CHANGE_TERMINATOR; i++)
@@ -51,12 +56,14 @@ TEST("Form change targets have the appropriate species flags")
 {
     u32 i;
     u32 species = SPECIES_NONE;
+    const struct FormChange *formChangeTable;
+
     for (i = 0; i < NUM_SPECIES; i++)
     {
         if (gSpeciesInfo[i].formChangeTable) PARAMETRIZE { species = i; }
     }
 
-    const struct FormChange *formChangeTable = gSpeciesInfo[species].formChangeTable;
+    formChangeTable = gSpeciesInfo[species].formChangeTable;
     for (i = 0; formChangeTable[i].method != FORM_CHANGE_TERMINATOR; i++)
     {
         const struct SpeciesInfo *targetSpeciesInfo = &gSpeciesInfo[formChangeTable[i].targetSpecies];

--- a/test/test_runner.c
+++ b/test/test_runner.c
@@ -668,7 +668,11 @@ static s32 MgbaVPrintf_(const char *fmt, va_list va)
 /* Entry point for the Debugging and Control System. Handles illegal
  * instructions, which are typically caused by branching to an invalid
  * address. */
+#if MODERN
 __attribute__((naked, section(".dacs"), target("arm")))
+#else
+__attribute__((naked, section(".dacs")))
+#endif
 void DACSEntry(void)
 {
     asm(".arm\n\


### PR DESCRIPTION
fixes issues with the building tests with agbcc and ensures that build directories are cleaned properly

## Description
`make clean` explicitly removes `build/test` aswell as `build/modern-test` now.
also fixes some issues that prevent building tests with agbcc. 

## **Discord contact info**
u8.Salem