### PR TITLE
Fix Life Orb inflicting self damage when using status moves (#6767)

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -8202,6 +8202,7 @@ u32 ItemBattleEffects(enum ItemCaseId caseID, u32 battler, bool32 moveTurn)
             break;
         case HOLD_EFFECT_LIFE_ORB:
             if (IsBattlerAlive(gBattlerAttacker)
+                && !IsBattleMoveStatus(gCurrentMove)
                 && (IsBattlerTurnDamaged(gBattlerTarget) || !(gBattleStruct->moveResultFlags[gBattlerTarget] & MOVE_RESULT_NO_EFFECT)) // Needs the second check in case of Substitute
                 && !(TestIfSheerForceAffected(gBattlerAttacker, gCurrentMove))
                 && GetBattlerAbility(gBattlerAttacker) != ABILITY_MAGIC_GUARD

--- a/test/battle/hold_effect/life_orb.c
+++ b/test/battle/hold_effect/life_orb.c
@@ -15,3 +15,19 @@ SINGLE_BATTLE_TEST("Life Orb activates if it hits a Substitute")
         MESSAGE("Wobbuffet was hurt by the Life Orb!");
     }
 }
+
+SINGLE_BATTLE_TEST("Life Orb does not activate if using a status move")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_LIFE_ORB); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_GROWL); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_GROWL, player);
+        NONE_OF {
+            HP_BAR(player);
+            MESSAGE("Wobbuffet was hurt by the Life Orb!");
+        }
+    }
+}


### PR DESCRIPTION
## Description
Fixes issue #6767 
Add a test for Life Orb for the case of using status moves

## **Discord contact info**
spindrift64