### PR TITLE
Fix a display issue with B_SHOW_TYPES

### DIFF
--- a/include/battle_controllers.h
+++ b/include/battle_controllers.h
@@ -313,6 +313,8 @@ void MoveSelectionDestroyCursorAt(u8 cursorPosition);
 void PlayerHandleChooseMove(u32 battler);
 void HandleInputChooseMove(u32 battler);
 void HandleInputChooseTarget(u32 battler);
+void HandleInputShowEntireFieldTargets(u32 battler);
+void HandleInputShowTargets(u32 battler);
 void HandleMoveSwitching(u32 battler);
 void HandleChooseMoveAfterDma3(u32 battler);
 

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -593,7 +593,7 @@ static void HideShownTargets(u32 battler)
     }
 }
 
-static void HandleInputShowEntireFieldTargets(u32 battler)
+void HandleInputShowEntireFieldTargets(u32 battler)
 {
     if (JOY_HELD(DPAD_ANY) && gSaveBlock2Ptr->optionsButtonMode == OPTIONS_BUTTON_MODE_L_EQUALS_A)
         gPlayerDpadHoldFrames++;
@@ -621,7 +621,7 @@ static void HandleInputShowEntireFieldTargets(u32 battler)
     }
 }
 
-static void HandleInputShowTargets(u32 battler)
+void HandleInputShowTargets(u32 battler)
 {
     if (JOY_HELD(DPAD_ANY) && gSaveBlock2Ptr->optionsButtonMode == OPTIONS_BUTTON_MODE_L_EQUALS_A)
         gPlayerDpadHoldFrames++;

--- a/src/type_icons.c
+++ b/src/type_icons.c
@@ -471,23 +471,24 @@ static void FreeAllTypeIconResources(void)
     }
 }
 
