### PR TITLE
Fixes gBattlerTarget Out of Bounds error

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -4210,6 +4210,7 @@ BattleScript_EffectPerishSong::
 	attackcanceler
 	attackstring
 	ppreduce
+	savetarget
 	trysetperishsong BattleScript_ButItFailed
 	attackanimation
 	waitanimation
@@ -4222,6 +4223,7 @@ BattleScript_PerishSongLoop::
 BattleScript_PerishSongLoopIncrement::
 	addbyte gBattlerTarget, 1
 	jumpifbytenotequal gBattlerTarget, gBattlersCount, BattleScript_PerishSongLoop
+ 	restoretarget
 	goto BattleScript_MoveEnd
 
 BattleScript_PerishSongBlocked::


### PR DESCRIPTION
When perish song was looping through battlers it increased gBattlerTarget till it was able to break out when it reach 4. This fixes it by storing and restoring the target/
