### PR TITLE
Fixes damage calcs for moves that check the turn order

### DIFF
--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -150,6 +150,12 @@ enum {
 
 extern const struct TypePower gNaturalGiftTable[];
 
+enum DmgCalcState
+{
+    BATTLE_DMG_CALC, // Records abilities/items and checks various effects during actual battle (non simulated damage)
+    AI_DMG_CALC, // Skips the above mentioned calculations during ai calcs (simulated damage)
+};
+
 struct DamageCalculationData
 {
     u32 battlerAtk:3;
@@ -158,8 +164,8 @@ struct DamageCalculationData
     u32 moveType:5;
     u32 isCrit:1;
     u32 randomFactor:1;
-    u32 updateFlags:1;
-    u32 padding:2;
+    enum DmgCalcState state:1;
+    u32 padding:1;
 };
 STATIC_ASSERT(sizeof(struct DamageCalculationData) <= 4, StructExceedsFourBytes);
 

--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -160,12 +160,12 @@ struct DamageCalculationData
 {
     u32 battlerAtk:3;
     u32 battlerDef:3;
-    u32 move:16;
+    u32 move:12;
     u32 moveType:5;
     u32 isCrit:1;
     u32 randomFactor:1;
     enum DmgCalcState state:1;
-    u32 padding:1;
+    u32 padding:6;
 };
 STATIC_ASSERT(sizeof(struct DamageCalculationData) <= 4, StructExceedsFourBytes);
 

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -677,7 +677,7 @@ struct SimulatedDamage AI_CalcDamage(u32 move, u32 battlerAtk, u32 battlerDef, u
         damageCalcData.moveType = moveType;
         damageCalcData.isCrit = FALSE;
         damageCalcData.randomFactor = FALSE;
-        damageCalcData.updateFlags = FALSE;
+        damageCalcData.state = AI_DMG_CALC;
 
         critChanceIndex = CalcCritChanceStage(battlerAtk, battlerDef, move, FALSE, aiData->abilities[battlerAtk], aiData->abilities[battlerDef], aiData->holdEffects[battlerAtk]);
         if (critChanceIndex > 1) // Consider crit damage only if a move has at least +2 crit chance

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2049,7 +2049,7 @@ static void Cmd_damagecalc(void)
     damageCalcData.move = gCurrentMove;
     damageCalcData.moveType = GetBattleMoveType(gCurrentMove);
     damageCalcData.randomFactor = TRUE;
-    damageCalcData.updateFlags = TRUE;
+    damageCalcData.state = BATTLE_DMG_CALC;
 
     if (IsSpreadMove(moveTarget))
     {

--- a/src/battle_tv.c
+++ b/src/battle_tv.c
@@ -1258,7 +1258,7 @@ static void TrySetBattleSeminarShow(void)
             damageCalcData.moveType = GetMoveType(gCurrentMove);
             damageCalcData.isCrit = FALSE;
             damageCalcData.randomFactor = FALSE;
-            damageCalcData.updateFlags = FALSE;
+            damageCalcData.state = AI_DMG_CALC;
             gBattleStruct->moveDamage[gBattlerTarget] = CalculateMoveDamage(&damageCalcData, powerOverride);
             dmgByMove[i] = gBattleStruct->moveDamage[gBattlerTarget];
             if (dmgByMove[i] == 0 && !(gBattleStruct->moveResultFlags[gBattlerTarget] & MOVE_RESULT_NO_EFFECT))

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -9347,7 +9347,7 @@ static inline u32 CalcMoveBasePowerAfterModifiers(struct DamageCalculationData *
             modifier = uq4_12_multiply(modifier, UQ_4_12(2.0));
         break;
     case EFFECT_RETALIATE:
-        if (gSideTimers[atkSide].retaliateTimer == 1 || (amageCalcData->state == AI_DMG_CALC && gSideTimers[atkSide].retaliateTimer == 2))
+        if (gSideTimers[atkSide].retaliateTimer == 1 || (damageCalcData->state == AI_DMG_CALC && gSideTimers[atkSide].retaliateTimer == 2))
             modifier = uq4_12_multiply(modifier, UQ_4_12(2.0));
         break;
     case EFFECT_SOLAR_BEAM:

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -10557,7 +10557,7 @@ s32 CalculateMoveDamage(struct DamageCalculationData *damageCalcData, u32 fixedB
                                                                       damageCalcData->battlerAtk,
                                                                       damageCalcData->battlerDef,
                                                                       GetBattlerAbility(damageCalcData->battlerDef),
-                                                                      damageCalcData->state);
+                                                                      damageCalcData->state == BATTLE_DMG_CALC);
 
     if (GetMoveEffect(damageCalcData->move) == EFFECT_FUTURE_SIGHT
      && IsFutureSightAttackerInParty(damageCalcData->battlerAtk, damageCalcData->battlerDef))

--- a/test/battle/ai/ai.c
+++ b/test/battle/ai/ai.c
@@ -917,7 +917,6 @@ SINGLE_BATTLE_TEST("AI correctly records used moves")
 
 AI_SINGLE_BATTLE_TEST("AI sees Bolt Beak's boosted damage")
 {
-    ASSUME(GetMoveEffect(MOVE_BOLT_BEAK) == EFFECT_BOLT_BEAK);
     GIVEN {
         AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_OMNISCIENT);
         PLAYER(SPECIES_FLOATZEL) { Speed(2); Moves(MOVE_FLIP_TURN); }
@@ -926,6 +925,6 @@ AI_SINGLE_BATTLE_TEST("AI sees Bolt Beak's boosted damage")
         OPPONENT(SPECIES_ARCTOZOLT) { Speed(1); Ability(ABILITY_SLUSH_RUSH); Moves(MOVE_BOLT_BEAK, MOVE_ROCK_SLIDE); Nature(NATURE_JOLLY); Item(ITEM_LIFE_ORB); HPIV(31); AttackIV(31); DefenseIV(31); SpAttackIV(31); SpDefenseIV(31); }
     } WHEN {
         TURN { MOVE(player, MOVE_FLIP_TURN); EXPECT_MOVE(opponent, MOVE_SCRATCH); SEND_OUT(player, 1); EXPECT_SEND_OUT(opponent, 1); }
-        TURN { EXPECT_MOVE(opponent, MOVE_BOLT_BEAK); MOVE(player, MOVE_FLAMETHROWER); SEND_OUT(player, 1); }
+        TURN { EXPECT_MOVE(opponent, MOVE_BOLT_BEAK); MOVE(player, MOVE_FLAMETHROWER); SEND_OUT(player, 0); }
     }
 }

--- a/test/battle/ai/ai.c
+++ b/test/battle/ai/ai.c
@@ -914,3 +914,18 @@ SINGLE_BATTLE_TEST("AI correctly records used moves")
         EXPECT_EQ(BATTLE_HISTORY->usedMoves[B_POSITION_OPPONENT_LEFT][3], MOVE_EARTHQUAKE);
     }
 }
+
+AI_SINGLE_BATTLE_TEST("AI sees Bolt Beak's boosted damage")
+{
+    ASSUME(GetMoveEffect(MOVE_BOLT_BEAK) == EFFECT_BOLT_BEAK);
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_OMNISCIENT);
+        PLAYER(SPECIES_FLOATZEL) { Speed(2); Moves(MOVE_FLIP_TURN); }
+        PLAYER(SPECIES_SIMISEAR) { Speed(2); Moves(MOVE_FLAMETHROWER); Nature(NATURE_MODEST); Item(ITEM_SITRUS_BERRY); HPIV(31); AttackIV(31); DefenseIV(31); SpAttackIV(31); SpDefenseIV(31); }
+        OPPONENT(SPECIES_SNOVER) { Speed(1); HP(1); Ability(ABILITY_SNOW_WARNING); Moves(MOVE_SCRATCH); }
+        OPPONENT(SPECIES_ARCTOZOLT) { Speed(1); Ability(ABILITY_SLUSH_RUSH); Moves(MOVE_BOLT_BEAK, MOVE_ROCK_SLIDE); Nature(NATURE_JOLLY); Item(ITEM_LIFE_ORB); HPIV(31); AttackIV(31); DefenseIV(31); SpAttackIV(31); SpDefenseIV(31); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_FLIP_TURN); EXPECT_MOVE(opponent, MOVE_SCRATCH); SEND_OUT(player, 1); EXPECT_SEND_OUT(opponent, 1); }
+        TURN { EXPECT_MOVE(opponent, MOVE_BOLT_BEAK); MOVE(player, MOVE_FLAMETHROWER); SEND_OUT(player, 1); }
+    }
+}


### PR DESCRIPTION
When the damage was calculated for moves that rely on turn order, the turn order from the previous turn was applied which meant that the calc for AI was misleading.

I couldn't come up with a proper test for this so has to be tested in-game, or I try an other time. 
