### PR TITLE
Update .all-contributorsrc to skip CI

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -133,5 +133,6 @@
   ],
   "contributorsPerLine": 7,
   "linkToUsage": true,
-  "commitType": "docs"
+  "commitType": "docs",
+  "skipCi": true,
 }


### PR DESCRIPTION
CI doesn't need to run when bot is adding new contributors. This enables the setting to skip the CI. Other settings: https://allcontributors.org/docs/en/bot/configuration#docsNav

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->

pkmnsnfrn