### PR TITLE
Fix gems activating for moves that don't deal type damage

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -6074,7 +6074,9 @@ void SetTypeBeforeUsingMove(u32 move, u32 battler)
         gBattleStruct->dynamicMoveType = TYPE_ELECTRIC | F_DYNAMIC_TYPE_SET;
 
     // Check if a gem should activate.
-    if (holdEffect == HOLD_EFFECT_GEMS && GetBattleMoveType(move) == ItemId_GetSecondaryId(heldItem))
+    if (holdEffect == HOLD_EFFECT_GEMS
+        && GetBattleMoveType(move) == ItemId_GetSecondaryId(heldItem)
+        && GetMovePower(move) > 1)
     {
         gSpecialStatuses[battler].gemParam = GetBattlerHoldEffectParam(battler);
         gSpecialStatuses[battler].gemBoost = TRUE;

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -6076,6 +6076,7 @@ void SetTypeBeforeUsingMove(u32 move, u32 battler)
     // Check if a gem should activate.
     if (holdEffect == HOLD_EFFECT_GEMS
         && GetBattleMoveType(move) == ItemId_GetSecondaryId(heldItem)
+        && GetMoveEffect(move) != EFFECT_PLEDGE
         && GetMovePower(move) > 1)
     {
         gSpecialStatuses[battler].gemParam = GetBattlerHoldEffectParam(battler);

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2095,7 +2095,6 @@ static void Cmd_adjustdamage(void)
     u32 affectionScore = GetBattlerAffectionHearts(gBattlerTarget);
     u32 moveTarget = GetBattlerMoveTargetType(gBattlerAttacker, gCurrentMove);
     u32 moveEffect = GetMoveEffect(gCurrentMove);
-    u32 movePower = GetMovePower(gCurrentMove);
     bool32 calcSpreadMoveDamage = IsSpreadMove(moveTarget) && !IsBattleMoveStatus(gCurrentMove);
 
     for (battlerDef = 0; battlerDef < gBattlersCount; battlerDef++)
@@ -2203,8 +2202,6 @@ static void Cmd_adjustdamage(void)
         && !(gBattleStruct->moveResultFlags[gBattlerTarget] & MOVE_RESULT_NO_EFFECT)
         && !(gHitMarker & HITMARKER_UNABLE_TO_USE_MOVE)
         && gBattleMons[gBattlerAttacker].item
-        && moveEffect != EFFECT_PLEDGE
-        && movePower > 1
         && gCurrentMove != MOVE_STRUGGLE)
     {
         BattleScriptPushCursor();

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2095,6 +2095,7 @@ static void Cmd_adjustdamage(void)
     u32 affectionScore = GetBattlerAffectionHearts(gBattlerTarget);
     u32 moveTarget = GetBattlerMoveTargetType(gBattlerAttacker, gCurrentMove);
     u32 moveEffect = GetMoveEffect(gCurrentMove);
+    u32 movePower = GetMovePower(gCurrentMove);
     bool32 calcSpreadMoveDamage = IsSpreadMove(moveTarget) && !IsBattleMoveStatus(gCurrentMove);
 
     for (battlerDef = 0; battlerDef < gBattlersCount; battlerDef++)
@@ -2203,6 +2204,7 @@ static void Cmd_adjustdamage(void)
         && !(gHitMarker & HITMARKER_UNABLE_TO_USE_MOVE)
         && gBattleMons[gBattlerAttacker].item
         && moveEffect != EFFECT_PLEDGE
+        && movePower > 1
         && gCurrentMove != MOVE_STRUGGLE)
     {
         BattleScriptPushCursor();

--- a/test/battle/hold_effect/gems.c
+++ b/test/battle/hold_effect/gems.c
@@ -90,13 +90,12 @@ SINGLE_BATTLE_TEST("Gem is consumed if the move type is changed")
 
 SINGLE_BATTLE_TEST("Gem is not consumed if a no type damage move is used") //ie. Counter, Psywave, Super Fang. All these moves have 1 base power.
 {
+    ASSUME(GetMovePower(MOVE_PSYWAVE) == 1);
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_PSYCHIC_GEM); };
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
-        TURN {
-            MOVE(player, MOVE_PSYWAVE);
-        }
+        TURN { MOVE(player, MOVE_PSYWAVE); }
     } SCENE {
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);

--- a/test/battle/hold_effect/gems.c
+++ b/test/battle/hold_effect/gems.c
@@ -87,3 +87,20 @@ SINGLE_BATTLE_TEST("Gem is consumed if the move type is changed")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_FEINT_ATTACK, player);
     }
 }
+
+SINGLE_BATTLE_TEST("Gem is not consumed if a no type damage move is used") //ie. Counter, Psywave, Super Fang. All these moves have 1 base power.
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_PSYCHIC_GEM); };
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN {
+            MOVE(player, MOVE_PSYWAVE);
+        }
+    } SCENE {
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+            MESSAGE("The Psychic Gem strengthened Wobbuffet's power!");
+        }
+    }
+}


### PR DESCRIPTION
Gems do not activate for no type damage moves such as Counter/Psywave/Super Fang.

## Description
Check for base power of the move used. Moves that would trigger the bug have 1 base power.

## Issue(s) that this PR fixes
Fixes #6785

## **Discord contact info**
spindrift64