### PR TITLE
Fixed incorrect rounding when maxHP <16

### DIFF
--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -1564,9 +1564,9 @@ static u32 GetSwitchinStatusDamage(u32 battler)
             if ((status & STATUS1_TOXIC_COUNTER) != STATUS1_TOXIC_TURN(15)) // not 16 turns
                 AI_DATA->switchinCandidate.battleMon.status1 += STATUS1_TOXIC_TURN(1);
             statusDamage = maxHP / 16;
-            statusDamage *= AI_DATA->switchinCandidate.battleMon.status1 & STATUS1_TOXIC_COUNTER >> 8;
             if (statusDamage == 0)
                 statusDamage = 1;
+            statusDamage *= AI_DATA->switchinCandidate.battleMon.status1 & STATUS1_TOXIC_COUNTER >> 8;
         }
     }
 

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -2514,7 +2514,7 @@ u32 GetBattlerSecondaryDamage(u32 battlerId)
 bool32 BattlerWillFaintFromWeather(u32 battler, u32 ability)
 {
     if ((BattlerAffectedBySandstorm(battler, ability) || BattlerAffectedByHail(battler, ability))
-      && gBattleMons[battler].hp <= gBattleMons[battler].maxHP / 16)
+      && gBattleMons[battler].hp <= max(1, gBattleMons[battler].maxHP / 16))
         return TRUE;
 
     return FALSE;
@@ -2523,7 +2523,7 @@ bool32 BattlerWillFaintFromWeather(u32 battler, u32 ability)
 bool32 BattlerWillFaintFromSecondaryDamage(u32 battler, u32 ability)
 {
     if (GetBattlerSecondaryDamage(battler) != 0
-      && gBattleMons[battler].hp <= gBattleMons[battler].maxHP / 16)
+      && gBattleMons[battler].hp <= max(1, gBattleMons[battler].maxHP / 16))
         return TRUE;
     return FALSE;
 }

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -2387,6 +2387,8 @@ u8 DoBattlerEndTurnEffects(void)
             {
                 gBattleScripting.battler = battler;
                 gBattleMoveDamage = GetNonDynamaxMaxHP(battler) / 16;
+                if (gBattleMoveDamage == 0)
+                    gBattleMoveDamage = 1;
                 BattleScriptExecute(BattleScript_DamagingWeather);
                 effect++;
             }
@@ -2397,7 +2399,7 @@ u8 DoBattlerEndTurnEffects(void)
                   && !(gStatuses3[battler] & STATUS3_HEAL_BLOCK))
             {
                 gBattleScripting.battler = battler;
-                gBattleMoveDamage = -1 * (GetNonDynamaxMaxHP(battler) / 16);
+                gBattleMoveDamage = -1 * max(1, GetNonDynamaxMaxHP(battler) / 16);
                 BattleScriptExecute(BattleScript_IceBodyHeal);
                 effect++;
             }
@@ -2411,6 +2413,8 @@ u8 DoBattlerEndTurnEffects(void)
             {
                 gBattleScripting.battler = battler;
                 gBattleMoveDamage = GetNonDynamaxMaxHP(battler) / 16;
+                if (gBattleMoveDamage == 0)
+                    gBattleMoveDamage = 1;
                 BattleScriptExecute(BattleScript_DamagingWeather);
                 effect++;
             }

--- a/test/battle/ability/ice_body.c
+++ b/test/battle/ability/ice_body.c
@@ -1,13 +1,21 @@
 #include "global.h"
 #include "test/battle.h"
 
+ASSUMPTIONS {
+    ASSUME(gMovesInfo[MOVE_HAIL].effect == EFFECT_HAIL);
+    ASSUME(gMovesInfo[MOVE_SNOWSCAPE].effect == EFFECT_SNOWSCAPE);
+}
+
 SINGLE_BATTLE_TEST("Ice Body prevents damage from hail")
 {
+    u32 move;
+    PARAMETRIZE { move = MOVE_HAIL; }
+    PARAMETRIZE { move = MOVE_SNOWSCAPE; }
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_GLALIE) { Ability(ABILITY_ICE_BODY); }
     } WHEN {
-        TURN { MOVE(player, MOVE_HAIL); MOVE(opponent, MOVE_SKILL_SWAP); }
+        TURN { MOVE(player, move); MOVE(opponent, MOVE_SKILL_SWAP); }
     } SCENE {
         NONE_OF { HP_BAR(player); }
     }
@@ -15,11 +23,14 @@ SINGLE_BATTLE_TEST("Ice Body prevents damage from hail")
 
 SINGLE_BATTLE_TEST("Ice Body recovers 1/16th of Max HP in hail.")
 {
+    u32 move;
+    PARAMETRIZE { move = MOVE_HAIL; }
+    PARAMETRIZE { move = MOVE_SNOWSCAPE; }
     GIVEN {
         PLAYER(SPECIES_GLALIE) { Ability(ABILITY_ICE_BODY); HP(1); MaxHP(100); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
-        TURN { MOVE(opponent, MOVE_HAIL); }
+        TURN { MOVE(opponent, move); }
     } SCENE {
         ABILITY_POPUP(player, ABILITY_ICE_BODY);
         HP_BAR(player, damage: -(100 / 16));
@@ -27,4 +38,17 @@ SINGLE_BATTLE_TEST("Ice Body recovers 1/16th of Max HP in hail.")
     }
 }
 
-TO_DO_BATTLE_TEST("Sand Rush doesn't recover HP if Cloud Nine/Air Lock is on the field");
+SINGLE_BATTLE_TEST("Ice Body doesn't recover HP if Cloud Nine/Air Lock is on the field")
+{
+    u32 move;
+    PARAMETRIZE { move = MOVE_HAIL; }
+    PARAMETRIZE { move = MOVE_SNOWSCAPE; }
+    GIVEN {
+        PLAYER(SPECIES_GLALIE) { Ability(ABILITY_ICE_BODY); HP(1); MaxHP(100); }
+        OPPONENT(SPECIES_GOLDUCK) { Ability(ABILITY_CLOUD_NINE); }
+    } WHEN {
+        TURN { MOVE(opponent, move); }
+    } SCENE {
+        NOT ABILITY_POPUP(player, ABILITY_ICE_BODY);
+    }
+}

--- a/test/battle/ability/rain_dish.c
+++ b/test/battle/ability/rain_dish.c
@@ -1,6 +1,10 @@
 #include "global.h"
 #include "test/battle.h"
 
+ASSUMPTIONS {
+    ASSUME(gMovesInfo[MOVE_RAIN_DANCE].effect == EFFECT_RAIN_DANCE);
+}
+
 SINGLE_BATTLE_TEST("Rain Dish recovers 1/16th of Max HP in Rain")
 {
     GIVEN {
@@ -11,8 +15,18 @@ SINGLE_BATTLE_TEST("Rain Dish recovers 1/16th of Max HP in Rain")
     } SCENE {
         ABILITY_POPUP(player, ABILITY_RAIN_DISH);
         MESSAGE("Ludicolo's Rain Dish restored its HP a little!");
-        HP_BAR(player, damage: -(100 / 16));
+        HP_BAR(player, damage:  -(100 / 16));
     }
 }
 
-TO_DO_BATTLE_TEST("Rain Dish doesn't recover HP if Cloud Nine/Air Lock is on the field");
+SINGLE_BATTLE_TEST("Rain Dish doesn't recover HP if Cloud Nine/Air Lock is on the field")
+{
+    GIVEN {
+        PLAYER(SPECIES_LUDICOLO) { Ability(ABILITY_RAIN_DISH); HP(1); MaxHP(100); }
+        OPPONENT(SPECIES_GOLDUCK) { Ability(ABILITY_CLOUD_NINE); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_RAIN_DANCE); }
+    } SCENE {
+        NOT ABILITY_POPUP(player, ABILITY_RAIN_DISH);
+    }
+}

--- a/test/battle/weather/hail.c
+++ b/test/battle/weather/hail.c
@@ -70,3 +70,15 @@ DOUBLE_BATTLE_TEST("Hail deals damage based on turn order")
         HP_BAR(playerRight);
    }
 }
+
+SINGLE_BATTLE_TEST("Hail damage rounds properly when maxHP < 16")
+{
+    GIVEN {
+        PLAYER(SPECIES_MAGIKARP) { Level(1); MaxHP(11); HP(11); }
+        OPPONENT(SPECIES_GLALIE);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_HAIL); }
+    } SCENE {
+        HP_BAR(player, damage: 1);
+    }
+}

--- a/test/battle/weather/sandstorm.c
+++ b/test/battle/weather/sandstorm.c
@@ -82,3 +82,15 @@ DOUBLE_BATTLE_TEST("Sandstorm deals damage based on turn order")
         HP_BAR(playerRight);
    }
 }
+
+SINGLE_BATTLE_TEST("Sandstorm damage rounds properly when maxHP < 16")
+{
+    GIVEN {
+        PLAYER(SPECIES_MAGIKARP) { Level(1); MaxHP(11); HP(11); }
+        OPPONENT(SPECIES_SANDSLASH);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SANDSTORM); }
+    } SCENE {
+        HP_BAR(player, damage: 1);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added code to make `maxHP / 16` round to 1 if 0 in several cases.
Weather damage, Ice Body healing and some AI calculations adjusted.
Wrote tests for weather damage.
Wrote 2 "TO_DO" tests found along the way.

## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, fixes #2222." -->
<!-- If it doesn't apply, feel free to remove this section. -->
#5180 

## **Discord contact info**
<!--- formatted as name#numbers, e.g. Lunos#4026 -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara
