### PR TITLE
Fixes Wormadam define for teachable learnset script

### DIFF
--- a/tools/learnset_helpers/porymoves_files/b2w2.json
+++ b/tools/learnset_helpers/porymoves_files/b2w2.json
@@ -50290,7 +50290,7 @@
       "MOVE_SNORE"
     ]
   },
-  "WORMADAM_PLANT_CLOAK": {
+  "WORMADAM_PLANT": {
     "LevelMoves": [
       {
         "Level": 1,

--- a/tools/learnset_helpers/porymoves_files/bdsp.json
+++ b/tools/learnset_helpers/porymoves_files/bdsp.json
@@ -46223,7 +46223,7 @@
     "EggMoves": [],
     "TutorMoves": []
   },
-  "WORMADAM_PLANT_CLOAK": {
+  "WORMADAM_PLANT": {
     "LevelMoves": [
       {
         "Level": 0,

--- a/tools/learnset_helpers/porymoves_files/bw.json
+++ b/tools/learnset_helpers/porymoves_files/bw.json
@@ -45087,7 +45087,7 @@
     "EggMoves": [],
     "TutorMoves": []
   },
-  "WORMADAM_PLANT_CLOAK": {
+  "WORMADAM_PLANT": {
     "LevelMoves": [
       {
         "Level": 1,

--- a/tools/learnset_helpers/porymoves_files/dp.json
+++ b/tools/learnset_helpers/porymoves_files/dp.json
@@ -44067,7 +44067,7 @@
     "EggMoves": [],
     "TutorMoves": []
   },
-  "WORMADAM_PLANT_CLOAK": {
+  "WORMADAM_PLANT": {
     "LevelMoves": [
       {
         "Level": 1,

--- a/tools/learnset_helpers/porymoves_files/hgss.json
+++ b/tools/learnset_helpers/porymoves_files/hgss.json
@@ -49305,7 +49305,7 @@
       "MOVE_STRING_SHOT"
     ]
   },
-  "WORMADAM_PLANT_CLOAK": {
+  "WORMADAM_PLANT": {
     "LevelMoves": [
       {
         "Level": 1,

--- a/tools/learnset_helpers/porymoves_files/la.json
+++ b/tools/learnset_helpers/porymoves_files/la.json
@@ -8433,7 +8433,7 @@
     "EggMoves": [],
     "TutorMoves": []
   },
-  "WORMADAM_PLANT_CLOAK": {
+  "WORMADAM_PLANT": {
     "LevelMoves": [
       {
         "Level": 1,

--- a/tools/learnset_helpers/porymoves_files/oras.json
+++ b/tools/learnset_helpers/porymoves_files/oras.json
@@ -53725,7 +53725,7 @@
       "MOVE_SNORE"
     ]
   },
-  "WORMADAM_PLANT_CLOAK": {
+  "WORMADAM_PLANT": {
     "LevelMoves": [
       {
         "Level": 1,

--- a/tools/learnset_helpers/porymoves_files/pt.json
+++ b/tools/learnset_helpers/porymoves_files/pt.json
@@ -48085,7 +48085,7 @@
       "MOVE_SNORE"
     ]
   },
-  "WORMADAM_PLANT_CLOAK": {
+  "WORMADAM_PLANT": {
     "LevelMoves": [
       {
         "Level": 1,

--- a/tools/learnset_helpers/porymoves_files/sm.json
+++ b/tools/learnset_helpers/porymoves_files/sm.json
@@ -48246,7 +48246,7 @@
     "EggMoves": [],
     "TutorMoves": []
   },
-  "WORMADAM_PLANT_CLOAK": {
+  "WORMADAM_PLANT": {
     "LevelMoves": [
       {
         "Level": 0,

--- a/tools/learnset_helpers/porymoves_files/sv.json
+++ b/tools/learnset_helpers/porymoves_files/sv.json
@@ -36838,7 +36838,7 @@
     "EggMoves": [],
     "TutorMoves": []
   },
-  "WORMADAM_PLANT_CLOAK": {
+  "WORMADAM_PLANT": {
     "LevelMoves": [],
     "PreEvoMoves": [],
     "TMMoves": [],

--- a/tools/learnset_helpers/porymoves_files/usum.json
+++ b/tools/learnset_helpers/porymoves_files/usum.json
@@ -53477,7 +53477,7 @@
       "MOVE_SNORE"
     ]
   },
-  "WORMADAM_PLANT_CLOAK": {
+  "WORMADAM_PLANT": {
     "LevelMoves": [
       {
         "Level": 0,

--- a/tools/learnset_helpers/porymoves_files/xy.json
+++ b/tools/learnset_helpers/porymoves_files/xy.json
@@ -47960,7 +47960,7 @@
     "EggMoves": [],
     "TutorMoves": []
   },
-  "WORMADAM_PLANT_CLOAK": {
+  "WORMADAM_PLANT": {
     "LevelMoves": [
       {
         "Level": 1,


### PR DESCRIPTION
The teachable learnset file script didn't run because the Wormadam define wasn't updated in the json files.

Since it broke silently maybe an upcoming merge would be good.   