### PR TITLE
Typo from original devs in original game: | should be ||

### DIFF
--- a/src/field_poison.c
+++ b/src/field_poison.c
@@ -93,7 +93,7 @@ static void Task_TryFieldPoisonWhiteOut(u8 taskId)
         if (AllMonsFainted())
         {
             // Battle facilities have their own white out script to handle the challenge loss
-            if (InBattlePyramid() | InBattlePike() || InTrainerHillChallenge())
+            if (InBattlePyramid() || InBattlePike() || InTrainerHillChallenge())
                 gSpecialVar_Result = FLDPSN_FRONTIER_WHITEOUT;
             else
                 gSpecialVar_Result = FLDPSN_WHITEOUT;


### PR DESCRIPTION
Doesn't fix any behavior, but it's just better this way.

## **Discord contact info**
<!--- formatted as name#numbers, e.g. Lunos#4026 -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
RSilicon