### PR TITLE
Add AI_FLAG_SEQUENCE_SWITCHING

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -369,7 +369,7 @@ struct AiLogicData
     bool8 shouldSwitchMon; // Because all available moves have no/little effect. Each bit per battler.
     u8 monToSwitchId[MAX_BATTLERS_COUNT]; // ID of the mon to switch.
     bool8 weatherHasEffect; // The same as WEATHER_HAS_EFFECT. Stored here, so it's called only once.
-    u32 mostSuitableMonId[MAX_BATTLERS_COUNT]; // Stores result of GetMostSuitableMonToSwitchInto, which decides which generic mon the AI would switch into if they decide to switch. This can be overruled by specific mons found in ShouldSwitch; the final resulting mon is stored in AI_monToSwitchIntoId.
+    u8 mostSuitableMonId[MAX_BATTLERS_COUNT]; // Stores result of GetMostSuitableMonToSwitchInto, which decides which generic mon the AI would switch into if they decide to switch. This can be overruled by specific mons found in ShouldSwitch; the final resulting mon is stored in AI_monToSwitchIntoId.
     struct SwitchinCandidate switchinCandidate; // Struct used for deciding which mon to switch to in battle_ai_switch_items.c
 };
 

--- a/include/battle.h
+++ b/include/battle.h
@@ -369,7 +369,7 @@ struct AiLogicData
     bool8 shouldSwitchMon; // Because all available moves have no/little effect. Each bit per battler.
     u8 monToSwitchId[MAX_BATTLERS_COUNT]; // ID of the mon to switch.
     bool8 weatherHasEffect; // The same as WEATHER_HAS_EFFECT. Stored here, so it's called only once.
-    u8 mostSuitableMonId[MAX_BATTLERS_COUNT]; // Stores result of GetMostSuitableMonToSwitchInto, which decides which generic mon the AI would switch into if they decide to switch. This can be overruled by specific mons found in ShouldSwitch; the final resulting mon is stored in AI_monToSwitchIntoId.
+    u32 mostSuitableMonId[MAX_BATTLERS_COUNT]; // Stores result of GetMostSuitableMonToSwitchInto, which decides which generic mon the AI would switch into if they decide to switch. This can be overruled by specific mons found in ShouldSwitch; the final resulting mon is stored in AI_monToSwitchIntoId.
     struct SwitchinCandidate switchinCandidate; // Struct used for deciding which mon to switch to in battle_ai_switch_items.c
 };
 

--- a/include/battle_ai_switch_items.h
+++ b/include/battle_ai_switch_items.h
@@ -3,7 +3,7 @@
 
 void GetAIPartyIndexes(u32 battlerId, s32 *firstId, s32 *lastId);
 void AI_TrySwitchOrUseItem(u32 battler);
-u8 GetMostSuitableMonToSwitchInto(u32 battler, bool32 switchAfterMonKOd);
+u32 GetMostSuitableMonToSwitchInto(u32 battler, bool32 switchAfterMonKOd);
 bool32 ShouldSwitch(u32 battler, bool32 emitResult);
 
 #endif // GUARD_BATTLE_AI_SWITCH_ITEMS_H

--- a/include/constants/battle_ai.h
+++ b/include/constants/battle_ai.h
@@ -47,7 +47,7 @@
 #define AI_FLAG_OMNISCIENT            (1 << 17)  // AI has full knowledge of player moves, abilities, hold items
 #define AI_FLAG_SMART_MON_CHOICES     (1 << 18)  // AI will make smarter decisions when choosing which mon to send out mid-battle and after a KO, which are separate decisions. Automatically included by AI_FLAG_SMART_SWITCHING.
 #define AI_FLAG_CONSERVATIVE          (1 << 19)  // AI assumes all moves will low roll damage
