### PR TITLE
Add OW_FLAG_PAUSE_TIME, pausefakertc, resumefakertc and togglefakertc

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -2307,17 +2307,17 @@
 	callnative ScriptSetDoubleBattleFlag
 	.endm
 
-    @ When OW_USE_FAKE_RTC and OW_FLAG_PAUSE_TIME is assigned, this macro will stop the flow of time.
-    .macro pausefakertc
-    callnative Script_PauseFakeRtc
-    .endm
+	@ When OW_USE_FAKE_RTC and OW_FLAG_PAUSE_TIME is assigned, this macro will stop the flow of time.
+	.macro pausefakertc
+	callnative Script_PauseFakeRtc
+	.endm
 
-    @ When OW_USE_FAKE_RTC and OW_FLAG_PAUSE_TIME is assigned, this macro will resume the flow of time.
-    .macro resumefakertc
-    callnative Script_ResumeFakeRtc
-    .endm
+	@ When OW_USE_FAKE_RTC and OW_FLAG_PAUSE_TIME is assigned, this macro will resume the flow of time.
+	.macro resumefakertc
+	callnative Script_ResumeFakeRtc
+	.endm
 
-    @ When OW_USE_FAKE_RTC and OW_FLAG_PAUSE_TIME is assigned, this macro will resume the flow of time if paused, and stop the flow of time otherwise.
-    .macro togglefakertc
-    callnative Script_ToggleFakeRtc
-    .endm
+	@ When OW_USE_FAKE_RTC and OW_FLAG_PAUSE_TIME is assigned, this macro will resume the flow of time if paused, and stop the flow of time otherwise.
+	.macro togglefakertc
+	callnative Script_ToggleFakeRtc
+	.endm

--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -2309,15 +2309,15 @@
 
     @ When OW_USE_FAKE_RTC and OW_FLAG_PAUSE_TIME is assigned, this macro will stop the flow of time.
     .macro pausefakertc
-    callnative PauseFakeRtc
+    callnative Script_PauseFakeRtc
     .endm
 
     @ When OW_USE_FAKE_RTC and OW_FLAG_PAUSE_TIME is assigned, this macro will resume the flow of time.
     .macro resumefakertc
-    callnative ResumeFakeRtc
+    callnative Script_ResumeFakeRtc
     .endm
 
     @ When OW_USE_FAKE_RTC and OW_FLAG_PAUSE_TIME is assigned, this macro will resume the flow of time if paused, and stop the flow of time otherwise.
     .macro togglefakertc
-    callnative ToggleFakeRtc
+    callnative Script_ToggleFakeRtc
     .endm

--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -1055,7 +1055,7 @@
 	.endm
 
 	@ creates a mon for a given party and slot
-	@ otherwise 
+	@ otherwise
 	.macro createmon side:req, slot:req, species:req, level:req, item, ball, nature, abilityNum, gender, hpEv, atkEv, defEv, speedEv, spAtkEv, spDefEv, hpIv, atkIv, defIv, speedIv, spAtkIv, spDefIv, move1, move2, move3, move4, isShiny, ggMaxFactor, teraType
 	callnative ScrCmd_createmon
 	.byte \side	 @ 0 - player, 1 - opponent
@@ -2094,7 +2094,7 @@
 	setvar VAR_0x8006, \item
 	special CreateEnemyEventMon
 	.endm
-    
+
 	.macro setdynamicaifunc func:req
 	callnative ScriptSetDynamicAiFunc
 	.4byte \func
@@ -2300,9 +2300,24 @@
 	.byte \sourceId
 	.byte \targetId
 	.endm
-    
+
 	@ set the wild double battle flag
 	@ can be used in conjunection with createmon to set up a wild battle with 2 player mons vs. 1 enemy mon
 	.macro setwilddoubleflag
 	callnative ScriptSetDoubleBattleFlag
 	.endm
+
+    @ When OW_USE_FAKE_RTC and OW_FLAG_PAUSE_TIME is assigned, this macro will stop the flow of time.
+    .macro pausefakertc
+    callnative PauseFakeRtc
+    .endm
+
+    @ When OW_USE_FAKE_RTC and OW_FLAG_PAUSE_TIME is assigned, this macro will resume the flow of time.
+    .macro resumefakertc
+    callnative ResumeFakeRtc
+    .endm
+
+    @ When OW_USE_FAKE_RTC and OW_FLAG_PAUSE_TIME is assigned, this macro will resume the flow of time if paused, and stop the flow of time otherwise.
+    .macro togglefakertc
+    callnative ToggleFakeRtc
+    .endm

--- a/data/scripts/debug.inc
+++ b/data/scripts/debug.inc
@@ -137,40 +137,15 @@ Debug_EventScript_Text_OffensiveIVs:
 Debug_EventScript_Text_DefensiveIVs:
 	.string "HP IVs: {STR_VAR_1}, DEF IVs: {STR_VAR_2}, SPDEF IVs: {STR_VAR_3}$"
 
-    Debug_EventScript_Script_1::
-	msgbox Debug_EventScript_Script_1_Text_2
-    togglefakertc
-	goto_if_set OW_FLAG_PAUSE_TIME, Debug_EventScript_Script_1_1
-	msgbox Debug_EventScript_Script_1_Text_1
-    closemessage
-	return
-
-Debug_EventScript_Script_1_1:
-	msgbox Debug_EventScript_Script_1_Text_0
-    closemessage
-	return
-
-
-Debug_EventScript_Script_1_Text_0:
-	.string "time is stopped.$"
-
-Debug_EventScript_Script_1_Text_1:
-	.string "time is not stopped.$"
-
-Debug_EventScript_Script_1_Text_2:
-	.string "toggle activated.$"
+Debug_EventScript_Script_1::
+	release
+	end
 
 Debug_EventScript_Script_2::
-    resumefakertc
-	msgbox Debug_EventScript_Script_1_Text_1
-    closemessage
 	release
 	end
 
 Debug_EventScript_Script_3::
-   pausefakertc
-	msgbox Debug_EventScript_Script_1_Text_0
-    closemessage
 	release
 	end
 

--- a/data/scripts/debug.inc
+++ b/data/scripts/debug.inc
@@ -137,15 +137,40 @@ Debug_EventScript_Text_OffensiveIVs:
 Debug_EventScript_Text_DefensiveIVs:
 	.string "HP IVs: {STR_VAR_1}, DEF IVs: {STR_VAR_2}, SPDEF IVs: {STR_VAR_3}$"
 
-Debug_EventScript_Script_1::
-	release
-	end
+    Debug_EventScript_Script_1::
+	msgbox Debug_EventScript_Script_1_Text_2
+    togglefakertc
+	goto_if_set OW_FLAG_PAUSE_TIME, Debug_EventScript_Script_1_1
+	msgbox Debug_EventScript_Script_1_Text_1
+    closemessage
+	return
+
+Debug_EventScript_Script_1_1:
+	msgbox Debug_EventScript_Script_1_Text_0
+    closemessage
+	return
+
+
+Debug_EventScript_Script_1_Text_0:
+	.string "time is stopped.$"
+
+Debug_EventScript_Script_1_Text_1:
+	.string "time is not stopped.$"
+
+Debug_EventScript_Script_1_Text_2:
+	.string "toggle activated.$"
 
 Debug_EventScript_Script_2::
+    resumefakertc
+	msgbox Debug_EventScript_Script_1_Text_1
+    closemessage
 	release
 	end
 
 Debug_EventScript_Script_3::
+   pausefakertc
+	msgbox Debug_EventScript_Script_1_Text_0
+    closemessage
 	release
 	end
 

--- a/include/config/overworld.h
+++ b/include/config/overworld.h
@@ -69,7 +69,7 @@
 // Overworld flags
 // To use the following features in scripting, replace the 0s with the flag ID you're assigning it to.
 // Eg: Replace with FLAG_UNUSED_0x264 so you can use that flag to toggle the feature.
-#define OW_FLAG_PAUSE_TIME          0 // If this flag is set and OW_USE_FAKE_RTC is enabled, seconds on the in-game clock will not advance.
+#define OW_FLAG_PAUSE_TIME          0  // If this flag is set and OW_USE_FAKE_RTC is enabled, seconds on the in-game clock will not advance.
 #define OW_FLAG_NO_ENCOUNTER        0  // If this flag is set, wild encounters will be disabled.
 #define OW_FLAG_NO_TRAINER_SEE      0  // If this flag is set, trainers will not battle the player unless they're talked to.
 #define OW_FLAG_NO_COLLISION        0  // If this flag is set, the player will be able to walk over tiles with collision. Mainly intended for debugging purposes.

--- a/include/config/overworld.h
+++ b/include/config/overworld.h
@@ -63,7 +63,7 @@
 
 //Time
 #define OW_TIMES_OF_DAY                 GEN_LATEST // Different generations have the times of day change at different times.
-#define OW_USE_FAKE_RTC                 TRUE // When TRUE, seconds on the in-game clock will only advance once every 60 playTimeVBlanks (every 60 frames).
+#define OW_USE_FAKE_RTC                 FALSE // When TRUE, seconds on the in-game clock will only advance once every 60 playTimeVBlanks (every 60 frames).
 #define OW_ALTERED_TIME_RATIO           GEN_LATEST // In GEN_8_PLA, the time in game moves forward 60 seconds for every second in the RTC. In GEN_9, it is 20 seconds. This has no effect if OW_USE_FAKE_RTC is FALSE.
 
 // Overworld flags
@@ -72,7 +72,7 @@
 #define OW_FLAG_NO_ENCOUNTER        0  // If this flag is set, wild encounters will be disabled.
 #define OW_FLAG_NO_TRAINER_SEE      0  // If this flag is set, trainers will not battle the player unless they're talked to.
 #define OW_FLAG_NO_COLLISION        0  // If this flag is set, the player will be able to walk over tiles with collision. Mainly intended for debugging purposes.
-#define OW_FLAG_PAUSE_TIME          FLAG_UNUSED_0x264  // If this flag is set and `OW_USE_FAKE_RTC` is enabled, seconds on the in-game clock will not advance.
+#define OW_FLAG_PAUSE_TIME          0 // If this flag is set and `OW_USE_FAKE_RTC` is enabled, seconds on the in-game clock will not advance.
 
 #define BATTLE_PYRAMID_RANDOM_ENCOUNTERS    FALSE    // If set to TRUE, battle pyramid Pokemon will be generated randomly based on the round's challenge instead of hardcoded in src/data/battle_frontier/battle_pyramid_level_50_wild_mons.h (or open_level_wild_mons.h)
 

--- a/include/config/overworld.h
+++ b/include/config/overworld.h
@@ -63,16 +63,16 @@
 
 //Time
 #define OW_TIMES_OF_DAY                 GEN_LATEST // Different generations have the times of day change at different times.
-#define OW_USE_FAKE_RTC                 FALSE // When TRUE, seconds on the in-game clock will only advance once every 60 playTimeVBlanks (every 60 frames).
+#define OW_USE_FAKE_RTC                 TRUE // When TRUE, seconds on the in-game clock will only advance once every 60 playTimeVBlanks (every 60 frames).
 #define OW_ALTERED_TIME_RATIO           GEN_LATEST // In GEN_8_PLA, the time in game moves forward 60 seconds for every second in the RTC. In GEN_9, it is 20 seconds. This has no effect if OW_USE_FAKE_RTC is FALSE.
 
 // Overworld flags
 // To use the following features in scripting, replace the 0s with the flag ID you're assigning it to.
 // Eg: Replace with FLAG_UNUSED_0x264 so you can use that flag to toggle the feature.
+#define OW_FLAG_PAUSE_TIME          0 // If this flag is set and OW_USE_FAKE_RTC is enabled, seconds on the in-game clock will not advance.
 #define OW_FLAG_NO_ENCOUNTER        0  // If this flag is set, wild encounters will be disabled.
 #define OW_FLAG_NO_TRAINER_SEE      0  // If this flag is set, trainers will not battle the player unless they're talked to.
 #define OW_FLAG_NO_COLLISION        0  // If this flag is set, the player will be able to walk over tiles with collision. Mainly intended for debugging purposes.
-#define OW_FLAG_PAUSE_TIME          0 // If this flag is set and `OW_USE_FAKE_RTC` is enabled, seconds on the in-game clock will not advance.
 
 #define BATTLE_PYRAMID_RANDOM_ENCOUNTERS    FALSE    // If set to TRUE, battle pyramid Pokemon will be generated randomly based on the round's challenge instead of hardcoded in src/data/battle_frontier/battle_pyramid_level_50_wild_mons.h (or open_level_wild_mons.h)
 

--- a/include/config/overworld.h
+++ b/include/config/overworld.h
@@ -58,12 +58,21 @@
 #define OW_STORM_DRAIN              GEN_LATEST // In Gen8+, if a Pokémon with Storm Drain is leading the party, there is a 50% chance to encounter a Water-type Pokémon.
 #define OW_FLASH_FIRE               GEN_LATEST // In Gen8+, if a Pokémon with Flash Fire is leading the party, there is a 50% chance to encounter a Fire-type Pokémon.
 
+// These generational defines only make a distinction for OW_ALTERED_TIME_RATIO
+#define GEN_8_PLA                       GEN_LATEST + 2
+
+//Time
+#define OW_TIMES_OF_DAY                 GEN_LATEST // Different generations have the times of day change at different times.
+#define OW_USE_FAKE_RTC                 TRUE // When TRUE, seconds on the in-game clock will only advance once every 60 playTimeVBlanks (every 60 frames).
+#define OW_ALTERED_TIME_RATIO           GEN_LATEST // In GEN_8_PLA, the time in game moves forward 60 seconds for every second in the RTC. In GEN_9, it is 20 seconds. This has no effect if OW_USE_FAKE_RTC is FALSE.
+
 // Overworld flags
 // To use the following features in scripting, replace the 0s with the flag ID you're assigning it to.
 // Eg: Replace with FLAG_UNUSED_0x264 so you can use that flag to toggle the feature.
 #define OW_FLAG_NO_ENCOUNTER        0  // If this flag is set, wild encounters will be disabled.
 #define OW_FLAG_NO_TRAINER_SEE      0  // If this flag is set, trainers will not battle the player unless they're talked to.
 #define OW_FLAG_NO_COLLISION        0  // If this flag is set, the player will be able to walk over tiles with collision. Mainly intended for debugging purposes.
+#define OW_FLAG_PAUSE_TIME          FLAG_UNUSED_0x264  // If this flag is set and `OW_USE_FAKE_RTC` is enabled, seconds on the in-game clock will not advance.
 
 #define BATTLE_PYRAMID_RANDOM_ENCOUNTERS    FALSE    // If set to TRUE, battle pyramid Pokemon will be generated randomly based on the round's challenge instead of hardcoded in src/data/battle_frontier/battle_pyramid_level_50_wild_mons.h (or open_level_wild_mons.h)
 
@@ -84,14 +93,6 @@
 #define OW_POPUP_BW_COLOR          OW_POPUP_BW_COLOR_BLACK  // B2W2 use different colors for their map pop-ups.
 #define OW_POPUP_BW_TIME_MODE      OW_POPUP_BW_TIME_NONE    // Determines what type of time is shown.
 #define OW_POPUP_BW_ALPHA_BLEND    FALSE                    // Enables alpha blending/transparency for the pop-ups. Mainly intended to be used with the black color option.
-
-// These generational defines only make a distinction for OW_ALTERED_TIME_RATIO
-#define GEN_8_PLA                       GEN_LATEST + 2
-
-//Time
-#define OW_TIMES_OF_DAY                 GEN_LATEST // Different generations have the times of day change at different times.
-#define OW_USE_FAKE_RTC                 FALSE      // When TRUE, seconds on the in-clock will only advance once every 60 playTimeVBlanks (every 60 frames).
-#define OW_ALTERED_TIME_RATIO           GEN_LATEST // In GEN_8_PLA, the time in game moves forward 60 seconds for every second in the RTC. In GEN_9, it is 20 seconds. This has no effect if OW_USE_FAKE_RTC is FALSE.
 
 // Pokémon Center
 #define OW_IGNORE_EGGS_ON_HEAL     GEN_LATEST               // In Gen 4+, the nurse in the Pokémon Center does not heal Eggs on healing machine.

--- a/src/fake_rtc.c
+++ b/src/fake_rtc.c
@@ -86,7 +86,7 @@ u32 FakeRtc_GetSecondsRatio(void)
                                                   1;
 }
 
-STATIC_ASSERT(OW_FLAG_PAUSE_TIME != 0 && OW_USE_FAKE_RTC == FALSE, FakeRtcMustBeTrueToPauseTime)
+STATIC_ASSERT((OW_FLAG_PAUSE_TIME == 0 || OW_USE_FAKE_RTC == TRUE), FakeRtcMustBeTrueToPauseTime);
 
 void PauseFakeRtc(void)
 {

--- a/src/fake_rtc.c
+++ b/src/fake_rtc.c
@@ -4,6 +4,7 @@
 #include "text.h"
 #include "rtc.h"
 #include "fake_rtc.h"
+#include "event_data.h"
 
 struct Time *FakeRtc_GetCurrentTime(void)
 {
@@ -26,6 +27,9 @@ void FakeRtc_GetRawInfo(struct SiiRtcInfo *rtc)
 void FakeRtc_TickTimeForward(void)
 {
     if (!OW_USE_FAKE_RTC)
+        return;
+
+    if (FlagGet(OW_FLAG_PAUSE_TIME))
         return;
 
     FakeRtc_AdvanceTimeBy(0, 0, FakeRtc_GetSecondsRatio());
@@ -82,3 +86,19 @@ u32 FakeRtc_GetSecondsRatio(void)
                                                   1;
 }
 
+STATIC_ASSERT(OW_FLAG_PAUSE_TIME != 0 && OW_USE_FAKE_RTC == FALSE, FakeRtcMustBeTrueToPauseTime)
+
+void PauseFakeRtc(void)
+{
+    FlagSet(OW_FLAG_PAUSE_TIME);
+}
+
+void ResumeFakeRtc(void)
+{
+    FlagClear(OW_FLAG_PAUSE_TIME);
+}
+
+void ToggleFakeRtc(void)
+{
+    FlagToggle(OW_FLAG_PAUSE_TIME);
+}

--- a/src/fake_rtc.c
+++ b/src/fake_rtc.c
@@ -88,17 +88,17 @@ u32 FakeRtc_GetSecondsRatio(void)
 
 STATIC_ASSERT((OW_FLAG_PAUSE_TIME == 0 || OW_USE_FAKE_RTC == TRUE), FakeRtcMustBeTrueToPauseTime);
 
-void PauseFakeRtc(void)
+void Script_PauseFakeRtc(void)
 {
     FlagSet(OW_FLAG_PAUSE_TIME);
 }
 
-void ResumeFakeRtc(void)
+void Script_ResumeFakeRtc(void)
 {
     FlagClear(OW_FLAG_PAUSE_TIME);
 }
 
-void ToggleFakeRtc(void)
+void Script_ToggleFakeRtc(void)
 {
     FlagToggle(OW_FLAG_PAUSE_TIME);
 }


### PR DESCRIPTION
# Description

* Added `OW_FLAG_PAUSE_TIME`, allowing users to designate a flag for stopping and starting the flow of time when `OW_USE_FAKE_RTC` is enabled.
    * Introduce a `STATIC_ASSERT` to prevent users from attempting to pause time unless FakeRtc is enabled.
* Added `pausefakertc`, `resumefakertc`, and `togglefakertc` allowing users to pause, resume and toggle the flow of time when `OW_USE_FAKE_RTC` is enabled.

# Usage

## `OW_FLAG_PAUSE_TIME`
In [`include/config/overworld.h`](https://github.com/PokemonSanFran/pokeemerald-expansion/blob/fakeRTC_branch/include/config/overworld.h), developers must assign a flag to `OW_FLAG_PAUSE_TIME`.

### Set Flag
Setting the flag will pause the flow of time.

### Clear Flag
Clearing the flag will resume the flow of time.

### Toggle Flag
If time is paused, the flag will be cleared. If time is not paused, the flag will be set.

# Testing
## Clean Branch
You can recreate this branch by applying a patch or pulling the repo. From a clean version of expansion's upcoming, you can either:

### Patch
`wget https://files.catbox.moe/igk1yp.patch -O fakeRTC.patch ; git apply fakeRTC.patch ; rm fakeRTC.patch`

### Repo
`git remote add psf-expansion https://github.com/PokemonSanFran/pokeemerald-expansion/ ; git pull psf-expansion fakeRTC_branch`

## Manual Tests
After replicating the branch, to recreate my testing environment, you can either directly download the debug script and config file, or manually create the changes.

### Download
| `OW_USE_FAKE_RTC`  |  `OW_FLAG_PAUSE_TIME` |  Command |
|---|---|---|
| `FALSE`  | `FLAG_UNUSED_0x264` |  `wget https://files.catbox.moe/h8ef5x.h -O include/config/overworld.h && wget https://files.catbox.moe/7sgzz3.inc -O data/scripts/debug.inc`|
| `FALSE`  | `0` |  `wget https://files.catbox.moe/lxkglx.h -O include/config/overworld.h && wget https://files.catbox.moe/7sgzz3.inc -O data/scripts/debug.inc`|
| `TRUE` | `FLAG_UNUSED_0x264` |  `wget https://files.catbox.moe/g1t68r.h -O include/config/overworld.h && wget https://files.catbox.moe/7sgzz3.inc -O data/scripts/debug.inc`|
| `TRUE`  | `0` |  `wget https://files.catbox.moe/xfvd8h.h -O include/config/overworld.h && wget https://files.catbox.moe/7sgzz3.inc -O data/scripts/debug.inc`|

### Manual Testing
* Open the [config file](https://raw.githubusercontent.com/PokemonSanFran/pokeemerald-expansion/fakeRTC_branch/include/config/overworld.h) and change `OW_USE_FAKE_RTC` and `OW_ALTERED_TIME_RATIO` to their desired values.
* Change [data/scripts/debug.inc](https://files.catbox.moe/7sgzz3.inc) to match the one provided
* Compile the game
* Start a new save
* Run Script 1

## Verified Scenarios

All videos attempt to show:
* The player sets the clock to 10:00
* `pausefakertc` is run
* The player battles against `TRAINER_RONALD` and wins in 6 turns.
* A script prints the current time.

### `OW_USE_FAKE_RTC` == `FALSE` && `OW_FLAG_PAUSE_TIME` == `FLAG_UNUSED_0x264`
Does not compile

### `OW_USE_FAKE_RTC` == `FALSE` && `OW_FLAG_PAUSE_TIME` == `0`
https://github.com/user-attachments/assets/dd06df54-865e-47d2-bde2-0cd99ee079fd

### `OW_USE_FAKE_RTC` == `TRUE` && `OW_FLAG_PAUSE_TIME` == `FLAG_UNUSED_0x264`
https://github.com/user-attachments/assets/35993ac6-1a6a-47a8-a1a9-84b03ba6ef2d

### `OW_USE_FAKE_RTC` == `TRUE` && `OW_FLAG_PAUSE_TIME` == `0`
https://github.com/user-attachments/assets/76dbe739-4978-43ac-8484-600271cfeec8

# Discord Contact Info
I am `pkmnsnfrn` on Discord.