### PR TITLE
AI mid turn switch wrong set data

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -379,6 +379,7 @@ void Ai_UpdateSwitchInData(u32 battler)
         ClearBattlerAbilityHistory(battler);
         ClearBattlerItemEffectHistory(battler);
         CopyBattlerDataToAIParty(GetBattlerPosition(battler), side);
+        SetBattlerAiData(battler, AI_DATA);
     }
 }
 


### PR DESCRIPTION
Not all the data was correctly set for the AI. This was apparent when the mon switched out witch Eject Pack / Eject Button
