### PR TITLE
Allowed rematches to occur if I_VS_SEEKER_CHARGING isn't enabled

### DIFF
--- a/include/vs_seeker.h
+++ b/include/vs_seeker.h
@@ -8,6 +8,7 @@ bool8 UpdateVsSeekerStepCounter(void);
 void MapResetTrainerRematches(u16 mapGroup, u16 mapNum);
 void ClearRematchMovementByTrainerId(void);
 u16 GetRematchTrainerIdVSSeeker(u16 trainerId);
+bool32 IsVsSeekerEnabled(void);
 
 #define VSSEEKER_RECHARGE_STEPS 100
 

--- a/src/battle_setup.c
+++ b/src/battle_setup.c
@@ -1916,15 +1916,16 @@ static bool32 HasAtLeastFiveBadges(void)
 void IncrementRematchStepCounter(void)
 {
 #if FREE_MATCH_CALL == FALSE
-    if (HasAtLeastFiveBadges()
-        && (I_VS_SEEKER_CHARGING != 0)
-        && (!CheckBagHasItem(ITEM_VS_SEEKER, 1)))
-    {
-        if (gSaveBlock1Ptr->trainerRematchStepCounter >= STEP_COUNTER_MAX)
-            gSaveBlock1Ptr->trainerRematchStepCounter = STEP_COUNTER_MAX;
-        else
-            gSaveBlock1Ptr->trainerRematchStepCounter++;
-    }
+    if (!HasAtLeastFiveBadges())
+        return;
+    
+    if (IsVsSeekerEnabled())
+        return;
+
+    if (gSaveBlock1Ptr->trainerRematchStepCounter >= STEP_COUNTER_MAX)
+        gSaveBlock1Ptr->trainerRematchStepCounter = STEP_COUNTER_MAX;
+    else
+        gSaveBlock1Ptr->trainerRematchStepCounter++;
 #endif //FREE_MATCH_CALL
 }
 

--- a/src/vs_seeker.c
+++ b/src/vs_seeker.c
@@ -577,6 +577,14 @@ u16 GetRematchTrainerIdVSSeeker(u16 trainerId)
     return gRematchTable[tableId].trainerIds[rematchTrainerIdx];
 }
 
+bool32 IsVsSeekerEnabled(void)
+{
+    if (I_VS_SEEKER_CHARGING == 0)
+        return FALSE;
+    
+    return (CheckBagHasItem(ITEM_VS_SEEKER, 1));
+}
+
 static bool8 ObjectEventIdIsSane(u8 objectEventId)
 {
     struct ObjectEvent *objectEvent = &gObjectEvents[objectEventId];


### PR DESCRIPTION
## Description
The way the code is currently written, the step counter for rematches will never increment if `I_VS_SEEKER_CHARGING` is disabled

## **Discord contact info**
Frankfurter
