### PR TITLE
Fixes Absorb regression caused by #5670

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -3022,7 +3022,6 @@ BattleScript_EffectAbsorb::
 	printfromtable gAbsorbDrainStringIds
 	waitmessage B_WAIT_TIME_LONG
 	tryfaintmon BS_ATTACKER
-	tryfaintmon BS_TARGET
 	return
 
 BattleScript_EffectExplosion::

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -5727,6 +5727,7 @@ static void Cmd_moveend(void)
                         gBattleMoveDamage = 1;
                     gBattleMoveDamage = GetDrainedBigRootHp(gBattlerAttacker, gBattleMoveDamage);
                     gHitMarker |= HITMARKER_IGNORE_SUBSTITUTE | HITMARKER_IGNORE_DISGUISE;
+                    effect = TRUE;
                     if (GetBattlerAbility(gBattlerTarget) == ABILITY_LIQUID_OOZE)
                     {
                         gBattleMoveDamage *= -1;

--- a/test/battle/move_effect/absorb.c
+++ b/test/battle/move_effect/absorb.c
@@ -107,4 +107,22 @@ DOUBLE_BATTLE_TEST("Matcha Gatcha will faint the pokemon if Liquid Ooze drain de
     }
 }
 
+SINGLE_BATTLE_TEST("Draining Kiss recovers 75% of the damage dealt")
+{
+    s16 damage;
+    s16 healed;
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { HP(1); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_DRAINING_KISS); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAINING_KISS, player);
+        HP_BAR(opponent, captureDamage: &damage);
+        HP_BAR(player, captureDamage: &healed);
+    } THEN {
+        EXPECT_MUL_EQ(damage, Q_4_12(-0.75), healed);
+    }
+}
+
 TO_DO_BATTLE_TEST("Absorb recovers 50% of the damage dealt to a Substitute");

--- a/test/battle/move_effect/absorb.c
+++ b/test/battle/move_effect/absorb.c
@@ -107,23 +107,4 @@ DOUBLE_BATTLE_TEST("Matcha Gatcha will faint the pokemon if Liquid Ooze drain de
     }
 }
 
-
-SINGLE_BATTLE_TEST("Draining Kiss recovers 75% of the damage dealt")
-{
-    s16 damage;
-    s16 healed;
-    GIVEN {
-        PLAYER(SPECIES_WOBBUFFET) { HP(1); }
-        OPPONENT(SPECIES_WOBBUFFET);
-    } WHEN {
-        TURN { MOVE(player, MOVE_DRAINING_KISS); }
-    } SCENE {
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAINING_KISS, player);
-        HP_BAR(opponent, captureDamage: &damage);
-        HP_BAR(player, captureDamage: &healed);
-    } THEN {
-        EXPECT_MUL_EQ(damage, Q_4_12(-0.75), healed);
-    }
-}
-
 TO_DO_BATTLE_TEST("Absorb recovers 50% of the damage dealt to a Substitute");


### PR DESCRIPTION
Fixes #5687

I forgot that `tryfaintmon BS_TARGET` was already handled in `EffectHit`. Also was unable to write a test. For some reason a mon during the test always switched in. 

![absorb](https://github.com/user-attachments/assets/5fa8f67e-5a29-464b-9075-d19a4e3b41f3)
