### PR TITLE
Fixed loading into the wrong version of a map after saving in areas with multiple layouts

### DIFF
--- a/src/overworld.c
+++ b/src/overworld.c
@@ -624,7 +624,7 @@ static void LoadCurrentMapData(void)
 static void LoadSaveblockMapHeader(void)
 {
     gMapHeader = *Overworld_GetMapHeaderByGroupAndId(gSaveBlock1Ptr->location.mapGroup, gSaveBlock1Ptr->location.mapNum);
-    gMapHeader.mapLayout = GetMapLayout(gMapHeader.mapLayoutId);
+    gMapHeader.mapLayout = GetMapLayout(gSaveBlock1Ptr->mapLayoutId);
 }
 
 static void SetPlayerCoordsFromWarp(void)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When loading the map from the save, it didn't actually read `gSaveBlock1Ptr->mapLayoutId` anywhere, so the "default" layout was always loaded, and no transition script could actually run to change it on a save load.
This change makes the map you load into match the one saved in.
It was not extensively tested, just in shoal cave, that it works and in other maps that nothing is immediately broken.

## Images
<!-- Please provide with relevant GIFs or images to make it easier for reviewers to accept your PR quicker.-->
<!-- If it doesn't apply, feel free to remove this section. -->

https://github.com/user-attachments/assets/440a1009-ed5f-4e8d-a410-2b14f03dc582



## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, fixes #2222." -->
<!-- If it doesn't apply, feel free to remove this section. -->
Fixes #5343 

## **Discord contact info**
<!--- formatted as name#numbers, e.g. Lunos#4026 -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara
