### PR TITLE
Add Chooseboxmon special

### DIFF
--- a/data/specials.inc
+++ b/data/specials.inc
@@ -555,3 +555,4 @@ gSpecials::
 	def_special Script_GetChosenMonOffensiveIVs
 	def_special Script_GetChosenMonDefensiveIVs
 	def_special UseBlankMessageToCancelPokemonPic
+	def_special ChooseBoxMon

--- a/include/pokemon_storage_system.h
+++ b/include/pokemon_storage_system.h
@@ -76,5 +76,8 @@ bool32 IsWaldaPhraseEmpty(void);
 
 void EnterPokeStorage(u8 boxOption);
 u32 CountPartyNonEggMons(void);
+void ChooseBoxMon(void);
+u8 GetSavedCursorPos(void);
+u8 GetInPartyMenu(void);
 
 #endif // GUARD_POKEMON_STORAGE_SYSTEM_H


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a `ChooseBoxMon` special that can be used instead of `ChoosePartyMon` to select a Pokemon. This only provides functionality for `ChooseBoxMon` and does not modify any other functions to handle the results. 

`ChooseBoxMon` returns the species selected in `VAR_RESULT` (for NPCs that ask to see specific Pokemon) and the Pc box cursor position/party slot id in `VAR_0x8004` (as `ChoosePartyMon` uses that var for the party slot id). 

The `BoxMon` data can be found by using these 3 functions
- `GetInPartyMenu` which returns 1 if the Pokemon selected is in the party, 0 otherwise 
- `GetSavedCursorPos` returns either the party slot id of the slot id in the box
- `StorageGetCurrentBox` returns the box id 
You can then use either `&gPlayerParty[slotId]` or `&gPokemonStoragePtr->boxes[boxId][slotId]` to get the Pokemon's data. 

See [this commit](https://github.com/Artrios/pokeemerald/commit/1e0a2315b4f2fe484a14ae35140ddf663107c27b) for an example of how to use this for the daycare. 

## Images
<!-- Please provide with relevant GIFs or images to make it easier for reviewers to accept your PR quicker.-->
<!-- If it doesn't apply, feel free to remove this section. -->
![ChooseBoxMon](https://github.com/user-attachments/assets/9dd67dcb-0cd7-414a-bc96-e273d667f8bc)

## **Discord contact info**
<!--- formatted as name#numbers, e.g. Lunos#4026 -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
paccy.