### PR TITLE
Gen 1 no recharge on KO

### DIFF
--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -128,6 +128,7 @@
 #define B_QUASH_TURN_ORDER          GEN_LATEST // In Gen8+, Quash-affected battlers move according to speed order. Before Gen8, Quash-affected battlers move in the order they were affected by Quash.
 #define B_DESTINY_BOND_FAIL         GEN_LATEST // In Gen7+, Destiny Bond fails if used repeatedly.
 #define B_PURSUIT_TARGET            GEN_LATEST // In Gen4+, Pursuit attacks a switching opponent even if they weren't targeting them. Before Gen4, Pursuit only attacks a switching opponent that it originally targeted.
+#define B_SKIP_RECHARGE             GEN_LATEST // In Gen1, recharging moves such as Hyper Beam skip the recharge if the target gets KO'd
 
 // Ability settings
 #define B_GALE_WINGS                GEN_LATEST // In Gen7+ requires full HP to trigger.

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -3619,6 +3619,9 @@ void SetMoveEffect(bool32 primary, bool32 certain)
                 }
                 break;
             case MOVE_EFFECT_RECHARGE:
+                if (B_SKIP_RECHARGE == GEN_1 && !IsBattlerAlive(gBattlerTarget))  // Skip recharge if gen 1 and foe is KO'd
+                    break;
+
                 gBattleMons[gEffectBattler].status2 |= STATUS2_RECHARGE;
                 gDisableStructs[gEffectBattler].rechargeTimer = 2;
                 gLockedMoves[gEffectBattler] = gCurrentMove;

--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -29,9 +29,15 @@ static const u8 sMegaDrainDescription[] = _(
     "An attack that absorbs\n"
     "half the damage inflicted.");
 
+#if B_SKIP_RECHARGE != GEN_1
 static const u8 sHyperBeamDescription[] = _(
     "Powerful, but leaves the\n"
     "user immobile the next turn.");
+#else
+static const u8 sHyperBeamDescription[] = _(
+    "Leaves the user immobile\n"
+    "if target is not KO'd.");
+#endif
 
 static const u8 sRevengeDescription[] = _(
     "An attack that gains power\n"


### PR DESCRIPTION
re-PRing #6853 using upcoming as a base

## Description
Implements the gen1 no recharge on KO mechanic on a toggleable flag. This applies to all recharge moves such as Hyper Beam, Blast Burn, etc.
As such:
If the B_SKIP_RECHARGE flag is set to GEN_1, if the user of Hyper Beam (or any other move with the MOVE_EFFECT_RECHARGE effect) KOes its target, it skips the recharge turn.

## Issue(s) that this PR fixes
fixes #6142

## Feature(s) this PR does NOT handle:
No tests yet. The changes were tested directly in-game, both for GEN_LATEST and GEN_1 settings. I had problems during my tests, where in the following case:
```
{
    ASSUME(MoveHasAdditionalEffect(MOVE_HYPER_BEAM, MOVE_EFFECT_RECHARGE) == TRUE);
    ASSUME(MoveHasAdditionalEffect(MOVE_DIRE_CLAW, MOVE_EFFECT_DIRE_CLAW) == TRUE);
}
```
The first assume would fail, and the second assume would work, which I think is not normal behavior?

## **Discord contact info**
spindrift64
