### PR TITLE
Fix Revive in double battles

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -16073,6 +16073,7 @@ void BS_ItemRestoreHP(void)
             if (gBattleTypeFlags & BATTLE_TYPE_DOUBLE && battler != MAX_BATTLERS_COUNT)
             {
                 gAbsentBattlerFlags &= ~gBitTable[battler];
+                gBattleMons[battler].hp = hp;
                 gBattleCommunication[MULTIUSE_STATE] = TRUE;
             }
             gBattlescriptCurrInstr = cmd->nextInstr;

--- a/test/battle/item_effect/revive.c
+++ b/test/battle/item_effect/revive.c
@@ -73,4 +73,30 @@ SINGLE_BATTLE_TEST("Max Honey restores a fainted battler's HP fully")
     }
 }
 
+// Note: this test is oddly specific with implicit moves/speeds, because I had errors/invalids without them.
+DOUBLE_BATTLE_TEST("Revive works for a partner in a double battle")
+{
+    GIVEN {
+        ASSUME(gItemsInfo[ITEM_REVIVE].battleUsage == EFFECT_ITEM_REVIVE);
+        PLAYER(SPECIES_WYNAUT) { HP(1); MaxHP(200); Moves(MOVE_IRON_DEFENSE, MOVE_CELEBRATE); Speed(5); }
+        PLAYER(SPECIES_WOBBUFFET) { HP(1); Speed(4); }
+        OPPONENT(SPECIES_ABRA) { Speed(3); Moves(MOVE_TACKLE, MOVE_PSYCHIC, MOVE_CELEBRATE); }
+        OPPONENT(SPECIES_KADABRA) { Speed(2); Moves(MOVE_TACKLE, MOVE_PSYCHIC, MOVE_CELEBRATE, MOVE_EXPLOSION); }
+    } WHEN {
+        TURN { MOVE(opponentRight, MOVE_PSYCHIC, target:playerLeft); MOVE(playerLeft, MOVE_CELEBRATE); } // Wynaut faints
+        TURN { USE_ITEM(playerRight, ITEM_REVIVE, partyIndex: 0); MOVE(opponentRight, MOVE_PSYCHIC, target:playerRight); } // Wynaut gets revived, Wobb faints
+        // Wynaut is functionally back
+        TURN { MOVE(opponentLeft, MOVE_TACKLE, target:playerLeft); }
+        TURN { MOVE(opponentRight, MOVE_TACKLE, target:playerLeft); }
+        TURN { MOVE(opponentRight, MOVE_EXPLOSION); } // Everyone dies, the test can finish.
+    } SCENE {
+        MESSAGE("Wynaut fainted!");
+        MESSAGE("You used Revive!");
+        // Switch-in animation
+        MESSAGE("Wobbuffet fainted!");
+        HP_BAR(playerLeft);
+        HP_BAR(playerLeft);
+    }
+}
+
 TO_DO_BATTLE_TEST("Revive won't restore a battler's HP if it hasn't fainted")


### PR DESCRIPTION
Fixes #4783

The battler's HP was not updated, so the game treated the revived mon as fainted which caused the weird Mega Evo glitch.