### PR TITLE
fix: avoid unexpected data shifting by removing preproc'd array size

### DIFF
--- a/include/wild_encounter.h
+++ b/include/wild_encounter.h
@@ -40,12 +40,7 @@ struct WildPokemonHeader
 {
     u8 mapGroup;
     u8 mapNum;
-
-#if OW_TIME_OF_DAY_ENCOUNTERS
     const struct WildEncounterTypes encounterTypes[TIMES_OF_DAY_COUNT];
-#else
-    const struct WildEncounterTypes encounterTypes[1];
-#endif
 };
 
 


### PR DESCRIPTION
## Description
just removes the preproc'd array size, since it was causing issues by changing where data was stored after switching `OW_TIME_OF_DAY_ENCOUNTERS` to TRUE but not doing a `make clean`. this change only results in a rom space usage increase of 9.2Kb.

## Discord contact info
khbsd
