### PR TITLE
Fixed DNS off config sometimes breaking palettes on map change

### DIFF
--- a/src/overworld.c
+++ b/src/overworld.c
@@ -1560,8 +1560,6 @@ const struct BlendSettings gTimeOfDayBlend[] =
 
 void UpdateTimeOfDay(void)
 {
-    if (!OW_ENABLE_DNS)
-        return;
     s32 hours, minutes;
     RtcCalcLocalTime();
     hours = sHoursOverride ? sHoursOverride : gLocalTime.hours;
@@ -1621,10 +1619,11 @@ void UpdateTimeOfDay(void)
 // Whether a map type is naturally lit/outside
 bool32 MapHasNaturalLight(u8 mapType)
 {
-    return (mapType == MAP_TYPE_TOWN
-         || mapType == MAP_TYPE_CITY
-         || mapType == MAP_TYPE_ROUTE
-         || mapType == MAP_TYPE_OCEAN_ROUTE);
+    return (OW_ENABLE_DNS
+         && (mapType == MAP_TYPE_TOWN
+          || mapType == MAP_TYPE_CITY
+          || mapType == MAP_TYPE_ROUTE
+          || mapType == MAP_TYPE_OCEAN_ROUTE));
 }
 
 bool32 CurrentMapHasShadows(void)
@@ -1637,8 +1636,6 @@ bool32 CurrentMapHasShadows(void)
 // Update & mix day / night bg palettes (into unfaded)
 void UpdateAltBgPalettes(u16 palettes)
 {
-    if (!OW_ENABLE_DNS)
-        return;
     const struct Tileset *primary = gMapHeader.mapLayout->primaryTileset;
     const struct Tileset *secondary = gMapHeader.mapLayout->secondaryTileset;
     u32 i = 1;
@@ -1666,7 +1663,7 @@ void UpdateAltBgPalettes(u16 palettes)
 
 void UpdatePalettesWithTime(u32 palettes)
 {
-    if (!OW_ENABLE_DNS || !MapHasNaturalLight(gMapHeader.mapType))
+    if (!MapHasNaturalLight(gMapHeader.mapType))
         return;
     u32 i;
     u32 mask = 1 << 16;
@@ -1685,8 +1682,7 @@ void UpdatePalettesWithTime(u32 palettes)
 
 u8 UpdateSpritePaletteWithTime(u8 paletteNum)
 {
-    if (OW_ENABLE_DNS
-     && MapHasNaturalLight(gMapHeader.mapType)
+    if (MapHasNaturalLight(gMapHeader.mapType)
      && !IS_BLEND_IMMUNE_TAG(GetSpritePaletteTagByPaletteNum(paletteNum)))
         TimeMixPalettes(1, &gPlttBufferUnfaded[OBJ_PLTT_ID(paletteNum)], &gPlttBufferFaded[OBJ_PLTT_ID(paletteNum)], &gTimeBlend.startBlend, &gTimeBlend.endBlend, gTimeBlend.weight);
     return paletteNum;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Before submitting, please make sure your pull request meets the scope guidelines. If unsure, please open a thread in #pr-discussions.-->
<!--- Scope Guidelines: https://github.com/rh-hideout/pokeemerald-expansion/blob/master/docs/team_procedures/scope.md  -->
<!--- #pr-discussions:  https://discord.com/channels/419213663107416084/1102784418369785948 -->

## Description
<!--- Describe your changes in detail -->
<!--- If you believe this PR qualifies as a "Big Feature" as defined in docs/team_procedures/schedule.md, please let a Maintainer know! -->
The old setting to turn off DNS could break palettes on map transitions when `FALSE`.
This should be a more reliable way to turn off DNS.

## Images
<!-- Please provide with relevant GIFs or images to make it easier for reviewers to accept your PR quicker.-->
<!-- If it doesn't apply, feel free to remove this section. -->
![pokeemerald-35](https://github.com/user-attachments/assets/23b6dc90-d1ae-4e30-af11-108f0fdba106)

## **Discord contact info**
<!--- Formatted as username (e.g. Lunos) or username#numbers (e.g. Lunos#4026) -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara