### PR TITLE
Fixed trainerproc behavior with Unicode characters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -346,7 +346,7 @@ sound/%.bin: sound/%.aif ; $(AIF) $< $@
 
 COMPETITIVE_PARTY_SYNTAX := $(shell PATH="$(PATH)"; echo 'COMPETITIVE_PARTY_SYNTAX' | $(CPP) $(CPPFLAGS) -imacros include/global.h | tail -n1)
 ifeq ($(COMPETITIVE_PARTY_SYNTAX),1)
-%.h: %.party tools ; $(CPP) $(CPPFLAGS) - < $< | sed '/#[^p]/d' | $(TRAINERPROC) -o $@ -i $< -
+%.h: %.party tools ; $(CPP) $(CPPFLAGS) -traditional-cpp - < $< | sed '/#[^p]/d' | $(TRAINERPROC) -o $@ -i $< -
 endif
 
 ifeq ($(MODERN),0)

--- a/src/data/trainers.party
+++ b/src/data/trainers.party
@@ -1,3 +1,21 @@
+/*
+Trainer and their parties defined with Competetive Syntax
+Compatible with Pokemon Showdown exports.
+
+This file is processed with a custom preprocessor.
+#defines can be used and will be expanded during the make process
+#define TRICKMON 0 Spe would expand all cases of TRICKMON to 0 Spe,
+thus giving all Pokemon with IVs set to TRICKMON have 31/31/31/31/31/0 IVs
+*/
+
+/*
+Comments can be added as C comment blocks
+// cannot be used as comments
+*/
+
+/*Comments can also be on a single line*/
+
+
 === TRAINER_NONE ===
 Name:
 Class: Pkmn Trainer 1

--- a/tools/preproc/string_parser.cpp
+++ b/tools/preproc/string_parser.cpp
@@ -87,7 +87,7 @@ std::string StringParser::ReadCharOrEscape()
         if (isEscape)
             RaiseError("unknown escape '\\%c'", code);
         else
-            RaiseError("unknown character U+%X", code);
+            RaiseError("unknown character U+%X\nIf this character is intended to be used, it needs to be implemented", code);
     }
 
     return sequence;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Makefile fix to Unicode issues in `trainers.party`

## Description
<!--- Describe your changes in detail -->
Fixed some Unicode characters expanding into `U\xxxxxxxx` when compiling the ROM by adding `-traditional-cpp` to the command that runs `trainerproc`.
Made error message more detailed when the `trainerproc` encounters a character the ROM won't be able to display.
Added some usage instructions to `trainers.party`.

## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, fixes #2222." -->
<!-- If it doesn't apply, feel free to remove this section. -->
Fixes #4531 

## **People who collaborated with me in this PR**
<!-- Please credit everyone else that contributed to this PR, be it code and/or assets. -->
<!-- Use their GitHub tag if they have one. -->
<!-- If it doesn't apply, feel free to remove this section. -->
mrgriffin
Bassoonian

## **Discord contact info**
<!--- formatted as name#numbers, e.g. Lunos#4026 -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara