### PR TITLE
Add B_ENEMY_THROW_BALLS, B_PLAYER_THROW_BALLS_SOUND, and B_ENEMY_THROW_BALLS_SOUND

### DIFF
--- a/data/scripts/debug.inc
+++ b/data/scripts/debug.inc
@@ -138,14 +138,26 @@ Debug_EventScript_Text_DefensiveIVs:
 	.string "HP IVs: {STR_VAR_1}, DEF IVs: {STR_VAR_2}, SPDEF IVs: {STR_VAR_3}$"
 
 Debug_EventScript_Script_1::
+	setflag FLAG_BADGE01_GET
+	setflag FLAG_BADGE02_GET
+	setflag FLAG_BADGE03_GET
+	setflag FLAG_BADGE04_GET
+	setflag FLAG_BADGE05_GET
+	setflag FLAG_BADGE06_GET
+	setflag FLAG_BADGE07_GET
+	setflag FLAG_BADGE08_GET
+	givemon SPECIES_ARCEUS, 100, ITEM_EARTH_PLATE, ball=ITEM_POKE_BALL
+	givemon SPECIES_ARCEUS, 100, ITEM_PIXIE_PLATE, ball=ITEM_GREAT_BALL
 	release
 	end
 
 Debug_EventScript_Script_2::
+	trainerbattle_double TRAINER_GINA_AND_MIA_1, Route104_Text_GinaIntro, Route104_Text_GinaDefeat, Route104_Text_GinaNotEnoughMons
 	release
 	end
 
 Debug_EventScript_Script_3::
+	trainerbattle_single TRAINER_CINDY_1, Route104_Text_CindyIntro, Route104_Text_CindyDefeat, Route104_EventScript_TryRegisterCindyAfterBattle
 	release
 	end
 

--- a/data/scripts/debug.inc
+++ b/data/scripts/debug.inc
@@ -138,26 +138,14 @@ Debug_EventScript_Text_DefensiveIVs:
 	.string "HP IVs: {STR_VAR_1}, DEF IVs: {STR_VAR_2}, SPDEF IVs: {STR_VAR_3}$"
 
 Debug_EventScript_Script_1::
-	setflag FLAG_BADGE01_GET
-	setflag FLAG_BADGE02_GET
-	setflag FLAG_BADGE03_GET
-	setflag FLAG_BADGE04_GET
-	setflag FLAG_BADGE05_GET
-	setflag FLAG_BADGE06_GET
-	setflag FLAG_BADGE07_GET
-	setflag FLAG_BADGE08_GET
-	givemon SPECIES_ARCEUS, 100, ITEM_EARTH_PLATE, ball=ITEM_POKE_BALL
-	givemon SPECIES_ARCEUS, 100, ITEM_PIXIE_PLATE, ball=ITEM_GREAT_BALL
 	release
 	end
 
 Debug_EventScript_Script_2::
-	trainerbattle_double TRAINER_GINA_AND_MIA_1, Route104_Text_GinaIntro, Route104_Text_GinaDefeat, Route104_Text_GinaNotEnoughMons
 	release
 	end
 
 Debug_EventScript_Script_3::
-	trainerbattle_single TRAINER_CINDY_1, Route104_Text_CindyIntro, Route104_Text_CindyDefeat, Route104_EventScript_TryRegisterCindyAfterBattle
 	release
 	end
 

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -268,5 +268,6 @@
 #define B_NEW_IMPACT_PALETTE            TRUE    // If set to TRUE, it updates the basic 'hit' palette.
 #define B_NEW_SURF_PARTICLE_PALETTE     TRUE    // If set to TRUE, it updates Surf's wave palette.
 #define B_OPPONENT_THROW_BALLS          GEN_LATEST    // In GEN_6+, opposing Trainers throw Pokeballs into battle instead of just dropping them.
+#define B_THROW_BALLS_SOUND             GEN_LATEST    // In GEN_5+, Trainers Pokeballs make a sound when thrown to send out a Pokemon.
 
 #endif // GUARD_CONFIG_BATTLE_H

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -267,7 +267,10 @@
 #define B_NEW_MORNING_SUN_STAR_PARTICLE TRUE    // If set to TRUE, it updates Morning Sun's star particles.
 #define B_NEW_IMPACT_PALETTE            TRUE    // If set to TRUE, it updates the basic 'hit' palette.
 #define B_NEW_SURF_PARTICLE_PALETTE     TRUE    // If set to TRUE, it updates Surf's wave palette.
-#define B_OPPONENT_THROW_BALLS          GEN_LATEST // In GEN_6+, opposing Trainers throw PokéBalls into battle instead of just dropping them.
-#define B_THROW_BALLS_SOUND             GEN_LATEST // In GEN_5+, Trainers PokéBalls make a sound when thrown to send out a Pokémon.
+
+// Poké Ball animation and sounds
+#define B_ENEMY_THROW_BALLS          GEN_LATEST  // In GEN_6+, enemy Trainers throw Poké Balls into battle instead of them just appearing on the ground and opening.
+#define B_ENEMY_THROW_BALLS_SOUND    GEN_LATEST  // In GEN_5+, enemy Trainer's Poké Balls make a sound when thrown to send out a Pokémon. This can only be used when B_ENEMY_THROW_BALLS is set to GEN_6 or later.
+#define B_PLAYER_THROW_BALLS_SOUND   GEN_LATEST  // In GEN_5+, the player's Poké Balls make a sound when thrown to send out a Pokémon.
 
 #endif // GUARD_CONFIG_BATTLE_H

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -267,7 +267,7 @@
 #define B_NEW_MORNING_SUN_STAR_PARTICLE TRUE    // If set to TRUE, it updates Morning Sun's star particles.
 #define B_NEW_IMPACT_PALETTE            TRUE    // If set to TRUE, it updates the basic 'hit' palette.
 #define B_NEW_SURF_PARTICLE_PALETTE     TRUE    // If set to TRUE, it updates Surf's wave palette.
-#define B_OPPONENT_THROW_BALLS          GEN_LATEST    // In GEN_6+, opposing Trainers throw Pokeballs into battle instead of just dropping them.
-#define B_THROW_BALLS_SOUND             GEN_LATEST    // In GEN_5+, Trainers Pokeballs make a sound when thrown to send out a Pokemon.
+#define B_OPPONENT_THROW_BALLS          GEN_LATEST // In GEN_6+, opposing Trainers throw PokéBalls into battle instead of just dropping them.
+#define B_THROW_BALLS_SOUND             GEN_LATEST // In GEN_5+, Trainers PokéBalls make a sound when thrown to send out a Pokémon.
 
 #endif // GUARD_CONFIG_BATTLE_H

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -267,5 +267,6 @@
 #define B_NEW_MORNING_SUN_STAR_PARTICLE TRUE    // If set to TRUE, it updates Morning Sun's star particles.
 #define B_NEW_IMPACT_PALETTE            TRUE    // If set to TRUE, it updates the basic 'hit' palette.
 #define B_NEW_SURF_PARTICLE_PALETTE     TRUE    // If set to TRUE, it updates Surf's wave palette.
+#define B_OPPONENT_THROW_BALLS          GEN_LATEST    // In GEN_6+, opposing Trainers throw Pokeballs into battle instead of just dropping them.
 
 #endif // GUARD_CONFIG_BATTLE_H

--- a/src/pokeball.c
+++ b/src/pokeball.c
@@ -16,9 +16,12 @@
 #include "constants/songs.h"
 
 static void Task_DoPokeballSendOutAnim(u8 taskId);
+static void *GetOpponentMonSendOutCallback(void);
 static void SpriteCB_PlayerMonSendOut_1(struct Sprite *sprite);
 static void SpriteCB_PlayerMonSendOut_2(struct Sprite *sprite);
 static void SpriteCB_OpponentMonSendOut(struct Sprite *sprite);
+static void SpriteCB_OpponentMonSendOut_1(struct Sprite *sprite);
+static void SpriteCB_OpponentMonSendOut_2(struct Sprite *sprite);
 static void SpriteCB_BallThrow(struct Sprite *sprite);
 static void SpriteCB_BallThrow_ReachMon(struct Sprite *sprite);
 static void SpriteCB_BallThrow_StartShrinkMon(struct Sprite *sprite);
@@ -548,6 +551,8 @@ static void Task_DoPokeballSendOutAnim(u8 taskId)
 {
     u32 throwCaseId, ballId, battlerId, ballSpriteId;
     bool32 notSendOut = FALSE;
+	u32 throwXoffset = (B_OPPONENT_THROW_BALLS >= GEN_6) ? 24 : 0;
+	s32 throwYoffset = (B_OPPONENT_THROW_BALLS >= GEN_6) ? -16 : 24;
 
     if (gTasks[taskId].tFrames == 0)
     {
@@ -578,11 +583,11 @@ static void Task_DoPokeballSendOutAnim(u8 taskId)
         gSprites[ballSpriteId].callback = SpriteCB_PlayerMonSendOut_1;
         break;
     case POKEBALL_OPPONENT_SENDOUT:
-        gSprites[ballSpriteId].x = GetBattlerSpriteCoord(battlerId, BATTLER_COORD_X);
-        gSprites[ballSpriteId].y = GetBattlerSpriteCoord(battlerId, BATTLER_COORD_Y) + 24;
+        gSprites[ballSpriteId].x = GetBattlerSpriteCoord(battlerId, BATTLER_COORD_X) + throwXoffset;
+        gSprites[ballSpriteId].y = GetBattlerSpriteCoord(battlerId, BATTLER_COORD_Y) + throwYoffset;
         gBattlerTarget = battlerId;
         gSprites[ballSpriteId].data[0] = 0;
-        gSprites[ballSpriteId].callback = SpriteCB_OpponentMonSendOut;
+        gSprites[ballSpriteId].callback = GetOpponentMonSendOutCallback();
         break;
     default:
         gBattlerTarget = GetBattlerAtPosition(B_POSITION_OPPONENT_LEFT);
@@ -1179,8 +1184,6 @@ static void SpriteCB_PlayerMonSendOut_2(struct Sprite *sprite)
     }
 }
 
-#undef HIBYTE
-
 static void SpriteCB_ReleaseMon2FromBall(struct Sprite *sprite)
 {
     if (sprite->data[0]++ > 24)
@@ -1188,6 +1191,11 @@ static void SpriteCB_ReleaseMon2FromBall(struct Sprite *sprite)
         sprite->data[0] = 0;
         sprite->callback = SpriteCB_ReleaseMonFromBall;
     }
+}
+
+static void *GetOpponentMonSendOutCallback(void)
+{
+	return (B_OPPONENT_THROW_BALLS >= GEN_6) ? SpriteCB_OpponentMonSendOut_1 : SpriteCB_OpponentMonSendOut;
 }
 
 static void SpriteCB_OpponentMonSendOut(struct Sprite *sprite)
@@ -1204,6 +1212,72 @@ static void SpriteCB_OpponentMonSendOut(struct Sprite *sprite)
     }
 }
 
+static void SpriteCB_OpponentMonSendOut_1(struct Sprite *sprite)
+{
+    sprite->data[0] = 25;
+    sprite->data[2] = GetBattlerSpriteCoord(sprite->sBattler, BATTLER_COORD_X);
+    sprite->data[4] = GetBattlerSpriteCoord(sprite->sBattler, BATTLER_COORD_Y) + 24;
+    sprite->data[5] = -30;
+    sprite->oam.affineParam = sprite->sBattler;
+    InitAnimArcTranslation(sprite);
+    sprite->callback = SpriteCB_OpponentMonSendOut_2;
+}
+
+static void SpriteCB_OpponentMonSendOut_2(struct Sprite *sprite)
+{
+    u32 r6;
+    u32 r7;
+
+    if (HIBYTE(sprite->data[7]) >= 35 && HIBYTE(sprite->data[7]) < 80)
+    {
+        s16 r4;
+
+        if ((sprite->oam.affineParam & 0xFF00) == 0)
+        {
+            r6 = sprite->data[1] & 1;
+            r7 = sprite->data[2] & 1;
+            sprite->data[1] = ((sprite->data[1] / 3) & ~1) | r6;
+            sprite->data[2] = ((sprite->data[2] / 3) & ~1) | r7;
+            StartSpriteAffineAnim(sprite, 4);
+        }
+        r4 = sprite->data[0];
+        AnimTranslateLinear(sprite);
+        sprite->data[7] += sprite->sBattler / 3;
+        sprite->y2 += Sin(HIBYTE(sprite->data[7]), sprite->data[5]);
+        sprite->oam.affineParam += 0x100;
+        if ((sprite->oam.affineParam >> 8) % 3 != 0)
+            sprite->data[0] = r4;
+        else
+            sprite->data[0] = r4 - 1;
+        if (HIBYTE(sprite->data[7]) >= 80)
+        {
+            r6 = sprite->data[1] & 1;
+            r7 = sprite->data[2] & 1;
+            sprite->data[1] = ((sprite->data[1] * 3) & ~1) | r6;
+            sprite->data[2] = ((sprite->data[2] * 3) & ~1) | r7;
+        }
+    }
+    else
+    {
+        if (TranslateAnimHorizontalArc(sprite))
+        {
+            sprite->x += sprite->x2;
+            sprite->y += sprite->y2;
+            sprite->y2 = 0;
+            sprite->x2 = 0;
+            sprite->sBattler = sprite->oam.affineParam & 0xFF;
+            sprite->data[0] = 0;
+
+            if (IsDoubleBattle() && gBattleSpritesDataPtr->animationData->introAnimActive
+             && sprite->sBattler == GetBattlerAtPosition(B_POSITION_OPPONENT_RIGHT))
+                sprite->callback = SpriteCB_ReleaseMon2FromBall;
+            else
+                sprite->callback = SpriteCB_ReleaseMonFromBall;
+
+            StartSpriteAffineAnim(sprite, 0);
+        }
+    }
+}
 #undef sBattler
 
 static u8 AnimateBallOpenParticlesForPokeball(u8 x, u8 y, u8 kindOfStars, u8 subpriority)

--- a/src/pokeball.c
+++ b/src/pokeball.c
@@ -1132,7 +1132,7 @@ static void SpriteCB_BallThrow_CaptureMon(struct Sprite *sprite)
 
 static bool32 IsBattlerPlayer(u32 battler)
 {
-    return (battler % 2) ? FALSE : TRUE;
+    return (battler % B_POSITION_PLAYER_RIGHT) ? FALSE : TRUE;
 }
 
 static void SpriteCB_MonSendOut_1(struct Sprite *sprite)

--- a/src/pokeball.c
+++ b/src/pokeball.c
@@ -616,8 +616,6 @@ static void Task_DoPokeballSendOutAnim(u8 taskId)
     PlaySE(SE_BALL_THROW);
 }
 
-STATIC_ASSERT(B_ENEMY_THROW_BALLS_SOUND < GEN_5 || B_ENEMY_THROW_BALLS >= GEN_6,OpponentThrowBallAndSoundMustBeOnTogether)
-
 static inline void DoPokeballSendOutSoundEffect(u32 battler)
 {
     if (IsBattlerPlayer(battler) && B_PLAYER_THROW_BALLS_SOUND < GEN_5)

--- a/src/pokeball.c
+++ b/src/pokeball.c
@@ -1156,8 +1156,7 @@ static void SpriteCB_MonSendOut_2(struct Sprite *sprite)
 {
     u32 r6;
     u32 r7;
-    bool32 isPlayer = IsBattlerPlayer(sprite->sBattler);
-    bool32 rightPosition = (isPlayer) ? B_POSITION_PLAYER_RIGHT : B_POSITION_OPPONENT_RIGHT;
+    bool32 rightPosition = (IsBattlerPlayer(sprite->sBattler)) ? B_POSITION_PLAYER_RIGHT : B_POSITION_OPPONENT_RIGHT;
 
     if (HIBYTE(sprite->data[7]) >= 35 && HIBYTE(sprite->data[7]) < 80)
     {
@@ -1209,6 +1208,8 @@ static void SpriteCB_MonSendOut_2(struct Sprite *sprite)
         }
     }
 }
+
+#undef HIBYTE
 
 static void SpriteCB_ReleaseMon2FromBall(struct Sprite *sprite)
 {

--- a/src/pokeball.c
+++ b/src/pokeball.c
@@ -16,6 +16,7 @@
 #include "constants/songs.h"
 
 static void Task_DoPokeballSendOutAnim(u8 taskId);
+static void DoPokeballSendOutSoundEffect(void);
 static void *GetOpponentMonSendOutCallback(void);
 static void SpriteCB_PlayerMonSendOut_1(struct Sprite *sprite);
 static void SpriteCB_PlayerMonSendOut_2(struct Sprite *sprite);
@@ -581,6 +582,7 @@ static void Task_DoPokeballSendOutAnim(u8 taskId)
         gSprites[ballSpriteId].x = 24;
         gSprites[ballSpriteId].y = 68;
         gSprites[ballSpriteId].callback = SpriteCB_PlayerMonSendOut_1;
+		DoPokeballSendOutSoundEffect();
         break;
     case POKEBALL_OPPONENT_SENDOUT:
         gSprites[ballSpriteId].x = GetBattlerSpriteCoord(battlerId, BATTLER_COORD_X) + throwXoffset;
@@ -588,6 +590,7 @@ static void Task_DoPokeballSendOutAnim(u8 taskId)
         gBattlerTarget = battlerId;
         gSprites[ballSpriteId].data[0] = 0;
         gSprites[ballSpriteId].callback = GetOpponentMonSendOutCallback();
+		DoPokeballSendOutSoundEffect();
         break;
     default:
         gBattlerTarget = GetBattlerAtPosition(B_POSITION_OPPONENT_LEFT);
@@ -612,6 +615,14 @@ static void Task_DoPokeballSendOutAnim(u8 taskId)
     gTasks[taskId].tOpponentBattler = gBattlerTarget;
     gTasks[taskId].func = TaskDummy;
     PlaySE(SE_BALL_THROW);
+}
+
+static void DoPokeballSendOutSoundEffect(void)
+{
+	if (B_THROW_BALLS_SOUND < GEN_5)
+		return;
+
+	 PlaySE(SE_BALL_THROW);
 }
 
 // This sequence of functions is very similar to those that get run when

--- a/src/pokeball.c
+++ b/src/pokeball.c
@@ -551,8 +551,8 @@ static void Task_DoPokeballSendOutAnim(u8 taskId)
 {
     u32 throwCaseId, ballId, battlerId, ballSpriteId;
     bool32 notSendOut = FALSE;
-	u32 throwXoffset = (B_OPPONENT_THROW_BALLS >= GEN_6) ? 24 : 0;
-	s32 throwYoffset = (B_OPPONENT_THROW_BALLS >= GEN_6) ? -16 : 24;
+    u32 throwXoffset = (B_OPPONENT_THROW_BALLS >= GEN_6) ? 24 : 0;
+    s32 throwYoffset = (B_OPPONENT_THROW_BALLS >= GEN_6) ? -16 : 24;
 
     if (gTasks[taskId].tFrames == 0)
     {
@@ -581,7 +581,7 @@ static void Task_DoPokeballSendOutAnim(u8 taskId)
         gSprites[ballSpriteId].x = 24;
         gSprites[ballSpriteId].y = 68;
         gSprites[ballSpriteId].callback = SpriteCB_MonSendOut_1;
-		DoPokeballSendOutSoundEffect();
+        DoPokeballSendOutSoundEffect();
         break;
     case POKEBALL_OPPONENT_SENDOUT:
         gSprites[ballSpriteId].x = GetBattlerSpriteCoord(battlerId, BATTLER_COORD_X) + throwXoffset;
@@ -589,7 +589,7 @@ static void Task_DoPokeballSendOutAnim(u8 taskId)
         gBattlerTarget = battlerId;
         gSprites[ballSpriteId].data[0] = 0;
         gSprites[ballSpriteId].callback = GetOpponentMonSendOutCallback();
-		DoPokeballSendOutSoundEffect();
+        DoPokeballSendOutSoundEffect();
         break;
     default:
         gBattlerTarget = GetBattlerAtPosition(B_POSITION_OPPONENT_LEFT);
@@ -618,15 +618,15 @@ static void Task_DoPokeballSendOutAnim(u8 taskId)
 
 static void DoPokeballSendOutSoundEffect(void)
 {
-	if (B_THROW_BALLS_SOUND < GEN_5)
-		return;
+    if (B_THROW_BALLS_SOUND < GEN_5)
+        return;
 
-	 PlaySE(SE_BALL_THROW);
+     PlaySE(SE_BALL_THROW);
 }
 
 static void *GetOpponentMonSendOutCallback(void)
 {
-	return (B_OPPONENT_THROW_BALLS >= GEN_6) ? SpriteCB_MonSendOut_1 : SpriteCB_OpponentMonSendOut;
+    return (B_OPPONENT_THROW_BALLS >= GEN_6) ? SpriteCB_MonSendOut_1 : SpriteCB_OpponentMonSendOut;
 }
 
 // This sequence of functions is very similar to those that get run when
@@ -1137,9 +1137,9 @@ static bool32 IsBattlerPlayer(u32 battler)
 
 static void SpriteCB_MonSendOut_1(struct Sprite *sprite)
 {
-	bool32 isPlayer = IsBattlerPlayer(sprite->sBattler);
-	u32 coordX = (isPlayer) ? BATTLER_COORD_X_2 : BATTLER_COORD_X;
-	u32 coordY = (isPlayer) ? BATTLER_COORD_Y_PIC_OFFSET : BATTLER_COORD_Y;
+    bool32 isPlayer = IsBattlerPlayer(sprite->sBattler);
+    u32 coordX = (isPlayer) ? BATTLER_COORD_X_2 : BATTLER_COORD_X;
+    u32 coordY = (isPlayer) ? BATTLER_COORD_Y_PIC_OFFSET : BATTLER_COORD_Y;
 
     sprite->data[0] = 25;
     sprite->data[2] = GetBattlerSpriteCoord(sprite->sBattler, coordX);
@@ -1156,8 +1156,8 @@ static void SpriteCB_MonSendOut_2(struct Sprite *sprite)
 {
     u32 r6;
     u32 r7;
-	bool32 isPlayer = IsBattlerPlayer(sprite->sBattler);
-	bool32 rightPosition = (isPlayer) ? B_POSITION_PLAYER_RIGHT : B_POSITION_OPPONENT_RIGHT;
+    bool32 isPlayer = IsBattlerPlayer(sprite->sBattler);
+    bool32 rightPosition = (isPlayer) ? B_POSITION_PLAYER_RIGHT : B_POSITION_OPPONENT_RIGHT;
 
     if (HIBYTE(sprite->data[7]) >= 35 && HIBYTE(sprite->data[7]) < 80)
     {


### PR DESCRIPTION
# Description
![Gif of May throwing in a ball](https://i.imgur.com/Vxr7kvF.gif)

* Added `B_ENEMY_THROW_BALLS`, a config that allows enemy Trainers to throw balls into battle.
* Added `B_ENEMY_THROW_BALLS_SOUND` / `B_PLAYER_THROW_BALLS_SOUND`, configs that plays the ball throw sound when a Trainer throws a ball.
* Refactored `SpriteCB_PlayerMonSendOut_1` into `SpriteCB_MonSendOut_1` to support both sides of battle.

# Usage
## `B_OPPONENT_THROW_BALLS`
### `>= GEN_6`
Enemy Trainers throw their Poké Balls into battle.

### `< GEN_6`
Enemy Trainers drop their Poké Balls into battle. Vanilla behavior.

## `B_PLAYER_THROW_BALLS_SOUND`
### `>= GEN_5`
`SE_BALL_THROW` is played when Trainers on the player's side throw Poké Balls into battle.

## `B_ENEMY_THROW_BALLS_SOUND`
### `>= GEN_5`
`SE_BALL_THROW` is played when Trainers on the enemy's side throw Poké Balls into battle.

### `< GEN_5`
No sound is placed played Trainers throw Poké Balls into battle.

# Testing
## Clean Branch
You can recreate this branch by applying a patch or pulling the repo. From a clean version of expansion's upcoming, you can either:

### Patch
`wget https://files.catbox.moe/ezgna2.patch -O enemyThrowBall.patch ; git apply enemyThrowBall.patch ; rm enemyThrowBall.patch`

### Repo
`git remote add psf-expansion https://github.com/PokemonSanFran/pokeemerald-expansion/ ; git pull psf-expansion enemyThrowBall`

## Manual Tests
After replicating the branch, to recreate my testing environment, you can either directly download the debug script and config file, or manually create the changes.

### Download
| `B_ENEMY_THROW_BALLS` | `B_ENEMY_THROW_BALLS_SOUND` | `B_PLAYER_THROW_BALLS_SOUND` | Command | 
|---|---|---|---|
|`GEN_9`|`GEN_9`|`GEN_9`|`wget https://files.catbox.moe/81j8ot.h -O include/config/battle.h && wget https://files.catbox.moe/8ow6wi.inc -O data/scripts/debug.inc`|
|`GEN_9`|`GEN_9`|`GEN_3`|`wget https://files.catbox.moe/19p0qw.h -O include/config/battle.h && wget https://files.catbox.moe/8ow6wi.inc -O data/scripts/debug.inc`|
|`GEN_9`|`GEN_3`|`GEN_9`|`wget https://files.catbox.moe/j4z74g.h -O include/config/battle.h && wget https://files.catbox.moe/8ow6wi.inc -O data/scripts/debug.inc`|
|`GEN_3`|`GEN_9`|`GEN_9`|`wget https://files.catbox.moe/pkw2yj.h -O include/config/battle.h && wget https://files.catbox.moe/8ow6wi.inc -O data/scripts/debug.inc`|
|`GEN_3`|`GEN_3`|`GEN_9`|`wget https://files.catbox.moe/95xidm.h -O include/config/battle.h && wget https://files.catbox.moe/8ow6wi.inc -O data/scripts/debug.inc`|
|`GEN_3`|`GEN_9`|`GEN_3`|`wget https://files.catbox.moe/bdmxjc.h -O include/config/battle.h && wget https://files.catbox.moe/8ow6wi.inc -O data/scripts/debug.inc`|
|`GEN_9`|`GEN_3`|`GEN_3`|`wget https://files.catbox.moe/axqlw9.h -O include/config/battle.h && wget https://files.catbox.moe/8ow6wi.inc -O data/scripts/debug.inc`|
|`GEN_3`|`GEN_3`|`GEN_3`|`wget https://files.catbox.moe/sltx84.h -O include/config/battle.h && wget https://files.catbox.moe/8ow6wi.inc -O data/scripts/debug.inc`|

### Manual Testing
* Change `B_ENEMY_THROW_BALLS`, `B_ENEMY_THROW_BALLS_SOUND` and `B_PLAYER_THROW_BALLS_SOUND` to their desired value in [`include/config/battle.h`](https://github.com/PokemonSanFran/pokeemerald-expansion/blob/enemyThrowBall/include/config/battle.h)
* Change [`data/scripts/debug.inc`](https://files.catbox.moe/8ow6wi.inc) to match the one provided
* Compile the game
* Start a new save
* Run Debug Script 1
* Run Debug Script 2
* Run Debug Script 3

## Verified Scenarios
All videos show the player:
* Run Debug Script 1
* Run Debug Script 2
* Complete a double battle
* Run Debug Script 3
* Compelte a single battle

#### Note
These videos were tested when `B_ENEMY_THROW_BALLS_SOUND` and `B_PLAYER_THROW_BALLS_SOUND` were a single config. All of the combinations of `B_ENEMY_THROW_BALLS_SOUND` and `B_ENEMY_THROW_BALLS` have been tested, but did not get re-recorded.

### `B_OPPONENT_THROW_BALLS == GEN_3` && `B_THROW_BALLS_SOUND == GEN_3`
https://github.com/user-attachments/assets/53610dc9-ac32-45b7-8052-829de9664bbb

### `B_OPPONENT_THROW_BALLS == GEN_3` && `B_THROW_BALLS_SOUND == GEN_9`
https://github.com/user-attachments/assets/80cd9f51-4f9c-4735-a5a2-55af0ea081a5

### `B_OPPONENT_THROW_BALLS == GEN_9` && `B_THROW_BALLS_SOUND == GEN_9`
https://github.com/user-attachments/assets/45ec13bf-3b7d-4e01-9387-19fb8e48080c

### `B_OPPONENT_THROW_BALLS == GEN_9` && `B_THROW_BALLS_SOUND == GEN_3`
https://github.com/user-attachments/assets/4ebb0c1b-f588-4260-ac82-f073ea7525c1

# **People who collaborated with me in this PR**
This feature was [originally written by](https://www.pokecommunity.com/threads/simple-modifications-directory.416647/page-21#post-10546712) セケツ.

# Features this PR does NOT handle:
n/a

# Discord Contact Info
I am `pkmnsnfrn` on Discord.