### PR TITLE
Fix tests when B_USE_FROSTBITE is TRUE

### DIFF
--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -244,7 +244,7 @@
 #define B_TRAINER_CLASS_POKE_BALLS      GEN_LATEST // In Gen7+, trainers will use certain types of Poké Balls depending on their trainer class.
 #define B_TRAINER_MON_RANDOM_ABILITY    FALSE      // If this is set to TRUE a random legal ability will be generated for a trainer mon
 #define B_OBEDIENCE_MECHANICS           GEN_LATEST // In PLA+ (here Gen8+), obedience restrictions also apply to non-outsider Pokémon, albeit based on their level met rather than actual level
-#define B_USE_FROSTBITE                 TRUE      // In PLA, Frostbite replaces Freeze. Enabling this flag does the same here. Moves can still be cherry-picked to either Freeze or Frostbite. Freeze-Dry, Secret Power & Tri Attack depend on this config.
+#define B_USE_FROSTBITE                 FALSE      // In PLA, Frostbite replaces Freeze. Enabling this flag does the same here. Moves can still be cherry-picked to either Freeze or Frostbite. Freeze-Dry, Secret Power & Tri Attack depend on this config.
 #define B_OVERWORLD_SNOW                GEN_LATEST // In Gen9+, overworld Snow will summon snow instead of hail in battle.
 #define B_OVERWORLD_FOG                 GEN_LATEST // In Gen8+, overworld Fog summons Misty Terrain in battle. In Gen4 only, overworld Fog summons the unique fog weather condition in battle.
 #define B_TOXIC_REVERSAL                GEN_LATEST // In Gen5+, bad poison will change to regular poison at the end of battles.

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -244,7 +244,7 @@
 #define B_TRAINER_CLASS_POKE_BALLS      GEN_LATEST // In Gen7+, trainers will use certain types of Poké Balls depending on their trainer class.
 #define B_TRAINER_MON_RANDOM_ABILITY    FALSE      // If this is set to TRUE a random legal ability will be generated for a trainer mon
 #define B_OBEDIENCE_MECHANICS           GEN_LATEST // In PLA+ (here Gen8+), obedience restrictions also apply to non-outsider Pokémon, albeit based on their level met rather than actual level
-#define B_USE_FROSTBITE                 FALSE      // In PLA, Frostbite replaces Freeze. Enabling this flag does the same here. Moves can still be cherry-picked to either Freeze or Frostbite. Freeze-Dry, Secret Power & Tri Attack depend on this config.
+#define B_USE_FROSTBITE                 TRUE      // In PLA, Frostbite replaces Freeze. Enabling this flag does the same here. Moves can still be cherry-picked to either Freeze or Frostbite. Freeze-Dry, Secret Power & Tri Attack depend on this config.
 #define B_OVERWORLD_SNOW                GEN_LATEST // In Gen9+, overworld Snow will summon snow instead of hail in battle.
 #define B_OVERWORLD_FOG                 GEN_LATEST // In Gen8+, overworld Fog summons Misty Terrain in battle. In Gen4 only, overworld Fog summons the unique fog weather condition in battle.
 #define B_TOXIC_REVERSAL                GEN_LATEST // In Gen5+, bad poison will change to regular poison at the end of battles.

--- a/include/test/battle.h
+++ b/include/test/battle.h
@@ -996,6 +996,9 @@ void SendOut(u32 sourceLine, struct BattlePokemon *, u32 partyIndex);
 #define MESSAGE(pattern) do {static const u8 msg[] = _(pattern); QueueMessage(__LINE__, msg);} while (0)
 #define STATUS_ICON(battler, status) QueueStatus(__LINE__, battler, (struct StatusEventContext) { status })
 
+#define FREEZE_OR_FROSTBURN_STATUS(battler, isFrostbite) \
+    (B_USE_FROSTBITE ? STATUS_ICON(battler, frostbite: isFrostbite) : STATUS_ICON(battler, freeze: isFrostbite))
+
 #define SWITCH_OUT_MESSAGE(name) ONE_OF {                                         \
                                      MESSAGE(name ", that's enough! Come back!"); \
                                      MESSAGE(name ", come back!");                \

--- a/test/battle/form_change/status.c
+++ b/test/battle/form_change/status.c
@@ -24,7 +24,7 @@ SINGLE_BATTLE_TEST("Shaymin-Sky reverts to Shaymin-Land when frozen or frostbitt
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, move, opponent);
         if (move == MOVE_POWDER_SNOW) {
-            STATUS_ICON(player, freeze: TRUE);
+            FREEZE_OR_FROSTBURN_STATUS(player, TRUE);
             NOT HP_BAR(player); // Regression caused by Mimikyu form change
             MESSAGE("Shaymin transformed!");
         } else {

--- a/test/battle/hold_effect/cure_status.c
+++ b/test/battle/hold_effect/cure_status.c
@@ -72,7 +72,7 @@ SINGLE_BATTLE_TEST("Rawst and Lum Berries cure burn")
     }
 }
 
-SINGLE_BATTLE_TEST("Aspear and Lum Berries cure freeze")
+SINGLE_BATTLE_TEST("Aspear and Lum Berries cure freeze or frostbite")
 {
     u16 item;
 
@@ -88,9 +88,9 @@ SINGLE_BATTLE_TEST("Aspear and Lum Berries cure freeze")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ICE_PUNCH, player);
         ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_FRZ, opponent);
-        STATUS_ICON(opponent, freeze: TRUE);
+        FREEZE_OR_FROSTBURN_STATUS(opponent, TRUE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
-        STATUS_ICON(opponent, freeze: FALSE);
+        FREEZE_OR_FROSTBURN_STATUS(opponent, FALSE);
     }
 }
 

--- a/test/battle/move_effect_secondary/freeze.c
+++ b/test/battle/move_effect_secondary/freeze.c
@@ -7,7 +7,11 @@ ASSUMPTIONS
     ASSUME(gMovesInfo[MOVE_BLIZZARD].accuracy == 70);
 }
 
+#if B_USE_FROSTBITE == TRUE
+SINGLE_BATTLE_TEST("Powder Snow inflicts frostbite")
+#else
 SINGLE_BATTLE_TEST("Powder Snow inflicts freeze")
+#endif
 {
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);
@@ -18,11 +22,15 @@ SINGLE_BATTLE_TEST("Powder Snow inflicts freeze")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_POWDER_SNOW, player);
         HP_BAR(opponent);
         ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_FRZ, opponent);
-        STATUS_ICON(opponent, freeze: TRUE);
+        FREEZE_OR_FROSTBURN_STATUS(opponent, TRUE);
     }
 }
 
+#if B_USE_FROSTBITE == TRUE
+SINGLE_BATTLE_TEST("Powder Snow cannot frostbite an Ice-type Pokémon")
+#else
 SINGLE_BATTLE_TEST("Powder Snow cannot freeze an Ice-type Pokémon")
+#endif
 {
     GIVEN {
         ASSUME(gSpeciesInfo[SPECIES_SNORUNT].types[0] == TYPE_ICE);
@@ -35,7 +43,7 @@ SINGLE_BATTLE_TEST("Powder Snow cannot freeze an Ice-type Pokémon")
         HP_BAR(opponent);
         NONE_OF {
             ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_FRZ, opponent);
-            STATUS_ICON(opponent, freeze: TRUE);
+            FREEZE_OR_FROSTBURN_STATUS(opponent, TRUE);
         }
     }
 }
@@ -68,9 +76,17 @@ SINGLE_BATTLE_TEST("Blizzard bypasses accuracy checks in Hail and Snow")
 }
 
 #if B_STATUS_TYPE_IMMUNITY > GEN_1
+#if B_USE_FROSTBITE == TRUE
+SINGLE_BATTLE_TEST("Freezing Glare should frostbite Psychic-types")
+#else
 SINGLE_BATTLE_TEST("Freezing Glare should freeze Psychic-types")
+#endif
+#else
+#if B_USE_FROSTBITE == TRUE
+SINGLE_BATTLE_TEST("Freezing Glare shouldn't freeze Psychic-types")
 #else
 SINGLE_BATTLE_TEST("Freezing Glare shouldn't freeze Psychic-types")
+#endif
 #endif
 {
     GIVEN {
@@ -86,11 +102,11 @@ SINGLE_BATTLE_TEST("Freezing Glare shouldn't freeze Psychic-types")
         HP_BAR(opponent);
         #if B_STATUS_TYPE_IMMUNITY > GEN_1
             ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_FRZ, opponent);
-            STATUS_ICON(opponent, freeze: TRUE);
+            FREEZE_OR_FROSTBURN_STATUS(opponent, TRUE);
         #else
             NONE_OF {
                 ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_FRZ, opponent);
-                STATUS_ICON(opponent, freeze: TRUE);
+                FREEZE_OR_FROSTBURN_STATUS(opponent, TRUE);
             }
         #endif
     }

--- a/test/battle/move_effect_secondary/tri_attack.c
+++ b/test/battle/move_effect_secondary/tri_attack.c
@@ -6,7 +6,11 @@ ASSUMPTIONS
     ASSUME(MoveHasAdditionalEffect(MOVE_TRI_ATTACK, MOVE_EFFECT_TRI_ATTACK) == TRUE);
 }
 
+#if B_USE_FROSTBITE == TRUE
+SINGLE_BATTLE_TEST("Tri Attack can inflict paralysis, burn or frostbite")
+#else
 SINGLE_BATTLE_TEST("Tri Attack can inflict paralysis, burn or freeze")
+#endif
 {
     u8 statusAnim;
     PARAMETRIZE { statusAnim = B_ANIM_STATUS_PRZ; }
@@ -26,14 +30,18 @@ SINGLE_BATTLE_TEST("Tri Attack can inflict paralysis, burn or freeze")
         if (statusAnim == B_ANIM_STATUS_BRN) {
             STATUS_ICON(opponent, burn: TRUE);
         } else if (statusAnim == B_ANIM_STATUS_FRZ) {
-            STATUS_ICON(opponent, freeze: TRUE);
+            FREEZE_OR_FROSTBURN_STATUS(opponent, TRUE);
         } else if (statusAnim == B_ANIM_STATUS_PRZ) {
             STATUS_ICON(opponent, paralysis: TRUE);
         }
     }
 }
 
+#if B_USE_FROSTBITE == TRUE
+SINGLE_BATTLE_TEST("Tri Attack cannot paralyze/burn/frostbite electric/fire/ice types respectively")
+#else
 SINGLE_BATTLE_TEST("Tri Attack cannot paralyze/burn/freeze electric/fire/ice types respectively")
+#endif
 {
     u8 statusAnim;
     u16 species;
@@ -42,7 +50,7 @@ SINGLE_BATTLE_TEST("Tri Attack cannot paralyze/burn/freeze electric/fire/ice typ
     PARAMETRIZE { statusAnim = B_ANIM_STATUS_PRZ; rng = MOVE_EFFECT_PARALYSIS; species = SPECIES_RAICHU; }
     #endif // B_PARALYZE_ELECTRIC
     PARAMETRIZE { statusAnim = B_ANIM_STATUS_BRN; rng = MOVE_EFFECT_BURN; species = SPECIES_ARCANINE; }
-    PARAMETRIZE { statusAnim = B_ANIM_STATUS_FRZ; rng = MOVE_EFFECT_FREEZE; species = SPECIES_GLALIE; }
+    PARAMETRIZE { statusAnim = B_ANIM_STATUS_FRZ; rng = MOVE_EFFECT_FREEZE_OR_FROSTBITE; species = SPECIES_GLALIE; }
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(species);
@@ -57,7 +65,7 @@ SINGLE_BATTLE_TEST("Tri Attack cannot paralyze/burn/freeze electric/fire/ice typ
             if (statusAnim == B_ANIM_STATUS_BRN) {
                 STATUS_ICON(opponent, burn: TRUE);
             } else if (statusAnim == B_ANIM_STATUS_FRZ) {
-                STATUS_ICON(opponent, freeze: TRUE);
+                FREEZE_OR_FROSTBURN_STATUS(opponent, TRUE);
             } else if (statusAnim == B_ANIM_STATUS_PRZ) {
                 STATUS_ICON(opponent, paralysis: TRUE);
             }
@@ -65,7 +73,11 @@ SINGLE_BATTLE_TEST("Tri Attack cannot paralyze/burn/freeze electric/fire/ice typ
     }
 }
 
+#if B_USE_FROSTBITE == TRUE
+SINGLE_BATTLE_TEST("Tri Attack cannot paralyze/burn/frostbite pokemon with abilities preventing respective statuses")
+#else
 SINGLE_BATTLE_TEST("Tri Attack cannot paralyze/burn/freeze pokemon with abilities preventing respective statuses")
+#endif
 {
     u8 statusAnim;
     u16 species, ability;
@@ -75,8 +87,8 @@ SINGLE_BATTLE_TEST("Tri Attack cannot paralyze/burn/freeze pokemon with abilitie
     PARAMETRIZE { statusAnim = B_ANIM_STATUS_BRN; rng = MOVE_EFFECT_BURN; species = SPECIES_DEWPIDER; ability = ABILITY_WATER_BUBBLE; }
     PARAMETRIZE { statusAnim = B_ANIM_STATUS_BRN; rng = MOVE_EFFECT_BURN; species = SPECIES_SEAKING; ability = ABILITY_WATER_VEIL; }
     PARAMETRIZE { statusAnim = B_ANIM_STATUS_BRN; rng = MOVE_EFFECT_BURN; species = SPECIES_KOMALA; ability = ABILITY_COMATOSE; }
-    PARAMETRIZE { statusAnim = B_ANIM_STATUS_FRZ; rng = MOVE_EFFECT_FREEZE; species = SPECIES_CAMERUPT; ability = ABILITY_MAGMA_ARMOR; }
-    PARAMETRIZE { statusAnim = B_ANIM_STATUS_FRZ; rng = MOVE_EFFECT_FREEZE; species = SPECIES_KOMALA; ability = ABILITY_COMATOSE; }
+    PARAMETRIZE { statusAnim = B_ANIM_STATUS_FRZ; rng = MOVE_EFFECT_FREEZE_OR_FROSTBITE; species = SPECIES_CAMERUPT; ability = ABILITY_MAGMA_ARMOR; }
+    PARAMETRIZE { statusAnim = B_ANIM_STATUS_FRZ; rng = MOVE_EFFECT_FREEZE_OR_FROSTBITE; species = SPECIES_KOMALA; ability = ABILITY_COMATOSE; }
 
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);
@@ -92,7 +104,7 @@ SINGLE_BATTLE_TEST("Tri Attack cannot paralyze/burn/freeze pokemon with abilitie
             if (statusAnim == B_ANIM_STATUS_BRN) {
                 STATUS_ICON(opponent, burn: TRUE);
             } else if (statusAnim == B_ANIM_STATUS_FRZ) {
-                STATUS_ICON(opponent, freeze: TRUE);
+                FREEZE_OR_FROSTBURN_STATUS(opponent, TRUE);
             } else if (statusAnim == B_ANIM_STATUS_PRZ) {
                 STATUS_ICON(opponent, paralysis: TRUE);
             }
@@ -100,13 +112,17 @@ SINGLE_BATTLE_TEST("Tri Attack cannot paralyze/burn/freeze pokemon with abilitie
     }
 }
 
+#if B_USE_FROSTBITE == TRUE
+SINGLE_BATTLE_TEST("Tri Attack cannot paralyze/burn/frostbite a mon which is already statused")
+#else
 SINGLE_BATTLE_TEST("Tri Attack cannot paralyze/burn/freeze a mon which is already statused")
+#endif
 {
     u8 statusAnim;
     u32 rng;
     PARAMETRIZE { statusAnim = B_ANIM_STATUS_PRZ; rng = MOVE_EFFECT_PARALYSIS; }
     PARAMETRIZE { statusAnim = B_ANIM_STATUS_BRN; rng = MOVE_EFFECT_BURN; }
-    PARAMETRIZE { statusAnim = B_ANIM_STATUS_FRZ; rng = MOVE_EFFECT_FREEZE; }
+    PARAMETRIZE { statusAnim = B_ANIM_STATUS_FRZ; rng = MOVE_EFFECT_FREEZE_OR_FROSTBITE; }
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET) { Status1(STATUS1_SLEEP); }
@@ -121,7 +137,7 @@ SINGLE_BATTLE_TEST("Tri Attack cannot paralyze/burn/freeze a mon which is alread
             if (statusAnim == B_ANIM_STATUS_BRN) {
                 STATUS_ICON(opponent, burn: TRUE);
             } else if (statusAnim == B_ANIM_STATUS_FRZ) {
-                STATUS_ICON(opponent, freeze: TRUE);
+                FREEZE_OR_FROSTBURN_STATUS(opponent, TRUE);
             } else if (statusAnim == B_ANIM_STATUS_PRZ) {
                 STATUS_ICON(opponent, paralysis: TRUE);
             }

--- a/test/battle/move_effects_combined/flinch_status.c
+++ b/test/battle/move_effects_combined/flinch_status.c
@@ -5,7 +5,7 @@ ASSUMPTIONS
 {
     ASSUME(MoveHasAdditionalEffect(MOVE_THUNDER_FANG, MOVE_EFFECT_PARALYSIS) == TRUE);
     ASSUME(MoveHasAdditionalEffect(MOVE_THUNDER_FANG, MOVE_EFFECT_FLINCH) == TRUE);
-    ASSUME(MoveHasAdditionalEffect(MOVE_ICE_FANG, MOVE_EFFECT_FREEZE) == TRUE);
+    ASSUME(MoveHasAdditionalEffect(MOVE_ICE_FANG, MOVE_EFFECT_FREEZE_OR_FROSTBITE) == TRUE);
     ASSUME(MoveHasAdditionalEffect(MOVE_ICE_FANG, MOVE_EFFECT_FLINCH) == TRUE);
     ASSUME(MoveHasAdditionalEffect(MOVE_FIRE_FANG, MOVE_EFFECT_BURN) == TRUE);
     ASSUME(MoveHasAdditionalEffect(MOVE_FIRE_FANG, MOVE_EFFECT_FLINCH) == TRUE);
@@ -33,7 +33,7 @@ SINGLE_BATTLE_TEST("Thunder, Ice and Fire Fang inflict status 10% of the time")
             STATUS_ICON(opponent, paralysis: TRUE);
         } if (move == MOVE_ICE_FANG) {
             ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_FRZ, opponent);
-            STATUS_ICON(opponent, freeze: TRUE);
+            FREEZE_OR_FROSTBURN_STATUS(opponent, TRUE);
         } if (move == MOVE_FIRE_FANG) {
             ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, opponent);
             STATUS_ICON(opponent, burn: TRUE);


### PR DESCRIPTION
I wanted to fix these tests specifically because a lot of users are likely to enable B_USE_FROSTBITE in their hacks and I thought it would be nice to prevent it from killing the CI.

I'm using the macro FREEZE_OR_FROSTBURN_STATUS as a stand in for STATUS_ICON when checking for the appropriate status as it should be fairly easy to use and it still allows us to make tests that check one or the other irrespective of B_USE_FROSTBITE