### PR TITLE
Fixes Dynamax reversion animation when fainting

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -9994,9 +9994,12 @@ BattleScript_DynamaxEnds::
 
 BattleScript_DynamaxEnds_Ret::
 	flushtextbox
+	spriteignore0hp TRUE
 	updatedynamax
 	playanimation BS_SCRIPTING, B_ANIM_FORM_CHANGE
 	waitanimation
+	spriteignore0hp FALSE
+	pause B_WAIT_TIME_SHORT
 	return
 
 BattleScript_MoveBlockedByDynamax::

--- a/test/battle/gimmick/dynamax.c
+++ b/test/battle/gimmick/dynamax.c
@@ -68,6 +68,29 @@ SINGLE_BATTLE_TEST("Dynamax: Dynamax Level increases HP and max HP multipliers b
     }
 }
 
+SINGLE_BATTLE_TEST("Dynamax: Dynamax expires when fainted")
+{
+    u32 dynamax;
+    PARAMETRIZE { dynamax = GIMMICK_NONE; }
+    PARAMETRIZE { dynamax = GIMMICK_DYNAMAX; }
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { HP(1); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_TACKLE, gimmick: dynamax); MOVE(opponent, MOVE_TACKLE); }
+    } SCENE {
+        if (dynamax)
+            MESSAGE("Wobbuffet used Max Strike!");
+        else
+            MESSAGE("Wobbuffet used Tackle!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponent);
+        HP_BAR(player);
+        if (dynamax) // Expect to have visual reversion when fainting.
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
+        MESSAGE("Wobbuffet fainted!");
+    }
+}
+
 SINGLE_BATTLE_TEST("Dynamax: Dynamax expires after three turns", u16 hp)
 {
     u32 dynamax;


### PR DESCRIPTION
Fixes Dynamax reversion animation when fainting. This happened since for some animations, the battler's sprite is not considered to exist if fainted, unless `gBattleStruct->spriteIgnore0Hp` is set.

Fixed animation:

https://github.com/user-attachments/assets/4ed150cd-2fbf-467e-ae74-be52cc36cdcd

## **Discord contact info**
PhallenTree
