### PR TITLE
Fixes AI not being aware during calcs

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -461,12 +461,20 @@ void SetAiLogicDataForTurn(struct AiLogicData *aiData)
     aiData->weatherHasEffect = WEATHER_HAS_EFFECT;
     // get/assume all battler data and simulate AI damage
     battlersCount = gBattlersCount;
+
     for (battlerAtk = 0; battlerAtk < battlersCount; battlerAtk++)
     {
         if (!IsBattlerAlive(battlerAtk))
             continue;
 
         SetBattlerAiData(battlerAtk, aiData);
+    }
+
+    for (battlerAtk = 0; battlerAtk < battlersCount; battlerAtk++)
+    {
+        if (!IsBattlerAlive(battlerAtk))
+            continue;
+
         SetBattlerAiMovesData(aiData, battlerAtk, battlersCount);
     }
 }

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -378,10 +378,8 @@ bool32 IsDamageMoveUnusable(u32 move, u32 battlerAtk, u32 battlerDef)
     else
         battlerDefAbility = aiData->abilities[battlerDef];
 
-    // Battler doesn't see partners Ability for some reason.
-    // This is a small hack to avoid the issue but should be investigated
     if (battlerDef == BATTLE_PARTNER(battlerAtk))
-        battlerDefAbility = GetBattlerAbility(battlerDef);
+        battlerDefAbility = aiData->abilities[battlerDef];
 
     switch (battlerDefAbility)
     {


### PR DESCRIPTION
This has been a bug for some time now but I couldn't figure out the problem until now.

When the AI started looping over all battlers it didn't got all of the information at once (only on the last loop of battlerAtk was it complete). To solve this I made a loop outside of the main loop to avoid redundant calls. There was an issue in `IsDamageMoveUnusable` that was fixed by this and probably a lot of hidden issues as well.  