### PR TITLE
Expand trainerproc to support additional battle types

### DIFF
--- a/include/data.h
+++ b/include/data.h
@@ -81,6 +81,11 @@ struct TrainerMon
 
 #define TRAINER_PARTY(partyArray) partyArray, .partySize = ARRAY_COUNT(partyArray)
 
+enum TrainerBattleType {
+    TRAINER_BATTLE_TYPE_SINGLES,
+    TRAINER_BATTLE_TYPE_DOUBLES,
+};
+
 struct Trainer
 {
     /*0x00*/ u32 aiFlags;
@@ -90,8 +95,7 @@ struct Trainer
     /*0x11*/ u8 encounterMusic_gender; // last bit is gender
     /*0x12*/ u8 trainerPic;
     /*0x13*/ u8 trainerName[TRAINER_NAME_LENGTH + 1];
-    /*0x1E*/ bool8 doubleBattle:1;
-             bool8 padding:1;
+    /*0x1E*/ u8 battleType:2;
              u8 startingStatus:6;    // this trainer starts a battle with a given status. see include/constants/battle.h for values
     /*0x1F*/ u8 mugshotColor;
     /*0x20*/ u8 partySize;
@@ -253,12 +257,12 @@ static inline const u8 GetTrainerStartingStatusFromId(u16 trainerId)
     return gTrainers[GetCurrentDifficultyLevel()][SanitizeTrainerId(trainerId)].startingStatus;
 }
 
-static inline const bool32 IsTrainerDoubleBattle(u16 trainerId)
+static inline const enum TrainerBattleType GetTrainerBattleType(u16 trainerId)
 {
     u32 sanitizedTrainerId = SanitizeTrainerId(trainerId);
     enum DifficultyLevel difficulty = GetTrainerDifficultyLevel(sanitizedTrainerId);
 
-    return gTrainers[difficulty][sanitizedTrainerId].doubleBattle;
+    return gTrainers[difficulty][sanitizedTrainerId].battleType;
 }
 
 static inline const u8 GetTrainerPartySizeFromId(u16 trainerId)

--- a/include/data.h
+++ b/include/data.h
@@ -81,7 +81,8 @@ struct TrainerMon
 
 #define TRAINER_PARTY(partyArray) partyArray, .partySize = ARRAY_COUNT(partyArray)
 
-enum TrainerBattleType {
+enum TrainerBattleType 
+{
     TRAINER_BATTLE_TYPE_SINGLES,
     TRAINER_BATTLE_TYPE_DOUBLES,
 };

--- a/migration_scripts/1.12/convert_trainer_battle_types.py
+++ b/migration_scripts/1.12/convert_trainer_battle_types.py
@@ -1,0 +1,12 @@
+import re
+
+def trainer_battle_types(data):
+    data = re.sub(re.escape("Double Battle: No"), "Battle Type: Singles", data)
+    data = re.sub(re.escape("Double Battle: Yes"), "Battle Type: Doubles", data)
+
+    return data
+
+with open('src/data/trainers.party', 'r') as file:
+    data = file.read()
+with open('src/data/trainers.party', 'w') as file:
+    file.write(trainer_battle_types(data))

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -526,7 +526,14 @@ static void CB2_InitBattleInternal(void)
                                                                         | BATTLE_TYPE_TRAINER_HILL
                                                                         | BATTLE_TYPE_RECORDED)))
     {
-        gBattleTypeFlags |= (IsTrainerDoubleBattle(TRAINER_BATTLE_PARAM.opponentA) ? BATTLE_TYPE_DOUBLE : 0);
+        switch (GetTrainerBattleType(TRAINER_BATTLE_PARAM.opponentA))
+        {
+        case TRAINER_BATTLE_TYPE_SINGLES:
+            break;
+        case TRAINER_BATTLE_TYPE_DOUBLES:
+            gBattleTypeFlags |= BATTLE_TYPE_DOUBLE;
+            break;
+        }
     }
 
     InitBattleBgsVideo();
@@ -1903,7 +1910,7 @@ u8 CreateNPCTrainerPartyFromTrainer(struct Pokemon *party, const struct Trainer 
             u32 fixedOtId = 0;
             u32 abilityNum = 0;
 
-            if (trainer->doubleBattle == TRUE)
+            if (trainer->battleType != TRAINER_BATTLE_TYPE_SINGLES)
                 personalityValue = 0x80;
             else if (trainer->encounterMusic_gender & F_TRAINER_FEMALE)
                 personalityValue = 0x78; // Use personality more likely to result in a female Pokémon

--- a/src/battle_setup.c
+++ b/src/battle_setup.c
@@ -772,7 +772,7 @@ u8 GetWildBattleTransition(void)
 
 u8 GetTrainerBattleTransition(void)
 {
-    u8 minPartyCount;
+    u8 minPartyCount = 1;
     u8 transitionType;
     u8 enemyLevel;
     u8 playerLevel;
@@ -792,10 +792,15 @@ u8 GetTrainerBattleTransition(void)
         || trainerClass == TRAINER_CLASS_AQUA_ADMIN)
         return B_TRANSITION_AQUA;
 
-    if (IsTrainerDoubleBattle(trainerId))
-        minPartyCount = 2; // double battles always at least have 2 Pokémon.
-    else
+    switch (GetTrainerBattleType(trainerId))
+    {
+    case TRAINER_BATTLE_TYPE_SINGLES:
         minPartyCount = 1;
+        break;
+    case TRAINER_BATTLE_TYPE_DOUBLES:
+        minPartyCount = 2; // double battles always at least have 2 Pokémon.
+        break;
+    }
 
     transitionType = GetBattleTransitionTypeByMap();
     enemyLevel = GetSumOfEnemyPartyLevel(trainerId, minPartyCount);

--- a/src/data/trainers.h
+++ b/src/data/trainers.h
@@ -19,7 +19,7 @@
 #line 81
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 82
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
         .partySize = 0,
         .party = (const struct TrainerMon[])
         {
@@ -38,7 +38,7 @@
 #line 89
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 90
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 91
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -70,7 +70,7 @@
 #line 102
             TRAINER_ENCOUNTER_MUSIC_AQUA,
 #line 103
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 104
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -102,7 +102,7 @@
 #line 115
             TRAINER_ENCOUNTER_MUSIC_AQUA,
 #line 116
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 117
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -145,7 +145,7 @@
 #line 132
             TRAINER_ENCOUNTER_MUSIC_AQUA,
 #line 133
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 134
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -177,7 +177,7 @@
 #line 145
             TRAINER_ENCOUNTER_MUSIC_AQUA,
 #line 146
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 147
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -209,7 +209,7 @@
 #line 158
             TRAINER_ENCOUNTER_MUSIC_AQUA,
 #line 159
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 160
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -241,7 +241,7 @@
 #line 171
             TRAINER_ENCOUNTER_MUSIC_AQUA,
 #line 172
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 173
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -273,7 +273,7 @@
 #line 184
             TRAINER_ENCOUNTER_MUSIC_AQUA,
 #line 185
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 186
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -307,7 +307,7 @@ F_TRAINER_FEMALE |
 #line 197
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 198
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 199
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 6,
@@ -394,7 +394,7 @@ F_TRAINER_FEMALE |
 #line 230
             TRAINER_ENCOUNTER_MUSIC_AQUA,
 #line 231
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 232
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -428,7 +428,7 @@ F_TRAINER_FEMALE |
 #line 244
         .items = { ITEM_HYPER_POTION },
 #line 245
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 246
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -471,7 +471,7 @@ F_TRAINER_FEMALE |
 #line 261
             TRAINER_ENCOUNTER_MUSIC_COOL,
 #line 262
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 263
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -514,7 +514,7 @@ F_TRAINER_FEMALE |
 #line 278
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 279
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 280
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -559,7 +559,7 @@ F_TRAINER_FEMALE |
 #line 295
             TRAINER_ENCOUNTER_MUSIC_AQUA,
 #line 296
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 297
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -591,7 +591,7 @@ F_TRAINER_FEMALE |
 #line 308
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 309
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 310
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -623,7 +623,7 @@ F_TRAINER_FEMALE |
 #line 321
             TRAINER_ENCOUNTER_MUSIC_AQUA,
 #line 322
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 323
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -655,7 +655,7 @@ F_TRAINER_FEMALE |
 #line 334
             TRAINER_ENCOUNTER_MUSIC_AQUA,
 #line 335
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 336
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -698,7 +698,7 @@ F_TRAINER_FEMALE |
 #line 351
             TRAINER_ENCOUNTER_MUSIC_AQUA,
 #line 352
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 353
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -741,7 +741,7 @@ F_TRAINER_FEMALE |
 #line 368
             TRAINER_ENCOUNTER_MUSIC_AQUA,
 #line 369
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 370
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -795,7 +795,7 @@ F_TRAINER_FEMALE |
 #line 389
             TRAINER_ENCOUNTER_MUSIC_AQUA,
 #line 390
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 391
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -827,7 +827,7 @@ F_TRAINER_FEMALE |
 #line 402
             TRAINER_ENCOUNTER_MUSIC_AQUA,
 #line 403
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 404
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -870,7 +870,7 @@ F_TRAINER_FEMALE |
 #line 419
             TRAINER_ENCOUNTER_MUSIC_MAGMA,
 #line 420
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 421
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -902,7 +902,7 @@ F_TRAINER_FEMALE |
 #line 432
             TRAINER_ENCOUNTER_MUSIC_AQUA,
 #line 433
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 434
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -934,7 +934,7 @@ F_TRAINER_FEMALE |
 #line 445
             TRAINER_ENCOUNTER_MUSIC_AQUA,
 #line 446
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 447
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -966,7 +966,7 @@ F_TRAINER_FEMALE |
 #line 458
             TRAINER_ENCOUNTER_MUSIC_AQUA,
 #line 459
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 460
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -1011,7 +1011,7 @@ F_TRAINER_FEMALE |
 #line 475
             TRAINER_ENCOUNTER_MUSIC_AQUA,
 #line 476
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 477
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -1045,7 +1045,7 @@ F_TRAINER_FEMALE |
 #line 488
             TRAINER_ENCOUNTER_MUSIC_AQUA,
 #line 489
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 490
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -1079,7 +1079,7 @@ F_TRAINER_FEMALE |
 #line 501
             TRAINER_ENCOUNTER_MUSIC_AQUA,
 #line 502
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 503
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -1111,7 +1111,7 @@ F_TRAINER_FEMALE |
 #line 514
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 515
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 516
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -1156,7 +1156,7 @@ F_TRAINER_FEMALE |
 #line 532
         .items = { ITEM_SUPER_POTION },
 #line 533
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 534
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -1199,7 +1199,7 @@ F_TRAINER_FEMALE |
 #line 549
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 550
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 551
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -1233,7 +1233,7 @@ F_TRAINER_FEMALE |
 #line 562
             TRAINER_ENCOUNTER_MUSIC_AQUA,
 #line 563
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 564
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -1278,7 +1278,7 @@ F_TRAINER_FEMALE |
 #line 579
             TRAINER_ENCOUNTER_MUSIC_AQUA,
 #line 580
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 581
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -1323,7 +1323,7 @@ F_TRAINER_FEMALE |
 #line 597
         .items = { ITEM_SUPER_POTION, ITEM_SUPER_POTION },
 #line 598
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 599
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -1379,7 +1379,7 @@ F_TRAINER_FEMALE |
 #line 618
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 619
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 620
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -1413,7 +1413,7 @@ F_TRAINER_FEMALE |
 #line 631
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 632
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 633
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -1458,7 +1458,7 @@ F_TRAINER_FEMALE |
 #line 648
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 649
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 650
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -1514,7 +1514,7 @@ F_TRAINER_FEMALE |
 #line 670
         .items = { ITEM_FULL_RESTORE },
 #line 671
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 672
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -1568,7 +1568,7 @@ F_TRAINER_FEMALE |
 #line 690
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 691
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 692
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -1613,7 +1613,7 @@ F_TRAINER_FEMALE |
 #line 707
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 708
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 709
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -1658,7 +1658,7 @@ F_TRAINER_FEMALE |
 #line 724
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 725
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 726
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -1714,7 +1714,7 @@ F_TRAINER_FEMALE |
 #line 745
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 746
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 747
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -1770,7 +1770,7 @@ F_TRAINER_FEMALE |
 #line 766
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 767
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 768
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -1824,7 +1824,7 @@ F_TRAINER_FEMALE |
 #line 787
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 788
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 789
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -1863,7 +1863,7 @@ F_TRAINER_FEMALE |
 #line 804
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 805
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 806
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -1938,7 +1938,7 @@ F_TRAINER_FEMALE |
 #line 837
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 838
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 839
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -1995,7 +1995,7 @@ F_TRAINER_FEMALE |
 #line 862
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 863
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 864
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -2034,7 +2034,7 @@ F_TRAINER_FEMALE |
 #line 879
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 880
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 881
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -2073,7 +2073,7 @@ F_TRAINER_FEMALE |
 #line 896
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 897
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 898
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -2112,7 +2112,7 @@ F_TRAINER_FEMALE |
 #line 913
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 914
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 915
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -2151,7 +2151,7 @@ F_TRAINER_FEMALE |
 #line 930
             TRAINER_ENCOUNTER_MUSIC_INTERVIEWER,
 #line 931
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 932
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -2194,7 +2194,7 @@ F_TRAINER_FEMALE |
 #line 947
             TRAINER_ENCOUNTER_MUSIC_INTERVIEWER,
 #line 948
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 949
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -2237,7 +2237,7 @@ F_TRAINER_FEMALE |
 #line 964
             TRAINER_ENCOUNTER_MUSIC_INTERVIEWER,
 #line 965
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 966
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -2280,7 +2280,7 @@ F_TRAINER_FEMALE |
 #line 981
             TRAINER_ENCOUNTER_MUSIC_INTERVIEWER,
 #line 982
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 983
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -2323,7 +2323,7 @@ F_TRAINER_FEMALE |
 #line 998
             TRAINER_ENCOUNTER_MUSIC_INTERVIEWER,
 #line 999
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 1000
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -2366,7 +2366,7 @@ F_TRAINER_FEMALE |
 #line 1015
             TRAINER_ENCOUNTER_MUSIC_INTERVIEWER,
 #line 1016
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 1017
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -2425,7 +2425,7 @@ F_TRAINER_FEMALE |
 #line 1040
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 1041
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1042
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -2470,7 +2470,7 @@ F_TRAINER_FEMALE |
 #line 1057
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 1058
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1059
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -2504,7 +2504,7 @@ F_TRAINER_FEMALE |
 #line 1070
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 1071
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1072
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -2538,7 +2538,7 @@ F_TRAINER_FEMALE |
 #line 1083
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 1084
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1085
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -2583,7 +2583,7 @@ F_TRAINER_FEMALE |
 #line 1100
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 1101
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1102
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -2628,7 +2628,7 @@ F_TRAINER_FEMALE |
 #line 1117
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 1118
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1119
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -2673,7 +2673,7 @@ F_TRAINER_FEMALE |
 #line 1134
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 1135
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1136
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -2716,7 +2716,7 @@ F_TRAINER_FEMALE |
 #line 1151
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 1152
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1153
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -2755,7 +2755,7 @@ F_TRAINER_FEMALE |
 #line 1168
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 1169
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1170
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -2798,7 +2798,7 @@ F_TRAINER_FEMALE |
 #line 1185
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 1186
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1187
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -2830,7 +2830,7 @@ F_TRAINER_FEMALE |
 #line 1198
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 1199
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1200
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -2869,7 +2869,7 @@ F_TRAINER_FEMALE |
 #line 1215
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 1216
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1217
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -2908,7 +2908,7 @@ F_TRAINER_FEMALE |
 #line 1232
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 1233
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1234
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -2947,7 +2947,7 @@ F_TRAINER_FEMALE |
 #line 1249
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 1250
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1251
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -2988,7 +2988,7 @@ F_TRAINER_FEMALE |
 #line 1267
         .items = { ITEM_HYPER_POTION },
 #line 1268
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1269
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -3028,7 +3028,7 @@ F_TRAINER_FEMALE |
 #line 1284
         .items = { ITEM_HYPER_POTION },
 #line 1285
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1286
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -3068,7 +3068,7 @@ F_TRAINER_FEMALE |
 #line 1301
         .items = { ITEM_HYPER_POTION },
 #line 1302
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1303
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -3110,7 +3110,7 @@ F_TRAINER_FEMALE |
 #line 1318
         .items = { ITEM_HYPER_POTION },
 #line 1319
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1320
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -3149,7 +3149,7 @@ F_TRAINER_FEMALE |
 #line 1334
         .items = { ITEM_HYPER_POTION },
 #line 1335
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1336
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 5,
@@ -3262,7 +3262,7 @@ F_TRAINER_FEMALE |
 #line 1384
         .items = { ITEM_FULL_RESTORE },
 #line 1385
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1386
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -3318,7 +3318,7 @@ F_TRAINER_FEMALE |
 #line 1406
         .items = { ITEM_FULL_RESTORE },
 #line 1407
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1408
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -3363,7 +3363,7 @@ F_TRAINER_FEMALE |
 #line 1424
         .items = { ITEM_SUPER_POTION },
 #line 1425
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1426
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -3419,7 +3419,7 @@ F_TRAINER_FEMALE |
 #line 1446
         .items = { ITEM_FULL_RESTORE },
 #line 1447
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1448
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -3464,7 +3464,7 @@ F_TRAINER_FEMALE |
 #line 1464
         .items = { ITEM_FULL_RESTORE },
 #line 1465
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1466
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -3509,7 +3509,7 @@ F_TRAINER_FEMALE |
 #line 1482
         .items = { ITEM_FULL_RESTORE },
 #line 1483
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1484
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -3565,7 +3565,7 @@ F_TRAINER_FEMALE |
 #line 1504
         .items = { ITEM_FULL_RESTORE },
 #line 1505
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1506
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 4,
@@ -3632,7 +3632,7 @@ F_TRAINER_FEMALE |
 #line 1530
         .items = { ITEM_FULL_RESTORE },
 #line 1531
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1532
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -3688,7 +3688,7 @@ F_TRAINER_FEMALE |
 #line 1552
         .items = { ITEM_HYPER_POTION },
 #line 1553
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1554
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -3744,7 +3744,7 @@ F_TRAINER_FEMALE |
 #line 1574
         .items = { ITEM_HYPER_POTION },
 #line 1575
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1576
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -3800,7 +3800,7 @@ F_TRAINER_FEMALE |
 #line 1596
         .items = { ITEM_FULL_RESTORE },
 #line 1597
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1598
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -3856,7 +3856,7 @@ F_TRAINER_FEMALE |
 #line 1618
         .items = { ITEM_FULL_RESTORE },
 #line 1619
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1620
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -3912,7 +3912,7 @@ F_TRAINER_FEMALE |
 #line 1640
         .items = { ITEM_FULL_RESTORE },
 #line 1641
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1642
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -3959,7 +3959,7 @@ F_TRAINER_FEMALE |
 #line 1658
         .items = { ITEM_HYPER_POTION },
 #line 1659
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1660
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -4000,7 +4000,7 @@ F_TRAINER_FEMALE |
 #line 1674
         .items = { ITEM_HYPER_POTION },
 #line 1675
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1676
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -4042,7 +4042,7 @@ F_TRAINER_FEMALE |
 #line 1691
         .items = { ITEM_HYPER_POTION },
 #line 1692
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1693
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_FORCE_SETUP_FIRST_TURN,
         .partySize = 1,
@@ -4083,7 +4083,7 @@ F_TRAINER_FEMALE |
 #line 1707
         .items = { ITEM_FULL_RESTORE },
 #line 1708
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1709
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_FORCE_SETUP_FIRST_TURN,
         .partySize = 3,
@@ -4162,7 +4162,7 @@ F_TRAINER_FEMALE |
 #line 1741
         .items = { ITEM_FULL_RESTORE },
 #line 1742
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1743
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_FORCE_SETUP_FIRST_TURN,
         .partySize = 2,
@@ -4209,7 +4209,7 @@ F_TRAINER_FEMALE |
 #line 1759
         .items = { ITEM_SUPER_POTION },
 #line 1760
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1761
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -4267,7 +4267,7 @@ F_TRAINER_FEMALE |
 #line 1781
         .items = { ITEM_FULL_RESTORE },
 #line 1782
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1783
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -4303,7 +4303,7 @@ F_TRAINER_FEMALE |
 #line 1795
         .items = { ITEM_FULL_RESTORE },
 #line 1796
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1797
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -4339,7 +4339,7 @@ F_TRAINER_FEMALE |
 #line 1809
         .items = { ITEM_FULL_RESTORE },
 #line 1810
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1811
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -4375,7 +4375,7 @@ F_TRAINER_FEMALE |
 #line 1823
         .items = { ITEM_FULL_RESTORE },
 #line 1824
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1825
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -4433,7 +4433,7 @@ F_TRAINER_FEMALE |
 #line 1845
         .items = { ITEM_FULL_RESTORE },
 #line 1846
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1847
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -4480,7 +4480,7 @@ F_TRAINER_FEMALE |
 #line 1863
         .items = { ITEM_FULL_RESTORE },
 #line 1864
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1865
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -4538,7 +4538,7 @@ F_TRAINER_FEMALE |
 #line 1885
         .items = { ITEM_HYPER_POTION },
 #line 1886
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1887
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -4596,7 +4596,7 @@ F_TRAINER_FEMALE |
 #line 1907
         .items = { ITEM_HYPER_POTION },
 #line 1908
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1909
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -4654,7 +4654,7 @@ F_TRAINER_FEMALE |
 #line 1929
         .items = { ITEM_FULL_RESTORE },
 #line 1930
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1931
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -4712,7 +4712,7 @@ F_TRAINER_FEMALE |
 #line 1951
         .items = { ITEM_FULL_RESTORE },
 #line 1952
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1953
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -4768,7 +4768,7 @@ F_TRAINER_FEMALE |
 #line 1972
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 1973
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1974
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -4813,7 +4813,7 @@ F_TRAINER_FEMALE |
 #line 1989
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 1990
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 1991
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -4858,7 +4858,7 @@ F_TRAINER_FEMALE |
 #line 2006
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 2007
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2008
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -4903,7 +4903,7 @@ F_TRAINER_FEMALE |
 #line 2023
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 2024
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2025
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -4937,7 +4937,7 @@ F_TRAINER_FEMALE |
 #line 2036
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 2037
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2038
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -4971,7 +4971,7 @@ F_TRAINER_FEMALE |
 #line 2049
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 2050
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2051
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -5016,7 +5016,7 @@ F_TRAINER_FEMALE |
 #line 2066
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 2067
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2068
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -5061,7 +5061,7 @@ F_TRAINER_FEMALE |
 #line 2083
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 2084
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2085
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -5106,7 +5106,7 @@ F_TRAINER_FEMALE |
 #line 2100
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 2101
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2102
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -5164,7 +5164,7 @@ F_TRAINER_FEMALE |
 #line 2122
         .items = { ITEM_FULL_RESTORE },
 #line 2123
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2124
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -5202,7 +5202,7 @@ F_TRAINER_FEMALE |
 #line 2136
         .items = { ITEM_FULL_RESTORE },
 #line 2137
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2138
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -5263,7 +5263,7 @@ F_TRAINER_FEMALE |
 #line 2161
             TRAINER_ENCOUNTER_MUSIC_MAGMA,
 #line 2162
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2163
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -5321,7 +5321,7 @@ F_TRAINER_FEMALE |
 #line 2183
         .items = { ITEM_FULL_RESTORE },
 #line 2184
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2185
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -5364,7 +5364,7 @@ F_TRAINER_FEMALE |
 #line 2199
         .items = { ITEM_FULL_RESTORE },
 #line 2200
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2201
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -5402,7 +5402,7 @@ F_TRAINER_FEMALE |
 #line 2213
         .items = { ITEM_FULL_RESTORE },
 #line 2214
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2215
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -5440,7 +5440,7 @@ F_TRAINER_FEMALE |
 #line 2227
         .items = { ITEM_FULL_RESTORE },
 #line 2228
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2229
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -5478,7 +5478,7 @@ F_TRAINER_FEMALE |
 #line 2241
         .items = { ITEM_FULL_RESTORE },
 #line 2242
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2243
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -5516,7 +5516,7 @@ F_TRAINER_FEMALE |
 #line 2255
         .items = { ITEM_FULL_RESTORE },
 #line 2256
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2257
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -5554,7 +5554,7 @@ F_TRAINER_FEMALE |
 #line 2269
         .items = { ITEM_FULL_RESTORE },
 #line 2270
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2271
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -5597,7 +5597,7 @@ F_TRAINER_FEMALE |
 #line 2286
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 2287
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2288
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -5631,7 +5631,7 @@ F_TRAINER_FEMALE |
 #line 2299
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 2300
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2301
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -5665,7 +5665,7 @@ F_TRAINER_FEMALE |
 #line 2312
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 2313
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2314
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -5699,7 +5699,7 @@ F_TRAINER_FEMALE |
 #line 2325
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 2326
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2327
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -5758,7 +5758,7 @@ F_TRAINER_FEMALE |
 #line 2350
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 2351
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2352
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -5792,7 +5792,7 @@ F_TRAINER_FEMALE |
 #line 2363
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 2364
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2365
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -5826,7 +5826,7 @@ F_TRAINER_FEMALE |
 #line 2376
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 2377
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2378
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -5902,7 +5902,7 @@ F_TRAINER_FEMALE |
 #line 2408
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 2409
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2410
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -5947,7 +5947,7 @@ F_TRAINER_FEMALE |
 #line 2425
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 2426
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2427
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -6006,7 +6006,7 @@ F_TRAINER_FEMALE |
 #line 2450
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 2451
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2452
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -6065,7 +6065,7 @@ F_TRAINER_FEMALE |
 #line 2475
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 2476
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2477
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -6124,7 +6124,7 @@ F_TRAINER_FEMALE |
 #line 2500
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 2501
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2502
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -6183,7 +6183,7 @@ F_TRAINER_FEMALE |
 #line 2526
         .items = { ITEM_FULL_RESTORE },
 #line 2527
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2528
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -6219,7 +6219,7 @@ F_TRAINER_FEMALE |
 #line 2539
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 2540
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2541
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -6264,7 +6264,7 @@ F_TRAINER_FEMALE |
 #line 2557
         .items = { ITEM_FULL_RESTORE },
 #line 2558
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2559
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -6300,7 +6300,7 @@ F_TRAINER_FEMALE |
 #line 2571
         .items = { ITEM_FULL_RESTORE },
 #line 2572
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2573
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -6336,7 +6336,7 @@ F_TRAINER_FEMALE |
 #line 2585
         .items = { ITEM_FULL_RESTORE },
 #line 2586
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2587
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -6372,7 +6372,7 @@ F_TRAINER_FEMALE |
 #line 2599
         .items = { ITEM_FULL_RESTORE },
 #line 2600
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2601
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -6408,7 +6408,7 @@ F_TRAINER_FEMALE |
 #line 2613
         .items = { ITEM_FULL_RESTORE },
 #line 2614
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2615
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -6449,7 +6449,7 @@ F_TRAINER_FEMALE |
 #line 2630
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 2631
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2632
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -6483,7 +6483,7 @@ F_TRAINER_FEMALE |
 #line 2643
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 2644
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2645
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -6526,7 +6526,7 @@ F_TRAINER_FEMALE |
 #line 2660
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 2661
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2662
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -6560,7 +6560,7 @@ F_TRAINER_FEMALE |
 #line 2673
             TRAINER_ENCOUNTER_MUSIC_MAGMA,
 #line 2674
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2675
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -6592,7 +6592,7 @@ F_TRAINER_FEMALE |
 #line 2686
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 2687
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2688
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -6624,7 +6624,7 @@ F_TRAINER_FEMALE |
 #line 2699
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 2700
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2701
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -6667,7 +6667,7 @@ F_TRAINER_FEMALE |
 #line 2716
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 2717
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2718
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -6710,7 +6710,7 @@ F_TRAINER_FEMALE |
 #line 2733
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 2734
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2735
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -6753,7 +6753,7 @@ F_TRAINER_FEMALE |
 #line 2750
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 2751
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2752
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -6785,7 +6785,7 @@ F_TRAINER_FEMALE |
 #line 2763
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 2764
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2765
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -6817,7 +6817,7 @@ F_TRAINER_FEMALE |
 #line 2776
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 2777
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2778
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -6860,7 +6860,7 @@ F_TRAINER_FEMALE |
 #line 2793
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 2794
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2795
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -6914,7 +6914,7 @@ F_TRAINER_FEMALE |
 #line 2814
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 2815
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2816
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -6946,7 +6946,7 @@ F_TRAINER_FEMALE |
 #line 2827
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 2828
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2829
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -6978,7 +6978,7 @@ F_TRAINER_FEMALE |
 #line 2840
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 2841
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2842
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -7010,7 +7010,7 @@ F_TRAINER_FEMALE |
 #line 2853
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 2854
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2855
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -7053,7 +7053,7 @@ F_TRAINER_FEMALE |
 #line 2870
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 2871
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2872
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -7096,7 +7096,7 @@ F_TRAINER_FEMALE |
 #line 2887
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 2888
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2889
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -7128,7 +7128,7 @@ F_TRAINER_FEMALE |
 #line 2900
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 2901
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2902
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -7160,7 +7160,7 @@ F_TRAINER_FEMALE |
 #line 2913
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 2914
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2915
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -7192,7 +7192,7 @@ F_TRAINER_FEMALE |
 #line 2926
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 2927
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2928
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -7224,7 +7224,7 @@ F_TRAINER_FEMALE |
 #line 2939
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 2940
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2941
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -7278,7 +7278,7 @@ F_TRAINER_FEMALE |
 #line 2960
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 2961
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2962
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -7310,7 +7310,7 @@ F_TRAINER_FEMALE |
 #line 2973
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 2974
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2975
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -7342,7 +7342,7 @@ F_TRAINER_FEMALE |
 #line 2986
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 2987
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 2988
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -7385,7 +7385,7 @@ F_TRAINER_FEMALE |
 #line 3003
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 3004
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3005
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -7428,7 +7428,7 @@ F_TRAINER_FEMALE |
 #line 3020
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 3021
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3022
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -7460,7 +7460,7 @@ F_TRAINER_FEMALE |
 #line 3033
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 3034
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3035
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -7492,7 +7492,7 @@ F_TRAINER_FEMALE |
 #line 3046
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 3047
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3048
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -7524,7 +7524,7 @@ F_TRAINER_FEMALE |
 #line 3059
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 3060
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3061
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -7556,7 +7556,7 @@ F_TRAINER_FEMALE |
 #line 3072
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 3073
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3074
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -7610,7 +7610,7 @@ F_TRAINER_FEMALE |
 #line 3093
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 3094
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3095
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -7653,7 +7653,7 @@ F_TRAINER_FEMALE |
 #line 3110
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 3111
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3112
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -7685,7 +7685,7 @@ F_TRAINER_FEMALE |
 #line 3123
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 3124
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3125
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -7717,7 +7717,7 @@ F_TRAINER_FEMALE |
 #line 3136
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 3137
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3138
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -7760,7 +7760,7 @@ F_TRAINER_FEMALE |
 #line 3153
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 3154
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3155
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -7803,7 +7803,7 @@ F_TRAINER_FEMALE |
 #line 3170
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 3171
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3172
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -7835,7 +7835,7 @@ F_TRAINER_FEMALE |
 #line 3183
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 3184
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3185
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -7878,7 +7878,7 @@ F_TRAINER_FEMALE |
 #line 3200
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 3201
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3202
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -7910,7 +7910,7 @@ F_TRAINER_FEMALE |
 #line 3213
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 3214
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3215
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -7953,7 +7953,7 @@ F_TRAINER_FEMALE |
 #line 3230
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 3231
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3232
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -7985,7 +7985,7 @@ F_TRAINER_FEMALE |
 #line 3243
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 3244
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3245
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -8017,7 +8017,7 @@ F_TRAINER_FEMALE |
 #line 3256
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 3257
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3258
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -8060,7 +8060,7 @@ F_TRAINER_FEMALE |
 #line 3273
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 3274
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3275
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -8114,7 +8114,7 @@ F_TRAINER_FEMALE |
 #line 3294
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 3295
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3296
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 4,
@@ -8181,7 +8181,7 @@ F_TRAINER_FEMALE |
 #line 3319
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 3320
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3321
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -8224,7 +8224,7 @@ F_TRAINER_FEMALE |
 #line 3336
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 3337
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3338
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -8256,7 +8256,7 @@ F_TRAINER_FEMALE |
 #line 3349
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 3350
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3351
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -8288,7 +8288,7 @@ F_TRAINER_FEMALE |
 #line 3362
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 3363
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3364
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -8346,7 +8346,7 @@ F_TRAINER_FEMALE |
 #line 3386
             TRAINER_ENCOUNTER_MUSIC_AQUA,
 #line 3387
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3388
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -8389,7 +8389,7 @@ F_TRAINER_FEMALE |
 #line 3403
             TRAINER_ENCOUNTER_MUSIC_AQUA,
 #line 3404
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3405
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -8421,7 +8421,7 @@ F_TRAINER_FEMALE |
 #line 3416
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 3417
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3418
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -8464,7 +8464,7 @@ F_TRAINER_FEMALE |
 #line 3433
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 3434
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3435
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -8507,7 +8507,7 @@ F_TRAINER_FEMALE |
 #line 3450
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 3451
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3452
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -8550,7 +8550,7 @@ F_TRAINER_FEMALE |
 #line 3467
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 3468
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3469
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -8604,7 +8604,7 @@ F_TRAINER_FEMALE |
 #line 3488
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 3489
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3490
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -8658,7 +8658,7 @@ F_TRAINER_FEMALE |
 #line 3509
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 3510
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3511
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -8712,7 +8712,7 @@ F_TRAINER_FEMALE |
 #line 3530
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 3531
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3532
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -8766,7 +8766,7 @@ F_TRAINER_FEMALE |
 #line 3551
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 3552
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3553
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -8798,7 +8798,7 @@ F_TRAINER_FEMALE |
 #line 3564
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 3565
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3566
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -8841,7 +8841,7 @@ F_TRAINER_FEMALE |
 #line 3581
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 3582
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3583
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -8873,7 +8873,7 @@ F_TRAINER_FEMALE |
 #line 3594
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 3595
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3596
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -8905,7 +8905,7 @@ F_TRAINER_FEMALE |
 #line 3607
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 3608
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3609
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -8937,7 +8937,7 @@ F_TRAINER_FEMALE |
 #line 3620
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 3621
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3622
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -8980,7 +8980,7 @@ F_TRAINER_FEMALE |
 #line 3637
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 3638
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3639
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -9023,7 +9023,7 @@ F_TRAINER_FEMALE |
 #line 3654
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 3655
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3656
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -9066,7 +9066,7 @@ F_TRAINER_FEMALE |
 #line 3671
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 3672
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3673
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -9109,7 +9109,7 @@ F_TRAINER_FEMALE |
 #line 3688
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 3689
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3690
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -9152,7 +9152,7 @@ F_TRAINER_FEMALE |
 #line 3705
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 3706
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3707
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -9191,7 +9191,7 @@ F_TRAINER_FEMALE |
 #line 3722
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 3723
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3724
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -9266,7 +9266,7 @@ F_TRAINER_FEMALE |
 #line 3755
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 3756
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3757
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -9298,7 +9298,7 @@ F_TRAINER_FEMALE |
 #line 3768
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 3769
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3770
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -9341,7 +9341,7 @@ F_TRAINER_FEMALE |
 #line 3785
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 3786
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3787
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -9373,7 +9373,7 @@ F_TRAINER_FEMALE |
 #line 3798
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 3799
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3800
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -9418,7 +9418,7 @@ F_TRAINER_FEMALE |
 #line 3815
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 3816
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3817
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -9450,7 +9450,7 @@ F_TRAINER_FEMALE |
 #line 3828
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 3829
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3830
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -9482,7 +9482,7 @@ F_TRAINER_FEMALE |
 #line 3841
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 3842
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3843
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -9525,7 +9525,7 @@ F_TRAINER_FEMALE |
 #line 3858
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 3859
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3860
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -9568,7 +9568,7 @@ F_TRAINER_FEMALE |
 #line 3875
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 3876
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3877
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -9622,7 +9622,7 @@ F_TRAINER_FEMALE |
 #line 3896
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 3897
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3898
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -9676,7 +9676,7 @@ F_TRAINER_FEMALE |
 #line 3917
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 3918
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3919
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -9708,7 +9708,7 @@ F_TRAINER_FEMALE |
 #line 3930
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 3931
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3932
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -9762,7 +9762,7 @@ F_TRAINER_FEMALE |
 #line 3951
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 3952
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3953
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -9816,7 +9816,7 @@ F_TRAINER_FEMALE |
 #line 3972
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 3973
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3974
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -9870,7 +9870,7 @@ F_TRAINER_FEMALE |
 #line 3993
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 3994
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 3995
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -9913,7 +9913,7 @@ F_TRAINER_FEMALE |
 #line 4010
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 4011
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4012
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -9967,7 +9967,7 @@ F_TRAINER_FEMALE |
 #line 4031
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 4032
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4033
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -10021,7 +10021,7 @@ F_TRAINER_FEMALE |
 #line 4052
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 4053
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4054
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 4,
@@ -10086,7 +10086,7 @@ F_TRAINER_FEMALE |
 #line 4077
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 4078
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4079
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 5,
@@ -10164,7 +10164,7 @@ F_TRAINER_FEMALE |
 #line 4106
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 4107
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4108
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -10200,7 +10200,7 @@ F_TRAINER_FEMALE |
 #line 4120
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 4121
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4122
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -10232,7 +10232,7 @@ F_TRAINER_FEMALE |
 #line 4133
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 4134
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4135
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -10264,7 +10264,7 @@ F_TRAINER_FEMALE |
 #line 4146
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 4147
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4148
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -10296,7 +10296,7 @@ F_TRAINER_FEMALE |
 #line 4159
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 4160
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4161
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -10350,7 +10350,7 @@ F_TRAINER_FEMALE |
 #line 4180
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 4181
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4182
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -10393,7 +10393,7 @@ F_TRAINER_FEMALE |
 #line 4197
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 4198
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4199
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -10425,7 +10425,7 @@ F_TRAINER_FEMALE |
 #line 4210
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 4211
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4212
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -10468,7 +10468,7 @@ F_TRAINER_FEMALE |
 #line 4227
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 4228
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4229
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -10511,7 +10511,7 @@ F_TRAINER_FEMALE |
 #line 4244
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 4245
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4246
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -10554,7 +10554,7 @@ F_TRAINER_FEMALE |
 #line 4261
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 4262
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4263
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -10599,7 +10599,7 @@ F_TRAINER_FEMALE |
 #line 4278
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 4279
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4280
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -10637,7 +10637,7 @@ F_TRAINER_FEMALE |
 #line 4292
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 4293
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4294
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -10671,7 +10671,7 @@ F_TRAINER_FEMALE |
 #line 4305
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 4306
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4307
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -10705,7 +10705,7 @@ F_TRAINER_FEMALE |
 #line 4318
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 4319
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4320
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -10739,7 +10739,7 @@ F_TRAINER_FEMALE |
 #line 4331
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 4332
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4333
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -10795,7 +10795,7 @@ F_TRAINER_FEMALE |
 #line 4352
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 4353
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4354
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -10840,7 +10840,7 @@ F_TRAINER_FEMALE |
 #line 4369
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 4370
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4371
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -10885,7 +10885,7 @@ F_TRAINER_FEMALE |
 #line 4386
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 4387
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4388
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -10930,7 +10930,7 @@ F_TRAINER_FEMALE |
 #line 4403
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 4404
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4405
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -10975,7 +10975,7 @@ F_TRAINER_FEMALE |
 #line 4420
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 4421
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4422
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -11020,7 +11020,7 @@ F_TRAINER_FEMALE |
 #line 4437
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 4438
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4439
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -11063,7 +11063,7 @@ F_TRAINER_FEMALE |
 #line 4454
             TRAINER_ENCOUNTER_MUSIC_RICH,
 #line 4455
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4456
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -11095,7 +11095,7 @@ F_TRAINER_FEMALE |
 #line 4467
             TRAINER_ENCOUNTER_MUSIC_RICH,
 #line 4468
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4469
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -11138,7 +11138,7 @@ F_TRAINER_FEMALE |
 #line 4484
             TRAINER_ENCOUNTER_MUSIC_RICH,
 #line 4485
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4486
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -11170,7 +11170,7 @@ F_TRAINER_FEMALE |
 #line 4497
             TRAINER_ENCOUNTER_MUSIC_RICH,
 #line 4498
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4499
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -11202,7 +11202,7 @@ F_TRAINER_FEMALE |
 #line 4510
             TRAINER_ENCOUNTER_MUSIC_RICH,
 #line 4511
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4512
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -11259,7 +11259,7 @@ F_TRAINER_FEMALE |
 #line 4535
             TRAINER_ENCOUNTER_MUSIC_RICH,
 #line 4536
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4537
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -11315,7 +11315,7 @@ F_TRAINER_FEMALE |
 #line 4559
             TRAINER_ENCOUNTER_MUSIC_RICH,
 #line 4560
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4561
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -11392,7 +11392,7 @@ F_TRAINER_FEMALE |
 #line 4593
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 4594
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4595
         .aiFlags = AI_FLAG_BASIC_TRAINER | AI_FLAG_FORCE_SETUP_FIRST_TURN,
 #line 4596
@@ -11511,7 +11511,7 @@ F_TRAINER_FEMALE |
 #line 4644
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 4645
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4646
         .aiFlags = AI_FLAG_BASIC_TRAINER,
 #line 4647
@@ -11630,7 +11630,7 @@ F_TRAINER_FEMALE |
 #line 4695
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 4696
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4697
         .aiFlags = AI_FLAG_BASIC_TRAINER,
 #line 4698
@@ -11747,7 +11747,7 @@ F_TRAINER_FEMALE |
 #line 4746
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 4747
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4748
         .aiFlags = AI_FLAG_BASIC_TRAINER,
 #line 4749
@@ -11866,7 +11866,7 @@ F_TRAINER_FEMALE |
 #line 4797
         .items = { ITEM_POTION, ITEM_POTION },
 #line 4798
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4799
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -11945,7 +11945,7 @@ F_TRAINER_FEMALE |
 #line 4831
         .items = { ITEM_SUPER_POTION, ITEM_SUPER_POTION },
 #line 4832
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4833
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -12024,7 +12024,7 @@ F_TRAINER_FEMALE |
 #line 4865
         .items = { ITEM_SUPER_POTION, ITEM_SUPER_POTION },
 #line 4866
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4867
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 4,
@@ -12123,7 +12123,7 @@ F_TRAINER_FEMALE |
 #line 4907
         .items = { ITEM_HYPER_POTION, ITEM_HYPER_POTION },
 #line 4908
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4909
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 4,
@@ -12220,7 +12220,7 @@ F_TRAINER_FEMALE |
 #line 4949
         .items = { ITEM_HYPER_POTION, ITEM_HYPER_POTION },
 #line 4950
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4951
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 4,
@@ -12319,7 +12319,7 @@ F_TRAINER_FEMALE |
 #line 4991
         .items = { ITEM_HYPER_POTION, ITEM_HYPER_POTION },
 #line 4992
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 4993
         .aiFlags = AI_FLAG_BASIC_TRAINER | AI_FLAG_RISKY,
         .partySize = 5,
@@ -12434,7 +12434,7 @@ F_TRAINER_FEMALE |
 #line 5041
         .items = { ITEM_HYPER_POTION, ITEM_HYPER_POTION, ITEM_HYPER_POTION, ITEM_HYPER_POTION },
 #line 5042
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 5043
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 4,
@@ -12533,7 +12533,7 @@ F_TRAINER_FEMALE |
 #line 5083
         .items = { ITEM_HYPER_POTION, ITEM_HYPER_POTION },
 #line 5084
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5085
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 5,
@@ -12646,7 +12646,7 @@ F_TRAINER_FEMALE |
 #line 5132
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 5133
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5134
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -12678,7 +12678,7 @@ F_TRAINER_FEMALE |
 #line 5145
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 5146
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5147
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -12710,7 +12710,7 @@ F_TRAINER_FEMALE |
 #line 5158
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 5159
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5160
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -12764,7 +12764,7 @@ F_TRAINER_FEMALE |
 #line 5179
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 5180
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5181
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -12807,7 +12807,7 @@ F_TRAINER_FEMALE |
 #line 5196
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 5197
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5198
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -12850,7 +12850,7 @@ F_TRAINER_FEMALE |
 #line 5213
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 5214
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5215
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -12893,7 +12893,7 @@ F_TRAINER_FEMALE |
 #line 5230
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 5231
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5232
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -12949,7 +12949,7 @@ F_TRAINER_FEMALE |
 #line 5251
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 5252
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5253
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -12983,7 +12983,7 @@ F_TRAINER_FEMALE |
 #line 5264
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 5265
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5266
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -13028,7 +13028,7 @@ F_TRAINER_FEMALE |
 #line 5281
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 5282
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5283
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -13073,7 +13073,7 @@ F_TRAINER_FEMALE |
 #line 5298
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 5299
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5300
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -13118,7 +13118,7 @@ F_TRAINER_FEMALE |
 #line 5315
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 5316
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5317
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -13163,7 +13163,7 @@ F_TRAINER_FEMALE |
 #line 5332
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 5333
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5334
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -13206,7 +13206,7 @@ F_TRAINER_FEMALE |
 #line 5349
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 5350
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 5351
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -13263,7 +13263,7 @@ F_TRAINER_FEMALE |
 #line 5374
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 5375
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 5376
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -13319,7 +13319,7 @@ F_TRAINER_FEMALE |
 #line 5398
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 5399
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 5400
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -13375,7 +13375,7 @@ F_TRAINER_FEMALE |
 #line 5422
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 5423
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 5424
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -13431,7 +13431,7 @@ F_TRAINER_FEMALE |
 #line 5446
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 5447
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 5448
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -13487,7 +13487,7 @@ F_TRAINER_FEMALE |
 #line 5470
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 5471
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 5472
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -13543,7 +13543,7 @@ F_TRAINER_FEMALE |
 #line 5494
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 5495
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5496
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -13590,7 +13590,7 @@ F_TRAINER_FEMALE |
 #line 5511
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 5512
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5513
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -13624,7 +13624,7 @@ F_TRAINER_FEMALE |
 #line 5524
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 5525
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5526
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 6,
@@ -13765,7 +13765,7 @@ F_TRAINER_FEMALE |
 #line 5581
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 5582
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5583
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -13799,7 +13799,7 @@ F_TRAINER_FEMALE |
 #line 5594
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 5595
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5596
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -13833,7 +13833,7 @@ F_TRAINER_FEMALE |
 #line 5607
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 5608
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5609
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -13867,7 +13867,7 @@ F_TRAINER_FEMALE |
 #line 5620
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 5621
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5622
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -13903,7 +13903,7 @@ F_TRAINER_FEMALE |
 #line 5633
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 5634
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5635
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT,
         .partySize = 1,
@@ -13939,7 +13939,7 @@ F_TRAINER_FEMALE |
 #line 5646
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 5647
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5648
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -13975,7 +13975,7 @@ F_TRAINER_FEMALE |
 #line 5659
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 5660
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5661
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -14037,7 +14037,7 @@ F_TRAINER_FEMALE |
 #line 5680
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 5681
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5682
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -14086,7 +14086,7 @@ F_TRAINER_FEMALE |
 #line 5697
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 5698
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5699
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -14135,7 +14135,7 @@ F_TRAINER_FEMALE |
 #line 5714
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 5715
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5716
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -14184,7 +14184,7 @@ F_TRAINER_FEMALE |
 #line 5731
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 5732
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5733
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -14233,7 +14233,7 @@ F_TRAINER_FEMALE |
 #line 5748
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 5749
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5750
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -14280,7 +14280,7 @@ F_TRAINER_FEMALE |
 #line 5765
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 5766
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5767
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -14312,7 +14312,7 @@ F_TRAINER_FEMALE |
 #line 5778
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 5779
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5780
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -14351,7 +14351,7 @@ F_TRAINER_FEMALE |
 #line 5795
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 5796
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5797
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -14390,7 +14390,7 @@ F_TRAINER_FEMALE |
 #line 5812
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 5813
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5814
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -14429,7 +14429,7 @@ F_TRAINER_FEMALE |
 #line 5829
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 5830
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5831
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -14470,7 +14470,7 @@ F_TRAINER_FEMALE |
 #line 5846
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 5847
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5848
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -14511,7 +14511,7 @@ F_TRAINER_FEMALE |
 #line 5863
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 5864
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5865
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -14556,7 +14556,7 @@ F_TRAINER_FEMALE |
 #line 5880
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 5881
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5882
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -14601,7 +14601,7 @@ F_TRAINER_FEMALE |
 #line 5897
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 5898
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5899
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -14646,7 +14646,7 @@ F_TRAINER_FEMALE |
 #line 5914
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 5915
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5916
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -14691,7 +14691,7 @@ F_TRAINER_FEMALE |
 #line 5931
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 5932
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5933
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -14734,7 +14734,7 @@ F_TRAINER_FEMALE |
 #line 5948
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 5949
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5950
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -14766,7 +14766,7 @@ F_TRAINER_FEMALE |
 #line 5961
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 5962
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5963
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -14809,7 +14809,7 @@ F_TRAINER_FEMALE |
 #line 5978
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 5979
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5980
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -14845,7 +14845,7 @@ F_TRAINER_FEMALE |
 #line 5992
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 5993
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 5994
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -14888,7 +14888,7 @@ F_TRAINER_FEMALE |
 #line 6009
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 6010
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6011
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -14920,7 +14920,7 @@ F_TRAINER_FEMALE |
 #line 6022
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 6023
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6024
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -14979,7 +14979,7 @@ F_TRAINER_FEMALE |
 #line 6048
         .items = { ITEM_FULL_RESTORE },
 #line 6049
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6050
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -15040,7 +15040,7 @@ F_TRAINER_FEMALE |
 #line 6074
         .items = { ITEM_FULL_RESTORE },
 #line 6075
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6076
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -15097,7 +15097,7 @@ F_TRAINER_FEMALE |
 #line 6099
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 6100
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6101
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -15129,7 +15129,7 @@ F_TRAINER_FEMALE |
 #line 6112
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 6113
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6114
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -15161,7 +15161,7 @@ F_TRAINER_FEMALE |
 #line 6125
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 6126
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6127
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -15193,7 +15193,7 @@ F_TRAINER_FEMALE |
 #line 6138
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 6139
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6140
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -15236,7 +15236,7 @@ F_TRAINER_FEMALE |
 #line 6155
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 6156
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6157
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -15290,7 +15290,7 @@ F_TRAINER_FEMALE |
 #line 6176
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 6177
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6178
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -15344,7 +15344,7 @@ F_TRAINER_FEMALE |
 #line 6197
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 6198
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6199
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -15387,7 +15387,7 @@ F_TRAINER_FEMALE |
 #line 6214
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 6215
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6216
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -15430,7 +15430,7 @@ F_TRAINER_FEMALE |
 #line 6231
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 6232
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6233
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -15475,7 +15475,7 @@ F_TRAINER_FEMALE |
 #line 6249
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 6250
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6251
         .aiFlags = AI_FLAG_BASIC_TRAINER,
 #line 6252
@@ -15608,7 +15608,7 @@ F_TRAINER_FEMALE |
 #line 6307
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 6308
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6309
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -15662,7 +15662,7 @@ F_TRAINER_FEMALE |
 #line 6328
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 6329
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6330
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -15716,7 +15716,7 @@ F_TRAINER_FEMALE |
 #line 6349
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 6350
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6351
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -15770,7 +15770,7 @@ F_TRAINER_FEMALE |
 #line 6370
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 6371
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6372
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -15824,7 +15824,7 @@ F_TRAINER_FEMALE |
 #line 6391
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 6392
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6393
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -15856,7 +15856,7 @@ F_TRAINER_FEMALE |
 #line 6404
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 6405
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6406
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 4,
@@ -15921,7 +15921,7 @@ F_TRAINER_FEMALE |
 #line 6429
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 6430
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6431
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -15953,7 +15953,7 @@ F_TRAINER_FEMALE |
 #line 6442
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 6443
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6444
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -15996,7 +15996,7 @@ F_TRAINER_FEMALE |
 #line 6459
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 6460
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6461
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -16028,7 +16028,7 @@ F_TRAINER_FEMALE |
 #line 6472
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 6473
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6474
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -16071,7 +16071,7 @@ F_TRAINER_FEMALE |
 #line 6489
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 6490
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6491
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -16125,7 +16125,7 @@ F_TRAINER_FEMALE |
 #line 6510
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 6511
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6512
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 4,
@@ -16190,7 +16190,7 @@ F_TRAINER_FEMALE |
 #line 6535
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 6536
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6537
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 4,
@@ -16255,7 +16255,7 @@ F_TRAINER_FEMALE |
 #line 6560
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 6561
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6562
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT,
         .partySize = 4,
@@ -16320,7 +16320,7 @@ F_TRAINER_FEMALE |
 #line 6585
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 6586
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6587
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 6,
@@ -16407,7 +16407,7 @@ F_TRAINER_FEMALE |
 #line 6618
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 6619
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6620
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -16461,7 +16461,7 @@ F_TRAINER_FEMALE |
 #line 6639
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 6640
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6641
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -16504,7 +16504,7 @@ F_TRAINER_FEMALE |
 #line 6656
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 6657
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6658
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -16536,7 +16536,7 @@ F_TRAINER_FEMALE |
 #line 6669
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 6670
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6671
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -16568,7 +16568,7 @@ F_TRAINER_FEMALE |
 #line 6682
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 6683
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6684
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -16600,7 +16600,7 @@ F_TRAINER_FEMALE |
 #line 6695
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 6696
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6697
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -16632,7 +16632,7 @@ F_TRAINER_FEMALE |
 #line 6708
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 6709
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6710
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -16666,7 +16666,7 @@ F_TRAINER_FEMALE |
 #line 6721
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 6722
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6723
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -16700,7 +16700,7 @@ F_TRAINER_FEMALE |
 #line 6734
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 6735
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6736
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -16756,7 +16756,7 @@ F_TRAINER_FEMALE |
 #line 6755
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 6756
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6757
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -16790,7 +16790,7 @@ F_TRAINER_FEMALE |
 #line 6768
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 6769
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6770
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -16824,7 +16824,7 @@ F_TRAINER_FEMALE |
 #line 6781
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 6782
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6783
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -16858,7 +16858,7 @@ F_TRAINER_FEMALE |
 #line 6794
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 6795
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6796
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -16890,7 +16890,7 @@ F_TRAINER_FEMALE |
 #line 6807
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 6808
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6809
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -16922,7 +16922,7 @@ F_TRAINER_FEMALE |
 #line 6820
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 6821
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6822
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -16954,7 +16954,7 @@ F_TRAINER_FEMALE |
 #line 6833
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 6834
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6835
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -16986,7 +16986,7 @@ F_TRAINER_FEMALE |
 #line 6846
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 6847
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6848
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -17018,7 +17018,7 @@ F_TRAINER_FEMALE |
 #line 6859
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 6860
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6861
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -17052,7 +17052,7 @@ F_TRAINER_FEMALE |
 #line 6872
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 6873
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6874
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -17086,7 +17086,7 @@ F_TRAINER_FEMALE |
 #line 6885
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 6886
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6887
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -17120,7 +17120,7 @@ F_TRAINER_FEMALE |
 #line 6898
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 6899
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6900
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -17154,7 +17154,7 @@ F_TRAINER_FEMALE |
 #line 6911
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 6912
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6913
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -17188,7 +17188,7 @@ F_TRAINER_FEMALE |
 #line 6924
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 6925
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6926
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -17220,7 +17220,7 @@ F_TRAINER_FEMALE |
 #line 6937
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 6938
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6939
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -17263,7 +17263,7 @@ F_TRAINER_FEMALE |
 #line 6954
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 6955
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6956
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -17306,7 +17306,7 @@ F_TRAINER_FEMALE |
 #line 6971
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 6972
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6973
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -17338,7 +17338,7 @@ F_TRAINER_FEMALE |
 #line 6984
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 6985
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 6986
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -17381,7 +17381,7 @@ F_TRAINER_FEMALE |
 #line 7001
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 7002
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7003
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -17424,7 +17424,7 @@ F_TRAINER_FEMALE |
 #line 7018
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 7019
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7020
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -17456,7 +17456,7 @@ F_TRAINER_FEMALE |
 #line 7031
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 7032
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7033
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -17488,7 +17488,7 @@ F_TRAINER_FEMALE |
 #line 7044
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 7045
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7046
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -17520,7 +17520,7 @@ F_TRAINER_FEMALE |
 #line 7057
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 7058
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7059
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -17554,7 +17554,7 @@ F_TRAINER_FEMALE |
 #line 7070
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 7071
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7072
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -17588,7 +17588,7 @@ F_TRAINER_FEMALE |
 #line 7083
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 7084
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7085
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -17633,7 +17633,7 @@ F_TRAINER_FEMALE |
 #line 7100
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 7101
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7102
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -17667,7 +17667,7 @@ F_TRAINER_FEMALE |
 #line 7113
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 7114
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7115
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -17701,7 +17701,7 @@ F_TRAINER_FEMALE |
 #line 7126
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 7127
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7128
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -17746,7 +17746,7 @@ F_TRAINER_FEMALE |
 #line 7143
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 7144
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7145
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -17780,7 +17780,7 @@ F_TRAINER_FEMALE |
 #line 7156
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 7157
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7158
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -17814,7 +17814,7 @@ F_TRAINER_FEMALE |
 #line 7169
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 7170
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7171
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -17848,7 +17848,7 @@ F_TRAINER_FEMALE |
 #line 7182
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 7183
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7184
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -17880,7 +17880,7 @@ F_TRAINER_FEMALE |
 #line 7195
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 7196
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7197
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -17923,7 +17923,7 @@ F_TRAINER_FEMALE |
 #line 7212
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 7213
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7214
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -17966,7 +17966,7 @@ F_TRAINER_FEMALE |
 #line 7229
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 7230
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7231
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -18009,7 +18009,7 @@ F_TRAINER_FEMALE |
 #line 7246
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 7247
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7248
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -18063,7 +18063,7 @@ F_TRAINER_FEMALE |
 #line 7267
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 7268
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7269
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -18119,7 +18119,7 @@ F_TRAINER_FEMALE |
 #line 7288
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 7289
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7290
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -18158,7 +18158,7 @@ F_TRAINER_FEMALE |
 #line 7305
             TRAINER_ENCOUNTER_MUSIC_COOL,
 #line 7306
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7307
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -18190,7 +18190,7 @@ F_TRAINER_FEMALE |
 #line 7318
             TRAINER_ENCOUNTER_MUSIC_COOL,
 #line 7319
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7320
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -18233,7 +18233,7 @@ F_TRAINER_FEMALE |
 #line 7335
             TRAINER_ENCOUNTER_MUSIC_COOL,
 #line 7336
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7337
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -18265,7 +18265,7 @@ F_TRAINER_FEMALE |
 #line 7348
             TRAINER_ENCOUNTER_MUSIC_COOL,
 #line 7349
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7350
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -18319,7 +18319,7 @@ F_TRAINER_FEMALE |
 #line 7369
             TRAINER_ENCOUNTER_MUSIC_COOL,
 #line 7370
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7371
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -18351,7 +18351,7 @@ F_TRAINER_FEMALE |
 #line 7382
             TRAINER_ENCOUNTER_MUSIC_COOL,
 #line 7383
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7384
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -18394,7 +18394,7 @@ F_TRAINER_FEMALE |
 #line 7399
             TRAINER_ENCOUNTER_MUSIC_COOL,
 #line 7400
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7401
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -18437,7 +18437,7 @@ F_TRAINER_FEMALE |
 #line 7416
             TRAINER_ENCOUNTER_MUSIC_COOL,
 #line 7417
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7418
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -18480,7 +18480,7 @@ F_TRAINER_FEMALE |
 #line 7433
             TRAINER_ENCOUNTER_MUSIC_COOL,
 #line 7434
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7435
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -18512,7 +18512,7 @@ F_TRAINER_FEMALE |
 #line 7446
             TRAINER_ENCOUNTER_MUSIC_COOL,
 #line 7447
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7448
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -18566,7 +18566,7 @@ F_TRAINER_FEMALE |
 #line 7467
             TRAINER_ENCOUNTER_MUSIC_COOL,
 #line 7468
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7469
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -18609,7 +18609,7 @@ F_TRAINER_FEMALE |
 #line 7484
             TRAINER_ENCOUNTER_MUSIC_COOL,
 #line 7485
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7486
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -18652,7 +18652,7 @@ F_TRAINER_FEMALE |
 #line 7501
             TRAINER_ENCOUNTER_MUSIC_COOL,
 #line 7502
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7503
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -18695,7 +18695,7 @@ F_TRAINER_FEMALE |
 #line 7518
             TRAINER_ENCOUNTER_MUSIC_COOL,
 #line 7519
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7520
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -18738,7 +18738,7 @@ F_TRAINER_FEMALE |
 #line 7535
             TRAINER_ENCOUNTER_MUSIC_COOL,
 #line 7536
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7537
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -18781,7 +18781,7 @@ F_TRAINER_FEMALE |
 #line 7552
             TRAINER_ENCOUNTER_MUSIC_COOL,
 #line 7553
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7554
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -18824,7 +18824,7 @@ F_TRAINER_FEMALE |
 #line 7569
             TRAINER_ENCOUNTER_MUSIC_COOL,
 #line 7570
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7571
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -18856,7 +18856,7 @@ F_TRAINER_FEMALE |
 #line 7582
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 7583
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7584
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT,
         .partySize = 1,
@@ -18888,7 +18888,7 @@ F_TRAINER_FEMALE |
 #line 7595
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 7596
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7597
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT,
         .partySize = 2,
@@ -18935,7 +18935,7 @@ F_TRAINER_FEMALE |
 #line 7613
         .items = { ITEM_FULL_RESTORE },
 #line 7614
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
         .partySize = 2,
         .party = (const struct TrainerMon[])
         {
@@ -18988,7 +18988,7 @@ F_TRAINER_FEMALE |
 #line 7633
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 7634
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
         .partySize = 1,
         .party = (const struct TrainerMon[])
         {
@@ -19018,7 +19018,7 @@ F_TRAINER_FEMALE |
 #line 7645
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 7646
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
         .partySize = 3,
         .party = (const struct TrainerMon[])
         {
@@ -19091,7 +19091,7 @@ F_TRAINER_FEMALE |
 #line 7677
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 7678
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
         .partySize = 2,
         .party = (const struct TrainerMon[])
         {
@@ -19132,7 +19132,7 @@ F_TRAINER_FEMALE |
 #line 7693
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 7694
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
         .partySize = 4,
         .party = (const struct TrainerMon[])
         {
@@ -19220,7 +19220,7 @@ F_TRAINER_FEMALE |
 #line 7730
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 7731
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
         .partySize = 4,
         .party = (const struct TrainerMon[])
         {
@@ -19308,7 +19308,7 @@ F_TRAINER_FEMALE |
 #line 7767
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 7768
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
         .partySize = 4,
         .party = (const struct TrainerMon[])
         {
@@ -19394,7 +19394,7 @@ F_TRAINER_FEMALE |
 #line 7802
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 7803
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
         .partySize = 4,
         .party = (const struct TrainerMon[])
         {
@@ -19486,7 +19486,7 @@ F_TRAINER_FEMALE |
 #line 7839
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 7840
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7841
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -19520,7 +19520,7 @@ F_TRAINER_FEMALE |
 #line 7852
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 7853
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7854
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -19554,7 +19554,7 @@ F_TRAINER_FEMALE |
 #line 7865
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 7866
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7867
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -19599,7 +19599,7 @@ F_TRAINER_FEMALE |
 #line 7882
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 7883
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7884
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -19633,7 +19633,7 @@ F_TRAINER_FEMALE |
 #line 7895
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 7896
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7897
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -19667,7 +19667,7 @@ F_TRAINER_FEMALE |
 #line 7908
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 7909
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7910
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -19712,7 +19712,7 @@ F_TRAINER_FEMALE |
 #line 7925
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 7926
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7927
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -19757,7 +19757,7 @@ F_TRAINER_FEMALE |
 #line 7942
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 7943
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7944
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -19802,7 +19802,7 @@ F_TRAINER_FEMALE |
 #line 7959
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 7960
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7961
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -19847,7 +19847,7 @@ F_TRAINER_FEMALE |
 #line 7976
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 7977
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7978
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -19888,7 +19888,7 @@ F_TRAINER_FEMALE |
 #line 7993
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 7994
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 7995
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -19933,7 +19933,7 @@ F_TRAINER_FEMALE |
 #line 8010
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 8011
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8012
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -19974,7 +19974,7 @@ F_TRAINER_FEMALE |
 #line 8027
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 8028
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8029
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -20015,7 +20015,7 @@ F_TRAINER_FEMALE |
 #line 8044
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 8045
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8046
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -20056,7 +20056,7 @@ F_TRAINER_FEMALE |
 #line 8061
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 8062
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8063
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -20115,7 +20115,7 @@ F_TRAINER_FEMALE |
 #line 8086
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 8087
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8088
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -20174,7 +20174,7 @@ F_TRAINER_FEMALE |
 #line 8111
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 8112
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8113
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -20219,7 +20219,7 @@ F_TRAINER_FEMALE |
 #line 8128
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 8129
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8130
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -20253,7 +20253,7 @@ F_TRAINER_FEMALE |
 #line 8141
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 8142
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8143
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -20287,7 +20287,7 @@ F_TRAINER_FEMALE |
 #line 8154
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 8155
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8156
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -20332,7 +20332,7 @@ F_TRAINER_FEMALE |
 #line 8171
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 8172
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8173
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -20366,7 +20366,7 @@ F_TRAINER_FEMALE |
 #line 8184
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 8185
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8186
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -20411,7 +20411,7 @@ F_TRAINER_FEMALE |
 #line 8201
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 8202
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8203
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -20445,7 +20445,7 @@ F_TRAINER_FEMALE |
 #line 8214
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 8215
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8216
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -20501,7 +20501,7 @@ F_TRAINER_FEMALE |
 #line 8235
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 8236
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8237
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -20535,7 +20535,7 @@ F_TRAINER_FEMALE |
 #line 8248
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 8249
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8250
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -20569,7 +20569,7 @@ F_TRAINER_FEMALE |
 #line 8261
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 8262
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8263
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -20603,7 +20603,7 @@ F_TRAINER_FEMALE |
 #line 8274
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 8275
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8276
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -20637,7 +20637,7 @@ F_TRAINER_FEMALE |
 #line 8287
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 8288
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8289
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -20682,7 +20682,7 @@ F_TRAINER_FEMALE |
 #line 8304
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 8305
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8306
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -20716,7 +20716,7 @@ F_TRAINER_FEMALE |
 #line 8317
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 8318
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8319
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -20761,7 +20761,7 @@ F_TRAINER_FEMALE |
 #line 8334
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 8335
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8336
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -20795,7 +20795,7 @@ F_TRAINER_FEMALE |
 #line 8347
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 8348
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8349
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -20829,7 +20829,7 @@ F_TRAINER_FEMALE |
 #line 8360
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 8361
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8362
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -20863,7 +20863,7 @@ F_TRAINER_FEMALE |
 #line 8373
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 8374
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8375
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -20908,7 +20908,7 @@ F_TRAINER_FEMALE |
 #line 8390
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 8391
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8392
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -20942,7 +20942,7 @@ F_TRAINER_FEMALE |
 #line 8403
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 8404
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8405
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -20987,7 +20987,7 @@ F_TRAINER_FEMALE |
 #line 8420
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 8421
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8422
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -21032,7 +21032,7 @@ F_TRAINER_FEMALE |
 #line 8437
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 8438
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8439
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -21077,7 +21077,7 @@ F_TRAINER_FEMALE |
 #line 8454
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 8455
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8456
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -21111,7 +21111,7 @@ F_TRAINER_FEMALE |
 #line 8467
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 8468
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8469
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -21145,7 +21145,7 @@ F_TRAINER_FEMALE |
 #line 8480
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 8481
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8482
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -21179,7 +21179,7 @@ F_TRAINER_FEMALE |
 #line 8493
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 8494
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8495
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -21224,7 +21224,7 @@ F_TRAINER_FEMALE |
 #line 8510
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 8511
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8512
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -21280,7 +21280,7 @@ F_TRAINER_FEMALE |
 #line 8531
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 8532
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8533
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -21339,7 +21339,7 @@ F_TRAINER_FEMALE |
 #line 8556
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 8557
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8558
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -21398,7 +21398,7 @@ F_TRAINER_FEMALE |
 #line 8581
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 8582
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8583
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -21443,7 +21443,7 @@ F_TRAINER_FEMALE |
 #line 8598
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 8599
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8600
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -21488,7 +21488,7 @@ F_TRAINER_FEMALE |
 #line 8615
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 8616
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8617
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -21533,7 +21533,7 @@ F_TRAINER_FEMALE |
 #line 8632
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 8633
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8634
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -21587,7 +21587,7 @@ F_TRAINER_FEMALE |
 #line 8653
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 8654
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8655
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -21628,7 +21628,7 @@ F_TRAINER_FEMALE |
 #line 8670
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 8671
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8672
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -21673,7 +21673,7 @@ F_TRAINER_FEMALE |
 #line 8687
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 8688
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8689
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -21729,7 +21729,7 @@ F_TRAINER_FEMALE |
 #line 8708
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 8709
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8710
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -21785,7 +21785,7 @@ F_TRAINER_FEMALE |
 #line 8729
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 8730
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8731
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -21841,7 +21841,7 @@ F_TRAINER_FEMALE |
 #line 8750
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 8751
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8752
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -21895,7 +21895,7 @@ F_TRAINER_FEMALE |
 #line 8771
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 8772
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 8773
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -21938,7 +21938,7 @@ F_TRAINER_FEMALE |
 #line 8788
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 8789
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 8790
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -21981,7 +21981,7 @@ F_TRAINER_FEMALE |
 #line 8805
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 8806
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 8807
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -22024,7 +22024,7 @@ F_TRAINER_FEMALE |
 #line 8822
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 8823
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 8824
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -22067,7 +22067,7 @@ F_TRAINER_FEMALE |
 #line 8839
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 8840
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 8841
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -22110,7 +22110,7 @@ F_TRAINER_FEMALE |
 #line 8856
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 8857
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 8858
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -22163,7 +22163,7 @@ F_TRAINER_FEMALE |
 #line 8877
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 8878
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 8879
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -22206,7 +22206,7 @@ F_TRAINER_FEMALE |
 #line 8894
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 8895
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 8896
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -22263,7 +22263,7 @@ F_TRAINER_FEMALE |
 #line 8919
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 8920
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 8921
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -22320,7 +22320,7 @@ F_TRAINER_FEMALE |
 #line 8944
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 8945
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8946
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -22363,7 +22363,7 @@ F_TRAINER_FEMALE |
 #line 8961
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 8962
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8963
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -22395,7 +22395,7 @@ F_TRAINER_FEMALE |
 #line 8974
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 8975
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8976
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -22438,7 +22438,7 @@ F_TRAINER_FEMALE |
 #line 8991
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 8992
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 8993
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -22492,7 +22492,7 @@ F_TRAINER_FEMALE |
 #line 9012
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 9013
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9014
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -22535,7 +22535,7 @@ F_TRAINER_FEMALE |
 #line 9029
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 9030
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9031
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -22589,7 +22589,7 @@ F_TRAINER_FEMALE |
 #line 9050
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 9051
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9052
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -22632,7 +22632,7 @@ F_TRAINER_FEMALE |
 #line 9067
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 9068
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9069
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -22686,7 +22686,7 @@ F_TRAINER_FEMALE |
 #line 9088
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 9089
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9090
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -22740,7 +22740,7 @@ F_TRAINER_FEMALE |
 #line 9109
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 9110
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9111
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -22794,7 +22794,7 @@ F_TRAINER_FEMALE |
 #line 9130
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 9131
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9132
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -22848,7 +22848,7 @@ F_TRAINER_FEMALE |
 #line 9151
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 9152
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9153
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -22882,7 +22882,7 @@ F_TRAINER_FEMALE |
 #line 9164
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 9165
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9166
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -22947,7 +22947,7 @@ F_TRAINER_FEMALE |
 #line 9190
         .items = { ITEM_HYPER_POTION },
 #line 9191
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9192
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -22979,7 +22979,7 @@ F_TRAINER_FEMALE |
 #line 9203
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 9204
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9205
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -23020,7 +23020,7 @@ F_TRAINER_FEMALE |
 #line 9220
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 9221
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9222
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -23059,7 +23059,7 @@ F_TRAINER_FEMALE |
 #line 9237
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 9238
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9239
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -23102,7 +23102,7 @@ F_TRAINER_FEMALE |
 #line 9254
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 9255
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9256
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -23149,7 +23149,7 @@ F_TRAINER_FEMALE |
 #line 9272
         .items = { ITEM_HYPER_POTION },
 #line 9273
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9274
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -23190,7 +23190,7 @@ F_TRAINER_FEMALE |
 #line 9289
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 9290
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9291
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -23233,7 +23233,7 @@ F_TRAINER_FEMALE |
 #line 9306
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 9307
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9308
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -23265,7 +23265,7 @@ F_TRAINER_FEMALE |
 #line 9319
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 9320
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9321
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -23308,7 +23308,7 @@ F_TRAINER_FEMALE |
 #line 9336
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 9337
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9338
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -23351,7 +23351,7 @@ F_TRAINER_FEMALE |
 #line 9353
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 9354
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9355
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -23394,7 +23394,7 @@ F_TRAINER_FEMALE |
 #line 9370
             TRAINER_ENCOUNTER_MUSIC_MAGMA,
 #line 9371
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9372
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -23448,7 +23448,7 @@ F_TRAINER_FEMALE |
 #line 9391
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 9392
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9393
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -23491,7 +23491,7 @@ F_TRAINER_FEMALE |
 #line 9408
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 9409
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9410
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -23534,7 +23534,7 @@ F_TRAINER_FEMALE |
 #line 9425
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 9426
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9427
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -23577,7 +23577,7 @@ F_TRAINER_FEMALE |
 #line 9442
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 9443
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9444
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -23622,7 +23622,7 @@ F_TRAINER_FEMALE |
 #line 9460
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 9461
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9462
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 5,
@@ -23733,7 +23733,7 @@ F_TRAINER_FEMALE |
 #line 9509
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 9510
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9511
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -23765,7 +23765,7 @@ F_TRAINER_FEMALE |
 #line 9522
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 9523
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9524
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -23819,7 +23819,7 @@ F_TRAINER_FEMALE |
 #line 9543
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 9544
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9545
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -23873,7 +23873,7 @@ F_TRAINER_FEMALE |
 #line 9564
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 9565
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9566
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_FORCE_SETUP_FIRST_TURN,
         .partySize = 1,
@@ -23905,7 +23905,7 @@ F_TRAINER_FEMALE |
 #line 9577
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 9578
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9579
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -23959,7 +23959,7 @@ F_TRAINER_FEMALE |
 #line 9598
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 9599
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9600
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -24013,7 +24013,7 @@ F_TRAINER_FEMALE |
 #line 9619
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 9620
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9621
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -24045,7 +24045,7 @@ F_TRAINER_FEMALE |
 #line 9632
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 9633
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9634
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -24099,7 +24099,7 @@ F_TRAINER_FEMALE |
 #line 9653
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 9654
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9655
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -24155,7 +24155,7 @@ F_TRAINER_FEMALE |
 #line 9674
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 9675
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9676
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -24189,7 +24189,7 @@ F_TRAINER_FEMALE |
 #line 9687
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 9688
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9689
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -24245,7 +24245,7 @@ F_TRAINER_FEMALE |
 #line 9708
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 9709
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9710
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -24301,7 +24301,7 @@ F_TRAINER_FEMALE |
 #line 9729
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 9730
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9731
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -24335,7 +24335,7 @@ F_TRAINER_FEMALE |
 #line 9742
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 9743
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9744
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -24391,7 +24391,7 @@ F_TRAINER_FEMALE |
 #line 9763
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 9764
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9765
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -24447,7 +24447,7 @@ F_TRAINER_FEMALE |
 #line 9784
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 9785
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9786
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -24481,7 +24481,7 @@ F_TRAINER_FEMALE |
 #line 9797
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 9798
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9799
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -24537,7 +24537,7 @@ F_TRAINER_FEMALE |
 #line 9818
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 9819
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9820
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -24591,7 +24591,7 @@ F_TRAINER_FEMALE |
 #line 9839
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 9840
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9841
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 6,
@@ -24678,7 +24678,7 @@ F_TRAINER_FEMALE |
 #line 9872
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 9873
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9874
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -24710,7 +24710,7 @@ F_TRAINER_FEMALE |
 #line 9885
             TRAINER_ENCOUNTER_MUSIC_COOL,
 #line 9886
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9887
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -24767,7 +24767,7 @@ F_TRAINER_FEMALE |
 #line 9910
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 9911
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9912
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 6,
@@ -24854,7 +24854,7 @@ F_TRAINER_FEMALE |
 #line 9943
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 9944
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9945
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 6,
@@ -24941,7 +24941,7 @@ F_TRAINER_FEMALE |
 #line 9976
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 9977
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 9978
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 6,
@@ -25028,7 +25028,7 @@ F_TRAINER_FEMALE |
 #line 10009
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 10010
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10011
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 6,
@@ -25117,7 +25117,7 @@ F_TRAINER_FEMALE |
 #line 10042
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 10043
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10044
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 6,
@@ -25208,7 +25208,7 @@ F_TRAINER_FEMALE |
 #line 10076
         .items = { ITEM_FULL_RESTORE },
 #line 10077
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10078
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -25251,7 +25251,7 @@ F_TRAINER_FEMALE |
 #line 10093
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 10094
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10095
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -25285,7 +25285,7 @@ F_TRAINER_FEMALE |
 #line 10106
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 10107
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10108
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 6,
@@ -25374,7 +25374,7 @@ F_TRAINER_FEMALE |
 #line 10139
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 10140
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10141
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 6,
@@ -25463,7 +25463,7 @@ F_TRAINER_FEMALE |
 #line 10172
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 10173
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10174
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 6,
@@ -25552,7 +25552,7 @@ F_TRAINER_FEMALE |
 #line 10205
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 10206
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10207
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 6,
@@ -25641,7 +25641,7 @@ F_TRAINER_FEMALE |
 #line 10239
         .items = { ITEM_FULL_RESTORE },
 #line 10240
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10241
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -25675,7 +25675,7 @@ F_TRAINER_FEMALE |
 #line 10253
         .items = { ITEM_FULL_RESTORE },
 #line 10254
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10255
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -25731,7 +25731,7 @@ F_TRAINER_FEMALE |
 #line 10275
         .items = { ITEM_FULL_RESTORE },
 #line 10276
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10277
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -25765,7 +25765,7 @@ F_TRAINER_FEMALE |
 #line 10289
         .items = { ITEM_FULL_RESTORE },
 #line 10290
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10291
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_FORCE_SETUP_FIRST_TURN,
         .partySize = 1,
@@ -25799,7 +25799,7 @@ F_TRAINER_FEMALE |
 #line 10303
         .items = { ITEM_FULL_RESTORE },
 #line 10304
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10305
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -25833,7 +25833,7 @@ F_TRAINER_FEMALE |
 #line 10317
         .items = { ITEM_FULL_RESTORE },
 #line 10318
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10319
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_FORCE_SETUP_FIRST_TURN,
         .partySize = 1,
@@ -25867,7 +25867,7 @@ F_TRAINER_FEMALE |
 #line 10331
         .items = { ITEM_FULL_RESTORE },
 #line 10332
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10333
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -25914,7 +25914,7 @@ F_TRAINER_FEMALE |
 #line 10349
         .items = { ITEM_FULL_RESTORE },
 #line 10350
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10351
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_FORCE_SETUP_FIRST_TURN,
         .partySize = 2,
@@ -25961,7 +25961,7 @@ F_TRAINER_FEMALE |
 #line 10367
         .items = { ITEM_FULL_RESTORE },
 #line 10368
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10369
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_FORCE_SETUP_FIRST_TURN,
         .partySize = 3,
@@ -26019,7 +26019,7 @@ F_TRAINER_FEMALE |
 #line 10389
         .items = { ITEM_FULL_RESTORE },
 #line 10390
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10391
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -26066,7 +26066,7 @@ F_TRAINER_FEMALE |
 #line 10407
         .items = { ITEM_FULL_RESTORE },
 #line 10408
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10409
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_FORCE_SETUP_FIRST_TURN,
         .partySize = 2,
@@ -26113,7 +26113,7 @@ F_TRAINER_FEMALE |
 #line 10425
         .items = { ITEM_FULL_RESTORE },
 #line 10426
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10427
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -26160,7 +26160,7 @@ F_TRAINER_FEMALE |
 #line 10443
         .items = { ITEM_FULL_RESTORE },
 #line 10444
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10445
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_FORCE_SETUP_FIRST_TURN,
         .partySize = 2,
@@ -26207,7 +26207,7 @@ F_TRAINER_FEMALE |
 #line 10461
         .items = { ITEM_FULL_RESTORE },
 #line 10462
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10463
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -26250,7 +26250,7 @@ F_TRAINER_FEMALE |
 #line 10478
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 10479
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10480
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -26282,7 +26282,7 @@ F_TRAINER_FEMALE |
 #line 10491
             TRAINER_ENCOUNTER_MUSIC_AQUA,
 #line 10492
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10493
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -26327,7 +26327,7 @@ F_TRAINER_FEMALE |
 #line 10508
             TRAINER_ENCOUNTER_MUSIC_AQUA,
 #line 10509
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10510
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -26372,7 +26372,7 @@ F_TRAINER_FEMALE |
 #line 10525
             TRAINER_ENCOUNTER_MUSIC_AQUA,
 #line 10526
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10527
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -26415,7 +26415,7 @@ F_TRAINER_FEMALE |
 #line 10542
             TRAINER_ENCOUNTER_MUSIC_MAGMA,
 #line 10543
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10544
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -26458,7 +26458,7 @@ F_TRAINER_FEMALE |
 #line 10559
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 10560
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10561
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -26501,7 +26501,7 @@ F_TRAINER_FEMALE |
 #line 10576
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 10577
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10578
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -26535,7 +26535,7 @@ F_TRAINER_FEMALE |
 #line 10589
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 10590
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10591
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -26567,7 +26567,7 @@ F_TRAINER_FEMALE |
 #line 10602
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 10603
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10604
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -26601,7 +26601,7 @@ F_TRAINER_FEMALE |
 #line 10615
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 10616
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10617
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -26633,7 +26633,7 @@ F_TRAINER_FEMALE |
 #line 10628
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 10629
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10630
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -26669,7 +26669,7 @@ F_TRAINER_FEMALE |
 #line 10642
         .items = { ITEM_HYPER_POTION },
 #line 10643
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10644
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -26723,7 +26723,7 @@ F_TRAINER_FEMALE |
 #line 10664
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 10665
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10666
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -26755,7 +26755,7 @@ F_TRAINER_FEMALE |
 #line 10677
             TRAINER_ENCOUNTER_MUSIC_MAGMA,
 #line 10678
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10679
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -26787,7 +26787,7 @@ F_TRAINER_FEMALE |
 #line 10690
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 10691
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10692
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -26821,7 +26821,7 @@ F_TRAINER_FEMALE |
 #line 10703
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 10704
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10705
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -26853,7 +26853,7 @@ F_TRAINER_FEMALE |
 #line 10716
             TRAINER_ENCOUNTER_MUSIC_RICH,
 #line 10717
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10718
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -26887,7 +26887,7 @@ F_TRAINER_FEMALE |
 #line 10729
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 10730
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10731
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -26919,7 +26919,7 @@ F_TRAINER_FEMALE |
 #line 10742
             TRAINER_ENCOUNTER_MUSIC_RICH,
 #line 10743
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10744
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -26951,7 +26951,7 @@ F_TRAINER_FEMALE |
 #line 10755
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 10756
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10757
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -26985,7 +26985,7 @@ F_TRAINER_FEMALE |
 #line 10768
             TRAINER_ENCOUNTER_MUSIC_MAGMA,
 #line 10769
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10770
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -27028,7 +27028,7 @@ F_TRAINER_FEMALE |
 #line 10785
             TRAINER_ENCOUNTER_MUSIC_MAGMA,
 #line 10786
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10787
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -27060,7 +27060,7 @@ F_TRAINER_FEMALE |
 #line 10798
             TRAINER_ENCOUNTER_MUSIC_MAGMA,
 #line 10799
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10800
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -27092,7 +27092,7 @@ F_TRAINER_FEMALE |
 #line 10811
             TRAINER_ENCOUNTER_MUSIC_MAGMA,
 #line 10812
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10813
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -27124,7 +27124,7 @@ F_TRAINER_FEMALE |
 #line 10824
             TRAINER_ENCOUNTER_MUSIC_MAGMA,
 #line 10825
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10826
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -27158,7 +27158,7 @@ F_TRAINER_FEMALE |
 #line 10837
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 10838
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10839
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -27190,7 +27190,7 @@ F_TRAINER_FEMALE |
 #line 10850
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 10851
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10852
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -27233,7 +27233,7 @@ F_TRAINER_FEMALE |
 #line 10867
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 10868
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10869
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -27276,7 +27276,7 @@ F_TRAINER_FEMALE |
 #line 10884
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 10885
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10886
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -27321,7 +27321,7 @@ F_TRAINER_FEMALE |
 #line 10901
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 10902
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10903
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -27355,7 +27355,7 @@ F_TRAINER_FEMALE |
 #line 10914
             TRAINER_ENCOUNTER_MUSIC_AQUA,
 #line 10915
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10916
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -27398,7 +27398,7 @@ F_TRAINER_FEMALE |
 #line 10931
             TRAINER_ENCOUNTER_MUSIC_MAGMA,
 #line 10932
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10933
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 4,
@@ -27465,7 +27465,7 @@ F_TRAINER_FEMALE |
 #line 10957
         .items = { ITEM_HYPER_POTION },
 #line 10958
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10959
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_FORCE_SETUP_FIRST_TURN,
         .partySize = 2,
@@ -27508,7 +27508,7 @@ F_TRAINER_FEMALE |
 #line 10974
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 10975
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10976
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -27553,7 +27553,7 @@ F_TRAINER_FEMALE |
 #line 10991
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 10992
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 10993
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_FORCE_SETUP_FIRST_TURN,
         .partySize = 2,
@@ -27598,7 +27598,7 @@ F_TRAINER_FEMALE |
 #line 11009
         .items = { ITEM_SUPER_POTION, ITEM_SUPER_POTION },
 #line 11010
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11011
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -27654,7 +27654,7 @@ F_TRAINER_FEMALE |
 #line 11031
         .items = { ITEM_SUPER_POTION, ITEM_SUPER_POTION },
 #line 11032
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11033
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -27710,7 +27710,7 @@ F_TRAINER_FEMALE |
 #line 11052
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 11053
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11054
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -27755,7 +27755,7 @@ F_TRAINER_FEMALE |
 #line 11069
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 11070
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11071
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -27800,7 +27800,7 @@ F_TRAINER_FEMALE |
 #line 11086
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 11087
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11088
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -27834,7 +27834,7 @@ F_TRAINER_FEMALE |
 #line 11099
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 11100
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11101
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -27890,7 +27890,7 @@ F_TRAINER_FEMALE |
 #line 11120
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 11121
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11122
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -27935,7 +27935,7 @@ F_TRAINER_FEMALE |
 #line 11137
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 11138
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11139
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -27980,7 +27980,7 @@ F_TRAINER_FEMALE |
 #line 11154
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 11155
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11156
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -28025,7 +28025,7 @@ F_TRAINER_FEMALE |
 #line 11171
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 11172
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11173
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -28081,7 +28081,7 @@ F_TRAINER_FEMALE |
 #line 11192
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 11193
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11194
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -28115,7 +28115,7 @@ F_TRAINER_FEMALE |
 #line 11205
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 11206
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11207
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -28171,7 +28171,7 @@ F_TRAINER_FEMALE |
 #line 11226
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 11227
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11228
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -28205,7 +28205,7 @@ F_TRAINER_FEMALE |
 #line 11239
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 11240
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11241
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -28248,7 +28248,7 @@ F_TRAINER_FEMALE |
 #line 11256
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 11257
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11258
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -28291,7 +28291,7 @@ F_TRAINER_FEMALE |
 #line 11273
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 11274
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11275
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 4,
@@ -28356,7 +28356,7 @@ F_TRAINER_FEMALE |
 #line 11298
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 11299
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11300
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -28399,7 +28399,7 @@ F_TRAINER_FEMALE |
 #line 11315
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 11316
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11317
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -28442,7 +28442,7 @@ F_TRAINER_FEMALE |
 #line 11332
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 11333
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11334
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -28485,7 +28485,7 @@ F_TRAINER_FEMALE |
 #line 11349
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 11350
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11351
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -28517,7 +28517,7 @@ F_TRAINER_FEMALE |
 #line 11362
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 11363
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11364
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -28560,7 +28560,7 @@ F_TRAINER_FEMALE |
 #line 11379
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 11380
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11381
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -28592,7 +28592,7 @@ F_TRAINER_FEMALE |
 #line 11392
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 11393
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11394
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -28635,7 +28635,7 @@ F_TRAINER_FEMALE |
 #line 11409
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 11410
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11411
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -28689,7 +28689,7 @@ F_TRAINER_FEMALE |
 #line 11430
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 11431
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11432
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 4,
@@ -28754,7 +28754,7 @@ F_TRAINER_FEMALE |
 #line 11455
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 11456
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11457
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -28797,7 +28797,7 @@ F_TRAINER_FEMALE |
 #line 11472
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 11473
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11474
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -28851,7 +28851,7 @@ F_TRAINER_FEMALE |
 #line 11493
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 11494
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11495
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -28894,7 +28894,7 @@ F_TRAINER_FEMALE |
 #line 11510
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 11511
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11512
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -28937,7 +28937,7 @@ F_TRAINER_FEMALE |
 #line 11527
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 11528
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11529
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -28991,7 +28991,7 @@ F_TRAINER_FEMALE |
 #line 11548
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 11549
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11550
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -29023,7 +29023,7 @@ F_TRAINER_FEMALE |
 #line 11561
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 11562
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11563
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -29066,7 +29066,7 @@ F_TRAINER_FEMALE |
 #line 11578
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 11579
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11580
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -29103,7 +29103,7 @@ F_TRAINER_FEMALE |
 #line 11593
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 11594
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11595
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -29156,7 +29156,7 @@ F_TRAINER_FEMALE |
 #line 11614
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 11615
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11616
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -29210,7 +29210,7 @@ F_TRAINER_FEMALE |
 #line 11635
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 11636
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11637
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 4,
@@ -29275,7 +29275,7 @@ F_TRAINER_FEMALE |
 #line 11660
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 11661
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11662
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 4,
@@ -29340,7 +29340,7 @@ F_TRAINER_FEMALE |
 #line 11685
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 11686
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11687
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 4,
@@ -29405,7 +29405,7 @@ F_TRAINER_FEMALE |
 #line 11710
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 11711
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11712
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 4,
@@ -29470,7 +29470,7 @@ F_TRAINER_FEMALE |
 #line 11735
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 11736
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 11737
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -29513,7 +29513,7 @@ F_TRAINER_FEMALE |
 #line 11752
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 11753
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 11754
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -29556,7 +29556,7 @@ F_TRAINER_FEMALE |
 #line 11769
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 11770
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 11771
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -29599,7 +29599,7 @@ F_TRAINER_FEMALE |
 #line 11786
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 11787
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 11788
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -29642,7 +29642,7 @@ F_TRAINER_FEMALE |
 #line 11803
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 11804
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 11805
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -29685,7 +29685,7 @@ F_TRAINER_FEMALE |
 #line 11820
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 11821
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 11822
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -29728,7 +29728,7 @@ F_TRAINER_FEMALE |
 #line 11837
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 11838
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 11839
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -29773,7 +29773,7 @@ F_TRAINER_FEMALE |
 #line 11854
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 11855
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11856
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -29807,7 +29807,7 @@ F_TRAINER_FEMALE |
 #line 11868
         .items = { ITEM_HYPER_POTION },
 #line 11869
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11870
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -29848,7 +29848,7 @@ F_TRAINER_FEMALE |
 #line 11885
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 11886
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11887
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -29907,7 +29907,7 @@ F_TRAINER_FEMALE |
 #line 11910
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 11911
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11912
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -29946,7 +29946,7 @@ F_TRAINER_FEMALE |
 #line 11927
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 11928
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11929
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT,
         .partySize = 2,
@@ -30003,7 +30003,7 @@ F_TRAINER_FEMALE |
 #line 11952
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 11953
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11954
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT,
         .partySize = 2,
@@ -30060,7 +30060,7 @@ F_TRAINER_FEMALE |
 #line 11977
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 11978
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 11979
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT,
         .partySize = 2,
@@ -30117,7 +30117,7 @@ F_TRAINER_FEMALE |
 #line 12002
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 12003
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 12004
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -30162,7 +30162,7 @@ F_TRAINER_FEMALE |
 #line 12019
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 12020
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 12021
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -30216,7 +30216,7 @@ F_TRAINER_FEMALE |
 #line 12040
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 12041
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 12042
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -30250,7 +30250,7 @@ F_TRAINER_FEMALE |
 #line 12054
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 12055
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 12056
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 5,
@@ -30363,7 +30363,7 @@ F_TRAINER_FEMALE |
 #line 12104
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 12105
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 12106
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 5,
@@ -30476,7 +30476,7 @@ F_TRAINER_FEMALE |
 #line 12154
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 12155
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 12156
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 5,
@@ -30589,7 +30589,7 @@ F_TRAINER_FEMALE |
 #line 12204
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 12205
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 12206
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 5,
@@ -30700,7 +30700,7 @@ F_TRAINER_FEMALE |
 #line 12253
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 12254
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 12255
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 4,
@@ -30765,7 +30765,7 @@ F_TRAINER_FEMALE |
 #line 12278
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 12279
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 12280
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 4,
@@ -30830,7 +30830,7 @@ F_TRAINER_FEMALE |
 #line 12303
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 12304
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 12305
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 4,
@@ -30897,7 +30897,7 @@ F_TRAINER_FEMALE |
 #line 12328
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 12329
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 12330
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 4,
@@ -30964,7 +30964,7 @@ F_TRAINER_FEMALE |
 #line 12353
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 12354
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 12355
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 4,
@@ -31031,7 +31031,7 @@ F_TRAINER_FEMALE |
 #line 12378
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 12379
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 12380
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 4,
@@ -31096,7 +31096,7 @@ F_TRAINER_FEMALE |
 #line 12403
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 12404
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 12405
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -31150,7 +31150,7 @@ F_TRAINER_FEMALE |
 #line 12424
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 12425
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 12426
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -31193,7 +31193,7 @@ F_TRAINER_FEMALE |
 #line 12441
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 12442
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 12443
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -31251,7 +31251,7 @@ F_TRAINER_FEMALE |
 #line 12463
         .items = { ITEM_FULL_RESTORE },
 #line 12464
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 12465
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -31296,7 +31296,7 @@ F_TRAINER_FEMALE |
 #line 12481
         .items = { ITEM_HYPER_POTION },
 #line 12482
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 12483
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -31339,7 +31339,7 @@ F_TRAINER_FEMALE |
 #line 12498
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 12499
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 12500
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -31371,7 +31371,7 @@ F_TRAINER_FEMALE |
 #line 12511
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 12512
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 12513
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -31425,7 +31425,7 @@ F_TRAINER_FEMALE |
 #line 12532
             TRAINER_ENCOUNTER_MUSIC_COOL,
 #line 12533
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 12534
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -31468,7 +31468,7 @@ F_TRAINER_FEMALE |
 #line 12549
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 12550
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 12551
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -31513,7 +31513,7 @@ F_TRAINER_FEMALE |
 #line 12566
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 12567
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 12568
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -31545,7 +31545,7 @@ F_TRAINER_FEMALE |
 #line 12579
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 12580
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 12581
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -31588,7 +31588,7 @@ F_TRAINER_FEMALE |
 #line 12596
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 12597
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 12598
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -31645,7 +31645,7 @@ F_TRAINER_FEMALE |
 #line 12621
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 12622
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 12623
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -31702,7 +31702,7 @@ F_TRAINER_FEMALE |
 #line 12646
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 12647
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 12648
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -31759,7 +31759,7 @@ F_TRAINER_FEMALE |
 #line 12671
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 12672
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 12673
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -31816,7 +31816,7 @@ F_TRAINER_FEMALE |
 #line 12696
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 12697
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 12698
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -31873,7 +31873,7 @@ F_TRAINER_FEMALE |
 #line 12721
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 12722
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 12723
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -31930,7 +31930,7 @@ F_TRAINER_FEMALE |
 #line 12746
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 12747
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 12748
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_FORCE_SETUP_FIRST_TURN,
         .partySize = 2,
@@ -31987,7 +31987,7 @@ F_TRAINER_FEMALE |
 #line 12771
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 12772
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 12773
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -32044,7 +32044,7 @@ F_TRAINER_FEMALE |
 #line 12796
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 12797
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 12798
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -32087,7 +32087,7 @@ F_TRAINER_FEMALE |
 #line 12813
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 12814
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 12815
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -32130,7 +32130,7 @@ F_TRAINER_FEMALE |
 #line 12830
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 12831
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 12832
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -32173,7 +32173,7 @@ F_TRAINER_FEMALE |
 #line 12847
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 12848
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 12849
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -32216,7 +32216,7 @@ F_TRAINER_FEMALE |
 #line 12864
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 12865
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 12866
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -32259,7 +32259,7 @@ F_TRAINER_FEMALE |
 #line 12881
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 12882
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 12883
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -32302,7 +32302,7 @@ F_TRAINER_FEMALE |
 #line 12898
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 12899
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 12900
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -32345,7 +32345,7 @@ F_TRAINER_FEMALE |
 #line 12915
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 12916
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 12917
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 4,
@@ -32410,7 +32410,7 @@ F_TRAINER_FEMALE |
 #line 12940
             TRAINER_ENCOUNTER_MUSIC_RICH,
 #line 12941
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 12942
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -32459,7 +32459,7 @@ F_TRAINER_FEMALE |
 #line 12958
         .items = { ITEM_FULL_RESTORE },
 #line 12959
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 12960
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -32504,7 +32504,7 @@ F_TRAINER_FEMALE |
 #line 12975
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 12976
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 12977
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -32538,7 +32538,7 @@ F_TRAINER_FEMALE |
 #line 12988
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 12989
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 12990
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -32570,7 +32570,7 @@ F_TRAINER_FEMALE |
 #line 13001
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 13002
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13003
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -32613,7 +32613,7 @@ F_TRAINER_FEMALE |
 #line 13018
             TRAINER_ENCOUNTER_MUSIC_TWINS,
 #line 13019
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13020
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -32660,7 +32660,7 @@ F_TRAINER_FEMALE |
 #line 13035
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 13036
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13037
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -32705,7 +32705,7 @@ F_TRAINER_FEMALE |
 #line 13052
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 13053
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13054
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -32737,7 +32737,7 @@ F_TRAINER_FEMALE |
 #line 13065
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 13066
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13067
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -32769,7 +32769,7 @@ F_TRAINER_FEMALE |
 #line 13078
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 13079
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13080
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -32801,7 +32801,7 @@ F_TRAINER_FEMALE |
 #line 13091
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 13092
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13093
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -32835,7 +32835,7 @@ F_TRAINER_FEMALE |
 #line 13104
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 13105
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13106
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -32869,7 +32869,7 @@ F_TRAINER_FEMALE |
 #line 13117
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 13118
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13119
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -32901,7 +32901,7 @@ F_TRAINER_FEMALE |
 #line 13130
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 13131
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13132
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -32935,7 +32935,7 @@ F_TRAINER_FEMALE |
 #line 13143
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 13144
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13145
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -32978,7 +32978,7 @@ F_TRAINER_FEMALE |
 #line 13160
             TRAINER_ENCOUNTER_MUSIC_COOL,
 #line 13161
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13162
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -33021,7 +33021,7 @@ F_TRAINER_FEMALE |
 #line 13177
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 13178
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13179
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -33064,7 +33064,7 @@ F_TRAINER_FEMALE |
 #line 13194
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 13195
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13196
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -33109,7 +33109,7 @@ F_TRAINER_FEMALE |
 #line 13211
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 13212
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13213
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -33152,7 +33152,7 @@ F_TRAINER_FEMALE |
 #line 13228
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 13229
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13230
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -33186,7 +33186,7 @@ F_TRAINER_FEMALE |
 #line 13241
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 13242
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13243
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -33218,7 +33218,7 @@ F_TRAINER_FEMALE |
 #line 13254
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 13255
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13256
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -33272,7 +33272,7 @@ F_TRAINER_FEMALE |
 #line 13275
             TRAINER_ENCOUNTER_MUSIC_MAGMA,
 #line 13276
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13277
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -33304,7 +33304,7 @@ F_TRAINER_FEMALE |
 #line 13288
             TRAINER_ENCOUNTER_MUSIC_MAGMA,
 #line 13289
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13290
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -33336,7 +33336,7 @@ F_TRAINER_FEMALE |
 #line 13301
             TRAINER_ENCOUNTER_MUSIC_MAGMA,
 #line 13302
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13303
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -33368,7 +33368,7 @@ F_TRAINER_FEMALE |
 #line 13314
             TRAINER_ENCOUNTER_MUSIC_MAGMA,
 #line 13315
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13316
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -33411,7 +33411,7 @@ F_TRAINER_FEMALE |
 #line 13331
             TRAINER_ENCOUNTER_MUSIC_MAGMA,
 #line 13332
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13333
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -33454,7 +33454,7 @@ F_TRAINER_FEMALE |
 #line 13348
             TRAINER_ENCOUNTER_MUSIC_MAGMA,
 #line 13349
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13350
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -33486,7 +33486,7 @@ F_TRAINER_FEMALE |
 #line 13361
             TRAINER_ENCOUNTER_MUSIC_MAGMA,
 #line 13362
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13363
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -33518,7 +33518,7 @@ F_TRAINER_FEMALE |
 #line 13374
             TRAINER_ENCOUNTER_MUSIC_MAGMA,
 #line 13375
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13376
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -33550,7 +33550,7 @@ F_TRAINER_FEMALE |
 #line 13387
             TRAINER_ENCOUNTER_MUSIC_MAGMA,
 #line 13388
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13389
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -33582,7 +33582,7 @@ F_TRAINER_FEMALE |
 #line 13400
             TRAINER_ENCOUNTER_MUSIC_MAGMA,
 #line 13401
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13402
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -33614,7 +33614,7 @@ F_TRAINER_FEMALE |
 #line 13413
             TRAINER_ENCOUNTER_MUSIC_MAGMA,
 #line 13414
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13415
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -33646,7 +33646,7 @@ F_TRAINER_FEMALE |
 #line 13426
             TRAINER_ENCOUNTER_MUSIC_MAGMA,
 #line 13427
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13428
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -33678,7 +33678,7 @@ F_TRAINER_FEMALE |
 #line 13439
             TRAINER_ENCOUNTER_MUSIC_MAGMA,
 #line 13440
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13441
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -33712,7 +33712,7 @@ F_TRAINER_FEMALE |
 #line 13452
             TRAINER_ENCOUNTER_MUSIC_MAGMA,
 #line 13453
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13454
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -33746,7 +33746,7 @@ F_TRAINER_FEMALE |
 #line 13465
             TRAINER_ENCOUNTER_MUSIC_MAGMA,
 #line 13466
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13467
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -33780,7 +33780,7 @@ F_TRAINER_FEMALE |
 #line 13478
             TRAINER_ENCOUNTER_MUSIC_MAGMA,
 #line 13479
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13480
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -33812,7 +33812,7 @@ F_TRAINER_FEMALE |
 #line 13491
             TRAINER_ENCOUNTER_MUSIC_MAGMA,
 #line 13492
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13493
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 4,
@@ -33881,7 +33881,7 @@ F_TRAINER_FEMALE |
 #line 13517
         .items = { ITEM_HYPER_POTION },
 #line 13518
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13519
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -33924,7 +33924,7 @@ F_TRAINER_FEMALE |
 #line 13534
             TRAINER_ENCOUNTER_MUSIC_MAGMA,
 #line 13535
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13536
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -33978,7 +33978,7 @@ F_TRAINER_FEMALE |
 #line 13555
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 13556
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13557
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -34012,7 +34012,7 @@ F_TRAINER_FEMALE |
 #line 13568
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 13569
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13570
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -34044,7 +34044,7 @@ F_TRAINER_FEMALE |
 #line 13581
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 13582
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13583
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -34087,7 +34087,7 @@ F_TRAINER_FEMALE |
 #line 13598
             TRAINER_ENCOUNTER_MUSIC_COOL,
 #line 13599
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13600
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -34130,7 +34130,7 @@ F_TRAINER_FEMALE |
 #line 13615
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 13616
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13617
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -34162,7 +34162,7 @@ F_TRAINER_FEMALE |
 #line 13628
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 13629
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13630
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -34220,7 +34220,7 @@ F_TRAINER_FEMALE |
 #line 13650
         .items = { ITEM_HYPER_POTION },
 #line 13651
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13652
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -34274,7 +34274,7 @@ F_TRAINER_FEMALE |
 #line 13671
             TRAINER_ENCOUNTER_MUSIC_COOL,
 #line 13672
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13673
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -34319,7 +34319,7 @@ F_TRAINER_FEMALE |
 #line 13688
             TRAINER_ENCOUNTER_MUSIC_GIRL,
 #line 13689
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13690
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -34362,7 +34362,7 @@ F_TRAINER_FEMALE |
 #line 13705
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 13706
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13707
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -34405,7 +34405,7 @@ F_TRAINER_FEMALE |
 #line 13722
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 13723
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13724
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -34448,7 +34448,7 @@ F_TRAINER_FEMALE |
 #line 13739
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 13740
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13741
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -34493,7 +34493,7 @@ F_TRAINER_FEMALE |
 #line 13756
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 13757
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13758
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -34538,7 +34538,7 @@ F_TRAINER_FEMALE |
 #line 13773
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 13774
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13775
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -34581,7 +34581,7 @@ F_TRAINER_FEMALE |
 #line 13790
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 13791
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13792
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -34626,7 +34626,7 @@ F_TRAINER_FEMALE |
 #line 13807
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 13808
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13809
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -34671,7 +34671,7 @@ F_TRAINER_FEMALE |
 #line 13824
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 13825
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13826
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -34716,7 +34716,7 @@ F_TRAINER_FEMALE |
 #line 13841
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 13842
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13843
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -34759,7 +34759,7 @@ F_TRAINER_FEMALE |
 #line 13858
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 13859
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13860
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -34802,7 +34802,7 @@ F_TRAINER_FEMALE |
 #line 13875
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 13876
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13877
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -34847,7 +34847,7 @@ F_TRAINER_FEMALE |
 #line 13892
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 13893
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13894
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -34881,7 +34881,7 @@ F_TRAINER_FEMALE |
 #line 13905
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 13906
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13907
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -34915,7 +34915,7 @@ F_TRAINER_FEMALE |
 #line 13918
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 13919
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13920
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -34951,7 +34951,7 @@ F_TRAINER_FEMALE |
 #line 13932
         .items = { ITEM_HYPER_POTION },
 #line 13933
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13934
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -34994,7 +34994,7 @@ F_TRAINER_FEMALE |
 #line 13949
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 13950
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13951
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -35026,7 +35026,7 @@ F_TRAINER_FEMALE |
 #line 13962
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 13963
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13964
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -35071,7 +35071,7 @@ F_TRAINER_FEMALE |
 #line 13979
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 13980
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13981
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 1,
@@ -35105,7 +35105,7 @@ F_TRAINER_FEMALE |
 #line 13993
         .items = { ITEM_HYPER_POTION },
 #line 13994
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 13995
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -35145,7 +35145,7 @@ F_TRAINER_FEMALE |
 #line 14009
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 14010
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 14011
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -35188,7 +35188,7 @@ F_TRAINER_FEMALE |
 #line 14026
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 14027
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 14028
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -35231,7 +35231,7 @@ F_TRAINER_FEMALE |
 #line 14043
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 14044
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 14045
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 6,
@@ -35320,7 +35320,7 @@ F_TRAINER_FEMALE |
 #line 14076
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 14077
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 14078
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 6,
@@ -35411,7 +35411,7 @@ F_TRAINER_FEMALE |
 #line 14110
         .items = { ITEM_HYPER_POTION },
 #line 14111
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 14112
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -35456,7 +35456,7 @@ F_TRAINER_FEMALE |
 #line 14127
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 14128
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 14129
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -35501,7 +35501,7 @@ F_TRAINER_FEMALE |
 #line 14144
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 14145
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 14146
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -35548,7 +35548,7 @@ F_TRAINER_FEMALE |
 #line 14162
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 14163
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 14164
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 4,
@@ -35649,7 +35649,7 @@ F_TRAINER_FEMALE |
 #line 14204
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 14205
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 14206
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 5,
@@ -35768,7 +35768,7 @@ F_TRAINER_FEMALE |
 #line 14254
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 14255
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 14256
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 5,
@@ -35887,7 +35887,7 @@ F_TRAINER_FEMALE |
 #line 14304
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 14305
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 14306
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 6,
@@ -36022,7 +36022,7 @@ F_TRAINER_FEMALE |
 #line 14362
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 14363
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 14364
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 4,
@@ -36121,7 +36121,7 @@ F_TRAINER_FEMALE |
 #line 14404
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 14405
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 14406
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 4,
@@ -36220,7 +36220,7 @@ F_TRAINER_FEMALE |
 #line 14446
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 14447
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 14448
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 5,
@@ -36337,7 +36337,7 @@ F_TRAINER_FEMALE |
 #line 14496
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 14497
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 14498
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 6,
@@ -36472,7 +36472,7 @@ F_TRAINER_FEMALE |
 #line 14554
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 14555
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 14556
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 4,
@@ -36571,7 +36571,7 @@ F_TRAINER_FEMALE |
 #line 14596
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 14597
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 14598
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 5,
@@ -36688,7 +36688,7 @@ F_TRAINER_FEMALE |
 #line 14646
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 14647
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 14648
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 5,
@@ -36805,7 +36805,7 @@ F_TRAINER_FEMALE |
 #line 14696
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 14697
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 14698
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 6,
@@ -36942,7 +36942,7 @@ F_TRAINER_FEMALE |
 #line 14754
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 14755
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 14756
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 4,
@@ -37045,7 +37045,7 @@ F_TRAINER_FEMALE |
 #line 14796
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 14797
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 14798
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 5,
@@ -37166,7 +37166,7 @@ F_TRAINER_FEMALE |
 #line 14846
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 14847
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 14848
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 6,
@@ -37305,7 +37305,7 @@ F_TRAINER_FEMALE |
 #line 14904
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 14905
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 14906
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 6,
@@ -37442,7 +37442,7 @@ F_TRAINER_FEMALE |
 #line 14962
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 14963
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 14964
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 4,
@@ -37541,7 +37541,7 @@ F_TRAINER_FEMALE |
 #line 15004
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 15005
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 15006
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 5,
@@ -37658,7 +37658,7 @@ F_TRAINER_FEMALE |
 #line 15054
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 15055
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 15056
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 5,
@@ -37775,7 +37775,7 @@ F_TRAINER_FEMALE |
 #line 15104
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 15105
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 15106
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 6,
@@ -37912,7 +37912,7 @@ F_TRAINER_FEMALE |
 #line 15162
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 15163
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 15164
         .aiFlags = AI_FLAG_BASIC_TRAINER | AI_FLAG_RISKY,
         .partySize = 5,
@@ -38031,7 +38031,7 @@ F_TRAINER_FEMALE |
 #line 15212
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 15213
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 15214
         .aiFlags = AI_FLAG_BASIC_TRAINER | AI_FLAG_RISKY,
         .partySize = 6,
@@ -38168,7 +38168,7 @@ F_TRAINER_FEMALE |
 #line 15270
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 15271
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 15272
         .aiFlags = AI_FLAG_BASIC_TRAINER | AI_FLAG_RISKY,
         .partySize = 6,
@@ -38305,7 +38305,7 @@ F_TRAINER_FEMALE |
 #line 15328
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 15329
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 15330
         .aiFlags = AI_FLAG_BASIC_TRAINER | AI_FLAG_RISKY,
         .partySize = 6,
@@ -38440,7 +38440,7 @@ F_TRAINER_FEMALE |
 #line 15386
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 15387
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 15388
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 5,
@@ -38559,7 +38559,7 @@ F_TRAINER_FEMALE |
 #line 15436
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 15437
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 15438
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 6,
@@ -38696,7 +38696,7 @@ F_TRAINER_FEMALE |
 #line 15494
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 15495
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 15496
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 6,
@@ -38833,7 +38833,7 @@ F_TRAINER_FEMALE |
 #line 15552
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 15553
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 15554
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 6,
@@ -38970,7 +38970,7 @@ F_TRAINER_FEMALE |
 #line 15610
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 15611
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 15612
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 5,
@@ -39087,7 +39087,7 @@ F_TRAINER_FEMALE |
 #line 15660
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 15661
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 15662
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 5,
@@ -39204,7 +39204,7 @@ F_TRAINER_FEMALE |
 #line 15710
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 15711
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 15712
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 6,
@@ -39339,7 +39339,7 @@ F_TRAINER_FEMALE |
 #line 15768
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 15769
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 15770
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 6,
@@ -39472,7 +39472,7 @@ F_TRAINER_FEMALE |
 #line 15825
             TRAINER_ENCOUNTER_MUSIC_SUSPICIOUS,
 #line 15826
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 15827
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -39527,7 +39527,7 @@ F_TRAINER_FEMALE |
 #line 15848
             TRAINER_ENCOUNTER_MUSIC_COOL,
 #line 15849
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 15850
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -39561,7 +39561,7 @@ F_TRAINER_FEMALE |
 #line 15862
         .items = { ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE, ITEM_FULL_RESTORE },
 #line 15863
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 15864
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 6,
@@ -39694,7 +39694,7 @@ F_TRAINER_FEMALE |
 #line 15919
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 15920
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 15921
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -39726,7 +39726,7 @@ F_TRAINER_FEMALE |
 #line 15932
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 15933
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 15934
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -39758,7 +39758,7 @@ F_TRAINER_FEMALE |
 #line 15945
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 15946
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 15947
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -39792,7 +39792,7 @@ F_TRAINER_FEMALE |
 #line 15958
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 15959
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 15960
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -39824,7 +39824,7 @@ F_TRAINER_FEMALE |
 #line 15971
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 15972
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 15973
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -39858,7 +39858,7 @@ F_TRAINER_FEMALE |
 #line 15984
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 15985
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 15986
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -39890,7 +39890,7 @@ F_TRAINER_FEMALE |
 #line 15997
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 15998
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 15999
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 1,
@@ -39922,7 +39922,7 @@ F_TRAINER_FEMALE |
 #line 16010
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 16011
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16012
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -39965,7 +39965,7 @@ F_TRAINER_FEMALE |
 #line 16027
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 16028
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16029
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -40019,7 +40019,7 @@ F_TRAINER_FEMALE |
 #line 16048
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 16049
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16050
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -40073,7 +40073,7 @@ F_TRAINER_FEMALE |
 #line 16069
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 16070
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16071
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -40127,7 +40127,7 @@ F_TRAINER_FEMALE |
 #line 16090
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 16091
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16092
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -40181,7 +40181,7 @@ F_TRAINER_FEMALE |
 #line 16111
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 16112
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16113
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -40235,7 +40235,7 @@ F_TRAINER_FEMALE |
 #line 16132
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 16133
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16134
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -40289,7 +40289,7 @@ F_TRAINER_FEMALE |
 #line 16153
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 16154
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16155
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -40343,7 +40343,7 @@ F_TRAINER_FEMALE |
 #line 16174
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 16175
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16176
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -40386,7 +40386,7 @@ F_TRAINER_FEMALE |
 #line 16191
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 16192
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16193
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -40440,7 +40440,7 @@ F_TRAINER_FEMALE |
 #line 16212
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 16213
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16214
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -40494,7 +40494,7 @@ F_TRAINER_FEMALE |
 #line 16233
             TRAINER_ENCOUNTER_MUSIC_SWIMMER,
 #line 16234
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16235
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -40548,7 +40548,7 @@ F_TRAINER_FEMALE |
 #line 16254
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 16255
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16256
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -40591,7 +40591,7 @@ F_TRAINER_FEMALE |
 #line 16271
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 16272
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16273
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -40645,7 +40645,7 @@ F_TRAINER_FEMALE |
 #line 16292
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 16293
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16294
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -40699,7 +40699,7 @@ F_TRAINER_FEMALE |
 #line 16313
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 16314
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16315
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -40757,7 +40757,7 @@ F_TRAINER_FEMALE |
 #line 16335
         .items = { ITEM_HYPER_POTION },
 #line 16336
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16337
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -40804,7 +40804,7 @@ F_TRAINER_FEMALE |
 #line 16353
         .items = { ITEM_HYPER_POTION },
 #line 16354
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16355
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -40862,7 +40862,7 @@ F_TRAINER_FEMALE |
 #line 16375
         .items = { ITEM_HYPER_POTION },
 #line 16376
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16377
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -40920,7 +40920,7 @@ F_TRAINER_FEMALE |
 #line 16397
         .items = { ITEM_HYPER_POTION },
 #line 16398
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16399
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -40974,7 +40974,7 @@ F_TRAINER_FEMALE |
 #line 16418
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 16419
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16420
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -41028,7 +41028,7 @@ F_TRAINER_FEMALE |
 #line 16439
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 16440
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16441
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -41082,7 +41082,7 @@ F_TRAINER_FEMALE |
 #line 16460
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 16461
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16462
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -41136,7 +41136,7 @@ F_TRAINER_FEMALE |
 #line 16481
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 16482
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16483
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -41190,7 +41190,7 @@ F_TRAINER_FEMALE |
 #line 16502
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 16503
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16504
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 2,
@@ -41233,7 +41233,7 @@ F_TRAINER_FEMALE |
 #line 16519
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 16520
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16521
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -41287,7 +41287,7 @@ F_TRAINER_FEMALE |
 #line 16540
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 16541
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16542
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -41341,7 +41341,7 @@ F_TRAINER_FEMALE |
 #line 16561
             TRAINER_ENCOUNTER_MUSIC_HIKER,
 #line 16562
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16563
         .aiFlags = AI_FLAG_BASIC_TRAINER,
         .partySize = 3,
@@ -41397,7 +41397,7 @@ F_TRAINER_FEMALE |
 #line 16582
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 16583
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16584
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 6,
@@ -41486,7 +41486,7 @@ F_TRAINER_FEMALE |
 #line 16615
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 16616
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16617
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 6,
@@ -41575,7 +41575,7 @@ F_TRAINER_FEMALE |
 #line 16648
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 16649
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16650
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 6,
@@ -41664,7 +41664,7 @@ F_TRAINER_FEMALE |
 #line 16681
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 16682
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16683
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 6,
@@ -41753,7 +41753,7 @@ F_TRAINER_FEMALE |
 #line 16714
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 16715
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16716
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 2,
@@ -41798,7 +41798,7 @@ F_TRAINER_FEMALE |
 #line 16731
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 16732
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16733
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -41854,7 +41854,7 @@ F_TRAINER_FEMALE |
 #line 16752
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 16753
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16754
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -41910,7 +41910,7 @@ F_TRAINER_FEMALE |
 #line 16773
             TRAINER_ENCOUNTER_MUSIC_FEMALE,
 #line 16774
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 16775
         .aiFlags = AI_FLAG_CHECK_BAD_MOVE,
         .partySize = 3,
@@ -41966,7 +41966,7 @@ F_TRAINER_FEMALE |
 #line 16794
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 16795
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
         .partySize = 1,
         .party = (const struct TrainerMon[])
         {
@@ -41996,7 +41996,7 @@ F_TRAINER_FEMALE |
 #line 16806
             TRAINER_ENCOUNTER_MUSIC_INTENSE,
 #line 16807
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
         .partySize = 2,
         .party = (const struct TrainerMon[])
         {
@@ -42037,7 +42037,7 @@ F_TRAINER_FEMALE |
 #line 16822
             TRAINER_ENCOUNTER_MUSIC_RICH,
 #line 16823
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
         .partySize = 1,
         .party = (const struct TrainerMon[])
         {
@@ -42067,7 +42067,7 @@ F_TRAINER_FEMALE |
 #line 16834
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 16835
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
         .partySize = 1,
         .party = (const struct TrainerMon[])
         {
@@ -42099,7 +42099,7 @@ F_TRAINER_FEMALE |
 #line 16846
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 16847
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
         .partySize = 1,
         .party = (const struct TrainerMon[])
         {
@@ -42129,7 +42129,7 @@ F_TRAINER_FEMALE |
 #line 16858
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 16859
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
         .partySize = 1,
         .party = (const struct TrainerMon[])
         {
@@ -42161,7 +42161,7 @@ F_TRAINER_FEMALE |
 #line 16870
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 16871
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
         .partySize = 1,
         .party = (const struct TrainerMon[])
         {

--- a/src/data/trainers.party
+++ b/src/data/trainers.party
@@ -20,7 +20,7 @@ Optional (but still recommended) fields for trainers:
     - Music
     - Items (Some Item / Another Item / Third Item)
             (Can also be specified with ITEM_SOME_ITEM)
-    - Double Battle (Yes/No, defaults to No)
+    - Battle Type (Singles / Doubles, defaults to Singles)
     - AI (Ai Flag / Another Flag / Third Flag / ...
           see "constants/battle_ai.h" for all flags)
     - Mugshot (enable Mugshots during battle transition
@@ -79,7 +79,7 @@ Class: Pkmn Trainer 1
 Pic: Hiker
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 
 === TRAINER_SAWYER_1 ===
 Name: SAWYER
@@ -87,7 +87,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Geodude
@@ -100,7 +100,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Poochyena
@@ -113,7 +113,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zubat
@@ -130,7 +130,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zubat
@@ -143,7 +143,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Carvanha
@@ -156,7 +156,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Poochyena
@@ -169,7 +169,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Carvanha
@@ -182,7 +182,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zubat
@@ -195,7 +195,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder F
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Skitty
@@ -228,7 +228,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Poochyena
@@ -242,7 +242,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Manectric
@@ -259,7 +259,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Pelipper
@@ -276,7 +276,7 @@ Class: Collector
 Pic: Collector
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zangoose
@@ -293,7 +293,7 @@ Class: Team Aqua
 Pic: Aqua Grunt F
 Gender: Female
 Music: Aqua
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Carvanha
@@ -306,7 +306,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Gyarados
@@ -319,7 +319,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Poochyena
@@ -332,7 +332,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zubat
@@ -349,7 +349,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Poochyena
@@ -366,7 +366,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Poochyena
@@ -387,7 +387,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Carvanha
@@ -400,7 +400,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zubat
@@ -417,7 +417,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Numel
@@ -430,7 +430,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zubat
@@ -443,7 +443,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Carvanha
@@ -456,7 +456,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Poochyena
@@ -473,7 +473,7 @@ Class: Team Aqua
 Pic: Aqua Grunt F
 Gender: Female
 Music: Aqua
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Carvanha
@@ -486,7 +486,7 @@ Class: Team Aqua
 Pic: Aqua Grunt F
 Gender: Female
 Music: Aqua
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Carvanha
@@ -499,7 +499,7 @@ Class: Team Aqua
 Pic: Aqua Grunt F
 Gender: Female
 Music: Aqua
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zubat
@@ -512,7 +512,7 @@ Class: Expert
 Pic: Expert M
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Makuhita
@@ -530,7 +530,7 @@ Pic: Aqua Admin M
 Gender: Male
 Music: Aqua
 Items: Super Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Mightyena
@@ -547,7 +547,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Hariyama
@@ -560,7 +560,7 @@ Class: Aqua Admin
 Pic: Aqua Admin F
 Gender: Female
 Music: Aqua
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Carvanha
@@ -577,7 +577,7 @@ Class: Aqua Admin
 Pic: Aqua Admin F
 Gender: Female
 Music: Aqua
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Sharpedo
@@ -595,7 +595,7 @@ Pic: Aqua Leader Archie
 Gender: Male
 Music: Aqua
 Items: Super Potion / Super Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Mightyena
@@ -616,7 +616,7 @@ Class: Hex Maniac
 Pic: Hex Maniac
 Gender: Female
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Spoink
@@ -629,7 +629,7 @@ Class: Aroma Lady
 Pic: Aroma Lady
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Shroomish
@@ -646,7 +646,7 @@ Class: Aroma Lady
 Pic: Aroma Lady
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Roselia
@@ -668,7 +668,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Medicham
@@ -688,7 +688,7 @@ Class: Aroma Lady
 Pic: Aroma Lady
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Roselia
@@ -705,7 +705,7 @@ Class: Aroma Lady
 Pic: Aroma Lady
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Shroomish
@@ -722,7 +722,7 @@ Class: Aroma Lady
 Pic: Aroma Lady
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Shroomish
@@ -743,7 +743,7 @@ Class: Aroma Lady
 Pic: Aroma Lady
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Shroomish
@@ -764,7 +764,7 @@ Class: Aroma Lady
 Pic: Aroma Lady
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Breloom
@@ -785,7 +785,7 @@ Class: Ruin Maniac
 Pic: Ruin Maniac
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Sandslash
@@ -802,7 +802,7 @@ Class: Ruin Maniac
 Pic: Ruin Maniac
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Baltoy
@@ -835,7 +835,7 @@ Class: Ruin Maniac
 Pic: Ruin Maniac
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Sandshrew
@@ -860,7 +860,7 @@ Class: Ruin Maniac
 Pic: Ruin Maniac
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Sandslash
@@ -877,7 +877,7 @@ Class: Ruin Maniac
 Pic: Ruin Maniac
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Sandslash
@@ -894,7 +894,7 @@ Class: Ruin Maniac
 Pic: Ruin Maniac
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Sandslash
@@ -911,7 +911,7 @@ Class: Ruin Maniac
 Pic: Ruin Maniac
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Sandslash
@@ -928,7 +928,7 @@ Class: Interviewer
 Pic: Interviewer
 Gender: Male
 Music: Interviewer
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Magnemite
@@ -945,7 +945,7 @@ Class: Interviewer
 Pic: Interviewer
 Gender: Male
 Music: Interviewer
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Magnemite
@@ -962,7 +962,7 @@ Class: Interviewer
 Pic: Interviewer
 Gender: Male
 Music: Interviewer
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Magneton
@@ -979,7 +979,7 @@ Class: Interviewer
 Pic: Interviewer
 Gender: Male
 Music: Interviewer
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Magneton
@@ -996,7 +996,7 @@ Class: Interviewer
 Pic: Interviewer
 Gender: Male
 Music: Interviewer
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Magneton
@@ -1013,7 +1013,7 @@ Class: Interviewer
 Pic: Interviewer
 Gender: Male
 Music: Interviewer
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Magneton
@@ -1038,7 +1038,7 @@ Class: Tuber F
 Pic: Tuber F
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Azurill
@@ -1055,7 +1055,7 @@ Class: Tuber F
 Pic: Tuber F
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Marill
@@ -1068,7 +1068,7 @@ Class: Tuber F
 Pic: Tuber F
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Marill
@@ -1081,7 +1081,7 @@ Class: Tuber F
 Pic: Tuber F
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Marill
@@ -1098,7 +1098,7 @@ Class: Tuber F
 Pic: Tuber F
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Marill
@@ -1115,7 +1115,7 @@ Class: Tuber F
 Pic: Tuber F
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Marill
@@ -1132,7 +1132,7 @@ Class: Tuber F
 Pic: Tuber F
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Azumarill
@@ -1149,7 +1149,7 @@ Class: Tuber M
 Pic: Tuber M
 Gender: Male
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zigzagoon
@@ -1166,7 +1166,7 @@ Class: Tuber M
 Pic: Tuber M
 Gender: Male
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Azurill
@@ -1183,7 +1183,7 @@ Class: Tuber M
 Pic: Tuber M
 Gender: Male
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Marill
@@ -1196,7 +1196,7 @@ Class: Tuber M
 Pic: Tuber M
 Gender: Male
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Linoone
@@ -1213,7 +1213,7 @@ Class: Tuber M
 Pic: Tuber M
 Gender: Male
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Linoone
@@ -1230,7 +1230,7 @@ Class: Tuber M
 Pic: Tuber M
 Gender: Male
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Linoone
@@ -1247,7 +1247,7 @@ Class: Tuber M
 Pic: Tuber M
 Gender: Male
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Linoone
@@ -1265,7 +1265,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Swellow
@@ -1282,7 +1282,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Spinda
@@ -1299,7 +1299,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Slakoth @ Sitrus Berry
@@ -1316,7 +1316,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Vigoroth
@@ -1332,7 +1332,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Swellow
@@ -1382,7 +1382,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Sableye
@@ -1404,7 +1404,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Mawile
@@ -1422,7 +1422,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Super Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Electrike
@@ -1444,7 +1444,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Cacturne
@@ -1462,7 +1462,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Magneton
@@ -1480,7 +1480,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Swellow
@@ -1502,7 +1502,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Dodrio
@@ -1528,7 +1528,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Kecleon
@@ -1550,7 +1550,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Electrike
@@ -1572,7 +1572,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Manectric
@@ -1594,7 +1594,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Manectric
@@ -1616,7 +1616,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Manectric
@@ -1638,7 +1638,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Graveler
@@ -1656,7 +1656,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Delcatty
@@ -1672,7 +1672,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Wigglytuff
@@ -1689,7 +1689,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move / Try To Faint / Force Setup First Turn
 
 Zangoose
@@ -1705,7 +1705,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move / Try To Faint / Force Setup First Turn
 
 Mawile
@@ -1739,7 +1739,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move / Try To Faint / Force Setup First Turn
 
 Lairon
@@ -1757,7 +1757,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Super Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Wingull
@@ -1779,7 +1779,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Sableye
@@ -1793,7 +1793,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Roselia
@@ -1807,7 +1807,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Claydol
@@ -1821,7 +1821,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Torkoal
@@ -1843,7 +1843,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Skarmory
@@ -1861,7 +1861,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Sandslash
@@ -1883,7 +1883,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Wingull
@@ -1905,7 +1905,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Pelipper
@@ -1927,7 +1927,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Pelipper
@@ -1949,7 +1949,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Pelipper
@@ -1970,7 +1970,7 @@ Class: Hex Maniac
 Pic: Hex Maniac
 Gender: Female
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Banette
@@ -1987,7 +1987,7 @@ Class: Hex Maniac
 Pic: Hex Maniac
 Gender: Female
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Duskull
@@ -2004,7 +2004,7 @@ Class: Hex Maniac
 Pic: Hex Maniac
 Gender: Female
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Duskull
@@ -2021,7 +2021,7 @@ Class: Hex Maniac
 Pic: Hex Maniac
 Gender: Female
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Sableye
@@ -2034,7 +2034,7 @@ Class: Hex Maniac
 Pic: Hex Maniac
 Gender: Female
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Shuppet
@@ -2047,7 +2047,7 @@ Class: Hex Maniac
 Pic: Hex Maniac
 Gender: Female
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Sableye
@@ -2064,7 +2064,7 @@ Class: Hex Maniac
 Pic: Hex Maniac
 Gender: Female
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Spoink
@@ -2081,7 +2081,7 @@ Class: Hex Maniac
 Pic: Hex Maniac
 Gender: Female
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Spoink
@@ -2098,7 +2098,7 @@ Class: Hex Maniac
 Pic: Hex Maniac
 Gender: Female
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Duskull
@@ -2120,7 +2120,7 @@ Pic: Lady
 Gender: Female
 Music: Female
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zigzagoon @ Nugget
@@ -2134,7 +2134,7 @@ Pic: Lady
 Gender: Female
 Music: Female
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Luvdisc @ Nugget
@@ -2159,7 +2159,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Mightyena
@@ -2181,7 +2181,7 @@ Pic: Lady
 Gender: Female
 Music: Female
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zigzagoon @ Nugget
@@ -2197,7 +2197,7 @@ Pic: Lady
 Gender: Female
 Music: Female
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Seaking @ Nugget
@@ -2211,7 +2211,7 @@ Pic: Lady
 Gender: Female
 Music: Female
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Roselia @ Nugget
@@ -2225,7 +2225,7 @@ Pic: Lady
 Gender: Female
 Music: Female
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Linoone @ Nugget
@@ -2239,7 +2239,7 @@ Pic: Lady
 Gender: Female
 Music: Female
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Linoone @ Nugget
@@ -2253,7 +2253,7 @@ Pic: Lady
 Gender: Female
 Music: Female
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Linoone @ Nugget
@@ -2267,7 +2267,7 @@ Pic: Lady
 Gender: Female
 Music: Female
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Linoone @ Nugget
@@ -2284,7 +2284,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Marill
@@ -2297,7 +2297,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Shroomish
@@ -2310,7 +2310,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Numel
@@ -2323,7 +2323,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Kecleon
@@ -2348,7 +2348,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Goldeen
@@ -2361,7 +2361,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Azumarill
@@ -2374,7 +2374,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Clamperl
@@ -2406,7 +2406,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Carvanha
@@ -2423,7 +2423,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Kecleon
@@ -2448,7 +2448,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Kecleon
@@ -2473,7 +2473,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Kecleon
@@ -2498,7 +2498,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Kecleon
@@ -2524,7 +2524,7 @@ Pic: Rich Boy
 Gender: Male
 Music: Rich
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zigzagoon @ Nugget
@@ -2537,7 +2537,7 @@ Class: Expert
 Pic: Expert F
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Whiscash
@@ -2555,7 +2555,7 @@ Pic: Rich Boy
 Gender: Male
 Music: Rich
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Azumarill @ Nugget
@@ -2569,7 +2569,7 @@ Pic: Rich Boy
 Gender: Male
 Music: Rich
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Linoone @ Nugget
@@ -2583,7 +2583,7 @@ Pic: Rich Boy
 Gender: Male
 Music: Rich
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Linoone @ Nugget
@@ -2597,7 +2597,7 @@ Pic: Rich Boy
 Gender: Male
 Music: Rich
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Linoone @ Nugget
@@ -2611,7 +2611,7 @@ Pic: Rich Boy
 Gender: Male
 Music: Rich
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Linoone @ Nugget
@@ -2628,7 +2628,7 @@ Class: Pokemaniac
 Pic: Pokemaniac
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Aron
@@ -2641,7 +2641,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wailmer
@@ -2658,7 +2658,7 @@ Class: Pokemaniac
 Pic: Pokemaniac
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Rhyhorn
@@ -2671,7 +2671,7 @@ Class: Team Magma
 Pic: Magma Grunt F
 Gender: Female
 Music: Magma
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Numel
@@ -2684,7 +2684,7 @@ Class: Pokemaniac
 Pic: Pokemaniac
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Lairon
@@ -2697,7 +2697,7 @@ Class: Pokemaniac
 Pic: Pokemaniac
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Lairon
@@ -2714,7 +2714,7 @@ Class: Pokemaniac
 Pic: Pokemaniac
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Lairon
@@ -2731,7 +2731,7 @@ Class: Pokemaniac
 Pic: Pokemaniac
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Aggron
@@ -2748,7 +2748,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Carvanha
@@ -2761,7 +2761,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Tentacool
@@ -2774,7 +2774,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Tentacool
@@ -2791,7 +2791,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Tentacool
@@ -2812,7 +2812,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Carvanha
@@ -2825,7 +2825,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Tentacruel
@@ -2838,7 +2838,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Carvanha
@@ -2851,7 +2851,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Tentacool
@@ -2868,7 +2868,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Tentacool
@@ -2885,7 +2885,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Carvanha
@@ -2898,7 +2898,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Tentacruel
@@ -2911,7 +2911,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Horsea
@@ -2924,7 +2924,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Gyarados
@@ -2937,7 +2937,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Carvanha
@@ -2958,7 +2958,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Gyarados
@@ -2971,7 +2971,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Pelipper
@@ -2984,7 +2984,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wingull
@@ -3001,7 +3001,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Tentacruel
@@ -3018,7 +3018,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Sharpedo
@@ -3031,7 +3031,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Sealeo
@@ -3044,7 +3044,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Spheal
@@ -3057,7 +3057,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Gyarados
@@ -3070,7 +3070,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Tentacool
@@ -3091,7 +3091,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Tentacool
@@ -3108,7 +3108,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Sharpedo
@@ -3121,7 +3121,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Sharpedo
@@ -3134,7 +3134,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Staryu
@@ -3151,7 +3151,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Starmie
@@ -3168,7 +3168,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Machop
@@ -3181,7 +3181,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Machop
@@ -3198,7 +3198,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Hariyama
@@ -3211,7 +3211,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Machop
@@ -3228,7 +3228,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Machop
@@ -3241,7 +3241,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Machoke
@@ -3254,7 +3254,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Machop
@@ -3271,7 +3271,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Machop
@@ -3292,7 +3292,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Machop
@@ -3317,7 +3317,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Makuhita
@@ -3334,7 +3334,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Machop
@@ -3347,7 +3347,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Hariyama
@@ -3360,7 +3360,7 @@ Class: Guitarist
 Pic: Guitarist
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Electrike
@@ -3384,7 +3384,7 @@ Class: Team Aqua
 Pic: Aqua Grunt F
 Gender: Female
 Music: Aqua
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Poochyena
@@ -3401,7 +3401,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Carvanha
@@ -3414,7 +3414,7 @@ Class: Guitarist
 Pic: Guitarist
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Voltorb
@@ -3431,7 +3431,7 @@ Class: Guitarist
 Pic: Guitarist
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Electrike
@@ -3448,7 +3448,7 @@ Class: Guitarist
 Pic: Guitarist
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Magnemite
@@ -3465,7 +3465,7 @@ Class: Guitarist
 Pic: Guitarist
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Magnemite
@@ -3486,7 +3486,7 @@ Class: Guitarist
 Pic: Guitarist
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Magnemite
@@ -3507,7 +3507,7 @@ Class: Guitarist
 Pic: Guitarist
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Magneton
@@ -3528,7 +3528,7 @@ Class: Guitarist
 Pic: Guitarist
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Magneton
@@ -3549,7 +3549,7 @@ Class: Kindler
 Pic: Kindler
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Numel
@@ -3562,7 +3562,7 @@ Class: Kindler
 Pic: Kindler
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Slugma
@@ -3579,7 +3579,7 @@ Class: Kindler
 Pic: Kindler
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Numel
@@ -3592,7 +3592,7 @@ Class: Kindler
 Pic: Kindler
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Slugma
@@ -3605,7 +3605,7 @@ Class: Kindler
 Pic: Kindler
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Slugma
@@ -3618,7 +3618,7 @@ Class: Kindler
 Pic: Kindler
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Slugma
@@ -3635,7 +3635,7 @@ Class: Kindler
 Pic: Kindler
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Slugma
@@ -3652,7 +3652,7 @@ Class: Kindler
 Pic: Kindler
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Slugma
@@ -3669,7 +3669,7 @@ Class: Kindler
 Pic: Kindler
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Slugma
@@ -3686,7 +3686,7 @@ Class: Kindler
 Pic: Kindler
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Magcargo
@@ -3703,7 +3703,7 @@ Class: Camper
 Pic: Camper
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Sandshrew
@@ -3720,7 +3720,7 @@ Class: Camper
 Pic: Camper
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Baltoy
@@ -3753,7 +3753,7 @@ Class: Camper
 Pic: Camper
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Nuzleaf
@@ -3766,7 +3766,7 @@ Class: Camper
 Pic: Camper
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Sandshrew
@@ -3783,7 +3783,7 @@ Class: Camper
 Pic: Camper
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Kecleon
@@ -3796,7 +3796,7 @@ Class: Camper
 Pic: Camper
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zigzagoon
@@ -3813,7 +3813,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Shroomish
@@ -3826,7 +3826,7 @@ Class: Camper
 Pic: Camper
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Sandshrew
@@ -3839,7 +3839,7 @@ Class: Camper
 Pic: Camper
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zigzagoon
@@ -3856,7 +3856,7 @@ Class: Camper
 Pic: Camper
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Linoone
@@ -3873,7 +3873,7 @@ Class: Camper
 Pic: Camper
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Sandshrew
@@ -3894,7 +3894,7 @@ Class: Camper
 Pic: Camper
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Swellow
@@ -3915,7 +3915,7 @@ Class: Bug Maniac
 Pic: Bug Maniac
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Surskit
@@ -3928,7 +3928,7 @@ Class: Bug Maniac
 Pic: Bug Maniac
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wurmple
@@ -3949,7 +3949,7 @@ Class: Bug Maniac
 Pic: Bug Maniac
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wurmple
@@ -3970,7 +3970,7 @@ Class: Bug Maniac
 Pic: Bug Maniac
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Surskit
@@ -3991,7 +3991,7 @@ Class: Bug Maniac
 Pic: Bug Maniac
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Dustox
@@ -4008,7 +4008,7 @@ Class: Bug Maniac
 Pic: Bug Maniac
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Surskit
@@ -4029,7 +4029,7 @@ Class: Bug Maniac
 Pic: Bug Maniac
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Surskit
@@ -4050,7 +4050,7 @@ Class: Bug Maniac
 Pic: Bug Maniac
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Surskit
@@ -4075,7 +4075,7 @@ Class: Bug Maniac
 Pic: Bug Maniac
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Surskit
@@ -4104,7 +4104,7 @@ Class: Psychic
 Pic: Psychic M
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Abra
@@ -4118,7 +4118,7 @@ Class: Psychic
 Pic: Psychic M
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Kirlia
@@ -4131,7 +4131,7 @@ Class: Psychic
 Pic: Psychic M
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Ralts
@@ -4144,7 +4144,7 @@ Class: Psychic
 Pic: Psychic M
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Girafarig
@@ -4157,7 +4157,7 @@ Class: Psychic
 Pic: Psychic M
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Ralts
@@ -4178,7 +4178,7 @@ Class: Psychic
 Pic: Psychic M
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Kadabra
@@ -4195,7 +4195,7 @@ Class: Psychic
 Pic: Psychic M
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Solrock
@@ -4208,7 +4208,7 @@ Class: Psychic
 Pic: Psychic M
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Kadabra
@@ -4225,7 +4225,7 @@ Class: Psychic
 Pic: Psychic M
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Kadabra
@@ -4242,7 +4242,7 @@ Class: Psychic
 Pic: Psychic M
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Kadabra
@@ -4259,7 +4259,7 @@ Class: Psychic
 Pic: Psychic M
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Solrock
@@ -4276,7 +4276,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Abra
@@ -4290,7 +4290,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Kirlia
@@ -4303,7 +4303,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Xatu
@@ -4316,7 +4316,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Kadabra
@@ -4329,7 +4329,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wobbuffet
@@ -4350,7 +4350,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Kirlia
@@ -4367,7 +4367,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Kadabra
@@ -4384,7 +4384,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Kadabra
@@ -4401,7 +4401,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Kadabra
@@ -4418,7 +4418,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Kadabra
@@ -4435,7 +4435,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Lunatone
@@ -4452,7 +4452,7 @@ Class: Gentleman
 Pic: Gentleman
 Gender: Male
 Music: Rich
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Manectric
@@ -4465,7 +4465,7 @@ Class: Gentleman
 Pic: Gentleman
 Gender: Male
 Music: Rich
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Manectric
@@ -4482,7 +4482,7 @@ Class: Gentleman
 Pic: Gentleman
 Gender: Male
 Music: Rich
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zangoose
@@ -4495,7 +4495,7 @@ Class: Gentleman
 Pic: Gentleman
 Gender: Male
 Music: Rich
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Manectric
@@ -4508,7 +4508,7 @@ Class: Gentleman
 Pic: Gentleman
 Gender: Male
 Music: Rich
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Linoone
@@ -4533,7 +4533,7 @@ Class: Gentleman
 Pic: Gentleman
 Gender: Male
 Music: Rich
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Linoone
@@ -4557,7 +4557,7 @@ Class: Gentleman
 Pic: Gentleman
 Gender: Male
 Music: Rich
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Linoone
@@ -4591,7 +4591,7 @@ Pic: Elite Four Sidney
 Gender: Male
 Music: Elite Four
 Items: Full Restore / Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer / Force Setup First Turn
 Mugshot: Purple
 
@@ -4642,7 +4642,7 @@ Pic: Elite Four Phoebe
 Gender: Female
 Music: Elite Four
 Items: Full Restore / Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 Mugshot: Green
 
@@ -4693,7 +4693,7 @@ Pic: Elite Four Glacia
 Gender: Female
 Music: Elite Four
 Items: Full Restore / Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 Mugshot: Pink
 
@@ -4744,7 +4744,7 @@ Pic: Elite Four Drake
 Gender: Male
 Music: Elite Four
 Items: Full Restore / Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 Mugshot: Blue
 
@@ -4795,7 +4795,7 @@ Pic: Leader Roxanne
 Gender: Female
 Music: Female
 Items: Potion / Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Geodude
@@ -4829,7 +4829,7 @@ Pic: Leader Brawly
 Gender: Male
 Music: Male
 Items: Super Potion / Super Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Machop
@@ -4863,7 +4863,7 @@ Pic: Leader Wattson
 Gender: Male
 Music: Male
 Items: Super Potion / Super Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Voltorb
@@ -4905,7 +4905,7 @@ Pic: Leader Flannery
 Gender: Female
 Music: Female
 Items: Hyper Potion / Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Numel
@@ -4947,7 +4947,7 @@ Pic: Leader Norman
 Gender: Male
 Music: Male
 Items: Hyper Potion / Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Spinda
@@ -4989,7 +4989,7 @@ Pic: Leader Winona
 Gender: Female
 Music: Female
 Items: Hyper Potion / Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer / Risky
 
 Swablu
@@ -5039,7 +5039,7 @@ Pic: Leader Tate And Liza
 Gender: Male
 Music: Female
 Items: Hyper Potion / Hyper Potion / Hyper Potion / Hyper Potion
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Claydol
@@ -5081,7 +5081,7 @@ Pic: Leader Juan
 Gender: Male
 Music: Male
 Items: Hyper Potion / Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Luvdisc
@@ -5130,7 +5130,7 @@ Class: School Kid
 Pic: School Kid M
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Ralts
@@ -5143,7 +5143,7 @@ Class: School Kid
 Pic: School Kid M
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Ralts
@@ -5156,7 +5156,7 @@ Class: School Kid
 Pic: School Kid M
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Numel
@@ -5177,7 +5177,7 @@ Class: School Kid
 Pic: School Kid M
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Ralts
@@ -5194,7 +5194,7 @@ Class: School Kid
 Pic: School Kid M
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Kirlia
@@ -5211,7 +5211,7 @@ Class: School Kid
 Pic: School Kid M
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Kirlia
@@ -5228,7 +5228,7 @@ Class: School Kid
 Pic: School Kid M
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Kirlia
@@ -5249,7 +5249,7 @@ Class: School Kid
 Pic: School Kid F
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Shroomish
@@ -5262,7 +5262,7 @@ Class: School Kid
 Pic: School Kid F
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Shroomish
@@ -5279,7 +5279,7 @@ Class: School Kid
 Pic: School Kid F
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Shroomish
@@ -5296,7 +5296,7 @@ Class: School Kid
 Pic: School Kid F
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Shroomish
@@ -5313,7 +5313,7 @@ Class: School Kid
 Pic: School Kid F
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Breloom
@@ -5330,7 +5330,7 @@ Class: School Kid
 Pic: School Kid F
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Breloom
@@ -5347,7 +5347,7 @@ Class: Sr And Jr
 Pic: Sr And Jr
 Gender: Male
 Music: Twins
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Spinda
@@ -5372,7 +5372,7 @@ Class: Sr And Jr
 Pic: Sr And Jr
 Gender: Male
 Music: Twins
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Zigzagoon
@@ -5396,7 +5396,7 @@ Class: Sr And Jr
 Pic: Sr And Jr
 Gender: Male
 Music: Twins
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Zigzagoon
@@ -5420,7 +5420,7 @@ Class: Sr And Jr
 Pic: Sr And Jr
 Gender: Male
 Music: Twins
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Zigzagoon
@@ -5444,7 +5444,7 @@ Class: Sr And Jr
 Pic: Sr And Jr
 Gender: Male
 Music: Twins
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Linoone
@@ -5468,7 +5468,7 @@ Class: Sr And Jr
 Pic: Sr And Jr
 Gender: Male
 Music: Twins
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Linoone
@@ -5492,7 +5492,7 @@ Class: Winstrate
 Pic: Pokefan M
 Gender: Male
 Music: Twins
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Taillow @ Oran Berry
@@ -5509,7 +5509,7 @@ Class: Pokefan
 Pic: Pokefan M
 Gender: Male
 Music: Twins
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Skitty @ Oran Berry
@@ -5522,7 +5522,7 @@ Class: Pokefan
 Pic: Pokefan M
 Gender: Male
 Music: Twins
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Skitty @ Oran Berry
@@ -5579,7 +5579,7 @@ Class: Pokefan
 Pic: Pokefan M
 Gender: Male
 Music: Twins
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Skitty @ Oran Berry
@@ -5592,7 +5592,7 @@ Class: Pokefan
 Pic: Pokefan M
 Gender: Male
 Music: Twins
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Skitty @ Oran Berry
@@ -5605,7 +5605,7 @@ Class: Pokefan
 Pic: Pokefan M
 Gender: Male
 Music: Twins
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Delcatty @ Oran Berry
@@ -5618,7 +5618,7 @@ Class: Pokefan
 Pic: Pokefan M
 Gender: Male
 Music: Twins
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Delcatty @ Sitrus Berry
@@ -5631,7 +5631,7 @@ Class: Winstrate
 Pic: Pokefan F
 Gender: Female
 Music: Twins
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move / Try To Faint
 
 Roselia @ Oran Berry
@@ -5644,7 +5644,7 @@ Class: Pokefan
 Pic: Pokefan F
 Gender: Female
 Music: Twins
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Pikachu @ Oran Berry
@@ -5657,7 +5657,7 @@ Class: Pokefan
 Pic: Pokefan F
 Gender: Female
 Music: Twins
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Azurill @ Oran Berry
@@ -5678,7 +5678,7 @@ Class: Pokefan
 Pic: Pokefan F
 Gender: Female
 Music: Twins
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Plusle @ Oran Berry
@@ -5695,7 +5695,7 @@ Class: Pokefan
 Pic: Pokefan F
 Gender: Female
 Music: Twins
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Plusle @ Oran Berry
@@ -5712,7 +5712,7 @@ Class: Pokefan
 Pic: Pokefan F
 Gender: Female
 Music: Twins
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Plusle @ Oran Berry
@@ -5729,7 +5729,7 @@ Class: Pokefan
 Pic: Pokefan F
 Gender: Female
 Music: Twins
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Plusle @ Oran Berry
@@ -5746,7 +5746,7 @@ Class: Pokefan
 Pic: Pokefan F
 Gender: Female
 Music: Twins
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Plusle @ Sitrus Berry
@@ -5763,7 +5763,7 @@ Class: Expert
 Pic: Expert M
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Hariyama
@@ -5776,7 +5776,7 @@ Class: Expert
 Pic: Expert M
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Hariyama
@@ -5793,7 +5793,7 @@ Class: Expert
 Pic: Expert M
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Hariyama
@@ -5810,7 +5810,7 @@ Class: Expert
 Pic: Expert M
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Hariyama
@@ -5827,7 +5827,7 @@ Class: Expert
 Pic: Expert M
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Hariyama
@@ -5844,7 +5844,7 @@ Class: Winstrate
 Pic: Expert F
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Meditite
@@ -5861,7 +5861,7 @@ Class: Expert
 Pic: Expert F
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Meditite
@@ -5878,7 +5878,7 @@ Class: Expert
 Pic: Expert F
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Meditite
@@ -5895,7 +5895,7 @@ Class: Expert
 Pic: Expert F
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Medicham
@@ -5912,7 +5912,7 @@ Class: Expert
 Pic: Expert F
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Medicham
@@ -5929,7 +5929,7 @@ Class: Expert
 Pic: Expert F
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Medicham
@@ -5946,7 +5946,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Poochyena
@@ -5959,7 +5959,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zigzagoon
@@ -5976,7 +5976,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Geodude
@@ -5990,7 +5990,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Geodude
@@ -6007,7 +6007,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Machop
@@ -6020,7 +6020,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zigzagoon
@@ -6046,7 +6046,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Slaking
@@ -6072,7 +6072,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Gardevoir
@@ -6097,7 +6097,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Trapinch
@@ -6110,7 +6110,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Aron
@@ -6123,7 +6123,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Mightyena
@@ -6136,7 +6136,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Swellow
@@ -6153,7 +6153,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Swellow
@@ -6174,7 +6174,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Swellow
@@ -6195,7 +6195,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zigzagoon
@@ -6212,7 +6212,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zigzagoon
@@ -6229,7 +6229,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Aron
@@ -6247,7 +6247,7 @@ Pic: Champion Wallace
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore / Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 Mugshot: Yellow
 
@@ -6305,7 +6305,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Magikarp
@@ -6326,7 +6326,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Magikarp
@@ -6347,7 +6347,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Magikarp
@@ -6368,7 +6368,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Magikarp
@@ -6389,7 +6389,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Tentacool
@@ -6402,7 +6402,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Tentacool
@@ -6427,7 +6427,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Barboach
@@ -6440,7 +6440,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Tentacool
@@ -6457,7 +6457,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Tentacool
@@ -6470,7 +6470,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wailmer
@@ -6487,7 +6487,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Tentacool
@@ -6508,7 +6508,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Gyarados
@@ -6533,7 +6533,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Gyarados
@@ -6558,7 +6558,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move / Try To Faint
 
 Gyarados
@@ -6583,7 +6583,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Magikarp
@@ -6616,7 +6616,7 @@ Class: Triathlete
 Pic: Cycling Triathlete M
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Voltorb
@@ -6637,7 +6637,7 @@ Class: Triathlete
 Pic: Cycling Triathlete M
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Magnemite
@@ -6654,7 +6654,7 @@ Class: Triathlete
 Pic: Cycling Triathlete M
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Magnemite
@@ -6667,7 +6667,7 @@ Class: Triathlete
 Pic: Cycling Triathlete M
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Magnemite
@@ -6680,7 +6680,7 @@ Class: Triathlete
 Pic: Cycling Triathlete M
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Magnemite
@@ -6693,7 +6693,7 @@ Class: Triathlete
 Pic: Cycling Triathlete M
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Magneton
@@ -6706,7 +6706,7 @@ Class: Triathlete
 Pic: Cycling Triathlete M
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Magneton
@@ -6719,7 +6719,7 @@ Class: Triathlete
 Pic: Cycling Triathlete F
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Magnemite
@@ -6732,7 +6732,7 @@ Class: Triathlete
 Pic: Cycling Triathlete F
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Magnemite
@@ -6753,7 +6753,7 @@ Class: Triathlete
 Pic: Cycling Triathlete F
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Magnemite
@@ -6766,7 +6766,7 @@ Class: Triathlete
 Pic: Cycling Triathlete F
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Magnemite
@@ -6779,7 +6779,7 @@ Class: Triathlete
 Pic: Cycling Triathlete F
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Magneton
@@ -6792,7 +6792,7 @@ Class: Triathlete
 Pic: Cycling Triathlete F
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Magneton
@@ -6805,7 +6805,7 @@ Class: Triathlete
 Pic: Running Triathlete M
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Doduo
@@ -6818,7 +6818,7 @@ Class: Triathlete
 Pic: Running Triathlete M
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Doduo
@@ -6831,7 +6831,7 @@ Class: Triathlete
 Pic: Running Triathlete M
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Doduo
@@ -6844,7 +6844,7 @@ Class: Triathlete
 Pic: Running Triathlete M
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Dodrio
@@ -6857,7 +6857,7 @@ Class: Triathlete
 Pic: Running Triathlete M
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Dodrio
@@ -6870,7 +6870,7 @@ Class: Triathlete
 Pic: Running Triathlete F
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Doduo
@@ -6883,7 +6883,7 @@ Class: Triathlete
 Pic: Running Triathlete F
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Doduo
@@ -6896,7 +6896,7 @@ Class: Triathlete
 Pic: Running Triathlete F
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Doduo
@@ -6909,7 +6909,7 @@ Class: Triathlete
 Pic: Running Triathlete F
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Dodrio
@@ -6922,7 +6922,7 @@ Class: Triathlete
 Pic: Running Triathlete F
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Dodrio
@@ -6935,7 +6935,7 @@ Class: Triathlete
 Pic: Swimming Triathlete M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Staryu
@@ -6952,7 +6952,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zigzagoon
@@ -6969,7 +6969,7 @@ Class: Triathlete
 Pic: Swimming Triathlete M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Staryu
@@ -6982,7 +6982,7 @@ Class: Triathlete
 Pic: Swimming Triathlete M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Staryu
@@ -6999,7 +6999,7 @@ Class: Triathlete
 Pic: Swimming Triathlete M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wingull
@@ -7016,7 +7016,7 @@ Class: Triathlete
 Pic: Swimming Triathlete M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Staryu
@@ -7029,7 +7029,7 @@ Class: Triathlete
 Pic: Swimming Triathlete M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Staryu
@@ -7042,7 +7042,7 @@ Class: Triathlete
 Pic: Swimming Triathlete M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Starmie
@@ -7055,7 +7055,7 @@ Class: Triathlete
 Pic: Swimming Triathlete M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Starmie
@@ -7068,7 +7068,7 @@ Class: Triathlete
 Pic: Swimming Triathlete F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Staryu
@@ -7081,7 +7081,7 @@ Class: Triathlete
 Pic: Swimming Triathlete F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wingull
@@ -7098,7 +7098,7 @@ Class: Triathlete
 Pic: Swimming Triathlete F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Staryu
@@ -7111,7 +7111,7 @@ Class: Triathlete
 Pic: Swimming Triathlete F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Staryu
@@ -7124,7 +7124,7 @@ Class: Triathlete
 Pic: Swimming Triathlete F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wingull
@@ -7141,7 +7141,7 @@ Class: Triathlete
 Pic: Swimming Triathlete F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Staryu
@@ -7154,7 +7154,7 @@ Class: Triathlete
 Pic: Swimming Triathlete F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Staryu
@@ -7167,7 +7167,7 @@ Class: Triathlete
 Pic: Swimming Triathlete F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Starmie
@@ -7180,7 +7180,7 @@ Class: Triathlete
 Pic: Swimming Triathlete F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Starmie
@@ -7193,7 +7193,7 @@ Class: Dragon Tamer
 Pic: Dragon Tamer
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Altaria
@@ -7210,7 +7210,7 @@ Class: Dragon Tamer
 Pic: Dragon Tamer
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Altaria
@@ -7227,7 +7227,7 @@ Class: Dragon Tamer
 Pic: Dragon Tamer
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Altaria
@@ -7244,7 +7244,7 @@ Class: Dragon Tamer
 Pic: Dragon Tamer
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Bagon
@@ -7265,7 +7265,7 @@ Class: Dragon Tamer
 Pic: Dragon Tamer
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Altaria
@@ -7286,7 +7286,7 @@ Class: Dragon Tamer
 Pic: Dragon Tamer
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Bagon
@@ -7303,7 +7303,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wingull
@@ -7316,7 +7316,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wingull
@@ -7333,7 +7333,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Swellow
@@ -7346,7 +7346,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Doduo
@@ -7367,7 +7367,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Skarmory
@@ -7380,7 +7380,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Tropius
@@ -7397,7 +7397,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Doduo
@@ -7414,7 +7414,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wingull
@@ -7431,7 +7431,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Swablu
@@ -7444,7 +7444,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Swellow
@@ -7465,7 +7465,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Taillow
@@ -7482,7 +7482,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Natu
@@ -7499,7 +7499,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Natu
@@ -7516,7 +7516,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Natu
@@ -7533,7 +7533,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Altaria
@@ -7550,7 +7550,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Natu
@@ -7567,7 +7567,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Tropius
@@ -7580,7 +7580,7 @@ Class: Ninja Boy
 Pic: Ninja Boy
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move / Try To Faint
 
 Ninjask
@@ -7593,7 +7593,7 @@ Class: Ninja Boy
 Pic: Ninja Boy
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move / Try To Faint
 
 Ninjask
@@ -7611,7 +7611,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 
 Claydol
 Level: 43
@@ -7631,7 +7631,7 @@ Class: Tuber F
 Pic: Tuber F
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 
 Marill
 Level: 26
@@ -7643,7 +7643,7 @@ Class: Ninja Boy
 Pic: Ninja Boy
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 
 Koffing
 Level: 17
@@ -7675,7 +7675,7 @@ Class: Ninja Boy
 Pic: Ninja Boy
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 
 Koffing
 Level: 18
@@ -7691,7 +7691,7 @@ Class: Ninja Boy
 Pic: Ninja Boy
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 
 Koffing
 Level: 24
@@ -7728,7 +7728,7 @@ Class: Ninja Boy
 Pic: Ninja Boy
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 
 Koffing
 Level: 27
@@ -7765,7 +7765,7 @@ Class: Ninja Boy
 Pic: Ninja Boy
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 
 Koffing
 Level: 30
@@ -7800,7 +7800,7 @@ Class: Ninja Boy
 Pic: Ninja Boy
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 
 Koffing
 Level: 33
@@ -7837,7 +7837,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Meditite
@@ -7850,7 +7850,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Meditite
@@ -7863,7 +7863,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Meditite
@@ -7880,7 +7880,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Meditite
@@ -7893,7 +7893,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Breloom
@@ -7906,7 +7906,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Meditite
@@ -7923,7 +7923,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Meditite
@@ -7940,7 +7940,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Medicham
@@ -7957,7 +7957,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Medicham
@@ -7974,7 +7974,7 @@ Class: Parasol Lady
 Pic: Parasol Lady
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Numel
@@ -7991,7 +7991,7 @@ Class: Parasol Lady
 Pic: Parasol Lady
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Roselia
@@ -8008,7 +8008,7 @@ Class: Parasol Lady
 Pic: Parasol Lady
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Castform
@@ -8025,7 +8025,7 @@ Class: Parasol Lady
 Pic: Parasol Lady
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Numel
@@ -8042,7 +8042,7 @@ Class: Parasol Lady
 Pic: Parasol Lady
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Numel
@@ -8059,7 +8059,7 @@ Class: Parasol Lady
 Pic: Parasol Lady
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Roselia
@@ -8084,7 +8084,7 @@ Class: Parasol Lady
 Pic: Parasol Lady
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Roselia
@@ -8109,7 +8109,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wingull
@@ -8126,7 +8126,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Marill
@@ -8139,7 +8139,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wailmer
@@ -8152,7 +8152,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wingull
@@ -8169,7 +8169,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Goldeen
@@ -8182,7 +8182,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Horsea
@@ -8199,7 +8199,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Goldeen
@@ -8212,7 +8212,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Goldeen
@@ -8233,7 +8233,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wailmer
@@ -8246,7 +8246,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Marill
@@ -8259,7 +8259,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Luvdisc
@@ -8272,7 +8272,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Seaking
@@ -8285,7 +8285,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Marill
@@ -8302,7 +8302,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Goldeen
@@ -8315,7 +8315,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Goldeen
@@ -8332,7 +8332,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Luvdisc
@@ -8345,7 +8345,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Seaking
@@ -8358,7 +8358,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Azumarill
@@ -8371,7 +8371,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Luvdisc
@@ -8388,7 +8388,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Seaking
@@ -8401,7 +8401,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Horsea
@@ -8418,7 +8418,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Lanturn
@@ -8435,7 +8435,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Luvdisc
@@ -8452,7 +8452,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Seaking
@@ -8465,7 +8465,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wailmer
@@ -8478,7 +8478,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wailmer
@@ -8491,7 +8491,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Staryu
@@ -8508,7 +8508,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Luvdisc
@@ -8529,7 +8529,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Sandshrew
@@ -8554,7 +8554,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Sandshrew
@@ -8579,7 +8579,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Taillow
@@ -8596,7 +8596,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Marill
@@ -8613,7 +8613,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Skitty
@@ -8630,7 +8630,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Shroomish
@@ -8651,7 +8651,7 @@ Class: Psychic
 Pic: Psychic M
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wobbuffet
@@ -8668,7 +8668,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Shroomish
@@ -8685,7 +8685,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Shroomish
@@ -8706,7 +8706,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Breloom
@@ -8727,7 +8727,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Breloom
@@ -8748,7 +8748,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Breloom
@@ -8769,7 +8769,7 @@ Class: Twins
 Pic: Twins
 Gender: Male
 Music: Twins
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Plusle
@@ -8786,7 +8786,7 @@ Class: Twins
 Pic: Twins
 Gender: Male
 Music: Twins
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Plusle
@@ -8803,7 +8803,7 @@ Class: Twins
 Pic: Twins
 Gender: Male
 Music: Twins
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Seedot
@@ -8820,7 +8820,7 @@ Class: Twins
 Pic: Twins
 Gender: Male
 Music: Twins
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Beautifly
@@ -8837,7 +8837,7 @@ Class: Twins
 Pic: Twins
 Gender: Male
 Music: Twins
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Plusle
@@ -8854,7 +8854,7 @@ Class: Twins
 Pic: Twins
 Gender: Male
 Music: Twins
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Duskull
@@ -8875,7 +8875,7 @@ Class: Twins
 Pic: Twins
 Gender: Male
 Music: Twins
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Plusle
@@ -8892,7 +8892,7 @@ Class: Twins
 Pic: Twins
 Gender: Male
 Music: Twins
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Plusle
@@ -8917,7 +8917,7 @@ Class: Twins
 Pic: Twins
 Gender: Male
 Music: Twins
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Plusle
@@ -8942,7 +8942,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wingull
@@ -8959,7 +8959,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wingull
@@ -8972,7 +8972,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wingull
@@ -8989,7 +8989,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wingull
@@ -9010,7 +9010,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Tentacruel
@@ -9027,7 +9027,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Machop
@@ -9048,7 +9048,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Spheal
@@ -9065,7 +9065,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wingull
@@ -9086,7 +9086,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Pelipper
@@ -9107,7 +9107,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Pelipper
@@ -9128,7 +9128,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Pelipper
@@ -9149,7 +9149,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Numel
@@ -9162,7 +9162,7 @@ Class: Pokefan
 Pic: Pokefan F
 Gender: Female
 Music: Twins
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Feebas @ Oran Berry
@@ -9188,7 +9188,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Absol
@@ -9201,7 +9201,7 @@ Class: Ninja Boy
 Pic: Ninja Boy
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Koffing
@@ -9218,7 +9218,7 @@ Class: Parasol Lady
 Pic: Parasol Lady
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Castform
@@ -9235,7 +9235,7 @@ Class: Expert
 Pic: Expert M
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Manectric
@@ -9252,7 +9252,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Machoke
@@ -9270,7 +9270,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Manectric
@@ -9287,7 +9287,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Meditite
@@ -9304,7 +9304,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wailmer
@@ -9317,7 +9317,7 @@ Class: Expert
 Pic: Expert M
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Chinchou
@@ -9334,7 +9334,7 @@ Class: Collector
 Pic: Collector
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Lombre
@@ -9351,7 +9351,7 @@ Class: Collector
 Pic: Collector
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zangoose
@@ -9368,7 +9368,7 @@ Class: Magma Admin
 Pic: Magma Admin
 Gender: Male
 Music: Magma
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Camerupt
@@ -9389,7 +9389,7 @@ Class: Collector
 Pic: Collector
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Lombre
@@ -9406,7 +9406,7 @@ Class: Collector
 Pic: Collector
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Lombre
@@ -9423,7 +9423,7 @@ Class: Collector
 Pic: Collector
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Lombre
@@ -9440,7 +9440,7 @@ Class: Collector
 Pic: Collector
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Ludicolo
@@ -9458,7 +9458,7 @@ Pic: Wally
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Altaria
@@ -9507,7 +9507,7 @@ Class: Rival
 Pic: Brendan
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Treecko
@@ -9520,7 +9520,7 @@ Class: Rival
 Pic: Brendan
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Slugma
@@ -9541,7 +9541,7 @@ Class: Rival
 Pic: Brendan
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Slugma
@@ -9562,7 +9562,7 @@ Class: Rival
 Pic: Brendan
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move / Try To Faint / Force Setup First Turn
 
 Torchic
@@ -9575,7 +9575,7 @@ Class: Rival
 Pic: Brendan
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Wingull
@@ -9596,7 +9596,7 @@ Class: Rival
 Pic: Brendan
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Pelipper
@@ -9617,7 +9617,7 @@ Class: Rival
 Pic: Brendan
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Mudkip
@@ -9630,7 +9630,7 @@ Class: Rival
 Pic: Brendan
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Lombre
@@ -9651,7 +9651,7 @@ Class: Rival
 Pic: Brendan
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Lombre
@@ -9672,7 +9672,7 @@ Class: Rival
 Pic: May
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Treecko
@@ -9685,7 +9685,7 @@ Class: Rival
 Pic: May
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Wingull
@@ -9706,7 +9706,7 @@ Class: Rival
 Pic: May
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Slugma
@@ -9727,7 +9727,7 @@ Class: Rival
 Pic: May
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Torchic
@@ -9740,7 +9740,7 @@ Class: Rival
 Pic: May
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Wingull
@@ -9761,7 +9761,7 @@ Class: Rival
 Pic: May
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Pelipper
@@ -9782,7 +9782,7 @@ Class: Rival
 Pic: May
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Mudkip
@@ -9795,7 +9795,7 @@ Class: Rival
 Pic: May
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Lombre
@@ -9816,7 +9816,7 @@ Class: Rival
 Pic: May
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Lombre
@@ -9837,7 +9837,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder M
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Whismur
@@ -9870,7 +9870,7 @@ Class: Bug Catcher
 Pic: Bug Catcher
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Pinsir
@@ -9883,7 +9883,7 @@ Class: Cooltrainer
 Pic: Cooltrainer M
 Gender: Male
 Music: Cool
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Lunatone
@@ -9908,7 +9908,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder M
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Loudred
@@ -9941,7 +9941,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder M
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Loudred
@@ -9974,7 +9974,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder M
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Loudred
@@ -10007,7 +10007,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder M
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Loudred
@@ -10040,7 +10040,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder F
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wingull
@@ -10074,7 +10074,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Sableye
@@ -10091,7 +10091,7 @@ Class: Ruin Maniac
 Pic: Ruin Maniac
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Sandslash
@@ -10104,7 +10104,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder F
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wingull
@@ -10137,7 +10137,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder F
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Pelipper
@@ -10170,7 +10170,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder F
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Pelipper
@@ -10203,7 +10203,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder F
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Pelipper
@@ -10237,7 +10237,7 @@ Pic: Pokemon Ranger M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Breloom
@@ -10251,7 +10251,7 @@ Pic: Pokemon Ranger M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Seedot
@@ -10273,7 +10273,7 @@ Pic: Pokemon Ranger M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Cacturne
@@ -10287,7 +10287,7 @@ Pic: Pokemon Ranger M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move / Try To Faint / Force Setup First Turn
 
 Breloom
@@ -10301,7 +10301,7 @@ Pic: Pokemon Ranger M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Breloom
@@ -10315,7 +10315,7 @@ Pic: Pokemon Ranger M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move / Try To Faint / Force Setup First Turn
 
 Breloom
@@ -10329,7 +10329,7 @@ Pic: Pokemon Ranger M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Kecleon
@@ -10347,7 +10347,7 @@ Pic: Pokemon Ranger F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move / Try To Faint / Force Setup First Turn
 
 Gloom
@@ -10365,7 +10365,7 @@ Pic: Pokemon Ranger F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move / Try To Faint / Force Setup First Turn
 
 Lotad
@@ -10387,7 +10387,7 @@ Pic: Pokemon Ranger F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Swablu
@@ -10405,7 +10405,7 @@ Pic: Pokemon Ranger F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move / Try To Faint / Force Setup First Turn
 
 Gloom
@@ -10423,7 +10423,7 @@ Pic: Pokemon Ranger F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Gloom
@@ -10441,7 +10441,7 @@ Pic: Pokemon Ranger F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move / Try To Faint / Force Setup First Turn
 
 Gloom
@@ -10459,7 +10459,7 @@ Pic: Pokemon Ranger F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Bellossom
@@ -10476,7 +10476,7 @@ Class: Triathlete
 Pic: Cycling Triathlete M
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Magnemite
@@ -10489,7 +10489,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Mightyena
@@ -10506,7 +10506,7 @@ Class: Team Magma
 Pic: Aqua Grunt F
 Gender: Female
 Music: Aqua
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wailmer
@@ -10523,7 +10523,7 @@ Class: Team Aqua
 Pic: Aqua Grunt F
 Gender: Female
 Music: Aqua
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wailmer
@@ -10540,7 +10540,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Poochyena
@@ -10557,7 +10557,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Geodude
@@ -10574,7 +10574,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Machop
@@ -10587,7 +10587,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Meditite
@@ -10600,7 +10600,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Makuhita
@@ -10613,7 +10613,7 @@ Class: Hex Maniac
 Pic: Hex Maniac
 Gender: Female
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Meditite
@@ -10626,7 +10626,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Carvanha
@@ -10640,7 +10640,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Manectric
@@ -10662,7 +10662,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Tentacruel
@@ -10675,7 +10675,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zubat
@@ -10688,7 +10688,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Sharpedo
@@ -10701,7 +10701,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Girafarig
@@ -10714,7 +10714,7 @@ Class: Gentleman
 Pic: Gentleman
 Gender: Male
 Music: Rich
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Spoink
@@ -10727,7 +10727,7 @@ Class: Hex Maniac
 Pic: Hex Maniac
 Gender: Female
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Kadabra
@@ -10740,7 +10740,7 @@ Class: Gentleman
 Pic: Gentleman
 Gender: Male
 Music: Rich
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Girafarig
@@ -10753,7 +10753,7 @@ Class: Psychic
 Pic: Psychic M
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wobbuffet
@@ -10766,7 +10766,7 @@ Class: Team Magma
 Pic: Magma Grunt F
 Gender: Female
 Music: Magma
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zubat
@@ -10783,7 +10783,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Baltoy
@@ -10796,7 +10796,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zubat
@@ -10809,7 +10809,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Mightyena
@@ -10822,7 +10822,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Baltoy
@@ -10835,7 +10835,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Natu
@@ -10848,7 +10848,7 @@ Class: Rival
 Pic: Brendan
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Lotad
@@ -10865,7 +10865,7 @@ Class: Rival
 Pic: Brendan
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wingull
@@ -10882,7 +10882,7 @@ Class: Expert
 Pic: Expert M
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Swellow
@@ -10899,7 +10899,7 @@ Class: Triathlete
 Pic: Swimming Triathlete F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Staryu
@@ -10912,7 +10912,7 @@ Class: Team Aqua
 Pic: Aqua Grunt F
 Gender: Female
 Music: Aqua
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zubat
@@ -10929,7 +10929,7 @@ Class: Magma Admin
 Pic: Magma Admin
 Gender: Male
 Music: Magma
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Numel
@@ -10955,7 +10955,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move / Try To Faint / Force Setup First Turn
 
 Kecleon
@@ -10972,7 +10972,7 @@ Class: Rival
 Pic: Brendan
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Slugma
@@ -10989,7 +10989,7 @@ Class: Rival
 Pic: May
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move / Try To Faint / Force Setup First Turn
 
 Wingull
@@ -11007,7 +11007,7 @@ Pic: Magma Leader Maxie
 Gender: Male
 Music: Magma
 Items: Super Potion / Super Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Mightyena
@@ -11029,7 +11029,7 @@ Pic: Magma Leader Maxie
 Gender: Male
 Music: Magma
 Items: Super Potion / Super Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Mightyena
@@ -11050,7 +11050,7 @@ Class: Lass
 Pic: Lass
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zigzagoon
@@ -11067,7 +11067,7 @@ Class: Lass
 Pic: Lass
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Lotad
@@ -11084,7 +11084,7 @@ Class: Lass
 Pic: Lass
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Marill
@@ -11097,7 +11097,7 @@ Class: Winstrate
 Pic: Lass
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Marill
@@ -11118,7 +11118,7 @@ Class: Lass
 Pic: Lass
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Lombre
@@ -11135,7 +11135,7 @@ Class: Lass
 Pic: Lass
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Lombre
@@ -11152,7 +11152,7 @@ Class: Lass
 Pic: Lass
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Lombre
@@ -11169,7 +11169,7 @@ Class: Lass
 Pic: Lass
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Swellow
@@ -11190,7 +11190,7 @@ Class: Lass
 Pic: Lass
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Oddish
@@ -11203,7 +11203,7 @@ Class: Lass
 Pic: Lass
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Skitty
@@ -11224,7 +11224,7 @@ Class: Lass
 Pic: Lass
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Luvdisc
@@ -11237,7 +11237,7 @@ Class: Lass
 Pic: Lass
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Goldeen
@@ -11254,7 +11254,7 @@ Class: Bug Catcher
 Pic: Bug Catcher
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wurmple
@@ -11271,7 +11271,7 @@ Class: Bug Catcher
 Pic: Bug Catcher
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wurmple
@@ -11296,7 +11296,7 @@ Class: Bug Catcher
 Pic: Bug Catcher
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wurmple
@@ -11313,7 +11313,7 @@ Class: Bug Catcher
 Pic: Bug Catcher
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Nincada
@@ -11330,7 +11330,7 @@ Class: Bug Catcher
 Pic: Bug Catcher
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Volbeat
@@ -11347,7 +11347,7 @@ Class: Bug Catcher
 Pic: Bug Catcher
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Ninjask
@@ -11360,7 +11360,7 @@ Class: Bug Catcher
 Pic: Bug Catcher
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Nincada
@@ -11377,7 +11377,7 @@ Class: Bug Catcher
 Pic: Bug Catcher
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Ninjask
@@ -11390,7 +11390,7 @@ Class: Bug Catcher
 Pic: Bug Catcher
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Dustox
@@ -11407,7 +11407,7 @@ Class: Bug Catcher
 Pic: Bug Catcher
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Surskit
@@ -11428,7 +11428,7 @@ Class: Bug Catcher
 Pic: Bug Catcher
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Surskit
@@ -11453,7 +11453,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Numel
@@ -11470,7 +11470,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Geodude
@@ -11491,7 +11491,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Geodude
@@ -11508,7 +11508,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Geodude
@@ -11525,7 +11525,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Geodude
@@ -11546,7 +11546,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Geodude
@@ -11559,7 +11559,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Geodude
@@ -11576,7 +11576,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wailmer
@@ -11591,7 +11591,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Pelipper
@@ -11612,7 +11612,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Geodude
@@ -11633,7 +11633,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Geodude
@@ -11658,7 +11658,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Geodude
@@ -11683,7 +11683,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Geodude
@@ -11708,7 +11708,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Graveler
@@ -11733,7 +11733,7 @@ Class: Young Couple
 Pic: Young Couple
 Gender: Male
 Music: Girl
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Delcatty
@@ -11750,7 +11750,7 @@ Class: Young Couple
 Pic: Young Couple
 Gender: Male
 Music: Girl
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Luvdisc
@@ -11767,7 +11767,7 @@ Class: Young Couple
 Pic: Young Couple
 Gender: Male
 Music: Girl
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Volbeat
@@ -11784,7 +11784,7 @@ Class: Young Couple
 Pic: Young Couple
 Gender: Male
 Music: Girl
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Volbeat
@@ -11801,7 +11801,7 @@ Class: Young Couple
 Pic: Young Couple
 Gender: Male
 Music: Girl
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Volbeat
@@ -11818,7 +11818,7 @@ Class: Young Couple
 Pic: Young Couple
 Gender: Male
 Music: Girl
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Volbeat
@@ -11835,7 +11835,7 @@ Class: Young Couple
 Pic: Young Couple
 Gender: Male
 Music: Girl
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Volbeat
@@ -11852,7 +11852,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Goldeen
@@ -11866,7 +11866,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Kecleon
@@ -11883,7 +11883,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Meditite
@@ -11908,7 +11908,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Meditite
@@ -11925,7 +11925,7 @@ Class: Ninja Boy
 Pic: Ninja Boy
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move / Try To Faint
 
 Koffing
@@ -11950,7 +11950,7 @@ Class: Ninja Boy
 Pic: Ninja Boy
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move / Try To Faint
 
 Koffing
@@ -11975,7 +11975,7 @@ Class: Ninja Boy
 Pic: Ninja Boy
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move / Try To Faint
 
 Nincada
@@ -12000,7 +12000,7 @@ Class: Camper
 Pic: Camper
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Swellow
@@ -12017,7 +12017,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Swablu
@@ -12038,7 +12038,7 @@ Class: Rival
 Pic: Wally
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Ralts
@@ -12052,7 +12052,7 @@ Pic: Wally
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Altaria
@@ -12102,7 +12102,7 @@ Pic: Wally
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Altaria
@@ -12152,7 +12152,7 @@ Pic: Wally
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Altaria
@@ -12202,7 +12202,7 @@ Pic: Wally
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Altaria
@@ -12251,7 +12251,7 @@ Class: Rival
 Pic: Brendan
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Tropius
@@ -12276,7 +12276,7 @@ Class: Rival
 Pic: Brendan
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Tropius
@@ -12301,7 +12301,7 @@ Class: Rival
 Pic: Brendan
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Tropius
@@ -12326,7 +12326,7 @@ Class: Rival
 Pic: May
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Tropius
@@ -12351,7 +12351,7 @@ Class: Rival
 Pic: May
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Tropius
@@ -12376,7 +12376,7 @@ Class: Rival
 Pic: May
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Tropius
@@ -12401,7 +12401,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wailmer
@@ -12422,7 +12422,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Carvanha
@@ -12439,7 +12439,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Magikarp
@@ -12461,7 +12461,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Gloom
@@ -12479,7 +12479,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Shiftry
@@ -12496,7 +12496,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Machoke
@@ -12509,7 +12509,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Tentacool
@@ -12530,7 +12530,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Swellow
@@ -12547,7 +12547,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Spheal
@@ -12564,7 +12564,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Chinchou
@@ -12577,7 +12577,7 @@ Class: Twins
 Pic: Twins
 Gender: Male
 Music: Twins
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Spinda
@@ -12594,7 +12594,7 @@ Class: Sr And Jr
 Pic: Sr And Jr
 Gender: Male
 Music: Twins
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Swablu
@@ -12619,7 +12619,7 @@ Class: Sr And Jr
 Pic: Sr And Jr
 Gender: Male
 Music: Twins
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Roselia
@@ -12644,7 +12644,7 @@ Class: Young Couple
 Pic: Young Couple
 Gender: Male
 Music: Girl
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Dustox
@@ -12669,7 +12669,7 @@ Class: Old Couple
 Pic: Old Couple
 Gender: Male
 Music: Intense
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Medicham
@@ -12694,7 +12694,7 @@ Class: Old Couple
 Pic: Old Couple
 Gender: Male
 Music: Intense
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Medicham
@@ -12719,7 +12719,7 @@ Class: Old Couple
 Pic: Old Couple
 Gender: Male
 Music: Intense
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Medicham
@@ -12744,7 +12744,7 @@ Class: Old Couple
 Pic: Old Couple
 Gender: Male
 Music: Intense
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move / Try To Faint / Force Setup First Turn
 
 Medicham
@@ -12769,7 +12769,7 @@ Class: Old Couple
 Pic: Old Couple
 Gender: Male
 Music: Intense
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Medicham
@@ -12794,7 +12794,7 @@ Class: Sis And Bro
 Pic: Sis And Bro
 Gender: Male
 Music: Swimmer
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Azumarill
@@ -12811,7 +12811,7 @@ Class: Sis And Bro
 Pic: Sis And Bro
 Gender: Male
 Music: Swimmer
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Chinchou
@@ -12828,7 +12828,7 @@ Class: Sis And Bro
 Pic: Sis And Bro
 Gender: Male
 Music: Swimmer
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Chinchou
@@ -12845,7 +12845,7 @@ Class: Sis And Bro
 Pic: Sis And Bro
 Gender: Male
 Music: Swimmer
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Lanturn
@@ -12862,7 +12862,7 @@ Class: Sis And Bro
 Pic: Sis And Bro
 Gender: Male
 Music: Swimmer
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Lanturn
@@ -12879,7 +12879,7 @@ Class: Sis And Bro
 Pic: Sis And Bro
 Gender: Male
 Music: Swimmer
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Lanturn
@@ -12896,7 +12896,7 @@ Class: Sis And Bro
 Pic: Sis And Bro
 Gender: Male
 Music: Swimmer
-Double Battle: Yes
+Battle Type: Doubles
 AI: Check Bad Move
 
 Goldeen
@@ -12913,7 +12913,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Magikarp
@@ -12938,7 +12938,7 @@ Class: Rich Boy
 Pic: Rich Boy
 Gender: Male
 Music: Rich
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zigzagoon @ Nugget
@@ -12956,7 +12956,7 @@ Pic: Lady
 Gender: Female
 Music: Female
 Items: Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Lotad
@@ -12973,7 +12973,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Magikarp
@@ -12986,7 +12986,7 @@ Class: Tuber F
 Pic: Tuber F
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Marill
@@ -12999,7 +12999,7 @@ Class: Tuber M
 Pic: Tuber M
 Gender: Male
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Tentacool
@@ -13016,7 +13016,7 @@ Class: Pokefan
 Pic: Pokefan M
 Gender: Male
 Music: Twins
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Minun @ Oran Berry
@@ -13033,7 +13033,7 @@ Class: Guitarist
 Pic: Guitarist
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Electrike
@@ -13050,7 +13050,7 @@ Class: Triathlete
 Pic: Cycling Triathlete F
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Magnemite
@@ -13063,7 +13063,7 @@ Class: Guitarist
 Pic: Guitarist
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Voltorb
@@ -13076,7 +13076,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Makuhita
@@ -13089,7 +13089,7 @@ Class: Camper
 Pic: Camper
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Sandshrew
@@ -13102,7 +13102,7 @@ Class: Aroma Lady
 Pic: Aroma Lady
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Roselia
@@ -13115,7 +13115,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Shroomish
@@ -13128,7 +13128,7 @@ Class: Kindler
 Pic: Kindler
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Numel
@@ -13141,7 +13141,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Marill
@@ -13158,7 +13158,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Skarmory
@@ -13175,7 +13175,7 @@ Class: Camper
 Pic: Camper
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Baltoy
@@ -13192,7 +13192,7 @@ Class: Pokemaniac
 Pic: Pokemaniac
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Aron
@@ -13209,7 +13209,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Lombre
@@ -13226,7 +13226,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Barboach
@@ -13239,7 +13239,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Nuzleaf
@@ -13252,7 +13252,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zigzagoon
@@ -13273,7 +13273,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zubat
@@ -13286,7 +13286,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Poochyena
@@ -13299,7 +13299,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Numel
@@ -13312,7 +13312,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Baltoy
@@ -13329,7 +13329,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Baltoy
@@ -13346,7 +13346,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Mightyena
@@ -13359,7 +13359,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zubat
@@ -13372,7 +13372,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Poochyena
@@ -13385,7 +13385,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zubat
@@ -13398,7 +13398,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Mightyena
@@ -13411,7 +13411,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Baltoy
@@ -13424,7 +13424,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Numel
@@ -13437,7 +13437,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Zubat
@@ -13450,7 +13450,7 @@ Class: Team Magma
 Pic: Magma Grunt F
 Gender: Female
 Music: Magma
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Mightyena
@@ -13463,7 +13463,7 @@ Class: Team Magma
 Pic: Magma Grunt F
 Gender: Female
 Music: Magma
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Numel
@@ -13476,7 +13476,7 @@ Class: Team Magma
 Pic: Magma Grunt F
 Gender: Female
 Music: Magma
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Baltoy
@@ -13489,7 +13489,7 @@ Class: Magma Admin
 Pic: Magma Admin
 Gender: Male
 Music: Magma
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Numel
@@ -13515,7 +13515,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Pelipper
@@ -13532,7 +13532,7 @@ Class: Magma Leader
 Pic: Magma Leader Maxie
 Gender: Male
 Music: Magma
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Mightyena
@@ -13553,7 +13553,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Tentacool
@@ -13566,7 +13566,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Marill
@@ -13579,7 +13579,7 @@ Class: Ruin Maniac
 Pic: Ruin Maniac
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Sandshrew
@@ -13596,7 +13596,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Taillow
@@ -13613,7 +13613,7 @@ Class: Triathlete
 Pic: Swimming Triathlete M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Staryu
@@ -13626,7 +13626,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wingull
@@ -13648,7 +13648,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Manectric
@@ -13669,7 +13669,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Skarmory
@@ -13686,7 +13686,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Marill
@@ -13703,7 +13703,7 @@ Class: Ruin Maniac
 Pic: Ruin Maniac
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Sandshrew
@@ -13720,7 +13720,7 @@ Class: Camper
 Pic: Camper
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Taillow
@@ -13737,7 +13737,7 @@ Class: Kindler
 Pic: Kindler
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Numel
@@ -13754,7 +13754,7 @@ Class: Aroma Lady
 Pic: Aroma Lady
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Shroomish
@@ -13771,7 +13771,7 @@ Class: Triathlete
 Pic: Running Triathlete F
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Doduo
@@ -13788,7 +13788,7 @@ Class: Ninja Boy
 Pic: Ninja Boy
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Ninjask
@@ -13805,7 +13805,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Kadabra
@@ -13822,7 +13822,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Meditite
@@ -13839,7 +13839,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Meditite
@@ -13856,7 +13856,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Geodude
@@ -13873,7 +13873,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Shroomish
@@ -13890,7 +13890,7 @@ Class: Triathlete
 Pic: Running Triathlete F
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Doduo
@@ -13903,7 +13903,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Ralts
@@ -13916,7 +13916,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Meditite
@@ -13930,7 +13930,7 @@ Pic: Expert F
 Gender: Female
 Music: Intense
 Items: Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Roselia
@@ -13947,7 +13947,7 @@ Class: Guitarist
 Pic: Guitarist
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Manectric
@@ -13960,7 +13960,7 @@ Class: Kindler
 Pic: Kindler
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Slugma
@@ -13977,7 +13977,7 @@ Class: Parasol Lady
 Pic: Parasol Lady
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Goldeen
@@ -13991,7 +13991,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Manectric
@@ -14007,7 +14007,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Meditite
@@ -14024,7 +14024,7 @@ Class: Bug Maniac
 Pic: Bug Maniac
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Dustox
@@ -14041,7 +14041,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder M
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Makuhita
@@ -14074,7 +14074,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder F
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Poochyena
@@ -14108,7 +14108,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Loudred
@@ -14125,7 +14125,7 @@ Class: Rival
 Pic: May
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Lotad
@@ -14142,7 +14142,7 @@ Class: Rival
 Pic: May
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Torkoal
@@ -14160,7 +14160,7 @@ Pic: Leader Roxanne
 Gender: Female
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Golem
@@ -14202,7 +14202,7 @@ Pic: Leader Roxanne
 Gender: Female
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Omanyte
@@ -14252,7 +14252,7 @@ Pic: Leader Roxanne
 Gender: Female
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Omastar
@@ -14302,7 +14302,7 @@ Pic: Leader Roxanne
 Gender: Female
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Aerodactyl
@@ -14360,7 +14360,7 @@ Pic: Leader Brawly
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Machamp @ Sitrus Berry
@@ -14402,7 +14402,7 @@ Pic: Leader Brawly
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Machamp @ Sitrus Berry
@@ -14444,7 +14444,7 @@ Pic: Leader Brawly
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Hitmonchan
@@ -14494,7 +14494,7 @@ Pic: Leader Brawly
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Hitmonlee
@@ -14552,7 +14552,7 @@ Pic: Leader Wattson
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Mareep
@@ -14594,7 +14594,7 @@ Pic: Leader Wattson
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Pikachu
@@ -14644,7 +14644,7 @@ Pic: Leader Wattson
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Raichu
@@ -14694,7 +14694,7 @@ Pic: Leader Wattson
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Electabuzz
@@ -14752,7 +14752,7 @@ Pic: Leader Flannery
 Gender: Female
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Magcargo @ White Herb
@@ -14794,7 +14794,7 @@ Pic: Leader Flannery
 Gender: Female
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Growlithe
@@ -14844,7 +14844,7 @@ Pic: Leader Flannery
 Gender: Female
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Houndour
@@ -14902,7 +14902,7 @@ Pic: Leader Flannery
 Gender: Female
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Arcanine
@@ -14960,7 +14960,7 @@ Pic: Leader Norman
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Chansey
@@ -15002,7 +15002,7 @@ Pic: Leader Norman
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Slaking @ Sitrus Berry
@@ -15052,7 +15052,7 @@ Pic: Leader Norman
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Slaking @ Sitrus Berry
@@ -15102,7 +15102,7 @@ Pic: Leader Norman
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Slaking @ Sitrus Berry
@@ -15160,7 +15160,7 @@ Pic: Leader Winona
 Gender: Female
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer / Risky
 
 Dratini @ Sitrus Berry
@@ -15210,7 +15210,7 @@ Pic: Leader Winona
 Gender: Female
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer / Risky
 
 Hoothoot
@@ -15268,7 +15268,7 @@ Pic: Leader Winona
 Gender: Female
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer / Risky
 
 Noctowl
@@ -15326,7 +15326,7 @@ Pic: Leader Winona
 Gender: Female
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer / Risky
 
 Noctowl
@@ -15384,7 +15384,7 @@ Pic: Leader Tate And Liza
 Gender: Male
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Slowpoke
@@ -15434,7 +15434,7 @@ Pic: Leader Tate And Liza
 Gender: Male
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Drowzee
@@ -15492,7 +15492,7 @@ Pic: Leader Tate And Liza
 Gender: Male
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Hypno
@@ -15550,7 +15550,7 @@ Pic: Leader Tate And Liza
 Gender: Male
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Hypno
@@ -15608,7 +15608,7 @@ Pic: Leader Juan
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Poliwag
@@ -15658,7 +15658,7 @@ Pic: Leader Juan
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Poliwhirl
@@ -15708,7 +15708,7 @@ Pic: Leader Juan
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Lapras
@@ -15766,7 +15766,7 @@ Pic: Leader Juan
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Double Battle: Yes
+Battle Type: Doubles
 AI: Basic Trainer
 
 Lapras
@@ -15823,7 +15823,7 @@ Class: Bug Maniac
 Pic: Bug Maniac
 Gender: Male
 Music: Suspicious
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Illumise
@@ -15846,7 +15846,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Tropius
@@ -15860,7 +15860,7 @@ Pic: Steven
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore / Full Restore
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Skarmory
@@ -15917,7 +15917,7 @@ Class: Salon Maiden
 Pic: Salon Maiden Anabel
 Gender: Female
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Beldum
@@ -15930,7 +15930,7 @@ Class: Dome Ace
 Pic: Dome Ace Tucker
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Beldum
@@ -15943,7 +15943,7 @@ Class: Palace Maven
 Pic: Palace Maven Spenser
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Beldum
@@ -15956,7 +15956,7 @@ Class: Arena Tycoon
 Pic: Arena Tycoon Greta
 Gender: Female
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Beldum
@@ -15969,7 +15969,7 @@ Class: Factory Head
 Pic: Factory Head Noland
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Beldum
@@ -15982,7 +15982,7 @@ Class: Pike Queen
 Pic: Pike Queen Lucy
 Gender: Female
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Beldum
@@ -15995,7 +15995,7 @@ Class: Pyramid King
 Pic: Pyramid King Brandon
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Beldum
@@ -16008,7 +16008,7 @@ Class: Ruin Maniac
 Pic: Ruin Maniac
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Sandshrew
@@ -16025,7 +16025,7 @@ Class: Ruin Maniac
 Pic: Ruin Maniac
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Nosepass
@@ -16046,7 +16046,7 @@ Class: Ruin Maniac
 Pic: Ruin Maniac
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Nosepass
@@ -16067,7 +16067,7 @@ Class: Ruin Maniac
 Pic: Ruin Maniac
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Nosepass
@@ -16088,7 +16088,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wingull
@@ -16109,7 +16109,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Pelipper
@@ -16130,7 +16130,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Pelipper
@@ -16151,7 +16151,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Pelipper
@@ -16172,7 +16172,7 @@ Class: Triathlete
 Pic: Swimming Triathlete M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Staryu
@@ -16189,7 +16189,7 @@ Class: Triathlete
 Pic: Swimming Triathlete M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wingull
@@ -16210,7 +16210,7 @@ Class: Triathlete
 Pic: Swimming Triathlete M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Pelipper
@@ -16231,7 +16231,7 @@ Class: Triathlete
 Pic: Swimming Triathlete M
 Gender: Male
 Music: Swimmer
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Pelipper
@@ -16252,7 +16252,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Machoke
@@ -16269,7 +16269,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Makuhita
@@ -16290,7 +16290,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Hariyama
@@ -16311,7 +16311,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Hariyama
@@ -16333,7 +16333,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Loudred
@@ -16351,7 +16351,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Spinda
@@ -16373,7 +16373,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Spinda
@@ -16395,7 +16395,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Hyper Potion
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Spinda
@@ -16416,7 +16416,7 @@ Class: Guitarist
 Pic: Guitarist
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Electrike
@@ -16437,7 +16437,7 @@ Class: Guitarist
 Pic: Guitarist
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Electrike
@@ -16458,7 +16458,7 @@ Class: Guitarist
 Pic: Guitarist
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Manectric
@@ -16479,7 +16479,7 @@ Class: Guitarist
 Pic: Guitarist
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Manectric
@@ -16500,7 +16500,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Geodude
@@ -16517,7 +16517,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Machop
@@ -16538,7 +16538,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Machop
@@ -16559,7 +16559,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Double Battle: No
+Battle Type: Singles
 AI: Basic Trainer
 
 Machoke
@@ -16580,7 +16580,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder F
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Skitty
@@ -16613,7 +16613,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder F
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Skitty
@@ -16646,7 +16646,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder F
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Delcatty
@@ -16679,7 +16679,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder F
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Delcatty
@@ -16712,7 +16712,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Wailmer
@@ -16729,7 +16729,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Luvdisc
@@ -16750,7 +16750,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Luvdisc
@@ -16771,7 +16771,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Double Battle: No
+Battle Type: Singles
 AI: Check Bad Move
 
 Luvdisc
@@ -16792,7 +16792,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 
 Chimecho
 Level: 41
@@ -16804,7 +16804,7 @@ Class: Psychic
 Pic: Psychic M
 Gender: Male
 Music: Intense
-Double Battle: No
+Battle Type: Singles
 
 Banette
 Level: 41
@@ -16820,7 +16820,7 @@ Class: Gentleman
 Pic: Gentleman
 Gender: Male
 Music: Rich
-Double Battle: No
+Battle Type: Singles
 
 Wobbuffet
 Level: 41
@@ -16832,7 +16832,7 @@ Class: Rival
 Pic: Red
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 
 Charmander
 Level: 5
@@ -16844,7 +16844,7 @@ Class: Rival
 Pic: Leaf
 Gender: Female
 Music: Male
-Double Battle: No
+Battle Type: Singles
 
 Bulbasaur
 Level: 5
@@ -16856,7 +16856,7 @@ Class: RS Protag
 Pic: RS Brendan
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 
 Groudon
 Level: 5
@@ -16868,7 +16868,7 @@ Class: RS Protag
 Pic: RS May
 Gender: Female
 Music: Male
-Double Battle: No
+Battle Type: Singles
 
 Kyogre
 Level: 5

--- a/src/data/trainers.party
+++ b/src/data/trainers.party
@@ -79,7 +79,7 @@ Class: Pkmn Trainer 1
 Pic: Hiker
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 
 === TRAINER_SAWYER_1 ===
 Name: SAWYER
@@ -87,7 +87,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Geodude
@@ -100,7 +100,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Poochyena
@@ -113,7 +113,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zubat
@@ -130,7 +130,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zubat
@@ -143,7 +143,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Carvanha
@@ -156,7 +156,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Poochyena
@@ -169,7 +169,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Carvanha
@@ -182,7 +182,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zubat
@@ -195,7 +195,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder F
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Skitty
@@ -228,7 +228,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Poochyena
@@ -242,7 +242,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Manectric
@@ -259,7 +259,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Pelipper
@@ -276,7 +276,7 @@ Class: Collector
 Pic: Collector
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zangoose
@@ -293,7 +293,7 @@ Class: Team Aqua
 Pic: Aqua Grunt F
 Gender: Female
 Music: Aqua
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Carvanha
@@ -306,7 +306,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Gyarados
@@ -319,7 +319,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Poochyena
@@ -332,7 +332,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zubat
@@ -349,7 +349,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Poochyena
@@ -366,7 +366,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Poochyena
@@ -387,7 +387,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Carvanha
@@ -400,7 +400,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zubat
@@ -417,7 +417,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Numel
@@ -430,7 +430,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zubat
@@ -443,7 +443,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Carvanha
@@ -456,7 +456,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Poochyena
@@ -473,7 +473,7 @@ Class: Team Aqua
 Pic: Aqua Grunt F
 Gender: Female
 Music: Aqua
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Carvanha
@@ -486,7 +486,7 @@ Class: Team Aqua
 Pic: Aqua Grunt F
 Gender: Female
 Music: Aqua
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Carvanha
@@ -499,7 +499,7 @@ Class: Team Aqua
 Pic: Aqua Grunt F
 Gender: Female
 Music: Aqua
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zubat
@@ -512,7 +512,7 @@ Class: Expert
 Pic: Expert M
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Makuhita
@@ -530,7 +530,7 @@ Pic: Aqua Admin M
 Gender: Male
 Music: Aqua
 Items: Super Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Mightyena
@@ -547,7 +547,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Hariyama
@@ -560,7 +560,7 @@ Class: Aqua Admin
 Pic: Aqua Admin F
 Gender: Female
 Music: Aqua
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Carvanha
@@ -577,7 +577,7 @@ Class: Aqua Admin
 Pic: Aqua Admin F
 Gender: Female
 Music: Aqua
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Sharpedo
@@ -595,7 +595,7 @@ Pic: Aqua Leader Archie
 Gender: Male
 Music: Aqua
 Items: Super Potion / Super Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Mightyena
@@ -616,7 +616,7 @@ Class: Hex Maniac
 Pic: Hex Maniac
 Gender: Female
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Spoink
@@ -629,7 +629,7 @@ Class: Aroma Lady
 Pic: Aroma Lady
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Shroomish
@@ -646,7 +646,7 @@ Class: Aroma Lady
 Pic: Aroma Lady
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Roselia
@@ -668,7 +668,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Medicham
@@ -688,7 +688,7 @@ Class: Aroma Lady
 Pic: Aroma Lady
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Roselia
@@ -705,7 +705,7 @@ Class: Aroma Lady
 Pic: Aroma Lady
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Shroomish
@@ -722,7 +722,7 @@ Class: Aroma Lady
 Pic: Aroma Lady
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Shroomish
@@ -743,7 +743,7 @@ Class: Aroma Lady
 Pic: Aroma Lady
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Shroomish
@@ -764,7 +764,7 @@ Class: Aroma Lady
 Pic: Aroma Lady
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Breloom
@@ -785,7 +785,7 @@ Class: Ruin Maniac
 Pic: Ruin Maniac
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Sandslash
@@ -802,7 +802,7 @@ Class: Ruin Maniac
 Pic: Ruin Maniac
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Baltoy
@@ -835,7 +835,7 @@ Class: Ruin Maniac
 Pic: Ruin Maniac
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Sandshrew
@@ -860,7 +860,7 @@ Class: Ruin Maniac
 Pic: Ruin Maniac
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Sandslash
@@ -877,7 +877,7 @@ Class: Ruin Maniac
 Pic: Ruin Maniac
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Sandslash
@@ -894,7 +894,7 @@ Class: Ruin Maniac
 Pic: Ruin Maniac
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Sandslash
@@ -911,7 +911,7 @@ Class: Ruin Maniac
 Pic: Ruin Maniac
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Sandslash
@@ -928,7 +928,7 @@ Class: Interviewer
 Pic: Interviewer
 Gender: Male
 Music: Interviewer
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Magnemite
@@ -945,7 +945,7 @@ Class: Interviewer
 Pic: Interviewer
 Gender: Male
 Music: Interviewer
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Magnemite
@@ -962,7 +962,7 @@ Class: Interviewer
 Pic: Interviewer
 Gender: Male
 Music: Interviewer
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Magneton
@@ -979,7 +979,7 @@ Class: Interviewer
 Pic: Interviewer
 Gender: Male
 Music: Interviewer
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Magneton
@@ -996,7 +996,7 @@ Class: Interviewer
 Pic: Interviewer
 Gender: Male
 Music: Interviewer
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Magneton
@@ -1013,7 +1013,7 @@ Class: Interviewer
 Pic: Interviewer
 Gender: Male
 Music: Interviewer
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Magneton
@@ -1038,7 +1038,7 @@ Class: Tuber F
 Pic: Tuber F
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Azurill
@@ -1055,7 +1055,7 @@ Class: Tuber F
 Pic: Tuber F
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Marill
@@ -1068,7 +1068,7 @@ Class: Tuber F
 Pic: Tuber F
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Marill
@@ -1081,7 +1081,7 @@ Class: Tuber F
 Pic: Tuber F
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Marill
@@ -1098,7 +1098,7 @@ Class: Tuber F
 Pic: Tuber F
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Marill
@@ -1115,7 +1115,7 @@ Class: Tuber F
 Pic: Tuber F
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Marill
@@ -1132,7 +1132,7 @@ Class: Tuber F
 Pic: Tuber F
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Azumarill
@@ -1149,7 +1149,7 @@ Class: Tuber M
 Pic: Tuber M
 Gender: Male
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zigzagoon
@@ -1166,7 +1166,7 @@ Class: Tuber M
 Pic: Tuber M
 Gender: Male
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Azurill
@@ -1183,7 +1183,7 @@ Class: Tuber M
 Pic: Tuber M
 Gender: Male
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Marill
@@ -1196,7 +1196,7 @@ Class: Tuber M
 Pic: Tuber M
 Gender: Male
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Linoone
@@ -1213,7 +1213,7 @@ Class: Tuber M
 Pic: Tuber M
 Gender: Male
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Linoone
@@ -1230,7 +1230,7 @@ Class: Tuber M
 Pic: Tuber M
 Gender: Male
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Linoone
@@ -1247,7 +1247,7 @@ Class: Tuber M
 Pic: Tuber M
 Gender: Male
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Linoone
@@ -1265,7 +1265,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Swellow
@@ -1282,7 +1282,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Spinda
@@ -1299,7 +1299,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Slakoth @ Sitrus Berry
@@ -1316,7 +1316,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Vigoroth
@@ -1332,7 +1332,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Swellow
@@ -1382,7 +1382,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Sableye
@@ -1404,7 +1404,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Mawile
@@ -1422,7 +1422,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Super Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Electrike
@@ -1444,7 +1444,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Cacturne
@@ -1462,7 +1462,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Magneton
@@ -1480,7 +1480,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Swellow
@@ -1502,7 +1502,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Dodrio
@@ -1528,7 +1528,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Kecleon
@@ -1550,7 +1550,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Electrike
@@ -1572,7 +1572,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Manectric
@@ -1594,7 +1594,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Manectric
@@ -1616,7 +1616,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Manectric
@@ -1638,7 +1638,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Graveler
@@ -1656,7 +1656,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Delcatty
@@ -1672,7 +1672,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Wigglytuff
@@ -1689,7 +1689,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move / Try To Faint / Force Setup First Turn
 
 Zangoose
@@ -1705,7 +1705,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move / Try To Faint / Force Setup First Turn
 
 Mawile
@@ -1739,7 +1739,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move / Try To Faint / Force Setup First Turn
 
 Lairon
@@ -1757,7 +1757,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Super Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Wingull
@@ -1779,7 +1779,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Sableye
@@ -1793,7 +1793,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Roselia
@@ -1807,7 +1807,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Claydol
@@ -1821,7 +1821,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Torkoal
@@ -1843,7 +1843,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Skarmory
@@ -1861,7 +1861,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Sandslash
@@ -1883,7 +1883,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Wingull
@@ -1905,7 +1905,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Pelipper
@@ -1927,7 +1927,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Pelipper
@@ -1949,7 +1949,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Pelipper
@@ -1970,7 +1970,7 @@ Class: Hex Maniac
 Pic: Hex Maniac
 Gender: Female
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Banette
@@ -1987,7 +1987,7 @@ Class: Hex Maniac
 Pic: Hex Maniac
 Gender: Female
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Duskull
@@ -2004,7 +2004,7 @@ Class: Hex Maniac
 Pic: Hex Maniac
 Gender: Female
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Duskull
@@ -2021,7 +2021,7 @@ Class: Hex Maniac
 Pic: Hex Maniac
 Gender: Female
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Sableye
@@ -2034,7 +2034,7 @@ Class: Hex Maniac
 Pic: Hex Maniac
 Gender: Female
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Shuppet
@@ -2047,7 +2047,7 @@ Class: Hex Maniac
 Pic: Hex Maniac
 Gender: Female
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Sableye
@@ -2064,7 +2064,7 @@ Class: Hex Maniac
 Pic: Hex Maniac
 Gender: Female
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Spoink
@@ -2081,7 +2081,7 @@ Class: Hex Maniac
 Pic: Hex Maniac
 Gender: Female
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Spoink
@@ -2098,7 +2098,7 @@ Class: Hex Maniac
 Pic: Hex Maniac
 Gender: Female
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Duskull
@@ -2120,7 +2120,7 @@ Pic: Lady
 Gender: Female
 Music: Female
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zigzagoon @ Nugget
@@ -2134,7 +2134,7 @@ Pic: Lady
 Gender: Female
 Music: Female
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Luvdisc @ Nugget
@@ -2159,7 +2159,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Mightyena
@@ -2181,7 +2181,7 @@ Pic: Lady
 Gender: Female
 Music: Female
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zigzagoon @ Nugget
@@ -2197,7 +2197,7 @@ Pic: Lady
 Gender: Female
 Music: Female
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Seaking @ Nugget
@@ -2211,7 +2211,7 @@ Pic: Lady
 Gender: Female
 Music: Female
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Roselia @ Nugget
@@ -2225,7 +2225,7 @@ Pic: Lady
 Gender: Female
 Music: Female
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Linoone @ Nugget
@@ -2239,7 +2239,7 @@ Pic: Lady
 Gender: Female
 Music: Female
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Linoone @ Nugget
@@ -2253,7 +2253,7 @@ Pic: Lady
 Gender: Female
 Music: Female
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Linoone @ Nugget
@@ -2267,7 +2267,7 @@ Pic: Lady
 Gender: Female
 Music: Female
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Linoone @ Nugget
@@ -2284,7 +2284,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Marill
@@ -2297,7 +2297,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Shroomish
@@ -2310,7 +2310,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Numel
@@ -2323,7 +2323,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Kecleon
@@ -2348,7 +2348,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Goldeen
@@ -2361,7 +2361,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Azumarill
@@ -2374,7 +2374,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Clamperl
@@ -2406,7 +2406,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Carvanha
@@ -2423,7 +2423,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Kecleon
@@ -2448,7 +2448,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Kecleon
@@ -2473,7 +2473,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Kecleon
@@ -2498,7 +2498,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Kecleon
@@ -2524,7 +2524,7 @@ Pic: Rich Boy
 Gender: Male
 Music: Rich
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zigzagoon @ Nugget
@@ -2537,7 +2537,7 @@ Class: Expert
 Pic: Expert F
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Whiscash
@@ -2555,7 +2555,7 @@ Pic: Rich Boy
 Gender: Male
 Music: Rich
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Azumarill @ Nugget
@@ -2569,7 +2569,7 @@ Pic: Rich Boy
 Gender: Male
 Music: Rich
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Linoone @ Nugget
@@ -2583,7 +2583,7 @@ Pic: Rich Boy
 Gender: Male
 Music: Rich
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Linoone @ Nugget
@@ -2597,7 +2597,7 @@ Pic: Rich Boy
 Gender: Male
 Music: Rich
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Linoone @ Nugget
@@ -2611,7 +2611,7 @@ Pic: Rich Boy
 Gender: Male
 Music: Rich
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Linoone @ Nugget
@@ -2628,7 +2628,7 @@ Class: Pokemaniac
 Pic: Pokemaniac
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Aron
@@ -2641,7 +2641,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wailmer
@@ -2658,7 +2658,7 @@ Class: Pokemaniac
 Pic: Pokemaniac
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Rhyhorn
@@ -2671,7 +2671,7 @@ Class: Team Magma
 Pic: Magma Grunt F
 Gender: Female
 Music: Magma
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Numel
@@ -2684,7 +2684,7 @@ Class: Pokemaniac
 Pic: Pokemaniac
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Lairon
@@ -2697,7 +2697,7 @@ Class: Pokemaniac
 Pic: Pokemaniac
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Lairon
@@ -2714,7 +2714,7 @@ Class: Pokemaniac
 Pic: Pokemaniac
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Lairon
@@ -2731,7 +2731,7 @@ Class: Pokemaniac
 Pic: Pokemaniac
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Aggron
@@ -2748,7 +2748,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Carvanha
@@ -2761,7 +2761,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Tentacool
@@ -2774,7 +2774,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Tentacool
@@ -2791,7 +2791,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Tentacool
@@ -2812,7 +2812,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Carvanha
@@ -2825,7 +2825,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Tentacruel
@@ -2838,7 +2838,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Carvanha
@@ -2851,7 +2851,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Tentacool
@@ -2868,7 +2868,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Tentacool
@@ -2885,7 +2885,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Carvanha
@@ -2898,7 +2898,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Tentacruel
@@ -2911,7 +2911,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Horsea
@@ -2924,7 +2924,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Gyarados
@@ -2937,7 +2937,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Carvanha
@@ -2958,7 +2958,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Gyarados
@@ -2971,7 +2971,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Pelipper
@@ -2984,7 +2984,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wingull
@@ -3001,7 +3001,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Tentacruel
@@ -3018,7 +3018,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Sharpedo
@@ -3031,7 +3031,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Sealeo
@@ -3044,7 +3044,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Spheal
@@ -3057,7 +3057,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Gyarados
@@ -3070,7 +3070,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Tentacool
@@ -3091,7 +3091,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Tentacool
@@ -3108,7 +3108,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Sharpedo
@@ -3121,7 +3121,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Sharpedo
@@ -3134,7 +3134,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Staryu
@@ -3151,7 +3151,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Starmie
@@ -3168,7 +3168,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Machop
@@ -3181,7 +3181,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Machop
@@ -3198,7 +3198,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Hariyama
@@ -3211,7 +3211,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Machop
@@ -3228,7 +3228,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Machop
@@ -3241,7 +3241,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Machoke
@@ -3254,7 +3254,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Machop
@@ -3271,7 +3271,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Machop
@@ -3292,7 +3292,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Machop
@@ -3317,7 +3317,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Makuhita
@@ -3334,7 +3334,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Machop
@@ -3347,7 +3347,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Hariyama
@@ -3360,7 +3360,7 @@ Class: Guitarist
 Pic: Guitarist
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Electrike
@@ -3384,7 +3384,7 @@ Class: Team Aqua
 Pic: Aqua Grunt F
 Gender: Female
 Music: Aqua
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Poochyena
@@ -3401,7 +3401,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Carvanha
@@ -3414,7 +3414,7 @@ Class: Guitarist
 Pic: Guitarist
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Voltorb
@@ -3431,7 +3431,7 @@ Class: Guitarist
 Pic: Guitarist
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Electrike
@@ -3448,7 +3448,7 @@ Class: Guitarist
 Pic: Guitarist
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Magnemite
@@ -3465,7 +3465,7 @@ Class: Guitarist
 Pic: Guitarist
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Magnemite
@@ -3486,7 +3486,7 @@ Class: Guitarist
 Pic: Guitarist
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Magnemite
@@ -3507,7 +3507,7 @@ Class: Guitarist
 Pic: Guitarist
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Magneton
@@ -3528,7 +3528,7 @@ Class: Guitarist
 Pic: Guitarist
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Magneton
@@ -3549,7 +3549,7 @@ Class: Kindler
 Pic: Kindler
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Numel
@@ -3562,7 +3562,7 @@ Class: Kindler
 Pic: Kindler
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Slugma
@@ -3579,7 +3579,7 @@ Class: Kindler
 Pic: Kindler
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Numel
@@ -3592,7 +3592,7 @@ Class: Kindler
 Pic: Kindler
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Slugma
@@ -3605,7 +3605,7 @@ Class: Kindler
 Pic: Kindler
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Slugma
@@ -3618,7 +3618,7 @@ Class: Kindler
 Pic: Kindler
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Slugma
@@ -3635,7 +3635,7 @@ Class: Kindler
 Pic: Kindler
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Slugma
@@ -3652,7 +3652,7 @@ Class: Kindler
 Pic: Kindler
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Slugma
@@ -3669,7 +3669,7 @@ Class: Kindler
 Pic: Kindler
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Slugma
@@ -3686,7 +3686,7 @@ Class: Kindler
 Pic: Kindler
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Magcargo
@@ -3703,7 +3703,7 @@ Class: Camper
 Pic: Camper
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Sandshrew
@@ -3720,7 +3720,7 @@ Class: Camper
 Pic: Camper
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Baltoy
@@ -3753,7 +3753,7 @@ Class: Camper
 Pic: Camper
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Nuzleaf
@@ -3766,7 +3766,7 @@ Class: Camper
 Pic: Camper
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Sandshrew
@@ -3783,7 +3783,7 @@ Class: Camper
 Pic: Camper
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Kecleon
@@ -3796,7 +3796,7 @@ Class: Camper
 Pic: Camper
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zigzagoon
@@ -3813,7 +3813,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Shroomish
@@ -3826,7 +3826,7 @@ Class: Camper
 Pic: Camper
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Sandshrew
@@ -3839,7 +3839,7 @@ Class: Camper
 Pic: Camper
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zigzagoon
@@ -3856,7 +3856,7 @@ Class: Camper
 Pic: Camper
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Linoone
@@ -3873,7 +3873,7 @@ Class: Camper
 Pic: Camper
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Sandshrew
@@ -3894,7 +3894,7 @@ Class: Camper
 Pic: Camper
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Swellow
@@ -3915,7 +3915,7 @@ Class: Bug Maniac
 Pic: Bug Maniac
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Surskit
@@ -3928,7 +3928,7 @@ Class: Bug Maniac
 Pic: Bug Maniac
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wurmple
@@ -3949,7 +3949,7 @@ Class: Bug Maniac
 Pic: Bug Maniac
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wurmple
@@ -3970,7 +3970,7 @@ Class: Bug Maniac
 Pic: Bug Maniac
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Surskit
@@ -3991,7 +3991,7 @@ Class: Bug Maniac
 Pic: Bug Maniac
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Dustox
@@ -4008,7 +4008,7 @@ Class: Bug Maniac
 Pic: Bug Maniac
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Surskit
@@ -4029,7 +4029,7 @@ Class: Bug Maniac
 Pic: Bug Maniac
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Surskit
@@ -4050,7 +4050,7 @@ Class: Bug Maniac
 Pic: Bug Maniac
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Surskit
@@ -4075,7 +4075,7 @@ Class: Bug Maniac
 Pic: Bug Maniac
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Surskit
@@ -4104,7 +4104,7 @@ Class: Psychic
 Pic: Psychic M
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Abra
@@ -4118,7 +4118,7 @@ Class: Psychic
 Pic: Psychic M
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Kirlia
@@ -4131,7 +4131,7 @@ Class: Psychic
 Pic: Psychic M
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Ralts
@@ -4144,7 +4144,7 @@ Class: Psychic
 Pic: Psychic M
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Girafarig
@@ -4157,7 +4157,7 @@ Class: Psychic
 Pic: Psychic M
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Ralts
@@ -4178,7 +4178,7 @@ Class: Psychic
 Pic: Psychic M
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Kadabra
@@ -4195,7 +4195,7 @@ Class: Psychic
 Pic: Psychic M
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Solrock
@@ -4208,7 +4208,7 @@ Class: Psychic
 Pic: Psychic M
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Kadabra
@@ -4225,7 +4225,7 @@ Class: Psychic
 Pic: Psychic M
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Kadabra
@@ -4242,7 +4242,7 @@ Class: Psychic
 Pic: Psychic M
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Kadabra
@@ -4259,7 +4259,7 @@ Class: Psychic
 Pic: Psychic M
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Solrock
@@ -4276,7 +4276,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Abra
@@ -4290,7 +4290,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Kirlia
@@ -4303,7 +4303,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Xatu
@@ -4316,7 +4316,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Kadabra
@@ -4329,7 +4329,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wobbuffet
@@ -4350,7 +4350,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Kirlia
@@ -4367,7 +4367,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Kadabra
@@ -4384,7 +4384,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Kadabra
@@ -4401,7 +4401,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Kadabra
@@ -4418,7 +4418,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Kadabra
@@ -4435,7 +4435,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Lunatone
@@ -4452,7 +4452,7 @@ Class: Gentleman
 Pic: Gentleman
 Gender: Male
 Music: Rich
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Manectric
@@ -4465,7 +4465,7 @@ Class: Gentleman
 Pic: Gentleman
 Gender: Male
 Music: Rich
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Manectric
@@ -4482,7 +4482,7 @@ Class: Gentleman
 Pic: Gentleman
 Gender: Male
 Music: Rich
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zangoose
@@ -4495,7 +4495,7 @@ Class: Gentleman
 Pic: Gentleman
 Gender: Male
 Music: Rich
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Manectric
@@ -4508,7 +4508,7 @@ Class: Gentleman
 Pic: Gentleman
 Gender: Male
 Music: Rich
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Linoone
@@ -4533,7 +4533,7 @@ Class: Gentleman
 Pic: Gentleman
 Gender: Male
 Music: Rich
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Linoone
@@ -4557,7 +4557,7 @@ Class: Gentleman
 Pic: Gentleman
 Gender: Male
 Music: Rich
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Linoone
@@ -4591,7 +4591,7 @@ Pic: Elite Four Sidney
 Gender: Male
 Music: Elite Four
 Items: Full Restore / Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer / Force Setup First Turn
 Mugshot: Purple
 
@@ -4642,7 +4642,7 @@ Pic: Elite Four Phoebe
 Gender: Female
 Music: Elite Four
 Items: Full Restore / Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 Mugshot: Green
 
@@ -4693,7 +4693,7 @@ Pic: Elite Four Glacia
 Gender: Female
 Music: Elite Four
 Items: Full Restore / Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 Mugshot: Pink
 
@@ -4744,7 +4744,7 @@ Pic: Elite Four Drake
 Gender: Male
 Music: Elite Four
 Items: Full Restore / Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 Mugshot: Blue
 
@@ -4795,7 +4795,7 @@ Pic: Leader Roxanne
 Gender: Female
 Music: Female
 Items: Potion / Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Geodude
@@ -4829,7 +4829,7 @@ Pic: Leader Brawly
 Gender: Male
 Music: Male
 Items: Super Potion / Super Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Machop
@@ -4863,7 +4863,7 @@ Pic: Leader Wattson
 Gender: Male
 Music: Male
 Items: Super Potion / Super Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Voltorb
@@ -4905,7 +4905,7 @@ Pic: Leader Flannery
 Gender: Female
 Music: Female
 Items: Hyper Potion / Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Numel
@@ -4947,7 +4947,7 @@ Pic: Leader Norman
 Gender: Male
 Music: Male
 Items: Hyper Potion / Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Spinda
@@ -4989,7 +4989,7 @@ Pic: Leader Winona
 Gender: Female
 Music: Female
 Items: Hyper Potion / Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer / Risky
 
 Swablu
@@ -5039,7 +5039,7 @@ Pic: Leader Tate And Liza
 Gender: Male
 Music: Female
 Items: Hyper Potion / Hyper Potion / Hyper Potion / Hyper Potion
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Claydol
@@ -5081,7 +5081,7 @@ Pic: Leader Juan
 Gender: Male
 Music: Male
 Items: Hyper Potion / Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Luvdisc
@@ -5130,7 +5130,7 @@ Class: School Kid
 Pic: School Kid M
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Ralts
@@ -5143,7 +5143,7 @@ Class: School Kid
 Pic: School Kid M
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Ralts
@@ -5156,7 +5156,7 @@ Class: School Kid
 Pic: School Kid M
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Numel
@@ -5177,7 +5177,7 @@ Class: School Kid
 Pic: School Kid M
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Ralts
@@ -5194,7 +5194,7 @@ Class: School Kid
 Pic: School Kid M
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Kirlia
@@ -5211,7 +5211,7 @@ Class: School Kid
 Pic: School Kid M
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Kirlia
@@ -5228,7 +5228,7 @@ Class: School Kid
 Pic: School Kid M
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Kirlia
@@ -5249,7 +5249,7 @@ Class: School Kid
 Pic: School Kid F
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Shroomish
@@ -5262,7 +5262,7 @@ Class: School Kid
 Pic: School Kid F
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Shroomish
@@ -5279,7 +5279,7 @@ Class: School Kid
 Pic: School Kid F
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Shroomish
@@ -5296,7 +5296,7 @@ Class: School Kid
 Pic: School Kid F
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Shroomish
@@ -5313,7 +5313,7 @@ Class: School Kid
 Pic: School Kid F
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Breloom
@@ -5330,7 +5330,7 @@ Class: School Kid
 Pic: School Kid F
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Breloom
@@ -5347,7 +5347,7 @@ Class: Sr And Jr
 Pic: Sr And Jr
 Gender: Male
 Music: Twins
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Spinda
@@ -5372,7 +5372,7 @@ Class: Sr And Jr
 Pic: Sr And Jr
 Gender: Male
 Music: Twins
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Zigzagoon
@@ -5396,7 +5396,7 @@ Class: Sr And Jr
 Pic: Sr And Jr
 Gender: Male
 Music: Twins
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Zigzagoon
@@ -5420,7 +5420,7 @@ Class: Sr And Jr
 Pic: Sr And Jr
 Gender: Male
 Music: Twins
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Zigzagoon
@@ -5444,7 +5444,7 @@ Class: Sr And Jr
 Pic: Sr And Jr
 Gender: Male
 Music: Twins
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Linoone
@@ -5468,7 +5468,7 @@ Class: Sr And Jr
 Pic: Sr And Jr
 Gender: Male
 Music: Twins
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Linoone
@@ -5492,7 +5492,7 @@ Class: Winstrate
 Pic: Pokefan M
 Gender: Male
 Music: Twins
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Taillow @ Oran Berry
@@ -5509,7 +5509,7 @@ Class: Pokefan
 Pic: Pokefan M
 Gender: Male
 Music: Twins
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Skitty @ Oran Berry
@@ -5522,7 +5522,7 @@ Class: Pokefan
 Pic: Pokefan M
 Gender: Male
 Music: Twins
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Skitty @ Oran Berry
@@ -5579,7 +5579,7 @@ Class: Pokefan
 Pic: Pokefan M
 Gender: Male
 Music: Twins
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Skitty @ Oran Berry
@@ -5592,7 +5592,7 @@ Class: Pokefan
 Pic: Pokefan M
 Gender: Male
 Music: Twins
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Skitty @ Oran Berry
@@ -5605,7 +5605,7 @@ Class: Pokefan
 Pic: Pokefan M
 Gender: Male
 Music: Twins
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Delcatty @ Oran Berry
@@ -5618,7 +5618,7 @@ Class: Pokefan
 Pic: Pokefan M
 Gender: Male
 Music: Twins
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Delcatty @ Sitrus Berry
@@ -5631,7 +5631,7 @@ Class: Winstrate
 Pic: Pokefan F
 Gender: Female
 Music: Twins
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move / Try To Faint
 
 Roselia @ Oran Berry
@@ -5644,7 +5644,7 @@ Class: Pokefan
 Pic: Pokefan F
 Gender: Female
 Music: Twins
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Pikachu @ Oran Berry
@@ -5657,7 +5657,7 @@ Class: Pokefan
 Pic: Pokefan F
 Gender: Female
 Music: Twins
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Azurill @ Oran Berry
@@ -5678,7 +5678,7 @@ Class: Pokefan
 Pic: Pokefan F
 Gender: Female
 Music: Twins
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Plusle @ Oran Berry
@@ -5695,7 +5695,7 @@ Class: Pokefan
 Pic: Pokefan F
 Gender: Female
 Music: Twins
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Plusle @ Oran Berry
@@ -5712,7 +5712,7 @@ Class: Pokefan
 Pic: Pokefan F
 Gender: Female
 Music: Twins
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Plusle @ Oran Berry
@@ -5729,7 +5729,7 @@ Class: Pokefan
 Pic: Pokefan F
 Gender: Female
 Music: Twins
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Plusle @ Oran Berry
@@ -5746,7 +5746,7 @@ Class: Pokefan
 Pic: Pokefan F
 Gender: Female
 Music: Twins
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Plusle @ Sitrus Berry
@@ -5763,7 +5763,7 @@ Class: Expert
 Pic: Expert M
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Hariyama
@@ -5776,7 +5776,7 @@ Class: Expert
 Pic: Expert M
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Hariyama
@@ -5793,7 +5793,7 @@ Class: Expert
 Pic: Expert M
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Hariyama
@@ -5810,7 +5810,7 @@ Class: Expert
 Pic: Expert M
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Hariyama
@@ -5827,7 +5827,7 @@ Class: Expert
 Pic: Expert M
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Hariyama
@@ -5844,7 +5844,7 @@ Class: Winstrate
 Pic: Expert F
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Meditite
@@ -5861,7 +5861,7 @@ Class: Expert
 Pic: Expert F
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Meditite
@@ -5878,7 +5878,7 @@ Class: Expert
 Pic: Expert F
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Meditite
@@ -5895,7 +5895,7 @@ Class: Expert
 Pic: Expert F
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Medicham
@@ -5912,7 +5912,7 @@ Class: Expert
 Pic: Expert F
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Medicham
@@ -5929,7 +5929,7 @@ Class: Expert
 Pic: Expert F
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Medicham
@@ -5946,7 +5946,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Poochyena
@@ -5959,7 +5959,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zigzagoon
@@ -5976,7 +5976,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Geodude
@@ -5990,7 +5990,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Geodude
@@ -6007,7 +6007,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Machop
@@ -6020,7 +6020,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zigzagoon
@@ -6046,7 +6046,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Slaking
@@ -6072,7 +6072,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Gardevoir
@@ -6097,7 +6097,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Trapinch
@@ -6110,7 +6110,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Aron
@@ -6123,7 +6123,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Mightyena
@@ -6136,7 +6136,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Swellow
@@ -6153,7 +6153,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Swellow
@@ -6174,7 +6174,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Swellow
@@ -6195,7 +6195,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zigzagoon
@@ -6212,7 +6212,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zigzagoon
@@ -6229,7 +6229,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Aron
@@ -6247,7 +6247,7 @@ Pic: Champion Wallace
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore / Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 Mugshot: Yellow
 
@@ -6305,7 +6305,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Magikarp
@@ -6326,7 +6326,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Magikarp
@@ -6347,7 +6347,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Magikarp
@@ -6368,7 +6368,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Magikarp
@@ -6389,7 +6389,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Tentacool
@@ -6402,7 +6402,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Tentacool
@@ -6427,7 +6427,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Barboach
@@ -6440,7 +6440,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Tentacool
@@ -6457,7 +6457,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Tentacool
@@ -6470,7 +6470,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wailmer
@@ -6487,7 +6487,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Tentacool
@@ -6508,7 +6508,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Gyarados
@@ -6533,7 +6533,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Gyarados
@@ -6558,7 +6558,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move / Try To Faint
 
 Gyarados
@@ -6583,7 +6583,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Magikarp
@@ -6616,7 +6616,7 @@ Class: Triathlete
 Pic: Cycling Triathlete M
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Voltorb
@@ -6637,7 +6637,7 @@ Class: Triathlete
 Pic: Cycling Triathlete M
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Magnemite
@@ -6654,7 +6654,7 @@ Class: Triathlete
 Pic: Cycling Triathlete M
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Magnemite
@@ -6667,7 +6667,7 @@ Class: Triathlete
 Pic: Cycling Triathlete M
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Magnemite
@@ -6680,7 +6680,7 @@ Class: Triathlete
 Pic: Cycling Triathlete M
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Magnemite
@@ -6693,7 +6693,7 @@ Class: Triathlete
 Pic: Cycling Triathlete M
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Magneton
@@ -6706,7 +6706,7 @@ Class: Triathlete
 Pic: Cycling Triathlete M
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Magneton
@@ -6719,7 +6719,7 @@ Class: Triathlete
 Pic: Cycling Triathlete F
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Magnemite
@@ -6732,7 +6732,7 @@ Class: Triathlete
 Pic: Cycling Triathlete F
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Magnemite
@@ -6753,7 +6753,7 @@ Class: Triathlete
 Pic: Cycling Triathlete F
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Magnemite
@@ -6766,7 +6766,7 @@ Class: Triathlete
 Pic: Cycling Triathlete F
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Magnemite
@@ -6779,7 +6779,7 @@ Class: Triathlete
 Pic: Cycling Triathlete F
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Magneton
@@ -6792,7 +6792,7 @@ Class: Triathlete
 Pic: Cycling Triathlete F
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Magneton
@@ -6805,7 +6805,7 @@ Class: Triathlete
 Pic: Running Triathlete M
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Doduo
@@ -6818,7 +6818,7 @@ Class: Triathlete
 Pic: Running Triathlete M
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Doduo
@@ -6831,7 +6831,7 @@ Class: Triathlete
 Pic: Running Triathlete M
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Doduo
@@ -6844,7 +6844,7 @@ Class: Triathlete
 Pic: Running Triathlete M
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Dodrio
@@ -6857,7 +6857,7 @@ Class: Triathlete
 Pic: Running Triathlete M
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Dodrio
@@ -6870,7 +6870,7 @@ Class: Triathlete
 Pic: Running Triathlete F
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Doduo
@@ -6883,7 +6883,7 @@ Class: Triathlete
 Pic: Running Triathlete F
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Doduo
@@ -6896,7 +6896,7 @@ Class: Triathlete
 Pic: Running Triathlete F
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Doduo
@@ -6909,7 +6909,7 @@ Class: Triathlete
 Pic: Running Triathlete F
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Dodrio
@@ -6922,7 +6922,7 @@ Class: Triathlete
 Pic: Running Triathlete F
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Dodrio
@@ -6935,7 +6935,7 @@ Class: Triathlete
 Pic: Swimming Triathlete M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Staryu
@@ -6952,7 +6952,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zigzagoon
@@ -6969,7 +6969,7 @@ Class: Triathlete
 Pic: Swimming Triathlete M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Staryu
@@ -6982,7 +6982,7 @@ Class: Triathlete
 Pic: Swimming Triathlete M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Staryu
@@ -6999,7 +6999,7 @@ Class: Triathlete
 Pic: Swimming Triathlete M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wingull
@@ -7016,7 +7016,7 @@ Class: Triathlete
 Pic: Swimming Triathlete M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Staryu
@@ -7029,7 +7029,7 @@ Class: Triathlete
 Pic: Swimming Triathlete M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Staryu
@@ -7042,7 +7042,7 @@ Class: Triathlete
 Pic: Swimming Triathlete M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Starmie
@@ -7055,7 +7055,7 @@ Class: Triathlete
 Pic: Swimming Triathlete M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Starmie
@@ -7068,7 +7068,7 @@ Class: Triathlete
 Pic: Swimming Triathlete F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Staryu
@@ -7081,7 +7081,7 @@ Class: Triathlete
 Pic: Swimming Triathlete F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wingull
@@ -7098,7 +7098,7 @@ Class: Triathlete
 Pic: Swimming Triathlete F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Staryu
@@ -7111,7 +7111,7 @@ Class: Triathlete
 Pic: Swimming Triathlete F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Staryu
@@ -7124,7 +7124,7 @@ Class: Triathlete
 Pic: Swimming Triathlete F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wingull
@@ -7141,7 +7141,7 @@ Class: Triathlete
 Pic: Swimming Triathlete F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Staryu
@@ -7154,7 +7154,7 @@ Class: Triathlete
 Pic: Swimming Triathlete F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Staryu
@@ -7167,7 +7167,7 @@ Class: Triathlete
 Pic: Swimming Triathlete F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Starmie
@@ -7180,7 +7180,7 @@ Class: Triathlete
 Pic: Swimming Triathlete F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Starmie
@@ -7193,7 +7193,7 @@ Class: Dragon Tamer
 Pic: Dragon Tamer
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Altaria
@@ -7210,7 +7210,7 @@ Class: Dragon Tamer
 Pic: Dragon Tamer
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Altaria
@@ -7227,7 +7227,7 @@ Class: Dragon Tamer
 Pic: Dragon Tamer
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Altaria
@@ -7244,7 +7244,7 @@ Class: Dragon Tamer
 Pic: Dragon Tamer
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Bagon
@@ -7265,7 +7265,7 @@ Class: Dragon Tamer
 Pic: Dragon Tamer
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Altaria
@@ -7286,7 +7286,7 @@ Class: Dragon Tamer
 Pic: Dragon Tamer
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Bagon
@@ -7303,7 +7303,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wingull
@@ -7316,7 +7316,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wingull
@@ -7333,7 +7333,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Swellow
@@ -7346,7 +7346,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Doduo
@@ -7367,7 +7367,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Skarmory
@@ -7380,7 +7380,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Tropius
@@ -7397,7 +7397,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Doduo
@@ -7414,7 +7414,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wingull
@@ -7431,7 +7431,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Swablu
@@ -7444,7 +7444,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Swellow
@@ -7465,7 +7465,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Taillow
@@ -7482,7 +7482,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Natu
@@ -7499,7 +7499,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Natu
@@ -7516,7 +7516,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Natu
@@ -7533,7 +7533,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Altaria
@@ -7550,7 +7550,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Natu
@@ -7567,7 +7567,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Tropius
@@ -7580,7 +7580,7 @@ Class: Ninja Boy
 Pic: Ninja Boy
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move / Try To Faint
 
 Ninjask
@@ -7593,7 +7593,7 @@ Class: Ninja Boy
 Pic: Ninja Boy
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move / Try To Faint
 
 Ninjask
@@ -7611,7 +7611,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 
 Claydol
 Level: 43
@@ -7631,7 +7631,7 @@ Class: Tuber F
 Pic: Tuber F
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 
 Marill
 Level: 26
@@ -7643,7 +7643,7 @@ Class: Ninja Boy
 Pic: Ninja Boy
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 
 Koffing
 Level: 17
@@ -7675,7 +7675,7 @@ Class: Ninja Boy
 Pic: Ninja Boy
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 
 Koffing
 Level: 18
@@ -7691,7 +7691,7 @@ Class: Ninja Boy
 Pic: Ninja Boy
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 
 Koffing
 Level: 24
@@ -7728,7 +7728,7 @@ Class: Ninja Boy
 Pic: Ninja Boy
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 
 Koffing
 Level: 27
@@ -7765,7 +7765,7 @@ Class: Ninja Boy
 Pic: Ninja Boy
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 
 Koffing
 Level: 30
@@ -7800,7 +7800,7 @@ Class: Ninja Boy
 Pic: Ninja Boy
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 
 Koffing
 Level: 33
@@ -7837,7 +7837,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Meditite
@@ -7850,7 +7850,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Meditite
@@ -7863,7 +7863,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Meditite
@@ -7880,7 +7880,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Meditite
@@ -7893,7 +7893,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Breloom
@@ -7906,7 +7906,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Meditite
@@ -7923,7 +7923,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Meditite
@@ -7940,7 +7940,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Medicham
@@ -7957,7 +7957,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Medicham
@@ -7974,7 +7974,7 @@ Class: Parasol Lady
 Pic: Parasol Lady
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Numel
@@ -7991,7 +7991,7 @@ Class: Parasol Lady
 Pic: Parasol Lady
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Roselia
@@ -8008,7 +8008,7 @@ Class: Parasol Lady
 Pic: Parasol Lady
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Castform
@@ -8025,7 +8025,7 @@ Class: Parasol Lady
 Pic: Parasol Lady
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Numel
@@ -8042,7 +8042,7 @@ Class: Parasol Lady
 Pic: Parasol Lady
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Numel
@@ -8059,7 +8059,7 @@ Class: Parasol Lady
 Pic: Parasol Lady
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Roselia
@@ -8084,7 +8084,7 @@ Class: Parasol Lady
 Pic: Parasol Lady
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Roselia
@@ -8109,7 +8109,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wingull
@@ -8126,7 +8126,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Marill
@@ -8139,7 +8139,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wailmer
@@ -8152,7 +8152,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wingull
@@ -8169,7 +8169,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Goldeen
@@ -8182,7 +8182,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Horsea
@@ -8199,7 +8199,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Goldeen
@@ -8212,7 +8212,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Goldeen
@@ -8233,7 +8233,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wailmer
@@ -8246,7 +8246,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Marill
@@ -8259,7 +8259,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Luvdisc
@@ -8272,7 +8272,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Seaking
@@ -8285,7 +8285,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Marill
@@ -8302,7 +8302,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Goldeen
@@ -8315,7 +8315,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Goldeen
@@ -8332,7 +8332,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Luvdisc
@@ -8345,7 +8345,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Seaking
@@ -8358,7 +8358,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Azumarill
@@ -8371,7 +8371,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Luvdisc
@@ -8388,7 +8388,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Seaking
@@ -8401,7 +8401,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Horsea
@@ -8418,7 +8418,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Lanturn
@@ -8435,7 +8435,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Luvdisc
@@ -8452,7 +8452,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Seaking
@@ -8465,7 +8465,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wailmer
@@ -8478,7 +8478,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wailmer
@@ -8491,7 +8491,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Staryu
@@ -8508,7 +8508,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Luvdisc
@@ -8529,7 +8529,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Sandshrew
@@ -8554,7 +8554,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Sandshrew
@@ -8579,7 +8579,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Taillow
@@ -8596,7 +8596,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Marill
@@ -8613,7 +8613,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Skitty
@@ -8630,7 +8630,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Shroomish
@@ -8651,7 +8651,7 @@ Class: Psychic
 Pic: Psychic M
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wobbuffet
@@ -8668,7 +8668,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Shroomish
@@ -8685,7 +8685,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Shroomish
@@ -8706,7 +8706,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Breloom
@@ -8727,7 +8727,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Breloom
@@ -8748,7 +8748,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Breloom
@@ -8769,7 +8769,7 @@ Class: Twins
 Pic: Twins
 Gender: Male
 Music: Twins
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Plusle
@@ -8786,7 +8786,7 @@ Class: Twins
 Pic: Twins
 Gender: Male
 Music: Twins
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Plusle
@@ -8803,7 +8803,7 @@ Class: Twins
 Pic: Twins
 Gender: Male
 Music: Twins
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Seedot
@@ -8820,7 +8820,7 @@ Class: Twins
 Pic: Twins
 Gender: Male
 Music: Twins
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Beautifly
@@ -8837,7 +8837,7 @@ Class: Twins
 Pic: Twins
 Gender: Male
 Music: Twins
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Plusle
@@ -8854,7 +8854,7 @@ Class: Twins
 Pic: Twins
 Gender: Male
 Music: Twins
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Duskull
@@ -8875,7 +8875,7 @@ Class: Twins
 Pic: Twins
 Gender: Male
 Music: Twins
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Plusle
@@ -8892,7 +8892,7 @@ Class: Twins
 Pic: Twins
 Gender: Male
 Music: Twins
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Plusle
@@ -8917,7 +8917,7 @@ Class: Twins
 Pic: Twins
 Gender: Male
 Music: Twins
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Plusle
@@ -8942,7 +8942,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wingull
@@ -8959,7 +8959,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wingull
@@ -8972,7 +8972,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wingull
@@ -8989,7 +8989,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wingull
@@ -9010,7 +9010,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Tentacruel
@@ -9027,7 +9027,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Machop
@@ -9048,7 +9048,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Spheal
@@ -9065,7 +9065,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wingull
@@ -9086,7 +9086,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Pelipper
@@ -9107,7 +9107,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Pelipper
@@ -9128,7 +9128,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Pelipper
@@ -9149,7 +9149,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Numel
@@ -9162,7 +9162,7 @@ Class: Pokefan
 Pic: Pokefan F
 Gender: Female
 Music: Twins
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Feebas @ Oran Berry
@@ -9188,7 +9188,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Absol
@@ -9201,7 +9201,7 @@ Class: Ninja Boy
 Pic: Ninja Boy
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Koffing
@@ -9218,7 +9218,7 @@ Class: Parasol Lady
 Pic: Parasol Lady
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Castform
@@ -9235,7 +9235,7 @@ Class: Expert
 Pic: Expert M
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Manectric
@@ -9252,7 +9252,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Machoke
@@ -9270,7 +9270,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Manectric
@@ -9287,7 +9287,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Meditite
@@ -9304,7 +9304,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wailmer
@@ -9317,7 +9317,7 @@ Class: Expert
 Pic: Expert M
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Chinchou
@@ -9334,7 +9334,7 @@ Class: Collector
 Pic: Collector
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Lombre
@@ -9351,7 +9351,7 @@ Class: Collector
 Pic: Collector
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zangoose
@@ -9368,7 +9368,7 @@ Class: Magma Admin
 Pic: Magma Admin
 Gender: Male
 Music: Magma
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Camerupt
@@ -9389,7 +9389,7 @@ Class: Collector
 Pic: Collector
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Lombre
@@ -9406,7 +9406,7 @@ Class: Collector
 Pic: Collector
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Lombre
@@ -9423,7 +9423,7 @@ Class: Collector
 Pic: Collector
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Lombre
@@ -9440,7 +9440,7 @@ Class: Collector
 Pic: Collector
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Ludicolo
@@ -9458,7 +9458,7 @@ Pic: Wally
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Altaria
@@ -9507,7 +9507,7 @@ Class: Rival
 Pic: Brendan
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Treecko
@@ -9520,7 +9520,7 @@ Class: Rival
 Pic: Brendan
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Slugma
@@ -9541,7 +9541,7 @@ Class: Rival
 Pic: Brendan
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Slugma
@@ -9562,7 +9562,7 @@ Class: Rival
 Pic: Brendan
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move / Try To Faint / Force Setup First Turn
 
 Torchic
@@ -9575,7 +9575,7 @@ Class: Rival
 Pic: Brendan
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Wingull
@@ -9596,7 +9596,7 @@ Class: Rival
 Pic: Brendan
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Pelipper
@@ -9617,7 +9617,7 @@ Class: Rival
 Pic: Brendan
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Mudkip
@@ -9630,7 +9630,7 @@ Class: Rival
 Pic: Brendan
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Lombre
@@ -9651,7 +9651,7 @@ Class: Rival
 Pic: Brendan
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Lombre
@@ -9672,7 +9672,7 @@ Class: Rival
 Pic: May
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Treecko
@@ -9685,7 +9685,7 @@ Class: Rival
 Pic: May
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Wingull
@@ -9706,7 +9706,7 @@ Class: Rival
 Pic: May
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Slugma
@@ -9727,7 +9727,7 @@ Class: Rival
 Pic: May
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Torchic
@@ -9740,7 +9740,7 @@ Class: Rival
 Pic: May
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Wingull
@@ -9761,7 +9761,7 @@ Class: Rival
 Pic: May
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Pelipper
@@ -9782,7 +9782,7 @@ Class: Rival
 Pic: May
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Mudkip
@@ -9795,7 +9795,7 @@ Class: Rival
 Pic: May
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Lombre
@@ -9816,7 +9816,7 @@ Class: Rival
 Pic: May
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Lombre
@@ -9837,7 +9837,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder M
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Whismur
@@ -9870,7 +9870,7 @@ Class: Bug Catcher
 Pic: Bug Catcher
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Pinsir
@@ -9883,7 +9883,7 @@ Class: Cooltrainer
 Pic: Cooltrainer M
 Gender: Male
 Music: Cool
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Lunatone
@@ -9908,7 +9908,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder M
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Loudred
@@ -9941,7 +9941,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder M
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Loudred
@@ -9974,7 +9974,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder M
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Loudred
@@ -10007,7 +10007,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder M
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Loudred
@@ -10040,7 +10040,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder F
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wingull
@@ -10074,7 +10074,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Sableye
@@ -10091,7 +10091,7 @@ Class: Ruin Maniac
 Pic: Ruin Maniac
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Sandslash
@@ -10104,7 +10104,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder F
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wingull
@@ -10137,7 +10137,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder F
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Pelipper
@@ -10170,7 +10170,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder F
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Pelipper
@@ -10203,7 +10203,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder F
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Pelipper
@@ -10237,7 +10237,7 @@ Pic: Pokemon Ranger M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Breloom
@@ -10251,7 +10251,7 @@ Pic: Pokemon Ranger M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Seedot
@@ -10273,7 +10273,7 @@ Pic: Pokemon Ranger M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Cacturne
@@ -10287,7 +10287,7 @@ Pic: Pokemon Ranger M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move / Try To Faint / Force Setup First Turn
 
 Breloom
@@ -10301,7 +10301,7 @@ Pic: Pokemon Ranger M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Breloom
@@ -10315,7 +10315,7 @@ Pic: Pokemon Ranger M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move / Try To Faint / Force Setup First Turn
 
 Breloom
@@ -10329,7 +10329,7 @@ Pic: Pokemon Ranger M
 Gender: Male
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Kecleon
@@ -10347,7 +10347,7 @@ Pic: Pokemon Ranger F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move / Try To Faint / Force Setup First Turn
 
 Gloom
@@ -10365,7 +10365,7 @@ Pic: Pokemon Ranger F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move / Try To Faint / Force Setup First Turn
 
 Lotad
@@ -10387,7 +10387,7 @@ Pic: Pokemon Ranger F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Swablu
@@ -10405,7 +10405,7 @@ Pic: Pokemon Ranger F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move / Try To Faint / Force Setup First Turn
 
 Gloom
@@ -10423,7 +10423,7 @@ Pic: Pokemon Ranger F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Gloom
@@ -10441,7 +10441,7 @@ Pic: Pokemon Ranger F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move / Try To Faint / Force Setup First Turn
 
 Gloom
@@ -10459,7 +10459,7 @@ Pic: Pokemon Ranger F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Bellossom
@@ -10476,7 +10476,7 @@ Class: Triathlete
 Pic: Cycling Triathlete M
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Magnemite
@@ -10489,7 +10489,7 @@ Class: Team Aqua
 Pic: Aqua Grunt M
 Gender: Male
 Music: Aqua
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Mightyena
@@ -10506,7 +10506,7 @@ Class: Team Magma
 Pic: Aqua Grunt F
 Gender: Female
 Music: Aqua
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wailmer
@@ -10523,7 +10523,7 @@ Class: Team Aqua
 Pic: Aqua Grunt F
 Gender: Female
 Music: Aqua
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wailmer
@@ -10540,7 +10540,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Poochyena
@@ -10557,7 +10557,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Geodude
@@ -10574,7 +10574,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Machop
@@ -10587,7 +10587,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Meditite
@@ -10600,7 +10600,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Makuhita
@@ -10613,7 +10613,7 @@ Class: Hex Maniac
 Pic: Hex Maniac
 Gender: Female
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Meditite
@@ -10626,7 +10626,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Carvanha
@@ -10640,7 +10640,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Manectric
@@ -10662,7 +10662,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Tentacruel
@@ -10675,7 +10675,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zubat
@@ -10688,7 +10688,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Sharpedo
@@ -10701,7 +10701,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Girafarig
@@ -10714,7 +10714,7 @@ Class: Gentleman
 Pic: Gentleman
 Gender: Male
 Music: Rich
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Spoink
@@ -10727,7 +10727,7 @@ Class: Hex Maniac
 Pic: Hex Maniac
 Gender: Female
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Kadabra
@@ -10740,7 +10740,7 @@ Class: Gentleman
 Pic: Gentleman
 Gender: Male
 Music: Rich
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Girafarig
@@ -10753,7 +10753,7 @@ Class: Psychic
 Pic: Psychic M
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wobbuffet
@@ -10766,7 +10766,7 @@ Class: Team Magma
 Pic: Magma Grunt F
 Gender: Female
 Music: Magma
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zubat
@@ -10783,7 +10783,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Baltoy
@@ -10796,7 +10796,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zubat
@@ -10809,7 +10809,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Mightyena
@@ -10822,7 +10822,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Baltoy
@@ -10835,7 +10835,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Natu
@@ -10848,7 +10848,7 @@ Class: Rival
 Pic: Brendan
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Lotad
@@ -10865,7 +10865,7 @@ Class: Rival
 Pic: Brendan
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wingull
@@ -10882,7 +10882,7 @@ Class: Expert
 Pic: Expert M
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Swellow
@@ -10899,7 +10899,7 @@ Class: Triathlete
 Pic: Swimming Triathlete F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Staryu
@@ -10912,7 +10912,7 @@ Class: Team Aqua
 Pic: Aqua Grunt F
 Gender: Female
 Music: Aqua
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zubat
@@ -10929,7 +10929,7 @@ Class: Magma Admin
 Pic: Magma Admin
 Gender: Male
 Music: Magma
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Numel
@@ -10955,7 +10955,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move / Try To Faint / Force Setup First Turn
 
 Kecleon
@@ -10972,7 +10972,7 @@ Class: Rival
 Pic: Brendan
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Slugma
@@ -10989,7 +10989,7 @@ Class: Rival
 Pic: May
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move / Try To Faint / Force Setup First Turn
 
 Wingull
@@ -11007,7 +11007,7 @@ Pic: Magma Leader Maxie
 Gender: Male
 Music: Magma
 Items: Super Potion / Super Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Mightyena
@@ -11029,7 +11029,7 @@ Pic: Magma Leader Maxie
 Gender: Male
 Music: Magma
 Items: Super Potion / Super Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Mightyena
@@ -11050,7 +11050,7 @@ Class: Lass
 Pic: Lass
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zigzagoon
@@ -11067,7 +11067,7 @@ Class: Lass
 Pic: Lass
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Lotad
@@ -11084,7 +11084,7 @@ Class: Lass
 Pic: Lass
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Marill
@@ -11097,7 +11097,7 @@ Class: Winstrate
 Pic: Lass
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Marill
@@ -11118,7 +11118,7 @@ Class: Lass
 Pic: Lass
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Lombre
@@ -11135,7 +11135,7 @@ Class: Lass
 Pic: Lass
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Lombre
@@ -11152,7 +11152,7 @@ Class: Lass
 Pic: Lass
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Lombre
@@ -11169,7 +11169,7 @@ Class: Lass
 Pic: Lass
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Swellow
@@ -11190,7 +11190,7 @@ Class: Lass
 Pic: Lass
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Oddish
@@ -11203,7 +11203,7 @@ Class: Lass
 Pic: Lass
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Skitty
@@ -11224,7 +11224,7 @@ Class: Lass
 Pic: Lass
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Luvdisc
@@ -11237,7 +11237,7 @@ Class: Lass
 Pic: Lass
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Goldeen
@@ -11254,7 +11254,7 @@ Class: Bug Catcher
 Pic: Bug Catcher
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wurmple
@@ -11271,7 +11271,7 @@ Class: Bug Catcher
 Pic: Bug Catcher
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wurmple
@@ -11296,7 +11296,7 @@ Class: Bug Catcher
 Pic: Bug Catcher
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wurmple
@@ -11313,7 +11313,7 @@ Class: Bug Catcher
 Pic: Bug Catcher
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Nincada
@@ -11330,7 +11330,7 @@ Class: Bug Catcher
 Pic: Bug Catcher
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Volbeat
@@ -11347,7 +11347,7 @@ Class: Bug Catcher
 Pic: Bug Catcher
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Ninjask
@@ -11360,7 +11360,7 @@ Class: Bug Catcher
 Pic: Bug Catcher
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Nincada
@@ -11377,7 +11377,7 @@ Class: Bug Catcher
 Pic: Bug Catcher
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Ninjask
@@ -11390,7 +11390,7 @@ Class: Bug Catcher
 Pic: Bug Catcher
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Dustox
@@ -11407,7 +11407,7 @@ Class: Bug Catcher
 Pic: Bug Catcher
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Surskit
@@ -11428,7 +11428,7 @@ Class: Bug Catcher
 Pic: Bug Catcher
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Surskit
@@ -11453,7 +11453,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Numel
@@ -11470,7 +11470,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Geodude
@@ -11491,7 +11491,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Geodude
@@ -11508,7 +11508,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Geodude
@@ -11525,7 +11525,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Geodude
@@ -11546,7 +11546,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Geodude
@@ -11559,7 +11559,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Geodude
@@ -11576,7 +11576,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wailmer
@@ -11591,7 +11591,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Pelipper
@@ -11612,7 +11612,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Geodude
@@ -11633,7 +11633,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Geodude
@@ -11658,7 +11658,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Geodude
@@ -11683,7 +11683,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Geodude
@@ -11708,7 +11708,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Graveler
@@ -11733,7 +11733,7 @@ Class: Young Couple
 Pic: Young Couple
 Gender: Male
 Music: Girl
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Delcatty
@@ -11750,7 +11750,7 @@ Class: Young Couple
 Pic: Young Couple
 Gender: Male
 Music: Girl
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Luvdisc
@@ -11767,7 +11767,7 @@ Class: Young Couple
 Pic: Young Couple
 Gender: Male
 Music: Girl
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Volbeat
@@ -11784,7 +11784,7 @@ Class: Young Couple
 Pic: Young Couple
 Gender: Male
 Music: Girl
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Volbeat
@@ -11801,7 +11801,7 @@ Class: Young Couple
 Pic: Young Couple
 Gender: Male
 Music: Girl
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Volbeat
@@ -11818,7 +11818,7 @@ Class: Young Couple
 Pic: Young Couple
 Gender: Male
 Music: Girl
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Volbeat
@@ -11835,7 +11835,7 @@ Class: Young Couple
 Pic: Young Couple
 Gender: Male
 Music: Girl
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Volbeat
@@ -11852,7 +11852,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Goldeen
@@ -11866,7 +11866,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Kecleon
@@ -11883,7 +11883,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Meditite
@@ -11908,7 +11908,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Meditite
@@ -11925,7 +11925,7 @@ Class: Ninja Boy
 Pic: Ninja Boy
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move / Try To Faint
 
 Koffing
@@ -11950,7 +11950,7 @@ Class: Ninja Boy
 Pic: Ninja Boy
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move / Try To Faint
 
 Koffing
@@ -11975,7 +11975,7 @@ Class: Ninja Boy
 Pic: Ninja Boy
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move / Try To Faint
 
 Nincada
@@ -12000,7 +12000,7 @@ Class: Camper
 Pic: Camper
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Swellow
@@ -12017,7 +12017,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Swablu
@@ -12038,7 +12038,7 @@ Class: Rival
 Pic: Wally
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Ralts
@@ -12052,7 +12052,7 @@ Pic: Wally
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Altaria
@@ -12102,7 +12102,7 @@ Pic: Wally
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Altaria
@@ -12152,7 +12152,7 @@ Pic: Wally
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Altaria
@@ -12202,7 +12202,7 @@ Pic: Wally
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Altaria
@@ -12251,7 +12251,7 @@ Class: Rival
 Pic: Brendan
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Tropius
@@ -12276,7 +12276,7 @@ Class: Rival
 Pic: Brendan
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Tropius
@@ -12301,7 +12301,7 @@ Class: Rival
 Pic: Brendan
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Tropius
@@ -12326,7 +12326,7 @@ Class: Rival
 Pic: May
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Tropius
@@ -12351,7 +12351,7 @@ Class: Rival
 Pic: May
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Tropius
@@ -12376,7 +12376,7 @@ Class: Rival
 Pic: May
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Tropius
@@ -12401,7 +12401,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wailmer
@@ -12422,7 +12422,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Carvanha
@@ -12439,7 +12439,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Magikarp
@@ -12461,7 +12461,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Gloom
@@ -12479,7 +12479,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Shiftry
@@ -12496,7 +12496,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Machoke
@@ -12509,7 +12509,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Tentacool
@@ -12530,7 +12530,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Swellow
@@ -12547,7 +12547,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Spheal
@@ -12564,7 +12564,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Chinchou
@@ -12577,7 +12577,7 @@ Class: Twins
 Pic: Twins
 Gender: Male
 Music: Twins
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Spinda
@@ -12594,7 +12594,7 @@ Class: Sr And Jr
 Pic: Sr And Jr
 Gender: Male
 Music: Twins
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Swablu
@@ -12619,7 +12619,7 @@ Class: Sr And Jr
 Pic: Sr And Jr
 Gender: Male
 Music: Twins
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Roselia
@@ -12644,7 +12644,7 @@ Class: Young Couple
 Pic: Young Couple
 Gender: Male
 Music: Girl
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Dustox
@@ -12669,7 +12669,7 @@ Class: Old Couple
 Pic: Old Couple
 Gender: Male
 Music: Intense
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Medicham
@@ -12694,7 +12694,7 @@ Class: Old Couple
 Pic: Old Couple
 Gender: Male
 Music: Intense
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Medicham
@@ -12719,7 +12719,7 @@ Class: Old Couple
 Pic: Old Couple
 Gender: Male
 Music: Intense
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Medicham
@@ -12744,7 +12744,7 @@ Class: Old Couple
 Pic: Old Couple
 Gender: Male
 Music: Intense
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move / Try To Faint / Force Setup First Turn
 
 Medicham
@@ -12769,7 +12769,7 @@ Class: Old Couple
 Pic: Old Couple
 Gender: Male
 Music: Intense
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Medicham
@@ -12794,7 +12794,7 @@ Class: Sis And Bro
 Pic: Sis And Bro
 Gender: Male
 Music: Swimmer
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Azumarill
@@ -12811,7 +12811,7 @@ Class: Sis And Bro
 Pic: Sis And Bro
 Gender: Male
 Music: Swimmer
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Chinchou
@@ -12828,7 +12828,7 @@ Class: Sis And Bro
 Pic: Sis And Bro
 Gender: Male
 Music: Swimmer
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Chinchou
@@ -12845,7 +12845,7 @@ Class: Sis And Bro
 Pic: Sis And Bro
 Gender: Male
 Music: Swimmer
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Lanturn
@@ -12862,7 +12862,7 @@ Class: Sis And Bro
 Pic: Sis And Bro
 Gender: Male
 Music: Swimmer
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Lanturn
@@ -12879,7 +12879,7 @@ Class: Sis And Bro
 Pic: Sis And Bro
 Gender: Male
 Music: Swimmer
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Lanturn
@@ -12896,7 +12896,7 @@ Class: Sis And Bro
 Pic: Sis And Bro
 Gender: Male
 Music: Swimmer
-Battle Type: Doubles
+Double Battle: Yes
 AI: Check Bad Move
 
 Goldeen
@@ -12913,7 +12913,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Magikarp
@@ -12938,7 +12938,7 @@ Class: Rich Boy
 Pic: Rich Boy
 Gender: Male
 Music: Rich
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zigzagoon @ Nugget
@@ -12956,7 +12956,7 @@ Pic: Lady
 Gender: Female
 Music: Female
 Items: Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Lotad
@@ -12973,7 +12973,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Magikarp
@@ -12986,7 +12986,7 @@ Class: Tuber F
 Pic: Tuber F
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Marill
@@ -12999,7 +12999,7 @@ Class: Tuber M
 Pic: Tuber M
 Gender: Male
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Tentacool
@@ -13016,7 +13016,7 @@ Class: Pokefan
 Pic: Pokefan M
 Gender: Male
 Music: Twins
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Minun @ Oran Berry
@@ -13033,7 +13033,7 @@ Class: Guitarist
 Pic: Guitarist
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Electrike
@@ -13050,7 +13050,7 @@ Class: Triathlete
 Pic: Cycling Triathlete F
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Magnemite
@@ -13063,7 +13063,7 @@ Class: Guitarist
 Pic: Guitarist
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Voltorb
@@ -13076,7 +13076,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Makuhita
@@ -13089,7 +13089,7 @@ Class: Camper
 Pic: Camper
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Sandshrew
@@ -13102,7 +13102,7 @@ Class: Aroma Lady
 Pic: Aroma Lady
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Roselia
@@ -13115,7 +13115,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Shroomish
@@ -13128,7 +13128,7 @@ Class: Kindler
 Pic: Kindler
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Numel
@@ -13141,7 +13141,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Marill
@@ -13158,7 +13158,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Skarmory
@@ -13175,7 +13175,7 @@ Class: Camper
 Pic: Camper
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Baltoy
@@ -13192,7 +13192,7 @@ Class: Pokemaniac
 Pic: Pokemaniac
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Aron
@@ -13209,7 +13209,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Lombre
@@ -13226,7 +13226,7 @@ Class: Fisherman
 Pic: Fisherman
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Barboach
@@ -13239,7 +13239,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Nuzleaf
@@ -13252,7 +13252,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zigzagoon
@@ -13273,7 +13273,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zubat
@@ -13286,7 +13286,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Poochyena
@@ -13299,7 +13299,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Numel
@@ -13312,7 +13312,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Baltoy
@@ -13329,7 +13329,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Baltoy
@@ -13346,7 +13346,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Mightyena
@@ -13359,7 +13359,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zubat
@@ -13372,7 +13372,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Poochyena
@@ -13385,7 +13385,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zubat
@@ -13398,7 +13398,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Mightyena
@@ -13411,7 +13411,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Baltoy
@@ -13424,7 +13424,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Numel
@@ -13437,7 +13437,7 @@ Class: Team Magma
 Pic: Magma Grunt M
 Gender: Male
 Music: Magma
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Zubat
@@ -13450,7 +13450,7 @@ Class: Team Magma
 Pic: Magma Grunt F
 Gender: Female
 Music: Magma
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Mightyena
@@ -13463,7 +13463,7 @@ Class: Team Magma
 Pic: Magma Grunt F
 Gender: Female
 Music: Magma
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Numel
@@ -13476,7 +13476,7 @@ Class: Team Magma
 Pic: Magma Grunt F
 Gender: Female
 Music: Magma
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Baltoy
@@ -13489,7 +13489,7 @@ Class: Magma Admin
 Pic: Magma Admin
 Gender: Male
 Music: Magma
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Numel
@@ -13515,7 +13515,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Pelipper
@@ -13532,7 +13532,7 @@ Class: Magma Leader
 Pic: Magma Leader Maxie
 Gender: Male
 Music: Magma
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Mightyena
@@ -13553,7 +13553,7 @@ Class: Swimmer M
 Pic: Swimmer M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Tentacool
@@ -13566,7 +13566,7 @@ Class: Swimmer F
 Pic: Swimmer F
 Gender: Female
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Marill
@@ -13579,7 +13579,7 @@ Class: Ruin Maniac
 Pic: Ruin Maniac
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Sandshrew
@@ -13596,7 +13596,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Taillow
@@ -13613,7 +13613,7 @@ Class: Triathlete
 Pic: Swimming Triathlete M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Staryu
@@ -13626,7 +13626,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wingull
@@ -13648,7 +13648,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Manectric
@@ -13669,7 +13669,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Skarmory
@@ -13686,7 +13686,7 @@ Class: Picnicker
 Pic: Picnicker
 Gender: Female
 Music: Girl
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Marill
@@ -13703,7 +13703,7 @@ Class: Ruin Maniac
 Pic: Ruin Maniac
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Sandshrew
@@ -13720,7 +13720,7 @@ Class: Camper
 Pic: Camper
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Taillow
@@ -13737,7 +13737,7 @@ Class: Kindler
 Pic: Kindler
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Numel
@@ -13754,7 +13754,7 @@ Class: Aroma Lady
 Pic: Aroma Lady
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Shroomish
@@ -13771,7 +13771,7 @@ Class: Triathlete
 Pic: Running Triathlete F
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Doduo
@@ -13788,7 +13788,7 @@ Class: Ninja Boy
 Pic: Ninja Boy
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Ninjask
@@ -13805,7 +13805,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Kadabra
@@ -13822,7 +13822,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Meditite
@@ -13839,7 +13839,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Meditite
@@ -13856,7 +13856,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Geodude
@@ -13873,7 +13873,7 @@ Class: Youngster
 Pic: Youngster
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Shroomish
@@ -13890,7 +13890,7 @@ Class: Triathlete
 Pic: Running Triathlete F
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Doduo
@@ -13903,7 +13903,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Ralts
@@ -13916,7 +13916,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Meditite
@@ -13930,7 +13930,7 @@ Pic: Expert F
 Gender: Female
 Music: Intense
 Items: Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Roselia
@@ -13947,7 +13947,7 @@ Class: Guitarist
 Pic: Guitarist
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Manectric
@@ -13960,7 +13960,7 @@ Class: Kindler
 Pic: Kindler
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Slugma
@@ -13977,7 +13977,7 @@ Class: Parasol Lady
 Pic: Parasol Lady
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Goldeen
@@ -13991,7 +13991,7 @@ Pic: Cooltrainer M
 Gender: Male
 Music: Cool
 Items: Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Manectric
@@ -14007,7 +14007,7 @@ Class: Battle Girl
 Pic: Battle Girl
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Meditite
@@ -14024,7 +14024,7 @@ Class: Bug Maniac
 Pic: Bug Maniac
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Dustox
@@ -14041,7 +14041,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder M
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Makuhita
@@ -14074,7 +14074,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder F
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Poochyena
@@ -14108,7 +14108,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Loudred
@@ -14125,7 +14125,7 @@ Class: Rival
 Pic: May
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Lotad
@@ -14142,7 +14142,7 @@ Class: Rival
 Pic: May
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Torkoal
@@ -14160,7 +14160,7 @@ Pic: Leader Roxanne
 Gender: Female
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Golem
@@ -14202,7 +14202,7 @@ Pic: Leader Roxanne
 Gender: Female
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Omanyte
@@ -14252,7 +14252,7 @@ Pic: Leader Roxanne
 Gender: Female
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Omastar
@@ -14302,7 +14302,7 @@ Pic: Leader Roxanne
 Gender: Female
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Aerodactyl
@@ -14360,7 +14360,7 @@ Pic: Leader Brawly
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Machamp @ Sitrus Berry
@@ -14402,7 +14402,7 @@ Pic: Leader Brawly
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Machamp @ Sitrus Berry
@@ -14444,7 +14444,7 @@ Pic: Leader Brawly
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Hitmonchan
@@ -14494,7 +14494,7 @@ Pic: Leader Brawly
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Hitmonlee
@@ -14552,7 +14552,7 @@ Pic: Leader Wattson
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Mareep
@@ -14594,7 +14594,7 @@ Pic: Leader Wattson
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Pikachu
@@ -14644,7 +14644,7 @@ Pic: Leader Wattson
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Raichu
@@ -14694,7 +14694,7 @@ Pic: Leader Wattson
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Electabuzz
@@ -14752,7 +14752,7 @@ Pic: Leader Flannery
 Gender: Female
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Magcargo @ White Herb
@@ -14794,7 +14794,7 @@ Pic: Leader Flannery
 Gender: Female
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Growlithe
@@ -14844,7 +14844,7 @@ Pic: Leader Flannery
 Gender: Female
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Houndour
@@ -14902,7 +14902,7 @@ Pic: Leader Flannery
 Gender: Female
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Arcanine
@@ -14960,7 +14960,7 @@ Pic: Leader Norman
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Chansey
@@ -15002,7 +15002,7 @@ Pic: Leader Norman
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Slaking @ Sitrus Berry
@@ -15052,7 +15052,7 @@ Pic: Leader Norman
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Slaking @ Sitrus Berry
@@ -15102,7 +15102,7 @@ Pic: Leader Norman
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Slaking @ Sitrus Berry
@@ -15160,7 +15160,7 @@ Pic: Leader Winona
 Gender: Female
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer / Risky
 
 Dratini @ Sitrus Berry
@@ -15210,7 +15210,7 @@ Pic: Leader Winona
 Gender: Female
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer / Risky
 
 Hoothoot
@@ -15268,7 +15268,7 @@ Pic: Leader Winona
 Gender: Female
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer / Risky
 
 Noctowl
@@ -15326,7 +15326,7 @@ Pic: Leader Winona
 Gender: Female
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer / Risky
 
 Noctowl
@@ -15384,7 +15384,7 @@ Pic: Leader Tate And Liza
 Gender: Male
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Slowpoke
@@ -15434,7 +15434,7 @@ Pic: Leader Tate And Liza
 Gender: Male
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Drowzee
@@ -15492,7 +15492,7 @@ Pic: Leader Tate And Liza
 Gender: Male
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Hypno
@@ -15550,7 +15550,7 @@ Pic: Leader Tate And Liza
 Gender: Male
 Music: Female
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Hypno
@@ -15608,7 +15608,7 @@ Pic: Leader Juan
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Poliwag
@@ -15658,7 +15658,7 @@ Pic: Leader Juan
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Poliwhirl
@@ -15708,7 +15708,7 @@ Pic: Leader Juan
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Lapras
@@ -15766,7 +15766,7 @@ Pic: Leader Juan
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore
-Battle Type: Doubles
+Double Battle: Yes
 AI: Basic Trainer
 
 Lapras
@@ -15823,7 +15823,7 @@ Class: Bug Maniac
 Pic: Bug Maniac
 Gender: Male
 Music: Suspicious
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Illumise
@@ -15846,7 +15846,7 @@ Class: Bird Keeper
 Pic: Bird Keeper
 Gender: Male
 Music: Cool
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Tropius
@@ -15860,7 +15860,7 @@ Pic: Steven
 Gender: Male
 Music: Male
 Items: Full Restore / Full Restore / Full Restore / Full Restore
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Skarmory
@@ -15917,7 +15917,7 @@ Class: Salon Maiden
 Pic: Salon Maiden Anabel
 Gender: Female
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Beldum
@@ -15930,7 +15930,7 @@ Class: Dome Ace
 Pic: Dome Ace Tucker
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Beldum
@@ -15943,7 +15943,7 @@ Class: Palace Maven
 Pic: Palace Maven Spenser
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Beldum
@@ -15956,7 +15956,7 @@ Class: Arena Tycoon
 Pic: Arena Tycoon Greta
 Gender: Female
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Beldum
@@ -15969,7 +15969,7 @@ Class: Factory Head
 Pic: Factory Head Noland
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Beldum
@@ -15982,7 +15982,7 @@ Class: Pike Queen
 Pic: Pike Queen Lucy
 Gender: Female
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Beldum
@@ -15995,7 +15995,7 @@ Class: Pyramid King
 Pic: Pyramid King Brandon
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Beldum
@@ -16008,7 +16008,7 @@ Class: Ruin Maniac
 Pic: Ruin Maniac
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Sandshrew
@@ -16025,7 +16025,7 @@ Class: Ruin Maniac
 Pic: Ruin Maniac
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Nosepass
@@ -16046,7 +16046,7 @@ Class: Ruin Maniac
 Pic: Ruin Maniac
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Nosepass
@@ -16067,7 +16067,7 @@ Class: Ruin Maniac
 Pic: Ruin Maniac
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Nosepass
@@ -16088,7 +16088,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wingull
@@ -16109,7 +16109,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Pelipper
@@ -16130,7 +16130,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Pelipper
@@ -16151,7 +16151,7 @@ Class: Sailor
 Pic: Sailor
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Pelipper
@@ -16172,7 +16172,7 @@ Class: Triathlete
 Pic: Swimming Triathlete M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Staryu
@@ -16189,7 +16189,7 @@ Class: Triathlete
 Pic: Swimming Triathlete M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wingull
@@ -16210,7 +16210,7 @@ Class: Triathlete
 Pic: Swimming Triathlete M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Pelipper
@@ -16231,7 +16231,7 @@ Class: Triathlete
 Pic: Swimming Triathlete M
 Gender: Male
 Music: Swimmer
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Pelipper
@@ -16252,7 +16252,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Machoke
@@ -16269,7 +16269,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Makuhita
@@ -16290,7 +16290,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Hariyama
@@ -16311,7 +16311,7 @@ Class: Black Belt
 Pic: Black Belt
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Hariyama
@@ -16333,7 +16333,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Loudred
@@ -16351,7 +16351,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Spinda
@@ -16373,7 +16373,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Spinda
@@ -16395,7 +16395,7 @@ Pic: Cooltrainer F
 Gender: Female
 Music: Cool
 Items: Hyper Potion
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Spinda
@@ -16416,7 +16416,7 @@ Class: Guitarist
 Pic: Guitarist
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Electrike
@@ -16437,7 +16437,7 @@ Class: Guitarist
 Pic: Guitarist
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Electrike
@@ -16458,7 +16458,7 @@ Class: Guitarist
 Pic: Guitarist
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Manectric
@@ -16479,7 +16479,7 @@ Class: Guitarist
 Pic: Guitarist
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Manectric
@@ -16500,7 +16500,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Geodude
@@ -16517,7 +16517,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Machop
@@ -16538,7 +16538,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Machop
@@ -16559,7 +16559,7 @@ Class: Hiker
 Pic: Hiker
 Gender: Male
 Music: Hiker
-Battle Type: Singles
+Double Battle: No
 AI: Basic Trainer
 
 Machoke
@@ -16580,7 +16580,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder F
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Skitty
@@ -16613,7 +16613,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder F
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Skitty
@@ -16646,7 +16646,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder F
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Delcatty
@@ -16679,7 +16679,7 @@ Class: Pkmn Breeder
 Pic: Pokemon Breeder F
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Delcatty
@@ -16712,7 +16712,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Wailmer
@@ -16729,7 +16729,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Luvdisc
@@ -16750,7 +16750,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Luvdisc
@@ -16771,7 +16771,7 @@ Class: Beauty
 Pic: Beauty
 Gender: Female
 Music: Female
-Battle Type: Singles
+Double Battle: No
 AI: Check Bad Move
 
 Luvdisc
@@ -16792,7 +16792,7 @@ Class: Psychic
 Pic: Psychic F
 Gender: Female
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 
 Chimecho
 Level: 41
@@ -16804,7 +16804,7 @@ Class: Psychic
 Pic: Psychic M
 Gender: Male
 Music: Intense
-Battle Type: Singles
+Double Battle: No
 
 Banette
 Level: 41
@@ -16820,7 +16820,7 @@ Class: Gentleman
 Pic: Gentleman
 Gender: Male
 Music: Rich
-Battle Type: Singles
+Double Battle: No
 
 Wobbuffet
 Level: 41
@@ -16832,7 +16832,7 @@ Class: Rival
 Pic: Red
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 
 Charmander
 Level: 5
@@ -16844,7 +16844,7 @@ Class: Rival
 Pic: Leaf
 Gender: Female
 Music: Male
-Battle Type: Singles
+Double Battle: No
 
 Bulbasaur
 Level: 5
@@ -16856,7 +16856,7 @@ Class: RS Protag
 Pic: RS Brendan
 Gender: Male
 Music: Male
-Battle Type: Singles
+Double Battle: No
 
 Groudon
 Level: 5
@@ -16868,7 +16868,7 @@ Class: RS Protag
 Pic: RS May
 Gender: Female
 Music: Male
-Battle Type: Singles
+Double Battle: No
 
 Kyogre
 Level: 5

--- a/test/battle/trainer_control.c
+++ b/test/battle/trainer_control.c
@@ -12,7 +12,7 @@
 #include "constants/trainers.h"
 #include "constants/battle.h"
 
-#define NUM_TEST_TRAINERS 9
+#define NUM_TEST_TRAINERS 11
 
 static const struct Trainer sTestTrainers[DIFFICULTY_COUNT][NUM_TEST_TRAINERS] =
 {
@@ -281,4 +281,13 @@ TEST("Trainer Party Pool can choose which functions to use for picking mons")
     EXPECT(GetMonData(&testParty[0], MON_DATA_SPECIES) == SPECIES_WYNAUT);
     EXPECT(GetMonData(&testParty[1], MON_DATA_SPECIES) == SPECIES_WOBBUFFET);
     Free(testParty);
+}
+
+TEST("trainerproc supports both Double Battle: Yes and Battle Type: Doubles")
+{
+    u32 currTrainer;
+    PARAMETRIZE { currTrainer = 9; }
+    PARAMETRIZE { currTrainer = 10; }
+    const struct Trainer trainer = sTestTrainers[GetTrainerDifficultyLevelTest(currTrainer)][currTrainer];
+    EXPECT(trainer.battleType == TRAINER_BATTLE_TYPE_DOUBLES);
 }

--- a/test/battle/trainer_control.h
+++ b/test/battle/trainer_control.h
@@ -21,7 +21,7 @@
 #line 6
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 7
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
         .partySize = 3,
         .party = (const struct TrainerMon[])
         {
@@ -101,7 +101,7 @@
 #line 38
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 39
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
         .partySize = 1,
         .party = (const struct TrainerMon[])
         {
@@ -132,7 +132,7 @@
 #line 50
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 51
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
         .partySize = 1,
         .party = (const struct TrainerMon[])
         {
@@ -163,7 +163,7 @@
 #line 62
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 63
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
         .partySize = 1,
         .party = (const struct TrainerMon[])
         {
@@ -194,7 +194,7 @@
 #line 74
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 75
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
         .partySize = 1,
         .party = (const struct TrainerMon[])
         {
@@ -224,7 +224,7 @@
 #line 86
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 87
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 88
         .partySize = 1,
         .poolSize = 4,
@@ -289,7 +289,7 @@
 #line 103
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 104
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 105
         .partySize = 3,
         .poolSize = 6,
@@ -384,7 +384,7 @@
 #line 128
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 129
-        .doubleBattle = TRUE,
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
 #line 131
         .poolRuleIndex = POOL_RULESET_WEATHER_DOUBLES,
 #line 130
@@ -533,7 +533,7 @@
 #line 166
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 167
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 169
         .poolRuleIndex = POOL_RULESET_BASIC,
 #line 168
@@ -595,7 +595,7 @@
 #line 185
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 186
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 188
         .poolRuleIndex = POOL_RULESET_BASIC,
 #line 189
@@ -655,7 +655,7 @@
 #line 203
             TRAINER_ENCOUNTER_MUSIC_MALE,
 #line 204
-        .doubleBattle = FALSE,
+        .battleType = TRAINER_BATTLE_TYPE_SINGLES,
 #line 206
         .poolRuleIndex = POOL_RULESET_BASIC,
 #line 207

--- a/test/battle/trainer_control.h
+++ b/test/battle/trainer_control.h
@@ -704,3 +704,89 @@
             },
         },
     },
+#line 217
+    [DIFFICULTY_NORMAL][9] =
+    {
+#line 218
+        .trainerName = _("Test9"),
+#line 219
+        .trainerClass = TRAINER_CLASS_PKMN_TRAINER_1,
+#line 220
+        .trainerPic = TRAINER_PIC_RED,
+        .encounterMusic_gender =
+#line 222
+            TRAINER_ENCOUNTER_MUSIC_MALE,
+#line 223
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
+#line 224
+        .partySize = 2,
+        .poolSize = 2,
+        .party = (const struct TrainerMon[])
+        {
+            {
+#line 226
+            .species = SPECIES_WYNAUT,
+            .gender = TRAINER_MON_RANDOM_GENDER,
+#line 227
+            .iv = TRAINER_PARTY_IVS(31, 31, 31, 31, 31, 31),
+#line 227
+            .lvl = 100,
+            .nature = NATURE_HARDY,
+            .dynamaxLevel = MAX_DYNAMAX_LEVEL,
+            },
+            {
+#line 228
+            .species = SPECIES_WOBBUFFET,
+            .gender = TRAINER_MON_RANDOM_GENDER,
+#line 229
+            .iv = TRAINER_PARTY_IVS(31, 31, 31, 31, 31, 31),
+#line 229
+            .lvl = 100,
+            .nature = NATURE_HARDY,
+            .dynamaxLevel = MAX_DYNAMAX_LEVEL,
+            },
+        },
+    },
+#line 230
+    [DIFFICULTY_NORMAL][10] =
+    {
+#line 231
+        .trainerName = _("Test10"),
+#line 232
+        .trainerClass = TRAINER_CLASS_PKMN_TRAINER_1,
+#line 233
+        .trainerPic = TRAINER_PIC_RED,
+        .encounterMusic_gender =
+#line 235
+            TRAINER_ENCOUNTER_MUSIC_MALE,
+#line 236
+        .battleType = TRAINER_BATTLE_TYPE_DOUBLES,
+#line 237
+        .partySize = 2,
+        .poolSize = 2,
+        .party = (const struct TrainerMon[])
+        {
+            {
+#line 239
+            .species = SPECIES_WYNAUT,
+            .gender = TRAINER_MON_RANDOM_GENDER,
+#line 240
+            .iv = TRAINER_PARTY_IVS(31, 31, 31, 31, 31, 31),
+#line 240
+            .lvl = 100,
+            .nature = NATURE_HARDY,
+            .dynamaxLevel = MAX_DYNAMAX_LEVEL,
+            },
+            {
+#line 241
+            .species = SPECIES_WOBBUFFET,
+            .gender = TRAINER_MON_RANDOM_GENDER,
+#line 242
+            .iv = TRAINER_PARTY_IVS(31, 31, 31, 31, 31, 31),
+#line 242
+            .lvl = 100,
+            .nature = NATURE_HARDY,
+            .dynamaxLevel = MAX_DYNAMAX_LEVEL,
+            },
+        },
+    },

--- a/test/battle/trainer_control.party
+++ b/test/battle/trainer_control.party
@@ -4,7 +4,7 @@ Class: Pkmn Trainer 1
 Pic: Red
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 
 Bubbles (Wobbuffet) (F) @ Assault Vest
 Hasty Nature
@@ -36,7 +36,7 @@ Class: Pkmn Trainer 1
 Pic: Red
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 Difficulty: Normal
 
 Mewtwo
@@ -48,7 +48,7 @@ Class: Pkmn Trainer 1
 Pic: Red
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 Difficulty: Normal
 
 Mewtwo
@@ -60,7 +60,7 @@ Class: Pkmn Trainer 1
 Pic: Red
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 Difficulty: Easy
 
 Metapod
@@ -72,7 +72,7 @@ Class: Pkmn Trainer 1
 Pic: Red
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 Difficulty: Hard
 
 Arceus
@@ -84,7 +84,7 @@ Class: Pkmn Trainer 1
 Pic: Red
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 Party Size: 1
 
 Wynaut
@@ -101,7 +101,7 @@ Class: Pkmn Trainer 1
 Pic: Red
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 Party Size: 3
 
 Wynaut
@@ -126,7 +126,7 @@ Class: Pkmn Trainer 1
 Pic: Red
 Gender: Male
 Music: Male
-Double Battle: Yes
+Battle Type: Doubles
 Party Size: 3
 Pool Rules: Weather Doubles
 
@@ -164,7 +164,7 @@ Class: Pkmn Trainer 1
 Pic: Red
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 Party Size: 2
 Pool Rules: Basic
 
@@ -183,7 +183,7 @@ Class: Pkmn Trainer 1
 Pic: Red
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 Party Size: 2
 Pool Rules: Basic
 Pool Prune: Test
@@ -201,7 +201,7 @@ Class: Pkmn Trainer 1
 Pic: Red
 Gender: Male
 Music: Male
-Double Battle: No
+Battle Type: Singles
 Party Size: 2
 Pool Rules: Basic
 Pool Pick Functions: Lowest

--- a/test/battle/trainer_control.party
+++ b/test/battle/trainer_control.party
@@ -213,3 +213,29 @@ Wobbuffet
 
 Eevee
 Tags: Lead
+
+=== 9 ===
+Name: Test9
+Class: Pkmn Trainer 1
+Pic: Red
+Gender: Male
+Music: Male
+Double Battle: Yes
+Party Size: 2
+
+Wynaut
+
+Wobbuffet
+
+=== 10 ===
+Name: Test10
+Class: Pkmn Trainer 1
+Pic: Red
+Gender: Male
+Music: Male
+Battle Type: Doubles
+Party Size: 2
+
+Wynaut
+
+Wobbuffet

--- a/tools/trainerproc/main.c
+++ b/tools/trainerproc/main.c
@@ -123,8 +123,8 @@ struct Trainer
     struct String name;
     int name_line;
 
-    enum BattleType double_battle;
-    int double_battle_line;
+    enum BattleType battle_type;
+    int battle_type_line;
 
     struct Pokemon pokemon[PARTY_SIZE];
     int pokemon_n;
@@ -1224,10 +1224,10 @@ static bool parse_trainer(struct Parser *p, const struct Parsed *parsed, struct 
         }
         else if (is_literal_token(&key, "Battle Type"))
         {
-            if (trainer->double_battle_line)
+            if (trainer->battle_type_line)
                 any_error = !set_show_parse_error(p, key.location, "duplicate 'Battle Type'");
-            trainer->double_battle_line = value.location.line;
-            if (!token_battle_type(p, &value, &trainer->double_battle))
+            trainer->battle_type_line = value.location.line;
+            if (!token_battle_type(p, &value, &trainer->battle_type))
                 any_error = !show_parse_error(p);
         }
         else if (is_literal_token(&key, "Mugshot"))
@@ -1786,11 +1786,11 @@ static void fprint_trainers(const char *output_path, FILE *f, struct Parsed *par
             fprintf(f, " },\n");
         }
 
-        if (trainer->double_battle_line)
+        if (trainer->battle_type_line)
         {
-            fprintf(f, "#line %d\n", trainer->double_battle_line);
+            fprintf(f, "#line %d\n", trainer->battle_type_line);
             fprintf(f, "        .battleType = ");
-            if (trainer->double_battle == BATTLE_TYPE_DOUBLE)
+            if (trainer->battle_type == BATTLE_TYPE_DOUBLE)
                 fprintf(f, "TRAINER_BATTLE_TYPE_DOUBLES,\n");
             else
                 fprintf(f, "TRAINER_BATTLE_TYPE_SINGLES,\n");

--- a/tools/trainerproc/main.c
+++ b/tools/trainerproc/main.c
@@ -1222,10 +1222,20 @@ static bool parse_trainer(struct Parser *p, const struct Parsed *parsed, struct 
             trainer->name_line = value.location.line;
             trainer->name = token_string(&value);
         }
+        else if (is_literal_token(&key, "Double Battle"))
+        {
+            if (trainer->battle_type_line)
+                any_error = !set_show_parse_error(p, key.location, "duplicate 'Double Battle' or 'Battle Type'");
+            trainer->battle_type_line = value.location.line;
+            bool is_double_battle;
+            if (!token_bool(p, &value, is_double_battle))
+                any_error = !show_parse_error(p);
+            trainer->battle_type = is_double_battle ? BATTLE_TYPE_DOUBLE : BATTLE_TYPE_SINGLE;
+        }
         else if (is_literal_token(&key, "Battle Type"))
         {
             if (trainer->battle_type_line)
-                any_error = !set_show_parse_error(p, key.location, "duplicate 'Battle Type'");
+                any_error = !set_show_parse_error(p, key.location, "duplicate 'Double Battle' or 'Battle Type'");
             trainer->battle_type_line = value.location.line;
             if (!token_battle_type(p, &value, &trainer->battle_type))
                 any_error = !show_parse_error(p);

--- a/tools/trainerproc/main.c
+++ b/tools/trainerproc/main.c
@@ -847,12 +847,7 @@ static struct String token_string(const struct Token *t)
 
 static bool token_gender(struct Parser *p, const struct Token *t, enum Gender *g)
 {
-    if (is_empty_token(t))
-    {
-        *g = GENDER_ANY;
-        return true;
-    }
-    else if (is_literal_token(t, "M") || is_literal_token(t, "Male"))
+    if (is_literal_token(t, "M") || is_literal_token(t, "Male"))
     {
         *g = GENDER_MALE;
         return true;
@@ -870,12 +865,7 @@ static bool token_gender(struct Parser *p, const struct Token *t, enum Gender *g
 
 static bool token_battle_type(struct Parser *p, const struct Token *t, enum BattleType *g)
 {
-    if (is_empty_token(t))
-    {
-        *g = BATTLE_TYPE_SINGLE;
-        return true;
-    }
-    else if (is_literal_token(t, "Single") || is_literal_token(t, "Singles"))
+    if (is_literal_token(t, "Single") || is_literal_token(t, "Singles"))
     {
         *g = BATTLE_TYPE_SINGLE;
         return true;
@@ -1228,7 +1218,7 @@ static bool parse_trainer(struct Parser *p, const struct Parsed *parsed, struct 
                 any_error = !set_show_parse_error(p, key.location, "duplicate 'Double Battle' or 'Battle Type'");
             trainer->battle_type_line = value.location.line;
             bool is_double_battle;
-            if (!token_bool(p, &value, is_double_battle))
+            if (!token_bool(p, &value, &is_double_battle))
                 any_error = !show_parse_error(p);
             trainer->battle_type = is_double_battle ? BATTLE_TYPE_DOUBLE : BATTLE_TYPE_SINGLE;
         }
@@ -1333,7 +1323,9 @@ static bool parse_trainer(struct Parser *p, const struct Parsed *parsed, struct 
 
         pokemon->nickname = token_string(&nickname);
         pokemon->species = token_string(&species);
-        if (!token_gender(p, &gender, &pokemon->gender))
+        if (is_empty_token(&gender))
+            pokemon->gender = GENDER_ANY;
+        else if (!token_gender(p, &gender, &pokemon->gender))
             any_error = !show_parse_error(p);
         pokemon->item = token_string(&item);
         pokemon->header_line = species.location.line;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Before submitting, please make sure your pull request meets the scope guidelines. If unsure, please open a thread in #pr-discussions.-->
<!--- Scope Guidelines: https://github.com/rh-hideout/pokeemerald-expansion/blob/master/docs/team_procedures/scope.md  -->
<!--- #pr-discussions:  https://discord.com/channels/419213663107416084/1102784418369785948 -->

## Description
Changes `Double Battle` to `Battle Type`, in order to support future battle types with trainerproc.

Includes migration script.

## Feature(s) this PR does NOT handle:
Doesn't add any additional battle types.

## **Discord contact info**
AsparagusEduardo
