### PR TITLE
 Refactor / Simlify Cmd_adjustdamage and remove redundancy 

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -205,14 +205,14 @@ struct SpecialStatus
     u8 emergencyExited:1;
     u8 afterYou:1;
     u8 enduredDamage:1;
-    u8 unused_1:1;
-    // End of byte
     u8 stormDrainRedirected:1;
+    // End of byte
     u8 switchInAbilityDone:1;
     u8 switchInItemDone:1;
     u8 instructedChosenTarget:3;
     u8 berryReduced:1;
-    u8 unused_2:1;
+    u8 announceNeutralizingGas:1;   // See Cmd_switchineffects
+    u8 neutralizingGasRemoved:1;    // See VARIOUS_TRY_END_NEUTRALIZING_GAS
     // End of byte
     u8 gemParam;
     // End of byte
@@ -220,16 +220,14 @@ struct SpecialStatus
     u8 rototillerAffected:1;  // to be affected by rototiller
     u8 parentalBondState:2;
     u8 multiHitOn:1;
-    u8 announceNeutralizingGas:1;   // See Cmd_switchineffects
-    u8 neutralizingGasRemoved:1;    // See VARIOUS_TRY_END_NEUTRALIZING_GAS
-    u8 unused_3:1;
+    u8 distortedTypeMatchups:1;
+    u8 teraShellAbilityDone:1;
+    u8 criticalHit:1;
     // End of byte
     u8 dancerUsedMove:1;
     u8 dancerOriginalTarget:3;
     u8 preventLifeOrbDamage:1; // So that Life Orb doesn't activate various effects.
-    u8 distortedTypeMatchups:1;
-    u8 teraShellAbilityDone:1;
-    u8 criticalHit:1;
+    u8 unused:3;
     // End of byte
 };
 

--- a/include/battle.h
+++ b/include/battle.h
@@ -202,17 +202,17 @@ struct SpecialStatus
     u8 lightningRodRedirected:1;
     u8 restoredBattlerSprite: 1;
     u8 faintedHasReplacement:1;
-    u8 focusBanded:1;
-    u8 focusSashed:1;
     u8 emergencyExited:1;
     u8 afterYou:1;
+    u8 enduredDamage:1;
+    u8 unused_1:1;
     // End of byte
-    u8 sturdied:1;
     u8 stormDrainRedirected:1;
     u8 switchInAbilityDone:1;
     u8 switchInItemDone:1;
     u8 instructedChosenTarget:3;
     u8 berryReduced:1;
+    u8 unused_2:1;
     // End of byte
     u8 gemParam;
     // End of byte
@@ -222,7 +222,7 @@ struct SpecialStatus
     u8 multiHitOn:1;
     u8 announceNeutralizingGas:1;   // See Cmd_switchineffects
     u8 neutralizingGasRemoved:1;    // See VARIOUS_TRY_END_NEUTRALIZING_GAS
-    u8 affectionEndured:1;
+    u8 unused_3:1;
     // End of byte
     u8 dancerUsedMove:1;
     u8 dancerOriginalTarget:3;
@@ -231,8 +231,6 @@ struct SpecialStatus
     u8 teraShellAbilityDone:1;
     u8 criticalHit:1;
     // End of byte
-    u8 enduredDamage:1;
-    u8 padding:7;
 };
 
 struct SideTimer

--- a/include/constants/battle_script_commands.h
+++ b/include/constants/battle_script_commands.h
@@ -312,4 +312,13 @@ enum MoveEndEffects
 #define ARG_TRY_REMOVE_TERRAIN_HIT     1
 #define ARG_TRY_REMOVE_TERRAIN_FAIL    2
 
+// Methods with which a pokemon can endure damage (survive on 1 HP)
+enum EnduredDamage
+{
+    NOT_ENDURED,
+    FOCUS_SASH_OR_BAND_ENDURED,
+    STURDY_ENDURED,
+    AFFECTION_ENDURED,
+};
+
 #endif // GUARD_CONSTANTS_BATTLE_SCRIPT_COMMANDS_H

--- a/include/constants/battle_script_commands.h
+++ b/include/constants/battle_script_commands.h
@@ -312,13 +312,4 @@ enum MoveEndEffects
 #define ARG_TRY_REMOVE_TERRAIN_HIT     1
 #define ARG_TRY_REMOVE_TERRAIN_FAIL    2
 
-// Methods with which a pokemon can endure damage (survive on 1 HP)
-enum EnduredDamage
-{
-    NOT_ENDURED,
-    FOCUS_SASH_OR_BAND_ENDURED,
-    STURDY_ENDURED,
-    AFFECTION_ENDURED,
-};
-
 #endif // GUARD_CONSTANTS_BATTLE_SCRIPT_COMMANDS_H

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -13028,12 +13028,12 @@ static void Cmd_tryKO(void)
                 gBattleStruct->moveDamage[gBattlerTarget] = gBattleMons[gBattlerTarget].hp - 1;
                 gBattleStruct->moveResultFlags[gBattlerTarget] |= MOVE_RESULT_FOE_ENDURED;
             }
-            // else if (endured == FOCUS_BANDED || endured == FOCUS_SASHED)
-            // {
-            //     gBattleStruct->moveDamage[gBattlerTarget] = gBattleMons[gBattlerTarget].hp - 1;
-            //     gBattleStruct->moveResultFlags[gBattlerTarget] |= MOVE_RESULT_FOE_HUNG_ON;
-            //     gLastUsedItem = gBattleMons[gBattlerTarget].item;
-            // }
+            else if (endured == FOCUS_BANDED || endured == FOCUS_SASHED)
+            {
+                gBattleStruct->moveDamage[gBattlerTarget] = gBattleMons[gBattlerTarget].hp - 1;
+                gBattleStruct->moveResultFlags[gBattlerTarget] |= MOVE_RESULT_FOE_HUNG_ON;
+                gLastUsedItem = gBattleMons[gBattlerTarget].item;
+            }
             else if (endured == AFFECTION_ENDURED)
             {
                 gBattleStruct->moveDamage[gBattlerTarget] = gBattleMons[gBattlerTarget].hp - 1;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -13028,12 +13028,12 @@ static void Cmd_tryKO(void)
                 gBattleStruct->moveDamage[gBattlerTarget] = gBattleMons[gBattlerTarget].hp - 1;
                 gBattleStruct->moveResultFlags[gBattlerTarget] |= MOVE_RESULT_FOE_ENDURED;
             }
-            else if (endured == FOCUS_BANDED || endured == FOCUS_SASHED)
-            {
-                gBattleStruct->moveDamage[gBattlerTarget] = gBattleMons[gBattlerTarget].hp - 1;
-                gBattleStruct->moveResultFlags[gBattlerTarget] |= MOVE_RESULT_FOE_HUNG_ON;
-                gLastUsedItem = gBattleMons[gBattlerTarget].item;
-            }
+            // else if (endured == FOCUS_BANDED || endured == FOCUS_SASHED)
+            // {
+            //     gBattleStruct->moveDamage[gBattlerTarget] = gBattleMons[gBattlerTarget].hp - 1;
+            //     gBattleStruct->moveResultFlags[gBattlerTarget] |= MOVE_RESULT_FOE_HUNG_ON;
+            //     gLastUsedItem = gBattleMons[gBattlerTarget].item;
+            // }
             else if (endured == AFFECTION_ENDURED)
             {
                 gBattleStruct->moveDamage[gBattlerTarget] = gBattleMons[gBattlerTarget].hp - 1;

--- a/test/battle/move_effect/ohko.c
+++ b/test/battle/move_effect/ohko.c
@@ -24,7 +24,7 @@ SINGLE_BATTLE_TEST("Sheer Cold doesn't affect Ice-type Pokémon")
 SINGLE_BATTLE_TEST("OHKO moves can hit semi-invulnerable mons when the user has No-Guard")
 {
     GIVEN {
-        ASSUME(gItemsInfo[ITEM_FOCUS_SASH].holdEffect == HOLD_EFFECT_FOCUS_SASH);
+        ASSUME(ItemId_GetHoldEffect(ITEM_FOCUS_SASH) == HOLD_EFFECT_FOCUS_SASH);
         PLAYER(SPECIES_WOBBUFFET) { Ability(ABILITY_NO_GUARD); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {

--- a/test/battle/move_effect/ohko.c
+++ b/test/battle/move_effect/ohko.c
@@ -24,7 +24,7 @@ SINGLE_BATTLE_TEST("Sheer Cold doesn't affect Ice-type Pokémon")
 SINGLE_BATTLE_TEST("OHKO moves can hit semi-invulnerable mons when the user has No-Guard")
 {
     GIVEN {
-        ASSUME(GetMoveEffect(MOVE_SHEER_COLD) == EFFECT_OHKO);
+        ASSUME(gItemsInfo[ITEM_FOCUS_SASH].holdEffect == HOLD_EFFECT_FOCUS_SASH);
         PLAYER(SPECIES_WOBBUFFET) { Ability(ABILITY_NO_GUARD); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
@@ -33,6 +33,34 @@ SINGLE_BATTLE_TEST("OHKO moves can hit semi-invulnerable mons when the user has 
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SHEER_COLD, player);
         HP_BAR(opponent, hp: 0);
+    }
+}
+
+SINGLE_BATTLE_TEST("OHKO moves can can be endured by Focus Sash")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_FOCUS_SASH); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SHEER_COLD); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SHEER_COLD, player);
+        HP_BAR(opponent, hp: 1);
+        MESSAGE("The opposing Wobbuffet hung on using its Focus Sash!");
+    }
+}
+
+SINGLE_BATTLE_TEST("OHKO moves can can be endured by Sturdy")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_GEODUDE) { Ability(ABILITY_STURDY); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SHEER_COLD); }
+    } SCENE {
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_SHEER_COLD, player);
+        ABILITY_POPUP(opponent, ABILITY_STURDY);
+        MESSAGE("The opposing Geodude was protected by Sturdy!");
     }
 }
 


### PR DESCRIPTION
The global variables used in `Cmd_adjustdamage` didn't have that much purpose. All of their use case was locally and we actually had to fix a few bugs because they weren't properly reset. 

This PR removes those global and restructures the function so you don't have to first set a variable and check them later. Once a mon endured damage the proper resultFlags can be set in the first if-else chain. The only thing is the damage set to one which is handled with the local var `enduredDamage`. In case users want to have the damage being endured for a multi hit they can turn it into a global variable. Though I don't think this is something we should support since we aren't aware of the side effects. 

Also there was a bug with False Swipes which this pr fixes. I can pr a standalone fix for this on master