### PR TITLE
Sleep Clause global config

### DIFF
--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -317,5 +317,6 @@ u32 GetMoveType(u32 move);
 void TryActivateSleepClause(u32 battler, u32 indexInParty);
 void TryDeactivateSleepClause(u32 battlerSide, u32 indexInParty);
 bool8 IsSleepClauseActiveForSide(u32 battlerSide);
+bool32 IsSleepClauseEnabled();
 
 #endif // GUARD_BATTLE_UTIL_H

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -256,6 +256,7 @@
 #define B_OVERWORLD_FOG                 GEN_LATEST // In Gen8+, overworld Fog summons Misty Terrain in battle. In Gen4 only, overworld Fog summons the unique fog weather condition in battle.
 #define B_TOXIC_REVERSAL                GEN_LATEST // In Gen5+, bad poison will change to regular poison at the end of battles.
 #define B_TRY_CATCH_TRAINER_BALL        GEN_LATEST // In Gen4+, trying to catch a Trainer's Pokémon does not consume the Poké Ball.
+#define B_SLEEP_CLAUSE                  FALSE      // Enables Sleep Clause all the time in every case, overriding B_FLAG_SLEEP_CLAUSE. Use that for modularity.
 
 // Animation Settings
 #define B_NEW_SWORD_PARTICLE            FALSE    // If set to TRUE, it updates Swords Dance's particle.

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -3420,7 +3420,6 @@ bool32 PartnerMoveIsSameNoTarget(u32 battlerAtkPartner, u32 move, u32 partnerMov
 
 bool32 PartnerMoveActivatesSleepClause(u32 partnerMove)
 {
-    u32 effect = gMovesInfo[partnerMove].effect;
     if (!IsDoubleBattle() || !IsSleepClauseEnabled())
         return FALSE;
     return IsMoveSleepClauseTrigger(partnerMove);

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -3395,7 +3395,7 @@ bool32 PartnerMoveIsSameNoTarget(u32 battlerAtkPartner, u32 move, u32 partnerMov
 bool32 PartnerMoveActivatesSleepClause(u32 partnerMove)
 {
     u32 effect = gMovesInfo[partnerMove].effect;
-    if (!IsDoubleBattle() || !FlagGet(B_FLAG_SLEEP_CLAUSE))
+    if (!IsDoubleBattle() || !IsSleepClauseEnabled())
         return FALSE;
     if (effect == EFFECT_SLEEP
         || effect == EFFECT_YAWN)

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3122,7 +3122,7 @@ static void BattleStartClearSetData(void)
     gSelectedMonPartyId = PARTY_SIZE; // Revival Blessing
     gCategoryIconSpriteId = 0xFF;
 
-    if(FlagGet(B_FLAG_SLEEP_CLAUSE))
+    if(IsSleepClauseEnabled())
     {
         // If monCausingSleepClause[side] equals PARTY_SIZE, Sleep Clause is not active for the given side.
         gBattleStruct->monCausingSleepClause[B_SIDE_PLAYER] = PARTY_SIZE;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -17268,7 +17268,7 @@ void BS_JumpIfSleepClause(void)
     NATIVE_ARGS(const u8 *jumpInstr);
 
     // Can freely sleep own partner
-    if (IsDoubleBattle() && B_FLAG_SLEEP_CLAUSE && GetBattlerSide(gBattlerAttacker) == GetBattlerSide(gBattlerTarget))
+    if (IsDoubleBattle() && IsSleepClauseEnabled() && GetBattlerSide(gBattlerAttacker) == GetBattlerSide(gBattlerTarget))
     {
         gBattleStruct->sleepClauseEffectExempt |= (1u << gBattlerTarget);
         gBattlescriptCurrInstr = cmd->nextInstr;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3334,7 +3334,7 @@ u8 AtkCanceller_UnableToUseMove(u32 moveType)
                     gHitMarker |= HITMARKER_OBEYS;
                     break;
                 case DISOBEYS_FALL_ASLEEP:
-                    if (FlagGet(B_FLAG_SLEEP_CLAUSE))
+                    if (IsSleepClauseEnabled())
                         gBattleStruct->sleepClauseEffectExempt |= (1u << gBattlerAttacker);
                     gBattlescriptCurrInstr = BattleScript_IgnoresAndFallsAsleep;
                     gMoveResultFlags |= MOVE_RESULT_MISSED;
@@ -5833,7 +5833,7 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
                  && GetBattlerHoldEffect(gBattlerAttacker, TRUE) != HOLD_EFFECT_PROTECTIVE_PADS
                  && IsMoveMakingContact(move, gBattlerAttacker))
                 {
-                    if (FlagGet(B_FLAG_SLEEP_CLAUSE))
+                    if (IsSleepClauseEnabled())
                         gBattleStruct->sleepClauseEffectExempt |= (1u << gBattlerAttacker);
                     gBattleScripting.moveEffect = MOVE_EFFECT_AFFECTS_USER | MOVE_EFFECT_SLEEP;
                     PREPARE_ABILITY_BUFFER(gBattleTextBuff1, gLastUsedAbility);
@@ -12012,7 +12012,7 @@ void TryActivateSleepClause(u32 battler, u32 indexInParty)
         return;
     }
 
-    if (FlagGet(B_FLAG_SLEEP_CLAUSE))
+    if (IsSleepClauseEnabled())
         gBattleStruct->monCausingSleepClause[GetBattlerSide(battler)] = indexInParty;
 }
 
@@ -12020,7 +12020,7 @@ void TryDeactivateSleepClause(u32 battlerSide, u32 indexInParty)
 {
     // If the pokemon on the given side at the given index in the party is the one causing Sleep Clause to be active,
     // set monCausingSleepClause[battlerSide] = PARTY_SIZE, which means Sleep Clause is not active for the given side
-    if (FlagGet(B_FLAG_SLEEP_CLAUSE) && gBattleStruct->monCausingSleepClause[battlerSide] == indexInParty)
+    if (IsSleepClauseEnabled() && gBattleStruct->monCausingSleepClause[battlerSide] == indexInParty)
         gBattleStruct->monCausingSleepClause[battlerSide] = PARTY_SIZE;
 }
 
@@ -12029,5 +12029,12 @@ bool8 IsSleepClauseActiveForSide(u32 battlerSide)
     // If monCausingSleepClause[battlerSide] == PARTY_SIZE, Sleep Clause is not active for the given side.
     // If monCausingSleepClause[battlerSide] < PARTY_SIZE, it means it is storing the index of the mon that is causing Sleep Clause to be active,
     // from which it follows that Sleep Clause is active.
-    return (FlagGet(B_FLAG_SLEEP_CLAUSE) && (gBattleStruct->monCausingSleepClause[battlerSide] < PARTY_SIZE));
+    return (IsSleepClauseEnabled() && (gBattleStruct->monCausingSleepClause[battlerSide] < PARTY_SIZE));
+}
+
+bool32 IsSleepClauseEnabled()
+{
+    if (B_SLEEP_CLAUSE || FlagGet(B_FLAG_SLEEP_CLAUSE))
+        return TRUE;
+    return FALSE;
 }

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -12034,7 +12034,9 @@ bool8 IsSleepClauseActiveForSide(u32 battlerSide)
 
 bool32 IsSleepClauseEnabled()
 {
-    if (B_SLEEP_CLAUSE || FlagGet(B_FLAG_SLEEP_CLAUSE))
+    if (B_SLEEP_CLAUSE)
+        return TRUE;
+    if (FlagGet(B_FLAG_SLEEP_CLAUSE))
         return TRUE;
     return FALSE;
 }


### PR DESCRIPTION
## Description
@AlexOn1ine suggested adding a global overriding config to enable or disable Sleep Clause at the project level for convenience, and that's what this PR adds.

Frankly I think it also cleans up a lot of the conditionals super nicely, `IsSleepClauseActive` reads like `IsDoubleBattle` and I like that a lot for some reason lol

## **Discord contact info**
@Pawkkie 
