### PR TITLE
Add modern gen utility options (rename, relearn) to party/box menus

### DIFF
--- a/include/config/pokemon.h
+++ b/include/config/pokemon.h
@@ -41,6 +41,7 @@
 // Optional party/box menu actions
 #define P_CAN_RENAME_FROM_PARTY          TRUE
 #define P_CAN_RENAME_FROM_BOX            TRUE
+#define P_CAN_RELEARN_FROM_PARTY         TRUE
 
 // Other settings
 #define P_CUSTOM_GENDER_DIFF_ICONS       TRUE        // If TRUE, will give more Pokémon custom icons for their female forms, i.e. Hippopotas and Hippowdon

--- a/include/config/pokemon.h
+++ b/include/config/pokemon.h
@@ -38,6 +38,10 @@
 #define P_SHUCKLE_BERRY_JUICE       GEN_LATEST  // In Gen 2, Shuckle had a 1/16 chance of converting Berry that it's holding into Berry Juice. Enabling this will allow Shuckle to do this with an Oran Berry, which is the spiritual succesor of the Berry item.
 #define P_ARCEUS_UNIQUE_FORM_ICONS  GEN_LATEST  // Since Gen 9, Arceus additionally changes its icon to reflect its current form.
 
+// Optional party/box menu actions
+#define P_CAN_RENAME_FROM_PARTY          TRUE
+#define P_CAN_RENAME_FROM_BOX            TRUE
+
 // Other settings
 #define P_CUSTOM_GENDER_DIFF_ICONS       TRUE        // If TRUE, will give more Pokémon custom icons for their female forms, i.e. Hippopotas and Hippowdon
 #define P_FOOTPRINTS                     TRUE        // If TRUE, Pokémon will have footprints (as was the case up to Gen 5 and in BDSP). Disabling this saves some ROM space.

--- a/include/strings.h
+++ b/include/strings.h
@@ -2178,6 +2178,7 @@ extern const u8 gText_Summary5[];
 extern const u8 gText_Switch2[];
 extern const u8 gText_Item[];
 extern const u8 gText_Rename[];
+extern const u8 gText_Relearn[];
 extern const u8 gText_NotPkmnOtherTrainerWants[];
 extern const u8 gText_ThatIsntAnEgg[];
 extern const u8 gText_OtherTrainersPkmnCantBeTraded[];

--- a/include/strings.h
+++ b/include/strings.h
@@ -2041,6 +2041,7 @@ extern const u8 gPCText_Place[];
 extern const u8 gPCText_Summary[];
 extern const u8 gPCText_Release[];
 extern const u8 gPCText_Mark[];
+extern const u8 gPCText_Rename[];
 extern const u8 gPCText_Jump[];
 extern const u8 gPCText_Wallpaper[];
 extern const u8 gPCText_Name[];

--- a/include/strings.h
+++ b/include/strings.h
@@ -2176,6 +2176,7 @@ extern const u8 gText_Trade4[];
 extern const u8 gText_Summary5[];
 extern const u8 gText_Switch2[];
 extern const u8 gText_Item[];
+extern const u8 gText_Rename[];
 extern const u8 gText_NotPkmnOtherTrainerWants[];
 extern const u8 gText_ThatIsntAnEgg[];
 extern const u8 gText_OtherTrainersPkmnCantBeTraded[];

--- a/src/data/party_menu.h
+++ b/src/data/party_menu.h
@@ -719,6 +719,7 @@ struct
     [MENU_CATALOG_MOWER] = {gText_LawnMower, CursorCb_CatalogMower},
     [MENU_CHANGE_FORM] = {gText_ChangeForm, CursorCb_ChangeForm},
     [MENU_CHANGE_ABILITY] = {gText_ChangeAbility, CursorCb_ChangeAbility},
+    [MENU_RENAME] = {gText_Rename, CursorCb_Rename},
 };
 
 static const u8 sPartyMenuAction_SummarySwitchCancel[] = {MENU_SUMMARY, MENU_SWITCH, MENU_CANCEL1};

--- a/src/data/party_menu.h
+++ b/src/data/party_menu.h
@@ -720,6 +720,7 @@ struct
     [MENU_CHANGE_FORM] = {gText_ChangeForm, CursorCb_ChangeForm},
     [MENU_CHANGE_ABILITY] = {gText_ChangeAbility, CursorCb_ChangeAbility},
     [MENU_RENAME] = {gText_Rename, CursorCb_Rename},
+    [MENU_RELEARN] = {gText_Relearn, CursorCb_Relearn},
 };
 
 static const u8 sPartyMenuAction_SummarySwitchCancel[] = {MENU_SUMMARY, MENU_SWITCH, MENU_CANCEL1};

--- a/src/strings.c
+++ b/src/strings.c
@@ -373,6 +373,7 @@ const u8 gText_Switch2[] = _("SWITCH");
 const u8 gText_Summary5[] = _("SUMMARY");
 const u8 gText_Moves[] = _("MOVES"); // Unused
 const u8 gText_Enter[] = _("ENTER");
+const u8 gText_Rename[] = _("RENAME");
 const u8 gText_NoEntry[] = _("NO ENTRY");
 const u8 gText_Take2[] = _("TAKE");
 const u8 gText_Read2[] = _("READ");

--- a/src/strings.c
+++ b/src/strings.c
@@ -374,6 +374,7 @@ const u8 gText_Summary5[] = _("SUMMARY");
 const u8 gText_Moves[] = _("MOVES"); // Unused
 const u8 gText_Enter[] = _("ENTER");
 const u8 gText_Rename[] = _("RENAME");
+const u8 gText_Relearn[] = _("RELEARN");
 const u8 gText_NoEntry[] = _("NO ENTRY");
 const u8 gText_Take2[] = _("TAKE");
 const u8 gText_Read2[] = _("READ");

--- a/src/strings.c
+++ b/src/strings.c
@@ -912,6 +912,7 @@ const u8 gPCText_Place[] = _("PLACE");
 const u8 gPCText_Summary[] = _("SUMMARY");
 const u8 gPCText_Release[] = _("RELEASE");
 const u8 gPCText_Mark[] = _("MARK");
+const u8 gPCText_Rename[] = _("RENAME");
 const u8 gPCText_Name[] = _("NAME");
 const u8 gPCText_Jump[] = _("JUMP");
 const u8 gPCText_Wallpaper[] = _("WALLPAPER");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds (toggleable) options to the party/box menus for the following features available in modern generations:

- Rename: change mon's nickname (party and box)
- Relearn (TODO): relearn previous moves (party)

TODO:

- [x] Add move renamer option
- [x] Add move relearner option
- [ ] Make party/box menus scrollable (#3918)
  - [ ] Alternative for submenu

## Images
<!-- Please provide with relevant GIFs or images to make it easier for reviewers to accept your PR quicker.-->
<!-- If it doesn't apply, feel free to remove this section. -->
TODO

## **Discord contact info**
<!--- formatted as name#numbers, e.g. Lunos#4026 -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
notnotjagan