### PR TITLE
Fix roamers having 0 hp on repeat encounters

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -5678,7 +5678,7 @@ static void FreeResetData_ReturnToOvOrDoEvolutions(void)
     {
         // To account for Battle Factory and Slateport Battle Tent, enemy parties are zeroed out in the facilitites respective src/xxx.c files
         // The ZeroEnemyPartyMons() call happens in SaveXXXChallenge function (eg. SaveFactoryChallenge)
-        if (!(gBattleTypeFlags & BATTLE_TYPE_FRONTIER))
+        if (!(gBattleTypeFlags & (BATTLE_TYPE_FRONTIER | BATTLE_TYPE_ROAMER)))
         {
             ZeroEnemyPartyMons();
         }
@@ -5751,6 +5751,7 @@ static void ReturnFromBattleToOverworld(void)
     if (gBattleTypeFlags & BATTLE_TYPE_ROAMER)
     {
         UpdateRoamerHPStatus(&gEnemyParty[0]);
+        ZeroEnemyPartyMons();
 
 #ifndef BUGFIX
         if ((gBattleOutcome & B_OUTCOME_WON) || gBattleOutcome == B_OUTCOME_CAUGHT)


### PR DESCRIPTION
## Description
Fixes https://github.com/rh-hideout/pokeemerald-expansion/issues/5805, which is consistently reproducible by:
1. Encountering a roamer;
2. Letting it flee;
3. Encountering a roamer of the same species again.

The fix is to ensure that `ZeroEnemyPartyMons` is called after `UpdateRoamerHPStatus`.

## Images

Demonstration of the bug (mGBA 10.4, expansion 1.10):

https://private-user-images.githubusercontent.com/105816064/418068804-a0471103-355d-4b15-a6a7-14579691207a.webm?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDA5MTU5NzksIm5iZiI6MTc0MDkxNTY3OSwicGF0aCI6Ii8xMDU4MTYwNjQvNDE4MDY4ODA0LWEwNDcxMTAzLTM1NWQtNGIxNS1hNmE3LTE0NTc5NjkxMjA3YS53ZWJtP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI1MDMwMiUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNTAzMDJUMTE0MTE5WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9YWI5Zjc4M2RjOWI4ODUwMTE3MDZhNTZhNjI5Y2IzNzViMjE0MzYwOTEzMGFkNWEwZjk1ZmM0Njg3OTNhNGRjNSZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.GVIPeindi9nfoIdY2Psp-trCtRxB1GAQ9cth-j64gNc

## Issue(s) that this PR fixes
Fixes https://github.com/rh-hideout/pokeemerald-expansion/issues/5805.

## **Discord contact info**
yyatsuta
