### PR TITLE
Fix Overzealous Absorber Switching

### DIFF
--- a/include/config/ai.h
+++ b/include/config/ai.h
@@ -9,7 +9,7 @@
 #define SHOULD_SWITCH_WONDER_GUARD_PERCENTAGE                   100
 #define SHOULD_SWITCH_TRUANT_PERCENTAGE                         100
 #define SHOULD_SWITCH_ALL_MOVES_BAD_PERCENTAGE                  100
-#define STAY_IN_STATS_RAISED                                    2  // Number of stat stages that must be raised across any stats before the AI won't switch mon out
+#define STAY_IN_STATS_RAISED                                    2  // Number of stat stages that must be raised across any stats before the AI won't switch mon out in certain cases
 
 // AI smart switching chances; if you want more complex behaviour, modify GetSwitchChance
 #define SHOULD_SWITCH_ABSORBS_MOVE_PERCENTAGE                       100

--- a/include/config/ai.h
+++ b/include/config/ai.h
@@ -9,6 +9,7 @@
 #define SHOULD_SWITCH_WONDER_GUARD_PERCENTAGE                   100
 #define SHOULD_SWITCH_TRUANT_PERCENTAGE                         100
 #define SHOULD_SWITCH_ALL_MOVES_BAD_PERCENTAGE                  100
+#define STAY_IN_STATS_RAISED                                    2  // Number of stat stages that must be raised across any stats before the AI won't switch mon out
 
 // AI smart switching chances; if you want more complex behaviour, modify GetSwitchChance
 #define SHOULD_SWITCH_ABSORBS_MOVE_PERCENTAGE                       100

--- a/include/config/general.h
+++ b/include/config/general.h
@@ -6,7 +6,7 @@
 // still has them in the ROM. This is because the developers forgot
 // to define NDEBUG before release, however this has been changed as
 // Ruby's actual debug build does not use the AGBPrint features.
-// #define NDEBUG
+#define NDEBUG
 
 // To enable printf debugging, comment out "#define NDEBUG". This allows
 // the various AGBPrint functions to be used. (See include/gba/isagbprint.h).

--- a/include/config/general.h
+++ b/include/config/general.h
@@ -6,7 +6,7 @@
 // still has them in the ROM. This is because the developers forgot
 // to define NDEBUG before release, however this has been changed as
 // Ruby's actual debug build does not use the AGBPrint features.
-#define NDEBUG
+// #define NDEBUG
 
 // To enable printf debugging, comment out "#define NDEBUG". This allows
 // the various AGBPrint functions to be used. (See include/gba/isagbprint.h).

--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -136,7 +136,7 @@ static bool32 AreStatsRaised(u32 battler)
             buffedStatsValue += gBattleMons[battler].statStages[i] - DEFAULT_STAT_STAGE;
     }
 
-    return (buffedStatsValue > 3);
+    return (buffedStatsValue > STAY_IN_STATS_RAISED);
 }
 
 void GetAIPartyIndexes(u32 battler, s32 *firstId, s32 *lastId)
@@ -449,12 +449,8 @@ static bool32 FindMonThatAbsorbsOpponentsMove(u32 battler)
             // Only check damage if it's a damaging move
             if (!IsBattleMoveStatus(aiMove))
             {
-                if (AI_DATA->simulatedDmg[battler][opposingBattler][i].expected > gBattleMons[opposingBattler].hp);
-                {
-                    DebugPrintf("Expect damage: %d", AI_DATA->simulatedDmg[battler][opposingBattler][i].expected);
-                    DebugPrintf("Opponent HP: %u", gBattleMons[opposingBattler].hp);
+                if (AI_DATA->simulatedDmg[battler][opposingBattler][i].expected > gBattleMons[opposingBattler].hp)
                     return FALSE;
-                }
             }
         }
     }

--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -125,6 +125,20 @@ static bool32 IsAceMon(u32 battler, u32 monPartyId)
     return FALSE;
 }
 
+static bool32 AreStatsRaised(u32 battler)
+{
+    u8 buffedStatsValue = 0;
+    s32 i;
+
+    for (i = 0; i < NUM_BATTLE_STATS; i++)
+    {
+        if (gBattleMons[battler].statStages[i] > DEFAULT_STAT_STAGE)
+            buffedStatsValue += gBattleMons[battler].statStages[i] - DEFAULT_STAT_STAGE;
+    }
+
+    return (buffedStatsValue > 3);
+}
+
 void GetAIPartyIndexes(u32 battler, s32 *firstId, s32 *lastId)
 {
     if (BATTLE_TWO_VS_ONE_OPPONENT && (battler & BIT_SIDE) == B_SIDE_OPPONENT)
@@ -408,7 +422,7 @@ static bool32 FindMonThatAbsorbsOpponentsMove(u32 battler)
     s32 firstId;
     s32 lastId;
     struct Pokemon *party;
-    u16 monAbility;
+    u16 monAbility, aiMove;
     u32 opposingBattler = GetOppositeBattler(battler);
     u32 incomingMove = AI_DATA->lastUsedMove[opposingBattler];
     u32 incomingType = GetMoveType(incomingMove);
@@ -421,9 +435,29 @@ static bool32 FindMonThatAbsorbsOpponentsMove(u32 battler)
         return FALSE;
     if (gBattleStruct->prevTurnSpecies[battler] != gBattleMons[battler].species) // AI mon has changed, player's behaviour no longer reliable; note to override this if using AI_FLAG_PREDICT_MOVE
         return FALSE; 
-
     if (HasSuperEffectiveMoveAgainstOpponents(battler, TRUE) && (RandomPercentage(RNG_AI_SWITCH_ABSORBING_STAY_IN, STAY_IN_ABSORBING_PERCENTAGE) || AI_DATA->aiSwitchPredictionInProgress))
         return FALSE;
+    if (AreStatsRaised(battler))
+        return FALSE;
+
+    // Don't switch if mon could OHKO
+    for (i = 0; i < MAX_MON_MOVES; i++)
+    {
+        aiMove = gBattleMons[battler].moves[i];
+        if (aiMove != MOVE_NONE)
+        {
+            // Only check damage if it's a damaging move
+            if (!IsBattleMoveStatus(aiMove))
+            {
+                if (AI_DATA->simulatedDmg[battler][opposingBattler][i].expected > gBattleMons[opposingBattler].hp);
+                {
+                    DebugPrintf("Expect damage: %d", AI_DATA->simulatedDmg[battler][opposingBattler][i].expected);
+                    DebugPrintf("Opponent HP: %u", gBattleMons[opposingBattler].hp);
+                    return FALSE;
+                }
+            }
+        }
+    }
 
     if (IsDoubleBattle())
     {
@@ -760,20 +794,6 @@ static bool32 HasSuperEffectiveMoveAgainstOpponents(u32 battler, bool32 noRng)
     }
 
     return FALSE;
-}
-
-static bool32 AreStatsRaised(u32 battler)
-{
-    u8 buffedStatsValue = 0;
-    s32 i;
-
-    for (i = 0; i < NUM_BATTLE_STATS; i++)
-    {
-        if (gBattleMons[battler].statStages[i] > DEFAULT_STAT_STAGE)
-            buffedStatsValue += gBattleMons[battler].statStages[i] - DEFAULT_STAT_STAGE;
-    }
-
-    return (buffedStatsValue > 3);
 }
 
 static bool32 FindMonWithFlagsAndSuperEffective(u32 battler, u16 flags, u32 percentChance)


### PR DESCRIPTION
## Description
Got some fabulous data from @iriv24 indicating just how overeager this switching is, makes for some truly embarrassing behaviour.

This PR adds clauses to check that the AI's current mon can't OHKO the player and also doesn't have any stats raised before it switches out for an absorber to fix the issue. I've also pulled the number for "how many stats raised do you want to stay in for" into a config as it's been hardcoded to 3 up to this point which I hadn't realized, and definitely shouldn't be.

To upcoming because this code has seen significant refactoring.

I should note I'm intending to do a major overhaul to how `ShouldSwitch` is structured in the not-too-distant future so these kinds of checks can be applied more universally without rerunning them for every sub function, but that's way out of scope for this fix and won't be happening for a while yet. This should solve the problem in this specific case, where it's the most severe, for now :)

## **People who collaborated with me in this PR**
@iriv24 and @ravepossum for squinting at a conditional for nearly 30mins with me to find a semicolon

## **Discord contact info**
@Pawkkie 
