### PR TITLE
Fixes Scale Shot not activating + Known Failing Round test

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -6016,15 +6016,18 @@ static void Cmd_moveend(void)
             && gMultiHitCounter
             && !(gMovesInfo[gCurrentMove].effect == EFFECT_PRESENT && gBattleStruct->presentBasePower == 0)) // Silly edge case
             {
+                gMultiHitCounter--;
+                if (!IsBattlerAlive(gBattlerTarget) && gMovesInfo[gCurrentMove].effect != EFFECT_DRAGON_DARTS)
+                    gMultiHitCounter = 0;
+
                 gBattleScripting.multihitString[4]++;
-                if (--gMultiHitCounter == 0)
+                if (gMultiHitCounter == 0)
                 {
                     if (gMovesInfo[gCurrentMove].argument == MOVE_EFFECT_SCALE_SHOT && !NoAliveMonsForEitherParty())
                     {
                         BattleScriptPush(gBattlescriptCurrInstr + 1);
                         gBattlescriptCurrInstr = BattleScript_DefDownSpeedUp;
                     }
-
                     BattleScriptPushCursor();
                     gBattlescriptCurrInstr = BattleScript_MultiHitPrintStrings;
                     effect = TRUE;
@@ -16119,7 +16122,6 @@ static void TryUpdateRoundTurnOrder(void)
         for (i = 0; roundUsers[i] != 0xFF && i < 3; i++)
         {
             gBattlerByTurnOrder[currRounder] = roundUsers[i];
-            gActionsByTurnOrder[currRounder] = gActionsByTurnOrder[roundUsers[i]];
             gProtectStructs[roundUsers[i]].quash = TRUE; // Make it so their turn order can't be changed again
             currRounder++;
         }
@@ -16128,7 +16130,6 @@ static void TryUpdateRoundTurnOrder(void)
         for (i = 0; nonRoundUsers[i] != 0xFF && i < 3; i++)
         {
             gBattlerByTurnOrder[currRounder] = nonRoundUsers[i];
-            gActionsByTurnOrder[currRounder] = gActionsByTurnOrder[nonRoundUsers[i]];
             currRounder++;
         }
     }

--- a/test/battle/move_effect/multi_hit.c
+++ b/test/battle/move_effect/multi_hit.c
@@ -198,7 +198,7 @@ SINGLE_BATTLE_TEST("Scale Shot decreases defense and increases speed after the 4
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SCALE_SHOT, player);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SCALE_SHOT, player);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SCALE_SHOT, player);
-        MESSAGE("Hit 5 time(s)!");
+        MESSAGE("Hit 4 time(s)!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
         MESSAGE("Wobbuffet's Defense fell!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);

--- a/test/battle/move_effect/multi_hit.c
+++ b/test/battle/move_effect/multi_hit.c
@@ -183,3 +183,51 @@ SINGLE_BATTLE_TEST("Endure does not prevent multiple hits and stat changes occur
         MESSAGE("Wobbuffet's Speed rose!");
     }
 }
+
+SINGLE_BATTLE_TEST("Scale Shot decreases defense and increases speed after the 4th hit of Loaded Dice")
+{
+    PASSES_RANDOMLY(50, 100, RNG_LOADED_DICE);
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_SCALE_SHOT].effect == EFFECT_MULTI_HIT);
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_LOADED_DICE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_SCALE_SHOT); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCALE_SHOT, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCALE_SHOT, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCALE_SHOT, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCALE_SHOT, player);
+        MESSAGE("Hit 5 time(s)!");
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        MESSAGE("Wobbuffet's Defense fell!");
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        MESSAGE("Wobbuffet's Speed rose!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Scale Shot decreases defense and increases speed after killing opposing with less then 4 hits")
+{
+    u32 item;
+    PARAMETRIZE { item = ITEM_NONE; }
+    PARAMETRIZE { item = ITEM_LOADED_DICE; }
+
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_SCALE_SHOT].effect == EFFECT_MULTI_HIT);
+        PLAYER(SPECIES_BAGON) { Item(item); }
+        OPPONENT(SPECIES_SLUGMA) { Ability(ABILITY_WEAK_ARMOR); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_SCALE_SHOT); SEND_OUT(opponent, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCALE_SHOT, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCALE_SHOT, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCALE_SHOT, player);
+        MESSAGE("Foe Slugma fainted!");
+        MESSAGE("Hit 3 time(s)!");
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        MESSAGE("Bagon's Defense fell!");
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        MESSAGE("Bagon's Speed rose!");
+    }
+}

--- a/test/battle/move_effect/round.c
+++ b/test/battle/move_effect/round.c
@@ -74,7 +74,6 @@ DOUBLE_BATTLE_TEST("Round still preserves the turn order outside of the other Ro
 }
 DOUBLE_BATTLE_TEST("Round still preserves the turn order outside of the other Round users moving immediately with switch")
 {
-    KNOWN_FAILING; // #5148
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);
         PLAYER(SPECIES_WYNAUT);


### PR DESCRIPTION
Fixes #5148

Also fixes Scale Shot not activating when `gMultiHitCounter` was not decreased to zero while opposing mon fainted. 