### PR TITLE
Fixes wrong padding in struct SpeciesInfo

### DIFF
--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -441,7 +441,7 @@ struct SpeciesInfo /*0xC4*/
             u32 dexForceRequired:1; // This species will be taken into account for Pokédex ratings even if they have the "isMythical" flag set.
             u32 tmIlliterate:1;     // This species will be unable to learn the universal moves.
             u32 isFrontierBanned:1; // This species is not allowed to participate in Battle Frontier facilities.
-            u32 padding4:14;
+            u32 padding4:13;
             // Move Data
  /* 0x80 */ const struct LevelUpMove *levelUpLearnset;
  /* 0x84 */ const u16 *teachableLearnset;


### PR DESCRIPTION
Fixes wrong padding in struct SpeciesInfo that is if I counted correctly.

After I opened #5138 I realized it might be an issue on master as well.

Feel free to close one of those but I think it should be solved on master for sure as well
