### PR TITLE
Remove one redundant call of SetAiLogicDataForTurn in DoBattleIntro

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3750,7 +3750,6 @@ static void DoBattleIntro(void)
             gBattleStruct->eventsBeforeFirstTurnState = 0;
             gBattleStruct->switchInBattlerCounter = 0;
             gBattleStruct->overworldWeatherDone = FALSE;
-            SetAiLogicDataForTurn(AI_DATA); // get assumed abilities, hold effects, etc of all battlers
             Ai_InitPartyStruct(); // Save mons party counts, and first 2/4 mons on the battlefield.
 
             // Try to set a status to start the battle with


### PR DESCRIPTION
This is already run at the end of `TryDoEventsBeforeFirstTurn` which makes the first calc redundant.

I've had this removed in my project for a while and didn't notice any problems
