### PR TITLE
Remove misleading preprocs

### DIFF
--- a/src/wild_encounter.c
+++ b/src/wild_encounter.c
@@ -75,11 +75,8 @@ EWRAM_DATA static u8 sWildEncountersDisabled = 0;
 EWRAM_DATA static u32 sFeebasRngValue = 0;
 EWRAM_DATA bool8 gIsFishingEncounter = 0;
 EWRAM_DATA bool8 gIsSurfingEncounter = 0;
-
-#ifdef I_FISHING_CHAIN
 EWRAM_DATA u8 gChainFishingDexNavStreak = 0;
 EWRAM_DATA static u16 sLastFishingSpecies = 0;
-#endif
 
 #include "data/wild_encounters.h"
 


### PR DESCRIPTION
The preprocs didn't do anything because the whole feature has to be preproc'd otherwise the EWRAM is still compiled.