### PR TITLE
Update shed_tail.c

### DIFF
--- a/test/battle/move_effect/shed_tail.c
+++ b/test/battle/move_effect/shed_tail.c
@@ -88,6 +88,7 @@ SINGLE_BATTLE_TEST("Shed Tail's HP cost doesn't trigger effects that trigger on 
 
 AI_SINGLE_BATTLE_TEST("AI will use Shed Tail to pivot to another mon while in damage stalemate with player")
 {
+    KNOWN_FAILING; // missing AI code
     GIVEN {
         AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT);
         PLAYER(SPECIES_WOBBUFFET) { Speed(100); Ability(ABILITY_RUN_AWAY); Moves(MOVE_TACKLE, MOVE_CELEBRATE); }


### PR DESCRIPTION
Shed Tail doesn't have any AI implementation, and with some changed AI code a broken test that erroneously passed before now rightfully fails. This PR adds `KNOWN_FAILING` to said test. To be merged asap as upcoming currently will not have all tests pass without this PR.

## **Discord contact info**
bassoonian
