### PR TITLE
Don't specify sDexSearchTypeOptions array size

### DIFF
--- a/src/pokedex.c
+++ b/src/pokedex.c
@@ -1387,7 +1387,7 @@ static const struct SearchOptionText sDexSearchColorOptions[] =
     {},
 };
 
-static const struct SearchOptionText sDexSearchTypeOptions[NUMBER_OF_MON_TYPES] = // + 2 for "None" and terminator, - 2 for Mystery and Stellar
+static const struct SearchOptionText sDexSearchTypeOptions[] =
 {
     {gText_DexEmptyString, gTypesInfo[TYPE_NONE].name},
     {gText_DexEmptyString, gTypesInfo[TYPE_NORMAL].name},

--- a/src/pokedex_plus_hgss.c
+++ b/src/pokedex_plus_hgss.c
@@ -1901,7 +1901,7 @@ static const struct SearchOptionText sDexSearchColorOptions[] =
     {},
 };
 
-static const struct SearchOptionText sDexSearchTypeOptions[NUMBER_OF_MON_TYPES] = // + 2 for "None" and terminator, - 2 for Mystery and Stellar
+static const struct SearchOptionText sDexSearchTypeOptions[] =
 {
     {gText_DexEmptyString, gTypesInfo[TYPE_NONE].name},
     {gText_DexEmptyString, gTypesInfo[TYPE_NORMAL].name},


### PR DESCRIPTION
## Description
Remove pointless specified size that keeps breaking Pokedex search (image below) whenever a new non-conventional type is added.

## Images
![image](https://github.com/rh-hideout/pokeemerald-expansion/assets/56992013/7c4fc885-f596-41f9-a501-f903a7bdde7f)
## **Discord contact info**
duke5614