### PR TITLE
Fix Tectonic Rage causing a freeze after leveling up

### DIFF
--- a/data/battle_anim_scripts.s
+++ b/data/battle_anim_scripts.s
@@ -29113,6 +29113,7 @@ Move_TECTONIC_RAGE:
 	waitforvisualfinish
 	call UnsetPsychicBg
 	waitbgfadein
+	clearmonbg_static ANIM_ATTACKER
 	createvisualtask AnimTask_AllBattlersVisible, 0xA
 	waitforvisualfinish
 	end


### PR DESCRIPTION
Fixes #4537

`clearmonbg_static` cmd was missing from the anim's battlescript.

![tecon rage](https://github.com/rh-hideout/pokeemerald-expansion/assets/16259973/6d046916-2328-4619-a36b-0564d6c58a1e)
