### PR TITLE
Slightly optimize rolling DMA buffer

### DIFF
--- a/gflib/dma3_manager.c
+++ b/gflib/dma3_manager.c
@@ -88,10 +88,7 @@ void ProcessDma3Requests(void)
         sDma3Requests[sDma3RequestCursor].size = 0;
         sDma3Requests[sDma3RequestCursor].mode = 0;
         sDma3Requests[sDma3RequestCursor].value = 0;
-        sDma3RequestCursor++;
-
-        if (sDma3RequestCursor >= MAX_DMA_REQUESTS) // loop back to the first DMA request
-            sDma3RequestCursor = 0;
+        sDma3RequestCursor = (sDma3RequestCursor + 1) & (MAX_DMA_REQUESTS - 1);
     }
 }
 
@@ -119,8 +116,7 @@ s16 RequestDma3Copy(const void *src, void *dest, u16 size, u32 mode)
             sDma3ManagerLocked = FALSE;
             return cursor;
         }
-        if (++cursor >= MAX_DMA_REQUESTS) // loop back to start.
-            cursor = 0;
+        cursor = (cursor + 1) & (MAX_DMA_REQUESTS - 1);
         i++;
     }
     sDma3ManagerLocked = FALSE;
@@ -152,8 +148,7 @@ s16 RequestDma3Fill(s32 value, void *dest, u16 size, u32 mode)
             sDma3ManagerLocked = FALSE;
             return cursor;
         }
-        if (++cursor >= MAX_DMA_REQUESTS) // loop back to start.
-            cursor = 0;
+        cursor = (cursor + 1) & (MAX_DMA_REQUESTS - 1);
         i++;
     }
     sDma3ManagerLocked = FALSE;


### PR DESCRIPTION
It’s a rolling buffer, with a max value of 128, so we can optimize this branch out by using & 127 instead.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Images
<!-- Please provide with relevant GIFs or images to make it easier for reviewers to accept your PR quicker.-->
<!-- If it doesn't apply, feel free to remove this section. -->

## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, fixes #2222." -->
<!-- If it doesn't apply, feel free to remove this section. -->

## **People who collaborated with me in this PR**
<!-- Please credit everyone else that contributed to this PR, be it code and/or assets. -->
<!-- Use their GitHub tag if they have one. -->
<!-- If it doesn't apply, feel free to remove this section. -->

## Feature(s) this PR does NOT handle:
<!-- If your PR contains any unfinished features that are not considered merge-blocking, please list them here for clarity so no one can forget. -->
<!-- If it doesn't apply, feel free to remove this section. -->

## **Discord contact info**
<!--- formatted as name#numbers, e.g. Lunos#4026 -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
