### PR TITLE
Fixes spread damage in double battles

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -9653,7 +9653,7 @@ static inline s32 CalculateBaseDamage(u32 power, u32 userFinalAttack, u32 level,
 
 static inline uq4_12_t GetTargetDamageModifier(u32 move, u32 battlerAtk, u32 battlerDef)
 {
-    if (GetMoveTargetCount(move, battlerAtk, battlerDef) >= 2)
+    if (IsDoubleBattle() && GetMoveTargetCount(move, battlerAtk, battlerDef) >= 2)
         return B_MULTIPLE_TARGETS_DMG >= GEN_4 ? UQ_4_12(0.75) : UQ_4_12(0.5);
     return UQ_4_12(1.0);
 }

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -8531,12 +8531,12 @@ u32 GetMoveTargetCount(u32 move, u32 battlerAtk, u32 battlerDef)
     switch (GetBattlerMoveTargetType(gBattlerAttacker, move))
     {
     case MOVE_TARGET_BOTH:
-        return IsBattlerAlive(battlerDef)
-             + IsBattlerAlive(BATTLE_PARTNER(battlerDef));
+        return !(gAbsentBattlerFlags & gBitTable[battlerDef])
+             + !(gAbsentBattlerFlags & gBitTable[BATTLE_PARTNER(battlerDef)]);
     case MOVE_TARGET_FOES_AND_ALLY:
-        return IsBattlerAlive(battlerDef)
-             + IsBattlerAlive(BATTLE_PARTNER(battlerDef))
-             + IsBattlerAlive(BATTLE_PARTNER(battlerAtk));
+        return !(gAbsentBattlerFlags & gBitTable[battlerDef])
+             + !(gAbsentBattlerFlags & gBitTable[BATTLE_PARTNER(battlerDef)])
+             + !(gAbsentBattlerFlags & gBitTable[BATTLE_PARTNER(battlerAtk)]);
     case MOVE_TARGET_OPPONENTS_FIELD:
         return 1;
     case MOVE_TARGET_DEPENDS:

--- a/src/data/trainer_parties.h
+++ b/src/data/trainer_parties.h
@@ -5945,14 +5945,6 @@ static const struct TrainerMon sParty_GinaAndMia1[] = {
     {
     .lvl = 6,
     .species = SPECIES_LOTAD,
-    },
-    {
-    .lvl = 6,
-    .species = SPECIES_SEEDOT,
-    },
-    {
-    .lvl = 6,
-    .species = SPECIES_LOTAD,
     }
 };
 

--- a/src/data/trainer_parties.h
+++ b/src/data/trainer_parties.h
@@ -5945,6 +5945,14 @@ static const struct TrainerMon sParty_GinaAndMia1[] = {
     {
     .lvl = 6,
     .species = SPECIES_LOTAD,
+    },
+    {
+    .lvl = 6,
+    .species = SPECIES_SEEDOT,
+    },
+    {
+    .lvl = 6,
+    .species = SPECIES_LOTAD,
     }
 };
 

--- a/test/battle/damage_formula.c
+++ b/test/battle/damage_formula.c
@@ -119,15 +119,15 @@ SINGLE_BATTLE_TEST("Damage calculation matches Gen5+ (Marshadow vs Mawile)")
 
 DOUBLE_BATTLE_TEST("A spread move will do correct damage to the second mon if the first target faints from first hit of the spread move")
 {
-    s16 damage[5];
+    s16 damage[6];
     GIVEN {
         PLAYER(SPECIES_REGIROCK);
-        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_REGIROCK);
         OPPONENT(SPECIES_WOBBUFFET) { HP(200); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
         TURN { MOVE(playerLeft, MOVE_ROCK_SLIDE); }
-        TURN { MOVE(playerLeft, MOVE_ROCK_SLIDE); }
+        TURN { MOVE(playerLeft, MOVE_ROCK_SLIDE); MOVE(playerRight, MOVE_ROCK_SLIDE); }
         TURN { MOVE(playerLeft, MOVE_ROCK_SLIDE); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROCK_SLIDE, playerLeft);
@@ -138,11 +138,15 @@ DOUBLE_BATTLE_TEST("A spread move will do correct damage to the second mon if th
         HP_BAR(opponentLeft, captureDamage: &damage[2]);
         HP_BAR(opponentRight, captureDamage: &damage[3]);
 
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_ROCK_SLIDE, playerLeft);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ROCK_SLIDE, playerRight);
         HP_BAR(opponentRight, captureDamage: &damage[4]);
+
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ROCK_SLIDE, playerLeft);
+        HP_BAR(opponentRight, captureDamage: &damage[5]);
     } THEN {
         EXPECT_EQ(damage[0], damage[1]);
         EXPECT_EQ(damage[1], damage[3]);
-        EXPECT_MUL_EQ(damage[4], UQ_4_12(0.75), damage[3]);
+        EXPECT_MUL_EQ(damage[5], UQ_4_12(0.75), damage[3]);
+        EXPECT_EQ(damage[4], damage[5]);
     }
 }

--- a/test/battle/damage_formula.c
+++ b/test/battle/damage_formula.c
@@ -116,3 +116,33 @@ SINGLE_BATTLE_TEST("Damage calculation matches Gen5+ (Marshadow vs Mawile)")
         EXPECT_EQ(expectedDamage, dmg);
     }
 }
+
+DOUBLE_BATTLE_TEST("A spread move will do correct damage to the second mon if the first target faints from first hit of the spread move")
+{
+    s16 damage[5];
+    GIVEN {
+        PLAYER(SPECIES_REGIROCK);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { HP(200); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_ROCK_SLIDE); }
+        TURN { MOVE(playerLeft, MOVE_ROCK_SLIDE); }
+        TURN { MOVE(playerLeft, MOVE_ROCK_SLIDE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ROCK_SLIDE, playerLeft);
+        HP_BAR(opponentLeft, captureDamage: &damage[0]);
+        HP_BAR(opponentRight, captureDamage: &damage[1]);
+
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ROCK_SLIDE, playerLeft);
+        HP_BAR(opponentLeft, captureDamage: &damage[2]);
+        HP_BAR(opponentRight, captureDamage: &damage[3]);
+
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ROCK_SLIDE, playerLeft);
+        HP_BAR(opponentRight, captureDamage: &damage[4]);
+    } THEN {
+        EXPECT_EQ(damage[0], damage[1]);
+        EXPECT_EQ(damage[1], damage[3]);
+        EXPECT_MUL_EQ(damage[4], UQ_4_12(0.75), damage[3]);
+    }
+}


### PR DESCRIPTION
In double battles when `B_POSITION_OPPONENT_LEFT` fainted from the first hit of a spread move, the second hit dealt 100% of damage to `B_POSITION_OPPONENT_RIGHT` 

Using `gAbsentBattlerFlags` fixes this because it is set when there is no other mon to replace the fainted mon with