### PR TITLE
Fix Jubilife Muffin full heal effect + better full heal tests

### DIFF
--- a/src/data/items.h
+++ b/src/data/items.h
@@ -13867,6 +13867,7 @@ const struct Item gItemsInfo[] =
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
         .battleUsage = EFFECT_ITEM_CURE_STATUS,
+        .effect = gItemEffect_FullHeal,
         .flingPower = 30,
         .iconPic = gItemIcon_JubilifeMuffin,
         .iconPalette = gItemIconPalette_JubilifeMuffin,

--- a/test/battle/item_effect/cure_status.c
+++ b/test/battle/item_effect/cure_status.c
@@ -94,11 +94,14 @@ SINGLE_BATTLE_TEST("Burn Heal heals a battler from being burned")
     }
 }
 
-SINGLE_BATTLE_TEST("Ice Heal heals a battler from being frozen")
+SINGLE_BATTLE_TEST("Ice Heal heals a battler from being frozen or frostbite")
 {
+    u16 status;
+    PARAMETRIZE { status = STATUS1_FREEZE; }
+    PARAMETRIZE { status = STATUS1_FROSTBITE; }
     GIVEN {
         ASSUME(gItemsInfo[ITEM_ICE_HEAL].battleUsage == EFFECT_ITEM_CURE_STATUS);
-        PLAYER(SPECIES_WOBBUFFET) { Status1(STATUS1_FREEZE); }
+        PLAYER(SPECIES_WOBBUFFET) { Status1(status); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
         TURN { USE_ITEM(player, ITEM_ICE_HEAL, partyIndex: 0); }
@@ -112,12 +115,13 @@ SINGLE_BATTLE_TEST("Ice Heal heals a battler from being frozen")
 SINGLE_BATTLE_TEST("Full Heal heals a battler from any primary status")
 {
     u16 status;
+    PARAMETRIZE { status = STATUS1_SLEEP; }
+    PARAMETRIZE { status = STATUS1_POISON; }
     PARAMETRIZE { status = STATUS1_BURN; }
     PARAMETRIZE { status = STATUS1_FREEZE; }
     PARAMETRIZE { status = STATUS1_PARALYSIS; }
-    PARAMETRIZE { status = STATUS1_POISON; }
     PARAMETRIZE { status = STATUS1_TOXIC_POISON; }
-    PARAMETRIZE { status = STATUS1_SLEEP; }
+    PARAMETRIZE { status = STATUS1_FROSTBITE; }
     GIVEN {
         ASSUME(gItemsInfo[ITEM_FULL_HEAL].battleUsage == EFFECT_ITEM_CURE_STATUS);
         PLAYER(SPECIES_WOBBUFFET) { Status1(status); }
@@ -134,12 +138,13 @@ SINGLE_BATTLE_TEST("Full Heal heals a battler from any primary status")
 SINGLE_BATTLE_TEST("Heal Powder heals a battler from any primary status")
 {
     u16 status;
+    PARAMETRIZE { status = STATUS1_SLEEP; }
+    PARAMETRIZE { status = STATUS1_POISON; }
     PARAMETRIZE { status = STATUS1_BURN; }
     PARAMETRIZE { status = STATUS1_FREEZE; }
     PARAMETRIZE { status = STATUS1_PARALYSIS; }
-    PARAMETRIZE { status = STATUS1_POISON; }
     PARAMETRIZE { status = STATUS1_TOXIC_POISON; }
-    PARAMETRIZE { status = STATUS1_SLEEP; }
+    PARAMETRIZE { status = STATUS1_FROSTBITE; }
     GIVEN {
         ASSUME(gItemsInfo[ITEM_HEAL_POWDER].battleUsage == EFFECT_ITEM_CURE_STATUS);
         PLAYER(SPECIES_WOBBUFFET) { Status1(status); }
@@ -156,12 +161,13 @@ SINGLE_BATTLE_TEST("Heal Powder heals a battler from any primary status")
 SINGLE_BATTLE_TEST("Pewter Crunchies heals a battler from any primary status")
 {
     u16 status;
+    PARAMETRIZE { status = STATUS1_SLEEP; }
+    PARAMETRIZE { status = STATUS1_POISON; }
     PARAMETRIZE { status = STATUS1_BURN; }
     PARAMETRIZE { status = STATUS1_FREEZE; }
     PARAMETRIZE { status = STATUS1_PARALYSIS; }
-    PARAMETRIZE { status = STATUS1_POISON; }
     PARAMETRIZE { status = STATUS1_TOXIC_POISON; }
-    PARAMETRIZE { status = STATUS1_SLEEP; }
+    PARAMETRIZE { status = STATUS1_FROSTBITE; }
     GIVEN {
         ASSUME(gItemsInfo[ITEM_PEWTER_CRUNCHIES].battleUsage == EFFECT_ITEM_CURE_STATUS);
         PLAYER(SPECIES_WOBBUFFET) { Status1(status); }
@@ -178,12 +184,13 @@ SINGLE_BATTLE_TEST("Pewter Crunchies heals a battler from any primary status")
 SINGLE_BATTLE_TEST("Lava Cookies heals a battler from any primary status")
 {
     u16 status;
+    PARAMETRIZE { status = STATUS1_SLEEP; }
+    PARAMETRIZE { status = STATUS1_POISON; }
     PARAMETRIZE { status = STATUS1_BURN; }
     PARAMETRIZE { status = STATUS1_FREEZE; }
     PARAMETRIZE { status = STATUS1_PARALYSIS; }
-    PARAMETRIZE { status = STATUS1_POISON; }
     PARAMETRIZE { status = STATUS1_TOXIC_POISON; }
-    PARAMETRIZE { status = STATUS1_SLEEP; }
+    PARAMETRIZE { status = STATUS1_FROSTBITE; }
     GIVEN {
         ASSUME(gItemsInfo[ITEM_LAVA_COOKIE].battleUsage == EFFECT_ITEM_CURE_STATUS);
         PLAYER(SPECIES_WOBBUFFET) { Status1(status); }
@@ -200,12 +207,13 @@ SINGLE_BATTLE_TEST("Lava Cookies heals a battler from any primary status")
 SINGLE_BATTLE_TEST("Rage Candy Bar heals a battler from any primary status")
 {
     u16 status;
+    PARAMETRIZE { status = STATUS1_SLEEP; }
+    PARAMETRIZE { status = STATUS1_POISON; }
     PARAMETRIZE { status = STATUS1_BURN; }
     PARAMETRIZE { status = STATUS1_FREEZE; }
     PARAMETRIZE { status = STATUS1_PARALYSIS; }
-    PARAMETRIZE { status = STATUS1_POISON; }
     PARAMETRIZE { status = STATUS1_TOXIC_POISON; }
-    PARAMETRIZE { status = STATUS1_SLEEP; }
+    PARAMETRIZE { status = STATUS1_FROSTBITE; }
     GIVEN {
         ASSUME(gItemsInfo[ITEM_RAGE_CANDY_BAR].battleUsage == EFFECT_ITEM_CURE_STATUS);
         PLAYER(SPECIES_WOBBUFFET) { Status1(status); }
@@ -222,12 +230,13 @@ SINGLE_BATTLE_TEST("Rage Candy Bar heals a battler from any primary status")
 SINGLE_BATTLE_TEST("Old Gateu heals a battler from any primary status")
 {
     u16 status;
+    PARAMETRIZE { status = STATUS1_SLEEP; }
+    PARAMETRIZE { status = STATUS1_POISON; }
     PARAMETRIZE { status = STATUS1_BURN; }
     PARAMETRIZE { status = STATUS1_FREEZE; }
     PARAMETRIZE { status = STATUS1_PARALYSIS; }
-    PARAMETRIZE { status = STATUS1_POISON; }
     PARAMETRIZE { status = STATUS1_TOXIC_POISON; }
-    PARAMETRIZE { status = STATUS1_SLEEP; }
+    PARAMETRIZE { status = STATUS1_FROSTBITE; }
     GIVEN {
         ASSUME(gItemsInfo[ITEM_OLD_GATEAU].battleUsage == EFFECT_ITEM_CURE_STATUS);
         PLAYER(SPECIES_WOBBUFFET) { Status1(status); }
@@ -244,12 +253,13 @@ SINGLE_BATTLE_TEST("Old Gateu heals a battler from any primary status")
 SINGLE_BATTLE_TEST("Casteliacone heals a battler from any primary status")
 {
     u16 status;
+    PARAMETRIZE { status = STATUS1_SLEEP; }
+    PARAMETRIZE { status = STATUS1_POISON; }
     PARAMETRIZE { status = STATUS1_BURN; }
     PARAMETRIZE { status = STATUS1_FREEZE; }
     PARAMETRIZE { status = STATUS1_PARALYSIS; }
-    PARAMETRIZE { status = STATUS1_POISON; }
     PARAMETRIZE { status = STATUS1_TOXIC_POISON; }
-    PARAMETRIZE { status = STATUS1_SLEEP; }
+    PARAMETRIZE { status = STATUS1_FROSTBITE; }
     GIVEN {
         ASSUME(gItemsInfo[ITEM_CASTELIACONE].battleUsage == EFFECT_ITEM_CURE_STATUS);
         PLAYER(SPECIES_WOBBUFFET) { Status1(status); }
@@ -266,12 +276,13 @@ SINGLE_BATTLE_TEST("Casteliacone heals a battler from any primary status")
 SINGLE_BATTLE_TEST("Lumiose Galette heals a battler from any primary status")
 {
     u16 status;
+    PARAMETRIZE { status = STATUS1_SLEEP; }
+    PARAMETRIZE { status = STATUS1_POISON; }
     PARAMETRIZE { status = STATUS1_BURN; }
     PARAMETRIZE { status = STATUS1_FREEZE; }
     PARAMETRIZE { status = STATUS1_PARALYSIS; }
-    PARAMETRIZE { status = STATUS1_POISON; }
     PARAMETRIZE { status = STATUS1_TOXIC_POISON; }
-    PARAMETRIZE { status = STATUS1_SLEEP; }
+    PARAMETRIZE { status = STATUS1_FROSTBITE; }
     GIVEN {
         ASSUME(gItemsInfo[ITEM_LUMIOSE_GALETTE].battleUsage == EFFECT_ITEM_CURE_STATUS);
         PLAYER(SPECIES_WOBBUFFET) { Status1(status); }
@@ -288,12 +299,13 @@ SINGLE_BATTLE_TEST("Lumiose Galette heals a battler from any primary status")
 SINGLE_BATTLE_TEST("Shalour Sable heals a battler from any primary status")
 {
     u16 status;
+    PARAMETRIZE { status = STATUS1_SLEEP; }
+    PARAMETRIZE { status = STATUS1_POISON; }
     PARAMETRIZE { status = STATUS1_BURN; }
     PARAMETRIZE { status = STATUS1_FREEZE; }
     PARAMETRIZE { status = STATUS1_PARALYSIS; }
-    PARAMETRIZE { status = STATUS1_POISON; }
     PARAMETRIZE { status = STATUS1_TOXIC_POISON; }
-    PARAMETRIZE { status = STATUS1_SLEEP; }
+    PARAMETRIZE { status = STATUS1_FROSTBITE; }
     GIVEN {
         ASSUME(gItemsInfo[ITEM_SHALOUR_SABLE].battleUsage == EFFECT_ITEM_CURE_STATUS);
         PLAYER(SPECIES_WOBBUFFET) { Status1(status); }
@@ -310,18 +322,42 @@ SINGLE_BATTLE_TEST("Shalour Sable heals a battler from any primary status")
 SINGLE_BATTLE_TEST("Big Malasada heals a battler from any primary status")
 {
     u16 status;
+    PARAMETRIZE { status = STATUS1_SLEEP; }
+    PARAMETRIZE { status = STATUS1_POISON; }
     PARAMETRIZE { status = STATUS1_BURN; }
     PARAMETRIZE { status = STATUS1_FREEZE; }
     PARAMETRIZE { status = STATUS1_PARALYSIS; }
-    PARAMETRIZE { status = STATUS1_POISON; }
     PARAMETRIZE { status = STATUS1_TOXIC_POISON; }
-    PARAMETRIZE { status = STATUS1_SLEEP; }
+    PARAMETRIZE { status = STATUS1_FROSTBITE; }
     GIVEN {
         ASSUME(gItemsInfo[ITEM_BIG_MALASADA].battleUsage == EFFECT_ITEM_CURE_STATUS);
         PLAYER(SPECIES_WOBBUFFET) { Status1(status); }
         OPPONENT(SPECIES_WYNAUT);
     } WHEN {
         TURN { USE_ITEM(player, ITEM_BIG_MALASADA, partyIndex: 0); }
+    } SCENE {
+        MESSAGE("Wobbuffet had its status healed!");
+    } THEN {
+        EXPECT_EQ(player->status1, STATUS1_NONE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Jubilife Muffin heals a battler from any primary status")
+{
+    u16 status;
+    PARAMETRIZE { status = STATUS1_SLEEP; }
+    PARAMETRIZE { status = STATUS1_POISON; }
+    PARAMETRIZE { status = STATUS1_BURN; }
+    PARAMETRIZE { status = STATUS1_FREEZE; }
+    PARAMETRIZE { status = STATUS1_PARALYSIS; }
+    PARAMETRIZE { status = STATUS1_TOXIC_POISON; }
+    PARAMETRIZE { status = STATUS1_FROSTBITE; }
+    GIVEN {
+        ASSUME(gItemsInfo[ITEM_JUBILIFE_MUFFIN].battleUsage == EFFECT_ITEM_CURE_STATUS);
+        PLAYER(SPECIES_WOBBUFFET) { Status1(status); }
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN { USE_ITEM(player, ITEM_JUBILIFE_MUFFIN, partyIndex: 0); }
     } SCENE {
         MESSAGE("Wobbuffet had its status healed!");
     } THEN {
@@ -342,6 +378,7 @@ SINGLE_BATTLE_TEST("Full Heal, Heal Powder and Local Specialties heal a battler 
     PARAMETRIZE { item = ITEM_LUMIOSE_GALETTE; }
     PARAMETRIZE { item = ITEM_SHALOUR_SABLE; }
     PARAMETRIZE { item = ITEM_BIG_MALASADA; }
+    PARAMETRIZE { item = ITEM_JUBILIFE_MUFFIN; }
     GIVEN {
         ASSUME(gItemsInfo[item].battleUsage == EFFECT_ITEM_CURE_STATUS);
         PLAYER(SPECIES_WOBBUFFET);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes Jubilife Muffin not actually working, due to a missing effect.
Also adds Jubilife Muffin to local specialty and full heal tests, as well as adding frostbite to the test which was missing.

## **Discord contact info**
kittenchilly