### PR TITLE
Wonder Guard AI Fix

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -889,7 +889,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
                 break;
             case ABILITY_WONDER_GUARD:
                 if (effectiveness < AI_EFFECTIVENESS_x2)
-                    return 0;
+                    return 1;
                 break;
             case ABILITY_JUSTIFIED:
                 if (moveType == TYPE_DARK && !IS_MOVE_STATUS(move))

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -889,7 +889,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
                 break;
             case ABILITY_WONDER_GUARD:
                 if (effectiveness < AI_EFFECTIVENESS_x2)
-                    return 1;
+                    RETURN_SCORE_MINUS(20);
                 break;
             case ABILITY_JUSTIFIED:
                 if (moveType == TYPE_DARK && !IS_MOVE_STATUS(move))
@@ -1498,7 +1498,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             break;
         case EFFECT_OHKO:
             if (B_SHEER_COLD_IMMUNITY >= GEN_7 && move == MOVE_SHEER_COLD && IS_BATTLER_OF_TYPE(battlerDef, TYPE_ICE))
-                return 0;
+                RETURN_SCORE_MINUS(20);
             if (!ShouldTryOHKO(battlerAtk, battlerDef, aiData->abilities[battlerAtk], aiData->abilities[battlerDef], move))
                 ADJUST_SCORE(-10);
             else if (GetActiveGimmick(battlerDef) == GIMMICK_DYNAMAX)
@@ -2478,7 +2478,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             if (IS_TARGETING_PARTNER(battlerAtk, battlerDef))
             {
                 if (gStatuses3[battlerDef] & STATUS3_HEAL_BLOCK)
-                    return 0;
+                    return 0; // cannot even select
                 if (AtMaxHp(battlerDef))
                     ADJUST_SCORE(-10);
                 else if (gBattleMons[battlerDef].hp > gBattleMons[battlerDef].maxHP / 2)


### PR DESCRIPTION
## Description
Wiz pinged me this afternoon having encountered weird behaviour while developing one of their escape rooms. In this scenario, the player's Porygon has Wonder Guard, and the AI has no moves that can affect it (Astonish, Rest, Rock Slide). The AI uses Rest until it runs out of PP, and then the game hangs, because all 3 moves have an AI score of 0, but 2 of the moves still have PP so it can't use struggle.

On investigation, this seems to be related to the way Check Bad Move handles Wonder Guard. Currently, it just returns a score of 0 if the move can't damage the Wonder Guard mon.

This PR changes this line to return a 1 instead, which should be lower than virtually all other legal move options, but is still nonzero so the AI can select it in battle if required.

Open to criticism or alternative suggestions, but this worked for Wiz and I wanted to PR it ASAP as it is a crash-worthy bug.

EDIT: Applied the same fix to the Sheer Cold logic, which seems to be the only other case this might occur.

## Images

Before fix, showing AI's scores before Wiz passes the turn and triggers the freeze:

https://github.com/user-attachments/assets/41e89144-30a4-4ce4-8486-656fcb496ed7

## **People who collaborated with me in this PR**
Wiz for finding, reporting, and helping test the solution!

## **Discord contact info**
@Pawkkie 
