### PR TITLE
Healer ability tests

### DIFF
--- a/include/random.h
+++ b/include/random.h
@@ -169,6 +169,7 @@ enum RandomTag
     RNG_AI_SWITCH_SEEDED,
     RNG_SHELL_SIDE_ARM,
     RNG_RANDOM_TARGET,
+    RNG_HEALER,
 };
 
 #define RandomWeighted(tag, ...) \

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -5225,7 +5225,7 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
                 gBattleScripting.battler = BATTLE_PARTNER(battler);
                 if (IsBattlerAlive(gBattleScripting.battler)
                     && gBattleMons[gBattleScripting.battler].status1 & STATUS1_ANY
-                    && (Random() % 100) < 30)
+                    && RandomPercentage(RNG_HEALER, 30))
                 {
                     BattleScriptPushCursorAndCallback(BattleScript_HealerActivates);
                     effect++;

--- a/test/battle/ability/healer.c
+++ b/test/battle/ability/healer.c
@@ -1,0 +1,53 @@
+#include "global.h"
+#include "test/battle.h"
+
+DOUBLE_BATTLE_TEST("Healer cures adjacent ally's status condition 30% of the time")
+{
+    u16 status;
+    PARAMETRIZE { status = STATUS1_SLEEP; }
+    PARAMETRIZE { status = STATUS1_POISON; }
+    PARAMETRIZE { status = STATUS1_BURN; }
+    // PARAMETRIZE { status = STATUS1_FREEZE; }
+    PARAMETRIZE { status = STATUS1_PARALYSIS; }
+    PARAMETRIZE { status = STATUS1_TOXIC_POISON; }
+    PARAMETRIZE { status = STATUS1_FROSTBITE; }
+    PASSES_RANDOMLY(30, 100, RNG_HEALER);
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { Status1(status); }
+        OPPONENT(SPECIES_CHANSEY) { Ability(ABILITY_HEALER); }
+    } WHEN {
+        TURN { }
+    } SCENE {
+        MESSAGE("The opposing Chansey's Healer cured the opposing Wobbuffet's problem!");
+    }
+}
+
+DOUBLE_BATTLE_TEST("Healer cures status condition before burn or poison damage is dealt")
+{
+    KNOWN_FAILING; // According to Bulbapedia, Healer should trigger before status damage and Wobbuffet should live
+    // Source: https://bulbapedia.bulbagarden.net/wiki/Healer_(Ability)#Effect
+    u16 status;
+    PARAMETRIZE { status = STATUS1_POISON; }
+    PARAMETRIZE { status = STATUS1_BURN; }
+    PARAMETRIZE { status = STATUS1_TOXIC_POISON; }
+    PARAMETRIZE { status = STATUS1_FROSTBITE; }
+    PASSES_RANDOMLY(30, 100, RNG_HEALER);
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { HP(1); Status1(status); }
+        OPPONENT(SPECIES_CHANSEY) { Ability(ABILITY_HEALER); }
+    } WHEN {
+        TURN {}
+    } SCENE {
+        NOT {
+            MESSAGE("The opposing Wobbuffet fainted!");
+        }
+        MESSAGE("The opposing Chansey's Healer cured Foe Wobbuffet's problem!");
+    }
+}
+
+// Triple battles
+TO_DO_BATTLE_TEST("Healer has a 30% chance of curing each of its ally's status conditions independently");


### PR DESCRIPTION
## Description
Adds tests for Healer ~~because I need to reference RNG_HEALER for sleep clause tests~~

I'm not entirely sure how to handle the test for curing Freeze, as the Wobbuffet thaws before Healer can cure it based on `RNG_FROZEN`, and I'm not sure how to (or if we even can?) nest `PASSES_RANDOMLY` statements. Hardcoding the 20% chance reduction and using `PASSES_RANDOMLY(24, 100, RNG_HEALER)` for Freeze didn't work unfortunately.

Note that one of these that should pass according to Bulbapedia fails, I've marked it as `KNOWN_FAILING`.

## **Discord contact info**
Pawkkie