### PR TITLE
Fix safari zone player healthbox

### DIFF
--- a/src/battle_gimmick.c
+++ b/src/battle_gimmick.c
@@ -330,6 +330,9 @@ void UpdateIndicatorVisibilityAndType(u32 healthboxId, bool32 invisible)
     u32 palTag = GetIndicatorPalTag(battler);
     struct Sprite *sprite = &gSprites[GetIndicatorSpriteId(healthboxId)];
 
+    if (GetIndicatorSpriteId(healthboxId) == 0) // safari zone means the player doesn't have an indicator sprite id
+        return;
+
     if (tileTag != TAG_NONE && palTag != TAG_NONE)
     {
         sprite->oam.tileNum = GetSpriteTileStartByTag(tileTag);


### PR DESCRIPTION
Fixes an issue brought forward by the gimmick refactor, where a healthbox without indicator sprite (i.e. the player's healthbox in a safari contest) would be hidden instead of the indicator sprite.

## **Discord contact info**
bassoonian
