### PR TITLE
Fix missing break in two ENDTURN cases

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -2884,9 +2884,11 @@ u8 DoBattlerEndTurnEffects(void)
         case ENDTURN_ELECTRIFY:
             gStatuses4[battler] &= ~STATUS4_ELECTRIFIED;
             gBattleStruct->turnEffectsTracker++;
+            break;
         case ENDTURN_POWDER:
             gBattleMons[battler].status2 &= ~STATUS2_POWDER;
             gBattleStruct->turnEffectsTracker++;
+            break;
         case ENDTURN_THROAT_CHOP:
             if (gDisableStructs[battler].throatChopTimer && --gDisableStructs[battler].throatChopTimer == 0)
             {


### PR DESCRIPTION
Missing `break` in ENDTURN_ELECTRIFY and ENDTURN_POWDER