### PR TITLE
Refactor HasWeatherEffect and IsUnnerveAbilityOnOpposingSide

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -12306,6 +12306,9 @@ bool32 HasWeatherEffect(void)
 {
     for (u32 battler = 0; battler < gBattlersCount; battler++)
     {
+        if (!IsBattlerAlive(battler))
+            continue;
+
         u32 ability = GetBattlerAbility(battler);
         if (ability == ABILITY_CLOUD_NINE || ability == ABILITY_AIR_LOCK)
             return TRUE;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -12304,7 +12304,12 @@ void ClearPursuitValuesIfSet(u32 battler)
 
 bool32 HasWeatherEffect(void)
 {
-    if (IsAbilityOnField(ABILITY_CLOUD_NINE) || IsAbilityOnField(ABILITY_AIR_LOCK))
-        return FALSE;
-    return TRUE;
+    for (u32 battler = 0; battler < gBattlersCount; battler++)
+    {
+        u32 ability = GetBattlerAbility(battler);
+        if (ability == ABILITY_CLOUD_NINE || ability == ABILITY_AIR_LOCK)
+            return TRUE;
+    }
+
+    return FALSE;
 }

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -11428,7 +11428,7 @@ static bool32 IsUnnerveAbilityOnOpposingSide(u32 battler)
         if (!IsBattlerAlive(battlerDef))
             continue;
 
-        u32 ability = GetBattlerAbility(battler);
+        u32 ability = GetBattlerAbility(battlerDef);
         switch (ability)
         {
         case ABILITY_UNNERVE:

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -11420,10 +11420,26 @@ static bool32 TryRemoveScreens(u32 battler)
 
 static bool32 IsUnnerveAbilityOnOpposingSide(u32 battler)
 {
-    if (IsAbilityOnOpposingSide(battler, ABILITY_UNNERVE)
-      || IsAbilityOnOpposingSide(battler, ABILITY_AS_ONE_ICE_RIDER)
-      || IsAbilityOnOpposingSide(battler, ABILITY_AS_ONE_SHADOW_RIDER))
-        return TRUE;
+    for (u32 battlerDef = 0; battlerDef < gBattlersCount; battlerDef++)
+    {
+        if (battler == battlerDef || IsBattlerAlly(battler, battlerDef))
+            continue;
+
+        if (!IsBattlerAlive(battlerDef))
+            continue;
+
+        u32 ability = GetBattlerAbility(battler);
+        switch (ability)
+        {
+        case ABILITY_UNNERVE:
+        case ABILITY_AS_ONE_ICE_RIDER:
+        case ABILITY_AS_ONE_SHADOW_RIDER:
+            return TRUE;
+        default:
+            return FALSE;
+        }
+    }
+
     return FALSE;
 }
 
@@ -12310,8 +12326,14 @@ bool32 HasWeatherEffect(void)
             continue;
 
         u32 ability = GetBattlerAbility(battler);
-        if (ability == ABILITY_CLOUD_NINE || ability == ABILITY_AIR_LOCK)
+        switch (ability)
+        {
+        case ABILITY_CLOUD_NINE
+        case ABILITY_AIR_LOCK
             return FALSE;
+        default:
+            return TRUE;
+        }
     }
 
     return TRUE;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -12311,8 +12311,8 @@ bool32 HasWeatherEffect(void)
 
         u32 ability = GetBattlerAbility(battler);
         if (ability == ABILITY_CLOUD_NINE || ability == ABILITY_AIR_LOCK)
-            return TRUE;
+            return FALSE;
     }
 
-    return FALSE;
+    return TRUE;
 }

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -12328,8 +12328,8 @@ bool32 HasWeatherEffect(void)
         u32 ability = GetBattlerAbility(battler);
         switch (ability)
         {
-        case ABILITY_CLOUD_NINE
-        case ABILITY_AIR_LOCK
+        case ABILITY_CLOUD_NINE:
+        case ABILITY_AIR_LOCK:
             return FALSE;
         default:
             return TRUE;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -11435,8 +11435,6 @@ static bool32 IsUnnerveAbilityOnOpposingSide(u32 battler)
         case ABILITY_AS_ONE_ICE_RIDER:
         case ABILITY_AS_ONE_SHADOW_RIDER:
             return TRUE;
-        default:
-            return FALSE;
         }
     }
 
@@ -12331,8 +12329,6 @@ bool32 HasWeatherEffect(void)
         case ABILITY_CLOUD_NINE:
         case ABILITY_AIR_LOCK:
             return FALSE;
-        default:
-            return TRUE;
         }
     }
 


### PR DESCRIPTION
The function was inefficient because the `IsAbilityOnField` was called for each ability meaning that it needed double the amount of `GetBattlerAbility` calls. Did the same for `IsUnnerveAbilityOnOpposingSide`. This one needed 3 times as many GetBattlerAbility calls.
