### PR TITLE
Added missing Move Effect TODO tests - Volume C

### DIFF
--- a/test/battle/gimmick/dynamax.c
+++ b/test/battle/gimmick/dynamax.c
@@ -362,21 +362,6 @@ SINGLE_BATTLE_TEST("(DYNAMAX) Dynamaxed Pokemon lose their substitutes")
     }
 }
 
-DOUBLE_BATTLE_TEST("(DYNAMAX) Dynamaxed Pokemon can have their base moves copied by Copycat")
-{
-    GIVEN {
-        PLAYER(SPECIES_WOBBUFFET);
-        PLAYER(SPECIES_WYNAUT);
-        OPPONENT(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_WYNAUT);
-    } WHEN {
-        TURN { MOVE(playerLeft, MOVE_TRICK_ROOM, gimmick: GIMMICK_DYNAMAX, target: opponentLeft); MOVE(playerRight, MOVE_COPYCAT, target: opponentLeft); }
-    } SCENE {
-        MESSAGE("Wobbuffet used Max Guard!");
-        MESSAGE("Wynaut used Trick Room!");
-    }
-}
-
 SINGLE_BATTLE_TEST("(DYNAMAX) Dynamaxed Pokemon take double damage from Dynamax Cannon", s16 damage)
 {
     u32 dynamax;

--- a/test/battle/move_effect/calm_mind.c
+++ b/test/battle/move_effect/calm_mind.c
@@ -1,0 +1,4 @@
+#include "global.h"
+#include "test/battle.h"
+
+TO_DO_BATTLE_TEST("Calm Mind increases the user's Sp. Attack and Sp. Defense by 1 stage each");

--- a/test/battle/move_effect/camouflage.c
+++ b/test/battle/move_effect/camouflage.c
@@ -1,0 +1,8 @@
+#include "global.h"
+#include "test/battle.h"
+
+TO_DO_BATTLE_TEST("Camouflage changes the type of the user based on battle environment");
+TO_DO_BATTLE_TEST("Camouflage changes the type of the user to Grass if Grassy Terrain is active");
+TO_DO_BATTLE_TEST("Camouflage changes the type of the user to Electric if Electric Terrain is active");
+TO_DO_BATTLE_TEST("Camouflage changes the type of the user to Psychic if Psychic Terrain is active");
+TO_DO_BATTLE_TEST("Camouflage changes the type of the user to Fairy if Misty Terrain is active");

--- a/test/battle/move_effect/captivate.c
+++ b/test/battle/move_effect/captivate.c
@@ -1,0 +1,7 @@
+#include "global.h"
+#include "test/battle.h"
+
+TO_DO_BATTLE_TEST("Captivate decreases the target's Sp. Attack if they're opposite gender from the user");
+TO_DO_BATTLE_TEST("Captivate fails if the target and user share gender");
+TO_DO_BATTLE_TEST("Captivate fails if the target is genderless");
+TO_DO_BATTLE_TEST("Captivate fails if the user is genderless");

--- a/test/battle/move_effect/change_type_on_item.c
+++ b/test/battle/move_effect/change_type_on_item.c
@@ -7,8 +7,7 @@ ASSUMPTIONS
     ASSUME(gMovesInfo[MOVE_TECHNO_BLAST].argument == HOLD_EFFECT_DRIVE);
 }
 
-
-SINGLE_BATTLE_TEST("Techno Blast changes the move type depending on the mask the user holds")
+SINGLE_BATTLE_TEST("Techno Blast changes type depending on the drive the user holds")
 {
     u16 species;
     u16 item;
@@ -29,3 +28,6 @@ SINGLE_BATTLE_TEST("Techno Blast changes the move type depending on the mask the
         MESSAGE("It's super effective!");
     }
 }
+
+TO_DO_BATTLE_TEST("Judgement changes type depending on the plate the user holds");
+TO_DO_BATTLE_TEST("Multi Attack changes type depending on the memory the user holds");

--- a/test/battle/move_effect/charge.c
+++ b/test/battle/move_effect/charge.c
@@ -1,0 +1,9 @@
+#include "global.h"
+#include "test/battle.h"
+
+TO_DO_BATTLE_TEST("Charge doubles the damage of the next Electric move of the user");
+TO_DO_BATTLE_TEST("Charge's effect is removed regardless if the next move is Electric or not (Gen 3-8)");
+TO_DO_BATTLE_TEST("Charge's effect is kept until the user uses an Electric move (Gen 9+)");
+TO_DO_BATTLE_TEST("Charge's effect is removed if the user fails using an Electric move (Gen 9+)");
+TO_DO_BATTLE_TEST("Charge's effect does not stack with Electromorphosis");
+TO_DO_BATTLE_TEST("Charge's effect does not stack with Wind Power");

--- a/test/battle/move_effect/chilly_reception.c
+++ b/test/battle/move_effect/chilly_reception.c
@@ -88,3 +88,4 @@ SINGLE_BATTLE_TEST("Chilly Reception changes the weather, even if the user canno
     }
 }
 
+TO_DO_BATTLE_TEST("Chilly Reception doesn't announce its move if it's called by a different move");

--- a/test/battle/move_effect/clangorous_soul.c
+++ b/test/battle/move_effect/clangorous_soul.c
@@ -1,0 +1,11 @@
+#include "global.h"
+#include "test/battle.h"
+
+TO_DO_BATTLE_TEST("Clangorous Soul raises the user's Attack by 1 stage");
+TO_DO_BATTLE_TEST("Clangorous Soul raises the user's Defense by 1 stage");
+TO_DO_BATTLE_TEST("Clangorous Soul raises the user's Sp. Attack by 1 stage");
+TO_DO_BATTLE_TEST("Clangorous Soul raises the user's Sp. Defense by 1 stage");
+TO_DO_BATTLE_TEST("Clangorous Soul raises the user's Speed by 1 stage");
+TO_DO_BATTLE_TEST("Clangorous Soul cuts the user's HP by 1/3");
+TO_DO_BATTLE_TEST("Clangorous Soul fails if Attack, Defense, Sp. Attack, Sp. Defense and Speed are all maxed out");
+TO_DO_BATTLE_TEST("Clangorous Soul fails if the user's HP is less or equal than 1/3");

--- a/test/battle/move_effect/coaching.c
+++ b/test/battle/move_effect/coaching.c
@@ -1,0 +1,8 @@
+#include "global.h"
+#include "test/battle.h"
+
+TO_DO_BATTLE_TEST("Coaching raises Attack and Defense of ally by 1 stage each");
+TO_DO_BATTLE_TEST("Coaching doesn't raise stats of the user");
+TO_DO_BATTLE_TEST("Coaching bypasses protection of allies");
+TO_DO_BATTLE_TEST("Coaching fails in single battles");
+TO_DO_BATTLE_TEST("Coaching fails if there's no ally");

--- a/test/battle/move_effect/coil.c
+++ b/test/battle/move_effect/coil.c
@@ -1,0 +1,6 @@
+#include "global.h"
+#include "test/battle.h"
+
+TO_DO_BATTLE_TEST("Coil raises the user's Attack by 1 stage");
+TO_DO_BATTLE_TEST("Coil raises the user's Defense by 1 stage");
+TO_DO_BATTLE_TEST("Coil raises the user's Accuracy by 1 stage");

--- a/test/battle/move_effect/conversion.c
+++ b/test/battle/move_effect/conversion.c
@@ -1,0 +1,10 @@
+#include "global.h"
+#include "test/battle.h"
+
+TO_DO_BATTLE_TEST("Conversion changes the user's types to the target's current types (Gen 1)");
+TO_DO_BATTLE_TEST("Conversion changes the user's types randomly to one of the user's move (Gen 2-5)");
+TO_DO_BATTLE_TEST("Conversion ignores moves that share types with the user (Gen 2-5)");
+TO_DO_BATTLE_TEST("Conversion fails if all the user's moves share types with the user (Gen 2-5)");
+TO_DO_BATTLE_TEST("Conversion changes the user's types to the one in the user's first slot (Gen 6+)");
+TO_DO_BATTLE_TEST("Conversion can read the user's first move slot even if that move cannot be selected (Gen 6+)"); //Eg. Disable
+TO_DO_BATTLE_TEST("Conversion can change the user's types to Conversion's type");

--- a/test/battle/move_effect/conversion_2.c
+++ b/test/battle/move_effect/conversion_2.c
@@ -1,0 +1,14 @@
+#include "global.h"
+#include "test/battle.h"
+
+TO_DO_BATTLE_TEST("Conversion 2 randomly changes the type of the user to a type that resists the last move that hit the user (Gen 3-4)");
+TO_DO_BATTLE_TEST("Conversion 2 randomly changes the type of the user to a type that resists the last move used by the target (Gen 5+)");
+TO_DO_BATTLE_TEST("Conversion 2's type change considers the type of moves called by other moves");
+TO_DO_BATTLE_TEST("Conversion 2's type change considers dynamic type moves"); // Eg. Weather Ball
+TO_DO_BATTLE_TEST("Conversion 2's type change considers move types changed by Normalize and Electrify");
+TO_DO_BATTLE_TEST("Conversion 2's type change considers move types changed by Normalize");
+TO_DO_BATTLE_TEST("Conversion 2's type change considers Struggle to be Normal type (Gen 3-4)");
+TO_DO_BATTLE_TEST("Conversion 2 fails if the move used is of typeless damage (Gen 5+)");
+TO_DO_BATTLE_TEST("Conversion 2's type change considers status moves (Gen 5+)");
+TO_DO_BATTLE_TEST("Conversion 2's type change considers Inverse Battles");
+TO_DO_BATTLE_TEST("Conversion 2 fails if the move used is Stellar Type");

--- a/test/battle/move_effect/copycat.c
+++ b/test/battle/move_effect/copycat.c
@@ -1,0 +1,37 @@
+#include "global.h"
+#include "test/battle.h"
+
+TO_DO_BATTLE_TEST("Copycat causes the user to use the last move used in battle");
+TO_DO_BATTLE_TEST("Copycat can call the user's last move used if it was the last move used in battle");
+TO_DO_BATTLE_TEST("Copycat fails if no move has been made");
+TO_DO_BATTLE_TEST("Copycat chooses a target at random if the copied move wasn't the user's");
+TO_DO_BATTLE_TEST("Copycat can copy moves regardless if they failed or not"); //Has "X used move!"
+TO_DO_BATTLE_TEST("Copycat fails if the last move used is a Z-Move");
+
+// Gen 4
+TO_DO_BATTLE_TEST("Copycat can only copy charging moves after it has been executed (Gen 4)");
+TO_DO_BATTLE_TEST("Copycat can only copy recharging moves after it has been executed (Gen 4)");
+TO_DO_BATTLE_TEST("Copycat cannot copy Bide's final turn (Gen 4)");
+TO_DO_BATTLE_TEST("Copycat copies other calling moves instead of the move they called (Gen 4)");
+TO_DO_BATTLE_TEST("Copycat copies moves called by other calling moves instead of the calling move if they are executed in a second turn (Gen 5+)"); //Eg. Dig
+
+// Gen 5+
+TO_DO_BATTLE_TEST("Copycat can copy charging moves in both the charging and the executing turn (Gen 5+)");
+TO_DO_BATTLE_TEST("Copycat ignores the recharging turn of recharging moves (Gen 5+)");
+TO_DO_BATTLE_TEST("Copycat can copy Bide on all turns");
+TO_DO_BATTLE_TEST("Copycat copies moves called by other calling moves instead of the calling move (Gen 5+)");
+
+DOUBLE_BATTLE_TEST("(DYNAMAX) Dynamaxed Pokemon can have their base moves copied by Copycat")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_TRICK_ROOM, gimmick: GIMMICK_DYNAMAX, target: opponentLeft); MOVE(playerRight, MOVE_COPYCAT, target: opponentLeft); }
+    } SCENE {
+        MESSAGE("Wobbuffet used Max Guard!");
+        MESSAGE("Wynaut used Trick Room!");
+    }
+}

--- a/test/battle/move_effect/corrosive_gas.c
+++ b/test/battle/move_effect/corrosive_gas.c
@@ -117,3 +117,6 @@ DOUBLE_BATTLE_TEST("Corrosive Gas destroys foes and ally's items if they have on
         EXPECT_EQ(opponentRight->item, ITEM_NONE);
     }
 }
+
+TO_DO_BATTLE_TEST("Corrosive Gas doesn't destroy the item of a Pokemon behind a Substitute");
+TO_DO_BATTLE_TEST("Corrosive Gas doesn't destroy items if they change the Pokémon's form"); // Giratina, Genesect, Silvally, Zacian, Zamazenta. Bulbapedia hasn't confirmed Arceus or Ogerpon, but it's a safe assumption that they will also fail.

--- a/test/battle/move_effect/cosmic_power.c
+++ b/test/battle/move_effect/cosmic_power.c
@@ -1,0 +1,4 @@
+#include "global.h"
+#include "test/battle.h"
+
+TO_DO_BATTLE_TEST("Cosmic Power increases the user's Defense and Sp. Defense by 1 stage each");

--- a/test/battle/move_effect/counter.c
+++ b/test/battle/move_effect/counter.c
@@ -1,0 +1,22 @@
+#include "global.h"
+#include "test/battle.h"
+
+TO_DO_BATTLE_TEST("Counter will do twice as much damage received from the opponent");
+TO_DO_BATTLE_TEST("Counter cannot affect ally Pokémon");
+TO_DO_BATTLE_TEST("Counter hits the last opponent that hit the user"); //Doubles
+
+// Gen 1
+TO_DO_BATTLE_TEST("Counter can only counter Normal and Fighting-type moves (Gen 1)");
+TO_DO_BATTLE_TEST("Counter can hit ghost-type Pokémon (Gen 1)");
+TO_DO_BATTLE_TEST("Counter can return damage dealt to a substitute (Gen 1)");
+
+// Gen 2-3
+TO_DO_BATTLE_TEST("Counter can counter Hidden Power regardless of type (Gen 2-3)");
+
+// Gen 2+
+TO_DO_BATTLE_TEST("Counter can only counter physical moves (Gen 2+)");
+TO_DO_BATTLE_TEST("Counter cannot hit ghost-type Pokémon (Gen 2+)");
+TO_DO_BATTLE_TEST("Counter cannot return damage dealt to a substitute (Gen 2+)");
+
+// Triple Battles required to test
+//TO_DO_BATTLE_TEST("Counter can hit non-adjacent opponents if they were the last Pokémon to hit the user");

--- a/test/battle/move_effect/court_change.c
+++ b/test/battle/move_effect/court_change.c
@@ -78,7 +78,7 @@ DOUBLE_BATTLE_TEST("Court Change swaps entry hazards used by the player")
     }
 }
 
