### PR TITLE
Mark RTC/Flash save hint string as used

### DIFF
--- a/src/siirtc.c
+++ b/src/siirtc.c
@@ -75,7 +75,7 @@ static u8 ReadData();
 static void EnableGpioPortRead();
 static void DisableGpioPortRead();
 
-static const char AgbLibRtcVersion[] = "SIIRTC_V001";
+USED static const char AgbLibRtcVersion[] = "SIIRTC_V001";
 
 void SiiRtcUnprotect(void)
 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Before submitting, please make sure your pull request meets the scope guidelines. If unsure, please open a thread in #pr-discussions.-->
<!--- Scope Guidelines: https://github.com/rh-hideout/pokeemerald-expansion/blob/master/docs/team_procedures/scope.md  -->
<!--- #pr-discussions:  https://discord.com/channels/419213663107416084/1102784418369785948 -->

## Description
<!--- Describe your changes in detail -->
<!--- If you believe this PR qualifies as a "Big Feature" as defined in docs/team_procedures/schedule.md, please let a Maintainer know! -->
The RTC hint string gets optimized out these days. Marking it with `USED` puts it back in the ROM. This fixes some emulators out of the box.

## Proof of fix
<!-- Please provide with relevant GIFs or images to make it easier for reviewers to accept your PR quicker.-->
<!-- If it doesn't apply, feel free to remove this section. -->
```bash
~ # arm-none-eabi-nm -a pokeemerald.elf | grep AgbLibRtcVersion
0833b594 r AgbLibRtcVersion
```

## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, fixes #2222." -->
<!-- If it doesn't apply, feel free to remove this section. -->
[mGBA](https://github.com/mgba-emu/mgba/blob/10eb794cfd602eac6f70f01838a420eebd9b8267/src/gba/overrides.c#L388) and [other emulators](https://github.com/SourMesen/Mesen2/blob/02180abed132599f3f1e4b769a16eac808fd862c/Core/GBA/GbaConsole.cpp#L160) sometimes fail to detect the game as using Flash saves because it's (partially) tied to searching for the RTC hint string for whatever reason and not the save hint string. This should fix auto-detection on emulator platforms where it was once broken.

## **People who collaborated with me in this PR**
<!-- Please credit everyone else that contributed to this PR, be it code and/or assets. -->
<!-- Use their GitHub tag if they have one (or add "@/" at the start if they don't). Be sure to start the line using @ so the automatic changelog can properly detect the collaborators. -->
<!-- Eg.: "@Lunos for sprites, @/Masuda for support" -->
<!-- If it doesn't apply, feel free to remove this section. -->
SBird -- pointed out the USED attribute to avoid a worse hack, thanks!


## **Discord contact info**
<!--- Formatted as username (e.g. Lunos) or username#numbers (e.g. Lunos#4026) -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
`luigi___`
