### PR TITLE
PlayerHandleStatusXor - change u8 to u32

### DIFF
--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -2236,7 +2236,7 @@ void PlayerHandleExpUpdate(u32 battler)
 
 static void PlayerHandleStatusXor(u32 battler)
 {
-    u8 val = GetMonData(&gPlayerParty[gBattlerPartyIndexes[battler]], MON_DATA_STATUS) ^ gBattleResources->bufferA[battler][1];
+    u32 val = GetMonData(&gPlayerParty[gBattlerPartyIndexes[battler]], MON_DATA_STATUS) ^ gBattleResources->bufferA[battler][1];
 
     SetMonData(&gPlayerParty[gBattlerPartyIndexes[battler]], MON_DATA_STATUS, &val);
     PlayerBufferExecCompleted(battler);


### PR DESCRIPTION
```
In function 'SetMonData',
    inlined from 'PlayerHandleStatusXor'
error: array subscript 1 is outside array bounds of 'u8[1]' {aka 'unsigned char[1]'} [-Werror=array-bounds=]
SET32_pokemon(mon->status);
```