### PR TITLE
AI burn score fixes and improvements

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -3735,11 +3735,14 @@ void IncreaseBurnScore(u32 battlerAtk, u32 battlerDef, u32 move, s32 *score)
 
     if (AI_CanBurn(battlerAtk, battlerDef, AI_DATA->abilities[battlerDef], BATTLE_PARTNER(battlerAtk), move, AI_DATA->partnerMove))
     {
-        ADJUST_SCORE_PTR(WEAK_EFFECT); // burning is good
-        if (HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_PHYSICAL))
+        if (HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_PHYSICAL)
+            || (!(AI_THINKING_STRUCT->aiFlags[battlerAtk] & AI_FLAG_OMNISCIENT) // Not Omniscient but expects physical attacker
+                && gSpeciesInfo[gBattleMons[battlerDef].species].baseAttack >= gSpeciesInfo[gBattleMons[battlerDef].species].baseSpAttack + 10))
         {
-            if (CanTargetFaintAi(battlerDef, battlerAtk))
+            if (CanTargetFaintAi(battlerDef, battlerAtk) && gMovesInfo[GetBestDmgMoveFromBattler(battlerDef, battlerAtk)].category == DAMAGE_CATEGORY_PHYSICAL)
                 ADJUST_SCORE_PTR(DECENT_EFFECT); // burning the target to stay alive is cool
+            else
+                ADJUST_SCORE_PTR(WEAK_EFFECT); // burning is good
         }
 
         if (HasMoveEffectANDArg(battlerAtk, EFFECT_DOUBLE_POWER_ON_ARG_STATUS, STATUS1_BURN)

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -3739,10 +3739,10 @@ void IncreaseBurnScore(u32 battlerAtk, u32 battlerDef, u32 move, s32 *score)
             || (!(AI_THINKING_STRUCT->aiFlags[battlerAtk] & AI_FLAG_OMNISCIENT) // Not Omniscient but expects physical attacker
                 && gSpeciesInfo[gBattleMons[battlerDef].species].baseAttack >= gSpeciesInfo[gBattleMons[battlerDef].species].baseSpAttack + 10))
         {
-            if (CanTargetFaintAi(battlerDef, battlerAtk) && gMovesInfo[GetBestDmgMoveFromBattler(battlerDef, battlerAtk)].category == DAMAGE_CATEGORY_PHYSICAL)
-                ADJUST_SCORE_PTR(DECENT_EFFECT); // burning the target to stay alive is cool
+            if (gMovesInfo[GetBestDmgMoveFromBattler(battlerDef, battlerAtk)].category == DAMAGE_CATEGORY_PHYSICAL)
+                ADJUST_SCORE_PTR(DECENT_EFFECT);
             else
-                ADJUST_SCORE_PTR(WEAK_EFFECT); // burning is good
+                ADJUST_SCORE_PTR(WEAK_EFFECT);
         }
 
         if (HasMoveEffectANDArg(battlerAtk, EFFECT_DOUBLE_POWER_ON_ARG_STATUS, STATUS1_BURN)


### PR DESCRIPTION
## Description
Addresses issues brought up in #5272. The ties were the result of a flat +1 score increase to any burning move as long as the AI was able to burn the target, in all cases. This increase has now been gated behind checks for the player mon having a physical attacking move that the AI knows about, or guessing that it might be a physical attacker based on its base stats. The stronger stat increase in the case of very high incoming damage was also improved to ensure as best we can that the incoming damage is physical nature before applying the score increase.

## Images
Scoring after fix
![image (1)](https://github.com/user-attachments/assets/9514ca27-3994-44f0-8a2c-16637ccd613b)

## Issue(s) that this PR fixes
Fixes #5272 

## **People who collaborated with me in this PR**
@iriv24 and @AlexOn1ine

## **Discord contact info**
@Pawkkie @iriv24
