### PR TITLE
Use mdBook includes instead of symlinks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,1 +1,1 @@
-../CHANGELOG.md
+{{#include ../CHANGELOG.md}}

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,1 +1,1 @@
-../INSTALL.md
+{{#include ../INSTALL.md}}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,1 @@
-../README.md
+{{#include ../README.md}}


### PR DESCRIPTION
## Description
Use mdBook includes instead of symlinks. This avoids issues with Git for Windows, at the cost of `mdbook watch` and `mdbook serve` no longer detecting changes to these files.

## **Discord contact info**
leo60228
