### PR TITLE
fixed bug giving immunity to full-paralysis when B_MAGIC_GUARD is >= GEN_4

### DIFF
--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -156,7 +156,7 @@
                                                // In Gen3, Effect Spore has a 10% chance to sleep, poison or paralyze, with an equal chance.
                                                // In Gen4, it's 30%. In Gen5+ it has 11% to sleep, 9% chance to poison and 10% chance to paralyze.
 #define B_PICKUP_WILD               GEN_LATEST // In Gen9+, Pickup allows its user to pickup its own used item at the end of the turn in wild battles.
-#define B_MAGIC_GUARD               GEN_LATEST // In Gen4+, Magic Guard ignores immobilization caused by paralysis
+#define B_MAGIC_GUARD               GEN_LATEST // In Gen4 only, Magic Guard ignores immobilization caused by paralysis
 
 // Item settings
 #define B_HP_BERRIES                GEN_LATEST // In Gen4+, berries which restore HP activate immediately after HP drops to half. In Gen3, the effect occurs at the end of the turn.

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3507,21 +3507,15 @@ u8 AtkCanceller_UnableToUseMove(u32 moveType)
         case CANCELLER_PARALYSED: // paralysis
             if (!gBattleStruct->isAtkCancelerForCalledMove
              && gBattleMons[gBattlerAttacker].status1 & STATUS1_PARALYSIS
+             && !(B_MAGIC_GUARD >= GEN_4 && GetBattlerAbility(gBattlerAttacker) == ABILITY_MAGIC_GUARD)
              && !RandomPercentage(RNG_PARALYSIS, 75))
             {
-                if (GetBattlerAbility(gBattlerAttacker) == ABILITY_MAGIC_GUARD && B_MAGIC_GUARD >= GEN_4)
-                {
-                    // Don't get fully paralyzed
-                }
-                else
-                {
-                    gProtectStructs[gBattlerAttacker].prlzImmobility = TRUE;
-                    // This is removed in FRLG and Emerald for some reason
-                    //CancelMultiTurnMoves(gBattlerAttacker);
-                    gBattlescriptCurrInstr = BattleScript_MoveUsedIsParalyzed;
-                    gHitMarker |= HITMARKER_UNABLE_TO_USE_MOVE;
-                    effect = 1;
-                }
+                gProtectStructs[gBattlerAttacker].prlzImmobility = TRUE;
+                // This is removed in FRLG and Emerald for some reason
+                //CancelMultiTurnMoves(gBattlerAttacker);
+                gBattlescriptCurrInstr = BattleScript_MoveUsedIsParalyzed;
+                gHitMarker |= HITMARKER_UNABLE_TO_USE_MOVE;
+                effect = 1;
             }
             gBattleStruct->atkCancellerTracker++;
             break;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3507,7 +3507,7 @@ u8 AtkCanceller_UnableToUseMove(u32 moveType)
         case CANCELLER_PARALYSED: // paralysis
             if (!gBattleStruct->isAtkCancelerForCalledMove
              && gBattleMons[gBattlerAttacker].status1 & STATUS1_PARALYSIS
-             && !(B_MAGIC_GUARD >= GEN_4 && GetBattlerAbility(gBattlerAttacker) == ABILITY_MAGIC_GUARD)
+             && !(B_MAGIC_GUARD == GEN_4 && GetBattlerAbility(gBattlerAttacker) == ABILITY_MAGIC_GUARD)
              && !RandomPercentage(RNG_PARALYSIS, 75))
             {
                 gProtectStructs[gBattlerAttacker].prlzImmobility = TRUE;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3507,15 +3507,21 @@ u8 AtkCanceller_UnableToUseMove(u32 moveType)
         case CANCELLER_PARALYSED: // paralysis
             if (!gBattleStruct->isAtkCancelerForCalledMove
              && gBattleMons[gBattlerAttacker].status1 & STATUS1_PARALYSIS
-             && (GetBattlerAbility(gBattlerAttacker) != ABILITY_MAGIC_GUARD && B_MAGIC_GUARD >= GEN_4)
              && !RandomPercentage(RNG_PARALYSIS, 75))
             {
-                gProtectStructs[gBattlerAttacker].prlzImmobility = TRUE;
-                // This is removed in FRLG and Emerald for some reason
-                //CancelMultiTurnMoves(gBattlerAttacker);
-                gBattlescriptCurrInstr = BattleScript_MoveUsedIsParalyzed;
-                gHitMarker |= HITMARKER_UNABLE_TO_USE_MOVE;
-                effect = 1;
+                if (GetBattlerAbility(gBattlerAttacker) == ABILITY_MAGIC_GUARD && B_MAGIC_GUARD >= GEN_4)
+                {
+                    // Don't get fully paralyzed
+                }
+                else
+                {
+                    gProtectStructs[gBattlerAttacker].prlzImmobility = TRUE;
+                    // This is removed in FRLG and Emerald for some reason
+                    //CancelMultiTurnMoves(gBattlerAttacker);
+                    gBattlescriptCurrInstr = BattleScript_MoveUsedIsParalyzed;
+                    gHitMarker |= HITMARKER_UNABLE_TO_USE_MOVE;
+                    effect = 1;
+                }
             }
             gBattleStruct->atkCancellerTracker++;
             break;

--- a/test/battle/ability/magic_guard.c
+++ b/test/battle/ability/magic_guard.c
@@ -18,7 +18,7 @@ SINGLE_BATTLE_TEST("Magic Guard prevents recoil damage to the user")
 
 SINGLE_BATTLE_TEST("Magic Guard ignores immobilization that can be caused by paralysis")
 {
-    if (B_MAGIC_GUARD >= GEN_4)
+    if (B_MAGIC_GUARD == GEN_4)
         PASSES_RANDOMLY(1, 1, RNG_PARALYSIS);
     else
         PASSES_RANDOMLY(75, 100, RNG_PARALYSIS);


### PR DESCRIPTION
## Description

This should fix a bug reproducible by setting `B_MAGIC_GUARD` to `GEN_3` or lower.

My approach isn't ideal as `RNG_PARALYSIS` will now needlessly roll, but I wrote this fix for personal use and figured it couldn't hurt.

Feel free to test.

## **disc**
47929991024