### PR TITLE
Fix Salt Cure script

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -7582,13 +7582,8 @@ BattleScript_AbilityPopUp:
 	return
 
 BattleScript_AbilityPopUpScripting:
-	.if B_ABILITY_POP_UP == TRUE
-	showabilitypopup BS_SCRIPTING
-	pause 40
-	.endif
-	recordability BS_SCRIPTING
-	sethword sABILITY_OVERWRITE, 0
-	return
+    copybyte gBattlerAbility, sBATTLER
+    goto BattleScript_AbilityPopUp
 
 BattleScript_AbilityPopUpOverwriteThenNormal:
 	setbyte sFIXED_ABILITY_POPUP, TRUE

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -7582,8 +7582,8 @@ BattleScript_AbilityPopUp:
 	return
 
 BattleScript_AbilityPopUpScripting:
-    copybyte gBattlerAbility, sBATTLER
-    goto BattleScript_AbilityPopUp
+	copybyte gBattlerAbility, sBATTLER
+	goto BattleScript_AbilityPopUp
 
 BattleScript_AbilityPopUpOverwriteThenNormal:
 	setbyte sFIXED_ABILITY_POPUP, TRUE

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -407,13 +407,13 @@ BattleScript_SaltCureExtraDamage::
 	call BattleScript_HurtTarget_NoString
 	printstring STRINGID_TARGETISHURTBYSALTCURE
 	waitmessage B_WAIT_TIME_LONG
+	tryfaintmon BS_TARGET
 	end2
 
 BattleScript_HurtTarget_NoString:
 	orword gHitMarker, HITMARKER_IGNORE_SUBSTITUTE | HITMARKER_PASSIVE_DAMAGE
 	healthbarupdate BS_TARGET
 	datahpupdate BS_TARGET
-	tryfaintmon BS_TARGET
 	return
 
 BattleScript_EffectCorrosiveGas::

--- a/test/battle/move_effect/salt_cure.c
+++ b/test/battle/move_effect/salt_cure.c
@@ -117,3 +117,18 @@ SINGLE_BATTLE_TEST("Salt Cure residual damage does not inflict any damage agains
         }
     }
 }
+
+SINGLE_BATTLE_TEST("If Salt Cure faints the target, messages will be applied in the correct order")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { HP(25); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SALT_CURE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SALT_CURE, player);
+        MESSAGE("The opposing Wobbuffet is being salt cured!");
+        MESSAGE("The opposing Wobbuffet is hurt by Salt Cure!");
+        MESSAGE("The opposing Wobbuffet fainted!");
+    }
+}


### PR DESCRIPTION
Fixes Salt Cure battle script order of operations. `tryfaintmon` was running before `printstring`, so "x fainted!" would print before "x was hurt by Salt Cure!"

Also simplifies BattleScript_AbilityPopUpScripting to jump to BattleScript_AbilityPopUp to remove duplicate code