### PR TITLE
-fno-toplevel-reorder is only needed for m4a, agb_flash, and librfu_intr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ TEST_BUILDDIR = $(OBJ_DIR)/$(TEST_SUBDIR)
 ASFLAGS := -mcpu=arm7tdmi --defsym MODERN=1
 
 CC1              = $(shell $(PATH_ARMCC) --print-prog-name=cc1) -quiet
-override CFLAGS += -mthumb -mthumb-interwork -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -fno-toplevel-reorder -Wno-pointer-to-int-cast -std=gnu17 -Werror -Wall -Wno-strict-aliasing -Wno-attribute-alias -Woverride-init
+override CFLAGS += -mthumb -mthumb-interwork -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -Wno-pointer-to-int-cast -std=gnu17 -Werror -Wall -Wno-strict-aliasing -Wno-attribute-alias -Woverride-init
 
 ifeq ($(ANALYZE),1)
 override CFLAGS += -fanalyzer
@@ -313,6 +313,9 @@ COMPETITIVE_PARTY_SYNTAX := $(shell PATH="$(PATH)"; echo 'COMPETITIVE_PARTY_SYNT
 ifeq ($(COMPETITIVE_PARTY_SYNTAX),1)
 %.h: %.party tools ; $(CPP) $(CPPFLAGS) -traditional-cpp - < $< | $(TRAINERPROC) -o $@ -i $< -
 endif
+
+$(C_BUILDDIR)/m4a.o: CFLAGS += -fno-toplevel-reorder
+$(C_BUILDDIR)/agb_flash.o: CFLAGS += -fno-toplevel-reorder
 
 $(C_BUILDDIR)/berry_crush.o: override CFLAGS += -Wno-address-of-packed-member
 $(C_BUILDDIR)/librfu_intr.o: CFLAGS := -mthumb-interwork -O2 -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -fno-toplevel-reorder -Wno-pointer-to-int-cast


### PR DESCRIPTION
-fno-toplevel-reorder prevents the compiler from moving around functions and ensures the memory layout of the assembler of each function matches the source code order.

Relying on a particular order of functions is UB, but some code like the one in m4a, relies on this for the sake of using the start of other functions to determine the size a function would be for the sake of copying code to memory. This has been tested so the game boots and works.

## **Discord contact info**
<!--- formatted as name#numbers, e.g. Lunos#4026 -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
RoseSilicon
