### PR TITLE
Fix Pokemon with No Guard failing OHKO Moves into Semi-Invulnerable Pokemon

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -3413,7 +3413,7 @@ BattleScript_EffectOHKO::
 	attackcanceler
 	attackstring
 	ppreduce
-	accuracycheck BattleScript_ButItFailed, NO_ACC_CALC_CHECK_LOCK_ON
+	accuracycheck BattleScript_ButItFailed, ACC_CURR_MOVE
 	typecalc
 	jumpifmovehadnoeffect BattleScript_HitFromAtkAnimation
 	tryKO BattleScript_KOFail

--- a/test/battle/move_effect/ohko.c
+++ b/test/battle/move_effect/ohko.c
@@ -20,6 +20,23 @@ SINGLE_BATTLE_TEST("Sheer Cold doesn't affect Ice-type Pokémon")
         MESSAGE("It doesn't affect the opposing Glalie…");
     }
 }
+
+SINGLE_BATTLE_TEST("OHKO moves can hit semi-invulnerable mons when the user has No-Guard")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_SHEER_COLD].effect == EFFECT_OHKO);
+        PLAYER(SPECIES_WOBBUFFET) { Ability(ABILITY_NO_GUARD); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_FLY); }
+        TURN { MOVE(player, MOVE_SHEER_COLD); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SHEER_COLD, player);
+        HP_BAR(opponent, hp: 0);
+    }
+}
+
+
 TO_DO_BATTLE_TEST("Fissure faints the target, skipping regular damage calculations")
 TO_DO_BATTLE_TEST("Fissure always fails if the target has a higher level than the user")
 TO_DO_BATTLE_TEST("Fissure's accuracy increases by 1% for every level the user has over the target")

--- a/test/battle/move_effect/ohko.c
+++ b/test/battle/move_effect/ohko.c
@@ -36,7 +36,6 @@ SINGLE_BATTLE_TEST("OHKO moves can hit semi-invulnerable mons when the user has 
     }
 }
 
-
 TO_DO_BATTLE_TEST("Fissure faints the target, skipping regular damage calculations")
 TO_DO_BATTLE_TEST("Fissure always fails if the target has a higher level than the user")
 TO_DO_BATTLE_TEST("Fissure's accuracy increases by 1% for every level the user has over the target")


### PR DESCRIPTION
Issue is described in the linked issue: mon with ability no guard tries to use an OHKO move on a mon that is semi-invulernable (flying, underground, diving, etc) but the move fails, which is incorrect. Normal moves hit under these circumstances, and so should OHKO moves according to bulbapedia.

## Description
Made `BattleScript_EffectOHKO` call `accuracycheck` with `ACC_CURR_MOVE` instead of `NO_ACC_CALC_CHECK_LOCK_ON`.
I couldn't figure out why it was using `NO_ACC_CALC_CHECK_LOCK_ON` in the first place, so if there was a specific reason for that that I am missing and this is the incorrect fix, please let me know. 

Wrote accompanying test and tested the scenario in game.

## Issue(s) that this PR fixes
#5745

## **People who collaborated with me in this PR**
Issue reported by @Cafeei

## **Discord contact info**
iriv24
