### PR TITLE
Remove potential uninitialized behavior

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -8935,7 +8935,7 @@ static bool32 ChangeOrderTargetAfterAttacker(void)
         || GetBattlerTurnOrderNum(gBattlerAttacker) + 1 == GetBattlerTurnOrderNum(gBattlerTarget))
         return FALSE;
 
-    for (i = 0; i < gBattlersCount; i++)
+    for (i = 0; i < MAX_BATTLERS_COUNT; i++)
     {
         data[i] = gBattlerByTurnOrder[i];
         actionsData[i] = gActionsByTurnOrder[i];


### PR DESCRIPTION
`MAX_BATTLERS_COUNT` can be used here because we iterate over max battlers in the first place.