### PR TITLE
Improved Surf/Thunderbolt test

### DIFF
--- a/include/random.h
+++ b/include/random.h
@@ -188,6 +188,7 @@ enum RandomTag
     RNG_QUICK_CLAW,
     RNG_TRACE,
     RNG_FICKLE_BEAM,
+    RNG_AI_ABILITY,
 };
 
 #define RandomWeighted(tag, ...) \

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -1111,7 +1111,7 @@ s32 AI_DecideKnownAbilityForTurn(u32 battlerId)
         u32 abilityGuess = ABILITY_NONE;
         while (abilityGuess == ABILITY_NONE)
         {
-            abilityGuess = gSpeciesInfo[gBattleMons[battlerId].species].abilities[RandomUniform(RNG_AI_ABILITY, 0, 2) % NUM_ABILITY_SLOTS];
+            abilityGuess = gSpeciesInfo[gBattleMons[battlerId].species].abilities[RandomUniform(RNG_AI_ABILITY, 0, 2)];
         }
 
         return abilityGuess;

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -1111,7 +1111,7 @@ s32 AI_DecideKnownAbilityForTurn(u32 battlerId)
         u32 abilityGuess = ABILITY_NONE;
         while (abilityGuess == ABILITY_NONE)
         {
-            abilityGuess = gSpeciesInfo[gBattleMons[battlerId].species].abilities[Random() % NUM_ABILITY_SLOTS];
+            abilityGuess = gSpeciesInfo[gBattleMons[battlerId].species].abilities[RandomUniform(RNG_AI_ABILITY, 0, 2) % NUM_ABILITY_SLOTS];
         }
 
         return abilityGuess;

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -1108,8 +1108,10 @@ s32 AI_DecideKnownAbilityForTurn(u32 battlerId)
         return knownAbility;
 
     for (i = 0; i < NUM_ABILITY_SLOTS; i++)
+    {
         if (gSpeciesInfo[gBattleMons[battlerId].species].abilities[i] != ABILITY_NONE)
             validAbilities[numValidAbilities++] = gSpeciesInfo[gBattleMons[battlerId].species].abilities[i];
+    }
 
     if (numValidAbilities > 0)
         return validAbilities[RandomUniform(RNG_AI_ABILITY, 0, numValidAbilities - 1)];

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -1084,6 +1084,8 @@ bool32 AI_IsAbilityOnSide(u32 battlerId, u32 ability)
 // does NOT include ability suppression checks
 s32 AI_DecideKnownAbilityForTurn(u32 battlerId)
 {
+    u8 validAbilitySlots[ABILITIES_COUNT];
+    u8 i, numValidAbilities = 0;
     u32 knownAbility = GetBattlerAbility(battlerId);
 
     // We've had ability overwritten by e.g. Worry Seed. It is not part of AI_PARTY in case of switching
@@ -1105,17 +1107,12 @@ s32 AI_DecideKnownAbilityForTurn(u32 battlerId)
     if (knownAbility == ABILITY_SHADOW_TAG || knownAbility == ABILITY_MAGNET_PULL || knownAbility == ABILITY_ARENA_TRAP)
         return knownAbility;
 
-    // Else, guess the ability
-    if (gSpeciesInfo[gBattleMons[battlerId].species].abilities[0] != ABILITY_NONE)
-    {
-        u32 abilityGuess = ABILITY_NONE;
-        while (abilityGuess == ABILITY_NONE)
-        {
-            abilityGuess = gSpeciesInfo[gBattleMons[battlerId].species].abilities[RandomUniform(RNG_AI_ABILITY, 0, 2)];
-        }
+    for (i = 0; i < NUM_ABILITY_SLOTS; i++)
+        if (gSpeciesInfo[gBattleMons[battlerId].species].abilities[i] != ABILITY_NONE)
+            validAbilitySlots[numValidAbilities++] = i;
 
-        return abilityGuess;
-    }
+    if (numValidAbilities > 0)
+        return gSpeciesInfo[gBattleMons[battlerId].species].abilities[validAbilitySlots[RandomUniform(RNG_AI_ABILITY, 0, numValidAbilities - 1)]];
 
     return ABILITY_NONE; // Unknown.
 }

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -1084,7 +1084,7 @@ bool32 AI_IsAbilityOnSide(u32 battlerId, u32 ability)
 // does NOT include ability suppression checks
 s32 AI_DecideKnownAbilityForTurn(u32 battlerId)
 {
-    u8 validAbilitySlots[ABILITIES_COUNT];
+    u32 validAbilities[NUM_ABILITY_SLOTS];
     u8 i, numValidAbilities = 0;
     u32 knownAbility = GetBattlerAbility(battlerId);
 
@@ -1109,10 +1109,10 @@ s32 AI_DecideKnownAbilityForTurn(u32 battlerId)
 
     for (i = 0; i < NUM_ABILITY_SLOTS; i++)
         if (gSpeciesInfo[gBattleMons[battlerId].species].abilities[i] != ABILITY_NONE)
-            validAbilitySlots[numValidAbilities++] = i;
+            validAbilities[numValidAbilities++] = gSpeciesInfo[gBattleMons[battlerId].species].abilities[i];
 
     if (numValidAbilities > 0)
-        return gSpeciesInfo[gBattleMons[battlerId].species].abilities[validAbilitySlots[RandomUniform(RNG_AI_ABILITY, 0, numValidAbilities - 1)]];
+        return validAbilities[RandomUniform(RNG_AI_ABILITY, 0, numValidAbilities - 1)];
 
     return ABILITY_NONE; // Unknown.
 }

--- a/test/battle/ai.c
+++ b/test/battle/ai.c
@@ -819,8 +819,9 @@ AI_SINGLE_BATTLE_TEST("AI will not choose Burn Up if the user lost the Fire typi
     }
 }
 
-AI_SINGLE_BATTLE_TEST("AI will choose Surf over Thunderbolt and Ice Beam if the opposing mon has Volt Absorb")
+AI_SINGLE_BATTLE_TEST("AI will only choose Surf 1/3 times if the opposing mon has Volt Absorb")
 {
+    PASSES_RANDOMLY(1, 3, RNG_AI_ABILITY);
     GIVEN {
         ASSUME(gMovesInfo[MOVE_THUNDERBOLT].type == TYPE_ELECTRIC);
         AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT);
@@ -828,6 +829,27 @@ AI_SINGLE_BATTLE_TEST("AI will choose Surf over Thunderbolt and Ice Beam if the 
         OPPONENT(SPECIES_LANTURN) { Moves(MOVE_THUNDERBOLT, MOVE_ICE_BEAM, MOVE_SURF); }
     } WHEN {
         TURN { EXPECT_MOVE(opponent, MOVE_SURF); }
+        TURN { EXPECT_MOVE(opponent, MOVE_SURF); }
+    } SCENE {
+        MESSAGE("Foe Lanturn used Surf!");
+        MESSAGE("Foe Lanturn used Surf!");
+    }
+}
+
+AI_SINGLE_BATTLE_TEST("AI will choose Thunderbolt then Surf 2/3 times if the opposing mon has Volt Absorb")
+{
+    PASSES_RANDOMLY(2, 3, RNG_AI_ABILITY);
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_THUNDERBOLT].type == TYPE_ELECTRIC);
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT);
+        PLAYER(SPECIES_LANTURN) { Ability(ABILITY_VOLT_ABSORB); };
+        OPPONENT(SPECIES_LANTURN) { Moves(MOVE_THUNDERBOLT, MOVE_ICE_BEAM, MOVE_SURF); }
+    } WHEN {
+        TURN { EXPECT_MOVE(opponent, MOVE_THUNDERBOLT); }
+        TURN { EXPECT_MOVE(opponent, MOVE_SURF); }
+    } SCENE {
+        MESSAGE("Foe Lanturn used Thunderbolt!");
+        MESSAGE("Foe Lanturn used Surf!");
     }
 }
 


### PR DESCRIPTION
## Description
The "Surf/Thunderbolt" test previously relied on AI guessing the opponents Ability correctly. Now all 3 possible ability guess scenarios are covered.
This PR introduces a new RandomTag for AI ability guesses.
Only using EXPECT_MOVE does not seem to work correctly, which is why the SCENE statements have been added.

## **Discord contact info**
.cawt
