### PR TITLE
AI adds score to Pursuit if it OHKOs

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -787,7 +787,11 @@ static bool32 AI_IsMoveEffectInPlus(u32 battlerAtk, u32 battlerDef, u32 move, s3
             return TRUE;
         break;
     case EFFECT_FELL_STINGER:
-        if (BattlerStatCanRise(battlerAtk, abilityAtk, STAT_ATK))
+        if (BattlerStatCanRise(battlerAtk, abilityAtk, STAT_ATK) && noOfHitsToKo == 1)
+            return TRUE;
+        break;
+    case EFFECT_PURSUIT:
+        if(noOfHitsToKo == 1)
             return TRUE;
         break;
     }

--- a/test/battle/ai/ai_check_viability.c
+++ b/test/battle/ai/ai_check_viability.c
@@ -254,3 +254,16 @@ AI_DOUBLE_BATTLE_TEST("AI prioritizes Skill Swapping Contrary to allied mons tha
         TURN { EXPECT_MOVE(opponentLeft, MOVE_SKILL_SWAP, target:opponentRight); EXPECT_MOVE(opponentRight, MOVE_OVERHEAT); }
     }
 }
+
+AI_SINGLE_BATTLE_TEST("AI prioritizes Pursuit if it would KO opponent")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_PURSUIT) == EFFECT_PURSUIT);
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY);
+        PLAYER(SPECIES_ESPEON) { Level(5); }
+        PLAYER(SPECIES_TYRANITAR);
+        OPPONENT(SPECIES_TYRANITAR) { Moves(MOVE_CRUNCH, MOVE_PURSUIT); }
+    } WHEN {
+        TURN { SWITCH(player, 1); EXPECT_MOVE(opponent, MOVE_PURSUIT); SEND_OUT(player, 1); }
+    }
+}


### PR DESCRIPTION
## Description
This was talked about on Discord this morning, that the AI should associate a positive effect with using Pursuit if it OHKOs the player so they can't switch to get out of it. Also fixes Fell Stinger not looking for a OHKO before getting a bonus.

## **Discord contact info**
@Pawkkie 
