### PR TITLE
Fixes moves based on Dragon Darts with strikeCount > 2 always hitting the same battler from the second hit onwards

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1734,7 +1734,6 @@ static void AccuracyCheck(bool32 recalcDragonDarts, const u8 *nextInstr, const u
                 {
                     // Smart target to partner if miss
                     gBattlerTarget = BATTLE_PARTNER(battlerDef);
-                    gBattleStruct->moveResultFlags[battlerDef] &= ~MOVE_RESULT_MISSED;
                     AccuracyCheck(TRUE, nextInstr, failInstr, move);
                     return;
                 }
@@ -6511,7 +6510,7 @@ static void Cmd_moveend(void)
                 else
                 {
                     if (gMovesInfo[gCurrentMove].effect == EFFECT_DRAGON_DARTS
-                     && gBattleStruct->moveTarget[gBattlerAttacker] == gBattlerTarget // Haven't already changed targets
+                     && !(gBattleStruct->moveResultFlags[BATTLE_PARTNER(gBattlerTarget)] & MOVE_RESULT_MISSED) // didn't miss the other target
                      && CanTargetPartner(gBattlerAttacker, gBattlerTarget)
                      && !TargetFullyImmuneToCurrMove(gBattlerAttacker, BATTLE_PARTNER(gBattlerTarget)))
                         gBattlerTarget = BATTLE_PARTNER(gBattlerTarget); // Target the partner in doubles for second hit.


### PR DESCRIPTION
Doesn't impact the functionality of Dragon Darts itself, but users that create moves with `EFFECT_DRAGON_DARTS` may run into this issue. The previous check only impacted whenever Dragon Darts missed a target, therefore this should not create other issues.

## **Discord contact info**
PhallenTree
