### PR TITLE
Fix Mold Breaker-like abilities, AI Move Accuracy function, Fury Cutter with Parental Bond

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -402,7 +402,7 @@ static u32 Ai_SetMoveAccuracy(struct AiLogicData *aiData, u32 battlerAtk, u32 ba
 {
     u32 accuracy;
     u32 abilityAtk = aiData->abilities[battlerAtk];
-    u32 abilityDef = aiData->abilities[battlerAtk];
+    u32 abilityDef = aiData->abilities[battlerDef];
     if (abilityAtk == ABILITY_NO_GUARD || abilityDef == ABILITY_NO_GUARD || gMovesInfo[move].accuracy == 0) // Moves with accuracy 0 or no guard ability always hit.
         accuracy = 100;
     else

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -13407,7 +13407,7 @@ static void Cmd_handlefurycutter(void)
             max = 5;
 
         if (gDisableStructs[gBattlerAttacker].furyCutterCounter < max
-            && gSpecialStatuses[gBattlerAttacker].parentalBondState != PARENTAL_BOND_1ST_HIT) // Don't increment counter on first hit
+            && gSpecialStatuses[gBattlerAttacker].parentalBondState != PARENTAL_BOND_2ND_HIT) // Don't increment counter on second hit
             gDisableStructs[gBattlerAttacker].furyCutterCounter++;
 
         gBattlescriptCurrInstr = cmd->nextInstr;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -6242,7 +6242,7 @@ u32 GetBattlerAbility(u32 battler)
             && gAbilitiesInfo[gBattleMons[battler].ability].breakable
             && noAbilityShield
             && gBattlerByTurnOrder[gCurrentTurnActionNumber] == gBattlerAttacker
-            && gActionsByTurnOrder[gBattlerByTurnOrder[gBattlerAttacker]] == B_ACTION_USE_MOVE
+            && gActionsByTurnOrder[gCurrentTurnActionNumber] == B_ACTION_USE_MOVE
             && gCurrentTurnActionNumber < gBattlersCount)
         return ABILITY_NONE;
 

--- a/test/battle/move_effect/fury_cutter.c
+++ b/test/battle/move_effect/fury_cutter.c
@@ -43,7 +43,7 @@ SINGLE_BATTLE_TEST("Fury Cutter counter is the same for both hits of Parental Bo
 
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET) { Ability(ABILITY_PARENTAL_BOND); }
-        OPPONENT(SPECIES_LINOONE) { HP(900); }
+        OPPONENT(SPECIES_REGIROCK);
     } WHEN {
         TURN { MOVE(player, MOVE_FURY_CUTTER); }
         TURN { MOVE(player, MOVE_FURY_CUTTER); }

--- a/test/battle/move_effect/fury_cutter.c
+++ b/test/battle/move_effect/fury_cutter.c
@@ -36,3 +36,27 @@ SINGLE_BATTLE_TEST("Fury Cutter power doubles with each use, up to 160 power")
         EXPECT_EQ(damage[maxTurns - 2], damage[maxTurns - 1]);
     }
 }
+
+SINGLE_BATTLE_TEST("Fury Cutter counter is the same for both hits of Parental Bond")
+{
+    s16 damage[4];
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Ability(ABILITY_PARENTAL_BOND); }
+        OPPONENT(SPECIES_LINOONE) { HP(900); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_FURY_CUTTER); }
+        TURN { MOVE(player, MOVE_FURY_CUTTER); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FURY_CUTTER, player);
+        HP_BAR(opponent, captureDamage: &damage[0]);
+        HP_BAR(opponent, captureDamage: &damage[1]);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FURY_CUTTER, player);
+        HP_BAR(opponent, captureDamage: &damage[2]);
+        HP_BAR(opponent, captureDamage: &damage[3]);
+    } THEN {
+        EXPECT_MUL_EQ(damage[0], B_PARENTAL_BOND_DMG >= GEN_7 ? UQ_4_12(0.25) : UQ_4_12(0.5), damage[1]);
+        EXPECT_MUL_EQ(damage[2], B_PARENTAL_BOND_DMG >= GEN_7 ? UQ_4_12(0.25) : UQ_4_12(0.5), damage[3]);
+        EXPECT_NE(damage[0], damage[2]);
+    }
+}


### PR DESCRIPTION
Fixes GetBattlerAbility potentially checking the wrong battler's action in doubles, causing Mold Breaker-like abilities to not ignore the target's ability.

Fixes AI_SetMoveAccuracy using battlerAtk's ability as abilityDef.

Fixes Fury Cutter counter getting incremented on the second hit of Parental Bond instead of the first.
Adds a test for this.

## Issue(s) that this PR fixes
Fixes #5019, fixes #4956

## **Discord contact info**
PhallenTree