### PR TITLE
Minor shouldUseGimmick refactor

### DIFF
--- a/include/data.h
+++ b/include/data.h
@@ -70,11 +70,12 @@ struct TrainerMon
     u8 nature:5;
     bool8 gender:2;
     bool8 isShiny:1;
-    u8 useGimmick:4;
-    u8 dynamaxLevel:4;
     u8 teraType:5;
     bool8 gigantamaxFactor:1;
-    u8 padding:2;
+    u8 shouldUseDynamax:1;
+    u8 padding1:1;
+    u8 dynamaxLevel:4;
+    u8 padding2:4;
 };
 
 #define TRAINER_PARTY(partyArray) partyArray, .partySize = ARRAY_COUNT(partyArray)

--- a/src/battle_gimmick.c
+++ b/src/battle_gimmick.c
@@ -82,8 +82,14 @@ bool32 ShouldTrainerBattlerUseGimmick(u32 battler, enum Gimmick gimmick)
         bool32 isSecondTrainer = (GetBattlerPosition(battler) == B_POSITION_OPPONENT_RIGHT) && (gBattleTypeFlags & BATTLE_TYPE_TWO_OPPONENTS) && !BATTLE_TWO_VS_ONE_OPPONENT;
         u16 trainerId = isSecondTrainer ? gTrainerBattleOpponent_B : gTrainerBattleOpponent_A;
         const struct TrainerMon *mon = &GetTrainerPartyFromId(trainerId)[isSecondTrainer ? gBattlerPartyIndexes[battler] - MULTI_PARTY_SIZE : gBattlerPartyIndexes[battler]];
-        return mon->useGimmick == gimmick;
+
+        if (gimmick == GIMMICK_TERA && mon->teraType != TYPE_NONE)
+            return TRUE;
+        if (gimmick == GIMMICK_DYNAMAX && mon->shouldUseDynamax)
+            return TRUE;
     }
+
+    return FALSE;
 }
 
 // Returns whether a trainer has used a gimmick during a battle.
@@ -290,7 +296,7 @@ static inline u32 GetIndicatorSpriteId(u32 healthboxId)
 u32 GetIndicatorTileTag(u32 battler)
 {
     u32 gimmick = GetActiveGimmick(battler);
-    
+
     if (IsBattlerPrimalReverted(battler))
     {
         if (gBattleMons[battler].species == SPECIES_GROUDON_PRIMAL)

--- a/src/battle_terastal.c
+++ b/src/battle_terastal.c
@@ -34,7 +34,7 @@ void ActivateTera(u32 battler)
     {
         FlagClear(B_FLAG_TERA_ORB_CHARGED);
     }
-    
+
     // Execute battle script.
     PREPARE_TYPE_BUFFER(gBattleTextBuff1, GetBattlerTeraType(battler));
     if (TryBattleFormChange(gBattlerAttacker, FORM_CHANGE_BATTLE_TERASTALLIZATION))
@@ -63,16 +63,19 @@ bool32 CanTerastallize(u32 battler)
 {
     u32 holdEffect = GetBattlerHoldEffect(battler, FALSE);
 
-    // Check if Player has Tera Orb and has charge.
-    if (!TESTING && !CheckBagHasItem(ITEM_TERA_ORB, 1))
-        return FALSE;
-
-    if (!TESTING 
-     && !(B_FLAG_TERA_ORB_NO_COST != 0 && FlagGet(B_FLAG_TERA_ORB_NO_COST))
-     && (battler == B_POSITION_PLAYER_LEFT || (!(gBattleTypeFlags & BATTLE_TYPE_MULTI) && battler == B_POSITION_PLAYER_RIGHT)))
+    if (GetBattlerSide(battler) == B_SIDE_PLAYER)
     {
-        if (B_FLAG_TERA_ORB_CHARGED != 0 && !FlagGet(B_FLAG_TERA_ORB_CHARGED))
+        // Check if Player has Tera Orb and has charge.
+        if (!TESTING && !CheckBagHasItem(ITEM_TERA_ORB, 1))
             return FALSE;
+
+        if (!TESTING
+        && !(B_FLAG_TERA_ORB_NO_COST != 0 && FlagGet(B_FLAG_TERA_ORB_NO_COST))
+        && (battler == B_POSITION_PLAYER_LEFT || (!(gBattleTypeFlags & BATTLE_TYPE_MULTI) && battler == B_POSITION_PLAYER_RIGHT)))
+        {
+            if (B_FLAG_TERA_ORB_CHARGED != 0 && !FlagGet(B_FLAG_TERA_ORB_CHARGED))
+                return FALSE;
+        }
     }
 
     // Check if Trainer has already Terastallized.

--- a/test/battle/trainer_control.h
+++ b/test/battle/trainer_control.h
@@ -52,7 +52,7 @@
             .isShiny = TRUE,
 #line 18
             .dynamaxLevel = 5,
-            .useGimmick = GIMMICK_DYNAMAX,
+            .shouldUseDynamax = TRUE,
             .moves = {
 #line 19
                 MOVE_AIR_SLASH,

--- a/tools/trainerproc/main.c
+++ b/tools/trainerproc/main.c
@@ -1824,7 +1824,7 @@ static void fprint_trainers(const char *output_path, FILE *f, struct Parsed *par
 
             if (pokemon->dynamax_level_line || pokemon->gigantamax_factor_line)
             {
-                fprintf(f, "            .useGimmick = GIMMICK_DYNAMAX,\n");
+                fprintf(f, "            .shouldUseDynamax = TRUE,\n");
             }
             else if (pokemon->tera_type_line)
             {
@@ -1832,7 +1832,6 @@ static void fprint_trainers(const char *output_path, FILE *f, struct Parsed *par
                 fprintf(f, "            .teraType = ");
                 fprint_constant(f, "TYPE", pokemon->tera_type);
                 fprintf(f, ",\n");
-                fprintf(f, "            .useGimmick = GIMMICK_TERA,\n");
             }
 
             if (pokemon->moves_n > 0)


### PR DESCRIPTION
#4861

Replaced `shouldUseGimmick` with `shouldUseDynamax`.

Simplifies the usage for tera since you only need to set the tera type now. Also the field was misleading since it implies you have to set it for Mega and Z moves as well which wasn't true. We still need it for dynamax though since dynamlevel is set by default. See the comment from Duke.

Also fixes an issue where enemy trainers couldn't use tera