### PR TITLE
Fix Sleep Clause AI handling of partner sleeping moves

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -2391,6 +2391,7 @@ bool32 IsMoveSleepClauseTrigger(u32 move)
         {
         case MAX_EFFECT_EFFECT_SPORE_FOES:
         case MAX_EFFECT_YAWN_FOE:
+            return TRUE;
         }
     }
     return FALSE;

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -2371,6 +2371,31 @@ bool32 IsSwitchOutEffect(u32 effect)
     }
 }
 
+bool32 IsMoveSleepClauseTrigger(u32 move)
+{
+    u32 i, effect = gMovesInfo[move].effect;
+
+    // Sleeping effects like Sleep Powder, Yawn, Dark Void, etc.
+    switch (effect)
+    {
+    case EFFECT_SLEEP:
+    case EFFECT_YAWN:
+    case EFFECT_DARK_VOID:
+        return TRUE;
+    }
+
+    // Sleeping effects like G-Max Befuddle, G-Max Snooze, etc.
+    for (i = 0; i < gMovesInfo[move].numAdditionalEffects; i++)
+    {
+        switch (gMovesInfo[move].additionalEffects[i].moveEffect)
+        {
+        case MAX_EFFECT_EFFECT_SPORE_FOES:
+        case MAX_EFFECT_YAWN_FOE:
+        }
+    }
+    return FALSE;
+}
+
 bool32 HasDamagingMove(u32 battlerId)
 {
     u32 i;
@@ -3394,13 +3419,9 @@ bool32 PartnerMoveIsSameNoTarget(u32 battlerAtkPartner, u32 move, u32 partnerMov
 
 bool32 PartnerMoveActivatesSleepClause(u32 partnerMove)
 {
-    u32 effect = gMovesInfo[partnerMove].effect;
     if (!IsDoubleBattle() || !FlagGet(B_FLAG_SLEEP_CLAUSE))
         return FALSE;
-    if (effect == EFFECT_SLEEP
-        || effect == EFFECT_YAWN)
-        return TRUE;
-    return FALSE;
+    return IsMoveSleepClauseTrigger(partnerMove);
 }
 
 bool32 ShouldUseWishAromatherapy(u32 battlerAtk, u32 battlerDef, u32 move)

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -2371,7 +2371,7 @@ bool32 IsSwitchOutEffect(u32 effect)
     }
 }
 
-bool32 IsMoveSleepClauseTrigger(u32 move)
+static inline bool32 IsMoveSleepClauseTrigger(u32 move)
 {
     u32 i, effect = gMovesInfo[move].effect;
 


### PR DESCRIPTION
## Description
Before this fix, the AI only considered its partner triggering sleep clause with moves that use EFFECT_SLEEP and EFFECT_YAWN.

This fix introduces `IsMoveSleepClauseTrigger` to be referenced instead, a one-stop shop for these moves to be referenced anywhere else, and also a single place to add any new move effects in the future. This means the AI now handles all sleep clause triggering moves (I checked on [bulbapedia](https://bulbapedia.bulbagarden.net/wiki/Category:Moves_that_can_inflict_sleep)), including Dark Void, G-Max Befuddle, and G-Max Snooze.

## **Discord contact info**
@Pawkkie 
