### PR TITLE
Update README.md to link to INSTALL.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,15 @@
 
 pokeemerald-expansion is a decomp hack base project based off pret's [pokeemerald](https://github.com/pret/pokeemerald) decompilation project. It's recommended that any new projects that plan on using it, to clone this repository instead of pret's vanilla repository, as we regurlarly incorporate pret's documentation changes. This is ***NOT*** a standalone romhack, and as such, most features will be unavailable and/or unbalanced if played as is.
 
+## Using pokeemerald-expansion
+
 If you use pokeemerald-expansion in your hack, please add RHH (Rom Hacking Hideout) to your credits list. Optionally, you can list the version used, so it can help players know what features to expect.
 You can phrase it as the following:
 ```
 Based off RHH's pokeemerald-expansion 1.9.3 https://github.com/rh-hideout/pokeemerald-expansion/
 ```
+
+Please follow the instructions in `INSTALL.md` to get pokeemerald-expansion set up on your machine.
 
 ## What features are included?
 - ***IMPORTANT*❗❗ Read through these to learn what features you can toggle**:


### PR DESCRIPTION
## Description
Same as my feedback on #5640 that's now on ice until Edu gets back, functionally reopening #5643 but that has commit history tied to the wrong GitHub account, my bad lol

Adds a link to INSTALL.md near the top of README.md, and gives the section a new header. Doesn't do anything else that's already included in #5640 

## **Discord contact info**
@Pawkkie 