### PR TITLE
Don't write to NULL in TryFindHiddenPokemon

### DIFF
--- a/src/dexnav.c
+++ b/src/dexnav.c
@@ -2499,7 +2499,8 @@ bool8 TryFindHiddenPokemon(void)
             || FlagGet(FLAG_SYS_DEXNAV_SEARCH)
             || GetFlashLevel() > 0)
     {
-        (*stepPtr) = 0;
+        if (stepPtr != NULL)
+            (*stepPtr) = 0;
         return FALSE;
     }
     


### PR DESCRIPTION
Compiler may decide to crash the game if it knows `stepPtr` is `NULL`.