### PR TITLE
Use GetBattlerAbility instead of the ability field in more places

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3580,7 +3580,7 @@ u8 AtkCanceller_UnableToUseMove(u32 moveType)
         case CANCELLER_MULTIHIT_MOVES:
             if (gMovesInfo[gCurrentMove].effect == EFFECT_MULTI_HIT)
             {
-                u16 ability = gBattleMons[gBattlerAttacker].ability;
+                u32 ability = GetBattlerAbility(gBattlerAttacker);
 
                 if (ability == ABILITY_SKILL_LINK)
                 {

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -11170,7 +11170,7 @@ void RemoveConfusionStatus(u32 battler)
 
 static bool32 CanBeInfinitelyConfused(u32 battler)
 {
-    if  (gBattleMons[battler].ability == ABILITY_OWN_TEMPO
+    if  (GetBattlerAbility(battler) == ABILITY_OWN_TEMPO
          || IsBattlerTerrainAffected(battler, STATUS_FIELD_MISTY_TERRAIN)
          || gSideStatuses[GetBattlerSide(battler)] & SIDE_STATUS_SAFEGUARD)
     {


### PR DESCRIPTION
Fixes Skill Link ignoring gastro acid and neutralising gas.
Fixes Own Tempo ignoring gastro acid and neutralising gas when protecting against Berserk Gene's confusion.
## **Discord contact info**
duke5614