### PR TITLE
Fixes dmax move base power not seen by ai

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -8820,6 +8820,9 @@ static inline u32 CalcMoveBasePower(u32 move, u32 battlerAtk, u32 battlerDef, u3
     if (GetActiveGimmick(battlerAtk) == GIMMICK_Z_MOVE)
         return GetZMovePower(gBattleStruct->zmove.baseMoves[battlerAtk]);
 
+    if (GetActiveGimmick(battlerAtk) == GIMMICK_DYNAMAX)
+        return GetMaxMovePower(move);
+
     switch (gMovesInfo[move].effect)
     {
     case EFFECT_PLEDGE:


### PR DESCRIPTION
Fixes  #5214

Before: 
![pokeemerald-0](https://github.com/user-attachments/assets/97f163db-8140-4da8-bdc7-d0f5a44cb169)

After:
![pokeemerald-1](https://github.com/user-attachments/assets/e7f1c67d-7b3a-4517-bdf8-ca9a5d7a0f43)
