### PR TITLE
Changed KNOWN_FAILING test

### DIFF
--- a/test/battle/move_effect/toxic_spikes.c
+++ b/test/battle/move_effect/toxic_spikes.c
@@ -186,13 +186,9 @@ SINGLE_BATTLE_TEST("Toxic Spikes are removed by grounded Poison-type Pokémon on
     }
 }
 
-// This would test for what I believe to be a bug in the mainline games.
-// A Pokémon that gets passed magnet rise should still remove the Toxic
-// Spikes even though it is airborne.
-// The test currently fails, because we don't incorporate this bug.
-SINGLE_BATTLE_TEST("Toxic Spikes are removed by Poison-type Pokémon affected by Magnet Rise on switch in")
+//  Tested in Gen 7 on cartridge
+SINGLE_BATTLE_TEST("Toxic Spikes are not removed by Poison-type Pokémon affected by Magnet Rise on switch in")
 {
-    KNOWN_FAILING;
     GIVEN {
         ASSUME(gSpeciesInfo[SPECIES_EKANS].types[0] == TYPE_POISON);
         PLAYER(SPECIES_WOBBUFFET);
@@ -203,9 +199,8 @@ SINGLE_BATTLE_TEST("Toxic Spikes are removed by Poison-type Pokémon affected by
         TURN { MOVE(player, MOVE_TOXIC_SPIKES); MOVE(opponent, MOVE_BATON_PASS); SEND_OUT(opponent, 1); }
         TURN { SWITCH(opponent, 0); }
     } SCENE {
-        NOT STATUS_ICON(opponent, poison: TRUE);
-        MESSAGE("The poison spikes disappeared from the ground around the opposing team!");
-        NOT STATUS_ICON(opponent, poison: TRUE);
+        NOT MESSAGE("The poison spikes disappeared from the ground around the opposing team!");
+        STATUS_ICON(opponent, poison: TRUE);
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Before submitting, please make sure your pull request meets the scope guidelines. If unsure, please open a thread in #pr-discussions.-->
<!--- Scope Guidelines: https://github.com/rh-hideout/pokeemerald-expansion/blob/master/docs/team_procedures/scope.md  -->
<!--- #pr-discussions:  https://discord.com/channels/419213663107416084/1102784418369785948 -->

## Description
<!--- Describe your changes in detail -->
<!--- If you believe this PR qualifies as a "Big Feature" as defined in docs/team_procedures/schedule.md, please let a Maintainer know! -->
Test was set as `KNOWN_FAILING` but behaviour is actually correct for at least Gen 7.

## **Discord contact info**
<!--- Formatted as username (e.g. Lunos) or username#numbers (e.g. Lunos#4026) -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara