### PR TITLE
Fix Hit Escape moves giving Exp to the mon that switches in

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -2791,6 +2791,8 @@ BattleScript_EffectHitEscape::
 	jumpifbattleend BattleScript_HitEscapeEnd
 	jumpifbyte CMP_NOT_EQUAL, gBattleOutcome, 0, BattleScript_HitEscapeEnd
 	jumpifemergencyexited BS_TARGET, BattleScript_HitEscapeEnd
+	setbyte sGIVEEXP_STATE, 0
+	getexp BS_TARGET
 	goto BattleScript_MoveSwitch
 BattleScript_HitEscapeEnd:
 	end

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -2791,8 +2791,10 @@ BattleScript_EffectHitEscape::
 	jumpifbattleend BattleScript_HitEscapeEnd
 	jumpifbyte CMP_NOT_EQUAL, gBattleOutcome, 0, BattleScript_HitEscapeEnd
 	jumpifemergencyexited BS_TARGET, BattleScript_HitEscapeEnd
+	jumpiffainted BS_TARGET, FALSE, BattleScript_HitEscapeSwitch
 	setbyte sGIVEEXP_STATE, 0
 	getexp BS_TARGET
+BattleScript_HitEscapeSwitch:
 	goto BattleScript_MoveSwitch
 BattleScript_HitEscapeEnd:
 	end


### PR DESCRIPTION
## Description
When a hit escape move (like u-turn) faints a mon, it gave exp to the mon that switched in when it shouldn't have.
This fixes it simply, similar to how hazard fainting works with exp.

## Issue(s) that this PR fixes
#5843

## **Discord contact info**
kittenchilly