### PR TITLE
Add known failing learnset cap test

### DIFF
--- a/include/constants/pokemon.h
+++ b/include/constants/pokemon.h
@@ -169,6 +169,7 @@
 #define LEVEL_UP_MOVE_END  0xFFFF
 
 #define MAX_LEVEL_UP_MOVES       20
+#define MAX_RELEARNER_MOVES      max(MAX_LEVEL_UP_MOVES, 25)
 
 #define MON_MALE       0x00
 #define MON_FEMALE     0xFE

--- a/src/move_relearner.c
+++ b/src/move_relearner.c
@@ -160,8 +160,6 @@ enum {
 #define GFXTAG_UI       5525
 #define PALTAG_UI       5526
 
-#define MAX_RELEARNER_MOVES max(MAX_LEVEL_UP_MOVES, 25)
-
 static EWRAM_DATA struct
 {
     u8 state;

--- a/test/pokemon.c
+++ b/test/pokemon.c
@@ -399,3 +399,23 @@ TEST("createmon [simple]")
     EXPECT_EQ(GetMonData(&gEnemyParty[1], MON_DATA_SPECIES), SPECIES_WYNAUT);
     EXPECT_EQ(GetMonData(&gEnemyParty[1], MON_DATA_LEVEL), 10);
 }
+
+TEST("Pokémon level up learnsets fit within MAX_LEVEL_UP_MOVES and MAX_RELEARNER_MOVES")
+{
+    KNOWN_FAILING;
+
+    u32 j, count, species = 0;
+    const struct LevelUpMove *learnset;
+
+    for(j = 0; j < SPECIES_EGG; j++)
+    {
+        PARAMETRIZE { species = j; }
+    }
+
+    learnset = GetSpeciesLevelUpLearnset(species);
+    count = 0;
+    for (j = 0; learnset[j].move != LEVEL_UP_MOVE_END; j++)
+        count++;
+    EXPECT_LT(count, MAX_LEVEL_UP_MOVES);
+    EXPECT_LT(count, MAX_RELEARNER_MOVES - 1); // - 1 because at least one move is already known
+}


### PR DESCRIPTION
Adds a known failing test that proves #5633 and moves `MAX_RELEARNER_MOVES` for that purpose outside of the move relearner file.

#5633 refers to `MAX_LEVEL_UP_MOVES` and `MAX_RELEARNER_MOVES` being too low for the level up learnsets that come preshipped with expansion, leading to unexpected behaviour. Both defines are actively used in EWRAM context (`MAX_RELEARNER_MOVES` natively, which is why it's capped, and `MAX_LEVEL_UP_MOVES` in the HGSS dex), so enlarging them comes with memory consequences that need to be carefully reviewed. This PR does not include a fix, only a test that will prove that a hypothetical fix is correct.

## **Discord contact info**
bassoonian
