### PR TITLE
remove obsolete check for steven when retrieving partner name

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -6056,15 +6056,8 @@ const u8 *GetTrainerPartnerName(void)
 {
     if (gBattleTypeFlags & BATTLE_TYPE_INGAME_PARTNER)
     {
-        if (gPartnerTrainerId == TRAINER_PARTNER(PARTNER_STEVEN))
-        {
-            return GetTrainerNameFromId(TRAINER_STEVEN);
-        }
-        else
-        {
-            GetFrontierTrainerName(gStringVar1, gPartnerTrainerId);
-            return gStringVar1;
-        }
+        GetFrontierTrainerName(gStringVar1, gPartnerTrainerId);
+        return gStringVar1;
     }
     else
     {


### PR DESCRIPTION
## Description
removes a now obsolete check when retrieving partners name in multi battles. `GetFrontierTrainerName` handles this correctly so the extra check for steven is not needed anymore. Also fixes a bug related to incorrect name being loaded

## Issue(s) that this PR fixes
Fixes #6282 

## **People who collaborated with me in this PR**
@hedara90 

## **Discord contact info**
u8.salem
