### PR TITLE
Add Memento to AI_FLAG_RISKY

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -4911,6 +4911,8 @@ static s32 AI_SetupFirstTurn(u32 battlerAtk, u32 battlerDef, u32 move, s32 score
 static s32 AI_Risky(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
 {
     u8 i;
+    struct AiLogicData *aiData = AI_DATA;
+
     if (IS_TARGETING_PARTNER(battlerAtk, battlerDef))
         return score;
 
@@ -4933,12 +4935,16 @@ static s32 AI_Risky(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
         break;
 
     // +2 Score
+    case EFFECT_MEMENTO:
+        if (aiData->hpPercents[battlerAtk] < 50 && AI_RandLessThan(128))
+            ADJUST_SCORE(AVERAGE_RISKY_EFFECT);
+        break;
     case EFFECT_REVENGE:
         if (gSpeciesInfo[gBattleMons[battlerDef].species].baseSpeed >= gSpeciesInfo[gBattleMons[battlerAtk].species].baseSpeed + 10)
             ADJUST_SCORE(AVERAGE_RISKY_EFFECT);
         break;
     case EFFECT_BELLY_DRUM:
-        if (gBattleMons[battlerAtk].hp >= gBattleMons[battlerAtk].maxHP * 90 / 100)
+        if (aiData->hpPercents[battlerAtk] >= 90)
             ADJUST_SCORE(AVERAGE_RISKY_EFFECT);
         break;
     case EFFECT_MAX_HP_50_RECOIL:


### PR DESCRIPTION
## Description
The only thing that AI_FLAG_WILL_SUICIDE favours that AI_FLAG_RISKY doesn't is Memento, which should have been considered by Risky from the beginning and was an oversight when we were brainstorming Risky effects initially.

This adds Memento to Risky to functionally deprecate AI_FLAG_WILL_SUICIDE in time for the AI Flags poll. The scoring conditional is exactly the same as AI_FLAG_WILL_SUICIDE for now, we can consider tweaking it after the AI poll feedback, I just wanted to make sure it was included as is beforehand.

Tiny change also to use `aiData->hpPercents`, which I was unaware of in the initial AI_FLAG_RISKY PR.

## **Discord contact info**
@Pawkkie
