### PR TITLE
Implemented clear animation for also overworld pokemon

### DIFF
--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -1007,8 +1007,13 @@ bool8 ScrCmd_applymovement(struct ScriptContext *ctx)
     // When applying script movements to follower, it may have frozen animation that must be cleared
     if (localId == OBJ_EVENT_ID_FOLLOWER && (objEvent = GetFollowerObject()) && objEvent->frozen)
     {
-        ClearObjectEventMovement(objEvent, &gSprites[objEvent->spriteId]);
-        gSprites[objEvent->spriteId].animCmdIndex = 0; // Reset start frame of animation
+        goto clear_animation;
+    }
+    if ((objEvent = &gObjectEvents[GetObjectEventIdByLocalId(localId)]) && IS_OW_MON_OBJ(objEvent))
+    {
+        clear_animation:
+            ClearObjectEventMovement(objEvent, &gSprites[objEvent->spriteId]);
+            gSprites[objEvent->spriteId].animCmdIndex = 0; // Reset start frame of animation
     }
 
     gObjectEvents[GetObjectEventIdByLocalId(localId)].directionOverwrite = DIR_NONE;

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -1005,15 +1005,11 @@ bool8 ScrCmd_applymovement(struct ScriptContext *ctx)
     struct ObjectEvent *objEvent;
 
     // When applying script movements to follower, it may have frozen animation that must be cleared
-    if (localId == OBJ_EVENT_ID_FOLLOWER && (objEvent = GetFollowerObject()) && objEvent->frozen)
+    if ((localId == OBJ_EVENT_ID_FOLLOWER && (objEvent = GetFollowerObject()) && objEvent->frozen) 
+            || ((objEvent = &gObjectEvents[GetObjectEventIdByLocalId(localId)]) && IS_OW_MON_OBJ(objEvent)))
     {
-        goto clear_animation;
-    }
-    if ((objEvent = &gObjectEvents[GetObjectEventIdByLocalId(localId)]) && IS_OW_MON_OBJ(objEvent))
-    {
-        clear_animation:
-            ClearObjectEventMovement(objEvent, &gSprites[objEvent->spriteId]);
-            gSprites[objEvent->spriteId].animCmdIndex = 0; // Reset start frame of animation
+        ClearObjectEventMovement(objEvent, &gSprites[objEvent->spriteId]);
+        gSprites[objEvent->spriteId].animCmdIndex = 0; // Reset start frame of animation
     }
 
     gObjectEvents[GetObjectEventIdByLocalId(localId)].directionOverwrite = DIR_NONE;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Before submitting, please make sure your pull request meets the scope guidelines. If unsure, please open a thread in #pr-discussions.-->
<!--- Scope Guidelines: https://github.com/rh-hideout/pokeemerald-expansion/blob/master/docs/scope.md  -->
<!--- #pr-discussions:  https://discord.com/channels/419213663107416084/1102784418369785948 -->

## Description
<!--- Describe your changes in detail -->
Naively applying the same logic for follower mons to also ow mons as well was what fixed it. For talking directly, it doesn't seem to cause an issue, so I think this PR is really just a bandaid fix. I'm not so sure though.

## Images

https://github.com/user-attachments/assets/b7eecf3f-5823-4851-97a6-10754451f284



## Issue(s) that this PR fixes
Fixes #5824 
<!-- Format: "Fixes #2345, fixes #4523, fixes #2222." -->
<!-- If it doesn't apply, feel free to remove this section. -->

## **People who collaborated with me in this PR**
me
<!-- Please credit everyone else that contributed to this PR, be it code and/or assets. -->
<!-- Use their GitHub tag if they have one (or add "@/" at the start if they don't). Be sure to start the line using @ so the automatic changelog can properly detect the collaborators. -->
<!-- Eg.: "@Lunos for sprites, @/Masuda for support" -->
<!-- If it doesn't apply, feel free to remove this section. -->

## **Discord contact info**
accelgor
<!--- Formatted as username (e.g. Lunos) or username#numbers (e.g. Lunos#4026) -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
