### PR TITLE
Restore test file dependencies so they're rebuilt properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -414,6 +414,10 @@ $(TEST_BUILDDIR)/%.o: $(TEST_SUBDIR)/%.c
 $(TEST_BUILDDIR)/%.d: $(TEST_SUBDIR)/%.c
 	$(SCANINC) -M $@ $(INCLUDE_SCANINC_ARGS) -I tools/agbcc/include $<
 
+ifneq ($(NODEP),1)
+-include $(addprefix $(OBJ_DIR)/,$(TEST_SRCS:.c=.d))
+endif
+
 $(ASM_BUILDDIR)/%.o: $(ASM_SUBDIR)/%.s
 	$(AS) $(ASFLAGS) -o $@ $<
 


### PR DESCRIPTION
## Description
This restores the missing rules for test file dependencies that were removed by #5594 (while still taking advantage of the new build system's speed).

This can by tested by compiling and running a test such as `"Poke Toy lets the player escape from a wild battle"`, swapping the item ID constant for `ITEM_POKE_TOY` with another item that doesn't have `EFFECT_ITEM_ESCAPE`, and then re-running the test. Before these changes the assumptions would fail, but afterwards they succeed. You should also be able to observe that `.d` files are successfully generated in `build/modern-test/test`, whereas they were not beforehand.


## Issue(s) that this PR fixes
- Regression caused by #5594 where test files were not getting rebuilt properly when their dependencies were updated

## **Discord contact info**
ravepossum
