### PR TITLE
Fixes Magic Guard causing Wrap to end immediately

### DIFF
--- a/src/battle_end_turn.c
+++ b/src/battle_end_turn.c
@@ -746,8 +746,11 @@ static bool32 HandleEndTurnWrap(u32 battler)
 
     if (gBattleMons[battler].status2 & STATUS2_WRAPPED && IsBattlerAlive(battler))
     {
-        if (--gDisableStructs[battler].wrapTurns != 0 && !IsBattlerProtectedByMagicGuard(battler, GetBattlerAbility(battler)))
+        if (--gDisableStructs[battler].wrapTurns != 0)
         {
+            if (IsBattlerProtectedByMagicGuard(battler, GetBattlerAbility(battler)))
+                return effect;
+
             gBattleScripting.animArg1 = gBattleStruct->wrappedMove[battler];
             gBattleScripting.animArg2 = gBattleStruct->wrappedMove[battler] >> 8;
             PREPARE_MOVE_BUFFER(gBattleTextBuff1, gBattleStruct->wrappedMove[battler]);


### PR DESCRIPTION
If the battler had Magic Guard and Wrap active, it would reach the "else" code, causing wrap to end at the end of the turn that Magic Guard was obtained or at the end of the turn that Wrap was applied.

## **Discord contact info**
PhallenTree
