### PR TITLE
Mold Breaker does not ignore targets partner ability in doubles

### DIFF
--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -150,6 +150,7 @@ bool32 TryPrimalReversion(u32 battler);
 bool32 IsNeutralizingGasOnField(void);
 bool32 IsMoldBreakerTypeAbility(u32 ability);
 u32 GetBattlerAbility(u32 battler);
+u32 GetBattlerAbilityIgnoreUserAbility(u32 battler);
 u32 IsAbilityOnSide(u32 battler, u32 ability);
 u32 IsAbilityOnOpposingSide(u32 battler, u32 ability);
 u32 IsAbilityOnField(u32 ability);

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -6209,6 +6209,7 @@ static u32 GetBattlerAbilityWithArg(u32 battler, bool32 ignoreUserAbility)
         return gBattleMons[battler].ability;
 
     if (gAbilitiesInfo[gBattleMons[battler].ability].breakable
+     && battler != gBattlerAttacker
      && gBattlerByTurnOrder[gCurrentTurnActionNumber] == gBattlerAttacker
      && gActionsByTurnOrder[gBattlerByTurnOrder[gBattlerAttacker]] == B_ACTION_USE_MOVE
      && gCurrentTurnActionNumber < gBattlersCount)

--- a/test/battle/ability/dazzling.c
+++ b/test/battle/ability/dazzling.c
@@ -50,3 +50,45 @@ DOUBLE_BATTLE_TEST("Dazzling, Queenly Majesty and Armor Tail protect users partn
         MESSAGE("Wobbuffet cannot use Quick Attack!");
     }
 }
+
+SINGLE_BATTLE_TEST("Dazzling, Queenly Majesty and Armor Tail are ignored by Mold Breaker")
+{
+    u32 species, ability;
+
+    PARAMETRIZE { species = SPECIES_BRUXISH; ability = ABILITY_DAZZLING; }
+    PARAMETRIZE { species = SPECIES_FARIGIRAF; ability = ABILITY_ARMOR_TAIL; }
+    PARAMETRIZE { species = SPECIES_TSAREENA; ability = ABILITY_QUEENLY_MAJESTY; }
+
+    GIVEN {
+        PLAYER(SPECIES_PINSIR) { Ability(ABILITY_MOLD_BREAKER); };
+        OPPONENT(species) { Ability(ability); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_QUICK_ATTACK); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_QUICK_ATTACK, player);
+        NOT ABILITY_POPUP(opponent, ability);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Dazzling, Queenly Majesty and Armor Tail protect users partner from priority moves even on Mold Breaker - Doubles")
+{
+    u32 species, ability;
+
+    PARAMETRIZE { species = SPECIES_BRUXISH; ability = ABILITY_DAZZLING; }
+    PARAMETRIZE { species = SPECIES_FARIGIRAF; ability = ABILITY_ARMOR_TAIL; }
+    PARAMETRIZE { species = SPECIES_TSAREENA; ability = ABILITY_QUEENLY_MAJESTY; }
+
+    GIVEN {
+        PLAYER(SPECIES_PINSIR) { Ability(ABILITY_MOLD_BREAKER); };
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(species) { Ability(ability); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_QUICK_ATTACK, target: opponentRight); }
+    } SCENE {
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_QUICK_ATTACK, opponentRight);
+        ABILITY_POPUP(opponentLeft, ability);
+        MESSAGE("Pinsir cannot use Quick Attack!");
+    }
+}


### PR DESCRIPTION
When a user has Mold Breaker the targets partner ability is not ignored. Also rewrote `GetBattlerAbility` slightly to make it more readable.  