### PR TITLE
Added option to disable species cries

### DIFF
--- a/include/config/pokemon.h
+++ b/include/config/pokemon.h
@@ -41,6 +41,7 @@
 // Other settings
 #define P_CUSTOM_GENDER_DIFF_ICONS  TRUE        // If TRUE, will give more Pokémon custom icons for their female forms, i.e. Hippopotas and Hippowdon
 #define P_FOOTPRINTS                TRUE        // If TRUE, Pokémon will have footprints (as was the case up to Gen 5 and in BDSP). Disabling this saves some ROM space.
+#define P_CRIES_ENABLED             TRUE        // If TRUE, Pokémon will have cries. Disabling this saves around a LOT of ROM space (over 25%!), but instead we recommend disabling individual unused Pokémon families in include/config/species_enabled.h.
 #define P_LEGENDARY_PERFECT_IVS     GEN_LATEST  // Since Gen 6, Legendaries, Mythicals and Ultra Beasts found in the wild or given through gifts have at least 3 perfect IVs.
 #define P_EV_CAP                    GEN_LATEST  // Since Gen 6, the max EVs per stat is 252 instead of 255.
 #define P_SHOW_TERA_TYPE            GEN_8       // Since Gen 9, the Tera Type is shown on the summary screen.

--- a/sound/cry_tables.inc
+++ b/sound/cry_tables.inc
@@ -1,5 +1,6 @@
 	.align 2
 gCryTable::
+.if P_CRIES_ENABLED == TRUE
 .if P_FAMILY_BULBASAUR == TRUE
 	cry Cry_Bulbasaur
 	cry Cry_Ivysaur
@@ -2423,9 +2424,11 @@ gCryTable::
 .if P_FAMILY_PECHARUNT == TRUE
 	cry Cry_Pecharunt
 .endif @ P_FAMILY_PECHARUNT
+.endif @ P_CRIES_ENABLED
 
 	.align 2
 gCryTable_Reverse::
+.if P_CRIES_ENABLED == TRUE
 .if P_FAMILY_BULBASAUR == TRUE
 	cry_reverse Cry_Bulbasaur
 	cry_reverse Cry_Ivysaur
@@ -4849,3 +4852,4 @@ gCryTable_Reverse::
 .if P_FAMILY_PECHARUNT == TRUE
 	cry_reverse Cry_Pecharunt
 .endif @ P_FAMILY_PECHARUNT
+.endif @ P_CRIES_ENABLED

--- a/sound/direct_sound_data.inc
+++ b/sound/direct_sound_data.inc
@@ -386,6 +386,7 @@ DirectSoundWaveData_unknown_16::
 DirectSoundWaveData_unknown_17::
 	.incbin "sound/direct_sound_samples/unknown_17.bin"
 
+.if P_CRIES_ENABLED == TRUE
 .if P_FAMILY_BULBASAUR == TRUE
 	.align 2
 Cry_Bulbasaur::
@@ -6153,6 +6154,7 @@ Cry_Terapagos::
 Cry_Pecharunt::
 	.incbin "sound/direct_sound_samples/cries/pecharunt.bin"
 .endif @ P_FAMILY_PECHARUNT
+.endif @ P_CRIES_ENABLED
 
 	.align 2
 DirectSoundWaveData_register_noise::

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -6814,8 +6814,8 @@ void HealBoxPokemon(struct BoxPokemon *boxMon)
 u16 GetCryIdBySpecies(u16 species)
 {
     species = SanitizeSpeciesId(species);
-    if (gSpeciesInfo[species].cryId >= CRY_COUNT)
-        return 0;
+    if (gSpeciesInfo[species].cryId >= CRY_COUNT || P_CRIES_ENABLED == FALSE)
+        return CRY_NONE;
     return gSpeciesInfo[species].cryId;
 }
 

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -6814,7 +6814,7 @@ void HealBoxPokemon(struct BoxPokemon *boxMon)
 u16 GetCryIdBySpecies(u16 species)
 {
     species = SanitizeSpeciesId(species);
-    if (gSpeciesInfo[species].cryId >= CRY_COUNT || P_CRIES_ENABLED == FALSE)
+    if (P_CRIES_ENABLED == FALSE || gSpeciesInfo[species].cryId >= CRY_COUNT)
         return CRY_NONE;
     return gSpeciesInfo[species].cryId;
 }

--- a/src/sound.c
+++ b/src/sound.c
@@ -5,6 +5,7 @@
 #include "m4a.h"
 #include "main.h"
 #include "pokemon.h"
+#include "constants/cries.h"
 #include "constants/songs.h"
 #include "task.h"
 
@@ -460,7 +461,7 @@ void PlayCryInternal(u16 species, s8 pan, s8 volume, u8 priority, u8 mode)
     SetPokemonCryPriority(priority);
 
     species = GetCryIdBySpecies(species);
-    if (species != 0)
+    if (species != CRY_NONE)
     {
         species--;
         gMPlay_PokemonCry = SetPokemonCryTone(reverse ? &gCryTable_Reverse[species] : &gCryTable[species]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Had this made for a bit after some people were asking about it, but myself I don't see it being much useful without determining a "default cry". This PR could be used as a point of discussion as well.

## Feature(s) this PR does NOT handle:
Doesn't remove the "cry" page from the pokedexes. 

## **Discord contact info**
AsparagusEduardo
