### PR TITLE
Disguise tests

### DIFF
--- a/test/battle/ability/disguise.c
+++ b/test/battle/ability/disguise.c
@@ -134,3 +134,17 @@ SINGLE_BATTLE_TEST("Disguised Mimikyu is ignored by Mold Breaker")
         NOT ABILITY_POPUP(player, ABILITY_DISGUISE);
     }
 }
+
+SINGLE_BATTLE_TEST("Disguised Mimikyu's types revert back to Ghost/Fairy when Disguise is broken")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_SHADOW_CLAW].type == TYPE_GHOST);
+        PLAYER(SPECIES_MIMIKYU_DISGUISED) { Ability(ABILITY_DISGUISE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SOAK); }
+        TURN { MOVE(opponent, MOVE_TACKLE); }
+        TURN { MOVE(opponent, MOVE_SHADOW_CLAW); }
+    } SCENE {
+    }
+}

--- a/test/battle/ability/disguise.c
+++ b/test/battle/ability/disguise.c
@@ -146,5 +146,30 @@ SINGLE_BATTLE_TEST("Disguised Mimikyu's types revert back to Ghost/Fairy when Di
         TURN { MOVE(opponent, MOVE_TACKLE); }
         TURN { MOVE(opponent, MOVE_SHADOW_CLAW); }
     } SCENE {
+        MESSAGE("Foe Wobbuffet used Soak!");
+        MESSAGE("Mimikyu transformed into the Water type!");
+        MESSAGE("Foe Wobbuffet used Tackle!");
+        ABILITY_POPUP(player, ABILITY_DISGUISE);
+        MESSAGE("Foe Wobbuffet used Shadow Claw!");
+        MESSAGE("It's super effective!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Disguised Mimikyu blocks a move after getting Gastro Acid Batton Passed")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_BATON_PASS].effect == EFFECT_BATON_PASS);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_MIMIKYU_DISGUISED) { Ability(ABILITY_DISGUISE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_GASTRO_ACID); MOVE(player, MOVE_BATON_PASS); SEND_OUT(player, 1); }
+        TURN { MOVE(opponent, MOVE_SHADOW_CLAW); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_GASTRO_ACID, opponent);
+        MESSAGE("Wobbuffet's ability was suppressed!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BATON_PASS, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SHADOW_CLAW, opponent);
+        ABILITY_POPUP(player, ABILITY_DISGUISE);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds the missing tests for the old Disguise issue.

- Type Change: If Mimikyu's type had been changed beforehand, it is restored to Ghost/Fairy when it changes to its Busted Form.
- Baton Pass: If a Pokémon that has its Ability suppressed passes that effect to a Pokémon with this Ability via Baton Pass, that effect fades.

## **Discord contact info**
<!--- formatted as name#numbers, e.g. Lunos#4026 -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara