### PR TITLE
Remove redundant script declaration in `battle_scripts.h`

### DIFF
--- a/include/battle_scripts.h
+++ b/include/battle_scripts.h
@@ -489,7 +489,6 @@ extern const u8 BattleScript_ShellTrapSetUp[];
 extern const u8 BattleScript_StealthRockActivates[];
 extern const u8 BattleScript_CouldntFullyProtect[];
 extern const u8 BattleScript_MoveEffectStockpileWoreOff[];
-extern const u8 BattleScript_StealthRockActivates[];
 extern const u8 BattleScript_SpikesActivates[];
 extern const u8 BattleScript_BerserkGeneRet[];
 extern const u8 BattleScript_BerserkGeneRetEnd2[];


### PR DESCRIPTION
Removes a duplicate script declaration from the file.

## **People who collaborated with me in this PR**
@i0brendan0

## **Discord contact info**
bassoonian
