### PR TITLE
Fixes Suction Cups ability popup and Red Card + Guard Dog interaction

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -8254,14 +8254,14 @@ BattleScript_FlashFireBoost::
 
 BattleScript_AbilityPreventsPhasingOut::
 	pause B_WAIT_TIME_SHORT
-	call BattleScript_AbilityPopUp
+	call BattleScript_AbilityPopUpTarget
 	printstring STRINGID_PKMNANCHORSITSELFWITH
 	waitmessage B_WAIT_TIME_LONG
 	goto BattleScript_MoveEnd
 
 BattleScript_AbilityPreventsPhasingOutRet::
 	pause B_WAIT_TIME_SHORT
-	call BattleScript_AbilityPopUp
+	call BattleScript_AbilityPopUpTarget
 	printstring STRINGID_PKMNANCHORSITSELFWITH
 	waitmessage B_WAIT_TIME_LONG
 	return

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -8253,10 +8253,7 @@ BattleScript_FlashFireBoost::
 	goto BattleScript_MoveEnd
 
 BattleScript_AbilityPreventsPhasingOut::
-	pause B_WAIT_TIME_SHORT
-	call BattleScript_AbilityPopUpTarget
-	printstring STRINGID_PKMNANCHORSITSELFWITH
-	waitmessage B_WAIT_TIME_LONG
+	call BattleScript_AbilityPreventsPhasingOutRet
 	goto BattleScript_MoveEnd
 
 BattleScript_AbilityPreventsPhasingOutRet::

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -6566,8 +6566,7 @@ static void Cmd_moveend(void)
                 if (redCardBattlers
                   && (gMovesInfo[gCurrentMove].effect != EFFECT_HIT_SWITCH_TARGET || gBattleStruct->hitSwitchTargetFailed)
                   && IsBattlerAlive(gBattlerAttacker)
-                  && !TestIfSheerForceAffected(gBattlerAttacker, gCurrentMove)
-                  && GetBattlerAbility(gBattlerAttacker) != ABILITY_GUARD_DOG)
+                  && !TestIfSheerForceAffected(gBattlerAttacker, gCurrentMove))
                 {
                     // Since we check if battler was damaged, we don't need to check move result.
                     // In fact, doing so actually prevents multi-target moves from activating red card properly
@@ -6592,7 +6591,8 @@ static void Cmd_moveend(void)
                             if (gMovesInfo[gCurrentMove].effect == EFFECT_HIT_ESCAPE)
                                 gBattlescriptCurrInstr = BattleScript_MoveEnd;  // Prevent user switch-in selection
                             BattleScriptPushCursor();
-                            if (gBattleStruct->commanderActive[gBattlerAttacker] != SPECIES_NONE)
+                            if (gBattleStruct->commanderActive[gBattlerAttacker] != SPECIES_NONE
+                             || GetBattlerAbility(gBattlerAttacker) == ABILITY_GUARD_DOG)
                             {
                                 gBattlescriptCurrInstr = BattleScript_RedCardActivationNoSwitch;
                             }

--- a/test/battle/hold_effect/red_card.c
+++ b/test/battle/hold_effect/red_card.c
@@ -338,8 +338,6 @@ DOUBLE_BATTLE_TEST("Red Card activates but fails if the attacker has Guard Dog")
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, playerLeft);
             MESSAGE("Wobbuffet held up its Red Card against the opposing Wynaut!");
         }
-    } THEN {
-        EXPECT_EQ(opponentLeft->species, SPECIES_OKIDOGI);
     }
 }
 

--- a/test/battle/hold_effect/red_card.c
+++ b/test/battle/hold_effect/red_card.c
@@ -278,7 +278,7 @@ DOUBLE_BATTLE_TEST("Red Card activates but fails if the attacker is rooted")
         // Red Card already consumed so cannot activate.
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentRight);
         NONE_OF {
-            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, playerRight);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, playerLeft);
             MESSAGE("Wobbuffet held up its Red Card against the opposing Wynaut!");
         }
     }
@@ -307,7 +307,7 @@ DOUBLE_BATTLE_TEST("Red Card activates but fails if the attacker has Suction Cup
         // Red Card already consumed so cannot activate.
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentRight);
         NONE_OF {
-            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, playerRight);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, playerLeft);
             MESSAGE("Wobbuffet held up its Red Card against the opposing Wynaut!");
         }
     }
@@ -335,7 +335,7 @@ DOUBLE_BATTLE_TEST("Red Card activates but fails if the attacker has Guard Dog")
         // Red Card already consumed so cannot activate.
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentRight);
         NONE_OF {
-            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, playerRight);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, playerLeft);
             MESSAGE("Wobbuffet held up its Red Card against the opposing Wynaut!");
         }
     } THEN {

--- a/test/battle/hold_effect/red_card.c
+++ b/test/battle/hold_effect/red_card.c
@@ -273,12 +273,13 @@ DOUBLE_BATTLE_TEST("Red Card activates but fails if the attacker is rooted")
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, playerLeft);
         MESSAGE("Wobbuffet held up its Red Card against the opposing Wobbuffet!");
         MESSAGE("The opposing Wobbuffet anchored itself with its roots!");
+        NOT MESSAGE("The opposing Unown was dragged out!");
 
         // Red Card already consumed so cannot activate.
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentRight);
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, playerRight);
-            MESSAGE("Wynaut held up its Red Card against the opposing Wynaut!");
+            MESSAGE("Wobbuffet held up its Red Card against the opposing Wynaut!");
         }
     }
 }
@@ -301,13 +302,44 @@ DOUBLE_BATTLE_TEST("Red Card activates but fails if the attacker has Suction Cup
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, playerLeft);
         MESSAGE("Wobbuffet held up its Red Card against the opposing Octillery!");
         MESSAGE("The opposing Octillery anchors itself with Suction Cups!");
+        NOT MESSAGE("The opposing Unown was dragged out!");
 
         // Red Card already consumed so cannot activate.
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentRight);
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, playerRight);
-            MESSAGE("Wynaut held up its Red Card against the opposing Wynaut!");
+            MESSAGE("Wobbuffet held up its Red Card against the opposing Wynaut!");
         }
+    }
+}
+
+DOUBLE_BATTLE_TEST("Red Card activates but fails if the attacker has Guard Dog")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_RED_CARD); }
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_OKIDOGI) { Ability(ABILITY_GUARD_DOG); }
+        OPPONENT(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_UNOWN);
+    } WHEN {
+        TURN {
+            MOVE(opponentLeft, MOVE_TACKLE, target: playerLeft);
+            MOVE(opponentRight, MOVE_TACKLE, target: playerLeft);
+        }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentLeft);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, playerLeft);
+        MESSAGE("Wobbuffet held up its Red Card against the opposing Okidogi!");
+        NOT MESSAGE("The opposing Unown was dragged out!");
+
+        // Red Card already consumed so cannot activate.
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentRight);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, playerRight);
+            MESSAGE("Wobbuffet held up its Red Card against the opposing Wynaut!");
+        }
+    } THEN {
+        EXPECT_EQ(opponentLeft->species, SPECIES_OKIDOGI);
     }
 }
 

--- a/test/battle/move_effect/hit_switch_target.c
+++ b/test/battle/move_effect/hit_switch_target.c
@@ -90,7 +90,7 @@ SINGLE_BATTLE_TEST("Dragon Tail switches the target after Rocky Helmet and Iron 
     }
 }
 
-SINGLE_BATTLE_TEST("Dragon Tail effect fails against target with Guard Dog ability")
+SINGLE_BATTLE_TEST("Dragon Tail effect fails against target with Guard Dog")
 {
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);
@@ -104,7 +104,7 @@ SINGLE_BATTLE_TEST("Dragon Tail effect fails against target with Guard Dog abili
     }
 }
 
-SINGLE_BATTLE_TEST("Dragon Tail effect fails against Suction Cups ability")
+SINGLE_BATTLE_TEST("Dragon Tail effect fails against target with Suction Cups")
 {
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);

--- a/test/battle/move_effect/hit_switch_target.c
+++ b/test/battle/move_effect/hit_switch_target.c
@@ -90,7 +90,7 @@ SINGLE_BATTLE_TEST("Dragon Tail switches the target after Rocky Helmet and Iron 
     }
 }
 
-SINGLE_BATTLE_TEST("Dragon Tail effect will fails against Guard Dog ability")
+SINGLE_BATTLE_TEST("Dragon Tail effect fails against target with Guard Dog ability")
 {
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);
@@ -104,7 +104,7 @@ SINGLE_BATTLE_TEST("Dragon Tail effect will fails against Guard Dog ability")
     }
 }
 
-SINGLE_BATTLE_TEST("Dragon Tail effect will fails against Suction Cups ability")
+SINGLE_BATTLE_TEST("Dragon Tail effect fails against Suction Cups ability")
 {
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);
@@ -114,6 +114,7 @@ SINGLE_BATTLE_TEST("Dragon Tail effect will fails against Suction Cups ability")
         TURN { MOVE(player, MOVE_DRAGON_TAIL); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_TAIL, player);
+        ABILITY_POPUP(opponent, ABILITY_SUCTION_CUPS);
         MESSAGE("The opposing Octillery anchors itself with Suction Cups!");
         NOT MESSAGE("The opposing Charmander was dragged out!");
     }

--- a/test/battle/move_effect/roar.c
+++ b/test/battle/move_effect/roar.c
@@ -69,7 +69,7 @@ SINGLE_BATTLE_TEST("Roar fails if replacements fainted")
     }
 }
 
-SINGLE_BATTLE_TEST("Roar fails against target with Guard Dog ability")
+SINGLE_BATTLE_TEST("Roar fails against target with Guard Dog")
 {
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);
@@ -87,7 +87,7 @@ SINGLE_BATTLE_TEST("Roar fails against target with Guard Dog ability")
     }
 }
 
-SINGLE_BATTLE_TEST("Roar fails to switch out target with Suction Cups ability")
+SINGLE_BATTLE_TEST("Roar fails to switch out target with Suction Cups")
 {
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);

--- a/test/battle/move_effect/roar.c
+++ b/test/battle/move_effect/roar.c
@@ -68,3 +68,38 @@ SINGLE_BATTLE_TEST("Roar fails if replacements fainted")
         MESSAGE("But it failed!");
     }
 }
+
+SINGLE_BATTLE_TEST("Roar fails against target with Guard Dog ability")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_OKIDOGI) { Ability(ABILITY_GUARD_DOG); }
+        OPPONENT(SPECIES_CHARMANDER);
+    } WHEN {
+        TURN { MOVE(player, MOVE_ROAR); }
+    } SCENE {
+        NONE_OF {        
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_ROAR, player);
+            MESSAGE("The opposing Charmander was dragged out!");
+        }
+        MESSAGE("Wobbuffet used Roar!");
+        MESSAGE("But it failed!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Roar fails to switch out target with Suction Cups ability")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_OCTILLERY) { Ability(ABILITY_SUCTION_CUPS); }
+        OPPONENT(SPECIES_CHARMANDER);
+    } WHEN {
+        TURN { MOVE(player, MOVE_ROAR); }
+    } SCENE {
+        MESSAGE("Wobbuffet used Roar!");
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_ROAR, player);
+        ABILITY_POPUP(opponent, ABILITY_SUCTION_CUPS);
+        MESSAGE("The opposing Octillery anchors itself with Suction Cups!");
+        NOT MESSAGE("The opposing Charmander was dragged out!");
+    }
+}


### PR DESCRIPTION
Fixes Suction Cups displaying an incorrect ability popup.
Added Roar tests for Guard Dog and Suction Cups interactions.

Fixes Guard Dog preventing Red Cards from activating instead of allowing them to be consumed but not switching out the attacker. ([Source](https://www.youtube.com/watch?v=rggthHKGgTM))
Added Red Card test for Guard Dog interaction.

## Issue(s) that this PR fixes
Fixes #6153 

## **Discord contact info**
PhallenTree
