### PR TITLE
Refactors Smart AI flags to be able to add any amount of flags

### DIFF
--- a/include/constants/battle_ai.h
+++ b/include/constants/battle_ai.h
@@ -51,6 +51,9 @@
 #define AI_FLAG_SMART_TRAINER         (AI_FLAG_BASIC_TRAINER | AI_FLAG_OMNISCIENT | AI_FLAG_SMART_SWITCHING | AI_FLAG_SMART_MON_CHOICES | AI_FLAG_WEIGH_ABILITY_PREDICTION)
 #define AI_FLAG_PREDICTION            (AI_FLAG_PREDICT_SWITCH | AI_FLAG_PREDICT_INCOMING_MON)
 
+#define AI_FLAG_WILD_ENCOUNTER        (AI_FLAG_CHECK_BAD_MOVE) // You can append any flag you want depending on how smart you want the ai to be. See above how to combine several flags
+
+
 // 'other' ai logic flags
 #define AI_FLAG_DYNAMIC_FUNC          (1 << 28)  // Create custom AI functions for specific battles via "setdynamicaifunc" cmd
 #define AI_FLAG_ROAMING               (1 << 29)

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -132,16 +132,13 @@ static u32 GetWildAiFlags(void)
     if (IsDoubleBattle())
         avgLevel = (GetMonData(&gEnemyParty[0], MON_DATA_LEVEL) + GetMonData(&gEnemyParty[1], MON_DATA_LEVEL)) / 2;
 
-    flags |= AI_FLAG_CHECK_BAD_MOVE;
+    flags |= AI_FLAG_WILD_ENCOUNTER;
     if (avgLevel >= 20)
         flags |= AI_FLAG_CHECK_VIABILITY;
     if (avgLevel >= 60)
         flags |= AI_FLAG_TRY_TO_2HKO;
     if (avgLevel >= 80)
         flags |= AI_FLAG_HP_AWARE;
-
-    if (B_VAR_WILD_AI_FLAGS != 0 && VarGet(B_VAR_WILD_AI_FLAGS) != 0)
-        flags |= VarGet(B_VAR_WILD_AI_FLAGS);
 
     return flags;
 }

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -417,10 +417,6 @@ void Overworld_ResetBattleFlagsAndVars(void)
         VarSet(B_VAR_STARTING_STATUS_TIMER, 0);
     #endif
 
-    #if B_VAR_WILD_AI_FLAGS != 0
-        VarSet(B_VAR_WILD_AI_FLAGS,0);
-    #endif
-
     FlagClear(B_FLAG_INVERSE_BATTLE);
     FlagClear(B_FLAG_FORCE_DOUBLE_WILD);
     FlagClear(B_SMART_WILD_AI_FLAG);


### PR DESCRIPTION
Closes #6540 and supersedes #6543

The problem with the current approach is that the amount of flags is limited to 16 because a var is used but a var is not necessary because a define to combine any amount of flags solves this as well. 
