### PR TITLE
Fix Slateport Battle Tent/Battle Factory

### DIFF
--- a/include/frontier_util.h
+++ b/include/frontier_util.h
@@ -24,5 +24,6 @@ u16 GetFrontierBrainMonMove(u8 monId, u8 moveSlotId);
 u8 GetFrontierBrainMonNature(u8 monId);
 u8 GetFrontierBrainMonEvs(u8 monId, u8 evStatId);
 s32 GetFronterBrainSymbol(void);
+void ClearEnemyPartyAfterChallenge(void);
 
 #endif // GUARD_FRONTIER_UTIL_H

--- a/src/battle_arena.c
+++ b/src/battle_arena.c
@@ -529,6 +529,13 @@ static void SetArenaData(void)
 
 static void SaveArenaChallenge(void)
 {
+    // We zero out the Enemy's party here when the player either wins or loses the challenge since we
+    // can't do it the usual way in FreeResetData_ReturnToOvOrDoEvolutions() in battle_main.c due to the
+    // way facilities like the Battle Factory and the Slateport Battle Tent work
+    if (gSpecialVar_0x8005 == 0)
+    {
+        ZeroEnemyPartyMons();
+    }
     gSaveBlock2Ptr->frontier.challengeStatus = gSpecialVar_0x8005;
     VarSet(VAR_TEMP_CHALLENGE_STATUS, 0);
     gSaveBlock2Ptr->frontier.challengePaused = TRUE;

--- a/src/battle_arena.c
+++ b/src/battle_arena.c
@@ -529,13 +529,7 @@ static void SetArenaData(void)
 
 static void SaveArenaChallenge(void)
 {
-    // We zero out the Enemy's party here when the player either wins or loses the challenge since we
-    // can't do it the usual way in FreeResetData_ReturnToOvOrDoEvolutions() in battle_main.c due to the
-    // way facilities like the Battle Factory and the Slateport Battle Tent work
-    if (gSpecialVar_0x8005 == 0)
-    {
-        ZeroEnemyPartyMons();
-    }
+    ClearEnemyPartyAfterChallenge();
     gSaveBlock2Ptr->frontier.challengeStatus = gSpecialVar_0x8005;
     VarSet(VAR_TEMP_CHALLENGE_STATUS, 0);
     gSaveBlock2Ptr->frontier.challengePaused = TRUE;

--- a/src/battle_dome.c
+++ b/src/battle_dome.c
@@ -2593,6 +2593,13 @@ static void SetDomeOpponentGraphicsId(void)
 
 static void SaveDomeChallenge(void)
 {
+    // We zero out the Enemy's party here when the player either wins or loses the challenge since we
+    // can't do it the usual way in FreeResetData_ReturnToOvOrDoEvolutions() in battle_main.c due to the
+    // way facilities like the Battle Factory and the Slateport Battle Tent work
+    if (gSpecialVar_0x8005 == 0)
+    {
+        ZeroEnemyPartyMons();
+    }
     gSaveBlock2Ptr->frontier.challengeStatus = gSpecialVar_0x8005;
     VarSet(VAR_TEMP_CHALLENGE_STATUS, 0);
     gSaveBlock2Ptr->frontier.challengePaused = TRUE;

--- a/src/battle_dome.c
+++ b/src/battle_dome.c
@@ -2593,13 +2593,7 @@ static void SetDomeOpponentGraphicsId(void)
 
 static void SaveDomeChallenge(void)
 {
-    // We zero out the Enemy's party here when the player either wins or loses the challenge since we
-    // can't do it the usual way in FreeResetData_ReturnToOvOrDoEvolutions() in battle_main.c due to the
-    // way facilities like the Battle Factory and the Slateport Battle Tent work
-    if (gSpecialVar_0x8005 == 0)
-    {
-        ZeroEnemyPartyMons();
-    }
+    ClearEnemyPartyAfterChallenge();
     gSaveBlock2Ptr->frontier.challengeStatus = gSpecialVar_0x8005;
     VarSet(VAR_TEMP_CHALLENGE_STATUS, 0);
     gSaveBlock2Ptr->frontier.challengePaused = TRUE;

--- a/src/battle_factory.c
+++ b/src/battle_factory.c
@@ -437,9 +437,6 @@ static void SetPlayerAndOpponentParties(void)
             ivs = gSaveBlock2Ptr->frontier.rentalMons[i].ivs;
 
             CreateFacilityMon(&gFacilityTrainerMons[monId], monLevel, ivs, OT_ID_PLAYER_ID, FLAG_FRONTIER_MON_FACTORY, &gPlayerParty[i]);
-            SetMonData(&gPlayerParty[i], MON_DATA_PERSONALITY,
-                    &gSaveBlock2Ptr->frontier.rentalMons[i].personality);
-            CalculateMonStats(&gPlayerParty[i]);
         }
     }
 
@@ -451,12 +448,7 @@ static void SetPlayerAndOpponentParties(void)
         {
             monId = gSaveBlock2Ptr->frontier.rentalMons[i + FRONTIER_PARTY_SIZE].monId;
             ivs = gSaveBlock2Ptr->frontier.rentalMons[i + FRONTIER_PARTY_SIZE].ivs;
-            CreateFacilityMon(&gFacilityTrainerMons[monId],
-                    monLevel, ivs, OT_ID_PLAYER_ID, FLAG_FRONTIER_MON_FACTORY,
-                    &gEnemyParty[i]);
-            SetMonData(&gPlayerParty[i], MON_DATA_PERSONALITY,
-                    &gSaveBlock2Ptr->frontier.rentalMons[i + FRONTIER_PARTY_SIZE].personality);
-            CalculateMonStats(&gPlayerParty[i]);
+            CreateFacilityMon(&gFacilityTrainerMons[monId], monLevel, ivs, OT_ID_PLAYER_ID, FLAG_FRONTIER_MON_FACTORY, &gEnemyParty[i]);
         }
         break;
     }

--- a/src/battle_factory.c
+++ b/src/battle_factory.c
@@ -268,13 +268,7 @@ static void SetBattleFactoryData(void)
 
 static void SaveFactoryChallenge(void)
 {
-    // We zero out the Enemy's party here when the player either wins or loses the challenge since we
-    // can't do it the usual way in FreeResetData_ReturnToOvOrDoEvolutions() in battle_main.c due to the
-    // way facilities like the Battle Factory and the Slateport Battle Tent work
-    if (gSpecialVar_0x8005 == 0)
-    {
-        ZeroEnemyPartyMons();
-    }
+    ClearEnemyPartyAfterChallenge();
     gSaveBlock2Ptr->frontier.challengeStatus = gSpecialVar_0x8005;
     VarSet(VAR_TEMP_CHALLENGE_STATUS, 0);
     gSaveBlock2Ptr->frontier.challengePaused = TRUE;

--- a/src/battle_factory.c
+++ b/src/battle_factory.c
@@ -268,6 +268,13 @@ static void SetBattleFactoryData(void)
 
 static void SaveFactoryChallenge(void)
 {
+    // We zero out the Enemy's party here when the player either wins or loses the challenge since we
+    // can't do it the usual way in FreeResetData_ReturnToOvOrDoEvolutions() in battle_main.c due to the
+    // way facilities like the Battle Factory and the Slateport Battle Tent work
+    if (gSpecialVar_0x8005 == 0)
+    {
+        ZeroEnemyPartyMons();
+    }
     gSaveBlock2Ptr->frontier.challengeStatus = gSpecialVar_0x8005;
     VarSet(VAR_TEMP_CHALLENGE_STATUS, 0);
     gSaveBlock2Ptr->frontier.challengePaused = TRUE;

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -5624,9 +5624,14 @@ static void FreeResetData_ReturnToOvOrDoEvolutions(void)
     }
 
     FreeAllWindowBuffers();
-    if (gBattleStruct != NULL && !(gBattleTypeFlags & BATTLE_TYPE_LINK))
+    if (!(gBattleTypeFlags & BATTLE_TYPE_LINK))
     {
-        ZeroEnemyPartyMons();
+        // To account for Battle Factory and Slateport Battle Tent, enemy parties are zeroed out in the facilitites respective src/xxx.c files
+        // The ZeroEnemyPartyMons() call happens in SaveXXXChallenge function (eg. SaveFactoryChallenge)
+        if (!(gBattleTypeFlags & BATTLE_TYPE_FRONTIER))
+        {
+            ZeroEnemyPartyMons();
+        }
         ResetDynamicAiFunc();
         FreeMonSpritesGfx();
         FreeBattleResources();

--- a/src/battle_palace.c
+++ b/src/battle_palace.c
@@ -180,13 +180,7 @@ static void IncrementPalaceStreak(void)
 
 static void SavePalaceChallenge(void)
 {
-    // We zero out the Enemy's party here when the player either wins or loses the challenge since we
-    // can't do it the usual way in FreeResetData_ReturnToOvOrDoEvolutions() in battle_main.c due to the
-    // way facilities like the Battle Factory and the Slateport Battle Tent work
-    if (gSpecialVar_0x8005 == 0)
-    {
-        ZeroEnemyPartyMons();
-    }
+    ClearEnemyPartyAfterChallenge();
     gSaveBlock2Ptr->frontier.challengeStatus = gSpecialVar_0x8005;
     VarSet(VAR_TEMP_CHALLENGE_STATUS, 0);
     gSaveBlock2Ptr->frontier.challengePaused = TRUE;

--- a/src/battle_palace.c
+++ b/src/battle_palace.c
@@ -180,6 +180,13 @@ static void IncrementPalaceStreak(void)
 
 static void SavePalaceChallenge(void)
 {
+    // We zero out the Enemy's party here when the player either wins or loses the challenge since we
+    // can't do it the usual way in FreeResetData_ReturnToOvOrDoEvolutions() in battle_main.c due to the
+    // way facilities like the Battle Factory and the Slateport Battle Tent work
+    if (gSpecialVar_0x8005 == 0)
+    {
+        ZeroEnemyPartyMons();
+    }
     gSaveBlock2Ptr->frontier.challengeStatus = gSpecialVar_0x8005;
     VarSet(VAR_TEMP_CHALLENGE_STATUS, 0);
     gSaveBlock2Ptr->frontier.challengePaused = TRUE;

--- a/src/battle_pike.c
+++ b/src/battle_pike.c
@@ -707,13 +707,7 @@ static void ClearInWildMonRoom(void)
 
 static void SavePikeChallenge(void)
 {
-    // We zero out the Enemy's party here when the player either wins or loses the challenge since we
-    // can't do it the usual way in FreeResetData_ReturnToOvOrDoEvolutions() in battle_main.c due to the
-    // way facilities like the Battle Factory and the Slateport Battle Tent work
-    if (gSpecialVar_0x8005 == 0)
-    {
-        ZeroEnemyPartyMons();
-    }
+    ClearEnemyPartyAfterChallenge();
     gSaveBlock2Ptr->frontier.challengeStatus = gSpecialVar_0x8005;
     VarSet(VAR_TEMP_CHALLENGE_STATUS, 0);
     gSaveBlock2Ptr->frontier.challengePaused = TRUE;

--- a/src/battle_pike.c
+++ b/src/battle_pike.c
@@ -707,6 +707,13 @@ static void ClearInWildMonRoom(void)
 
 static void SavePikeChallenge(void)
 {
+    // We zero out the Enemy's party here when the player either wins or loses the challenge since we
+    // can't do it the usual way in FreeResetData_ReturnToOvOrDoEvolutions() in battle_main.c due to the
+    // way facilities like the Battle Factory and the Slateport Battle Tent work
+    if (gSpecialVar_0x8005 == 0)
+    {
+        ZeroEnemyPartyMons();
+    }
     gSaveBlock2Ptr->frontier.challengeStatus = gSpecialVar_0x8005;
     VarSet(VAR_TEMP_CHALLENGE_STATUS, 0);
     gSaveBlock2Ptr->frontier.challengePaused = TRUE;

--- a/src/battle_pyramid.c
+++ b/src/battle_pyramid.c
@@ -936,6 +936,13 @@ static void SetBattlePyramidData(void)
 
 static void SavePyramidChallenge(void)
 {
+    // We zero out the Enemy's party here when the player either wins or loses the challenge since we
+    // can't do it the usual way in FreeResetData_ReturnToOvOrDoEvolutions() in battle_main.c due to the
+    // way facilities like the Battle Factory and the Slateport Battle Tent work
+    if (gSpecialVar_0x8005 == 0)
+    {
+        ZeroEnemyPartyMons();
+    }
     gSaveBlock2Ptr->frontier.challengeStatus = gSpecialVar_0x8005;
     VarSet(VAR_TEMP_CHALLENGE_STATUS, 0);
     gSaveBlock2Ptr->frontier.challengePaused = TRUE;

--- a/src/battle_pyramid.c
+++ b/src/battle_pyramid.c
@@ -2,6 +2,7 @@
 #include "battle_pyramid.h"
 #include "battle_pyramid_bag.h"
 #include "event_data.h"
+#include "frontier_util.h"
 #include "battle.h"
 #include "battle_setup.h"
 #include "battle_tower.h"
@@ -936,13 +937,7 @@ static void SetBattlePyramidData(void)
 
 static void SavePyramidChallenge(void)
 {
-    // We zero out the Enemy's party here when the player either wins or loses the challenge since we
-    // can't do it the usual way in FreeResetData_ReturnToOvOrDoEvolutions() in battle_main.c due to the
-    // way facilities like the Battle Factory and the Slateport Battle Tent work
-    if (gSpecialVar_0x8005 == 0)
-    {
-        ZeroEnemyPartyMons();
-    }
+    ClearEnemyPartyAfterChallenge();
     gSaveBlock2Ptr->frontier.challengeStatus = gSpecialVar_0x8005;
     VarSet(VAR_TEMP_CHALLENGE_STATUS, 0);
     gSaveBlock2Ptr->frontier.challengePaused = TRUE;

--- a/src/battle_tent.c
+++ b/src/battle_tent.c
@@ -139,6 +139,13 @@ static void BufferVerdanturfTentTrainerIntro(void)
 
 static void SaveVerdanturfTentChallenge(void)
 {
+    // We zero out the Enemy's party here when the player either wins or loses the challenge since we
+    // can't do it the usual way in FreeResetData_ReturnToOvOrDoEvolutions() in battle_main.c due to the
+    // way facilities like the Battle Factory and the Slateport Battle Tent work
+    if (gSpecialVar_0x8005 == 0)
+    {
+        ZeroEnemyPartyMons();
+    }
     gSaveBlock2Ptr->frontier.challengeStatus = gSpecialVar_0x8005;
     VarSet(VAR_TEMP_CHALLENGE_STATUS, 0);
     gSaveBlock2Ptr->frontier.challengePaused = TRUE;
@@ -189,6 +196,13 @@ static void SetFallarborTentPrize(void)
 
 static void SaveFallarborTentChallenge(void)
 {
+    // We zero out the Enemy's party here when the player either wins or loses the challenge since we
+    // can't do it the usual way in FreeResetData_ReturnToOvOrDoEvolutions() in battle_main.c due to the
+    // way facilities like the Battle Factory and the Slateport Battle Tent work
+    if (gSpecialVar_0x8005 == 0)
+    {
+        ZeroEnemyPartyMons();
+    }
     gSaveBlock2Ptr->frontier.challengeStatus = gSpecialVar_0x8005;
     VarSet(VAR_TEMP_CHALLENGE_STATUS, 0);
     gSaveBlock2Ptr->frontier.challengePaused = TRUE;
@@ -244,6 +258,13 @@ static void SetSlateportTentPrize(void)
 
 static void SaveSlateportTentChallenge(void)
 {
+    // We zero out the Enemy's party here when the player either wins or loses the challenge since we
+    // can't do it the usual way in FreeResetData_ReturnToOvOrDoEvolutions() in battle_main.c due to the
+    // way facilities like the Battle Factory and the Slateport Battle Tent work
+    if (gSpecialVar_0x8005 == 0)
+    {
+        ZeroEnemyPartyMons();
+    }
     gSaveBlock2Ptr->frontier.challengeStatus = gSpecialVar_0x8005;
     VarSet(VAR_TEMP_CHALLENGE_STATUS, 0);
     gSaveBlock2Ptr->frontier.challengePaused = TRUE;

--- a/src/battle_tent.c
+++ b/src/battle_tent.c
@@ -139,13 +139,7 @@ static void BufferVerdanturfTentTrainerIntro(void)
 
 static void SaveVerdanturfTentChallenge(void)
 {
-    // We zero out the Enemy's party here when the player either wins or loses the challenge since we
-    // can't do it the usual way in FreeResetData_ReturnToOvOrDoEvolutions() in battle_main.c due to the
-    // way facilities like the Battle Factory and the Slateport Battle Tent work
-    if (gSpecialVar_0x8005 == 0)
-    {
-        ZeroEnemyPartyMons();
-    }
+    ClearEnemyPartyAfterChallenge();
     gSaveBlock2Ptr->frontier.challengeStatus = gSpecialVar_0x8005;
     VarSet(VAR_TEMP_CHALLENGE_STATUS, 0);
     gSaveBlock2Ptr->frontier.challengePaused = TRUE;
@@ -196,13 +190,7 @@ static void SetFallarborTentPrize(void)
 
 static void SaveFallarborTentChallenge(void)
 {
-    // We zero out the Enemy's party here when the player either wins or loses the challenge since we
-    // can't do it the usual way in FreeResetData_ReturnToOvOrDoEvolutions() in battle_main.c due to the
-    // way facilities like the Battle Factory and the Slateport Battle Tent work
-    if (gSpecialVar_0x8005 == 0)
-    {
-        ZeroEnemyPartyMons();
-    }
+    ClearEnemyPartyAfterChallenge();
     gSaveBlock2Ptr->frontier.challengeStatus = gSpecialVar_0x8005;
     VarSet(VAR_TEMP_CHALLENGE_STATUS, 0);
     gSaveBlock2Ptr->frontier.challengePaused = TRUE;
@@ -258,13 +246,7 @@ static void SetSlateportTentPrize(void)
 
 static void SaveSlateportTentChallenge(void)
 {
-    // We zero out the Enemy's party here when the player either wins or loses the challenge since we
-    // can't do it the usual way in FreeResetData_ReturnToOvOrDoEvolutions() in battle_main.c due to the
-    // way facilities like the Battle Factory and the Slateport Battle Tent work
-    if (gSpecialVar_0x8005 == 0)
-    {
-        ZeroEnemyPartyMons();
-    }
+    ClearEnemyPartyAfterChallenge();
     gSaveBlock2Ptr->frontier.challengeStatus = gSpecialVar_0x8005;
     VarSet(VAR_TEMP_CHALLENGE_STATUS, 0);
     gSaveBlock2Ptr->frontier.challengePaused = TRUE;

--- a/src/battle_tower.c
+++ b/src/battle_tower.c
@@ -2206,13 +2206,7 @@ static void SaveTowerChallenge(void)
     if (gSpecialVar_0x8005 == 0 && (challengeNum > 1 || gSaveBlock2Ptr->frontier.curChallengeBattleNum != 0))
         SaveBattleTowerRecord();
 
-    // We zero out the Enemy's party here when the player either wins or loses the challenge since we
-    // can't do it the usual way in FreeResetData_ReturnToOvOrDoEvolutions() in battle_main.c due to the
-    // way facilities like the Battle Factory and the Slateport Battle Tent work
-    if (gSpecialVar_0x8005 == 0)
-    {
-        ZeroEnemyPartyMons();
-    }
+    ClearEnemyPartyAfterChallenge();
     gSaveBlock2Ptr->frontier.challengeStatus = gSpecialVar_0x8005;
     VarSet(VAR_TEMP_CHALLENGE_STATUS, 0);
     gSaveBlock2Ptr->frontier.challengePaused = TRUE;

--- a/src/battle_tower.c
+++ b/src/battle_tower.c
@@ -2206,6 +2206,13 @@ static void SaveTowerChallenge(void)
     if (gSpecialVar_0x8005 == 0 && (challengeNum > 1 || gSaveBlock2Ptr->frontier.curChallengeBattleNum != 0))
         SaveBattleTowerRecord();
 
+    // We zero out the Enemy's party here when the player either wins or loses the challenge since we
+    // can't do it the usual way in FreeResetData_ReturnToOvOrDoEvolutions() in battle_main.c due to the
+    // way facilities like the Battle Factory and the Slateport Battle Tent work
+    if (gSpecialVar_0x8005 == 0)
+    {
+        ZeroEnemyPartyMons();
+    }
     gSaveBlock2Ptr->frontier.challengeStatus = gSpecialVar_0x8005;
     VarSet(VAR_TEMP_CHALLENGE_STATUS, 0);
     gSaveBlock2Ptr->frontier.challengePaused = TRUE;

--- a/src/frontier_util.c
+++ b/src/frontier_util.c
@@ -2578,3 +2578,14 @@ static void CopyFrontierBrainText(bool8 playerWonText)
         break;
     }
 }
+
+void ClearEnemyPartyAfterChallenge()
+{
+    // We zero out the Enemy's party here when the player either wins or loses the challenge since we
+    // can't do it the usual way in FreeResetData_ReturnToOvOrDoEvolutions() in battle_main.c due to the
+    // way facilities like the Battle Factory and the Slateport Battle Tent work
+    if (gSpecialVar_0x8005 == 0)
+    {
+        ZeroEnemyPartyMons();
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes the Battle Factory and Slateport Battle Tent returning no Pokémon when the player wants to swap their Pokémon with one of the Pokémon from the last opponent.

## Videos
<!-- Please provide with relevant GIFs or images to make it easier for reviewers to accept your PR quicker.-->
<!-- If it doesn't apply, feel free to remove this section. -->
Fix for #5082
https://github.com/user-attachments/assets/af9ef3c1-41be-48f6-81b5-9dd106ebd8ee

Fix for #5280
https://github.com/user-attachments/assets/ac853b13-a689-4878-844d-d9733cb7198d


## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, fixes #2222." -->
<!-- If it doesn't apply, feel free to remove this section. -->
Fixes #5082 
Fixes #5280

## **Discord contact info**
<!--- formatted as name#numbers, e.g. Lunos#4026 -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
sarnnn