### PR TITLE
Add evolution tracker check tests

### DIFF
--- a/test/species.c
+++ b/test/species.c
@@ -85,3 +85,47 @@ TEST("Form change targets have the appropriate species flags")
        }
     }
 }
+
+TEST("No species has two evolutions that use the evolution tracker")
+{
+    u32 i;
+    u32 species = SPECIES_NONE;
+    u32 evolutionTrackerEvolutions;
+    bool32 hasGenderBasedRecoil;
+    const struct Evolution *evolutions;
+
+    for (i = 0; i < NUM_SPECIES; i++)
+    {
+        if (GetSpeciesEvolutions(i) != NULL) PARAMETRIZE { species = i; }
+    }
+
+    evolutionTrackerEvolutions = 0;
+    hasGenderBasedRecoil = FALSE;
+    evolutions = GetSpeciesEvolutions(species);
+
+    for (i = 0; evolutions[i].method != EVOLUTIONS_END; i++)
+    {
+        if (evolutions[i].method == EVO_LEVEL_MOVE_TWENTY_TIMES
+    #ifdef EVO_DEFEAT_WITH_ITEM
+         || evolutions[i].method == EVO_DEFEAT_WITH_ITEM
+    #endif //EVO_DEFEAT_WITH_ITEM
+    #ifdef EVO_OVERWORLD_STEPS
+         || evolutions[i].method == EVO_OVERWORLD_STEPS
+    #endif //EVO_OVERWORLD_STEPS
+        )
+            evolutionTrackerEvolutions++;
+
+        if (evolutions[i].method == EVO_LEVEL_RECOIL_DAMAGE_MALE
+         || evolutions[i].method == EVO_LEVEL_RECOIL_DAMAGE_FEMALE)
+        {
+            // Special handling for these since they can be combined as the evolution tracker field is used for the same purpose
+            if (!hasGenderBasedRecoil)
+            {
+                hasGenderBasedRecoil = TRUE;
+                evolutionTrackerEvolutions++;
+            }
+        }
+    }
+
+    EXPECT(evolutionTrackerEvolutions < 2);
+}


### PR DESCRIPTION
Due to there being a single evolution tracker field (because it'd be impossible otherwise), Pokémon with two evolution methods that both need the field but conflict in usage (e.g. trying to both keep track of steps in the overworld and recoil damage) now no longer pass the test. This helps prevent unwanted behaviour when expansion users add new species or forms that would use two different evolution tracker methods.

I know the #ifdefs are a little unorthodox, but this allows this test to go to master (where we already have two different evoliution tracker usages) without the test accidentally becoming out of date when the two new evolution methods introduced in upcoming drop.

## **Discord contact info**
bassoonian
