### PR TITLE
Remove out of bounds gSprites access in move relearner

### DIFF
--- a/src/move_relearner.c
+++ b/src/move_relearner.c
@@ -1007,7 +1007,6 @@ void MoveRelearnerShowHideCategoryIcon(s32 moveId)
             DestroySprite(&gSprites[sMoveRelearnerStruct->categoryIconSpriteId]);
 
         sMoveRelearnerStruct->categoryIconSpriteId = 0xFF;
-        gSprites[sMoveRelearnerStruct->categoryIconSpriteId].invisible = TRUE;
     }
     else
     {


### PR DESCRIPTION
`error: array subscript 255 is above array bounds of 'struct Sprite[65]' [-Werror=array-bounds=]`