### PR TITLE
Fixes dynamicMoveType global not being reset during AI calcs

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -561,8 +561,6 @@ struct SimulatedDamage AI_CalcDamage(u32 move, u32 battlerAtk, u32 battlerDef, u
         break;
     }
 
-    gBattleStruct->dynamicMoveType = 0;
-
     SetTypeBeforeUsingMove(move, battlerAtk);
     GET_MOVE_TYPE(move, moveType);
     effectivenessMultiplier = CalcTypeEffectivenessMultiplier(move, moveType, battlerAtk, battlerDef, aiData->abilities[battlerDef], FALSE);
@@ -734,6 +732,7 @@ struct SimulatedDamage AI_CalcDamage(u32 move, u32 battlerAtk, u32 battlerDef, u
     *typeEffectiveness = AI_GetEffectiveness(effectivenessMultiplier);
 
     // Undo temporary settings
+    gBattleStruct->dynamicMoveType = 0;
     gBattleStruct->aiCalcInProgress = FALSE;
     gBattleStruct->swapDamageCategory = FALSE;
     gBattleStruct->zmove.baseMoves[battlerAtk] = MOVE_NONE;


### PR DESCRIPTION
`gBattleStruct->dynamicMoveType` was not properly reset during AI calcs. Also it is set to 0 at the start of the `SetTypeBeforeUsingMove` function so I just moved it to the end of `AI_CalcDamage`
