### PR TITLE
Fixes Neutralizing Gas activating again after switch-in

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -8179,6 +8179,7 @@ static bool32 DoSwitchInEffectsForBattler(u32 battler)
     {
         gBattleCommunication[MULTISTRING_CHOOSER] = B_MSG_SWITCHIN_NEUTRALIZING_GAS;
         gSpecialStatuses[battler].announceNeutralizingGas = TRUE;
+        gDisableStructs[battler].neutralizingGas = TRUE;
         gBattlerAbility = battler;
         BattleScriptPushCursor();
         gBattlescriptCurrInstr = BattleScript_SwitchInAbilityMsgRet;

--- a/test/battle/ability/teraform_zero.c
+++ b/test/battle/ability/teraform_zero.c
@@ -84,7 +84,6 @@ SINGLE_BATTLE_TEST("Teraform Zero cannot be copied")
 
 DOUBLE_BATTLE_TEST("Teraform Zero shouldn't cause Neutralizing Gas to show it's popup when trying to activate")
 {
-    KNOWN_FAILING; // #5010
     GIVEN {
         PLAYER(SPECIES_TERAPAGOS_TERASTAL);
         PLAYER(SPECIES_ABSOL) {Ability(ABILITY_PRESSURE); }
@@ -95,8 +94,8 @@ DOUBLE_BATTLE_TEST("Teraform Zero shouldn't cause Neutralizing Gas to show it's 
         TURN {  SWITCH(playerRight, 2); MOVE(playerLeft, MOVE_CELEBRATE, gimmick: GIMMICK_TERA); }
     } SCENE {
         MESSAGE("Terapagos is storing energy!");
-        MESSAGE("Terapagos terastalized into the Stellar type!");
+        MESSAGE("Terapagos terastallized into the Stellar type!");
         NOT ABILITY_POPUP(playerRight, ABILITY_NEUTRALIZING_GAS);
-        MESSAGE("Terapagos used Celebreate!");
+        MESSAGE("Terapagos used Celebrate!");
     }
 }


### PR DESCRIPTION
Fixes Teraform Zero + Neutralizing Gas known failing test. (Neutralizing Gas doesn't activate for `battler` if `gDisableStructs[battler].neutralizingGas` is set to true)

Reminder to keep Known Failing tests "passable" so that when the problem is solved the test actually passes.

## Issue(s) that this PR fixes
Fixes #5010

## **Discord contact info**
PhallenTree
