### PR TITLE
Fix Mirror Armor and Sticky Web interaction

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -3213,7 +3213,8 @@ BattleScript_MirrorArmorReflectStickyWeb:
 	call BattleScript_AbilityPopUp
 	setattackertostickywebuser
 	jumpifbyteequal gBattlerAttacker, gBattlerTarget, BattleScript_StickyWebOnSwitchInEnd   @ Sticky web user not on field -> no stat loss
-	goto BattleScript_MirrorArmorReflectStatLoss
+	call BattleScript_MirrorArmorReflectStatLoss
+	goto BattleScript_StickyWebOnSwitchInEnd
 
 BattleScript_StatDown::
 	playanimation BS_EFFECT_BATTLER, B_ANIM_STATS_CHANGE, sB_ANIM_ARG1
@@ -6338,6 +6339,7 @@ BattleScript_ToxicSpikesPoisoned::
 
 BattleScript_StickyWebOnSwitchIn::
 	savetarget
+	saveattacker
 	copybyte gBattlerTarget, sBATTLER
 	setbyte sSTICKY_WEB_STAT_DROP, 1
 	printstring STRINGID_STICKYWEBSWITCHIN
@@ -6356,6 +6358,7 @@ BattleScript_StickyWebOnSwitchInPrintStatMsg:
 	waitmessage B_WAIT_TIME_LONG
 BattleScript_StickyWebOnSwitchInEnd:
 	restoretarget
+	restoreattacker
 	return
 
 BattleScript_PerishSongTakesLife::

--- a/test/battle/move_effect/sticky_web.c
+++ b/test/battle/move_effect/sticky_web.c
@@ -129,8 +129,14 @@ DOUBLE_BATTLE_TEST("Sticky Web has correct interactions with Mirror Armor - the 
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, BATTLER_OPPONENT);
         if (opponentSetUpper == 0) {
             MESSAGE("Foe Caterpie's Speed fell!");
+            NONE_OF {
+                MESSAGE("Foe Caterpie was caught in a Sticky Web");
+            }
         } else {
             MESSAGE("Foe Weedle's Speed fell!");
+            NONE_OF {
+                MESSAGE("Foe Weedle was caught in a Sticky Web");
+            }
         }
     }
 }

--- a/test/battle/move_effect/sticky_web.c
+++ b/test/battle/move_effect/sticky_web.c
@@ -130,12 +130,12 @@ DOUBLE_BATTLE_TEST("Sticky Web has correct interactions with Mirror Armor - the 
         if (opponentSetUpper == 0) {
             MESSAGE("Foe Caterpie's Speed fell!");
             NONE_OF {
-                MESSAGE("Foe Caterpie was caught in a Sticky Web");
+                MESSAGE("Foe Caterpie was caught in a Sticky Web!");
             }
         } else {
             MESSAGE("Foe Weedle's Speed fell!");
             NONE_OF {
-                MESSAGE("Foe Weedle was caught in a Sticky Web");
+                MESSAGE("Foe Weedle was caught in a Sticky Web!");
             }
         }
     }


### PR DESCRIPTION
## Description
Fixes Mirror Armor causing the web setter to trigger its own switch in effects.
On `upcoming` instead of  `master` as it needs `saveattacker`.

## Images
Longer Version Gif of the bug
![webs](https://github.com/rh-hideout/pokeemerald-expansion/assets/56992013/fd5a72c7-8826-44d9-90e1-d8e272f2e16d)
Shorter Version Video

https://github.com/rh-hideout/pokeemerald-expansion/assets/56992013/b4371c1a-9af1-4306-b197-c13e0c7633a9



## **Discord contact info**
duke5614