### PR TITLE
Fix Match Call Behavior (#5931)

### DIFF
--- a/src/battle_setup.c
+++ b/src/battle_setup.c
@@ -1742,8 +1742,8 @@ static bool32 UpdateRandomTrainerRematches(const struct RematchTrainer *table, u
 
     for (i = 0; i <= REMATCH_SPECIAL_TRAINER_START; i++)
     {
-        if (DoesCurrentMapMatchRematchTrainerMap(i,table,mapGroup,mapNum) && !IsRematchForbidden(i))
-            continue;
+        if (!DoesCurrentMapMatchRematchTrainerMap(i,table,mapGroup,mapNum) || IsRematchForbidden(i))
+            continue; // Only check permitted trainers within the current map.
 
         if (gSaveBlock1Ptr->trainerRematches[i] != 0)
         {


### PR DESCRIPTION
Match Call now attempts to rematch NPC trainers _within_ the current map, rather than outside of it. This is a straight-up bugfix and returning to original Emerald behavior.

This change cannot affect Vs Seeker functionality in any way.

Fixes #5931.

You can find me on Discord at `mercycle`. I am in the RH Hideout Discord.
