### PR TITLE
AI frostbite score fixes and improvements

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -3816,11 +3816,14 @@ void IncreaseFrostbiteScore(u32 battlerAtk, u32 battlerDef, u32 move, s32 *score
 
     if (AI_CanGiveFrostbite(battlerAtk, battlerDef, AI_DATA->abilities[battlerDef], BATTLE_PARTNER(battlerAtk), move, AI_DATA->partnerMove))
     {
-        ADJUST_SCORE_PTR(WEAK_EFFECT); // frostbite is good
-        if (HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_SPECIAL))
+        if (HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_SPECIAL)
+            || (!(AI_THINKING_STRUCT->aiFlags[battlerAtk] & AI_FLAG_OMNISCIENT) // Not Omniscient but expects special attacker
+                && gSpeciesInfo[gBattleMons[battlerDef].species].baseSpAttack >= gSpeciesInfo[gBattleMons[battlerDef].species].baseAttack + 10))
         {
-            if (CanTargetFaintAi(battlerDef, battlerAtk))
-                ADJUST_SCORE_PTR(DECENT_EFFECT); // frostbiting the target to stay alive is cool
+            if (gMovesInfo[GetBestDmgMoveFromBattler(battlerDef, battlerAtk)].category == DAMAGE_CATEGORY_SPECIAL)
+                ADJUST_SCORE_PTR(DECENT_EFFECT);
+            else
+                ADJUST_SCORE_PTR(WEAK_EFFECT);
         }
 
         if (HasMoveEffectANDArg(battlerAtk, EFFECT_DOUBLE_POWER_ON_ARG_STATUS, STATUS1_FROSTBITE)


### PR DESCRIPTION
## Description
This is *exactly* the same changes made in #5356 and fixes the same issue, they're just applied to Frostbite instead of Burn. Shoutout to @kittenchilly for the suggestion.

While we don't have a Frostbite copy of Will-O-Wisp, `IncreaseFrostbiteScore` is still used in the existing codebase when handling Psycho Shift, and as such I don't see a reason that its AI shouldn't be kept at parity with Burn's in the same scenarios. The real reason behind supporting parity in my opinion is because of how commonly users make frostbite equivalents for burning moves like Scald and Will-O-Wisp, and while I understand that supporting that as the only reason may be out of scope, we *do* use identical handling for Psycho Shift anyways, so I don't see this as being a problem.

## **People who collaborated with me in this PR**
@kittenchilly for the suggestion!

## **Discord contact info**
@Pawkkie 
