### PR TITLE
Metal Coat can evolve Pokemon

### DIFF
--- a/src/data/items.h
+++ b/src/data/items.h
@@ -6950,8 +6950,8 @@ const struct Item gItemsInfo[] =
             "raises the power of\n"
             "Steel-type moves."),
         .pocket = POCKET_ITEMS,
-        .type = EVO_HELD_ITEM_TYPE,
-        .fieldUseFunc = EVO_HELD_ITEM_FIELD_FUNC,
+        .type = ITEM_USE_PARTY_MENU,
+        .fieldUseFunc = ItemUseOutOfBattle_EvolutionStone,
         .effect = gItemEffect_EvoItem,
         .flingPower = 30,
     },


### PR DESCRIPTION
Metal Coat is set as an evolution item for Onix, but it couldn't actually evolve it.