### PR TITLE
remove unused bs signature

### DIFF
--- a/include/battle_scripts.h
+++ b/include/battle_scripts.h
@@ -469,7 +469,6 @@ extern const u8 BattleScript_AngerShellActivates[];
 extern const u8 BattleScript_WellBakedBodyActivates[];
 extern const u8 BattleScript_WindRiderActivatesMoveEnd[];
 extern const u8 BattleScript_WindPowerActivates[];
-extern const u8 BattleScript_WindPowerActivatesEnd2[];
 extern const u8 BattleScript_ProtosynthesisActivates[];
 extern const u8 BattleScript_QuarkDriveActivates[];
 extern const u8 BattleScript_GoodAsGoldActivates[];


### PR DESCRIPTION
removes an unused battlescript signature. the battlescript doesnt exist and is not referenced anywhere.
likely leftover from initial implementation. 

<!--- formatted as name#numbers, e.g. Lunos#4026 -->
u8-Salem