### PR TITLE
Rename follower npc macros for better specificity and to match documentation

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -2525,10 +2525,10 @@
 	@ Sets an NPC up to follow the player.
 	@ Follower flags are defined in include/constants/follower_npc.h
 	@ If you want to specify a battle partner without specifying a custom script, you can set the script parameter to 0.
-	.macro setfollower localId:req, flags:req, script=0, battlePartner=0
-	checkfollower
+	.macro setfollowernpc localId:req, flags:req, script=0, battlePartner=0
+	checkfollowernpc
 	goto_if_eq VAR_RESULT, TRUE, 1f
-	hidefollower
+	hidefollowernpc
 	delay 16
 	callnative ScriptSetFollowerNPC
 	.if \script == 0
@@ -2546,12 +2546,12 @@
 	.endm
 
 	@ Remove the follower NPC (assumes there will only ever be one).
-	.macro destroyfollower
+	.macro destroyfollowernpc
 	callnative ScriptDestroyFollowerNPC
 	.endm
 
 	@ Makes the player and follower NPC face one another.
-	.macro facefollower
+	.macro facefollowernpc
 	callnative ScriptFaceFollowerNPC
 	.endm
 
@@ -2569,7 +2569,7 @@
 	.endm
 
 	@ Checks if you have a follower NPC. Returns the result to VAR_RESULT.
-	.macro checkfollower
+	.macro checkfollowernpc
 	callnative ScriptCheckFollowerNPC
 	.endm
 

--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -2528,7 +2528,7 @@
 	.macro setfollowernpc localId:req, flags:req, script=0, battlePartner=0
 	checkfollowernpc
 	goto_if_eq VAR_RESULT, TRUE, 1f
-	hidefollowernpc
+	hidefollower
 	delay 16
 	callnative ScriptSetFollowerNPC
 	.if \script == 0

--- a/include/constants/follower_npc.h
+++ b/include/constants/follower_npc.h
@@ -14,7 +14,7 @@
 #define FOLLOWER_NPC_FLAG_ALL_WATER             FOLLOWER_NPC_FLAG_CAN_SURF | FOLLOWER_NPC_FLAG_CAN_WATERFALL | FOLLOWER_NPC_FLAG_CAN_DIVE
 #define FOLLOWER_NPC_FLAG_ALL                   FOLLOWER_NPC_FLAG_ALL_LAND | FOLLOWER_NPC_FLAG_ALL_WATER | FOLLOWER_NPC_FLAG_CLEAR_ON_WHITE_OUT
 
-// Shorter flag names for ease of use in setfollower script macro
+// Shorter flag names for ease of use in setfollowernpc script macro
 #define FNPC_RUNNING                          FOLLOWER_NPC_FLAG_HAS_RUNNING_FRAMES
 #define FNPC_BIKE                             FOLLOWER_NPC_FLAG_CAN_BIKE
 #define FNPC_LEAVE_ROUTE                      FOLLOWER_NPC_FLAG_CAN_LEAVE_ROUTE


### PR DESCRIPTION
## Description
Changed the names of the follower npc script macros to specify that they are for the npc followers. This change also makes the names line up with the documentation in #6704.

## **Discord contact info**
bivurnum
