### PR TITLE
Fixed Unnerve message and wrote tests

### DIFF
--- a/src/battle_message.c
+++ b/src/battle_message.c
@@ -3095,6 +3095,7 @@ u32 BattleStringExpandPlaceholders(const u8 *src, u8 *dst, u32 dstSize)
                     toCpy = sText_Opposing2;
                 break;
             case B_TXT_DEF_TEAM1:
+                MgbaPrintf(MGBA_LOG_WARN, "Stuff %u", gBattlerTarget);
                 if (GetBattlerSide(gBattlerTarget) == B_SIDE_PLAYER)
                     toCpy = sText_Your1;
                 else

--- a/src/battle_message.c
+++ b/src/battle_message.c
@@ -3095,7 +3095,6 @@ u32 BattleStringExpandPlaceholders(const u8 *src, u8 *dst, u32 dstSize)
                     toCpy = sText_Opposing2;
                 break;
             case B_TXT_DEF_TEAM1:
-                MgbaPrintf(MGBA_LOG_WARN, "Stuff %u", gBattlerTarget);
                 if (GetBattlerSide(gBattlerTarget) == B_SIDE_PLAYER)
                     toCpy = sText_Your1;
                 else

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4640,6 +4640,7 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
         case ABILITY_AS_ONE_SHADOW_RIDER:
             if (!gSpecialStatuses[battler].switchInAbilityDone)
             {
+                gBattlerTarget = GetBattlerAtPosition(BATTLE_OPPOSITE(GetBattlerAtPosition(battler)));
                 gBattleCommunication[MULTISTRING_CHOOSER] = B_MSG_SWITCHIN_ASONE;
                 gSpecialStatuses[battler].switchInAbilityDone = TRUE;
                 BattleScriptPushCursorAndCallback(BattleScript_ActivateAsOne);

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4629,6 +4629,7 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
         case ABILITY_UNNERVE:
             if (!gSpecialStatuses[battler].switchInAbilityDone)
             {
+                gBattlerTarget = GetBattlerAtPosition(BATTLE_OPPOSITE(GetBattlerAtPosition(battler)));
                 gBattleCommunication[MULTISTRING_CHOOSER] = B_MSG_SWITCHIN_UNNERVE;
                 gSpecialStatuses[battler].switchInAbilityDone = TRUE;
                 BattleScriptPushCursorAndCallback(BattleScript_SwitchInAbilityMsg);

--- a/test/battle/ability/unnerve.c
+++ b/test/battle/ability/unnerve.c
@@ -41,7 +41,6 @@ SINGLE_BATTLE_TEST("Unnerve doesn't prevent opposing Pokémon from using Natural
 
 SINGLE_BATTLE_TEST("Unnerve prints the correct string (player)")
 {
-    KNOWN_FAILING;
     u16 mon;
     u16 ability;
     PARAMETRIZE { mon = SPECIES_JOLTIK, ability = ABILITY_UNNERVE; }

--- a/test/battle/ability/unnerve.c
+++ b/test/battle/ability/unnerve.c
@@ -2,5 +2,74 @@
 #include "test/battle.h"
 
 // Remember to add a PARAMETRIZE for As One in the following tests:
-TO_DO_BATTLE_TEST("Unnerve prevents opposing Pokémon from eating their own berries");
-TO_DO_BATTLE_TEST("Unnerve doesn't prevent opposing Pokémon from using Natural Gift");
+SINGLE_BATTLE_TEST("Unnerve prevents opposing Pokémon from eating their own berries")
+{
+    u16 mon;
+    u16 ability;
+    PARAMETRIZE { mon = SPECIES_JOLTIK, ability = ABILITY_UNNERVE; }
+    PARAMETRIZE { mon = SPECIES_CALYREX_ICE, ability = ABILITY_AS_ONE_ICE_RIDER; }
+    GIVEN {
+        ASSUME(gItemsInfo[ITEM_RAWST_BERRY].holdEffect == HOLD_EFFECT_CURE_BRN);
+        PLAYER(mon) { Ability(ability); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_RAWST_BERRY); Status1(STATUS1_BURN); }
+    } WHEN {
+        TURN { }
+    } SCENE {
+        ABILITY_POPUP(player, ability);
+        NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
+        HP_BAR(opponent);
+    }
+}
+
+SINGLE_BATTLE_TEST("Unnerve doesn't prevent opposing Pokémon from using Natural Gift")
+{
+    u16 mon;
+    u16 ability;
+    PARAMETRIZE { mon = SPECIES_JOLTIK, ability = ABILITY_UNNERVE; }
+    PARAMETRIZE { mon = SPECIES_CALYREX_ICE, ability = ABILITY_AS_ONE_ICE_RIDER; }
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_NATURAL_GIFT].effect == EFFECT_NATURAL_GIFT);
+        PLAYER(mon) { Ability(ability); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_ORAN_BERRY); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_NATURAL_GIFT); }
+    } SCENE {
+        ABILITY_POPUP(player, ability);
+        HP_BAR(player);
+    }
+}
+
+SINGLE_BATTLE_TEST("Unnerve prints the correct string (player)")
+{
+    u16 mon;
+    u16 ability;
+    PARAMETRIZE { mon = SPECIES_JOLTIK, ability = ABILITY_UNNERVE; }
+    PARAMETRIZE { mon = SPECIES_CALYREX_ICE, ability = ABILITY_AS_ONE_ICE_RIDER; }
+    GIVEN {
+        PLAYER(mon) { Ability(ability); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN {}
+    } SCENE {
+        ABILITY_POPUP(player, ability);
+        MESSAGE("The opposing team is too nervous to eat Berries!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Unnerve prints the correct string (opponent)")
+{
+    KNOWN_FAILING;
+    u16 mon;
+    u16 ability;
+    PARAMETRIZE { mon = SPECIES_JOLTIK, ability = ABILITY_UNNERVE; }
+    PARAMETRIZE { mon = SPECIES_CALYREX_ICE, ability = ABILITY_AS_ONE_ICE_RIDER; }
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(mon) { Ability(ability); }
+    } WHEN {
+        TURN {}
+    } SCENE {
+        ABILITY_POPUP(opponent, ability);
+        MESSAGE("Your team is too nervous to eat Berries!");
+    }
+}

--- a/test/battle/ability/unnerve.c
+++ b/test/battle/ability/unnerve.c
@@ -41,6 +41,7 @@ SINGLE_BATTLE_TEST("Unnerve doesn't prevent opposing Pokémon from using Natural
 
 SINGLE_BATTLE_TEST("Unnerve prints the correct string (player)")
 {
+    KNOWN_FAILING;
     u16 mon;
     u16 ability;
     PARAMETRIZE { mon = SPECIES_JOLTIK, ability = ABILITY_UNNERVE; }
@@ -58,7 +59,6 @@ SINGLE_BATTLE_TEST("Unnerve prints the correct string (player)")
 
 SINGLE_BATTLE_TEST("Unnerve prints the correct string (opponent)")
 {
-    KNOWN_FAILING;
     u16 mon;
     u16 ability;
     PARAMETRIZE { mon = SPECIES_JOLTIK, ability = ABILITY_UNNERVE; }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Before submitting, please make sure your pull request meets the scope guidelines. If unsure, please open a thread in #pr-discussions.-->
<!--- Scope Guidelines: https://github.com/rh-hideout/pokeemerald-expansion/blob/master/docs/team_procedures/scope.md  -->
<!--- #pr-discussions:  https://discord.com/channels/419213663107416084/1102784418369785948 -->
Unnerve would print "Your team is too nervous to eat Berries!" regardless of what side the user was on.
Couldn't fix As One which is also affected by this bug.

## Description
<!--- Describe your changes in detail -->
<!--- If you believe this PR qualifies as a "Big Feature" as defined in docs/team_procedures/schedule.md, please let a Maintainer know! -->


## **Discord contact info**
<!--- Formatted as username (e.g. Lunos) or username#numbers (e.g. Lunos#4026) -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara