### PR TITLE
Fixes Thermal Exchange not curing existing burn

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -6356,6 +6356,7 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
                 break;
             case ABILITY_WATER_VEIL:
             case ABILITY_WATER_BUBBLE:
+            case ABILITY_THERMAL_EXCHANGE:
                 if (gBattleMons[battler].status1 & STATUS1_BURN)
                 {
                     StringCopy(gBattleTextBuff1, gStatusConditionString_BurnJpn);

--- a/test/battle/ability/thermal_exchange.c
+++ b/test/battle/ability/thermal_exchange.c
@@ -36,7 +36,6 @@ SINGLE_BATTLE_TEST("Thermal Exchange prevents the user from getting burned when 
 
 SINGLE_BATTLE_TEST("Thermal Exchange cures burns when acquired")
 {
-    KNOWN_FAILING;
     GIVEN {
         ASSUME(gMovesInfo[MOVE_WILL_O_WISP].effect == EFFECT_WILL_O_WISP);
         ASSUME(gMovesInfo[MOVE_SKILL_SWAP].effect == EFFECT_SKILL_SWAP);
@@ -48,11 +47,13 @@ SINGLE_BATTLE_TEST("Thermal Exchange cures burns when acquired")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_WILL_O_WISP, player);
         STATUS_ICON(opponent, burn: TRUE);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SKILL_SWAP, opponent);
+        ABILITY_POPUP(opponent, ABILITY_THERMAL_EXCHANGE);
+        STATUS_ICON(opponent, burn: FALSE);
         NOT HP_BAR(opponent);
     }
 }
 
-SINGLE_BATTLE_TEST("Thermal Exchange burn prevention can be bypassed with Mold Breaker")
+SINGLE_BATTLE_TEST("Thermal Exchange burn prevention can be bypassed with Mold Breaker but is cured after")
 {
     GIVEN {
         ASSUME(gMovesInfo[MOVE_WILL_O_WISP].effect == EFFECT_WILL_O_WISP);
@@ -63,6 +64,9 @@ SINGLE_BATTLE_TEST("Thermal Exchange burn prevention can be bypassed with Mold B
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_WILL_O_WISP, opponent);
         STATUS_ICON(player, burn: TRUE);
+        ABILITY_POPUP(player, ABILITY_THERMAL_EXCHANGE);
+        STATUS_ICON(player, burn: FALSE);
+        NOT HP_BAR(player);
     }
 }
 


### PR DESCRIPTION
Fixes Thermal Exchange not curing already existing burns, which happens if the ability is obtained while burned or if a burn is obtained due to Mold Breaker and similar abilities ignoring Thermal Exchange's burn immunity.

## Issue(s) that this PR fixes
Fixes #6535

## **Discord contact info**
PhallenTree
