### PR TITLE
Fixing grammar of Berry Tree strings

### DIFF
--- a/src/berry.c
+++ b/src/berry.c
@@ -2174,6 +2174,11 @@ void ObjectEventInteractionGetBerryCountString(void)
     u8 berry = GetBerryTypeByBerryTreeId(treeId);
     u8 count = GetBerryCountByBerryTreeId(treeId);
 
+    // The strings for growing Berries all refer to a singular berry plant.
+    // This ensures that text about planting a Berry and the growing Berry reads correctly.
+    if (GetStageByBerryTreeId(treeId) != BERRY_STAGE_BERRIES)
+        count = 1;
+
     gSpecialVar_0x8006 = BerryTypeToItemId(berry);
     CopyItemNameHandlePlural(BerryTypeToItemId(berry), gStringVar1, count);
     berry = GetTreeMutationValue(treeId);


### PR DESCRIPTION
When a Berry Tree is growing, all of the strings expect a singular berry. Previously, it had taken the number of berries from the final berry tree, so every in-progress string was grammatically wrong unless it was going to result only in one Berry.

## Description
This checks the status of the berry tree it's grabbing the item string for.  If it is not at the final Berry stage, it will return the singular form of the item, which is what all the calls in `data/scripts/berry_tree.inc` actually wanted.
 
## Images
Before:
![pokeemerald-75](https://github.com/user-attachments/assets/e5da1993-c4d0-4804-87d0-ef1ff356a3c3)
After:
![pokeemerald-76](https://github.com/user-attachments/assets/c523c84b-6878-4d01-9dd6-bb0fab9f5cdc)

## Things to note in the release changelog:
Berry trees berries are no longer erroneously plural.

## **Discord contact info**
wildvenonat