### PR TITLE
Fix ScrollableMultichoice_UpdateScrollArrows

### DIFF
--- a/src/field_specials.c
+++ b/src/field_specials.c
@@ -2778,7 +2778,7 @@ static void ScrollableMultichoice_UpdateScrollArrows(u8 taskId)
         u32 y0 = (8 * (task->tTop - 1));
 
         template.firstX = (task->tWidth / 2) * 8 + 12 + (task->tLeft - 1) * 8;
-        template.firstY = 8 = y0;
+        template.firstY = 8 + y0;
         template.secondX = (task->tWidth / 2) * 8 + 12 + (task->tLeft - 1) * 8;
         template.secondY = task->tHeight * 8 + 10 + y0;
         template.fullyUpThreshold = 0;

--- a/src/field_specials.c
+++ b/src/field_specials.c
@@ -2775,10 +2775,12 @@ static void ScrollableMultichoice_UpdateScrollArrows(u8 taskId)
     struct ScrollArrowsTemplate template = sScrollableMultichoice_ScrollArrowsTemplate;
     if (task->tMaxItemsOnScreen != task->tNumItems)
     {
+        u32 y0 = (8 * (task->tTop - 1));
+
         template.firstX = (task->tWidth / 2) * 8 + 12 + (task->tLeft - 1) * 8;
-        template.firstY = 8;
+        template.firstY = 8 = y0;
         template.secondX = (task->tWidth / 2) * 8 + 12 + (task->tLeft - 1) * 8;
-        template.secondY = task->tHeight * 8 + 10;
+        template.secondY = task->tHeight * 8 + 10 + y0;
         template.fullyUpThreshold = 0;
         template.fullyDownThreshold = task->tNumItems - task->tMaxItemsOnScreen;
         task->tScrollArrowId = AddScrollIndicatorArrowPair(&template, &gScrollableMultichoice_ScrollOffset);


### PR DESCRIPTION
Fixes scroll arrow positions for scripting list menus that don't start at y=1

![image](https://github.com/user-attachments/assets/c0432e3e-471b-40b1-8612-a892df083d38)
