### PR TITLE
Restore lock/lockall/locktrainer/release/releaseall in triggers

### DIFF
--- a/include/script.h
+++ b/include/script.h
@@ -1,8 +1,6 @@
 #ifndef GUARD_SCRIPT_H
 #define GUARD_SCRIPT_H
 
-#include <setjmp.h>
-
 struct ScriptContext;
 
 typedef bool8 (*ScrCmdFunc)(struct ScriptContext *);
@@ -107,9 +105,11 @@ enum // effects
     SCREFF_TRAINERBATTLE = 1 << 2, // 'trainerbattle' command.
 };
 
+#define SCREFF_ANY (SCREFF_SAVE | SCREFF_HARDWARE | SCREFF_TRAINERBATTLE)
+
 enum // effects versions
 {
-    SCREFF_V1 = ~7,
+    SCREFF_V1 = 0xFFFFFFF8,
 };
 
 extern struct ScriptEffectContext *gScriptEffectContext;
@@ -140,7 +140,7 @@ static inline bool32 Script_IsAnalyzingEffects(void)
         _Static_assert((effects) & 0x80000000, "Script_RequestEffects requires an effects version"); \
         if ((effects) != SCREFF_V1) \
             if (Script_IsAnalyzingEffects()) \
-                Script_RequestEffects_Internal(effects); \
+                Script_RequestEffects_Internal((effects) & SCREFF_ANY); \
     })
 
 /* Optimize 'Script_RequestWriteVar' to a no-op if it would have no

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -1527,9 +1527,6 @@ bool8 ScrCmd_turnvobject(struct ScriptContext *ctx)
 // The player is frozen after waiting for their current movement to finish.
 bool8 ScrCmd_lockall(struct ScriptContext *ctx)
 {
-    // As a special case, skip this during analysis.
-    if (Script_IsAnalyzingEffects())
-        return FALSE;
     Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
 
     if (IsOverworldLinkActive())
@@ -1548,9 +1545,6 @@ bool8 ScrCmd_lockall(struct ScriptContext *ctx)
 // The player and selected object are frozen after waiting for their current movement to finish.
 bool8 ScrCmd_lock(struct ScriptContext *ctx)
 {
-    // As a special case, skip this during analysis.
-    if (Script_IsAnalyzingEffects())
-        return FALSE;
     Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
 
     if (IsOverworldLinkActive())
@@ -1581,9 +1575,6 @@ bool8 ScrCmd_lock(struct ScriptContext *ctx)
 
 bool8 ScrCmd_releaseall(struct ScriptContext *ctx)
 {
-    // As a special case, skip this during analysis.
-    if (Script_IsAnalyzingEffects())
-        return FALSE;
     Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
 
     u8 playerObjectId;
@@ -1603,9 +1594,6 @@ bool8 ScrCmd_releaseall(struct ScriptContext *ctx)
 
 bool8 ScrCmd_release(struct ScriptContext *ctx)
 {
-    // As a special case, skip this during analysis.
-    if (Script_IsAnalyzingEffects())
-        return FALSE;
     Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
 
     u8 playerObjectId;
@@ -2858,9 +2846,6 @@ bool8 ScrCmd_selectapproachingtrainer(struct ScriptContext *ctx)
 
 bool8 ScrCmd_lockfortrainer(struct ScriptContext *ctx)
 {
-    // As a special case, skip this during analysis.
-    if (Script_IsAnalyzingEffects())
-        return FALSE;
     Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
 
     if (IsOverworldLinkActive())


### PR DESCRIPTION
#5033 caused some weirdness with `lock*` and `release*` commands in triggers. This PR _should_ restore the behavior, but it needs some testing :)

Reported by AGSMGMaster64. Testing by HunarPG.