### PR TITLE
Use gCurrentMove instead of checking FF move

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -5804,7 +5804,7 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
              && IsBattlerAlive(gBattlerAttacker))
             {
                 //special Future Sight handling
-                if (gMovesInfo[gWishFutureKnock.futureSightMove[battler]].effect == EFFECT_FUTURE_SIGHT)
+                if (gMovesInfo[gCurrentMove].effect == EFFECT_FUTURE_SIGHT)
                 {
                     //no Innards Out effect if Future Sight user is currently not on field
                     if (gWishFutureKnock.futureSightPartyIndex[gBattlerTarget] == gBattlerPartyIndexes[gBattlerAttacker]


### PR DESCRIPTION
This can potentially lead to a bug if the current move isn't a future sight move
