### PR TITLE
Fix Off-by-One Error in Move Relearner

### DIFF
--- a/src/move_relearner.c
+++ b/src/move_relearner.c
@@ -165,18 +165,18 @@ enum {
 static EWRAM_DATA struct
 {
     u8 state;
-    u8 heartSpriteIds[16];                               /*0x001*/
-    u16 movesToLearn[MAX_RELEARNER_MOVES];               /*0x01A*/
-    u8 partyMon;                                         /*0x044*/
-    u8 moveSlot;                                         /*0x045*/
-    struct ListMenuItem menuItems[MAX_RELEARNER_MOVES];  /*0x0E8*/
-    u8 numMenuChoices;                                   /*0x110*/
-    u8 numToShowAtOnce;                                  /*0x111*/
-    u8 moveListMenuTask;                                 /*0x112*/
-    u8 moveListScrollArrowTask;                          /*0x113*/
-    u8 moveDisplayArrowTask;                             /*0x114*/
-    u16 scrollOffset;                                    /*0x116*/
-    u8 categoryIconSpriteId;                             /*0x117*/
+    u8 heartSpriteIds[16];                                   /*0x001*/
+    u16 movesToLearn[MAX_RELEARNER_MOVES];                   /*0x01A*/
+    u8 partyMon;                                             /*0x044*/
+    u8 moveSlot;                                             /*0x045*/
+    struct ListMenuItem menuItems[MAX_RELEARNER_MOVES + 1];  /*0x0E8*/
+    u8 numMenuChoices;                                       /*0x110*/
+    u8 numToShowAtOnce;                                      /*0x111*/
+    u8 moveListMenuTask;                                     /*0x112*/
+    u8 moveListScrollArrowTask;                              /*0x113*/
+    u8 moveDisplayArrowTask;                                 /*0x114*/
+    u16 scrollOffset;                                        /*0x116*/
+    u8 categoryIconSpriteId;                                 /*0x117*/
 } *sMoveRelearnerStruct = {0};
 
 static EWRAM_DATA struct {


### PR DESCRIPTION
Took a look at the move relearner under the following conditions:
**BEFORE THE FIX:**
1) Increased `MAX_LEVEL_UP_MOVES` from 20 -> 25 (note, `MAX_RELEARNER_MOVES`  is defined as `max(MAX_LEVEL_UP_MOVES, 25)`)
2) Increased Venusaur's level up learnset to contain 25 moves
![venasaur learnset](https://github.com/user-attachments/assets/989349ca-a05d-40f2-8388-8b21e49b1afc)

3) Taught Venusaur 4 moves that were not in its learnset
![pokeemerald-1](https://github.com/user-attachments/assets/d1a3027c-6dc7-412c-b4b3-afcccca6bc5a)
and saw the following:
![pokeemerald-0](https://github.com/user-attachments/assets/28a3373f-1c14-4ddf-b043-239454772e83)


**AFTER FIX:**
Works as intended under the same conditions after adding 1 to `MAX_RELEARNER_MOVES` to `menuItems` in `sMoveRelearnerStruct`. 
![pokeemerald-2](https://github.com/user-attachments/assets/5a4b0436-b69e-4aca-ad4b-2cc034abc3ec)

Not sure if this is something that tests can be written for, please let me know if further testing is required.

## Issue(s) that this PR fixes
#5768

## **People who collaborated with me in this PR**
issue reported by @luckytyphlosion


## **Discord contact info**
iriv24
