### PR TITLE
Add basic Unaware check bad move scoring

### DIFF
--- a/include/battle_ai_util.h
+++ b/include/battle_ai_util.h
@@ -236,5 +236,6 @@ u32 IncreaseSubstituteMoveScore(u32 battlerAtk, u32 battlerDef, u32 move);
 bool32 IsBattlerItemEnabled(u32 battler);
 bool32 IsBattlerPredictedToSwitch(u32 battler);
 bool32 HasLowAccuracyMove(u32 battlerAtk, u32 battlerDef);
+bool32 IsBattlerSideUnaware(u32 battler);
 
 #endif //GUARD_BATTLE_AI_UTIL_H

--- a/include/battle_ai_util.h
+++ b/include/battle_ai_util.h
@@ -236,6 +236,6 @@ u32 IncreaseSubstituteMoveScore(u32 battlerAtk, u32 battlerDef, u32 move);
 bool32 IsBattlerItemEnabled(u32 battler);
 bool32 IsBattlerPredictedToSwitch(u32 battler);
 bool32 HasLowAccuracyMove(u32 battlerAtk, u32 battlerDef);
-bool32 IsBattlerSideUnaware(u32 battler);
+bool32 HasBattlerSideAbility(u32 battlerDef, u32 ability, struct AiLogicData *aiData);
 
 #endif //GUARD_BATTLE_AI_UTIL_H

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -1738,6 +1738,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
         case EFFECT_BELLY_DRUM:
         case EFFECT_FILLET_AWAY:
             if (aiData->abilities[battlerDef] == ABILITY_UNAWARE)
+                ADJUST_SCORE(-10);
             if (aiData->abilities[battlerAtk] == ABILITY_CONTRARY)
                 ADJUST_SCORE(-10);
             else if (aiData->hpPercents[battlerAtk] <= 60)

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -1200,6 +1200,8 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             break;
         case EFFECT_QUIVER_DANCE:
         case EFFECT_GEOMANCY:
+            if (aiData->abilities[battlerDef] == ABILITY_UNAWARE)
+                ADJUST_SCORE(-10);
             if (gBattleMons[battlerAtk].statStages[STAT_SPATK] >= MAX_STAT_STAGE || !HasMoveWithCategory(battlerAtk, DAMAGE_CATEGORY_SPECIAL))
                 ADJUST_SCORE(-10);
             else if (!BattlerStatCanRise(battlerAtk, aiData->abilities[battlerAtk], STAT_SPEED))
@@ -1735,6 +1737,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             break;
         case EFFECT_BELLY_DRUM:
         case EFFECT_FILLET_AWAY:
+            if (aiData->abilities[battlerDef] == ABILITY_UNAWARE)
             if (aiData->abilities[battlerAtk] == ABILITY_CONTRARY)
                 ADJUST_SCORE(-10);
             else if (aiData->hpPercents[battlerAtk] <= 60)

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -1200,7 +1200,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             break;
         case EFFECT_QUIVER_DANCE:
         case EFFECT_GEOMANCY:
-            if (IsBattlerSideUnaware(battlerDef))
+            if (HasBattlerSideAbility(battlerDef, ABILITY_UNAWARE, aiData))
                 ADJUST_SCORE(-10);
             if (gBattleMons[battlerAtk].statStages[STAT_SPATK] >= MAX_STAT_STAGE || !HasMoveWithCategory(battlerAtk, DAMAGE_CATEGORY_SPECIAL))
                 ADJUST_SCORE(-10);
@@ -1737,7 +1737,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             break;
         case EFFECT_BELLY_DRUM:
         case EFFECT_FILLET_AWAY:
-            if (IsBattlerSideUnaware(battlerDef))
+            if (HasBattlerSideAbility(battlerDef, ABILITY_UNAWARE, aiData))
                 ADJUST_SCORE(-10);
             if (aiData->abilities[battlerAtk] == ABILITY_CONTRARY)
                 ADJUST_SCORE(-10);

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -1200,7 +1200,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             break;
         case EFFECT_QUIVER_DANCE:
         case EFFECT_GEOMANCY:
-            if (aiData->abilities[battlerDef] == ABILITY_UNAWARE)
+            if (IsBattlerSideUnaware(battlerDef))
                 ADJUST_SCORE(-10);
             if (gBattleMons[battlerAtk].statStages[STAT_SPATK] >= MAX_STAT_STAGE || !HasMoveWithCategory(battlerAtk, DAMAGE_CATEGORY_SPECIAL))
                 ADJUST_SCORE(-10);
@@ -1737,7 +1737,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             break;
         case EFFECT_BELLY_DRUM:
         case EFFECT_FILLET_AWAY:
-            if (aiData->abilities[battlerDef] == ABILITY_UNAWARE)
+            if (IsBattlerSideUnaware(battlerDef))
                 ADJUST_SCORE(-10);
             if (aiData->abilities[battlerAtk] == ABILITY_CONTRARY)
                 ADJUST_SCORE(-10);

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -3937,6 +3937,10 @@ static u32 IncreaseStatUpScoreInternal(u32 battlerAtk, u32 battlerDef, u32 statI
     if (considerContrary && AI_DATA->abilities[battlerAtk] == ABILITY_CONTRARY)
         return NO_INCREASE;
 
+    // Don't increase stats if opposing battler has Unaware
+    if (AI_DATA->abilities[battlerDef] == ABILITY_UNAWARE)
+        return NO_INCREASE;
+
     // Don't increase stat if AI is at +4
     if (gBattleMons[battlerAtk].statStages[statId] >= MAX_STAT_STAGE - 2)
         return NO_INCREASE;

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -3938,7 +3938,7 @@ static u32 IncreaseStatUpScoreInternal(u32 battlerAtk, u32 battlerDef, u32 statI
         return NO_INCREASE;
 
     // Don't increase stats if opposing battler has Unaware
-    if (AI_DATA->abilities[battlerDef] == ABILITY_UNAWARE)
+    if (IsBattlerSideUnaware(battlerDef))
         return NO_INCREASE;
 
     // Don't increase stat if AI is at +4
@@ -4426,4 +4426,13 @@ bool32 IsBattlerItemEnabled(u32 battler)
     if (gBattleMons[battler].ability == ABILITY_KLUTZ && !(gStatuses3[battler] & STATUS3_GASTRO_ACID))
         return FALSE;
     return TRUE;
+}
+
+bool32 IsBattlerSideUnaware(u32 battler)
+{
+    if (AI_DATA->abilities[battler] == ABILITY_UNAWARE)
+        return TRUE;
+    if (IsDoubleBattle() && AI_DATA->abilities[BATTLE_PARTNER(battler)] == ABILITY_UNAWARE)
+        return TRUE;
+    return FALSE;
 }

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -3938,7 +3938,7 @@ static u32 IncreaseStatUpScoreInternal(u32 battlerAtk, u32 battlerDef, u32 statI
         return NO_INCREASE;
 
     // Don't increase stats if opposing battler has Unaware
-    if (IsBattlerSideUnaware(battlerDef))
+    if (HasBattlerSideAbility(battlerDef, ABILITY_UNAWARE, AI_DATA))
         return NO_INCREASE;
 
     // Don't increase stat if AI is at +4
@@ -4428,11 +4428,11 @@ bool32 IsBattlerItemEnabled(u32 battler)
     return TRUE;
 }
 
-bool32 IsBattlerSideUnaware(u32 battler)
+bool32 HasBattlerSideAbility(u32 battler, u32 ability, struct AiLogicData *aiData)
 {
-    if (AI_DATA->abilities[battler] == ABILITY_UNAWARE)
+    if (aiData->abilities[battler] == ability)
         return TRUE;
-    if (IsDoubleBattle() && AI_DATA->abilities[BATTLE_PARTNER(battler)] == ABILITY_UNAWARE)
+    if (IsDoubleBattle() && AI_DATA->abilities[BATTLE_PARTNER(battler)] == ability)
         return TRUE;
     return FALSE;
 }

--- a/test/battle/ai/ai.c
+++ b/test/battle/ai/ai.c
@@ -899,3 +899,15 @@ AI_SINGLE_BATTLE_TEST("AI_FLAG_SMART_SWITCHING: AI considers Focus Sash when det
         TURN { MOVE(player, MOVE_AIR_SLASH); EXPECT_MOVE(opponent, MOVE_FLAMETHROWER); }
     }
 }
+
+AI_SINGLE_BATTLE_TEST("AI won't boost stats against opponent with Unaware")
+{
+    GIVEN {
+        MoveHasAdditionalEffectSelf(MOVE_SWORDS_DANCE, MOVE_EFFECT_ATK_PLUS_2);
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY);
+        PLAYER(SPECIES_QUAGSIRE) { Ability(ABILITY_UNAWARE); Moves(MOVE_TACKLE); }
+        OPPONENT(SPECIES_ZIGZAGOON) { Moves(MOVE_BODY_SLAM, MOVE_SWORDS_DANCE); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_TACKLE); EXPECT_MOVE(opponent, MOVE_BODY_SLAM); }
+    }
+}


### PR DESCRIPTION
## Description
Adds a few basic cases where the AI should score a move negatively if the opponent has Unaware. I'm sure there are more cases, but this is a simple start that'll cover most of them.

## **Discord contact info**
@Pawkkie 
