### PR TITLE
Fixed LGPE move test fail with `B_UPDATED_MOVE_DATA` to `GEN_7`

### DIFF
--- a/test/battle/move_effect_secondary/haze.c
+++ b/test/battle/move_effect_secondary/haze.c
@@ -16,7 +16,10 @@ SINGLE_BATTLE_TEST("Freeze Frost restores stat changes when it was succesful")
         PLAYER(SPECIES_WYNAUT);
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
-        TURN { MOVE(player, MOVE_FREEZY_FROST, hit: moveSuccess); }
+        TURN {
+            MOVE(opponent, MOVE_SAND_ATTACK);
+            MOVE(player, MOVE_FREEZY_FROST, hit: moveSuccess);
+        }
     } SCENE {
         if (moveSuccess == TRUE)
         {

--- a/test/battle/move_effect_secondary/leech_seed.c
+++ b/test/battle/move_effect_secondary/leech_seed.c
@@ -26,7 +26,10 @@ SINGLE_BATTLE_TEST("Sappy Seed is not going to seed the target if it fails")
         PLAYER(SPECIES_WYNAUT);
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
-        TURN { MOVE(player, MOVE_SAPPY_SEED, hit: FALSE); }
+        TURN {
+            MOVE(opponent, MOVE_SAND_ATTACK);
+            MOVE(player, MOVE_SAPPY_SEED, hit: FALSE);
+        }
     } SCENE {
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_SAPPY_SEED, player);

--- a/test/battle/move_effect_secondary/light_screen.c
+++ b/test/battle/move_effect_secondary/light_screen.c
@@ -16,7 +16,10 @@ SINGLE_BATTLE_TEST("Glitzy Glow sets up Light Screen when it was succesful")
         PLAYER(SPECIES_WYNAUT);
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
-        TURN { MOVE(player, MOVE_GLITZY_GLOW, hit: moveSuccess); }
+        TURN {
+            MOVE(opponent, MOVE_SAND_ATTACK);
+            MOVE(player, MOVE_GLITZY_GLOW, hit: moveSuccess);
+        }
     } SCENE {
         if (moveSuccess == TRUE)
         {

--- a/test/battle/move_effect_secondary/reflect.c
+++ b/test/battle/move_effect_secondary/reflect.c
@@ -16,7 +16,10 @@ SINGLE_BATTLE_TEST("Baddy Bad sets up Reflect when it was succesful")
         PLAYER(SPECIES_WYNAUT);
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
-        TURN { MOVE(player, MOVE_BADDY_BAD, hit: moveSuccess); }
+        TURN {
+            MOVE(opponent, MOVE_SAND_ATTACK);
+            MOVE(player, MOVE_BADDY_BAD, hit: moveSuccess);
+        }
     } SCENE {
         if (moveSuccess == TRUE)
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Before submitting, please make sure your pull request meets the scope guidelines. If unsure, please open a thread in #pr-discussions.-->
<!--- Scope Guidelines: https://github.com/rh-hideout/pokeemerald-expansion/blob/master/docs/team_procedures/scope.md  -->
<!--- #pr-discussions:  https://discord.com/channels/419213663107416084/1102784418369785948 -->

## Description
The tests relied on Gen 8 versions that had 95% accuracy, unlike the Gen 7 version with 100% accuracy.

## **Discord contact info**
AsparagusEduardo
