### PR TITLE
Commenting in config files to explain limits of map popups and wild AI flags

### DIFF
--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -217,8 +217,12 @@
 // To use the following features, change the 0 for a var present in include/constants/vars.h, preferably an unused one.
 // Eg: You may rename VAR_UNUSED_0x404E to a descriptive name and use it below.
 #define B_VAR_STARTING_STATUS       0     // If this var has a value, assigning a STATUS_FIELD_xx_TERRAIN to it before battle causes the battle to start with that terrain active.
+                                          // This var should never remain non-zero long enough for the player to save.
 #define B_VAR_STARTING_STATUS_TIMER 0     // If this var has a value greater or equal than 1 field terrains will last that number of turns, otherwise they will last until they're overwritten.
-#define B_VAR_WILD_AI_FLAGS         0     // If not 0, you can use this var to add to default wild AI flags. NOT usable with flags above (1 << 15)
+#define B_VAR_WILD_AI_FLAGS         0     // If not 0, you can use this var to add to default wild AI flags. IMPORTANT: NOT usable with flags above (1 << 15)
+                                          // This var should never remain non-zero long enough for the player to save.
+                                          // For better wild AI handling, edit GetWildAiFlags() in src/battle_ai_main.c
+
 #define B_VAR_DIFFICULTY            0     // If not 0, you can use this var to control which difficulty version of a Trainer is loaded. This should be manually set by the developer using Script_SetDifficulty AFTER NewGameInitData has run.
 
 // Sky Battles

--- a/include/config/overworld.h
+++ b/include/config/overworld.h
@@ -117,7 +117,6 @@
                                             // Only choices are GEN_3 and GEN_5, all others will default to Gen3 pop-ups.
                                             // Due to changes in project scope, as detailed in docs/team_procedures/scope.md,
                                             // no other overworld popups will be implemented in expansion.
-                                            // Note that gen5 map popups are prone to visual bugs when combined with the DNS.
 
 // Gen5 map pop-up config
 // Constants
@@ -132,6 +131,7 @@
 #define OW_POPUP_BW_COLOR          OW_POPUP_BW_COLOR_BLACK  // B2W2 use different colors for their map pop-ups.
 #define OW_POPUP_BW_TIME_MODE      OW_POPUP_BW_TIME_NONE    // Determines what type of time is shown.
 #define OW_POPUP_BW_ALPHA_BLEND    FALSE                    // Enables alpha blending/transparency for the pop-ups. Mainly intended to be used with the black color option.
+                                                            // Setting this to TRUE will cause graphical errors with the Day Night System enabled.
 
 // Pokémon Center
 #define OW_IGNORE_EGGS_ON_HEAL           GEN_LATEST         // In Gen 4+, the nurse in the Pokémon Center does not heal Eggs on healing machine.

--- a/include/config/overworld.h
+++ b/include/config/overworld.h
@@ -114,7 +114,10 @@
 
 // Map pop-up config
 #define OW_POPUP_GENERATION        GEN_3    // Different generations display location names in overworld pop-ups differently.
-                                            // Only choices are currently GEN_3 and GEN_5, all others will default to Gen3 pop-ups.
+                                            // Only choices are GEN_3 and GEN_5, all others will default to Gen3 pop-ups.
+                                            // Due to changes in project scope, as detailed in docs/team_procedures/scope.md,
+                                            // no other overworld popups will be implemented in expansion.
+                                            // Note that gen5 map popups are prone to visual bugs when combined with the DNS.
 
 // Gen5 map pop-up config
 // Constants


### PR DESCRIPTION
Users ought to be warned of the footguns involved with both gen 5 map popups and B_VAR_WILD_AI_FLAGS.

Ideally, B_VAR_WILD_AI_FLAGS would be deprecated completely, but in the meantime, explaining how to avoid using it is sufficient.

## Discord contact info
wildvenonat