### PR TITLE
Added OBJ_EVENT_GFX_SPECIES_SHINY macro

### DIFF
--- a/include/constants/event_objects.h
+++ b/include/constants/event_objects.h
@@ -275,7 +275,8 @@
 #define OBJ_EVENT_GFX_SPECIES_MASK ((1 << OBJ_EVENT_GFX_SPECIES_BITS) - 1)
 
 // Used to call a specific species' follower graphics. Useful for static encounters.
-#define OBJ_EVENT_GFX_SPECIES(name) (OBJ_EVENT_GFX_MON_BASE + SPECIES_##name)
+#define OBJ_EVENT_GFX_SPECIES(name)       (SPECIES_##name + OBJ_EVENT_GFX_MON_BASE)
+#define OBJ_EVENT_GFX_SPECIES_SHINY(name) (SPECIES_##name + OBJ_EVENT_GFX_MON_BASE + SPECIES_SHINY_TAG)
 
 #define OW_SPECIES(x) (((x)->graphicsId & OBJ_EVENT_GFX_SPECIES_MASK) - OBJ_EVENT_GFX_MON_BASE)
 #define OW_FORM(x) ((x)->graphicsId >> OBJ_EVENT_GFX_SPECIES_BITS)

--- a/include/constants/species.h
+++ b/include/constants/species.h
@@ -1633,6 +1633,8 @@
 
 #define NUM_SPECIES SPECIES_EGG
 
+#define SPECIES_SHINY_TAG 5000
+
 // Competitive format aliases
 #define SPECIES_ALCREMIE_GMAX                           SPECIES_ALCREMIE_GIGANTAMAX
 #define SPECIES_APPLETUN_GMAX                           SPECIES_APPLETUN_GIGANTAMAX

--- a/include/data.h
+++ b/include/data.h
@@ -4,8 +4,6 @@
 #include "constants/moves.h"
 #include "constants/trainers.h"
 
-#define SPECIES_SHINY_TAG 5000
-
 #define MAX_TRAINER_ITEMS 4
 
 #define TRAINER_PIC_WIDTH 64

--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -1598,6 +1598,7 @@ static u8 TrySetupObjectEventSprite(const struct ObjectEventTemplate *objectEven
 
     if (OW_GFX_COMPRESS)
         spriteTemplate->tileTag = LoadSheetGraphicsInfo(graphicsInfo, objectEvent->graphicsId, NULL);
+
     if (objectEvent->graphicsId >= OBJ_EVENT_GFX_MON_BASE + SPECIES_SHINY_TAG)
     {
         objectEvent->shiny = TRUE;

--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -1598,6 +1598,11 @@ static u8 TrySetupObjectEventSprite(const struct ObjectEventTemplate *objectEven
 
     if (OW_GFX_COMPRESS)
         spriteTemplate->tileTag = LoadSheetGraphicsInfo(graphicsInfo, objectEvent->graphicsId, NULL);
+    if (objectEvent->graphicsId >= OBJ_EVENT_GFX_MON_BASE + SPECIES_SHINY_TAG)
+    {
+        objectEvent->shiny = TRUE;
+        objectEvent->graphicsId -= SPECIES_SHINY_TAG;
+    }
 
     spriteId = CreateSprite(spriteTemplate, 0, 0, 0);
     if (spriteId == MAX_SPRITES)
@@ -2751,6 +2756,8 @@ const struct ObjectEventGraphicsInfo *GetObjectEventGraphicsInfo(u16 graphicsId)
     if (graphicsId >= OBJ_EVENT_GFX_VARS && graphicsId <= OBJ_EVENT_GFX_VAR_F)
         graphicsId = VarGetObjectEventGraphicsId(graphicsId - OBJ_EVENT_GFX_VARS);
 
+    if (graphicsId >= OBJ_EVENT_GFX_MON_BASE + SPECIES_SHINY_TAG)
+        graphicsId -= SPECIES_SHINY_TAG;
     // graphicsId may contain mon form info
     if (graphicsId > OBJ_EVENT_GFX_SPECIES_MASK)
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I didn't realize until recently that users also want to put Shiny Pokémon in the same way that they can using `OBJ_EVENT_GFX_SPECIES`, so I added this new macro.
It wasn't working on its own, hence the other changes.

## Images
![mGBA_saPCLgFgwT](https://github.com/user-attachments/assets/40ecfa68-6a7d-4f0a-9eb3-27fb5f0e2b84)

## **Discord contact info**
AsparagusEduardo
