### PR TITLE
Fix AI wrongly thinking it strikes first with priority even if player is using priority themselves

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -1100,9 +1100,9 @@ s32 AI_WhoStrikesFirst(u32 battlerAI, u32 battler, u32 moveConsidered)
     s8 playerPriority = GetMovePriority(battler, predictedMove);
 
     if (aiPriority > playerPriority)
-        return AI_IS_SLOWER;
-    else if (aiPriority < playerPriority)
         return AI_IS_FASTER;
+    else if (aiPriority < playerPriority)
+        return AI_IS_SLOWER;
 
     speedBattlerAI = GetBattlerTotalSpeedStatArgs(battlerAI, abilityAI, holdEffectAI);
     speedBattler   = GetBattlerTotalSpeedStatArgs(battler, abilityPlayer, holdEffectPlayer);

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -1094,7 +1094,14 @@ s32 AI_WhoStrikesFirst(u32 battlerAI, u32 battler, u32 moveConsidered)
     u32 abilityAI = AI_DATA->abilities[battlerAI];
     u32 abilityPlayer = AI_DATA->abilities[battler];
 
-    if (GetMovePriority(battlerAI, moveConsidered) > 0)
+    u32 predictedMove = AI_DATA->lastUsedMove[battler];
+
+    s8 aiPriority = GetBattleMovePriority(battlerAI, moveConsidered);
+    s8 playerPriority = GetBattleMovePriority(battler, predictedMove);
+
+    if (aiPriority > playerPriority)
+        return AI_IS_SLOWER;
+    else if (aiPriority < playerPriority)
         return AI_IS_FASTER;
 
     speedBattlerAI = GetBattlerTotalSpeedStatArgs(battlerAI, abilityAI, holdEffectAI);

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -1096,8 +1096,8 @@ s32 AI_WhoStrikesFirst(u32 battlerAI, u32 battler, u32 moveConsidered)
 
     u32 predictedMove = AI_DATA->lastUsedMove[battler];
 
-    s8 aiPriority = GetBattleMovePriority(battlerAI, moveConsidered);
-    s8 playerPriority = GetBattleMovePriority(battler, predictedMove);
+    s8 aiPriority = GetMovePriority(AI, moveConsidered);
+    s8 playerPriority = GetMovePriority(battler, predictedMove);
 
     if (aiPriority > playerPriority)
         return AI_IS_SLOWER;

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -1094,7 +1094,7 @@ s32 AI_WhoStrikesFirst(u32 battlerAI, u32 battler, u32 moveConsidered)
     u32 abilityAI = AI_DATA->abilities[battlerAI];
     u32 abilityPlayer = AI_DATA->abilities[battler];
 
-    u32 predictedMove = AI_DATA->lastUsedMove[battler];
+    u32 predictedMove = AI_DATA->lastUsedMove[battler]; // TODO update for move prediction
 
     s8 aiPriority = GetMovePriority(battlerAI, moveConsidered);
     s8 playerPriority = GetMovePriority(battler, predictedMove);

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -1096,7 +1096,7 @@ s32 AI_WhoStrikesFirst(u32 battlerAI, u32 battler, u32 moveConsidered)
 
     u32 predictedMove = AI_DATA->lastUsedMove[battler];
 
-    s8 aiPriority = GetMovePriority(AI, moveConsidered);
+    s8 aiPriority = GetMovePriority(battlerAI, moveConsidered);
     s8 playerPriority = GetMovePriority(battler, predictedMove);
 
     if (aiPriority > playerPriority)

--- a/test/battle/ai/ai.c
+++ b/test/battle/ai/ai.c
@@ -831,3 +831,17 @@ AI_SINGLE_BATTLE_TEST("AI stays choice locked into moves in spite of the player'
         TURN { EXPECT_MOVE(opponent, aiMove); }
     }
 }
+
+AI_SINGLE_BATTLE_TEST("AI won't use Sucker Punch if it expects a move of the same priority bracket and the opponent is faster")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_QUICK_ATTACK].priority == 1);
+        ASSUME(gMovesInfo[MOVE_SUCKER_PUNCH].priority == 1);
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(300); Moves(MOVE_QUICK_ATTACK); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(100); Moves(MOVE_SUCKER_PUNCH, MOVE_TACKLE); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_QUICK_ATTACK); EXPECT_MOVE(opponent, MOVE_SUCKER_PUNCH); }
+        TURN { MOVE(player, MOVE_QUICK_ATTACK); EXPECT_MOVE(opponent, MOVE_TACKLE); }
+    }
+}


### PR DESCRIPTION
## Description
In the previous iteration of `AI_WhoStrikesFirst`, the code performed a check like this:

```c
if (GetMovePriority(battlerAI, moveConsidered) > 0)
        return AI_IS_FASTER;
```

This incorrectly assumes that the AI is always faster if the battle move's priority is above `0`. This did not take into account whether the player's predicted move was a priority move, and as such, would faultily use moves like `Sucker Punch` even if it the enemy has `Aqua Jet` with a higher speed stat.

The updated code now checks the player's predicted move through `AI_DATA->lastUsedMove[battler]` to see if the predicted move's priority is higher or lower than the AI's considered move. The rest of the checks stay the same, as this code simply fixes the faulty check.

## Issue(s) that this PR fixes
Fixes #6255 

## **Discord contact info**
viridian.