### PR TITLE
Update SCOPE.md with Intergenerational Feature Compatibility

### DIFF
--- a/docs/team_procedures/scope.md
+++ b/docs/team_procedures/scope.md
@@ -54,6 +54,7 @@ Pull Requests that fall into this category are not in scope by default and shoul
 2. **Fangame Features**: Adds a popular feature from other fangames  
 3. **Popular Non-SS Features**: Exceptions can be made for uniquely popular or requested features (Drowsy, PLA Legend Plate, etc.)
 4. **External Program**: External programs like poryscript, porymoves, etc.
+5. **Intergenerational Feature Compatibility**: Addresses limitations and issues resulting from including all generational behaviours in a GBA native title, and extrapolation of features no longer supported by GameFreak"
 
 ## Workflow for Proposed Feature Scope Discussion
 For the contributor:


### PR DESCRIPTION
## Description
Discussed on Discord, this doesn't change anything pertaining to the scope doc functionality, but it gives us a category / label we can use when discussing features that was missing before.

This category is for PRs that fix problems that exist due to the unique nature of expansion as a project that integrates all features from all games into one GBA cartridge, which encounters limitations both due to the difference in hardware and gaps of support in how new generation content interacts with no-longer-used old generation features. It's in the "Discussion Required" section because many of these implementations and fixes will be subjective, and thus benefit from senate consensus.

Just formally adding this to the doc after the discussion.

## **Discord contact info**
@Pawkkie 