### PR TITLE
Fallback on default BW map pop-up theme to reduce potential for error

### DIFF
--- a/src/map_name_popup.c
+++ b/src/map_name_popup.c
@@ -625,7 +625,7 @@ static void LoadMapNamePopUpWindowBg(void)
         switch (popUpThemeId)
         {
             // add additional gen 5-style pop-up themes as cases here
-            case MAPPOPUP_THEME_BW_DEFAULT:
+            default: // MAPPOPUP_THEME_BW_DEFAULT
                 if (OW_POPUP_BW_COLOR == OW_POPUP_BW_COLOR_WHITE)
                     LoadPalette(sMapPopUpTilesPalette_BW_White, BG_PLTT_ID(14), sizeof(sMapPopUpTilesPalette_BW_White));
                 else


### PR DESCRIPTION
## Description
This is a minor tweak to fallback to the default BW map pop-up theme if the current map section isn't in the theme array (`sRegionMapSectionId_To_PopUpThemeIdMapping_BW[]`), so that users won't encounter issues if they forget to include their new map section in it.

## Potential Issues
This doesn't actually address the potential UB of accessing the `sRegionMapSectionId_To_PopUpThemeIdMapping_BW[]` array out of bounds. This could mask errors, but it's my impression that this is not really likely to happen. Please let me know if that's a bad assumption.

## Images
An example of the behavior before the fix if you don't include the new map section in the theme array:
![image](https://github.com/user-attachments/assets/a4b80477-6b18-4b12-b38c-a58d83bcd5b2)

## Issue(s) that this PR fixes
Common source of error when adding new map sections while using BW map pop-ups.

## **Discord contact info**
ravepossum
