### PR TITLE
Cleanup extraneous function in battle_anim.h

### DIFF
--- a/include/battle_anim.h
+++ b/include/battle_anim.h
@@ -347,7 +347,6 @@ extern const union AnimCmd *const gAnims_WaterPulseBubble[];
 
 // battle_anim_flying.c
 void DestroyAnimSpriteAfterTimer(struct Sprite *sprite);
-void sub_810E2C8(struct Sprite *sprite);
 void AnimAirWaveCrescent(struct Sprite *sprite);
 void AnimFlyBallUp(struct Sprite *sprite);
 void AnimFlyBallAttack(struct Sprite *sprite);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removed `sub_810E2C8` from `include/battle_anim.h` which was renamed to `DestroyAnimSpriteAfterTimer` but was still present in Expansion.

sha1sum before removal: `26b50cc7ebc7be904aea2d21a12306504927aaa3  pokeemerald.gba `
sha1sum after removal: `26b50cc7ebc7be904aea2d21a12306504927aaa3  pokeemerald.gba`

## **Discord contact info**
<!--- formatted as name#numbers, e.g. Lunos#4026 -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara
