### PR TITLE
Explicitly specify dependencies for teachable learnset helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -426,8 +426,8 @@ $(OBJ_DIR)/sym_common.ld: sym_common.txt $(C_OBJS) $(wildcard common_syms/*.txt)
 $(OBJ_DIR)/sym_ewram.ld: sym_ewram.txt
 	$(RAMSCRGEN) ewram_data $< ENGLISH > $@
 
-# NOTE: Depending on event_scripts.o is hacky, but we want to depend on everything event_scripts.s depends on without having to alter scaninc
-$(DATA_SRC_SUBDIR)/pokemon/teachable_learnsets.h: $(DATA_ASM_BUILDDIR)/event_scripts.o
+TEACHABLE_DEPS := $(shell find data/ -type f -name '*.inc') $(INCLUDE_DIRS)/constants/tms_hms.h $(C_SUBDIR)/pokemon.c
+$(DATA_SRC_SUBDIR)/pokemon/teachable_learnsets.h: $(TEACHABLE_DEPS)
 	python3 $(TOOLS_DIR)/learnset_helpers/teachable.py
 
 # Linker script


### PR DESCRIPTION
## Description
Currently the teachable learnset helper depends on the event scripts file, which (as notated by the repo itself :) ) is hacky and produces misleading error messages like below any time there's an error in a scripts file:
```bash
make: *** No rule to make target 'build/modern/data/event_scripts.o', needed by 'src/data/pokemon/teachable_learnsets.h'.  Stop.
```

To address this, I've changed it so the learnset helper instead explicitly depends on all .inc files and the two other relevant files that affect it (`include/constants/tms_hms.h` and `src/pokemon.c`).

 Now only the relevant error message is included in the output:
 
 ```bash
 data/maps/LittlerootTown/scripts.inc: Assembler messages:
data/maps/LittlerootTown/scripts.inc:70: Error: bad instruction `foo'
make: *** [Makefile:411: build/modern/data/event_scripts.o] Error 1
```

In testing, this change did not significantly affect compile time in any way, and I confirmed that it works properly even when using poryscript to generate .inc files.

## **Discord contact info**
ravepossum
