### PR TITLE
Fixes Shed Tail substitute health

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -12638,7 +12638,10 @@ static void Cmd_setsubstitute(void)
 
         gBattleMons[gBattlerAttacker].status2 |= STATUS2_SUBSTITUTE;
         gBattleMons[gBattlerAttacker].status2 &= ~STATUS2_WRAPPED;
-        gDisableStructs[gBattlerAttacker].substituteHP = gBattleMoveDamage;
+        if (factor == 2)
+            gDisableStructs[gBattlerAttacker].substituteHP = gBattleMoveDamage / 2;
+        else
+            gDisableStructs[gBattlerAttacker].substituteHP = gBattleMoveDamage;
         gBattleCommunication[MULTISTRING_CHOOSER] = B_MSG_SET_SUBSTITUTE;
         gHitMarker |= HITMARKER_IGNORE_SUBSTITUTE;
     }

--- a/test/battle/move_effect/shed_tail.c
+++ b/test/battle/move_effect/shed_tail.c
@@ -102,16 +102,23 @@ AI_SINGLE_BATTLE_TEST("AI will use Shed Tail to pivot to another mon while in da
 
 SINGLE_BATTLE_TEST("Shed Tail creates a Substitute with 1/4 of user maximum health")
 {
+    u32 hp;
+    PARAMETRIZE { hp = 160; }
+    PARAMETRIZE { hp = 164; }
+
     GIVEN {
-        ASSUME(gMovesInfo[MOVE_GUST].power == 40);
-        ASSUME(gMovesInfo[MOVE_GUST].type == TYPE_FLYING);
-        PLAYER(SPECIES_BULBASAUR);
+        ASSUME(gMovesInfo[MOVE_DRAGON_RAGE].argument == 40);
+        ASSUME(gMovesInfo[MOVE_DRAGON_RAGE].effect == EFFECT_FIXED_DAMAGE_ARG);
+        PLAYER(SPECIES_BULBASAUR) { MaxHP(hp); }
         PLAYER(SPECIES_BULBASAUR);
         OPPONENT(SPECIES_CHARMANDER);
     } WHEN {
-        TURN { MOVE(player, MOVE_SHED_TAIL); MOVE(opponent, MOVE_GUST); SEND_OUT(player, 1); }
+        TURN { MOVE(player, MOVE_SHED_TAIL); MOVE(opponent, MOVE_DRAGON_RAGE); SEND_OUT(player, 1); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SHED_TAIL, player);
-        MESSAGE("Bulbasaur's substitute faded!");
+        if (hp == 160)
+            MESSAGE("Bulbasaur's substitute faded!");
+        else
+            NOT MESSAGE("Bulbasaur's substitute faded!");
     }
 }

--- a/test/battle/move_effect/shed_tail.c
+++ b/test/battle/move_effect/shed_tail.c
@@ -99,3 +99,19 @@ AI_SINGLE_BATTLE_TEST("AI will use Shed Tail to pivot to another mon while in da
         TURN { MOVE(player, MOVE_TACKLE); EXPECT_MOVE(opponent, MOVE_SHED_TAIL); }
     }
 }
+
+SINGLE_BATTLE_TEST("Shed Tail creates a Substitute with 1/4 of user maximum health")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_GUST].power == 40);
+        ASSUME(gMovesInfo[MOVE_GUST].type == TYPE_FLYING);
+        PLAYER(SPECIES_BULBASAUR);
+        PLAYER(SPECIES_BULBASAUR);
+        OPPONENT(SPECIES_CHARMANDER);
+    } WHEN {
+        TURN { MOVE(player, MOVE_SHED_TAIL); MOVE(opponent, MOVE_GUST); SEND_OUT(player, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SHED_TAIL, player);
+        MESSAGE("Bulbasaur's substitute faded!");
+    }
+}


### PR DESCRIPTION
According to [Bulbapedia](https://bulbapedia.bulbagarden.net/wiki/Shed_Tail_(move)) the sub Shed Tail creates still has 1/4 hp.

The move gust in the test does a little more damage then 1/4 to the Shed Tail user. Maybe there is a way to write a test with Dragon Rage though.  