### PR TITLE
Update the All Move Animations test

### DIFF
--- a/include/config/test.h
+++ b/include/config/test.h
@@ -1140,4 +1140,8 @@
 //  Move animation testing
 #define T_SHOULD_RUN_MOVE_ANIM  FALSE       //  If TRUE, enables the move animation tests, these are very computationally heavy and takes a long time to run.
 
+#define ANIM_TEST_START_MOVE 1              //  First move to test
+#define ANIM_TEST_END_MOVE   MOVES_COUNT-1  //  Last move to test
+
+
 #endif // GUARD_CONFIG_TEST_H

--- a/test/battle/move_animations/all_anims.c
+++ b/test/battle/move_animations/all_anims.c
@@ -369,20 +369,16 @@ SINGLE_BATTLE_TEST("Move Animations don't leak when used - Singles (player to op
     u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
     u32 tempMove, tempSpecies;
     FORCE_MOVE_ANIM(TRUE);
-    for (; j <= ANIM_TEST_END_MOVE; j++)
-    {
+    for (; j <= ANIM_TEST_END_MOVE; j++) {
         ParametrizeMovesAndSpecies(j, &tempMove, &tempSpecies);
         PARAMETRIZE { move = tempMove; species = tempSpecies; }
     }
     GIVEN {
         PLAYER(species) {
             HP(9997); MaxHP(9999); Item(ITEM_ORAN_BERRY);
-            if (species == SPECIES_WOBBUFFET)
-                Gender(MON_FEMALE);
-            if (gMovesInfo[move].effect == EFFECT_LAST_RESORT)
-                Moves(move, MOVE_POUND);
-            if (species == SPECIES_KLINKLANG)
-                Ability(ABILITY_PLUS);
+            if (species == SPECIES_WOBBUFFET) Gender(MON_FEMALE);
+            if (gMovesInfo[move].effect == EFFECT_LAST_RESORT) Moves(move, MOVE_POUND);
+            if (species == SPECIES_KLINKLANG) Ability(ABILITY_PLUS);
         }
         PLAYER(SPECIES_WOBBUFFET)   {
             Gender(MON_MALE); MaxHP(9999); Moves(MOVE_POUND);
@@ -411,20 +407,16 @@ SINGLE_BATTLE_TEST("Move Animations don't leak when used - Singles (opponent to 
     u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
     u32 tempMove, tempSpecies;
     FORCE_MOVE_ANIM(TRUE);
-    for (; j <= ANIM_TEST_END_MOVE; j++)
-    {
+    for (; j <= ANIM_TEST_END_MOVE; j++) {
         ParametrizeMovesAndSpecies(j, &tempMove, &tempSpecies);
         PARAMETRIZE { move = tempMove; species = tempSpecies; }
     }
     GIVEN {
         OPPONENT(species) {
             HP(9997); MaxHP(9999); Item(ITEM_ORAN_BERRY);
-            if (species == SPECIES_WOBBUFFET)
-                Gender(MON_FEMALE);
-            if (gMovesInfo[move].effect == EFFECT_LAST_RESORT)
-                Moves(move, MOVE_POUND);
-            if (species == SPECIES_KLINKLANG)
-                Ability(ABILITY_PLUS);
+            if (species == SPECIES_WOBBUFFET) Gender(MON_FEMALE);
+            if (gMovesInfo[move].effect == EFFECT_LAST_RESORT) Moves(move, MOVE_POUND);
+            if (species == SPECIES_KLINKLANG) Ability(ABILITY_PLUS);
         }
         OPPONENT(SPECIES_WOBBUFFET)   {
             Gender(MON_MALE); MaxHP(9999); Moves(MOVE_POUND);
@@ -457,8 +449,7 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerLeft t
     struct BattlePokemon *target = opponentLeft;
     struct BattlePokemon *ignore1 = playerRight;
     struct BattlePokemon *ignore2 = opponentRight;
-    for (; j <= ANIM_TEST_END_MOVE; j++)
-    {
+    for (; j <= ANIM_TEST_END_MOVE; j++) {
         ParametrizeMovesAndSpecies(j, &tempMove, &tempSpecies);
         PARAMETRIZE { move = tempMove; species = tempSpecies; }
     }
@@ -466,24 +457,18 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerLeft t
         PLAYER(species) {
             HP(9997); MaxHP(9999); Item(ITEM_ORAN_BERRY);
             if (attacker == playerLeft) {
-                if (species == SPECIES_WOBBUFFET)
-                    Gender(MON_FEMALE);
-                if (gMovesInfo[move].effect == EFFECT_LAST_RESORT)
-                    Moves(move, MOVE_POUND);
-                if (species == SPECIES_KLINKLANG)
-                    Ability(ABILITY_PLUS);
+                if (species == SPECIES_WOBBUFFET) Gender(MON_FEMALE);
+                if (gMovesInfo[move].effect == EFFECT_LAST_RESORT) Moves(move, MOVE_POUND);
+                if (species == SPECIES_KLINKLANG) Ability(ABILITY_PLUS);
             }
         }
         PLAYER(species) {
             HP(9997); MaxHP(9999); Item(ITEM_ORAN_BERRY);
             if (attacker == playerRight)
             {
-                if (species == SPECIES_WOBBUFFET)
-                    Gender(MON_FEMALE);
-                if (gMovesInfo[move].effect == EFFECT_LAST_RESORT)
-                    Moves(move, MOVE_POUND);
-                if (species == SPECIES_KLINKLANG)
-                    Ability(ABILITY_PLUS);
+                if (species == SPECIES_WOBBUFFET) Gender(MON_FEMALE);
+                if (gMovesInfo[move].effect == EFFECT_LAST_RESORT) Moves(move, MOVE_POUND);
+                if (species == SPECIES_KLINKLANG) Ability(ABILITY_PLUS);
             }
         }
         PLAYER(SPECIES_WOBBUFFET) {
@@ -522,8 +507,7 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (opponentLeft
     struct BattlePokemon *target = playerLeft;
     struct BattlePokemon *ignore1 = opponentRight;
     struct BattlePokemon *ignore2 = playerRight;
-    for (; j <= ANIM_TEST_END_MOVE; j++)
-    {
+    for (; j <= ANIM_TEST_END_MOVE; j++) {
         ParametrizeMovesAndSpecies(j, &tempMove, &tempSpecies);
         PARAMETRIZE { move = tempMove; species = tempSpecies; }
     }
@@ -582,8 +566,7 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerLeft t
     struct BattlePokemon *target = opponentRight;
     struct BattlePokemon *ignore1 = playerRight;
     struct BattlePokemon *ignore2 = opponentLeft;
-    for (; j <= ANIM_TEST_END_MOVE; j++)
-    {
+    for (; j <= ANIM_TEST_END_MOVE; j++) {
         ParametrizeMovesAndSpecies(j, &tempMove, &tempSpecies);
         PARAMETRIZE { move = tempMove; species = tempSpecies; }
     }
@@ -642,8 +625,7 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (opponentRigh
     struct BattlePokemon *target = playerLeft;
     struct BattlePokemon *ignore1 = opponentLeft;
     struct BattlePokemon *ignore2 = playerRight;
-    for (; j <= ANIM_TEST_END_MOVE; j++)
-    {
+    for (; j <= ANIM_TEST_END_MOVE; j++) {
         ParametrizeMovesAndSpecies(j, &tempMove, &tempSpecies);
         PARAMETRIZE { move = tempMove; species = tempSpecies; }
     }
@@ -702,8 +684,7 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerRight 
     struct BattlePokemon *target = opponentLeft;
     struct BattlePokemon *ignore1 = playerLeft;
     struct BattlePokemon *ignore2 = opponentRight;
-    for (; j <= ANIM_TEST_END_MOVE; j++)
-    {
+    for (; j <= ANIM_TEST_END_MOVE; j++) {
         ParametrizeMovesAndSpecies(j, &tempMove, &tempSpecies);
         PARAMETRIZE { move = tempMove; species = tempSpecies; }
     }
@@ -762,8 +743,7 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (opponentLeft
     struct BattlePokemon *target = playerRight;
     struct BattlePokemon *ignore1 = playerLeft;
     struct BattlePokemon *ignore2 = opponentRight;
-    for (; j <= ANIM_TEST_END_MOVE; j++)
-    {
+    for (; j <= ANIM_TEST_END_MOVE; j++) {
         ParametrizeMovesAndSpecies(j, &tempMove, &tempSpecies);
         PARAMETRIZE { move = tempMove; species = tempSpecies; }
     }
@@ -822,8 +802,7 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerRight 
     struct BattlePokemon *target = opponentRight;
     struct BattlePokemon *ignore1 = playerLeft;
     struct BattlePokemon *ignore2 = opponentLeft;
-    for (; j <= ANIM_TEST_END_MOVE; j++)
-    {
+    for (; j <= ANIM_TEST_END_MOVE; j++) {
         ParametrizeMovesAndSpecies(j, &tempMove, &tempSpecies);
         PARAMETRIZE { move = tempMove; species = tempSpecies; }
     }
@@ -882,8 +861,7 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (opponentRigh
     struct BattlePokemon *target = playerRight;
     struct BattlePokemon *ignore1 = playerLeft;
     struct BattlePokemon *ignore2 = opponentLeft;
-    for (; j <= ANIM_TEST_END_MOVE; j++)
-    {
+    for (; j <= ANIM_TEST_END_MOVE; j++) {
         ParametrizeMovesAndSpecies(j, &tempMove, &tempSpecies);
         PARAMETRIZE { move = tempMove; species = tempSpecies; }
     }
@@ -943,8 +921,7 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerLeft t
     struct BattlePokemon *target = playerRight;
     struct BattlePokemon *ignore1 = opponentRight;
     struct BattlePokemon *ignore2 = opponentLeft;
-    for (; j <= ANIM_TEST_END_MOVE; j++)
-    {
+    for (; j <= ANIM_TEST_END_MOVE; j++) {
         ParametrizeMovesAndSpecies(j, &tempMove, &tempSpecies);
         PARAMETRIZE { move = tempMove; species = tempSpecies; }
     }
@@ -1003,8 +980,7 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerRight 
     struct BattlePokemon *target = playerLeft;
     struct BattlePokemon *ignore1 = opponentRight;
     struct BattlePokemon *ignore2 = opponentLeft;
-    for (; j <= ANIM_TEST_END_MOVE; j++)
-    {
+    for (; j <= ANIM_TEST_END_MOVE; j++) {
         ParametrizeMovesAndSpecies(j, &tempMove, &tempSpecies);
         PARAMETRIZE { move = tempMove; species = tempSpecies; }
     }
@@ -1063,8 +1039,7 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (opponentleft
     struct BattlePokemon *target = opponentRight;
     struct BattlePokemon *ignore1 = playerLeft;
     struct BattlePokemon *ignore2 = playerRight;
-    for (; j <= ANIM_TEST_END_MOVE; j++)
-    {
+    for (; j <= ANIM_TEST_END_MOVE; j++) {
         ParametrizeMovesAndSpecies(j, &tempMove, &tempSpecies);
         PARAMETRIZE { move = tempMove; species = tempSpecies; }
     }
@@ -1123,8 +1098,7 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (opponentRigh
     struct BattlePokemon *target = opponentLeft;
     struct BattlePokemon *ignore1 = playerLeft;
     struct BattlePokemon *ignore2 = playerRight;
-    for (; j <= ANIM_TEST_END_MOVE; j++)
-    {
+    for (; j <= ANIM_TEST_END_MOVE; j++) {
         ParametrizeMovesAndSpecies(j, &tempMove, &tempSpecies);
         PARAMETRIZE { move = tempMove; species = tempSpecies; }
     }

--- a/test/battle/move_animations/all_anims.c
+++ b/test/battle/move_animations/all_anims.c
@@ -359,22 +359,20 @@ static void DoublesScene(u32 move, struct BattlePokemon *attacker)
     }
 }
 
-static void PlayerToPlayerDoublesScene(u32 move, struct BattlePokemon *attacker)
+static void SameSideTargeting(u32 move, struct BattlePokemon *attacker)
 {
-    if (gMovesInfo[move].category == DAMAGE_CATEGORY_STATUS)
-    {
-        ANIMATION(ANIM_TYPE_MOVE, move, attacker);
-    }
+    //  Don't know how to make sure this is correct, some moves don't display
 }
 
 SINGLE_BATTLE_TEST("Move Animations don't leak when used - Singles (player to opponent)")
 {
     u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
+    u32 tempMove, tempSpecies;
     FORCE_MOVE_ANIM(TRUE);
     for (; j <= ANIM_TEST_END_MOVE; j++)
     {
-        ParametrizeMovesAndSpecies(j, &move, &species);
-        PARAMETRIZE { move = move; species = species; }
+        ParametrizeMovesAndSpecies(j, &tempMove, &tempSpecies);
+        PARAMETRIZE { move = tempMove; species = tempSpecies; }
     }
     GIVEN {
         PLAYER(species) {
@@ -411,11 +409,12 @@ SINGLE_BATTLE_TEST("Move Animations don't leak when used - Singles (player to op
 SINGLE_BATTLE_TEST("Move Animations don't leak when used - Singles (opponent to player)")
 {
     u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
+    u32 tempMove, tempSpecies;
     FORCE_MOVE_ANIM(TRUE);
     for (; j <= ANIM_TEST_END_MOVE; j++)
     {
-        ParametrizeMovesAndSpecies(j, &move, &species);
-        PARAMETRIZE { move = move; species = species; }
+        ParametrizeMovesAndSpecies(j, &tempMove, &tempSpecies);
+        PARAMETRIZE { move = tempMove; species = tempSpecies; }
     }
     GIVEN {
         OPPONENT(species) {
@@ -452,6 +451,7 @@ SINGLE_BATTLE_TEST("Move Animations don't leak when used - Singles (opponent to 
 DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerLeft to opponentLeft)")
 {
     u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
+    u32 tempMove, tempSpecies;
     FORCE_MOVE_ANIM(TRUE);
     struct BattlePokemon *attacker = playerLeft;
     struct BattlePokemon *target = opponentLeft;
@@ -459,8 +459,8 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerLeft t
     struct BattlePokemon *ignore2 = opponentRight;
     for (; j <= ANIM_TEST_END_MOVE; j++)
     {
-        ParametrizeMovesAndSpecies(j, &move, &species);
-        PARAMETRIZE { move = move; species = species; }
+        ParametrizeMovesAndSpecies(j, &tempMove, &tempSpecies);
+        PARAMETRIZE { move = tempMove; species = tempSpecies; }
     }
     GIVEN {
         PLAYER(species) {
@@ -516,14 +516,16 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerLeft t
 DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (opponentLeft to playerLeft)")
 {
     u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
+    u32 tempMove, tempSpecies;
     FORCE_MOVE_ANIM(TRUE);
     struct BattlePokemon *attacker = opponentLeft;
     struct BattlePokemon *target = playerLeft;
     struct BattlePokemon *ignore1 = opponentRight;
     struct BattlePokemon *ignore2 = playerRight;
-    for (; j <= ANIM_TEST_END_MOVE; j++) {
-        ParametrizeMovesAndSpecies(j, &move, &species);
-        PARAMETRIZE { move = move; species = species; }
+    for (; j <= ANIM_TEST_END_MOVE; j++)
+    {
+        ParametrizeMovesAndSpecies(j, &tempMove, &tempSpecies);
+        PARAMETRIZE { move = tempMove; species = tempSpecies; }
     }
     GIVEN {
         OPPONENT(species) {
@@ -574,14 +576,16 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (opponentLeft
 DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerLeft to opponentRight)")
 {
     u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
+    u32 tempMove, tempSpecies;
     FORCE_MOVE_ANIM(TRUE);
     struct BattlePokemon *attacker = playerLeft;
     struct BattlePokemon *target = opponentRight;
     struct BattlePokemon *ignore1 = playerRight;
     struct BattlePokemon *ignore2 = opponentLeft;
-    for (; j <= ANIM_TEST_END_MOVE; j++) {
-        ParametrizeMovesAndSpecies(j, &move, &species);
-        PARAMETRIZE { move = move; species = species; }
+    for (; j <= ANIM_TEST_END_MOVE; j++)
+    {
+        ParametrizeMovesAndSpecies(j, &tempMove, &tempSpecies);
+        PARAMETRIZE { move = tempMove; species = tempSpecies; }
     }
     GIVEN {
         PLAYER(species) {
@@ -632,14 +636,16 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerLeft t
 DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (opponentRight to playerLeft)")
 {
     u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
+    u32 tempMove, tempSpecies;
     FORCE_MOVE_ANIM(TRUE);
     struct BattlePokemon *attacker = opponentRight;
     struct BattlePokemon *target = playerLeft;
     struct BattlePokemon *ignore1 = opponentLeft;
     struct BattlePokemon *ignore2 = playerRight;
-    for (; j <= ANIM_TEST_END_MOVE; j++) {
-        ParametrizeMovesAndSpecies(j, &move, &species);
-        PARAMETRIZE { move = move; species = species; }
+    for (; j <= ANIM_TEST_END_MOVE; j++)
+    {
+        ParametrizeMovesAndSpecies(j, &tempMove, &tempSpecies);
+        PARAMETRIZE { move = tempMove; species = tempSpecies; }
     }
     GIVEN {
         OPPONENT(species) {
@@ -690,14 +696,16 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (opponentRigh
 DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerRight to opponentLeft)")
 {
     u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
+    u32 tempMove, tempSpecies;
     FORCE_MOVE_ANIM(TRUE);
     struct BattlePokemon *attacker = playerRight;
     struct BattlePokemon *target = opponentLeft;
     struct BattlePokemon *ignore1 = playerLeft;
     struct BattlePokemon *ignore2 = opponentRight;
-    for (; j <= ANIM_TEST_END_MOVE; j++) {
-        ParametrizeMovesAndSpecies(j, &move, &species);
-        PARAMETRIZE { move = move; species = species; }
+    for (; j <= ANIM_TEST_END_MOVE; j++)
+    {
+        ParametrizeMovesAndSpecies(j, &tempMove, &tempSpecies);
+        PARAMETRIZE { move = tempMove; species = tempSpecies; }
     }
     GIVEN {
         PLAYER(species) {
@@ -748,14 +756,16 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerRight 
 DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (opponentLeft to playerRight)")
 {
     u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
+    u32 tempMove, tempSpecies;
     FORCE_MOVE_ANIM(TRUE);
     struct BattlePokemon *attacker = opponentLeft;
     struct BattlePokemon *target = playerRight;
     struct BattlePokemon *ignore1 = playerLeft;
     struct BattlePokemon *ignore2 = opponentRight;
-    for (; j <= ANIM_TEST_END_MOVE; j++) {
-        ParametrizeMovesAndSpecies(j, &move, &species);
-        PARAMETRIZE { move = move; species = species; }
+    for (; j <= ANIM_TEST_END_MOVE; j++)
+    {
+        ParametrizeMovesAndSpecies(j, &tempMove, &tempSpecies);
+        PARAMETRIZE { move = tempMove; species = tempSpecies; }
     }
     GIVEN {
         OPPONENT(species) {
@@ -806,14 +816,16 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (opponentLeft
 DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerRight to opponentRight)")
 {
     u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
+    u32 tempMove, tempSpecies;
     FORCE_MOVE_ANIM(TRUE);
     struct BattlePokemon *attacker = playerRight;
     struct BattlePokemon *target = opponentRight;
     struct BattlePokemon *ignore1 = playerLeft;
     struct BattlePokemon *ignore2 = opponentLeft;
-    for (; j <= ANIM_TEST_END_MOVE; j++) {
-        ParametrizeMovesAndSpecies(j, &move, &species);
-        PARAMETRIZE { move = move; species = species; }
+    for (; j <= ANIM_TEST_END_MOVE; j++)
+    {
+        ParametrizeMovesAndSpecies(j, &tempMove, &tempSpecies);
+        PARAMETRIZE { move = tempMove; species = tempSpecies; }
     }
     GIVEN {
         PLAYER(species) {
@@ -864,14 +876,16 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerRight 
 DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (opponentRight to playerRight)")
 {
     u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
+    u32 tempMove, tempSpecies;
     FORCE_MOVE_ANIM(TRUE);
     struct BattlePokemon *attacker = opponentRight;
     struct BattlePokemon *target = playerRight;
     struct BattlePokemon *ignore1 = playerLeft;
     struct BattlePokemon *ignore2 = opponentLeft;
-    for (; j <= ANIM_TEST_END_MOVE; j++) {
-        ParametrizeMovesAndSpecies(j, &move, &species);
-        PARAMETRIZE { move = move; species = species; }
+    for (; j <= ANIM_TEST_END_MOVE; j++)
+    {
+        ParametrizeMovesAndSpecies(j, &tempMove, &tempSpecies);
+        PARAMETRIZE { move = tempMove; species = tempSpecies; }
     }
     GIVEN {
         OPPONENT(species) {
@@ -922,14 +936,16 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (opponentRigh
 DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerLeft to playerRight)")
 {
     u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
+    u32 tempMove, tempSpecies;
     FORCE_MOVE_ANIM(TRUE);
     struct BattlePokemon *attacker = playerLeft;
     struct BattlePokemon *target = playerRight;
     struct BattlePokemon *ignore1 = opponentRight;
     struct BattlePokemon *ignore2 = opponentLeft;
-    for (; j <= ANIM_TEST_END_MOVE; j++) {
-        ParametrizeMovesAndSpecies(j, &move, &species);
-        PARAMETRIZE { move = move; species = species; }
+    for (; j <= ANIM_TEST_END_MOVE; j++)
+    {
+        ParametrizeMovesAndSpecies(j, &tempMove, &tempSpecies);
+        PARAMETRIZE { move = tempMove; species = tempSpecies; }
     }
     GIVEN {
         OPPONENT(species) {
@@ -968,7 +984,7 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerLeft t
     } WHEN {
         DoublesWhen(move, attacker, target, ignore1, ignore2);
     } SCENE {
-        PlayerToPlayerDoublesScene(move, attacker);
+        SameSideTargeting(move, attacker);
     } THEN {
         FORCE_MOVE_ANIM(FALSE);
         if (gLoadFail)
@@ -980,14 +996,16 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerLeft t
 DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerRight to playerLeft)")
 {
     u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
+    u32 tempMove, tempSpecies;
     FORCE_MOVE_ANIM(TRUE);
     struct BattlePokemon *attacker = playerRight;
     struct BattlePokemon *target = playerLeft;
     struct BattlePokemon *ignore1 = opponentRight;
     struct BattlePokemon *ignore2 = opponentLeft;
-    for (; j <= ANIM_TEST_END_MOVE; j++) {
-        ParametrizeMovesAndSpecies(j, &move, &species);
-        PARAMETRIZE { move = move; species = species; }
+    for (; j <= ANIM_TEST_END_MOVE; j++)
+    {
+        ParametrizeMovesAndSpecies(j, &tempMove, &tempSpecies);
+        PARAMETRIZE { move = tempMove; species = tempSpecies; }
     }
     GIVEN {
         OPPONENT(species) {
@@ -1026,7 +1044,7 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerRight 
     } WHEN {
         DoublesWhen(move, attacker, target, ignore1, ignore2);
     } SCENE {
-        PlayerToPlayerDoublesScene(move, attacker);
+        SameSideTargeting(move, attacker);
     } THEN {
         FORCE_MOVE_ANIM(FALSE);
         if (gLoadFail)
@@ -1038,14 +1056,16 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerRight 
 DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (opponentleft to opponentRight)")
 {
     u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
+    u32 tempMove, tempSpecies;
     FORCE_MOVE_ANIM(TRUE);
     struct BattlePokemon *attacker = opponentLeft;
     struct BattlePokemon *target = opponentRight;
     struct BattlePokemon *ignore1 = playerLeft;
     struct BattlePokemon *ignore2 = playerRight;
-    for (; j <= ANIM_TEST_END_MOVE; j++) {
-        ParametrizeMovesAndSpecies(j, &move, &species);
-        PARAMETRIZE { move = move; species = species; }
+    for (; j <= ANIM_TEST_END_MOVE; j++)
+    {
+        ParametrizeMovesAndSpecies(j, &tempMove, &tempSpecies);
+        PARAMETRIZE { move = tempMove; species = tempSpecies; }
     }
     GIVEN {
         OPPONENT(species) {
@@ -1084,7 +1104,7 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (opponentleft
     } WHEN {
         DoublesWhen(move, attacker, target, ignore1, ignore2);
     } SCENE {
-        DoublesScene(move, attacker);
+        SameSideTargeting(move, attacker);
     } THEN {
         FORCE_MOVE_ANIM(FALSE);
         if (gLoadFail)
@@ -1096,14 +1116,16 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (opponentleft
 DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (opponentRight to opponentLeft)")
 {
     u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
+    u32 tempMove, tempSpecies;
     FORCE_MOVE_ANIM(TRUE);
     struct BattlePokemon *attacker = opponentRight;
     struct BattlePokemon *target = opponentLeft;
     struct BattlePokemon *ignore1 = playerLeft;
     struct BattlePokemon *ignore2 = playerRight;
-    for (; j <= ANIM_TEST_END_MOVE; j++) {
-        ParametrizeMovesAndSpecies(j, &move, &species);
-        PARAMETRIZE { move = move; species = species; }
+    for (; j <= ANIM_TEST_END_MOVE; j++)
+    {
+        ParametrizeMovesAndSpecies(j, &tempMove, &tempSpecies);
+        PARAMETRIZE { move = tempMove; species = tempSpecies; }
     }
     GIVEN {
         OPPONENT(species) {
@@ -1142,7 +1164,7 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (opponentRigh
     } WHEN {
         DoublesWhen(move, attacker, target, ignore1, ignore2);
     } SCENE {
-        DoublesScene(move, attacker);
+        SameSideTargeting(move, attacker);
     } THEN {
         FORCE_MOVE_ANIM(FALSE);
         if (gLoadFail)

--- a/test/battle/move_animations/all_anims.c
+++ b/test/battle/move_animations/all_anims.c
@@ -933,6 +933,7 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (opponentRigh
     }
 }
 
+/*
 DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerLeft to playerRight)")
 {
     u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
@@ -1172,5 +1173,6 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (opponentRigh
         EXPECT_EQ(gLoadFail, FALSE);
     }
 }
+*/
 
 #endif

--- a/test/battle/move_animations/all_anims.c
+++ b/test/battle/move_animations/all_anims.c
@@ -359,11 +359,19 @@ static void DoublesScene(u32 move, struct BattlePokemon *attacker)
     }
 }
 
+static void PlayerToPlayerDoublesScene(u32 move, struct BattlePokemon *attacker)
+{
+    if (gMovesInfo[move].category == DAMAGE_CATEGORY_STATUS)
+    {
+        ANIMATION(ANIM_TYPE_MOVE, move, attacker);
+    }
+}
+
 SINGLE_BATTLE_TEST("Move Animations don't leak when used - Singles (player to opponent)")
 {
-    u32 j = 1, move = 0, species = 0;
+    u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
     FORCE_MOVE_ANIM(TRUE);
-    for (; j < MOVES_COUNT; j++)
+    for (; j <= ANIM_TEST_END_MOVE; j++)
     {
         ParametrizeMovesAndSpecies(j, &move, &species);
         PARAMETRIZE { move = move; species = species; }
@@ -402,9 +410,9 @@ SINGLE_BATTLE_TEST("Move Animations don't leak when used - Singles (player to op
 
 SINGLE_BATTLE_TEST("Move Animations don't leak when used - Singles (opponent to player)")
 {
-    u32 j = 1, move = 0, species = 0;
+    u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
     FORCE_MOVE_ANIM(TRUE);
-    for (; j < MOVES_COUNT; j++)
+    for (; j <= ANIM_TEST_END_MOVE; j++)
     {
         ParametrizeMovesAndSpecies(j, &move, &species);
         PARAMETRIZE { move = move; species = species; }
@@ -443,13 +451,13 @@ SINGLE_BATTLE_TEST("Move Animations don't leak when used - Singles (opponent to 
 
 DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerLeft to opponentLeft)")
 {
-    u32 j = 1, move = 0, species = 0;
+    u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
     FORCE_MOVE_ANIM(TRUE);
     struct BattlePokemon *attacker = playerLeft;
     struct BattlePokemon *target = opponentLeft;
     struct BattlePokemon *ignore1 = playerRight;
     struct BattlePokemon *ignore2 = opponentRight;
-    for (; j < MOVES_COUNT; j++)
+    for (; j <= ANIM_TEST_END_MOVE; j++)
     {
         ParametrizeMovesAndSpecies(j, &move, &species);
         PARAMETRIZE { move = move; species = species; }
@@ -507,13 +515,13 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerLeft t
 
 DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (opponentLeft to playerLeft)")
 {
-    u32 j = 1, move = 0, species = 0;
+    u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
     FORCE_MOVE_ANIM(TRUE);
     struct BattlePokemon *attacker = opponentLeft;
     struct BattlePokemon *target = playerLeft;
     struct BattlePokemon *ignore1 = opponentRight;
     struct BattlePokemon *ignore2 = playerRight;
-    for (; j < MOVES_COUNT; j++) {
+    for (; j <= ANIM_TEST_END_MOVE; j++) {
         ParametrizeMovesAndSpecies(j, &move, &species);
         PARAMETRIZE { move = move; species = species; }
     }
@@ -565,13 +573,13 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (opponentLeft
 
 DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerLeft to opponentRight)")
 {
-    u32 j = 1, move = 0, species = 0;
+    u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
     FORCE_MOVE_ANIM(TRUE);
     struct BattlePokemon *attacker = playerLeft;
     struct BattlePokemon *target = opponentRight;
     struct BattlePokemon *ignore1 = playerRight;
     struct BattlePokemon *ignore2 = opponentLeft;
-    for (; j < MOVES_COUNT; j++) {
+    for (; j <= ANIM_TEST_END_MOVE; j++) {
         ParametrizeMovesAndSpecies(j, &move, &species);
         PARAMETRIZE { move = move; species = species; }
     }
@@ -623,13 +631,13 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerLeft t
 
 DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (opponentRight to playerLeft)")
 {
-    u32 j = 1, move = 0, species = 0;
+    u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
     FORCE_MOVE_ANIM(TRUE);
     struct BattlePokemon *attacker = opponentRight;
     struct BattlePokemon *target = playerLeft;
     struct BattlePokemon *ignore1 = opponentLeft;
     struct BattlePokemon *ignore2 = playerRight;
-    for (; j < MOVES_COUNT; j++) {
+    for (; j <= ANIM_TEST_END_MOVE; j++) {
         ParametrizeMovesAndSpecies(j, &move, &species);
         PARAMETRIZE { move = move; species = species; }
     }
@@ -681,13 +689,13 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (opponentRigh
 
 DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerRight to opponentLeft)")
 {
-    u32 j = 1, move = 0, species = 0;
+    u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
     FORCE_MOVE_ANIM(TRUE);
     struct BattlePokemon *attacker = playerRight;
     struct BattlePokemon *target = opponentLeft;
     struct BattlePokemon *ignore1 = playerLeft;
     struct BattlePokemon *ignore2 = opponentRight;
-    for (; j < MOVES_COUNT; j++) {
+    for (; j <= ANIM_TEST_END_MOVE; j++) {
         ParametrizeMovesAndSpecies(j, &move, &species);
         PARAMETRIZE { move = move; species = species; }
     }
@@ -739,13 +747,13 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerRight 
 
 DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (opponentLeft to playerRight)")
 {
-    u32 j = 1, move = 0, species = 0;
+    u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
     FORCE_MOVE_ANIM(TRUE);
     struct BattlePokemon *attacker = opponentLeft;
     struct BattlePokemon *target = playerRight;
     struct BattlePokemon *ignore1 = playerLeft;
     struct BattlePokemon *ignore2 = opponentRight;
-    for (; j < MOVES_COUNT; j++) {
+    for (; j <= ANIM_TEST_END_MOVE; j++) {
         ParametrizeMovesAndSpecies(j, &move, &species);
         PARAMETRIZE { move = move; species = species; }
     }
@@ -797,13 +805,13 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (opponentLeft
 
 DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerRight to opponentRight)")
 {
-    u32 j = 1, move = 0, species = 0;
+    u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
     FORCE_MOVE_ANIM(TRUE);
     struct BattlePokemon *attacker = playerRight;
     struct BattlePokemon *target = opponentRight;
     struct BattlePokemon *ignore1 = playerLeft;
     struct BattlePokemon *ignore2 = opponentLeft;
-    for (; j < MOVES_COUNT; j++) {
+    for (; j <= ANIM_TEST_END_MOVE; j++) {
         ParametrizeMovesAndSpecies(j, &move, &species);
         PARAMETRIZE { move = move; species = species; }
     }
@@ -855,13 +863,245 @@ DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerRight 
 
 DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (opponentRight to playerRight)")
 {
-    u32 j = 1, move = 0, species = 0;
+    u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
     FORCE_MOVE_ANIM(TRUE);
     struct BattlePokemon *attacker = opponentRight;
     struct BattlePokemon *target = playerRight;
     struct BattlePokemon *ignore1 = playerLeft;
     struct BattlePokemon *ignore2 = opponentLeft;
-    for (; j < MOVES_COUNT; j++) {
+    for (; j <= ANIM_TEST_END_MOVE; j++) {
+        ParametrizeMovesAndSpecies(j, &move, &species);
+        PARAMETRIZE { move = move; species = species; }
+    }
+    GIVEN {
+        OPPONENT(species) {
+            HP(9997); MaxHP(9999); Item(ITEM_ORAN_BERRY);
+            if (attacker == opponentLeft) {
+                if (species == SPECIES_WOBBUFFET) Gender(MON_FEMALE);
+                if (gMovesInfo[move].effect == EFFECT_LAST_RESORT) Moves(move, MOVE_POUND);
+                if (species == SPECIES_KLINKLANG) Ability(ABILITY_PLUS);
+            }
+        }
+        OPPONENT(species) {
+            HP(9997); MaxHP(9999); Item(ITEM_ORAN_BERRY);
+            if (attacker == opponentRight) {
+                if (species == SPECIES_WOBBUFFET) Gender(MON_FEMALE);
+                if (gMovesInfo[move].effect == EFFECT_LAST_RESORT) Moves(move, MOVE_POUND);
+                if (species == SPECIES_KLINKLANG) Ability(ABILITY_PLUS);
+            }
+        }
+        OPPONENT(SPECIES_WOBBUFFET) {
+            Gender(MON_MALE); MaxHP(9999); Moves(MOVE_POUND, MOVE_CELEBRATE);
+            HP(gMovesInfo[move].effect == EFFECT_REVIVAL_BLESSING ? 0 : 9998);
+        }
+        PLAYER(SPECIES_WOBBUFFET) {
+            Gender(MON_MALE); HP(9998); MaxHP(9999); SpDefense(9999); Defense(9999); Ability(ABILITY_TELEPATHY);
+            if (gMovesInfo[move].effect != EFFECT_BESTOW) {
+                Item(ITEM_ORAN_BERRY);
+            }
+        }
+        PLAYER(SPECIES_WOBBUFFET) {
+            Gender(MON_MALE); HP(9998); MaxHP(9999); SpDefense(9999); Defense(9999); Ability(ABILITY_TELEPATHY);
+            if (gMovesInfo[move].effect != EFFECT_BESTOW) {
+                Item(ITEM_ORAN_BERRY);
+            }
+        }
+        PLAYER(SPECIES_WOBBUFFET) { Gender(MON_FEMALE); HP(9998); MaxHP(9999); SpDefense(9999); Defense(9999); }
+    } WHEN {
+        DoublesWhen(move, attacker, target, ignore1, ignore2);
+    } SCENE {
+        DoublesScene(move, attacker);
+    } THEN {
+        FORCE_MOVE_ANIM(FALSE);
+        if (gLoadFail)
+            DebugPrintf("Move failed: %S (%u)", gMovesInfo[move].name, move);
+        EXPECT_EQ(gLoadFail, FALSE);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerLeft to playerRight)")
+{
+    u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
+    FORCE_MOVE_ANIM(TRUE);
+    struct BattlePokemon *attacker = playerLeft;
+    struct BattlePokemon *target = playerRight;
+    struct BattlePokemon *ignore1 = opponentRight;
+    struct BattlePokemon *ignore2 = opponentLeft;
+    for (; j <= ANIM_TEST_END_MOVE; j++) {
+        ParametrizeMovesAndSpecies(j, &move, &species);
+        PARAMETRIZE { move = move; species = species; }
+    }
+    GIVEN {
+        OPPONENT(species) {
+            HP(9997); MaxHP(9999); Item(ITEM_ORAN_BERRY);
+            if (attacker == opponentLeft) {
+                if (species == SPECIES_WOBBUFFET) Gender(MON_FEMALE);
+                if (gMovesInfo[move].effect == EFFECT_LAST_RESORT) Moves(move, MOVE_POUND);
+                if (species == SPECIES_KLINKLANG) Ability(ABILITY_PLUS);
+            }
+        }
+        OPPONENT(species) {
+            HP(9997); MaxHP(9999); Item(ITEM_ORAN_BERRY);
+            if (attacker == opponentRight) {
+                if (species == SPECIES_WOBBUFFET) Gender(MON_FEMALE);
+                if (gMovesInfo[move].effect == EFFECT_LAST_RESORT) Moves(move, MOVE_POUND);
+                if (species == SPECIES_KLINKLANG) Ability(ABILITY_PLUS);
+            }
+        }
+        OPPONENT(SPECIES_WOBBUFFET) {
+            Gender(MON_MALE); MaxHP(9999); Moves(MOVE_POUND, MOVE_CELEBRATE);
+            HP(gMovesInfo[move].effect == EFFECT_REVIVAL_BLESSING ? 0 : 9998);
+        }
+        PLAYER(SPECIES_WOBBUFFET) {
+            Gender(MON_MALE); HP(9998); MaxHP(9999); SpDefense(9999); Defense(9999); Ability(ABILITY_TELEPATHY);
+            if (gMovesInfo[move].effect != EFFECT_BESTOW) {
+                Item(ITEM_ORAN_BERRY);
+            }
+        }
+        PLAYER(SPECIES_WOBBUFFET) {
+            Gender(MON_MALE); HP(9998); MaxHP(9999); SpDefense(9999); Defense(9999); Ability(ABILITY_TELEPATHY);
+            if (gMovesInfo[move].effect != EFFECT_BESTOW) {
+                Item(ITEM_ORAN_BERRY);
+            }
+        }
+        PLAYER(SPECIES_WOBBUFFET) { Gender(MON_FEMALE); HP(9998); MaxHP(9999); SpDefense(9999); Defense(9999); }
+    } WHEN {
+        DoublesWhen(move, attacker, target, ignore1, ignore2);
+    } SCENE {
+        PlayerToPlayerDoublesScene(move, attacker);
+    } THEN {
+        FORCE_MOVE_ANIM(FALSE);
+        if (gLoadFail)
+            DebugPrintf("Move failed: %S (%u)", gMovesInfo[move].name, move);
+        EXPECT_EQ(gLoadFail, FALSE);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (playerRight to playerLeft)")
+{
+    u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
+    FORCE_MOVE_ANIM(TRUE);
+    struct BattlePokemon *attacker = playerRight;
+    struct BattlePokemon *target = playerLeft;
+    struct BattlePokemon *ignore1 = opponentRight;
+    struct BattlePokemon *ignore2 = opponentLeft;
+    for (; j <= ANIM_TEST_END_MOVE; j++) {
+        ParametrizeMovesAndSpecies(j, &move, &species);
+        PARAMETRIZE { move = move; species = species; }
+    }
+    GIVEN {
+        OPPONENT(species) {
+            HP(9997); MaxHP(9999); Item(ITEM_ORAN_BERRY);
+            if (attacker == opponentLeft) {
+                if (species == SPECIES_WOBBUFFET) Gender(MON_FEMALE);
+                if (gMovesInfo[move].effect == EFFECT_LAST_RESORT) Moves(move, MOVE_POUND);
+                if (species == SPECIES_KLINKLANG) Ability(ABILITY_PLUS);
+            }
+        }
+        OPPONENT(species) {
+            HP(9997); MaxHP(9999); Item(ITEM_ORAN_BERRY);
+            if (attacker == opponentRight) {
+                if (species == SPECIES_WOBBUFFET) Gender(MON_FEMALE);
+                if (gMovesInfo[move].effect == EFFECT_LAST_RESORT) Moves(move, MOVE_POUND);
+                if (species == SPECIES_KLINKLANG) Ability(ABILITY_PLUS);
+            }
+        }
+        OPPONENT(SPECIES_WOBBUFFET) {
+            Gender(MON_MALE); MaxHP(9999); Moves(MOVE_POUND, MOVE_CELEBRATE);
+            HP(gMovesInfo[move].effect == EFFECT_REVIVAL_BLESSING ? 0 : 9998);
+        }
+        PLAYER(SPECIES_WOBBUFFET) {
+            Gender(MON_MALE); HP(9998); MaxHP(9999); SpDefense(9999); Defense(9999); Ability(ABILITY_TELEPATHY);
+            if (gMovesInfo[move].effect != EFFECT_BESTOW) {
+                Item(ITEM_ORAN_BERRY);
+            }
+        }
+        PLAYER(SPECIES_WOBBUFFET) {
+            Gender(MON_MALE); HP(9998); MaxHP(9999); SpDefense(9999); Defense(9999); Ability(ABILITY_TELEPATHY);
+            if (gMovesInfo[move].effect != EFFECT_BESTOW) {
+                Item(ITEM_ORAN_BERRY);
+            }
+        }
+        PLAYER(SPECIES_WOBBUFFET) { Gender(MON_FEMALE); HP(9998); MaxHP(9999); SpDefense(9999); Defense(9999); }
+    } WHEN {
+        DoublesWhen(move, attacker, target, ignore1, ignore2);
+    } SCENE {
+        PlayerToPlayerDoublesScene(move, attacker);
+    } THEN {
+        FORCE_MOVE_ANIM(FALSE);
+        if (gLoadFail)
+            DebugPrintf("Move failed: %S (%u)", gMovesInfo[move].name, move);
+        EXPECT_EQ(gLoadFail, FALSE);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (opponentleft to opponentRight)")
+{
+    u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
+    FORCE_MOVE_ANIM(TRUE);
+    struct BattlePokemon *attacker = opponentLeft;
+    struct BattlePokemon *target = opponentRight;
+    struct BattlePokemon *ignore1 = playerLeft;
+    struct BattlePokemon *ignore2 = playerRight;
+    for (; j <= ANIM_TEST_END_MOVE; j++) {
+        ParametrizeMovesAndSpecies(j, &move, &species);
+        PARAMETRIZE { move = move; species = species; }
+    }
+    GIVEN {
+        OPPONENT(species) {
+            HP(9997); MaxHP(9999); Item(ITEM_ORAN_BERRY);
+            if (attacker == opponentLeft) {
+                if (species == SPECIES_WOBBUFFET) Gender(MON_FEMALE);
+                if (gMovesInfo[move].effect == EFFECT_LAST_RESORT) Moves(move, MOVE_POUND);
+                if (species == SPECIES_KLINKLANG) Ability(ABILITY_PLUS);
+            }
+        }
+        OPPONENT(species) {
+            HP(9997); MaxHP(9999); Item(ITEM_ORAN_BERRY);
+            if (attacker == opponentRight) {
+                if (species == SPECIES_WOBBUFFET) Gender(MON_FEMALE);
+                if (gMovesInfo[move].effect == EFFECT_LAST_RESORT) Moves(move, MOVE_POUND);
+                if (species == SPECIES_KLINKLANG) Ability(ABILITY_PLUS);
+            }
+        }
+        OPPONENT(SPECIES_WOBBUFFET) {
+            Gender(MON_MALE); MaxHP(9999); Moves(MOVE_POUND, MOVE_CELEBRATE);
+            HP(gMovesInfo[move].effect == EFFECT_REVIVAL_BLESSING ? 0 : 9998);
+        }
+        PLAYER(SPECIES_WOBBUFFET) {
+            Gender(MON_MALE); HP(9998); MaxHP(9999); SpDefense(9999); Defense(9999); Ability(ABILITY_TELEPATHY);
+            if (gMovesInfo[move].effect != EFFECT_BESTOW) {
+                Item(ITEM_ORAN_BERRY);
+            }
+        }
+        PLAYER(SPECIES_WOBBUFFET) {
+            Gender(MON_MALE); HP(9998); MaxHP(9999); SpDefense(9999); Defense(9999); Ability(ABILITY_TELEPATHY);
+            if (gMovesInfo[move].effect != EFFECT_BESTOW) {
+                Item(ITEM_ORAN_BERRY);
+            }
+        }
+        PLAYER(SPECIES_WOBBUFFET) { Gender(MON_FEMALE); HP(9998); MaxHP(9999); SpDefense(9999); Defense(9999); }
+    } WHEN {
+        DoublesWhen(move, attacker, target, ignore1, ignore2);
+    } SCENE {
+        DoublesScene(move, attacker);
+    } THEN {
+        FORCE_MOVE_ANIM(FALSE);
+        if (gLoadFail)
+            DebugPrintf("Move failed: %S (%u)", gMovesInfo[move].name, move);
+        EXPECT_EQ(gLoadFail, FALSE);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Move Animations don't leak when used - Doubles (opponentRight to opponentLeft)")
+{
+    u32 j = ANIM_TEST_START_MOVE, move = 0, species = 0;
+    FORCE_MOVE_ANIM(TRUE);
+    struct BattlePokemon *attacker = opponentRight;
+    struct BattlePokemon *target = opponentLeft;
+    struct BattlePokemon *ignore1 = playerLeft;
+    struct BattlePokemon *ignore2 = playerRight;
+    for (; j <= ANIM_TEST_END_MOVE; j++) {
         ParametrizeMovesAndSpecies(j, &move, &species);
         PARAMETRIZE { move = move; species = species; }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Before submitting, please make sure your pull request meets the scope guidelines. If unsure, please open a thread in #pr-discussions.-->
<!--- Scope Guidelines: https://github.com/rh-hideout/pokeemerald-expansion/blob/master/docs/team_procedures/scope.md  -->
<!--- #pr-discussions:  https://discord.com/channels/419213663107416084/1102784418369785948 -->

## Description
<!--- Describe your changes in detail -->
<!--- If you believe this PR qualifies as a "Big Feature" as defined in docs/team_procedures/schedule.md, please let a Maintainer know! -->
Updates the "All move animations" test with self-targeting tests and options to choose the start and end moves to test.
Note that the self-targeting tests are currently commented out due to them not working properly right now, the `SCENE` blocks aren't set up for the sometimes lack of animation for same-side targeting.

## **Discord contact info**
<!--- Formatted as username (e.g. Lunos) or username#numbers (e.g. Lunos#4026) -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara