### PR TITLE
Replace hardcoded flute check with consumability check

### DIFF
--- a/include/item.h
+++ b/include/item.h
@@ -18,7 +18,9 @@ struct Item
     u8 pluralName[ITEM_NAME_PLURAL_LENGTH];
     u8 holdEffect;
     u8 holdEffectParam;
-    u8 importance;
+    u8 importance:2;
+    u8 notConsumed:1;
+    u8 padding:5;
     u8 pocket;
     u8 type;
     u8 battleUsage;
@@ -73,6 +75,7 @@ u32 ItemId_GetHoldEffect(u32 itemId);
 u32 ItemId_GetHoldEffectParam(u32 itemId);
 const u8 *ItemId_GetDescription(u16 itemId);
 u8 ItemId_GetImportance(u16 itemId);
+u8 ItemId_GetConsumability(u16 itemId);
 u8 ItemId_GetPocket(u16 itemId);
 u8 ItemId_GetType(u16 itemId);
 ItemUseFunc ItemId_GetFieldFunc(u16 itemId);

--- a/include/party_menu.h
+++ b/include/party_menu.h
@@ -102,6 +102,5 @@ void MoveDeleterForgetMove(void);
 void BufferMoveDeleterNicknameAndMove(void);
 void GetNumMovesSelectedMonHas(void);
 void MoveDeleterChooseMoveToForget(void);
-bool32 IsItemFlute(u16 item);
 
 #endif // GUARD_PARTY_MENU_H

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -384,8 +384,8 @@ static void HandleInputChooseAction(u32 battler)
          && !(gAbsentBattlerFlags & (1u << GetBattlerAtPosition(B_POSITION_PLAYER_LEFT)))
          && !(gBattleTypeFlags & BATTLE_TYPE_MULTI))
         {
-            // Return item to bag if partner had selected one (except flutes).
-            if (gBattleResources->bufferA[battler][1] == B_ACTION_USE_ITEM && !IsItemFlute(itemId))
+            // Return item to bag if partner had selected one (if consumable).
+            if (gBattleResources->bufferA[battler][1] == B_ACTION_USE_ITEM && ItemId_GetConsumability(itemId))
             {
                 AddBagItem(itemId, 1);
             }

--- a/src/data/items.h
+++ b/src/data/items.h
@@ -2036,6 +2036,7 @@ const struct Item gItemsInfo[] =
             "A glass flute that\n"
             "awakens sleeping\n"
             "Pokémon."),
+        .notConsumed = TRUE,
         .pocket = POCKET_ITEMS,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
@@ -2054,6 +2055,7 @@ const struct Item gItemsInfo[] =
             "A glass flute that\n"
             "snaps Pokémon\n"
             "out of confusion."),
+        .notConsumed = TRUE,
         .pocket = POCKET_ITEMS,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
@@ -2072,6 +2074,7 @@ const struct Item gItemsInfo[] =
             "A glass flute that\n"
             "snaps Pokémon\n"
             "out of attraction."),
+        .notConsumed = TRUE,
         .pocket = POCKET_ITEMS,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
@@ -2093,6 +2096,7 @@ const struct Item gItemsInfo[] =
             "A glass flute that\n"
             "keeps away wild\n"
             "Pokémon."),
+        .notConsumed = TRUE,
         .pocket = POCKET_ITEMS,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_BlackWhiteFlute,
@@ -2109,6 +2113,7 @@ const struct Item gItemsInfo[] =
         .description = COMPOUND_STRING(
             "A glass flute that\n"
             "lures wild Pokémon."),
+        .notConsumed = TRUE,
         .pocket = POCKET_ITEMS,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_BlackWhiteFlute,

--- a/src/item.c
+++ b/src/item.c
@@ -916,6 +916,11 @@ u8 ItemId_GetImportance(u16 itemId)
     return gItemsInfo[SanitizeItemId(itemId)].importance;
 }
 
+u8 ItemId_GetConsumability(u16 itemId)
+{
+    return !gItemsInfo[SanitizeItemId(itemId)].notConsumed;
+}
+
 u8 ItemId_GetPocket(u16 itemId)
 {
     return gItemsInfo[SanitizeItemId(itemId)].pocket;

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -4578,7 +4578,7 @@ static bool8 NotUsingHPEVItemOnShedinja(struct Pokemon *mon, u16 item)
     return TRUE;
 }
 
-bool32 IsItemFlute(u16 item)
+static bool32 IsItemFlute(u16 item)
 {
     if (item == ITEM_BLUE_FLUTE || item == ITEM_RED_FLUTE || item == ITEM_YELLOW_FLUTE)
         return TRUE;


### PR DESCRIPTION
#5436 fixed a bug that would duplicate flutes, but introduced a hardcoded check for flutes. This PR replaces said hardcoded check with a per-item field that indicates inconsumability for items that can be used in battle.

## Issue(s) that this PR fixes
Fixes #5464

## **Discord contact info**
bassoonian