### PR TITLE
Fixed curing status2 with items in double battles

### DIFF
--- a/src/item_use.c
+++ b/src/item_use.c
@@ -1171,6 +1171,15 @@ void ItemUseInBattle_PartyMenuChooseMove(u8 taskId)
     ItemUseInBattle_ShowPartyMenu(taskId);
 }
 
+static bool32 SelectedMonHasStatus2(u16 itemId)
+{
+    if (gPartyMenu.slotId == 0)
+        return gBattleMons[0].status2 & GetItemStatus2Mask(itemId);
+    else if (gBattleTypeFlags & (BATTLE_TYPE_DOUBLE | BATTLE_TYPE_MULTI) && gPartyMenu.slotId == 1)
+        return gBattleMons[2].status2 & GetItemStatus2Mask(itemId);
+    return FALSE;
+}
+
 // Returns whether an item can be used in battle and sets the fail text.
 bool32 CannotUseItemsInBattle(u16 itemId, struct Pokemon *mon)
 {
@@ -1243,13 +1252,13 @@ bool32 CannotUseItemsInBattle(u16 itemId, struct Pokemon *mon)
         break;
     case EFFECT_ITEM_CURE_STATUS:
         if (!((GetMonData(mon, MON_DATA_STATUS) & GetItemStatus1Mask(itemId))
-            || (gPartyMenu.slotId == 0 && gBattleMons[gBattlerInMenuId].status2 & GetItemStatus2Mask(itemId))))
+            || SelectedMonHasStatus2(itemId)))
             cannotUse = TRUE;
         break;
     case EFFECT_ITEM_HEAL_AND_CURE_STATUS:
         if ((hp == 0 || hp == GetMonData(mon, MON_DATA_MAX_HP))
             && !((GetMonData(mon, MON_DATA_STATUS) & GetItemStatus1Mask(itemId))
-            || (gPartyMenu.slotId == 0 && gBattleMons[gBattlerInMenuId].status2 & GetItemStatus2Mask(itemId))))
+            || SelectedMonHasStatus2(itemId)))
             cannotUse = TRUE;
         break;
     case EFFECT_ITEM_REVIVE:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Before submitting, please make sure your pull request meets the scope guidelines. If unsure, please open a thread in #pr-discussions.-->
<!--- Scope Guidelines: https://github.com/rh-hideout/pokeemerald-expansion/blob/master/docs/team_procedures/scope.md  -->
<!--- #pr-discussions:  https://discord.com/channels/419213663107416084/1102784418369785948 -->

## Description
<!--- Describe your changes in detail -->
<!--- If you believe this PR qualifies as a "Big Feature" as defined in docs/team_procedures/schedule.md, please let a Maintainer know! -->
Fixed using items to cure `status2` conditions from targets that are different from the one using the item in double battles.
Tested in regular double battles and multi-battles.

## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, fixes #2222." -->
<!-- If it doesn't apply, feel free to remove this section. -->
![20250225_10h23m17s_grim](https://github.com/user-attachments/assets/204428ae-e901-4250-b674-c085d2971566)


## **People who collaborated with me in this PR**
<!-- Please credit everyone else that contributed to this PR, be it code and/or assets. -->
<!-- Use their GitHub tag if they have one (or add "@/" at the start if they don't). Be sure to start the line using @ so the automatic changelog can properly detect the collaborators. -->
<!-- Eg.: "@Lunos for sprites, @/Masuda for support" -->
<!-- If it doesn't apply, feel free to remove this section. -->
Reported by @wiz1989

## **Discord contact info**
<!--- Formatted as username (e.g. Lunos) or username#numbers (e.g. Lunos#4026) -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara