### PR TITLE
Fix Cmd_trainerslidein/out

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -15647,7 +15647,7 @@ static void Cmd_trainerslideout(void)
 {
     CMD_ARGS(u8 position);
 
-    u32 battler = GetBattlerAtPosition(cmd->position);
+    u32 battler = GetBattlerForBattleScript(cmd->position);
     BtlController_EmitTrainerSlideBack(battler, BUFFER_A);
     MarkBattlerForControllerExec(battler);
 

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -7439,7 +7439,7 @@ static void Cmd_trainerslidein(void)
 {
     CMD_ARGS(u8 battler);
 
-    u32 battler = GetBattlerAtPosition(cmd->battler);
+    u32 battler = GetBattlerForBattleScript(cmd->battler);
     BtlController_EmitTrainerSlide(battler, BUFFER_A);
     MarkBattlerForControllerExec(battler);
 


### PR DESCRIPTION
Uses `GetBattlerForBattleScript` instead of `GetBattlerAtPosition`