### PR TITLE
Fix Choice'd mons referring to incorrect move when switching

### DIFF
--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -875,7 +875,7 @@ static bool32 ShouldSwitchIfBadChoiceLock(u32 battler)
 
     if (HOLD_EFFECT_CHOICE(holdEffect) && gBattleMons[battler].ability != ABILITY_KLUTZ)
     {
-        if (GetMoveCategory(gLastUsedMove) == DAMAGE_CATEGORY_STATUS)
+        if (GetMoveCategory(AI_DATA->lastUsedMove[battler]) == DAMAGE_CATEGORY_STATUS)
             return SetSwitchinAndSwitch(battler, PARTY_SIZE);
     }
 

--- a/test/battle/ai/ai_choice.c
+++ b/test/battle/ai/ai_choice.c
@@ -42,6 +42,20 @@ AI_SINGLE_BATTLE_TEST("Choiced Pokémon switch out after using a status move onc
     }
 }
 
+AI_SINGLE_BATTLE_TEST("Choiced Pokémon only consider their own status moves when determining if they should switch")
+{
+    GIVEN 
+    {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_RISKY | AI_FLAG_SMART_SWITCHING | AI_FLAG_OMNISCIENT | AI_FLAG_SMART_MON_CHOICES);
+        PLAYER(SPECIES_ZIGZAGOON) { Speed(4); Moves(MOVE_TAIL_WHIP, MOVE_TACKLE); }
+        OPPONENT(SPECIES_ZIGZAGOON) { Speed(5); Moves(MOVE_TACKLE); Item(ITEM_CHOICE_BAND); }
+        OPPONENT(SPECIES_ZIGZAGOON) { Speed(5); Moves(MOVE_TACKLE); }
+    } WHEN {
+        TURN { EXPECT_MOVE(opponent, MOVE_TACKLE); MOVE(player, MOVE_TAIL_WHIP); }
+        TURN { EXPECT_MOVE(opponent, MOVE_TACKLE); MOVE(player, MOVE_TAIL_WHIP); }
+    }
+}
+
 AI_SINGLE_BATTLE_TEST("Choiced Pokémon won't use stat boosting moves")
 {
     // Moves defined by MOVE_TARGET_USER (with exceptions?)


### PR DESCRIPTION
## Description
One of @iriv24's players sent a recording of some weird switching behaviour which lead to this discovery. Turns out `ShouldSwitchIfBadChoiceLock` was checking if the last move used _globally_ was a status move, not the last move the choice'd mon had used was. Whoops!

This is to upcoming because `GetMoveCategory` isn't in master.

## **People who collaborated with me in this PR**
@/capncrunch

## **Discord contact info**
@Pawkkie 
