### PR TITLE
Fixed honey use altering tiles

### DIFF
--- a/src/item_use.c
+++ b/src/item_use.c
@@ -1422,7 +1422,9 @@ void Task_UseHoneyOnField(u8 taskId)
 static void ItemUseOnFieldCB_Honey(u8 taskId)
 {
     Overworld_ResetStateAfterDigEscRope();
-    RemoveUsedItem();
+    RemoveBagItem(gSpecialVar_ItemId, 1);
+    CopyItemName(gSpecialVar_ItemId, gStringVar2);
+    StringExpandPlaceholders(gStringVar4, gText_PlayerUsedVar2);
     gTasks[taskId].data[0] = 0;
     DisplayItemMessageOnField(taskId, gStringVar4, Task_UseHoneyOnField);
 }


### PR DESCRIPTION
## Description
Using honey corrupted(?) some tiles at the top of the screen.

## Images
Before:  
![honeybug](https://github.com/rh-hideout/pokeemerald-expansion/assets/38510667/0f79be05-55e6-478f-b15f-95ebd3729444)
After:  
![honeyfixed](https://github.com/rh-hideout/pokeemerald-expansion/assets/38510667/86c522cd-aaaa-4ab8-8d70-d20ae1e8bf60)

## **Discord contact info**
.cawt
