### PR TITLE
Remove gPaletteDecompressionBuffer and unused palette functions/vars

### DIFF
--- a/include/palette.h
+++ b/include/palette.h
@@ -54,33 +54,31 @@ struct PaletteFadeControl
 
 extern struct PaletteFadeControl gPaletteFade;
 extern u32 gPlttBufferTransferPending;
-extern u8 ALIGNED(4) gPaletteDecompressionBuffer[];
 extern u16 ALIGNED(4) gPlttBufferUnfaded[PLTT_BUFFER_SIZE];
 extern u16 ALIGNED(4) gPlttBufferFaded[PLTT_BUFFER_SIZE];
 
-void LoadCompressedPalette(const u32 *src, u16 offset, u16 size);
-void LoadPalette(const void *src, u16 offset, u16 size);
-void FillPalette(u16 value, u16 offset, u16 size);
+void LoadCompressedPalette(const u32 *src, u32 offset, u32 size);
+void LoadPalette(const void *src, u32 offset, u32 size);
+void FillPalette(u32 value, u32 offset, u32 size);
 void TransferPlttBuffer(void);
-u8 UpdatePaletteFade(void);
+u32 UpdatePaletteFade(void);
 void ResetPaletteFade(void);
-bool8 BeginNormalPaletteFade(u32 selectedPalettes, s8 delay, u8 startY, u8 targetY, u16 blendColor);
-void PaletteStruct_ResetById(u16 id);
+bool32 BeginNormalPaletteFade(u32 selectedPalettes, s8 delay, u8 startY, u8 targetY, u32 blendColor);
 void ResetPaletteFadeControl(void);
 void InvertPlttBuffer(u32 selectedPalettes);
 void TintPlttBuffer(u32 selectedPalettes, s8 r, s8 g, s8 b);
 void UnfadePlttBuffer(u32 selectedPalettes);
-void BeginFastPaletteFade(u8 submode);
-void BeginHardwarePaletteFade(u8 blendCnt, u8 delay, u8 y, u8 targetY, u8 shouldResetBlendRegisters);
-void BlendPalettes(u32 selectedPalettes, u8 coeff, u16 color);
-void BlendPalettesUnfaded(u32 selectedPalettes, u8 coeff, u16 color);
+void BeginFastPaletteFade(u32 submode);
+void BeginHardwarePaletteFade(u32 blendCnt, u32 delay, u32 y, u32 targetY, u32 shouldResetBlendRegisters);
+void BlendPalettes(u32 selectedPalettes, u8 coeff, u32 color);
+void BlendPalettesUnfaded(u32 selectedPalettes, u8 coeff, u32 color);
 void BlendPalettesGradually(u32 selectedPalettes, s8 delay, u8 coeff, u8 coeffTarget, u16 color, u8 priority, u8 id);
-void TintPalette_GrayScale(u16 *palette, u16 count);
-void TintPalette_GrayScale2(u16 *palette, u16 count);
-void TintPalette_SepiaTone(u16 *palette, u16 count);
-void TintPalette_CustomTone(u16 *palette, u16 count, u16 rTone, u16 gTone, u16 bTone);
+void TintPalette_GrayScale(u16 *palette, u32 count);
+void TintPalette_GrayScale2(u16 *palette, u32 count);
+void TintPalette_SepiaTone(u16 *palette, u32 count);
+void TintPalette_CustomTone(u16 *palette, u32 count, u16 rTone, u16 gTone, u16 bTone);
 
-static inline void SetBackdropFromColor(u16 color)
+static inline void SetBackdropFromColor(u32 color)
 {
   FillPalette(color, 0, PLTT_SIZEOF(1));
 }

--- a/src/battle_anim_mons.c
+++ b/src/battle_anim_mons.c
@@ -663,12 +663,6 @@ static void UNUSED TranslateSpriteToBattleAttackerPos(struct Sprite *sprite)
 #undef sStartY
 #undef sTargetY
 
-static void UNUSED EndUnkPaletteAnim(struct Sprite *sprite)
-{
-    PaletteStruct_ResetById(sprite->data[5]);
-    DestroySpriteAndMatrix(sprite);
-}
-
 void RunStoredCallbackWhenAffineAnimEnds(struct Sprite *sprite)
 {
     if (sprite->affineAnimEnded)

--- a/src/fldeff_sweetscent.c
+++ b/src/fldeff_sweetscent.c
@@ -1,4 +1,5 @@
 #include "global.h"
+#include "decompress.h"
 #include "event_data.h"
 #include "event_scripts.h"
 #include "field_effect.h"
@@ -52,7 +53,7 @@ void StartSweetScentFieldEffect(void)
     u32 palettes = ~(1 << (gSprites[GetPlayerAvatarSpriteId()].oam.paletteNum + 16) | (1 << 13) | (1 << 14) | (1 << 15));
 
     PlaySE(SE_M_SWEET_SCENT);
-    CpuFastCopy(gPlttBufferUnfaded, gPaletteDecompressionBuffer, PLTT_SIZE);
+    CpuFastCopy(gPlttBufferUnfaded, gDecompressionBuffer, PLTT_SIZE);
     CpuFastCopy(gPlttBufferFaded, gPlttBufferUnfaded, PLTT_SIZE);
     BeginNormalPaletteFade(palettes, 4, 0, 8, RGB_RED);
     taskId = CreateTask(TrySweetScentEncounter, 0);
@@ -91,7 +92,7 @@ static void FailSweetScentEncounter(u8 taskId)
 {
     if (!gPaletteFade.active)
     {
-        CpuFastCopy(gPaletteDecompressionBuffer, gPlttBufferUnfaded, PLTT_SIZE);
+        CpuFastCopy(gDecompressionBuffer, gPlttBufferUnfaded, PLTT_SIZE);
         SetWeatherPalStateIdle();
         ScriptContext_SetupScript(EventScript_FailSweetScent);
         DestroyTask(taskId);

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -8,6 +8,7 @@
 #include "contest_util.h"
 #include "contest_painting.h"
 #include "data.h"
+#include "decompress.h"
 #include "decoration.h"
 #include "decoration_inventory.h"
 #include "event_data.h"
@@ -656,12 +657,12 @@ bool8 ScrCmd_fadescreenswapbuffers(struct ScriptContext *ctx)
     case FADE_TO_BLACK:
     case FADE_TO_WHITE:
     default:
-        CpuCopy32(gPlttBufferUnfaded, gPaletteDecompressionBuffer, PLTT_SIZE);
+        CpuCopy32(gPlttBufferUnfaded, gDecompressionBuffer, PLTT_SIZE);
         FadeScreen(mode, 0);
         break;
     case FADE_FROM_BLACK:
     case FADE_FROM_WHITE:
-        CpuCopy32(gPaletteDecompressionBuffer, gPlttBufferUnfaded, PLTT_SIZE);
+        CpuCopy32(gDecompressionBuffer, gPlttBufferUnfaded, PLTT_SIZE);
         FadeScreen(mode, 0);
         break;
     }


### PR DESCRIPTION
- removes `gPaletteDecompressionBuffer` and replaces it with `gDecompressionBuffer` (for now, `gDecompressionBuffer` could get removed/changed in the future )
- removes unused palette system. I don't think anyone uses that, so hopefully there's no harm in getting rid of that.
- changes some u8/u16 to u32 for faster and smaller code. Hopefully doesn't break anything

This frees about 4000 rom bytes and 1200 `EWRAM` bytes.

I tested it a bit, and it shouldn't break anything, but obviously if someone feels like it, they're free to check some more.