### PR TITLE
Mimicry updates typing with RemoveAllTerrains()

### DIFF
--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -267,6 +267,7 @@ bool32 CanGetFrostbite(u32 battler);
 bool32 CanBeConfused(u32 battler);
 bool32 IsBattlerTerrainAffected(u32 battler, u32 terrainFlag);
 u32 GetBattlerAffectionHearts(u32 battler);
+void TryToRevertMimicryAndFlags(void);
 u32 CountBattlerStatIncreases(u32 battler, bool32 countEvasionAcc);
 bool32 ChangeTypeBasedOnTerrain(u32 battler);
 void RemoveConfusionStatus(u32 battler);

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -8655,6 +8655,7 @@ static void RemoveAllTerrains(void)
         break;
     }
     gFieldStatuses &= ~STATUS_FIELD_TERRAIN_ANY;    // remove the terrain
+    TryToRevertMimicryAndFlags();
 }
 
 #define DEFOG_CLEAR(status, structField, battlescript, move)\

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -1612,7 +1612,7 @@ u32 GetBattlerAffectionHearts(u32 battler)
     return GetMonAffectionHearts(&party[gBattlerPartyIndexes[battler]]);
 }
 
-static void TryToRevertMimicryAndFlags(void)
+void TryToRevertMimicryAndFlags(void)
 {
     u32 i;
 

--- a/test/battle/move_effect/hit_set_remove_terrain.c
+++ b/test/battle/move_effect/hit_set_remove_terrain.c
@@ -147,7 +147,7 @@ SINGLE_BATTLE_TEST("Steel Roller and Ice Spinner reverts typing on Mimicry users
 
     GIVEN {
         ASSUME(gSpeciesInfo[SPECIES_STUNFISK_GALARIAN].types[1] == TYPE_STEEL);
-        PLAYER(SPECIES_WOBBUFFET) { Ability(ABILITY_NO_GUARD); }
+        PLAYER(SPECIES_WOBBUFFET); 
         OPPONENT(SPECIES_STUNFISK_GALARIAN) { Ability(ABILITY_MIMICRY); }
     } WHEN {
         TURN { MOVE(opponent, terrainMove); MOVE(player, removeTerrainMove); }

--- a/test/battle/move_effect/hit_set_remove_terrain.c
+++ b/test/battle/move_effect/hit_set_remove_terrain.c
@@ -124,3 +124,35 @@ AI_SINGLE_BATTLE_TEST("Ice Spinner can be chosen by the AI regardless if there i
         }
     }
 }
+
+SINGLE_BATTLE_TEST("Steel Roller and Ice Spinner reverts typing on Mimicry users")
+{
+    u32 j;
+    static const u16 terrainMoves[] =
+    {
+        MOVE_ELECTRIC_TERRAIN,
+        MOVE_PSYCHIC_TERRAIN,
+        MOVE_GRASSY_TERRAIN,
+        MOVE_MISTY_TERRAIN,
+    };
+
+    u16 terrainMove = MOVE_NONE;
+    u16 removeTerrainMove = MOVE_NONE;
+
+    for (j = 0; j < ARRAY_COUNT(terrainMoves); j++)
+    {
+        PARAMETRIZE { removeTerrainMove = MOVE_STEEL_ROLLER; terrainMove = terrainMoves[j]; }
+        PARAMETRIZE { removeTerrainMove = MOVE_ICE_SPINNER; terrainMove =  terrainMoves[j]; }
+    }
+
+    GIVEN {
+        ASSUME(gSpeciesInfo[SPECIES_STUNFISK_GALARIAN].types[1] == TYPE_STEEL);
+        PLAYER(SPECIES_WOBBUFFET) { Ability(ABILITY_NO_GUARD); }
+        OPPONENT(SPECIES_STUNFISK_GALARIAN) { Ability(ABILITY_MIMICRY); }
+    } WHEN {
+        TURN { MOVE(opponent, terrainMove); MOVE(player, removeTerrainMove); }
+        TURN { MOVE(player, MOVE_TOXIC); }
+    } SCENE {
+        MESSAGE("It doesn't affect Foe Stunfisk…");
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
`TryToRevertMimicryAndFlags()` only triggers when the terrain counter/timer turns 0.
If you use `Steel Roller`, Mimicry doesn't revert to the original typing since `RemoveAllTerrains()` never calls `TryToRevertMimicryAndFlags()`. This PR just adds `TryToRevertMimicryAndFlags()` to the end of `RemoveAllTerrains()`

Originally wasn't sure if this was vanilla behavior, at least simulating it on showdown shows that `Steel Roller` should revert typing. (Unless I overlooked something)

47929991024