### PR TITLE
Improve line breaks/scrolls

### DIFF
--- a/src/battle_message.c
+++ b/src/battle_message.c
@@ -3340,6 +3340,7 @@ u32 BattleStringExpandPlaceholders(const u8 *src, u8 *dst, u32 dstSize)
     u8 fontId = FONT_NORMAL;
     s16 letterSpacing = 0;
     u32 lineNum = 1;
+    u32 displayedLineNums = 1;
 
     if (gBattleTypeFlags & BATTLE_TYPE_RECORDED_LINK)
         multiplayerId = gRecordedBattleMultiplayerId;
@@ -3753,8 +3754,12 @@ u32 BattleStringExpandPlaceholders(const u8 *src, u8 *dst, u32 dstSize)
 
                 if (dstWidth + toCpyWidth > BATTLE_MSG_MAX_WIDTH)
                 {
-                    dst[lastValidSkip] = lineNum == 1 ? CHAR_NEWLINE : CHAR_PROMPT_SCROLL;
+                    dst[lastValidSkip] = displayedLineNums == 1 ? CHAR_NEWLINE : CHAR_PROMPT_SCROLL;
                     dstWidth = GetStringLineWidth(fontId, dst, letterSpacing, lineNum, dstSize);
+                    if (displayedLineNums == 1)
+                        displayedLineNums++;
+                    else
+                        displayedLineNums = 1;
                     lineNum++;
                 }
                 while (*toCpy != EOS)
@@ -3780,15 +3785,20 @@ u32 BattleStringExpandPlaceholders(const u8 *src, u8 *dst, u32 dstSize)
             dst[dstID] = *src;
             if (dstWidth + toCpyWidth > BATTLE_MSG_MAX_WIDTH)
             {
-                dst[lastValidSkip] = lineNum == 1 ? CHAR_NEWLINE : CHAR_PROMPT_SCROLL;
+                dst[lastValidSkip] = displayedLineNums == 1 ? CHAR_NEWLINE : CHAR_PROMPT_SCROLL;
+                if (displayedLineNums == 1)
+                    displayedLineNums++;
+                else
+                    displayedLineNums = 1;
                 lineNum++;
                 dstWidth = 0;
             }
             switch (*src)
             {
-            case CHAR_NEWLINE:
-            case CHAR_PROMPT_SCROLL:
             case CHAR_PROMPT_CLEAR:
+            case CHAR_PROMPT_SCROLL:
+                displayedLineNums = 1;
+            case CHAR_NEWLINE:
                 lineNum++;
                 dstWidth = 0;
                 //fallthrough


### PR DESCRIPTION
## Description
The current implementation adds only scrolls when there is more than 1 line. With these changes scroll and new line alternate.

## Images
old:
![old_text](https://github.com/user-attachments/assets/5b0ee819-f39d-497f-b3d3-5b59a60783e6)
new:
![new_text](https://github.com/user-attachments/assets/737616a2-a322-476c-83cb-ce2e8a6e7df7)


## **Discord contact info**
.cawt
