### PR TITLE
Fix wrong palette in player backsprite in recorded battle

### DIFF
--- a/src/battle_controller_recorded_player.c
+++ b/src/battle_controller_recorded_player.c
@@ -517,7 +517,7 @@ static void RecordedPlayerHandleIntroTrainerBallThrow(u32 battler)
     else
         trainerPicId = gSaveBlock2Ptr->playerGender + TRAINER_BACK_PIC_BRENDAN;
 
-    trainerPal = gTrainerSprites[trainerPicId].palette.data;
+    trainerPal = gTrainerBacksprites[trainerPicId].palette.data;
     BtlController_HandleIntroTrainerBallThrow(battler, 0xD6F9, trainerPal, 24, Intro_TryShinyAnimShowHealthbox);
 }
 


### PR DESCRIPTION
Title,

this has been around for like over a year probably, but enough is enough lol
![pic_before](https://github.com/rh-hideout/pokeemerald-expansion/assets/16259973/9c90682f-5a48-4b8c-8dcd-5734548bf394)
![pic_after](https://github.com/rh-hideout/pokeemerald-expansion/assets/16259973/83f2c9a8-eb00-4688-88de-be4f1be920e3)
