### PR TITLE
Capture odds refactor and new catch rate modifiers

### DIFF
--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -269,6 +269,9 @@
 #define B_CATCHING_CHARM_BOOST          20         // % boost in Critical Capture odds if player has the Catching Charm.
 #define B_CRITICAL_CAPTURE              TRUE       // If set to TRUE, Critical Capture will be enabled.
 #define B_CRITICAL_CAPTURE_LOCAL_DEX    TRUE       // If set to FALSE, Critical Capture % is based off of the National Pokedex estimated by enabled generations.
+#define B_CATCH_SLEEP_FREEZE_BONUS      GEN_LATEST // In Gen5+, the catch rate bonus for a mon with sleep or freeze is 2.5x. In Gen4 and below its only a 2x bonus.
+#define B_CATCH_LOW_LEVEL_BONUS         GEN_LATEST // In Gen8, a bonus is added to the catch rate if catching a mon lower than level 20. In Gen9, the bonus is only applied to mons lower than level 13.
+#define B_CATCH_BADGE_PENALTY           GEN_LATEST // In Gen9, a penalty is added to the catch rate if trying to catch a mon 5 levels above the current obedience level, based on the number of gym badges obtained.
 
 #define B_LAST_USED_BALL            TRUE       // If TRUE, the "last used ball" feature from Gen 7 will be implemented
 #define B_LAST_USED_BALL_BUTTON     R_BUTTON   // If last used ball is implemented, this button (or button combo) will trigger throwing the last used ball.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Before submitting, please make sure your pull request meets the scope guidelines. If unsure, please open a thread in #pr-discussions.-->
<!--- Scope Guidelines: https://github.com/rh-hideout/pokeemerald-expansion/blob/master/docs/team_procedures/scope.md  -->
<!--- #pr-discussions:  https://discord.com/channels/419213663107416084/1102784418369785948 -->

## Description
Refactors catch rate to be done in steps, which is exactly how its done in vanilla games like SV. The odds end up being the same but it makes it easier to modify a certain portion. Also added debug strings to track the odds throughout the various steps.
Added 3 new configs corresponding to 3 new capture modifiers that exist in SV but we didn't have until now.
B_CATCH_SLEEP_FREEZE_BONUS - The catch rate modifier in gen 5 onwards if an mon is asleep or frozen is 2.5x instead of just 2x. (Honestly can't believe we missed this)
B_CATCH_LOW_LEVEL_BONUS - Gen 8 and Gen 9 have increased catch rate for below lvl 20 mons in gen 8 and below lvl 13 mons in gen 9.
B_CATCH_BADGE_PENALTY - Gen 9 reduces catch rate depending on the current badge count for wild mons with a lvl higher than the max obedience level + 5. (i.e. if you dont have any badges, mons higher than lvl 15 will be harder to catch). Won't affect vanilla emerald at all, but might affect some hacks.

## Issue(s) that this PR fixes
Fixes #3906

## **Discord contact info**
kittenchilly
