### PR TITLE
Remove vestigial AdvanceScript function used for testing

### DIFF
--- a/src/fake_rtc.c
+++ b/src/fake_rtc.c
@@ -65,11 +65,6 @@ void FakeRtc_ManuallySetTime(u32 day, u32 hour, u32 minute, u32 second)
     FakeRtc_AdvanceTimeBy(day, hour, minute, second);
 }
 
-void AdvanceScript(void)
-{
-    FakeRtc_AdvanceTimeBy(300, 0, 0, 0);
-}
-
 u32 FakeRtc_GetSecondsRatio(void)
 {
     return (OW_ALTERED_TIME_RATIO == GEN_8_PLA) ? 60 :


### PR DESCRIPTION
## Description
Removes a vestigial function (presumably from testing) inside fake_rtc.c, brought in from the merge of #5695 `FakeRtc datetime and ResetRtcScreen day increments`.

## **Discord contact info**
ruby
ruby.raven