### PR TITLE
Reduces AI_WhoStrikesFirst to the most essential parts

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -1042,22 +1042,26 @@ static u32 AI_GetEffectiveness(uq4_12_t multiplier)
 */
 s32 AI_WhoStrikesFirst(u32 battlerAI, u32 battler, u32 moveConsidered)
 {
-    s32 prioAI = 0, prioBattler = 0;
     u32 speedBattlerAI, speedBattler;
     u32 holdEffectAI = AI_DATA->holdEffects[battlerAI];
     u32 holdEffectPlayer = AI_DATA->holdEffects[battler];
-    prioAI = GetMovePriority(battlerAI, moveConsidered);
+    u32 abilityAI = AI_DATA->abilities[battlerAI];
+    u32 abilityPlayer = AI_DATA->abilities[battler];
 
-    if (prioAI > prioBattler)
+    if (GetMovePriority(battlerAI, moveConsidered) > 0)
         return AI_IS_FASTER;
 
-    speedBattlerAI = GetBattlerTotalSpeedStatArgs(battlerAI, AI_DATA->abilities[battlerAI], holdEffectAI);
-    speedBattler   = GetBattlerTotalSpeedStatArgs(battler, AI_DATA->abilities[battler], holdEffectPlayer);
+    speedBattlerAI = GetBattlerTotalSpeedStatArgs(battlerAI, abilityAI, holdEffectAI);
+    speedBattler   = GetBattlerTotalSpeedStatArgs(battler, abilityPlayer, holdEffectPlayer);
 
     if (holdEffectAI == HOLD_EFFECT_LAGGING_TAIL && holdEffectPlayer != HOLD_EFFECT_LAGGING_TAIL)
         return AI_IS_SLOWER;
+    else if (holdEffectAI != HOLD_EFFECT_LAGGING_TAIL && holdEffectPlayer == HOLD_EFFECT_LAGGING_TAIL)
+        return AI_IS_FASTER;
 
-    if (holdEffectAI != HOLD_EFFECT_LAGGING_TAIL && holdEffectPlayer == HOLD_EFFECT_LAGGING_TAIL)
+    if (abilityAI == ABILITY_STALL && abilityPlayer != ABILITY_STALL)
+        return AI_IS_SLOWER;
+    else if (abilityAI != ABILITY_STALL && abilityPlayer == ABILITY_STALL)
         return AI_IS_FASTER;
 
     if (speedBattlerAI > speedBattler)

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -1040,23 +1040,45 @@ static u32 AI_GetEffectiveness(uq4_12_t multiplier)
     * AI_IS_FASTER: is user(ai) faster
     * AI_IS_SLOWER: is target faster
 */
-s32 AI_WhoStrikesFirst(u32 battlerAI, u32 battler2, u32 moveConsidered)
+s32 AI_WhoStrikesFirst(u32 battlerAI, u32 battler, u32 moveConsidered)
 {
-    s8 prioAI = 0;
-    s8 prioBattler2 = 0;
+    s32 prioAI = 0, prioBattler = 0;
+    u32 holdEffectAI = AI_DATA->holdEffects[battlerAI];
+    u32 holdEffectPlayer = AI_DATA->holdEffects[battler];
     prioAI = GetMovePriority(battlerAI, moveConsidered);
 
-    if (prioAI > prioBattler2)
+    if (prioAI > prioBattler)
         return AI_IS_FASTER;
 
-    if (GetWhichBattlerFasterArgs(battlerAI, battler2, TRUE,
-                                  AI_DATA->abilities[battlerAI], AI_DATA->abilities[battler2],
-                                  AI_DATA->holdEffects[battlerAI], AI_DATA->holdEffects[battler2],
-                                  AI_DATA->speedStats[battlerAI], AI_DATA->speedStats[battler2],
-                                  prioAI, prioBattler2) == 1)
-        return AI_IS_FASTER;
-    else
+    u32 speedBattlerAI = GetBattlerTotalSpeedStatArgs(battlerAI, AI_DATA->abilities[battlerAI], holdEffectAI);
+    u32 speedBattler   = GetBattlerTotalSpeedStatArgs(battler, AI_DATA->abilities[battler], holdEffectPlayer);
+
+    if (holdEffectAI == HOLD_EFFECT_LAGGING_TAIL && holdEffectPlayer != HOLD_EFFECT_LAGGING_TAIL)
         return AI_IS_SLOWER;
+
+    if (holdEffectAI != HOLD_EFFECT_LAGGING_TAIL && holdEffectPlayer == HOLD_EFFECT_LAGGING_TAIL)
+        return AI_IS_FASTER;
+
+    if (speedBattlerAI > speedBattler)
+    {
+        if (gFieldStatuses & STATUS_FIELD_TRICK_ROOM)
+            return AI_IS_SLOWER;
+        else
+            return AI_IS_FASTER;
+    }
+    else if (speedBattlerAI == speedBattler)
+    {
+        return AI_IS_FASTER;
+    }
+    else
+    {
+        if (gFieldStatuses & STATUS_FIELD_TRICK_ROOM)
+            return AI_IS_FASTER;
+        else
+            return AI_IS_SLOWER;
+    }
+
+    return AI_IS_SLOWER;
 }
 
 // Check if target has means to faint ai mon.

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -1036,6 +1036,7 @@ static u32 AI_GetEffectiveness(uq4_12_t multiplier)
 }
 
 /* Checks to see if AI will move ahead of another battler
+ * The function uses a stripped down version of the checks from GetWhichBattlerFasterArgs
  * Output:
     * AI_IS_FASTER: is user(ai) faster
     * AI_IS_SLOWER: is target faster

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -1043,6 +1043,7 @@ static u32 AI_GetEffectiveness(uq4_12_t multiplier)
 s32 AI_WhoStrikesFirst(u32 battlerAI, u32 battler, u32 moveConsidered)
 {
     s32 prioAI = 0, prioBattler = 0;
+    u32 speedBattlerAI, speedBattler;
     u32 holdEffectAI = AI_DATA->holdEffects[battlerAI];
     u32 holdEffectPlayer = AI_DATA->holdEffects[battler];
     prioAI = GetMovePriority(battlerAI, moveConsidered);
@@ -1050,8 +1051,8 @@ s32 AI_WhoStrikesFirst(u32 battlerAI, u32 battler, u32 moveConsidered)
     if (prioAI > prioBattler)
         return AI_IS_FASTER;
 
-    u32 speedBattlerAI = GetBattlerTotalSpeedStatArgs(battlerAI, AI_DATA->abilities[battlerAI], holdEffectAI);
-    u32 speedBattler   = GetBattlerTotalSpeedStatArgs(battler, AI_DATA->abilities[battler], holdEffectPlayer);
+    speedBattlerAI = GetBattlerTotalSpeedStatArgs(battlerAI, AI_DATA->abilities[battlerAI], holdEffectAI);
+    speedBattler   = GetBattlerTotalSpeedStatArgs(battler, AI_DATA->abilities[battler], holdEffectPlayer);
 
     if (holdEffectAI == HOLD_EFFECT_LAGGING_TAIL && holdEffectPlayer != HOLD_EFFECT_LAGGING_TAIL)
         return AI_IS_SLOWER;


### PR DESCRIPTION
Most checks in `GetWhichBattlerFasterArgs` are not relevant during ai calcs so I just copied the ones that are essential.  
Also I removed the randomness when there is a tie and made it so that the AI thinks it is faster. This will help with consistency in tests and I don't think it is that bad for AI to think it is slower in this case since the player risks a speed tie.