### PR TITLE
metaprogram.h without global.h

### DIFF
--- a/include/metaprogram.h
+++ b/include/metaprogram.h
@@ -4,11 +4,11 @@
 
 /* Check if VA_OPT_ is supported by the compiler. GCC's version should be at least 9.5*/
 #define PP_THIRD_ARG(a,b,c,...) c
-#define VA_OPT_SUPPORTED_I(...) PP_THIRD_ARG(__VA_OPT__(,),TRUE,FALSE,)
+#define VA_OPT_SUPPORTED_I(...) PP_THIRD_ARG(__VA_OPT__(,),1,0,)
 #define VA_OPT_SUPPORTED VA_OPT_SUPPORTED_I(?)
 
 #if !VA_OPT_SUPPORTED
-#error ERROR: VA_OPT__ is not supported. Please update your gcc compiler to version 10 or higher
+#error ERROR: __VA_OPT__ is not supported. Please update your arm-none-eabi-gcc compiler to version 10 or higher
 #endif // VA_OPT_SUPPORTED
 
 /* Calls m0/m1/.../m8 depending on how many arguments are passed. */


### PR DESCRIPTION
Allows `metaprogram.h` to be included without having included `global.h`. (Useful for testing preprocessor things locally by manually invoking `cpp`)

Also fixes a small typo.