### PR TITLE
Adds SHOW_TYPES_SEEN to the B_SHOW_TYPES option

### DIFF
--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -316,11 +316,11 @@
 #define B_ENEMY_THROW_BALLS_SOUND    GEN_LATEST  // In GEN_5+, enemy Trainer's Poké Balls make a sound when thrown to send out a Pokémon. This can only be used when B_ENEMY_THROW_BALLS is set to GEN_6 or later.
 #define B_PLAYER_THROW_BALLS_SOUND   GEN_LATEST  // In GEN_5+, the player's Poké Balls make a sound when thrown to send out a Pokémon.
 
-#define SHOW_TYPES_NEVER    0 // Never shows types in battle
-#define SHOW_TYPES_ALWAYS   1 // Always show types in battle
-#define SHOW_TYPES_CAUGHT   2 // Only show types if you've caught a species of the mon.
-#define SHOW_TYPES_SEEN     3 // Only show types if you've seen a species of the mon.
-#define B_SHOW_TYPES        SHOW_TYPES_SEEN // When defined as SHOW_TYPES_ALWAYS, after selecting "Fight" in battle, the types of all Pokemon are revealed. Whe defined as SHOW_TYPES_OWN, types are only revealed if the player owns the mon in question.
+#define SHOW_TYPES_NEVER    0                    // Never shows types in battle
+#define SHOW_TYPES_ALWAYS   1                    // Always show types in battle
+#define SHOW_TYPES_CAUGHT   2                    // Only show types if you've caught a species of the mon.
+#define SHOW_TYPES_SEEN     3                    // Only show types if you've seen a species of the mon.
+#define B_SHOW_TYPES        SHOW_TYPES_NEVER     // When to show type indicators next to Pokémon health bars in battle, while choosing a move after selecting a target Pokémon.
 
 // Pokémon battle sprite settings
 #define B_ENEMY_MON_SHADOW_STYLE        GEN_LATEST // In Gen4+, all enemy Pokemon will have a shadow drawn beneath them.

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -316,10 +316,11 @@
 #define B_ENEMY_THROW_BALLS_SOUND    GEN_LATEST  // In GEN_5+, enemy Trainer's Poké Balls make a sound when thrown to send out a Pokémon. This can only be used when B_ENEMY_THROW_BALLS is set to GEN_6 or later.
 #define B_PLAYER_THROW_BALLS_SOUND   GEN_LATEST  // In GEN_5+, the player's Poké Balls make a sound when thrown to send out a Pokémon.
 
-#define SHOW_TYPES_NEVER    0
-#define SHOW_TYPES_ALWAYS   1
-#define SHOW_TYPES_CAUGHT   2
-#define B_SHOW_TYPES        SHOW_TYPES_NEVER // When defined as SHOW_TYPES_ALWAYS, after selecting "Fight" in battle, the types of all Pokemon are revealed. Whe defined as SHOW_TYPES_OWN, types are only revealed if the player owns the mon in question.
+#define SHOW_TYPES_NEVER    0 // Never shows types in battle
+#define SHOW_TYPES_ALWAYS   1 // Always show types in battle
+#define SHOW_TYPES_CAUGHT   2 // Only show types if you've caught a species of the mon.
+#define SHOW_TYPES_SEEN     3 // Only show types if you've seen a species of the mon.
+#define B_SHOW_TYPES        SHOW_TYPES_SEEN // When defined as SHOW_TYPES_ALWAYS, after selecting "Fight" in battle, the types of all Pokemon are revealed. Whe defined as SHOW_TYPES_OWN, types are only revealed if the player owns the mon in question.
 
 // Pokémon battle sprite settings
 #define B_ENEMY_MON_SHADOW_STYLE        GEN_LATEST // In Gen4+, all enemy Pokemon will have a shadow drawn beneath them.

--- a/include/type_icons.h
+++ b/include/type_icons.h
@@ -1,7 +1,7 @@
 #ifndef GUARD_TYPE_ICONS_H
 #define GUARD_TYPE_ICONS_H
 
-void LoadTypeIcons(u32);
+void LoadTypeIcons(u32 battler);
 
 #define TYPE_ICON_TAG 0x2720
 #define TYPE_ICON_TAG_2 0x2721

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3696,20 +3696,6 @@ static void DoBattleIntro(void)
     case BATTLE_INTRO_STATE_SET_DEX_AND_BATTLE_VARS:
         if (!gBattleControllerExecFlags)
         {
-            for (battler = 0; battler < gBattlersCount; battler++)
-            {
-                if (GetBattlerSide(battler) == B_SIDE_OPPONENT
-                    && (B_SHOW_TYPES != SHOW_TYPES_SEEN)
-                    && !(gBattleTypeFlags & (BATTLE_TYPE_EREADER_TRAINER
-                                          | BATTLE_TYPE_FRONTIER
-                                          | BATTLE_TYPE_LINK
-                                          | BATTLE_TYPE_RECORDED_LINK
-                                          | BATTLE_TYPE_TRAINER_HILL)))
-                {
-                    HandleSetPokedexFlag(SpeciesToNationalPokedexNum(gBattleMons[battler].species), FLAG_SET_SEEN, gBattleMons[battler].personality);
-                }
-            }
-
             gBattleStruct->eventsBeforeFirstTurnState = 0;
             gBattleStruct->switchInBattlerCounter = 0;
             gBattleStruct->overworldWeatherDone = FALSE;
@@ -5551,7 +5537,7 @@ static void HandleEndTurn_FinishBattle(void)
                         GetMonData(&gPlayerParty[gBattlerPartyIndexes[battler]], MON_DATA_NICKNAME, gBattleResults.playerMon2Name);
                     }
                 }
-                else if (GetBattlerSide(battler) == B_SIDE_OPPONENT && B_SHOW_TYPES == SHOW_TYPES_SEEN)
+                else if (GetBattlerSide(battler) == B_SIDE_OPPONENT)
                 {
                     HandleSetPokedexFlag(SpeciesToNationalPokedexNum(gBattleMons[battler].species), FLAG_SET_SEEN, gBattleMons[battler].personality);
                 }

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3699,7 +3699,8 @@ static void DoBattleIntro(void)
             for (battler = 0; battler < gBattlersCount; battler++)
             {
                 if (GetBattlerSide(battler) == B_SIDE_OPPONENT
-                 && !(gBattleTypeFlags & (BATTLE_TYPE_EREADER_TRAINER
+                    && (B_SHOW_TYPES != SHOW_TYPES_SEEN)
+                    && !(gBattleTypeFlags & (BATTLE_TYPE_EREADER_TRAINER
                                           | BATTLE_TYPE_FRONTIER
                                           | BATTLE_TYPE_LINK
                                           | BATTLE_TYPE_RECORDED_LINK
@@ -5549,6 +5550,10 @@ static void HandleEndTurn_FinishBattle(void)
                         gBattleResults.playerMon2Species = GetMonData(&gPlayerParty[gBattlerPartyIndexes[battler]], MON_DATA_SPECIES, NULL);
                         GetMonData(&gPlayerParty[gBattlerPartyIndexes[battler]], MON_DATA_NICKNAME, gBattleResults.playerMon2Name);
                     }
+                }
+                else if (GetBattlerSide(battler) == B_SIDE_OPPONENT && B_SHOW_TYPES == SHOW_TYPES_SEEN)
+                {
+                    HandleSetPokedexFlag(SpeciesToNationalPokedexNum(gBattleMons[battler].species), FLAG_SET_SEEN, gBattleMons[battler].personality);
                 }
             }
             TryPutPokemonTodayOnAir();

--- a/src/type_icons.c
+++ b/src/type_icons.c
@@ -15,7 +15,8 @@ static void LoadTypeIconsPerBattler(u32, u32);
 static bool32 UseDoubleBattleCoords(u32);
 
 static u32 GetMonPublicType(u32, u32);
-static bool32 ShouldHideUncaughtType(u32);
+static bool32 ShouldHideUncaughtType(u32 species);
+static bool32 ShouldHideUnseenType(u32 species);
 static u32 GetMonDefensiveTeraType(struct Pokemon *, struct Pokemon*, u32, u32, u32, u32);
 static u32 IsIllusionActiveAndTypeUnchanged(struct Pokemon*, u32, u32);
 
@@ -239,7 +240,11 @@ void LoadTypeIcons(u32 battler)
 {
     u32 position;
 
-    if (B_SHOW_TYPES == SHOW_TYPES_NEVER)
+    struct Pokemon* mon = GetPartyBattlerData(battler);
+    u32 species = GetMonData(mon, MON_DATA_SPECIES, NULL);
+
+    if (B_SHOW_TYPES == SHOW_TYPES_NEVER 
+        || (B_SHOW_TYPES == SHOW_TYPES_SEEN && !GetSetPokedexFlag(SpeciesToNationalPokedexNum(species), FLAG_GET_SEEN)))
         return;
 
     LoadTypeSpritesAndPalettes();
@@ -296,7 +301,7 @@ static u32 GetMonPublicType(u32 battlerId, u32 typeNum)
     struct Pokemon* monIllusion;
     u32 illusionSpecies;
 
-    if (ShouldHideUncaughtType(monSpecies))
+    if (ShouldHideUncaughtType(monSpecies) || ShouldHideUnseenType(monSpecies))
         return TYPE_MYSTERY;
 
     monIllusion = GetIllusionMonPtr(battlerId);
@@ -316,7 +321,18 @@ static bool32 ShouldHideUncaughtType(u32 species)
     if (B_SHOW_TYPES != SHOW_TYPES_CAUGHT)
         return FALSE;
 
-    if (GetSetPokedexFlag(SpeciesToNationalPokedexNum(species),FLAG_GET_CAUGHT))
+    if (GetSetPokedexFlag(SpeciesToNationalPokedexNum(species), FLAG_GET_CAUGHT))
+        return FALSE;
+
+    return TRUE;
+}
+
+static bool32 ShouldHideUnseenType(u32 species)
+{
+    if (B_SHOW_TYPES != SHOW_TYPES_SEEN)
+        return FALSE;
+
+    if (GetSetPokedexFlag(SpeciesToNationalPokedexNum(species), FLAG_GET_SEEN))
         return FALSE;
 
     return TRUE;


### PR DESCRIPTION
## Description
adds the option to show the type indicators only when a mon has been seen before by:
- adding `SHOW_TYPES_SEEN` as a `#define` option
- when `SHOW_TYPES_SEEN` is selected, mons will be marked as seen once a battle finishes, not as soon as it starts, so the type indicators wont read the mon as seen (they load after that flag is set).
- adding a little logic to handle when a mon has been seen but not caught

## Images
![show_types_seen](https://github.com/user-attachments/assets/020f72b5-ae42-43a5-9126-5ca6ac1f79d2)

## Things to note in the release changelog:
- this slightly alters how the flag `FLAG_GET_SEEN` is set, so keep that in mind if you have any functionality that relies on it being at the start of the battle.

## **Discord contact info**
@khbsd
