### PR TITLE
Revert #5033 change to MapHeaderRunScriptType

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -317,11 +317,7 @@ void MapHeaderRunScriptType(u8 tag)
 {
     const u8 *ptr = MapHeaderGetScriptTable(tag);
     if (ptr)
-    {
-        struct ScriptContext ctx;
-        if (RunScriptImmediatelyUntilEffect(SCREFF_V1 | SCREFF_HARDWARE, ptr, &ctx))
-            ScriptContext_ContinueScript(&ctx);
-    }
+        RunScriptImmediately(ptr);
 }
 
 const u8 *MapHeaderCheckScriptTable(u8 tag)


### PR DESCRIPTION
Revert #5033 change to `MapHeaderRunScriptType`.

Reported by AGSMGMaster64, some vanilla scripts are broken by my change. I think I should be able to restore the feature, but this quickly turns it off to prevent `upcoming` from being totally broken in the meantime.