### PR TITLE
`removeobject` and `removeobjectat` macros work properly with npc followers

### DIFF
--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -1523,14 +1523,6 @@ void RemoveObjectEvent(struct ObjectEvent *objectEvent)
 void RemoveObjectEventByLocalIdAndMap(u8 localId, u8 mapNum, u8 mapGroup)
 {
     u8 objectEventId;
-
-    if (localId == OBJ_EVENT_ID_NPC_FOLLOWER)
-    {
-        gObjectEvents[GetFollowerNPCData(FNPC_DATA_OBJ_ID)].invisible = TRUE;
-        SetFollowerNPCData(FNPC_DATA_WARP_END, FNPC_WARP_REAPPEAR);
-        return;
-    }
-
     if (!TryGetObjectEventIdByLocalIdAndMap(localId, mapNum, mapGroup, &objectEventId))
     {
         FlagSet(GetObjectEventFlagIdByObjectEventId(objectEventId));

--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -1523,6 +1523,14 @@ void RemoveObjectEvent(struct ObjectEvent *objectEvent)
 void RemoveObjectEventByLocalIdAndMap(u8 localId, u8 mapNum, u8 mapGroup)
 {
     u8 objectEventId;
+
+    if (localId == OBJ_EVENT_ID_NPC_FOLLOWER)
+    {
+        gObjectEvents[GetFollowerNPCData(FNPC_DATA_OBJ_ID)].invisible = TRUE;
+        SetFollowerNPCData(FNPC_DATA_WARP_END, FNPC_WARP_REAPPEAR);
+        return;
+    }
+
     if (!TryGetObjectEventIdByLocalIdAndMap(localId, mapNum, mapGroup, &objectEventId))
     {
         FlagSet(GetObjectEventFlagIdByObjectEventId(objectEventId));

--- a/src/follower_npc.c
+++ b/src/follower_npc.c
@@ -1022,6 +1022,13 @@ void NPCFollow(struct ObjectEvent *npc, u32 state, bool32 ignoreScriptActive)
     else if (ArePlayerFieldControlsLocked() && !ignoreScriptActive)
         return;
 
+    // If the follower's object has been removed, create a new one and set it to reappear.
+    if (!follower->active)
+    {
+        CreateFollowerNPCAvatar();
+        SetFollowerNPCData(FNPC_DATA_WARP_END, FNPC_WARP_REAPPEAR);
+    }
+
     // Follower changes to normal sprite after getting off surf blob.
     if (GetFollowerNPCData(FNPC_DATA_CURRENT_SPRITE) == FOLLOWER_NPC_SPRITE_INDEX_SURF && !CheckFollowerNPCFlag(PLAYER_AVATAR_FLAG_SURFING) && follower->fieldEffectSpriteId == 0)
     {


### PR DESCRIPTION
## Description
Currently, using the `removeobject` and `removeobjectat` macros on a npc follower permanently removes the follower until a warp happens. Walking through a map connection while the follower is removed like this can cause the game to crash.

This PR adds handling that makes the npc follower only get set up to reappear like normal instead of being removed entirely.

## **Discord contact info**
bivurnum
