### PR TITLE
Deprecate agbcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -509,7 +509,12 @@ $(ROM): $(ELF)
 	$(OBJCOPY) -O binary $< $@
 	$(FIX) $@ -p --silent
 
-agbcc: all
+# Uncomment the next line, and then comment the 4 lines after it to reenable agbcc.
+#agbcc: all
+agbcc:
+	@echo "'make agbcc' is deprecated as of Expansion 1.9 and will likely be removed in Expansion 1.10"
+	@echo "search for 'agbcc: all' in Makefile to reenable agbcc"
+	@exit 1
 
 modern: all
 

--- a/Makefile
+++ b/Makefile
@@ -512,7 +512,7 @@ $(ROM): $(ELF)
 # Uncomment the next line, and then comment the 4 lines after it to reenable agbcc.
 #agbcc: all
 agbcc:
-	@echo "'make agbcc' is deprecated as of Expansion 1.9 and will likely be removed in Expansion 1.10"
+	@echo "'make agbcc' is deprecated as of pokeemerald-expansion 1.9 and will be removed in 1.10"
 	@echo "search for 'agbcc: all' in Makefile to reenable agbcc"
 	@exit 1
 

--- a/Makefile
+++ b/Makefile
@@ -512,8 +512,8 @@ $(ROM): $(ELF)
 # Uncomment the next line, and then comment the 4 lines after it to reenable agbcc.
 #agbcc: all
 agbcc:
-	@echo "'make agbcc' is deprecated as of pokeemerald-expansion 1.9 and will be removed in 1.10"
-	@echo "search for 'agbcc: all' in Makefile to reenable agbcc"
+	@echo "'make agbcc' is deprecated as of pokeemerald-expansion 1.9 and will be removed in 1.10."
+	@echo "Search for 'agbcc: all' in Makefile to reenable agbcc."
 	@exit 1
 
 modern: all


### PR DESCRIPTION
Causes `make agbcc` to exit with an error. Leaves the old implementation commented-out so that it can be reenabled.