### PR TITLE
Removes vestigial EWRAM variable from debug menu.

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -338,7 +338,6 @@ static EWRAM_DATA struct DebugMenuListData *sDebugMenuListData = NULL;
 static EWRAM_DATA struct DebugBattleData *sDebugBattleData = NULL;
 EWRAM_DATA bool8 gIsDebugBattle = FALSE;
 EWRAM_DATA u32 gDebugAIFlags = 0;
-EWRAM_DATA u32 gDebugTime = 0;
 
 // *******************************
 // Define functions


### PR DESCRIPTION
## Description
There was an EWRAM variable I declared in my first attempts to clean up and refactor my own code for the Time Menu, and realized it was still there after it was merged

## Images
![Screen Shot 2025-04-24 at 1 46 14 AM](https://github.com/user-attachments/assets/91eafdb2-99ed-405d-8fd9-35da76e4db49)

## **Discord contact info**
ruby
ruby.raven