### PR TITLE
Fixes absorb still draining HP when flinched

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -5674,7 +5674,9 @@ static void Cmd_moveend(void)
             gBattleScripting.moveendState++;
             break;
         case MOVEEND_ABSORB:
-            if (gMovesInfo[gCurrentMove].effect == EFFECT_ABSORB)
+            if (gMovesInfo[gCurrentMove].effect == EFFECT_ABSORB
+             && !(gHitMarker & HITMARKER_UNABLE_TO_USE_MOVE)
+             && TARGET_TURN_DAMAGED)
             {
                 if (gStatuses3[gBattlerAttacker] & STATUS3_HEAL_BLOCK && gMovesInfo[gCurrentMove].healingMove)
                 {

--- a/test/battle/move_effect/absorb.c
+++ b/test/battle/move_effect/absorb.c
@@ -125,4 +125,20 @@ SINGLE_BATTLE_TEST("Draining Kiss recovers 75% of the damage dealt")
     }
 }
 
+SINGLE_BATTLE_TEST("Absorb does not drain any HP if user flinched")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_FAKE_OUT); MOVE(player, MOVE_ABSORB); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FAKE_OUT, opponent);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_ABSORB, player);
+            MESSAGE("The opposing Wobbuffet had its energy drained!");
+        }
+    }
+}
+
 TO_DO_BATTLE_TEST("Absorb recovers 50% of the damage dealt to a Substitute");


### PR DESCRIPTION
Reported by Kasan on discord

Absorb still drained HP when the user flinched. 