### PR TITLE
Refactor Frontier Brains

### DIFF
--- a/src/frontier_util.c
+++ b/src/frontier_util.c
@@ -94,6 +94,10 @@ static void ShowPyramidResultsWindow(void);
 static void ShowLinkContestResultsWindow(void);
 static void CopyFrontierBrainText(bool8 playerWonText);
 
+#define FRONTIER_BRAIN_TEXTS(Brain)                                        \
+    .lostTexts = {gText_##Brain##DefeatSilver, gText_##Brain##DefeatGold}, \
+    .wonTexts = {gText_##Brain##WonSilver, gText_##Brain##WonGold}
+
 // battledBit: Flags to change the conversation when the Frontier Brain is encountered for a battle
 // First bit is has battled them before and not won yet, second bit is has battled them and won (obtained a Symbol)
 const struct FrontierBrain gFrontierBrainInfo[NUM_FRONTIER_FACILITIES] =
@@ -103,8 +107,7 @@ const struct FrontierBrain gFrontierBrainInfo[NUM_FRONTIER_FACILITIES] =
         .trainerId = TRAINER_ANABEL,
         .objEventGfx = OBJ_EVENT_GFX_ANABEL,
         .isFemale = TRUE,
-        .lostTexts = {gText_AnabelDefeatSilver, gText_AnabelDefeatGold},
-        .wonTexts = {gText_AnabelWonSilver, gText_AnabelWonGold},
+        FRONTIER_BRAIN_TEXTS(Anabel),
         .battledBit = {1 << 0, 1 << 1},
         .streakAppearances = {35, 70, 35, 1},
     },
@@ -113,8 +116,7 @@ const struct FrontierBrain gFrontierBrainInfo[NUM_FRONTIER_FACILITIES] =
         .trainerId = TRAINER_TUCKER,
         .objEventGfx = OBJ_EVENT_GFX_TUCKER,
         .isFemale = FALSE,
-        .lostTexts = {gText_TuckerDefeatSilver, gText_TuckerDefeatGold},
-        .wonTexts = {gText_TuckerWonSilver, gText_TuckerWonGold},
+        FRONTIER_BRAIN_TEXTS(Tucker),
         .battledBit = {1 << 2, 1 << 3},
         .streakAppearances = {1, 2, 5, 0},
     },
@@ -123,8 +125,7 @@ const struct FrontierBrain gFrontierBrainInfo[NUM_FRONTIER_FACILITIES] =
         .trainerId = TRAINER_SPENSER,
         .objEventGfx = OBJ_EVENT_GFX_SPENSER,
         .isFemale = FALSE,
-        .lostTexts = {gText_SpenserDefeatSilver, gText_SpenserDefeatGold},
-        .wonTexts = {gText_SpenserWonSilver, gText_SpenserWonGold},
+        FRONTIER_BRAIN_TEXTS(Spenser),
         .battledBit = {1 << 4, 1 << 5},
         .streakAppearances = {21, 42, 21, 1},
     },
@@ -133,8 +134,7 @@ const struct FrontierBrain gFrontierBrainInfo[NUM_FRONTIER_FACILITIES] =
         .trainerId = TRAINER_GRETA,
         .objEventGfx = OBJ_EVENT_GFX_GRETA,
         .isFemale = TRUE,
-        .lostTexts = {gText_GretaDefeatSilver, gText_GretaDefeatGold},
-        .wonTexts = {gText_GretaWonSilver, gText_GretaWonGold},
+        FRONTIER_BRAIN_TEXTS(Greta),
         .battledBit = {1 << 6, 1 << 7},
         .streakAppearances = {28, 56, 28, 1},
     },
@@ -143,8 +143,7 @@ const struct FrontierBrain gFrontierBrainInfo[NUM_FRONTIER_FACILITIES] =
         .trainerId = TRAINER_NOLAND,
         .objEventGfx = OBJ_EVENT_GFX_NOLAND,
         .isFemale = FALSE,
-        .lostTexts = {gText_NolandDefeatSilver, gText_NolandDefeatGold},
-        .wonTexts = {gText_NolandWonSilver, gText_NolandWonGold},
+        FRONTIER_BRAIN_TEXTS(Noland),
         .battledBit = {1 << 8, 1 << 9},
         .streakAppearances = {21, 42, 21, 1},
     },
@@ -153,8 +152,7 @@ const struct FrontierBrain gFrontierBrainInfo[NUM_FRONTIER_FACILITIES] =
         .trainerId = TRAINER_LUCY,
         .objEventGfx = OBJ_EVENT_GFX_LUCY,
         .isFemale = TRUE,
-        .lostTexts = {gText_LucyDefeatSilver, gText_LucyDefeatGold},
-        .wonTexts = {gText_LucyWonSilver, gText_LucyWonGold},
+        FRONTIER_BRAIN_TEXTS(Lucy),
         .battledBit = {1 << 10, 1 << 11},
         .streakAppearances = {28, 140, 56, 1},
     },
@@ -163,8 +161,7 @@ const struct FrontierBrain gFrontierBrainInfo[NUM_FRONTIER_FACILITIES] =
         .trainerId = TRAINER_BRANDON,
         .objEventGfx = OBJ_EVENT_GFX_BRANDON,
         .isFemale = FALSE,
