### PR TITLE
Revert wrongly done reversion

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -687,6 +687,7 @@ struct BattleStruct
     u8 startingStatusDone:1;
     u8 isAtkCancelerForCalledMove:1; // Certain cases in atk canceler should only be checked once, when the original move is called, however others need to be checked the twice.
     u8 terrainDone:1;
+    u8 switchInAbilityPostponed:4; // To not activate against an empty field, each bit for battler
     u8 startingStatus; // status to apply at battle start. defined in constants/battle.h
     u8 startingStatusTimer;
     u8 atkCancellerTracker;

--- a/include/battle_script_commands.h
+++ b/include/battle_script_commands.h
@@ -53,7 +53,7 @@ u8 GetCatchingBattler(void);
 u32 GetHighestStatId(u32 battlerId);
 bool32 ProteanTryChangeType(u32 battler, u32 ability, u32 move, u32 moveType);
 bool32 IsMoveNotAllowedInSkyBattles(u32 move);
-bool32 DoSwitchInAbilities(u32 battlerId);
+bool32 DoSwitchInAbilitiesItems(u32 battlerId);
 u8 GetFirstFaintedPartyIndex(u8 battlerId);
 bool32 IsMoveAffectedByParentalBond(u32 move, u32 battler);
 

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3069,7 +3069,7 @@ bool32 HandleWishPerishSongOnTurnEnd(void)
     return FALSE;
 }
 
-#define FAINTED_ACTIONS_MAX_CASE 7
+#define FAINTED_ACTIONS_MAX_CASE 8
 
 bool32 HandleFaintedMonActions(void)
 {
@@ -3153,7 +3153,19 @@ bool32 HandleFaintedMonActions(void)
             else
                 gBattleStruct->faintedActionsState = 4;
             break;
-        case 6:
+        case 6: // All battlers switch-in abilities happen here to prevent them happening against an empty field.
+            for (i = 0; i < gBattlersCount; i++)
+            {
+                if (gBattleStruct->switchInAbilityPostponed & gBitTable[i])
+                {
+                    if (DoSwitchInAbilitiesItems(i))
+                        return TRUE;
+                    gBattleStruct->switchInAbilityPostponed &= ~(gBitTable[i]);
+                }
+            }
+            gBattleStruct->faintedActionsState++;
+            break;
+        case 7:
             if (ItemBattleEffects(ITEMEFFECT_NORMAL, 0, TRUE))
                 return TRUE;
             gBattleStruct->faintedActionsState++;

--- a/test/battle/ability/beads_of_ruin.c
+++ b/test/battle/ability/beads_of_ruin.c
@@ -46,9 +46,9 @@ SINGLE_BATTLE_TEST("Beads of Ruin's message displays correctly after all battler
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, opponent);
         // Everyone faints.
         MESSAGE("Go! Chi-Yu!");
+        MESSAGE("2 sent out Wobbuffet!");
         ABILITY_POPUP(player, ABILITY_BEADS_OF_RUIN);
         MESSAGE("Chi-Yu's Beads of Ruin weakened the Sp. Def of all surrounding Pokémon!");
-        MESSAGE("2 sent out Wobbuffet!");
     }
 }
 

--- a/test/battle/ability/download.c
+++ b/test/battle/ability/download.c
@@ -56,7 +56,6 @@ SINGLE_BATTLE_TEST("Download raises Sp.Attack if enemy has lower Sp. Def than De
 SINGLE_BATTLE_TEST("Download doesn't activate if target hasn't been sent out yet", s16 damagePhysical, s16 damageSpecial)
 {
     u32 ability;
-    KNOWN_FAILING;
     PARAMETRIZE { ability = ABILITY_TRACE; }
     PARAMETRIZE { ability = ABILITY_DOWNLOAD; }
     GIVEN {

--- a/test/battle/ability/supreme_overlord.c
+++ b/test/battle/ability/supreme_overlord.c
@@ -107,9 +107,9 @@ SINGLE_BATTLE_TEST("Supreme Overlord's message displays correctly after all batt
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, opponent);
         // Everyone faints.
         MESSAGE("Go! Kingambit!");
+        MESSAGE("2 sent out Wobbuffet!");
         ABILITY_POPUP(player, ABILITY_SUPREME_OVERLORD);
         MESSAGE("Kingambit gained strength from the fallen!");
-        MESSAGE("2 sent out Wobbuffet!");
     }
 }
 

--- a/test/battle/ability/sword_of_ruin.c
+++ b/test/battle/ability/sword_of_ruin.c
@@ -46,9 +46,9 @@ SINGLE_BATTLE_TEST("Sword of Ruin's message displays correctly after all battler
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, opponent);
         // Everyone faints.
         MESSAGE("Go! Chien-Pao!");
+        MESSAGE("2 sent out Wobbuffet!");
         ABILITY_POPUP(player, ABILITY_SWORD_OF_RUIN);
         MESSAGE("Chien-Pao's Sword of Ruin weakened the Defense of all surrounding Pokémon!");
-        MESSAGE("2 sent out Wobbuffet!");
     }
 }
 

--- a/test/battle/ability/tablets_of_ruin.c
+++ b/test/battle/ability/tablets_of_ruin.c
@@ -46,9 +46,9 @@ SINGLE_BATTLE_TEST("Tablets of Ruin's message displays correctly after all battl
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, opponent);
         // Everyone faints.
         MESSAGE("Go! Wo-Chien!");
+        MESSAGE("2 sent out Wobbuffet!");
         ABILITY_POPUP(player, ABILITY_TABLETS_OF_RUIN);
         MESSAGE("Wo-Chien's Tablets of Ruin weakened the Attack of all surrounding Pokémon!");
-        MESSAGE("2 sent out Wobbuffet!");
     }
 }
 

--- a/test/battle/ability/vessel_of_ruin.c
+++ b/test/battle/ability/vessel_of_ruin.c
@@ -46,9 +46,9 @@ SINGLE_BATTLE_TEST("Vessel of Ruin's message displays correctly after all battle
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, opponent);
         // Everyone faints.
         MESSAGE("Go! Ting-Lu!");
+        MESSAGE("2 sent out Wobbuffet!");
         ABILITY_POPUP(player, ABILITY_VESSEL_OF_RUIN);
         MESSAGE("Ting-Lu's Vessel of Ruin weakened the Sp. Atk of all surrounding Pokémon!");
-        MESSAGE("2 sent out Wobbuffet!");
     }
 }
 

--- a/test/battle/ability/zero_to_hero.c
+++ b/test/battle/ability/zero_to_hero.c
@@ -153,9 +153,9 @@ SINGLE_BATTLE_TEST("Zero to Hero's message displays correctly after all battlers
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, opponent);
         // Everyone faints.
         MESSAGE("Go! Palafin!");
+        MESSAGE("2 sent out Wobbuffet!");
         ABILITY_POPUP(player, ABILITY_ZERO_TO_HERO);
         MESSAGE("Palafin underwent a heroic transformation!");
-        MESSAGE("2 sent out Wobbuffet!");
     }
 }
 

--- a/test/battle/form_change/primal_reversion.c
+++ b/test/battle/form_change/primal_reversion.c
@@ -227,9 +227,9 @@ SINGLE_BATTLE_TEST("Primal reversion happens immediately if it was brought in by
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_U_TURN, player);
         HP_BAR(opponent);
+        MESSAGE("2 sent out Wynaut!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_PRIMAL_REVERSION, player);
         MESSAGE("Groudon's Primal Reversion! It reverted to its primal form!");
-        MESSAGE("2 sent out Wynaut!");
     } THEN {
         EXPECT_EQ(player->species, SPECIES_GROUDON_PRIMAL);
     }

--- a/test/battle/move_effect/hit_escape.c
+++ b/test/battle/move_effect/hit_escape.c
@@ -126,10 +126,11 @@ SINGLE_BATTLE_TEST("Held items are consumed immediately after a mon switched in 
         ABILITY_POPUP(player, ABILITY_ELECTRIC_SURGE);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_U_TURN, player);
         HP_BAR(opponent);
+        NOT ABILITY_POPUP(player, ABILITY_INTIMIDATE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
         MESSAGE("2 sent out Wynaut!");
-        NOT ABILITY_POPUP(player, ABILITY_INTIMIDATE);
+        ABILITY_POPUP(player, ABILITY_INTIMIDATE);
     } THEN {
         EXPECT_EQ(player->statStages[STAT_DEF], DEFAULT_STAT_STAGE + 1);
     }
@@ -137,7 +138,6 @@ SINGLE_BATTLE_TEST("Held items are consumed immediately after a mon switched in 
 
 SINGLE_BATTLE_TEST("Held items are consumed immediately after a mon switched in by U-turn and Intimidate activates after it: opposing side")
 {
-    KNOWN_FAILING;
     GIVEN {
         PLAYER(SPECIES_TAPU_KOKO) { Ability(ABILITY_ELECTRIC_SURGE); };
         PLAYER(SPECIES_EKANS) { Ability(ABILITY_INTIMIDATE);  }
@@ -153,7 +153,7 @@ SINGLE_BATTLE_TEST("Held items are consumed immediately after a mon switched in 
         MESSAGE("2 sent out Wynaut!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-        NOT ABILITY_POPUP(player, ABILITY_INTIMIDATE);
+        ABILITY_POPUP(player, ABILITY_INTIMIDATE);
     } THEN {
         EXPECT_EQ(opponent->statStages[STAT_DEF], DEFAULT_STAT_STAGE + 1);
     }


### PR DESCRIPTION
Reverts wrongly done reversion by me.

Corrected a bunch of tests that were wrongly written but I had to add one 'KNOW_FAILING' to one test. The comment should explain why. 
```
Intimidate activates immediately after the mon was switched in as long as other battles still have to do their turn
```
Also some old test marked by #4856 as `KNOWN_FAILING` were removed but not the new ones. Those still didn't pass. 

Sorry again Egg. If I'm about to do something like this I will consult you first.  