### PR TITLE
Removes unnecessary checks for Shield Dust and Covert Cloak

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -11704,16 +11704,6 @@ static u32 ChangeStatBuffs(s8 statValue, u32 statId, u32 flags, const u8 *BS_ptr
             }
             return STAT_CHANGE_DIDNT_WORK;
         }
-        else if (battlerAbility == ABILITY_SHIELD_DUST && flags == 0)
-        {
-            RecordAbilityBattle(battler, ABILITY_SHIELD_DUST);
-            return STAT_CHANGE_DIDNT_WORK;
-        }
-        else if (flags == 0 && battlerHoldEffect == HOLD_EFFECT_COVERT_CLOAK)
-        {
-            RecordItemEffectBattle(battler, HOLD_EFFECT_COVERT_CLOAK);
-            return STAT_CHANGE_DIDNT_WORK;
-        }
         else // try to decrease
         {
             statValue = -GET_STAT_BUFF_VALUE(statValue);

--- a/test/battle/ability/shield_dust.c
+++ b/test/battle/ability/shield_dust.c
@@ -173,6 +173,6 @@ SINGLE_BATTLE_TEST("Shield Dust does not prevent ability stat changes")
     } WHEN {
         TURN { MOVE(player, MOVE_TACKLE); }
     } SCENE {
-        NOT MESSAGE("Wobbuffet's Speed won't go lower!");
+        MESSAGE("Vivillon's Speed fell!");
     }
 }

--- a/test/battle/ability/shield_dust.c
+++ b/test/battle/ability/shield_dust.c
@@ -164,3 +164,15 @@ SINGLE_BATTLE_TEST("Shield Dust blocks Sparkling Aria in singles")
         }
     }
 }
+
+SINGLE_BATTLE_TEST("Shield Dust does not prevent ability stat changes")
+{
+    GIVEN {
+        PLAYER(SPECIES_VIVILLON) { Ability(ABILITY_SHIELD_DUST); }
+        OPPONENT(SPECIES_ELDEGOSS) { Ability(ABILITY_COTTON_DOWN); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_TACKLE); }
+    } SCENE {
+        NOT MESSAGE("Wobbuffet's Speed won't go lower!");
+    }
+}

--- a/test/battle/hold_effect/covert_cloak.c
+++ b/test/battle/hold_effect/covert_cloak.c
@@ -176,6 +176,6 @@ SINGLE_BATTLE_TEST("Covert Cloak does not prevent ability stat changes")
     } WHEN {
         TURN { MOVE(player, MOVE_TACKLE); }
     } SCENE {
-        NOT MESSAGE("Wobbuffet's Speed won't go lower!");
+        MESSAGE("Wobbuffet's Speed fell!");
     }
 }

--- a/test/battle/hold_effect/covert_cloak.c
+++ b/test/battle/hold_effect/covert_cloak.c
@@ -6,9 +6,6 @@ ASSUMPTIONS
     ASSUME(gItemsInfo[ITEM_COVERT_CLOAK].holdEffect == HOLD_EFFECT_COVERT_CLOAK);
 }
 
-#include "global.h"
-#include "test/battle.h"
-
 SINGLE_BATTLE_TEST("Covert Cloak blocks secondary effects")
 {
     u16 move;

--- a/test/battle/hold_effect/covert_cloak.c
+++ b/test/battle/hold_effect/covert_cloak.c
@@ -1,6 +1,14 @@
 #include "global.h"
 #include "test/battle.h"
 
+ASSUMPTIONS
+{
+    ASSUME(gItemsInfo[ITEM_COVERT_CLOAK].holdEffect == HOLD_EFFECT_COVERT_CLOAK);
+}
+
+#include "global.h"
+#include "test/battle.h"
+
 SINGLE_BATTLE_TEST("Covert Cloak blocks secondary effects")
 {
     u16 move;
@@ -160,5 +168,17 @@ SINGLE_BATTLE_TEST("Covert Cloak blocks Sparkling Aria in singles")
             MESSAGE("Foe Wobbuffet's burn was healed.");
             STATUS_ICON(opponent, none: TRUE);
         }
+    }
+}
+
+SINGLE_BATTLE_TEST("Covert Cloak does not prevent ability stat changes")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_COVERT_CLOAK); }
+        OPPONENT(SPECIES_ELDEGOSS) { Ability(ABILITY_COTTON_DOWN); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_TACKLE); }
+    } SCENE {
+        NOT MESSAGE("Wobbuffet's Speed won't go lower!");
     }
 }


### PR DESCRIPTION
Removes unnecessary checks for Shield Dust and Covert Cloak. I'm not sure why they were there in the first place. The checks caused the user to be protected by abilities.

Also moved the covert cloak file.