-        .lostTexts = {gText_BrandonDefeatSilver, gText_BrandonDefeatGold},
-        .wonTexts = {gText_BrandonWonSilver, gText_BrandonWonGold},
+        FRONTIER_BRAIN_TEXTS(Brandon),
         .battledBit = {1 << 12, 1 << 13},
         .streakAppearances = {21, 70, 35, 0},
     },

--- a/src/frontier_util.c
+++ b/src/frontier_util.c
@@ -94,6 +94,10 @@ static void ShowPyramidResultsWindow(void);
 static void ShowLinkContestResultsWindow(void);
 static void CopyFrontierBrainText(bool8 playerWonText);
 
+#define FRONTIER_BRAIN_SPRITES(Brain) \
+    .trainerId = TRAINER_##Brain,     \
+    .objEventGfx = OBJ_EVENT_GFX_##Brain
+
 #define FRONTIER_BRAIN_TEXTS(Brain)                                        \
     .lostTexts = {gText_##Brain##DefeatSilver, gText_##Brain##DefeatGold}, \
     .wonTexts = {gText_##Brain##WonSilver, gText_##Brain##WonGold}
@@ -104,8 +108,7 @@ const struct FrontierBrain gFrontierBrainInfo[NUM_FRONTIER_FACILITIES] =
 {
     [FRONTIER_FACILITY_TOWER] =
     {
-        .trainerId = TRAINER_ANABEL,
-        .objEventGfx = OBJ_EVENT_GFX_ANABEL,
+        FRONTIER_BRAIN_SPRITES(ANABEL),
         .isFemale = TRUE,
         FRONTIER_BRAIN_TEXTS(Anabel),
         .battledBit = {1 << 0, 1 << 1},
@@ -113,8 +116,7 @@ const struct FrontierBrain gFrontierBrainInfo[NUM_FRONTIER_FACILITIES] =
     },
     [FRONTIER_FACILITY_DOME] =
     {
-        .trainerId = TRAINER_TUCKER,
-        .objEventGfx = OBJ_EVENT_GFX_TUCKER,
+        FRONTIER_BRAIN_SPRITES(TUCKER),
         .isFemale = FALSE,
         FRONTIER_BRAIN_TEXTS(Tucker),
         .battledBit = {1 << 2, 1 << 3},
@@ -122,8 +124,7 @@ const struct FrontierBrain gFrontierBrainInfo[NUM_FRONTIER_FACILITIES] =
     },
     [FRONTIER_FACILITY_PALACE] =
     {
-        .trainerId = TRAINER_SPENSER,
-        .objEventGfx = OBJ_EVENT_GFX_SPENSER,
+        FRONTIER_BRAIN_SPRITES(SPENSER),
         .isFemale = FALSE,
         FRONTIER_BRAIN_TEXTS(Spenser),
         .battledBit = {1 << 4, 1 << 5},
@@ -131,8 +132,7 @@ const struct FrontierBrain gFrontierBrainInfo[NUM_FRONTIER_FACILITIES] =
     },
     [FRONTIER_FACILITY_ARENA] =
     {
-        .trainerId = TRAINER_GRETA,
-        .objEventGfx = OBJ_EVENT_GFX_GRETA,
+        FRONTIER_BRAIN_SPRITES(GRETA),
         .isFemale = TRUE,
         FRONTIER_BRAIN_TEXTS(Greta),
         .battledBit = {1 << 6, 1 << 7},
@@ -140,8 +140,7 @@ const struct FrontierBrain gFrontierBrainInfo[NUM_FRONTIER_FACILITIES] =
     },
     [FRONTIER_FACILITY_FACTORY] =
     {
-        .trainerId = TRAINER_NOLAND,
-        .objEventGfx = OBJ_EVENT_GFX_NOLAND,
+        FRONTIER_BRAIN_SPRITES(NOLAND),
         .isFemale = FALSE,
         FRONTIER_BRAIN_TEXTS(Noland),
         .battledBit = {1 << 8, 1 << 9},
@@ -149,8 +148,7 @@ const struct FrontierBrain gFrontierBrainInfo[NUM_FRONTIER_FACILITIES] =
     },
     [FRONTIER_FACILITY_PIKE] =
     {
-        .trainerId = TRAINER_LUCY,
-        .objEventGfx = OBJ_EVENT_GFX_LUCY,
+        FRONTIER_BRAIN_SPRITES(LUCY),
         .isFemale = TRUE,
         FRONTIER_BRAIN_TEXTS(Lucy),
         .battledBit = {1 << 10, 1 << 11},
@@ -158,8 +156,7 @@ const struct FrontierBrain gFrontierBrainInfo[NUM_FRONTIER_FACILITIES] =
     },
     [FRONTIER_FACILITY_PYRAMID] =
     {
-        .trainerId = TRAINER_BRANDON,
-        .objEventGfx = OBJ_EVENT_GFX_BRANDON,
+        FRONTIER_BRAIN_SPRITES(BRANDON),
         .isFemale = FALSE,
         FRONTIER_BRAIN_TEXTS(Brandon),
         .battledBit = {1 << 12, 1 << 13},

--- a/src/frontier_util.c
+++ b/src/frontier_util.c
@@ -49,6 +49,43 @@ struct FrontierBrainMon
     u16 moves[MAX_MON_MOVES];
 };
 
+struct FrontierBrain
+{
+    u16 trainerId;
+};
+
+const struct FrontierBrain gFrontierBrainInfo[NUM_FRONTIER_FACILITIES] =
+{
+    [FRONTIER_FACILITY_TOWER] =
+    {
+        .trainerId = TRAINER_ANABEL
+    },
+    [FRONTIER_FACILITY_DOME] =
+    {
+        .trainerId = TRAINER_TUCKER
+    },
+    [FRONTIER_FACILITY_PALACE] =
+    {
+        .trainerId = TRAINER_SPENSER
+    },
+    [FRONTIER_FACILITY_ARENA] =
+    {
+        .trainerId = TRAINER_GRETA
+    },
+    [FRONTIER_FACILITY_FACTORY] =
+    {
+        .trainerId = TRAINER_NOLAND
+    },
+    [FRONTIER_FACILITY_PIKE] =
+    {
+        .trainerId = TRAINER_LUCY
+    },
+    [FRONTIER_FACILITY_PYRAMID] =
+    {
+        .trainerId = TRAINER_BRANDON
+    },
+};
+
 // This file's functions.
 static void GetChallengeStatus(void);
 static void GetFrontierData(void);
@@ -655,17 +692,6 @@ static const u8 *const sHallFacilityToRecordsText[] =
     [RANKING_HALL_PIKE]          = gText_FrontierFacilityRoomsCleared,
     [RANKING_HALL_PYRAMID]       = gText_FrontierFacilityFloorsCleared,
     [RANKING_HALL_TOWER_LINK]    = gText_FrontierFacilityWinStreak,
-};
-
-static const u16 sFrontierBrainTrainerIds[NUM_FRONTIER_FACILITIES] =
-{
-    [FRONTIER_FACILITY_TOWER]   = TRAINER_ANABEL,
-    [FRONTIER_FACILITY_DOME]    = TRAINER_TUCKER,
-    [FRONTIER_FACILITY_PALACE]  = TRAINER_SPENSER,
-    [FRONTIER_FACILITY_ARENA]   = TRAINER_GRETA,
-    [FRONTIER_FACILITY_FACTORY] = TRAINER_NOLAND,
-    [FRONTIER_FACILITY_PIKE]    = TRAINER_LUCY,
-    [FRONTIER_FACILITY_PYRAMID] = TRAINER_BRANDON,
 };
 
 static const u8 *const sFrontierBrainPlayerLostSilverTexts[NUM_FRONTIER_FACILITIES] =
@@ -2396,7 +2422,7 @@ u8 GetFrontierBrainTrainerPicIndex(void)
     else
         facility = VarGet(VAR_FRONTIER_FACILITY);
 
-    return GetTrainerPicFromId(sFrontierBrainTrainerIds[facility]);
+    return GetTrainerPicFromId(gFrontierBrainInfo[facility].trainerId);
 }
 
 u8 GetFrontierBrainTrainerClass(void)
@@ -2408,7 +2434,7 @@ u8 GetFrontierBrainTrainerClass(void)
     else
         facility = VarGet(VAR_FRONTIER_FACILITY);
 
-    return GetTrainerClassFromId(sFrontierBrainTrainerIds[facility]);
+    return GetTrainerClassFromId(gFrontierBrainInfo[facility].trainerId);
 }
 
 void CopyFrontierBrainTrainerName(u8 *dst)
@@ -2422,7 +2448,7 @@ void CopyFrontierBrainTrainerName(u8 *dst)
     else
         facility = VarGet(VAR_FRONTIER_FACILITY);
 
-    trainerName = GetTrainerNameFromId(sFrontierBrainTrainerIds[facility]);
+    trainerName = GetTrainerNameFromId(gFrontierBrainInfo[facility].trainerId);
     for (i = 0; i < PLAYER_NAME_LENGTH; i++)
         dst[i] = trainerName[i];
 

--- a/src/frontier_util.c
+++ b/src/frontier_util.c
@@ -56,6 +56,8 @@ struct FrontierBrain
     u8 isFemale;
     const u8 *lostTexts[2];
     const u8 *wonTexts[2];
+    u16 battledBit[2];
+    u8 streakAppearances[4];
 };
 
 // This file's functions.
@@ -92,18 +94,8 @@ static void ShowPyramidResultsWindow(void);
 static void ShowLinkContestResultsWindow(void);
 static void CopyFrontierBrainText(bool8 playerWonText);
 
-// const rom data
-static const u8 sFrontierBrainStreakAppearances[NUM_FRONTIER_FACILITIES][4] =
-{
-    [FRONTIER_FACILITY_TOWER]   = {35,  70, 35, 1},
-    [FRONTIER_FACILITY_DOME]    = { 1,   2,  5, 0},
-    [FRONTIER_FACILITY_PALACE]  = {21,  42, 21, 1},
-    [FRONTIER_FACILITY_ARENA]   = {28,  56, 28, 1},
-    [FRONTIER_FACILITY_FACTORY] = {21,  42, 21, 1},
-    [FRONTIER_FACILITY_PIKE]    = {28, 140, 56, 1},
-    [FRONTIER_FACILITY_PYRAMID] = {21,  70, 35, 0},
-};
-
+// battledBit: Flags to change the conversation when the Frontier Brain is encountered for a battle
+// First bit is has battled them before and not won yet, second bit is has battled them and won (obtained a Symbol)
 const struct FrontierBrain gFrontierBrainInfo[NUM_FRONTIER_FACILITIES] =
 {
     [FRONTIER_FACILITY_TOWER] =
@@ -113,6 +105,8 @@ const struct FrontierBrain gFrontierBrainInfo[NUM_FRONTIER_FACILITIES] =
         .isFemale = TRUE,
         .lostTexts = {gText_AnabelDefeatSilver, gText_AnabelDefeatGold},
         .wonTexts = {gText_AnabelWonSilver, gText_AnabelWonGold},
+        .battledBit = {1 << 0, 1 << 1},
+        .streakAppearances = {35, 70, 35, 1},
     },
     [FRONTIER_FACILITY_DOME] =
     {
@@ -121,6 +115,8 @@ const struct FrontierBrain gFrontierBrainInfo[NUM_FRONTIER_FACILITIES] =
         .isFemale = FALSE,
         .lostTexts = {gText_TuckerDefeatSilver, gText_TuckerDefeatGold},
         .wonTexts = {gText_TuckerWonSilver, gText_TuckerWonGold},
+        .battledBit = {1 << 2, 1 << 3},
+        .streakAppearances = {1, 2, 5, 0},
     },
     [FRONTIER_FACILITY_PALACE] =
     {
@@ -129,6 +125,8 @@ const struct FrontierBrain gFrontierBrainInfo[NUM_FRONTIER_FACILITIES] =
         .isFemale = FALSE,
         .lostTexts = {gText_SpenserDefeatSilver, gText_SpenserDefeatGold},
         .wonTexts = {gText_SpenserWonSilver, gText_SpenserWonGold},
+        .battledBit = {1 << 4, 1 << 5},
+        .streakAppearances = {21, 42, 21, 1},
     },
     [FRONTIER_FACILITY_ARENA] =
     {
@@ -137,6 +135,8 @@ const struct FrontierBrain gFrontierBrainInfo[NUM_FRONTIER_FACILITIES] =
         .isFemale = TRUE,
         .lostTexts = {gText_GretaDefeatSilver, gText_GretaDefeatGold},
         .wonTexts = {gText_GretaWonSilver, gText_GretaWonGold},
+        .battledBit = {1 << 6, 1 << 7},
+        .streakAppearances = {28, 56, 28, 1},
     },
     [FRONTIER_FACILITY_FACTORY] =
     {
@@ -145,6 +145,8 @@ const struct FrontierBrain gFrontierBrainInfo[NUM_FRONTIER_FACILITIES] =
         .isFemale = FALSE,
         .lostTexts = {gText_NolandDefeatSilver, gText_NolandDefeatGold},
         .wonTexts = {gText_NolandWonSilver, gText_NolandWonGold},
+        .battledBit = {1 << 8, 1 << 9},
+        .streakAppearances = {21, 42, 21, 1},
     },
     [FRONTIER_FACILITY_PIKE] =
     {
@@ -153,6 +155,8 @@ const struct FrontierBrain gFrontierBrainInfo[NUM_FRONTIER_FACILITIES] =
         .isFemale = TRUE,
         .lostTexts = {gText_LucyDefeatSilver, gText_LucyDefeatGold},
         .wonTexts = {gText_LucyWonSilver, gText_LucyWonGold},
+        .battledBit = {1 << 10, 1 << 11},
+        .streakAppearances = {28, 140, 56, 1},
     },
     [FRONTIER_FACILITY_PYRAMID] =
     {
@@ -161,6 +165,8 @@ const struct FrontierBrain gFrontierBrainInfo[NUM_FRONTIER_FACILITIES] =
         .isFemale = FALSE,
         .lostTexts = {gText_BrandonDefeatSilver, gText_BrandonDefeatGold},
         .wonTexts = {gText_BrandonWonSilver, gText_BrandonWonGold},
+        .battledBit = {1 << 12, 1 << 13},
+        .streakAppearances = {21, 70, 35, 0},
     },
 };
 
