### PR TITLE
Fix specific tiles changing to pc tiles when using boxlink/debug pc

### DIFF
--- a/include/tilesets.h
+++ b/include/tilesets.h
@@ -7,4 +7,7 @@ extern const u16 gTilesetPalettes_General[][16];
 extern const struct Tileset * const gTilesetPointer_SecretBase;
 extern const struct Tileset * const gTilesetPointer_SecretBaseRedCave;
 
+extern const struct Tileset gTileset_Building;
+extern const struct Tileset gTileset_BrendansMaysHouse;
+
 #endif //GUARD_tilesets_H

--- a/src/field_specials.c
+++ b/src/field_specials.c
@@ -44,6 +44,7 @@
 #include "strings.h"
 #include "task.h"
 #include "text.h"
+#include "tilesets.h"
 #include "tv.h"
 #include "wallclock.h"
 #include "window.h"
@@ -969,6 +970,20 @@ void FieldShowRegionMap(void)
     SetMainCallback2(CB2_FieldShowRegionMap);
 }
 
+static bool32 IsBuildingPCTile(u32 tileId)
+{
+    return gMapHeader.mapLayout->primaryTileset == &gTileset_Building && (tileId == METATILE_Building_PC_On || tileId == METATILE_Building_PC_Off);
+}
+
+static bool32 IsPlayerHousePCTile(u32 tileId)
+{
+    return gMapHeader.mapLayout->secondaryTileset == &gTileset_BrendansMaysHouse 
+        && (tileId == METATILE_BrendansMaysHouse_BrendanPC_On 
+            || tileId == METATILE_BrendansMaysHouse_BrendanPC_Off
+            || tileId == METATILE_BrendansMaysHouse_MayPC_On
+            || tileId == METATILE_BrendansMaysHouse_MayPC_Off);
+}
+
 static bool8 IsPlayerInFrontOfPC(void)
 {
     s16 x, y;
@@ -977,12 +992,7 @@ static bool8 IsPlayerInFrontOfPC(void)
     GetXYCoordsOneStepInFrontOfPlayer(&x, &y);
     tileInFront = MapGridGetMetatileIdAt(x, y);
 
-    return (tileInFront == METATILE_BrendansMaysHouse_BrendanPC_On
-         || tileInFront == METATILE_BrendansMaysHouse_BrendanPC_Off
-         || tileInFront == METATILE_BrendansMaysHouse_MayPC_On
-         || tileInFront == METATILE_BrendansMaysHouse_MayPC_Off
-         || tileInFront == METATILE_Building_PC_On
-         || tileInFront == METATILE_Building_PC_Off);
+    return IsBuildingPCTile(tileInFront) || IsPlayerHousePCTile(tileInFront);
 }
 
 // Task data for Task_PCTurnOnEffect and Task_LotteryCornerComputerEffect


### PR DESCRIPTION
## Description
Some tiles can change to PC tiles when using boxlink or the debug menu PC access.

## Images
![pcbug](https://github.com/user-attachments/assets/84c60e46-b58d-435a-8889-e27bc06639be)

## **Discord contact info**
.cawt