### PR TITLE
Fixes Powder (status) interactions + tests

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -7384,6 +7384,17 @@ BattleScript_DoSelfConfusionDmg::
 BattleScript_MoveUsedIsConfusedRet::
 	return
 
+BattleScript_ZMoveActivatePowder::
+	flushtextbox
+	trytrainerslidezmovemsg
+	savetarget
+	printstring STRINGID_ZPOWERSURROUNDS
+	playanimation BS_ATTACKER, B_ANIM_ZMOVE_ACTIVATE, NULL
+	setzeffect
+	restoretarget
+	goto BattleScript_MoveUsedPowder
+
+
 BattleScript_MoveUsedPowder::
 	bicword gHitMarker, HITMARKER_NO_ATTACKSTRING | HITMARKER_ATTACKSTRING_PRINTED
 	attackstring

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -7384,17 +7384,6 @@ BattleScript_DoSelfConfusionDmg::
 BattleScript_MoveUsedIsConfusedRet::
 	return
 
-BattleScript_ZMoveActivatePowder::
-	flushtextbox
-	trytrainerslidezmovemsg
-	savetarget
-	printstring STRINGID_ZPOWERSURROUNDS
-	playanimation BS_ATTACKER, B_ANIM_ZMOVE_ACTIVATE, NULL
-	setzeffect
-	restoretarget
-	goto BattleScript_MoveUsedPowder
-
-
 BattleScript_MoveUsedPowder::
 	bicword gHitMarker, HITMARKER_NO_ATTACKSTRING | HITMARKER_ATTACKSTRING_PRINTED
 	attackstring

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -9415,6 +9415,16 @@ BattleScript_ZMoveActivateStatus::
 	copybyte sSTATCHANGER, sSAVED_STAT_CHANGER
 	return
 
+BattleScript_ZMoveActivatePowder::
+	flushtextbox
+	trytrainerslidezmovemsg
+	savetarget
+	printstring STRINGID_ZPOWERSURROUNDS
+	playanimation BS_ATTACKER, B_ANIM_ZMOVE_ACTIVATE, NULL
+	setzeffect
+	restoretarget
+	goto BattleScript_MoveUsedPowder
+
 BattleScript_ZEffectPrintString::
 	printfromtable gZEffectStringIds
 	waitmessage B_WAIT_TIME_LONG

--- a/include/battle_scripts.h
+++ b/include/battle_scripts.h
@@ -329,6 +329,7 @@ extern const u8 BattleScript_ProteanActivates[];
 extern const u8 BattleScript_DazzlingProtected[];
 extern const u8 BattleScript_MoveUsedPsychicTerrainPrevents[];
 extern const u8 BattleScript_MoveUsedPowder[];
+extern const u8 BattleScript_ZMoveActivatePowder[];
 extern const u8 BattleScript_SelectingNotAllowedStuffCheeks[];
 extern const u8 BattleScript_SelectingNotAllowedStuffCheeksInPalace[];
 extern const u8 BattleScript_SelectingNotAllowedBelch[];

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -122,6 +122,7 @@
 #define B_KNOCK_OFF_REMOVAL         GEN_LATEST // In Gen5+, Knock Off removes the foe's item instead of rendering it unusable.
 #define B_HEAL_BELL_SOUNDPROOF      GEN_LATEST // In Gen5, Heal Bell affects all mons with Soundproof.  In Gen6-8 it affects inactive mons, but not battlers. In Gen9 it always affects the user.
 #define B_CHARGE                    GEN_LATEST // In Gen8-, Charge status is lost regardless of the typing of the next move.
+#define B_POWDER_RAIN               GEN_LATEST // In Gen7+, Powder doesn't damage the user of a Fire type move in rain.
 
 // Ability settings
 #define B_EXPANDED_ABILITY_NAMES    TRUE       // If TRUE, ability names are increased from 12 characters to 16 characters.

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -122,7 +122,7 @@
 #define B_KNOCK_OFF_REMOVAL         GEN_LATEST // In Gen5+, Knock Off removes the foe's item instead of rendering it unusable.
 #define B_HEAL_BELL_SOUNDPROOF      GEN_LATEST // In Gen5, Heal Bell affects all mons with Soundproof.  In Gen6-8 it affects inactive mons, but not battlers. In Gen9 it always affects the user.
 #define B_CHARGE                    GEN_LATEST // In Gen8-, Charge status is lost regardless of the typing of the next move.
-#define B_POWDER_RAIN               GEN_LATEST // In Gen7+, Powder doesn't damage the user of a Fire type move in rain.
+#define B_POWDER_RAIN               GEN_LATEST // In Gen7+, Powder doesn't damage the user of a Fire type move in heavy rain.
 
 // Ability settings
 #define B_EXPANDED_ABILITY_NAMES    TRUE       // If TRUE, ability names are increased from 12 characters to 16 characters.

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -6290,19 +6290,20 @@ static void Cmd_moveend(void)
             if (gMovesInfo[gCurrentMove].danceMove)
             {
                 u32 battler, nextDancer = 0;
-                bool32 turnOnHitmarker = FALSE;
+                bool32 hasDancerTriggered = FALSE;
 
                 for (battler = 0; battler < gBattlersCount; battler++)
                 {
                     if (gSpecialStatuses[battler].dancerUsedMove)
                     {
                         // in case a battler fails to act on a Dancer-called move
-                        turnOnHitmarker = TRUE;
+                        hasDancerTriggered = TRUE;
                         break;
                     }
                 }
 
                 if (!(gMoveResultFlags & (MOVE_RESULT_FAILED | MOVE_RESULT_DOESNT_AFFECT_FOE)
+                 || (gHitMarker & HITMARKER_UNABLE_TO_USE_MOVE && !hasDancerTriggered)
                  || (!gSpecialStatuses[gBattlerAttacker].dancerUsedMove && gBattleStruct->bouncedMoveIsUsed)))
                 {   // Dance move succeeds
                     // Set target for other Dancer mons; set bit so that mon cannot activate Dancer off of its own move
@@ -6316,8 +6317,6 @@ static void Cmd_moveend(void)
                     {
                         if (GetBattlerAbility(battler) == ABILITY_DANCER && !gSpecialStatuses[battler].dancerUsedMove)
                         {
-                            if (turnOnHitmarker)
-                                gHitMarker |= HITMARKER_ATTACKSTRING_PRINTED;
                             if (!nextDancer || (gBattleMons[battler].speed < gBattleMons[nextDancer & 0x3].speed))
                                 nextDancer = battler | 0x4;
                         }

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3568,19 +3568,10 @@ u8 AtkCanceller_UnableToUseMove(u32 moveType)
                     && (B_POWDER_RAIN < GEN_7 || !IsBattlerWeatherAffected(gBattlerAttacker, B_WEATHER_RAIN_PRIMAL)))
                         gBattleMoveDamage = GetNonDynamaxMaxHP(gBattlerAttacker) / 4;
 
-                    if (GetActiveGimmick(gBattlerAttacker) == GIMMICK_Z_MOVE
-                     && gBattleStruct->obedienceResult == OBEYS
-                     && !HasTrainerUsedGimmick(gBattlerAttacker, GIMMICK_Z_MOVE))
-                    {
-                        RecordItemEffectBattle(gBattlerAttacker, HOLD_EFFECT_Z_CRYSTAL);
-                        SetGimmickAsActivated(gBattlerAttacker, GIMMICK_Z_MOVE);
-                        gBattleScripting.battler = gBattlerAttacker;
-                        gBattlescriptCurrInstr = BattleScript_ZMoveActivatePowder;
-                    }
-                    else
-                    {
+                    if (GetActiveGimmick(gBattlerAttacker) != GIMMICK_Z_MOVE
+                     || gBattleStruct->obedienceResult != OBEYS
+                     || HasTrainerUsedGimmick(gBattlerAttacker, GIMMICK_Z_MOVE))
                         gBattlescriptCurrInstr = BattleScript_MoveUsedPowder;
-                    }
                     gHitMarker |= HITMARKER_UNABLE_TO_USE_MOVE;
                     effect = 1;
                 }
@@ -3610,7 +3601,15 @@ u8 AtkCanceller_UnableToUseMove(u32 moveType)
                 SetGimmickAsActivated(gBattlerAttacker, GIMMICK_Z_MOVE);
 
                 gBattleScripting.battler = gBattlerAttacker;
-                if (gMovesInfo[gCurrentMove].category == DAMAGE_CATEGORY_STATUS)
+                if (gProtectStructs[gBattlerAttacker].powderSelfDmg)
+                {
+                    if (!alreadyUsed)
+                    {
+                        BattleScriptPushCursor();
+                        gBattlescriptCurrInstr = BattleScript_ZMoveUsedPowder;
+                    }
+                }
+                else if (gMovesInfo[gCurrentMove].category == DAMAGE_CATEGORY_STATUS)
                 {
                     if (!alreadyUsed)
                     {

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3558,11 +3558,29 @@ u8 AtkCanceller_UnableToUseMove(u32 moveType)
         case CANCELLER_POWDER_STATUS:
             if (gBattleMons[gBattlerAttacker].status2 & STATUS2_POWDER)
             {
-                if (moveType == TYPE_FIRE)
+                u32 partnerMove = gBattleMons[BATTLE_PARTNER(gBattlerAttacker)].moves[gBattleStruct->chosenMovePositions[BATTLE_PARTNER(gBattlerAttacker)]];
+                if ((moveType == TYPE_FIRE && !gBattleStruct->pledgeMove)
+                 || (gCurrentMove == MOVE_FIRE_PLEDGE && partnerMove == MOVE_GRASS_PLEDGE)
+                 || (gCurrentMove == MOVE_GRASS_PLEDGE && partnerMove == MOVE_FIRE_PLEDGE && gBattleStruct->pledgeMove))
                 {
                     gProtectStructs[gBattlerAttacker].powderSelfDmg = TRUE;
-                    gBattleMoveDamage = GetNonDynamaxMaxHP(gBattlerAttacker) / 4;
-                    gBattlescriptCurrInstr = BattleScript_MoveUsedPowder;
+                    if (GetBattlerAbility(gBattlerAttacker) != ABILITY_MAGIC_GUARD
+                    && !IsBattlerWeatherAffected(gBattlerAttacker, B_WEATHER_RAIN_PRIMAL))
+                        gBattleMoveDamage = GetNonDynamaxMaxHP(gBattlerAttacker) / 4;
+
+                    if (GetActiveGimmick(gBattlerAttacker) == GIMMICK_Z_MOVE
+                     && gBattleStruct->obedienceResult == OBEYS
+                     && !HasTrainerUsedGimmick(gBattlerAttacker, GIMMICK_Z_MOVE))
+                    {
+                        RecordItemEffectBattle(gBattlerAttacker, HOLD_EFFECT_Z_CRYSTAL);
+                        SetGimmickAsActivated(gBattlerAttacker, GIMMICK_Z_MOVE);
+                        gBattleScripting.battler = gBattlerAttacker;
+                        gBattlescriptCurrInstr = BattleScript_ZMoveActivatePowder;
+                    }
+                    else
+                    {
+                        gBattlescriptCurrInstr = BattleScript_MoveUsedPowder;
+                    }
                     gHitMarker |= HITMARKER_UNABLE_TO_USE_MOVE;
                     effect = 1;
                 }

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3565,7 +3565,7 @@ u8 AtkCanceller_UnableToUseMove(u32 moveType)
                 {
                     gProtectStructs[gBattlerAttacker].powderSelfDmg = TRUE;
                     if (GetBattlerAbility(gBattlerAttacker) != ABILITY_MAGIC_GUARD
-                    && !IsBattlerWeatherAffected(gBattlerAttacker, B_WEATHER_RAIN_PRIMAL))
+                    && (B_POWDER_RAIN < GEN_7 || !IsBattlerWeatherAffected(gBattlerAttacker, B_WEATHER_RAIN)))
                         gBattleMoveDamage = GetNonDynamaxMaxHP(gBattlerAttacker) / 4;
 
                     if (GetActiveGimmick(gBattlerAttacker) == GIMMICK_Z_MOVE

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3565,7 +3565,7 @@ u8 AtkCanceller_UnableToUseMove(u32 moveType)
                 {
                     gProtectStructs[gBattlerAttacker].powderSelfDmg = TRUE;
                     if (GetBattlerAbility(gBattlerAttacker) != ABILITY_MAGIC_GUARD
-                    && (B_POWDER_RAIN < GEN_7 || !IsBattlerWeatherAffected(gBattlerAttacker, B_WEATHER_RAIN)))
+                    && (B_POWDER_RAIN < GEN_7 || !IsBattlerWeatherAffected(gBattlerAttacker, B_WEATHER_RAIN_PRIMAL)))
                         gBattleMoveDamage = GetNonDynamaxMaxHP(gBattlerAttacker) / 4;
 
                     if (GetActiveGimmick(gBattlerAttacker) == GIMMICK_Z_MOVE

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -6058,7 +6058,6 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
             if (IsBattlerAlive(battler)
              && (gMovesInfo[gCurrentMove].danceMove)
              && !gSpecialStatuses[battler].dancerUsedMove
-             && (gHitMarker & HITMARKER_ATTACKSTRING_PRINTED)
              && gBattlerAttacker != battler)
             {
                 // Set bit and save Dancer mon's original target

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3606,7 +3606,7 @@ u8 AtkCanceller_UnableToUseMove(u32 moveType)
                     if (!alreadyUsed)
                     {
                         BattleScriptPushCursor();
-                        gBattlescriptCurrInstr = BattleScript_ZMoveUsedPowder;
+                        gBattlescriptCurrInstr = BattleScript_ZMoveActivatePowder;
                     }
                 }
                 else if (gMovesInfo[gCurrentMove].category == DAMAGE_CATEGORY_STATUS)

--- a/test/battle/ability/dancer.c
+++ b/test/battle/ability/dancer.c
@@ -145,3 +145,25 @@ SINGLE_BATTLE_TEST("Dancer-called attacks have their type updated")
         MESSAGE("It's super effective!");
     }
 }
+
+DOUBLE_BATTLE_TEST("Dancer doesn't call a move that didn't execute due to Powder")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_FIERY_DANCE].danceMove == TRUE);
+        ASSUME(gMovesInfo[MOVE_FIERY_DANCE].type == TYPE_FIRE);
+        PLAYER(SPECIES_VOLCARONA);
+        PLAYER(SPECIES_ORICORIO);
+        OPPONENT(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_VIVILLON);
+    } WHEN {
+        TURN { MOVE(opponentRight, MOVE_POWDER, target: playerLeft); MOVE(playerLeft, MOVE_FIERY_DANCE, target: opponentLeft); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POWDER, opponentRight);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_FIERY_DANCE, playerLeft);
+            HP_BAR(opponentLeft);
+            ABILITY_POPUP(playerRight, ABILITY_DANCER);
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_FIERY_DANCE, playerRight);
+        }
+    }
+}

--- a/test/battle/gimmick/zmove.c
+++ b/test/battle/gimmick/zmove.c
@@ -397,6 +397,58 @@ SINGLE_BATTLE_TEST("(Z-MOVE) Z-Sleep Talk turns Weather Ball into Breakneck Blit
     }
 }
 
+SINGLE_BATTLE_TEST("(Z-MOVE) Powder blocks Fire type Z-Moves")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_EMBER].type == TYPE_FIRE);
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_FIRIUM_Z); }
+        OPPONENT(SPECIES_VIVILLON);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_POWDER); MOVE(player, MOVE_EMBER, gimmick: GIMMICK_Z_MOVE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POWDER, opponent);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ZMOVE_ACTIVATE, player);
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_INFERNO_OVERDRIVE, player);
+    }
+}
+
+DOUBLE_BATTLE_TEST("(Z-MOVE) Powder blocks Fire type Z-Moves (from Z-Mirror Move)")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_EMBER].type == TYPE_FIRE);
+        ASSUME(gMovesInfo[MOVE_MIRROR_MOVE].type == TYPE_FLYING);
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_FLYINIUM_Z); }
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_VIVILLON);
+    } WHEN {
+        TURN { MOVE(opponentRight, MOVE_POWDER, target: playerLeft); MOVE(opponentLeft, MOVE_EMBER, target: playerLeft); MOVE(playerLeft, MOVE_MIRROR_MOVE, gimmick: GIMMICK_Z_MOVE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POWDER, opponentRight);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EMBER, opponentLeft);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ZMOVE_ACTIVATE, playerLeft);
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_INFERNO_OVERDRIVE, playerLeft);
+    }
+}
+
+SINGLE_BATTLE_TEST("(Z-MOVE) Powder blocks Fire type Z-Moves but not boosts granted")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_WILL_O_WISP].type == TYPE_FIRE);
+        ASSUME(gMovesInfo[MOVE_WILL_O_WISP].zMove.effect == Z_EFFECT_ATK_UP_1);
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_FIRIUM_Z); }
+        OPPONENT(SPECIES_VIVILLON);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_POWDER); MOVE(player, MOVE_WILL_O_WISP, gimmick: GIMMICK_Z_MOVE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POWDER, opponent);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ZMOVE_ACTIVATE, player);
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_WILL_O_WISP, player);
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_ATK], DEFAULT_STAT_STAGE + 1);
+    }
+}
+
 // Miscellaneous Interactions
 DOUBLE_BATTLE_TEST("(Z-MOVE) Instruct fails if the target last used a Z-Move")
 {

--- a/test/battle/gimmick/zmove.c
+++ b/test/battle/gimmick/zmove.c
@@ -397,7 +397,7 @@ SINGLE_BATTLE_TEST("(Z-MOVE) Z-Sleep Talk turns Weather Ball into Breakneck Blit
     }
 }
 
-SINGLE_BATTLE_TEST("(Z-MOVE) Powder blocks Fire type Z-Moves")
+SINGLE_BATTLE_TEST("(Z-MOVE) Powder blocks Fire type Z-Moves and deals 25% of maximum HP to the user")
 {
     GIVEN {
         ASSUME(gMovesInfo[MOVE_EMBER].type == TYPE_FIRE);
@@ -409,6 +409,8 @@ SINGLE_BATTLE_TEST("(Z-MOVE) Powder blocks Fire type Z-Moves")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_POWDER, opponent);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ZMOVE_ACTIVATE, player);
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_INFERNO_OVERDRIVE, player);
+    } THEN {
+        EXPECT_MUL_EQ(player->maxHP, UQ_4_12(0.75), player->hp);
     }
 }
 

--- a/test/battle/move_effect/powder.c
+++ b/test/battle/move_effect/powder.c
@@ -4,6 +4,7 @@
 ASSUMPTIONS
 {
     ASSUME(gMovesInfo[MOVE_POWDER].effect == EFFECT_POWDER);
+    ASSUME(gMovesInfo[MOVE_POWDER].powderMove == TRUE);
     ASSUME(gMovesInfo[MOVE_EMBER].type == TYPE_FIRE);
 }
 

--- a/test/battle/move_effect/powder.c
+++ b/test/battle/move_effect/powder.c
@@ -80,11 +80,11 @@ SINGLE_BATTLE_TEST("Powder doesn't damage target if it has Magic Guard")
     }
 }
 
-SINGLE_BATTLE_TEST("Powder doesn't damage target under rain")
+SINGLE_BATTLE_TEST("Powder doesn't damage target under heavy rain")
 {
     GIVEN {
         ASSUME(B_POWDER_RAIN >= GEN_7);
-        PLAYER(SPECIES_KYOGRE);
+        PLAYER(SPECIES_KYOGRE_PRIMAL) { Ability(ABILITY_PRIMORDIAL_SEA); }
         OPPONENT(SPECIES_VIVILLON);
     } WHEN {
         TURN { MOVE(opponent, MOVE_POWDER); MOVE(player, MOVE_EMBER); }

--- a/test/battle/move_effect/powder.c
+++ b/test/battle/move_effect/powder.c
@@ -80,10 +80,11 @@ SINGLE_BATTLE_TEST("Powder doesn't damage target if it has Magic Guard")
     }
 }
 
-SINGLE_BATTLE_TEST("Powder doesn't damage target under heavy rain")
+SINGLE_BATTLE_TEST("Powder doesn't damage target under rain")
 {
     GIVEN {
-        PLAYER(SPECIES_KYOGRE_PRIMAL) { Ability(ABILITY_PRIMORDIAL_SEA); }
+        ASSUME(B_POWDER_RAIN >= GEN_7);
+        PLAYER(SPECIES_KYOGRE);
         OPPONENT(SPECIES_VIVILLON);
     } WHEN {
         TURN { MOVE(opponent, MOVE_POWDER); MOVE(player, MOVE_EMBER); }

--- a/test/battle/move_effect/powder.c
+++ b/test/battle/move_effect/powder.c
@@ -1,0 +1,293 @@
+#include "global.h"
+#include "test/battle.h"
+
+ASSUMPTIONS
+{
+    ASSUME(gMovesInfo[MOVE_POWDER].effect == EFFECT_POWDER);
+    ASSUME(gMovesInfo[MOVE_EMBER].type == TYPE_FIRE);
+}
+
+
+SINGLE_BATTLE_TEST("Powder blocks the target's Fire type moves and deals 25% of maximum HP to target")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_VIVILLON);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_POWDER); MOVE(player, MOVE_EMBER); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POWDER, opponent);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_EMBER, player);
+            HP_BAR(opponent);
+        }
+    } THEN {
+        EXPECT_MUL_EQ(player->maxHP, UQ_4_12(0.75), player->hp);
+    }
+}
+
+SINGLE_BATTLE_TEST("Powder blocks the target's Fire type moves and consumes PP")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Moves(MOVE_EMBER); }
+        OPPONENT(SPECIES_VIVILLON);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_POWDER); MOVE(player, MOVE_EMBER); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POWDER, opponent);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_EMBER, player);
+            HP_BAR(opponent);
+        }
+    } THEN {
+        EXPECT_EQ(player->pp[0], gMovesInfo[MOVE_EMBER].pp - 1);
+    }
+}
+
+SINGLE_BATTLE_TEST("Powder only blocks the target's Fire type moves on the same turn")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_VIVILLON);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_POWDER); }
+        TURN { MOVE(player, MOVE_EMBER); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POWDER, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EMBER, player);
+        HP_BAR(opponent);
+    } THEN {
+        EXPECT_EQ(player->maxHP, player->hp);
+    }
+}
+
+SINGLE_BATTLE_TEST("Powder doesn't damage target if it has Magic Guard")
+{
+    GIVEN {
+        PLAYER(SPECIES_ALAKAZAM) { Ability(ABILITY_MAGIC_GUARD); }
+        OPPONENT(SPECIES_VIVILLON);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_POWDER); MOVE(player, MOVE_EMBER); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POWDER, opponent);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_EMBER, player);
+            HP_BAR(opponent);
+        }
+    } THEN {
+        EXPECT_EQ(player->maxHP, player->hp);
+    }
+}
+
+SINGLE_BATTLE_TEST("Powder doesn't damage target under heavy rain")
+{
+    GIVEN {
+        PLAYER(SPECIES_KYOGRE_PRIMAL) { Ability(ABILITY_PRIMORDIAL_SEA); }
+        OPPONENT(SPECIES_VIVILLON);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_POWDER); MOVE(player, MOVE_EMBER); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POWDER, opponent);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_EMBER, player);
+            HP_BAR(opponent);
+        }
+    } THEN {
+        EXPECT_EQ(player->maxHP, player->hp);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Powder blocks the target's Fire type moves even if it doesn't target Powder user")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_VIVILLON);
+    } WHEN {
+        TURN { MOVE(opponentRight, MOVE_POWDER, target: playerLeft); MOVE(playerLeft, MOVE_EMBER, target: opponentLeft); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POWDER, opponentRight);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_EMBER, playerLeft);
+            HP_BAR(opponentLeft);
+        }
+    }
+}
+
+DOUBLE_BATTLE_TEST("Powder fails if target is already affected by Powder")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_VIVILLON);
+        OPPONENT(SPECIES_VIVILLON);
+    } WHEN {
+        TURN { MOVE(opponentRight, MOVE_POWDER, target: playerLeft); MOVE(opponentLeft, MOVE_POWDER, target: playerLeft); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POWDER, opponentRight);
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_POWDER, opponentLeft);
+    }
+}
+
+SINGLE_BATTLE_TEST("Powder fails if the target is Grass type")
+{
+    GIVEN {
+        ASSUME(gSpeciesInfo[SPECIES_VENUSAUR].types[0] == TYPE_GRASS || gSpeciesInfo[SPECIES_VENUSAUR].types[1] == TYPE_GRASS);
+        PLAYER(SPECIES_VENUSAUR);
+        OPPONENT(SPECIES_VIVILLON);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_POWDER); MOVE(player, MOVE_EMBER); }
+    } SCENE {
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_POWDER, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EMBER, player);
+        HP_BAR(opponent);
+    }
+}
+
+SINGLE_BATTLE_TEST("Powder fails if the target has Overcoat")
+{
+    GIVEN {
+        PLAYER(SPECIES_FORRETRESS) { Ability(ABILITY_OVERCOAT); }
+        OPPONENT(SPECIES_VIVILLON);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_POWDER); MOVE(player, MOVE_EMBER); }
+    } SCENE {
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_POWDER, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EMBER, player);
+        HP_BAR(opponent);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Powder still blocks the target's Fire type moves even if it was given Grass type")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_FORESTS_CURSE].effect == EFFECT_THIRD_TYPE);
+        ASSUME(gMovesInfo[MOVE_FORESTS_CURSE].argument == TYPE_GRASS);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_TREVENANT);
+        OPPONENT(SPECIES_VIVILLON);
+    } WHEN {
+        TURN { MOVE(opponentRight, MOVE_POWDER, target: playerLeft); MOVE(opponentLeft, MOVE_FORESTS_CURSE, target: playerLeft); MOVE(playerLeft, MOVE_EMBER, target: opponentRight); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POWDER, opponentRight);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FORESTS_CURSE, opponentLeft);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_EMBER, playerLeft);
+            HP_BAR(opponentLeft);
+        }
+    }
+}
+
+DOUBLE_BATTLE_TEST("Powder still blocks the target's Fire type moves even if it was given Overcoat")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_DOODLE].effect == EFFECT_DOODLE);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_FORRETRESS) { Ability(ABILITY_OVERCOAT); }
+        OPPONENT(SPECIES_VIVILLON);
+    } WHEN {
+        TURN { MOVE(opponentRight, MOVE_POWDER, target: playerLeft); MOVE(playerRight, MOVE_DOODLE, target: opponentLeft); MOVE(playerLeft, MOVE_EMBER, target: opponentRight); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POWDER, opponentRight);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DOODLE, playerRight);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_EMBER, playerLeft);
+            HP_BAR(opponentLeft);
+        }
+    } THEN {
+        EXPECT_EQ(playerLeft->ability, ABILITY_OVERCOAT);
+    }
+}
+
+SINGLE_BATTLE_TEST("Powder prevents Protean from changing its user to Fire type")
+{
+    GIVEN {
+        PLAYER(SPECIES_GRENINJA) { Ability(ABILITY_PROTEAN); }
+        OPPONENT(SPECIES_VIVILLON);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_POWDER); MOVE(player, MOVE_EMBER); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POWDER, opponent);
+        NONE_OF {
+            ABILITY_POPUP(player, ABILITY_PROTEAN);
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_EMBER, player);
+            HP_BAR(opponent);
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Powder doesn't prevent a Fire move from thawing its user out")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_FLAME_WHEEL].thawsUser);
+        ASSUME(gMovesInfo[MOVE_FLAME_WHEEL].type == TYPE_FIRE);
+        PLAYER(SPECIES_WOBBUFFET) { Status1(STATUS1_FREEZE); }
+        OPPONENT(SPECIES_VIVILLON);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_POWDER); MOVE(player, MOVE_FLAME_WHEEL); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POWDER, opponent);
+        MESSAGE("Wobbuffet was defrosted by Flame Wheel!");
+        STATUS_ICON(player, none: TRUE);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_FLAME_WHEEL, player);
+            HP_BAR(opponent);
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Powder doesn't consume Berry from Fire type Natural Gift but prevents using the move")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_NATURAL_GIFT].effect == EFFECT_NATURAL_GIFT);
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_CHERI_BERRY); }
+        OPPONENT(SPECIES_VIVILLON);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_POWDER); MOVE(player, MOVE_NATURAL_GIFT); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POWDER, opponent);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_NATURAL_GIFT, player);
+            HP_BAR(opponent);
+        }
+    } THEN {
+        EXPECT_EQ(player->item, ITEM_CHERI_BERRY);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Powder damages a target using Shell Trap even if it wasn't hit by a Physical move")
+{
+    u32 move;
+    PARAMETRIZE { move = MOVE_TACKLE; }
+    PARAMETRIZE { move = MOVE_EMBER; }
+    PARAMETRIZE { move = MOVE_TICKLE;}
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_SHELL_TRAP].effect == EFFECT_SHELL_TRAP);
+        ASSUME(gMovesInfo[MOVE_SHELL_TRAP].type == TYPE_FIRE);
+        ASSUME(gMovesInfo[MOVE_TACKLE].category == DAMAGE_CATEGORY_PHYSICAL);
+        ASSUME(gMovesInfo[MOVE_EMBER].category == DAMAGE_CATEGORY_SPECIAL);
+        ASSUME(gMovesInfo[MOVE_TICKLE].category == DAMAGE_CATEGORY_STATUS);
+        ASSUME(gMovesInfo[MOVE_TICKLE].effect == EFFECT_TICKLE);
+        PLAYER(SPECIES_TURTONATOR);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_VIVILLON);
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_SHELL_TRAP); MOVE(opponentRight, MOVE_POWDER, target: playerLeft); MOVE(opponentLeft, move, target: playerLeft); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_SHELL_TRAP_SETUP, playerLeft);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POWDER, opponentRight);
+        ANIMATION(ANIM_TYPE_MOVE, move, opponentLeft);
+        if (move != MOVE_TICKLE)
+            HP_BAR(playerLeft);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_SHELL_TRAP, playerLeft);
+            HP_BAR(opponentLeft);
+            HP_BAR(opponentRight);
+        }
+        HP_BAR(playerLeft);
+    }
+}


### PR DESCRIPTION
Simplified the fix from #4638 to use a more suitable HitMarker.

Other fixed interactions:

> - If a Pokémon with Magic Guard affected by Powder attempts to use a Fire-type move, it will fail to execute the move but take no damage.

> **Generation VII**
> - Powder will no longer damage the Pokémon during heavy rain.
> - If a Pokémon affected by Powder uses Fire Pledge after an ally uses Water Pledge, such that the Pokémon ends up using Water Pledge as a combination move, Powder will not affect that move. If a Pokémon affected by Powder uses Fire Pledge otherwise (including as the first move of a combination move, or when using Grass Pledge as a combination move after an ally's Fire Pledge), Fire Pledge will be prevented by Powder like any other Fire-type move.

Currently it stopped all first or second move Fire Pledge only.

> Powder can prevent a Pokémon from using a Fire-type Z-Move, but status Z-Moves still gain their Z-Power effects.

Currently it doesn't display the Z-Move triggering animation and didn't grant the effects.

## **Discord contact info**
PhallenTree
