### PR TITLE
Include Missed `GetInteractedMetatileScript` Entries for Mart & Center Signs

### DIFF
--- a/src/field_control_avatar.c
+++ b/src/field_control_avatar.c
@@ -487,6 +487,20 @@ static const u8 *GetInteractedMetatileScript(struct MapPosition *position, u8 me
         return EventScript_Questionnaire;
     if (MetatileBehavior_IsTrainerHillTimer(metatileBehavior) == TRUE)
         return EventScript_TrainerHillTimer;
+    if (MetatileBehavior_IsPokeMartSign(metatileBehavior) == TRUE)
+    {
+        if(direction != DIR_NORTH)
+            return NULL;
+        SetMsgSignPostAndVarFacing(direction);
+        return Common_EventScript_ShowPokemartSign;
+    }
+    if (MetatileBehavior_IsPokemonCenterSign(metatileBehavior) == TRUE)
+    {
+        if(direction != DIR_NORTH)
+            return NULL;
+        SetMsgSignPostAndVarFacing(direction);
+        return Common_EventScript_ShowPokemonCenterSign;
+    }
 
     elevation = position->elevation;
     if (elevation == MapGridGetElevationAt(position->x, position->y))


### PR DESCRIPTION
## Description
Currently, the player cannot bring up the Pokemon Mart and Center sign scripts by pressing A on the metatile. Whoever added the metatile behaviors for these tiles forgot to add them to `GetInteractedMetatileScript`. This PR fixes that.

~~It would also be really cool if maintainers would check to make sure that super basic functionality like the original commit that added these sign metatile behaviors is working properly before merging.~~

## **Discord contact info**
deokishisu

