### PR TITLE
Fixes fainted battler being able to select an action

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3875,7 +3875,7 @@ static void TryDoEventsBeforeFirstTurn(void)
             gBattleStruct->monToSwitchIntoId[i] = PARTY_SIZE;
             gChosenActionByBattler[i] = B_ACTION_NONE;
             gChosenMoveByBattler[i] = MOVE_NONE;
-            gBattleStruct->battlerState[i].absentBattlerFlags = gAbsentBattlerFlags & (1u << i);
+            gBattleStruct->battlerState[i].absentBattlerFlags = (gAbsentBattlerFlags & (1u << i) ? TRUE : FALSE);
         }
         TurnValuesCleanUp(FALSE);
         SpecialStatusesClear();
@@ -3993,7 +3993,7 @@ void BattleTurnPassed(void)
     {
         gChosenActionByBattler[i] = B_ACTION_NONE;
         gChosenMoveByBattler[i] = MOVE_NONE;
-        gBattleStruct->battlerState[i].absentBattlerFlags = gAbsentBattlerFlags & (1u << i);
+        gBattleStruct->battlerState[i].absentBattlerFlags = (gAbsentBattlerFlags & (1u << i) ? TRUE : FALSE);
         gBattleStruct->monToSwitchIntoId[i] = PARTY_SIZE;
         gStatuses4[i] &= ~STATUS4_ELECTRIFIED;
     }


### PR DESCRIPTION
Fixes fainted battlers on the right slot being given the option to select an action. This happened because `battlerState.absentBattlerFlags` was not being set correctly.

Fixed interaction:

https://github.com/user-attachments/assets/fdc914b8-86f9-43f6-9807-04482d63f730


## Issue(s) that this PR fixes
Fixes #6294

## **Discord contact info**
PhallenTree