### PR TITLE
Add switching message macros for tests

### DIFF
--- a/include/test/battle.h
+++ b/include/test/battle.h
@@ -999,6 +999,20 @@ void SendOut(u32 sourceLine, struct BattlePokemon *, u32 partyIndex);
 #define MESSAGE(pattern) do {static const u8 msg[] = _(pattern); QueueMessage(__LINE__, msg);} while (0)
 #define STATUS_ICON(battler, status) QueueStatus(__LINE__, battler, (struct StatusEventContext) { status })
 
+#define SWITCH_OUT_MESSAGE(name) ONE_OF {                                         \
+                                     MESSAGE(name ", that's enough! Come back!"); \
+                                     MESSAGE(name ", come back!");                \
+                                     MESSAGE(name ", OK! Come back!");            \
+                                     MESSAGE(name ", good! Come back!");          \
+                                 }
+
+#define SEND_IN_MESSAGE(name)    ONE_OF {                                            \
+                                     MESSAGE("Go! " name "!");                       \
+                                     MESSAGE("Do it! " name "!");                    \
+                                     MESSAGE("Go for it, " name "!");                \
+                                     MESSAGE("Your foe's weak! Get 'em, " name "!"); \
+                                 }
+
 enum QueueGroupType
 {
     QUEUE_GROUP_NONE,

--- a/test/battle/ability/beads_of_ruin.c
+++ b/test/battle/ability/beads_of_ruin.c
@@ -67,7 +67,7 @@ SINGLE_BATTLE_TEST("Beads of Ruin's message displays correctly after all battler
         HP_BAR(player, hp: 0);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, player);
         // Everyone faints.
-        MESSAGE("Go! Wobbuffet!");
+        SEND_IN_MESSAGE("Wobbuffet");
         MESSAGE("2 sent out Chi-Yu!");
         ABILITY_POPUP(opponent, ABILITY_BEADS_OF_RUIN);
         MESSAGE("Foe Chi-Yu's Beads of Ruin weakened the Sp. Def of all surrounding Pokémon!");

--- a/test/battle/ability/dauntless_shield.c
+++ b/test/battle/ability/dauntless_shield.c
@@ -56,7 +56,7 @@ SINGLE_BATTLE_TEST("Dauntless Shield activates when it's no longer effected by N
     } SCENE {
         ABILITY_POPUP(player, ABILITY_NEUTRALIZING_GAS);
         MESSAGE("Neutralizing Gas filled the area!");
-        MESSAGE("Weezing, that's enough! Come back!");
+        SWITCH_OUT_MESSAGE("Weezing");
         MESSAGE("The effects of Neutralizing Gas wore off!");
         ABILITY_POPUP(opponent, ABILITY_DAUNTLESS_SHIELD);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);

--- a/test/battle/ability/defiant.c
+++ b/test/battle/ability/defiant.c
@@ -128,7 +128,7 @@ SINGLE_BATTLE_TEST("Defiant activates after Sticky Web lowers Speed")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_STICKY_WEB, opponent);
         // Switch-in - Sticky Web activates
-        MESSAGE("Go! Mankey!");
+        SEND_IN_MESSAGE("Mankey");
         MESSAGE("Mankey was caught in a Sticky Web!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
         MESSAGE("Mankey's Speed fell!");

--- a/test/battle/ability/download.c
+++ b/test/battle/ability/download.c
@@ -72,7 +72,7 @@ SINGLE_BATTLE_TEST("Download doesn't activate if target hasn't been sent out yet
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, player);
         // Everyone faints.
 
-        MESSAGE("Go! Porygon!");
+        SEND_IN_MESSAGE("Porygon");
         MESSAGE("2 sent out Porygon2!");
 
         NONE_OF {

--- a/test/battle/ability/embody_aspect.c
+++ b/test/battle/ability/embody_aspect.c
@@ -50,7 +50,7 @@ SINGLE_BATTLE_TEST("Embody Aspect activates when it's no longer effected by Neut
     } SCENE {
         ABILITY_POPUP(player, ABILITY_NEUTRALIZING_GAS);
         MESSAGE("Neutralizing Gas filled the area!");
-        MESSAGE("Weezing, that's enough! Come back!");
+        SWITCH_OUT_MESSAGE("Weezing");
         MESSAGE("The effects of Neutralizing Gas wore off!");
         ABILITY_POPUP(opponent, ABILITY_EMBODY_ASPECT_TEAL_MASK);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);

--- a/test/battle/ability/flower_gift.c
+++ b/test/battle/ability/flower_gift.c
@@ -143,7 +143,7 @@ SINGLE_BATTLE_TEST("Flower Gift transforms Cherrim back when it switches out")
         ABILITY_POPUP(player, ABILITY_FLOWER_GIFT);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
         MESSAGE("Cherrim transformed!");
-        MESSAGE("Cherrim, that's enough! Come back!");
+        SWITCH_OUT_MESSAGE("Cherrim");
     } THEN {
         EXPECT_EQ(GetMonData(&gPlayerParty[0], MON_DATA_SPECIES), SPECIES_CHERRIM);
     }

--- a/test/battle/ability/forecast.c
+++ b/test/battle/ability/forecast.c
@@ -368,7 +368,7 @@ SINGLE_BATTLE_TEST("Forecast transforms Castform back when it switches out")
         ABILITY_POPUP(player, ABILITY_FORECAST);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
         MESSAGE("Castform transformed!");
-        MESSAGE("Castform, that's enough! Come back!");
+        SWITCH_OUT_MESSAGE("Castform");
     } THEN {
         EXPECT_EQ(GetMonData(&gPlayerParty[0], MON_DATA_SPECIES), SPECIES_CASTFORM);
     }