-DOUBLE_BATTLE_TEST("Court Change used by the player swaps Mist, Safeguard, Lucky Chant, Reflect, Light Screen, Tailwind")
+DOUBLE_BATTLE_TEST("Court Change used by the player swaps Mist, Safeguard, Aurora Veil, Reflect, Light Screen, Tailwind")
 {
     GIVEN {
         PLAYER(SPECIES_WYNAUT);
@@ -88,8 +88,8 @@ DOUBLE_BATTLE_TEST("Court Change used by the player swaps Mist, Safeguard, Lucky
         OPPONENT(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
-        TURN { MOVE(opponentLeft, MOVE_MIST); MOVE(opponentRight, MOVE_SAFEGUARD); }
-        TURN { MOVE(opponentLeft, MOVE_LUCKY_CHANT); MOVE(opponentRight, MOVE_REFLECT); }
+        TURN { MOVE(playerLeft, MOVE_SNOWSCAPE); MOVE(opponentLeft, MOVE_MIST); MOVE(opponentRight, MOVE_SAFEGUARD); }
+        TURN { MOVE(opponentLeft, MOVE_AURORA_VEIL); MOVE(opponentRight, MOVE_REFLECT); }
         TURN { MOVE(opponentLeft, MOVE_LIGHT_SCREEN); MOVE(opponentRight, MOVE_TAILWIND); }
         TURN { MOVE(playerLeft, MOVE_COURT_CHANGE); }
         TURN { }
@@ -97,9 +97,10 @@ DOUBLE_BATTLE_TEST("Court Change used by the player swaps Mist, Safeguard, Lucky
         TURN { }
         TURN { }
     } SCENE {
+        MESSAGE("Wynaut used Snowscape!");
         MESSAGE("Foe Wobbuffet used Mist!");
         MESSAGE("Foe Wobbuffet used Safeguard!");
-        MESSAGE("Foe Wobbuffet used Lucky Chant!");
+        MESSAGE("Foe Wobbuffet used Aurora Veil!");
         MESSAGE("Foe Wobbuffet used Reflect!");
         MESSAGE("Foe Wobbuffet used Light Screen!");
         MESSAGE("Foe Wobbuffet used Tailwind!");
@@ -109,13 +110,13 @@ DOUBLE_BATTLE_TEST("Court Change used by the player swaps Mist, Safeguard, Lucky
         MESSAGE("Ally's Mist wore off!");
         MESSAGE("Ally's party is no longer protected by Safeguard!");
         MESSAGE("Ally's Reflect wore off!");
-        MESSAGE("Your team's Lucky Chant wore off!");
+        MESSAGE("Ally's Aurora Veil wore off!");
         MESSAGE("Your team's tailwind petered out!");
         MESSAGE("Ally's Light Screen wore off!");
     }
 }
 
-DOUBLE_BATTLE_TEST("Court Change used by the opponent swaps Mist, Safeguard, Lucky Chant, Reflect, Light Screen, Tailwind")
+DOUBLE_BATTLE_TEST("Court Change used by the opponent swaps Mist, Safeguard, Aurora Veil, Reflect, Light Screen, Tailwind")
 {
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);
@@ -125,8 +126,8 @@ DOUBLE_BATTLE_TEST("Court Change used by the opponent swaps Mist, Safeguard, Luc
         OPPONENT(SPECIES_WYNAUT);
         OPPONENT(SPECIES_WYNAUT);
     } WHEN {
-        TURN { MOVE(playerLeft, MOVE_MIST); MOVE(playerRight, MOVE_SAFEGUARD); }
-        TURN { MOVE(playerLeft, MOVE_LUCKY_CHANT); MOVE(playerRight, MOVE_REFLECT); }
+        TURN { MOVE(opponentLeft, MOVE_SNOWSCAPE); MOVE(playerLeft, MOVE_MIST); MOVE(playerRight, MOVE_SAFEGUARD); }
+        TURN { MOVE(playerLeft, MOVE_AURORA_VEIL); MOVE(playerRight, MOVE_REFLECT); }
         TURN { MOVE(playerLeft, MOVE_LIGHT_SCREEN); MOVE(playerRight, MOVE_TAILWIND); }
         TURN { MOVE(opponentLeft, MOVE_COURT_CHANGE); }
         TURN { }
@@ -136,7 +137,7 @@ DOUBLE_BATTLE_TEST("Court Change used by the opponent swaps Mist, Safeguard, Luc
     } SCENE {
         MESSAGE("Wobbuffet used Mist!");
         MESSAGE("Wobbuffet used Safeguard!");
-        MESSAGE("Wobbuffet used Lucky Chant!");
+        MESSAGE("Wobbuffet used Aurora Veil!");
         MESSAGE("Wobbuffet used Reflect!");
         MESSAGE("Wobbuffet used Light Screen!");
         MESSAGE("Wobbuffet used Tailwind!");
@@ -146,8 +147,10 @@ DOUBLE_BATTLE_TEST("Court Change used by the opponent swaps Mist, Safeguard, Luc
         MESSAGE("Foe's Mist wore off!");
         MESSAGE("Foe's party is no longer protected by Safeguard!");
         MESSAGE("Foe's Reflect wore off!");
-        MESSAGE("The opposing team's Lucky Chant wore off!");
+        MESSAGE("Foe's Aurora Veil wore off!");
         MESSAGE("The opposing team's tailwind petered out!");
         MESSAGE("Foe's Light Screen wore off!");
     }
 }
+
+TO_DO_BATTLE_TEST("Court Change used by the player swaps G-Max Steelsurge, G-Max Vine Lash, G-Max Wildfire, G-Max Cannonade");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
3rd part of a long-term plan of adding all missing TODO tests to the repository.
~~One of the few PRs I did while my power is out~~

Also:
- Moved Copycat Dynamax test to the new `test/battle/move_effect/copycat.c` file.
- Court Change and Lucky Chant never existed in the same Gen, so their interaction cannot be officially confirmed. Bulbapedia listed Aurora Veil instead, so I replaced Lucky Chant for it.

## **Discord contact info**
AsparagusEduardo
