### PR TITLE
Fix P_FRIENDSHIP_EVO_THRESHOLD not checking for Gen 8

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -60,7 +60,7 @@
 #include "constants/weather.h"
 #include "wild_encounter.h"
 
-#define FRIENDSHIP_EVO_THRESHOLD ((P_FRIENDSHIP_EVO_THRESHOLD >= GEN_9) ? 160 : 220)
+#define FRIENDSHIP_EVO_THRESHOLD ((P_FRIENDSHIP_EVO_THRESHOLD >= GEN_8) ? 160 : 220)
 
 struct SpeciesItem
 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The P_FRIENDSHIP_EVO_THRESHOLD config accidentally checked for Gen 9 for if the new threshold should be applied and not Gen 8 (which is how it should be), so I fixed that. Don't know how this slipped past.

## **Discord contact info**
kittenchilly