### PR TITLE
Fix Sprite Changing to Female when Terastallizing

### DIFF
--- a/src/battle_gfx_sfx_util.c
+++ b/src/battle_gfx_sfx_util.c
@@ -911,7 +911,7 @@ void HandleSpeciesGfxDataChange(u8 battlerAtk, u8 battlerDef, bool32 megaEvo, bo
             HandleLoadSpecialPokePic(FALSE,
                                      gMonSpritesGfxPtr->spritesGfx[position],
                                      targetSpecies,
-                                     gTransformedPersonalities[battlerAtk]);
+                                     personalityValue);
         }
         else
         {
@@ -929,7 +929,7 @@ void HandleSpeciesGfxDataChange(u8 battlerAtk, u8 battlerDef, bool32 megaEvo, bo
             HandleLoadSpecialPokePic(TRUE,
                                      gMonSpritesGfxPtr->spritesGfx[position],
                                      targetSpecies,
-                                     gTransformedPersonalities[battlerAtk]);
+                                     personalityValue);
         }
     }
     src = gMonSpritesGfxPtr->spritesGfx[position];


### PR DESCRIPTION
The original issue was that upon terastallizing, a mon's sprite would change to use the female version if a different one was available. I went into the calls to `HandleLoadSpecialPokePic` and changed the last parameter (`personality`) from `gTransformedPersonalities[battlerAtk]` to `personalityValue`, which is defined a few lines above this call. 


## Images
See original for GIF with the issue, here is one with the fixed behavior
![teragender](https://github.com/user-attachments/assets/d7cc9e85-665e-447c-9fb7-fe868e49168b)


## Issue(s) that this PR fixes
Fixes #4961


## **People who collaborated with me in this PR**
https://github.com/rh-hideout/pokeemerald-expansion/issues/4961#issuecomment-2227045273 -- helpful comment

## Feature(s) this PR does NOT handle:
accounting for every other form change case, i am not fully confident that this didnt break something else, someone smarter than me please review this thank you!

## **Discord contact info**
iriv24
