### PR TITLE
fix spit up getting skipped

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -4009,7 +4009,7 @@ static void DebugAction_Give_Pokemon_ComplexCreateMon(u8 taskId) //https://githu
     //Moves
     for (i = 0; i < MAX_MON_MOVES; i++)
     {
-        if (moves[i] == 0 || moves[i] == 0xFF || moves[i] >= MOVES_COUNT)
+        if (moves[i] == MOVE_NONE || moves[i] >= MOVES_COUNT)
             continue;
 
         SetMonMoveSlot(&mon, moves[i], i);


### PR DESCRIPTION
## Description
moveId 255 is getting skipped, which is Spit up. Didn't find any reason why 0xFF was skipped specifically.

## **Discord contact info**
.cawt
