### PR TITLE
Fix move category and category icon when PSS is off

### DIFF
--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -1759,7 +1759,6 @@ static void MoveSelectionDisplayMoveDescription(u32 battler)
     u16 move = moveInfo->moves[gMoveSelectionCursor[battler]];
     u16 pwr = gMovesInfo[move].power;
     u16 acc = gMovesInfo[move].accuracy;
-    u8 cat = gMovesInfo[move].category;
 
     u8 pwr_num[3], acc_num[3];
     u8 cat_desc[7] = _("CAT: ");
@@ -1796,7 +1795,7 @@ static void MoveSelectionDisplayMoveDescription(u32 battler)
     if (gCategoryIconSpriteId == 0xFF)
         gCategoryIconSpriteId = CreateSprite(&gSpriteTemplate_CategoryIcons, 38, 64, 1);
 
-    StartSpriteAnim(&gSprites[gCategoryIconSpriteId], cat);
+    StartSpriteAnim(&gSprites[gCategoryIconSpriteId], GetBattleMoveCategory(move));
 
     CopyWindowToVram(B_WIN_MOVE_DESCRIPTION, COPYWIN_FULL);
 }

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -11212,7 +11212,7 @@ u8 GetBattleMoveCategory(u32 moveId)
 
     if (IS_MOVE_STATUS(moveId))
         return DAMAGE_CATEGORY_STATUS;
-    return gTypesInfo[GetMoveType(gCurrentMove)].damageCategory;
+    return gTypesInfo[GetMoveType(moveId)].damageCategory;
 }
 
 static bool32 TryRemoveScreens(u32 battler)


### PR DESCRIPTION
## Description
There's currently an issue with `GetBattleMoveCategory()` where it looks at `gCurrentMove` instead of the local variable `moveId` so the wrong category is retrieved when PSS is turned off. This fixes that as well as a bug with the category icon in battle move info where it wasn't accounting for PSS being turned off.

## Images
![pokeemerald-2](https://github.com/user-attachments/assets/6c7ff36a-ecff-4597-a039-a8d8e6ee1fdf)

## **Discord contact info**
ravepossum
