### PR TITLE
Fixes Switch in flag not restoring mons properly

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -3507,6 +3507,7 @@ u32 AI_WhoStrikesFirstPartyMon(u32 battlerAtk, u32 battlerDef, struct BattlePoke
     SetBattlerAiData(battlerAtk, AI_DATA);
     u32 aiMonFaster = AI_IsFaster(battlerAtk, battlerDef, moveConsidered);
     FreeRestoreBattleMons(savedBattleMons);
+    SetBattlerAiData(battlerAtk, AI_DATA);
 
     return aiMonFaster;
 }


### PR DESCRIPTION
In `AI_WhoStrikesFirstPartyMon` AI data was not properly reset after being overwritten