### PR TITLE
Fix starting terrain making all other terrains infinite

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -16372,9 +16372,9 @@ void BS_SetRemoveTerrain(void)
     }
     else
     {
-        u16 atkHoldEffect = GetBattlerHoldEffect(gBattlerAttacker, TRUE);
+        u32 atkHoldEffect = GetBattlerHoldEffect(gBattlerAttacker, TRUE);
 
-        gFieldStatuses &= ~STATUS_FIELD_TERRAIN_ANY;
+        gFieldStatuses &= ~(STATUS_FIELD_TERRAIN_ANY | STATUS_FIELD_TERRAIN_PERMANENT);
         gFieldStatuses |= statusFlag;
         gFieldTimers.terrainTimer = (atkHoldEffect == HOLD_EFFECT_TERRAIN_EXTENDER) ? 8 : 5;
         gBattlescriptCurrInstr = cmd->nextInstr;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3886,7 +3886,7 @@ static bool32 TryChangeBattleTerrain(u32 battler, u32 statusFlag, u8 *timer)
 {
     if ((!(gFieldStatuses & statusFlag) && (!gBattleStruct->isSkyBattle)))
     {
-        gFieldStatuses &= ~(STATUS_FIELD_MISTY_TERRAIN | STATUS_FIELD_GRASSY_TERRAIN | STATUS_FIELD_ELECTRIC_TERRAIN | STATUS_FIELD_PSYCHIC_TERRAIN);
+        gFieldStatuses &= ~(STATUS_FIELD_TERRAIN_ANY | STATUS_FIELD_TERRAIN_PERMANENT);
         gFieldStatuses |= statusFlag;
         gDisableStructs[battler].terrainAbilityDone = FALSE;
 

--- a/test/battle/terrain/starting_terrain.c
+++ b/test/battle/terrain/starting_terrain.c
@@ -1,0 +1,113 @@
+#include "global.h"
+#include "event_data.h"
+#include "test/battle.h"
+
+#if B_VAR_STARTING_STATUS != 0
+
+SINGLE_BATTLE_TEST("B_VAR_STARTING_STATUS starts a chosen terrain at the beginning of battle and lasts infinitely long")
+{
+    u16 terrain;
+
+    PARAMETRIZE { terrain = STARTING_STATUS_GRASSY_TERRAIN; }
+    PARAMETRIZE { terrain = STARTING_STATUS_PSYCHIC_TERRAIN; }
+    PARAMETRIZE { terrain = STARTING_STATUS_MISTY_TERRAIN; }
+    PARAMETRIZE { terrain = STARTING_STATUS_ELECTRIC_TERRAIN; }
+
+    VarSet(B_VAR_STARTING_STATUS, terrain);
+    VarSet(B_VAR_STARTING_STATUS_TIMER, 0);
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        // More than 5 turns
+        TURN { ; }
+        TURN { ; }
+        TURN { ; }
+        TURN { ; }
+        TURN { ; }
+        TURN { ; }
+        TURN { ; }
+    } SCENE {
+        switch (terrain) {
+            case STARTING_STATUS_GRASSY_TERRAIN:
+                MESSAGE("Grass grew to cover the battlefield!");
+                break;
+            case STARTING_STATUS_PSYCHIC_TERRAIN:
+                MESSAGE("The battlefield got weird!");
+                break;
+            case STARTING_STATUS_MISTY_TERRAIN:
+                MESSAGE("Mist swirled about the battlefield!");
+                break;
+            case STARTING_STATUS_ELECTRIC_TERRAIN:
+                MESSAGE("An electric current runs across the battlefield!");
+                break;
+        }
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_RESTORE_BG);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_RESTORE_BG);
+            MESSAGE("The weirdness disappeared from the battlefield.");
+            MESSAGE("The electricity disappeared from the battlefield.");
+            MESSAGE("The mist disappeared from the battlefield.");
+            MESSAGE("The grass disappeared from the battlefield.");
+        }
+    } THEN {
+        VarSet(B_VAR_STARTING_STATUS, 0);
+    }
+}
+
+SINGLE_BATTLE_TEST("Terrain started after the one which started the battle lasts only 5 turns")
+{
+    bool32 viaMove;
+
+    PARAMETRIZE { viaMove = TRUE; }
+    PARAMETRIZE { viaMove = FALSE; }
+
+    VarSet(B_VAR_STARTING_STATUS, STARTING_STATUS_ELECTRIC_TERRAIN);
+    VarSet(B_VAR_STARTING_STATUS_TIMER, 0);
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Ability(viaMove == TRUE ? ABILITY_SHADOW_TAG : ABILITY_GRASSY_SURGE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        // More than 5 turns
+        TURN { MOVE(player, viaMove == TRUE ? MOVE_GRASSY_TERRAIN : MOVE_CELEBRATE); }
+        TURN { ; }
+        TURN { ; }
+        TURN { ; }
+        TURN { ; }
+        TURN { ; }
+        TURN { ; }
+    } SCENE {
+        // Electric Terrain at battle's start
+        MESSAGE("An electric current runs across the battlefield!");
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_RESTORE_BG);
+        // Player uses Grassy Terrain
+        if (viaMove) {
+            MESSAGE("Wobbuffet used GrssyTerrain!");
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_GRASSY_TERRAIN, player);
+            MESSAGE("Grass grew to cover the battlefield!");
+        } else {
+            ABILITY_POPUP(player, ABILITY_GRASSY_SURGE);
+            MESSAGE("Grass grew to cover the battlefield!");
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_RESTORE_BG);
+        }
+
+        // 5 turns
+        MESSAGE("Wobbuffet used Celebrate!");
+        MESSAGE("Foe Wobbuffet used Celebrate!");
+
+        MESSAGE("Wobbuffet used Celebrate!");
+        MESSAGE("Foe Wobbuffet used Celebrate!");
+
+        MESSAGE("Wobbuffet used Celebrate!");
+        MESSAGE("Foe Wobbuffet used Celebrate!");
+
+        MESSAGE("The grass disappeared from the battlefield.");
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_RESTORE_BG);
+    } THEN {
+        VarSet(B_VAR_STARTING_STATUS, 0);
+    }
+}
+
+#endif // B_VAR_STARTING_STATUS


### PR DESCRIPTION
Fixes #4587

Note: the created tests won't run now, because `B_VAR_STARTING_STATUS ` is set to 0. But they'll run locally for users which use that variable, they failed before and now pass.