### PR TITLE
Mark all tests as used

### DIFF
--- a/include/test/battle.h
+++ b/include/test/battle.h
@@ -746,7 +746,7 @@ extern struct BattleTestRunnerState *const gBattleTestRunnerState;
 #define BATTLE_TEST_ARGS_SINGLE(_name, _type, ...) \
     struct CAT(Result, __LINE__) { RECURSIVELY(R_FOR_EACH(APPEND_SEMICOLON, __VA_ARGS__)) }; \
     static void CAT(Test, __LINE__)(struct CAT(Result, __LINE__) *, const u32, struct BattlePokemon *, struct BattlePokemon *); \
-    __attribute__((section(".tests"))) static const struct Test CAT(sTest, __LINE__) = \
+    __attribute__((section(".tests"), used)) static const struct Test CAT(sTest, __LINE__) = \
     { \
         .name = _name, \
         .filename = __FILE__, \
@@ -764,7 +764,7 @@ extern struct BattleTestRunnerState *const gBattleTestRunnerState;
 #define BATTLE_TEST_ARGS_DOUBLE(_name, _type, ...) \
     struct CAT(Result, __LINE__) { RECURSIVELY(R_FOR_EACH(APPEND_SEMICOLON, __VA_ARGS__)) }; \
     static void CAT(Test, __LINE__)(struct CAT(Result, __LINE__) *, const u32, struct BattlePokemon *, struct BattlePokemon *, struct BattlePokemon *, struct BattlePokemon *); \
-    __attribute__((section(".tests"))) static const struct Test CAT(sTest, __LINE__) = \
+    __attribute__((section(".tests"), used)) static const struct Test CAT(sTest, __LINE__) = \
     { \
         .name = _name, \
         .filename = __FILE__, \

--- a/include/test/test.h
+++ b/include/test/test.h
@@ -83,7 +83,7 @@ s32 Test_MgbaPrintf(const char *fmt, ...);
 
 #define TEST(_name) \
     static void CAT(Test, __LINE__)(void); \
-    __attribute__((section(".tests"))) static const struct Test CAT(sTest, __LINE__) = \
+    __attribute__((section(".tests"), used)) static const struct Test CAT(sTest, __LINE__) = \
     { \
         .name = _name, \
         .filename = __FILE__, \
@@ -95,7 +95,7 @@ s32 Test_MgbaPrintf(const char *fmt, ...);
 
 #define ASSUMPTIONS \
     static void Assumptions(void); \
-    __attribute__((section(".tests"))) static const struct Test sAssumptions = \
+    __attribute__((section(".tests"), used)) static const struct Test sAssumptions = \
     { \
         .name = "ASSUMPTIONS: " __FILE__, \
         .filename = __FILE__, \


### PR DESCRIPTION
`__attribute__((used))` to future-proof against disabling `-fno-toplevel-reorder` (e.g. a future iteration on #5515, see https://github.com/rh-hideout/pokeemerald-expansion/pull/5515#issuecomment-2408648464)