### PR TITLE
fix: missing break statement

### DIFF
--- a/src/wild_encounter.c
+++ b/src/wild_encounter.c
@@ -1182,7 +1182,7 @@ static u8 GetMaxLevelOfSpeciesInWildTable(const struct WildPokemon *wildMon, u16
     default:
     case WILD_AREA_FISHING:
     case WILD_AREA_HIDDEN:
-    break;
+        break;
     }
 
     for (i = 0; i < numMon; i++)

--- a/src/wild_encounter.c
+++ b/src/wild_encounter.c
@@ -1182,6 +1182,7 @@ static u8 GetMaxLevelOfSpeciesInWildTable(const struct WildPokemon *wildMon, u16
     default:
     case WILD_AREA_FISHING:
     case WILD_AREA_HIDDEN:
+    break;
     }
 
     for (i = 0; i < numMon; i++)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
just adds a missing break statement that causes compiler errors in older versions of gcc. i went through the other switch cases added and didn't see anything else i missed.

## **Discord contact info**
@khbsd
