### PR TITLE
Fixes large battle messages being cut off instead of being prompted to advance

### DIFF
--- a/src/battle_message.c
+++ b/src/battle_message.c
@@ -3153,7 +3153,7 @@ u32 BattleStringExpandPlaceholders(const u8 *src, u8 *dst, u32 dstSize)
     dst[dstID] = *src;
     dstID++;
 
-    BreakStringAutomatic(dst, BATTLE_MSG_MAX_WIDTH, BATTLE_MSG_MAX_WIDTH, fontId);
+    BreakStringAutomatic(dst, BATTLE_MSG_MAX_WIDTH, BATTLE_MSG_MAX_LINES, fontId);
 
     return dstID;
 }


### PR DESCRIPTION
Fixes battle messages' line breaks/scroll prompts being generated with the wrong amount of `maxLines`/`screenLines`, causing large messages to be cut off instead of prompting the user to scroll the message.

Current behavior:

https://github.com/user-attachments/assets/0c59877a-1aa3-4978-a250-4368891dda5d


With the fix:

https://github.com/user-attachments/assets/e7e50837-4010-4d52-944d-57ed0e4f0bc2



## **Discord contact info**
PhallenTree
