### PR TITLE
Add P_CAN_FORGET_HIDDEN_MOVE

### DIFF
--- a/include/config/pokemon.h
+++ b/include/config/pokemon.h
@@ -46,11 +46,11 @@
 #define P_EV_CAP                         GEN_LATEST  // Since Gen 6, the max EVs per stat is 252 instead of 255.
 #define P_SHOW_TERA_TYPE                 GEN_8       // Since Gen 9, the Tera Type is shown on the summary screen.
 #define P_TM_LITERACY                    GEN_LATEST  // Since Gen 6, TM illiterate Pokémon can learn TMs that teach moves that are in their level-up learnsets.
+#define P_CAN_FORGET_HIDDEN_MOVE         FALSE       // If TRUE, Pokémon can forget any move, even if it is a Hidden Move.
 #define P_EGG_CYCLE_LENGTH               GEN_LATEST  // Since Gen 8, egg cycles take half as many steps as before.
 #define P_TWO_FRAME_FRONT_SPRITES        TRUE        // In Pokémon Emerald, Pokémon front sprites always consist of two frames. This config can revert it to only use the first frame, as is the case in the other Gen 3 games.
 #define P_ONLY_OBTAINABLE_SHINIES        FALSE       // If TRUE, Pokémon encountered in the Battle Pyramid won't be shiny.
 #define P_NO_SHINIES_WITHOUT_POKEBALLS   FALSE       // If TRUE, Pokémon encountered when the player is out of Poké Balls won't be shiny
-#define P_CAN_FORGET_HIDDEN_MOVE         FALSE       // If TRUE, Pokémon can forget any move, even if it is a Hidden Move.
 
 // Learnset helper toggles
 #define P_LEARNSET_HELPER_TEACHABLE TRUE        // If TRUE, teachable_learnsets.h will be populated by tools/learnset_helpers/teachable.py using the included JSON files based on available TMs and tutors.

--- a/include/config/pokemon.h
+++ b/include/config/pokemon.h
@@ -50,6 +50,7 @@
 #define P_TWO_FRAME_FRONT_SPRITES        TRUE        // In Pokémon Emerald, Pokémon front sprites always consist of two frames. This config can revert it to only use the first frame, as is the case in the other Gen 3 games.
 #define P_ONLY_OBTAINABLE_SHINIES        FALSE       // If TRUE, Pokémon encountered in the Battle Pyramid won't be shiny.
 #define P_NO_SHINIES_WITHOUT_POKEBALLS   FALSE       // If TRUE, Pokémon encountered when the player is out of Poké Balls won't be shiny
+#define P_CAN_FORGET_HMS                 FALSE       // If TRUE, Pokémon can forget any move, even if it is an HM.
 
 // Learnset helper toggles
 #define P_LEARNSET_HELPER_TEACHABLE TRUE        // If TRUE, teachable_learnsets.h will be populated by tools/learnset_helpers/teachable.py using the included JSON files based on available TMs and tutors.

--- a/include/config/pokemon.h
+++ b/include/config/pokemon.h
@@ -50,7 +50,7 @@
 #define P_TWO_FRAME_FRONT_SPRITES        TRUE        // In Pokémon Emerald, Pokémon front sprites always consist of two frames. This config can revert it to only use the first frame, as is the case in the other Gen 3 games.
 #define P_ONLY_OBTAINABLE_SHINIES        FALSE       // If TRUE, Pokémon encountered in the Battle Pyramid won't be shiny.
 #define P_NO_SHINIES_WITHOUT_POKEBALLS   FALSE       // If TRUE, Pokémon encountered when the player is out of Poké Balls won't be shiny
-#define P_CAN_FORGET_HMS                 FALSE       // If TRUE, Pokémon can forget any move, even if it is an HM.
+#define P_CAN_FORGET_HIDDEN_MOVE         FALSE       // If TRUE, Pokémon can forget any move, even if it is a Hidden Move.
 
 // Learnset helper toggles
 #define P_LEARNSET_HELPER_TEACHABLE TRUE        // If TRUE, teachable_learnsets.h will be populated by tools/learnset_helpers/teachable.py using the included JSON files based on available TMs and tutors.

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -4016,7 +4016,7 @@ bool8 FieldCallback_PrepareFadeInFromMenu(void)
 
 // Same as above, but removes follower pokemon
 bool8 FieldCallback_PrepareFadeInForTeleport(void)
-{ 
+{
     RemoveFollowingPokemon();
     return FieldCallback_PrepareFadeInFromMenu();
 }
@@ -7762,6 +7762,6 @@ void IsLastMonThatKnowsSurf(void)
             }
         }
         if (AnyStorageMonWithMove(move) != TRUE)
-            gSpecialVar_Result = TRUE;
+            gSpecialVar_Result = !(P_CAN_FORGET_HMS);
     }
 }

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -7762,6 +7762,6 @@ void IsLastMonThatKnowsSurf(void)
             }
         }
         if (AnyStorageMonWithMove(move) != TRUE)
-            gSpecialVar_Result = !(P_CAN_FORGET_HMS);
+            gSpecialVar_Result = !(P_CAN_FORGET_HIDDEN_MOVE);
     }
 }

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -7762,6 +7762,6 @@ void IsLastMonThatKnowsSurf(void)
             }
         }
         if (AnyStorageMonWithMove(move) != TRUE)
