### PR TITLE
Fix Using a Safari Ball crashes the game #6206

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -42,6 +42,7 @@
 #include "pokemon.h"
 #include "random.h"
 #include "recorded_battle.h"
+#include "reshow_battle_screen.h"
 #include "roamer.h"
 #include "safari_zone.h"
 #include "scanline_effect.h"
@@ -3718,6 +3719,10 @@ static void DoBattleIntro(void)
             }
 
             PrepareStringBattle(STRINGID_INTROSENDOUT, battler);
+        }
+        else
+        {
+            CreateBattlerSprite(GetBattlerAtPosition(B_POSITION_PLAYER_LEFT));
         }
         gBattleStruct->introState++;
         break;


### PR DESCRIPTION
Fix [Using a Safari Ball crashes the game (#6206)](https://github.com/rh-hideout/pokeemerald-expansion/issues/6206)