### PR TITLE
Fixed B_TRANSITION_SHRED_SPLIT from softlocking the game

### DIFF
--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -267,4 +267,5 @@
 #define B_NEW_IMPACT_PALETTE            TRUE    // If set to TRUE, it updates the basic 'hit' palette.
 #define B_NEW_SURF_PARTICLE_PALETTE     TRUE    // If set to TRUE, it updates Surf's wave palette.
 
+#define B_ENABLE_SHRED_SPLIT            TRUE    // If set to TRUE, users can use B_TRANSITION_SHRED_SPLIT without softlocking the game.
 #endif // GUARD_CONFIG_BATTLE_H

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -267,5 +267,4 @@
 #define B_NEW_IMPACT_PALETTE            TRUE    // If set to TRUE, it updates the basic 'hit' palette.
 #define B_NEW_SURF_PARTICLE_PALETTE     TRUE    // If set to TRUE, it updates Surf's wave palette.
 
-#define B_ENABLE_SHRED_SPLIT            TRUE    // If set to TRUE, users can use B_TRANSITION_SHRED_SPLIT without softlocking the game.
 #endif // GUARD_CONFIG_BATTLE_H

--- a/src/battle_transition.c
+++ b/src/battle_transition.c
@@ -212,9 +212,6 @@ static bool8 AngledWipes_TryEnd(struct Task *);
 static bool8 AngledWipes_StartNext(struct Task *);
 static bool8 ShredSplit_Init(struct Task *);
 static bool8 ShredSplit_Main(struct Task *);
-#if B_ENABLE_SHRED_SPLIT == FALSE
-static bool8 ShredSplit_BrokenCheck(struct Task *);
-#endif
 static bool8 ShredSplit_End(struct Task *);
 static bool8 Blackhole_Init(struct Task *);
 static bool8 Blackhole_Vibrate(struct Task *);
@@ -563,9 +560,6 @@ static const TransitionStateFunc sShredSplit_Funcs[] =
 {
     ShredSplit_Init,
     ShredSplit_Main,
-#if B_ENABLE_SHRED_SPLIT == FALSE
-    ShredSplit_BrokenCheck,
-#endif
     ShredSplit_End
 };
 
@@ -2931,32 +2925,6 @@ static bool8 ShredSplit_Main(struct Task *task)
     sTransitionData->VBlank_DMA++;
     return FALSE;
 }
-
-#if B_ENABLE_SHRED_SPLIT == FALSE
-// This function never increments the state counter, because the loop condition
-// is always false, resulting in the game being stuck in an infinite loop.
-// It's possible this transition is only partially
-// done and the second part was left out.
-// In any case removing or bypassing this state allows the transition to finish.
-// You can bypass this by searching the repo for B_ENABLE_SHRED_SPLIT and setting it to TRUE.
-static bool8 ShredSplit_BrokenCheck(struct Task *task)
-{
-    u16 i;
-    bool32 done = TRUE;
-    u16 checkVar2 = 0xFF10;
-
-    for (i = 0; i < DISPLAY_HEIGHT; i++)
-    {
-        if (gScanlineEffectRegBuffers[1][i] != DISPLAY_WIDTH && gScanlineEffectRegBuffers[1][i] != checkVar2)
-            done = FALSE;
-    }
-
-    if (done == TRUE)
-        task->tState++;
-
-    return FALSE;
-}
-#endif
 
 static bool8 ShredSplit_End(struct Task *task)
 {

--- a/src/battle_transition.c
+++ b/src/battle_transition.c
@@ -212,7 +212,9 @@ static bool8 AngledWipes_TryEnd(struct Task *);
 static bool8 AngledWipes_StartNext(struct Task *);
 static bool8 ShredSplit_Init(struct Task *);
 static bool8 ShredSplit_Main(struct Task *);
+#if B_ENABLE_SHRED_SPLIT == FALSE
 static bool8 ShredSplit_BrokenCheck(struct Task *);
+#endif
 static bool8 ShredSplit_End(struct Task *);
 static bool8 Blackhole_Init(struct Task *);
 static bool8 Blackhole_Vibrate(struct Task *);
@@ -561,7 +563,9 @@ static const TransitionStateFunc sShredSplit_Funcs[] =
 {
     ShredSplit_Init,
     ShredSplit_Main,
+#if B_ENABLE_SHRED_SPLIT == FALSE
     ShredSplit_BrokenCheck,
+#endif
     ShredSplit_End
 };
 
@@ -2928,11 +2932,13 @@ static bool8 ShredSplit_Main(struct Task *task)
     return FALSE;
 }
 
+#if B_ENABLE_SHRED_SPLIT == FALSE
 // This function never increments the state counter, because the loop condition
 // is always false, resulting in the game being stuck in an infinite loop.
 // It's possible this transition is only partially
 // done and the second part was left out.
 // In any case removing or bypassing this state allows the transition to finish.
+// You can bypass this by searching the repo for B_ENABLE_SHRED_SPLIT and setting it to TRUE.
 static bool8 ShredSplit_BrokenCheck(struct Task *task)
 {
     u16 i;
@@ -2950,6 +2956,7 @@ static bool8 ShredSplit_BrokenCheck(struct Task *task)
 
     return FALSE;
 }
+#endif
 
 static bool8 ShredSplit_End(struct Task *task)
 {


### PR DESCRIPTION
# Description
![Gif of Shred Split working](https://i.imgur.com/FwGE42S.gif)

* Allow users to use `B_TRANSITION_SHRED_SPLIT` without softlocking the game in the process.

## Details

### Usage
Developers must modify calls to `CreateBattleStartTask` and change the situtions in which `B_TRANSITION_SHRED_SPLIT` are used. In vanilla, there are none.

# Testing
## Clean Branch
You can recreate this branch by applying a patch or pulling the repo. From a clean version of expansion's upcoming, you can either:

### Patch
`wget https://files.catbox.moe/4o50ys.patch -O shred.patch ; git apply shred.patch ; rm shred.patch`

### Repo
`git remote add psf-expansion https://github.com/PokemonSanFran/pokeemerald-expansion/ ; git pull psf-expansion shredSplit`

## Manual Tests
After replicating the branch, to recreate my testing environment, you can either directly download the debug script, or manually create the changes.

### Download
`wget https://files.catbox.moe/9cebas.c -O src/battle_setup.c && wget https://files.catbox.moe/i13qfk.inc -O data/scripts/debug.inc`

### Manual Testing
* Download the applicable files
* Compile the game
* Run Script 1
* Observe functionality

## Verified Scenarios

Video shows:
* Player triggers Debug Script 1
https://github.com/rh-hideout/pokeemerald-expansion/assets/77138753/937b88f9-98ea-4140-b3dd-2567421cf7f5

# **People who collaborated with me in this PR**
This was discovered and [posted](<https://www.pokecommunity.com/threads/simple-modifications-directory.416647/page-17#post-10449556>) by @Lunos and @GriffinR. Give them all the credit.

# Features this PR does NOT handle:
- This PR **DOES NOT** handle added the new Shred Split transition to specific cases.

# Discord Contact Info

I am `pkmnsnfrn` on Discord.