### PR TITLE
Fixes Regenerator healing past maxHP

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -15121,10 +15121,10 @@ static void Cmd_switchoutabilities(void)
             break;
         case ABILITY_REGENERATOR:
         {
-            u32 regenerate = GetNonDynamaxMaxHP(gBattlerAttacker) / 3;
+            u32 regenerate = GetNonDynamaxMaxHP(battler) / 3;
             regenerate += gBattleMons[battler].hp;
-            if (gBattleStruct->moveDamage[gBattlerAttacker] > gBattleMons[battler].maxHP)
-                gBattleStruct->moveDamage[gBattlerAttacker] = gBattleMons[battler].maxHP;
+            if (regenerate > gBattleMons[battler].maxHP)
+                regenerate = gBattleMons[battler].maxHP;
             BtlController_EmitSetMonData(battler, BUFFER_A, REQUEST_HP_BATTLE,
                                          1u << *(gBattleStruct->battlerPartyIndexes + battler),
                                          sizeof(regenerate),

--- a/test/battle/ability/regenerator.c
+++ b/test/battle/ability/regenerator.c
@@ -1,0 +1,50 @@
+#include "global.h"
+#include "test/battle.h"
+
+SINGLE_BATTLE_TEST("Regenerator heals 1/3 of max HP upon switching out")
+{
+    u32 currHP;
+    PARAMETRIZE { currHP = 1; }
+    PARAMETRIZE { currHP = 2; }
+    PARAMETRIZE { currHP = 3; }
+    GIVEN {
+        PLAYER(SPECIES_SLOWBRO) { Ability(ABILITY_REGENERATOR); HP(currHP); }
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { SWITCH(player, 1); }
+        TURN { SWITCH(player, 0); }
+    } SCENE {
+        SWITCH_OUT_MESSAGE("Slowbro");
+        SEND_IN_MESSAGE("Wobbuffet");
+        SWITCH_OUT_MESSAGE("Wobbuffet");
+        SEND_IN_MESSAGE("Slowbro");
+    } THEN {
+        EXPECT_EQ(player->hp, player->maxHP / 3 + currHP);
+    }
+}
+
+SINGLE_BATTLE_TEST("Regenerator heals 1/3 of max HP upon switching out but doesn't surpass max HP")
+{
+    u32 currHP;
+    PARAMETRIZE { currHP = 5; }
+    PARAMETRIZE { currHP = 4; }
+    PARAMETRIZE { currHP = 3; }
+    PARAMETRIZE { currHP = 2; }
+    PARAMETRIZE { currHP = 1; }
+    GIVEN {
+        PLAYER(SPECIES_SLOWBRO) { Ability(ABILITY_REGENERATOR); HP(currHP); MaxHP(5); }
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { SWITCH(player, 1); }
+        TURN { SWITCH(player, 0); }
+    } SCENE {
+        SWITCH_OUT_MESSAGE("Slowbro");
+        SEND_IN_MESSAGE("Wobbuffet");
+        SWITCH_OUT_MESSAGE("Wobbuffet");
+        SEND_IN_MESSAGE("Slowbro");
+    } THEN {
+        EXPECT_LE(player->hp, player->maxHP);
+    }
+}


### PR DESCRIPTION
Fixes Regenerator healing past maxHP due to checking the wrong value when trying to ensure it doesn't put the mon at more hp than maxHP. Also added back the Regenerator fix from #5694 since that got accidentally reverted.
Added basic Regenerator tests.

## **Discord contact info**
PhallenTree