### PR TITLE
Fixed potential undefined behaviour when using escape rope

### DIFF
--- a/src/item_use.c
+++ b/src/item_use.c
@@ -1041,14 +1041,10 @@ static void ItemUseOnFieldCB_EscapeRope(u8 taskId)
 {
     Overworld_ResetStateAfterDigEscRope();
     if (I_KEY_ESCAPE_ROPE < GEN_8)
-    {
-        RemoveUsedItem();
-    }
-    else
-    {
-        CopyItemName(gSpecialVar_ItemId, gStringVar2);
-        StringExpandPlaceholders(gStringVar4, gText_PlayerUsedVar2);
-    }
+        RemoveBagItem(gSpecialVar_ItemId, 1);
+
+    CopyItemName(gSpecialVar_ItemId, gStringVar2);
+    StringExpandPlaceholders(gStringVar4, gText_PlayerUsedVar2);
     gTasks[taskId].data[0] = 0;
     DisplayItemMessageOnField(taskId, gStringVar4, Task_UseDigEscapeRopeOnField);
 }


### PR DESCRIPTION
## Description
Same issue as in #4703. Using RemovedUsedItem with a field effect item potentially leads to undefined behaviour. This does seem to be the case in vanilla Emerald/FRLG, so maybe there is some background magic that I'm not aware of. From what I can see though this should also be an issue with escape rope.

As far as i can tell, there is no other RemoveUsedItem use related to field/overworld use.

## Images
Removed the escape functionality for testing purposes, and the issue also occurs with escape rope.
![escaperopebug](https://github.com/rh-hideout/pokeemerald-expansion/assets/38510667/4b8ef8fe-d651-4530-b6f2-83eec1a57709)

## **Discord contact info**
.cawt
