### PR TITLE
Add Revival Blessing AI

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -4401,9 +4401,9 @@ static u32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move)
         if (GetFirstFaintedPartyIndex(battlerAtk) != PARTY_SIZE)
         {
             ADJUST_SCORE(DECENT_EFFECT);
-            if (AI_DATA->shouldSwitch & battlerAtk) // Bad matchup
+            if (AI_DATA->shouldSwitch & (1u << battlerAtk)) // Bad matchup
                 ADJUST_SCORE(DECENT_EFFECT);
-            if (AI_DATA->mostSuitableMonId != PARTY_SIZE) // Good mon to send in after
+            if (AI_DATA->mostSuitableMonId[battlerAtk] != PARTY_SIZE) // Good mon to send in after
                 ADJUST_SCORE(DECENT_EFFECT);
         }
         break;

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -4399,7 +4399,13 @@ static u32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move)
         break;
     case EFFECT_REVIVAL_BLESSING:
         if (GetFirstFaintedPartyIndex(battlerAtk) != PARTY_SIZE)
+        {
             ADJUST_SCORE(DECENT_EFFECT);
+            if (AI_DATA->shouldSwitch & battlerAtk) // Bad matchup
+                ADJUST_SCORE(DECENT_EFFECT);
+            if (AI_DATA->mostSuitableMonId != PARTY_SIZE) // Good mon to send in after
+                ADJUST_SCORE(DECENT_EFFECT);
+        }
         break;
     //case EFFECT_EXTREME_EVOBOOST: // TODO
         //break;

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -4402,9 +4402,9 @@ static u32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move)
         {
             ADJUST_SCORE(DECENT_EFFECT);
             if (AI_DATA->shouldSwitch & (1u << battlerAtk)) // Bad matchup
-                ADJUST_SCORE(DECENT_EFFECT);
+                ADJUST_SCORE(WEAK_EFFECT);
             if (AI_DATA->mostSuitableMonId[battlerAtk] != PARTY_SIZE) // Good mon to send in after
-                ADJUST_SCORE(DECENT_EFFECT);
+                ADJUST_SCORE(WEAK_EFFECT);
         }
         break;
     //case EFFECT_EXTREME_EVOBOOST: // TODO


### PR DESCRIPTION
## Description
Basic handling for Revival Blessing score increases attached to Check Viability.

Score is only increased if the AI has a fainted mon in its party. Score is further increased if the mon considering Revival Blessing has a bad matchup, and if the AI has another mon that has a favourable matchup against the player's current mon.

This felt like competent handling without being over the top to me.

## Issue(s) that this PR fixes
Closes #5487 

## **People who collaborated with me in this PR**
Cybeast for the idea!

## **Discord contact info**
@Pawkkie 