### PR TITLE
Initialize m4a and IRQ handler in a loaded section

### DIFF
--- a/include/main.h
+++ b/include/main.h
@@ -53,7 +53,6 @@ extern u16 gKeyRepeatContinueDelay;
 extern bool8 gSoftResetDisabled;
 extern IntrFunc gIntrTable[];
 extern u8 gLinkVSyncDisabled;
-extern u32 IntrMain_Buffer[];
 extern s8 gPcmDmaCounter;
 
 void AgbMain(void);

--- a/ld_script_test.ld
+++ b/ld_script_test.ld
@@ -118,7 +118,7 @@ SECTIONS {
     } > ROM =0
 
     .data.iwram :
-    ALIGN(4)
+    ALIGN(8)
     {
         __iwram_lma = .;
         . = . + (__iwram_end - __iwram_start);

--- a/ld_script_test.ld
+++ b/ld_script_test.ld
@@ -38,7 +38,7 @@ SECTIONS {
         __iwram_end = .;
     } > IWRAM
 
-    .iwram.sbss (NOLOAD) :
+    .iwram.bss (NOLOAD) :
     ALIGN(4)
     {
         src/*.o(.bss);
@@ -55,13 +55,17 @@ SECTIONS {
         data/*.o(COMMON);
         test/*.o(COMMON);
         *libc.a:sbrkr.o(COMMON);
-        . = ALIGN(4);
+    } > IWRAM
 
 	/* .persistent starts at 0x3007F00 */
 	/* WARNING: This is the end of the IRQ stack, if there's too
 	 * much data it WILL be overwritten. */
-	. = 0x7F00;
-	test/*.o(.persistent);
+
+    . = 0x03007F00;
+    .iwram.persistent (NOLOAD) :
+    ALIGN(4)
+    {
+        test/*.o(.persistent);
     } > IWRAM
 
     /* BEGIN ROM DATA */

--- a/ld_script_test.ld
+++ b/ld_script_test.ld
@@ -57,9 +57,9 @@ SECTIONS {
         *libc.a:sbrkr.o(COMMON);
     } > IWRAM
 
-	/* .persistent starts at 0x3007F00 */
-	/* WARNING: This is the end of the IRQ stack, if there's too
-	 * much data it WILL be overwritten. */
+    /* .persistent starts at 0x3007F00 */
+    /* WARNING: This is the end of the IRQ stack, if there's too
+     * much data it WILL be overwritten. */
 
     . = 0x03007F00;
     .iwram.persistent (NOLOAD) :
@@ -83,7 +83,7 @@ SECTIONS {
     script_data :
     ALIGN(4)
     {
-	data/*.o(script_data);
+    data/*.o(script_data);
     } > ROM =0
 
     lib_text :

--- a/src/crt0.s
+++ b/src/crt0.s
@@ -14,15 +14,15 @@ Init::
 	mov r0, #PSR_SYS_MODE
 	msr cpsr_cf, r0
 	ldr sp, sp_sys
-@ Prepare for interrupt handling
-	ldr r1, =INTR_VECTOR
-	adr r0, IntrMain
-	str r0, [r1]
 @ Dispatch memory reset request to hardware
 	mov r0, #255 @ RESET_ALL
 	svc #1 << 16
 @ Fill RAM areas with appropriate data
 	bl InitializeWorkingMemory
+@ Prepare for interrupt handling
+	ldr r1, =INTR_VECTOR
+	ldr r0, =IntrMain
+	str r0, [r1]
 @ Jump to AgbMain
 	ldr r1, =AgbMain + 1
 	mov lr, pc
@@ -37,6 +37,7 @@ sp_irq: .word IWRAM_END - 0x60
 	.pool
 
 	.arm
+	.section .iwram.code
 	.align 2, 0
 IntrMain::
 	mov r3, #REG_BASE
@@ -129,6 +130,7 @@ IntrMain_RetAddr:
 
 	.pool
 
+	.text
 	.align 2, 0 @ Don't pad with nop.
 
 @ Fills initialized IWRAM and EWRAM sections in RAM from LMA areas in ROM

--- a/src/m4a.c
+++ b/src/m4a.c
@@ -6,8 +6,6 @@ extern const u8 gCgb3Vol[];
 
 #define BSS_CODE __attribute__((section(".bss.code")))
 
-BSS_CODE ALIGNED(4) char SoundMainRAM_Buffer[0x800] = {0};
-
 COMMON_DATA struct SoundInfo gSoundInfo = {0};
 COMMON_DATA struct PokemonCrySong gPokemonCrySongs[MAX_POKEMON_CRIES] = {0};
 COMMON_DATA struct MusicPlayerInfo gPokemonCryMusicPlayers[MAX_POKEMON_CRIES] = {0};
@@ -71,8 +69,6 @@ void MPlayFadeOut(struct MusicPlayerInfo *mplayInfo, u16 speed)
 void m4aSoundInit(void)
 {
     s32 i;
-
-    CpuCopy32((void *)((s32)SoundMainRAM & ~1), SoundMainRAM_Buffer, sizeof(SoundMainRAM_Buffer));
 
     SoundInit(&gSoundInfo);
     MPlayExtender(gCgbChans);

--- a/src/m4a_1.s
+++ b/src/m4a_1.s
@@ -52,11 +52,11 @@ SoundMain_3:
 	cmp r3, 0
 	beq SoundMain_4
 	ldr r0, [r0, o_SoundInfo_musicPlayerHead]
-	bl _081DD25E
+	bl call_r3
 	ldr r0, [sp, 0x18]
 SoundMain_4:
 	ldr r3, [r0, o_SoundInfo_CgbSound]
-	bl _081DD25E
+	bl call_r3
 	ldr r0, [sp, 0x18]
 	ldr r3, [r0, o_SoundInfo_pcmSamplesPerVBlank]
 	mov r8, r3
@@ -73,18 +73,19 @@ SoundMain_4:
 SoundMain_5:
 	str r5, [sp, 0x8]
 	ldr r6, lt_PCM_DMA_BUF_SIZE
-	ldr r3, lt_SoundMainRAM_Buffer
+	ldr r3, lt_SoundMainRAM
 	bx r3
 
 	.align 2, 0
 lt_SOUND_INFO_PTR:        .word SOUND_INFO_PTR
 lt_ID_NUMBER:             .word ID_NUMBER
-lt_SoundMainRAM_Buffer:   .word SoundMainRAM_Buffer + 1
+lt_SoundMainRAM:          .word SoundMainRAM + 1
 lt_REG_VCOUNT:            .word REG_VCOUNT
 lt_o_SoundInfo_pcmBuffer: .word o_SoundInfo_pcmBuffer
 lt_PCM_DMA_BUF_SIZE:      .word PCM_DMA_BUF_SIZE
 	thumb_func_end SoundMain
 
+	.section .iwram.code
 	thumb_func_start SoundMainRAM
 SoundMainRAM:
 	ldrb r3, [r0, o_SoundInfo_reverb]
@@ -708,6 +709,7 @@ _081DD594:
 	.pool
 	arm_func_end SoundMainRAM_Unk2
 
+	.text
 	thumb_func_start SoundMainBTM
 SoundMainBTM:
 	mov r12, r4

--- a/src/main.c
+++ b/src/main.c
@@ -69,7 +69,6 @@ COMMON_DATA u16 gKeyRepeatContinueDelay = 0;
 COMMON_DATA bool8 gSoftResetDisabled = 0;
 COMMON_DATA IntrFunc gIntrTable[INTR_COUNT] = {0};
 COMMON_DATA u8 gLinkVSyncDisabled = 0;
-COMMON_DATA u32 IntrMain_Buffer[0x200] = {0};
 COMMON_DATA s8 gPcmDmaCounter = 0;
 COMMON_DATA void *gAgbMainLoop_sp = NULL;
 
@@ -316,9 +315,7 @@ void InitIntrHandlers(void)
     for (i = 0; i < INTR_COUNT; i++)
         gIntrTable[i] = gIntrTableTemplate[i];
 
-    DmaCopy32(3, IntrMain, IntrMain_Buffer, sizeof(IntrMain_Buffer));
-
-    INTR_VECTOR = IntrMain_Buffer;
+    INTR_VECTOR = IntrMain;
 
     SetVBlankCallback(NULL);
     SetHBlankCallback(NULL);


### PR DESCRIPTION
## Description
moves `SoundMainRAM` and `IntrMain` to a loaded section in `.iwram.code` instead of manually loading them. Saves around 2kb of memory.

This also fixes an issue where you were unable to have loaded data in the test binary, because the `.persistent` section would overflow.

## **Discord contact info**
karathan