### PR TITLE
Destiny Bond and OHKO moves are blocked by Dynamax

### DIFF
--- a/src/battle_dynamax.c
+++ b/src/battle_dynamax.c
@@ -242,10 +242,10 @@ bool32 IsMoveBlockedByDynamax(u32 move)
     // TODO: Certain moves are banned in raids.
     switch (gMovesInfo[move].effect)
     {
+        case EFFECT_DESTINY_BOND:
         case EFFECT_HEAT_CRASH:
         case EFFECT_LOW_KICK:
         case EFFECT_OHKO:
-        case EFFECT_DESTINTY_BOND:
             return TRUE;
     }
     return FALSE;

--- a/src/battle_dynamax.c
+++ b/src/battle_dynamax.c
@@ -244,6 +244,8 @@ bool32 IsMoveBlockedByDynamax(u32 move)
     {
         case EFFECT_HEAT_CRASH:
         case EFFECT_LOW_KICK:
+        case EFFECT_OHKO:
+        case EFFECT_DESTINTY_BOND:
             return TRUE;
     }
     return FALSE;


### PR DESCRIPTION
Source: [Bulbapedia](https://bulbapedia.bulbagarden.net/wiki/Dynamax)