### PR TITLE
use `OBJ_EVENT_GFX_SPECIES_MASK` in `bufferspeciesname`

### DIFF
--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -1693,7 +1693,7 @@ bool8 ScrCmd_vmessage(struct ScriptContext *ctx)
 bool8 ScrCmd_bufferspeciesname(struct ScriptContext *ctx)
 {
     u8 stringVarIndex = ScriptReadByte(ctx);
-    u16 species = VarGet(ScriptReadHalfword(ctx)) & ((1 << 10) - 1); // ignore possible shiny / form bits
+    u16 species = VarGet(ScriptReadHalfword(ctx)) & OBJ_EVENT_GFX_SPECIES_MASK; // ignore possible shiny / form bits
 
     StringCopy(sScriptStringVars[stringVarIndex], GetSpeciesName(species));
     return FALSE;


### PR DESCRIPTION
`ScrCmd_bufferspeciesname` would truncate species above 1023.

## Issue(s) that this PR fixes
fixes #5087

## **Discord contact info**
karathan
