### PR TITLE
Fixed OBJ_EVENT_GFX_SPECIES_SHINY and Swinub/Piloswine sprites

### DIFF
--- a/include/field_weather.h
+++ b/include/field_weather.h
@@ -4,7 +4,7 @@
 #include "sprite.h"
 #include "constants/field_weather.h"
 
-#define TAG_WEATHER_START 0x1200
+#define TAG_WEATHER_START 0x1FF // 511 (changed from 0x1200, to avoid conflicting with OW mon palette tags)
 enum {
     GFXTAG_CLOUD = TAG_WEATHER_START,
     GFXTAG_FOG_H,

--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -2899,7 +2899,7 @@ const struct ObjectEventGraphicsInfo *GetObjectEventGraphicsInfo(u16 graphicsId)
     if (graphicsId > OBJ_EVENT_GFX_SPECIES_MASK)
     {
         form = graphicsId >> OBJ_EVENT_GFX_SPECIES_BITS;
-        graphicsId = graphicsId & OBJ_EVENT_GFX_SPECIES_MASK;
+        graphicsId = (graphicsId - (graphicsId >= OBJ_EVENT_GFX_MON_BASE + SPECIES_SHINY_TAG ? SPECIES_SHINY_TAG : 0)) & OBJ_EVENT_GFX_SPECIES_MASK;
     }
 
     if (graphicsId == OBJ_EVENT_GFX_BARD)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Before submitting, please make sure your pull request meets the scope guidelines. If unsure, please open a thread in #pr-discussions.-->
<!--- Scope Guidelines: https://github.com/rh-hideout/pokeemerald-expansion/blob/master/docs/team_procedures/scope.md  -->
<!--- #pr-discussions:  https://discord.com/channels/419213663107416084/1102784418369785948 -->

## Description
Supersedes #5953

## Images
### Before vs after
![image](https://github.com/user-attachments/assets/ab39b373-1e49-4f4e-afd2-450af19f4f46) ![image](https://github.com/user-attachments/assets/8e65253a-80c7-47e4-8958-cf9635c9937b)
![image](https://github.com/user-attachments/assets/f7e38f73-8794-4454-9fc0-3d45b98c1e21) ![image](https://github.com/user-attachments/assets/939cc409-9148-42f8-ab5c-b05bd08b427f)
![mGBA_TLce6JAS5g](https://github.com/user-attachments/assets/2d514f6e-cf75-4bba-a30d-a0fda249a456) ![mGBA_GkZN0URNqU](https://github.com/user-attachments/assets/1ed2c6bb-980a-4cb8-8968-ab5a07e07191)
![image](https://github.com/user-attachments/assets/12afe090-5373-4910-82c5-7dc260f84adc) ![image](https://github.com/user-attachments/assets/20120169-5b67-4579-8a14-104e29f5f696)
### Checking weather to make sure that it wasn't broken
![mGBA_JkrIDT25pA](https://github.com/user-attachments/assets/6403456d-baa5-4e5c-90d0-180b4d899cc2)
### Bulbasaur as a control variable
![image](https://github.com/user-attachments/assets/9288c2f0-095e-4f4f-8f8d-f1da43a201f9) ![image](https://github.com/user-attachments/assets/141b210b-2be6-4ab8-8990-e2ba26ccca8a)

## Issue(s) that this PR fixes
Fixes #5683, fixes #5147

## **People who collaborated with me in this PR**
@hedara90

## **Discord contact info**
AspargusEduardo
