### PR TITLE
Remove redundacy in AI for the holdEffect check

### DIFF
--- a/include/battle_ai_util.h
+++ b/include/battle_ai_util.h
@@ -69,9 +69,7 @@ u32 GetBestDmgFromBattler(u32 battler, u32 battlerTarget, enum DamageCalcContext
 bool32 CanTargetMoveFaintAi(u32 move, u32 battlerDef, u32 battlerAtk, u32 nHits);
 bool32 CanTargetFaintAiWithMod(u32 battlerDef, u32 battlerAtk, s32 hpMod, s32 dmgMod);
 s32 AI_DecideKnownAbilityForTurn(u32 battlerId);
-u32 AI_DecideItemForTurn(u32 battler);
 u32 AI_DecideHoldEffectForTurn(u32 battlerId);
-bool32 IsBattlerItemEnabled(u32 battler);
 bool32 DoesBattlerIgnoreAbilityChecks(u32 battlerAtk, u32 atkAbility, u32 move);
 u32 AI_GetWeather(void);
 bool32 CanAIFaintTarget(u32 battlerAtk, u32 battlerDef, u32 numHits);

--- a/include/battle_ai_util.h
+++ b/include/battle_ai_util.h
@@ -233,7 +233,6 @@ bool32 AI_ShouldSetUpHazards(u32 battlerAtk, u32 battlerDef, struct AiLogicData 
 void IncreaseTidyUpScore(u32 battlerAtk, u32 battlerDef, u32 move, s32 *score);
 bool32 AI_ShouldSpicyExtract(u32 battlerAtk, u32 battlerAtkPartner, u32 move, struct AiLogicData *aiData);
 u32 IncreaseSubstituteMoveScore(u32 battlerAtk, u32 battlerDef, u32 move);
-bool32 IsBattlerItemEnabled(u32 battler);
 bool32 IsBattlerPredictedToSwitch(u32 battler);
 bool32 HasLowAccuracyMove(u32 battlerAtk, u32 battlerDef);
 

--- a/include/battle_ai_util.h
+++ b/include/battle_ai_util.h
@@ -69,7 +69,9 @@ u32 GetBestDmgFromBattler(u32 battler, u32 battlerTarget, enum DamageCalcContext
 bool32 CanTargetMoveFaintAi(u32 move, u32 battlerDef, u32 battlerAtk, u32 nHits);
 bool32 CanTargetFaintAiWithMod(u32 battlerDef, u32 battlerAtk, s32 hpMod, s32 dmgMod);
 s32 AI_DecideKnownAbilityForTurn(u32 battlerId);
+u32 AI_DecideItemForTurn(u32 battler);
 u32 AI_DecideHoldEffectForTurn(u32 battlerId);
+bool32 IsBattlerItemEnabled(u32 battler);
 bool32 DoesBattlerIgnoreAbilityChecks(u32 battlerAtk, u32 atkAbility, u32 move);
 u32 AI_GetWeather(void);
 bool32 CanAIFaintTarget(u32 battlerAtk, u32 battlerDef, u32 numHits);

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -382,7 +382,7 @@ void SetBattlerAiData(u32 battler, struct AiLogicData *aiData)
     u32 ability, holdEffect;
 
     ability = aiData->abilities[battler] = AI_DecideKnownAbilityForTurn(battler);
-    aiData->items[battler] = AI_DecideItemForTurn(battler);
+    aiData->items[battler] = gBattleMons[battler].item;
     holdEffect = aiData->holdEffects[battler] = AI_DecideHoldEffectForTurn(battler);
     aiData->holdEffectParams[battler] = GetBattlerHoldEffectParam(battler);
     aiData->lastUsedMove[battler] = gLastMoves[battler];

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -1112,7 +1112,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
                 ADJUST_SCORE(-10);
             break;
         case EFFECT_STUFF_CHEEKS:
-            if (ItemId_GetPocket(gBattleMons[battlerAtk].item) != POCKET_BERRIES)
+            if (ItemId_GetPocket(aiData->items[battlerAtk]) != POCKET_BERRIES)
                 return 0;   // cannot even select
             //fallthrough
         case EFFECT_DEFENSE_UP:
@@ -2323,7 +2323,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             }
             break;
         case EFFECT_NATURAL_GIFT:
-            if (GetPocketByItemId(gBattleMons[battlerAtk].item) != POCKET_BERRIES)
+            if (GetPocketByItemId(aiData->items[battlerAtk]) != POCKET_BERRIES)
                 ADJUST_SCORE(-10);
             break;
         case EFFECT_GRASSY_TERRAIN:

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -382,7 +382,7 @@ void SetBattlerAiData(u32 battler, struct AiLogicData *aiData)
     u32 ability, holdEffect;
 
     ability = aiData->abilities[battler] = AI_DecideKnownAbilityForTurn(battler);
-    aiData->items[battler] = gBattleMons[battler].item;
+    aiData->items[battler] = AI_DecideItemForTurn(battler);
     holdEffect = aiData->holdEffects[battler] = AI_DecideHoldEffectForTurn(battler);
     aiData->holdEffectParams[battler] = GetBattlerHoldEffectParam(battler);
     aiData->lastUsedMove[battler] = gLastMoves[battler];

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -2323,7 +2323,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             }
             break;
         case EFFECT_NATURAL_GIFT:
-            if (!IsBattlerItemEnabled(battlerAtk) || GetPocketByItemId(gBattleMons[battlerAtk].item) != POCKET_BERRIES)
+            if (GetPocketByItemId(gBattleMons[battlerAtk].item) != POCKET_BERRIES)
                 ADJUST_SCORE(-10);
             break;
         case EFFECT_GRASSY_TERRAIN:
@@ -2430,8 +2430,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             }
             break;
         case EFFECT_EMBARGO:
