### PR TITLE
Prevent scaninc touching tests when `make`-ing non-test builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -401,6 +401,7 @@ ifneq ($(NODEP),1)
 -include $(addprefix $(OBJ_DIR)/,$(C_SRCS:.c=.d))
 endif
 
+ifeq ($(TEST),1)
 $(TEST_BUILDDIR)/%.o: $(TEST_SUBDIR)/%.c
 	@echo "$(CC1) <flags> -o $@ $<"
 	@$(CPP) $(CPPFLAGS) $< | $(PREPROC) -i $< charmap.txt | $(CC1) $(CFLAGS) -o - - | cat - <(echo -e ".text\n\t.align\t2, 0") | $(AS) $(ASFLAGS) -o $@ -
@@ -410,6 +411,7 @@ $(TEST_BUILDDIR)/%.d: $(TEST_SUBDIR)/%.c
 
 ifneq ($(NODEP),1)
 -include $(addprefix $(OBJ_DIR)/,$(TEST_SRCS:.c=.d))
+endif
 endif
 
 $(ASM_BUILDDIR)/%.o: $(ASM_SUBDIR)/%.s


### PR DESCRIPTION
## Description

This won't affect most devs who has an average or just better PC in general, but it is nice-to-have for devs who only has more low-end PC.

Below are the results with `make tidy -j1 -O` before and `make -j1 -O` after.

Before the scaninc fix:
```sh
Executed in  514.76 secs    fish           external
   usr time  346.42 secs  998.00 micros  346.42 secs
   sys time   31.28 secs  390.00 micros   31.28 secs
```

After the scaninc fix:
```sh
Executed in  506.27 secs    fish           external
   usr time  328.54 secs  848.00 micros  328.54 secs
   sys time   27.90 secs  509.00 micros   27.90 secs
```

## **Discord contact info**
mudskipper13
