### PR TITLE
Fixes bug in Cmd_jumpifnodamage

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -14194,7 +14194,9 @@ static void Cmd_jumpifnodamage(void)
 {
     CMD_ARGS(const u8 *jumpInstr);
 
-    if (BATTLER_TURN_DAMAGED(gBattlerAttacker))
+    if (gProtectStructs[gBattlerAttacker].physicalDmg
+     || gProtectStructs[gBattlerAttacker].specialDmg
+     || gBattleStruct->enduredDamage & (1u << gBattlerAttacker))
         gBattlescriptCurrInstr = cmd->nextInstr;
     else
         gBattlescriptCurrInstr = cmd->jumpInstr;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -14194,7 +14194,7 @@ static void Cmd_jumpifnodamage(void)
 {
     CMD_ARGS(const u8 *jumpInstr);
 
-    if (gProtectStructs[gBattlerAttacker].physicalDmg || gProtectStructs[gBattlerAttacker].specialDmg)
+    if (IsBattlerTurnDamaged(gBattlerAttacker))
         gBattlescriptCurrInstr = cmd->nextInstr;
     else
         gBattlescriptCurrInstr = cmd->jumpInstr;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -14194,7 +14194,7 @@ static void Cmd_jumpifnodamage(void)
 {
     CMD_ARGS(const u8 *jumpInstr);
 
-    if (IsBattlerTurnDamaged(gBattlerAttacker))
+    if (BATTLER_TURN_DAMAGED(gBattlerAttacker))
         gBattlescriptCurrInstr = cmd->nextInstr;
     else
         gBattlescriptCurrInstr = cmd->jumpInstr;


### PR DESCRIPTION
Endured damage is also considered damage even if 0 damage has been taken.
