### PR TITLE
Fix a sprite issue with B_SHOW_TYPES

### DIFF
--- a/src/type_icons.c
+++ b/src/type_icons.c
@@ -432,7 +432,10 @@ static void SpriteCB_TypeIcon(struct Sprite* sprite)
 static void DestroyTypeIcon(struct Sprite* sprite)
 {
     u32 i;
+    FreeSpriteTilesByTag(TYPE_ICON_TAG_2);
+    FreeSpriteTilesByTag(TYPE_ICON_TAG);
     DestroySpriteAndFreeResources(sprite);
+
 
     for (i = 0; i < MAX_SPRITES; ++i)
     {

--- a/src/type_icons.c
+++ b/src/type_icons.c
@@ -28,6 +28,7 @@ static bool32 ShouldFlipTypeIcon(bool32, u32, u32);
 
 static void SpriteCB_TypeIcon(struct Sprite*);
 static void DestroyTypeIcon(struct Sprite*);
+static void FreeAllTypeIconResources(void);
 static bool32 ShouldHideTypeIcon(u32);
 static s32 GetTypeIconHideMovement(bool32, u32);
 static s32 GetTypeIconSlideMovement(bool32, u32, s32);
@@ -429,33 +430,45 @@ static void SpriteCB_TypeIcon(struct Sprite* sprite)
     sprite->y = GetTypeIconBounceMovement(sprite->tVerticalPosition,position);
 }
 
+static const u32 typeIconTags[] =
+{
+    TYPE_ICON_TAG,
+    TYPE_ICON_TAG_2
+};
+
 static void DestroyTypeIcon(struct Sprite* sprite)
 {
-    u32 i;
+    u32 spriteId, tag;
+
     DestroySpriteAndFreeResources(sprite);
 
-    for (i = 0; i < MAX_SPRITES; ++i)
+    for (spriteId = 0; spriteId < MAX_SPRITES; ++spriteId)
     {
-        if (!gSprites[i].inUse)
+        if (!gSprites[spriteId].inUse)
             continue;
 
-        if (gSprites[i].template->paletteTag == TYPE_ICON_TAG)
-            return;
+        for (tag = 0; tag < 2; tag++)
+        {
+            if (gSprites[spriteId].template->paletteTag == typeIconTags[tag])
+                return;
 
-        if (gSprites[i].template->paletteTag == TYPE_ICON_TAG_2)
-            return;
-
-        if (gSprites[i].template->tileTag == TYPE_ICON_TAG_1)
-            return;
-
-        if (gSprites[i].template->tileTag == TYPE_ICON_TAG_2)
-            return;
+            if (gSprites[spriteId].template->tileTag == typeIconTags[tag])
+                return;
+        }
     }
 
-    FreeSpriteTilesByTag(TYPE_ICON_TAG);
-    FreeSpriteTilesByTag(TYPE_ICON_TAG_2);
-    FreeSpritePaletteByTag(TYPE_ICON_TAG);
-    FreeSpritePaletteByTag(TYPE_ICON_TAG_2);
+    FreeAllTypeIconResources();
+}
+
+static void FreeAllTypeIconResources(void)
+{
+    u32 tag;
+
+    for (tag = 0; tag < 2; tag++)
+    {
+        FreeSpriteTilesByTag(typeIconTags[tag]);
+        FreeSpritePaletteByTag(typeIconTags[tag]);
+    }
 }
 
 static bool32 ShouldHideTypeIcon(u32 battlerId)

--- a/src/type_icons.c
+++ b/src/type_icons.c
@@ -439,10 +439,16 @@ static void DestroyTypeIcon(struct Sprite* sprite)
         if (!gSprites[i].inUse)
             continue;
 
-        if ((gSprites[i].template->paletteTag == TYPE_ICON_TAG) || (gSprites[i].template->paletteTag == TYPE_ICON_TAG_2))
+        if (gSprites[i].template->paletteTag == TYPE_ICON_TAG)
             return;
 
-        if ((gSprites[i].template->tileTag == TYPE_ICON_TAG) || (gSprites[i].template->tileTag == TYPE_ICON_TAG_2))
+        if (gSprites[i].template->paletteTag == TYPE_ICON_TAG_2)
+            return;
+
+        if (gSprites[i].template->tileTag == TYPE_ICON_TAG_1)
+            return;
+
+        if (gSprites[i].template->tileTag == TYPE_ICON_TAG_2)
             return;
     }
 

--- a/src/type_icons.c
+++ b/src/type_icons.c
@@ -432,20 +432,22 @@ static void SpriteCB_TypeIcon(struct Sprite* sprite)
 static void DestroyTypeIcon(struct Sprite* sprite)
 {
     u32 i;
-    FreeSpriteTilesByTag(TYPE_ICON_TAG_2);
-    FreeSpriteTilesByTag(TYPE_ICON_TAG);
     DestroySpriteAndFreeResources(sprite);
-
 
     for (i = 0; i < MAX_SPRITES; ++i)
     {
         if (!gSprites[i].inUse)
             continue;
 
-        if (gSprites[i].template->paletteTag == TYPE_ICON_TAG)
+        if ((gSprites[i].template->paletteTag == TYPE_ICON_TAG) || (gSprites[i].template->paletteTag == TYPE_ICON_TAG_2))
+            return;
+
+        if ((gSprites[i].template->tileTag == TYPE_ICON_TAG) || (gSprites[i].template->tileTag == TYPE_ICON_TAG_2))
             return;
     }
 
+    FreeSpriteTilesByTag(TYPE_ICON_TAG);
+    FreeSpriteTilesByTag(TYPE_ICON_TAG_2);
     FreeSpritePaletteByTag(TYPE_ICON_TAG);
     FreeSpritePaletteByTag(TYPE_ICON_TAG_2);
 }


### PR DESCRIPTION
## Description
Added `FreeAllTypeIconResources` which fixed an issue with https://github.com/rh-hideout/pokeemerald-expansion/pull/5131 where the type icon sprite was not being properly handled when hidden.
## Testing
```diff
Debug_EventScript_Script_1::
+    setflag FLAG_BADGE01_GET
+    setflag FLAG_BADGE02_GET
+    setflag FLAG_BADGE03_GET
+    setflag FLAG_BADGE04_GET
+    setflag FLAG_BADGE05_GET
+    setflag FLAG_BADGE06_GET
+    setflag FLAG_BADGE07_GET
+    setflag FLAG_BADGE08_GET
+    givemon SPECIES_WOBBUFFET,100,ITEM_LEPPA_BERRY
+    givemon SPECIES_GYARADOS,100,ITEM_GYARADOSITE
+    additem ITEM_MEGA_RING,1
+    setwildbattle SPECIES_WOBBUFFET,100,ITEM_LEPPA_BERRY
+    dowildbattle
    release
    end
```
## Video

https://github.com/user-attachments/assets/075483c1-715a-4194-8ccb-0252cf98ec99

## Issue(s) that this PR fixes
[Reported on Discord](https://discord.com/channels/419213663107416084/1267947673936330783/1272303073733251215)

## **People who collaborated with me in this PR**
Reported by awakeon from RHH Discord

## **Discord contact info**
I am pkmnsnfrn and there is a [discussion thread](https://discord.com/channels/419213663107416084/1267947673936330783).