### PR TITLE
BattlerSet

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -814,7 +814,7 @@ struct BattleStruct
     u8 speedTieBreaks; // MAX_BATTLERS_COUNT! values.
     u8 boosterEnergyActivates;
     u8 categoryOverride; // for Z-Moves and Max Moves
-    u8 commandingDondozo;
+    struct BattlerSet commandingDondozo;
     u16 commanderActive[MAX_BATTLERS_COUNT];
     u32 stellarBoostFlags[NUM_BATTLE_SIDES]; // stored as a bitfield of flags for all types for each side
     u8 redCardActivates:1;

--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -3,6 +3,31 @@
 
 #include "move.h"
 
+struct BattlerSet
+{
+    u8 bitset;
+} PACKED;
+
+static inline void BattlerSetClear(struct BattlerSet *bs)
+{
+    bs->bitset = 0u;
+}
+
+static inline void BattlerSetAdd(struct BattlerSet *bs, u32 battler)
+{
+    bs->bitset |= 1u << battler;
+}
+
+static inline void BattlerSetRemove(struct BattlerSet *bs, u32 battler)
+{
+    bs->bitset &= ~(1u << battler);
+}
+
+static inline bool32 BattlerSetContains(struct BattlerSet *bs, u32 battler)
+{
+    return bs->bitset & (1u << battler);
+}
+
 #define MOVE_LIMITATION_ZEROMOVE                (1 << 0)
 #define MOVE_LIMITATION_PP                      (1 << 1)
 #define MOVE_LIMITATION_DISABLED                (1 << 2)

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -734,7 +734,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
     if (IsTwoTurnNotSemiInvulnerableMove(battlerAtk, move) && CanTargetFaintAi(battlerDef, battlerAtk))
         RETURN_SCORE_MINUS(10);
 
-    if (gBattleStruct->commandingDondozo & (1u << battlerDef))
+    if (BattlerSetContains(&gBattleStruct->commandingDondozo, battlerDef))
         RETURN_SCORE_MINUS(20);
 
     // check if negates type

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -430,7 +430,7 @@ bool32 IsDamageMoveUnusable(u32 battlerAtk, u32 battlerDef, u32 move, u32 moveTy
     if (battlerDef == BATTLE_PARTNER(battlerAtk))
         battlerDefAbility = aiData->abilities[battlerDef];
 
-    if (gBattleStruct->commandingDondozo & (1u << battlerDef))
+    if (BattlerSetContains(&gBattleStruct->commandingDondozo, battlerDef))
         return TRUE;
 
     if (CanAbilityBlockMove(battlerAtk, battlerDef, move, aiData->abilities[battlerDef]))
@@ -1510,7 +1510,7 @@ bool32 IsSemiInvulnerable(u32 battlerDef, u32 move)
 {
     if (gStatuses3[battlerDef] & STATUS3_PHANTOM_FORCE)
         return TRUE;
-    else if (gBattleStruct->commandingDondozo & (1u << battlerDef))
+    else if (BattlerSetContains(&gBattleStruct->commandingDondozo, battlerDef))
         return TRUE;
     else if (!MoveDamagesAirborne(move) && gStatuses3[battlerDef] & STATUS3_ON_AIR)
         return TRUE;

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4265,7 +4265,7 @@ static void HandleTurnActionSelectionState(void)
                 || gBattleStruct->absentBattlerFlags & (1u << GetBattlerAtPosition(BATTLE_PARTNER(position)))
                 || gBattleCommunication[GetBattlerAtPosition(BATTLE_PARTNER(position))] == STATE_WAIT_ACTION_CONFIRMED)
             {
-                if ((gBattleStruct->absentBattlerFlags & (1u << battler)) || (gBattleStruct->commandingDondozo & (1u << battler)))
+                if ((gBattleStruct->absentBattlerFlags & (1u << battler)) || BattlerSetContains(&gBattleStruct->commandingDondozo, battler))
                 {
                     gChosenActionByBattler[battler] = B_ACTION_NOTHING_FAINTED;
                     if (!(gBattleTypeFlags & BATTLE_TYPE_MULTI))
@@ -5189,7 +5189,7 @@ static void TurnValuesCleanUp(bool8 var0)
             gBattleMons[i].status2 &= ~STATUS2_SUBSTITUTE;
 
         if (!(gStatuses3[i] & STATUS3_COMMANDER))
-            gBattleStruct->commandingDondozo &= ~(1u << i);
+            BattlerSetRemove(&gBattleStruct->commandingDondozo, i);
 
         gSpecialStatuses[i].parentalBondState = PARENTAL_BOND_OFF;
     }

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -137,7 +137,7 @@ void HandleAction_UseMove(void)
 
     gBattlerAttacker = gBattlerByTurnOrder[gCurrentTurnActionNumber];
     if (gBattleStruct->absentBattlerFlags & (1u << gBattlerAttacker)
-     || gBattleStruct->commandingDondozo & (1u << gBattlerAttacker)
+     || BattlerSetContains(&gBattleStruct->commandingDondozo, gBattlerAttacker)
      || !IsBattlerAlive(gBattlerAttacker))
     {
         gCurrentActionFuncId = B_ACTION_FINISHED;
@@ -5242,7 +5242,7 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
                 SaveBattlerAttacker(gBattlerAttacker);
                 gSpecialStatuses[battler].switchInAbilityDone = TRUE;
                 gBattlerAttacker = partner;
-                gBattleStruct->commandingDondozo |= 1u << battler;
+                BattlerSetAdd(&gBattleStruct->commandingDondozo, battler);
                 gBattleStruct->commanderActive[partner] = gBattleMons[battler].species;
                 gStatuses3[battler] |= STATUS3_COMMANDER;
                 if (gBattleMons[battler].status2 & STATUS2_CONFUSION


### PR DESCRIPTION
Adds a `struct BattlerSet` and `static inline` functions to manipulate it.

## Description
This may help with readability for people who are not used to thinking about bitsets (probably many of our users, and even some of our maintainers). Using a specific `struct BattlerSet` rather than a generic `struct BitSet` was intentional, because it helps document what's going on at the use-sites.

## Feature(s) this PR does NOT handle:
Takes `u32 battler` rather than `enum BattlerId battler` because we currently represent battler IDs as integers but in the future it would be good to change this so that `-Wenum-conversion` can catch mistakes.

Doesn't roll this out across all bitsets. From a quick scan:
- `SpecialStatus.damagedMons`.
- `BattleStruct.absentBattlerFlags`.
- `BattleStruct.focusPunchBattlers`.
- `BattleStruct.multipleSwitchInBattlers`.
- `BattleStruct.alreadyStatusedMoveAttempt`.
- `BattleStruct.activeAbilityPopUps`.
- `BattleStruct.lastMoveFailed`.
- `BattleStruct.forcedSwitch`.
- `BattleStruct.targetsDone`.
- `BattleStruct.storedHealingWish`.
- `BattleStruct.storedLunarDance`.
- `BattleStruct.enduredDamage`.
- `BattleStruct.boosterEnergyActivates`.
- `BattleStruct.usedEjectItem`.
- `BattleStruct.sleepClauseEffectExempt`.
- `BattleStruct.usedMicleBerry`.
- `BattleStruct.pursuitTarget`.
- `gAbsentBattlerFlags`.

It could make sense to introduce a `struct PartySet` for:
- `SpecialStatus.damagedMons`.
- `WishFutureKnock.knockedOffMons`.
- `BattleStruct.givenExpMons`.
- `BattleStruct.expSentInMons`.
- `BattleStruct.arenaLostPlayerMons`.
- `BattleStruct.arenaLostOpponentMons`.
- `BattleStruct.ateBerry`.
- `BattleStruct.appearedInBattle`.
- `BattleStruct.battleBondTransformed`.
- `BattleStruct.transformZeroToZero`.
- `BattleStruct.intrepidSwordBoost`.
- `BattleStruct.dauntlessShieldBoost`.
- `BattleStruct.supersweetSyrup`.
- `gSentPokesToOpponent`?
- `gLeveledUpInBattle`.

And a `struct MoveSet` for:
- `DisableStruct.mimickedMoves`.
- `DisableStruct.usedMoves`.

## Things to note in the release changelog:
- `set |= (1u << battler)` is `BattlerSetAdd(&set, battler)`.
- `set &= ~(1u << battler)` is `BattlerSetRemove(&set, battler)`.
- `(set & (1u << battler))` is `BattlerSetContains(&set, battler)`.
- `set = 0` is `BattlerSetClear(&set)`.