### PR TITLE
Fix potential bug in BattleScript_FriskActivates

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -8528,9 +8528,11 @@ BattleScript_FriskMsg::
 
 BattleScript_FriskActivates::
 	saveattacker
+        savetarget
 	copybyte gBattlerAttacker, sBATTLER
 	tryfriskmsg BS_SCRIPTING
 	restoreattacker
+        restoretarget
 	end3
 
 BattleScript_ImposterActivates::


### PR DESCRIPTION
`tryfriskmsg` overwrites `gBattlerTarget` and depneding on when it activates it might cause a bug.