### PR TITLE
Fixes Ally Switch cancelling partner's moves targeting that side of the field

### DIFF
--- a/src/battle_anim_effects_1.c
+++ b/src/battle_anim_effects_1.c
@@ -6941,7 +6941,8 @@ static void AnimTask_AllySwitchDataSwap(u8 taskId)
     for (i = 0; i < gBattlersCount; i++)
     {
         u16 ability = GetBattlerAbility(i);
-        if (IsBattlerAlly(i, battlerAtk))
+        // if not targeting a slot that got switched, continue
+        if (!IsBattlerAlly(gBattleStruct->moveTarget[i], battlerAtk))
             continue;
 
         if (gChosenMoveByBattler[i] == MOVE_SNIPE_SHOT || ability == ABILITY_PROPELLER_TAIL || ability == ABILITY_STALWART)

--- a/src/battle_anim_effects_1.c
+++ b/src/battle_anim_effects_1.c
@@ -6914,11 +6914,11 @@ static void AnimTask_AllySwitchDataSwap(u8 taskId)
     SWAP(gMoveSelectionCursor[battlerAtk], gMoveSelectionCursor[battlerPartner], temp);
     // Swap turn order, so that all the battlers take action
     SWAP(gChosenActionByBattler[battlerAtk], gChosenActionByBattler[battlerPartner], temp);
-    for (i = 0; i < MAX_BATTLERS_COUNT; i++)
+    for (i = 0; i < gBattlersCount; i++)
     {
         if (gBattlerByTurnOrder[i] == battlerAtk || gBattlerByTurnOrder[i] == battlerPartner)
         {
-            for (j = i + 1; j < MAX_BATTLERS_COUNT; j++)
+            for (j = i + 1; j < gBattlersCount; j++)
             {
                 if (gBattlerByTurnOrder[j] == battlerAtk || gBattlerByTurnOrder[j] == battlerPartner)
                     break;
@@ -6938,9 +6938,12 @@ static void AnimTask_AllySwitchDataSwap(u8 taskId)
     TrySwapWishBattlerIds(battlerAtk, battlerPartner);
 
     // For Snipe Shot and abilities Stalwart/Propeller Tail - keep the original target.
-    for (i = 0; i < MAX_BATTLERS_COUNT; i++)
+    for (i = 0; i < gBattlersCount; i++)
     {
         u16 ability = GetBattlerAbility(i);
+        if (IsBattlerAlly(i, battlerAtk))
+            continue;
+
         if (gChosenMoveByBattler[i] == MOVE_SNIPE_SHOT || ability == ABILITY_PROPELLER_TAIL || ability == ABILITY_STALWART)
             gBattleStruct->moveTarget[i] ^= BIT_FLANK;
     }

--- a/test/battle/move_effect/acupressure.c
+++ b/test/battle/move_effect/acupressure.c
@@ -16,17 +16,37 @@ DOUBLE_BATTLE_TEST("Acupressure fails on the user if it targeted its ally but sw
         OPPONENT(SPECIES_KADABRA);
         OPPONENT(SPECIES_ABRA);
     } WHEN {
-        TURN { MOVE(playerLeft, MOVE_ALLY_SWITCH); MOVE(playerRight, MOVE_ACUPRESSURE, target:playerLeft); }
+        TURN { MOVE(playerLeft, MOVE_ALLY_SWITCH); MOVE(playerRight, MOVE_ACUPRESSURE, target: playerLeft); }
     } SCENE {
         MESSAGE("Wobbuffet used Ally Switch!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ALLY_SWITCH, playerLeft);
         MESSAGE("Wobbuffet and Wynaut switched places!");
-
+        MESSAGE("Wynaut used Acupressure!");
         MESSAGE("But it failed!");
         NONE_OF {
-            ANIMATION(ANIM_TYPE_MOVE, MOVE_ACUPRESSURE);
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_ACUPRESSURE, playerLeft);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
         }
+    }
+}
+
+DOUBLE_BATTLE_TEST("Acupressure works on the ally if it targeted itself but switched positions via Ally Switch")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_KADABRA);
+        OPPONENT(SPECIES_ABRA);
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_ALLY_SWITCH); MOVE(playerRight, MOVE_ACUPRESSURE, target: playerRight); }
+    } SCENE {
+        MESSAGE("Wobbuffet used Ally Switch!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ALLY_SWITCH, playerLeft);
+        MESSAGE("Wobbuffet and Wynaut switched places!");
+        MESSAGE("Wynaut used Acupressure!");
+        NOT MESSAGE("But it failed!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ACUPRESSURE, playerLeft);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerRight);
     }
 }
 

--- a/test/battle/move_effect/ally_switch.c
+++ b/test/battle/move_effect/ally_switch.c
@@ -167,6 +167,24 @@ DOUBLE_BATTLE_TEST("Ally Switch - move fails if the target was ally which change
     }
 }
 
+DOUBLE_BATTLE_TEST("Ally Switch doesn't make self-targeting status moves fail")
+{
+    GIVEN {
+        ASSUME(gMovesInfo[MOVE_HARDEN].target == MOVE_TARGET_USER);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_ALLY_SWITCH); MOVE(playerRight, MOVE_HARDEN); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ALLY_SWITCH, playerLeft);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_HARDEN, playerLeft);
+    } THEN {
+        EXPECT_EQ(playerLeft->statStages[STAT_DEF], DEFAULT_STAT_STAGE + 1);
+    }
+}
+
 DOUBLE_BATTLE_TEST("Ally Switch increases the Protect-like moves counter")
 {
     GIVEN {


### PR DESCRIPTION
- Fixes moves failing after Ally Switch if the Attacker is the ally of the battler that used Ally Switch and if they target a battler on the same side of the field (changed so that only moves that did not originally target the user, but target the user after Ally Switch fail).
- Fixes Acupressure failing regardless of target if Ally Switch was used by their partner.
- Fixes Snipe Shot, Propeller Tail and Stalwart redirecting moves for some battlers when they shouldn't (after Ally Switch).


## Issue(s) that this PR fixes
Fixes #6646

## **People who collaborated with me in this PR**
@hedara90 made the Ally Switch test in #6646

## **Discord contact info**
PhallenTree
