### PR TITLE
Change HasTwoFramesAnimation to take into account species with 1 frame

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -6334,7 +6334,10 @@ void HandleSetPokedexFlag(u16 nationalNum, u8 caseId, u32 personality)
 
 bool8 HasTwoFramesAnimation(u16 species)
 {
-    return P_TWO_FRAME_FRONT_SPRITES && gSpeciesInfo[species].frontAnimFrames != sAnims_SingleFramePlaceHolder && species != SPECIES_UNOWN && !gTestRunnerHeadless;
+    return P_TWO_FRAME_FRONT_SPRITES 
+        && gSpeciesInfo[species].frontAnimFrames != sAnims_SingleFramePlaceHolder 
+        && species != SPECIES_UNOWN 
+        && !gTestRunnerHeadless;
 }
 
 static bool8 ShouldSkipFriendshipChange(void)

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -6334,7 +6334,7 @@ void HandleSetPokedexFlag(u16 nationalNum, u8 caseId, u32 personality)
 
 bool8 HasTwoFramesAnimation(u16 species)
 {
-    return P_TWO_FRAME_FRONT_SPRITES && species != SPECIES_UNOWN && !gTestRunnerHeadless;
+    return P_TWO_FRAME_FRONT_SPRITES && gSpeciesInfo[species].frontAnimFrames != sAnims_SingleFramePlaceHolder && species != SPECIES_UNOWN && !gTestRunnerHeadless;
 }
 
 static bool8 ShouldSkipFriendshipChange(void)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Before submitting, please make sure your pull request meets the scope guidelines. If unsure, please open a thread in #pr-discussions.-->
<!--- Scope Guidelines: https://github.com/rh-hideout/pokeemerald-expansion/blob/master/docs/team_procedures/scope.md  -->
<!--- #pr-discussions:  https://discord.com/channels/419213663107416084/1102784418369785948 -->

## Description
<!--- Describe your changes in detail -->
<!--- If you believe this PR qualifies as a "Big Feature" as defined in docs/team_procedures/schedule.md, please let a Maintainer know! -->
Fixes the `HasTwoFramesAnimation` to take into account species that only has 1 animation frame.
This was causing issues with the post-KO animations.
Issue discovered by PCG on Discord.

Test to see the behaviour.
```C
SINGLE_BATTLE_TEST("blergh")
{
    GIVEN {
        PLAYER(SPECIES_SHEDINJA);
        OPPONENT(SPECIES_ABSOL) { Item(ITEM_ABSOLITE); }
    } WHEN {
        TURN { MOVE(opponent, MOVE_CRUNCH, gimmick: GIMMICK_MEGA); }
    }
}
```

## Images
<!-- Please provide with relevant GIFs or images to make it easier for reviewers to accept your PR quicker.-->
<!-- If it doesn't apply, feel free to remove this section. -->
Bugged behaviour
![welp](https://github.com/user-attachments/assets/1930ff72-8c12-4589-8b8b-4e192cf49c18)


## **Discord contact info**
<!--- Formatted as username (e.g. Lunos) or username#numbers (e.g. Lunos#4026) -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara