### PR TITLE
Update Magic Guard paralysis config

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3504,7 +3504,7 @@ u8 AtkCanceller_UnableToUseMove(u32 moveType)
         case CANCELLER_PARALYSED: // paralysis
             if (!gBattleStruct->isAtkCancelerForCalledMove
              && gBattleMons[gBattlerAttacker].status1 & STATUS1_PARALYSIS
-             && (GetBattlerAbility(gBattlerAttacker) != ABILITY_MAGIC_GUARD && B_MAGIC_GUARD >= GEN_4)
+             && (GetBattlerAbility(gBattlerAttacker) != ABILITY_MAGIC_GUARD && B_MAGIC_GUARD == GEN_4)
              && !RandomPercentage(RNG_PARALYSIS, 75))
             {
                 gProtectStructs[gBattlerAttacker].prlzImmobility = TRUE;


### PR DESCRIPTION
> This config seems to be implemented incorrectly. Magic Guard only prevents immobilization of paralysis in gen 4. In gens 5 onward, it does not prevent immobilization of paralysis. [bulbapedia link](https://bulbapedia.bulbagarden.net/wiki/Magic_Guard_(Ability))

Quote from #5893