### PR TITLE
Missing string_util.h include in mini_printf.c

### DIFF
--- a/src/mini_printf.c
+++ b/src/mini_printf.c
@@ -37,6 +37,7 @@
 #include "gba/defines.h"
 #include "config/general.h"
 #include "constants/characters.h"
+#include "string_util.h"
 
 #ifndef NDEBUG
 


### PR DESCRIPTION
`mini_printf.c` does not build due to `#include "string_util.h"` being lost during a pret merge. The exact error is about `StringLength` not being defined.