### PR TITLE
Force species in tests

### DIFF
--- a/include/config/test.h
+++ b/include/config/test.h
@@ -306,6 +306,7 @@
 #define P_FAMILY_HO_OH                   TRUE
 #undef P_FAMILY_CELEBI
 #define P_FAMILY_CELEBI                  TRUE
+
 #undef P_FAMILY_TREECKO
 #define P_FAMILY_TREECKO                 TRUE
 #undef P_FAMILY_TORCHIC

--- a/include/config/test.h
+++ b/include/config/test.h
@@ -888,6 +888,7 @@
 #define P_FAMILY_ZERAORA                 TRUE
 #undef P_FAMILY_MELTAN
 #define P_FAMILY_MELTAN                  TRUE
+
 #undef P_FAMILY_GROOKEY
 #define P_FAMILY_GROOKEY                 TRUE
 #undef P_FAMILY_SCORBUNNY

--- a/include/config/test.h
+++ b/include/config/test.h
@@ -984,6 +984,7 @@
 #define P_FAMILY_CALYREX                 TRUE
 #undef P_FAMILY_ENAMORUS
 #define P_FAMILY_ENAMORUS                TRUE
+
 #undef P_FAMILY_SPRIGATITO
 #define P_FAMILY_SPRIGATITO              TRUE
 #undef P_FAMILY_FUECOCO

--- a/include/config/test.h
+++ b/include/config/test.h
@@ -203,6 +203,7 @@
 #define P_FAMILY_MEWTWO                  TRUE
 #undef P_FAMILY_MEW
 #define P_FAMILY_MEW                     TRUE
+
 #undef P_FAMILY_CHIKORITA
 #define P_FAMILY_CHIKORITA               TRUE
 #undef P_FAMILY_CYNDAQUIL

--- a/include/config/test.h
+++ b/include/config/test.h
@@ -36,8 +36,6 @@
 #define P_COSPLAY_PIKACHU_FORMS          TRUE
 #undef P_CAP_PIKACHU_FORMS
 #define P_CAP_PIKACHU_FORMS              TRUE
-#undef P_CROSS_GENERATION_EVOS
-#define P_CROSS_GENERATION_EVOS          TRUE
 #undef P_GEN_2_CROSS_EVOS
 #define P_GEN_2_CROSS_EVOS               TRUE
 #undef P_GEN_3_CROSS_EVOS

--- a/include/config/test.h
+++ b/include/config/test.h
@@ -22,8 +22,6 @@
 #define P_TERA_FORMS                     TRUE
 #undef P_FUSION_FORMS
 #define P_FUSION_FORMS                   TRUE
-#undef P_REGIONAL_FORMS
-#define P_REGIONAL_FORMS                 TRUE
 #undef P_ALOLAN_FORMS
 #define P_ALOLAN_FORMS                   TRUE
 #undef P_GALARIAN_FORMS

--- a/include/config/test.h
+++ b/include/config/test.h
@@ -451,6 +451,7 @@
 #define P_FAMILY_JIRACHI                 TRUE
 #undef P_FAMILY_DEOXYS
 #define P_FAMILY_DEOXYS                  TRUE
+
 #undef P_FAMILY_TURTWIG
 #define P_FAMILY_TURTWIG                 TRUE
 #undef P_FAMILY_CHIMCHAR

--- a/include/config/test.h
+++ b/include/config/test.h
@@ -52,6 +52,7 @@
 #define P_GEN_8_CROSS_EVOS               TRUE
 #undef P_GEN_9_CROSS_EVOS
 #define P_GEN_9_CROSS_EVOS               TRUE
+
 #undef P_FAMILY_BULBASAUR
 #define P_FAMILY_BULBASAUR               TRUE
 #undef P_FAMILY_CHARMANDER

--- a/include/config/test.h
+++ b/include/config/test.h
@@ -779,6 +779,7 @@
 #define P_FAMILY_HOOPA                   TRUE
 #undef P_FAMILY_VOLCANION
 #define P_FAMILY_VOLCANION               TRUE
+
 #undef P_FAMILY_ROWLET
 #define P_FAMILY_ROWLET                  TRUE
 #undef P_FAMILY_LITTEN

--- a/include/config/test.h
+++ b/include/config/test.h
@@ -10,4 +10,1125 @@
 #undef B_EXPANDED_TYPE_NAMES
 #define B_EXPANDED_TYPE_NAMES TRUE
 
