### PR TITLE
Add config to turn off two-framed front sprites

### DIFF
--- a/include/config/pokemon.h
+++ b/include/config/pokemon.h
@@ -46,6 +46,7 @@
 #define P_SHOW_TERA_TYPE            GEN_8       // Since Gen 9, the Tera Type is shown on the summary screen.
 #define P_TM_LITERACY               GEN_LATEST  // Since Gen 6, TM illiterate Pokémon can learn TMs that teach moves that are in their level-up learnsets.
 #define P_EGG_CYCLE_LENGTH          GEN_LATEST  // Since Gen 8, egg cycles take half as many steps as before.
+#define P_TWO_FRAME_FRONT_SPRITES   FALSE        // In Pokémon Emerald, Pokémon front sprites always consist of two frames. This config can revert it to only use the first frame, as is the case in the other Gen 3 games.
 
 // Learnset helper toggles
 #define P_LEARNSET_HELPER_TEACHABLE TRUE        // If TRUE, teachable_learnsets.h will be populated by tools/learnset_helpers/teachable.py using the included JSON files based on available TMs and tutors.

--- a/include/config/pokemon.h
+++ b/include/config/pokemon.h
@@ -46,7 +46,7 @@
 #define P_SHOW_TERA_TYPE            GEN_8       // Since Gen 9, the Tera Type is shown on the summary screen.
 #define P_TM_LITERACY               GEN_LATEST  // Since Gen 6, TM illiterate Pokémon can learn TMs that teach moves that are in their level-up learnsets.
 #define P_EGG_CYCLE_LENGTH          GEN_LATEST  // Since Gen 8, egg cycles take half as many steps as before.
-#define P_TWO_FRAME_FRONT_SPRITES   FALSE        // In Pokémon Emerald, Pokémon front sprites always consist of two frames. This config can revert it to only use the first frame, as is the case in the other Gen 3 games.
+#define P_TWO_FRAME_FRONT_SPRITES   TRUE        // In Pokémon Emerald, Pokémon front sprites always consist of two frames. This config can revert it to only use the first frame, as is the case in the other Gen 3 games.
 
 // Learnset helper toggles
 #define P_LEARNSET_HELPER_TEACHABLE TRUE        // If TRUE, teachable_learnsets.h will be populated by tools/learnset_helpers/teachable.py using the included JSON files based on available TMs and tutors.

--- a/src/data/pokemon_graphics/front_pic_anims.h
+++ b/src/data/pokemon_graphics/front_pic_anims.h
@@ -16,8 +16,6 @@ static const union AnimCmd sAnim_##name##_1[] = \
 
 static const union AnimCmd sAnim_None_1[] =
 {
-    ANIMCMD_FRAME(0, 30),
-    ANIMCMD_FRAME(1, 30),
     ANIMCMD_FRAME(0, 1),
     ANIMCMD_END,
 };

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -2199,7 +2199,7 @@ void SetMultiuseSpriteTemplateToPokemon(u16 speciesTag, u8 battlerPosition)
             speciesTag = speciesTag - SPECIES_SHINY_TAG;
 
         speciesTag = SanitizeSpeciesId(speciesTag);
-        if (gSpeciesInfo[speciesTag].frontAnimFrames != NULL)
+        if (P_TWO_FRAME_FRONT_SPRITES && gSpeciesInfo[speciesTag].frontAnimFrames != NULL)
             gMultiuseSpriteTemplate.anims = gSpeciesInfo[speciesTag].frontAnimFrames;
         else
             gMultiuseSpriteTemplate.anims = gSpeciesInfo[SPECIES_NONE].frontAnimFrames;

--- a/src/trainer_pokemon_sprites.c
+++ b/src/trainer_pokemon_sprites.c
@@ -221,7 +221,7 @@ u16 CreateMonPicSprite_Affine(u16 species, bool8 isShiny, u32 personality, u8 fl
         images[j].size = MON_PIC_SIZE;
     }
     sCreatingSpriteTemplate.tileTag = TAG_NONE;
-    sCreatingSpriteTemplate.anims = gSpeciesInfo[species].frontAnimFrames;
+    sCreatingSpriteTemplate.anims = gSpeciesInfo[P_TWO_FRAME_FRONT_SPRITES ? species : SPECIES_NONE].frontAnimFrames;
     sCreatingSpriteTemplate.images = images;
     if (type == MON_PIC_AFFINE_FRONT)
     {


### PR DESCRIPTION
In many Fakemon projects (or projects with extensive respriting), people don't want to bother with second frames for species. Lunos' tutorial on the pret wiki turned off animations in general (including affine animations etc), which may also not be desirable.

This PR adds a config that simple prevents the second frame from ever being shown. It is still compiled into the ROM, but at least it can be safely ignored. This change is extremely non-invasive and trivial to toggle.

## **Discord contact info**
bassoonian