-            if (!IsBattlerItemEnabled(battlerAtk)
-              || gDisableStructs[battlerDef].embargoTimer != 0
+            if (gDisableStructs[battlerDef].embargoTimer != 0
               || PartnerMoveIsSameAsAttacker(BATTLE_PARTNER(battlerAtk), battlerDef, move, aiData->partnerMove))
                 ADJUST_SCORE(-10);
             break;
@@ -2677,7 +2676,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
     } // move effect checks
 
     // Choice items
-    if (HOLD_EFFECT_CHOICE(aiData->holdEffects[battlerAtk]) && IsBattlerItemEnabled(battlerAtk))
+    if (HOLD_EFFECT_CHOICE(aiData->holdEffects[battlerAtk]))
     {
         // Don't use user-target moves ie. Swords Dance, with exceptions
         if ((moveTarget & MOVE_TARGET_USER)

--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -984,6 +984,17 @@ static bool32 ShouldSwitchIfEncored(u32 battler)
     return FALSE;
 }
 
+static bool32 IsBattlerItemEnabled(u32 battler)
+{
+    if (gFieldStatuses & STATUS_FIELD_MAGIC_ROOM)
+        return FALSE;
+    if (gStatuses3[battler] & STATUS3_EMBARGO)
+        return FALSE;
+    if (gBattleMons[battler].ability == ABILITY_KLUTZ && !(gStatuses3[battler] & STATUS3_GASTRO_ACID))
+        return FALSE;
+    return TRUE;
+}
+
 static bool32 ShouldSwitchIfBadChoiceLock(u32 battler)
 {
     u32 holdEffect = GetBattlerHoldEffect(battler, FALSE);

--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -452,7 +452,7 @@ static bool32 FindMonThatAbsorbsOpponentsMove(u32 battler)
     if (!(AI_THINKING_STRUCT->aiFlags[GetThinkingBattler(battler)] & AI_FLAG_SMART_SWITCHING))
         return FALSE;
     if (gBattleStruct->prevTurnSpecies[battler] != gBattleMons[battler].species) // AI mon has changed, player's behaviour no longer reliable; note to override this if using AI_FLAG_PREDICT_MOVE
-        return FALSE; 
+        return FALSE;
     if (HasSuperEffectiveMoveAgainstOpponents(battler, TRUE) && (RandomPercentage(RNG_AI_SWITCH_ABSORBING_STAY_IN, STAY_IN_ABSORBING_PERCENTAGE) || AI_DATA->aiSwitchPredictionInProgress))
         return FALSE;
     if (AreStatsRaised(battler))
@@ -675,7 +675,7 @@ static bool32 ShouldSwitchIfBadlyStatused(u32 battler)
                 && !(gBattleMons[battler].status2 & STATUS2_FORESIGHT)
                 && !(gStatuses3[battler] & STATUS3_MIRACLE_EYED))
                 switchMon = FALSE;
-            
+
             if (switchMon)
                 return SetSwitchinAndSwitch(battler, PARTY_SIZE);
         }
@@ -982,6 +982,17 @@ static bool32 ShouldSwitchIfEncored(u32 battler)
         return SetSwitchinAndSwitch(battler, PARTY_SIZE);
 
     return FALSE;
+}
+
+static bool32 IsBattlerItemEnabled(u32 battler)
+{
+    if (gFieldStatuses & STATUS_FIELD_MAGIC_ROOM)
+        return FALSE;
+    if (gStatuses3[battler] & STATUS3_EMBARGO)
+        return FALSE;
+    if (gBattleMons[battler].ability == ABILITY_KLUTZ && !(gStatuses3[battler] & STATUS3_GASTRO_ACID))
+        return FALSE;
+    return TRUE;
 }
 
 static bool32 ShouldSwitchIfBadChoiceLock(u32 battler)

--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -984,17 +984,6 @@ static bool32 ShouldSwitchIfEncored(u32 battler)
     return FALSE;
 }
 
-static bool32 IsBattlerItemEnabled(u32 battler)
-{
-    if (gFieldStatuses & STATUS_FIELD_MAGIC_ROOM)
-        return FALSE;
-    if (gStatuses3[battler] & STATUS3_EMBARGO)
-        return FALSE;
-    if (gBattleMons[battler].ability == ABILITY_KLUTZ && !(gStatuses3[battler] & STATUS3_GASTRO_ACID))
-        return FALSE;
-    return TRUE;
-}
-
 static bool32 ShouldSwitchIfBadChoiceLock(u32 battler)
 {
     u32 holdEffect = GetBattlerHoldEffect(battler, FALSE);

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -1435,20 +1435,9 @@ s32 AI_DecideKnownAbilityForTurn(u32 battlerId)
     return ABILITY_NONE; // Unknown.
 }
 
-u32 AI_DecideItemForTurn(u32 battler)
-{
-    if (IsBattlerItemEnabled(battler))
-        return ITEM_NONE;
-
-    return gBattleMons[battler].item;
-}
-
 u32 AI_DecideHoldEffectForTurn(u32 battlerId)
 {
-    u32 holdEffect = HOLD_EFFECT_NONE;
-
-    if (IsBattlerItemEnabled(battlerId))
-        return holdEffect;
+    u32 holdEffect;
 
     if (!IsAiBattlerAware(battlerId))
         holdEffect = AI_PARTY->mons[GetBattlerSide(battlerId)][gBattlerPartyIndexes[battlerId]].heldEffect;
@@ -1458,18 +1447,14 @@ u32 AI_DecideHoldEffectForTurn(u32 battlerId)
     if (AI_THINKING_STRUCT->aiFlags[battlerId] & AI_FLAG_NEGATE_UNAWARE)
         return holdEffect;
 
-    return holdEffect;
-}
-
-bool32 IsBattlerItemEnabled(u32 battler)
-{
+    if (gStatuses3[battlerId] & STATUS3_EMBARGO)
+        return HOLD_EFFECT_NONE;
     if (gFieldStatuses & STATUS_FIELD_MAGIC_ROOM)
-        return FALSE;
-    if (gStatuses3[battler] & STATUS3_EMBARGO)
-        return FALSE;
-    if (gBattleMons[battler].ability == ABILITY_KLUTZ && !(gStatuses3[battler] & STATUS3_GASTRO_ACID))
-        return FALSE;
-    return TRUE;
+        return HOLD_EFFECT_NONE;
+    if (AI_DATA->abilities[battlerId] == ABILITY_KLUTZ && !(gStatuses3[battlerId] & STATUS3_GASTRO_ACID))
+        return HOLD_EFFECT_NONE;
+
+    return holdEffect;
 }
 
 bool32 DoesBattlerIgnoreAbilityChecks(u32 battlerAtk, u32 atkAbility, u32 move)

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -1435,9 +1435,20 @@ s32 AI_DecideKnownAbilityForTurn(u32 battlerId)
     return ABILITY_NONE; // Unknown.
 }
 
