### PR TITLE
Use more accurate count in MovesInfo

### DIFF
--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -110,7 +110,7 @@ static const u8 sFeintDescription[] = _(
     "An attack that hits foes\n"
     "using moves like Protect.");
 
-const struct MoveInfo gMovesInfo[MOVES_COUNT_DYNAMAX] =
+const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
 {
     [MOVE_NONE] =
     {


### PR DESCRIPTION
Not a bug but I think it makes more sense to use the define that includes all moves.