### PR TITLE
Fix Trick/Switcheroo giving AI score even if the opponent has no held item

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -4065,7 +4065,7 @@ static u32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move)
                 ADJUST_SCORE(DECENT_EFFECT); // Force 'em out next turn
             break;
         default:
-            if (move != MOVE_BESTOW && aiData->items[battlerAtk] == ITEM_NONE)
+            if (move != MOVE_BESTOW && aiData->items[battlerAtk] == ITEM_NONE && aiData->items[battlerDef] != ITEM_NONE)
             {
                 switch (aiData->holdEffects[battlerDef])
                 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Simply checks if the AI knows the opponent has a held item before running the code that gives score depending on what hold effect it is. Before it always gave a weak score to the move even if the opponent had no held item.

## Issue(s) that this PR fixes
Fixes #5411

## **Discord contact info**
kittenchilly