@@ -606,20 +612,6 @@ static const u8 sBattlePointAwards[NUM_FRONTIER_FACILITIES][FRONTIER_MODE_COUNT]
     },
 };
 
-
-// Flags to change the conversation when the Frontier Brain is encountered for a battle
-// First bit is has battled them before and not won yet, second bit is has battled them and won (obtained a Symbol)
-static const u16 sBattledBrainBitFlags[NUM_FRONTIER_FACILITIES][2] =
-{
-    [FRONTIER_FACILITY_TOWER]   = {1 << 0, 1 << 1},
-    [FRONTIER_FACILITY_DOME]    = {1 << 2, 1 << 3},
-    [FRONTIER_FACILITY_PALACE]  = {1 << 4, 1 << 5},
-    [FRONTIER_FACILITY_ARENA]   = {1 << 6, 1 << 7},
-    [FRONTIER_FACILITY_FACTORY] = {1 << 8, 1 << 9},
-    [FRONTIER_FACILITY_PIKE]    = {1 << 10, 1 << 11},
-    [FRONTIER_FACILITY_PYRAMID] = {1 << 12, 1 << 13},
-};
-
 static void (* const sFrontierUtilFuncs[])(void) =
 {
     [FRONTIER_UTIL_FUNC_GET_STATUS]            = GetChallengeStatus,
@@ -775,7 +767,7 @@ static void GetFrontierData(void)
         gSpecialVar_Result = gSaveBlock2Ptr->frontier.disableRecordBattle;
         break;
     case FRONTIER_DATA_HEARD_BRAIN_SPEECH:
-        gSpecialVar_Result = gSaveBlock2Ptr->frontier.battledBrainFlags & sBattledBrainBitFlags[facility][hasSymbol];
+        gSpecialVar_Result = gSaveBlock2Ptr->frontier.battledBrainFlags & gFrontierBrainInfo[facility].battledBit[hasSymbol];
         break;
     }
 }
