### PR TITLE
Added Minimize interaction to Supercell Slam

### DIFF
--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -20605,6 +20605,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .priority = 0,
         .category = DAMAGE_CATEGORY_PHYSICAL,
         .makesContact = TRUE,
+        .minimizeDoubleDamage = TRUE,
         .battleAnimScript = Move_SUPERCELL_SLAM,
     },
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds `.minimizeDoubleDamage = TRUE` to Supercell Slam which is should have according to the [Smogon research thread](https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/page-55#post-10346635)

## **Discord contact info**
<!--- Formatted as username (e.g. Lunos) or username#numbers (e.g. Lunos#4026) -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara