### PR TITLE
Fixed objects not getting unloaded properly when event flags are set

### DIFF
--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -2783,8 +2783,7 @@ void RemoveObjectEventsOutsideView(void)
             // Followers should not go OOB, or their sprites may be freed early during a cross-map scripting event,
             // such as Wally's Ralts catch sequence
             if (objectEvent->active && !objectEvent->isPlayer && objectEvent->localId != OBJ_EVENT_ID_FOLLOWER
-             && (PlayerHasFollowerNPC() && i != GetFollowerNPCObjectId())
-             )
+             && objectEvent->localId != OBJ_EVENT_ID_NPC_FOLLOWER)
                 RemoveObjectEventIfOutsideView(objectEvent);
         }
     }


### PR DESCRIPTION
## Description
The check for preventing follower NPCs from being removed out of bounds was erroneously checking the objectId instead of the localId. This caused some other objects to not be removed properly even if their event flag was set. This commit fixes that issue.

## Issue(s) that this PR fixes
Fixes #6714

## **Discord contact info**
bivurnum