--- a/test/battle/ability/hospitality.c
+++ b/test/battle/ability/hospitality.c
@@ -41,8 +41,8 @@ DOUBLE_BATTLE_TEST("Hospitality user restores 25% of ally's health on switch-in"
     } WHEN {
         TURN { SWITCH(playerLeft, 2); }
     } SCENE {
-        MESSAGE("Wobbuffet, that's enough! Come back!");
-        MESSAGE("Go! Poltchageist!");
+        SWITCH_OUT_MESSAGE("Wobbuffet");
+        SEND_IN_MESSAGE("Poltchageist");
         ABILITY_POPUP(playerLeft, ABILITY_HOSPITALITY);
         MESSAGE("Wobbuffet drank down all the matcha that Poltchageist made!");
         HP_BAR(playerRight, damage: -25);
@@ -62,8 +62,8 @@ DOUBLE_BATTLE_TEST("Hospitality ignores Substitute")
         TURN { SWITCH(playerLeft, 2); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SUBSTITUTE, playerRight);
-        MESSAGE("Wobbuffet, that's enough! Come back!");
-        MESSAGE("Go! Poltchageist!");
+        SWITCH_OUT_MESSAGE("Wobbuffet");
+        SEND_IN_MESSAGE("Poltchageist");
         ABILITY_POPUP(playerLeft, ABILITY_HOSPITALITY);
         MESSAGE("Wobbuffet drank down all the matcha that Poltchageist made!");
     }
@@ -85,7 +85,7 @@ DOUBLE_BATTLE_TEST("Hospitality does not trigger if there is no ally on the fiel
         MESSAGE("Wobbuffet fainted!");
         HP_BAR(playerRight);
         MESSAGE("Wobbuffet fainted!");
-        MESSAGE("Go! Poltchageist!");
+        SEND_IN_MESSAGE("Poltchageist");
         NOT ABILITY_POPUP(playerLeft, ABILITY_HOSPITALITY);
     }
 }

--- a/test/battle/ability/intimidate.c
+++ b/test/battle/ability/intimidate.c
@@ -77,9 +77,9 @@ DOUBLE_BATTLE_TEST("Intimidate doesn't activate on an empty field in a double ba
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, playerLeft);
         // Everyone faints.
 
-        MESSAGE("Go! Ekans!");
+        SEND_IN_MESSAGE("Ekans");
         MESSAGE("2 sent out Arbok!");
-        MESSAGE("Go! Abra!");
+        SEND_IN_MESSAGE("Abra");
         MESSAGE("2 sent out Wynaut!");
 
         NONE_OF {
@@ -147,12 +147,12 @@ DOUBLE_BATTLE_TEST("Intimidate activates on an empty slot")
 
 
     } SCENE {
-        MESSAGE("Wobbuffet, that's enough! Come back!");
-        MESSAGE("Go! Wynaut!");
+        SWITCH_OUT_MESSAGE("Wobbuffet");
+        SEND_IN_MESSAGE("Wynaut");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_GUNK_SHOT, playerRight);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SPLASH, opponentRight);
-        MESSAGE("Wynaut, that's enough! Come back!");
-        MESSAGE("Go! Hitmontop!");
+        SWITCH_OUT_MESSAGE("Wynaut");
+        SEND_IN_MESSAGE("Hitmontop");
         ABILITY_POPUP(playerLeft, ABILITY_INTIMIDATE);
         NONE_OF {
             MESSAGE("Hitmontop's Intimidate cuts Foe Ralts's attack!");
@@ -222,9 +222,9 @@ SINGLE_BATTLE_TEST("Intimidate activates when it's no longer effected by Neutral
     } SCENE {
         ABILITY_POPUP(player, ABILITY_NEUTRALIZING_GAS);
         MESSAGE("Neutralizing Gas filled the area!");
-        MESSAGE("Weezing, that's enough! Come back!");
+        SWITCH_OUT_MESSAGE("Weezing");
         MESSAGE("The effects of Neutralizing Gas wore off!");
         ABILITY_POPUP(opponent, ABILITY_INTIMIDATE);
-        MESSAGE("Go! Wobbuffet!");
+        SEND_IN_MESSAGE("Wobbuffet");
     }
 }

--- a/test/battle/ability/intrepid_sword.c
+++ b/test/battle/ability/intrepid_sword.c
@@ -56,7 +56,7 @@ SINGLE_BATTLE_TEST("Intrepid Sword activates when it's no longer effected by Neu
     } SCENE {
         ABILITY_POPUP(player, ABILITY_NEUTRALIZING_GAS);
         MESSAGE("Neutralizing Gas filled the area!");
-        MESSAGE("Weezing, that's enough! Come back!");
+        SWITCH_OUT_MESSAGE("Weezing");
         MESSAGE("The effects of Neutralizing Gas wore off!");
         ABILITY_POPUP(opponent, ABILITY_INTREPID_SWORD);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);

--- a/test/battle/ability/mirror_armor.c
+++ b/test/battle/ability/mirror_armor.c
@@ -188,7 +188,7 @@ DOUBLE_BATTLE_TEST("Mirror Armor lowers Speed of the partner Pokemon after Court
         MESSAGE("Wobbuffet used Sticky Web!");
         MESSAGE("Foe Wynaut used Court Change!");
         MESSAGE("Foe Wynaut swapped the battle effects affecting each side!");
-        MESSAGE("Go! Corviknight!");
+        SEND_IN_MESSAGE("Corviknight");
         MESSAGE("Corviknight was caught in a Sticky Web!");
         ABILITY_POPUP(playerRight, ABILITY_MIRROR_ARMOR);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);

--- a/test/battle/ability/rattled.c
+++ b/test/battle/ability/rattled.c
@@ -88,6 +88,6 @@ SINGLE_BATTLE_TEST("Rattled triggers correctly when hit by U-Turn") // Specific 
         ABILITY_POPUP(opponent, ABILITY_RATTLED);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
         MESSAGE("Foe Sudowoodo's Speed rose!");
-        MESSAGE("Go! Wynaut!");
+        SEND_IN_MESSAGE("Wynaut");
     }
 }

--- a/test/battle/ability/supreme_overlord.c
+++ b/test/battle/ability/supreme_overlord.c
@@ -106,7 +106,7 @@ SINGLE_BATTLE_TEST("Supreme Overlord's message displays correctly after all batt
         HP_BAR(opponent, hp: 0);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, opponent);
         // Everyone faints.
-        MESSAGE("Go! Kingambit!");
+        SEND_IN_MESSAGE("Kingambit");
         ABILITY_POPUP(player, ABILITY_SUPREME_OVERLORD);
         MESSAGE("Kingambit gained strength from the fallen!");
         MESSAGE("2 sent out Wobbuffet!");
@@ -127,7 +127,7 @@ SINGLE_BATTLE_TEST("Supreme Overlord's message displays correctly after all batt
         HP_BAR(player, hp: 0);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, player);
         // Everyone faints.
-        MESSAGE("Go! Wobbuffet!");
+        SEND_IN_MESSAGE("Wobbuffet");
         MESSAGE("2 sent out Kingambit!");
         ABILITY_POPUP(opponent, ABILITY_SUPREME_OVERLORD);
         MESSAGE("Foe Kingambit gained strength from the fallen!");

--- a/test/battle/ability/sword_of_ruin.c
+++ b/test/battle/ability/sword_of_ruin.c
@@ -67,7 +67,7 @@ SINGLE_BATTLE_TEST("Sword of Ruin's message displays correctly after all battler
         HP_BAR(player, hp: 0);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, player);
         // Everyone faints.
-        MESSAGE("Go! Wobbuffet!");
+        SEND_IN_MESSAGE("Wobbuffet");
         MESSAGE("2 sent out Chien-Pao!");
         ABILITY_POPUP(opponent, ABILITY_SWORD_OF_RUIN);
         MESSAGE("Foe Chien-Pao's Sword of Ruin weakened the Defense of all surrounding Pokémon!");

--- a/test/battle/ability/tablets_of_ruin.c
+++ b/test/battle/ability/tablets_of_ruin.c
@@ -67,7 +67,7 @@ SINGLE_BATTLE_TEST("Tablets of Ruin's message displays correctly after all battl
         HP_BAR(player, hp: 0);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, player);
         // Everyone faints.
-        MESSAGE("Go! Wobbuffet!");
+        SEND_IN_MESSAGE("Wobbuffet");
         MESSAGE("2 sent out Wo-Chien!");
         ABILITY_POPUP(opponent, ABILITY_TABLETS_OF_RUIN);
         MESSAGE("Foe Wo-Chien's Tablets of Ruin weakened the Attack of all surrounding Pokémon!");

