### PR TITLE
Fixes Tar shot making all of the target's types weak to fire

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -10039,8 +10039,6 @@ static inline void MulByTypeEffectiveness(uq4_12_t *modifier, u32 move, u32 move
         mod = UQ_4_12(2.0);
     if (moveType == TYPE_GROUND && defType == TYPE_FLYING && IsBattlerGrounded(battlerDef) && mod == UQ_4_12(0.0))
         mod = UQ_4_12(1.0);
-    if (moveType == TYPE_FIRE && gDisableStructs[battlerDef].tarShot)
-        mod = UQ_4_12(2.0);
 
     // B_WEATHER_STRONG_WINDS weakens Super Effective moves against Flying-type Pokémon
     if (gBattleWeather & B_WEATHER_STRONG_WINDS && WEATHER_HAS_EFFECT)
@@ -10097,6 +10095,8 @@ static inline uq4_12_t CalcTypeEffectivenessMultiplierInternal(u32 move, u32 mov
     if (GetBattlerType(battlerDef, 2) != TYPE_MYSTERY && GetBattlerType(battlerDef, 2) != GetBattlerType(battlerDef, 1)
         && GetBattlerType(battlerDef, 2) != GetBattlerType(battlerDef, 0))
         MulByTypeEffectiveness(&modifier, move, moveType, battlerDef, GetBattlerType(battlerDef, 2), battlerAtk, recordAbilities);
+    if (moveType == TYPE_FIRE && gDisableStructs[battlerDef].tarShot)
+        modifier = uq4_12_multiply(modifier, UQ_4_12(2.0));
 
     if (recordAbilities && (illusionSpecies = GetIllusionMonSpecies(battlerDef)))
         TryNoticeIllusionInTypeEffectiveness(move, moveType, battlerAtk, battlerDef, modifier, illusionSpecies);

--- a/test/battle/move_effect/tar_shot.c
+++ b/test/battle/move_effect/tar_shot.c
@@ -24,7 +24,6 @@ SINGLE_BATTLE_TEST("Tar Shot doubles the effectiveness of Fire-type moves used o
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(species);
     } WHEN {
-        //TURN { MOVE(player, MOVE_FORESTS_CURSE); } // Adds third type
         TURN { MOVE(player, MOVE_EMBER); }
         TURN { MOVE(player, MOVE_TAR_SHOT); }
         TURN { MOVE(player, MOVE_EMBER); }

--- a/test/battle/move_effect/tar_shot.c
+++ b/test/battle/move_effect/tar_shot.c
@@ -1,0 +1,45 @@
+#include "global.h"
+#include "test/battle.h"
+
+ASSUMPTIONS
+{
+    ASSUME(gMovesInfo[MOVE_TAR_SHOT].effect == EFFECT_TAR_SHOT);
+}
+
+SINGLE_BATTLE_TEST("Tar Shot doubles the effectiveness of Fire-type moves used on the target")
+{
+    s16 damage[2];
+    u32 species;
+
+    PARAMETRIZE { species = SPECIES_WOBBUFFET; }
+    PARAMETRIZE { species = SPECIES_OMASTAR; } // Dual type with double resists
+
+    ASSUME(gSpeciesInfo[SPECIES_WOBBUFFET].types[0] == TYPE_PSYCHIC);
+    ASSUME(gSpeciesInfo[SPECIES_WOBBUFFET].types[1] == TYPE_PSYCHIC);
+    ASSUME(gSpeciesInfo[SPECIES_OMASTAR].types[0] == TYPE_ROCK);
+    ASSUME(gSpeciesInfo[SPECIES_OMASTAR].types[1] == TYPE_WATER);
+    ASSUME(gMovesInfo[MOVE_EMBER].type == TYPE_FIRE);
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(species);
+    } WHEN {
+        //TURN { MOVE(player, MOVE_FORESTS_CURSE); } // Adds third type
+        TURN { MOVE(player, MOVE_EMBER); }
+        TURN { MOVE(player, MOVE_TAR_SHOT); }
+        TURN { MOVE(player, MOVE_EMBER); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EMBER, player);
+        HP_BAR(opponent, captureDamage: &damage[0]);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TAR_SHOT, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EMBER, player);
+        HP_BAR(opponent, captureDamage: &damage[1]);
+        if (species != SPECIES_OMASTAR)
+            MESSAGE("It's super effective!");
+        else
+            MESSAGE("It's not very effective…");
+    } THEN {
+        EXPECT_MUL_EQ(damage[0], Q_4_12(2.0), damage[1]);
+    }
+}
+


### PR DESCRIPTION
## Description
Fixes tar shot overwriting the fire resistances/neutrality of types 0, 1 and 2 instead of applying separately.
This resulted in every mon taking x2, x4 or x8 fire damage depending on how many types it had.

## **Discord contact info**
duke5614