### PR TITLE
Add AUTO_GEN_TARGETS for .party files and map_groups_count

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -366,6 +366,9 @@ clean-generated:
 COMPETITIVE_PARTY_SYNTAX := $(shell PATH="$(PATH)"; echo 'COMPETITIVE_PARTY_SYNTAX' | $(CPP) $(CPPFLAGS) -imacros include/gba/defines.h -imacros include/config/general.h | tail -n1)
 ifeq ($(COMPETITIVE_PARTY_SYNTAX),1)
 %.h: %.party ; $(CPP) $(CPPFLAGS) -traditional-cpp - < $< | $(TRAINERPROC) -o $@ -i $< -
+
+AUTO_GEN_TARGETS += $(DATA_SRC_SUBDIR)/trainers.h
+AUTO_GEN_TARGETS += $(DATA_SRC_SUBDIR)/battle_partners.h
 endif
 
 $(C_BUILDDIR)/librfu_intr.o: CFLAGS := -mthumb-interwork -O2 -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -fno-toplevel-reorder -Wno-pointer-to-int-cast

--- a/map_data_rules.mk
+++ b/map_data_rules.mk
@@ -11,6 +11,7 @@ INCLUDECONSTS_OUTDIR := include/constants
 
 AUTO_GEN_TARGETS += $(INCLUDECONSTS_OUTDIR)/map_groups.h
 AUTO_GEN_TARGETS += $(INCLUDECONSTS_OUTDIR)/layouts.h
+AUTO_GEN_TARGETS += $(DATA_SRC_SUBDIR)/map_group_count.h
 
 MAP_DIRS := $(dir $(wildcard $(MAPS_DIR)/*/map.json))
 MAP_CONNECTIONS := $(patsubst $(MAPS_DIR)/%/,$(MAPS_DIR)/%/connections.inc,$(MAP_DIRS))


### PR DESCRIPTION
`src/data/trainers.h`, `src/data/battle_partners.h`, `src/data/map_groups_count.h` were missing from `AUTO_GEN_TARGETS`, which prevented them from being built if the file doesn't already exist.

To test:
```
$ make
$ rm src/data/trainers.h src/data/battle_partners.h src/data/map_group_count.h
$ make
```