### PR TITLE
Fixes After You/Shell Trap not updating battlers' actions correctly

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -8931,29 +8931,41 @@ static bool32 ChangeOrderTargetAfterAttacker(void)
 {
     u32 i;
     u8 data[MAX_BATTLERS_COUNT];
+    u8 actionsData[MAX_BATTLERS_COUNT];
 
     if (GetBattlerTurnOrderNum(gBattlerAttacker) > GetBattlerTurnOrderNum(gBattlerTarget)
         || GetBattlerTurnOrderNum(gBattlerAttacker) + 1 == GetBattlerTurnOrderNum(gBattlerTarget))
         return FALSE;
 
     for (i = 0; i < gBattlersCount; i++)
+    {
         data[i] = gBattlerByTurnOrder[i];
+        actionsData[i] = gActionsByTurnOrder[i];
+    }
     if (GetBattlerTurnOrderNum(gBattlerAttacker) == 0 && GetBattlerTurnOrderNum(gBattlerTarget) == 2)
     {
         gBattlerByTurnOrder[1] = gBattlerTarget;
+        gActionsByTurnOrder[1] = actionsData[2];
         gBattlerByTurnOrder[2] = data[1];
+        gActionsByTurnOrder[2] = actionsData[1];
         gBattlerByTurnOrder[3] = data[3];
+        gActionsByTurnOrder[3] = actionsData[3];
     }
     else if (GetBattlerTurnOrderNum(gBattlerAttacker) == 0 && GetBattlerTurnOrderNum(gBattlerTarget) == 3)
     {
         gBattlerByTurnOrder[1] = gBattlerTarget;
+        gActionsByTurnOrder[1] = actionsData[3];
         gBattlerByTurnOrder[2] = data[1];
+        gActionsByTurnOrder[2] = actionsData[1];
         gBattlerByTurnOrder[3] = data[2];
+        gActionsByTurnOrder[3] = actionsData[2];
     }
     else // Attacker == 1, Target == 3
     {
         gBattlerByTurnOrder[2] = gBattlerTarget;
+        gActionsByTurnOrder[2] = actionsData[3];
         gBattlerByTurnOrder[3] = data[2];
+        gActionsByTurnOrder[3] = actionsData[2];
     }
     return TRUE;
 }

--- a/test/battle/move_effect/after_you.c
+++ b/test/battle/move_effect/after_you.c
@@ -52,5 +52,39 @@ DOUBLE_BATTLE_TEST("After You does nothing if the target has already moved")
     }
 }
 
+DOUBLE_BATTLE_TEST("After You calculates correct targets if only one pokemon is left on the opposing side")
+{
+    GIVEN {
+        PLAYER(SPECIES_GRENINJA) { Speed(120); }
+        PLAYER(SPECIES_REGIROCK) { Speed(10); }
+        OPPONENT(SPECIES_PIDGEOT) { Speed(100); }
+        OPPONENT(SPECIES_DRAGONITE) { Speed(60); }
+    } WHEN {
+        TURN {
+            MOVE(playerLeft, MOVE_AFTER_YOU, target: playerRight);
+            MOVE(playerRight, MOVE_STONE_EDGE, target: opponentLeft);
+            MOVE(opponentRight, MOVE_CELEBRATE);
+        }
+        TURN {
+            MOVE(playerLeft, MOVE_AFTER_YOU, target: playerRight);
+            MOVE(playerRight, MOVE_STONE_EDGE, target: opponentRight);
+            MOVE(opponentRight, MOVE_CELEBRATE);
+        }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_AFTER_YOU, playerLeft);
+        MESSAGE("Regirock took the kind offer!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_STONE_EDGE, playerRight);
+        HP_BAR(opponentLeft);
+        MESSAGE("Foe Pidgeot fainted!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponentRight);
+
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_AFTER_YOU, playerLeft);
+        MESSAGE("Regirock took the kind offer!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_STONE_EDGE, playerRight);
+        HP_BAR(opponentRight);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponentRight);
+    }
+}
+
 TO_DO_BATTLE_TEST("After You doesn't fail if the turner remains the same after After You (Gen8+)");
 TO_DO_BATTLE_TEST("After You ignores the effects of Quash");

--- a/test/battle/move_effect/shell_trap.c
+++ b/test/battle/move_effect/shell_trap.c
@@ -166,3 +166,35 @@ DOUBLE_BATTLE_TEST("Shell Trap activates immediately after being hit on turn 3 a
         HP_BAR(opponentRight);
     }
 }
+
+DOUBLE_BATTLE_TEST("Shell Trap targets correctly if one of the opponents has fainted")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_SHELL_TRAP].target == MOVE_TARGET_BOTH);
+        PLAYER(SPECIES_GRENINJA) { Speed(60); }
+        PLAYER(SPECIES_TURTONATOR) { Speed(10); }
+        OPPONENT(SPECIES_BLASTOISE) { Speed(120); }
+        OPPONENT(SPECIES_SCIZOR) { Speed(100); }
+    } WHEN {
+        TURN {
+            MOVE(opponentLeft, MOVE_TACKLE, target: playerRight);
+            MOVE(playerRight, MOVE_SHELL_TRAP);
+        }
+        TURN {
+            MOVE(opponentLeft, MOVE_TACKLE, target: playerRight);
+            MOVE(playerRight, MOVE_SHELL_TRAP);
+        }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_SHELL_TRAP_SETUP, playerRight);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentLeft);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SHELL_TRAP, playerRight);
+        MESSAGE("Foe Scizor fainted!");
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponentRight);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, playerLeft);
+
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_SHELL_TRAP_SETUP, playerRight);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentLeft);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SHELL_TRAP, playerRight);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, playerLeft);
+    }
+}


### PR DESCRIPTION
Fixes `ChangeOrderTargetAfterAttacker` (used by both moves) not changing battlers' actions to reflect the new turn order. (`gActionsByTurnOrder`)
In the test presented in the issue, it saw the After You target having the action "NothingFainted" (since the battler which originally would move after the user of After You was the fainted Pidgeot) which made it not act. I presume similar effects may happen with other actions that don't happen before After You can be used.
Current interaction:

https://github.com/user-attachments/assets/8c9f0d70-329a-4e33-8cbc-648e224130be

Confirmed that the same issue occurred with Shell Trap.
Added the test from #5316 and a similar one for Shell Trap.

## Issue(s) that this PR fixes
Fixes #5316 

## **Discord contact info**
PhallenTree
