### PR TITLE
Move Relearner now displays move category

### DIFF
--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -219,7 +219,7 @@
 #define B_FAST_HP_DRAIN             TRUE  // If set to TRUE, HP bars will move faster.
 #define B_FAST_EXP_GROW             TRUE  // If set to TRUE, EXP bars will move faster.
 #define B_SHOW_TARGETS              TRUE  // If set to TRUE, all available targets, for moves hitting 2 or 3 Pokémon, will be shown before selecting a move.
-#define B_SHOW_CATEGORY_ICON        TRUE  // If set to TRUE, it will show an icon in the summary showing the move's category.
+#define B_SHOW_CATEGORY_ICON        TRUE  // If set to TRUE, it will show an icon in the summary and move relearner showing the move's category.
 #define B_HIDE_HEALTHBOX_IN_ANIMS   TRUE  // If set to TRUE, hides healthboxes during move animations.
 #define B_EXPANDED_MOVE_NAMES       TRUE  // If set to FALSE, move names are decreased from 16 characters to 12 characters.
 #define B_WAIT_TIME_MULTIPLIER      16    // This determines how long text pauses in battle last. Vanilla is 16. Lower values result in faster battles.

--- a/include/move_relearner.h
+++ b/include/move_relearner.h
@@ -3,5 +3,6 @@
 
 void TeachMoveRelearnerMove(void);
 void MoveRelearnerShowHideHearts(s32);
+u8 MoveRelearnerShowHideCategoryIcon(s32);
 
 #endif //GUARD_MOVE_RELEARNER_H

--- a/include/move_relearner.h
+++ b/include/move_relearner.h
@@ -3,6 +3,6 @@
 
 void TeachMoveRelearnerMove(void);
 void MoveRelearnerShowHideHearts(s32);
-u8 MoveRelearnerShowHideCategoryIcon(s32);
+void MoveRelearnerShowHideCategoryIcon(s32);
 
 #endif //GUARD_MOVE_RELEARNER_H

--- a/src/menu_specialized.c
+++ b/src/menu_specialized.c
@@ -756,6 +756,9 @@ static void MoveRelearnerLoadBattleMoveDescription(u32 chosenMove)
     u8 buffer[32];
     const u8 *str;
 
+    if (B_SHOW_CATEGORY_ICON == TRUE)
+        MoveRelearnerShowHideCategoryIcon(chosenMove);
+
     FillWindowPixelBuffer(RELEARNERWIN_DESC_BATTLE, PIXEL_FILL(1));
     str = gText_MoveRelearnerBattleMoves;
     x = GetStringCenterAlignXOffset(FONT_NORMAL, str, 128);

--- a/src/move_relearner.c
+++ b/src/move_relearner.c
@@ -1,9 +1,11 @@
 #include "global.h"
 #include "main.h"
 #include "battle.h"
+#include "battle_util.h"
 #include "bg.h"
 #include "contest_effect.h"
 #include "data.h"
+#include "decompress.h"
 #include "event_data.h"
 #include "field_screen_effect.h"
 #include "gpu_regs.h"
@@ -22,8 +24,6 @@
 #include "string_util.h"
 #include "strings.h"
 #include "task.h"
-#include "decompress.h"
-#include "battle_util.h"
 #include "constants/rgb.h"
 #include "constants/songs.h"
 
@@ -175,7 +175,7 @@ static EWRAM_DATA struct
     u8 moveListScrollArrowTask;                          /*0x113*/
     u8 moveDisplayArrowTask;                             /*0x114*/
     u16 scrollOffset;                                    /*0x116*/
-    u8 categoryIconSpriteId; //Physical/Special/Status category
+    u8 categoryIconSpriteId;                             //Physical/Special/Status category
 } *sMoveRelearnerStruct = {0};
 
 static EWRAM_DATA struct {

--- a/src/move_relearner.c
+++ b/src/move_relearner.c
@@ -175,7 +175,7 @@ static EWRAM_DATA struct
     u8 moveListScrollArrowTask;                          /*0x113*/
     u8 moveDisplayArrowTask;                             /*0x114*/
     u16 scrollOffset;                                    /*0x116*/
-    u8 categoryIconSpriteId;                             //Physical/Special/Status category
+    u8 categoryIconSpriteId;                             /*0x117*/
 } *sMoveRelearnerStruct = {0};
 
 static EWRAM_DATA struct {
@@ -968,12 +968,13 @@ void MoveRelearnerShowHideHearts(s32 moveId)
     }
 }
 
-u8 MoveRelearnerShowHideCategoryIcon(s32 moveId)
+void MoveRelearnerShowHideCategoryIcon(s32 moveId)
 {
     if (sMoveRelearnerMenuSate.showContestInfo || moveId == LIST_CANCEL)
     {
         if (sMoveRelearnerStruct->categoryIconSpriteId != 0xFF)
             DestroySprite(&gSprites[sMoveRelearnerStruct->categoryIconSpriteId]);
+
         sMoveRelearnerStruct->categoryIconSpriteId = 0xFF;
         gSprites[sMoveRelearnerStruct->categoryIconSpriteId].invisible = TRUE;
     }
@@ -985,5 +986,4 @@ u8 MoveRelearnerShowHideCategoryIcon(s32 moveId)
         gSprites[sMoveRelearnerStruct->categoryIconSpriteId].invisible = FALSE;
         StartSpriteAnim(&gSprites[sMoveRelearnerStruct->categoryIconSpriteId], GetBattleMoveCategory(moveId));
     }
