### PR TITLE
Fixed the animation tables being different sizes

### DIFF
--- a/src/data/battle_anim.h
+++ b/src/data/battle_anim.h
@@ -1455,6 +1455,9 @@ const struct CompressedSpriteSheet gBattleAnimPicTable[] =
     {gBattleAnimSpriteGfx_SyrupSplat, 0x400, ANIM_TAG_SYRUP_SPLAT_RED},
     {gBattleAnimSpriteGfx_SyrupSplat, 0x400, ANIM_TAG_SYRUP_SPLAT_YELLOW},
     {gBattleAnimSpriteGfx_IvyCudgel, 0x800, ANIM_TAG_IVY_CUDGEL_GRASS},
+    {NULL, 0x0, ANIM_TAG_IVY_CUDGEL_FIRE},
+    {NULL, 0x0, ANIM_TAG_IVY_CUDGEL_ROCK},
+    {NULL, 0x0, ANIM_TAG_IVY_CUDGEL_WATER},
 };
 
 const struct CompressedSpritePalette gBattleAnimPaletteTable[] =


### PR DESCRIPTION
 This happened due to the Ivy Cudgel animation

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added some padding to the animation sprite table to make the tables aligned again.

## Images
<!-- Please provide with relevant GIFs or images to make it easier for reviewers to accept your PR quicker.-->
<!-- If it doesn't apply, feel free to remove this section. -->

## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, fixes #2222." -->
<!-- If it doesn't apply, feel free to remove this section. -->
#5058 


## **Discord contact info**
<!--- formatted as name#numbers, e.g. Lunos#4026 -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara
