### PR TITLE
Fix Smack Down anim + move anim tests

### DIFF
--- a/data/battle_anim_scripts.s
+++ b/data/battle_anim_scripts.s
@@ -5168,7 +5168,6 @@ Move_SMACK_DOWN::
 	createvisualtask AnimTask_SmokescreenImpact, 0x8, 0x400, 0x1902
 	fadetobg BG_IN_AIR
 	waitbgfadeout
-	createvisualtask AnimTask_StartSlidingBg, 5, 0x0, 0x0, 0x0, 0xffff
 	createvisualtask AnimTask_SeismicTossBgAccelerateDownAtEnd, 3
 	goto SeismicTossWeak
 

--- a/include/test/battle.h
+++ b/include/test/battle.h
@@ -997,6 +997,8 @@ void SendOut(u32 sourceLine, struct BattlePokemon *, u32 partyIndex);
 #define NONE_OF for (OpenQueueGroup(__LINE__, QUEUE_GROUP_NONE_OF); gBattleTestRunnerState->data.queueGroupType != QUEUE_GROUP_NONE; CloseQueueGroup(__LINE__))
 #define NOT NONE_OF
 
+#define FORCE_MOVE_ANIM(set) gBattleTestRunnerState->forceMoveAnim = (set)
+
 #define ABILITY_POPUP(battler, ...) QueueAbility(__LINE__, battler, (struct AbilityEventContext) { __VA_ARGS__ })
 #define ANIMATION(type, id, ...) QueueAnimation(__LINE__, type, id, (struct AnimationEventContext) { __VA_ARGS__ })
 #define HP_BAR(battler, ...) QueueHP(__LINE__, battler, (struct HPEventContext) { APPEND_TRUE(__VA_ARGS__) })

--- a/include/test/battle.h
+++ b/include/test/battle.h
@@ -695,6 +695,7 @@ struct BattleTestData
 struct BattleTestRunnerState
 {
     u8 battlersCount;
+    bool8 forceMoveAnim;
     u16 parametersCount; // Valid only in BattleTest_Setup.
     u16 parameters;
     u16 runParameter;

--- a/src/battle_anim.c
+++ b/src/battle_anim.c
@@ -18,6 +18,7 @@
 #include "sprite.h"
 #include "task.h"
 #include "test_runner.h"
+#include "test/battle.h"
 #include "constants/battle_anim.h"
 #include "constants/moves.h"
 
@@ -238,7 +239,7 @@ void LaunchBattleAnimation(u32 animType, u32 animId)
     {
         TestRunner_Battle_RecordAnimation(animType, animId);
         // Play Transform and Ally Switch even in Headless as these move animations also change mon data.
-        if (gTestRunnerHeadless
+        if ((gTestRunnerHeadless && !gBattleTestRunnerState->forceMoveAnim)
             && !(animType == ANIM_TYPE_MOVE && (animId == MOVE_TRANSFORM || animId == MOVE_ALLY_SWITCH)))
         {
             gAnimScriptCallback = Nop;
@@ -446,7 +447,7 @@ static u8 GetBattleAnimMoveTargets(u8 battlerArgIndex, u8 *targets)
     u32 i;
     u32 ignoredTgt = gBattlerAttacker;
     u32 target = GetBattlerMoveTargetType(gBattleAnimAttacker, gAnimMoveIndex);
-    
+
     switch (battlerAnimId)
     {
     case ANIM_ATTACKER:
@@ -458,7 +459,7 @@ static u8 GetBattleAnimMoveTargets(u8 battlerArgIndex, u8 *targets)
         ignoredTgt = gBattlerAttacker;
         break;
     }
-    
+
     switch (target)
     {
     case MOVE_TARGET_FOES_AND_ALLY:

--- a/src/battle_anim.c
+++ b/src/battle_anim.c
@@ -238,6 +238,7 @@ void LaunchBattleAnimation(u32 animType, u32 animId)
     if (gTestRunnerEnabled)
     {
         TestRunner_Battle_RecordAnimation(animType, animId);
+        #if TESTING
         // Play Transform and Ally Switch even in Headless as these move animations also change mon data.
         if ((gTestRunnerHeadless && !gBattleTestRunnerState->forceMoveAnim)
             && !(animType == ANIM_TYPE_MOVE && (animId == MOVE_TRANSFORM || animId == MOVE_ALLY_SWITCH)))
@@ -246,6 +247,7 @@ void LaunchBattleAnimation(u32 animType, u32 animId)
             gAnimScriptActive = FALSE;
             return;
         }
+        #endif // TESTING
     }
 
     switch (animType)

--- a/src/battle_anim.c
+++ b/src/battle_anim.c
@@ -238,16 +238,17 @@ void LaunchBattleAnimation(u32 animType, u32 animId)
     if (gTestRunnerEnabled)
     {
         TestRunner_Battle_RecordAnimation(animType, animId);
-        #if TESTING
         // Play Transform and Ally Switch even in Headless as these move animations also change mon data.
-        if ((gTestRunnerHeadless && !gBattleTestRunnerState->forceMoveAnim)
+        if (gTestRunnerHeadless
+            #if TESTING // Because gBattleTestRunnerState is not seen outside of test env.
+             && !gBattleTestRunnerState->forceMoveAnim
+            #endif // TESTING
             && !(animType == ANIM_TYPE_MOVE && (animId == MOVE_TRANSFORM || animId == MOVE_ALLY_SWITCH)))
         {
             gAnimScriptCallback = Nop;
             gAnimScriptActive = FALSE;
             return;
         }
-        #endif // TESTING
     }
 
     switch (animType)

--- a/test/battle/move_animations/smack_down.c
+++ b/test/battle/move_animations/smack_down.c
@@ -3,8 +3,8 @@
 
 SINGLE_BATTLE_TEST("Move Animation Test: Smack Down works when used 15 times in a row")
 {
-    gBattleTestRunnerState->forceMoveAnim = TRUE;
     u16 j, nTurns = 15;
+    gBattleTestRunnerState->forceMoveAnim = TRUE;
 
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);

--- a/test/battle/move_animations/smack_down.c
+++ b/test/battle/move_animations/smack_down.c
@@ -4,7 +4,7 @@
 SINGLE_BATTLE_TEST("Move Animation Test: Smack Down works when used 15 times in a row")
 {
     u16 j, nTurns = 15;
-    gBattleTestRunnerState->forceMoveAnim = TRUE;
+    FORCE_MOVE_ANIM(TRUE);
 
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);
@@ -20,6 +20,6 @@ SINGLE_BATTLE_TEST("Move Animation Test: Smack Down works when used 15 times in 
             ANIMATION(ANIM_TYPE_MOVE, MOVE_SMACK_DOWN, player);
         }
     } THEN {
-        gBattleTestRunnerState->forceMoveAnim = FALSE;
+        FORCE_MOVE_ANIM(FALSE);
     }
 }

--- a/test/battle/move_animations/smack_down.c
+++ b/test/battle/move_animations/smack_down.c
@@ -1,0 +1,25 @@
+#include "global.h"
+#include "test/battle.h"
+
+SINGLE_BATTLE_TEST("Move Animation Test: Smack Down works when used 15 times in a row")
+{
+    gBattleTestRunnerState->forceMoveAnim = TRUE;
+    u16 j, nTurns = 15;
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        for (j = 0; j < nTurns; j++)
+        {
+            TURN { MOVE(player, MOVE_SMACK_DOWN); MOVE(opponent, MOVE_HELPING_HAND); } // Helping Hand, so there's no anim on the opponent's side.
+        }
+    } SCENE {
+        for (j = 0; j < nTurns; j++)
+        {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_SMACK_DOWN, player);
+        }
+    } THEN {
+        gBattleTestRunnerState->forceMoveAnim = FALSE;
+    }
+}


### PR DESCRIPTION
Fixes #4754

Turns out the issue wasn't related to obedience, but to how many times the Smack Down move was used. I was able to get the issue to happen exactly after 13th use.

I also added a way to check the move animations in tests(that is if they crash/softlock) with `gBattleTestRunnerState->forceMoveAnim = TRUE;`
With that we should be able to check all of the move animations now(with appropriate tests).