### PR TITLE
Fixes Hone Claws checking the wrong stats for its stat change animation and Stockpile drops being stopped by stat reduction prevention effects

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -2222,13 +2222,13 @@ BattleScript_AttackAccUpDoMoveAnim::
 	attackanimation
 	waitanimation
 	setbyte sSTAT_ANIM_PLAYED, FALSE
-	playstatchangeanimation BS_ATTACKER, BIT_SPATK | BIT_SPDEF, 0
+	playstatchangeanimation BS_ATTACKER, BIT_ATK | BIT_ACC, 0
 	setstatchanger STAT_ATK, 1, FALSE
-	statbuffchange MOVE_EFFECT_AFFECTS_USER | STAT_CHANGE_ALLOW_PTR, BattleScript_AttackAccUpTrySpDef
-	jumpifbyte CMP_EQUAL, cMULTISTRING_CHOOSER, B_MSG_STAT_WONT_INCREASE, BattleScript_AttackAccUpTrySpDef
+	statbuffchange MOVE_EFFECT_AFFECTS_USER | STAT_CHANGE_ALLOW_PTR, BattleScript_AttackAccUpTryAcc
+	jumpifbyte CMP_EQUAL, cMULTISTRING_CHOOSER, B_MSG_STAT_WONT_INCREASE, BattleScript_AttackAccUpTryAcc
 	printfromtable gStatUpStringIds
 	waitmessage B_WAIT_TIME_LONG
-BattleScript_AttackAccUpTrySpDef::
+BattleScript_AttackAccUpTryAcc::
 	setstatchanger STAT_ACC, 1, FALSE
 	statbuffchange MOVE_EFFECT_AFFECTS_USER | STAT_CHANGE_ALLOW_PTR, BattleScript_AttackAccUpEnd
 	jumpifbyte CMP_EQUAL, cMULTISTRING_CHOOSER, B_MSG_STAT_WONT_INCREASE, BattleScript_AttackAccUpEnd

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -4731,7 +4731,7 @@ BattleScript_MoveEffectStockpileWoreOff::
 	return
 
 BattleScript_StockpileStatChangeDown:
-	statbuffchange MOVE_EFFECT_AFFECTS_USER, BattleScript_StockpileStatChangeDown_Ret
+	statbuffchange MOVE_EFFECT_AFFECTS_USER | MOVE_EFFECT_CERTAIN, BattleScript_StockpileStatChangeDown_Ret
 	setgraphicalstatchangevalues
 	playanimation BS_ATTACKER, B_ANIM_STATS_CHANGE, sB_ANIM_ARG1
 	printfromtable gStatDownStringIds


### PR DESCRIPTION
Fixes Hone Claws checking if the user's Sp.Atk/Sp.Def can be boosted instead of Atk/Acc when choosing whether to play a stat change animation (If Sp.Atk and Sp.Def were at the maximum stage, the stat change animation wouldn't play, despite being able to boost Atk/Acc)

Fixes Stockpile stat drops (when using Spit Up or Swallow) being prevented by Clear Body and other stat reduction prevention effects.
From Bulbapedia:

> Generation V onwards
> The Stockpile removal is now shown as a stat change. For each Stockpile that successfully changed a defensive stat, that stat will drop by two stages if the Pokémon has Simple at the time of using Swallow, rise by one stage if the Pokémon has Contrary at that time, **or drop by one stage with any other Ability.**

## **Discord contact info**
PhallenTree
