### PR TITLE
Battle TV expansion

### DIFF
--- a/src/battle_tv.c
+++ b/src/battle_tv.c
@@ -359,16 +359,19 @@ void BattleTv_SetDataBasedOnString(enum StringID stringId)
     switch (stringId)
     {
     case STRINGID_ITDOESNTAFFECT:
+    case STRINGID_ITDOESNTAFFECTTWOFOES:
         AddMovePoints(PTS_EFFECTIVENESS, moveSlot, 2, 0);
         if (!(gBattleTypeFlags & BATTLE_TYPE_LINK))
             TrySetBattleSeminarShow();
         break;
     case STRINGID_NOTVERYEFFECTIVE:
+    case STRINGID_NOTVERYEFFECTIVETWOFOES:
         AddMovePoints(PTS_EFFECTIVENESS, moveSlot, 1, 0);
         if (!(gBattleTypeFlags & BATTLE_TYPE_LINK) && GetMonData(defMon, MON_DATA_HP, NULL) != 0)
             TrySetBattleSeminarShow();
         break;
     case STRINGID_SUPEREFFECTIVE:
+    case STRINGID_SUPEREFFECTIVETWOFOES:
         AddMovePoints(PTS_EFFECTIVENESS, moveSlot, 0, 0);
         break;
     case STRINGID_PKMNFORESAWATTACK:

--- a/src/battle_tv.c
+++ b/src/battle_tv.c
@@ -45,9 +45,11 @@ enum {
     PTS_FLINCHED,
     PTS_STAT_INCREASE_1,
     PTS_STAT_INCREASE_2,
+    PTS_STAT_INCREASE_3,
     PTS_STAT_DECREASE_SELF,
     PTS_STAT_DECREASE_1,
     PTS_STAT_DECREASE_2,
+    PTS_STAT_DECREASE_3,
     PTS_STAT_INCREASE_NOT_SELF,
 };
 
@@ -131,67 +133,6 @@ static const u16 sPoints_CriticalHit[] = { 6 };
 static const u16 sPoints_Faint[] = { 6 };
 static const u16 sPoints_Flinched[] = { 4 };
 
-static const u16 sPoints_StatIncrease1[NUM_BATTLE_STATS - 1] =
-{
-    [STAT_ATK - 1]     = 2,
-    [STAT_DEF - 1]     = 2,
-    [STAT_SPEED - 1]   = 2,
-    [STAT_SPATK - 1]   = 2,
-    [STAT_SPDEF - 1]   = 2,
-    [STAT_ACC - 1]     = 2,
-    [STAT_EVASION - 1] = 2
-};
-static const u16 sPoints_StatIncrease2[NUM_BATTLE_STATS - 1] =
-{
-    [STAT_ATK - 1]     = 4,
-    [STAT_DEF - 1]     = 4,
-    [STAT_SPEED - 1]   = 4,
-    [STAT_SPATK - 1]   = 4,
-    [STAT_SPDEF - 1]   = 4,
-    [STAT_ACC - 1]     = 4,
-    [STAT_EVASION - 1] = 4
-};
-static const u16 sPoints_StatDecreaseSelf[NUM_BATTLE_STATS - 1] =
-{
-    [STAT_ATK - 1]     = -1,
-    [STAT_DEF - 1]     = -1,
-    [STAT_SPEED - 1]   = -1,
-    [STAT_SPATK - 1]   = -1,
-    [STAT_SPDEF - 1]   = -1,
-    [STAT_ACC - 1]     = -1,
-    [STAT_EVASION - 1] = -1
-};
-static const u16 sPoints_StatDecrease1[NUM_BATTLE_STATS - 1] =
-{
-    [STAT_ATK - 1]     = 2,
-    [STAT_DEF - 1]     = 2,
-    [STAT_SPEED - 1]   = 2,
-    [STAT_SPATK - 1]   = 2,
-    [STAT_SPDEF - 1]   = 2,
-    [STAT_ACC - 1]     = 2,
-    [STAT_EVASION - 1] = 2
-};
-static const u16 sPoints_StatDecrease2[NUM_BATTLE_STATS - 1] =
-{
-    [STAT_ATK - 1]     = 4,
-    [STAT_DEF - 1]     = 4,
-    [STAT_SPEED - 1]   = 4,
-    [STAT_SPATK - 1]   = 4,
-    [STAT_SPDEF - 1]   = 4,
-    [STAT_ACC - 1]     = 4,
-    [STAT_EVASION - 1] = 4
-};
-static const u16 sPoints_StatIncreaseNotSelf[NUM_BATTLE_STATS - 1] =
-{
-    [STAT_ATK - 1]     = -2,
-    [STAT_DEF - 1]     = -2,
-    [STAT_SPEED - 1]   = -2,
-    [STAT_SPATK - 1]   = -2,
-    [STAT_SPDEF - 1]   = -2,
-    [STAT_ACC - 1]     = -2,
-    [STAT_EVASION - 1] = -2
-};
-
 static const u16 *const sPointsArray[] =
 {
     [PTS_EFFECTIVENESS]          = sPoints_Effectiveness,
@@ -210,12 +151,6 @@ static const u16 *const sPointsArray[] =
     [PTS_FAINT]                  = sPoints_Faint,
     [PTS_FAINT_SET_UP]           = sPoints_Faint,
     [PTS_FLINCHED]               = sPoints_Flinched,
-    [PTS_STAT_INCREASE_1]        = sPoints_StatIncrease1,
-    [PTS_STAT_INCREASE_2]        = sPoints_StatIncrease2,
-    [PTS_STAT_DECREASE_SELF]     = sPoints_StatDecreaseSelf,
-    [PTS_STAT_DECREASE_1]        = sPoints_StatDecrease1,
-    [PTS_STAT_DECREASE_2]        = sPoints_StatDecrease2,
-    [PTS_STAT_INCREASE_NOT_SELF] = sPoints_StatIncreaseNotSelf
 };
 
 // Points will always be calculated for these messages
@@ -356,7 +291,9 @@ void BattleTv_SetDataBasedOnString(enum StringID stringId)
     case STRINGID_ATTACKERSSTATROSE:
         if (gBattleTextBuff1[2] != 0)
         {
-            if (*statStringId == STRINGID_STATSHARPLY)
+            if (*statStringId == STRINGID_DRASTICALLY)
+                AddMovePoints(PTS_STAT_INCREASE_3, moveSlot, gBattleTextBuff1[2] - 1, 0);
+            else if (*statStringId == STRINGID_STATSHARPLY)
                 AddMovePoints(PTS_STAT_INCREASE_2, moveSlot, gBattleTextBuff1[2] - 1, 0);
             else
                 AddMovePoints(PTS_STAT_INCREASE_1, moveSlot, gBattleTextBuff1[2] - 1, 0);
@@ -367,7 +304,9 @@ void BattleTv_SetDataBasedOnString(enum StringID stringId)
         {
             if (gBattlerAttacker == gBattlerTarget)
             {
-                if (*statStringId == STRINGID_STATSHARPLY)
+                if (*statStringId == STRINGID_DRASTICALLY)
+                    AddMovePoints(PTS_STAT_INCREASE_3, moveSlot, gBattleTextBuff1[2] - 1, 0);
+                else if (*statStringId == STRINGID_STATSHARPLY)
                     AddMovePoints(PTS_STAT_INCREASE_2, moveSlot, gBattleTextBuff1[2] - 1, 0);
                 else
                     AddMovePoints(PTS_STAT_INCREASE_1, moveSlot, gBattleTextBuff1[2] - 1, 0);
@@ -385,7 +324,9 @@ void BattleTv_SetDataBasedOnString(enum StringID stringId)
     case STRINGID_DEFENDERSSTATFELL:
         if (gBattleTextBuff1[2] != 0)
         {
-            if (*statStringId == STRINGID_STATHARSHLY)
+            if (*statStringId == STRINGID_SEVERELY)
+                AddMovePoints(PTS_STAT_DECREASE_3, moveSlot, gBattleTextBuff1[2] - 1, 0);
+            else if (*statStringId == STRINGID_STATHARSHLY)
                 AddMovePoints(PTS_STAT_DECREASE_2, moveSlot, gBattleTextBuff1[2] - 1, 0);
             else
                 AddMovePoints(PTS_STAT_DECREASE_1, moveSlot, gBattleTextBuff1[2] - 1, 0);
@@ -500,8 +441,8 @@ void BattleTv_SetDataBasedOnString(enum StringID stringId)
         break;
     case STRINGID_PKMNFASTASLEEP:
         if (tvPtr->mon[atkSide][gBattlerPartyIndexes[gBattlerAttacker]].slpMonId != 0
-            && gBattleMsgDataPtr->currentMove != MOVE_SNORE
-            && gBattleMsgDataPtr->currentMove != MOVE_SLEEP_TALK)
+            && GetMoveEffect(gBattleMsgDataPtr->currentMove) != EFFECT_SNORE
+            && GetMoveEffect(gBattleMsgDataPtr->currentMove) != EFFECT_SLEEP_TALK)
             AddMovePoints(PTS_STATUS, 3, tvPtr->mon[atkSide][gBattlerPartyIndexes[gBattlerAttacker]].slpMonId - 1, tvPtr->mon[atkSide][gBattlerPartyIndexes[gBattlerAttacker]].slpMoveSlot);
         break;
     case STRINGID_PKMNWASFROZEN:
@@ -839,7 +780,6 @@ static void AddMovePoints(u8 caseId, u16 arg1, u8 arg2, u8 arg3)
     struct BattleTv *tvPtr = &gBattleStruct->tv;
     u32 atkSide = GetBattlerSide(gBattlerAttacker);
     u32 defSide = GetBattlerSide(gBattlerTarget);
-    const u16 *ptr;
     s32 i;
 
     switch (caseId)
@@ -952,13 +892,25 @@ static void AddMovePoints(u8 caseId, u16 arg1, u8 arg2, u8 arg3)
 #undef move
     case PTS_EFFECTIVENESS:
     case PTS_CRITICAL_HIT:
-    case PTS_STAT_INCREASE_1:
-    case PTS_STAT_INCREASE_2:
-    case PTS_STAT_DECREASE_SELF:
-    case PTS_STAT_DECREASE_1:
-    case PTS_STAT_DECREASE_2:
-    case PTS_STAT_INCREASE_NOT_SELF:
         movePoints->points[atkSide][gBattlerPartyIndexes[gBattlerAttacker] * 4 + arg1] += sPointsArray[caseId][arg2];
+        break;
+    case PTS_STAT_INCREASE_1:
+    case PTS_STAT_DECREASE_1:
+        movePoints->points[atkSide][gBattlerPartyIndexes[gBattlerAttacker] * 4 + arg1] += 2;
+        break;
+    case PTS_STAT_INCREASE_2:
+    case PTS_STAT_DECREASE_2:
+        movePoints->points[atkSide][gBattlerPartyIndexes[gBattlerAttacker] * 4 + arg1] += 4;
+        break;
+    case PTS_STAT_INCREASE_3:
+    case PTS_STAT_DECREASE_3:
+        movePoints->points[atkSide][gBattlerPartyIndexes[gBattlerAttacker] * 4 + arg1] += 6;
+        break;
+    case PTS_STAT_DECREASE_SELF:
+        movePoints->points[atkSide][gBattlerPartyIndexes[gBattlerAttacker] * 4 + arg1] -= 1;
+        break;
+    case PTS_STAT_INCREASE_NOT_SELF:
+        movePoints->points[atkSide][gBattlerPartyIndexes[gBattlerAttacker] * 4 + arg1] -= 2;
         break;
 
 #define move arg1
@@ -1017,7 +969,6 @@ static void AddMovePoints(u8 caseId, u16 arg1, u8 arg2, u8 arg3)
         default:
             break;
         }
-
         movePoints->points[atkSide][gBattlerPartyIndexes[gBattlerAttacker] * 4 + arg2] += points;
         break;
     }
@@ -1036,6 +987,7 @@ static void AddMovePoints(u8 caseId, u16 arg1, u8 arg2, u8 arg3)
         default:
             break;
         }
+        movePoints->points[atkSide][gBattlerPartyIndexes[gBattlerAttacker] * 4 + arg2] += points;
         break;
     }
     case PTS_ELECTRIC:

--- a/src/battle_tv.c
+++ b/src/battle_tv.c
@@ -30,7 +30,7 @@ enum {
     PTS_HAIL_SNOW,
     PTS_ELECTRIC,
     PTS_STATUS_DMG,
-    PTS_STATUS,
+    PTS_STATUS_SKIP_TURN,
     PTS_SPIKES,
     PTS_WATER_SPORT,
     PTS_MUD_SPORT,
@@ -112,45 +112,12 @@ static const u16 sPoints_StatusDmg[] =
     3, // Nightmare
     3  // Wrap (Trapping move)
 };
-static const u16 sPoints_Status[] =
-{
-    5, // Attraction
-    5, // Confusion
-    5, // Paralysis
-    5, // Sleep
-    5  // Freeze
-};
-
-static const u16 sPoints_Spikes[] = { 4 };
-static const u16 sPoints_WaterSport[] = { 5 };
-static const u16 sPoints_MudSport[] = { 5 };
-static const u16 sPoints_Reflect[] = { 3 };
-static const u16 sPoints_LightScreen[] = { 3 };
-static const u16 sPoints_Safeguard[] = { 4 };
-static const u16 sPoints_Mist[] = { 3 };
-static const u16 sPoints_BreakWall[] = { 6 };
-static const u16 sPoints_CriticalHit[] = { 6 };
-static const u16 sPoints_Faint[] = { 6 };
-static const u16 sPoints_Flinched[] = { 4 };
 
 static const u16 *const sPointsArray[] =
 {
     [PTS_EFFECTIVENESS]          = sPoints_Effectiveness,
     [PTS_SET_UP]                 = sPoints_SetUp,
     [PTS_STATUS_DMG]             = sPoints_StatusDmg,
-    [PTS_STATUS]                 = sPoints_Status,
-    [PTS_SPIKES]                 = sPoints_Spikes,
-    [PTS_WATER_SPORT]            = sPoints_WaterSport,
-    [PTS_MUD_SPORT]              = sPoints_MudSport,
-    [PTS_REFLECT]                = sPoints_Reflect,
-    [PTS_LIGHT_SCREEN]           = sPoints_LightScreen,
-    [PTS_SAFEGUARD]              = sPoints_Safeguard,
-    [PTS_MIST]                   = sPoints_Mist,
-    [PTS_BREAK_WALL]             = sPoints_BreakWall,
-    [PTS_CRITICAL_HIT]           = sPoints_CriticalHit,
-    [PTS_FAINT]                  = sPoints_Faint,
-    [PTS_FAINT_SET_UP]           = sPoints_Faint,
-    [PTS_FLINCHED]               = sPoints_Flinched,
 };
 
 // Points will always be calculated for these messages
@@ -425,7 +392,7 @@ void BattleTv_SetDataBasedOnString(enum StringID stringId)
         break;
     case STRINGID_PKMNIMMOBILIZEDBYLOVE:
         if (tvPtr->pos[atkSide][atkFlank].attractMonId != 0)
-            AddMovePoints(PTS_STATUS, 0, tvPtr->pos[atkSide][atkFlank].attractMonId - 1, tvPtr->pos[atkSide][atkFlank].attractMoveSlot);
+            AddMovePoints(PTS_STATUS_SKIP_TURN, 0, tvPtr->pos[atkSide][atkFlank].attractMonId - 1, tvPtr->pos[atkSide][atkFlank].attractMoveSlot);
         break;
     case STRINGID_PKMNWASPARALYZED:
         tvPtr->mon[effSide][gBattlerPartyIndexes[gEffectBattler]].prlzMonId = gBattlerPartyIndexes[gBattlerAttacker] + 1;
@@ -433,7 +400,7 @@ void BattleTv_SetDataBasedOnString(enum StringID stringId)
         break;
     case STRINGID_PKMNISPARALYZED:
         if (tvPtr->mon[atkSide][gBattlerPartyIndexes[gBattlerAttacker]].prlzMonId != 0)
-            AddMovePoints(PTS_STATUS, 2, tvPtr->mon[atkSide][gBattlerPartyIndexes[gBattlerAttacker]].prlzMonId - 1, tvPtr->mon[atkSide][gBattlerPartyIndexes[gBattlerAttacker]].prlzMoveSlot);
+            AddMovePoints(PTS_STATUS_SKIP_TURN, 2, tvPtr->mon[atkSide][gBattlerPartyIndexes[gBattlerAttacker]].prlzMonId - 1, tvPtr->mon[atkSide][gBattlerPartyIndexes[gBattlerAttacker]].prlzMoveSlot);
         break;
     case STRINGID_PKMNFELLASLEEP:
         tvPtr->mon[effSide][gBattlerPartyIndexes[gEffectBattler]].slpMonId = gBattlerPartyIndexes[gBattlerAttacker] + 1;
@@ -443,7 +410,7 @@ void BattleTv_SetDataBasedOnString(enum StringID stringId)
         if (tvPtr->mon[atkSide][gBattlerPartyIndexes[gBattlerAttacker]].slpMonId != 0
             && GetMoveEffect(gBattleMsgDataPtr->currentMove) != EFFECT_SNORE
             && GetMoveEffect(gBattleMsgDataPtr->currentMove) != EFFECT_SLEEP_TALK)
-            AddMovePoints(PTS_STATUS, 3, tvPtr->mon[atkSide][gBattlerPartyIndexes[gBattlerAttacker]].slpMonId - 1, tvPtr->mon[atkSide][gBattlerPartyIndexes[gBattlerAttacker]].slpMoveSlot);
+            AddMovePoints(PTS_STATUS_SKIP_TURN, 3, tvPtr->mon[atkSide][gBattlerPartyIndexes[gBattlerAttacker]].slpMonId - 1, tvPtr->mon[atkSide][gBattlerPartyIndexes[gBattlerAttacker]].slpMoveSlot);
         break;
     case STRINGID_PKMNWASFROZEN:
         tvPtr->mon[effSide][gBattlerPartyIndexes[gEffectBattler]].frzMonId = gBattlerPartyIndexes[gBattlerAttacker] + 1;
@@ -451,7 +418,7 @@ void BattleTv_SetDataBasedOnString(enum StringID stringId)
         break;
     case STRINGID_PKMNISFROZEN:
         if (tvPtr->mon[atkSide][gBattlerPartyIndexes[gBattlerAttacker]].frzMonId != 0)
-            AddMovePoints(PTS_STATUS, 4, tvPtr->mon[atkSide][gBattlerPartyIndexes[gBattlerAttacker]].frzMonId - 1, tvPtr->mon[atkSide][gBattlerPartyIndexes[gBattlerAttacker]].frzMoveSlot);
+            AddMovePoints(PTS_STATUS_SKIP_TURN, 4, tvPtr->mon[atkSide][gBattlerPartyIndexes[gBattlerAttacker]].frzMonId - 1, tvPtr->mon[atkSide][gBattlerPartyIndexes[gBattlerAttacker]].frzMoveSlot);
         break;
     case STRINGID_PKMNWASCONFUSED:
         tvPtr->pos[effSide][effFlank].confusionMonId = gBattlerPartyIndexes[gBattlerAttacker] + 1;
@@ -459,7 +426,7 @@ void BattleTv_SetDataBasedOnString(enum StringID stringId)
         break;
     case STRINGID_ITHURTCONFUSION:
         if (tvPtr->pos[atkSide][atkFlank].confusionMonId != 0)
-            AddMovePoints(PTS_STATUS, 1, tvPtr->pos[atkSide][atkFlank].confusionMonId - 1, tvPtr->pos[atkSide][atkFlank].confusionMoveSlot);
+            AddMovePoints(PTS_STATUS_SKIP_TURN, 1, tvPtr->pos[atkSide][atkFlank].confusionMonId - 1, tvPtr->pos[atkSide][atkFlank].confusionMoveSlot);
         tvPtr->side[atkSide].faintCause = FNT_CONFUSION;
         break;
     case STRINGID_SPIKESSCATTERED:
@@ -891,7 +858,6 @@ static void AddMovePoints(u8 caseId, u16 arg1, u8 arg2, u8 arg3)
     }
 #undef move
     case PTS_EFFECTIVENESS:
-    case PTS_CRITICAL_HIT:
         movePoints->points[atkSide][gBattlerPartyIndexes[gBattlerAttacker] * 4 + arg1] += sPointsArray[caseId][arg2];
         break;
     case PTS_STAT_INCREASE_1:
@@ -904,6 +870,7 @@ static void AddMovePoints(u8 caseId, u16 arg1, u8 arg2, u8 arg3)
         break;
     case PTS_STAT_INCREASE_3:
     case PTS_STAT_DECREASE_3:
+    case PTS_CRITICAL_HIT:
         movePoints->points[atkSide][gBattlerPartyIndexes[gBattlerAttacker] * 4 + arg1] += 6;
         break;
     case PTS_STAT_DECREASE_SELF:
@@ -997,27 +964,34 @@ static void AddMovePoints(u8 caseId, u16 arg1, u8 arg2, u8 arg3)
 #undef move
 
     case PTS_FAINT:
-        tvPtr->side[arg2 ^ 1].faintCause = FNT_NONE;
-        movePoints->points[arg2][0 * 4 + arg3] += sPointsArray[caseId][arg1];
+        tvPtr->side[arg2 ^ BIT_SIDE].faintCause = FNT_NONE;
+        movePoints->points[arg2][0 * 4 + arg3] += 6;
         break;
     case PTS_FAINT_SET_UP:
         tvPtr->side[arg2].faintCause = FNT_NONE;
-        // fallthrough
+        movePoints->points[arg2][0 * 4 + arg3] += 6;
+        break;
     case PTS_SET_UP:
         movePoints->points[arg2][0 * 4 + arg3] += sPointsArray[caseId][arg1];
         break;
     case PTS_BREAK_WALL:
-        movePoints->points[atkSide][arg2 * 4 + arg3] += sPointsArray[caseId][arg1];
+        movePoints->points[atkSide][arg2 * 4 + arg3] += 6;
         break;
     case PTS_STATUS_DMG:
-    case PTS_STATUS:
-    case PTS_SAFEGUARD:
-    case PTS_MIST:
-    case PTS_FLINCHED:
         movePoints->points[atkSide ^ BIT_SIDE][arg2 * 4 + arg3] += sPointsArray[caseId][arg1];
         break;
+    case PTS_STATUS_SKIP_TURN:
+        movePoints->points[atkSide ^ BIT_SIDE][arg2 * 4 + arg3] += 5;
+        break;
+    case PTS_MIST:
+        movePoints->points[atkSide ^ BIT_SIDE][arg2 * 4 + arg3] += 3;
+        break;
+    case PTS_SAFEGUARD:
+    case PTS_FLINCHED:
+        movePoints->points[atkSide ^ BIT_SIDE][arg2 * 4 + arg3] += 4;
+        break;
     case PTS_SPIKES:
-        movePoints->points[arg1][arg2 * 4 + arg3] += sPointsArray[caseId][0];
+        movePoints->points[arg1][arg2 * 4 + arg3] += 4;
         break;
 
 #define move arg1
@@ -1029,12 +1003,12 @@ static void AddMovePoints(u8 caseId, u16 arg1, u8 arg2, u8 arg3)
             if (tvPtr->pos[defSide][0].waterSportMonId != 0)
             {
                 u32 id = (tvPtr->pos[defSide][0].waterSportMonId - 1) * 4;
-                movePoints->points[defSide][id + tvPtr->pos[defSide][0].waterSportMoveSlot] += sPointsArray[caseId][0];
+                movePoints->points[defSide][id + tvPtr->pos[defSide][0].waterSportMoveSlot] += 5;
             }
             if (tvPtr->pos[defSide][1].waterSportMonId != 0)
             {
                 u32 id = (tvPtr->pos[defSide][1].waterSportMonId - 1) * 4;
-                movePoints->points[defSide][id + tvPtr->pos[defSide][1].waterSportMoveSlot] += sPointsArray[caseId][0];
+                movePoints->points[defSide][id + tvPtr->pos[defSide][1].waterSportMoveSlot] += 5;
             }
         }
         break;
@@ -1045,12 +1019,12 @@ static void AddMovePoints(u8 caseId, u16 arg1, u8 arg2, u8 arg3)
             if (tvPtr->pos[defSide][0].mudSportMonId != 0)
             {
                 u32 id = (tvPtr->pos[defSide][0].mudSportMonId - 1) * 4;
-                movePoints->points[defSide][id + tvPtr->pos[defSide][0].mudSportMoveSlot] += sPointsArray[caseId][0];
+                movePoints->points[defSide][id + tvPtr->pos[defSide][0].mudSportMoveSlot] += 5;
             }
             if (tvPtr->pos[defSide][1].mudSportMonId != 0)
             {
                 u32 id = (tvPtr->pos[defSide][1].mudSportMonId - 1) * 4;
-                movePoints->points[defSide][id + tvPtr->pos[defSide][1].mudSportMoveSlot] += sPointsArray[caseId][0];
+                movePoints->points[defSide][id + tvPtr->pos[defSide][1].mudSportMoveSlot] += 5;
             }
         }
         break;
@@ -1059,7 +1033,7 @@ static void AddMovePoints(u8 caseId, u16 arg1, u8 arg2, u8 arg3)
         if (IsBattleMovePhysical(move) && power != 0 && tvPtr->side[defSide].reflectMonId != 0)
         {
             u32 id = (tvPtr->side[defSide].reflectMonId - 1) * 4;
-            movePoints->points[defSide][id + tvPtr->side[defSide].reflectMoveSlot] += sPointsArray[caseId][0];
+            movePoints->points[defSide][id + tvPtr->side[defSide].reflectMoveSlot] += 3;
         }
         break;
     case PTS_LIGHT_SCREEN:

--- a/src/battle_tv.c
+++ b/src/battle_tv.c
@@ -100,19 +100,6 @@ static const u16 sPoints_SetUp[] =
     6,
     2  // Ingrain
 };
-static const u16 sPoints_ElectricMoves[] =
-{
-    MOVE_THUNDERBOLT, 3,
-    MOVE_THUNDER_PUNCH, 3,
-    MOVE_SPARK, 3,
-    MOVE_THUNDER_SHOCK, 3,
-    MOVE_ZAP_CANNON, 3,
-    MOVE_SHOCK_WAVE, 3,
-    MOVE_THUNDER_WAVE, 0, // Unnecessary, unlisted moves are already given 0 points
-    MOVE_THUNDER, 3,
-    MOVE_VOLT_TACKLE, 3,
-    TABLE_END, 0
-};
 static const u16 sPoints_StatusDmg[] =
 {
     5, // Curse
@@ -209,7 +196,6 @@ static const u16 *const sPointsArray[] =
 {
     [PTS_EFFECTIVENESS]          = sPoints_Effectiveness,
     [PTS_SET_UP]                 = sPoints_SetUp,
-    [PTS_ELECTRIC]               = sPoints_ElectricMoves,
     [PTS_STATUS_DMG]             = sPoints_StatusDmg,
     [PTS_STATUS]                 = sPoints_Status,
     [PTS_SPIKES]                 = sPoints_Spikes,
@@ -1053,17 +1039,8 @@ static void AddMovePoints(u8 caseId, u16 arg1, u8 arg2, u8 arg3)
         break;
     }
     case PTS_ELECTRIC:
-        i = 0;
-        ptr = sPointsArray[caseId];
-        do
-        {
-            if (move == ptr[i])
-            {
-                movePoints->points[atkSide][gBattlerPartyIndexes[gBattlerAttacker] * 4 + arg2] += ptr[i+1];
-                break;
-            }
-            i += 2;
-        } while (ptr[i] != TABLE_END);
+        if (!IsBattleMoveStatus(move) && GetMoveType(move) == TYPE_ELECTRIC)
+            movePoints->points[atkSide][gBattlerPartyIndexes[gBattlerAttacker] * 4 + arg2] += 3;
         break;
 #undef move
 

--- a/src/data/battle_move_effects.h
+++ b/src/data/battle_move_effects.h
@@ -2149,7 +2149,7 @@ const struct BattleMoveEffect gBattleMoveEffects[NUM_BATTLE_MOVE_EFFECTS] =
     [EFFECT_BLIZZARD] =
     {
         .battleScript = BattleScript_EffectHit,
-        .battleTvScore = 0, // TODO: Assign points
+        .battleTvScore = 1,
     },
 
     [EFFECT_RAIN_ALWAYS_HIT] =
@@ -2238,7 +2238,7 @@ const struct BattleMoveEffect gBattleMoveEffects[NUM_BATTLE_MOVE_EFFECTS] =
     [EFFECT_RAPID_SPIN] =
     {
         .battleScript = BattleScript_EffectHit,
-        .battleTvScore = 0, // TODO: Assign points
+        .battleTvScore = 2,
     },
 
     [EFFECT_SPECTRAL_THIEF] =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Before submitting, please make sure your pull request meets the scope guidelines. If unsure, please open a thread in #pr-discussions.-->
<!--- Scope Guidelines: https://github.com/rh-hideout/pokeemerald-expansion/blob/master/docs/team_procedures/scope.md  -->
<!--- #pr-discussions:  https://discord.com/channels/419213663107416084/1102784418369785948 -->

## Description
Modified Battle TV point functions to allow expansion of moves accounted for.

### Base effect expansion from vanilla:
```

    [EFFECT_POISON_HIT] = 1,                // MOVE_EFFECT_POISON (no change)
    [EFFECT_TWINEEDLE] = 1,                 // EFFECT_POISON_HIT + strikeCount == 2 (no change)
    [EFFECT_POISON_TAIL] = 1,               // EFFECT_POISON_HIT but high-crit (no change)
    [EFFECT_BURN_HIT] = 1,                  // MOVE_EFFECT_BURN (no change)
    [EFFECT_THAW_HIT] = 1,                  // EFFECT_BURN_HIT but thaws the user (no change)
    [EFFECT_BLAZE_KICK] = 1,                // EFFECT_BURN_HIT but high-crit (no change)
    [EFFECT_FREEZE_HIT] = 1,                // MOVE_EFFECT_FREEZE_OR_FROSTBITE (no change)
    [EFFECT_PARALYZE_HIT] = 1,              // MOVE_EFFECT_PARALYSIS (no change)
    [EFFECT_POISON_FANG] = 1,               // MOVE_EFFECT_TOXIC (no change)
    [EFFECT_ATTACK_DOWN_HIT] = 1,           // MOVE_EFFECT_ATK_MINUS_1 (no change)
    [EFFECT_DEFENSE_DOWN_HIT] = 1,          // MOVE_EFFECT_DEF_MINUS_1 (no change)
    [EFFECT_SPEED_DOWN_HIT] = 1,            // MOVE_EFFECT_SPD_MINUS_1 (no change)
    [EFFECT_SPECIAL_ATTACK_DOWN_HIT] = 1,   // MOVE_EFFECT_SP_ATK_MINUS_1 (no change)
    [EFFECT_SPECIAL_DEFENSE_DOWN_HIT] = 1,  // MOVE_EFFECT_SP_DEF_MINUS_1 (no change)
    [EFFECT_ACCURACY_DOWN_HIT] = 1,         // MOVE_EFFECT_ACC_MINUS_1 (no change)
    [EFFECT_EVASION_DOWN_HIT] = 1,          // unused (no change)
    [EFFECT_QUICK_ATTACK] = 1,              // Priority > 0 (no change)
    [EFFECT_FLINCH_HIT] = 1,                // MOVE_EFFECT_FLINCH (no change)
    [EFFECT_FLINCH_MINIMIZE_HIT] = 1,       // EFFECT_FLINCH_HIT with minimize hit (no change)
    [EFFECT_PAY_DAY] = 1,                   // MOVE_EFFECT_PAYDAY (no change)
    [EFFECT_TRI_ATTACK] = 1,                // MOVE_EFFECT_TRI_ATTACK (no change)
    [EFFECT_HIGH_CRITICAL] = 1,             // criticalHitStage > 0 (no change)
    [EFFECT_DOUBLE_HIT] = 1,                // strikeCount > 1 (no change)
    [EFFECT_CONFUSE_HIT] = 1,               // MOVE_EFFECT_CONFUSION (no change)
    [EFFECT_SPLASH] = 1,                    // Renamed to `EFFECT_DO_NOTHING`. (no change)
    [EFFECT_DEFENSE_UP_HIT] = 1,            // MOVE_EFFECT_DEF_PLUS_1 (no change)
    [EFFECT_ATTACK_UP_HIT] = 1,             // MOVE_EFFECT_ATK_PLUS_1 (no change)
    [EFFECT_ALL_STATS_UP_HIT] = 1,          // MOVE_EFFECT_ALL_STATS_UP (no change)
    [EFFECT_GUST] = 1,                      // damagesAirborneDoubleDamage (no change)
    [EFFECT_TWISTER] = 1,                   // damagesAirborneDoubleDamage + MOVE_EFFECT_FLINCH (no change)
    [EFFECT_SMELLINGSALT] = 1,              // MOVE_EFFECT_REMOVE_STATUS (No change)
    [EFFECT_ERUPTION] = 1,                  // EFFECT_POWER_BASED_ON_USER_HP (No change)
    [EFFECT_SECRET_POWER] = 1,              // MOVE_EFFECT_SECRET_POWER (No change)
    [EFFECT_SKY_UPPERCUT] = 1,              // damagesAirborne == TRUE  (No change)

    [EFFECT_RAMPAGE] = 4,                   // MOVE_EFFECT_THRASH => +3 (no change)
    [EFFECT_TRAP] = 4,                      // MOVE_EFFECT_WRAP added to calculation (no change)
    [EFFECT_RECHARGE] = 5,                  // MOVE_EFFECT_RECHARGE (no change)
    [EFFECT_THIEF] = 4,                     // MOVE_EFFECT_STEAL_ITEM => +3 (no change)
    [EFFECT_DOUBLE_EDGE] = 2,               // recoilPercentage > 0 (No change)

    [EFFECT_RAPID_SPIN] = 2,                // Was 2 in vanilla, restored to gMovesInfo and removed from calculation
    [EFFECT_BLIZZARD] = 1,                  // EFFECT_FREEZE_HIT but auto-hits in Hail/Snow (Assigned 1)
    [EFFECT_SONICBOOM] = 1,                 // 20 fixed damage
    [EFFECT_DRAGON_RAGE] = 2,               // 40 fixed damage (Added calculation to be based of fixedDamage)

    [EFFECT_ALWAYS_HIT] = 2,                // 0 Accuracy => +1
    [EFFECT_VITAL_THROW] = 1,               // EFFECT_ALWAYS_HIT but with -1 priority. (Added to calculation)

    [EFFECT_RAZOR_WIND] = 1,                // 2 turns (no change)
    [EFFECT_SKY_ATTACK] = 4,                // EFFECT_RAZOR_WIND + 30% MOVE_EFFECT_FLINCH (Added to calculation)
    [EFFECT_SKULL_BASH] = 3,                // EFFECT_RAZOR_WIND + guaranteed MOVE_EFFECT_DEF_PLUS_1 (Added to calculation)

    [EFFECT_FAKE_OUT] = 4,                  // EFFECT_FIRST_TURN_ONLY + 100% MOVE_EFFECT_FLINCH. (Added to calculation)
    
    [EFFECT_SUPERPOWER] = 3,                // 100% self MOVE_EFFECT_ATK_DEF_DOWN (No change)
    [EFFECT_OVERHEAT] = 3,                  // 100% self MOVE_EFFECT_SP_ATK_MINUS_2 (Added other minus user 2 stages to calculation)

    [EFFECT_TEETER_DANCE] = 6,              // EFFECT_CONFUSE + MOVE_TARGET_FOES_AND_ALLY (Added +2 to calculation, as EFFECT_CONFUSE already has 4 points
```
### Effectiveness
Added spread damage messages for effectiveness checks
### Weather moves
- Rain affects all damaging Fire and Water moves + Weather ball and Solar Beam/Blade.
- Sun affects all damaging Fire moves + Weather ball, Solar Beam/Blade, Synthesis, Morning Sun and Moonlight.
### Other
- Charge affects all damaging Electric moves
- Added conditions for +3 stat increases
- Removed redundant arrays.

## **Discord contact info**
AsparagusEduardo
