### PR TITLE
Fixed Hoenn dex off by 1 issues

### DIFF
--- a/src/pokedex.c
+++ b/src/pokedex.c
@@ -4539,7 +4539,7 @@ u16 GetHoennPokedexCount(u8 caseID)
     u16 count = 0;
     u16 i;
 
-    for (i = 0; i < HOENN_DEX_COUNT; i++)
+    for (i = 0; i < HOENN_DEX_COUNT - 1; i++)
     {
         switch (caseID)
         {
@@ -4582,7 +4582,7 @@ bool16 HasAllHoennMons(void)
 {
     u32 i, j;
 
-    for (i = 0; i < HOENN_DEX_COUNT; i++)
+    for (i = 0; i < HOENN_DEX_COUNT - 1; i++)
     {
         j = HoennToNationalOrder(i + 1);
         if (!(gSpeciesInfo[j].isMythical && !gSpeciesInfo[j].dexForceRequired) && !GetSetPokedexFlag(j, FLAG_GET_CAUGHT))


### PR DESCRIPTION
## Description
Changed two for loops to end at `HOENN_DEX_COUNT - 1` instead of `HOENN_DEX_COUNT`

One of these fixes the Hoenn Dex's owned off by 1 error, the other allows HasAllHoennMons to work correctly

## Issue(s) that this PR fixes
Fixes #6103 

## **Discord contact info**
Frankfurter
