### PR TITLE
Fixed broken palette load for shiny followers in the sprite visualizer

### DIFF
--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -1840,13 +1840,10 @@ u8 CreateObjectGraphicsSprite(u16 graphicsId, void (*callback)(struct Sprite *),
     const struct ObjectEventGraphicsInfo *graphicsInfo = GetObjectEventGraphicsInfo(graphicsId);
     struct Sprite *sprite;
     u8 spriteId;
-    bool32 isShiny = graphicsId & OBJ_EVENT_MON_SHINY;
 
     spriteTemplate = Alloc(sizeof(struct SpriteTemplate));
     CopyObjectGraphicsInfoToSpriteTemplate(graphicsId, callback, spriteTemplate, &subspriteTables);
 
-    if (isShiny)
-        graphicsId -= SPECIES_SHINY_TAG;
 
     if (OW_GFX_COMPRESS)
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Before submitting, please make sure your pull request meets the scope guidelines. If unsure, please open a thread in #pr-discussions.-->
<!--- Scope Guidelines: https://github.com/rh-hideout/pokeemerald-expansion/blob/master/docs/team_procedures/scope.md  -->
<!--- #pr-discussions:  https://discord.com/channels/419213663107416084/1102784418369785948 -->

## Description
<!--- Describe your changes in detail -->
<!--- If you believe this PR qualifies as a "Big Feature" as defined in docs/team_procedures/schedule.md, please let a Maintainer know! -->
Fixes broken palettes for shiny followers in the sprite visualizer.
Followers and OW object events works after this change, in combinations of shiny and female and not.
![pokeemerald-18](https://github.com/user-attachments/assets/ad6d5a64-7d7c-403d-9143-1b0b4e698fec)

The problem was probably a vestigial handling for the old graphics ID handling.

## **Discord contact info**
<!--- Formatted as username (e.g. Lunos) or username#numbers (e.g. Lunos#4026) -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara