### PR TITLE
Fixes Stalwart/Propeller Tail, Life Orb on confusion, Remove Status wrong battlescripts

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -5741,10 +5741,10 @@ static void Cmd_moveend(void)
                         gBattlescriptCurrInstr = BattleScript_TargetBurnHeal;
                         break;
                     case STATUS1_FREEZE:
-                        gBattlescriptCurrInstr = BattleScript_FrostbiteHealedViaFireMove;
+                        gBattlescriptCurrInstr = BattleScript_DefrostedViaFireMove;
                         break;
                     case STATUS1_FROSTBITE:
-                        gBattlescriptCurrInstr = BattleScript_DefrostedViaFireMove;
+                        gBattlescriptCurrInstr = BattleScript_FrostbiteHealedViaFireMove;
                         break;
                     case STATUS1_POISON:
                     case STATUS1_TOXIC_POISON:

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -236,8 +236,8 @@ void HandleAction_UseMove(void)
                 && GetBattlerTurnOrderNum(battler) < var
                 && gMovesInfo[gCurrentMove].effect != EFFECT_SNIPE_SHOT
                 && gMovesInfo[gCurrentMove].effect != EFFECT_PLEDGE
-                && (GetBattlerAbility(gBattlerAttacker) != ABILITY_PROPELLER_TAIL
-                 || GetBattlerAbility(gBattlerAttacker) != ABILITY_STALWART))
+                && GetBattlerAbility(gBattlerAttacker) != ABILITY_PROPELLER_TAIL
+                && GetBattlerAbility(gBattlerAttacker) != ABILITY_STALWART)
             {
                 var = GetBattlerTurnOrderNum(battler);
             }

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -7791,6 +7791,7 @@ u8 ItemBattleEffects(u8 caseID, u32 battler, bool32 moveTurn)
             if (IsBattlerAlive(gBattlerAttacker)
                 && !(TestIfSheerForceAffected(gBattlerAttacker, gCurrentMove))
                 && GetBattlerAbility(gBattlerAttacker) != ABILITY_MAGIC_GUARD
+                && !gProtectStructs[gBattlerAttacker].confusionSelfDmg
                 && !gSpecialStatuses[gBattlerAttacker].preventLifeOrbDamage
                 && gSpecialStatuses[gBattlerAttacker].damagedMons)
             {

--- a/test/battle/ability/stalwart.c
+++ b/test/battle/ability/stalwart.c
@@ -1,0 +1,55 @@
+#include "global.h"
+#include "test/battle.h"
+
+DOUBLE_BATTLE_TEST("Stalwart ignores redirection from Follow-Me")
+{
+    GIVEN {
+        PLAYER(SPECIES_ARCHALUDON) { Ability(ABILITY_STALWART); }
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponentLeft, MOVE_FOLLOW_ME); MOVE(playerLeft, MOVE_DRACO_METEOR, target: opponentRight); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FOLLOW_ME, opponentLeft);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DRACO_METEOR, playerLeft);
+        HP_BAR(opponentRight);
+        NOT HP_BAR(opponentLeft);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Stalwart stops Lightning Rod and Storm Drain from redirecting moves")
+{
+    u32 ability;
+    PARAMETRIZE { ability = ABILITY_STORM_DRAIN; }
+    PARAMETRIZE { ability = ABILITY_LIGHTNING_ROD; }
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_SPARK].type == TYPE_ELECTRIC);
+        ASSUME(gMovesInfo[MOVE_WATER_GUN].type == TYPE_WATER);
+        PLAYER(SPECIES_WOBBUFFET) { Ability(ABILITY_STALWART); }
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_RAICHU) { Ability(ability); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN {
+            if (ability == ABILITY_LIGHTNING_ROD)
+                MOVE(playerLeft, MOVE_SPARK, target: opponentRight);
+            else
+                MOVE(playerLeft, MOVE_WATER_GUN, target: opponentRight);
+        }
+    } SCENE {
+        if (B_REDIRECT_ABILITY_IMMUNITY >= GEN_5) {
+            HP_BAR(opponentRight);
+            NONE_OF {
+                ABILITY_POPUP(opponentLeft, ability);
+                ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
+                MESSAGE("Foe Raichu's Sp. Atk rose!");
+            }
+        } else {
+            HP_BAR(opponentRight);
+            NONE_OF {
+                HP_BAR(opponentLeft);
+            }
+        }
+    }
+}

--- a/test/battle/ability/stalwart.c
+++ b/test/battle/ability/stalwart.c
@@ -20,15 +20,15 @@ DOUBLE_BATTLE_TEST("Stalwart ignores redirection from Follow-Me")
 
 DOUBLE_BATTLE_TEST("Stalwart stops Lightning Rod and Storm Drain from redirecting moves")
 {
-    u32 ability;
-    PARAMETRIZE { ability = ABILITY_STORM_DRAIN; }
-    PARAMETRIZE { ability = ABILITY_LIGHTNING_ROD; }
+    u32 ability, species;
+    PARAMETRIZE { ability = ABILITY_STORM_DRAIN; species = SPECIES_LUMINEON; }
+    PARAMETRIZE { ability = ABILITY_LIGHTNING_ROD; species = SPECIES_RAICHU; }
     GIVEN {
         ASSUME(gMovesInfo[MOVE_SPARK].type == TYPE_ELECTRIC);
         ASSUME(gMovesInfo[MOVE_WATER_GUN].type == TYPE_WATER);
         PLAYER(SPECIES_WOBBUFFET) { Ability(ABILITY_STALWART); }
         PLAYER(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_RAICHU) { Ability(ability); }
+        OPPONENT(species) { Ability(ability); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
         TURN {


### PR DESCRIPTION
Fixes Stalwart and Propeller Tail not ignoring redirection from Storm Drain/Lightning Rod.
Adds a test for this.

Fixes Life Orb damaging its holder if it hits itself in confusion.

Fixes MoveEffectRemoveStatus (Sparkling Aria, Wake-Up Slap, ...) that cure Freeze/Frostbite using the other status' battlescript.

## Issue(s) that this PR fixes
Fixes #4907 

## **Discord contact info**
PhallenTree
