### PR TITLE
Redefine IsBattlerAlive in battle.h as a static inline

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -1186,6 +1186,18 @@ extern bool8 gLastUsedBallMenuPresent;
 extern u8 gPartyCriticalHits[PARTY_SIZE];
 extern u8 gCategoryIconSpriteId;
 
+static inline bool32 IsBattlerAlive(u32 battler)
+{
+    if (gBattleMons[battler].hp == 0)
+        return FALSE;
+    else if (battler >= gBattlersCount)
+        return FALSE;
+    else if (gAbsentBattlerFlags & (1u << battler))
+        return FALSE;
+    else
+        return TRUE;
+}
+
 static inline bool32 IsBattlerTurnDamaged(u32 battler)
 {
     return gSpecialStatuses[battler].physicalDmg != 0

--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -245,7 +245,6 @@ u32 GetBattlerHoldEffectInternal(u32 battler, bool32 checkNegating, bool32 check
 u32 GetBattlerHoldEffectParam(u32 battler);
 bool32 IsMoveMakingContact(u32 move, u32 battlerAtk);
 bool32 IsBattlerGrounded(u32 battler);
-bool32 IsBattlerAlive(u32 battler);
 u32 GetMoveSlot(u16 *moves, u32 move);
 u32 GetBattlerWeight(u32 battler);
 u32 CalcRolloutBasePower(u32 battlerAtk, u32 basePower, u32 rolloutTimer);

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -8852,18 +8852,6 @@ bool32 IsBattlerGrounded(u32 battler)
     return IsBattlerGroundedInverseCheck(battler, FALSE);
 }
 
-bool32 IsBattlerAlive(u32 battler)
-{
-    if (gBattleMons[battler].hp == 0)
-        return FALSE;
-    else if (battler >= gBattlersCount)
-        return FALSE;
-    else if (gAbsentBattlerFlags & (1u << battler))
-        return FALSE;
-    else
-        return TRUE;
-}
-
 u32 GetMoveSlot(u16 *moves, u32 move)
 {
     u32 i;


### PR DESCRIPTION
`IsBattlerAlive` is a really common check that I think it is worth to inline it. Especially because it is used in big loops like moveend. It might not be much of a speed improvement but it is also free to do.