-#define AI_FLAG_SEQUENCE_SWITCHING  (1 << 20)  // AI switches in mons in exactly party order, and never switches mid-battle
+#define AI_FLAG_SEQUENCE_SWITCHING    (1 << 20)  // AI switches in mons in exactly party order, and never switches mid-battle
 
 #define AI_FLAG_COUNT                       20
 

--- a/include/constants/battle_ai.h
+++ b/include/constants/battle_ai.h
@@ -47,7 +47,7 @@
 #define AI_FLAG_OMNISCIENT            (1 << 17)  // AI has full knowledge of player moves, abilities, hold items
 #define AI_FLAG_SMART_MON_CHOICES     (1 << 18)  // AI will make smarter decisions when choosing which mon to send out mid-battle and after a KO, which are separate decisions. Automatically included by AI_FLAG_SMART_SWITCHING.
 #define AI_FLAG_CONSERVATIVE          (1 << 19)  // AI assumes all moves will low roll damage
-#define AI_FLAG_BAD_SWITCHING         (1 << 20)  // AI switches in mons in exactly party order, and never switches mid-battle
+#define AI_FLAG_SEQUENCE_SWITCHING  (1 << 20)  // AI switches in mons in exactly party order, and never switches mid-battle
 
 #define AI_FLAG_COUNT                       20
 

--- a/include/constants/battle_ai.h
+++ b/include/constants/battle_ai.h
@@ -47,6 +47,7 @@
 #define AI_FLAG_OMNISCIENT            (1 << 17)  // AI has full knowledge of player moves, abilities, hold items
 #define AI_FLAG_SMART_MON_CHOICES     (1 << 18)  // AI will make smarter decisions when choosing which mon to send out mid-battle and after a KO, which are separate decisions. Automatically included by AI_FLAG_SMART_SWITCHING.
 #define AI_FLAG_CONSERVATIVE          (1 << 19)  // AI assumes all moves will low roll damage
+#define AI_FLAG_BAD_SWITCHING         (1 << 20)  // AI switches in mons in exactly party order, and never switches mid-battle
 
 #define AI_FLAG_COUNT                       20
 

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -511,7 +511,8 @@ static bool32 AI_ShouldSwitchIfBadMoves(u32 battler, bool32 doubleBattle)
     if (CountUsablePartyMons(battler) > 0
         && !IsBattlerTrapped(battler, TRUE)
         && !(gBattleTypeFlags & (BATTLE_TYPE_ARENA | BATTLE_TYPE_PALACE))
-        && AI_THINKING_STRUCT->aiFlags[battler] & (AI_FLAG_CHECK_VIABILITY | AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_PREFER_BATON_PASS))
+        && AI_THINKING_STRUCT->aiFlags[battler] & (AI_FLAG_CHECK_VIABILITY | AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_PREFER_BATON_PASS)
+        && !(AI_THINKING_STRUCT->aiFlags[battler] & AI_FLAG_SEQUENCE_SWITCHING))
     {
         // Consider switching if all moves are worthless to use.
         if (GetTotalBaseStat(gBattleMons[battler].species) >= 310 // Mon is not weak.

--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -1769,7 +1769,7 @@ static bool32 CanAbilityTrapOpponent(u16 ability, u32 opponent)
 // the Most Damage code will prioritize switching into whatever mon deals the most damage, which is generally not as good as having a good Type Matchup
 // Everything runs in the same loop to minimize computation time. This makes it harder to read, but hopefully the comments can guide you!
 
-static u32 GetBestMonIntegrated(struct Pokemon *party, int firstId, int lastId, u32 battler, u32 opposingBattler, u8 battlerIn1, u8 battlerIn2, bool32 isSwitchAfterKO)
+static u32 GetBestMonIntegrated(struct Pokemon *party, int firstId, int lastId, u32 battler, u32 opposingBattler, u32 battlerIn1, u32 battlerIn2, bool32 isSwitchAfterKO)
 {
     int revengeKillerId = PARTY_SIZE, slowRevengeKillerId = PARTY_SIZE, fastThreatenId = PARTY_SIZE, slowThreatenId = PARTY_SIZE, damageMonId = PARTY_SIZE;
     int batonPassId = PARTY_SIZE, typeMatchupId = PARTY_SIZE, typeMatchupEffectiveId = PARTY_SIZE, defensiveMonId = PARTY_SIZE, aceMonId = PARTY_SIZE, trapperId = PARTY_SIZE;
@@ -1981,7 +1981,7 @@ static u32 GetBestMonIntegrated(struct Pokemon *party, int firstId, int lastId, 
     return PARTY_SIZE;
 }
 
-static u32 GetNextMonInParty(struct Pokemon *party, int firstId, int lastId, u8 battlerIn1, u8 battlerIn2)
+static u32 GetNextMonInParty(struct Pokemon *party, int firstId, int lastId, u32 battlerIn1, u32 battlerIn2)
 {
     u32 i;
     // Iterate through mons
@@ -2001,11 +2001,11 @@ static u32 GetNextMonInParty(struct Pokemon *party, int firstId, int lastId, u8 
     return PARTY_SIZE;
 }
 
-u8 GetMostSuitableMonToSwitchInto(u32 battler, bool32 switchAfterMonKOd)
+u32 GetMostSuitableMonToSwitchInto(u32 battler, bool32 switchAfterMonKOd)
 {
     u32 opposingBattler = 0;
     u32 bestMonId = PARTY_SIZE;
-    u8 battlerIn1 = 0, battlerIn2 = 0;
+    u32 battlerIn1 = 0, battlerIn2 = 0;
     s32 firstId = 0;
     s32 lastId = 0; // + 1
     struct Pokemon *party;

--- a/test/battle/ai_flag_sequence_switching.c
+++ b/test/battle/ai_flag_sequence_switching.c
@@ -5,8 +5,8 @@ AI_SINGLE_BATTLE_TEST("AI_FLAG_SEQUENCE_SWITCHING: AI will always switch after a
 {
     u32 aiSequenceSwitchingFlag = 0;
 
-    PARAMETRIZE{ aiSequenceSwitchingFlag = 0; }
-    PARAMETRIZE{ aiSequenceSwitchingFlag = AI_FLAG_SEQUENCE_SWITCHING; }
+    PARAMETRIZE { aiSequenceSwitchingFlag = 0; }
+    PARAMETRIZE { aiSequenceSwitchingFlag = AI_FLAG_SEQUENCE_SWITCHING; }
 
     GIVEN {
         AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | aiSequenceSwitchingFlag);
@@ -76,8 +76,8 @@ AI_SINGLE_BATTLE_TEST("AI_FLAG_SEQUENCE_SWITCHING: AI will always switch into lo
 
     for (j = 0; j < ARRAY_COUNT(switchMoves); j++)
     {
-        PARAMETRIZE{ aiSequenceSwitchingFlag = 0;                           move = switchMoves[j]; }
-        PARAMETRIZE{ aiSequenceSwitchingFlag = AI_FLAG_SEQUENCE_SWITCHING;  move = switchMoves[j]; }
+        PARAMETRIZE { aiSequenceSwitchingFlag = 0;                           move = switchMoves[j]; }
+        PARAMETRIZE { aiSequenceSwitchingFlag = AI_FLAG_SEQUENCE_SWITCHING;  move = switchMoves[j]; }
     }
 
     GIVEN {
@@ -110,8 +110,8 @@ AI_SINGLE_BATTLE_TEST("AI_FLAG_SEQUENCE_SWITCHING: AI will not switch mid-battle
 {
     u32 aiSequenceSwitchingFlag = 0;
 
-    PARAMETRIZE{ aiSequenceSwitchingFlag = 0; }
-    PARAMETRIZE{ aiSequenceSwitchingFlag = AI_FLAG_SEQUENCE_SWITCHING; }
+    PARAMETRIZE { aiSequenceSwitchingFlag = 0; }
+    PARAMETRIZE { aiSequenceSwitchingFlag = AI_FLAG_SEQUENCE_SWITCHING; }
 
     GIVEN {
         AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | aiSequenceSwitchingFlag);

--- a/test/battle/ai_flag_sequence_switching.c
+++ b/test/battle/ai_flag_sequence_switching.c
@@ -1,0 +1,181 @@
+#include "global.h"
+#include "test/battle.h"
+
+AI_SINGLE_BATTLE_TEST("AI_FLAG_SEQUENCE_SWITCHING: AI will always switch after a KO in exactly party order")
+{
+    u32 aiSequenceSwitchingFlag = 0;
+
+    PARAMETRIZE{ aiSequenceSwitchingFlag = 0; }
+    PARAMETRIZE{ aiSequenceSwitchingFlag = AI_FLAG_SEQUENCE_SWITCHING; }
+
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | aiSequenceSwitchingFlag);
+        PLAYER(SPECIES_SWELLOW) { Level (50); }
+        OPPONENT(SPECIES_MACHOP) { Level(1); }
+        OPPONENT(SPECIES_MACHOP) { Level(2); }
+        OPPONENT(SPECIES_MACHOP) { Level(3); }
+        OPPONENT(SPECIES_MACHOP) { Level(4); }
+        OPPONENT(SPECIES_MACHOP) { Level(5); }
+        OPPONENT(SPECIES_MAGNEZONE) { Level(100); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_WING_ATTACK) ; EXPECT_SEND_OUT(opponent, aiSequenceSwitchingFlag ? 2 : 5); }
+        if (aiSequenceSwitchingFlag == AI_FLAG_SEQUENCE_SWITCHING) {
+            TURN { MOVE(player, MOVE_WING_ATTACK) ; EXPECT_SEND_OUT(opponent, 4); }
+            TURN { MOVE(player, MOVE_WING_ATTACK) ; EXPECT_SEND_OUT(opponent, 3); }
+            TURN { MOVE(player, MOVE_WING_ATTACK) ; EXPECT_SEND_OUT(opponent, 4); }
+            TURN { MOVE(player, MOVE_WING_ATTACK) ; EXPECT_SEND_OUT(opponent, 5); }
+        }
+    }
+}
+
+AI_SINGLE_BATTLE_TEST("AI_FLAG_SEQUENCE_SWITCHING: Roar still forces switch to random party member")
+{
+    PASSES_RANDOMLY(1, 2, RNG_FORCE_RANDOM_SWITCH);
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_ROAR].effect == EFFECT_ROAR);
+        AI_FLAGS(AI_FLAG_SEQUENCE_SWITCHING);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_BULBASAUR);
+        OPPONENT(SPECIES_CHARMANDER);
+        OPPONENT(SPECIES_SQUIRTLE) { HP(0); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_ROAR); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ROAR, player);
+        MESSAGE("Foe Bulbasaur was dragged out!");
+    }
+}
+
+AI_SINGLE_BATTLE_TEST("AI_FLAG_SEQUENCE_SWITCHING: AI will always switch after U-Turn in exactly party order")
+{
+    u32 j, aiSequenceSwitchingFlag = 0, move = MOVE_NONE;
+
+    static const u32 switchMoves[] = {
+        MOVE_U_TURN,
+        MOVE_U_TURN,
+        MOVE_U_TURN,
+    };
+    for (j = 0; j < ARRAY_COUNT(switchMoves); j++)
+    {
+        PARAMETRIZE{ aiSequenceSwitchingFlag = 0;                           move = switchMoves[j]; }
+        PARAMETRIZE{ aiSequenceSwitchingFlag = AI_FLAG_SEQUENCE_SWITCHING;  move = switchMoves[j]; }
+    }
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_U_TURN].effect == EFFECT_HIT_ESCAPE);
+        ASSUME(gMovesInfo[MOVE_PARTING_SHOT].effect == EFFECT_PARTING_SHOT);
+        ASSUME(gMovesInfo[MOVE_BATON_PASS].effect == EFFECT_BATON_PASS);
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | aiSequenceSwitchingFlag);
+        PLAYER(SPECIES_SWELLOW) { Level (50); }
+        OPPONENT(SPECIES_MACHOP) { Level(1); Moves(move); }
+        OPPONENT(SPECIES_MACHOP) { Level(2); Moves(move); }
+        OPPONENT(SPECIES_MACHOP) { Level(3); Moves(move); }
+        OPPONENT(SPECIES_MACHOP) { Level(4); Moves(move); }
+        OPPONENT(SPECIES_MACHOP) { Level(5); Moves(move); }
+        OPPONENT(SPECIES_MAGNEZONE) { Level(100); }
+    } WHEN {
+        TURN { EXPECT_MOVE(opponent, move) ; EXPECT_SEND_OUT(opponent, aiSequenceSwitchingFlag ? 1 : 1); }
+        if (aiSequenceSwitchingFlag == AI_FLAG_SEQUENCE_SWITCHING) {
+            TURN { EXPECT_MOVE(opponent, move) ; EXPECT_SEND_OUT(opponent, 0); }
+            TURN { EXPECT_MOVE(opponent, move) ; EXPECT_SEND_OUT(opponent, 1); }
+            TURN { EXPECT_MOVE(opponent, move) ; EXPECT_SEND_OUT(opponent, 0); }
+            TURN { EXPECT_MOVE(opponent, move) ; EXPECT_SEND_OUT(opponent, 1); }
+        }
+    }
+}
+
+AI_SINGLE_BATTLE_TEST("AI_FLAG_SEQUENCE_SWITCHING: AI will always switch after Parting Shot in exactly party order")
+{
+    u32 j, aiSequenceSwitchingFlag = 0, move = MOVE_NONE;
+
+    static const u32 switchMoves[] = {
+        MOVE_PARTING_SHOT,
+        MOVE_PARTING_SHOT,
+        MOVE_PARTING_SHOT,
+    };
+    for (j = 0; j < ARRAY_COUNT(switchMoves); j++)
+    {
+        PARAMETRIZE{ aiSequenceSwitchingFlag = 0;                           move = switchMoves[j]; }
+        PARAMETRIZE{ aiSequenceSwitchingFlag = AI_FLAG_SEQUENCE_SWITCHING;  move = switchMoves[j]; }
+    }
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_U_TURN].effect == EFFECT_HIT_ESCAPE);
+        ASSUME(gMovesInfo[MOVE_PARTING_SHOT].effect == EFFECT_PARTING_SHOT);
+        ASSUME(gMovesInfo[MOVE_BATON_PASS].effect == EFFECT_BATON_PASS);
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | aiSequenceSwitchingFlag);
+        PLAYER(SPECIES_SWELLOW) { Level (50); }
+        OPPONENT(SPECIES_MACHOP) { Level(1); Moves(move); }
+        OPPONENT(SPECIES_MACHOP) { Level(2); Moves(move); }
+        OPPONENT(SPECIES_MACHOP) { Level(3); Moves(move); }
+        OPPONENT(SPECIES_MACHOP) { Level(4); Moves(move); }
+        OPPONENT(SPECIES_MACHOP) { Level(5); Moves(move); }
+        OPPONENT(SPECIES_MAGNEZONE) { Level(100); }
+    } WHEN {
+        TURN { EXPECT_MOVE(opponent, move) ; EXPECT_SEND_OUT(opponent, aiSequenceSwitchingFlag ? 1 : 5); }
+        if (aiSequenceSwitchingFlag == AI_FLAG_SEQUENCE_SWITCHING) {
+            TURN { EXPECT_MOVE(opponent, move) ; EXPECT_SEND_OUT(opponent, 0); }
+            TURN { EXPECT_MOVE(opponent, move) ; EXPECT_SEND_OUT(opponent, 1); }
+            TURN { EXPECT_MOVE(opponent, move) ; EXPECT_SEND_OUT(opponent, 0); }
+            TURN { EXPECT_MOVE(opponent, move) ; EXPECT_SEND_OUT(opponent, 1); }
+        }
+    }
+}
+
+AI_SINGLE_BATTLE_TEST("AI_FLAG_SEQUENCE_SWITCHING: AI will always switch after Baton Pass in exactly party order")
+{
+    u32 j, aiSequenceSwitchingFlag = 0, move = MOVE_NONE;
+
+    static const u32 switchMoves[] = {
+        MOVE_BATON_PASS,
+        MOVE_BATON_PASS,
+        MOVE_BATON_PASS,
+    };
+    for (j = 0; j < ARRAY_COUNT(switchMoves); j++)
+    {
+        PARAMETRIZE{ aiSequenceSwitchingFlag = 0;                           move = switchMoves[j]; }
+        PARAMETRIZE{ aiSequenceSwitchingFlag = AI_FLAG_SEQUENCE_SWITCHING;  move = switchMoves[j]; }
+    }
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_U_TURN].effect == EFFECT_HIT_ESCAPE);
+        ASSUME(gMovesInfo[MOVE_PARTING_SHOT].effect == EFFECT_PARTING_SHOT);
+        ASSUME(gMovesInfo[MOVE_BATON_PASS].effect == EFFECT_BATON_PASS);
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | aiSequenceSwitchingFlag);
+        PLAYER(SPECIES_SWELLOW) { Level (50); }
+        OPPONENT(SPECIES_MACHOP) { Level(1); Moves(move); }
+        OPPONENT(SPECIES_MACHOP) { Level(2); Moves(move); }
+        OPPONENT(SPECIES_MACHOP) { Level(3); Moves(move); }
+        OPPONENT(SPECIES_MACHOP) { Level(4); Moves(move); }
+        OPPONENT(SPECIES_MACHOP) { Level(5); Moves(move); }
+        OPPONENT(SPECIES_MAGNEZONE) { Level(100); }
+    } WHEN {
+        TURN { EXPECT_MOVE(opponent, move) ; EXPECT_SEND_OUT(opponent, aiSequenceSwitchingFlag ? 1 : 5); }
+        if (aiSequenceSwitchingFlag == AI_FLAG_SEQUENCE_SWITCHING) {
+            TURN { EXPECT_MOVE(opponent, move) ; EXPECT_SEND_OUT(opponent, 0); }
+            TURN { EXPECT_MOVE(opponent, move) ; EXPECT_SEND_OUT(opponent, 1); }
+            TURN { EXPECT_MOVE(opponent, move) ; EXPECT_SEND_OUT(opponent, 0); }
+            TURN { EXPECT_MOVE(opponent, move) ; EXPECT_SEND_OUT(opponent, 1); }
+        }
+    }
+}
+
+AI_SINGLE_BATTLE_TEST("AI_FLAG_SEQUENCE_SWITCHING: AI will not switch mid-battle")
+{
+    u32 aiSequenceSwitchingFlag = 0;
+
+    PARAMETRIZE{ aiSequenceSwitchingFlag = 0; }
+    PARAMETRIZE{ aiSequenceSwitchingFlag = AI_FLAG_SEQUENCE_SWITCHING; }
+
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | aiSequenceSwitchingFlag);
+        PLAYER(SPECIES_ZIGZAGOON) { Moves(MOVE_LICK); }
+        OPPONENT(SPECIES_GASTLY) { Moves(MOVE_SHADOW_BALL); }
+        OPPONENT(SPECIES_ZIGZAGOON) { Moves(MOVE_KARATE_CHOP); }
+    } WHEN {
+        if (aiSequenceSwitchingFlag == AI_FLAG_SEQUENCE_SWITCHING) {
+            TURN { MOVE(player, MOVE_LICK) ; EXPECT_MOVE(opponent, MOVE_SHADOW_BALL); }
+        }
+        else {
+            TURN { MOVE(player, MOVE_LICK) ; EXPECT_SWITCH(opponent, 1); }
+        }
+    }
+}

--- a/test/battle/ai_flag_sequence_switching.c
+++ b/test/battle/ai_flag_sequence_switching.c
@@ -39,11 +39,17 @@ AI_SINGLE_BATTLE_TEST("AI_FLAG_SEQUENCE_SWITCHING: AI will always switch after a
     }
 }
 
-AI_SINGLE_BATTLE_TEST("AI_FLAG_SEQUENCE_SWITCHING: Roar still forces switch to random party member")
+AI_SINGLE_BATTLE_TEST("AI_FLAG_SEQUENCE_SWITCHING: Roar and Dragon Tail still force switch to random party member")
 {
+    u32 move;
+
+    PARAMETRIZE { move = MOVE_ROAR; }
+    PARAMETRIZE {move = MOVE_DRAGON_TAIL; }
+
     PASSES_RANDOMLY(1, 2, RNG_FORCE_RANDOM_SWITCH);
     GIVEN {
         ASSUME(gMovesInfo[MOVE_ROAR].effect == EFFECT_ROAR);
+        ASSUME(gMovesInfo[MOVE_DRAGON_TAIL].effect == EFFECT_HIT_SWITCH_TARGET);
         AI_FLAGS(AI_FLAG_SEQUENCE_SWITCHING);
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET);
@@ -51,9 +57,9 @@ AI_SINGLE_BATTLE_TEST("AI_FLAG_SEQUENCE_SWITCHING: Roar still forces switch to r
         OPPONENT(SPECIES_CHARMANDER);
         OPPONENT(SPECIES_SQUIRTLE) { HP(0); }
     } WHEN {
-        TURN { MOVE(player, MOVE_ROAR); }
+        TURN { MOVE(player, move); }
     } SCENE {
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_ROAR, player);
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
         MESSAGE("Foe Bulbasaur was dragged out!");
     }
 }


### PR DESCRIPTION
## Description
Floated this in Discord the other day and didn't get a lot of traction one way or the other so I thought I'd PR it and we can discuss from here if need be.

Recently Kasen from the Aqua discord was asking me how hard it'd be to make a flag where:
- The AI always switches in mons after a KO in exactly their party order regardless of other factors (index 1, then 2, etc.)
- U-Turn and other forced switches also always choose the lowest party index available
- Mid-battle switches aren't triggered

This PR implements that functionality in `AI_FLAG_SEQUENCE_SWITCHING`. I can see five main utilities for a flag like this:
- Battles where the designer wants a fully deterministic experience for both themselves and the user
- Hacks where battles are constructed more in the form of puzzles
- Hacks that balance low difficulty casual runs with deterministically solvable difficult nuzlocke runs
- Hacks that want to approximate the experience of playing Gen 1, which uses this switching order
- Battles with a "narrative", ie. switch in Machop -> Machoke -> Machamp even though Machamp would have been "better" to switch in first

I'm of the opinion that this is worth a flag slot as the behaviour is so radically different from existing AI flags, and it's applicable to niches that are not well served by existing flags. I fully understand though that we're tight on AI flags and need to be discerning about what we choose to add.

I've included tests to make sure the three intended features work correctly, as well as a safety net test to make sure this flag doesn't break forced random switching from Roar and effects like Dragon Tail.

## **People who collaborated with me in this PR**
Kasen had the initial idea, psf came up with the flag name, and Egg had some helpful suggestions for overhauling some of the tests.

## **Discord contact info**
@Pawkkie
