### PR TITLE
Adds missing Wind Rider activation and tests

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4766,6 +4766,18 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
                 effect++;
             }
             break;
+        case ABILITY_WIND_RIDER:
+            if (!gSpecialStatuses[battler].switchInAbilityDone && CompareStat(battler, STAT_ATK, MAX_STAT_STAGE, CMP_LESS_THAN)
+            && gSideStatuses[GetBattlerSide(battler)] & SIDE_STATUS_TAILWIND)
+            {
+                gBattleScripting.savedBattler = gBattlerAttacker;
+                gBattlerAttacker = battler;
+                gSpecialStatuses[battler].switchInAbilityDone = TRUE;
+                SET_STATCHANGER(STAT_ATK, 1, FALSE);
+                BattleScriptPushCursorAndCallback(BattleScript_BattlerAbilityStatRaiseOnSwitchIn);
+                effect++;
+            }
+            break;
         case ABILITY_DESOLATE_LAND:
             if (TryChangeBattleWeather(battler, ENUM_WEATHER_SUN_PRIMAL, TRUE))
             {

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4767,8 +4767,9 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
             }
             break;
         case ABILITY_WIND_RIDER:
-            if (!gSpecialStatuses[battler].switchInAbilityDone && CompareStat(battler, STAT_ATK, MAX_STAT_STAGE, CMP_LESS_THAN)
-            && gSideStatuses[GetBattlerSide(battler)] & SIDE_STATUS_TAILWIND)
+            if (!gSpecialStatuses[battler].switchInAbilityDone 
+             && CompareStat(battler, STAT_ATK, MAX_STAT_STAGE, CMP_LESS_THAN)
+             && gSideStatuses[GetBattlerSide(battler)] & SIDE_STATUS_TAILWIND)
             {
                 gBattleScripting.savedBattler = gBattlerAttacker;
                 gBattlerAttacker = battler;

--- a/test/battle/ability/wind_rider.c
+++ b/test/battle/ability/wind_rider.c
@@ -1,0 +1,104 @@
+#include "global.h"
+#include "test/battle.h"
+
+ASSUMPTIONS
+{
+    ASSUME(gMovesInfo[MOVE_TAILWIND].effect == EFFECT_TAILWIND);
+    ASSUME(gMovesInfo[MOVE_TAILWIND].windMove == TRUE);
+}
+
+SINGLE_BATTLE_TEST("Wind Rider raises Attack by one stage if it sets up Tailwind")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_BRAMBLIN) { Ability(ABILITY_WIND_RIDER); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_TAILWIND); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TAILWIND, opponent);
+        ABILITY_POPUP(opponent, ABILITY_WIND_RIDER);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
+        MESSAGE("Foe Bramblin's Attack rose!");
+    } THEN {
+        EXPECT_EQ(opponent->statStages[STAT_ATK], DEFAULT_STAT_STAGE + 1);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Wind Rider raises Attack by one stage if Tailwind is setup by its partner")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_BRAMBLIN) { Ability(ABILITY_WIND_RIDER); }
+    } WHEN {
+        TURN { MOVE(opponentLeft, MOVE_TAILWIND); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TAILWIND, opponentLeft);
+        ABILITY_POPUP(opponentRight, ABILITY_WIND_RIDER);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);
+        MESSAGE("Foe Bramblin's Attack rose!");
+    } THEN {
+        EXPECT_EQ(opponentRight->statStages[STAT_ATK], DEFAULT_STAT_STAGE + 1);
+    }
+}
+
+SINGLE_BATTLE_TEST("Wind Rider raises Attack by one stage if switched into Tailwind on its side of the field")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_BRAMBLIN) { Ability(ABILITY_WIND_RIDER); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_TAILWIND); }
+        TURN { SWITCH(opponent, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TAILWIND, opponent);
+        ABILITY_POPUP(opponent, ABILITY_WIND_RIDER);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
+        MESSAGE("Foe Bramblin's Wind Rider raised its Attack!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
+    } THEN {
+        EXPECT_EQ(opponent->statStages[STAT_ATK], DEFAULT_STAT_STAGE + 1);
+    }
+}
+
+SINGLE_BATTLE_TEST("Wind Rider activates when it's no longer effected by Neutralizing Gas")
+{
+    GIVEN {
+        PLAYER(SPECIES_WEEZING) { Ability(ABILITY_NEUTRALIZING_GAS); }
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_BRAMBLIN) { Ability(ABILITY_WIND_RIDER); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_TAILWIND); }
+        TURN { SWITCH(player, 1); }
+    } SCENE {
+        ABILITY_POPUP(player, ABILITY_NEUTRALIZING_GAS);
+        MESSAGE("Neutralizing Gas filled the area!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TAILWIND, opponent);
+        SWITCH_OUT_MESSAGE("Weezing");
+        MESSAGE("The effects of Neutralizing Gas wore off!");
+        ABILITY_POPUP(opponent, ABILITY_WIND_RIDER);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
+        MESSAGE("Foe Bramblin's Wind Rider raised its Attack!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Wind Rider absorbs Wind moves and raises Attack by one stage")
+{
+    ASSUME(gMovesInfo[MOVE_GUST].windMove == TRUE);
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_BRAMBLIN) { Ability(ABILITY_WIND_RIDER); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_GUST); }
+    } SCENE {
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_GUST, player);
+            HP_BAR(opponent);
+        }
+        ABILITY_POPUP(opponent, ABILITY_WIND_RIDER);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
+        MESSAGE("Foe Bramblin's Attack rose!");
+    }
+}

--- a/test/battle/ability/wind_rider.c
+++ b/test/battle/ability/wind_rider.c
@@ -43,6 +43,25 @@ DOUBLE_BATTLE_TEST("Wind Rider raises Attack by one stage if Tailwind is setup b
     }
 }
 
+SINGLE_BATTLE_TEST("Wind Rider doesn't raise Attack if opponent sets up Tailwind")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_BRAMBLIN) { Ability(ABILITY_WIND_RIDER); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_TAILWIND); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TAILWIND, player);
+        NONE_OF {
+            ABILITY_POPUP(opponent, ABILITY_WIND_RIDER);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
+            MESSAGE("Foe Bramblin's Attack rose!");
+        }
+    } THEN {
+        EXPECT_EQ(opponent->statStages[STAT_ATK], DEFAULT_STAT_STAGE);
+    }
+}
+
 SINGLE_BATTLE_TEST("Wind Rider raises Attack by one stage if switched into Tailwind on its side of the field")
 {
     GIVEN {
@@ -81,6 +100,8 @@ SINGLE_BATTLE_TEST("Wind Rider activates when it's no longer effected by Neutral
         ABILITY_POPUP(opponent, ABILITY_WIND_RIDER);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
         MESSAGE("Foe Bramblin's Wind Rider raised its Attack!");
+    } THEN {
+        EXPECT_EQ(opponent->statStages[STAT_ATK], DEFAULT_STAT_STAGE + 1);
     }
 }
 
@@ -100,5 +121,7 @@ SINGLE_BATTLE_TEST("Wind Rider absorbs Wind moves and raises Attack by one stage
         ABILITY_POPUP(opponent, ABILITY_WIND_RIDER);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
         MESSAGE("Foe Bramblin's Attack rose!");
+    } THEN {
+        EXPECT_EQ(opponent->statStages[STAT_ATK], DEFAULT_STAT_STAGE + 1);
     }
 }


### PR DESCRIPTION
Adds a missing activation of Wind Rider (when switched in while Tailwind is active on the user's side of the field).

> When Tailwind takes effect on its side **or when the Pokémon with Wind Rider is sent into battle while Tailwind is in effect on its side, its Attack is increased by one stage in addition to receiving the speed boosting effect of Tailwind.**

Also adds tests for Wind Rider.

## **Discord contact info**
PhallenTree