### PR TITLE
Switch AI hitsToKO considers one shot prevention

### DIFF
--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -1609,7 +1609,7 @@ static u32 GetSwitchinHitsToKO(s32 damageTaken, u32 battler)
     u16 maxHP = AI_DATA->switchinCandidate.battleMon.maxHP, item = AI_DATA->switchinCandidate.battleMon.item, heldItemEffect = ItemId_GetHoldEffect(item);
     u8 weatherDuration = gWishFutureKnock.weatherDuration, holdEffectParam = ItemId_GetHoldEffectParam(item);
     u32 opposingBattler = GetBattlerAtPosition(BATTLE_OPPOSITE(GetBattlerPosition(battler)));
-    u32 opposingAbility = gBattleMons[opposingBattler].ability;
+    u32 opposingAbility = gBattleMons[opposingBattler].ability, ability = AI_DATA->switchinCandidate.battleMon.ability;
     bool32 usedSingleUseHealingItem = FALSE;
     s32 currentHP = startingHP;
 
@@ -1630,6 +1630,10 @@ static u32 GetSwitchinHitsToKO(s32 damageTaken, u32 battler)
 
         // Take attack damage for the turn
         currentHP = currentHP - damageTaken;
+
+        // One shot prevention effects
+        if (damageTaken >= maxHP && currentHP == maxHP && (heldItemEffect == HOLD_EFFECT_FOCUS_SASH || B_STURDY >= GEN_5 && ability == ABILITY_STURDY))
+            currentHP = 1;
 
         // If mon is still alive, apply weather impact first, as it might KO the mon before it can heal with its item (order is weather -> item -> status)
         if (currentHP != 0)

--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -1632,7 +1632,7 @@ static u32 GetSwitchinHitsToKO(s32 damageTaken, u32 battler)
         currentHP = currentHP - damageTaken;
 
         // One shot prevention effects
-        if (damageTaken >= maxHP && currentHP == maxHP && (heldItemEffect == HOLD_EFFECT_FOCUS_SASH || B_STURDY >= GEN_5 && ability == ABILITY_STURDY))
+        if (damageTaken >= maxHP && currentHP == maxHP && (heldItemEffect == HOLD_EFFECT_FOCUS_SASH || (B_STURDY >= GEN_5 && ability == ABILITY_STURDY)))
             currentHP = 1;
 
         // If mon is still alive, apply weather impact first, as it might KO the mon before it can heal with its item (order is weather -> item -> status)


### PR DESCRIPTION
## Description
Addresses #5218 by adding a check for Focus Sash and Sturdy to the hitsToKO calculation that the smart switching AI flags use. Other cases are already handled in the damage calc and I didn't realize it at the time of suggestion :)

## Issue(s) that this PR fixes
Closes #5218 

## **Discord contact info**
@Pawkkie 
