### PR TITLE
Removes Crit Chance preproc

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1909,12 +1909,17 @@ static inline u32 GetCriticalHitOdds(u32 critChance)
     return sCriticalHitOdds[critChance];
 }
 
-static inline bool32 BattlerAffectedByLeek(u32 battler, u32 holdEffect)
+static inline bool32 IsCritChanceAffectedByHoldEffect(u32 battler, u32 holdEffect)
 {
-    if (holdEffect == HOLD_EFFECT_LEEK)
+    switch (holdEffect)
     {
+    case HOLD_EFFECT_LEEK:
         return GET_BASE_SPECIES_ID(gBattleMons[battler].species) == SPECIES_FARFETCHD
             || gBattleMons[battler].species == SPECIES_SIRFETCHD;
+    case HOLD_EFFECT_LUCKY_PUNCH:
+        return gBattleMons[battler].species == SPECIES_CHANSEY;
+    default:
+        return FALSE;
     }
 
     return FALSE;
@@ -1940,8 +1945,8 @@ s32 CalcCritChanceStageArgs(u32 battlerAtk, u32 battlerDef, u32 move, bool32 rec
                     + 1 * ((gBattleMons[battlerAtk].status2 & STATUS2_DRAGON_CHEER) != 0)
                     + gMovesInfo[move].criticalHitStage
                     + (holdEffectAtk == HOLD_EFFECT_SCOPE_LENS)
-                    + 2 * (holdEffectAtk == HOLD_EFFECT_LUCKY_PUNCH && gBattleMons[battlerAtk].species == SPECIES_CHANSEY)
-                    + 2 * BattlerAffectedByLeek(battlerAtk, holdEffectAtk)
+                    + 2 * IsCritChanceAffectedByHoldEffect(battlerAtk, holdEffectAtk)
+                    + 2 * IsCritChanceAffectedByHoldEffect(battlerAtk, holdEffectAtk)
                     + 2 * (B_AFFECTION_MECHANICS == TRUE && GetBattlerAffectionHearts(battlerAtk) == AFFECTION_FIVE_HEARTS)
                     + (abilityAtk == ABILITY_SUPER_LUCK)
                     + gBattleStruct->bonusCritStages[gBattlerAttacker];
@@ -2017,7 +2022,7 @@ s32 CalcCritChanceStageGen1(u8 battlerAtk, u8 battlerDef, u32 move, bool32 recor
     if (holdEffectAtk == HOLD_EFFECT_LUCKY_PUNCH && gBattleMons[gBattlerAttacker].species == SPECIES_CHANSEY)
         critChance = critChance * luckyPunchScaler;
 
-    if (BattlerAffectedByLeek(battlerAtk, holdEffectAtk))
+    if (IsCritChanceAffectedByHoldEffect(battlerAtk, holdEffectAtk))
         critChance = critChance * farfetchedLeekScaler;
 
     if (abilityAtk == ABILITY_SUPER_LUCK)

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1956,11 +1956,10 @@ s32 CalcCritChanceStageArgs(u32 battlerAtk, u32 battlerDef, u32 move, bool32 rec
     }
     else
     {
-        u32 getHoldEffectCritChanceIncrease = GetHoldEffectCritChanceIncrease(battlerAtk, holdEffectAtk, FALSE);
         critChance  = 2 * ((gBattleMons[battlerAtk].status2 & STATUS2_FOCUS_ENERGY) != 0)
-                    + ((gBattleMons[battlerAtk].status2 & STATUS2_DRAGON_CHEER) != 0)
+                    + 1 * ((gBattleMons[battlerAtk].status2 & STATUS2_DRAGON_CHEER) != 0)
                     + gMovesInfo[move].criticalHitStage
-                    + getHoldEffectCritChanceIncrease
+                    + GetHoldEffectCritChanceIncrease(battlerAtk, holdEffectAtk, FALSE)
                     + 2 * (B_AFFECTION_MECHANICS == TRUE && GetBattlerAffectionHearts(battlerAtk) == AFFECTION_FIVE_HEARTS)
                     + (abilityAtk == ABILITY_SUPER_LUCK)
                     + gBattleStruct->bonusCritStages[gBattlerAttacker];
@@ -2008,7 +2007,7 @@ s32 CalcCritChanceStageGen1(u8 battlerAtk, u8 battlerDef, u32 move, bool32 recor
     u32 superLuckScaler = 4;
     u32 scopeLensScaler = 4;
     u32 luckyPunchScaler = 8;
-    u32 farfetchedLeekScaler = 0;
+    u32 farfetchedLeekScaler = 8;
 
     s32 critChance = 0;
     s32 moveCritStage = gMovesInfo[gCurrentMove].criticalHitStage;
@@ -2036,8 +2035,7 @@ s32 CalcCritChanceStageGen1(u8 battlerAtk, u8 battlerDef, u32 move, bool32 recor
     if (holdEffectAtk == HOLD_EFFECT_LUCKY_PUNCH && gBattleMons[gBattlerAttacker].species == SPECIES_CHANSEY)
         critChance = critChance * luckyPunchScaler;
 
-    farfetchedLeekScaler = GetHoldEffectCritChanceIncrease(battlerAtk, holdEffectAtk, TRUE);
-    if (farfetchedLeekScaler)
+    if (GetHoldEffectCritChanceIncrease(battlerAtk, holdEffectAtk, TRUE) == farfetchedLeekScaler)
         critChance = critChance * farfetchedLeekScaler;
 
     if (abilityAtk == ABILITY_SUPER_LUCK)

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1909,6 +1909,7 @@ static inline u32 GetCriticalHitOdds(u32 critChance)
     return sCriticalHitOdds[critChance];
 }
 
+#define GEN_1_FARFETCHED_LEEK_SCALER 8
 static inline u32 GetHoldEffectCritChanceIncrease(u32 battler, u32 holdEffect, u32 checkGenOneCritChance)
 {
     u32 critStageIncrease = 0;
@@ -1927,7 +1928,7 @@ static inline u32 GetHoldEffectCritChanceIncrease(u32 battler, u32 holdEffect, u
          || gBattleMons[battler].species == SPECIES_SIRFETCHD)
         {
             if (checkGenOneCritChance)
-                critStageIncrease = 8;
+                critStageIncrease = GEN_1_FARFETCHED_LEEK_SCALER;
             else
                 critStageIncrease = 2;
         }
@@ -2007,7 +2008,6 @@ s32 CalcCritChanceStageGen1(u8 battlerAtk, u8 battlerDef, u32 move, bool32 recor
     u32 superLuckScaler = 4;
     u32 scopeLensScaler = 4;
     u32 luckyPunchScaler = 8;
-    u32 farfetchedLeekScaler = 8;
 
     s32 critChance = 0;
     s32 moveCritStage = gMovesInfo[gCurrentMove].criticalHitStage;
@@ -2035,8 +2035,8 @@ s32 CalcCritChanceStageGen1(u8 battlerAtk, u8 battlerDef, u32 move, bool32 recor
     if (holdEffectAtk == HOLD_EFFECT_LUCKY_PUNCH && gBattleMons[gBattlerAttacker].species == SPECIES_CHANSEY)
         critChance = critChance * luckyPunchScaler;
 
-    if (GetHoldEffectCritChanceIncrease(battlerAtk, holdEffectAtk, TRUE) == farfetchedLeekScaler)
-        critChance = critChance * farfetchedLeekScaler;
+    if (GetHoldEffectCritChanceIncrease(battlerAtk, holdEffectAtk, TRUE) == GEN_1_FARFETCHED_LEEK_SCALER)
+        critChance = critChance * GEN_1_FARFETCHED_LEEK_SCALER;
 
     if (abilityAtk == ABILITY_SUPER_LUCK)
         critChance = critChance * superLuckScaler;
@@ -2064,6 +2064,7 @@ s32 CalcCritChanceStageGen1(u8 battlerAtk, u8 battlerDef, u32 move, bool32 recor
 
     return critChance;
 }
+#undef GEN_1_FARFETCHED_LEEK_SCALER
 
 s32 GetCritHitOdds(s32 critChanceIndex)
 {

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1909,6 +1909,16 @@ static inline u32 GetCriticalHitOdds(u32 critChance)
     return sCriticalHitOdds[critChance];
 }
 
+static inline u32 IsBattlerLeekAffected(u32 battler, u32 holdEffect)
+{
+    if (holdEffect == HOLD_EFFECT_LEEK)
+    {
+        return GET_BASE_SPECIES_ID(gBattleMons[battler].species) == SPECIES_FARFETCHD
+            || gBattleMons[battler].species == SPECIES_SIRFETCHD;
+    }
+    return FALSE;
+}
+
 static inline u32 GetHoldEffectCritChanceIncrease(u32 battler, u32 holdEffect, u32 checkGenOneCritChance)
 {
     u32 critStageIncrease = 0;
@@ -1923,8 +1933,7 @@ static inline u32 GetHoldEffectCritChanceIncrease(u32 battler, u32 holdEffect, u
             critStageIncrease = 2;
         break;
     case HOLD_EFFECT_LEEK:
-        if (GET_BASE_SPECIES_ID(gBattleMons[battler].species) == SPECIES_FARFETCHD
-         || gBattleMons[battler].species == SPECIES_SIRFETCHD)
+        if (IsBattlerLeekAffected(battler, holdEffect))
             critStageIncrease = 2;
         break;
     default:
@@ -2025,19 +2034,11 @@ s32 CalcCritChanceStageGen1(u32 battlerAtk, u32 battlerDef, u32 move, bool32 rec
         critChance = critChance * focusEnergyScaler;
 
     if (holdEffectAtk == HOLD_EFFECT_SCOPE_LENS)
-    {
         critChance = critChance * scopeLensScaler;
-    }
     else if (holdEffectAtk == HOLD_EFFECT_LUCKY_PUNCH && gBattleMons[battlerAtk].species == SPECIES_CHANSEY)
-    {
         critChance = critChance * luckyPunchScaler;
-    }
-    else if (holdEffectAtk == HOLD_EFFECT_LEEK)
-    {
-        if (GET_BASE_SPECIES_ID(gBattleMons[battlerAtk].species) == SPECIES_FARFETCHD
-         || gBattleMons[battlerAtk].species == SPECIES_SIRFETCHD)
-            critChance = critChance * farfetchdLeekScaler;
-    }
+    else if (IsBattlerLeekAffected(battlerAtk, holdEffectAtk))
+        critChance = critChance * farfetchdLeekScaler;
 
     if (abilityAtk == ABILITY_SUPER_LUCK)
         critChance = critChance * superLuckScaler;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1919,7 +1919,7 @@ static inline u32 IsBattlerLeekAffected(u32 battler, u32 holdEffect)
     return FALSE;
 }
 
-static inline u32 GetHoldEffectCritChanceIncrease(u32 battler, u32 holdEffect, u32 checkGenOneCritChance)
+static inline u32 GetHoldEffectCritChanceIncrease(u32 battler, u32 holdEffect)
 {
     u32 critStageIncrease = 0;
 
@@ -1963,7 +1963,7 @@ s32 CalcCritChanceStageArgs(u32 battlerAtk, u32 battlerDef, u32 move, bool32 rec
         critChance  = 2 * ((gBattleMons[battlerAtk].status2 & STATUS2_FOCUS_ENERGY) != 0)
                     + 1 * ((gBattleMons[battlerAtk].status2 & STATUS2_DRAGON_CHEER) != 0)
                     + gMovesInfo[move].criticalHitStage
-                    + GetHoldEffectCritChanceIncrease(battlerAtk, holdEffectAtk, FALSE)
+                    + GetHoldEffectCritChanceIncrease(battlerAtk, holdEffectAtk)
                     + 2 * (B_AFFECTION_MECHANICS == TRUE && GetBattlerAffectionHearts(battlerAtk) == AFFECTION_FIVE_HEARTS)
                     + (abilityAtk == ABILITY_SUPER_LUCK)
                     + gBattleStruct->bonusCritStages[gBattlerAttacker];

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1899,7 +1899,7 @@ static const u32 sGen7CriticalHitOdds[] = {24, 8, 2, 1, 1};
 static const u32 sGen6CriticalHitOdds[] = {16, 8, 2, 1, 1};
 static const u32 sCriticalHitOdds[]     = {16, 8, 4, 3, 2}; // Gens 2,3,4,5
 
-static inline u32 GetCritHitOdds(u32 critChance)
+static inline u32 GetCriticalHitOdds(u32 critChance)
 {
     if (B_CRIT_CHANCE >= GEN_7)
         return sGen7CriticalHitOdds[critChance];
@@ -1957,7 +1957,7 @@ s32 CalcCritChanceStageArgs(u32 battlerAtk, u32 battlerDef, u32 move, bool32 rec
         {
             if (critChance == -2)
                 RecordAbilityBattle(battlerDef, abilityDef);
-            else if (GetCritHitOdds(critChance) == 1)
+            else if (GetCriticalHitOdds(critChance) == 1)
                 RecordAbilityBattle(battlerDef, abilityDef);
         }
         critChance = -1;
@@ -2052,7 +2052,7 @@ s32 GetCritHitOdds(s32 critChanceIndex)
     if (critChanceIndex < 0)
         return -1;
     else
-        return GetCritHitOdds(critChanceIndex);
+        return GetCriticalHitOdds(critChanceIndex);
 }
 
 static void Cmd_critcalc(void)
@@ -2086,7 +2086,7 @@ static void Cmd_critcalc(void)
                 gIsCriticalHit = 0;
         }
         else
-            gIsCriticalHit = RandomChance(RNG_CRITICAL_HIT, 1, GetCritHitOdds(critChance));
+            gIsCriticalHit = RandomChance(RNG_CRITICAL_HIT, 1, GetCriticalHitOdds(critChance));
     }
 
     // Counter for EVO_CRITICAL_HITS.

--- a/test/battle/ability/emergency_exit.c
+++ b/test/battle/ability/emergency_exit.c
@@ -47,20 +47,3 @@ SINGLE_BATTLE_TEST("Emergency Exit switches out when going below 50% max-HP but 
         ABILITY_POPUP(opponent, ABILITY_EMERGENCY_EXIT);
     }
 }
-
-SINGLE_BATTLE_TEST("Visual Hit Escape Bug")
-{
-    GIVEN {
-        PLAYER(SPECIES_WOBBUFFET);
-        PLAYER(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_GOLISOPOD) { Ability(ABILITY_EMERGENCY_EXIT); MaxHP(100); HP(55); };
-        OPPONENT(SPECIES_WOBBUFFET);
-    } WHEN {
-        TURN { MOVE(player, MOVE_U_TURN); SEND_OUT(opponent, 1); }
-        TURN {}
-    } SCENE {
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_U_TURN, player);
-        HP_BAR(opponent);
-        ABILITY_POPUP(opponent, ABILITY_EMERGENCY_EXIT);
-    }
-}

--- a/test/battle/ability/emergency_exit.c
+++ b/test/battle/ability/emergency_exit.c
@@ -47,3 +47,20 @@ SINGLE_BATTLE_TEST("Emergency Exit switches out when going below 50% max-HP but 
         ABILITY_POPUP(opponent, ABILITY_EMERGENCY_EXIT);
     }
 }
+
+SINGLE_BATTLE_TEST("Visual Hit Escape Bug")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_GOLISOPOD) { Ability(ABILITY_EMERGENCY_EXIT); MaxHP(100); HP(55); };
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_U_TURN); SEND_OUT(opponent, 1); }
+        TURN {}
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_U_TURN, player);
+        HP_BAR(opponent);
+        ABILITY_POPUP(opponent, ABILITY_EMERGENCY_EXIT);
+    }
+}

--- a/test/battle/crit_chance.c
+++ b/test/battle/crit_chance.c
@@ -148,6 +148,7 @@ SINGLE_BATTLE_TEST("Crit Chance: High crit rate increases the critical hit ratio
 {
     PASSES_RANDOMLY(1, 8, RNG_CRITICAL_HIT);
     GIVEN {
+        ASSUME(B_CRIT_CHANCE >= GEN_7);
         ASSUME(gMovesInfo[MOVE_SLASH].criticalHitStage == 1);
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET);
@@ -163,6 +164,7 @@ SINGLE_BATTLE_TEST("Crit Chance: Super Luck increases the critical hit ratio by 
 {
     PASSES_RANDOMLY(1, 8, RNG_CRITICAL_HIT);
     GIVEN {
+        ASSUME(B_CRIT_CHANCE >= GEN_7);
         PLAYER(SPECIES_TOGEPI) { Ability(ABILITY_SUPER_LUCK); };
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
@@ -177,6 +179,7 @@ SINGLE_BATTLE_TEST("Crit Chance: Scope Lens increases the critical hit ratio by 
 {
     PASSES_RANDOMLY(1, 8, RNG_CRITICAL_HIT);
     GIVEN {
+        ASSUME(B_CRIT_CHANCE >= GEN_7);
         ASSUME(gItemsInfo[ITEM_SCOPE_LENS].holdEffect == HOLD_EFFECT_SCOPE_LENS);
         PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_SCOPE_LENS); };
         OPPONENT(SPECIES_WOBBUFFET);

--- a/test/battle/crit_chance.c
+++ b/test/battle/crit_chance.c
@@ -130,6 +130,7 @@ SINGLE_BATTLE_TEST("Crit Chance: Focus Energy increases the user's critical hit 
 {
     PASSES_RANDOMLY(1, 2, RNG_CRITICAL_HIT);
     GIVEN {
+        ASSUME(B_CRIT_CHANCE >= GEN_7);
         ASSUME(gMovesInfo[MOVE_FOCUS_ENERGY].effect == EFFECT_FOCUS_ENERGY);
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET);
@@ -190,6 +191,7 @@ SINGLE_BATTLE_TEST("Crit Chance: Scope Lens increases the critical hit ratio by 
 SINGLE_BATTLE_TEST("Crit Chance: High crit rate, Super Luck and Scope Lens cause the move to result in a critical hit")
 {
     GIVEN {
+        ASSUME(B_CRIT_CHANCE >= GEN_7);
         ASSUME(gMovesInfo[MOVE_SLASH].criticalHitStage == 1);
         ASSUME(gItemsInfo[ITEM_SCOPE_LENS].holdEffect == HOLD_EFFECT_SCOPE_LENS);
         PLAYER(SPECIES_WOBBUFFET) { Ability(ABILITY_SUPER_LUCK); Item(ITEM_SCOPE_LENS); };
@@ -215,6 +217,7 @@ SINGLE_BATTLE_TEST("Crit Chance: Signature items Leek and Lucky Punch increase t
     PARAMETRIZE { species = SPECIES_CHANSEY; item = ITEM_LUCKY_PUNCH; }
 
     GIVEN {
+        ASSUME(B_CRIT_CHANCE >= GEN_7);
         ASSUME(gItemsInfo[ITEM_LEEK].holdEffect == HOLD_EFFECT_LEEK);
         ASSUME(gItemsInfo[ITEM_LUCKY_PUNCH].holdEffect == HOLD_EFFECT_LUCKY_PUNCH);
         PLAYER(SPECIES_WOBBUFFET);
@@ -231,6 +234,7 @@ SINGLE_BATTLE_TEST("Crit Chance: Dire Hit increases a battler's critical hit cha
 {
     PASSES_RANDOMLY(1, 2, RNG_CRITICAL_HIT);
     GIVEN {
+        ASSUME(B_CRIT_CHANCE >= GEN_7);
         ASSUME(gItemsInfo[ITEM_DIRE_HIT].battleUsage == EFFECT_ITEM_SET_FOCUS_ENERGY);
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET);
@@ -249,6 +253,7 @@ SINGLE_BATTLE_TEST("Crit Chance: Focus Energy increases critical hit ratio by tw
 {
     PASSES_RANDOMLY(8, 8, RNG_CRITICAL_HIT);
     GIVEN {
+        ASSUME(B_CRIT_CHANCE >= GEN_7);
         ASSUME(gMovesInfo[MOVE_SLASH].criticalHitStage == 1);
         ASSUME(gMovesInfo[MOVE_FOCUS_ENERGY].effect == EFFECT_FOCUS_ENERGY);
         PLAYER(SPECIES_WOBBUFFET);
@@ -281,6 +286,7 @@ DOUBLE_BATTLE_TEST("Crit Chance: Dragon Cheer increases critical hit ratio by on
 {
     PASSES_RANDOMLY(1, 8, RNG_CRITICAL_HIT);
     GIVEN {
+        ASSUME(B_CRIT_CHANCE >= GEN_7);
         ASSUME(gMovesInfo[MOVE_TACKLE].criticalHitStage == 0);
         ASSUME(gMovesInfo[MOVE_DRAGON_CHEER].effect == EFFECT_DRAGON_CHEER);
         PLAYER(SPECIES_WOBBUFFET);
@@ -301,6 +307,7 @@ DOUBLE_BATTLE_TEST("Crit Chance: Dragon Cheer increases critical hit ratio by tw
 {
     PASSES_RANDOMLY(1, 2, RNG_CRITICAL_HIT);
     GIVEN {
+        ASSUME(B_CRIT_CHANCE >= GEN_7);
         ASSUME(gMovesInfo[MOVE_TACKLE].criticalHitStage == 0);
         ASSUME(gMovesInfo[MOVE_DRAGON_CHEER].effect == EFFECT_DRAGON_CHEER);
         PLAYER(SPECIES_WOBBUFFET);

--- a/test/battle/crit_chance.c
+++ b/test/battle/crit_chance.c
@@ -212,7 +212,6 @@ SINGLE_BATTLE_TEST("Crit Chance: Signature items Leek and Lucky Punch increase t
     u32 species;
     u32 item;
 
-    KNOWN_FAILING; // No idea. Recording seems correct
     PASSES_RANDOMLY(1, 2, RNG_CRITICAL_HIT);
 
     PARAMETRIZE { species = SPECIES_FARFETCHD; item = ITEM_LEEK; }

--- a/test/battle/crit_chance.c
+++ b/test/battle/crit_chance.c
@@ -212,6 +212,7 @@ SINGLE_BATTLE_TEST("Crit Chance: Signature items Leek and Lucky Punch increase t
     u32 species;
     u32 item;
 
+    KNOWN_FAILING; // No idea. Recording seems correct
     PASSES_RANDOMLY(1, 2, RNG_CRITICAL_HIT);
 
     PARAMETRIZE { species = SPECIES_FARFETCHD; item = ITEM_LEEK; }

--- a/test/battle/crit_chance.c
+++ b/test/battle/crit_chance.c
@@ -1,11 +1,6 @@
 #include "global.h"
 #include "test/battle.h"
 
-ASSUMPTIONS
-{
-    ASSUME(B_CRIT_CHANCE >= GEN_7);
-}
-
 SINGLE_BATTLE_TEST("Crit Chance: Side effected by Lucky Chant blocks critical hits")
 {
     GIVEN {


### PR DESCRIPTION
Introduces the function `GetCritHitOdds` to switch between generational critical hits. 

Also I turned the macro `BENEFITS_FROM_LEEK` into an inline function for better readability and removed `ASSUME(B_CRIT_CHANCE >= GEN_7);` from `crit_chance.c`. Correct me if I'm wrong but it seems to me that it isn't needed by any current tests. If I'm wrong I can add it back to the specific tests which would need it. 