### PR TITLE
Fix some vanilla names that fit in the battle UI incorrectly using a narrow font

### DIFF
--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -1743,7 +1743,7 @@ static void UpdateNickInHealthbox(u8 healthboxSpriteId, struct Pokemon *mon)
         break;
     }
 
-    windowTileData = AddTextPrinterAndCreateWindowOnHealthboxToFit(gDisplayedStringBattle, 0, 3, 2, &windowId, 54);
+    windowTileData = AddTextPrinterAndCreateWindowOnHealthboxToFit(gDisplayedStringBattle, 0, 3, 2, &windowId, 55);
 
     spriteTileNum = gSprites[healthboxSpriteId].oam.tileNum * TILE_SIZE_4BPP;
 

--- a/test/text.c
+++ b/test/text.c
@@ -275,7 +275,7 @@ TEST("Item names fit on Shop Screen")
 TEST("Species names fit on Battle Screen HP box")
 {
     u32 i, genderWidthPx;
-    const u32 fontId = FONT_SMALL_NARROWER, widthPx = 54;
+    const u32 fontId = FONT_SMALL_NARROWER, widthPx = 55;
     u32 species = SPECIES_NONE;
     genderWidthPx = GetStringWidth(fontId, COMPOUND_STRING("♂"), 0);
     for (i = 1; i < NUM_SPECIES; i++)
@@ -499,6 +499,25 @@ TEST("Species names fit on PokeNav Ribbon List Screen")
         }
     }
     EXPECT_LE(GetStringWidth(fontId, gSpeciesInfo[species].speciesName, 0), widthPx);
+}
+
+TEST("Species names fit on Battle Screen HP box for vanilla mons with the default font")
+{
+    u32 i, genderWidthPx;
+    const u32 fontId = FONT_SMALL, widthPx = 55;
+    u32 species = SPECIES_NONE;
+    genderWidthPx = GetStringWidth(fontId, COMPOUND_STRING("♂"), 0);
+    for (i = 1; i < SPECIES_TURTWIG; i++)
+    {
+        if (IsSpeciesEnabled(i))
+        {
+            PARAMETRIZE_LABEL("%S", gSpeciesInfo[i].speciesName) { species = i; }
+        }
+    }
+    if (gSpeciesInfo[i].genderRatio != MON_GENDERLESS)
+        EXPECT_LE(GetStringWidth(fontId, gSpeciesInfo[species].speciesName, 0) - genderWidthPx, widthPx);
+    else
+        EXPECT_LE(GetStringWidth(fontId, gSpeciesInfo[species].speciesName, 0), widthPx);
 }
 
 TEST("Ability names fit on Pokemon Summary Screen")


### PR DESCRIPTION
Update width for AddTextPrinterAndCreateWindowOnHealthboxToFit which is used to calculate which font to use for the species name in the health box from 54 -> 55

## Images
Before fix (note the font for Charmander's name):
![charmander-font-before](https://github.com/user-attachments/assets/c5823a96-bfcf-468c-824e-67e8197d7a3b)


After fix:
![charmander-font-after](https://github.com/user-attachments/assets/b5dae5e0-c1f9-4e73-a362-fa9931f5dbda)


## Issue(s) that this PR fixes
Fixes #4712


## **People who collaborated with me in this PR**
@mrgriffin thank you for answering my questions!


## **Discord contact info**
iriv24
