### PR TITLE
Roamer's frostbite status carries over between battles

### DIFF
--- a/include/global.h
+++ b/include/global.h
@@ -597,14 +597,15 @@ struct Roamer
     /*0x08*/ u16 species;
     /*0x0A*/ u16 hp;
     /*0x0C*/ u8 level;
-    /*0x0D*/ u8 status;
+    /*0x0D*/ u8 statusA;
     /*0x0E*/ u8 cool;
     /*0x0F*/ u8 beauty;
     /*0x10*/ u8 cute;
     /*0x11*/ u8 smart;
     /*0x12*/ u8 tough;
     /*0x13*/ bool8 active;
-    /*0x14*/ u8 filler[0x8];
+    /*0x14*/ u8 statusB; // Stores frostbite
+    /*0x14*/ u8 filler[0x7];
 };
 
 struct RamScriptData

--- a/src/roamer.c
+++ b/src/roamer.c
@@ -90,7 +90,8 @@ static void CreateInitialRoamerMon(bool16 createLatios)
 
     CreateMon(&gEnemyParty[0], ROAMER->species, 40, USE_RANDOM_IVS, FALSE, 0, OT_ID_PLAYER_ID, 0);
     ROAMER->level = 40;
-    ROAMER->status = 0;
+    ROAMER->statusA = 0;
+    ROAMER->statusB = 0;
     ROAMER->active = TRUE;
     ROAMER->ivs = GetMonData(&gEnemyParty[0], MON_DATA_IVS);
     ROAMER->personality = GetMonData(&gEnemyParty[0], MON_DATA_PERSONALITY);
@@ -193,18 +194,11 @@ bool8 IsRoamerAt(u8 mapGroup, u8 mapNum)
 
 void CreateRoamerMonInstance(void)
 {
-    u32 status;
+    u32 status = ROAMER->statusA + (ROAMER->statusB << 8);
     struct Pokemon *mon = &gEnemyParty[0];
     ZeroEnemyPartyMons();
     CreateMonWithIVsPersonality(mon, ROAMER->species, ROAMER->level, ROAMER->ivs, ROAMER->personality);
-// The roamer's status field is u8, but SetMonData expects status to be u32, so will set the roamer's status
-// using the status field and the following 3 bytes (cool, beauty, and cute).
-#ifdef BUGFIX
-    status = ROAMER->status;
     SetMonData(mon, MON_DATA_STATUS, &status);
-#else
-    SetMonData(mon, MON_DATA_STATUS, &ROAMER->status);
-#endif
     SetMonData(mon, MON_DATA_HP, &ROAMER->hp);
     SetMonData(mon, MON_DATA_COOL, &ROAMER->cool);
     SetMonData(mon, MON_DATA_BEAUTY, &ROAMER->beauty);
@@ -228,8 +222,11 @@ bool8 TryStartRoamerEncounter(void)
 
 void UpdateRoamerHPStatus(struct Pokemon *mon)
 {
+    u32 status = GetMonData(mon, MON_DATA_STATUS);
+
     ROAMER->hp = GetMonData(mon, MON_DATA_HP);
-    ROAMER->status = GetMonData(mon, MON_DATA_STATUS);
+    ROAMER->statusA = status;
+    ROAMER->statusB = status >> 8;
 
     RoamerMoveToOtherLocationSet();
 }


### PR DESCRIPTION
## Description
Roamer stores status1 in 8 bytes but frostbite uses 13 bytes.
This PR lets roamers keep their frostbite status without altering the saveblock structure.

## **Discord contact info**
duke5614