### PR TITLE
Bug fix: setfollowernpc macro no longer runs when FNPC_ENABLE_NPC_FOLLOWERS is FALSE

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -2527,7 +2527,7 @@
 	@ If you want to specify a battle partner without specifying a custom script, you can set the script parameter to 0.
 	.macro setfollowernpc localId:req, flags:req, script=0, battlePartner=0
 	checkfollowernpc
-	goto_if_eq VAR_RESULT, TRUE, 1f
+	goto_if_ne VAR_RESULT, FALSE, 1f
 	hidefollower
 	delay 16
 	callnative ScriptSetFollowerNPC
@@ -2568,7 +2568,7 @@
 	callnative HideNPCFollower
 	.endm
 
-	@ Checks if you have a follower NPC. Returns the result to VAR_RESULT.
+	@ Checks if you have a follower NPC. Returns the result to VAR_RESULT. Returns 2 if follower NPCs are disabled.
 	.macro checkfollowernpc
 	callnative ScriptCheckFollowerNPC
 	.endm

--- a/include/constants/follower_npc.h
+++ b/include/constants/follower_npc.h
@@ -28,7 +28,8 @@
 #define FNPC_ALL                              FOLLOWER_NPC_FLAG_ALL
 
 
-#define FNPC_NONE   0
-#define FNPC_ALWAYS 2
+#define FNPC_NONE       0
+#define FNPC_ALWAYS     2
+#define FNPC_DISABLED   2
 
 #endif // GUARD_CONSTANTS_FOLLOWER_NPC_H

--- a/src/follower_npc.c
+++ b/src/follower_npc.c
@@ -1672,7 +1672,10 @@ void ScriptHideNPCFollower(struct ScriptContext *ctx)
 
 void ScriptCheckFollowerNPC(struct ScriptContext *ctx)
 {
-    gSpecialVar_Result = PlayerHasFollowerNPC();
+    if (!FNPC_ENABLE_NPC_FOLLOWERS)
+        gSpecialVar_Result = FNPC_DISABLED;
+    else
+        gSpecialVar_Result = PlayerHasFollowerNPC();
 }
 
 void ScriptUpdateFollowingMon(struct ScriptContext *ctx)


### PR DESCRIPTION
## Description
The checkfollowernpc macro did not have handling for when the follower NPC feature is disabled, making the setfollowernpc macro try to create a follower when it shouldn't. This commit adds that handling and fixes the bug.

## **Discord contact info**
bivurnum
