### PR TITLE
Follow up for Innards Out / Future Sight interaction

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -310,7 +310,7 @@ struct WishFutureKnock
     u8 wishPartyId[MAX_BATTLERS_COUNT];
     u8 weatherDuration;
     u8 knockedOffMons[NUM_BATTLE_SIDES]; // Each battler is represented by a bit.
-    u8 futureSightDmg[MAX_BATTLERS_COUNT];
+    s16 futureSightDmg;
 };
 
 struct AI_SavedBattleMon

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2460,10 +2460,8 @@ static void Cmd_datahpupdate(void)
                     gSpecialStatuses[battler].shellBellDmg = gHpDealt;
 
                 // Record damage for foreseen moves
-                if (gWishFutureKnock.futureSightDmg[battler] == 0
-                  && gMovesInfo[gWishFutureKnock.futureSightMove[battler]].effect == EFFECT_FUTURE_SIGHT)
-                    gWishFutureKnock.futureSightDmg[battler] = gHpDealt;
-                
+                gWishFutureKnock.futureSightDmg = gHpDealt;
+
                 // Note: While physicalDmg/specialDmg below are only distinguished between for Counter/Mirror Coat, they are
                 //       used in combination as general damage trackers for other purposes. specialDmg is additionally used
                 //       to help determine if a fire move should defrost the target.
@@ -13960,7 +13958,7 @@ static void Cmd_trysetfutureattack(void)
         gWishFutureKnock.futureSightBattlerIndex[gBattlerTarget] = gBattlerAttacker;
         gWishFutureKnock.futureSightPartyIndex[gBattlerTarget] = gBattlerPartyIndexes[gBattlerAttacker];
         gWishFutureKnock.futureSightCounter[gBattlerTarget] = 3;
-        gWishFutureKnock.futureSightDmg[gBattlerTarget] = 0;
+        gWishFutureKnock.futureSightDmg = 0;
 
         if (gCurrentMove == MOVE_DOOM_DESIRE)
             gBattleCommunication[MULTISTRING_CHOOSER] = B_MSG_DOOM_DESIRE;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -5808,9 +5808,10 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
                 {
                     //no Innards Out effect if Future Sight user is currently not on field
                     if (gWishFutureKnock.futureSightPartyIndex[gBattlerTarget] == gBattlerPartyIndexes[gBattlerAttacker]
-                    || gWishFutureKnock.futureSightPartyIndex[gBattlerTarget] == BATTLE_PARTNER(gBattlerPartyIndexes[gBattlerAttacker]))
+                     || gWishFutureKnock.futureSightPartyIndex[gBattlerTarget] == BATTLE_PARTNER(gBattlerPartyIndexes[gBattlerAttacker]))
                     {
-                        gBattleMoveDamage = gWishFutureKnock.futureSightDmg[gBattlerTarget];
+                        gBattleMoveDamage = gWishFutureKnock.futureSightDmg;
+                        gWishFutureKnock.futureSightDmg = 0;
                         BattleScriptPushCursor();
                         gBattlescriptCurrInstr = BattleScript_AftermathDmg;
                         effect++;


### PR DESCRIPTION
Follow Up for #5966

Sorry @wiz1989. I missed that it should have been a `s16` and the array is redundant. At least in master during dmg calculation only one species dmg matters at a time. This is done for every dmg variable so for consistency I've done it here as well. Also unless I'm missing something the check that assigns `gHpDealt` to `gWishFutureKnock.futureSightDmg`, is not needed as well. 