### PR TITLE
Some tera tests

### DIFF
--- a/test/battle/ability/illusion.c
+++ b/test/battle/ability/illusion.c
@@ -1,0 +1,24 @@
+#include "global.h"
+#include "test/battle.h"
+
+//  This test is eyes on only
+SINGLE_BATTLE_TEST("Illusion can only imitate Normal Form terapagos")
+{
+    GIVEN {
+        PLAYER(SPECIES_ZOROARK);
+        PLAYER(SPECIES_TERAPAGOS);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        //  Zoroark is out, should be normal form Terapagos
+        //  Switch to Terapagos which enters Terastal Form
+        TURN { SWITCH(player, 1); }
+        //  Switch back to Zoroark, should not be Terastal Terapagos
+        TURN { SWITCH(player, 1); }
+        // Switch back to Terapagos
+        TURN { SWITCH(player, 1); }
+        //  Terapagos Stellar, Zoroark gets Roared in, should not be Stellar Terapagos
+        TURN { MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_TERA); MOVE(opponent, MOVE_ROAR); }
+        //  Reveal the Zoroark
+        TURN { MOVE(player, MOVE_CELEBRATE); MOVE(opponent, MOVE_TACKLE); }
+    }
+}

--- a/test/battle/ability/illusion.c
+++ b/test/battle/ability/illusion.c
@@ -5,15 +5,15 @@
 SINGLE_BATTLE_TEST("Illusion can only imitate Normal Form terapagos")
 {
     GIVEN {
-        PLAYER(SPECIES_ZOROARK);
-        PLAYER(SPECIES_TERAPAGOS);
+        PLAYER(SPECIES_ZOROARK) { Moves(MOVE_CELEBRATE); }
+        PLAYER(SPECIES_TERAPAGOS) { Moves(MOVE_CELEBRATE); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
         //  Zoroark is out, should be normal form Terapagos
         //  Switch to Terapagos which enters Terastal Form
         TURN { SWITCH(player, 1); }
         //  Switch back to Zoroark, should not be Terastal Terapagos
-        TURN { SWITCH(player, 1); }
+        TURN { SWITCH(player, 0); MOVE(opponent, MOVE_TACKLE);}
         // Switch back to Terapagos
         TURN { SWITCH(player, 1); }
         //  Terapagos Stellar, Zoroark gets Roared in, should not be Stellar Terapagos

--- a/test/battle/ability/teraform_zero.c
+++ b/test/battle/ability/teraform_zero.c
@@ -1,0 +1,102 @@
+#include "global.h"
+#include "test/battle.h"
+
+DOUBLE_BATTLE_TEST("Teraform Zero clears weather and terrain upon activation")
+{
+    GIVEN {
+        PLAYER(SPECIES_TERAPAGOS_TERASTAL);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_KYOGRE) {Ability(ABILITY_DRIZZLE); }
+        OPPONENT(SPECIES_TAPU_KOKO) {Ability(ABILITY_ELECTRIC_SURGE); }
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_CELEBRATE, gimmick: GIMMICK_TERA); }
+    } SCENE {
+        ABILITY_POPUP(playerLeft, ABILITY_TERAFORM_ZERO);
+        MESSAGE("The rain stopped.");
+        MESSAGE("The electricity disappeared from the battlefield.");
+    }
+}
+
+DOUBLE_BATTLE_TEST("Teraform Zero can be supressed")
+{
+    GIVEN {
+        PLAYER(SPECIES_TERAPAGOS_TERASTAL);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WEEZING) {Ability(ABILITY_NEUTRALIZING_GAS); }
+        OPPONENT(SPECIES_KYOGRE) {Ability(ABILITY_DRIZZLE); }
+        OPPONENT(SPECIES_TAPU_KOKO) {Ability(ABILITY_ELECTRIC_SURGE); }
+    } WHEN {
+        TURN { SWITCH(playerRight, 2); MOVE(playerLeft, MOVE_CELEBRATE, gimmick: GIMMICK_TERA); }
+    } SCENE {
+        ABILITY_POPUP(playerRight, ABILITY_NEUTRALIZING_GAS);
+        NONE_OF {
+            MESSAGE("The rain stopped.");
+            MESSAGE("The electricity disappeared from the battlefield.");
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Teraform Zero can be replaced")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_WORRY_SEED].effect == EFFECT_WORRY_SEED);
+        ASSUME(gMovesInfo[MOVE_REST].effect == EFFECT_REST);
+        PLAYER(SPECIES_TERAPAGOS);
+        OPPONENT(SPECIES_WHIMSICOTT) { Ability(ABILITY_PRANKSTER); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_WORRY_SEED); MOVE(player, MOVE_REST, gimmick: GIMMICK_TERA); }
+    } SCENE {
+        MESSAGE("Foe Whimsicott used Worry Seed!");
+        MESSAGE("Terapagos acquired Insomnia!");
+        MESSAGE("Terapagos used Rest!");
+        ABILITY_POPUP(player, ABILITY_INSOMNIA);
+        MESSAGE("Terapagos stayed awake using its Insomnia!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Teraform Zero cannot be swapped")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_SKILL_SWAP].effect == EFFECT_SKILL_SWAP);
+        PLAYER(SPECIES_TERAPAGOS);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_TERA); MOVE(opponent, MOVE_SKILL_SWAP); }
+    } SCENE {
+        MESSAGE("Foe Wobbuffet used Skill Swap!");
+        MESSAGE("But if failed!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Teraform Zero cannot be copied")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_ROLE_PLAY].effect == EFFECT_ROLE_PLAY);
+        PLAYER(SPECIES_TERAPAGOS);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_TERA); MOVE(opponent, MOVE_ROLE_PLAY); }
+    } SCENE {
+        MESSAGE("Foe Wobbuffet used Role Play!");
+        MESSAGE("But if failed!");
+    }
+}
+
+DOUBLE_BATTLE_TEST("Teraform Zero shouldn't cause Neutralizing Gas to show it's popup when trying to activate")
+{
+    KNOWN_FAILING; // #5010
+    GIVEN {
+        PLAYER(SPECIES_TERAPAGOS_TERASTAL);
+        PLAYER(SPECIES_ABSOL) {Ability(ABILITY_PRESSURE); }
+        PLAYER(SPECIES_WEEZING) {Ability(ABILITY_NEUTRALIZING_GAS); }
+        OPPONENT(SPECIES_KYOGRE) {Ability(ABILITY_DRIZZLE); }
+        OPPONENT(SPECIES_TAPU_KOKO) {Ability(ABILITY_ELECTRIC_SURGE); }
+    } WHEN {
+        TURN {  SWITCH(playerRight, 2); MOVE(playerLeft, MOVE_CELEBRATE, gimmick: GIMMICK_TERA); }
+    } SCENE {
+        MESSAGE("Terapagos is storing energy!");
+        MESSAGE("Terapagos terastalized into the Stellar type!");
+        NOT ABILITY_POPUP(playerRight, ABILITY_NEUTRALIZING_GAS);
+        MESSAGE("Terapagos used Celebreate!");
+    }
+}

--- a/test/battle/ability/teraform_zero.c
+++ b/test/battle/ability/teraform_zero.c
@@ -64,7 +64,7 @@ SINGLE_BATTLE_TEST("Teraform Zero cannot be swapped")
         TURN { MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_TERA); MOVE(opponent, MOVE_SKILL_SWAP); }
     } SCENE {
         MESSAGE("Foe Wobbuffet used Skill Swap!");
-        MESSAGE("But if failed!");
+        MESSAGE("But it failed!");
     }
 }
 
@@ -78,7 +78,7 @@ SINGLE_BATTLE_TEST("Teraform Zero cannot be copied")
         TURN { MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_TERA); MOVE(opponent, MOVE_ROLE_PLAY); }
     } SCENE {
         MESSAGE("Foe Wobbuffet used Role Play!");
-        MESSAGE("But if failed!");
+        MESSAGE("But it failed!");
     }
 }
 

--- a/test/battle/gimmick/terastal.c
+++ b/test/battle/gimmick/terastal.c
@@ -881,8 +881,8 @@ SINGLE_BATTLE_TEST("(TERA) All type indicators function correctly")
 SINGLE_BATTLE_TEST("(TERA) All type indicators function correctly - Opponent")
 {
     u32 type;
-    PARAMETRIZE { type = TYPE_NORMAL; }
     PARAMETRIZE { type = TYPE_NONE; }
+    PARAMETRIZE { type = TYPE_NORMAL; }
     PARAMETRIZE { type = TYPE_FIGHTING; }
     PARAMETRIZE { type = TYPE_FLYING; }
     PARAMETRIZE { type = TYPE_POISON; }

--- a/test/battle/gimmick/terastal.c
+++ b/test/battle/gimmick/terastal.c
@@ -762,6 +762,72 @@ SINGLE_BATTLE_TEST("(TERA) Stellar type's one-time boost factors in dynamically-
     }
 }
 
+SINGLE_BATTLE_TEST("(TERA) Terapagos retains the Stellar type boost at all times")
+{
+    KNOWN_FAILING; // #5012
+    s16 damage[2];
+    u32 move;
+    PARAMETRIZE { move = MOVE_TACKLE; }
+    PARAMETRIZE { move = MOVE_MACH_PUNCH; }
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_TACKLE].type == TYPE_NORMAL);
+        ASSUME(gMovesInfo[MOVE_MACH_PUNCH].type != TYPE_NORMAL);
+        PLAYER(SPECIES_TERAPAGOS);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, move, gimmick: GIMMICK_TERA); }
+        TURN { MOVE(player, move); }
+    } SCENE {
+        HP_BAR(opponent, captureDamage: &damage[0]);
+        HP_BAR(opponent, captureDamage: &damage[1]);
+    } THEN {
+        EXPECT_EQ(damage[0], damage[1]);
+    }
+}
+
+SINGLE_BATTLE_TEST("(TERA) Terapagos retains its base defensive profile when Terastalizing")
+{
+    GIVEN {
+        PLAYER(SPECIES_TERAPAGOS);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_TERA); MOVE(opponent, MOVE_BRICK_BREAK); }
+    } SCENE {
+        MESSAGE("It's super effective!");
+    }
+}
+
+SINGLE_BATTLE_TEST("(TERA) Illusion breaks if the pokemon Terastalizes")
+{
+    KNOWN_FAILING; // #5015
+    u32 species;
+    PARAMETRIZE { species = SPECIES_TERAPAGOS; }
+    PARAMETRIZE { species = SPECIES_WOBBUFFET; }
+    GIVEN {
+        PLAYER(SPECIES_ZOROARK) { TeraType(TYPE_DARK); }
+        PLAYER(species);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_TERA); }
+    } SCENE {
+        MESSAGE("Zoroark's Illusion wore off!");
+    }
+}
+
+/*
+//  This test freezes the emulator
+SINGLE_BATTLE_TEST("(TERA) Transformed pokemon can't Terastalize")
+{
+    GIVEN {
+        PLAYER(SPECIES_DITTO);
+        OPPONENT(SPECIES_TERAPAGOS) { Moves(MOVE_CELEBRATE); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_TRANSFORM); }
+        TURN { MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_TERA); }
+    }
+}
+*/
+
 SINGLE_BATTLE_TEST("(TERA) Pokemon with Tera forms change upon Terastallizing")
 {
     u32 species, targetSpecies;
@@ -815,8 +881,8 @@ SINGLE_BATTLE_TEST("(TERA) All type indicators function correctly")
 SINGLE_BATTLE_TEST("(TERA) All type indicators function correctly - Opponent")
 {
     u32 type;
-    PARAMETRIZE { type = TYPE_NONE; }
     PARAMETRIZE { type = TYPE_NORMAL; }
+    PARAMETRIZE { type = TYPE_NONE; }
     PARAMETRIZE { type = TYPE_FIGHTING; }
     PARAMETRIZE { type = TYPE_FLYING; }
     PARAMETRIZE { type = TYPE_POISON; }

--- a/test/battle/move_effect/tera_starstorm.c
+++ b/test/battle/move_effect/tera_starstorm.c
@@ -59,3 +59,18 @@ SINGLE_BATTLE_TEST("Tera Starstorm becomes a physical move if the user is Terapa
         EXPECT_MUL_EQ(results[0].damage, UQ_4_12(2.5), results[1].damage);
     }
 }
+
+SINGLE_BATTLE_TEST("Tera Starstorm remains Normal-type if used by Pokemon other than Terapagos")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_TERA_STARSTORM].type == TYPE_NORMAL);
+        ASSUME(gSpeciesInfo[SPECIES_MISDREAVUS].types[0] == TYPE_GHOST);
+        PLAYER(SPECIES_WOBBUFFET) { TeraType(TYPE_STELLAR); }
+        OPPONENT(SPECIES_MISDREAVUS);
+    } WHEN {
+        TURN { MOVE(player, MOVE_TERA_STARSTORM, gimmick: GIMMICK_TERA); }
+    } SCENE {
+        MESSAGE("Wobbuffet used Tera Starstorm!");
+        MESSAGE("It doesn't affect Foe Misdreavus…");
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added tests for Terastalization and Terapagos interactions

## Description
<!--- Describe your changes in detail -->
Test for Illusion with Terapagos forms. Only visual, have to look at the test.
Test for Teraform Zero effect, suppression and swap/copy.
Test for incorrect Ability popup with Neutralizing Gas + Teraform Zero.
Test for Tera Starstorm when used by other pokemon.
Test for Terapagos Stellar damage boost.
Test for Illusion breaking upon Terastalization.

## **Discord contact info**
<!--- formatted as name#numbers, e.g. Lunos#4026 -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara