### PR TITLE
Added missing Dream Eater and Reflect Type tests

### DIFF
--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -3550,6 +3550,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
         .priority = 0,
         .category = DAMAGE_CATEGORY_SPECIAL,
         .healingMove = B_HEAL_BLOCKING >= GEN_6,
+        .ignoresSubstitute = B_UPDATED_MOVE_FLAGS >= GEN_5,
         .contestEffect = CONTEST_EFFECT_STARTLE_PREV_MONS,
         .contestCategory = CONTEST_CATEGORY_SMART,
         .contestComboStarterId = 0,

--- a/test/battle/move_effect/reflect_type.c
+++ b/test/battle/move_effect/reflect_type.c
@@ -1,9 +1,6 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("Reflect Type fails if the user is Terastallized");
-TO_DO_BATTLE_TEST("Reflect Type succeeds against a Terastallized target and copies its Tera type");
-
 SINGLE_BATTLE_TEST("Reflect Type does not affect any of Arceus' forms")
 {
     u32 j;
@@ -86,7 +83,7 @@ SINGLE_BATTLE_TEST("Reflect Type does not affect any of Silvally's forms")
     }
 }
 
-SINGLE_BATTLE_TEST("Reflect Type does not affect Pokémon with no types")
+SINGLE_BATTLE_TEST("Reflect Type fails if the target has no types")
 {
     GIVEN {
         ASSUME(gSpeciesInfo[SPECIES_ARCANINE].types[0] == TYPE_FIRE);
@@ -151,7 +148,7 @@ SINGLE_BATTLE_TEST("Reflect Type copies a target's pure type")
     }
 }
 
-SINGLE_BATTLE_TEST("Reflect Type defaults to Normal type for the user's types[0] and types[1] if the target only has a 3rd type")
+SINGLE_BATTLE_TEST("Reflect Type defaults to Normal type for the user's 1st and 2nd types if the target only has a 3rd type")
 {
     GIVEN {
         ASSUME(gSpeciesInfo[SPECIES_WOBBUFFET].types[0] == TYPE_PSYCHIC);
@@ -182,5 +179,42 @@ SINGLE_BATTLE_TEST("Reflect Type defaults to Normal type for the user's types[0]
         EXPECT_EQ(player->types[0], TYPE_NORMAL);
         EXPECT_EQ(player->types[1], TYPE_NORMAL);
         EXPECT_EQ(player->types[2], TYPE_GRASS);
+    }
+}
+
+SINGLE_BATTLE_TEST("Reflect Type fails if the user is Terastallized")
+{
+    GIVEN {
+        ASSUME(gSpeciesInfo[SPECIES_POLIWRATH].types[0] == TYPE_WATER);
+        ASSUME(gSpeciesInfo[SPECIES_POLIWRATH].types[1] == TYPE_FIGHTING);
+        PLAYER(SPECIES_ARCANINE) { TeraType(TYPE_NORMAL); }
+        OPPONENT(SPECIES_POLIWRATH);
+    } WHEN {
+        TURN { MOVE(player, MOVE_REFLECT_TYPE, gimmick: GIMMICK_TERA); }
+    } SCENE {
+        MESSAGE("Arcanine used Reflect Type!");
+        MESSAGE("But it failed!");
+    } THEN {
+        EXPECT_EQ(player->types[0], TYPE_FIRE);
+        EXPECT_EQ(player->types[1], TYPE_FIRE);
+        EXPECT_EQ(player->types[2], TYPE_MYSTERY);
+    }
+}
+
+SINGLE_BATTLE_TEST("Reflect Type succeeds against a Terastallized target and copies its Tera type")
+{
+    GIVEN {
+        ASSUME(gSpeciesInfo[SPECIES_POLIWRATH].types[0] == TYPE_WATER);
+        ASSUME(gSpeciesInfo[SPECIES_POLIWRATH].types[1] == TYPE_FIGHTING);
+        PLAYER(SPECIES_ARCANINE) { TeraType(TYPE_NORMAL); }
+        OPPONENT(SPECIES_POLIWRATH);
+    } WHEN {
+        TURN { MOVE(player, MOVE_TACKLE, gimmick: GIMMICK_TERA); MOVE(opponent, MOVE_REFLECT_TYPE); }
+    } SCENE {
+        MESSAGE("The opposing Poliwrath used Reflect Type!");
+    } THEN {
+        EXPECT_EQ(opponent->types[0], TYPE_NORMAL);
+        EXPECT_EQ(opponent->types[1], TYPE_NORMAL);
+        EXPECT_EQ(opponent->types[2], TYPE_NORMAL);
     }
 }

--- a/test/battle/move_effect/reflect_type.c
+++ b/test/battle/move_effect/reflect_type.c
@@ -185,8 +185,6 @@ SINGLE_BATTLE_TEST("Reflect Type defaults to Normal type for the user's 1st and 
 SINGLE_BATTLE_TEST("Reflect Type fails if the user is Terastallized")
 {
     GIVEN {
-        ASSUME(gSpeciesInfo[SPECIES_POLIWRATH].types[0] == TYPE_WATER);
-        ASSUME(gSpeciesInfo[SPECIES_POLIWRATH].types[1] == TYPE_FIGHTING);
         PLAYER(SPECIES_ARCANINE) { TeraType(TYPE_NORMAL); }
         OPPONENT(SPECIES_POLIWRATH);
     } WHEN {
@@ -204,8 +202,8 @@ SINGLE_BATTLE_TEST("Reflect Type fails if the user is Terastallized")
 SINGLE_BATTLE_TEST("Reflect Type succeeds against a Terastallized target and copies its Tera type")
 {
     GIVEN {
-        ASSUME(gSpeciesInfo[SPECIES_POLIWRATH].types[0] == TYPE_WATER);
-        ASSUME(gSpeciesInfo[SPECIES_POLIWRATH].types[1] == TYPE_FIGHTING);
+        ASSUME(gSpeciesInfo[SPECIES_POLIWRATH].types[0] != TYPE_NORMAL);
+        ASSUME(gSpeciesInfo[SPECIES_POLIWRATH].types[1] != TYPE_NORMAL);
         PLAYER(SPECIES_ARCANINE) { TeraType(TYPE_NORMAL); }
         OPPONENT(SPECIES_POLIWRATH);
     } WHEN {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Before submitting, please make sure your pull request meets the scope guidelines. If unsure, please open a thread in #pr-discussions.-->
<!--- Scope Guidelines: https://github.com/rh-hideout/pokeemerald-expansion/blob/master/docs/team_procedures/scope.md  -->
<!--- #pr-discussions:  https://discord.com/channels/419213663107416084/1102784418369785948 -->

## Description
Also fixed Dream Eater not ignoring Substitutes in Gen 5+.

## Feature(s) this PR does NOT handle:
There's no current way of changing move flags during a test, so the Dream Eater tests use preproc instead.

## **Discord contact info**
AsparagusEduardo
