### PR TITLE
Fixes gimmick icon flying off the screen

### DIFF
--- a/src/battle_gimmick.c
+++ b/src/battle_gimmick.c
@@ -204,6 +204,7 @@ static void SpriteCb_GimmickTrigger(struct Sprite *sprite)
 {
     s32 xSlide, xPriority, xOptimal;
     s32 yDiff;
+    s32 xHealthbox = gSprites[gHealthboxSpriteIds[sprite->tBattler]].x;
 
     if (IsDoubleBattle())
     {
@@ -222,25 +223,29 @@ static void SpriteCb_GimmickTrigger(struct Sprite *sprite)
 
     if (sprite->tHide)
     {
-        if (sprite->x != gSprites[gHealthboxSpriteIds[sprite->tBattler]].x - xSlide)
+        if (sprite->x < xHealthbox - xSlide)
             sprite->x++;
 
-        if (sprite->x >= gSprites[gHealthboxSpriteIds[sprite->tBattler]].x - xPriority)
+        if (sprite->x >= xHealthbox - xPriority)
             sprite->oam.priority = 2;
         else
             sprite->oam.priority = 1;
 
         sprite->y = gSprites[gHealthboxSpriteIds[sprite->tBattler]].y - yDiff;
         sprite->y2 = gSprites[gHealthboxSpriteIds[sprite->tBattler]].y2 - yDiff;
-        if (sprite->x == gSprites[gHealthboxSpriteIds[sprite->tBattler]].x - xSlide)
+        if (sprite->x == xHealthbox - xSlide)
             DestroyGimmickTriggerSprite();
     }
     else
     {
-        if (sprite->x != gSprites[gHealthboxSpriteIds[sprite->tBattler]].x - xOptimal)
+        // Edge case: in doubles, if selecting move and next mon's action too fast, the second battler's gimmick icon uses the x from the first battler's gimmick icon
+        if (sprite->y != gSprites[gHealthboxSpriteIds[sprite->tBattler]].y - yDiff)
+            sprite->x = xHealthbox - xSlide;
+
+        if (sprite->x > xHealthbox - xOptimal)
             sprite->x--;
 
-        if (sprite->x >= gSprites[gHealthboxSpriteIds[sprite->tBattler]].x - xPriority)
+        if (sprite->x >= xHealthbox - xPriority)
             sprite->oam.priority = 2;
         else
             sprite->oam.priority = 1;


### PR DESCRIPTION
Fixes gimmick icon flying off the screen if selecting a move (and target if applicable) and the next mon's action quickly.
This happened because the `x` value was not correctly updated in these cases, causing the x value from the previous mon's gimmick icon to be used (which was not on its "Optimal" position (`gSprites[gHealthboxSpriteIds[sprite->tBattler]].x - xOptimal`), so it tried reducing `x` until it was correct).
Also limited the movement of the gimmick icons to only happen within their normal bounds (between its "Optimal" position and its "Slide" position (`gSprites[gHealthboxSpriteIds[sprite->tBattler]].x - xSlide`)).
Haven't tested with other gimmicks but I presume this fix works since they use the same functions.

Fixed interaction:

https://github.com/user-attachments/assets/941b0de8-41de-471e-9fbb-48176d13729f

## Issue(s) that this PR fixes
Fixes #6384, fixes #4652

## **Discord contact info**
PhallenTree
