### PR TITLE
Tangling Hair Test Additional Check

### DIFF
--- a/test/battle/ability/tangling_hair.c
+++ b/test/battle/ability/tangling_hair.c
@@ -50,10 +50,10 @@ SINGLE_BATTLE_TEST("Tangling Hair does not cause Rocky Helmet miss activation")
     }
 }
 
-SINGLE_BATTLE_TEST("Tangling Hair Speed stat drop triggers defiant")
+SINGLE_BATTLE_TEST("Tangling Hair Speed stat drop triggers defiant and keeps original attacker/target")
 {
     GIVEN {
-        PLAYER(SPECIES_DUGTRIO) { Ability(ABILITY_TANGLING_HAIR); }
+        PLAYER(SPECIES_DUGTRIO) { Ability(ABILITY_TANGLING_HAIR); Item(ITEM_ROCKY_HELMET); }
         OPPONENT(SPECIES_PAWNIARD) { Ability(ABILITY_DEFIANT); }
     } WHEN {
         TURN { MOVE(opponent, MOVE_TACKLE); }
@@ -64,5 +64,7 @@ SINGLE_BATTLE_TEST("Tangling Hair Speed stat drop triggers defiant")
         MESSAGE("Foe Pawniard's Speed fell!");
         ABILITY_POPUP(opponent, ABILITY_DEFIANT);
         MESSAGE("Foe Pawniard's Attack sharply rose!");
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+        MESSAGE("Foe Pawniard was hurt by Dugtrio's Rocky Helmet!");
     }
 }


### PR DESCRIPTION
Adds rocky helmet dmg element to last tangling hair + defiant test to make sure that the chained effects do not overwrite relevant battler Ids. 