### PR TITLE
RTC-based wild encounters follow up

### DIFF
--- a/src/wild_encounter.c
+++ b/src/wild_encounter.c
@@ -355,7 +355,7 @@ static u8 ChooseWildMonLevel(const struct WildPokemon *wildPokemon, u8 wildMonIn
     }
 }
 
-static bool8 IsExactTimeOfDayMatchForWildEncounters(u8 currentTimeOfDay, u8 encounterTimeOfDay)
+static bool32 IsExactTimeOfDayMatchForWildEncounters(u32 currentTimeOfDay, u32 encounterTimeOfDay)
 {
     switch (currentTimeOfDay)
     {


### PR DESCRIPTION
During my review of #5313 I overlooked that the function vars used a u8 instead of u32. This follow up fixes it
