### PR TITLE
Add CRY_AFTER_TITLE so Rayquaza's voice plays when the player gets past the title screen

### DIFF
--- a/include/config/general.h
+++ b/include/config/general.h
@@ -73,6 +73,7 @@
 #define HQ_RANDOM                    TRUE    // If TRUE, replaces the default RNG with an implementation of SFC32 RNG. May break code that relies on RNG.
 #define COMPETITIVE_PARTY_SYNTAX     TRUE    // If TRUE, parties are defined in "competitive syntax".
 #define AUTO_SCROLL_TEXT             FALSE   // If TRUE, text will automatically scroll to the next line after NUM_FRAMES_AUTO_SCROLL_DELAY. Players can still press A_BUTTON or B_BUTTON to scroll on their own.
+#define CRY_AT_START                 TRUE    // If TRUE, Rayquaza's cry plays when A or Start is pressed at the title screen.
 #define NUM_FRAMES_AUTO_SCROLL_DELAY 49
 
 

--- a/include/config/general.h
+++ b/include/config/general.h
@@ -73,7 +73,7 @@
 #define HQ_RANDOM                    TRUE    // If TRUE, replaces the default RNG with an implementation of SFC32 RNG. May break code that relies on RNG.
 #define COMPETITIVE_PARTY_SYNTAX     TRUE    // If TRUE, parties are defined in "competitive syntax".
 #define AUTO_SCROLL_TEXT             FALSE   // If TRUE, text will automatically scroll to the next line after NUM_FRAMES_AUTO_SCROLL_DELAY. Players can still press A_BUTTON or B_BUTTON to scroll on their own.
-#define CRY_AT_START                 TRUE    // If TRUE, Rayquaza's cry plays when A or Start is pressed at the title screen.
+#define CRY_AFTER_TITLE              TRUE    // If TRUE, Rayquaza's cry plays when A or Start is pressed at the title screen.
 #define NUM_FRAMES_AUTO_SCROLL_DELAY 49
 
 

--- a/src/title_screen.c
+++ b/src/title_screen.c
@@ -782,7 +782,7 @@ static void Task_TitleScreenPhase3(u8 taskId)
     if (JOY_NEW(A_BUTTON) || JOY_NEW(START_BUTTON))
     {
         FadeOutBGM(4);
-        if (CRY_AT_START)
+        if (CRY_AFTER_TITLE)
             PlayCry_Normal(SPECIES_RAYQUAZA, 0);
         BeginNormalPaletteFade(PALETTES_ALL, 0, 0, 16, RGB_WHITEALPHA);
         SetMainCallback2(CB2_GoToMainMenu);

--- a/src/title_screen.c
+++ b/src/title_screen.c
@@ -782,6 +782,8 @@ static void Task_TitleScreenPhase3(u8 taskId)
     if (JOY_NEW(A_BUTTON) || JOY_NEW(START_BUTTON))
     {
         FadeOutBGM(4);
+        if (CRY_AT_START)
+            PlayCry_Normal(SPECIES_RAYQUAZA, 0);
         BeginNormalPaletteFade(PALETTES_ALL, 0, 0, 16, RGB_WHITEALPHA);
         SetMainCallback2(CB2_GoToMainMenu);
     }


### PR DESCRIPTION
From Platinum onwards (until the Switch era), pressing start would play the legendary cry. This adds that basically.

<!--- Provide a general summary of your changes in the Title above -->
## Description
Added CRY_AT_START flag.

Added call to PlayCry_Normal in Task_TitleScreenPhase3 that causes Rayquaza's cry to play.