@@ -810,7 +802,7 @@ static void SetFrontierData(void)
         gSaveBlock2Ptr->frontier.disableRecordBattle = gSpecialVar_0x8006;
         break;
     case FRONTIER_DATA_HEARD_BRAIN_SPEECH:
-        gSaveBlock2Ptr->frontier.battledBrainFlags |= sBattledBrainBitFlags[facility][hasSymbol];
+        gSaveBlock2Ptr->frontier.battledBrainFlags |= gFrontierBrainInfo[facility].battledBit[hasSymbol];
         break;
     }
 }
@@ -1590,7 +1582,7 @@ u8 GetFrontierBrainStatus(void)
     s32 facility = VarGet(VAR_FRONTIER_FACILITY);
     s32 battleMode = VarGet(VAR_FRONTIER_BATTLE_MODE);
     u16 winStreakNoModifier = GetCurrentFacilityWinStreak();
-    s32 winStreak = winStreakNoModifier + sFrontierBrainStreakAppearances[facility][3];
+    s32 winStreak = winStreakNoModifier + gFrontierBrainInfo[facility].streakAppearances[3];
     s32 symbolsCount;
 
     if (battleMode != FRONTIER_MODE_SINGLES)
@@ -1602,20 +1594,20 @@ u8 GetFrontierBrainStatus(void)
     // Missing a symbol
     case 0:
     case 1:
-        if (winStreak == sFrontierBrainStreakAppearances[facility][symbolsCount])
+        if (winStreak == gFrontierBrainInfo[facility].streakAppearances[symbolsCount])
             status = symbolsCount + 1; // FRONTIER_BRAIN_SILVER and FRONTIER_BRAIN_GOLD
         break;
     // Already received both symbols
     case 2:
     default:
         // Silver streak is reached
-        if (winStreak == sFrontierBrainStreakAppearances[facility][0])
+        if (winStreak == gFrontierBrainInfo[facility].streakAppearances[0])
             status = FRONTIER_BRAIN_STREAK;
         // Gold streak is reached
-        else if (winStreak == sFrontierBrainStreakAppearances[facility][1])
+        else if (winStreak == gFrontierBrainInfo[facility].streakAppearances[1])
             status = FRONTIER_BRAIN_STREAK_LONG;
         // Some increment of the gold streak is reached
-        else if (winStreak > sFrontierBrainStreakAppearances[facility][1] && (winStreak - sFrontierBrainStreakAppearances[facility][1]) % sFrontierBrainStreakAppearances[facility][2] == 0)
+        else if (winStreak > gFrontierBrainInfo[facility].streakAppearances[1] && (winStreak - gFrontierBrainInfo[facility].streakAppearances[1]) % gFrontierBrainInfo[facility].streakAppearances[2] == 0)
             status = FRONTIER_BRAIN_STREAK_LONG;
         break;
     }
@@ -2530,12 +2522,12 @@ s32 GetFronterBrainSymbol(void)
     if (symbol == 2)
     {
         u16 winStreak = GetCurrentFacilityWinStreak();
-        if (winStreak + sFrontierBrainStreakAppearances[facility][3] == sFrontierBrainStreakAppearances[facility][0])
+        if (winStreak + gFrontierBrainInfo[facility].streakAppearances[3] == gFrontierBrainInfo[facility].streakAppearances[0])
             symbol = 0;
-        else if (winStreak + sFrontierBrainStreakAppearances[facility][3] == sFrontierBrainStreakAppearances[facility][1])
+        else if (winStreak + gFrontierBrainInfo[facility].streakAppearances[3] == gFrontierBrainInfo[facility].streakAppearances[1])
             symbol = 1;
-        else if (winStreak + sFrontierBrainStreakAppearances[facility][3] > sFrontierBrainStreakAppearances[facility][1]
-                 && (winStreak + sFrontierBrainStreakAppearances[facility][3] - sFrontierBrainStreakAppearances[facility][1]) % sFrontierBrainStreakAppearances[facility][2] == 0)
+        else if (winStreak + gFrontierBrainInfo[facility].streakAppearances[3] > gFrontierBrainInfo[facility].streakAppearances[1]
+                 && (winStreak + gFrontierBrainInfo[facility].streakAppearances[3] - gFrontierBrainInfo[facility].streakAppearances[1]) % gFrontierBrainInfo[facility].streakAppearances[2] == 0)
             symbol = 1;
     }
     return symbol;

