### PR TITLE
Switch AI hitsToKO considers Disguise

### DIFF
--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -1610,7 +1610,7 @@ static u32 GetSwitchinHitsToKO(s32 damageTaken, u32 battler)
     u8 weatherDuration = gWishFutureKnock.weatherDuration, holdEffectParam = ItemId_GetHoldEffectParam(item);
     u32 opposingBattler = GetBattlerAtPosition(BATTLE_OPPOSITE(GetBattlerPosition(battler)));
     u32 opposingAbility = gBattleMons[opposingBattler].ability, ability = AI_DATA->switchinCandidate.battleMon.ability;
-    bool32 usedSingleUseHealingItem = FALSE;
+    bool32 usedSingleUseHealingItem = FALSE, opponentCanBreakMold = IsMoldBreakerTypeAbility(opposingBattler, opposingAbility);
     s32 currentHP = startingHP;
 
     // No damage being dealt
@@ -1632,7 +1632,7 @@ static u32 GetSwitchinHitsToKO(s32 damageTaken, u32 battler)
         currentHP = currentHP - damageTaken;
 
         // One shot prevention effects
-        if (damageTaken >= maxHP && currentHP == maxHP && (heldItemEffect == HOLD_EFFECT_FOCUS_SASH || (B_STURDY >= GEN_5 && ability == ABILITY_STURDY)))
+        if (damageTaken >= maxHP && currentHP == maxHP && (heldItemEffect == HOLD_EFFECT_FOCUS_SASH || (!opponentCanBreakMold && B_STURDY >= GEN_5 && ability == ABILITY_STURDY)))
             currentHP = 1;
 
         // If mon is still alive, apply weather impact first, as it might KO the mon before it can heal with its item (order is weather -> item -> status)
@@ -1696,6 +1696,10 @@ static u32 GetSwitchinHitsToKO(s32 damageTaken, u32 battler)
 
         hitsToKO++;
     }
+
+    // Disguise will always add an extra hit to KO
+    if (opponentCanBreakMold && AI_DATA->switchinCandidate.battleMon.species == SPECIES_MIMIKYU_DISGUISED)
+        hitsToKO++;
 
     // If mon had a hypothetical status from TSpikes, clear it
     if (AI_DATA->switchinCandidate.hypotheticalStatus == TRUE)


### PR DESCRIPTION
## Description
Cleanup / addition to #5371 that I was reminded about with #5373. Lets the smart switch AI's hitsToKO calculation consider Disguise, and also checks the player's mon for mold breaker abilities.

## Issue(s) that this PR fixes
Extends #5371 

## **Discord contact info**
@Pawkkie 
