### PR TITLE
Fixes wrong Id when AI chooses mon to switch in

### DIFF
--- a/src/battle_controller_opponent.c
+++ b/src/battle_controller_opponent.c
@@ -651,17 +651,17 @@ static void OpponentHandleChooseItem(u32 battler)
 static inline bool32 IsAcePokemon(u32 chosenMonId, u32 pokemonInBattle, u32 battler)
 {
     return AI_THINKING_STRUCT->aiFlags[battler] & AI_FLAG_ACE_POKEMON
-        || (chosenMonId == CalculateEnemyPartyCountInSide(battler) - 1)
-        || CountAIAliveNonEggMonsExcept(PARTY_SIZE) != pokemonInBattle;
+        && (chosenMonId == CalculateEnemyPartyCountInSide(battler) - 1)
+        && CountAIAliveNonEggMonsExcept(PARTY_SIZE) != pokemonInBattle;
 }
 
 static inline bool32 IsDoubleAcePokemon(u32 chosenMonId, u32 pokemonInBattle, u32 battler)
 {
     return AI_THINKING_STRUCT->aiFlags[battler] & AI_FLAG_DOUBLE_ACE_POKEMON
-        || (chosenMonId == CalculateEnemyPartyCountInSide(battler) - 1)
-        || (chosenMonId == CalculateEnemyPartyCountInSide(battler) - 2)
-        || CountAIAliveNonEggMonsExcept(PARTY_SIZE) != pokemonInBattle
-        || CountAIAliveNonEggMonsExcept(PARTY_SIZE-1) != pokemonInBattle;
+        && (chosenMonId == CalculateEnemyPartyCountInSide(battler) - 1)
+        && (chosenMonId == CalculateEnemyPartyCountInSide(battler) - 2)
+        && CountAIAliveNonEggMonsExcept(PARTY_SIZE) != pokemonInBattle
+        && CountAIAliveNonEggMonsExcept(PARTY_SIZE-1) != pokemonInBattle;
 }
 
 static void OpponentHandleChoosePokemon(u32 battler)

--- a/src/battle_controller_opponent.c
+++ b/src/battle_controller_opponent.c
@@ -648,6 +648,22 @@ static void OpponentHandleChooseItem(u32 battler)
     OpponentBufferExecCompleted(battler);
 }
 
+static inline bool32 IsAcePokemon(u32 chosenMonId, u32 pokemonInBattle, u32 battler)
+{
+    return !(AI_THINKING_STRUCT->aiFlags[battler] & AI_FLAG_ACE_POKEMON)
+        || (chosenMonId != CalculateEnemyPartyCountInSide(battler) - 1)
+        || CountAIAliveNonEggMonsExcept(PARTY_SIZE) == pokemonInBattle;
+}
+
+static inline bool32 IsDoubleAcePokemon(u32 chosenMonId, u32 pokemonInBattle, u32 battler)
+{
+    return !(AI_THINKING_STRUCT->aiFlags[battler] & AI_FLAG_DOUBLE_ACE_POKEMON)
+        || (chosenMonId != CalculateEnemyPartyCountInSide(battler) - 1)
+        || (chosenMonId != CalculateEnemyPartyCountInSide(battler) - 2)
+        || CountAIAliveNonEggMonsExcept(PARTY_SIZE) == pokemonInBattle
+        || CountAIAliveNonEggMonsExcept(PARTY_SIZE-1) == pokemonInBattle;
+}
+
 static void OpponentHandleChoosePokemon(u32 battler)
 {
     s32 chosenMonId;
@@ -680,20 +696,14 @@ static void OpponentHandleChoosePokemon(u32 battler)
             GetAIPartyIndexes(battler, &firstId, &lastId);
             for (chosenMonId = (lastId-1); chosenMonId >= firstId; chosenMonId--)
             {
-                if (!IsValidForBattle(&gEnemyParty[chosenMonId]))
-                    continue;
-                if (chosenMonId == gBattlerPartyIndexes[battler1]
+                if (!IsValidForBattle(&gEnemyParty[chosenMonId])
+                 || chosenMonId == gBattlerPartyIndexes[battler1]
                  || chosenMonId == gBattlerPartyIndexes[battler2])
                     continue;
-                if ((AI_THINKING_STRUCT->aiFlags[battler] & AI_FLAG_ACE_POKEMON)
-                 && ((chosenMonId == CalculateEnemyPartyCountInSide(battler) - 1) || CountAIAliveNonEggMonsExcept(PARTY_SIZE) == pokemonInBattle))
-                    continue;
-                if ((AI_THINKING_STRUCT->aiFlags[battler] & AI_FLAG_DOUBLE_ACE_POKEMON)
-                 && (((chosenMonId == CalculateEnemyPartyCountInSide(battler) - 1) || (chosenMonId == CalculateEnemyPartyCountInSide(battler) - 2))
-                 || (CountAIAliveNonEggMonsExcept(PARTY_SIZE) == pokemonInBattle || CountAIAliveNonEggMonsExcept(PARTY_SIZE-1) == pokemonInBattle)))
-                    continue;
-                // mon is valid
-                break;
+
+                if (IsAcePokemon(chosenMonId, pokemonInBattle, battler)
+                 && IsDoubleAcePokemon(chosenMonId, pokemonInBattle, battler))
+                    break;
             }
         }
         gBattleStruct->monToSwitchIntoId[battler] = chosenMonId;
@@ -709,7 +719,6 @@ static void OpponentHandleChoosePokemon(u32 battler)
     #endif // TESTING
     BtlController_EmitChosenMonReturnValue(battler, BUFFER_B, chosenMonId, NULL);
     OpponentBufferExecCompleted(battler);
-
 }
 
 static u8 CountAIAliveNonEggMonsExcept(u8 slotToIgnore)

--- a/src/battle_controller_opponent.c
+++ b/src/battle_controller_opponent.c
@@ -650,18 +650,18 @@ static void OpponentHandleChooseItem(u32 battler)
 
 static inline bool32 IsAcePokemon(u32 chosenMonId, u32 pokemonInBattle, u32 battler)
 {
-    return !(AI_THINKING_STRUCT->aiFlags[battler] & AI_FLAG_ACE_POKEMON)
-        || (chosenMonId != CalculateEnemyPartyCountInSide(battler) - 1)
-        || CountAIAliveNonEggMonsExcept(PARTY_SIZE) == pokemonInBattle;
+    return AI_THINKING_STRUCT->aiFlags[battler] & AI_FLAG_ACE_POKEMON
+        || (chosenMonId == CalculateEnemyPartyCountInSide(battler) - 1)
+        || CountAIAliveNonEggMonsExcept(PARTY_SIZE) != pokemonInBattle;
 }
 
 static inline bool32 IsDoubleAcePokemon(u32 chosenMonId, u32 pokemonInBattle, u32 battler)
 {
-    return !(AI_THINKING_STRUCT->aiFlags[battler] & AI_FLAG_DOUBLE_ACE_POKEMON)
-        || (chosenMonId != CalculateEnemyPartyCountInSide(battler) - 1)
-        || (chosenMonId != CalculateEnemyPartyCountInSide(battler) - 2)
-        || CountAIAliveNonEggMonsExcept(PARTY_SIZE) == pokemonInBattle
-        || CountAIAliveNonEggMonsExcept(PARTY_SIZE-1) == pokemonInBattle;
+    return AI_THINKING_STRUCT->aiFlags[battler] & AI_FLAG_DOUBLE_ACE_POKEMON
+        || (chosenMonId == CalculateEnemyPartyCountInSide(battler) - 1)
+        || (chosenMonId == CalculateEnemyPartyCountInSide(battler) - 2)
+        || CountAIAliveNonEggMonsExcept(PARTY_SIZE) != pokemonInBattle
+        || CountAIAliveNonEggMonsExcept(PARTY_SIZE-1) != pokemonInBattle;
 }
 
 static void OpponentHandleChoosePokemon(u32 battler)
@@ -701,8 +701,8 @@ static void OpponentHandleChoosePokemon(u32 battler)
                  || chosenMonId == gBattlerPartyIndexes[battler2])
                     continue;
 
-                if (IsAcePokemon(chosenMonId, pokemonInBattle, battler)
-                 && IsDoubleAcePokemon(chosenMonId, pokemonInBattle, battler))
+                if (!IsAcePokemon(chosenMonId, pokemonInBattle, battler)
+                 && !IsDoubleAcePokemon(chosenMonId, pokemonInBattle, battler))
                     break;
             }
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes regression caused by #5435. A wrong id was assigned to `gBattleStruct->monToSwitchIntoId` in `OpponentHandleChoosePokemon` which didn't manifest in expansion but for iriv a bad egg switched in.

