### PR TITLE
Prevented fanfares from playing in headless mode

### DIFF
--- a/src/sound.c
+++ b/src/sound.c
@@ -8,6 +8,7 @@
 #include "constants/cries.h"
 #include "constants/songs.h"
 #include "task.h"
+#include "test_runner.h"
 
 struct Fanfare
 {
@@ -237,6 +238,13 @@ bool8 IsFanfareTaskInactive(void)
 
 static void Task_Fanfare(u8 taskId)
 {
+    if (gTestRunnerHeadless)
+    {
+        DestroyTask(taskId);
+        sFanfareCounter = 0;
+        return;
+    }
+
     if (sFanfareCounter)
     {
         sFanfareCounter--;


### PR DESCRIPTION
## Description
Similar to https://github.com/rh-hideout/pokeemerald-expansion/pull/5889, this prevents Fanfares from running in headless mode. This will have small speed gains and prevents tests that end before the fanfares are finished from failing.

### After

## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, fixes #2222." -->
<!-- If it doesn't apply, feel free to remove this section. -->

## **People who collaborated with me in this PR**
@hedara90, @AsparagusEduardo

## Feature(s) this PR does NOT handle:
No other features are removed from headless mode.

## **Discord contact info**
pkmnsnfrn

This spawned from a [Senate discussion](https://discord.com/channels/419213663107416084/1077009799293710357/1337906390949298237).
