### PR TITLE
Fix Pokemon in tests not being male by default

### DIFF
--- a/test/battle/ability/prankster.c
+++ b/test/battle/ability/prankster.c
@@ -136,7 +136,7 @@ DOUBLE_BATTLE_TEST("Prankster-affected moves that target all Pokémon are succes
 {
     GIVEN {
         ASSUME(gMovesInfo[MOVE_CAPTIVATE].target == MOVE_TARGET_BOTH);
-        PLAYER(SPECIES_VOLBEAT) { Ability(ABILITY_PRANKSTER); }
+        PLAYER(SPECIES_ILLUMISE) { Ability(ABILITY_PRANKSTER); }
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_UMBREON);
         OPPONENT(SPECIES_WOBBUFFET);

--- a/test/test_runner_battle.c
+++ b/test/test_runner_battle.c
@@ -1553,7 +1553,7 @@ void OpenPokemon(u32 sourceLine, u32 side, u32 species)
     DATA.currentSide = side;
     DATA.currentPartyIndex = *partySize;
     DATA.currentMon = &party[DATA.currentPartyIndex];
-    DATA.gender = MON_MALE;
+    DATA.gender = 0xFF; // Male
     DATA.nature = NATURE_HARDY;
     (*partySize)++;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Apparently the Pokemon in tests were always meant to be male by default, but a define was read wrong and they all became female on accident. This properly fixes that.

## **Discord contact info**
kittenchilly