### PR TITLE
Fixed Liquid Voice's dynamic type for normal moves 

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -6028,30 +6028,30 @@ u32 GetDynamicMoveType(struct Pokemon *mon, u32 move, u32 battler, u8 *ateBoost)
         break;
     }
 
-    if (moveType == TYPE_NORMAL
-     && ((!gMain.inBattle || TrySetAteType(move, battler, ability))
-     && GetActiveGimmick(battler) != GIMMICK_DYNAMAX))
-    {
-        if (gMain.inBattle && ateBoost != NULL)
-            *ateBoost = TRUE;
-    }
-    else if (moveType != TYPE_NORMAL
-          && moveEffect != EFFECT_HIDDEN_POWER
-          && moveEffect != EFFECT_WEATHER_BALL
-          && ability == ABILITY_NORMALIZE
-          && GetActiveGimmick(battler) != GIMMICK_Z_MOVE)
-    {
-        if (gMain.inBattle && ateBoost != NULL && GetActiveGimmick(battler) != GIMMICK_DYNAMAX)
-            *ateBoost = TRUE;
-        return TYPE_NORMAL;
-    }
-    else if (gMovesInfo[move].soundMove && ability == ABILITY_LIQUID_VOICE)
+    if (IsSoundMove(move) && ability == ABILITY_LIQUID_VOICE)
     {
         return TYPE_WATER;
     }
     else if (moveEffect == EFFECT_AURA_WHEEL && species == SPECIES_MORPEKO_HANGRY)
     {
         return TYPE_DARK;
+    }
+    else if (moveType == TYPE_NORMAL
+        && ((!gMain.inBattle || TrySetAteType(move, battler, ability))
+        && GetActiveGimmick(battler) != GIMMICK_DYNAMAX))
+    {
+        if (gMain.inBattle && ateBoost != NULL)
+            *ateBoost = TRUE;
+    }
+    else if (moveType != TYPE_NORMAL
+        && moveEffect != EFFECT_HIDDEN_POWER
+        && moveEffect != EFFECT_WEATHER_BALL
+        && ability == ABILITY_NORMALIZE
+        && GetActiveGimmick(battler) != GIMMICK_Z_MOVE)
+    {
+        if (gMain.inBattle && ateBoost != NULL && GetActiveGimmick(battler) != GIMMICK_DYNAMAX)
+            *ateBoost = TRUE;
+        return TYPE_NORMAL;
     }
 
     return TYPE_NONE;

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -6028,7 +6028,7 @@ u32 GetDynamicMoveType(struct Pokemon *mon, u32 move, u32 battler, u8 *ateBoost)
         break;
     }
 
-    if (IsSoundMove(move) && ability == ABILITY_LIQUID_VOICE)
+    if (gMovesInfo[move].soundMove && ability == ABILITY_LIQUID_VOICE)
     {
         return TYPE_WATER;
     }

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -6037,17 +6037,17 @@ u32 GetDynamicMoveType(struct Pokemon *mon, u32 move, u32 battler, u8 *ateBoost)
         return TYPE_DARK;
     }
     else if (moveType == TYPE_NORMAL
-        && ((!gMain.inBattle || TrySetAteType(move, battler, ability))
-        && GetActiveGimmick(battler) != GIMMICK_DYNAMAX))
+          && ((!gMain.inBattle || TrySetAteType(move, battler, ability))
+          && GetActiveGimmick(battler) != GIMMICK_DYNAMAX))
     {
         if (gMain.inBattle && ateBoost != NULL)
             *ateBoost = TRUE;
     }
     else if (moveType != TYPE_NORMAL
-        && moveEffect != EFFECT_HIDDEN_POWER
-        && moveEffect != EFFECT_WEATHER_BALL
-        && ability == ABILITY_NORMALIZE
-        && GetActiveGimmick(battler) != GIMMICK_Z_MOVE)
+          && moveEffect != EFFECT_HIDDEN_POWER
+          && moveEffect != EFFECT_WEATHER_BALL
+          && ability == ABILITY_NORMALIZE
+          && GetActiveGimmick(battler) != GIMMICK_Z_MOVE)
     {
         if (gMain.inBattle && ateBoost != NULL && GetActiveGimmick(battler) != GIMMICK_DYNAMAX)
             *ateBoost = TRUE;

--- a/test/battle/ability/liquid_voice.c
+++ b/test/battle/ability/liquid_voice.c
@@ -1,0 +1,21 @@
+#include "global.h"
+#include "test/battle.h"
+
+ASSUMPTIONS
+{
+    ASSUME(GetMoveType(MOVE_HYPER_VOICE) == TYPE_NORMAL);
+    ASSUME(GetMovePower(MOVE_HYPER_VOICE) > 0);
+}
+
+SINGLE_BATTLE_TEST("Liquid voice turns a sound move into a Water-type move")
+{
+    GIVEN {
+        PLAYER(SPECIES_TYPHLOSION);
+        OPPONENT(SPECIES_PRIMARINA) { Ability(ABILITY_LIQUID_VOICE); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_HYPER_VOICE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_HYPER_VOICE, opponent);
+        MESSAGE("It's super effective!");
+    }
+}

--- a/test/battle/ability/liquid_voice.c
+++ b/test/battle/ability/liquid_voice.c
@@ -3,8 +3,8 @@
 
 ASSUMPTIONS
 {
-    ASSUME(GetMoveType(MOVE_HYPER_VOICE) == TYPE_NORMAL);
-    ASSUME(GetMovePower(MOVE_HYPER_VOICE) > 0);
+    ASSUME(gMovesInfo[MOVE_HYPER_VOICE].type == TYPE_NORMAL);
+    ASSUME(gMovesInfo[MOVE_HYPER_VOICE].power > 0);
 }
 
 SINGLE_BATTLE_TEST("Liquid voice turns a sound move into a Water-type move")


### PR DESCRIPTION
## Description
Reordered some steps in `GetDynamicMoveType` so that Normal-type sound moves would show the correct dynamic type outside of battle if affected by Liquid Voice

## Issue(s) that this PR fixes
Fixes #6091 

## **Discord contact info**
Frankfurter0
