### PR TITLE
Fix certain move data being cleared on turn end

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -738,8 +738,6 @@ void HandleAction_ActionFinished(void)
     gMoveResultFlags = 0;
     gBattleScripting.animTurn = 0;
     gBattleScripting.animTargetsHit = 0;
-    gLastLandedMoves[gBattlerAttacker] = 0;
-    gLastHitByType[gBattlerAttacker] = 0;
     gBattleStruct->dynamicMoveType = 0;
     gBattleScripting.moveendState = 0;
     gBattleCommunication[3] = 0;


### PR DESCRIPTION
## Description
`gLastLandedMoves` and `gLastHitByType` aren't used very often, but they are used for both Conversion 2's functionality and by the switch AI to determine whether the AI can switch in a mon that absorbs the last move they were hit by.

Now that we can write PASSES_RANDOMLY tests and I'm refactoring `ShouldSwitch` ahead of switch prediction, I discovered that both of these terms were being reset at the end of the turn, which means no continuity across turns, breaking both of these functions.

Alex helped brainstorm solutions and identified exactly where this needed to be removed from. Not including tests for the absorb switching as they'll be coming with the refactor instead, as the `RandomPercentage` changes are more invasive than what I typically PR to master.

## **People who collaborated with me in this PR**
@AlexOn1ine 

## **Discord contact info**
@Pawkkie 
