### PR TITLE
Battle Anim Debug Check

### DIFF
--- a/src/battle_anim.c
+++ b/src/battle_anim.c
@@ -793,6 +793,10 @@ static void Cmd_end(void)
 
     if (!continuousAnim) // May have been used for debug?
     {
+        // Debugging - ensure no hanging mon bg tasks
+        if (FuncIsActiveTask(Task_UpdateMonBg))
+            DebugPrintfLevel("Move %d animation still has Task_UpdateMonBg active at the end!", gAnimMoveIndex);
+        
         m4aMPlayVolumeControl(&gMPlayInfo_BGM, TRACKS_ALL, 256);
         if (!IsContest())
         {

--- a/src/battle_anim.c
+++ b/src/battle_anim.c
@@ -795,7 +795,7 @@ static void Cmd_end(void)
     {
         // Debugging - ensure no hanging mon bg tasks
         if (FuncIsActiveTask(Task_UpdateMonBg))
-            DebugPrintfLevel("Move %d animation still has Task_UpdateMonBg active at the end!", gAnimMoveIndex);
+            DebugPrintf("Move %d animation still has Task_UpdateMonBg active at the end!", gAnimMoveIndex);
         
         m4aMPlayVolumeControl(&gMPlayInfo_BGM, TRACKS_ALL, 256);
         if (!IsContest())


### PR DESCRIPTION
Checks if any `Task_UpdateMonBg` tasks remain at the "end" command of a battle anim. This could help debug battle animations not clearing data properly. I personally found a bug with the level up box after a bad animation wasn't clearing this task (and thus gBattleBg_X was continuously getting set to invalid sprite data)