### PR TITLE
Remove cmd_recordability

### DIFF
--- a/asm/macros/battle_script.inc
+++ b/asm/macros/battle_script.inc
@@ -649,9 +649,8 @@
 	.byte \battler
 	.endm
 
-	.macro recordability battler:req
+	.macro unused70
 	.byte 0x70
-	.byte \battler
 	.endm
 
 	.macro buffermovetolearn

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -7599,7 +7599,6 @@ BattleScript_AbilityPopUp:
 	showabilitypopup BS_ABILITY_BATTLER
 	pause 40
 	.endif
-	recordability BS_ABILITY_BATTLER
 	sethword sABILITY_OVERWRITE, 0
 	return
 
@@ -7608,7 +7607,6 @@ BattleScript_AbilityPopUpScripting:
 	showabilitypopup BS_SCRIPTING
 	pause 40
 	.endif
-	recordability BS_SCRIPTING
 	sethword sABILITY_OVERWRITE, 0
 	return
 

--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -1,6 +1,7 @@
 #include "global.h"
 #include "malloc.h"
 #include "battle.h"
+#include "battle_ai_util.h"
 #include "pokemon.h"
 #include "battle_controllers.h"
 #include "battle_interface.h"
@@ -2718,6 +2719,7 @@ void CreateAbilityPopUp(u8 battlerId, u32 ability, bool32 isDoubleBattle)
         LoadSpriteSheet(&sSpriteSheet_AbilityPopUp);
         LoadSpritePalette(&sSpritePalette_AbilityPopUp);
     }
+    RecordAbilityBattle(battlerId, ability);
     gBattleStruct->activeAbilityPopUps |= 1u << battlerId;
     battlerPosition = GetBattlerPosition(battlerId);
 

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -450,7 +450,7 @@ static void Cmd_drawlvlupbox(void);
 static void Cmd_resetsentmonsvalue(void);
 static void Cmd_setatktoplayer0(void);
 static void Cmd_makevisible(void);
-static void Cmd_recordability(void);
+static void Cmd_unused70(void);
 static void Cmd_buffermovetolearn(void);
 static void Cmd_jumpifplayerran(void);
 static void Cmd_hpthresholds(void);
@@ -709,7 +709,7 @@ void (* const gBattleScriptingCommandsTable[])(void) =
     Cmd_resetsentmonsvalue,                      //0x6D
     Cmd_setatktoplayer0,                         //0x6E
     Cmd_makevisible,                             //0x6F
-    Cmd_recordability,                           //0x70
+    Cmd_unused70,                           //0x70
     Cmd_buffermovetolearn,                       //0x71
     Cmd_jumpifplayerran,                         //0x72
     Cmd_hpthresholds,                            //0x73
@@ -8610,12 +8610,9 @@ static void Cmd_makevisible(void)
     gBattlescriptCurrInstr = cmd->nextInstr;
 }
 
-static void Cmd_recordability(void)
+static void Cmd_unused70(void)
 {
-    CMD_ARGS(u8 battler);
-
-    u8 battler = GetBattlerForBattleScript(cmd->battler);
-    RecordAbilityBattle(battler, gBattleMons[battler].ability);
+    CMD_ARGS();
     gBattlescriptCurrInstr = cmd->nextInstr;
 }
 


### PR DESCRIPTION
Removes cmd_recordability and calls directly in CreateAbilityPopup. This also catches `abilityPopupOverwrite` abilities