### PR TITLE
Fix using Population Dice with Loaded Dice printing garbage text

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3641,13 +3641,14 @@ u8 AtkCanceller_UnableToUseMove(u32 moveType)
                 else
                 {
                     gMultiHitCounter = gMovesInfo[gCurrentMove].strikeCount;
-                    PREPARE_BYTE_NUMBER_BUFFER(gBattleScripting.multihitString, 3, 0)
 
                     if (gMovesInfo[gCurrentMove].effect == EFFECT_DRAGON_DARTS
                      && CanTargetPartner(gBattlerAttacker, gBattlerTarget)
                      && TargetFullyImmuneToCurrMove(gBattlerAttacker, gBattlerTarget))
                         gBattlerTarget = BATTLE_PARTNER(gBattlerTarget);
                 }
+
+                PREPARE_BYTE_NUMBER_BUFFER(gBattleScripting.multihitString, 3, 0)
             }
             else if (B_BEAT_UP >= GEN_5 && gMovesInfo[gCurrentMove].effect == EFFECT_BEAT_UP)
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Self explanatory, the "Hit (num) time(s)" text was printing garbage if you used population bomb while holding loaded dice, as the string wasn't initialized properly. This fixes that by moving a line.

## **Discord contact info**
kittenchilly