### PR TITLE
Fixs Aftermath ability popup message

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -7076,12 +7076,14 @@ BattleScript_AnticipationActivates::
 BattleScript_AftermathDmg::
 	pause B_WAIT_TIME_SHORT
 	call BattleScript_AbilityPopUpScripting
+	jumpifability BS_ATTACKER, ABILITY_MAGIC_GUARD, BattleScript_AftermathDmgRet
 	orword gHitMarker, HITMARKER_IGNORE_SUBSTITUTE | HITMARKER_PASSIVE_DAMAGE
 	healthbarupdate BS_ATTACKER
 	datahpupdate BS_ATTACKER
 	printstring STRINGID_AFTERMATHDMG
 	waitmessage B_WAIT_TIME_LONG
 	tryfaintmon BS_ATTACKER
+BattleScript_AftermathDmgRet:
 	return
 
 BattleScript_DampPreventsAftermath::

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -7075,15 +7075,13 @@ BattleScript_AnticipationActivates::
 
 BattleScript_AftermathDmg::
 	pause B_WAIT_TIME_SHORT
-	call BattleScript_AbilityPopUp
-	jumpifability BS_ATTACKER, ABILITY_MAGIC_GUARD, BattleScript_AftermathDmgRet
+	call BattleScript_AbilityPopUpScripting
 	orword gHitMarker, HITMARKER_IGNORE_SUBSTITUTE | HITMARKER_PASSIVE_DAMAGE
 	healthbarupdate BS_ATTACKER
 	datahpupdate BS_ATTACKER
 	printstring STRINGID_AFTERMATHDMG
 	waitmessage B_WAIT_TIME_LONG
 	tryfaintmon BS_ATTACKER
-BattleScript_AftermathDmgRet:
 	return
 
 BattleScript_DampPreventsAftermath::

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -5891,6 +5891,7 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
                         break;
                 }
 
+                gBattleScripting.battler = gBattlerTarget;
                 gBattleStruct->moveDamage[gBattlerAttacker] = gBattleStruct->moveDamage[gBattlerTarget];
                 BattleScriptPushCursor();
                 gBattlescriptCurrInstr = BattleScript_AftermathDmg;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -5857,8 +5857,7 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
              && !IsBattlerAlive(gBattlerTarget)
              && IsBattlerAlive(gBattlerAttacker)
              && GetBattlerHoldEffect(gBattlerAttacker, TRUE) != HOLD_EFFECT_PROTECTIVE_PADS
-             && IsMoveMakingContact(move, gBattlerAttacker)
-             && !IsMagicGuardProtected(gBattlerAttacker, gLastUsedAbility))
+             && IsMoveMakingContact(move, gBattlerAttacker))
             {
                 if ((battler = IsAbilityOnField(ABILITY_DAMP)))
                 {

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -5857,7 +5857,8 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
              && !IsBattlerAlive(gBattlerTarget)
              && IsBattlerAlive(gBattlerAttacker)
              && GetBattlerHoldEffect(gBattlerAttacker, TRUE) != HOLD_EFFECT_PROTECTIVE_PADS
-             && IsMoveMakingContact(move, gBattlerAttacker))
+             && IsMoveMakingContact(move, gBattlerAttacker)
+             && !IsMagicGuardProtected(gBattlerAttacker, gLastUsedAbility))
             {
                 if ((battler = IsAbilityOnField(ABILITY_DAMP)))
                 {
@@ -5867,6 +5868,7 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
                 }
                 else
                 {
+                    gBattleScripting.battler = gBattlerTarget;
                     gBattleStruct->moveDamage[gBattlerAttacker] = GetNonDynamaxMaxHP(gBattlerAttacker) / 4;
                     if (gBattleStruct->moveDamage[gBattlerAttacker] == 0)
                         gBattleStruct->moveDamage[gBattlerAttacker] = 1;

--- a/test/battle/ability/aftermath.c
+++ b/test/battle/ability/aftermath.c
@@ -20,3 +20,31 @@ SINGLE_BATTLE_TEST("Aftermath damages the attacker by 1/4th of its max HP if fai
         EXPECT_EQ(aftermathDamage, opponent->maxHP / 4);
     }
 }
+
+SINGLE_BATTLE_TEST("Aftermath ability pop-up will be displayed correctly: player point of view")
+{
+    GIVEN {
+        PLAYER(SPECIES_SHROOMISH) { Ability(ABILITY_POISON_HEAL); };
+        OPPONENT(SPECIES_VOLTORB) { HP(1); Ability(ABILITY_AFTERMATH); };
+    } WHEN {
+        TURN {MOVE(player, MOVE_HEADBUTT);}
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_HEADBUTT, player);
+        MESSAGE("The opposing Voltorb fainted!");
+        ABILITY_POPUP(opponent, ABILITY_AFTERMATH);
+    }
+}
+
+SINGLE_BATTLE_TEST("Aftermath ability pop-up will be displayed correctly: opponent point of view")
+{
+    GIVEN {
+        PLAYER(SPECIES_VOLTORB) { HP(1); Ability(ABILITY_AFTERMATH); };
+        OPPONENT(SPECIES_SHROOMISH) { Ability(ABILITY_POISON_HEAL); };
+    } WHEN {
+        TURN {MOVE(opponent, MOVE_HEADBUTT);}
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_HEADBUTT, opponent);
+        MESSAGE("Voltorb fainted!");
+        ABILITY_POPUP(player, ABILITY_AFTERMATH);
+    }
+}


### PR DESCRIPTION
When Aftermath was triggered the wrong message was displayed. For some reason it only happened when the aftermath user was the opponent so I added two tests to make sure there is no regression