### PR TITLE
Remove SetBattlerData from AI_CalcDamage

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -512,9 +512,6 @@ struct SimulatedDamage AI_CalcDamage(u32 move, u32 battlerAtk, u32 battlerDef, u
     struct AiLogicData *aiData = AI_DATA;
     gBattleStruct->aiCalcInProgress = TRUE;
 
-    SetBattlerData(battlerAtk);
-    SetBattlerData(battlerDef);
-
     // Temporarily enable gimmicks for damage calcs if planned
     if (gBattleStruct->gimmick.usableGimmick[battlerAtk] && GetActiveGimmick(battlerAtk) == GIMMICK_NONE
         && !(gBattleStruct->gimmick.usableGimmick[battlerAtk] == GIMMICK_Z_MOVE && !considerZPower))


### PR DESCRIPTION
Since #4156 SetBattlerData and RestoreBattlerData were moved out of `AI_CalcDamage`. I assume this was a bad merge somewhere

