### PR TITLE
`AI_FLAG_ACE_POKEMON` takes into account separate trainers

### DIFF
--- a/docs/tutorials/ai_flags.md
+++ b/docs/tutorials/ai_flags.md
@@ -134,10 +134,10 @@ Affects when the AI chooses to switch. AI will make smarter decisions about when
 * The current mon loses the 1v1 quickly and has at least ½ HP, or ¼ and Regenerator
 
 ## `AI_FLAG_ACE_POKEMON`
-Marks the last Pokemon in the party as the Ace Pokemon. It will not be used unless it is the last one remaining, or is forced to be switched in (Roar, U-Turn with 1 mon remaining, etc.)
+Marks the last Pokemon in the party as the Ace Pokemon. It will not be used unless it is the last one remaining, or is forced to be switched in (Roar, U-Turn with 1 mon remaining, etc.). If you are challenged by two different trainers at the same time, only the ones with this flag will have Ace Pokémon. For example vs one trainer with `AI_FLAG_ACE_POKEMON`and the other without, there will be a total of 1 Ace Pokémon.
 
 ## `AI_FLAG_DOUBLE_ACE_POKEMON`
-Marks the last two Pokémon in the party as Ace Pokémon, with the same behaviour as `AI_FLAG_ACE_POKEMON`. Intented for double battles where you battle one trainer id that represents two trainers, ie Twins, Couples.
+Marks the last two Pokémon in the party as Ace Pokémon, with the same behaviour as `AI_FLAG_ACE_POKEMON`. Intented for double battles where you battle one trainer id that represents two trainers, ie Twins, Couples. If you apply this flag to trainers outside of double battles or in cases where two trainers can challenge you at the same time, it has the same behaviour. For example vs two trainers with `AI_FLAG_DOUBLE_ACE_POKEMON` there will be a total of 4 Ace Pokémon.
 
 ## `AI_FLAG_OMNISCIENT`
 AI has full knowledge of player moves, abilities, and hold items, and can use this knowledge when making decisions.

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -773,6 +773,7 @@ u8 GiveMonToPlayer(struct Pokemon *mon);
 u8 CopyMonToPC(struct Pokemon *mon);
 u8 CalculatePlayerPartyCount(void);
 u8 CalculateEnemyPartyCount(void);
+u8 CalculateEnemyPartyCountInSide(u32 battler);
 u8 GetMonsStateToDoubles(void);
 u8 GetMonsStateToDoubles_2(void);
 u16 GetAbilityBySpecies(u16 species, u8 abilityNum);

--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -41,7 +41,7 @@ static bool32 IsAceMon(u32 battler, u32 monPartyId)
 {
     if (AI_THINKING_STRUCT->aiFlags[battler] & AI_FLAG_ACE_POKEMON
             && !(gBattleStruct->forcedSwitch & (1u << battler))
-            && monPartyId == CalculateEnemyPartyCount()-1)
+            && monPartyId == CalculateEnemyPartyCountInSide(battler)-1)
         return TRUE;
     if (AI_THINKING_STRUCT->aiFlags[battler] & AI_FLAG_DOUBLE_ACE_POKEMON
             && !(gBattleStruct->forcedSwitch & (1u << battler))

--- a/src/battle_controller_opponent.c
+++ b/src/battle_controller_opponent.c
@@ -689,8 +689,8 @@ static void OpponentHandleChoosePokemon(u32 battler)
                  && ((chosenMonId == CalculateEnemyPartyCountInSide(battler) - 1) || CountAIAliveNonEggMonsExcept(PARTY_SIZE) == pokemonInBattle))
                     continue;
                 if ((AI_THINKING_STRUCT->aiFlags[battler] & AI_FLAG_DOUBLE_ACE_POKEMON)
-                 && (((chosenMonId == CalculateEnemyPartyCount() - 1) || (chosenMonId == CalculateEnemyPartyCount() - 1))
-                 || CountAIAliveNonEggMonsExcept(PARTY_SIZE) == pokemonInBattle))
+                 && (((chosenMonId == CalculateEnemyPartyCountInSide(battler) - 1) || (chosenMonId == CalculateEnemyPartyCountInSide(battler) - 2))
+                 || (CountAIAliveNonEggMonsExcept(PARTY_SIZE) == pokemonInBattle || CountAIAliveNonEggMonsExcept(PARTY_SIZE-1) == pokemonInBattle)))
                     continue;
                 // mon is valid
                 break;

--- a/src/battle_controller_opponent.c
+++ b/src/battle_controller_opponent.c
@@ -686,10 +686,10 @@ static void OpponentHandleChoosePokemon(u32 battler)
                  || chosenMonId == gBattlerPartyIndexes[battler2])
                     continue;
                 if ((AI_THINKING_STRUCT->aiFlags[battler] & AI_FLAG_ACE_POKEMON)
-                 && ((chosenMonId != CalculateEnemyPartyCount() - 1) || CountAIAliveNonEggMonsExcept(PARTY_SIZE) == pokemonInBattle))
+                 && ((chosenMonId == CalculateEnemyPartyCountInSide(battler) - 1) || CountAIAliveNonEggMonsExcept(PARTY_SIZE) == pokemonInBattle))
                     continue;
                 if ((AI_THINKING_STRUCT->aiFlags[battler] & AI_FLAG_DOUBLE_ACE_POKEMON)
-                 && (((chosenMonId != CalculateEnemyPartyCount() - 1) || (chosenMonId != CalculateEnemyPartyCount() - 1))
+                 && (((chosenMonId == CalculateEnemyPartyCount() - 1) || (chosenMonId == CalculateEnemyPartyCount() - 1))
                  || CountAIAliveNonEggMonsExcept(PARTY_SIZE) == pokemonInBattle))
                     continue;
                 // mon is valid

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -3369,16 +3369,16 @@ u8 CalculatePartyCount(struct Pokemon *party)
 
 u8 CalculatePartyCountOfSide(u32 battler, struct Pokemon *party)
 {
-    s32 partyStart, partySize;
-    GetAIPartyIndexes(battler, &partyStart, &partySize);
+    s32 partyCount, partySize;
+    GetAIPartyIndexes(battler, &partyCount, &partySize);
 
-    while (partyStart < partySize
-        && GetMonData(&party[partyStart], MON_DATA_SPECIES, NULL) != SPECIES_NONE)
+    while (partyCount < partySize
+        && GetMonData(&party[partyCount], MON_DATA_SPECIES, NULL) != SPECIES_NONE)
     {
-        partyStart++;
+        partyCount++;
     }
 
-    return partyStart;
+    return partyCount;
 }
 
 u8 CalculatePlayerPartyCount(void)
@@ -3393,8 +3393,6 @@ u8 CalculateEnemyPartyCount(void)
     return gEnemyPartyCount;
 }
 
-// Not messing with gEnemyPartyCount here because I'm unsure if it always has to be the total count
-// - GhoulMage
 u8 CalculateEnemyPartyCountInSide(u32 battler)
 {
     return CalculatePartyCountOfSide(battler, gEnemyParty);

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -3367,6 +3367,20 @@ u8 CalculatePartyCount(struct Pokemon *party)
     return partyCount;
 }
 
+u8 CalculatePartyCountOfSide(u32 battler, struct Pokemon *party)
+{
+    s32 partyStart, partySize;
+    GetAIPartyIndexes(battler, &partyStart, &partySize);
+
+    while (partyStart < partySize
+        && GetMonData(&party[partyStart], MON_DATA_SPECIES, NULL) != SPECIES_NONE)
+    {
+        partyStart++;
+    }
+
+    return partyStart;
+}
+
 u8 CalculatePlayerPartyCount(void)
 {
     gPlayerPartyCount = CalculatePartyCount(gPlayerParty);
@@ -3377,6 +3391,13 @@ u8 CalculateEnemyPartyCount(void)
 {
     gEnemyPartyCount = CalculatePartyCount(gEnemyParty);
     return gEnemyPartyCount;
+}
+
+// Not messing with gEnemyPartyCount here because I'm unsure if it always has to be the total count
+// - GhoulMage
+u8 CalculateEnemyPartyCountInSide(u32 battler)
+{
+    return CalculatePartyCountOfSide(battler, gEnemyParty);
 }
 
 u8 GetMonsStateToDoubles(void)


### PR DESCRIPTION
The behaviour for the `AI_FLAG_ACE_POKEMON` didn't take into account two separate trainers in double battles.

## Description
When `AI_FLAG_ACE_POKEMON` was relevant for choosing a mon, it compared the current selection to the total amount of mons of the trainer, but there was no differentiation between mons in the left side vs the right side for two completely separate trainers that merged due to seeing the trainer at the same time (which was already able to be checked with `BATTLE_TYPE_TWO_OPPONENTS`/`GetAIPartyIndexes`).

## **People who collaborated with me in this PR**
* @/uvula on Discord noted the weird behaviour.

## Feature(s) this PR does NOT handle:
* Testing for double (separate) trainers as that is still not possible. I had to create custom trainers and test all possible cases (like one with aces and the other without, both with and without).

## Things to note in the release changelog:
Fix for the AI not considering both trainers Ace Pokémons in double battles with `AI_FLAG_ACE_POKEMON`.

## **Discord contact info**
@ghoulmage