### PR TITLE
Adds gen9 weather mechanic: Prevent weather moves/abilities on overworld weather

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -7585,6 +7585,12 @@ BattleScript_ItemSteal::
 	waitmessage B_WAIT_TIME_LONG
 	return
 
+BattleScript_OverworldWeatherPrevents::
+	call BattleScript_AbilityPopUp
+	printstring STRINGID_BUTITFAILED
+	waitmessage B_WAIT_TIME_LONG
+	end3
+
 BattleScript_DrizzleActivates::
 	pause B_WAIT_TIME_SHORT
 	call BattleScript_AbilityPopUp

--- a/include/battle.h
+++ b/include/battle.h
@@ -828,9 +828,12 @@ struct BattleStruct
     u8 commandingDondozo;
     u16 commanderActive[MAX_BATTLERS_COUNT];
     u32 stellarBoostFlags[NUM_BATTLE_SIDES]; // stored as a bitfield of flags for all types for each side
-    u8 redCardActivates:1;
     u8 usedEjectItem;
     u8 usedMicleBerry;
+    u8 redCardActivates:1;
+    u8 overworldWeatherActivated:1;
+    u8 overworldTerrainActivated:1;
+    u8 padding:5;
 };
 
 // The palaceFlags member of struct BattleStruct contains 1 flag per move to indicate which moves the AI should consider,

--- a/include/battle_scripts.h
+++ b/include/battle_scripts.h
@@ -164,6 +164,7 @@ extern const u8 BattleScript_MaxHp50Recoil[];
 extern const u8 BattleScript_DoRecoil33[];
 extern const u8 BattleScript_Recoil33End[];
 extern const u8 BattleScript_ItemSteal[];
+extern const u8 BattleScript_OverworldWeatherPrevents[];
 extern const u8 BattleScript_DrizzleActivates[];
 extern const u8 BattleScript_SpeedBoostActivates[];
 extern const u8 BattleScript_TraceActivates[];

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -255,6 +255,7 @@
 #define B_OVERWORLD_FOG                 GEN_LATEST // In Gen8+, overworld Fog summons Misty Terrain in battle. In Gen4 only, overworld Fog summons the unique fog weather condition in battle.
 #define B_TOXIC_REVERSAL                GEN_LATEST // In Gen5+, bad poison will change to regular poison at the end of battles.
 #define B_TRY_CATCH_TRAINER_BALL        GEN_LATEST // In Gen4+, trying to catch a Trainer's Pokémon does not consume the Poké Ball.
+#define B_OVERWOLD_WEATHER_PREVENTION   GEN_LATEST // In Gen9+, Overworld weather prevents weather abilities and moves from activation.
 
 // Animation Settings
 #define B_NEW_SWORD_PARTICLE            FALSE    // If set to TRUE, it updates Swords Dance's particle.
@@ -287,5 +288,4 @@
 // Pokémon battle sprite settings
 #define B_ENEMY_MON_SHADOW_STYLE        GEN_3 // In Gen4+, all enemy Pokemon will have a shadow drawn beneath them.
                                               // Currently Gen4+ shadows don't properly work with Trainerslides
-
 #endif // GUARD_CONFIG_BATTLE_H

--- a/src/battle_dynamax.c
+++ b/src/battle_dynamax.c
@@ -606,7 +606,8 @@ void BS_SetMaxMoveEffect(void)
                     msg = B_MSG_STARTED_HAIL;
                     break;
             }
-            if (TryChangeBattleWeather(gBattlerAttacker, weather, FALSE))
+            if ((B_OVERWOLD_WEATHER_PREVENTION >= GEN_9 && gBattleStruct->overworldWeatherActivated)
+             || !TryChangeBattleWeather(gBattlerAttacker, weather, FALSE))
             {
                 gBattleCommunication[MULTISTRING_CHOOSER] = msg;
                 BattleScriptPush(gBattlescriptCurrInstr + 1);

--- a/src/battle_dynamax.c
+++ b/src/battle_dynamax.c
@@ -606,8 +606,11 @@ void BS_SetMaxMoveEffect(void)
                     msg = B_MSG_STARTED_HAIL;
                     break;
             }
-            if ((B_OVERWOLD_WEATHER_PREVENTION >= GEN_9 && gBattleStruct->overworldWeatherActivated)
-             || !TryChangeBattleWeather(gBattlerAttacker, weather, FALSE))
+            if (B_OVERWOLD_WEATHER_PREVENTION >= GEN_9 && gBattleStruct->overworldWeatherActivated)
+            {
+                break;
+            }
+            else if (TryChangeBattleWeather(gBattlerAttacker, weather, FALSE))
             {
                 gBattleCommunication[MULTISTRING_CHOOSER] = msg;
                 BattleScriptPush(gBattlescriptCurrInstr + 1);

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -11227,7 +11227,8 @@ static void Cmd_setfieldweather(void)
 
     u8 weather = cmd->weather;
 
-    if (!TryChangeBattleWeather(gBattlerAttacker, weather, FALSE))
+    if ((B_OVERWOLD_WEATHER_PREVENTION >= GEN_9 && gBattleStruct->overworldWeatherActivated)
+     || !TryChangeBattleWeather(gBattlerAttacker, weather, FALSE))
     {
         gMoveResultFlags |= MOVE_RESULT_MISSED;
         gBattleCommunication[MULTISTRING_CHOOSER] = B_MSG_WEATHER_FAILED;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3885,6 +3885,7 @@ static const u16 sWeatherFlagsInfo[][3] =
 bool32 TryChangeBattleWeather(u32 battler, u32 weatherEnumId, bool32 viaAbility)
 {
     u16 battlerAbility = GetBattlerAbility(battler);
+
     if (gBattleWeather & B_WEATHER_PRIMAL_ANY
         && battlerAbility != ABILITY_DESOLATE_LAND
         && battlerAbility != ABILITY_PRIMORDIAL_SEA
@@ -4436,6 +4437,7 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
         }
         if (effect != 0)
         {
+            gBattleStruct->overworldWeatherActivated = TRUE;
             gBattleCommunication[MULTISTRING_CHOOSER] = GetCurrentWeather();
             BattleScriptPushCursorAndCallback(BattleScript_OverworldWeatherStarts);
         }
@@ -4715,7 +4717,12 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
             }
             break;
         case ABILITY_DRIZZLE:
-            if (TryChangeBattleWeather(battler, ENUM_WEATHER_RAIN, TRUE))
+            if (B_OVERWOLD_WEATHER_PREVENTION >= GEN_9 && gBattleStruct->overworldWeatherActivated)
+            {
+                BattleScriptPushCursorAndCallback(BattleScript_OverworldWeatherPrevents);
+                effect++;
+            }
+            else if (TryChangeBattleWeather(battler, ENUM_WEATHER_RAIN, TRUE))
             {
                 BattleScriptPushCursorAndCallback(BattleScript_DrizzleActivates);
                 effect++;
@@ -4728,7 +4735,12 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
             }
             break;
         case ABILITY_SAND_STREAM:
-            if (TryChangeBattleWeather(battler, ENUM_WEATHER_SANDSTORM, TRUE))
+            if (B_OVERWOLD_WEATHER_PREVENTION >= GEN_9 && gBattleStruct->overworldWeatherActivated)
+            {
+                BattleScriptPushCursorAndCallback(BattleScript_OverworldWeatherPrevents);
+                effect++;
+            }
+            else if (TryChangeBattleWeather(battler, ENUM_WEATHER_SANDSTORM, TRUE))
             {
                 BattleScriptPushCursorAndCallback(BattleScript_SandstreamActivates);
                 effect++;
@@ -4741,7 +4753,12 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
             }
             break;
         case ABILITY_DROUGHT:
-            if (TryChangeBattleWeather(battler, ENUM_WEATHER_SUN, TRUE))
+            if (B_OVERWOLD_WEATHER_PREVENTION >= GEN_9 && gBattleStruct->overworldWeatherActivated)
+            {
+                BattleScriptPushCursorAndCallback(BattleScript_OverworldWeatherPrevents);
+                effect++;
+            }
+            else if (TryChangeBattleWeather(battler, ENUM_WEATHER_SUN, TRUE))
             {
                 BattleScriptPushCursorAndCallback(BattleScript_DroughtActivates);
                 effect++;
@@ -4754,7 +4771,12 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
             }
             break;
         case ABILITY_SNOW_WARNING:
-            if (B_SNOW_WARNING >= GEN_9 && TryChangeBattleWeather(battler, ENUM_WEATHER_SNOW, TRUE))
+            if (B_OVERWOLD_WEATHER_PREVENTION >= GEN_9 && gBattleStruct->overworldWeatherActivated)
+            {
+                BattleScriptPushCursorAndCallback(BattleScript_OverworldWeatherPrevents);
+                effect++;
+            }
+            else if (B_SNOW_WARNING >= GEN_9 && TryChangeBattleWeather(battler, ENUM_WEATHER_SNOW, TRUE))
             {
                 BattleScriptPushCursorAndCallback(BattleScript_SnowWarningActivatesSnow);
                 effect++;
@@ -4893,14 +4915,24 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
             }
             break;
         case ABILITY_DESOLATE_LAND:
-            if (TryChangeBattleWeather(battler, ENUM_WEATHER_SUN_PRIMAL, TRUE))
+            if (B_OVERWOLD_WEATHER_PREVENTION >= GEN_9 && gBattleStruct->overworldWeatherActivated)
+            {
+                BattleScriptPushCursorAndCallback(BattleScript_OverworldWeatherPrevents);
+                effect++;
+            }
+            else if (TryChangeBattleWeather(battler, ENUM_WEATHER_SUN_PRIMAL, TRUE))
             {
                 BattleScriptPushCursorAndCallback(BattleScript_DesolateLandActivates);
                 effect++;
             }
             break;
         case ABILITY_PRIMORDIAL_SEA:
-            if (TryChangeBattleWeather(battler, ENUM_WEATHER_RAIN_PRIMAL, TRUE))
+            if (B_OVERWOLD_WEATHER_PREVENTION >= GEN_9 && gBattleStruct->overworldWeatherActivated)
+            {
+                BattleScriptPushCursorAndCallback(BattleScript_OverworldWeatherPrevents);
+                effect++;
+            }
+            else if (TryChangeBattleWeather(battler, ENUM_WEATHER_RAIN_PRIMAL, TRUE))
             {
                 BattleScriptPushCursorAndCallback(BattleScript_PrimordialSeaActivates);
                 effect++;
@@ -4950,7 +4982,12 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
             }
             break;
         case ABILITY_ORICHALCUM_PULSE:
-            if (TryChangeBattleWeather(battler, ENUM_WEATHER_SUN, TRUE))
+            if (B_OVERWOLD_WEATHER_PREVENTION >= GEN_9 && gBattleStruct->overworldWeatherActivated)
+            {
+                BattleScriptPushCursorAndCallback(BattleScript_OverworldWeatherPrevents);
+                effect++;
+            }
+            else if (TryChangeBattleWeather(battler, ENUM_WEATHER_SUN, TRUE))
             {
                 BattleScriptPushCursorAndCallback(BattleScript_DroughtActivates);
                 effect++;


### PR DESCRIPTION
In Scarlet and Violet overworld weather prevents weather abilities and moves. 


https://github.com/user-attachments/assets/4d58dc5b-c282-4124-8ce4-3d7277148e84

![weather](https://github.com/user-attachments/assets/cac356fa-0fc8-447b-aa7c-6b3c36eee57d)
