### PR TITLE
Fix Starting Status being used on Wild Battles

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3755,7 +3755,7 @@ static void DoBattleIntro(void)
                 gBattleStruct->startingStatus = GetTrainerStartingStatusFromId(gTrainerBattleOpponent_B);
                 gBattleStruct->startingStatusTimer = 0; // infinite
             }
-            else if (GetTrainerStartingStatusFromId(gTrainerBattleOpponent_A))
+            else if (gBattleTypeFlags & BATTLE_TYPE_TRAINER && GetTrainerStartingStatusFromId(gTrainerBattleOpponent_A))
             {
                 gBattleStruct->startingStatus = GetTrainerStartingStatusFromId(gTrainerBattleOpponent_A);
                 gBattleStruct->startingStatusTimer = 0; // infinite


### PR DESCRIPTION
Fixes Wild Battles using the last trainer fought's Starting Status.

Current interaction:

https://github.com/user-attachments/assets/e693dc0a-e309-47ac-87af-c2bcf9d8b2d1

Fixed interaction:

https://github.com/user-attachments/assets/165f5da7-2497-4156-bc49-2de1176d7033

## **Discord contact info**
PhallenTree