--- a/src/frontier_util.c
+++ b/src/frontier_util.c
@@ -52,38 +52,8 @@ struct FrontierBrainMon
 struct FrontierBrain
 {
     u16 trainerId;
-};
-
-const struct FrontierBrain gFrontierBrainInfo[NUM_FRONTIER_FACILITIES] =
-{
-    [FRONTIER_FACILITY_TOWER] =
-    {
-        .trainerId = TRAINER_ANABEL
-    },
-    [FRONTIER_FACILITY_DOME] =
-    {
-        .trainerId = TRAINER_TUCKER
-    },
-    [FRONTIER_FACILITY_PALACE] =
-    {
-        .trainerId = TRAINER_SPENSER
-    },
-    [FRONTIER_FACILITY_ARENA] =
-    {
-        .trainerId = TRAINER_GRETA
-    },
-    [FRONTIER_FACILITY_FACTORY] =
-    {
-        .trainerId = TRAINER_NOLAND
-    },
-    [FRONTIER_FACILITY_PIKE] =
-    {
-        .trainerId = TRAINER_LUCY
-    },
-    [FRONTIER_FACILITY_PYRAMID] =
-    {
-        .trainerId = TRAINER_BRANDON
-    },
+    u8 objEventGfx;
+    u8 isFemale;
 };
 
 // This file's functions.
@@ -130,6 +100,52 @@ static const u8 sFrontierBrainStreakAppearances[NUM_FRONTIER_FACILITIES][4] =
     [FRONTIER_FACILITY_FACTORY] = {21,  42, 21, 1},
     [FRONTIER_FACILITY_PIKE]    = {28, 140, 56, 1},
     [FRONTIER_FACILITY_PYRAMID] = {21,  70, 35, 0},
+};
+
+const struct FrontierBrain gFrontierBrainInfo[NUM_FRONTIER_FACILITIES] =
+{
+    [FRONTIER_FACILITY_TOWER] =
+    {
+        .trainerId = TRAINER_ANABEL,
+        .objEventGfx = OBJ_EVENT_GFX_ANABEL,
+        .isFemale = TRUE,
+    },
+    [FRONTIER_FACILITY_DOME] =
+    {
+        .trainerId = TRAINER_TUCKER,
+        .objEventGfx = OBJ_EVENT_GFX_TUCKER,
+        .isFemale = FALSE,
+    },
+    [FRONTIER_FACILITY_PALACE] =
+    {
+        .trainerId = TRAINER_SPENSER,
+        .objEventGfx = OBJ_EVENT_GFX_SPENSER,
+        .isFemale = FALSE,
+    },
+    [FRONTIER_FACILITY_ARENA] =
+    {
+        .trainerId = TRAINER_GRETA,
+        .objEventGfx = OBJ_EVENT_GFX_GRETA,
+        .isFemale = TRUE,
+    },
+    [FRONTIER_FACILITY_FACTORY] =
+    {
+        .trainerId = TRAINER_NOLAND,
+        .objEventGfx = OBJ_EVENT_GFX_NOLAND,
+        .isFemale = FALSE,
+    },
+    [FRONTIER_FACILITY_PIKE] =
+    {
+        .trainerId = TRAINER_LUCY,
+        .objEventGfx = OBJ_EVENT_GFX_LUCY,
+        .isFemale = TRUE,
+    },
+    [FRONTIER_FACILITY_PYRAMID] =
+    {
+        .trainerId = TRAINER_BRANDON,
+        .objEventGfx = OBJ_EVENT_GFX_BRANDON,
+        .isFemale = FALSE,
+    },
 };
 
 static const struct FrontierBrainMon sFrontierBrainsMons[][2][FRONTIER_PARTY_SIZE] =
@@ -646,18 +662,6 @@ static const struct WindowTemplate sRankingHallRecordsWindowTemplate =
     .height = 17,
     .paletteNum = 15,
     .baseBlock = 1
-};
-
-// Second field - whether the character is female.
-static const u8 sFrontierBrainObjEventGfx[NUM_FRONTIER_FACILITIES][2] =
-{
-    [FRONTIER_FACILITY_TOWER]   = {OBJ_EVENT_GFX_ANABEL,  TRUE},
-    [FRONTIER_FACILITY_DOME]    = {OBJ_EVENT_GFX_TUCKER,  FALSE},
-    [FRONTIER_FACILITY_PALACE]  = {OBJ_EVENT_GFX_SPENSER, FALSE},
-    [FRONTIER_FACILITY_ARENA]   = {OBJ_EVENT_GFX_GRETA,   TRUE},
-    [FRONTIER_FACILITY_FACTORY] = {OBJ_EVENT_GFX_NOLAND,  FALSE},
-    [FRONTIER_FACILITY_PIKE]    = {OBJ_EVENT_GFX_LUCY,    TRUE},
-    [FRONTIER_FACILITY_PYRAMID] = {OBJ_EVENT_GFX_BRANDON, FALSE},
 };
 
 static const u8 *const sRecordsWindowChallengeTexts[][2] =
@@ -2458,13 +2462,13 @@ void CopyFrontierBrainTrainerName(u8 *dst)
 bool8 IsFrontierBrainFemale(void)
 {
     s32 facility = VarGet(VAR_FRONTIER_FACILITY);
-    return sFrontierBrainObjEventGfx[facility][1];
+    return gFrontierBrainInfo[facility].isFemale;
 }
 
 void SetFrontierBrainObjEventGfx_2(void)
 {
     s32 facility = VarGet(VAR_FRONTIER_FACILITY);
-    VarSet(VAR_OBJ_GFX_ID_0, sFrontierBrainObjEventGfx[facility][0]);
+    VarSet(VAR_OBJ_GFX_ID_0, gFrontierBrainInfo[facility].objEventGfx);
 }
 
 #define FRONTIER_BRAIN_OTID 61226
@@ -2531,7 +2535,7 @@ u16 GetFrontierBrainMonSpecies(u8 monId)
 void SetFrontierBrainObjEventGfx(u8 facility)
 {
     gTrainerBattleOpponent_A = TRAINER_FRONTIER_BRAIN;
-    VarSet(VAR_OBJ_GFX_ID_0, sFrontierBrainObjEventGfx[facility][0]);
+    VarSet(VAR_OBJ_GFX_ID_0, gFrontierBrainInfo[facility].objEventGfx);
 }
 
 u16 GetFrontierBrainMonMove(u8 monId, u8 moveSlotId)

--- a/src/frontier_util.c
+++ b/src/frontier_util.c
@@ -54,6 +54,8 @@ struct FrontierBrain
     u16 trainerId;
     u8 objEventGfx;
     u8 isFemale;
+    const u8 *lostTexts[2];
+    const u8 *wonTexts[2];
 };
 
 // This file's functions.
@@ -94,7 +96,7 @@ static void CopyFrontierBrainText(bool8 playerWonText);
 static const u8 sFrontierBrainStreakAppearances[NUM_FRONTIER_FACILITIES][4] =
 {
     [FRONTIER_FACILITY_TOWER]   = {35,  70, 35, 1},
-    [FRONTIER_FACILITY_DOME]    = { 4,   9,  5, 0},
+    [FRONTIER_FACILITY_DOME]    = { 1,   2,  5, 0},
     [FRONTIER_FACILITY_PALACE]  = {21,  42, 21, 1},
     [FRONTIER_FACILITY_ARENA]   = {28,  56, 28, 1},
     [FRONTIER_FACILITY_FACTORY] = {21,  42, 21, 1},
@@ -109,42 +111,56 @@ const struct FrontierBrain gFrontierBrainInfo[NUM_FRONTIER_FACILITIES] =
         .trainerId = TRAINER_ANABEL,
         .objEventGfx = OBJ_EVENT_GFX_ANABEL,
         .isFemale = TRUE,
+        .lostTexts = {gText_AnabelDefeatSilver, gText_AnabelDefeatGold},
+        .wonTexts = {gText_AnabelWonSilver, gText_AnabelWonGold},
     },
     [FRONTIER_FACILITY_DOME] =
     {
         .trainerId = TRAINER_TUCKER,
         .objEventGfx = OBJ_EVENT_GFX_TUCKER,
         .isFemale = FALSE,
+        .lostTexts = {gText_TuckerDefeatSilver, gText_TuckerDefeatGold},
+        .wonTexts = {gText_TuckerWonSilver, gText_TuckerWonGold},
     },
     [FRONTIER_FACILITY_PALACE] =
     {
         .trainerId = TRAINER_SPENSER,
         .objEventGfx = OBJ_EVENT_GFX_SPENSER,
         .isFemale = FALSE,
+        .lostTexts = {gText_SpenserDefeatSilver, gText_SpenserDefeatGold},
+        .wonTexts = {gText_SpenserWonSilver, gText_SpenserWonGold},
     },
     [FRONTIER_FACILITY_ARENA] =
     {
         .trainerId = TRAINER_GRETA,
         .objEventGfx = OBJ_EVENT_GFX_GRETA,
         .isFemale = TRUE,
+        .lostTexts = {gText_GretaDefeatSilver, gText_GretaDefeatGold},
+        .wonTexts = {gText_GretaWonSilver, gText_GretaWonGold},
     },
     [FRONTIER_FACILITY_FACTORY] =
     {
         .trainerId = TRAINER_NOLAND,
         .objEventGfx = OBJ_EVENT_GFX_NOLAND,
         .isFemale = FALSE,
+        .lostTexts = {gText_NolandDefeatSilver, gText_NolandDefeatGold},
+        .wonTexts = {gText_NolandWonSilver, gText_NolandWonGold},
     },
     [FRONTIER_FACILITY_PIKE] =
     {
         .trainerId = TRAINER_LUCY,
         .objEventGfx = OBJ_EVENT_GFX_LUCY,
         .isFemale = TRUE,
+        .lostTexts = {gText_LucyDefeatSilver, gText_LucyDefeatGold},
+        .wonTexts = {gText_LucyWonSilver, gText_LucyWonGold},
     },
     [FRONTIER_FACILITY_PYRAMID] =
     {
         .trainerId = TRAINER_BRANDON,
         .objEventGfx = OBJ_EVENT_GFX_BRANDON,
         .isFemale = FALSE,
+        .lostTexts = {gText_BrandonDefeatSilver, gText_BrandonDefeatGold},
+        .wonTexts = {gText_BrandonWonSilver, gText_BrandonWonGold},
     },
 };
 
@@ -696,62 +712,6 @@ static const u8 *const sHallFacilityToRecordsText[] =
     [RANKING_HALL_PIKE]          = gText_FrontierFacilityRoomsCleared,
     [RANKING_HALL_PYRAMID]       = gText_FrontierFacilityFloorsCleared,
     [RANKING_HALL_TOWER_LINK]    = gText_FrontierFacilityWinStreak,
-};
-
-static const u8 *const sFrontierBrainPlayerLostSilverTexts[NUM_FRONTIER_FACILITIES] =
-{
-    [FRONTIER_FACILITY_TOWER]   = gText_AnabelWonSilver,
-    [FRONTIER_FACILITY_DOME]    = gText_TuckerWonSilver,
-    [FRONTIER_FACILITY_PALACE]  = gText_SpenserWonSilver,
-    [FRONTIER_FACILITY_ARENA]   = gText_GretaWonSilver,
-    [FRONTIER_FACILITY_FACTORY] = gText_NolandWonSilver,
-    [FRONTIER_FACILITY_PIKE]    = gText_LucyWonSilver,
-    [FRONTIER_FACILITY_PYRAMID] = gText_BrandonWonSilver,
-};
-
-static const u8 *const sFrontierBrainPlayerWonSilverTexts[NUM_FRONTIER_FACILITIES] =
-{
-    [FRONTIER_FACILITY_TOWER]   = gText_AnabelDefeatSilver,
-    [FRONTIER_FACILITY_DOME]    = gText_TuckerDefeatSilver,
-    [FRONTIER_FACILITY_PALACE]  = gText_SpenserDefeatSilver,
-    [FRONTIER_FACILITY_ARENA]   = gText_GretaDefeatSilver,
-    [FRONTIER_FACILITY_FACTORY] = gText_NolandDefeatSilver,
-    [FRONTIER_FACILITY_PIKE]    = gText_LucyDefeatSilver,
-    [FRONTIER_FACILITY_PYRAMID] = gText_BrandonDefeatSilver,
-};
-
-static const u8 *const sFrontierBrainPlayerLostGoldTexts[NUM_FRONTIER_FACILITIES] =
-{
-    [FRONTIER_FACILITY_TOWER]   = gText_AnabelWonGold,
-    [FRONTIER_FACILITY_DOME]    = gText_TuckerWonGold,
-    [FRONTIER_FACILITY_PALACE]  = gText_SpenserWonGold,
-    [FRONTIER_FACILITY_ARENA]   = gText_GretaWonGold,
-    [FRONTIER_FACILITY_FACTORY] = gText_NolandWonGold,
-    [FRONTIER_FACILITY_PIKE]    = gText_LucyWonGold,
-    [FRONTIER_FACILITY_PYRAMID] = gText_BrandonWonGold,
-};
-
-static const u8 *const sFrontierBrainPlayerWonGoldTexts[NUM_FRONTIER_FACILITIES] =
-{
-    [FRONTIER_FACILITY_TOWER]   = gText_AnabelDefeatGold,
-    [FRONTIER_FACILITY_DOME]    = gText_TuckerDefeatGold,
-    [FRONTIER_FACILITY_PALACE]  = gText_SpenserDefeatGold,
-    [FRONTIER_FACILITY_ARENA]   = gText_GretaDefeatGold,
-    [FRONTIER_FACILITY_FACTORY] = gText_NolandDefeatGold,
-    [FRONTIER_FACILITY_PIKE]    = gText_LucyDefeatGold,
-    [FRONTIER_FACILITY_PYRAMID] = gText_BrandonDefeatGold,
-};
-
-static const u8 *const *const sFrontierBrainPlayerLostTexts[] =
-{
-    sFrontierBrainPlayerLostSilverTexts,
-    sFrontierBrainPlayerLostGoldTexts,
-};
-
-static const u8 *const *const sFrontierBrainPlayerWonTexts[] =
-{
-    sFrontierBrainPlayerWonSilverTexts,
-    sFrontierBrainPlayerWonGoldTexts,
 };
 
 // code
@@ -2601,10 +2561,10 @@ static void CopyFrontierBrainText(bool8 playerWonText)
     switch (playerWonText)
     {
     case FALSE:
-        StringCopy(gStringVar4, sFrontierBrainPlayerLostTexts[symbol][facility]);
+        StringCopy(gStringVar4, gFrontierBrainInfo[facility].wonTexts[symbol]);
         break;
     case TRUE:
-        StringCopy(gStringVar4, sFrontierBrainPlayerWonTexts[symbol][facility]);
+        StringCopy(gStringVar4, gFrontierBrainInfo[facility].lostTexts[symbol]);
         break;
     }
 }


### PR DESCRIPTION
## Description
Consolidates most of the Frontier Brain values into gFrontierBrainInfo to make adding/editing easier

## Feature(s) this PR does NOT handle:
sFrontierBrainsMons and sBattlePointAwards were left alone. sBattlePointAwards seemed best to leave as a sort of table the way it is now

## **Discord contact info**
Frankfurter0
