### PR TITLE
Fixed Hidden Power damage category for PSS < GEN_4

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -10828,6 +10828,7 @@ bool32 ShouldGetStatBadgeBoost(u16 badgeFlag, u32 battler)
 
 u8 GetBattleMoveCategory(u32 moveId)
 {
+    u8 moveType;
     if (gBattleStruct != NULL && gBattleStruct->zmove.active && !IS_MOVE_STATUS(moveId))
         return gBattleStruct->zmove.activeCategory;
     if (gBattleStruct != NULL && IsMaxMove(moveId)) // TODO: Might be buggy depending on when this is called.
@@ -10839,10 +10840,14 @@ u8 GetBattleMoveCategory(u32 moveId)
 
     if (IS_MOVE_STATUS(moveId))
         return DAMAGE_CATEGORY_STATUS;
-    else if (gMovesInfo[moveId].type < TYPE_MYSTERY)
-        return DAMAGE_CATEGORY_PHYSICAL;
     else
-        return DAMAGE_CATEGORY_SPECIAL;
+    {
+        GET_MOVE_TYPE(moveId, moveType);
+        if (moveType < TYPE_MYSTERY)
+            return DAMAGE_CATEGORY_PHYSICAL;
+        else
+            return DAMAGE_CATEGORY_SPECIAL;
+    }
 }
 
 static bool32 TryRemoveScreens(u32 battler)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Changed how Hidden Power checks its type in order decide if it's a Special or Physical move in pre-Gen 4 configs.

## Images
<!-- Please provide with relevant GIFs or images to make it easier for reviewers to accept your PR quicker.-->
<!-- If it doesn't apply, feel free to remove this section. -->
https://github.com/user-attachments/assets/3bbf01aa-e665-4671-ac68-e35990ad3258

## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, fixes #2222." -->
<!-- If it doesn't apply, feel free to remove this section. -->
#5052 

## Feature(s) this PR does NOT handle:
<!-- If your PR contains any unfinished features that are not considered merge-blocking, please list them here for clarity so no one can forget. -->
<!-- If it doesn't apply, feel free to remove this section. -->
Does not display the type the move will attack with in the Summary or Move Select screen.

## **Discord contact info**
<!--- formatted as name#numbers, e.g. Lunos#4026 -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara