### PR TITLE
Timemacros

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -2308,6 +2308,10 @@
 	callnative ScriptSetDoubleBattleFlag, requests_effects=1
 	.endm
 
+	@ ============================ @
+	@ FAKE RTC MACROS
+	@ Will only function if OW_USE_FAKE_RTC is true. If it has any additional requirements, it will be listed accordingly.
+	
 	@ When OW_USE_FAKE_RTC is true and OW_FLAG_PAUSE_TIME is assigned, this macro will stop the flow of time.
 	.macro pausefakertc
 	callnative Script_PauseFakeRtc, requests_effects=1
@@ -2325,42 +2329,41 @@
 
 	@ When OW_USE_FAKE_RTC is true, adds a specified amount of time.
 	.macro addtime days:req, hours:req, minutes:req
-	callnative ScrCmd_addtime
+	callnative ScrCmd_addtime, requests_effects=1
 	.4byte \days
 	.4byte \hours
 	.4byte \minutes
 	.endm
 
-	@ Adds a specified number of days to the time. 
+	@ When OW_USE_FAKE_RTC is true, adds a specified number of days to the time. 
 	.macro adddays days:req
-	callnative ScrCmd_adddays
+	callnative ScrCmd_adddays, requests_effects=1
 	.4byte \days
 	.endm
 
-	@ Adds a specified number of days, hours, and minutes to the time. 
+	@ When OW_USE_FAKE_RTC is true, adds a specified number of days, hours, and minutes to the time. 
 	.macro addhours hours:req
-	callnative ScrCmd_addhours
+	callnative ScrCmd_addhours, requests_effects=1
 	.4byte \hours
 	.endm
 
-	@ Adds a specified number of days, hours, and minutes to the time. 
+	@ When OW_USE_FAKE_RTC is true, adds a specified number of days, hours, and minutes to the time. 
 	.macro addminutes minutes:req
-	callnative ScrCmd_addminutes
+	callnative ScrCmd_addminutes, requests_effects=1
 	.4byte \minutes
 	.endm
 
 	@ Forwards the time to a specified hour and minute. 
 	@ This causes the time to go to the next day if the time has already been past. 
 	.macro fwdtime hours:req, minutes:req
-	callnative ScrCmd_fwdtime
+	callnative ScrCmd_fwdtime, requests_effects=1
 	.4byte \hours
 	.4byte \minutes
 	.endm
 
-	@ Forwards the time to a specified day of the week. Uses a 0-index starting from Monday.
-	@ This causes the time to go to the next day if the time has already been past. 
+	@ Forwards the time to a specified day of the week. Uses a 0-index starting from Sunday.
 	.macro fwdweekday weekday:req
-	callnative ScrCmd_fwdweekday
+	callnative ScrCmd_fwdweekday, requests_effects=1
 	.4byte \weekday
 	.endm
 

--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -341,7 +341,7 @@
 	@ Sets the values of variable VAR_0x8000 to the time of day according to those found in rtc.h.
 	@ 0 = MORNING, 1 = DAY, 2 = EVENING, 3 = NIGHT
 	.macro gettimeofday
-	callnative ScrCmd_gettimeofday
+	callnative ScrCmd_gettimeofday requests_effects=1
 	.endm
 
 	@ Plays the specified sound. Only one sound may play at a time, with newer ones interrupting older ones.
@@ -2308,7 +2308,7 @@
 	callnative ScriptSetDoubleBattleFlag, requests_effects=1
 	.endm
 
-	@ When OW_USE_FAKE_RTC and OW_FLAG_PAUSE_TIME is assigned, this macro will stop the flow of time.
+	@ When OW_USE_FAKE_RTC is true and OW_FLAG_PAUSE_TIME is assigned, this macro will stop the flow of time.
 	.macro pausefakertc
 	callnative Script_PauseFakeRtc, requests_effects=1
 	.endm
@@ -2321,6 +2321,47 @@
 	@ When OW_USE_FAKE_RTC and OW_FLAG_PAUSE_TIME is assigned, this macro will resume the flow of time if paused, and stop the flow of time otherwise.
 	.macro togglefakertc
 	callnative Script_ToggleFakeRtc, requests_effects=1
+	.endm
+
+	@ When OW_USE_FAKE_RTC is true, adds a specified amount of time.
+	.macro addtime days:req, hours:req, minutes:req
+	callnative ScrCmd_addtime
+	.4byte \days
+	.4byte \hours
+	.4byte \minutes
+	.endm
+
+	@ Adds a specified number of days to the time. 
+	.macro adddays days:req
+	callnative ScrCmd_adddays
+	.4byte \days
+	.endm
+
+	@ Adds a specified number of days, hours, and minutes to the time. 
+	.macro addhours hours:req
+	callnative ScrCmd_addhours
+	.4byte \hours
+	.endm
+
+	@ Adds a specified number of days, hours, and minutes to the time. 
+	.macro addminutes minutes:req
+	callnative ScrCmd_addminutes
+	.4byte \minutes
+	.endm
+
+	@ Forwards the time to a specified hour and minute. 
+	@ This causes the time to go to the next day if the time has already been past. 
+	.macro fwdtime hours:req, minutes:req
+	callnative ScrCmd_fwdtime
+	.4byte \hours
+	.4byte \minutes
+	.endm
+
+	@ Forwards the time to a specified day of the week. Uses a 0-index starting from Monday.
+	@ This causes the time to go to the next day if the time has already been past. 
+	.macro fwdweekday weekday:req
+	callnative ScrCmd_fwdweekday
+	.4byte \weekday
 	.endm
 
 	@ ============================ @

--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -341,7 +341,7 @@
 	@ Sets the values of variable VAR_0x8000 to the time of day according to those found in rtc.h.
 	@ 0 = MORNING, 1 = DAY, 2 = EVENING, 3 = NIGHT
 	.macro gettimeofday
-	callnative ScrCmd_gettimeofday requests_effects=1
+	callnative ScrCmd_gettimeofday, requests_effects=1
 	.endm
 
 	@ Plays the specified sound. Only one sound may play at a time, with newer ones interrupting older ones.

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -3148,7 +3148,7 @@ bool8 ScrCmd_addtime(struct ScriptContext *ctx)
     u32 hours = ScriptReadWord(ctx);
     u32 minutes = ScriptReadWord(ctx);
 
-    Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
+    Script_RequestEffects(SCREFF_V1 | SCREFF_SAVE);
     
     FakeRtc_AdvanceTimeBy(days, hours, minutes, 0);
 
@@ -3159,7 +3159,7 @@ bool8 ScrCmd_adddays(struct ScriptContext *ctx)
 {
     u32 days = ScriptReadWord(ctx);
 
-    Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
+    Script_RequestEffects(SCREFF_V1 | SCREFF_SAVE);
     
     FakeRtc_AdvanceTimeBy(days, 0, 0, 0);
 
@@ -3170,7 +3170,7 @@ bool8 ScrCmd_addhours(struct ScriptContext *ctx)
 {
     u32 hours = ScriptReadWord(ctx);
 
-    Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
+    Script_RequestEffects(SCREFF_V1 | SCREFF_SAVE);
     
     FakeRtc_AdvanceTimeBy(0, hours, 0, 0);
 
@@ -3181,7 +3181,7 @@ bool8 ScrCmd_addminutes(struct ScriptContext *ctx)
 {
     u32 minutes = ScriptReadWord(ctx);
 
-    Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
+    Script_RequestEffects(SCREFF_V1 | SCREFF_SAVE);
     
     FakeRtc_AdvanceTimeBy(0, 0, minutes, 0);
 
@@ -3193,7 +3193,7 @@ bool8 ScrCmd_fwdtime(struct ScriptContext *ctx)
     u32 hours = ScriptReadWord(ctx);
     u32 minutes = ScriptReadWord(ctx);
 
-    Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
+    Script_RequestEffects(SCREFF_V1 | SCREFF_SAVE);
     
     FakeRtc_ForwardTimeTo(hours, minutes, 0);
 
@@ -3208,7 +3208,7 @@ bool8 ScrCmd_fwdweekday(struct ScriptContext *ctx)
     u32 daysToAdd;
     daysToAdd = ((weekdayTarget - rtc->dayOfWeek) + 7) % 7;
     
-    Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
+    Script_RequestEffects(SCREFF_V1 | SCREFF_SAVE);
     
     FakeRtc_AdvanceTimeBy(daysToAdd, 0, 0, 0);
     return FALSE;

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -17,6 +17,7 @@
 #include "event_object_lock.h"
 #include "event_object_movement.h"
 #include "event_scripts.h"
+#include "fake_rtc.h"
 #include "field_message_box.h"
 #include "field_player_avatar.h"
 #include "field_screen_effect.h"
@@ -903,6 +904,8 @@ bool8 ScrCmd_gettime(struct ScriptContext *ctx)
 
 bool8 ScrCmd_gettimeofday(struct ScriptContext *ctx)
 {
+    Script_RequestEffects(SCREFF_V1);
+    
     gSpecialVar_0x8000 = GetTimeOfDay();
     return FALSE;
 }
@@ -3137,6 +3140,78 @@ bool8 ScrFunc_hidefollower(struct ScriptContext *ctx)
 
     // execute next script command with no delay
     return TRUE;
+}
+
+bool8 ScrCmd_addtime(struct ScriptContext *ctx)
+{
+    u32 days = ScriptReadWord(ctx);
+    u32 hours = ScriptReadWord(ctx);
+    u32 minutes = ScriptReadWord(ctx);
+
+    Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
+    
+    FakeRtc_AdvanceTimeBy(days, hours, minutes, 0);
+
+    return FALSE;
+}
+
+bool8 ScrCmd_adddays(struct ScriptContext *ctx)
+{
+    u32 days = ScriptReadWord(ctx);
+
+    Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
+    
+    FakeRtc_AdvanceTimeBy(days, 0, 0, 0);
+
+    return FALSE;
+}
+
+bool8 ScrCmd_addhours(struct ScriptContext *ctx)
+{
+    u32 hours = ScriptReadWord(ctx);
+
+    Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
+    
+    FakeRtc_AdvanceTimeBy(0, hours, 0, 0);
+
+    return FALSE;
+}
+
+bool8 ScrCmd_addminutes(struct ScriptContext *ctx)
+{
+    u32 minutes = ScriptReadWord(ctx);
+
+    Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
+    
+    FakeRtc_AdvanceTimeBy(0, 0, minutes, 0);
+
+    return FALSE;
+}
+
+bool8 ScrCmd_fwdtime(struct ScriptContext *ctx)
+{
+    u32 hours = ScriptReadWord(ctx);
+    u32 minutes = ScriptReadWord(ctx);
+
+    Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
+    
+    FakeRtc_ForwardTimeTo(hours, minutes, 0);
+
+    return FALSE;
+}
+
+bool8 ScrCmd_fwdweekday(struct ScriptContext *ctx)
+{
+    struct SiiRtcInfo *rtc = FakeRtc_GetCurrentTime();
+    
+    u32 weekdayTarget = ScriptReadWord(ctx);
+    u32 daysToAdd;
+    daysToAdd = ((weekdayTarget - rtc->dayOfWeek) + 7) % 7;
+    
+    Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
+    
+    FakeRtc_AdvanceTimeBy(daysToAdd, 0, 0, 0);
+    return FALSE;
 }
 
 void Script_EndTrainerCanSeeIf(struct ScriptContext *ctx)

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -3205,7 +3205,7 @@ bool8 ScrCmd_fwdweekday(struct ScriptContext *ctx)
     struct SiiRtcInfo *rtc = FakeRtc_GetCurrentTime();
     
     u32 weekdayTarget = ScriptReadWord(ctx);
-    u32 daysToAdd = ((weekdayTarget - rtc->dayOfWeek) + 7) % 7;
+    u32 daysToAdd = ((weekdayTarget - rtc->dayOfWeek) + WEEKDAY_COUNT) % WEEKDAY_COUNT;
     
     Script_RequestEffects(SCREFF_V1 | SCREFF_SAVE);
     

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -3205,8 +3205,7 @@ bool8 ScrCmd_fwdweekday(struct ScriptContext *ctx)
     struct SiiRtcInfo *rtc = FakeRtc_GetCurrentTime();
     
     u32 weekdayTarget = ScriptReadWord(ctx);
-    u32 daysToAdd;
-    daysToAdd = ((weekdayTarget - rtc->dayOfWeek) + 7) % 7;
+    u32 daysToAdd = ((weekdayTarget - rtc->dayOfWeek) + 7) % 7;
     
     Script_RequestEffects(SCREFF_V1 | SCREFF_SAVE);
     


### PR DESCRIPTION
## Description
Created several macros to manipulate the Fake RTC in scripts.
These are as follows:
- **addtime**: Adds a specified amount of time in the format of `(days, hours, minutes)`
- **adddays**: Adds a specified amount of days
- **addhours**: Adds a specified amount of hours
- **addminutes**: Adds a specified amount of minutes
- **fwdtime**: Forwards the time to a specified time in a 24h format
  - i.e., given `fwdtime 15, 0`, it forwards the time to 3 PM.
- **fwdweekday**: Forwards the time to a specified weekday, with the week as a 0 index starting on Sunday.

## Images
For the purposes of this demonstration, the function `FakeRtc_ForwardTimeTo` called by the `fwdtime` macros have had their RTC pausing and resuming sections commented out.
https://github.com/user-attachments/assets/0df6761d-4f67-4291-b219-0510a1a9df2f

## Issue(s) that this PR fixes
Fixes some issues in #6634 , wherein the `gettimeofday` macro has no script effects.

## **Discord contact info**
Name: ruby
Username: ruby.raven