### PR TITLE
Rename AI_FLAG_PREFER_STRONGEST_MOVE

### DIFF
--- a/docs/tutorials/ai_flags.md
+++ b/docs/tutorials/ai_flags.md
@@ -67,7 +67,7 @@ AI will generally behave more recklessly. This AI enables the following behaviou
 * Switch offensively mid battle rather than defensively (if using `AI_FLAG_SMART_MON_CHOICES`)
 * Prioritize Explosion moves
 
-## `AI_FLAG_PREFER_STRONGEST_MOVE`
+## `AI_FLAG_TRY_TO_2HKO`
 Adds score bonus to any move the AI has that either OHKOs or 2HKOs the player.
 
 Keep in mind that this is a weaker form of `AI_FLAG_TRY_TO_FAINT` at scoring OHKOs as it does not take into account who is attacking first, it does however handle 2HKOs.

--- a/include/constants/battle_ai.h
+++ b/include/constants/battle_ai.h
@@ -31,7 +31,7 @@
 #define AI_FLAG_CHECK_VIABILITY       (1 << 2)  // AI damaging moves and move effects to determine the best available move in the current situation.
 #define AI_FLAG_FORCE_SETUP_FIRST_TURN      (1 << 3) // AI will prioritize using setup moves on the first turn at the expensve of all else. AI_FLAG_CHECK_VIABILITY will instead do this when the AI determines it makes sense.
 #define AI_FLAG_RISKY                 (1 << 4)  // AI will generally behave more recklessly, prioritizing damage over accuracy, explosions, etc.
-#define AI_FLAG_PREFER_STRONGEST_MOVE (1 << 5)  // AI adds score bonus to any move the AI has that either OHKOs or 2HKOs the player.
+#define AI_FLAG_TRY_TO_2HKO           (1 << 5)  // AI adds score bonus to any move the AI has that either OHKOs or 2HKOs the player.
 #define AI_FLAG_PREFER_BATON_PASS     (1 << 6)  // AI prefers raising its own stats and setting for / using Baton Pass.
 #define AI_FLAG_DOUBLE_BATTLE         (1 << 7)  // Automatically set for double battles, handles AI behaviour with partner.
 #define AI_FLAG_HP_AWARE              (1 << 8)  // AI will favour certain move effects based on how much remaining HP it and the player's mon have.

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -48,7 +48,7 @@ static s32 AI_TryToFaint(u32 battlerAtk, u32 battlerDef, u32 move, s32 score);
 static s32 AI_CheckViability(u32 battlerAtk, u32 battlerDef, u32 move, s32 score);
 static s32 AI_ForceSetupFirstTurn(u32 battlerAtk, u32 battlerDef, u32 move, s32 score);
 static s32 AI_Risky(u32 battlerAtk, u32 battlerDef, u32 move, s32 score);
-static s32 AI_PreferStrongestMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score);
+static s32 AI_TryTo2HKO(u32 battlerAtk, u32 battlerDef, u32 move, s32 score);
 static s32 AI_PreferBatonPass(u32 battlerAtk, u32 battlerDef, u32 move, s32 score);
 static s32 AI_HPAware(u32 battlerAtk, u32 battlerDef, u32 move, s32 score);
 static s32 AI_Roaming(u32 battlerAtk, u32 battlerDef, u32 move, s32 score);
@@ -66,7 +66,7 @@ static s32 (*const sBattleAiFuncTable[])(u32, u32, u32, s32) =
     [2] = AI_CheckViability,         // AI_FLAG_CHECK_VIABILITY
     [3] = AI_ForceSetupFirstTurn,    // AI_FLAG_FORCE_SETUP_FIRST_TURN
     [4] = AI_Risky,                  // AI_FLAG_RISKY
-    [5] = AI_PreferStrongestMove,    // AI_FLAG_PREFER_STRONGEST_MOVE
+    [5] = AI_TryTo2HKO,              // AI_FLAG_TRY_TO_2HKO
     [6] = AI_PreferBatonPass,        // AI_FLAG_PREFER_BATON_PASS
     [7] = AI_DoubleBattle,           // AI_FLAG_DOUBLE_BATTLE
     [8] = AI_HPAware,                // AI_FLAG_HP_AWARE
@@ -136,7 +136,7 @@ static u32 GetWildAiFlags(void)
     if (avgLevel >= 20)
         flags |= AI_FLAG_CHECK_VIABILITY;
     if (avgLevel >= 60)
-        flags |= AI_FLAG_PREFER_STRONGEST_MOVE;
+        flags |= AI_FLAG_TRY_TO_2HKO;
     if (avgLevel >= 80)
         flags |= AI_FLAG_HP_AWARE;
 
@@ -4897,7 +4897,7 @@ static s32 AI_Risky(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
 }
 
 // Adds score bonus to best powered move
-static s32 AI_PreferStrongestMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
+static s32 AI_TryTo2HKO(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
 {
     if (IS_TARGETING_PARTNER(battlerAtk, battlerDef))
         return score;

--- a/src/battle_debug.c
+++ b/src/battle_debug.c
@@ -220,7 +220,7 @@ enum
     LIST_AI_CHECK_VIABILITY,
     LIST_AI_SETUP_FIRST_TURN,
     LIST_AI_RISKY,
-    LIST_AI_PREFER_STRONGEST_MOVE,
+    LIST_AI_TRY_TO_2HKO,
     LIST_AI_PREFER_BATON_PASS,
     LIST_AI_DOUBLE_BATTLE,
     LIST_AI_HP_AWARE,
@@ -385,7 +385,7 @@ static const u8 sText_TryToFaint[] = _("Try to Faint");
 static const u8 sText_CheckViability[] = _("Check Viability");
 static const u8 sText_SetUpFirstTurn[] = _("Setup First Turn");
 static const u8 sText_Risky[] = _("Risky");
-static const u8 sText_PreferStrongestMove[] = _("Prefer Strongest Move");
+static const u8 sText_TryTo2HKO[] = _("Try to 2HKO");
 static const u8 sText_PreferBatonPass[] = _("Prefer Baton Pass");
 static const u8 sText_DoubleBattle[] = _("Double Battle");
 static const u8 sText_HpAware[] = _("HP Aware");
@@ -628,7 +628,7 @@ static const struct ListMenuItem sAIListItems[] =
     {sText_CheckViability, LIST_AI_CHECK_VIABILITY},
     {sText_SetUpFirstTurn, LIST_AI_SETUP_FIRST_TURN},
     {sText_Risky, LIST_AI_RISKY},
-    {sText_PreferStrongestMove, LIST_AI_PREFER_STRONGEST_MOVE},
+    {sText_TryTo2HKO, LIST_AI_TRY_TO_2HKO},
     {sText_PreferBatonPass, LIST_AI_PREFER_BATON_PASS},
     {sText_DoubleBattle, LIST_AI_DOUBLE_BATTLE},
     {sText_HpAware, LIST_AI_HP_AWARE},


### PR DESCRIPTION
## Description
AI_FLAG_PREFER_STRONGEST_MOVE isn't representative of what the flag does, the flag prioritizes 2HKOs. It's been renamed as such.

New functionality that actually *does* prefer strongest move will be added alongside a new AI_FLAG_PREFER_STRONGEST_MOVE in the future.

## Issue(s) that this PR fixes
First half of #5969 

## **Discord contact info**
@Pawkkie 
