### PR TITLE
Zero Enemy Data at end of battles

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -5581,7 +5581,7 @@ static void FreeResetData_ReturnToOvOrDoEvolutions(void)
     }
 
     FreeAllWindowBuffers();
-    if (!(gBattleTypeFlags & BATTLE_TYPE_LINK))
+    if (gBattleStruct != NULL && !(gBattleTypeFlags & BATTLE_TYPE_LINK))
     {
         ZeroEnemyPartyMons();
         FreeMonSpritesGfx();

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -5583,6 +5583,7 @@ static void FreeResetData_ReturnToOvOrDoEvolutions(void)
     FreeAllWindowBuffers();
     if (!(gBattleTypeFlags & BATTLE_TYPE_LINK))
     {
+        ZeroEnemyPartyMons();
         FreeMonSpritesGfx();
         FreeBattleResources();
         FreeBattleSpritesData();


### PR DESCRIPTION
Enemy data is cleared at the start of trainer battles and with setwildbattle, but with #4688 there is a potential to use `createmon` to set up a complex wild battle without zeroing out said data beforehand, so stray pokemon data from previous battles could leak into such battles and cause problems. This PR just resets enemy mon data after each battle to prevent this from occurring.

It also adds a `gBattleStruct != NULL` check to the same block so `FreeBattleResources` and co. are only called once instead of over many frames while gPaletteFade is active