### PR TITLE
simple button config for the move description menu

### DIFF
--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -223,6 +223,7 @@
 #define B_EXPANDED_MOVE_NAMES       TRUE  // If set to FALSE, move names are decreased from 16 characters to 12 characters.
 #define B_WAIT_TIME_MULTIPLIER      16    // This determines how long text pauses in battle last. Vanilla is 16. Lower values result in faster battles.
 #define B_QUICK_MOVE_CURSOR_TO_RUN  FALSE // If set to TRUE, pushing B in the battle options against a wild encounter will move the cursor to the run option
+#define B_MOVE_DESCRIPTION_BUTTON   L_BUTTON // If set to a button other than B_LAST_USED_BALL_BUTTON, pressing this button will open the move description menu
 
 // Catching settings
 #define B_SEMI_INVULNERABLE_CATCH   GEN_LATEST // In Gen4+, you cannot throw a ball against a Pokemon that is in a semi-invulnerable state (dig/fly/etc)

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -894,7 +894,6 @@ static void HandleInputChooseMove(u32 battler)
             gBattlerControllerFuncs[battler] = HandleMoveSwitching;
         }
     }
-    #if B_MOVE_DESCRIPTION_BUTTON != B_LAST_USED_BALL_BUTTON
     else if (gBattleStruct->descriptionSubmenu)
     {
         if (JOY_NEW(B_MOVE_DESCRIPTION_BUTTON) || JOY_NEW(A_BUTTON) || JOY_NEW(B_BUTTON))
@@ -914,12 +913,11 @@ static void HandleInputChooseMove(u32 battler)
             MoveSelectionDisplayMoveType(battler);
         }
     }
-    else if (JOY_NEW(B_MOVE_DESCRIPTION_BUTTON))
+    else if (JOY_NEW(B_MOVE_DESCRIPTION_BUTTON) && B_MOVE_DESCRIPTION_BUTTON != B_LAST_USED_BALL_BUTTON)
     {
         gBattleStruct->descriptionSubmenu = TRUE;
         MoveSelectionDisplayMoveDescription(battler);
     }
-    #endif
     else if (JOY_NEW(START_BUTTON))
     {
         if (CanMegaEvolve(battler))

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -894,9 +894,10 @@ static void HandleInputChooseMove(u32 battler)
             gBattlerControllerFuncs[battler] = HandleMoveSwitching;
         }
     }
+    #if B_MOVE_DESCRIPTION_BUTTON != B_LAST_USED_BALL_BUTTON
     else if (gBattleStruct->descriptionSubmenu)
     {
-        if (JOY_NEW(L_BUTTON) || JOY_NEW(A_BUTTON) || JOY_NEW(B_BUTTON))
+        if (JOY_NEW(B_MOVE_DESCRIPTION_BUTTON) || JOY_NEW(A_BUTTON) || JOY_NEW(B_BUTTON))
         {
             gBattleStruct->descriptionSubmenu = FALSE;
             if (gCategoryIconSpriteId != 0xFF)
@@ -913,11 +914,12 @@ static void HandleInputChooseMove(u32 battler)
             MoveSelectionDisplayMoveType(battler);
         }
     }
-    else if (JOY_NEW(L_BUTTON))
+    else if (JOY_NEW(B_MOVE_DESCRIPTION_BUTTON))
     {
         gBattleStruct->descriptionSubmenu = TRUE;
         MoveSelectionDisplayMoveDescription(battler);
     }
+    #endif
     else if (JOY_NEW(START_BUTTON))
     {
         if (CanMegaEvolve(battler))


### PR DESCRIPTION
Adds a very simple config for setting the hotkey for the move description menu. I mainly made this because it bothered me that the prompt for the pokeball was on the left side but required you pressed the R button.

Now you can swap between the two. Also inelegantly handles the case where the same button is set for both.
