### PR TITLE
Fix rerolls overwriting Fixed Personality

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -1105,7 +1105,7 @@ void CreateMon(struct Pokemon *mon, u16 species, u8 level, u8 fixedIV, u8 hasFix
 void CreateBoxMon(struct BoxPokemon *boxMon, u16 species, u8 level, u8 fixedIV, u8 hasFixedPersonality, u32 fixedPersonality, u8 otIdType, u32 fixedOtId)
 {
     u8 speciesName[POKEMON_NAME_LENGTH + 1];
-    u32 personality;
+    u32 personality = Random32();
     u32 value;
     u16 checksum;
     u8 i;
@@ -1114,11 +1114,6 @@ void CreateBoxMon(struct BoxPokemon *boxMon, u16 species, u8 level, u8 fixedIV, 
     bool32 isShiny;
 
     ZeroBoxMonData(boxMon);
-
-    if (hasFixedPersonality)
-        personality = fixedPersonality;
-    else
-        personality = Random32();
 
     // Determine original trainer ID
     if (otIdType == OT_ID_RANDOM_NO_SHINY)
@@ -1129,7 +1124,7 @@ void CreateBoxMon(struct BoxPokemon *boxMon, u16 species, u8 level, u8 fixedIV, 
     else if (otIdType == OT_ID_PRESET)
     {
         value = fixedOtId;
-        isShiny = GET_SHINY_VALUE(value, personality) < SHINY_ODDS;
+        isShiny = GET_SHINY_VALUE(value, hasFixedPersonality ? fixedPersonality : personality) < SHINY_ODDS;
     }
     else // Player is the OT
     {
@@ -1175,6 +1170,9 @@ void CreateBoxMon(struct BoxPokemon *boxMon, u16 species, u8 level, u8 fixedIV, 
             isShiny = GET_SHINY_VALUE(value, personality) < SHINY_ODDS;
         }
     }
+    
+    if (hasFixedPersonality)
+        personality = fixedPersonality;
 
     SetBoxMonData(boxMon, MON_DATA_PERSONALITY, &personality);
     SetBoxMonData(boxMon, MON_DATA_OT_ID, &value);


### PR DESCRIPTION
## Description
When calling `CreateMon`/`CreateBoxMon` with a fixed personality, any attempt to reroll the personality (i.e. Shiny Charm) will overwrite the fixed personality. This mainly effects eggs received from the Daycare. The egg's personality is set when the Daycare Man has an egg and includes the nature if it were to inherit one. Overwriting the personality means the nature is no longer inherited, leaving the Everstone effect useless if the player has a Shiny Charm.

My fix lets the code reroll as normal to get whether or not the Pokemon is shiny, but uses the fixed personality in the Pokemon's data instead. This makes gender, nature, and ability preserved when rerolling. Includes when the OT ID is fixed, whether or not the personality is fixed.

## Issue(s) that this PR fixes
Fixes #4981, fixes #2803 

## **Discord contact info**
i0brendan0
