### PR TITLE
Fixes Pursuit + Emergency Exit causing double switches and Pursuit user fainting causing target to not finish switch

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3367,9 +3367,13 @@ const u8* FaintClearSetData(u32 battler)
     gBattleStruct->lastTakenMoveFrom[battler][1] = 0;
     gBattleStruct->lastTakenMoveFrom[battler][2] = 0;
     gBattleStruct->lastTakenMoveFrom[battler][3] = 0;
-    gBattleStruct->pursuitTarget = 0;
-    gBattleStruct->pursuitSwitchByMove = FALSE;
-    gBattleStruct->pursuitStoredSwitch = 0;
+    
+    if (gBattleStruct->pursuitTarget & (1u << battler))
+    {
+        gBattleStruct->pursuitTarget = 0;
+        gBattleStruct->pursuitSwitchByMove = FALSE;
+        gBattleStruct->pursuitStoredSwitch = 0;
+    }
 
     gBattleStruct->palaceFlags &= ~(1u << battler);
     gBattleStruct->boosterEnergyActivates &= ~(1u << battler);

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3225,6 +3225,9 @@ void SwitchInClearSetData(u32 battler)
     gBattleStruct->lastTakenMoveFrom[battler][1] = 0;
     gBattleStruct->lastTakenMoveFrom[battler][2] = 0;
     gBattleStruct->lastTakenMoveFrom[battler][3] = 0;
+    gBattleStruct->pursuitTarget = 0;
+    gBattleStruct->pursuitSwitchByMove = FALSE;
+    gBattleStruct->pursuitStoredSwitch = 0;
     gBattleStruct->lastMoveFailed &= ~(1u << battler);
     gBattleStruct->palaceFlags &= ~(1u << battler);
     gBattleStruct->boosterEnergyActivates &= ~(1u << battler);

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3225,13 +3225,17 @@ void SwitchInClearSetData(u32 battler)
     gBattleStruct->lastTakenMoveFrom[battler][1] = 0;
     gBattleStruct->lastTakenMoveFrom[battler][2] = 0;
     gBattleStruct->lastTakenMoveFrom[battler][3] = 0;
-    gBattleStruct->pursuitTarget = 0;
-    gBattleStruct->pursuitSwitchByMove = FALSE;
-    gBattleStruct->pursuitStoredSwitch = 0;
     gBattleStruct->lastMoveFailed &= ~(1u << battler);
     gBattleStruct->palaceFlags &= ~(1u << battler);
     gBattleStruct->boosterEnergyActivates &= ~(1u << battler);
     gBattleStruct->canPickupItem &= ~(1u << battler);
+
+    if (gBattleStruct->pursuitTarget & (1u << battler))
+    {
+        gBattleStruct->pursuitTarget = 0;
+        gBattleStruct->pursuitSwitchByMove = FALSE;
+        gBattleStruct->pursuitStoredSwitch = 0;
+    }
 
     for (i = 0; i < ARRAY_COUNT(gSideTimers); i++)
     {

--- a/test/battle/move_effect/pursuit.c
+++ b/test/battle/move_effect/pursuit.c
@@ -629,9 +629,10 @@ SINGLE_BATTLE_TEST("Pursuit doesn't cause mon with Emergency Exit to switch twic
     }
 }
 
-SINGLE_BATTLE_TEST("Pursuit user gets forced out by Red Card and still causes target to finish switch")
+SINGLE_BATTLE_TEST("Pursuit user gets forced out by Red Card and target still switches out")
 {
     GIVEN {
+        ASSUME(gItemsInfo[ITEM_RED_CARD].holdEffect == HOLD_EFFECT_RED_CARD);
         PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_RED_CARD); }
         PLAYER(SPECIES_VOLTORB);
         OPPONENT(SPECIES_WOBBUFFET);
@@ -643,6 +644,28 @@ SINGLE_BATTLE_TEST("Pursuit user gets forced out by Red Card and still causes ta
         ANIMATION(ANIM_TYPE_MOVE, MOVE_PURSUIT, opponent);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
         MESSAGE("The opposing Voltorb was dragged out!");
+        SEND_IN_MESSAGE("Voltorb");
+    } THEN {
+        EXPECT_EQ(player->species, SPECIES_VOLTORB);
+        EXPECT_EQ(opponent->species, SPECIES_VOLTORB);
+    }
+}
+
+SINGLE_BATTLE_TEST("Pursuit user faints to Life Orb and target still switches out")
+{
+    GIVEN {
+        ASSUME(gItemsInfo[ITEM_LIFE_ORB].holdEffect == HOLD_EFFECT_LIFE_ORB);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_VOLTORB);
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_LIFE_ORB); HP(1); }
+        OPPONENT(SPECIES_VOLTORB);
+    } WHEN {
+        TURN { SWITCH(player, 1); MOVE(opponent, MOVE_PURSUIT); SEND_OUT(opponent, 1); }
+    } SCENE {
+        SWITCH_OUT_MESSAGE("Wobbuffet");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_PURSUIT, opponent);
+        HP_BAR(opponent);
+        MESSAGE("The opposing Wobbuffet fainted!");
         SEND_IN_MESSAGE("Voltorb");
     } THEN {
         EXPECT_EQ(player->species, SPECIES_VOLTORB);

--- a/test/battle/move_effect/pursuit.c
+++ b/test/battle/move_effect/pursuit.c
@@ -610,4 +610,23 @@ SINGLE_BATTLE_TEST("Pursuit attacks a switching foe and switchin is correctly st
     }
 }
 
+SINGLE_BATTLE_TEST("Pursuit doesn't cause mon with Emergency Exit to switch twice")
+{
+    GIVEN {
+        PLAYER(SPECIES_GOLISOPOD) { HP(101); MaxHP(200); Ability(ABILITY_EMERGENCY_EXIT); }
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_VOLTORB);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { SWITCH(player, 1); MOVE(opponent, MOVE_PURSUIT); SEND_OUT(player, 2); }
+    } SCENE {
+        SWITCH_OUT_MESSAGE("Golisopod");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_PURSUIT, opponent);
+        ABILITY_POPUP(player, ABILITY_EMERGENCY_EXIT);
+        SEND_IN_MESSAGE("Voltorb");
+    } THEN {
+        EXPECT_EQ(player->species, SPECIES_VOLTORB);
+    }
+}
+
 TO_DO_BATTLE_TEST("Baton Pass doesn't cause Pursuit to increase its power or priority");

--- a/test/battle/move_effect/pursuit.c
+++ b/test/battle/move_effect/pursuit.c
@@ -629,4 +629,25 @@ SINGLE_BATTLE_TEST("Pursuit doesn't cause mon with Emergency Exit to switch twic
     }
 }
 
+SINGLE_BATTLE_TEST("Pursuit user gets forced out by Red Card and still causes target to finish switch")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_RED_CARD); }
+        PLAYER(SPECIES_VOLTORB);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_VOLTORB);
+    } WHEN {
+        TURN { SWITCH(player, 1); MOVE(opponent, MOVE_PURSUIT); }
+    } SCENE {
+        SWITCH_OUT_MESSAGE("Wobbuffet");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_PURSUIT, opponent);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+        MESSAGE("The opposing Voltorb was dragged out!");
+        SEND_IN_MESSAGE("Voltorb");
+    } THEN {
+        EXPECT_EQ(player->species, SPECIES_VOLTORB);
+        EXPECT_EQ(opponent->species, SPECIES_VOLTORB);
+    }
+}
+
 TO_DO_BATTLE_TEST("Baton Pass doesn't cause Pursuit to increase its power or priority");


### PR DESCRIPTION
Oversight from #5707.
Fixes Pursuit into Emergency Exit mon causing a switch but not stopping the Pursuit cycle, causing a second switch at the end of the Pursuit cycle. (likely also happens with Eject Button/Pack)
Also fixes Pursuit user fainting causing Pursuit Cycle to end. (stopping other Pursuiters from attacking and stopping the target from finishing their switch)

https://github.com/user-attachments/assets/d61eaa61-67e5-478e-ae30-bdab3cce065b

## **Discord contact info**
PhallenTree