+#undef P_MEGA_EVOLUTIONS
+#define P_MEGA_EVOLUTIONS                TRUE
+#undef P_PRIMAL_REVERSIONS
+#define P_PRIMAL_REVERSIONS              TRUE
+#undef P_ULTRA_BURST_FORMS
+#define P_ULTRA_BURST_FORMS              TRUE
+#undef P_GIGANTAMAX_FORMS
+#define P_GIGANTAMAX_FORMS               TRUE
+#undef P_TERA_FORMS
+#define P_TERA_FORMS                     TRUE
+#undef P_FUSION_FORMS
+#define P_FUSION_FORMS                   TRUE
+#undef P_REGIONAL_FORMS
+#define P_REGIONAL_FORMS                 TRUE
+#undef P_ALOLAN_FORMS
+#define P_ALOLAN_FORMS                   TRUE
+#undef P_GALARIAN_FORMS
+#define P_GALARIAN_FORMS                 TRUE
+#undef P_HISUIAN_FORMS
+#define P_HISUIAN_FORMS                  TRUE
+#undef P_PALDEAN_FORMS
+#define P_PALDEAN_FORMS                  TRUE
+#undef P_PIKACHU_EXTRA_FORMS
+#define P_PIKACHU_EXTRA_FORMS            TRUE
+#undef P_COSPLAY_PIKACHU_FORMS
+#define P_COSPLAY_PIKACHU_FORMS          TRUE
+#undef P_CAP_PIKACHU_FORMS
+#define P_CAP_PIKACHU_FORMS              TRUE
+#undef P_CROSS_GENERATION_EVOS
+#define P_CROSS_GENERATION_EVOS          TRUE
+#undef P_GEN_2_CROSS_EVOS
+#define P_GEN_2_CROSS_EVOS               TRUE
+#undef P_GEN_3_CROSS_EVOS
+#define P_GEN_3_CROSS_EVOS               TRUE
+#undef P_GEN_4_CROSS_EVOS
+#define P_GEN_4_CROSS_EVOS               TRUE
+#undef P_GEN_6_CROSS_EVOS
+#define P_GEN_6_CROSS_EVOS               TRUE
+#undef P_GEN_8_CROSS_EVOS
+#define P_GEN_8_CROSS_EVOS               TRUE
+#undef P_GEN_9_CROSS_EVOS
+#define P_GEN_9_CROSS_EVOS               TRUE
+#undef P_FAMILY_BULBASAUR
+#define P_FAMILY_BULBASAUR               TRUE
+#undef P_FAMILY_CHARMANDER
+#define P_FAMILY_CHARMANDER              TRUE
+#undef P_FAMILY_SQUIRTLE
+#define P_FAMILY_SQUIRTLE                TRUE
+#undef P_FAMILY_CATERPIE
+#define P_FAMILY_CATERPIE                TRUE
+#undef P_FAMILY_WEEDLE
+#define P_FAMILY_WEEDLE                  TRUE
+#undef P_FAMILY_PIDGEY
+#define P_FAMILY_PIDGEY                  TRUE
+#undef P_FAMILY_RATTATA
+#define P_FAMILY_RATTATA                 TRUE
+#undef P_FAMILY_SPEAROW
+#define P_FAMILY_SPEAROW                 TRUE
+#undef P_FAMILY_EKANS
+#define P_FAMILY_EKANS                   TRUE
+#undef P_FAMILY_PIKACHU
+#define P_FAMILY_PIKACHU                 TRUE
+#undef P_FAMILY_SANDSHREW
+#define P_FAMILY_SANDSHREW               TRUE
+#undef P_FAMILY_NIDORAN
+#define P_FAMILY_NIDORAN                 TRUE
+#undef P_FAMILY_CLEFAIRY
+#define P_FAMILY_CLEFAIRY                TRUE
+#undef P_FAMILY_VULPIX
+#define P_FAMILY_VULPIX                  TRUE
+#undef P_FAMILY_JIGGLYPUFF
+#define P_FAMILY_JIGGLYPUFF              TRUE
+#undef P_FAMILY_ZUBAT
+#define P_FAMILY_ZUBAT                   TRUE
+#undef P_FAMILY_ODDISH
+#define P_FAMILY_ODDISH                  TRUE
+#undef P_FAMILY_PARAS
+#define P_FAMILY_PARAS                   TRUE
+#undef P_FAMILY_VENONAT
+#define P_FAMILY_VENONAT                 TRUE
+#undef P_FAMILY_DIGLETT
+#define P_FAMILY_DIGLETT                 TRUE
+#undef P_FAMILY_MEOWTH
+#define P_FAMILY_MEOWTH                  TRUE
+#undef P_FAMILY_PSYDUCK
+#define P_FAMILY_PSYDUCK                 TRUE
+#undef P_FAMILY_MANKEY
+#define P_FAMILY_MANKEY                  TRUE
+#undef P_FAMILY_GROWLITHE
+#define P_FAMILY_GROWLITHE               TRUE
+#undef P_FAMILY_POLIWAG
+#define P_FAMILY_POLIWAG                 TRUE
+#undef P_FAMILY_ABRA
+#define P_FAMILY_ABRA                    TRUE
+#undef P_FAMILY_MACHOP
+#define P_FAMILY_MACHOP                  TRUE
+#undef P_FAMILY_BELLSPROUT
+#define P_FAMILY_BELLSPROUT              TRUE
+#undef P_FAMILY_TENTACOOL
+#define P_FAMILY_TENTACOOL               TRUE
+#undef P_FAMILY_GEODUDE
+#define P_FAMILY_GEODUDE                 TRUE
+#undef P_FAMILY_PONYTA
+#define P_FAMILY_PONYTA                  TRUE
+#undef P_FAMILY_SLOWPOKE
+#define P_FAMILY_SLOWPOKE                TRUE
+#undef P_FAMILY_MAGNEMITE
+#define P_FAMILY_MAGNEMITE               TRUE
+#undef P_FAMILY_FARFETCHD
+#define P_FAMILY_FARFETCHD               TRUE
+#undef P_FAMILY_DODUO
+#define P_FAMILY_DODUO                   TRUE
+#undef P_FAMILY_SEEL
+#define P_FAMILY_SEEL                    TRUE
+#undef P_FAMILY_GRIMER
+#define P_FAMILY_GRIMER                  TRUE
+#undef P_FAMILY_SHELLDER
+#define P_FAMILY_SHELLDER                TRUE
+#undef P_FAMILY_GASTLY
+#define P_FAMILY_GASTLY                  TRUE
+#undef P_FAMILY_ONIX
+#define P_FAMILY_ONIX                    TRUE
+#undef P_FAMILY_DROWZEE
+#define P_FAMILY_DROWZEE                 TRUE
+#undef P_FAMILY_KRABBY
+#define P_FAMILY_KRABBY                  TRUE
+#undef P_FAMILY_VOLTORB
+#define P_FAMILY_VOLTORB                 TRUE
+#undef P_FAMILY_EXEGGCUTE
+#define P_FAMILY_EXEGGCUTE               TRUE
+#undef P_FAMILY_CUBONE
+#define P_FAMILY_CUBONE                  TRUE
+#undef P_FAMILY_HITMONS
+#define P_FAMILY_HITMONS                 TRUE
+#undef P_FAMILY_LICKITUNG
+#define P_FAMILY_LICKITUNG               TRUE
+#undef P_FAMILY_KOFFING
+#define P_FAMILY_KOFFING                 TRUE
+#undef P_FAMILY_RHYHORN
+#define P_FAMILY_RHYHORN                 TRUE
+#undef P_FAMILY_CHANSEY
+#define P_FAMILY_CHANSEY                 TRUE
+#undef P_FAMILY_TANGELA
+#define P_FAMILY_TANGELA                 TRUE
+#undef P_FAMILY_KANGASKHAN
+#define P_FAMILY_KANGASKHAN              TRUE
+#undef P_FAMILY_HORSEA
+#define P_FAMILY_HORSEA                  TRUE
+#undef P_FAMILY_GOLDEEN
+#define P_FAMILY_GOLDEEN                 TRUE
+#undef P_FAMILY_STARYU
+#define P_FAMILY_STARYU                  TRUE
+#undef P_FAMILY_MR_MIME
+#define P_FAMILY_MR_MIME                 TRUE
+#undef P_FAMILY_SCYTHER
+#define P_FAMILY_SCYTHER                 TRUE
+#undef P_FAMILY_JYNX
+#define P_FAMILY_JYNX                    TRUE
+#undef P_FAMILY_ELECTABUZZ
+#define P_FAMILY_ELECTABUZZ              TRUE
+#undef P_FAMILY_MAGMAR
+#define P_FAMILY_MAGMAR                  TRUE
+#undef P_FAMILY_PINSIR
+#define P_FAMILY_PINSIR                  TRUE
+#undef P_FAMILY_TAUROS
+#define P_FAMILY_TAUROS                  TRUE
+#undef P_FAMILY_MAGIKARP
+#define P_FAMILY_MAGIKARP                TRUE
+#undef P_FAMILY_LAPRAS
+#define P_FAMILY_LAPRAS                  TRUE
+#undef P_FAMILY_DITTO
+#define P_FAMILY_DITTO                   TRUE
+#undef P_FAMILY_EEVEE
+#define P_FAMILY_EEVEE                   TRUE
+#undef P_FAMILY_PORYGON
+#define P_FAMILY_PORYGON                 TRUE
+#undef P_FAMILY_OMANYTE
+#define P_FAMILY_OMANYTE                 TRUE
+#undef P_FAMILY_KABUTO
+#define P_FAMILY_KABUTO                  TRUE
+#undef P_FAMILY_AERODACTYL
+#define P_FAMILY_AERODACTYL              TRUE
+#undef P_FAMILY_SNORLAX
+#define P_FAMILY_SNORLAX                 TRUE
+#undef P_FAMILY_ARTICUNO
+#define P_FAMILY_ARTICUNO                TRUE
+#undef P_FAMILY_ZAPDOS
+#define P_FAMILY_ZAPDOS                  TRUE
+#undef P_FAMILY_MOLTRES
+#define P_FAMILY_MOLTRES                 TRUE
+#undef P_FAMILY_DRATINI
+#define P_FAMILY_DRATINI                 TRUE
+#undef P_FAMILY_MEWTWO
+#define P_FAMILY_MEWTWO                  TRUE
+#undef P_FAMILY_MEW
+#define P_FAMILY_MEW                     TRUE
+#undef P_FAMILY_CHIKORITA
+#define P_FAMILY_CHIKORITA               TRUE
+#undef P_FAMILY_CYNDAQUIL
+#define P_FAMILY_CYNDAQUIL               TRUE
+#undef P_FAMILY_TOTODILE
+#define P_FAMILY_TOTODILE                TRUE
+#undef P_FAMILY_SENTRET
+#define P_FAMILY_SENTRET                 TRUE
+#undef P_FAMILY_HOOTHOOT
+#define P_FAMILY_HOOTHOOT                TRUE
+#undef P_FAMILY_LEDYBA
+#define P_FAMILY_LEDYBA                  TRUE
+#undef P_FAMILY_SPINARAK
+#define P_FAMILY_SPINARAK                TRUE
+#undef P_FAMILY_CHINCHOU
+#define P_FAMILY_CHINCHOU                TRUE
+#undef P_FAMILY_TOGEPI
+#define P_FAMILY_TOGEPI                  TRUE
+#undef P_FAMILY_NATU
+#define P_FAMILY_NATU                    TRUE
+#undef P_FAMILY_MAREEP
+#define P_FAMILY_MAREEP                  TRUE
+#undef P_FAMILY_MARILL
+#define P_FAMILY_MARILL                  TRUE
+#undef P_FAMILY_SUDOWOODO
+#define P_FAMILY_SUDOWOODO               TRUE
+#undef P_FAMILY_HOPPIP
+#define P_FAMILY_HOPPIP                  TRUE
+#undef P_FAMILY_AIPOM
+#define P_FAMILY_AIPOM                   TRUE
+#undef P_FAMILY_SUNKERN
+#define P_FAMILY_SUNKERN                 TRUE
+#undef P_FAMILY_YANMA
+#define P_FAMILY_YANMA                   TRUE
+#undef P_FAMILY_WOOPER
+#define P_FAMILY_WOOPER                  TRUE
+#undef P_FAMILY_MURKROW
+#define P_FAMILY_MURKROW                 TRUE
+#undef P_FAMILY_MISDREAVUS
+#define P_FAMILY_MISDREAVUS              TRUE
+#undef P_FAMILY_UNOWN
+#define P_FAMILY_UNOWN                   TRUE
+#undef P_FAMILY_WOBBUFFET
+#define P_FAMILY_WOBBUFFET               TRUE
+#undef P_FAMILY_GIRAFARIG
+#define P_FAMILY_GIRAFARIG               TRUE
+#undef P_FAMILY_PINECO
+#define P_FAMILY_PINECO                  TRUE
+#undef P_FAMILY_DUNSPARCE
+#define P_FAMILY_DUNSPARCE               TRUE
+#undef P_FAMILY_GLIGAR
+#define P_FAMILY_GLIGAR                  TRUE
+#undef P_FAMILY_SNUBBULL
+#define P_FAMILY_SNUBBULL                TRUE
+#undef P_FAMILY_QWILFISH
+#define P_FAMILY_QWILFISH                TRUE
+#undef P_FAMILY_SHUCKLE
+#define P_FAMILY_SHUCKLE                 TRUE
+#undef P_FAMILY_HERACROSS
+#define P_FAMILY_HERACROSS               TRUE
+#undef P_FAMILY_SNEASEL
+#define P_FAMILY_SNEASEL                 TRUE
+#undef P_FAMILY_TEDDIURSA
+#define P_FAMILY_TEDDIURSA               TRUE
+#undef P_FAMILY_SLUGMA
+#define P_FAMILY_SLUGMA                  TRUE
+#undef P_FAMILY_SWINUB
+#define P_FAMILY_SWINUB                  TRUE
+#undef P_FAMILY_CORSOLA
+#define P_FAMILY_CORSOLA                 TRUE
+#undef P_FAMILY_REMORAID
+#define P_FAMILY_REMORAID                TRUE
+#undef P_FAMILY_DELIBIRD
+#define P_FAMILY_DELIBIRD                TRUE
+#undef P_FAMILY_MANTINE
+#define P_FAMILY_MANTINE                 TRUE
+#undef P_FAMILY_SKARMORY
+#define P_FAMILY_SKARMORY                TRUE
+#undef P_FAMILY_HOUNDOUR
+#define P_FAMILY_HOUNDOUR                TRUE
+#undef P_FAMILY_PHANPY
+#define P_FAMILY_PHANPY                  TRUE
+#undef P_FAMILY_STANTLER
+#define P_FAMILY_STANTLER                TRUE
+#undef P_FAMILY_SMEARGLE
+#define P_FAMILY_SMEARGLE                TRUE
+#undef P_FAMILY_MILTANK
+#define P_FAMILY_MILTANK                 TRUE
+#undef P_FAMILY_RAIKOU
+#define P_FAMILY_RAIKOU                  TRUE
+#undef P_FAMILY_ENTEI
+#define P_FAMILY_ENTEI                   TRUE
+#undef P_FAMILY_SUICUNE
+#define P_FAMILY_SUICUNE                 TRUE
+#undef P_FAMILY_LARVITAR
+#define P_FAMILY_LARVITAR                TRUE
+#undef P_FAMILY_LUGIA
+#define P_FAMILY_LUGIA                   TRUE
+#undef P_FAMILY_HO_OH
+#define P_FAMILY_HO_OH                   TRUE
+#undef P_FAMILY_CELEBI
+#define P_FAMILY_CELEBI                  TRUE
+#undef P_FAMILY_TREECKO
+#define P_FAMILY_TREECKO                 TRUE
+#undef P_FAMILY_TORCHIC
+#define P_FAMILY_TORCHIC                 TRUE
+#undef P_FAMILY_MUDKIP
+#define P_FAMILY_MUDKIP                  TRUE
+#undef P_FAMILY_POOCHYENA
+#define P_FAMILY_POOCHYENA               TRUE
+#undef P_FAMILY_ZIGZAGOON
+#define P_FAMILY_ZIGZAGOON               TRUE
+#undef P_FAMILY_WURMPLE
+#define P_FAMILY_WURMPLE                 TRUE
+#undef P_FAMILY_LOTAD
+#define P_FAMILY_LOTAD                   TRUE
+#undef P_FAMILY_SEEDOT
+#define P_FAMILY_SEEDOT                  TRUE
+#undef P_FAMILY_TAILLOW
+#define P_FAMILY_TAILLOW                 TRUE
+#undef P_FAMILY_WINGULL
+#define P_FAMILY_WINGULL                 TRUE
+#undef P_FAMILY_RALTS
+#define P_FAMILY_RALTS                   TRUE
+#undef P_FAMILY_SURSKIT
+#define P_FAMILY_SURSKIT                 TRUE
+#undef P_FAMILY_SHROOMISH
+#define P_FAMILY_SHROOMISH               TRUE
+#undef P_FAMILY_SLAKOTH
+#define P_FAMILY_SLAKOTH                 TRUE
+#undef P_FAMILY_NINCADA
+#define P_FAMILY_NINCADA                 TRUE
+#undef P_FAMILY_WHISMUR
+#define P_FAMILY_WHISMUR                 TRUE
+#undef P_FAMILY_MAKUHITA
+#define P_FAMILY_MAKUHITA                TRUE
+#undef P_FAMILY_NOSEPASS
+#define P_FAMILY_NOSEPASS                TRUE
+#undef P_FAMILY_SKITTY
+#define P_FAMILY_SKITTY                  TRUE
+#undef P_FAMILY_SABLEYE
+#define P_FAMILY_SABLEYE                 TRUE
+#undef P_FAMILY_MAWILE
+#define P_FAMILY_MAWILE                  TRUE
+#undef P_FAMILY_ARON
+#define P_FAMILY_ARON                    TRUE
+#undef P_FAMILY_MEDITITE
+#define P_FAMILY_MEDITITE                TRUE
+#undef P_FAMILY_ELECTRIKE
+#define P_FAMILY_ELECTRIKE               TRUE
+#undef P_FAMILY_PLUSLE
+#define P_FAMILY_PLUSLE                  TRUE
+#undef P_FAMILY_MINUN
+#define P_FAMILY_MINUN                   TRUE
+#undef P_FAMILY_VOLBEAT_ILLUMISE
+#define P_FAMILY_VOLBEAT_ILLUMISE        TRUE
+#undef P_FAMILY_ROSELIA
+#define P_FAMILY_ROSELIA                 TRUE
+#undef P_FAMILY_GULPIN
+#define P_FAMILY_GULPIN                  TRUE
+#undef P_FAMILY_CARVANHA
+#define P_FAMILY_CARVANHA                TRUE
+#undef P_FAMILY_WAILMER
+#define P_FAMILY_WAILMER                 TRUE
+#undef P_FAMILY_NUMEL
+#define P_FAMILY_NUMEL                   TRUE
+#undef P_FAMILY_TORKOAL
+#define P_FAMILY_TORKOAL                 TRUE
+#undef P_FAMILY_SPOINK
+#define P_FAMILY_SPOINK                  TRUE
+#undef P_FAMILY_SPINDA
+#define P_FAMILY_SPINDA                  TRUE
+#undef P_FAMILY_TRAPINCH
+#define P_FAMILY_TRAPINCH                TRUE
+#undef P_FAMILY_CACNEA
+#define P_FAMILY_CACNEA                  TRUE
+#undef P_FAMILY_SWABLU
+#define P_FAMILY_SWABLU                  TRUE
+#undef P_FAMILY_ZANGOOSE
+#define P_FAMILY_ZANGOOSE                TRUE
+#undef P_FAMILY_SEVIPER
+#define P_FAMILY_SEVIPER                 TRUE
+#undef P_FAMILY_LUNATONE
+#define P_FAMILY_LUNATONE                TRUE
+#undef P_FAMILY_SOLROCK
+#define P_FAMILY_SOLROCK                 TRUE
+#undef P_FAMILY_BARBOACH
+#define P_FAMILY_BARBOACH                TRUE
+#undef P_FAMILY_CORPHISH
+#define P_FAMILY_CORPHISH                TRUE
+#undef P_FAMILY_BALTOY
+#define P_FAMILY_BALTOY                  TRUE
+#undef P_FAMILY_LILEEP
+#define P_FAMILY_LILEEP                  TRUE
+#undef P_FAMILY_ANORITH
+#define P_FAMILY_ANORITH                 TRUE
+#undef P_FAMILY_FEEBAS
+#define P_FAMILY_FEEBAS                  TRUE
+#undef P_FAMILY_CASTFORM
+#define P_FAMILY_CASTFORM                TRUE
+#undef P_FAMILY_KECLEON
+#define P_FAMILY_KECLEON                 TRUE
+#undef P_FAMILY_SHUPPET
+#define P_FAMILY_SHUPPET                 TRUE
+#undef P_FAMILY_DUSKULL
+#define P_FAMILY_DUSKULL                 TRUE
+#undef P_FAMILY_TROPIUS
+#define P_FAMILY_TROPIUS                 TRUE
+#undef P_FAMILY_CHIMECHO
+#define P_FAMILY_CHIMECHO                TRUE
+#undef P_FAMILY_ABSOL
+#define P_FAMILY_ABSOL                   TRUE
+#undef P_FAMILY_SNORUNT
+#define P_FAMILY_SNORUNT                 TRUE
+#undef P_FAMILY_SPHEAL
+#define P_FAMILY_SPHEAL                  TRUE
+#undef P_FAMILY_CLAMPERL
+#define P_FAMILY_CLAMPERL                TRUE
+#undef P_FAMILY_RELICANTH
+#define P_FAMILY_RELICANTH               TRUE
+#undef P_FAMILY_LUVDISC
+#define P_FAMILY_LUVDISC                 TRUE
+#undef P_FAMILY_BAGON
+#define P_FAMILY_BAGON                   TRUE
+#undef P_FAMILY_BELDUM
+#define P_FAMILY_BELDUM                  TRUE
+#undef P_FAMILY_REGIROCK
+#define P_FAMILY_REGIROCK                TRUE
+#undef P_FAMILY_REGICE
+#define P_FAMILY_REGICE                  TRUE
+#undef P_FAMILY_REGISTEEL
+#define P_FAMILY_REGISTEEL               TRUE
+#undef P_FAMILY_LATIAS
+#define P_FAMILY_LATIAS                  TRUE
+#undef P_FAMILY_LATIOS
+#define P_FAMILY_LATIOS                  TRUE
+#undef P_FAMILY_KYOGRE
+#define P_FAMILY_KYOGRE                  TRUE
+#undef P_FAMILY_GROUDON
+#define P_FAMILY_GROUDON                 TRUE
+#undef P_FAMILY_RAYQUAZA
+#define P_FAMILY_RAYQUAZA                TRUE
+#undef P_FAMILY_JIRACHI
+#define P_FAMILY_JIRACHI                 TRUE
+#undef P_FAMILY_DEOXYS
+#define P_FAMILY_DEOXYS                  TRUE
+#undef P_FAMILY_TURTWIG
+#define P_FAMILY_TURTWIG                 TRUE
+#undef P_FAMILY_CHIMCHAR
+#define P_FAMILY_CHIMCHAR                TRUE
+#undef P_FAMILY_PIPLUP
+#define P_FAMILY_PIPLUP                  TRUE
+#undef P_FAMILY_STARLY
+#define P_FAMILY_STARLY                  TRUE
+#undef P_FAMILY_BIDOOF
+#define P_FAMILY_BIDOOF                  TRUE
+#undef P_FAMILY_KRICKETOT
+#define P_FAMILY_KRICKETOT               TRUE
+#undef P_FAMILY_SHINX
+#define P_FAMILY_SHINX                   TRUE
+#undef P_FAMILY_CRANIDOS
+#define P_FAMILY_CRANIDOS                TRUE
+#undef P_FAMILY_SHIELDON
+#define P_FAMILY_SHIELDON                TRUE
+#undef P_FAMILY_BURMY
+#define P_FAMILY_BURMY                   TRUE
+#undef P_FAMILY_COMBEE
+#define P_FAMILY_COMBEE                  TRUE
+#undef P_FAMILY_PACHIRISU
+#define P_FAMILY_PACHIRISU               TRUE
+#undef P_FAMILY_BUIZEL
+#define P_FAMILY_BUIZEL                  TRUE
+#undef P_FAMILY_CHERUBI
+#define P_FAMILY_CHERUBI                 TRUE
+#undef P_FAMILY_SHELLOS
+#define P_FAMILY_SHELLOS                 TRUE
+#undef P_FAMILY_DRIFLOON
+#define P_FAMILY_DRIFLOON                TRUE
+#undef P_FAMILY_BUNEARY
+#define P_FAMILY_BUNEARY                 TRUE
+#undef P_FAMILY_GLAMEOW
+#define P_FAMILY_GLAMEOW                 TRUE
+#undef P_FAMILY_STUNKY
+#define P_FAMILY_STUNKY                  TRUE
+#undef P_FAMILY_BRONZOR
+#define P_FAMILY_BRONZOR                 TRUE
+#undef P_FAMILY_CHATOT
+#define P_FAMILY_CHATOT                  TRUE
+#undef P_FAMILY_SPIRITOMB
+#define P_FAMILY_SPIRITOMB               TRUE
+#undef P_FAMILY_GIBLE
+#define P_FAMILY_GIBLE                   TRUE
+#undef P_FAMILY_RIOLU
+#define P_FAMILY_RIOLU                   TRUE
+#undef P_FAMILY_HIPPOPOTAS
+#define P_FAMILY_HIPPOPOTAS              TRUE
+#undef P_FAMILY_SKORUPI
+#define P_FAMILY_SKORUPI                 TRUE
+#undef P_FAMILY_CROAGUNK
+#define P_FAMILY_CROAGUNK                TRUE
+#undef P_FAMILY_CARNIVINE
+#define P_FAMILY_CARNIVINE               TRUE
+#undef P_FAMILY_FINNEON
+#define P_FAMILY_FINNEON                 TRUE
+#undef P_FAMILY_SNOVER
+#define P_FAMILY_SNOVER                  TRUE
+#undef P_FAMILY_ROTOM
+#define P_FAMILY_ROTOM                   TRUE
+#undef P_FAMILY_UXIE
+#define P_FAMILY_UXIE                    TRUE
+#undef P_FAMILY_MESPRIT
+#define P_FAMILY_MESPRIT                 TRUE
+#undef P_FAMILY_AZELF
+#define P_FAMILY_AZELF                   TRUE
+#undef P_FAMILY_DIALGA
+#define P_FAMILY_DIALGA                  TRUE
+#undef P_FAMILY_PALKIA
+#define P_FAMILY_PALKIA                  TRUE
+#undef P_FAMILY_HEATRAN
+#define P_FAMILY_HEATRAN                 TRUE
+#undef P_FAMILY_REGIGIGAS
+#define P_FAMILY_REGIGIGAS               TRUE
+#undef P_FAMILY_GIRATINA
+#define P_FAMILY_GIRATINA                TRUE
+#undef P_FAMILY_CRESSELIA
+#define P_FAMILY_CRESSELIA               TRUE
+#undef P_FAMILY_MANAPHY
+#define P_FAMILY_MANAPHY                 TRUE
+#undef P_FAMILY_DARKRAI
+#define P_FAMILY_DARKRAI                 TRUE
+#undef P_FAMILY_SHAYMIN
+#define P_FAMILY_SHAYMIN                 TRUE
+#undef P_FAMILY_ARCEUS
+#define P_FAMILY_ARCEUS                  TRUE
+#undef P_FAMILY_VICTINI
+#define P_FAMILY_VICTINI                 TRUE
+#undef P_FAMILY_SNIVY
+#define P_FAMILY_SNIVY                   TRUE
+#undef P_FAMILY_TEPIG
+#define P_FAMILY_TEPIG                   TRUE
+#undef P_FAMILY_OSHAWOTT
+#define P_FAMILY_OSHAWOTT                TRUE
+#undef P_FAMILY_PATRAT
+#define P_FAMILY_PATRAT                  TRUE
+#undef P_FAMILY_LILLIPUP
+#define P_FAMILY_LILLIPUP                TRUE
+#undef P_FAMILY_PURRLOIN
+#define P_FAMILY_PURRLOIN                TRUE
+#undef P_FAMILY_PANSAGE
+#define P_FAMILY_PANSAGE                 TRUE
+#undef P_FAMILY_PANSEAR
+#define P_FAMILY_PANSEAR                 TRUE
+#undef P_FAMILY_PANPOUR
+#define P_FAMILY_PANPOUR                 TRUE
+#undef P_FAMILY_MUNNA
+#define P_FAMILY_MUNNA                   TRUE
+#undef P_FAMILY_PIDOVE
+#define P_FAMILY_PIDOVE                  TRUE
+#undef P_FAMILY_BLITZLE
+#define P_FAMILY_BLITZLE                 TRUE
+#undef P_FAMILY_ROGGENROLA
+#define P_FAMILY_ROGGENROLA              TRUE
+#undef P_FAMILY_WOOBAT
+#define P_FAMILY_WOOBAT                  TRUE
+#undef P_FAMILY_DRILBUR
+#define P_FAMILY_DRILBUR                 TRUE
+#undef P_FAMILY_AUDINO
+#define P_FAMILY_AUDINO                  TRUE
+#undef P_FAMILY_TIMBURR
+#define P_FAMILY_TIMBURR                 TRUE
+#undef P_FAMILY_TYMPOLE
+#define P_FAMILY_TYMPOLE                 TRUE
+#undef P_FAMILY_THROH
+#define P_FAMILY_THROH                   TRUE
+#undef P_FAMILY_SAWK
+#define P_FAMILY_SAWK                    TRUE
+#undef P_FAMILY_SEWADDLE
+#define P_FAMILY_SEWADDLE                TRUE
+#undef P_FAMILY_VENIPEDE
+#define P_FAMILY_VENIPEDE                TRUE
+#undef P_FAMILY_COTTONEE
+#define P_FAMILY_COTTONEE                TRUE
+#undef P_FAMILY_PETILIL
+#define P_FAMILY_PETILIL                 TRUE
+#undef P_FAMILY_BASCULIN
+#define P_FAMILY_BASCULIN                TRUE
+#undef P_FAMILY_SANDILE
+#define P_FAMILY_SANDILE                 TRUE
+#undef P_FAMILY_DARUMAKA
+#define P_FAMILY_DARUMAKA                TRUE
+#undef P_FAMILY_MARACTUS
+#define P_FAMILY_MARACTUS                TRUE
+#undef P_FAMILY_DWEBBLE
+#define P_FAMILY_DWEBBLE                 TRUE
+#undef P_FAMILY_SCRAGGY
+#define P_FAMILY_SCRAGGY                 TRUE
+#undef P_FAMILY_SIGILYPH
+#define P_FAMILY_SIGILYPH                TRUE
+#undef P_FAMILY_YAMASK
+#define P_FAMILY_YAMASK                  TRUE
+#undef P_FAMILY_TIRTOUGA
+#define P_FAMILY_TIRTOUGA                TRUE
+#undef P_FAMILY_ARCHEN
+#define P_FAMILY_ARCHEN                  TRUE
+#undef P_FAMILY_TRUBBISH
+#define P_FAMILY_TRUBBISH                TRUE
+#undef P_FAMILY_ZORUA
+#define P_FAMILY_ZORUA                   TRUE
+#undef P_FAMILY_MINCCINO
+#define P_FAMILY_MINCCINO                TRUE
+#undef P_FAMILY_GOTHITA
+#define P_FAMILY_GOTHITA                 TRUE
+#undef P_FAMILY_SOLOSIS
+#define P_FAMILY_SOLOSIS                 TRUE
+#undef P_FAMILY_DUCKLETT
+#define P_FAMILY_DUCKLETT                TRUE
+#undef P_FAMILY_VANILLITE
+#define P_FAMILY_VANILLITE               TRUE
+#undef P_FAMILY_DEERLING
+#define P_FAMILY_DEERLING                TRUE
+#undef P_FAMILY_EMOLGA
+#define P_FAMILY_EMOLGA                  TRUE
+#undef P_FAMILY_KARRABLAST
+#define P_FAMILY_KARRABLAST              TRUE
+#undef P_FAMILY_FOONGUS
+#define P_FAMILY_FOONGUS                 TRUE
+#undef P_FAMILY_FRILLISH
+#define P_FAMILY_FRILLISH                TRUE
+#undef P_FAMILY_ALOMOMOLA
+#define P_FAMILY_ALOMOMOLA               TRUE
+#undef P_FAMILY_JOLTIK
+#define P_FAMILY_JOLTIK                  TRUE
+#undef P_FAMILY_FERROSEED
+#define P_FAMILY_FERROSEED               TRUE
+#undef P_FAMILY_KLINK
+#define P_FAMILY_KLINK                   TRUE
+#undef P_FAMILY_TYNAMO
+#define P_FAMILY_TYNAMO                  TRUE
+#undef P_FAMILY_ELGYEM
+#define P_FAMILY_ELGYEM                  TRUE
+#undef P_FAMILY_LITWICK
+#define P_FAMILY_LITWICK                 TRUE
+#undef P_FAMILY_AXEW
+#define P_FAMILY_AXEW                    TRUE
+#undef P_FAMILY_CUBCHOO
+#define P_FAMILY_CUBCHOO                 TRUE
+#undef P_FAMILY_CRYOGONAL
+#define P_FAMILY_CRYOGONAL               TRUE
+#undef P_FAMILY_SHELMET
+#define P_FAMILY_SHELMET                 TRUE
+#undef P_FAMILY_STUNFISK
+#define P_FAMILY_STUNFISK                TRUE
+#undef P_FAMILY_MIENFOO
+#define P_FAMILY_MIENFOO                 TRUE
+#undef P_FAMILY_DRUDDIGON
+#define P_FAMILY_DRUDDIGON               TRUE
+#undef P_FAMILY_GOLETT
+#define P_FAMILY_GOLETT                  TRUE
+#undef P_FAMILY_PAWNIARD
+#define P_FAMILY_PAWNIARD                TRUE
+#undef P_FAMILY_BOUFFALANT
+#define P_FAMILY_BOUFFALANT              TRUE
+#undef P_FAMILY_RUFFLET
+#define P_FAMILY_RUFFLET                 TRUE
+#undef P_FAMILY_VULLABY
+#define P_FAMILY_VULLABY                 TRUE
+#undef P_FAMILY_HEATMOR
+#define P_FAMILY_HEATMOR                 TRUE
+#undef P_FAMILY_DURANT
+#define P_FAMILY_DURANT                  TRUE
+#undef P_FAMILY_DEINO
+#define P_FAMILY_DEINO                   TRUE
+#undef P_FAMILY_LARVESTA
+#define P_FAMILY_LARVESTA                TRUE
+#undef P_FAMILY_COBALION
+#define P_FAMILY_COBALION                TRUE
+#undef P_FAMILY_TERRAKION
+#define P_FAMILY_TERRAKION               TRUE
+#undef P_FAMILY_VIRIZION
+#define P_FAMILY_VIRIZION                TRUE
+#undef P_FAMILY_TORNADUS
+#define P_FAMILY_TORNADUS                TRUE
+#undef P_FAMILY_THUNDURUS
+#define P_FAMILY_THUNDURUS               TRUE
+#undef P_FAMILY_RESHIRAM
+#define P_FAMILY_RESHIRAM                TRUE
+#undef P_FAMILY_ZEKROM
+#define P_FAMILY_ZEKROM                  TRUE
+#undef P_FAMILY_LANDORUS
+#define P_FAMILY_LANDORUS                TRUE
+#undef P_FAMILY_KYUREM
+#define P_FAMILY_KYUREM                  TRUE
+#undef P_FAMILY_KELDEO
+#define P_FAMILY_KELDEO                  TRUE
+#undef P_FAMILY_MELOETTA
+#define P_FAMILY_MELOETTA                TRUE
+#undef P_FAMILY_GENESECT
+#define P_FAMILY_GENESECT                TRUE
+#undef P_FAMILY_CHESPIN
+#define P_FAMILY_CHESPIN                 TRUE
+#undef P_FAMILY_FENNEKIN
+#define P_FAMILY_FENNEKIN                TRUE
+#undef P_FAMILY_FROAKIE
+#define P_FAMILY_FROAKIE                 TRUE
+#undef P_FAMILY_BUNNELBY
+#define P_FAMILY_BUNNELBY                TRUE
+#undef P_FAMILY_FLETCHLING
+#define P_FAMILY_FLETCHLING              TRUE
+#undef P_FAMILY_SCATTERBUG
+#define P_FAMILY_SCATTERBUG              TRUE
+#undef P_FAMILY_LITLEO
+#define P_FAMILY_LITLEO                  TRUE
+#undef P_FAMILY_FLABEBE
+#define P_FAMILY_FLABEBE                 TRUE
+#undef P_FAMILY_SKIDDO
+#define P_FAMILY_SKIDDO                  TRUE
+#undef P_FAMILY_PANCHAM
+#define P_FAMILY_PANCHAM                 TRUE
+#undef P_FAMILY_FURFROU
+#define P_FAMILY_FURFROU                 TRUE
+#undef P_FAMILY_ESPURR
+#define P_FAMILY_ESPURR                  TRUE
+#undef P_FAMILY_HONEDGE
+#define P_FAMILY_HONEDGE                 TRUE
+#undef P_FAMILY_SPRITZEE
+#define P_FAMILY_SPRITZEE                TRUE
+#undef P_FAMILY_SWIRLIX
+#define P_FAMILY_SWIRLIX                 TRUE
+#undef P_FAMILY_INKAY
+#define P_FAMILY_INKAY                   TRUE
+#undef P_FAMILY_BINACLE
+#define P_FAMILY_BINACLE                 TRUE
+#undef P_FAMILY_SKRELP
+#define P_FAMILY_SKRELP                  TRUE
+#undef P_FAMILY_CLAUNCHER
+#define P_FAMILY_CLAUNCHER               TRUE
+#undef P_FAMILY_HELIOPTILE
+#define P_FAMILY_HELIOPTILE              TRUE
+#undef P_FAMILY_TYRUNT
+#define P_FAMILY_TYRUNT                  TRUE
+#undef P_FAMILY_AMAURA
+#define P_FAMILY_AMAURA                  TRUE
+#undef P_FAMILY_HAWLUCHA
+#define P_FAMILY_HAWLUCHA                TRUE
+#undef P_FAMILY_DEDENNE
+#define P_FAMILY_DEDENNE                 TRUE
+#undef P_FAMILY_CARBINK
+#define P_FAMILY_CARBINK                 TRUE
+#undef P_FAMILY_GOOMY
+#define P_FAMILY_GOOMY                   TRUE
+#undef P_FAMILY_KLEFKI
+#define P_FAMILY_KLEFKI                  TRUE
+#undef P_FAMILY_PHANTUMP
+#define P_FAMILY_PHANTUMP                TRUE
+#undef P_FAMILY_PUMPKABOO
+#define P_FAMILY_PUMPKABOO               TRUE
+#undef P_FAMILY_BERGMITE
+#define P_FAMILY_BERGMITE                TRUE
+#undef P_FAMILY_NOIBAT
+#define P_FAMILY_NOIBAT                  TRUE
+#undef P_FAMILY_XERNEAS
+#define P_FAMILY_XERNEAS                 TRUE
+#undef P_FAMILY_YVELTAL
+#define P_FAMILY_YVELTAL                 TRUE
+#undef P_FAMILY_ZYGARDE
+#define P_FAMILY_ZYGARDE                 TRUE
+#undef P_FAMILY_DIANCIE
+#define P_FAMILY_DIANCIE                 TRUE
+#undef P_FAMILY_HOOPA
+#define P_FAMILY_HOOPA                   TRUE
+#undef P_FAMILY_VOLCANION
+#define P_FAMILY_VOLCANION               TRUE
+#undef P_FAMILY_ROWLET
+#define P_FAMILY_ROWLET                  TRUE
+#undef P_FAMILY_LITTEN
+#define P_FAMILY_LITTEN                  TRUE
+#undef P_FAMILY_POPPLIO
+#define P_FAMILY_POPPLIO                 TRUE
+#undef P_FAMILY_PIKIPEK
+#define P_FAMILY_PIKIPEK                 TRUE
+#undef P_FAMILY_YUNGOOS
+#define P_FAMILY_YUNGOOS                 TRUE
+#undef P_FAMILY_GRUBBIN
+#define P_FAMILY_GRUBBIN                 TRUE
+#undef P_FAMILY_CRABRAWLER
+#define P_FAMILY_CRABRAWLER              TRUE
+#undef P_FAMILY_ORICORIO
+#define P_FAMILY_ORICORIO                TRUE
+#undef P_FAMILY_CUTIEFLY
+#define P_FAMILY_CUTIEFLY                TRUE
+#undef P_FAMILY_ROCKRUFF
+#define P_FAMILY_ROCKRUFF                TRUE
+#undef P_FAMILY_WISHIWASHI
+#define P_FAMILY_WISHIWASHI              TRUE
+#undef P_FAMILY_MAREANIE
+#define P_FAMILY_MAREANIE                TRUE
+#undef P_FAMILY_MUDBRAY
+#define P_FAMILY_MUDBRAY                 TRUE
+#undef P_FAMILY_DEWPIDER
+#define P_FAMILY_DEWPIDER                TRUE
+#undef P_FAMILY_FOMANTIS
+#define P_FAMILY_FOMANTIS                TRUE
+#undef P_FAMILY_MORELULL
+#define P_FAMILY_MORELULL                TRUE
+#undef P_FAMILY_SALANDIT
+#define P_FAMILY_SALANDIT                TRUE
+#undef P_FAMILY_STUFFUL
+#define P_FAMILY_STUFFUL                 TRUE
+#undef P_FAMILY_BOUNSWEET
+#define P_FAMILY_BOUNSWEET               TRUE
+#undef P_FAMILY_COMFEY
+#define P_FAMILY_COMFEY                  TRUE
+#undef P_FAMILY_ORANGURU
+#define P_FAMILY_ORANGURU                TRUE
+#undef P_FAMILY_PASSIMIAN
+#define P_FAMILY_PASSIMIAN               TRUE
+#undef P_FAMILY_WIMPOD
+#define P_FAMILY_WIMPOD                  TRUE
+#undef P_FAMILY_SANDYGAST
+#define P_FAMILY_SANDYGAST               TRUE
+#undef P_FAMILY_PYUKUMUKU
+#define P_FAMILY_PYUKUMUKU               TRUE
+#undef P_FAMILY_TYPE_NULL
+#define P_FAMILY_TYPE_NULL               TRUE
+#undef P_FAMILY_MINIOR
+#define P_FAMILY_MINIOR                  TRUE
+#undef P_FAMILY_KOMALA
+#define P_FAMILY_KOMALA                  TRUE
+#undef P_FAMILY_TURTONATOR
+#define P_FAMILY_TURTONATOR              TRUE
+#undef P_FAMILY_TOGEDEMARU
+#define P_FAMILY_TOGEDEMARU              TRUE
+#undef P_FAMILY_MIMIKYU
+#define P_FAMILY_MIMIKYU                 TRUE
+#undef P_FAMILY_BRUXISH
+#define P_FAMILY_BRUXISH                 TRUE
+#undef P_FAMILY_DRAMPA
+#define P_FAMILY_DRAMPA                  TRUE
+#undef P_FAMILY_DHELMISE
+#define P_FAMILY_DHELMISE                TRUE
+#undef P_FAMILY_JANGMO_O
+#define P_FAMILY_JANGMO_O                TRUE
+#undef P_FAMILY_TAPU_KOKO
+#define P_FAMILY_TAPU_KOKO               TRUE
+#undef P_FAMILY_TAPU_LELE
+#define P_FAMILY_TAPU_LELE               TRUE
+#undef P_FAMILY_TAPU_BULU
+#define P_FAMILY_TAPU_BULU               TRUE
+#undef P_FAMILY_TAPU_FINI
+#define P_FAMILY_TAPU_FINI               TRUE
+#undef P_FAMILY_COSMOG
+#define P_FAMILY_COSMOG                  TRUE
+#undef P_FAMILY_NIHILEGO
+#define P_FAMILY_NIHILEGO                TRUE
+#undef P_FAMILY_BUZZWOLE
+#define P_FAMILY_BUZZWOLE                TRUE
+#undef P_FAMILY_PHEROMOSA
+#define P_FAMILY_PHEROMOSA               TRUE
+#undef P_FAMILY_XURKITREE
+#define P_FAMILY_XURKITREE               TRUE
+#undef P_FAMILY_CELESTEELA
+#define P_FAMILY_CELESTEELA              TRUE
+#undef P_FAMILY_KARTANA
+#define P_FAMILY_KARTANA                 TRUE
+#undef P_FAMILY_GUZZLORD
+#define P_FAMILY_GUZZLORD                TRUE
+#undef P_FAMILY_NECROZMA
+#define P_FAMILY_NECROZMA                TRUE
+#undef P_FAMILY_MAGEARNA
+#define P_FAMILY_MAGEARNA                TRUE
+#undef P_FAMILY_MARSHADOW
+#define P_FAMILY_MARSHADOW               TRUE
+#undef P_FAMILY_POIPOLE
+#define P_FAMILY_POIPOLE                 TRUE
+#undef P_FAMILY_STAKATAKA
+#define P_FAMILY_STAKATAKA               TRUE
+#undef P_FAMILY_BLACEPHALON
+#define P_FAMILY_BLACEPHALON             TRUE
+#undef P_FAMILY_ZERAORA
+#define P_FAMILY_ZERAORA                 TRUE
+#undef P_FAMILY_MELTAN
+#define P_FAMILY_MELTAN                  TRUE
+#undef P_FAMILY_GROOKEY
+#define P_FAMILY_GROOKEY                 TRUE
+#undef P_FAMILY_SCORBUNNY
+#define P_FAMILY_SCORBUNNY               TRUE
+#undef P_FAMILY_SOBBLE
+#define P_FAMILY_SOBBLE                  TRUE
+#undef P_FAMILY_SKWOVET
+#define P_FAMILY_SKWOVET                 TRUE
+#undef P_FAMILY_ROOKIDEE
+#define P_FAMILY_ROOKIDEE                TRUE
+#undef P_FAMILY_BLIPBUG
+#define P_FAMILY_BLIPBUG                 TRUE
+#undef P_FAMILY_NICKIT
+#define P_FAMILY_NICKIT                  TRUE
+#undef P_FAMILY_GOSSIFLEUR
+#define P_FAMILY_GOSSIFLEUR              TRUE
+#undef P_FAMILY_WOOLOO
+#define P_FAMILY_WOOLOO                  TRUE
+#undef P_FAMILY_CHEWTLE
+#define P_FAMILY_CHEWTLE                 TRUE
+#undef P_FAMILY_YAMPER
+#define P_FAMILY_YAMPER                  TRUE
+#undef P_FAMILY_ROLYCOLY
+#define P_FAMILY_ROLYCOLY                TRUE
+#undef P_FAMILY_APPLIN
+#define P_FAMILY_APPLIN                  TRUE
+#undef P_FAMILY_SILICOBRA
+#define P_FAMILY_SILICOBRA               TRUE
+#undef P_FAMILY_CRAMORANT
+#define P_FAMILY_CRAMORANT               TRUE
+#undef P_FAMILY_ARROKUDA
+#define P_FAMILY_ARROKUDA                TRUE
+#undef P_FAMILY_TOXEL
+#define P_FAMILY_TOXEL                   TRUE
+#undef P_FAMILY_SIZZLIPEDE
+#define P_FAMILY_SIZZLIPEDE              TRUE
+#undef P_FAMILY_CLOBBOPUS
+#define P_FAMILY_CLOBBOPUS               TRUE
+#undef P_FAMILY_SINISTEA
+#define P_FAMILY_SINISTEA                TRUE
+#undef P_FAMILY_HATENNA
+#define P_FAMILY_HATENNA                 TRUE
+#undef P_FAMILY_IMPIDIMP
+#define P_FAMILY_IMPIDIMP                TRUE
+#undef P_FAMILY_MILCERY
+#define P_FAMILY_MILCERY                 TRUE
+#undef P_FAMILY_FALINKS
+#define P_FAMILY_FALINKS                 TRUE
+#undef P_FAMILY_PINCURCHIN
+#define P_FAMILY_PINCURCHIN              TRUE
+#undef P_FAMILY_SNOM
+#define P_FAMILY_SNOM                    TRUE
+#undef P_FAMILY_STONJOURNER
+#define P_FAMILY_STONJOURNER             TRUE
+#undef P_FAMILY_EISCUE
+#define P_FAMILY_EISCUE                  TRUE
+#undef P_FAMILY_INDEEDEE
+#define P_FAMILY_INDEEDEE                TRUE
+#undef P_FAMILY_MORPEKO
+#define P_FAMILY_MORPEKO                 TRUE
+#undef P_FAMILY_CUFANT
+#define P_FAMILY_CUFANT                  TRUE
+#undef P_FAMILY_DRACOZOLT
+#define P_FAMILY_DRACOZOLT               TRUE
+#undef P_FAMILY_ARCTOZOLT
+#define P_FAMILY_ARCTOZOLT               TRUE
+#undef P_FAMILY_DRACOVISH
+#define P_FAMILY_DRACOVISH               TRUE
+#undef P_FAMILY_ARCTOVISH
+#define P_FAMILY_ARCTOVISH               TRUE
+#undef P_FAMILY_DURALUDON
+#define P_FAMILY_DURALUDON               TRUE
+#undef P_FAMILY_DREEPY
+#define P_FAMILY_DREEPY                  TRUE
+#undef P_FAMILY_ZACIAN
+#define P_FAMILY_ZACIAN                  TRUE
+#undef P_FAMILY_ZAMAZENTA
+#define P_FAMILY_ZAMAZENTA               TRUE
+#undef P_FAMILY_ETERNATUS
+#define P_FAMILY_ETERNATUS               TRUE
+#undef P_FAMILY_KUBFU
+#define P_FAMILY_KUBFU                   TRUE
+#undef P_FAMILY_ZARUDE
+#define P_FAMILY_ZARUDE                  TRUE
+#undef P_FAMILY_REGIELEKI
+#define P_FAMILY_REGIELEKI               TRUE
+#undef P_FAMILY_REGIDRAGO
+#define P_FAMILY_REGIDRAGO               TRUE
+#undef P_FAMILY_GLASTRIER
+#define P_FAMILY_GLASTRIER               TRUE
+#undef P_FAMILY_SPECTRIER
+#define P_FAMILY_SPECTRIER               TRUE
+#undef P_FAMILY_CALYREX
+#define P_FAMILY_CALYREX                 TRUE
+#undef P_FAMILY_ENAMORUS
+#define P_FAMILY_ENAMORUS                TRUE
+#undef P_FAMILY_SPRIGATITO
+#define P_FAMILY_SPRIGATITO              TRUE
+#undef P_FAMILY_FUECOCO
+#define P_FAMILY_FUECOCO                 TRUE
+#undef P_FAMILY_QUAXLY
+#define P_FAMILY_QUAXLY                  TRUE
+#undef P_FAMILY_LECHONK
+#define P_FAMILY_LECHONK                 TRUE
+#undef P_FAMILY_TAROUNTULA
+#define P_FAMILY_TAROUNTULA              TRUE
+#undef P_FAMILY_NYMBLE
+#define P_FAMILY_NYMBLE                  TRUE
+#undef P_FAMILY_PAWMI
+#define P_FAMILY_PAWMI                   TRUE
+#undef P_FAMILY_TANDEMAUS
+#define P_FAMILY_TANDEMAUS               TRUE
+#undef P_FAMILY_FIDOUGH
+#define P_FAMILY_FIDOUGH                 TRUE
+#undef P_FAMILY_SMOLIV
+#define P_FAMILY_SMOLIV                  TRUE
+#undef P_FAMILY_SQUAWKABILLY
+#define P_FAMILY_SQUAWKABILLY            TRUE
+#undef P_FAMILY_NACLI
+#define P_FAMILY_NACLI                   TRUE
+#undef P_FAMILY_CHARCADET
+#define P_FAMILY_CHARCADET               TRUE
+#undef P_FAMILY_TADBULB
+#define P_FAMILY_TADBULB                 TRUE
+#undef P_FAMILY_WATTREL
+#define P_FAMILY_WATTREL                 TRUE
+#undef P_FAMILY_MASCHIFF
+#define P_FAMILY_MASCHIFF                TRUE
+#undef P_FAMILY_SHROODLE
+#define P_FAMILY_SHROODLE                TRUE
+#undef P_FAMILY_BRAMBLIN
+#define P_FAMILY_BRAMBLIN                TRUE
+#undef P_FAMILY_TOEDSCOOL
+#define P_FAMILY_TOEDSCOOL               TRUE
+#undef P_FAMILY_KLAWF
+#define P_FAMILY_KLAWF                   TRUE
+#undef P_FAMILY_CAPSAKID
+#define P_FAMILY_CAPSAKID                TRUE
+#undef P_FAMILY_RELLOR
+#define P_FAMILY_RELLOR                  TRUE
+#undef P_FAMILY_FLITTLE
+#define P_FAMILY_FLITTLE                 TRUE
+#undef P_FAMILY_TINKATINK
+#define P_FAMILY_TINKATINK               TRUE
+#undef P_FAMILY_WIGLETT
+#define P_FAMILY_WIGLETT                 TRUE
+#undef P_FAMILY_BOMBIRDIER
+#define P_FAMILY_BOMBIRDIER              TRUE
+#undef P_FAMILY_FINIZEN
+#define P_FAMILY_FINIZEN                 TRUE
+#undef P_FAMILY_VAROOM
+#define P_FAMILY_VAROOM                  TRUE
+#undef P_FAMILY_CYCLIZAR
+#define P_FAMILY_CYCLIZAR                TRUE
+#undef P_FAMILY_ORTHWORM
+#define P_FAMILY_ORTHWORM                TRUE
+#undef P_FAMILY_GLIMMET
+#define P_FAMILY_GLIMMET                 TRUE
+#undef P_FAMILY_GREAVARD
+#define P_FAMILY_GREAVARD                TRUE
+#undef P_FAMILY_FLAMIGO
+#define P_FAMILY_FLAMIGO                 TRUE
+#undef P_FAMILY_CETODDLE
+#define P_FAMILY_CETODDLE                TRUE
+#undef P_FAMILY_VELUZA
+#define P_FAMILY_VELUZA                  TRUE
+#undef P_FAMILY_DONDOZO
+#define P_FAMILY_DONDOZO                 TRUE
+#undef P_FAMILY_TATSUGIRI
+#define P_FAMILY_TATSUGIRI               TRUE
+#undef P_FAMILY_GREAT_TUSK
+#define P_FAMILY_GREAT_TUSK              TRUE
+#undef P_FAMILY_SCREAM_TAIL
+#define P_FAMILY_SCREAM_TAIL             TRUE
+#undef P_FAMILY_BRUTE_BONNET
+#define P_FAMILY_BRUTE_BONNET            TRUE
+#undef P_FAMILY_FLUTTER_MANE
+#define P_FAMILY_FLUTTER_MANE            TRUE
+#undef P_FAMILY_SLITHER_WING
+#define P_FAMILY_SLITHER_WING            TRUE
+#undef P_FAMILY_SANDY_SHOCKS
+#define P_FAMILY_SANDY_SHOCKS            TRUE
+#undef P_FAMILY_IRON_TREADS
+#define P_FAMILY_IRON_TREADS             TRUE
+#undef P_FAMILY_IRON_BUNDLE
+#define P_FAMILY_IRON_BUNDLE             TRUE
+#undef P_FAMILY_IRON_HANDS
+#define P_FAMILY_IRON_HANDS              TRUE
+#undef P_FAMILY_IRON_JUGULIS
+#define P_FAMILY_IRON_JUGULIS            TRUE
+#undef P_FAMILY_IRON_MOTH
+#define P_FAMILY_IRON_MOTH               TRUE
+#undef P_FAMILY_IRON_THORNS
+#define P_FAMILY_IRON_THORNS             TRUE
+#undef P_FAMILY_FRIGIBAX
+#define P_FAMILY_FRIGIBAX                TRUE
+#undef P_FAMILY_GIMMIGHOUL
+#define P_FAMILY_GIMMIGHOUL              TRUE
+#undef P_FAMILY_WO_CHIEN
+#define P_FAMILY_WO_CHIEN                TRUE
+#undef P_FAMILY_CHIEN_PAO
+#define P_FAMILY_CHIEN_PAO               TRUE
+#undef P_FAMILY_TING_LU
+#define P_FAMILY_TING_LU                 TRUE
+#undef P_FAMILY_CHI_YU
+#define P_FAMILY_CHI_YU                  TRUE
+#undef P_FAMILY_ROARING_MOON
+#define P_FAMILY_ROARING_MOON            TRUE
+#undef P_FAMILY_IRON_VALIANT
+#define P_FAMILY_IRON_VALIANT            TRUE
+#undef P_FAMILY_KORAIDON
+#define P_FAMILY_KORAIDON                TRUE
+#undef P_FAMILY_MIRAIDON
+#define P_FAMILY_MIRAIDON                TRUE
+#undef P_FAMILY_WALKING_WAKE
+#define P_FAMILY_WALKING_WAKE            TRUE
+#undef P_FAMILY_IRON_LEAVES
+#define P_FAMILY_IRON_LEAVES             TRUE
+#undef P_FAMILY_POLTCHAGEIST
+#define P_FAMILY_POLTCHAGEIST            TRUE
+#undef P_FAMILY_SINISTCHA
+#define P_FAMILY_SINISTCHA               TRUE
+#undef P_FAMILY_OKIDOGI
+#define P_FAMILY_OKIDOGI                 TRUE
+#undef P_FAMILY_MUNKIDORI
+#define P_FAMILY_MUNKIDORI               TRUE
+#undef P_FAMILY_FEZANDIPITI
+#define P_FAMILY_FEZANDIPITI             TRUE
+#undef P_FAMILY_OGERPON
+#define P_FAMILY_OGERPON                 TRUE
+#undef P_FAMILY_GOUGING_FIRE
+#define P_FAMILY_GOUGING_FIRE            TRUE
+#undef P_FAMILY_RAGING_BOLT
+#define P_FAMILY_RAGING_BOLT             TRUE
+#undef P_FAMILY_IRON_BOULDER
+#define P_FAMILY_IRON_BOULDER            TRUE
+#undef P_FAMILY_IRON_CROWN
+#define P_FAMILY_IRON_CROWN              TRUE
+#undef P_FAMILY_TERAPAGOS
+#define P_FAMILY_TERAPAGOS               TRUE
+#undef P_FAMILY_PECHARUNT
+#define P_FAMILY_PECHARUNT               TRUE
+
 #endif // GUARD_CONFIG_TEST_H

--- a/include/config/test.h
+++ b/include/config/test.h
@@ -704,6 +704,7 @@
 #define P_FAMILY_MELOETTA                TRUE
 #undef P_FAMILY_GENESECT
 #define P_FAMILY_GENESECT                TRUE
+
 #undef P_FAMILY_CHESPIN
 #define P_FAMILY_CHESPIN                 TRUE
 #undef P_FAMILY_FENNEKIN


### PR DESCRIPTION
This forces all species to be always enabled in tests. Prevent users from having a lot of tests failing. Especially applies to tests with forms because there are no assumes for them.