### PR TITLE
fix for battle ui for add to party menu (#6229)

### DIFF
--- a/include/reshow_battle_screen.h
+++ b/include/reshow_battle_screen.h
@@ -3,6 +3,7 @@
 
 void ReshowBattleScreenDummy(void);
 void ReshowBattleScreenAfterMenu(void);
+void ReshowBlankBattleScreenAfterMenu(void);
 void CreateBattlerSprite(u32 battler);
 
 #endif // GUARD_RESHOW_BATTLE_SCREEN_H

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -16437,12 +16437,13 @@ static void Cmd_trygivecaughtmonnick(void)
         {
             GetMonData(&gEnemyParty[gBattlerPartyIndexes[gBattlerTarget]], MON_DATA_NICKNAME, gBattleStruct->caughtMonNick);
             FreeAllWindowBuffers();
+            MainCallback callback = CalculatePlayerPartyCount() == PARTY_SIZE ? ReshowBlankBattleScreenAfterMenu : BattleMainCB2;
 
             DoNamingScreen(NAMING_SCREEN_CAUGHT_MON, gBattleStruct->caughtMonNick,
                            GetMonData(&gEnemyParty[gBattlerPartyIndexes[gBattlerTarget]], MON_DATA_SPECIES),
                            GetMonGender(&gEnemyParty[gBattlerPartyIndexes[gBattlerTarget]]),
                            GetMonData(&gEnemyParty[gBattlerPartyIndexes[gBattlerTarget]], MON_DATA_PERSONALITY, NULL),
-                           ReshowBattleScreenAfterMenu);
+                           callback);
 
             gBattleCommunication[MULTIUSE_STATE]++;
         }

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -7186,11 +7186,10 @@ void OpenPartyMenuInBattle(u8 partyAction)
     u8 partyMessage;
 
     if (partyAction == PARTY_ACTION_SEND_MON_TO_BOX)
-        partyMessage = PARTY_MSG_CHOOSE_MON_FOR_BOX;
+        InitPartyMenu(PARTY_MENU_TYPE_IN_BATTLE, GetPartyLayoutFromBattleType(), partyAction, FALSE, PARTY_MSG_CHOOSE_MON_FOR_BOX, Task_HandleChooseMonInput, ReshowBlankBattleScreenAfterMenu);
     else
-        partyMessage = PARTY_MSG_CHOOSE_MON;
-    
-    InitPartyMenu(PARTY_MENU_TYPE_IN_BATTLE, GetPartyLayoutFromBattleType(), partyAction, FALSE, partyMessage, Task_HandleChooseMonInput, CB2_SetUpReshowBattleScreenAfterMenu);
+        InitPartyMenu(PARTY_MENU_TYPE_IN_BATTLE, GetPartyLayoutFromBattleType(), partyAction, FALSE, PARTY_MSG_CHOOSE_MON, Task_HandleChooseMonInput, CB2_SetUpReshowBattleScreenAfterMenu);
+
     ReshowBattleScreenDummy();
     UpdatePartyToBattleOrder();
 }

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -7183,8 +7183,6 @@ static u8 GetPartyLayoutFromBattleType(void)
 
 void OpenPartyMenuInBattle(u8 partyAction)
 {
-    u8 partyMessage;
-
     if (partyAction == PARTY_ACTION_SEND_MON_TO_BOX)
         InitPartyMenu(PARTY_MENU_TYPE_IN_BATTLE, GetPartyLayoutFromBattleType(), partyAction, FALSE, PARTY_MSG_CHOOSE_MON_FOR_BOX, Task_HandleChooseMonInput, ReshowBlankBattleScreenAfterMenu);
     else


### PR DESCRIPTION
Fixes the dodgy battle UI sprites when returning to the battle for the "add to party?" prompt.

https://github.com/user-attachments/assets/5873e8f8-56a6-49bb-8c16-71f73e7fc363

This fix is likely how the original feature should have worked anyways. Rather than sending you back to the battle, it puts you in the post battle UI that would usually appear after registering a mon in the dex, with the mon you just caught in center screen.

Does not resolve whatever was going on with the register UI that causes the corrupted sprites in the first place.