### PR TITLE
Fix test TIMEOUT messaging in summary

### DIFF
--- a/test/test_runner.c
+++ b/test/test_runner.c
@@ -490,6 +490,7 @@ static void Intr_Timer2(void)
             if (gTestRunnerState.state == STATE_RUN_TEST)
                 gTestRunnerState.state = STATE_REPORT_RESULT;
             gTestRunnerState.result = TEST_RESULT_TIMEOUT;
+            Test_MgbaPrintf(":L%s - TIMEOUT", gTestRunnerState.test->name);
             ReinitCallbacks();
             IRQ_LR = ((uintptr_t)JumpToAgbMainLoop & ~1) + 4;
         }

--- a/test/test_runner.c
+++ b/test/test_runner.c
@@ -490,7 +490,7 @@ static void Intr_Timer2(void)
             if (gTestRunnerState.state == STATE_RUN_TEST)
                 gTestRunnerState.state = STATE_REPORT_RESULT;
             gTestRunnerState.result = TEST_RESULT_TIMEOUT;
-            Test_MgbaPrintf(":L%s - TIMEOUT", gTestRunnerState.test->name);
+            Test_MgbaPrintf(":L%s:%d - TIMEOUT", gTestRunnerState.test->filename, SourceLine(0));
             ReinitCallbacks();
             IRQ_LR = ((uintptr_t)JumpToAgbMainLoop & ~1) + 4;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Before submitting, please make sure your pull request meets the scope guidelines. If unsure, please open a thread in #pr-discussions.-->
<!--- Scope Guidelines: https://github.com/rh-hideout/pokeemerald-expansion/blob/master/docs/scope.md  -->
<!--- #pr-discussions:  https://discord.com/channels/419213663107416084/1102784418369785948 -->

## Description
Timeouts in tests weren't properly shown in the summary, making it harder to properly know why a test failed. This PR fixes that.

## Images
Before vs After
![image](https://github.com/user-attachments/assets/57808bac-e5e5-4ac5-9a31-66f15a63c824)
![image](https://github.com/user-attachments/assets/4b495312-aa03-4c04-90e3-e27c30faa496)

## **Discord contact info**
AsparagusEduardo