-    return sMoveRelearnerStruct->categoryIconSpriteId;
 }

--- a/src/move_relearner.c
+++ b/src/move_relearner.c
@@ -980,7 +980,7 @@ u8 MoveRelearnerShowHideCategoryIcon(s32 moveId)
     else
     {
         if (sMoveRelearnerStruct->categoryIconSpriteId == 0xFF)
-            sMoveRelearnerStruct->categoryIconSpriteId = CreateSprite(&gSpriteTemplate_CategoryIcons, 68, 40, 0);
+            sMoveRelearnerStruct->categoryIconSpriteId = CreateSprite(&gSpriteTemplate_CategoryIcons, 66, 40, 0);
 
         gSprites[sMoveRelearnerStruct->categoryIconSpriteId].invisible = FALSE;
         StartSpriteAnim(&gSprites[sMoveRelearnerStruct->categoryIconSpriteId], GetBattleMoveCategory(moveId));

--- a/src/move_relearner.c
+++ b/src/move_relearner.c
@@ -22,6 +22,8 @@
 #include "string_util.h"
 #include "strings.h"
 #include "task.h"
+#include "decompress.h"
+#include "battle_util.h"
 #include "constants/rgb.h"
 #include "constants/songs.h"
 
@@ -173,6 +175,7 @@ static EWRAM_DATA struct
     u8 moveListScrollArrowTask;                          /*0x113*/
     u8 moveDisplayArrowTask;                             /*0x114*/
     u16 scrollOffset;                                    /*0x116*/
+    u8 categoryIconSpriteId; //Physical/Special/Status category
 } *sMoveRelearnerStruct = {0};
 
 static EWRAM_DATA struct {
@@ -803,6 +806,9 @@ static void HandleInput(bool8 showContest)
 
         ScheduleBgCopyTilemapToVram(1);
         MoveRelearnerShowHideHearts(GetCurrentSelectedMove());
+        if (B_SHOW_CATEGORY_ICON == TRUE)
+            MoveRelearnerShowHideCategoryIcon(GetCurrentSelectedMove());
+
         break;
     case LIST_CANCEL:
         PlaySE(SE_SELECT);
@@ -850,6 +856,10 @@ static void CreateUISprites(void)
     sMoveRelearnerStruct->moveDisplayArrowTask = TASK_NONE;
     sMoveRelearnerStruct->moveListScrollArrowTask = TASK_NONE;
     AddScrollArrows();
+
+    sMoveRelearnerStruct->categoryIconSpriteId = 0xFF;
+    LoadCompressedSpriteSheet(&gSpriteSheet_CategoryIcons);
+    LoadSpritePalette(&gSpritePal_CategoryIcons);
 
     // These are the appeal hearts.
     for (i = 0; i < 8; i++)
@@ -956,4 +966,24 @@ void MoveRelearnerShowHideHearts(s32 moveId)
             gSprites[sMoveRelearnerStruct->heartSpriteIds[i + 8]].invisible = FALSE;
         }
     }
+}
+
+u8 MoveRelearnerShowHideCategoryIcon(s32 moveId)
+{
+    if (sMoveRelearnerMenuSate.showContestInfo || moveId == LIST_CANCEL)
+    {
+        if (sMoveRelearnerStruct->categoryIconSpriteId != 0xFF)
+            DestroySprite(&gSprites[sMoveRelearnerStruct->categoryIconSpriteId]);
+        sMoveRelearnerStruct->categoryIconSpriteId = 0xFF;
+        gSprites[sMoveRelearnerStruct->categoryIconSpriteId].invisible = TRUE;
+    }
+    else
+    {
+        if (sMoveRelearnerStruct->categoryIconSpriteId == 0xFF)
+            sMoveRelearnerStruct->categoryIconSpriteId = CreateSprite(&gSpriteTemplate_CategoryIcons, 68, 40, 0);
+
+        gSprites[sMoveRelearnerStruct->categoryIconSpriteId].invisible = FALSE;
+        StartSpriteAnim(&gSprites[sMoveRelearnerStruct->categoryIconSpriteId], GetBattleMoveCategory(moveId));
+    }
+    return sMoveRelearnerStruct->categoryIconSpriteId;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is something that was overlooked with B_SHOW_CATEGORY_ICON, but the move category displays now when relearning a move, as it should. Toggleable with B_SHOW_CATEGORY_ICON, of course.

## Images
![pokeemerald-0](https://github.com/user-attachments/assets/8c9cbae3-1bee-414a-9b9b-e237a75970a2)

## Feature(s) this PR does NOT handle:
Displaying the type icon instead of just text.

## **Discord contact info**
kittenchilly