+u32 AI_DecideItemForTurn(u32 battler)
+{
+    if (IsBattlerItemEnabled(battler))
+        return ITEM_NONE;
+
+    return gBattleMons[battler].item;
+}
+
 u32 AI_DecideHoldEffectForTurn(u32 battlerId)
 {
-    u32 holdEffect;
+    u32 holdEffect = HOLD_EFFECT_NONE;
+
+    if (IsBattlerItemEnabled(battlerId))
+        return holdEffect;
 
     if (!IsAiBattlerAware(battlerId))
         holdEffect = AI_PARTY->mons[GetBattlerSide(battlerId)][gBattlerPartyIndexes[battlerId]].heldEffect;
@@ -1447,14 +1458,18 @@ u32 AI_DecideHoldEffectForTurn(u32 battlerId)
     if (AI_THINKING_STRUCT->aiFlags[battlerId] & AI_FLAG_NEGATE_UNAWARE)
         return holdEffect;
 
-    if (gStatuses3[battlerId] & STATUS3_EMBARGO)
-        return HOLD_EFFECT_NONE;
-    if (gFieldStatuses & STATUS_FIELD_MAGIC_ROOM)
-        return HOLD_EFFECT_NONE;
-    if (AI_DATA->abilities[battlerId] == ABILITY_KLUTZ && !(gStatuses3[battlerId] & STATUS3_GASTRO_ACID))
-        return HOLD_EFFECT_NONE;
-
     return holdEffect;
+}
+
+bool32 IsBattlerItemEnabled(u32 battler)
+{
+    if (gFieldStatuses & STATUS_FIELD_MAGIC_ROOM)
+        return FALSE;
+    if (gStatuses3[battler] & STATUS3_EMBARGO)
+        return FALSE;
+    if (gBattleMons[battler].ability == ABILITY_KLUTZ && !(gStatuses3[battler] & STATUS3_GASTRO_ACID))
+        return FALSE;
+    return TRUE;
 }
 
 bool32 DoesBattlerIgnoreAbilityChecks(u32 battlerAtk, u32 atkAbility, u32 move)

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -512,7 +512,7 @@ bool32 IsDamageMoveUnusable(u32 battlerAtk, u32 battlerDef, u32 move, u32 moveTy
             return TRUE;
         break;
     case EFFECT_POLTERGEIST:
-        if (AI_DATA->items[battlerDef] == ITEM_NONE || !IsBattlerItemEnabled(battlerDef))
+        if (AI_DATA->items[battlerDef] == ITEM_NONE)
             return TRUE;
         break;
     case EFFECT_FIRST_TURN_ONLY:
@@ -4406,17 +4406,4 @@ bool32 HasLowAccuracyMove(u32 battlerAtk, u32 battlerDef)
             return TRUE;
     }
     return FALSE;
-}
-
-bool32 IsBattlerItemEnabled(u32 battler)
-{
-    if (AI_THINKING_STRUCT->aiFlags[battler] & AI_FLAG_NEGATE_UNAWARE)
-        return TRUE;
-    if (gFieldStatuses & STATUS_FIELD_MAGIC_ROOM)
-        return FALSE;
-    if (gStatuses3[battler] & STATUS3_EMBARGO)
-        return FALSE;
-    if (gBattleMons[battler].ability == ABILITY_KLUTZ && !(gStatuses3[battler] & STATUS3_GASTRO_ACID))
-        return FALSE;
-    return TRUE;
 }


### PR DESCRIPTION
`IsBattlerItemEnabled` is unnecessary in regular ai calcs because `AI_DecideHoldEffectForTurn` has those checks already included. I left it in the switch-in AI because I assume that is what Pawkkie would like it to be judging by the implementation. 