### PR TITLE
Prevent sameMoveTurns from incrementing when unable to use move

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -6744,7 +6744,7 @@ static void Cmd_moveend(void)
             gBattleScripting.moveendState++;
             break;
         case MOVEEND_SAME_MOVE_TURNS:
-            if (gCurrentMove != gLastResultingMoves[gBattlerAttacker] || gMoveResultFlags & MOVE_RESULT_NO_EFFECT)
+            if (gCurrentMove != gLastResultingMoves[gBattlerAttacker] || gMoveResultFlags & MOVE_RESULT_NO_EFFECT || gHitMarker & HITMARKER_UNABLE_TO_USE_MOVE)
                 gBattleStruct->sameMoveTurns[gBattlerAttacker] = 0;
             else if (gCurrentMove == gLastResultingMoves[gBattlerAttacker] && gSpecialStatuses[gBattlerAttacker].parentalBondState != PARENTAL_BOND_1ST_HIT)
                 gBattleStruct->sameMoveTurns[gBattlerAttacker]++;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The MOVEEND_SAME_MOVE_TURNS case did not take into account Pokemon being unable to use their move (sleep, flinch, etc.) when checking to increment the `sameMoveTurns` counter. This resulted in a disparity in damage when, e.g., an Amaura was flinched when selecting Echoed Voice. Selecting it again next turn would have the counter be higher than it should be. This is unintended behavior and as such, a bug; confirmed by testing it against Smogon's engine.

<!--- Before submitting, please make sure your pull request meets the scope guidelines. If unsure, please open a thread in #pr-discussions.-->
<!--- Scope Guidelines: https://github.com/rh-hideout/pokeemerald-expansion/blob/master/docs/team_procedures/scope.md  -->
<!--- #pr-discussions:  https://discord.com/channels/419213663107416084/1102784418369785948 -->

## Description
<!--- Describe your changes in detail -->
<!--- If you believe this PR qualifies as a "Big Feature" as defined in docs/team_procedures/schedule.md, please let a Maintainer know! -->

Adds a hitmarker check for `HITMARKER_UNABLE_TO_USE_MOVE` in the `MOVEEND_SAME_MOVE_TURNS` case in `Cmd_moveend`.

## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, fixes #2222." -->
<!-- If it doesn't apply, feel free to remove this section. -->

#6165 

## **Discord contact info**
<!--- Formatted as username (e.g. Lunos) or username#numbers (e.g. Lunos#4026) -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
viridian.