--- a/test/battle/ability/vessel_of_ruin.c
+++ b/test/battle/ability/vessel_of_ruin.c
@@ -67,7 +67,7 @@ SINGLE_BATTLE_TEST("Vessel of Ruin's message displays correctly after all battle
         HP_BAR(player, hp: 0);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, player);
         // Everyone faints.
-        MESSAGE("Go! Wobbuffet!");
+        SEND_IN_MESSAGE("Wobbuffet");
         MESSAGE("2 sent out Ting-Lu!");
         ABILITY_POPUP(opponent, ABILITY_VESSEL_OF_RUIN);
         MESSAGE("Foe Ting-Lu's Vessel of Ruin weakened the Sp. Atk of all surrounding Pokémon!");

--- a/test/battle/ability/zero_to_hero.c
+++ b/test/battle/ability/zero_to_hero.c
@@ -11,10 +11,10 @@ SINGLE_BATTLE_TEST("Zero to Hero transforms Palafin when it switches out")
         TURN { SWITCH(player, 1); }
         TURN { SWITCH(player, 0); }
     } SCENE {
-        MESSAGE("Palafin, that's enough! Come back!");
-        MESSAGE("Go! Wobbuffet!");
-        MESSAGE("Wobbuffet, that's enough! Come back!");
-        MESSAGE("Go! Palafin!");
+        SWITCH_OUT_MESSAGE("Palafin");
+        SEND_IN_MESSAGE("Wobbuffet");
+        SWITCH_OUT_MESSAGE("Wobbuffet");
+        SEND_IN_MESSAGE("Palafin");
         ABILITY_POPUP(player, ABILITY_ZERO_TO_HERO);
         MESSAGE("Palafin underwent a heroic transformation!");
     } THEN { EXPECT_EQ(player->species, SPECIES_PALAFIN_HERO); }
@@ -152,7 +152,7 @@ SINGLE_BATTLE_TEST("Zero to Hero's message displays correctly after all battlers
         HP_BAR(opponent, hp: 0);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, opponent);
         // Everyone faints.
-        MESSAGE("Go! Palafin!");
+        SEND_IN_MESSAGE("Palafin");
         ABILITY_POPUP(player, ABILITY_ZERO_TO_HERO);
         MESSAGE("Palafin underwent a heroic transformation!");
         MESSAGE("2 sent out Wobbuffet!");
@@ -175,7 +175,7 @@ SINGLE_BATTLE_TEST("Zero to Hero's message displays correctly after all battlers
         HP_BAR(player, hp: 0);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, player);
         // Everyone faints.
-        MESSAGE("Go! Wobbuffet!");
+        SEND_IN_MESSAGE("Wobbuffet");
         MESSAGE("2 sent out Palafin!");
         ABILITY_POPUP(opponent, ABILITY_ZERO_TO_HERO);
         MESSAGE("Foe Palafin underwent a heroic transformation!");

--- a/test/battle/battle_message.c
+++ b/test/battle/battle_message.c
@@ -1,0 +1,48 @@
+#include "global.h"
+#include "test/battle.h"
+
+SINGLE_BATTLE_TEST("Battle Message: Send-in message depends on foe HP")
+{
+    u32 hp;
+
+    PARAMETRIZE { hp = 100; }
+    PARAMETRIZE { hp = 69; }
+    PARAMETRIZE { hp = 39; }
+    PARAMETRIZE { hp = 9; }
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET) { HP(hp); MaxHP(100); }
+    } WHEN {
+        TURN { SWITCH(player, 1);  }
+    } SCENE {
+        if (hp > 69)
+            MESSAGE("Go! Wynaut!");
+        else if (hp > 39)
+            MESSAGE("Do it! Wynaut!");
+        else if (hp > 9)
+            MESSAGE("Go for it, Wynaut!");
+        else
+            MESSAGE("Your foe's weak! Get 'em, Wynaut!");
+    }
+}
+
+TO_DO_BATTLE_TEST("Battle Message: Switch-out message changes based on conditions")
+/*{
+    GIVEN {
+        PLAYER(SPECIES_WYNAUT);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { SWITCH(player, 1);  }
+    } SCENE {
+        if (???)
+            MESSAGE("Wynaut, that's enough! Come back!");
+        else if (???)
+            MESSAGE("Wynaut, come back!");
+        else if (???)
+            MESSAGE("Wynaut, OK! Come back!");
+        else
+            MESSAGE("Wynaut, good! Come back!");
+    }
+}*/

--- a/test/battle/form_change/primal_reversion.c
+++ b/test/battle/form_change/primal_reversion.c
@@ -166,7 +166,7 @@ SINGLE_BATTLE_TEST("Primal reversion happens after a switch-in caused by Eject B
         TURN { MOVE(opponent, MOVE_TACKLE); }
     } SCENE {
         MESSAGE("Wobbuffet is switched out with the Eject Button!");
-        MESSAGE("Go! Groudon!");
+        SEND_IN_MESSAGE("Groudon");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_PRIMAL_REVERSION, player);
         MESSAGE("Groudon's Primal Reversion! It reverted to its primal form!");
     } THEN {
@@ -205,7 +205,7 @@ SINGLE_BATTLE_TEST("Primal reversion happens after the entry hazards damage")
         TURN { MOVE(opponent, MOVE_SPIKES); }
         TURN { MOVE(opponent, MOVE_SPIKES); SWITCH(player, 1);}
     } SCENE {
-        MESSAGE("Go! Groudon!");
+        SEND_IN_MESSAGE("Groudon");
         HP_BAR(player);
         MESSAGE("Groudon is hurt by spikes!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_PRIMAL_REVERSION, player);

--- a/test/battle/hold_effect/cure_status.c
+++ b/test/battle/hold_effect/cure_status.c
@@ -249,7 +249,7 @@ SINGLE_BATTLE_TEST("Player Pokemon can be further poisoned with Toxic spikes aft
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TOXIC_SPIKES, opponent);
         MESSAGE("Poison Spikes were scattered all around your team's feet!");
         // 1st switch-in
-        MESSAGE("Go! Wobbuffet!");
+        SEND_IN_MESSAGE("Wobbuffet");
         ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, player);
         STATUS_ICON(player, poison: TRUE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
@@ -260,7 +260,7 @@ SINGLE_BATTLE_TEST("Player Pokemon can be further poisoned with Toxic spikes aft
         }
         STATUS_ICON(player, poison: FALSE);
         // 2nd switch-in
-        MESSAGE("Go! Wynaut!");
+        SEND_IN_MESSAGE("Wynaut");
         ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, player);
         STATUS_ICON(player, poison: TRUE);
     }

--- a/test/battle/hold_effect/eject_pack.c
+++ b/test/battle/hold_effect/eject_pack.c
@@ -20,7 +20,7 @@ SINGLE_BATTLE_TEST("Eject Pack does not cause the new Pokémon to lose HP due to
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
         MESSAGE("Wobbuffet is switched out with the Eject Pack!");
-        MESSAGE("Go! Wynaut!");
+        SEND_IN_MESSAGE("Wynaut");
         NOT MESSAGE("Wynaut was hurt by its Life Orb!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
     }
@@ -59,7 +59,7 @@ SINGLE_BATTLE_TEST("Eject Pack is triggered by self-inflicting stat decreases")
         NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
         MESSAGE("Wobbuffet is switched out with the Eject Pack!");
-        MESSAGE("Go! Wynaut!");
+        SEND_IN_MESSAGE("Wynaut");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
     }
 }

--- a/test/battle/hold_effect/red_card.c
+++ b/test/battle/hold_effect/red_card.c
@@ -394,7 +394,7 @@ SINGLE_BATTLE_TEST("Red Card activates before Emergency Exit")
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
         MESSAGE("Golisopod held up its Red Card against Foe Wobbuffet!");
         ABILITY_POPUP(player, ABILITY_EMERGENCY_EXIT);
-        MESSAGE("Go! Wimpod!");
+        SEND_IN_MESSAGE("Wimpod");
     }
 }
 

--- a/test/battle/move_effect/chilly_reception.c
+++ b/test/battle/move_effect/chilly_reception.c
@@ -19,7 +19,7 @@ SINGLE_BATTLE_TEST("Chilly Reception sets up snow and switches the user out")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CHILLY_RECEPTION, player);
         MESSAGE("It started to snow!");
         MESSAGE("Slowking went back to  1");
-        MESSAGE("Go! Slowpoke!");
+        SEND_IN_MESSAGE("Slowpoke");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_SNOW_CONTINUES);
     }
 }
@@ -37,7 +37,7 @@ SINGLE_BATTLE_TEST("Chilly Reception switches the user out, even if the weather 
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CHILLY_RECEPTION, player);
         MESSAGE("There is no relief from this heavy rain!");
         MESSAGE("Slowking went back to  1");
-        MESSAGE("Go! Slowpoke!");
+        SEND_IN_MESSAGE("Slowpoke");
         MESSAGE("Rain continues to fall.");
     }
 }

--- a/test/battle/move_effect/court_change.c
+++ b/test/battle/move_effect/court_change.c
@@ -27,7 +27,7 @@ DOUBLE_BATTLE_TEST("Court Change swaps entry hazards used by the opponent")
         MESSAGE("Foe Wobbuffet used Toxic Spikes!");
         MESSAGE("Wynaut used Court Change!");
         MESSAGE("Wynaut swapped the battle effects affecting each side!");