+static void (* const sShowTypesControllerFuncs[])(u32 battler) =
+{
+    PlayerHandleChooseMove,
+    HandleChooseMoveAfterDma3,
+    HandleInputChooseTarget,
+    HandleInputShowTargets,
+    HandleInputShowEntireFieldTargets,
+    HandleMoveSwitching,
+    HandleInputChooseMove,
+};
+
+
 static bool32 ShouldHideTypeIcon(u32 battlerId)
 {
     u32 funcIndex;
 
-    void* showTypesControllerFuncs[] =
-    {
-        PlayerHandleChooseMove,
-        HandleChooseMoveAfterDma3,
-        HandleInputChooseTarget,
-        HandleInputShowTargets,
-        HandleInputShowEntireFieldTargets,
-        HandleMoveSwitching,
-        HandleInputChooseMove,
-    };
-
-    for (funcIndex = 0; funcIndex < ARRAY_COUNT(showTypesControllerFuncs); funcIndex++)
-        if (gBattlerControllerFuncs[battlerId] == showTypesControllerFuncs[funcIndex])
+    for (funcIndex = 0; funcIndex < ARRAY_COUNT(sShowTypesControllerFuncs); funcIndex++)
+        if (gBattlerControllerFuncs[battlerId] == sShowTypesControllerFuncs[funcIndex])
             return FALSE;
 
     return TRUE;

--- a/src/type_icons.c
+++ b/src/type_icons.c
@@ -473,15 +473,22 @@ static void FreeAllTypeIconResources(void)
 
 static bool32 ShouldHideTypeIcon(u32 battlerId)
 {
-	bool32 test = (gBattlerControllerFuncs[battlerId] != PlayerHandleChooseMove
-        && gBattlerControllerFuncs[battlerId] != HandleChooseMoveAfterDma3
-        && gBattlerControllerFuncs[battlerId] != HandleInputChooseTarget
-        && gBattlerControllerFuncs[battlerId] != HandleInputShowTargets
-        && gBattlerControllerFuncs[battlerId] != HandleInputShowEntireFieldTargets
-        && gBattlerControllerFuncs[battlerId] != HandleMoveSwitching
-        && gBattlerControllerFuncs[battlerId] != HandleInputChooseMove);
-	DebugPrintf("test is %d",test);
-	return test;
+	if (gBattlerControllerFuncs[battlerId] == PlayerHandleChooseMove)
+		return FALSE;
+	if (gBattlerControllerFuncs[battlerId] == HandleChooseMoveAfterDma3)
+		return FALSE;
+	if (gBattlerControllerFuncs[battlerId] == HandleInputChooseTarget)
+		return FALSE;
+	if (gBattlerControllerFuncs[battlerId] == HandleInputShowTargets)
+		return FALSE;
+	if (gBattlerControllerFuncs[battlerId] == HandleInputShowEntireFieldTargets)
+		return FALSE;
+	if (gBattlerControllerFuncs[battlerId] == HandleMoveSwitching)
+		return FALSE;
+	if (gBattlerControllerFuncs[battlerId] == HandleInputChooseMove)
+		return FALSE;
+
+	return TRUE;
 }
 
 static s32 GetTypeIconHideMovement(bool32 useDoubleBattleCoords, u32 position)

--- a/src/type_icons.c
+++ b/src/type_icons.c
@@ -473,20 +473,22 @@ static void FreeAllTypeIconResources(void)
 
 static bool32 ShouldHideTypeIcon(u32 battlerId)
 {
-	if (gBattlerControllerFuncs[battlerId] == PlayerHandleChooseMove)
-		return FALSE;
-	if (gBattlerControllerFuncs[battlerId] == HandleChooseMoveAfterDma3)
-		return FALSE;
-	if (gBattlerControllerFuncs[battlerId] == HandleInputChooseTarget)
-		return FALSE;
-	if (gBattlerControllerFuncs[battlerId] == HandleInputShowTargets)
-		return FALSE;
-	if (gBattlerControllerFuncs[battlerId] == HandleInputShowEntireFieldTargets)
-		return FALSE;
-	if (gBattlerControllerFuncs[battlerId] == HandleMoveSwitching)
-		return FALSE;
-	if (gBattlerControllerFuncs[battlerId] == HandleInputChooseMove)
-		return FALSE;
+	u32 funcIndex;
+
+	void* showTypesControllerFuncs[] =
+	{
+		PlayerHandleChooseMove,
+		HandleChooseMoveAfterDma3,
+		HandleInputChooseTarget,
+		HandleInputShowTargets,
+		HandleInputShowEntireFieldTargets,
+		HandleMoveSwitching,
+		HandleInputChooseMove,
+	};
+
+	for (funcIndex = 0; funcIndex < ARRAY_COUNT(showTypesControllerFuncs); funcIndex++)
+		if (gBattlerControllerFuncs[battlerId] == showTypesControllerFuncs[funcIndex])
+			return FALSE;
 
 	return TRUE;
 }

--- a/src/type_icons.c
+++ b/src/type_icons.c
@@ -473,24 +473,24 @@ static void FreeAllTypeIconResources(void)
 
 static bool32 ShouldHideTypeIcon(u32 battlerId)
 {
-	u32 funcIndex;
+    u32 funcIndex;
 
-	void* showTypesControllerFuncs[] =
-	{
-		PlayerHandleChooseMove,
-		HandleChooseMoveAfterDma3,
-		HandleInputChooseTarget,
-		HandleInputShowTargets,
-		HandleInputShowEntireFieldTargets,
-		HandleMoveSwitching,
-		HandleInputChooseMove,
-	};
+    void* showTypesControllerFuncs[] =
+    {
+        PlayerHandleChooseMove,
+        HandleChooseMoveAfterDma3,
+        HandleInputChooseTarget,
+        HandleInputShowTargets,
+        HandleInputShowEntireFieldTargets,
+        HandleMoveSwitching,
+        HandleInputChooseMove,
+    };
 
-	for (funcIndex = 0; funcIndex < ARRAY_COUNT(showTypesControllerFuncs); funcIndex++)
-		if (gBattlerControllerFuncs[battlerId] == showTypesControllerFuncs[funcIndex])
-			return FALSE;
+    for (funcIndex = 0; funcIndex < ARRAY_COUNT(showTypesControllerFuncs); funcIndex++)
+        if (gBattlerControllerFuncs[battlerId] == showTypesControllerFuncs[funcIndex])
+            return FALSE;
 
-	return TRUE;
+    return TRUE;
 }
 
 static s32 GetTypeIconHideMovement(bool32 useDoubleBattleCoords, u32 position)

--- a/src/type_icons.c
+++ b/src/type_icons.c
@@ -473,13 +473,15 @@ static void FreeAllTypeIconResources(void)
 
 static bool32 ShouldHideTypeIcon(u32 battlerId)
 {
-    return gBattlerControllerFuncs[battlerId] != PlayerHandleChooseMove
-        && gBattlerControllerFuncs[battlerId] != HandleInputChooseMove
+	bool32 test = (gBattlerControllerFuncs[battlerId] != PlayerHandleChooseMove
         && gBattlerControllerFuncs[battlerId] != HandleChooseMoveAfterDma3
-        && gBattlerControllerFuncs[battlerId] != HandleInputChooseMove
         && gBattlerControllerFuncs[battlerId] != HandleInputChooseTarget
+        && gBattlerControllerFuncs[battlerId] != HandleInputShowTargets
+        && gBattlerControllerFuncs[battlerId] != HandleInputShowEntireFieldTargets
         && gBattlerControllerFuncs[battlerId] != HandleMoveSwitching
-        && gBattlerControllerFuncs[battlerId] != HandleInputChooseMove;
+        && gBattlerControllerFuncs[battlerId] != HandleInputChooseMove);
+	DebugPrintf("test is %d",test);
+	return test;
 }
 
 static s32 GetTypeIconHideMovement(bool32 useDoubleBattleCoords, u32 position)


### PR DESCRIPTION
## Description
Improved `ShouldHideTypeIcon` to fix https://github.com/rh-hideout/pokeemerald-expansion/pull/5200.
## Testing
```diff
Debug_EventScript_Script_1::
+	setflag FLAG_BADGE01_GET
+	setflag FLAG_BADGE02_GET
+	setflag FLAG_BADGE03_GET
+	setflag FLAG_BADGE04_GET
+	setflag FLAG_BADGE05_GET
+	setflag FLAG_BADGE06_GET
+	setflag FLAG_BADGE07_GET
+	setflag FLAG_BADGE08_GET
+	givemon SPECIES_TEDDIURSA, 100,0,move1=MOVE_EARTHQUAKE, move2=MOVE_WICKED_BLOW
+	givemon SPECIES_WATTREL,100,0,move1=MOVE_CELEBRATE, move2=MOVE_THUNDERBOLT
+	setwildbattle SPECIES_ELECTABUZZ,50,0,SPECIES_MAGMAR,50,0
+	dowildbattle
    release
    end
```
## Video

https://github.com/user-attachments/assets/ed92c2b0-d54f-4f97-b9bb-fb2539eac8ff

## Issue(s) that this PR fixes
https://github.com/rh-hideout/pokeemerald-expansion/pull/5200

## **People who collaborated with me in this PR**
@iriv24

## **Discord contact info**
I am pkmnsnfrn and there is a [discussion thread](https://discord.com/channels/419213663107416084/1267947673936330783).