### PR TITLE
Do not add TRAINER_FLAG_DOUBLE_BATTLE to recorded battles

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -512,7 +512,8 @@ static void CB2_InitBattleInternal(void)
 
     if (gBattleTypeFlags & BATTLE_TYPE_TRAINER && !(gBattleTypeFlags & (BATTLE_TYPE_FRONTIER
                                                                         | BATTLE_TYPE_EREADER_TRAINER
-                                                                        | BATTLE_TYPE_TRAINER_HILL)))
+                                                                        | BATTLE_TYPE_TRAINER_HILL
+                                                                        | BATTLE_TYPE_RECORDED)))
     {
         gBattleTypeFlags |= (IsTrainerDoubleBattle(TRAINER_BATTLE_PARAM.opponentA) ? BATTLE_TYPE_DOUBLE : 0);
     }


### PR DESCRIPTION
Needs testing, but may fix the problem described [on Discord](https://discord.com/channels/419213663107416084/774393519569502268/1341043092631064648).

## **People who collaborated with me in this PR**
All credit to @cawtds for finding it.