### PR TITLE
Fallback memmem implementation

### DIFF
--- a/tools/mgba-rom-test-hydra/Makefile
+++ b/tools/mgba-rom-test-hydra/Makefile
@@ -12,7 +12,7 @@ all: mgba-rom-test-hydra$(EXE)
 	@:
 
 mgba-rom-test-hydra$(EXE): $(SRCS)
-	$(CC) $(SRCS) -o $@ -lm $(LDFLAGS)
+	$(CC) $(SRCS) -Werror=implicit-function-declaration -o $@ -lm $(LDFLAGS)
 
 clean:
 	$(RM) mgba-rom-test-hydra$(EXE)

--- a/tools/mgba-rom-test-hydra/main.c
+++ b/tools/mgba-rom-test-hydra/main.c
@@ -106,6 +106,28 @@ static const struct Symbol *lookup_address(uint32_t address)
     return NULL;
 }
 
+#ifndef _GNU_SOURCE
+// Very naive implementation of 'memmem' for systems which don't make it
+// available by default.
+void *memmem(const void *haystack, size_t haystacklen, const void *needle, size_t needlelen)
+{
+    const char *haystack_ = haystack;
+    const char *needle_ = needle;
+    for (size_t i = 0; i < haystacklen - needlelen; i++)
+    {
+        size_t j;
+        for (j = 0; j < needlelen; j++)
+        {
+            if (haystack_[i+j] != needle_[j])
+                break;
+        }
+        if (j == needlelen)
+            return (void *)&haystack_[i];
+    }
+    return NULL;
+}
+#endif
+
 // Similar to 'fwrite(buffer, 1, size, f)' except that anything which
 // looks like the output of '%p' (i.e. '<0x\d{7}>') is translated into
 // the name of a symbol (if it represents one).


### PR DESCRIPTION
Zatsu noticed that CI doesn't declare `memmem` (but I suppose it must be available because we don't get a linker error... Meaning that the implicit definition casts a `void *` to `int` and causes hell to break loose). To support systems which don't provide `memmem` at all, I've added a very naive implementation for when `_GNU_SOURCE` isn't set (see [`memmem(3)`](https://www.man7.org/linux/man-pages/man3/memmem.3.html)).

EDIT: Please double-check my logic in `memmem`. I implemented it very quickly and carelessly.