-        MESSAGE("Go! Wynaut!");
+        SEND_IN_MESSAGE("Wynaut");
         NONE_OF {
             MESSAGE("Wynaut is hurt by spikes!");
             MESSAGE("Pointed stones dug into Wynaut!");
@@ -63,7 +63,7 @@ DOUBLE_BATTLE_TEST("Court Change swaps entry hazards used by the player")
         MESSAGE("Wobbuffet used Toxic Spikes!");
         MESSAGE("Foe Wynaut used Court Change!");
         MESSAGE("Foe Wynaut swapped the battle effects affecting each side!");
-        MESSAGE("Go! Wobbuffet!");
+        SEND_IN_MESSAGE("Wobbuffet");
         MESSAGE("Wobbuffet is hurt by spikes!");
         MESSAGE("Pointed stones dug into Wobbuffet!");
         MESSAGE("Wobbuffet was poisoned!");

--- a/test/battle/move_effect/defog.c
+++ b/test/battle/move_effect/defog.c
@@ -158,8 +158,8 @@ DOUBLE_BATTLE_TEST("Defog lowers evasiveness by 1 and removes Stealth Rock and S
             MESSAGE("The sticky web has disappeared from the ground around your team!");
         }
         // Switch happens
-        MESSAGE("Wobbuffet, that's enough! Come back!");
-        MESSAGE("Go! Wobbuffet!");
+        SWITCH_OUT_MESSAGE("Wobbuffet");
+        SEND_IN_MESSAGE("Wobbuffet");
         if (move != MOVE_DEFOG) {
             HP_BAR(playerLeft);
             MESSAGE("Pointed stones dug into Wobbuffet!");
@@ -201,8 +201,8 @@ SINGLE_BATTLE_TEST("Defog lowers evasiveness by 1 and removes Spikes from player
             MESSAGE("The spikes disappeared from the ground around your team!");
         }
         // Switch happens
-        MESSAGE("Wobbuffet, that's enough! Come back!");
-        MESSAGE("Go! Wobbuffet!");
+        SWITCH_OUT_MESSAGE("Wobbuffet");
+        SEND_IN_MESSAGE("Wobbuffet");
         if (move != MOVE_DEFOG) {
             HP_BAR(player);
             MESSAGE("Wobbuffet is hurt by spikes!");

--- a/test/battle/move_effect/embargo.c
+++ b/test/battle/move_effect/embargo.c
@@ -220,7 +220,7 @@ SINGLE_BATTLE_TEST("Baton Pass passes Embargo's effect")
         // Turn 2
         MESSAGE("Wobbuffet used Baton Pass!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BATON_PASS, player);
-        MESSAGE("Go! Wynaut!");
+        SEND_IN_MESSAGE("Wynaut");
         // Turn 3
         MESSAGE("Wynaut used Fling!");
         MESSAGE("But it failed!");

--- a/test/battle/move_effect/hit_escape.c
+++ b/test/battle/move_effect/hit_escape.c
@@ -17,7 +17,7 @@ SINGLE_BATTLE_TEST("U-turn switches the user out")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_U_TURN, player);
         HP_BAR(opponent);
-        MESSAGE("Go! Wynaut!");
+        SEND_IN_MESSAGE("Wynaut");
     }
 }
 
@@ -91,7 +91,7 @@ SINGLE_BATTLE_TEST("U-turn switches the user out if Wimp Out fails to activate")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_U_TURN, player);
         HP_BAR(opponent);
         NOT ABILITY_POPUP(opponent);
-        MESSAGE("Go for it, Wynaut!");
+        SEND_IN_MESSAGE("Wynaut");
     }
 }
 
@@ -109,7 +109,7 @@ SINGLE_BATTLE_TEST("U-turn switches the user out after Ice Face activates")
         HP_BAR(opponent);
         ABILITY_POPUP(opponent, ABILITY_ICE_FACE);
         MESSAGE("Foe Eiscue transformed!");
-        MESSAGE("Go! Wynaut!");
+        SEND_IN_MESSAGE("Wynaut");
     }
 }
 

--- a/test/battle/move_effect/protect.c
+++ b/test/battle/move_effect/protect.c
@@ -152,7 +152,7 @@ SINGLE_BATTLE_TEST("Spiky Shield does 1/8 dmg of max hp of attackers making cont
             HP_BAR(player, maxHp / 8);
             if (hp == 1) {
                 MESSAGE("Wobbuffet fainted!");
-                MESSAGE("Go! Wobbuffet!");
+                SEND_IN_MESSAGE("Wobbuffet");
             }
         }
     }

