### PR TITLE
Fixes hazards not respecting tera types

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -10892,11 +10892,11 @@ s32 GetStealthHazardDamageByTypesAndHP(enum TypeSideHazard hazardType, u8 type1,
 
 s32 GetStealthHazardDamage(enum TypeSideHazard hazardType, u32 battler)
 {
-    u8 type1 = gBattleMons[battler].types[0];
-    u8 type2 = gBattleMons[battler].types[1];
+    u32 types[3];
+    GetBattlerTypes(battler, FALSE, types);
     u32 maxHp = gBattleMons[battler].maxHP;
 
-    return GetStealthHazardDamageByTypesAndHP(hazardType, type1, type2, maxHp);
+    return GetStealthHazardDamageByTypesAndHP(hazardType, types[0], types[1], maxHp);
 }
 
 bool32 IsPartnerMonFromSameTrainer(u32 battler)

--- a/test/battle/move_effect/stealth_rock.c
+++ b/test/battle/move_effect/stealth_rock.c
@@ -73,3 +73,30 @@ DOUBLE_BATTLE_TEST("Stealth Rock damages the correct pokemon when Eject Button i
         EXPECT_EQ(opponentLeft->hp, opponentLeft->maxHP);
     }
 }
+
+SINGLE_BATTLE_TEST("Stealth Rock damage terastalized mons with the correct amount of damage", s16 damage)
+{
+    u32 tera;
+
+    PARAMETRIZE { tera = FALSE; }
+    PARAMETRIZE { tera = TRUE; }
+
+    GIVEN {
+        PLAYER(SPECIES_CHARIZARD) { TeraType(TYPE_NORMAL); }
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        if (tera == TRUE)
+            TURN { MOVE(opponent, MOVE_STEALTH_ROCK); MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_TERA); }
+        else
+            TURN { MOVE(opponent, MOVE_STEALTH_ROCK); MOVE(player, MOVE_CELEBRATE); }
+        TURN { SWITCH(player, 1); }
+        TURN { SWITCH(player, 0); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_STEALTH_ROCK, opponent);
+        HP_BAR(player);
+        HP_BAR(player, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_GT(results[0].damage, results[1].damage);
+    }
+}


### PR DESCRIPTION
When a mon was terastalized it still took hazards damage based on it's original typing. 