### PR TITLE
Fix AI hazard move handling, minor AI tweaks

### DIFF
--- a/include/battle_ai_util.h
+++ b/include/battle_ai_util.h
@@ -127,7 +127,7 @@ bool32 IsAromaVeilProtectedEffect(u32 moveEffect);
 bool32 IsNonVolatileStatusMoveEffect(u32 moveEffect);
 bool32 IsMoveRedirectionPrevented(u32 battlerAtk, u32 move, u32 atkAbility);
 bool32 IsMoveEncouragedToHit(u32 battlerAtk, u32 battlerDef, u32 move);
-bool32 IsHazardMoveEffect(u32 moveEffect);
+bool32 IsHazardMove(u32 move);
 bool32 IsTwoTurnNotSemiInvulnerableMove(u32 battlerAtk, u32 move);
 void ProtectChecks(u32 battlerAtk, u32 battlerDef, u32 move, u32 predictedMove, s32 *score);
 bool32 ShouldSetSandstorm(u32 battler, u32 ability, u32 holdEffect);
@@ -154,6 +154,7 @@ bool32 HasSubstituteIgnoringMove(u32 battler);
 bool32 HasHighCritRatioMove(u32 battler);
 bool32 HasMagicCoatAffectedMove(u32 battler);
 bool32 HasSnatchAffectedMove(u32 battler);
+bool32 IsHazardClearingMove(u32 move);
 
 // status checks
 bool32 AI_CanGetFrostbite(u32 battler, u32 ability);
@@ -217,5 +218,6 @@ void IncreaseTidyUpScore(u32 battlerAtk, u32 battlerDef, u32 move, s32 *score);
 bool32 AI_ShouldSpicyExtract(u32 battlerAtk, u32 battlerAtkPartner, u32 move, struct AiLogicData *aiData);
 void IncreaseSubstituteMoveScore(u32 battlerAtk, u32 battlerDef, u32 move, s32 *score);
 bool32 IsBattlerPredictedToSwitch(u32 battler);
+bool32 HasLowAccuracyMove(u32 battlerAtk, u32 battlerDef);
 
 #endif //GUARD_BATTLE_AI_UTIL_H

--- a/include/config/ai.h
+++ b/include/config/ai.h
@@ -44,7 +44,7 @@
 #define SHOULD_SWITCH_REGENERATOR_STATS_RAISED_PERCENTAGE           20
 
 // AI held item-based move scoring
-#define BLUNDER_POLICY_ACCURACY_THRESHOLD                     75 // Moves with accuracy equal below this value are prioritized when holding Blunder Policy  
+#define LOW_ACCURACY_THRESHOLD                                  75 // Moves with accuracy equal OR below this value are considered low accuracy 
 
 // AI prediction chances
 #define PREDICT_SWITCH_CHANCE                                   50

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -2112,7 +2112,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
 
             if (isDoubleBattle)
             {
-                if (IsHazardMoveEffect(GetMoveEffect(aiData->partnerMove)) // partner is going to set up hazards
+                if (IsHazardMove(aiData->partnerMove) // partner is going to set up hazards
                   && AI_IsFaster(BATTLE_PARTNER(battlerAtk), battlerAtk, aiData->partnerMove)) // partner is going to set up before the potential Defog
                 {
                     ADJUST_SCORE(-10);
@@ -3308,7 +3308,7 @@ static u32 AI_CalcHoldEffectMoveScore(u32 battlerAtk, u32 battlerDef, u32 move)
     {
         u32 moveAcc = aiData->moveAccuracy[battlerAtk][battlerDef][AI_THINKING_STRUCT->movesetIndex];
 
-        if (moveAcc <= BLUNDER_POLICY_ACCURACY_THRESHOLD)
+        if (moveAcc <= LOW_ACCURACY_THRESHOLD)
         {
             ADJUST_SCORE(GOOD_EFFECT);
         }
@@ -4015,7 +4015,7 @@ static u32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move)
         {
             if (isDoubleBattle)
             {
-                if (IsHazardMoveEffect(GetMoveEffect(aiData->partnerMove)) // Partner is going to set up hazards
+                if (IsHazardMove(aiData->partnerMove) // Partner is going to set up hazards
                     && AI_IsSlower(battlerAtk, BATTLE_PARTNER(battlerAtk), move)) // Partner going first
                     break; // Don't use Defog if partner is going to set up hazards
             }

--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -908,14 +908,8 @@ static bool32 CanMonSurviveHazardSwitchin(u32 battler)
             for (j = 0; j < MAX_MON_MOVES; j++)
             {
                 aiMove = GetMonData(&party[i], MON_DATA_MOVE1 + j, NULL);
-                u32 aiEffect = GetMoveEffect(aiMove);
-                if (aiEffect == EFFECT_RAPID_SPIN
-                 || (B_DEFOG_EFFECT_CLEARING >= GEN_6 && aiEffect == EFFECT_DEFOG)
-                 || aiEffect == EFFECT_TIDY_UP)
-                {
-                    // Have a mon that can clear the hazards, so switching out is okay
+                if (IsHazardClearingMove(aiMove)) // Have a mon that can clear the hazards, so switching out is okay
                     return TRUE;
-                }
             }
         }
         // Faints to hazards and party can't clear them, don't switch out


### PR DESCRIPTION
## Description
I went through everything in #6126 and added what I thought made sense.

Fixes:
- check all moves that can make hazards properly
- check all moves that can remove hazards properly
- `IsBattlerIncapacitated` considers Sleep Talk

Tweaks:
- Additional items added to `sRecycleEncouragedItems`
- Check for low accuracy move added when considering copying stat changes

This is to upcoming so I can rename `BLUNDER_POLICY_ACCURACY_THRESHOLD` to `LOW_ACCURACY_THRESHOLD` and reuse it.

## Issue(s) that this PR fixes
Closes #6126 
Closes #5763 

## **People who collaborated with me in this PR**
@ShadowzLmao2

## Feature(s) this PR does NOT handle:
Things I didn't think were good to add include:
- refactoring `IsSemiInvulnerable` (seems like unnecessary conflicts)
- Changing the ShouldSet[weather] functions to also check if a different weather is up and the opponent is using it (I don't fully understand what this means, we don't read the player's inputs)
- Make `IsUngroundingEffect` check for Skill Swap and Levitate on the opponent (this is just a move effect check function so it's inappropriate, it also isn't used anywhere atm to make changes there)

## **Discord contact info**
@Pawkkie 