### PR TITLE
Adjust enum AIScore

### DIFF
--- a/include/battle_ai_main.h
+++ b/include/battle_ai_main.h
@@ -39,11 +39,11 @@ enum StatChange
 // Scores given in AI_CalcMoveEffectScore and AI_CalcHoldEffectMoveScore
 enum AIScore
 {
-    NO_INCREASE,
-    WEAK_EFFECT,
-    DECENT_EFFECT,
-    GOOD_EFFECT,
-    BEST_EFFECT
+    NO_INCREASE = 0,
+    WEAK_EFFECT = 1,
+    DECENT_EFFECT = 2,
+    GOOD_EFFECT = 3,
+    BEST_EFFECT = 4
 };
 
 // AI_TryToFaint


### PR DESCRIPTION
Since the idea is that users can make adjustments to the score increases it might be better to just assign those now even if they are in consecutive order.
