### PR TITLE
Fixes Stomping Tantrum not boosting damage when missed due to Accuracy

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -622,7 +622,6 @@ struct BattlerState
     u32 multipleSwitchInBattlers:1;
     u32 alreadyStatusedMoveAttempt:1; // For example when using Thunder Wave on an already paralyzed Pokémon.
     u32 activeAbilityPopUps:1;
-    u32 lastMoveFailed:1; // For Stomping Tantrum
     u32 forcedSwitch:1;
     u32 storedHealingWish:1;
     u32 storedLunarDance:1;
@@ -630,7 +629,8 @@ struct BattlerState
     u32 sleepClauseEffectExempt:1; // Stores whether effect should be exempt from triggering Sleep Clause (Effect Spore)
     u32 usedMicleBerry:1;
     u32 pursuitTarget:1;
-    u32 padding:17;
+    u32 stompingTantrumTimer:2;
+    u32 padding:16;
     // End of Word
 };
 

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3183,7 +3183,7 @@ void SwitchInClearSetData(u32 battler)
     gBattleStruct->lastTakenMoveFrom[battler][1] = 0;
     gBattleStruct->lastTakenMoveFrom[battler][2] = 0;
     gBattleStruct->lastTakenMoveFrom[battler][3] = 0;
-    gBattleStruct->battlerState[battler].lastMoveFailed = FALSE;
+    gBattleStruct->battlerState[battler].stompingTantrumTimer = 0;
     gBattleStruct->palaceFlags &= ~(1u << battler);
     gBattleStruct->canPickupItem &= ~(1u << battler);
 
@@ -3985,6 +3985,9 @@ void BattleTurnPassed(void)
         gBattleStruct->battlerState[i].absentBattlerFlags = (gAbsentBattlerFlags & (1u << i) ? TRUE : FALSE);
         gBattleStruct->monToSwitchIntoId[i] = PARTY_SIZE;
         gStatuses4[i] &= ~STATUS4_ELECTRIFIED;
+
+        if (gBattleStruct->battlerState[i].stompingTantrumTimer > 0)
+            gBattleStruct->battlerState[i].stompingTantrumTimer--;
     }
 
     for (i = 0; i < NUM_BATTLE_SIDES; i++)

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -9352,7 +9352,7 @@ static inline u32 CalcMoveBasePowerAfterModifiers(struct DamageCalculationData *
             modifier = uq4_12_multiply(modifier, UQ_4_12(0.5));
         break;
     case EFFECT_STOMPING_TANTRUM:
-        if (gBattleStruct->battlerState[battlerAtk].lastMoveFailed)
+        if (gBattleStruct->battlerState[battlerAtk].stompingTantrumTimer == 1)
             modifier = uq4_12_multiply(modifier, UQ_4_12(2.0));
         break;
     case EFFECT_MAGNITUDE:
@@ -12201,8 +12201,8 @@ void ClearDamageCalcResults(void)
 bool32 DoesDestinyBondFail(u32 battler)
 {
     if (B_DESTINY_BOND_FAIL >= GEN_7
-        && GetMoveEffect(gLastResultingMoves[battler]) == EFFECT_DESTINY_BOND
-        && !gBattleStruct->battlerState[battler].lastMoveFailed)
+        && GetMoveEffect(gLastLandedMoves[battler]) == EFFECT_DESTINY_BOND
+        && GetMoveEffect(gLastResultingMoves[battler]) == EFFECT_DESTINY_BOND)
         return TRUE;
     return FALSE;
 }

--- a/test/battle/move_effect/stomping_tantrum.c
+++ b/test/battle/move_effect/stomping_tantrum.c
@@ -6,7 +6,7 @@ ASSUMPTIONS
     ASSUME(GetMoveEffect(MOVE_STOMPING_TANTRUM) == EFFECT_STOMPING_TANTRUM);
 }
 
-SINGLE_BATTLE_TEST("Stomping Tatrum will deal double damage if user flinched on the previous turn")
+SINGLE_BATTLE_TEST("Stomping Tantrum will deal double damage if user flinched on the previous turn")
 {
     s16 damage[3];
     GIVEN {
@@ -36,7 +36,7 @@ SINGLE_BATTLE_TEST("Stomping Tatrum will deal double damage if user flinched on 
     }
 }
 
-SINGLE_BATTLE_TEST("Stomping Tatrum will deal double damage if user failed to attack due to paralysis")
+SINGLE_BATTLE_TEST("Stomping Tantrum will deal double damage if user failed to attack due to paralysis")
 {
     s16 damage[3];
     PASSES_RANDOMLY(25, 100, RNG_PARALYSIS);
@@ -66,7 +66,7 @@ SINGLE_BATTLE_TEST("Stomping Tatrum will deal double damage if user failed to at
     }
 }
 
-SINGLE_BATTLE_TEST("Stomping Tatrum will not deal double damage if target protects")
+SINGLE_BATTLE_TEST("Stomping Tantrum will not deal double damage if target protects")
 {
     s16 damage[2];
     GIVEN {
@@ -90,7 +90,7 @@ SINGLE_BATTLE_TEST("Stomping Tatrum will not deal double damage if target protec
     }
 }
 
-SINGLE_BATTLE_TEST("Stomping Tatrum will not deal double if it missed")
+SINGLE_BATTLE_TEST("Stomping Tantrum will not deal double if it missed")
 {
     s16 damage[2];
     GIVEN {
@@ -107,11 +107,11 @@ SINGLE_BATTLE_TEST("Stomping Tatrum will not deal double if it missed")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_STOMPING_TANTRUM, player);
         HP_BAR(opponent, captureDamage: &damage[1]);
     } THEN {
-        EXPECT_EQ(damage[0], damage[1]);
+        EXPECT_MUL_EQ(damage[0], Q_4_12(2.0), damage[1]);
     }
 }
 
-SINGLE_BATTLE_TEST("Stomping Tatrum will deal double damage if user was immune to previous move")
+SINGLE_BATTLE_TEST("Stomping Tantrum will deal double damage if user was immune to previous move")
 {
     s16 damage[2];
     GIVEN {


### PR DESCRIPTION
i renamed `lastMoveFailed` to `stompingTantrumTimer` because it is easier to search and it it a timer now. 

Stomping Tantrum has some other obscure behavior which I open an issue for 