### PR TITLE
Fixes Dancer, adds Revelation Dance interactions with Z-Move, Roost and typeless mons

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -5824,16 +5824,20 @@ void SetTypeBeforeUsingMove(u32 move, u32 battlerAtk)
     {
         gBattleStruct->dynamicMoveType = ItemId_GetSecondaryId(gBattleMons[battlerAtk].item) | F_DYNAMIC_TYPE_SET;
     }
-    else if (gMovesInfo[move].effect == EFFECT_REVELATION_DANCE)
+    else if (gMovesInfo[move].effect == EFFECT_REVELATION_DANCE && GetActiveGimmick(battlerAtk) != GIMMICK_Z_MOVE)
     {
         if (GetActiveGimmick(battlerAtk) == GIMMICK_TERA && GetBattlerTeraType(battlerAtk) != TYPE_STELLAR)
             gBattleStruct->dynamicMoveType = GetBattlerTeraType(battlerAtk);
-        else if (gBattleMons[battlerAtk].types[0] != TYPE_MYSTERY)
+        else if (gBattleMons[battlerAtk].types[0] != TYPE_MYSTERY && !(gBattleResources->flags->flags[battlerAtk] & RESOURCE_FLAG_ROOST && gBattleMons[battlerAtk].types[0] == TYPE_FLYING))
             gBattleStruct->dynamicMoveType = gBattleMons[battlerAtk].types[0] | F_DYNAMIC_TYPE_SET;
-        else if (gBattleMons[battlerAtk].types[1] != TYPE_MYSTERY)
+        else if (gBattleMons[battlerAtk].types[1] != TYPE_MYSTERY && !(gBattleResources->flags->flags[battlerAtk] & RESOURCE_FLAG_ROOST && gBattleMons[battlerAtk].types[1] == TYPE_FLYING))
             gBattleStruct->dynamicMoveType = gBattleMons[battlerAtk].types[1] | F_DYNAMIC_TYPE_SET;
+        else if (gBattleResources->flags->flags[battlerAtk] & RESOURCE_FLAG_ROOST)
+            gBattleStruct->dynamicMoveType = (B_ROOST_PURE_FLYING >= GEN_5 ? TYPE_NORMAL : TYPE_MYSTERY) | F_DYNAMIC_TYPE_SET;
         else if (gBattleMons[battlerAtk].types[2] != TYPE_MYSTERY)
             gBattleStruct->dynamicMoveType = gBattleMons[battlerAtk].types[2] | F_DYNAMIC_TYPE_SET;
+        else
+            gBattleStruct->dynamicMoveType = TYPE_MYSTERY | F_DYNAMIC_TYPE_SET;
     }
     else if (gMovesInfo[move].effect == EFFECT_RAGING_BULL
             && (gBattleMons[battlerAtk].species == SPECIES_TAUROS_PALDEAN_COMBAT_BREED

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -12898,7 +12898,7 @@ static void Cmd_settypetorandomresistance(void)
     {
         gBattlescriptCurrInstr = cmd->failInstr;
     }
-    else if (gLastHitByType[gBattlerAttacker] == TYPE_STELLAR)
+    else if (gLastHitByType[gBattlerAttacker] == TYPE_STELLAR || gLastHitByType[gBattlerAttacker] == TYPE_MYSTERY)
     {
         gBattlescriptCurrInstr = cmd->failInstr;
     }

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -6257,7 +6257,7 @@ static void Cmd_moveend(void)
                 u32 battler, nextDancer = 0;
                 bool32 turnOnHitmarker = FALSE;
 
-                for (battler = 0; battler < MAX_BATTLERS_COUNT; battler++)
+                for (battler = 0; battler < gBattlersCount; battler++)
                 {
                     if (gSpecialStatuses[battler].dancerUsedMove)
                     {
@@ -6278,7 +6278,7 @@ static void Cmd_moveend(void)
                         gBattleScripting.savedBattler |= (gBattlerAttacker << 4);
                         gSpecialStatuses[gBattlerAttacker].dancerUsedMove = TRUE;
                     }
-                    for (battler = 0; battler < MAX_BATTLERS_COUNT; battler++)
+                    for (battler = 0; battler < gBattlersCount; battler++)
                     {
                         if (GetBattlerAbility(battler) == ABILITY_DANCER && !gSpecialStatuses[battler].dancerUsedMove)
                         {

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -6002,6 +6002,7 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
 
                 // Edge case for dance moves that hit multiply targets
                 gHitMarker &= ~HITMARKER_NO_ATTACKSTRING;
+                SetTypeBeforeUsingMove(gCalledMove, battler);
 
                 // Make sure that the target isn't an ally - if it is, target the original user
                 if (GetBattlerSide(gBattlerTarget) == GetBattlerSide(gBattlerAttacker))

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -5517,6 +5517,7 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
              && TARGET_TURN_DAMAGED
              && !IS_BATTLER_OF_TYPE(battler, moveType)
              && moveType != TYPE_STELLAR
+             && moveType != TYPE_MYSTERY
              && IsBattlerAlive(battler))
             {
                 SET_BATTLER_TYPE(battler, moveType);
@@ -9877,7 +9878,9 @@ static inline uq4_12_t GetParentalBondModifier(u32 battlerAtk)
 
 static inline uq4_12_t GetSameTypeAttackBonusModifier(u32 battlerAtk, u32 moveType, u32 move, u32 abilityAtk)
 {
-    if (gBattleStruct->pledgeMove && IS_BATTLER_OF_TYPE(BATTLE_PARTNER(battlerAtk), moveType))
+    if (moveType == TYPE_MYSTERY)
+        return UQ_4_12(1.0);
+    else if (gBattleStruct->pledgeMove && IS_BATTLER_OF_TYPE(BATTLE_PARTNER(battlerAtk), moveType))
         return (abilityAtk == ABILITY_ADAPTABILITY) ? UQ_4_12(2.0) : UQ_4_12(1.5);
     else if (!IS_BATTLER_OF_TYPE(battlerAtk, moveType) || move == MOVE_STRUGGLE || move == MOVE_NONE)
         return UQ_4_12(1.0);

--- a/test/battle/ability/dancer.c
+++ b/test/battle/ability/dancer.c
@@ -132,7 +132,7 @@ SINGLE_BATTLE_TEST("Dancer-called attacks have their type updated")
     GIVEN {
         ASSUME(gMovesInfo[MOVE_REVELATION_DANCE].danceMove == TRUE);
         PLAYER(SPECIES_ZOROARK_HISUIAN);
-        OPPONENT(SPECIES_ORICORIO_BAILE) { Ability(ABILITY_DANCER); }
+        OPPONENT(SPECIES_ORICORIO_BAILE) { Ability(ABILITY_DANCER); HP(900); }
     } WHEN {
         TURN { MOVE(player, MOVE_REVELATION_DANCE); }
     } SCENE {

--- a/test/battle/ability/dancer.c
+++ b/test/battle/ability/dancer.c
@@ -131,16 +131,19 @@ SINGLE_BATTLE_TEST("Dancer-called attacks have their type updated")
 {
     GIVEN {
         ASSUME(gMovesInfo[MOVE_REVELATION_DANCE].danceMove == TRUE);
-        PLAYER(SPECIES_ZOROARK_HISUIAN);
-        OPPONENT(SPECIES_ORICORIO_BAILE) { Ability(ABILITY_DANCER); HP(900); }
+        ASSUME(gMovesInfo[MOVE_REVELATION_DANCE].effect == EFFECT_REVELATION_DANCE);
+        PLAYER(SPECIES_TANGROWTH);
+        OPPONENT(SPECIES_ORICORIO_BAILE) { Ability(ABILITY_DANCER); }
     } WHEN {
         TURN { MOVE(player, MOVE_REVELATION_DANCE); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_REVELATION_DANCE, player);
         HP_BAR(opponent);
+        MESSAGE("It's not very effective…");
         ABILITY_POPUP(opponent, ABILITY_DANCER);
-        NOT MESSAGE("It doesn't affect Foe Zoroark…");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_REVELATION_DANCE, opponent);
         HP_BAR(player);
+        NOT MESSAGE("It's not very effective…");
+        MESSAGE("It's super effective!");
     }
 }

--- a/test/battle/ability/dancer.c
+++ b/test/battle/ability/dancer.c
@@ -126,3 +126,19 @@ DOUBLE_BATTLE_TEST("Dancer still triggers if another dancer flinches")
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
     }
 }
+
+SINGLE_BATTLE_TEST("Dancer-called attacks have their type updated")
+{
+    GIVEN {
+        PLAYER(SPECIES_ORICORIO_BAILE) { Ability(ABILITY_DANCER); }
+        OPPONENT(SPECIES_ZOROARK_HISUI);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_REVELATION_DANCE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_REVELATION_DANCE, opponent);
+        HP_BAR(player);
+        ABILITY_POPUP(player, ABILITY_DANCER);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_REVELATION_DANCE, player);
+        HP_BAR(opponent);
+    }
+}

--- a/test/battle/ability/dancer.c
+++ b/test/battle/ability/dancer.c
@@ -131,16 +131,16 @@ SINGLE_BATTLE_TEST("Dancer-called attacks have their type updated")
 {
     GIVEN {
         ASSUME(gMovesInfo[MOVE_REVELATION_DANCE].danceMove == TRUE);
-        PLAYER(SPECIES_ORICORIO_BAILE) { Ability(ABILITY_DANCER); }
-        OPPONENT(SPECIES_ZOROARK_HISUI);
+        PLAYER(SPECIES_ZOROARK_HISUI);
+        OPPONENT(SPECIES_ORICORIO_BAILE) { Ability(ABILITY_DANCER); }
     } WHEN {
-        TURN { MOVE(opponent, MOVE_REVELATION_DANCE); }
+        TURN { MOVE(player, MOVE_REVELATION_DANCE); }
     } SCENE {
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_REVELATION_DANCE, opponent);
-        HP_BAR(player);
-        ABILITY_POPUP(player, ABILITY_DANCER);
-        NOT MESSAGE("It doesn't affect Foe Zoroark…");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_REVELATION_DANCE, player);
         HP_BAR(opponent);
+        ABILITY_POPUP(opponent, ABILITY_DANCER);
+        NOT MESSAGE("It doesn't affect Foe Zoroark…");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_REVELATION_DANCE, opponent);
+        HP_BAR(player);
     }
 }

--- a/test/battle/ability/dancer.c
+++ b/test/battle/ability/dancer.c
@@ -138,6 +138,7 @@ SINGLE_BATTLE_TEST("Dancer-called attacks have their type updated")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_REVELATION_DANCE, opponent);
         HP_BAR(player);
         ABILITY_POPUP(player, ABILITY_DANCER);
+        NOT MESSAGE("It doesn't affect Foe Zoroark");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_REVELATION_DANCE, player);
         HP_BAR(opponent);
     }

--- a/test/battle/ability/dancer.c
+++ b/test/battle/ability/dancer.c
@@ -138,7 +138,7 @@ SINGLE_BATTLE_TEST("Dancer-called attacks have their type updated")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_REVELATION_DANCE, opponent);
         HP_BAR(player);
         ABILITY_POPUP(player, ABILITY_DANCER);
-        NOT MESSAGE("It doesn't affect Foe Zoroark");
+        NOT MESSAGE("It doesn't affect Foe Zoroark…");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_REVELATION_DANCE, player);
         HP_BAR(opponent);
     }

--- a/test/battle/ability/dancer.c
+++ b/test/battle/ability/dancer.c
@@ -138,11 +138,9 @@ SINGLE_BATTLE_TEST("Dancer-called attacks have their type updated")
         TURN { MOVE(player, MOVE_REVELATION_DANCE); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_REVELATION_DANCE, player);
-        HP_BAR(opponent);
         MESSAGE("It's not very effective…");
         ABILITY_POPUP(opponent, ABILITY_DANCER);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_REVELATION_DANCE, opponent);
-        HP_BAR(player);
         NOT MESSAGE("It's not very effective…");
         MESSAGE("It's super effective!");
     }

--- a/test/battle/ability/dancer.c
+++ b/test/battle/ability/dancer.c
@@ -133,7 +133,7 @@ SINGLE_BATTLE_TEST("Dancer-called attacks have their type updated")
         ASSUME(gMovesInfo[MOVE_REVELATION_DANCE].danceMove == TRUE);
         ASSUME(gMovesInfo[MOVE_REVELATION_DANCE].effect == EFFECT_REVELATION_DANCE);
         PLAYER(SPECIES_TANGROWTH);
-        OPPONENT(SPECIES_ORICORIO_BAILE) { Ability(ABILITY_DANCER); }
+        OPPONENT(SPECIES_ORICORIO_BAILE);
     } WHEN {
         TURN { MOVE(player, MOVE_REVELATION_DANCE); }
     } SCENE {

--- a/test/battle/ability/dancer.c
+++ b/test/battle/ability/dancer.c
@@ -130,6 +130,7 @@ DOUBLE_BATTLE_TEST("Dancer still triggers if another dancer flinches")
 SINGLE_BATTLE_TEST("Dancer-called attacks have their type updated")
 {
     GIVEN {
+        ASSUME(gMovesInfo[MOVE_REVELATION_DANCE].danceMove == TRUE);
         PLAYER(SPECIES_ORICORIO_BAILE) { Ability(ABILITY_DANCER); }
         OPPONENT(SPECIES_ZOROARK_HISUI);
     } WHEN {

--- a/test/battle/ability/dancer.c
+++ b/test/battle/ability/dancer.c
@@ -131,7 +131,7 @@ SINGLE_BATTLE_TEST("Dancer-called attacks have their type updated")
 {
     GIVEN {
         ASSUME(gMovesInfo[MOVE_REVELATION_DANCE].danceMove == TRUE);
-        PLAYER(SPECIES_ZOROARK_HISUI);
+        PLAYER(SPECIES_ZOROARK_HISUIAN);
         OPPONENT(SPECIES_ORICORIO_BAILE) { Ability(ABILITY_DANCER); }
     } WHEN {
         TURN { MOVE(player, MOVE_REVELATION_DANCE); }

--- a/test/battle/gimmick/zmove.c
+++ b/test/battle/gimmick/zmove.c
@@ -599,3 +599,22 @@ SINGLE_BATTLE_TEST("(Z-MOVE) Searing Sunraze Smash ignores the target's abilitie
         MESSAGE("A critical hit!");
     } 
 }
+
+SINGLE_BATTLE_TEST("(Z-MOVE) Z-Revelation Dance always transforms into Breakneck Blitz")
+{
+    u16 species;
+    PARAMETRIZE { species = SPECIES_ORICORIO_BAILE; }
+    PARAMETRIZE { species = SPECIES_ORICORIO_PAU; }
+    PARAMETRIZE { species = SPECIES_ORICORIO_POM_POM; }
+    PARAMETRIZE { species = SPECIES_ORICORIO_SENSU; }
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_REVELATION_DANCE].type == TYPE_NORMAL);
+        PLAYER(species) { Item(ITEM_NORMALIUM_Z); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_REVELATION_DANCE, gimmick: GIMMICK_Z_MOVE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ZMOVE_ACTIVATE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BREAKNECK_BLITZ, player);
+    }
+}

--- a/test/battle/move_effect/revelation_dance.c
+++ b/test/battle/move_effect/revelation_dance.c
@@ -1,0 +1,149 @@
+#include "global.h"
+#include "test/battle.h"
+
+ASSUMPTIONS
+{
+    ASSUME(gMovesInfo[MOVE_REVELATION_DANCE].effect == EFFECT_REVELATION_DANCE);
+    ASSUME(gMovesInfo[MOVE_REVELATION_DANCE].danceMove == TRUE);
+    ASSUME(MoveHasAdditionalEffectSelfArg(MOVE_BURN_UP, MOVE_EFFECT_REMOVE_ARG_TYPE, TYPE_FIRE));
+    ASSUME(gMovesInfo[MOVE_FORESTS_CURSE].effect == EFFECT_THIRD_TYPE);
+    ASSUME(gMovesInfo[MOVE_FORESTS_CURSE].argument == TYPE_GRASS);
+    ASSUME(gMovesInfo[MOVE_ROOST].effect == EFFECT_ROOST);
+}
+
+SINGLE_BATTLE_TEST("Revelation Dance changes its type depending on the user's 1st Type")
+{
+    u16 speciesPlayer;
+    u16 speciesOpponent;
+
+    PARAMETRIZE { speciesPlayer = SPECIES_ORICORIO_POM_POM; speciesOpponent = SPECIES_DUGTRIO; }
+    PARAMETRIZE { speciesPlayer = SPECIES_ORICORIO_BAILE; speciesOpponent = SPECIES_BLASTOISE; }
+    PARAMETRIZE { speciesPlayer = SPECIES_ORICORIO_PAU; speciesOpponent = SPECIES_LIEPARD; }
+    PARAMETRIZE { speciesPlayer = SPECIES_ORICORIO_SENSU; speciesOpponent = SPECIES_PERSIAN; }
+
+    GIVEN {
+        PLAYER(speciesPlayer);
+        OPPONENT(speciesOpponent);
+    } WHEN {
+        TURN { MOVE(player, MOVE_REVELATION_DANCE); }
+    } SCENE {
+        if (speciesPlayer == SPECIES_ORICORIO_BAILE) {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_REVELATION_DANCE, player);
+            HP_BAR(opponent);
+            MESSAGE("It's not very effective…");
+        }
+        else {
+            NONE_OF {
+                ANIMATION(ANIM_TYPE_MOVE, MOVE_REVELATION_DANCE, player);
+                HP_BAR(opponent);
+                MESSAGE("It's not very effective…");
+            } 
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Revelation Dance changes its type depending on the user's 2nd Type if it has no 1st type")
+{
+    GIVEN {
+        PLAYER(SPECIES_ORICORIO_BAILE);
+        OPPONENT(SPECIES_EMPOLEON);
+    } WHEN {
+        TURN { MOVE(player, MOVE_BURN_UP); }
+        TURN { MOVE(player, MOVE_REVELATION_DANCE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BURN_UP, player);
+        HP_BAR(opponent);
+        NONE_OF {
+            MESSAGE("It's not very effective…");
+            MESSAGE("It's super effective!");
+        }
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_REVELATION_DANCE, player);
+        HP_BAR(opponent);
+        MESSAGE("It's not very effective…");
+    }
+}
+
+SINGLE_BATTLE_TEST("Revelation Dance changes its type depending on the user's 3rd Type if it has no 1st or 2nd type")
+{
+    GIVEN {
+        PLAYER(SPECIES_GROWLITHE);
+        OPPONENT(SPECIES_TREVENANT);
+    } WHEN {
+        TURN { MOVE(player, MOVE_BURN_UP); MOVE(opponent, MOVE_FORESTS_CURSE); }
+        TURN { MOVE(player, MOVE_REVELATION_DANCE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BURN_UP, player);
+        HP_BAR(opponent);
+        MESSAGE("It's super effective!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FORESTS_CURSE, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_REVELATION_DANCE, player);
+        HP_BAR(opponent);
+        MESSAGE("It's not very effective…");
+    }
+}
+
+SINGLE_BATTLE_TEST("Revelation Dance becomes Typeless if its user is Typeless")
+{
+    u16 speciesOpponent;
+
+    PARAMETRIZE { speciesOpponent = SPECIES_BLISSEY; }
+    PARAMETRIZE { speciesOpponent = SPECIES_BLASTOISE; }
+    PARAMETRIZE { speciesOpponent = SPECIES_CHARIZARD; }
+    PARAMETRIZE { speciesOpponent = SPECIES_VENUSAUR; }
+    PARAMETRIZE { speciesOpponent = SPECIES_GOLEM; }
+    PARAMETRIZE { speciesOpponent = SPECIES_AEGISLASH; }
+
+    GIVEN {
+        PLAYER(SPECIES_GROWLITHE);
+        OPPONENT(speciesOpponent);
+    } WHEN {
+        TURN { MOVE(player, MOVE_BURN_UP); }
+        TURN { MOVE(player, MOVE_REVELATION_DANCE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BURN_UP, player);
+        HP_BAR(opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_REVELATION_DANCE, player);
+        HP_BAR(opponent);
+        NONE_OF {
+            MESSAGE("It's not very effective…");
+            MESSAGE("It's super effective!");
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Revelation Dance becomes Normal type if used by a Typeless Pokemon due to Roost")
+{
+    u16 speciesOpponent;
+
+    PARAMETRIZE { speciesOpponent = SPECIES_SABLEYE; }
+    PARAMETRIZE { speciesOpponent = SPECIES_AGGRON; }
+
+    ASSUME(B_ROOST_PURE_FLYING >= GEN_5);
+
+    GIVEN {
+        PLAYER(SPECIES_ORICORIO_BAILE) { Ability(ABILITY_DANCER); }
+        OPPONENT(speciesOpponent);
+    } WHEN {
+        TURN { MOVE(player, MOVE_BURN_UP); MOVE(opponent, MOVE_TACKLE); }
+        TURN { MOVE(player, MOVE_ROOST); MOVE(opponent, MOVE_REVELATION_DANCE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BURN_UP, player);
+        HP_BAR(opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_REVELATION_DANCE, opponent);
+        HP_BAR(player);
+        ABILITY_POPUP(player, ABILITY_DANCER);
+        if (speciesOpponent == SPECIES_AGGRON) {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_REVELATION_DANCE, player);
+            HP_BAR(opponent);
+            MESSAGE("It's not very effective…");
+        }
+        else {
+            NONE_OF {
+                ANIMATION(ANIM_TYPE_MOVE, MOVE_REVELATION_DANCE, player);
+                HP_BAR(opponent);
+                MESSAGE("It's not very effective…"); 
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds Tests for Revelation Dance.

The following Revelation Dance interactions were added:

- If a Pokémon is Typeless, Revelation Dance will have no type (in which case Revelation Dance will not receive STAB). If a Pokémon has lost its primary Flying type due to having used Roost earlier this turn and uses Revelation Dance due to Dancer, Revelation Dance's type will match its current type: its secondary type if it has any, or else be Normal-type (regardless of type additions by Forest's Curse or Trick-or-Treat).
- Typeless Revelation Dance does not activate Color Change and is blocked by Wonder Guard. Conversion 2 will fail if the last move used by the target was typeless Revelation Dance.
- Regardless of the user's types, Revelation Dance is always treated as Normal-type for Z-Move mechanics, and can be upgraded to Breakneck Blitz by a Normalium Z.

Also fixes Dancer-called moves not updating their type according to the new user of the move.

## Feature(s) this PR does NOT handle:
When merging to upcoming, will be necessary to modify the checks for CheckDynamicMoveType.

## **Discord contact info**
PhallenTree