-            gSpecialVar_Result = !(P_CAN_FORGET_HIDDEN_MOVE);
+            gSpecialVar_Result = !P_CAN_FORGET_HIDDEN_MOVE;
     }
 }

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -5840,8 +5840,8 @@ bool8 IsMoveHM(u16 move)
 {
     int i = 0;
 
-	if (P_CAN_FORGET_HIDDEN_MOVE)
-		return FALSE;
+    if (P_CAN_FORGET_HIDDEN_MOVE)
+        return FALSE;
 
     while (sHMMoves[i] != HM_MOVES_END)
     {

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -5840,7 +5840,7 @@ bool8 IsMoveHM(u16 move)
 {
     int i = 0;
 
-	if (P_CAN_FORGET_HMS)
+	if (P_CAN_FORGET_HIDDEN_MOVE)
 		return FALSE;
 
     while (sHMMoves[i] != HM_MOVES_END)

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -5839,6 +5839,10 @@ const u32 *GetMonSpritePalFromSpecies(u16 species, bool32 isShiny, bool32 isFema
 bool8 IsMoveHM(u16 move)
 {
     int i = 0;
+
+	if (P_CAN_FORGET_HMS)
+		return FALSE;
+
     while (sHMMoves[i] != HM_MOVES_END)
     {
         if (sHMMoves[i++] == move)
@@ -6926,7 +6930,7 @@ void UpdateDaysPassedSinceFormChange(u16 days)
         if (daysSinceFormChange == 0)
         {
             u16 targetSpecies = GetFormChangeTargetSpecies(mon, FORM_CHANGE_DAYS_PASSED, 0);
-            
+
             if (targetSpecies != SPECIES_NONE)
             {
                 SetMonData(mon, MON_DATA_SPECIES, &targetSpecies);


### PR DESCRIPTION
# Description
![Gif of Linoone forgetting Cut to learn Shock Wave via TM](https://i.imgur.com/gTMYk31.gif)

* Adds `P_CAN_FORGET_HIDDEN_MOVE` which allows Pokémon to forget Hidden Moves by overwriting them with another move.

## Details

### Usage

#### `IsLastMonThatKnowsSurf`
This special is used for the Move Deleter. When `P_CAN_FORGET_HIDDEN_MOVE` is enabled, it will always return `FALSE`.

#### `IsMoveHM`
This function is used for when a Pokémon is learning a new move via Level Up, TM, or Evolution, both in and out of battle. When `P_CAN_FORGET_HIDDEN_MOVE` is enabled, it will always return `FALSE`.

# Testing
## Clean Branch
You can recreate this branch by applying a patch or pulling the repo. From a clean version of expansion's upcoming, you can either:

### Patch
`wget https://files.catbox.moe/j0ekbv.patch -O forget.patch ; git apply forget.patch ; rm forget.patch`

### Repo
`git remote add psf-expansion https://github.com/PokemonSanFran/pokeemerald-expansion/ ; git pull psf-expansion forgetHMs`

## Manual Tests
After replicating the branch, to recreate my testing environment, you can either directly download the debug script, or manually create the changes.

### Download
#### `TRUE`
`wget https://files.catbox.moe/s1liez.h -O include/config/pokemon.h && wget https://files.catbox.moe/awxshu.inc -O data/scripts/debug.inc`
#### `FALSE`
`wget https://files.catbox.moe/v6tbax.h -O include/config/pokemon.h && wget https://files.catbox.moe/awxshu.inc -O data/scripts/debug.inc`

### Manual Testing
* Modify `include/config/pokemon.h` to the desired values
* Modify the [debug script](https://files.catbox.moe/awxshu.inc) for the correct scenario
* Compile the game
* Start new save
* Run Debug Script 1
* Defeat Chansey
* Attempt to teach Fire Spin over Strength
* Attempt to teach Mach Punch over Surf
* Open the bag, teach Sunny Day over Waterfall
* Use 3 Rare Candy on Monferno
* Deny teaching Close Combat to Monferno
* Attempt to teach Close Combat over Fly
* Run Debug Script 2
* Use the Move Deleter to attempt to delete Surf from Infernape and Chimchar

## Verified Scenarios
All videos show:
* Run Debug Script 1
* Defeat Chansey
* Attempt to teach Fire Spin over Strength
* Attempt to teach Mach Punch over Surf
* Open the bag, teach Sunny Day over Waterfall
* Use 3 Rare Candy on Monferno
* Deny teaching Close Combat to Monferno
* Attempt to teach Close Combat over Fly
* Run Debug Script 2
* Use the Move Deleter to attempt to delete Surf from Infernape and Chimchar

### TRUE
https://github.com/user-attachments/assets/989cfd08-35fb-44ea-a9a2-93cb01f9c10f

### FALSE
https://github.com/user-attachments/assets/45601ce9-9f40-4e99-b47a-3c41ca9196ae

# **People who collaborated with me in this PR**
This was originally [posted](<https://www.pokecommunity.com/threads/simple-modifications-directory.416647/page-6#post-10182839>) by @Lunos. Give them all the credit.

# Features this PR does NOT handle:
- This PR **DOES NOT** handle the ability to release Pokémon if they are the last Pokémon with a Hidden Move

# Discord Contact Info

I am `pkmnsnfrn` on Discord.