### PR TITLE
trainerproc: use -traditional-cpp to preserve Unicode characters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -346,7 +346,7 @@ sound/%.bin: sound/%.aif ; $(AIF) $< $@
 
 COMPETITIVE_PARTY_SYNTAX := $(shell PATH="$(PATH)"; echo 'COMPETITIVE_PARTY_SYNTAX' | $(CPP) $(CPPFLAGS) -imacros include/global.h | tail -n1)
 ifeq ($(COMPETITIVE_PARTY_SYNTAX),1)
-%.h: %.party tools ; $(CPP) $(CPPFLAGS) - < $< | sed '/#[^p]/d' | $(TRAINERPROC) -o $@ -i $< -
+%.h: %.party tools ; $(CPP) $(CPPFLAGS) -traditional-cpp - < $< | sed '/#[^p]/d' | $(TRAINERPROC) -o $@ -i $< -
 endif
 
 ifeq ($(MODERN),0)


### PR DESCRIPTION
Ported from hedara's #4734, just the change to enable `-traditional-cpp` which fixes the immediate bug, unblocking 1.9, and letting that PR focus on the documentation.