### PR TITLE
Add support for LF line endings to gbagfx

### DIFF
--- a/tools/gbagfx/jasc_pal.c
+++ b/tools/gbagfx/jasc_pal.c
@@ -46,10 +46,14 @@ void ReadJascPaletteLine(FILE *fp, char *line)
         }
 
         if (c == '\n')
-            FATAL_ERROR("LF line endings aren't supported.\n");
+        {
+            line[length] = 0;
+            
+            return;
+        }
 
         if (c == EOF)
-            FATAL_ERROR("Unexpected EOF. No CRLF at end of file.\n");
+            FATAL_ERROR("Unexpected EOF. No LF or CRLF at end of file.\n");
 
         if (c == 0)
             FATAL_ERROR("NUL character in file.\n");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Enables LF support for palette files by properly handling them within the gbagfx tool.

## Issue(s) that this PR fixes
Fixes #4814

## **Discord contact info**
crimsonocean
