### PR TITLE
Handle showdowns apostrophe the same way as ASCII apostrophe

### DIFF
--- a/tools/trainerproc/main.c
+++ b/tools/trainerproc/main.c
@@ -1545,6 +1545,7 @@ static void fprint_species(FILE *f, const char *prefix, struct String s)
         static const unsigned char *male = (unsigned char *)u8"♂";
         static const unsigned char *female = (unsigned char *)u8"♀";
         static const unsigned char *e_diacritic = (unsigned char *)u8"é";
+        static const unsigned char *right_single_quotation_mark = (unsigned char *)u8"’";
         for (int i = 0; i < s.string_n; i++)
         {
             unsigned char c = s.string[i];
@@ -1562,7 +1563,7 @@ static void fprint_species(FILE *f, const char *prefix, struct String s)
                 underscore = false;
                 fputc(c - 'a' + 'A', f);
             }
-            else if (c == '\'' || c == '%')
+            else if (c == '\'' || c == '%' || is_utf8_character(s, &i, right_single_quotation_mark))
             {
                 // Do nothing.
             }


### PR DESCRIPTION
## Description
Copy pasting Farfetch'd or Sirfetch'd from showndown generates an invalid species (e.g. `SPECIES_SIRFETCH_D` instead of `SPECIES_SIRFETCHD`). With this the showdown apostrophe is handled the same way the ascii one is.

## Images
![image](https://github.com/user-attachments/assets/46d999ba-a9d7-4578-a595-cf75f324a7f4)

## **Discord contact info**
.cawt