### PR TITLE
Change install.md to mention make debug instead of DINFO=1

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -110,9 +110,9 @@ To compile the `modern` target with this toolchain, the subdirectories `lib`, `i
 
 ### Building with debug info
 
-To build **pokeemerald.elf** with debug symbols under a modern toolchain:
+To build **pokeemerald.elf** with debug symbols and debug-compatible optimization under a modern toolchain:
 ```bash
-make DINFO=1
+make debug
 ```
 
 # Useful additional tools


### PR DESCRIPTION
## Description
Does what it says on the tin - changes INSTALL.MD to reference expansion's `debug` target instead of using `DINFO=1`, and also mentions the change to optimization level that it makes.

## **Discord contact info**
ravepossum
