### PR TITLE
Allowed double battles to occur with only one Pokemon by talking to the trainers

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -3392,6 +3392,9 @@ u8 GetMonsStateToDoubles(void)
     s32 i;
     CalculatePlayerPartyCount();
 
+    if (OW_DOUBLE_APPROACH_WITH_ONE_MON)
+        return PLAYER_HAS_TWO_USABLE_MONS;
+
     if (gPlayerPartyCount == 1)
         return gPlayerPartyCount; // PLAYER_HAS_ONE_MON
 


### PR DESCRIPTION
## Description
Adds if statement for `OW_DOUBLE_APPROACH_WITH_ONE_MON` in `GetMonsStateToDoubles` which is used when talking to a double battle trainer. Previously only `GetMonsStateToDoubles` (used for trainers' sight) had it

## **Discord contact info**
Frankfurter0
