### PR TITLE
Centralise AI Tests trainer name

### DIFF
--- a/include/test/battle.h
+++ b/include/test/battle.h
@@ -735,6 +735,8 @@ extern struct BattleTestRunnerState *const gBattleTestRunnerState;
 #define APPEND_COMMA_TRUE(a) , a, TRUE
 #define R_APPEND_TRUE(...) __VA_OPT__(FIRST(__VA_ARGS__), TRUE RECURSIVELY(R_FOR_EACH(APPEND_COMMA_TRUE, EXCEPT_1(__VA_ARGS__))))
 
+#define AI_TRAINER_NAME "{PKMN} TRAINER LEAF"
+
 /* Test */
 
 #define TO_DO_BATTLE_TEST(_name) \

--- a/test/battle/ai/ai_flag_sequence_switching.c
+++ b/test/battle/ai/ai_flag_sequence_switching.c
@@ -27,14 +27,14 @@ AI_SINGLE_BATTLE_TEST("AI_FLAG_SEQUENCE_SWITCHING: AI will always switch after a
         }
     } SCENE {
         if (aiSequenceSwitchingFlag) {
-            MESSAGE("{PKMN} TRAINER LEAF sent out Machoke!");
-            MESSAGE("{PKMN} TRAINER LEAF sent out Machamp!");
-            MESSAGE("{PKMN} TRAINER LEAF sent out Mankey!");
-            MESSAGE("{PKMN} TRAINER LEAF sent out Primeape!");
-            MESSAGE("{PKMN} TRAINER LEAF sent out Magnezone!");
+            MESSAGE(AI_TRAINER_NAME " sent out Machoke!");
+            MESSAGE(AI_TRAINER_NAME " sent out Machamp!");
+            MESSAGE(AI_TRAINER_NAME " sent out Mankey!");
+            MESSAGE(AI_TRAINER_NAME " sent out Primeape!");
+            MESSAGE(AI_TRAINER_NAME " sent out Magnezone!");
         }
         else {
-            MESSAGE("{PKMN} TRAINER LEAF sent out Magnezone!");
+            MESSAGE(AI_TRAINER_NAME " sent out Magnezone!");
         }
     }
 }

--- a/test/battle/ai/ai_switching.c
+++ b/test/battle/ai/ai_switching.c
@@ -35,7 +35,7 @@ AI_SINGLE_BATTLE_TEST("AI switches if Perish Song is about to kill")
             TURN { ; }
             TURN { EXPECT_SWITCH(opponent, 1); }
     } SCENE {
-        MESSAGE("{PKMN} TRAINER LEAF sent out Crobat!");
+        MESSAGE(AI_TRAINER_NAME " sent out Crobat!");
     }
 }
 
@@ -58,11 +58,11 @@ AI_DOUBLE_BATTLE_TEST("AI will not try to switch for the same pokemon for 2 spot
     } WHEN {
         TURN { EXPECT_SWITCH(opponentLeft, 3); };
     } SCENE {
-        MESSAGE("{PKMN} TRAINER LEAF withdrew Gengar!");
-        MESSAGE("{PKMN} TRAINER LEAF sent out Raticate!");
+        MESSAGE(AI_TRAINER_NAME " withdrew Gengar!");
+        MESSAGE(AI_TRAINER_NAME " sent out Raticate!");
         NONE_OF {
-            MESSAGE("{PKMN} TRAINER LEAF withdrew Haunter!");
-            MESSAGE("{PKMN} TRAINER LEAF sent out Raticate!");
+            MESSAGE(AI_TRAINER_NAME " withdrew Haunter!");
+            MESSAGE(AI_TRAINER_NAME " sent out Raticate!");
         }
     }
 }
@@ -160,9 +160,9 @@ AI_SINGLE_BATTLE_TEST("AI_FLAG_SMART_MON_CHOICES: AI will not switch in a Pokemo
     } SCENE {
         MESSAGE("Foe Kadabra fainted!");
         if (alakazamFirst) {
-            MESSAGE("{PKMN} TRAINER LEAF sent out Alakazam!");
+            MESSAGE(AI_TRAINER_NAME " sent out Alakazam!");
         } else {
-            MESSAGE("{PKMN} TRAINER LEAF sent out Blastoise!");
+            MESSAGE(AI_TRAINER_NAME " sent out Blastoise!");
         }
     }
 }


### PR DESCRIPTION
If you rename Leaf (or do decap or anything else), the AI tests have their message fail because the trainer name no longer matches. This PR centralises the AI trainer name and uses it in the message checks so that downstream users can simply change the define and they won't run into new expansion AI tests failing because they didn't update their messages.

## **Discord contact info**
bassoonian
