### PR TITLE
Fixed URL for contributors badge on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 # [Credits](CREDITS.md)
 
- [![](https://img.shields.io/github/all-contributors/rh-hideout/pokeemerald-expansion/upcoming)](CREDITS.md)
+ [![](https://img.shields.io/github/all-contributors/rh-hideout/pokeemerald-expansion/master)](CREDITS.md)
 
 If you use **`pokeemerald-expansion`**, please credit **RHH (Rom Hacking Hideout)**. Optionally, include the version number for clarity.
 


### PR DESCRIPTION
The URL previously pointed to `upcoming`, but the most recent version of `CREDITS.md` will be on `master`.

## Discord contact info
pkmnsnfrn