### PR TITLE
Revert map related enum conversion

### DIFF
--- a/include/constants/map_types.h
+++ b/include/constants/map_types.h
@@ -1,6 +1,19 @@
 #ifndef GUARD_CONSTANTS_MAP_TYPES_H
 #define GUARD_CONSTANTS_MAP_TYPES_H
 
+#define MAP_TYPE_NONE 0
+#define MAP_TYPE_TOWN 1
+#define MAP_TYPE_CITY 2
+#define MAP_TYPE_ROUTE 3
+#define MAP_TYPE_UNDERGROUND 4
+#define MAP_TYPE_UNDERWATER 5
+#define MAP_TYPE_OCEAN_ROUTE 6
+#define MAP_TYPE_UNKNOWN 7 // Not used by any map.
+#define MAP_TYPE_INDOOR 8
+#define MAP_TYPE_SECRET_BASE 9
+
+//  Commented out until the release of Porymap 6
+/*
 enum MapType
 {
     MAP_TYPE_NONE,
@@ -14,6 +27,7 @@ enum MapType
     MAP_TYPE_INDOOR,
     MAP_TYPE_SECRET_BASE,
 };
+*/
 
 enum MapBattleScene
 {

--- a/include/overworld.h
+++ b/include/overworld.h
@@ -118,13 +118,24 @@ void TryFadeOutOldMapMusic(void);
 bool8 BGMusicStopped(void);
 void Overworld_FadeOutMapMusic(void);
 void UpdateAmbientCry(s16 *state, u16 *delayCounter);
+/*
 enum MapType GetMapTypeByGroupAndId(s8 mapGroup, s8 mapNum);
 enum MapType GetMapTypeByWarpData(struct WarpData *warp);
 enum MapType GetCurrentMapType(void);
 enum MapType GetLastUsedWarpMapType(void);
+*/
+u8 GetMapTypeByGroupAndId(s8 mapGroup, s8 mapNum);
+u8 GetMapTypeByWarpData(struct WarpData *warp);
+u8 GetCurrentMapType(void);
+u8 GetLastUsedWarpMapType(void);
+bool8 IsMapTypeOutdoors(u8 mapType);
+bool8 Overworld_MapTypeAllowsTeleportAndFly(u8 mapType);
+bool8 IsMapTypeIndoors(u8 mapType);
+/*
 bool8 IsMapTypeOutdoors(enum MapType mapType);
 bool8 Overworld_MapTypeAllowsTeleportAndFly(enum MapType mapType);
 bool8 IsMapTypeIndoors(enum MapType mapType);
+*/
 u8 GetSavedWarpRegionMapSectionId(void);
 u8 GetCurrentRegionMapSectionId(void);
 enum MapBattleScene GetCurrentMapBattleScene(void);

--- a/src/dexnav.c
+++ b/src/dexnav.c
@@ -612,7 +612,8 @@ static bool8 DexNavPickTile(u8 environment, u8 areaX, u8 areaY, bool8 smallScan)
     bool8 nextIter;
     u8 scale = 0;
     u8 weight = 0;
-    enum MapType currMapType = GetCurrentMapType();
+    //enum MapType currMapType = GetCurrentMapType();
+    u8 currMapType = GetCurrentMapType();
     u8 tileBehaviour;
     u8 tileBuffer = 2;
     u8 *xPos = AllocZeroed((botX - topX) * (botY - topY) * sizeof(u8));
@@ -724,7 +725,8 @@ static bool8 DexNavPickTile(u8 environment, u8 areaX, u8 areaY, bool8 smallScan)
 
 static bool8 TryStartHiddenMonFieldEffect(u8 environment, u8 xSize, u8 ySize, bool8 smallScan)
 {
-    enum MapType currMapType = GetCurrentMapType();
+    //enum MapType currMapType = GetCurrentMapType();
+    u8 currMapType = GetCurrentMapType();
     u8 fldEffId = 0;
     
     if (DexNavPickTile(environment, xSize, ySize, smallScan))

--- a/src/field_screen_effect.c
+++ b/src/field_screen_effect.c
@@ -86,7 +86,8 @@ static void FillPalBufferBlack(void)
 
 void WarpFadeInScreen(void)
 {
-    enum MapType previousMapType = GetLastUsedWarpMapType();
+    //enum MapType previousMapType = GetLastUsedWarpMapType();
+    u8 previousMapType = GetLastUsedWarpMapType();
     switch (GetMapPairFadeFromType(previousMapType, GetCurrentMapType()))
     {
     case 0:
@@ -113,7 +114,8 @@ void FadeInFromBlack(void)
 
 void WarpFadeOutScreen(void)
 {
-    enum MapType currentMapType = GetCurrentMapType();
+    //enum MapType currentMapType = GetCurrentMapType();
+    u8 currentMapType = GetCurrentMapType();
     switch (GetMapPairFadeToType(currentMapType, GetDestinationWarpMapHeader()->mapType))
     {
     case 0:

--- a/src/fldeff_flash.c
+++ b/src/fldeff_flash.c
@@ -153,8 +153,12 @@ void CB2_DoChangeMap(void)
 static bool8 TryDoMapTransition(void)
 {
     u8 i;
+    /*
     enum MapType fromType = GetLastUsedWarpMapType();
     enum MapType toType = GetCurrentMapType();
+    */
+    u8 fromType = GetLastUsedWarpMapType();
+    u8 toType = GetCurrentMapType();
 
     for (i = 0; sTransitionTypes[i].fromType; i++)
     {

--- a/src/item_use.c
+++ b/src/item_use.c
@@ -1471,7 +1471,8 @@ static bool32 IsValidLocationForVsSeeker(void)
 {
     u16 mapGroup = gSaveBlock1Ptr->location.mapGroup;
     u16 mapNum = gSaveBlock1Ptr->location.mapNum;
-    enum MapType mapType = gMapHeader.mapType;
+    //enum MapType mapType = gMapHeader.mapType;
+    u8 mapType = gMapHeader.mapType;
 
     typedef struct {
         u16 mapGroup;

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -172,8 +172,12 @@ static void SetKeyInterceptCallback(u16 (*func)(u32));
 static void SetFieldVBlankCallback(void);
 static void FieldClearVBlankHBlankCallbacks(void);
 static void TransitionMapMusic(void);
+/*
 static u8 GetAdjustedInitialTransitionFlags(struct InitialPlayerAvatarState *playerStruct, u16 metatileBehavior, enum MapType mapType);
 static u8 GetAdjustedInitialDirection(struct InitialPlayerAvatarState *playerStruct, u8 transitionFlags, u16 metatileBehavior, enum MapType mapType);
+*/
+static u8 GetAdjustedInitialTransitionFlags(struct InitialPlayerAvatarState *playerStruct, u16 metatileBehavior, u8 mapType);
+static u8 GetAdjustedInitialDirection(struct InitialPlayerAvatarState *playerStruct, u8 transitionFlags, u16 metatileBehavior, u8 mapType);
 static u16 GetCenterScreenMetatileBehavior(void);
 
 static void *sUnusedOverworldCallback;
@@ -718,8 +722,12 @@ void SetLastHealLocationWarp(u8 healLocationId)
 
 void UpdateEscapeWarp(s16 x, s16 y)
 {
+    /*
     enum MapType currMapType = GetCurrentMapType();
     enum MapType destMapType = GetMapTypeByGroupAndId(sWarpDestination.mapGroup, sWarpDestination.mapNum);
+    */
+    u8 currMapType = GetCurrentMapType();
+    u8 destMapType = GetMapTypeByGroupAndId(sWarpDestination.mapGroup, sWarpDestination.mapNum);
     if (IsMapTypeOutdoors(currMapType) && IsMapTypeOutdoors(destMapType) != TRUE)
         SetEscapeWarp(gSaveBlock1Ptr->location.mapGroup, gSaveBlock1Ptr->location.mapNum, WARP_ID_NONE, x - MAP_OFFSET, y - MAP_OFFSET + 1);
 }
@@ -964,7 +972,8 @@ void StoreInitialPlayerAvatarState(void)
 static struct InitialPlayerAvatarState *GetInitialPlayerAvatarState(void)
 {
     struct InitialPlayerAvatarState playerStruct;
-    enum MapType mapType = GetCurrentMapType();
+    u8 mapType = GetCurrentMapType();
+    //enum MapType mapType = GetCurrentMapType();
     u16 metatileBehavior = GetCenterScreenMetatileBehavior();
     u8 transitionFlags = GetAdjustedInitialTransitionFlags(&sInitialPlayerAvatarState, metatileBehavior, mapType);
     playerStruct.transitionFlags = transitionFlags;
@@ -973,7 +982,8 @@ static struct InitialPlayerAvatarState *GetInitialPlayerAvatarState(void)
     return &sInitialPlayerAvatarState;
 }
 
-static u8 GetAdjustedInitialTransitionFlags(struct InitialPlayerAvatarState *playerStruct, u16 metatileBehavior, enum MapType mapType)
+//static u8 GetAdjustedInitialTransitionFlags(struct InitialPlayerAvatarState *playerStruct, u16 metatileBehavior, enum MapType mapType)
+static u8 GetAdjustedInitialTransitionFlags(struct InitialPlayerAvatarState *playerStruct, u16 metatileBehavior, u8 mapType)
 {
     if (mapType != MAP_TYPE_INDOOR && FlagGet(FLAG_SYS_CRUISE_MODE))
         return PLAYER_AVATAR_FLAG_ON_FOOT;
@@ -991,7 +1001,8 @@ static u8 GetAdjustedInitialTransitionFlags(struct InitialPlayerAvatarState *pla
         return PLAYER_AVATAR_FLAG_ACRO_BIKE;
 }
 
-static u8 GetAdjustedInitialDirection(struct InitialPlayerAvatarState *playerStruct, u8 transitionFlags, u16 metatileBehavior, enum MapType mapType)
+//static u8 GetAdjustedInitialDirection(struct InitialPlayerAvatarState *playerStruct, u8 transitionFlags, u16 metatileBehavior, enum MapType mapType)
+static u8 GetAdjustedInitialDirection(struct InitialPlayerAvatarState *playerStruct, u8 transitionFlags, u16 metatileBehavior, u8 mapType)
 {
     if (FlagGet(FLAG_SYS_CRUISE_MODE) && mapType == MAP_TYPE_OCEAN_ROUTE)
         return DIR_EAST;
@@ -1400,27 +1411,32 @@ static void ChooseAmbientCrySpecies(void)
     }
 }
 
-enum MapType GetMapTypeByGroupAndId(s8 mapGroup, s8 mapNum)
+//enum MapType GetMapTypeByGroupAndId(s8 mapGroup, s8 mapNum)
+u8 GetMapTypeByGroupAndId(s8 mapGroup, s8 mapNum)
 {
     return Overworld_GetMapHeaderByGroupAndId(mapGroup, mapNum)->mapType;
 }
 
-enum MapType GetMapTypeByWarpData(struct WarpData *warp)
+//enum MapType GetMapTypeByWarpData(struct WarpData *warp)
+u8 GetMapTypeByWarpData(struct WarpData *warp)
 {
     return GetMapTypeByGroupAndId(warp->mapGroup, warp->mapNum);
 }
 
-enum MapType GetCurrentMapType(void)
+//enum MapType GetCurrentMapType(void)
+u8 GetCurrentMapType(void)
 {
     return GetMapTypeByWarpData(&gSaveBlock1Ptr->location);
 }
 
-enum MapType GetLastUsedWarpMapType(void)
+//enum MapType GetLastUsedWarpMapType(void)
+u8 GetLastUsedWarpMapType(void)
 {
     return GetMapTypeByWarpData(&gLastUsedWarp);
 }
 
-bool8 IsMapTypeOutdoors(enum MapType mapType)
+//bool8 IsMapTypeOutdoors(enum MapType mapType)
+bool8 IsMapTypeOutdoors(u8 mapType)
 {
     if (mapType == MAP_TYPE_ROUTE
      || mapType == MAP_TYPE_TOWN
@@ -1432,7 +1448,8 @@ bool8 IsMapTypeOutdoors(enum MapType mapType)
         return FALSE;
 }
 
-bool8 Overworld_MapTypeAllowsTeleportAndFly(enum MapType mapType)
+//bool8 Overworld_MapTypeAllowsTeleportAndFly(enum MapType mapType)
+bool8 Overworld_MapTypeAllowsTeleportAndFly(u8 mapType)
 {
     if (mapType == MAP_TYPE_ROUTE
      || mapType == MAP_TYPE_TOWN
@@ -1443,7 +1460,8 @@ bool8 Overworld_MapTypeAllowsTeleportAndFly(enum MapType mapType)
         return FALSE;
 }
 
-bool8 IsMapTypeIndoors(enum MapType mapType)
+//bool8 IsMapTypeIndoors(enum MapType mapType)
+bool8 IsMapTypeIndoors(u8 mapType)
 {
     if (mapType == MAP_TYPE_INDOOR
      || mapType == MAP_TYPE_SECRET_BASE)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Before submitting, please make sure your pull request meets the scope guidelines. If unsure, please open a thread in #pr-discussions.-->
<!--- Scope Guidelines: https://github.com/rh-hideout/pokeemerald-expansion/blob/master/docs/team_procedures/scope.md  -->
<!--- #pr-discussions:  https://discord.com/channels/419213663107416084/1102784418369785948 -->

## Description
<!--- Describe your changes in detail -->
<!--- If you believe this PR qualifies as a "Big Feature" as defined in docs/team_procedures/schedule.md, please let a Maintainer know! -->
Current version of Porymap doesn't support `enum` variables. This reverts a change of some map variables to `enum`s while leaving the `enum` implementation commented out.

## **Discord contact info**
<!--- Formatted as username (e.g. Lunos) or username#numbers (e.g. Lunos#4026) -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara