### PR TITLE
Fix mycelium might and ability shield

### DIFF
--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -244,7 +244,6 @@ bool32 CanBeConfused(u32 battler);
 bool32 IsBattlerTerrainAffected(u32 battler, u32 terrainFlag);
 u32 GetBattlerAffectionHearts(u32 battler);
 u32 CountBattlerStatIncreases(u32 battler, bool32 countEvasionAcc);
-bool32 IsMyceliumMightOnField(void);
 bool32 ChangeTypeBasedOnTerrain(u32 battler);
 void RemoveConfusionStatus(u32 battler);
 u8 GetBattlerGender(u32 battler);

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -6177,7 +6177,7 @@ bool32 IsNeutralizingGasOnField(void)
 bool32 IsMoldBreakerTypeAbility(u32 ability)
 {
     return (ability == ABILITY_MOLD_BREAKER || ability == ABILITY_TERAVOLT || ability == ABILITY_TURBOBLAZE
-        || (ABILITY_MYCELIUM_MIGHT && IS_MOVE_STATUS(gCurrentMove)));
+        || (ability == ABILITY_MYCELIUM_MIGHT && IS_MOVE_STATUS(gCurrentMove)));
 }
 
 u32 GetBattlerAbility(u32 battler)

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -6174,26 +6174,16 @@ bool32 IsNeutralizingGasOnField(void)
     return FALSE;
 }
 
-bool32 IsMyceliumMightOnField(void)
-{
-    u32 i;
-
-    for (i = 0; i < gBattlersCount; i++)
-    {
-        if (IsBattlerAlive(i) && gBattleMons[i].ability == ABILITY_MYCELIUM_MIGHT && IS_MOVE_STATUS(gCurrentMove))
-            return TRUE;
-    }
-
-    return FALSE;
-}
-
 bool32 IsMoldBreakerTypeAbility(u32 ability)
 {
-    return (ability == ABILITY_MOLD_BREAKER || ability == ABILITY_TERAVOLT || ability == ABILITY_TURBOBLAZE);
+    return (ability == ABILITY_MOLD_BREAKER || ability == ABILITY_TERAVOLT || ability == ABILITY_TURBOBLAZE
+        || (ABILITY_MYCELIUM_MIGHT && IS_MOVE_STATUS(gCurrentMove)));
 }
 
 u32 GetBattlerAbility(u32 battler)
 {
+    bool32 noAbilityShield = GetBattlerHoldEffectIgnoreAbility(battler, TRUE) != HOLD_EFFECT_ABILITY_SHIELD;
+
     if (gAbilitiesInfo[gBattleMons[battler].ability].cantBeSuppressed)
         return gBattleMons[battler].ability;
 
@@ -6202,16 +6192,14 @@ u32 GetBattlerAbility(u32 battler)
 
     if (IsNeutralizingGasOnField()
      && gBattleMons[battler].ability != ABILITY_NEUTRALIZING_GAS
-     && GetBattlerHoldEffectIgnoreAbility(battler, TRUE) != HOLD_EFFECT_ABILITY_SHIELD)
-        return ABILITY_NONE;
-
-    if (IsMyceliumMightOnField())
+     && noAbilityShield)
         return ABILITY_NONE;
 
     if (((IsMoldBreakerTypeAbility(gBattleMons[gBattlerAttacker].ability)
             && !(gStatuses3[gBattlerAttacker] & STATUS3_GASTRO_ACID))
             || gMovesInfo[gCurrentMove].ignoresTargetAbility)
             && gAbilitiesInfo[gBattleMons[battler].ability].breakable
+            && noAbilityShield
             && gBattlerByTurnOrder[gCurrentTurnActionNumber] == gBattlerAttacker
             && gActionsByTurnOrder[gBattlerByTurnOrder[gBattlerAttacker]] == B_ACTION_USE_MOVE
             && gCurrentTurnActionNumber < gBattlersCount)

--- a/test/battle/hold_effect/ability_shield.c
+++ b/test/battle/hold_effect/ability_shield.c
@@ -32,3 +32,75 @@ SINGLE_BATTLE_TEST("Ability Shield prevents Neutralizing Gas")
         }
     }
 }
+
+SINGLE_BATTLE_TEST("Ability Shield protects against Mold Breaker")
+{
+    u32 item;
+
+    PARAMETRIZE { item = ITEM_ABILITY_SHIELD; }
+    PARAMETRIZE { item = ITEM_NONE; }
+
+    GIVEN {
+        PLAYER(SPECIES_SHEDINJA) { Ability(ABILITY_WONDER_GUARD); Item(item); }
+        OPPONENT(SPECIES_TINKATON) { Ability(ABILITY_MOLD_BREAKER); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_GIGATON_HAMMER); }
+    } SCENE {
+        if (item == ITEM_ABILITY_SHIELD) {
+            NONE_OF {
+                MESSAGE("Shedinja fainted!");
+            }
+        } else {
+            MESSAGE("Shedinja fainted!");
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Ability Shield protects against Mycelium Might")
+{
+    u32 item;
+
+    PARAMETRIZE { item = ITEM_ABILITY_SHIELD; }
+    PARAMETRIZE { item = ITEM_NONE; }
+
+    GIVEN {
+        PLAYER(SPECIES_VIGOROTH) { Ability(ABILITY_VITAL_SPIRIT); Item(item); }
+        OPPONENT(SPECIES_TOEDSCOOL) { Ability(ABILITY_MYCELIUM_MIGHT); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SPORE); MOVE(player, MOVE_SPORE); }
+    } SCENE {
+        
+        if (item == ITEM_ABILITY_SHIELD) {
+            NONE_OF {
+                ANIMATION(ANIM_TYPE_MOVE, MOVE_SPORE, opponent);
+                STATUS_ICON(player, sleep: TRUE);
+            }
+        } else {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_SPORE, opponent);
+            STATUS_ICON(player, sleep: TRUE);
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Ability Shield protects against Sunsteel Strike")
+{
+    u32 item;
+
+    PARAMETRIZE { item = ITEM_ABILITY_SHIELD; }
+    PARAMETRIZE { item = ITEM_NONE; }
+
+    GIVEN {
+        PLAYER(SPECIES_SHEDINJA) { Ability(ABILITY_WONDER_GUARD); Item(item); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SUNSTEEL_STRIKE); }
+    } SCENE {
+        if (item == ITEM_ABILITY_SHIELD) {
+            NONE_OF {
+                MESSAGE("Shedinja fainted!");
+            }
+        } else {
+            MESSAGE("Shedinja fainted!");
+        }
+    }
+}


### PR DESCRIPTION
## Description
Mycelium Might behaved as a strange combination of Mold Breaker + Neutralizing Gas for status moves used by any battler of the field.
This PR fixes it so it only works for the battler that has the ability.
Fixes ability shield not protecting against mold breaker type abilities and moves that ignore abilities.

## **Discord contact info**
duke5416
