### PR TITLE
Fix Extra `task->tState++` and `break` in `Task_DrawFieldMessageBox`

### DIFF
--- a/src/field_message_box.c
+++ b/src/field_message_box.c
@@ -38,8 +38,6 @@ static void Task_DrawFieldMessage(u8 taskId)
                 LoadMessageBoxAndBorderGfx();
             task->tState++;
             break;
-           task->tState++;
-           break;
         case 1:
            DrawDialogueFrame(0, TRUE);
            task->tState++;


### PR DESCRIPTION
Whoever ported this made a mistake and left two duplicate lines of code past case 0's break statement in `Task_DrawFieldMessage`.

## Description
Whoever ported this FRLG's walking into signpost functionality made a mistake and left two duplicate lines of code past `case 0`'s break statement in `Task_DrawFieldMessage`. This PR removes them.

## Issue(s) that this PR fixes
Mistakenly leftover code.

## **Discord contact info**
deokishisu
