### PR TITLE
Tera Shell AI calcs

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -718,6 +718,7 @@ struct BattleStruct
     } multiBuffer;
     u8 wishPerishSongState;
     u8 wishPerishSongBattlerId;
+    u8 aiCalcInProgress:1;
     u8 overworldWeatherDone:1;
     u8 startingStatusDone:1;
     u8 isAtkCancelerForCalledMove:1; // Certain cases in atk canceler should only be checked once, when the original move is called, however others need to be checked the twice.

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -496,11 +496,11 @@ s32 AI_CalcDamage(u32 move, u32 battlerAtk, u32 battlerDef, u8 *typeEffectivenes
 {
     s32 dmg, moveType;
     uq4_12_t effectivenessMultiplier;
-    gBattleStruct->aiCalcInProgress = TRUE;
     bool32 isDamageMoveUnusable = FALSE;
     bool32 toggledDynamax = FALSE;
     bool32 toggledTera = FALSE;
     struct AiLogicData *aiData = AI_DATA;
+    gBattleStruct->aiCalcInProgress = TRUE;
 
     // Temporarily enable Z-Moves for damage calcs
     if (considerZPower && IsViableZMove(battlerAtk, move))

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -496,6 +496,7 @@ s32 AI_CalcDamage(u32 move, u32 battlerAtk, u32 battlerDef, u8 *typeEffectivenes
 {
     s32 dmg, moveType;
     uq4_12_t effectivenessMultiplier;
+    gBattleStruct->aiCalcInProgress = TRUE;
     bool32 isDamageMoveUnusable = FALSE;
     bool32 toggledDynamax = FALSE;
     bool32 toggledTera = FALSE;
@@ -650,6 +651,7 @@ s32 AI_CalcDamage(u32 move, u32 battlerAtk, u32 battlerDef, u8 *typeEffectivenes
     // convert multiper to AI_EFFECTIVENESS_xX
     *typeEffectiveness = AI_GetEffectiveness(effectivenessMultiplier);
 
+    gBattleStruct->aiCalcInProgress = FALSE;
     gBattleStruct->swapDamageCategory = FALSE;
     gBattleStruct->zmove.active = FALSE;
     gBattleStruct->zmove.baseMoves[battlerAtk] = MOVE_NONE;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -10172,7 +10172,7 @@ static inline void MulByTypeEffectiveness(uq4_12_t *modifier, u32 move, u32 move
             mod = UQ_4_12(1.0);
     }
 
-    if (gBattleStruct->distortedTypeMatchups & gBitTable[battlerDef])
+    if (gBattleStruct->distortedTypeMatchups & gBitTable[battlerDef] || (gBattleStruct->aiCalcInProgress && ShouldTeraShellDistortTypeMatchups(move, battlerDef)))
     {
         mod = UQ_4_12(0.5);
         if (recordAbilities)


### PR DESCRIPTION
Fixes  #4468

I added a BattleStruct bool instead of passing down an argument because the function is already long enough. 

Full HP:
![pokeemerald-39](https://github.com/rh-hideout/pokeemerald-expansion/assets/93446519/0409c5df-7711-4de5-8719-d50d216a2c3e)

Taken damage:
![pokeemerald-40](https://github.com/rh-hideout/pokeemerald-expansion/assets/93446519/a086c89e-a827-4429-afcd-4ff86145178c)
