### PR TITLE
Display the correct shadow size when sending out a new Pokemon

### DIFF
--- a/src/battle_gfx_sfx_util.c
+++ b/src/battle_gfx_sfx_util.c
@@ -26,6 +26,7 @@
 #include "constants/rgb.h"
 #include "constants/battle_palace.h"
 #include "constants/battle_move_effects.h"
+#include "constants/event_objects.h" // only for SHADOW_SIZE constants
 
 // this file's functions
 static u8 GetBattlePalaceMoveGroup(u8 battler, u16 move);
@@ -1130,8 +1131,9 @@ void SetBattlerSpriteAffineMode(u8 affineMode)
     }
 }
 
-#define tBattlerId  data[0]
-#define tSpriteSide data[1]
+#define tBattlerId   data[0]
+#define tSpriteSide  data[1]
+#define tBaseTileNum data[2]
 
 #define SPRITE_SIDE_LEFT    0
 #define SPRITE_SIDE_RIGHT   1
@@ -1152,7 +1154,8 @@ void CreateEnemyShadowSprite(u32 battler)
             struct Sprite *sprite = &gSprites[gBattleSpritesDataPtr->healthBoxesData[battler].shadowSpriteIdPrimary];
             sprite->tBattlerId = battler;
             sprite->tSpriteSide = SPRITE_SIDE_LEFT;
-            sprite->oam.tileNum += 8 * size;
+            sprite->tBaseTileNum = sprite->oam.tileNum;
+            sprite->oam.tileNum = sprite->tBaseTileNum + (8 * size);
             sprite->invisible = TRUE;
         }
 
@@ -1165,7 +1168,8 @@ void CreateEnemyShadowSprite(u32 battler)
             struct Sprite *sprite = &gSprites[gBattleSpritesDataPtr->healthBoxesData[battler].shadowSpriteIdSecondary];
             sprite->tBattlerId = battler;
             sprite->tSpriteSide = SPRITE_SIDE_RIGHT;
-            sprite->oam.tileNum += (8 * size) + 4;
+            sprite->tBaseTileNum = sprite->oam.tileNum + 4;
+            sprite->oam.tileNum = sprite->tBaseTileNum + (8 * size);
             sprite->invisible = TRUE;
         }
     }
@@ -1179,6 +1183,7 @@ void CreateEnemyShadowSprite(u32 battler)
         {
             struct Sprite *sprite = &gSprites[gBattleSpritesDataPtr->healthBoxesData[battler].shadowSpriteIdPrimary];
             sprite->tBattlerId = battler;
+            sprite->tBaseTileNum = sprite->oam.tileNum;
             sprite->invisible = TRUE;
         }
     }
@@ -1234,13 +1239,14 @@ void SpriteCB_EnemyShadow(struct Sprite *shadowSprite)
         return;
     }
 
-    s8 xOffset = 0, yOffset = 0;
+    s8 xOffset = 0, yOffset = 0, size = SHADOW_SIZE_S;
     if (gAnimScriptActive || battlerSprite->invisible)
         invisible = TRUE;
     else if (transformSpecies != SPECIES_NONE)
     {
         xOffset = gSpeciesInfo[transformSpecies].enemyShadowXOffset;
         yOffset = gSpeciesInfo[transformSpecies].enemyShadowYOffset;
+        size = gSpeciesInfo[transformSpecies].enemyShadowSize;
 
         invisible = (B_ENEMY_MON_SHADOW_STYLE >= GEN_4 && P_GBA_STYLE_SPECIES_GFX == FALSE)
                   ? gSpeciesInfo[transformSpecies].suppressEnemyShadow
@@ -1251,6 +1257,7 @@ void SpriteCB_EnemyShadow(struct Sprite *shadowSprite)
         u16 species = SanitizeSpeciesId(gBattleMons[battler].species);
         xOffset = gSpeciesInfo[species].enemyShadowXOffset + (shadowSprite->tSpriteSide == SPRITE_SIDE_LEFT ? -16 : 16);
         yOffset = gSpeciesInfo[species].enemyShadowYOffset + 16;
+        size = gSpeciesInfo[species].enemyShadowSize;
     }
     else
     {
@@ -1264,6 +1271,9 @@ void SpriteCB_EnemyShadow(struct Sprite *shadowSprite)
     shadowSprite->x2 = battlerSprite->x2;
     shadowSprite->y = battlerSprite->y + yOffset;
     shadowSprite->invisible = invisible;
+
+    if (B_ENEMY_MON_SHADOW_STYLE >= GEN_4 && P_GBA_STYLE_SPECIES_GFX == FALSE)
+        shadowSprite->oam.tileNum = shadowSprite->tBaseTileNum + (8 * size);
 }
 
 #undef tBattlerId


### PR DESCRIPTION
## Description

This fixes a bug with the enemy shadows implementation where shadow size is not correctly set when a new Pokemon is sent out for a battler slot. This bug applies to both sending out the first Pokemon of a battle and replacing a fainted battler with a new one.

## Images

### Current Upcoming

![On current upcoming, Ting-Lu has an incorrectly-sized shadow on first send-out.](https://github.com/user-attachments/assets/78908848-5db4-4f70-aa7d-2ee7b4517570)

### With Changes

![With changes applied, Ting-Lu has the correctly-sized shadow on first send-out.](https://github.com/user-attachments/assets/5ff03650-dbd4-4802-875e-b0d547c98ccc)

## **Discord contact info**

lhea