### PR TITLE
Check that PASSES_RANDOMLY affected a Random call

### DIFF
--- a/include/test/battle.h
+++ b/include/test/battle.h
@@ -716,6 +716,7 @@ struct BattleTestRunnerState
     u16 observedRatio;
     u16 trialRatio;
     bool8 runRandomly:1;
+    bool8 didRunRandomly:1;
     bool8 runGiven:1;
     bool8 runWhen:1;
     bool8 runScene:1;

--- a/test/test_runner_battle.c
+++ b/test/test_runner_battle.c
@@ -373,6 +373,7 @@ u32 RandomUniform(enum RandomTag tag, u32 lo, u32 hi)
 
     if (tag == STATE->rngTag)
     {
+        STATE->didRunRandomly = TRUE;
         u32 n = hi - lo + 1;
         if (STATE->trials == 1)
         {
@@ -409,6 +410,7 @@ u32 RandomUniformExcept(enum RandomTag tag, u32 lo, u32 hi, bool32 (*reject)(u32
 
     if (tag == STATE->rngTag)
     {
+        STATE->didRunRandomly = TRUE;
         if (STATE->trials == 1)
         {
             u32 n = 0, i;
@@ -457,6 +459,7 @@ u32 RandomWeightedArray(enum RandomTag tag, u32 sum, u32 n, const u8 *weights)
 
     if (tag == STATE->rngTag)
     {
+        STATE->didRunRandomly = TRUE;
         if (STATE->trials == 1)
         {
             STATE->trials = n;
@@ -530,6 +533,7 @@ const void *RandomElementArray(enum RandomTag tag, const void *array, size_t siz
 
     if (tag == STATE->rngTag)
     {
+        STATE->didRunRandomly = TRUE;
         if (STATE->trials == 1)
         {
             STATE->trials = count;
@@ -1353,6 +1357,7 @@ static void CB2_BattleTest_NextParameter(void)
     else
     {
         STATE->trials = 0;
+        STATE->didRunRandomly = FALSE;
         BattleTest_Run(gTestRunnerState.test->data);
     }
 }
@@ -1403,6 +1408,9 @@ static void CB2_BattleTest_NextTrial(void)
     }
     else
     {
+        if (STATE->rngTag && !STATE->didRunRandomly && STATE->expectedRatio != Q_4_12(0.0) && STATE->expectedRatio != Q_4_12(1.0))
+            Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), ":L%s:%d: PASSES_RANDOMLY specified but no Random* call with that tag executed", gTestRunnerState.test->filename, SourceLine(0));
+
         // This is a tolerance of +/- ~2%.
         if (abs(STATE->observedRatio - STATE->expectedRatio) <= Q_4_12(0.02))
             gTestRunnerState.result = TEST_RESULT_PASS;


### PR DESCRIPTION
Checks that the tag specified in `PASSES_RANDOMLY` was the argument to a structured RNG call. This catches errors that look like "expected _, got 0.0" and "expected _, got 1.0" that are the result of there not actually being any randomness.

## **People who collaborated with me in this PR**
@Pawkkie 