### PR TITLE
Fixes Mirror Armor stat drops not being stopped by Substitute

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -3202,7 +3202,7 @@ BattleScript_StatDownEnd::
 BattleScript_MirrorArmorReflect::
 	pause B_WAIT_TIME_SHORT
 	call BattleScript_AbilityPopUp
-	jumpifsubstituteblocks BattleScript_AbilityNoSpecificStatLoss
+	jumpifstatus2 BS_ATTACKER, STATUS2_SUBSTITUTE, BattleScript_MirrorArmorDoesntAffect
 BattleScript_MirrorArmorReflectStatLoss:
 	statbuffchange MOVE_EFFECT_AFFECTS_USER | STAT_CHANGE_MIRROR_ARMOR | STAT_CHANGE_NOT_PROTECT_AFFECTED | STAT_CHANGE_ALLOW_PTR, BattleScript_MirrorArmorReflectEnd
 	jumpifbyte CMP_LESS_THAN, cMULTISTRING_CHOOSER, B_MSG_STAT_WONT_DECREASE, BattleScript_MirrorArmorReflectAnim
@@ -3214,6 +3214,13 @@ BattleScript_MirrorArmorReflectPrintString:
 	printfromtable gStatDownStringIds
 	waitmessage B_WAIT_TIME_LONG
 BattleScript_MirrorArmorReflectEnd:
+	return
+
+BattleScript_MirrorArmorDoesntAffect:
+	swapattackerwithtarget
+	printstring STRINGID_ITDOESNTAFFECT
+	waitmessage B_WAIT_TIME_LONG
+	swapattackerwithtarget
 	return
 
 BattleScript_MirrorArmorReflectWontFall:

--- a/test/battle/ability/mirror_armor.c
+++ b/test/battle/ability/mirror_armor.c
@@ -102,10 +102,8 @@ SINGLE_BATTLE_TEST("Mirror Armor lowers the Attack of Pokemon with Intimidate")
     }
 }
 
-// Unsure whether this should or should not fail, as Showdown has conflicting information. Needs testing in gen8 games.
 SINGLE_BATTLE_TEST("Mirror Armor doesn't lower the stats of an attacking Pokemon behind Substitute")
 {
-    KNOWN_FAILING;
     GIVEN {
         PLAYER(SPECIES_CORVIKNIGHT) { Ability(ABILITY_MIRROR_ARMOR); }
         OPPONENT(SPECIES_WYNAUT);


### PR DESCRIPTION
From Sword/Shield Research thread: (at the end of https://www.smogon.com/forums/threads/sword-shield-battle-mechanics-research.3655528/post-8330904)

> Pokemon A with Substitute uses Screech into Pokemon B with Mirror Armor. Mirror Armor activates, but Pokemon A's Defense does not drop ("it doesn't affect <Pokemon>..."). Pokemon B's Defense doesn't drop either, as expected. On an unrelated note, though I would have expected this, you can miss Screech on a Pokemon with Mirror Armor.

The previous check was incorrect since `jumpifsubstituteblocks` checks if `gBattlerAttacker`'s move is blocked by `gBattlerTarget`'s Substitute, when Mirror Armor is `gBattlerTarget` inflicting a debuff on `gBattlerAttacker`.
According to the research, this seems to ignore the `.ignoresSubstitute` attribute of the move, as Screech does ignore Substitute normally.

## **Discord contact info**
PhallenTree
