### PR TITLE
Fixes defrosting if frozen mon is not damaged by opponent

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -5846,6 +5846,7 @@ static void Cmd_moveend(void)
             break;
         case MOVEEND_DEFROST: // defrosting check
             if (gBattleMons[gBattlerTarget].status1 & STATUS1_FREEZE
+                && TARGET_TURN_DAMAGED
                 && IsBattlerAlive(gBattlerTarget)
                 && gBattlerAttacker != gBattlerTarget
                 && (moveType == TYPE_FIRE || CanBurnHitThaw(gCurrentMove))

--- a/test/battle/status1/freeze.c
+++ b/test/battle/status1/freeze.c
@@ -44,7 +44,7 @@ SINGLE_BATTLE_TEST("Freeze is thawed by user's Flame Wheel")
     }
 }
 
-SINGLE_BATTLE_TEST("Freeze isn't thawed if opponent is asleept during thawing attack")
+SINGLE_BATTLE_TEST("Freeze isn't thawed if opponent is asleep during thawing attack")
 {
     PASSES_RANDOMLY(80, 100, RNG_FROZEN);
     GIVEN {

--- a/test/battle/status1/freeze.c
+++ b/test/battle/status1/freeze.c
@@ -43,3 +43,21 @@ SINGLE_BATTLE_TEST("Freeze is thawed by user's Flame Wheel")
         MESSAGE("Wobbuffet used Flame Wheel!");
     }
 }
+
+SINGLE_BATTLE_TEST("Freeze isn't thawed if opponent is asleept during thawing attack")
+{
+    PASSES_RANDOMLY(80, 100, RNG_FROZEN);
+    GIVEN {
+        ASSUME(GetMoveType(MOVE_EMBER) == TYPE_FIRE);
+        PLAYER(SPECIES_WOBBUFFET) { Status1(STATUS1_FREEZE); }
+        OPPONENT(SPECIES_WOBBUFFET) { Status1(STATUS1_SLEEP); };
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_EMBER); MOVE(player, MOVE_CELEBRATE); }
+    } SCENE {
+        NONE_OF {
+            MESSAGE("The opposing Wobbuffet used Ember!");
+            MESSAGE("Wobbuffet thawed out!");
+            STATUS_ICON(player, none: TRUE);
+        }
+    }
+}


### PR DESCRIPTION
## Description
Fixes defrosting if frozon mon is not damaged by opponent.

The solution hitmaker was discussed but `TARGET_TURN_DAMAGED` covers more cases. For example when opponent was able to use the move but was unable to hit due to accuracy. 

Also a test with paralysis didn't work but sleep should be the same in this case. 
 

## **People who collaborated with me in this PR**
@Pawkkie provided the test and @AsparagusEduardo found the moveend case 
