### PR TITLE
Don't try to deploy to GitHub Pages if it's not enabled

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,8 +26,18 @@ jobs:
         run: |
           cd docs
           mdbook build
+      - name: Check if Pages is enabled
+        uses: octokit/request-action@v2.x
+        id: check_pages
+        continue-on-error: true
+        with:
+          route: GET /repos/{repo}/pages
+          repo: ${{ github.repository }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Pages
         uses: actions/configure-pages@v4
+        if: steps.check_pages.outcome == 'success'
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
@@ -35,3 +45,4 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        if: steps.check_pages.outcome == 'success'


### PR DESCRIPTION
## Description
This uses the [octokit/request-action](https://github.com/octokit/request-action) action (which I believe is owned by GitHub?) to intentionally fail early if GitHub Pages isn't enabled for the repository, and allows the workflow to still succeed. This is mostly inconsequential, but prevents forks with Actions enabled but not Pages from having their `master` branch marked as failing.

I haven't seen any other repos that do anything like this, but @AlexOn1ine reported confusion from the failing workflow on Discord. It could conceivably also mask legitimate issues, but this would be rare.

## **Discord contact info**
leo60228