### PR TITLE
Adds missing Friend Ball friendship bonus upon catching

### DIFF
--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -179,6 +179,7 @@
 #define B_DREAM_BALL_MODIFIER       GEN_LATEST // In Gen8+, Dream Ball's catch multiplier is x4 when the target is asleep or has the ability Comatose.
 #define B_SPORT_BALL_MODIFIER       GEN_LATEST // In Gen8+, Sport Ball's catch multiplier was reduced from x1.5 to x1.
 #define B_SAFARI_BALL_MODIFIER      GEN_LATEST // In Gen8+, Safari Ball's catch multiplier was reduced from x1.5 to x1.
+#define B_FRIEND_BALL_MODIFIER      GEN_LATEST // In Gen8+, Friend Ball's friendship boost was reduced from 200 to 150.
 #define B_SERENE_GRACE_BOOST        GEN_LATEST // In Gen5+, Serene Grace boosts the added flinch chance of King's Rock and Razor Fang.
 
 // Flag settings

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -15700,12 +15700,17 @@ static void Cmd_handleballthrow(void)
             else
                 gBattleCommunication[MULTISTRING_CHOOSER] = 1;
 
-            if (gLastUsedItem == BALL_HEAL)
+            if (ballId == BALL_HEAL)
             {
                 MonRestorePP(&gEnemyParty[gBattlerPartyIndexes[gBattlerTarget]]);
                 HealStatusConditions(&gEnemyParty[gBattlerPartyIndexes[gBattlerTarget]], STATUS1_ANY, gBattlerTarget);
                 gBattleMons[gBattlerTarget].hp = gBattleMons[gBattlerTarget].maxHP;
                 SetMonData(&gEnemyParty[gBattlerPartyIndexes[gBattlerTarget]], MON_DATA_HP, &gBattleMons[gBattlerTarget].hp);
+            }
+            else if (ballId == BALL_FRIEND)
+            {
+                u32 friendship = (B_FRIEND_BALL_MODIFIER >= GEN_8 ? 150 : 200);
+                SetMonData(&gEnemyParty[gBattlerPartyIndexes[gBattlerTarget]], MON_DATA_FRIENDSHIP, &friendship);
             }
         }
         else // mon may be caught, calculate shakes
@@ -15760,6 +15765,11 @@ static void Cmd_handleballthrow(void)
                     HealStatusConditions(&gEnemyParty[gBattlerPartyIndexes[gBattlerTarget]], STATUS1_ANY, gBattlerTarget);
                     gBattleMons[gBattlerTarget].hp = gBattleMons[gBattlerTarget].maxHP;
                     SetMonData(&gEnemyParty[gBattlerPartyIndexes[gBattlerTarget]], MON_DATA_HP, &gBattleMons[gBattlerTarget].hp);
+                }
+                else if (ballId == BALL_FRIEND)
+                {
+                    u32 friendship = (B_FRIEND_BALL_MODIFIER >= GEN_8 ? 150 : 200);
+                    SetMonData(&gEnemyParty[gBattlerPartyIndexes[gBattlerTarget]], MON_DATA_FRIENDSHIP, &friendship);
                 }
             }
             else // not caught

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2323,7 +2323,7 @@ static inline bool32 DoesBattlerNegateDamage(u32 battler)
         return FALSE;
     if (ability == ABILITY_DISGUISE && species == SPECIES_MIMIKYU)
         return TRUE;
-    if (ability == ABILITY_ICE_FACE && species == SPECIES_EISCUE && GetBattleMoveCategory(gCurrentMove) == DAMAGE_CATEGORY_SPECIAL)
+    if (ability == ABILITY_ICE_FACE && species == SPECIES_EISCUE && GetBattleMoveCategory(gCurrentMove) == DAMAGE_CATEGORY_PHYSICAL)
         return TRUE;
 
     return FALSE;


### PR DESCRIPTION
- Added missing Friend Ball effect:

> When used from the Bag in a wild encounter, it attempts to catch the wild Pokémon with a catch rate modifier of 1×. **If caught, the Pokémon's friendship is set to 200 in Generations II through VII, or 150 in Generation VIII onwards**. It has no effect on the friendship of Pokémon hatched in a Friend Ball.

- Added config `B_FRIEND_BALL_MODIFIER` to reflect Gen2-7 and Gen8+ effects.

- Fixed a small oversight from #5770 that caused an Eiscue with Ice Face to not play the effectiveness sound when hit by a Special move instead of a Physical move.

To test if the friendship was assigned correctly, the following change was made in `PrintMonOTID` to display a mon's friendship in the summary screen (not available in this PR, only for the videos presented below):

`ConvertIntToDecimalStringN(StringCopy(gStringVar1, gText_IDNumber2), (u16)sMonSummaryScreen->summary.OTID, STR_CONV_MODE_LEADING_ZEROS, 5);`

was changed to:

`ConvertIntToDecimalStringN(StringCopy(gStringVar1, gText_IDNumber2), (u16)sMonSummaryScreen->summary.friendship, STR_CONV_MODE_LEADING_ZEROS, 3);`

Current Friend Ball interaction:

https://github.com/user-attachments/assets/88d1016f-0b12-4d25-8b0b-84013386ee45

Friend Ball's interaction with this PR's changes:

https://github.com/user-attachments/assets/8ae40b8a-8bca-43bd-a6aa-7a572739180b

## **Discord contact info**
PhallenTree