--- a/test/battle/move_effect/pursuit.c
+++ b/test/battle/move_effect/pursuit.c
@@ -16,12 +16,12 @@ SINGLE_BATTLE_TEST("Pursuited mon correctly switches out after it got hit and ac
     } WHEN {
         TURN { SWITCH(player, 1); MOVE(opponent, MOVE_PURSUIT); }
     } SCENE {
-        MESSAGE("Dugtrio, that's enough! Come back!");
+        SWITCH_OUT_MESSAGE("Dugtrio");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_PURSUIT, opponent);
         ABILITY_POPUP(player, ABILITY_TANGLING_HAIR);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
         MESSAGE("Foe Wynaut's Speed fell!");
-        MESSAGE("Go! Wobbuffet!");
+        SEND_IN_MESSAGE("Wobbuffet");
     }
 }
 

--- a/test/battle/move_effect/rage_fist.c
+++ b/test/battle/move_effect/rage_fist.c
@@ -167,9 +167,9 @@ SINGLE_BATTLE_TEST("Rage Fist base power is not lost if user switches out")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_RAGE_FIST, player);
         HP_BAR(opponent, captureDamage: &timesGotHit[0]);
-        MESSAGE("Wobbuffet, that's enough! Come back!");
+        SWITCH_OUT_MESSAGE("Wobbuffet");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
-        MESSAGE("Wynaut, that's enough! Come back!");
+        SWITCH_OUT_MESSAGE("Wynaut");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_RAGE_FIST, player);
         HP_BAR(opponent, captureDamage: &timesGotHit[1]);
     } THEN {

--- a/test/battle/move_effect/recoil_if_miss.c
+++ b/test/battle/move_effect/recoil_if_miss.c
@@ -83,7 +83,7 @@ SINGLE_BATTLE_TEST("Jump Kick's recoil happens after Spiky Shield damage and Pok
         MESSAGE("Wobbuffet was hurt by Foe Wobbuffet's Spiky Shield!");
         if (faintOnSpiky){
             MESSAGE("Wobbuffet fainted!");
-            MESSAGE("Go! Wynaut!");
+            SEND_IN_MESSAGE("Wynaut");
             NONE_OF {
                 MESSAGE("Wobbuffet kept going and crashed!");
                 HP_BAR(player);
@@ -93,7 +93,7 @@ SINGLE_BATTLE_TEST("Jump Kick's recoil happens after Spiky Shield damage and Pok
             HP_BAR(player);
             if (faintOnJumpKick) {
                 MESSAGE("Wobbuffet fainted!");
-                MESSAGE("Go! Wynaut!");
+                SEND_IN_MESSAGE("Wynaut");
             }
         }
     }

--- a/test/battle/move_effect/shed_tail.c
+++ b/test/battle/move_effect/shed_tail.c
@@ -22,7 +22,7 @@ SINGLE_BATTLE_TEST("Shed Tail creates a Substitute at the cost of 1/2 users maxi
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SHED_TAIL, player);
         HP_BAR(player, captureDamage: &costHP);
         MESSAGE("Wobbuffet shed its tail to create a decoy!");
-        MESSAGE("Go! Wynaut!");
+        SEND_IN_MESSAGE("Wynaut");
     }THEN {
         EXPECT_EQ(maxHP / 2, costHP);
     }
@@ -53,7 +53,7 @@ SINGLE_BATTLE_TEST("Shed Tail's HP cost can trigger a berry before the user swit
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SHED_TAIL, player);
         MESSAGE("Wobbuffet's Sitrus Berry restored health!");
-        MESSAGE("Go! Wynaut!");
+        SEND_IN_MESSAGE("Wynaut");
     }
 }
 

--- a/test/battle/move_effect/shell_trap.c
+++ b/test/battle/move_effect/shell_trap.c
@@ -86,7 +86,7 @@ SINGLE_BATTLE_TEST("Shell Trap does not activate if battler faints before being 
         MESSAGE("Wobbuffet set a shell trap!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
         MESSAGE("Wobbuffet fainted!");
-        MESSAGE("Go! Wobbuffet!");
+        SEND_IN_MESSAGE("Wobbuffet");
         NONE_OF {
             MESSAGE("Wobbuffet used Shell Trap!");
             ANIMATION(ANIM_TYPE_MOVE, MOVE_SHELL_TRAP, player);

--- a/test/battle/move_effect/stealth_rock.c
+++ b/test/battle/move_effect/stealth_rock.c
@@ -46,7 +46,7 @@ SINGLE_BATTLE_TEST("Stealth Rock damages the correct pokemon when Eject Button i
         ANIMATION(ANIM_TYPE_MOVE, MOVE_QUICK_ATTACK, opponent);
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_HARDEN, player);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-        MESSAGE("Go! Metapod!");
+        SEND_IN_MESSAGE("Metapod");
         HP_BAR(player);
     } THEN {
         EXPECT_EQ(opponent->hp, opponent->maxHP);
@@ -67,7 +67,7 @@ DOUBLE_BATTLE_TEST("Stealth Rock damages the correct pokemon when Eject Button i
         ANIMATION(ANIM_TYPE_MOVE, MOVE_STEALTH_ROCK, opponentLeft);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentRight);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, playerLeft);
-        MESSAGE("Go! Metapod!");
+        SEND_IN_MESSAGE("Metapod");
         HP_BAR(playerLeft);
     } THEN {
         EXPECT_EQ(opponentLeft->hp, opponentLeft->maxHP);

--- a/test/battle/move_effect/sticky_web.c
+++ b/test/battle/move_effect/sticky_web.c
@@ -123,7 +123,7 @@ DOUBLE_BATTLE_TEST("Sticky Web has correct interactions with Mirror Armor - the 
         ANIMATION(ANIM_TYPE_MOVE, MOVE_STICKY_WEB, BATTLER_PLAYER);
         MESSAGE("A sticky web spreads out on the ground around the opposing team!");
 
-        MESSAGE("Go! Corviknight!");
+        SEND_IN_MESSAGE("Corviknight");
         MESSAGE("Corviknight was caught in a Sticky Web!");
         ABILITY_POPUP(playerRight, ABILITY_MIRROR_ARMOR);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, BATTLER_OPPONENT);
@@ -176,7 +176,7 @@ DOUBLE_BATTLE_TEST("Sticky Web has correct interactions with Mirror Armor - no o
             MESSAGE("A sticky web spreads out on the ground around the opposing team!");
         }
 
-        MESSAGE("Go! Corviknight!");
+        SEND_IN_MESSAGE("Corviknight");
         MESSAGE("Corviknight was caught in a Sticky Web!");
         ABILITY_POPUP(playerRight, ABILITY_MIRROR_ARMOR);
         NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
@@ -225,7 +225,7 @@ DOUBLE_BATTLE_TEST("Sticky Web has correct interactions with Mirror Armor - no o
             MESSAGE("2 sent out Pidgey!");
         }
 
-        MESSAGE("Go! Corviknight!");
+        SEND_IN_MESSAGE("Corviknight");
         MESSAGE("Corviknight was caught in a Sticky Web!");
         ABILITY_POPUP(playerRight, ABILITY_MIRROR_ARMOR);
         NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);

--- a/test/battle/move_effect/strength_sap.c
+++ b/test/battle/move_effect/strength_sap.c
@@ -190,7 +190,7 @@ SINGLE_BATTLE_TEST("Strength Sap makes attacker lose HP if target's ability is L
         MESSAGE("It sucked up the liquid ooze!");
         if (atkStat >= 490) {
             MESSAGE("Wobbuffet fainted!");
-            MESSAGE("Go! Wobbuffet!");
+            SEND_IN_MESSAGE("Wobbuffet");
         }
     } THEN {
         EXPECT_EQ(lostHp, atkStat);

--- a/test/battle/move_effect/toxic_spikes.c
+++ b/test/battle/move_effect/toxic_spikes.c
@@ -226,7 +226,7 @@ SINGLE_BATTLE_TEST("Toxic Spikes inflicts poison on switch in after Primal Rever
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TOXIC_SPIKES, opponent);
         MESSAGE("Poison Spikes were scattered all around your team's feet!");
         // Switch in
-        MESSAGE("Go! Groudon!");
+        SEND_IN_MESSAGE("Groudon");
         ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, player);
         STATUS_ICON(player, poison: TRUE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_PRIMAL_REVERSION, player);
@@ -235,7 +235,7 @@ SINGLE_BATTLE_TEST("Toxic Spikes inflicts poison on switch in after Primal Rever
         MESSAGE("Groudon used Memento!");
         MESSAGE("Groudon fainted!");
         // 2nd switch-in
-        MESSAGE("Go! Wynaut!");
+        SEND_IN_MESSAGE("Wynaut");
         ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, player);
         STATUS_ICON(player, poison: TRUE);
     }

--- a/test/battle/move_effect_secondary/syrup_bomb.c
+++ b/test/battle/move_effect_secondary/syrup_bomb.c
@@ -210,7 +210,7 @@ SINGLE_BATTLE_TEST("Sticky Syrup is removed when the user faints")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
         HP_BAR(player);
         MESSAGE("Wobbuffet fainted!");
-        MESSAGE("Go! Wynaut!");
+        SEND_IN_MESSAGE("Wynaut");
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_SYRUP_BOMB_SPEED_DROP, opponent);
             MESSAGE("Foe Wobbuffet's Speed fell!");


### PR DESCRIPTION
Adds two macros to use in tests in place of having to figure out which specific switch-out or send-in message will appear in each situation.

## **Discord contact info**
duke5614
