### PR TITLE
Fix Liquid Ooze + Leech Seed Test

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -5952,10 +5952,14 @@ BattleScript_SafeguardEnds::
 	waitmessage B_WAIT_TIME_LONG
 	end2
 
+@ Leech Seed end turn effect
+@ attacker is the victim
+@ target is the leech seeder (recieving HP)
 BattleScript_LeechSeedTurnDrainLiquidOoze::
 	call BattleScript_LeechSeedTurnDrain
 	copybyte gBattlerAbility, gBattlerAttacker
 	call BattleScript_AbilityPopUp
+	copybyte gBattlerAttacker, gBattlerTarget   @ needed to get liquid ooze message correct
 	goto BattleScript_LeechSeedTurnDrainGainHp
 
 BattleScript_LeechSeedTurnDrainHealBlock::

--- a/test/battle/ability/liquid_ooze.c
+++ b/test/battle/ability/liquid_ooze.c
@@ -108,9 +108,11 @@ SINGLE_BATTLE_TEST("Liquid Ooze causes Strength Sap users to lose HP instead of 
     }
 }
 
-SINGLE_BATTLE_TEST("Liquid Ooze causes leech seedee to faint before seeder")
+/* * https://bulbapedia.bulbagarden.net/wiki/Liquid_Ooze_(Ability)#In_battle:
+   * If the recipient of Leech Seed's effect were to faint due to Liquid Ooze on the same turn as the victim of Leech Seed, then the victim faints before the recipient. This means that the victim's team loses the battle if both teams had their final Pokémon sent out. 
+ */
+SINGLE_BATTLE_TEST("Liquid Ooze causes leech seed victim to faint before seeder")
 {
-    KNOWN_FAILING; // Message fails
     u16 ability;
     PARAMETRIZE { ability = ABILITY_CLEAR_BODY; }
     PARAMETRIZE { ability = ABILITY_LIQUID_OOZE; }
@@ -120,16 +122,17 @@ SINGLE_BATTLE_TEST("Liquid Ooze causes leech seedee to faint before seeder")
     } WHEN {
         TURN { MOVE(player, MOVE_LEECH_SEED); }
     } SCENE {
+        // Player seeds opponent
         MESSAGE("Bulbasaur used Leech Seed!");
         // Drain at end of turn
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_LEECH_SEED_DRAIN, opponent);
         if (ability != ABILITY_LIQUID_OOZE) {
-            MESSAGE("The opposing Tentacool's health is sapped by Leech Seed!");
             MESSAGE("The opposing Tentacool fainted!");
+            MESSAGE("The opposing Tentacool's health is sapped by Leech Seed!");
         } else {
+            MESSAGE("The opposing Tentacool fainted!");
             ABILITY_POPUP(opponent, ABILITY_LIQUID_OOZE);
             MESSAGE("Bulbasaur sucked up the liquid ooze!");
-            MESSAGE("The opposing Tentacool fainted!");
             MESSAGE("Bulbasaur fainted!");
         }
     }


### PR DESCRIPTION
This test was not testing the correct scenario. The liquid ooze battle script of leech seed also needed to set the attacker to the target (seeder) for the liquid ooze message to print properly. This should be safe since the BS_ATTACKER sequence had already been run at this point.