### PR TITLE
Fixes simu hp reduction when no partner was on field

### DIFF
--- a/include/constants/pokemon.h
+++ b/include/constants/pokemon.h
@@ -323,8 +323,9 @@ enum EvolutionMode {
 // - Unown has 1 frame, presumably to avoid the work of animating all 28 of its forms
 #define MAX_MON_PIC_FRAMES 2
 
-#define BATTLE_ALIVE_EXCEPT_BATTLER  0
-#define BATTLE_ALIVE_SIDE            1
+#define BATTLE_ALIVE_EXCEPT_BATTLER      0
+#define BATTLE_ALIVE_EXCEPT_BATTLER_SIDE 1
+#define BATTLE_ALIVE_SIDE                2
 
 #define SKIP_FRONT_ANIM (1 << 7)
 

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3696,7 +3696,7 @@ u8 AtkCanceller_UnableToUseMove(u32 moveType)
                     }
                 }
                 if (moveTarget == MOVE_TARGET_BOTH)
-                    gBattleStruct->numSpreadTargets = CountAliveMonsInBattle(BATTLE_ALIVE_SIDE, gBattlerAttacker);
+                    gBattleStruct->numSpreadTargets = CountAliveMonsInBattle(BATTLE_ALIVE_EXCEPT_BATTLER_SIDE, gBattlerAttacker);
                 else
                     gBattleStruct->numSpreadTargets = CountAliveMonsInBattle(BATTLE_ALIVE_EXCEPT_BATTLER, gBattlerAttacker);
 

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -2074,6 +2074,13 @@ u8 CountAliveMonsInBattle(u8 caseId, u32 battler)
                 retVal++;
         }
         break;
+    case BATTLE_ALIVE_EXCEPT_BATTLER_SIDE:
+        for (i = 0; i < MAX_BATTLERS_COUNT; i++)
+        {
+            if (i != battler && i != BATTLE_PARTNER(battler) && !(gAbsentBattlerFlags & (1u << i)))
+                retVal++;
+        }
+        break;
     case BATTLE_ALIVE_SIDE:
         for (i = 0; i < MAX_BATTLERS_COUNT; i++)
         {

--- a/test/battle/spread_moves.c
+++ b/test/battle/spread_moves.c
@@ -411,3 +411,25 @@ DOUBLE_BATTLE_TEST("Spread Moves: Doesn't affect message on both opposing mons")
         MESSAGE("It doesn't affect the opposing Pidgey and Hoothoot…");
     }
 }
+
+DOUBLE_BATTLE_TEST("Spread Moves: Unless move hits every target user will not include partner in the target count")
+{
+    GIVEN {
+        PLAYER(SPECIES_SANDSLASH);
+        PLAYER(SPECIES_WYNAUT) { HP(1); }
+        PLAYER(SPECIES_RALTS);
+        OPPONENT(SPECIES_TORKOAL);
+        OPPONENT(SPECIES_TORKOAL);
+    } WHEN {
+        TURN { MOVE(opponentRight, MOVE_ICY_WIND); MOVE(playerLeft, MOVE_ROCK_SLIDE); SEND_OUT(playerRight, 2); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ICY_WIND, opponentRight);
+        HP_BAR(playerLeft);
+        HP_BAR(playerRight);
+
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ROCK_SLIDE, playerLeft);
+        HP_BAR(opponentLeft);
+        HP_BAR(opponentRight);
+        MESSAGE("It's super effective on the opposing Torkoal and Torkoal!");
+    }
+}


### PR DESCRIPTION
When there was no partner on the field the simultaneous HP reduction didn't work because `numSpreadTargets` got the wrong amount of battlers. 