### PR TITLE
Fix alignment errors in EWRAM_INIT and friends when using u8, u16, etc.

### DIFF
--- a/ld_script.ld
+++ b/ld_script.ld
@@ -18,6 +18,7 @@ SECTIONS {
     {
         __ewram_start = .;
         *(.ewram*)
+        . = ALIGN(4);
         __ewram_end = .;
     } > EWRAM
 
@@ -38,6 +39,7 @@ SECTIONS {
     {
         __iwram_start = .;
         *(.iwram*);
+        . = ALIGN(4);
         __iwram_end = .;
     } > IWRAM
 

--- a/ld_script_modern.ld
+++ b/ld_script_modern.ld
@@ -19,6 +19,7 @@ SECTIONS {
     {
         __ewram_start = .;
         *(.ewram*)
+        . = ALIGN(4);
         __ewram_end = .;
     } > EWRAM
 
@@ -34,6 +35,7 @@ SECTIONS {
     {
         __iwram_start = .;
         *(.iwram*);
+        . = ALIGN(4);
         __iwram_end = .;
     } > IWRAM
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I opened a PR a while back to add EWRAM_INIT support to the project. The linker script modifications I made didn't take into account that users may define data sections that are not a multiple of 4 bytes in size. This leads the DMA transfer at init to copy garbage into the wrong sections, resulting in subtle errors at runtime when the feature is used. I've also aligned IWRAM_DATA to prevent the same error.

This is a one-line change, allow me to explain what's happening:
```diff
 .ewram ORIGIN(EWRAM) : AT (__ewram_lma)
     ALIGN(4)
 {
         __ewram_start = .;
         *(.ewram*);
+        . = ALIGN(4);
         __ewram_end = .;
 } > EWRAM
```

The `.` represents an address marching ahead in memory in ld scripts as each section is defined/filled. If we added a `EWRAM_INIT u8 foo = 1;` then this section would resolve `*(.ewram*)` in a way that marches the pointer forward by 1 byte. The section itself will be aligned to 4 bytes because of the original and first `ALIGN(4)` directive, but the __ewram_end symbol we export to the initialization assembly to tell it which sections to copy would be 1 byte ahead, not 4. This breaks assumptions in the assembly code and leads it to copy garbage into otherwise necessary sections. 

By adding the new line above, we force the pointer to march ahead anywhere from 0-3 bytes to ensure there is sufficient padding for the DMA copy to function.

This should resolve the issue. To test the issue and its resolution one can make a single line change to `main.c`:
```c
EWRAM_INIT u8 gTestu8 = 4;
```

Without the fix, a number of issues will the occur, the first being that the default option selected after the title screen on a blank save will be "Options" instead of "New Game".

## Images
<!-- Please provide with relevant GIFs or images to make it easier for reviewers to accept your PR quicker.-->
<!-- If it doesn't apply, feel free to remove this section. -->
![image](https://github.com/user-attachments/assets/0005e35c-7ef0-4292-8d3b-bbd8f5fb73a1)

## **Discord contact info**
<!--- formatted as name#numbers, e.g. Lunos#4026 -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
`@luigi___`