### PR TITLE
Fixed double battles send out breaking

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -5347,7 +5347,7 @@ static void Cmd_getexp(void)
 
 static u32 CountAliveMonsForBattlerSide(u32 battler)
 {
-    u32 i = 0;
+    u32 aliveMons = 0;
     struct Pokemon *party = GetBattlerParty(battler);
 
     for (u32 partyMon = 0; partyMon < PARTY_SIZE; partyMon++)
@@ -5355,10 +5355,10 @@ static u32 CountAliveMonsForBattlerSide(u32 battler)
         if (GetMonData(&party[partyMon], MON_DATA_SPECIES)
          && GetMonData(&party[partyMon], MON_DATA_HP) > 0
          && !GetMonData(&party[partyMon], MON_DATA_IS_EGG))
-            i++;
+            aliveMons++;
     }
 
-    return i;
+    return aliveMons;
 }
 
 bool32 NoAliveMonsForBattlerSide(u32 battler)

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -5345,6 +5345,27 @@ static void Cmd_getexp(void)
     }
 }
 
+static u32 CountAliveMonsForBattlerSide(u32 battler)
+{
+    u32 i = 0;
+    struct Pokemon *party = GetBattlerParty(battler);
+
+    for (u32 partyMon = 0; partyMon < PARTY_SIZE; partyMon++)
+    {
+        if (GetMonData(&party[partyMon], MON_DATA_SPECIES)
+         && GetMonData(&party[partyMon], MON_DATA_HP) > 0
+         && !GetMonData(&party[partyMon], MON_DATA_IS_EGG))
+            i++;
+    }
+
+    return i;
+}
+
+bool32 NoAliveMonsForBattlerSide(u32 battler)
+{
+    return CountAliveMonsForBattlerSide(battler) == 0;
+}
+
 bool32 NoAliveMonsForPlayer(void)
 {
     u32 i;
@@ -5460,7 +5481,12 @@ static void Cmd_checkteamslost(void)
         }
         else
         {
-            if (emptyOpponentSpots != 0 && emptyPlayerSpots != 0)
+            u32 occupiedPlayerSpots = (gBattlersCount / 2) - emptyPlayerSpots;
+            u32 occupiedOpponentSpots = (gBattlersCount / 2) - emptyOpponentSpots;
+            u32 alivePlayerPartyMons = CountAliveMonsForBattlerSide(B_POSITION_PLAYER_LEFT) - occupiedPlayerSpots;
+            u32 aliveOpponentPartyMons = CountAliveMonsForBattlerSide(B_POSITION_OPPONENT_LEFT) - occupiedOpponentSpots;
+
+            if (emptyPlayerSpots > 0 && alivePlayerPartyMons > 0 && emptyOpponentSpots > 0 && aliveOpponentPartyMons > 0)
                 gBattlescriptCurrInstr = cmd->jumpInstr;
             else
                 gBattlescriptCurrInstr = cmd->nextInstr;


### PR DESCRIPTION
## Description
Sendout breaks in doubles, if multiple mons fainted and both sides have 1 empty spot, while the player has no mons left to send out. 

Note: `NoAliveMonsForBattlerSide` is a function that already exists in upcoming, so this will result in merge conflicts. `NoAliveMonsForBattlerSide` makes use of `CountAliveMonsForBattlerSide` to deduplicate code.

## Images
![image](https://github.com/user-attachments/assets/811fe662-751c-474e-9021-f1b5ef26e98a)

## **Discord contact info**
.cawt
