### PR TITLE
Disable `P_TUTOR_MOVES_ARRAY` config

### DIFF
--- a/include/config/pokemon.h
+++ b/include/config/pokemon.h
@@ -63,7 +63,7 @@
 
 // Learnset helper toggles
 #define P_LEARNSET_HELPER_TEACHABLE      TRUE   // If TRUE, teachable_learnsets.h will be populated by tools/learnset_helpers/make_teachables.py using the included JSON files based on available TMs and tutors.
-#define P_TUTOR_MOVES_ARRAY              TRUE   // If TRUE, generates a gTutorMoves array automatically using make_teachables.py. (generally not needed, but the HGSS Pokedex has an optional use for it)
+#define P_TUTOR_MOVES_ARRAY              FALSE  // If TRUE, generates a gTutorMoves array automatically using make_teachables.py. (generally not needed, but the HGSS Pokedex has an optional use for it)
 
 // Flag settings
 // To use the following features in scripting, replace the 0s with the flag ID you're assigning it to.


### PR DESCRIPTION
This was a leftover I forgot to disable.

## Things to note in the release changelog:
<!-- We use an automated system to generate our changelogs, so if there's something of note that our end users should know in regards to this change besides the title of this PR, they should be added here. -->
<!-- *MUST* be structured as bullet points. -->
<!-- If it doesn't apply, feel free to remove this section. -->
- `P_TUTOR_MOVES_ARRAY` set to `FALSE` by default.

## **Discord contact info**
<!--- Formatted as username (e.g. Lunos) or username#numbers (e.g. Lunos#4026) -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
pcg06
