### PR TITLE
Fix Follow Me failing in Single Battles for Gen 6/7 config

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -4958,7 +4958,7 @@ BattleScript_EffectFollowMe::
 	attackcanceler
 	attackstring
 	ppreduce
-	.if B_UPDATED_MOVE_DATA >= GEN_6
+	.if B_UPDATED_MOVE_DATA >= GEN_8
 	jumpifnotbattletype BATTLE_TYPE_DOUBLE, BattleScript_ButItFailed
 	.endif
 	setforcedtarget


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Originally from #5253, separated this into its own PR.

> From [Pokémon Brilliant Diamond and Shining Pearl](https://bulbapedia.bulbagarden.net/wiki/Pok%C3%A9mon_Brilliant_Diamond_and_Shining_Pearl) onwards, Follow Me fails in Single Battles.

## **Discord contact info**
AsparagusEduardo
