### PR TITLE
Fixes Quash-affected battlers having the wrong order for End Turn effects

### DIFF
--- a/src/battle_anim_effects_1.c
+++ b/src/battle_anim_effects_1.c
@@ -6757,6 +6757,7 @@ static void AnimTask_AllySwitchDataSwap(u8 taskId)
                     break;
             }
             SWAP(gBattlerByTurnOrder[i], gBattlerByTurnOrder[j], temp);
+            SWAP(gActionsByTurnOrder[i], gActionsByTurnOrder[j], temp);
             break;
         }
     }

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -1679,17 +1679,12 @@ u8 DoFieldEndTurnEffects(void)
         switch (gBattleStruct->turnCountersTracker)
         {
         case ENDTURN_ORDER:
-            for (i = 0; i < gBattlersCount; i++)
-            {
-                gBattlerByTurnOrder[i] = i;
-            }
             for (i = 0; i < gBattlersCount - 1; i++)
             {
                 s32 j;
                 for (j = i + 1; j < gBattlersCount; j++)
                 {
-                    if (!gProtectStructs[i].quash
-                            && !gProtectStructs[j].quash
+                    if (!(gProtectStructs[i].quash && gProtectStructs[j].quash)
                             && GetWhichBattlerFaster(gBattlerByTurnOrder[i], gBattlerByTurnOrder[j], FALSE) == -1)
                         SwapTurnOrder(i, j);
                 }


### PR DESCRIPTION
Similar to how the previous implementation of Quash set the quash affected battler's act order equal to its position and how it didn't swap any battlers' actions, this caused quash affected battlers to have their end of turn effects happen in an order equal to their positions (playerLeft would always be first, playerRight would always be third, etc.) and if users decide to have certain effects not trigger due to having performed a certain action during a turn, these also took into account the wrong battler's action.

See #5400 for more information on these issues and about the previous implementation of Quash.

Also fixes Ally Switch not swapping battlers actions (likely irrelevant since either partner already acted if its action does not match)

## **Discord contact info**
PhallenTree
