### PR TITLE
Prevent Key Items that open other menus from causing a crash if registered and used from the field

### DIFF
--- a/src/item_use.c
+++ b/src/item_use.c
@@ -1560,10 +1560,18 @@ static void ItemUseOnFieldCB_TownMap(u8 taskId)
 
 void ItemUseOutOfBattle_TownMap(u8 taskId)
 {
-    sItemUseOnFieldCB = ItemUseOnFieldCB_TownMap;
-    gFieldCallback = FieldCB_UseItemOnField;
-    gBagMenu->newScreenCallback = CB2_ReturnToField;
-    Task_FadeAndCloseBagMenu(taskId);
+    if (!gTasks[taskId].tUsingRegisteredKeyItem)
+    {
+        sItemUseOnFieldCB = ItemUseOnFieldCB_TownMap;
+        gFieldCallback = FieldCB_UseItemOnField;
+        gBagMenu->newScreenCallback = CB2_ReturnToField;
+        Task_FadeAndCloseBagMenu(taskId);
+    }
+    else
+    {
+        // TODO: handle key items with callbacks to menus allow to be used by registering them.
+        DisplayDadsAdviceCannotUseItemMessage(taskId, gTasks[taskId].tUsingRegisteredKeyItem);
+    }
 }
 
 #undef tUsingRegisteredKeyItem

--- a/src/item_use.c
+++ b/src/item_use.c
@@ -1400,9 +1400,17 @@ void ItemUseOutOfBattle_ZygardeCube(u8 taskId)
 
 void ItemUseOutOfBattle_Fusion(u8 taskId)
 {
-    gItemUseCB = ItemUseCB_Fusion;
-    gTasks[taskId].data[0] = FALSE;
-    SetUpItemUseCallback(taskId);
+    if (!gTasks[taskId].tUsingRegisteredKeyItem)
+    {
+        gItemUseCB = ItemUseCB_Fusion;
+        gTasks[taskId].data[0] = FALSE;
+        SetUpItemUseCallback(taskId);
+    }
+    else
+    {
+        // TODO: handle key items with callbacks to menus allow to be used by registering them.
+        DisplayDadsAdviceCannotUseItemMessage(taskId, gTasks[taskId].tUsingRegisteredKeyItem);
+    }
 }
 
 void Task_UseHoneyOnField(u8 taskId)


### PR DESCRIPTION
The 4 Key Items that use `ItemUseOutOfBattle_Fusion` (DNA Splicers, Solarizer, Lunarizer, Reins of Unity) can cause a crash if they are registered and used.
Steps to reproduce:
1) register one of the above key items
2) use the registered key item by pressing select in the overworld
3) close whatever menu gets opened, save your game, close your emulator
4) reopen your game, use the registered key item by pressing select in the overworld
5) crash

## Images
The following behavior is **before** this fix. Had to capture it with 2 videos and a screenshot.

Registering the DNA Splicers and using them, then saving and closing the game
https://github.com/user-attachments/assets/a1c43224-f627-40e5-a51f-783534e00a67

Loading back up, pressing select to use my registered DNA Splicers
https://github.com/user-attachments/assets/1c6cd1e5-5a53-4253-9989-807654c7e522

crashing
![keyitemcrash3](https://github.com/user-attachments/assets/a1f9f600-63cc-4d6d-b5e4-2f698aa7bbf6)


The "fix" isn't really a fix, it's just making the Fusion Key Items behave like the other Key Items (Rotom Catalog, Zygarde Cube, etc) that open up another menu in that it will just do the "dad's advice" message if they are used from the field as a registered Key Item

## **Discord contact info**
iriv24
