### PR TITLE
Fixed typo in requests_effects

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -2339,7 +2339,7 @@
 
 	@ Stores the position of the given object in destX and destY. Mode CURRENT_POSITION will take the object's current position. Mode TEMPLATE_POSITION will take the object's template position.
 	.macro getobjectxy localId:req, posType:req, destX:req, destY:req
-	callnative ScrCmd_getobjectxy, request_effects=1
+	callnative ScrCmd_getobjectxy, requests_effects=1
 	.2byte \localId
 	.2byte \posType
 	.2byte \destX
@@ -2347,7 +2347,7 @@
 	.endm
 
 	.macro getobjecttemplatexy localId:req, posType = TEMPLATE_POSITION, destX:req, destY:req
-	callnative ScrCmd_getobjectxy, request_effects=1
+	callnative ScrCmd_getobjectxy, requests_effects=1
 	.2byte \localId
 	.2byte \posType
 	.2byte \destX
@@ -2355,7 +2355,7 @@
 	.endm
 
 	.macro getobjectcurrentxy localId:req, posType = CURRENT_POSITION, destX:req, destY:req
-	callnative ScrCmd_getobjectxy, request_effects=1
+	callnative ScrCmd_getobjectxy, requests_effects=1
 	.2byte \localId
 	.2byte \posType
 	.2byte \destX
@@ -2364,7 +2364,7 @@
 
 	@ Return TRUE to dest if there is an object at the position x and y.
 	.macro checkobjectat x:req, y:req, dest = VAR_RESULT
-	callnative ScrCmd_checkobjectat, request_effects=1
+	callnative ScrCmd_checkobjectat, requests_effects=1
 	.2byte \x
 	.2byte \y
 	.2byte \dest
@@ -2372,28 +2372,28 @@
 
 	@ Returns the state of the Pokedex Seen Flag to VAR_RESULT for the Pokemon with speciesId
 	.macro getseenmon species:req
-	callnative Scrcmd_getsetpokedexflag, request_effects=1
+	callnative Scrcmd_getsetpokedexflag, requests_effects=1
 	.2byte \species
 	.2byte FLAG_GET_SEEN
 	.endm
 
 	@ Returns the state of the Pokedex Caught Flag to VAR_RESULT for the Pokemon with speciesId
 	.macro getcaughtmon species:req
-	callnative Scrcmd_getsetpokedexflag, request_effects=1
+	callnative Scrcmd_getsetpokedexflag, requests_effects=1
 	.2byte \species
 	.2byte FLAG_GET_CAUGHT
 	.endm
 
 	@ Sets the Pokedex Seen Flag for the Pokemon with speciesId
 	.macro setseenmon species:req
-	callnative Scrcmd_getsetpokedexflag, request_effects=1
+	callnative Scrcmd_getsetpokedexflag, requests_effects=1
 	.2byte \species
 	.2byte FLAG_SET_SEEN
 	.endm
 
 	@ Sets the Pokedex Caught Flag for the Pokemon with speciesId
 	.macro setcaughtmon species:req
-	callnative Scrcmd_getsetpokedexflag, request_effects=1
+	callnative Scrcmd_getsetpokedexflag, requests_effects=1
 	.2byte \species
 	.2byte FLAG_SET_CAUGHT
 	.endm
@@ -2403,10 +2403,10 @@
 	.if \mode == OPEN_PARTY_SCREEN
 		special ChoosePartyMon
 		waitstate
-		callnative Scrcmd_checkspecies_choose, request_effects=1
+		callnative Scrcmd_checkspecies_choose, requests_effects=1
 		.2byte \speciesId
 	.else
-		callnative Scrcmd_checkspecies, request_effects=1
+		callnative Scrcmd_checkspecies, requests_effects=1
 		.2byte \speciesId
 	.endif
 	.endm
@@ -2417,7 +2417,7 @@
 
 	@ Gets the facing direction of a given event object and stores it in the variable dest.
 	.macro getobjectfacingdirection localId:req, dest:req
-	callnative Scrcmd_getobjectfacingdirection, request_effects=1
+	callnative Scrcmd_getobjectfacingdirection, requests_effects=1
 	.2byte \localId
 	.2byte \dest
 	.endm

--- a/include/script.h
+++ b/include/script.h
@@ -133,7 +133,7 @@ static inline bool32 Script_IsAnalyzingEffects(void)
 
 /* Optimize 'Script_RequestEffects' to a no-op if it would have no
  * effect. 'Script_RequestEffects' must be called in all commands and
- * natives/specials with 'request_effects=TRUE' even if it would have
+ * natives/specials with 'requests_effects=TRUE' even if it would have
  * no effect to future-proof against new effects. */
 #define Script_RequestEffects(effects) \
     ({ \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Before submitting, please make sure your pull request meets the scope guidelines. If unsure, please open a thread in #pr-discussions.-->
<!--- Scope Guidelines: https://github.com/rh-hideout/pokeemerald-expansion/blob/master/docs/team_procedures/scope.md  -->
<!--- #pr-discussions:  https://discord.com/channels/419213663107416084/1102784418369785948 -->

## Description
<!--- Describe your changes in detail -->
<!--- If you believe this PR qualifies as a "Big Feature" as defined in docs/team_procedures/schedule.md, please let a Maintainer know! -->
`requests_effects` was misspelled in macros.
Test before and after by adding these commands to any script.
```
         getobjectxy 0, CURRENT_POSITION, VAR_0x8000, VAR_0x8001                                                                                                                 
         getobjecttemplatexy 0, CURRENT_POSITION, VAR_0x8000, VAR_0x8001                                                                                                         
         getobjectcurrentxy 0, CURRENT_POSITION, VAR_0x8000, VAR_0x8001                                                                                                          
         checkobjectat 10, 10                                                                                                                                                    
         getseenmon SPECIES_SLOWPOKE
         getcaughtmon SPECIES_SLOWPOKE
         setseenmon SPECIES_SLOWPOKE               
         setcaughtmon SPECIES_SLOWPOKE                                                                                                                                           
         checkspecies SPECIES_SLOWPOKE                                                                                                                                           
         getobjectfacingdirection 0 VAR_RESULT
```

## **People who collaborated with me in this PR**
<!-- Please credit everyone else that contributed to this PR, be it code and/or assets. -->
<!-- Use their GitHub tag if they have one (or add "@/" at the start if they don't). Be sure to start the line using @ so the automatic changelog can properly detect the collaborators. -->
<!-- Eg.: "@Lunos for sprites, @/Masuda for support" -->
<!-- If it doesn't apply, feel free to remove this section. -->
Discovered by @purrfectdoodle

## **Discord contact info**
<!--- Formatted as username (e.g. Lunos) or username#numbers (e.g. Lunos#4026) -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara