### PR TITLE
Fixed swapped frostbite and freeze descriptions for Ice Fang

### DIFF
--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -10596,9 +10596,9 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .description = COMPOUND_STRING(
             "May cause flinching or\n"
         #if B_USE_FROSTBITE == TRUE
-            "leave the foe frozen."),
-        #else
             "leave the foe with frostbite."),
+        #else
+            "leave the foe frozen."),
         #endif
         .effect = EFFECT_HIT,
         .power = 65,


### PR DESCRIPTION
The descriptions for frostbite and freeze for Ice Fang were in the wrong order.
As far as I could see Ice Fang was the only mix up for freeze/ frostbite move descriptions.

## Description
The descriptions for frostbite and freeze for Ice Fang were in the wrong order, I swapped them to the correct order.

## **Discord contact info**
laserxdolphin
