### PR TITLE
Fix duplicating flute bug

### DIFF
--- a/include/party_menu.h
+++ b/include/party_menu.h
@@ -102,5 +102,6 @@ void MoveDeleterForgetMove(void);
 void BufferMoveDeleterNicknameAndMove(void);
 void GetNumMovesSelectedMonHas(void);
 void MoveDeleterChooseMoveToForget(void);
+bool32 IsItemFlute(u16 item);
 
 #endif // GUARD_PARTY_MENU_H

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -387,8 +387,8 @@ static void HandleInputChooseAction(u32 battler)
          && !(gAbsentBattlerFlags & gBitTable[GetBattlerAtPosition(B_POSITION_PLAYER_LEFT)])
          && !(gBattleTypeFlags & BATTLE_TYPE_MULTI))
         {
-            // Return item to bag if partner had selected one.
-            if (gBattleResources->bufferA[battler][1] == B_ACTION_USE_ITEM)
+            // Return item to bag if partner had selected one (except flutes).
+            if (gBattleResources->bufferA[battler][1] == B_ACTION_USE_ITEM && !IsItemFlute(itemId))
             {
                 AddBagItem(itemId, 1);
             }

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -4578,7 +4578,7 @@ static bool8 NotUsingHPEVItemOnShedinja(struct Pokemon *mon, u16 item)
     return TRUE;
 }
 
-static bool8 IsItemFlute(u16 item)
+bool32 IsItemFlute(u16 item)
 {
     if (item == ITEM_BLUE_FLUTE || item == ITEM_RED_FLUTE || item == ITEM_YELLOW_FLUTE)
         return TRUE;


### PR DESCRIPTION
In doubles, if you choose to use a flute item on battler 0 and then cancel, you end up with 2 flutes