### PR TITLE
Flame Burst + Substitute fix

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -1519,6 +1519,7 @@ BattleScript_MoveEffectFlameBurst::
 	waitmessage B_WAIT_TIME_LONG
 	savetarget
 	copybyte gBattlerTarget, sSAVED_BATTLER
+	orword gHitMarker, HITMARKER_IGNORE_SUBSTITUTE | HITMARKER_PASSIVE_DAMAGE
 	healthbarupdate BS_TARGET
 	datahpupdate BS_TARGET
 	tryfaintmon BS_TARGET

--- a/test/battle/move_effect/flame_burst.c
+++ b/test/battle/move_effect/flame_burst.c
@@ -1,0 +1,24 @@
+#include "global.h"
+#include "test/battle.h"
+
+ASSUMPTIONS
+{
+    ASSUME(gMovesInfo[MOVE_FLAME_BURST].additionalEffects->moveEffect == MOVE_EFFECT_FLAME_BURST);
+}
+
+//  Flame Burst AoE is supposed to hit through Substitute
+DOUBLE_BATTLE_TEST("Flame Burst Substitute")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_SUBSTITUTE].effect == EFFECT_SUBSTITUTE);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponentLeft, MOVE_SUBSTITUTE); MOVE(playerRight, MOVE_FLAME_BURST, target: opponentRight); }
+    } SCENE {
+        MESSAGE("The bursting flames hit Foe Wynaut!");
+        NOT MESSAGE("The SUBSTITUTE took damage for Foe Wynaut!");
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes Flame Burst damage dealt to allies of target dealing damage to Substitute instead of the Pokemon behind it.

## Description
<!--- Describe your changes in detail -->
Added missing hitmarker to the Flame Burst effect BattleScript

## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, fixes #2222." -->
<!-- If it doesn't apply, feel free to remove this section. -->
Fixes #4936 

## **Discord contact info**
<!--- formatted as name#numbers, e.g. Lunos#4026 -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara