### PR TITLE
Fix FindMonThatAbsorbsOpponentsMove not seeing Mold Breaker or choice items

### DIFF
--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -462,6 +462,8 @@ static bool32 FindMonThatAbsorbsOpponentsMove(u32 battler)
         return FALSE;
     if (AreStatsRaised(battler))
         return FALSE;
+    if (IsMoldBreakerTypeAbility(opposingBattler, GetBattlerAbility(opposingBattler)))
+        return FALSE;
 
     // Don't switch if mon could OHKO
     for (i = 0; i < MAX_MON_MOVES; i++)
@@ -472,7 +474,7 @@ static bool32 FindMonThatAbsorbsOpponentsMove(u32 battler)
             // Only check damage if it's a damaging move
             if (!IsBattleMoveStatus(aiMove))
             {
-                if (AI_GetDamage(battler, opposingBattler, i, AI_ATTACKING, gAiLogicData) > gBattleMons[opposingBattler].hp)
+                if (!AI_DoesChoiceItemBlockMove(battler, aiMove) && AI_GetDamage(battler, opposingBattler, i, AI_ATTACKING, gAiLogicData) > gBattleMons[opposingBattler].hp)
                     return FALSE;
             }
         }

--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -462,7 +462,7 @@ static bool32 FindMonThatAbsorbsOpponentsMove(u32 battler)
         return FALSE;
     if (AreStatsRaised(battler))
         return FALSE;
-    if (IsMoldBreakerTypeAbility(opposingBattler, GetBattlerAbility(opposingBattler)))
+    if (IsMoldBreakerTypeAbility(opposingBattler, gAiLogicData->abilities[opposingBattler]))
         return FALSE;
 
     // Don't switch if mon could OHKO


### PR DESCRIPTION
## Description
AI currently doesn't consider the player's Mold Breaker ability when sending in a mon with an absorbing ability. This is rather exploitable.

While fixing this, noticed that it also ran a damage calc without considering choice locked items. This has already been addressed in the other switching functions, must forgotten this one had one.

This PR fixes both of these issues.

## Issue(s) that this PR fixes
#6854 

## **Discord contact info**
@Pawkkie 
