### PR TITLE
Expand aiCalcInProgress Usages

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -716,7 +716,7 @@ struct BattleStruct
     } multiBuffer;
     u8 wishPerishSongState;
     u8 wishPerishSongBattlerId;
-    u8 aiCalcInProgress:1;
+    u8 aiCalcInProgress:1;      // computing ai dmg/scores
     u8 overworldWeatherDone:1;
     u8 startingStatusDone:1;
     u8 isAtkCancelerForCalledMove:1; // Certain cases in atk canceler should only be checked once, when the original move is called, however others need to be checked the twice.

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -485,6 +485,8 @@ void SetAiLogicDataForTurn(struct AiLogicData *aiData)
         SetBattlerAiData(battlerAtk, aiData);
     }
 
+    
+    gBattleStruct->aiCalcInProgress = TRUE;
     for (battlerAtk = 0; battlerAtk < battlersCount; battlerAtk++)
     {
         if (!IsBattlerAlive(battlerAtk))
@@ -492,6 +494,7 @@ void SetAiLogicDataForTurn(struct AiLogicData *aiData)
 
         SetBattlerAiMovesData(aiData, battlerAtk, battlersCount);
     }
+    gBattleStruct->aiCalcInProgress = FALSE;
 }
 
 static bool32 AI_SwitchMonIfSuitable(u32 battler, bool32 doubleBattle)

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -371,9 +371,7 @@ struct SimulatedDamage AI_CalcDamageSaveBattlers(u32 move, u32 battlerAtk, u32 b
     SaveBattlerData(battlerDef);
     SetBattlerData(battlerAtk);
     SetBattlerData(battlerDef);
-    gBattleStruct->aiCalcInProgress = TRUE;
     dmg = AI_CalcDamage(move, battlerAtk, battlerDef, typeEffectiveness, considerZPower, AI_GetWeather(AI_DATA), rollType);
-    gBattleStruct->aiCalcInProgress = FALSE;
     RestoreBattlerData(battlerAtk);
     RestoreBattlerData(battlerDef);
     return dmg;
@@ -3519,9 +3517,7 @@ s32 AI_CalcPartyMonDamage(u32 move, u32 battlerAtk, u32 battlerDef, struct Battl
         AI_THINKING_STRUCT->saved[battlerAtk].saved = FALSE;
     }
 
-    gBattleStruct->aiCalcInProgress = TRUE;
     dmg = AI_CalcDamage(move, battlerAtk, battlerDef, &effectiveness, FALSE, AI_GetWeather(AI_DATA), rollType);
-    gBattleStruct->aiCalcInProgress = FALSE;
     // restores original gBattleMon struct
     FreeRestoreBattleMons(savedBattleMons);
     return dmg.expected;

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -371,7 +371,9 @@ struct SimulatedDamage AI_CalcDamageSaveBattlers(u32 move, u32 battlerAtk, u32 b
     SaveBattlerData(battlerDef);
     SetBattlerData(battlerAtk);
     SetBattlerData(battlerDef);
+    gBattleStruct->aiCalcInProgress = TRUE;
     dmg = AI_CalcDamage(move, battlerAtk, battlerDef, typeEffectiveness, considerZPower, AI_GetWeather(AI_DATA), rollType);
+    gBattleStruct->aiCalcInProgress = FALSE;
     RestoreBattlerData(battlerAtk);
     RestoreBattlerData(battlerDef);
     return dmg;
@@ -526,7 +528,6 @@ struct SimulatedDamage AI_CalcDamage(u32 move, u32 battlerAtk, u32 battlerDef, u
     bool32 isDamageMoveUnusable = FALSE;
     bool32 toggledGimmick = FALSE;
     struct AiLogicData *aiData = AI_DATA;
-    gBattleStruct->aiCalcInProgress = TRUE;
 
     if (moveEffect == EFFECT_NATURE_POWER)
         move = GetNaturePowerMove(battlerAtk);
@@ -736,7 +737,6 @@ struct SimulatedDamage AI_CalcDamage(u32 move, u32 battlerAtk, u32 battlerDef, u
     *typeEffectiveness = AI_GetEffectiveness(effectivenessMultiplier);
 
     // Undo temporary settings
-    gBattleStruct->aiCalcInProgress = FALSE;
     gBattleStruct->swapDamageCategory = FALSE;
     gBattleStruct->zmove.baseMoves[battlerAtk] = MOVE_NONE;
     if (toggledGimmick)
@@ -3519,7 +3519,9 @@ s32 AI_CalcPartyMonDamage(u32 move, u32 battlerAtk, u32 battlerDef, struct Battl
         AI_THINKING_STRUCT->saved[battlerAtk].saved = FALSE;
     }
 
+    gBattleStruct->aiCalcInProgress = TRUE;
     dmg = AI_CalcDamage(move, battlerAtk, battlerDef, &effectiveness, FALSE, AI_GetWeather(AI_DATA), rollType);
+    gBattleStruct->aiCalcInProgress = FALSE;
     // restores original gBattleMon struct
     FreeRestoreBattleMons(savedBattleMons);
     return dmg.expected;

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4196,6 +4196,7 @@ static void HandleTurnActionSelectionState(void)
             if ((gBattleTypeFlags & BATTLE_TYPE_HAS_AI || IsWildMonSmart())
                     && (BattlerHasAi(battler) && !(gBattleTypeFlags & BATTLE_TYPE_PALACE)))
             {
+                gBattleStruct->aiCalcInProgress = TRUE;
                 if (ShouldSwitch(battler, FALSE))
                     AI_DATA->shouldSwitch |= (1u << battler);
                 if (AI_THINKING_STRUCT->aiFlags[battler] & AI_FLAG_RISKY) // Risky AI switches aggressively even mid battle
@@ -4203,6 +4204,7 @@ static void HandleTurnActionSelectionState(void)
                 else
                     AI_DATA->mostSuitableMonId[battler] = GetMostSuitableMonToSwitchInto(battler, FALSE);
                 gBattleStruct->aiMoveOrAction[battler] = ComputeBattleAiScores(battler);
+                gBattleStruct->aiCalcInProgress = FALSE;
             }
             // fallthrough
         case STATE_BEFORE_ACTION_CHOSEN: // Choose an action.

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -6458,7 +6458,11 @@ static inline bool32 CanBreakThroughAbility(u32 battlerAtk, u32 battlerDef, u32 
 
 u32 GetBattlerAbility(u32 battler)
 {
-    if (!gBattleStruct->aiCalcInProgress)
+    if (gBattleStruct->aiCalcInProgress)
+    {
+        return AI_DATA->abilities[battler];
+    }
+    else
     {
         bool32 noAbilityShield = GetBattlerHoldEffectIgnoreAbility(battler, TRUE) != HOLD_EFFECT_ABILITY_SHIELD;
         bool32 abilityCantBeSuppressed = gAbilitiesInfo[gBattleMons[battler].ability].cantBeSuppressed;
@@ -6487,9 +6491,9 @@ u32 GetBattlerAbility(u32 battler)
 
         if (noAbilityShield && CanBreakThroughAbility(gBattlerAttacker, battler, gBattleMons[gBattlerAttacker].ability))
             return ABILITY_NONE;
-    }
 
-    return gBattleMons[battler].ability;
+        return gBattleMons[battler].ability;
+    }
 }
 
 u32 IsAbilityOnSide(u32 battler, u32 ability)
@@ -8511,7 +8515,7 @@ u32 GetBattlerHoldEffectIgnoreAbility(u32 battler, bool32 checkNegating)
 u32 GetBattlerHoldEffectInternal(u32 battler, bool32 checkNegating, bool32 checkAbility)
 {
     if (gBattleStruct->aiCalcInProgress)
-        return ItemId_GetHoldEffect(gBattleMons[battler].item);
+        return AI_DATA->holdEffects[battler];
     
     if (checkNegating)
     {


### PR DESCRIPTION
Expands `gBattleStruct->aiCalcInProgress` usages such that `GetBattlerAbility` and `GetBattlerHoldEffectInternal` return AI_DATA values rather than checking suppression, etc. This isn't a huge speed up in baseline expansion, but is step 1 (if accepted) in my goal to allow referencing all battle_util functions directly in ai calcs rather than needing AI equivalents that check AI_DATA->abilities over gBattleMons, for instance. 