### PR TITLE
Fix negative mutation value

### DIFF
--- a/src/berry.c
+++ b/src/berry.c
@@ -2384,6 +2384,8 @@ static u8 GetTreeMutationValue(u8 id)
     myMutation.asField.a = tree->mutationA;
     myMutation.asField.b = tree->mutationB;
     myMutation.asField.unused = 0;
+    if (myMutation.value == 0) // no mutation
+        return 0;
     return sBerryMutations[myMutation.value - 1][2];
 #else
     return 0;


### PR DESCRIPTION
Fixes an issue with the mutation reading code that would attempt to look up spot `-1` in a table, resulting in it reading garbage and returning `Persim Berry` through sheer coincidence.

## Issue(s) that this PR fixes
Fixes #5432

## **Discord contact info**
bassoonian
