### PR TITLE
Shed Skin chance fix

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -5019,7 +5019,7 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
                 break;
             case ABILITY_SHED_SKIN:
                 if ((gBattleMons[battler].status1 & STATUS1_ANY)
-                 && (B_ABILITY_TRIGGER_CHANCE == GEN_4 ? RandomPercentage(RNG_SHED_SKIN, 30) : RandomPercentage(RNG_SHED_SKIN, 33)))
+                 && (B_ABILITY_TRIGGER_CHANCE == GEN_4 ? RandomPercentage(RNG_SHED_SKIN, 30) : RandomChance(RNG_SHED_SKIN, 1, 3)))
                 {
                 ABILITY_HEAL_MON_STATUS:
                     if (gBattleMons[battler].status1 & (STATUS1_POISON | STATUS1_TOXIC_POISON))

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -5019,7 +5019,7 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
                 break;
             case ABILITY_SHED_SKIN:
                 if ((gBattleMons[battler].status1 & STATUS1_ANY)
-                 && (B_ABILITY_TRIGGER_CHANCE >= GEN_4 ? RandomPercentage(RNG_SHED_SKIN, 30) : RandomChance(RNG_SHED_SKIN, 1, 3)))
+                 && (B_ABILITY_TRIGGER_CHANCE == GEN_4 ? RandomPercentage(RNG_SHED_SKIN, 30) : RandomPercentage(RNG_SHED_SKIN, 33)))
                 {
                 ABILITY_HEAL_MON_STATUS:
                     if (gBattleMons[battler].status1 & (STATUS1_POISON | STATUS1_TOXIC_POISON))

--- a/test/battle/ability/shed_skin.c
+++ b/test/battle/ability/shed_skin.c
@@ -1,11 +1,13 @@
 #include "global.h"
 #include "test/battle.h"
 
-SINGLE_BATTLE_TEST("Shed Skin triggers 30% of the time")
+SINGLE_BATTLE_TEST("Shed Skin triggers 33% of the time")
 {
-    PASSES_RANDOMLY(3, 10, RNG_SHED_SKIN);
+    if (B_ABILITY_TRIGGER_CHANCE == GEN_4)
+        PASSES_RANDOMLY(30, 100, RNG_SHED_SKIN);
+    else
+        PASSES_RANDOMLY(33, 100, RNG_SHED_SKIN);
     GIVEN {
-        ASSUME(B_ABILITY_TRIGGER_CHANCE >= GEN_4);
         ASSUME(gMovesInfo[MOVE_TACKLE].makesContact);
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_ARBOK) { Status1(STATUS1_POISON); Ability(ABILITY_SHED_SKIN); }


### PR DESCRIPTION
## Description
This is maybe the pettiest looking PR I've ever made, but I realized this was "broken" while writing tests for the sleep clause branch iriv and I are working on.

Shed Skin triggers 30% of the time in Gen 4, and 1/3 of the time otherwise, according to [Bulbapedia](https://bulbapedia.bulbagarden.net/wiki/Shed_Skin_(Ability)#Effect). As is, it triggers 30% of the time with configs set to Gen 4 or higher.

Gotta get that sweet sweet 3% proc chance ~~and fix my sleep clause test~~

## **Discord contact info**
Pawkkie
