### PR TITLE
Add AI_FLAG_PREFER_HIGHEST_DAMAGE_MOVE

### DIFF
--- a/docs/tutorials/ai_flags.md
+++ b/docs/tutorials/ai_flags.md
@@ -168,3 +168,6 @@ AI will always switch out after a KO in exactly party order as defined in the tr
 
 ## `AI_FLAG_WEIGH_ABILITY_PREDICTION`
 AI will predict the player's ability based to its aiRating. Without this flag the AI randomly assumes an ability with an even distribution between all possible abilities until one is confirmed. With this flag, it instead guesses proportionally to each ability's aiRating, making it far more likely to guess an ability like Water Absorb than Damp if both are options.
+
+## `AI_FLAG_PREFER_HIGHEST_DAMAGE_MOVE`
+AI will add score to its highest damaging move, regardless of accuracy or secondary effects. Replaces deprecated `AI_FLAG_PREFER_STRONGEST_MOVE`.

--- a/include/constants/battle_ai.h
+++ b/include/constants/battle_ai.h
@@ -50,8 +50,9 @@
 #define AI_FLAG_SEQUENCE_SWITCHING          (1 << 19)  // AI switches in mons in exactly party order, and never switches mid-battle.
 #define AI_FLAG_DOUBLE_ACE_POKEMON          (1 << 20)  // AI has *two* Ace Pokémon. The last two Pokémons in the party won't be used unless they're the last ones remaining. Goes well in battles where the trainer ID equals to twins, couples, etc.
 #define AI_FLAG_WEIGH_ABILITY_PREDICTION    (1 << 21)  // AI will predict player's ability based on aiRating
+#define AI_FLAG_PREFER_HIGHEST_DAMAGE_MOVE  (1 << 22)  // AI adds score to highest damage move regardless of accuracy or secondary effect
 
-#define AI_FLAG_COUNT                       22
+#define AI_FLAG_COUNT                       23
 
 // The following options are enough to have a basic/smart trainer. Any other addtion could make the trainer worse/better depending on the flag
 #define AI_FLAG_BASIC_TRAINER         (AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY)

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -4701,7 +4701,8 @@ static s32 AI_CheckViability(u32 battlerAtk, u32 battlerDef, u32 move, s32 score
             ADJUST_AND_RETURN_SCORE(NO_DAMAGE_OR_FAILS); // No point in checking the move further so return early
         else
         {
-            if ((AI_THINKING_STRUCT->aiFlags[battlerAtk] & AI_FLAG_RISKY) && GetBestDmgMoveFromBattler(battlerAtk, battlerDef) == move)
+            if (((AI_THINKING_STRUCT->aiFlags[battlerAtk] & AI_FLAG_RISKY) || AI_THINKING_STRUCT->aiFlags[battlerAtk] & AI_FLAG_PREFER_HIGHEST_DAMAGE_MOVE)
+                && GetBestDmgMoveFromBattler(battlerAtk, battlerDef) == move)
                 ADJUST_SCORE(BEST_DAMAGE_MOVE);
             else
                 ADJUST_SCORE(AI_CompareDamagingMoves(battlerAtk, battlerDef, AI_THINKING_STRUCT->movesetIndex));

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -4701,7 +4701,7 @@ static s32 AI_CheckViability(u32 battlerAtk, u32 battlerDef, u32 move, s32 score
             ADJUST_AND_RETURN_SCORE(NO_DAMAGE_OR_FAILS); // No point in checking the move further so return early
         else
         {
-            if (((AI_THINKING_STRUCT->aiFlags[battlerAtk] & AI_FLAG_RISKY) || AI_THINKING_STRUCT->aiFlags[battlerAtk] & AI_FLAG_PREFER_HIGHEST_DAMAGE_MOVE)
+            if (AI_THINKING_STRUCT->aiFlags[battlerAtk] & (AI_FLAG_RISKY | AI_FLAG_PREFER_HIGHEST_DAMAGE_MOVE)
                 && GetBestDmgMoveFromBattler(battlerAtk, battlerDef) == move)
                 ADJUST_SCORE(BEST_DAMAGE_MOVE);
             else

--- a/test/battle/ai/ai_flag_risky.c
+++ b/test/battle/ai/ai_flag_risky.c
@@ -74,12 +74,13 @@ AI_SINGLE_BATTLE_TEST("AI_FLAG_RISKY: Mid-battle switches prioritize offensive o
     }
 }
 
-AI_SINGLE_BATTLE_TEST("AI_FLAG_RISKY: AI prefers high damage moves at the expense of accuracy regardless of KO thresholds")
+AI_SINGLE_BATTLE_TEST("AI_FLAG_RISKY | AI_FLAG_PREFER_HIGHEST_DAMAGE_MOVE: AI prefers high damage moves at the expense of accuracy regardless of KO thresholds")
 {
     u32 aiRiskyFlag = 0;
 
     PARAMETRIZE { aiRiskyFlag = 0; }
     PARAMETRIZE { aiRiskyFlag = AI_FLAG_RISKY; }
+    PARAMETRIZE { aiRiskyFlag = AI_FLAG_PREFER_HIGHEST_DAMAGE_MOVE; }
 
     GIVEN {
         AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | aiRiskyFlag);


### PR DESCRIPTION
## Description
Adds flag that prioritizes using the highest damage move regardless of accuracy or secondary effects. Replacing what would have been the theoretical behaviour of `AI_PREFER_STRONGEST_MOVE`, under a new name for clarity and to avoid shadow-changing the behaviour of that flag for existing users.

## Issue(s) that this PR fixes
Closes #5969 

## **Discord contact info**
@Pawkkie 
