### PR TITLE
Fix Trainer Hill OOB array access

### DIFF
--- a/src/trainer_hill.c
+++ b/src/trainer_hill.c
@@ -212,6 +212,14 @@ static const struct TrainerHillChallenge *const sChallengeData[NUM_TRAINER_HILL_
     [HILL_MODE_EXPERT]  = &sChallenge_Expert,
 };
 
+static const struct TrainerHillFloor *const sFloorData[NUM_TRAINER_HILL_MODES] =
+{
+    [HILL_MODE_NORMAL]  = &sFloors_Normal[0],
+    [HILL_MODE_VARIETY] = &sFloors_Variety[0],
+    [HILL_MODE_UNIQUE]  = &sFloors_Unique[0],
+    [HILL_MODE_EXPERT]  = &sFloors_Expert[0],
+};
+
 // Unused.
 static const u8 *const sFloorStrings[] =
 {
@@ -357,20 +365,14 @@ void FreeTrainerHillBattleStruct(void)
 static void SetUpDataStruct(void)
 {
 #if FREE_TRAINER_HILL == FALSE
-    if (sHillData == NULL)
-    {
-        sHillData = AllocZeroed(sizeof(*sHillData));
-        sHillData->floorId = gMapHeader.mapLayoutId - LAYOUT_TRAINER_HILL_1F;
+    if (sHillData != NULL) return;
 
-        // This copy depends on the floor data for each challenge being directly after the
-        // challenge header data, and for the field 'floors' in sHillData to come directly
-        // after the field 'challenge'.
-        // e.g. for HILL_MODE_NORMAL, it will copy sChallenge_Normal to sHillData->challenge and
-        // it will copy sFloors_Normal to sHillData->floors
-        CpuCopy32(sChallengeData[gSaveBlock1Ptr->trainerHill.mode], &sHillData->challenge, sizeof(sHillData->challenge) + sizeof(sHillData->floors));
-        TrainerHillDummy();
-    }
-#endif //FREE_TRAINER_HILL
+    sHillData = AllocZeroed(sizeof(*sHillData));
+    sHillData->floorId = gMapHeader.mapLayoutId - LAYOUT_TRAINER_HILL_1F;
+
+    CpuCopy32(sChallengeData[gSaveBlock1Ptr->trainerHill.mode], &sHillData->challenge, sizeof(sHillData->challenge));
+    CpuCopy32(sFloorData[gSaveBlock1Ptr->trainerHill.mode], &sHillData->floors, sizeof(sHillData->floors));
+#endif // FREE_TRAINER_HILL
 }
 
 static void FreeDataStruct(void)


### PR DESCRIPTION
## Description

Fixes an out of bounds array access in `trainer_hill.c`'s `SetUpDataStruct` which caused map generation to break without `-fno-toplevel-reorder`.

## Images

After this PR:

![image](https://github.com/user-attachments/assets/d8aea38b-9cc1-46db-b7b6-21b7492b72ac)

Before this PR:

![image](https://github.com/user-attachments/assets/2e6a2062-a1a3-4eb0-921a-c91f19e92fb0)

## Issue(s) that this PR fixes

/

## **Discord contact info**

karathan
