### PR TITLE
Pledge fail into opponent pledge loop fix

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1220,7 +1220,8 @@ static void Cmd_attackcanceler(void)
         return;
     if (AtkCanceller_UnableToUseMove(moveType))
     {
-        gBattleStruct->pledgeMove = FALSE;
+        if (gHitMarker & HITMARKER_UNABLE_TO_USE_MOVE)
+            gBattleStruct->pledgeMove = FALSE;
         return;
     }
 

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1219,11 +1219,7 @@ static void Cmd_attackcanceler(void)
     if (B_STANCE_CHANGE_FAIL < GEN_7 && TryAegiFormChange())
         return;
     if (AtkCanceller_UnableToUseMove(moveType))
-    {
-        if (gHitMarker & HITMARKER_UNABLE_TO_USE_MOVE)
-            gBattleStruct->pledgeMove = FALSE;
         return;
-    }
 
     if (WEATHER_HAS_EFFECT && gMovesInfo[gCurrentMove].power)
     {
@@ -6442,6 +6438,8 @@ static void Cmd_moveend(void)
             gBattleStruct->poisonPuppeteerConfusion = FALSE;
             gBattleStruct->fickleBeamBoosted = FALSE;
             gBattleStruct->distortedTypeMatchups = 0;
+            if (gHitMarker & HITMARKER_UNABLE_TO_USE_MOVE)
+                gBattleStruct->pledgeMove = FALSE;
             if (GetActiveGimmick(gBattlerAttacker) == GIMMICK_Z_MOVE)
                 SetActiveGimmick(gBattlerAttacker, GIMMICK_NONE);
             if (B_CHARGE <= GEN_8 || moveType == TYPE_ELECTRIC)

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1219,7 +1219,10 @@ static void Cmd_attackcanceler(void)
     if (B_STANCE_CHANGE_FAIL < GEN_7 && TryAegiFormChange())
         return;
     if (AtkCanceller_UnableToUseMove(moveType))
+    {
+        gBattleStruct->pledgeMove = FALSE;
         return;
+    }
 
     if (WEATHER_HAS_EFFECT && gMovesInfo[gCurrentMove].power)
     {

--- a/test/battle/move_effect/pledge.c
+++ b/test/battle/move_effect/pledge.c
@@ -768,3 +768,26 @@ DOUBLE_BATTLE_TEST("Pledge move combo fails if ally fails to act - Flinch Both R
         }
     }
 }
+
+DOUBLE_BATTLE_TEST("Pledge move combo doesn't trigger on opponent's Pledge move")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Speed(4); }
+        PLAYER(SPECIES_WYNAUT) { Speed(3); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(8); }
+        OPPONENT(SPECIES_WYNAUT) { Speed(5); Status1(STATUS1_SLEEP_TURN(2)); }
+    } WHEN {
+        TURN { MOVE(opponentLeft, MOVE_FIRE_PLEDGE, target: playerLeft);
+               MOVE(opponentRight, MOVE_GRASS_PLEDGE, target: playerLeft); 
+               MOVE(playerLeft, MOVE_GRASS_PLEDGE, target: opponentRight); }
+    } SCENE {
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_FIRE_PLEDGE, opponentLeft);
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_FIRE_PLEDGE, opponentRight);
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_GRASS_PLEDGE, opponentRight);
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_FIRE_PLEDGE, playerLeft);
+        }
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_GRASS_PLEDGE, playerLeft);
+        HP_BAR(opponentRight);
+    }
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
If a called pledge execution failed due to the 'mon being incapacitated, the pledge status was still `TRUE` in `gBattleStruct` which messed up the execution flow if the opponent was also using a pledge move.
Setting the pledge status to `FALSE` if the 'mon fails to move solves this.

## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, fixes #2222." -->
<!-- If it doesn't apply, feel free to remove this section. -->
Fixes #5329 

## **People who collaborated with me in this PR**
<!-- Please credit everyone else that contributed to this PR, be it code and/or assets. -->
<!-- Use their GitHub tag if they have one. -->
<!-- If it doesn't apply, feel free to remove this section. -->
@PhallenTree found the issue, wrote the test and pointed in the right direction with the other pledge fix


## **Discord contact info**
<!--- formatted as name#numbers, e.g. Lunos#4026 -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara
