### PR TITLE
Fix Order Up + Tera Stellar breaking each other with Commander

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -826,7 +826,7 @@ struct BattleStruct
     u8 distortedTypeMatchups;
     u8 categoryOverride; // for Z-Moves and Max Moves
     u8 commandingDondozo;
-    u16 commanderActive[NUM_BATTLE_SIDES];
+    u16 commanderActive[MAX_BATTLERS_COUNT];
     u32 stellarBoostFlags[NUM_BATTLE_SIDES]; // stored as a bitfield of flags for all types for each side
     u8 redCardActivates:1;
     u8 usedEjectItem;


### PR DESCRIPTION
The following issues occur if the Dondozo is on the right slot (player or opponent) only:
- Order Up loses or changes its effect upon using a Stellar Boosted move.
- Some types start out with the Stellar Boost consumed.

These happen because `gBattleStruct` doesn't have enough space to store `commanderActive` for all battlers, so, as shown in the example program below, it instead stores on the next one (`stellarBoostFlags`).

![struct_test](https://github.com/user-attachments/assets/6644986f-721f-4a08-a962-46cef44c1380)

In a situation where both would be in use at the same time (example, Tera Stellar Dondozo affected by Commander on the right slot), both would modify the value stored, breaking the other's functionality.

This PR fixes these issues by giving proper space to store `commanderActive` for all battlers.

## **Discord contact info**
PhallenTree
