### PR TITLE
Fix Commander test name

### DIFF
--- a/test/battle/ability/commander.c
+++ b/test/battle/ability/commander.c
@@ -254,7 +254,7 @@ DOUBLE_BATTLE_TEST("Commander doesn't prevent Imposter from working on a Command
     }
 }
 
-DOUBLE_BATTLE_TEST("Commander Tatsugiri is still affected by Haze while controlling Dondozo")
+DOUBLE_BATTLE_TEST("Commander Tatsugiri is still affected by Perish Song while controlling Dondozo")
 {
     GIVEN {
         PLAYER(SPECIES_DONDOZO);


### PR DESCRIPTION
Fixes the fact that two Commander tests shared a name, even if it was unrelated to the actual contents of one of the tests

## **Discord contact info**
bassoonian
