### PR TITLE
Fix trainers.party parser failing on apostrophes

### DIFF
--- a/tools/trainerproc/main.c
+++ b/tools/trainerproc/main.c
@@ -459,7 +459,7 @@ static bool match_identifier(struct Parser *p, struct Token *t)
         if (!peek_char(&p_, &c))
             break;
 
-        if (('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z') || ('0' <= c && c <= '9') || c == '_')
+        if (('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z') || ('0' <= c && c <= '9') || c == '_'|| c == '\'')
             ;
         else
             break;
@@ -493,7 +493,7 @@ static bool match_human_identifier(struct Parser *p, struct Token *t)
         if (!peek_char(&p_, &c))
             break;
 
-        if (('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z') || c == '_' || c == '-' || c == ' ')
+        if (('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z') || c == '_' || c == '-' || c == ' ' || c == '\'')
             ;
         else if (p_.offset > t->begin && ('0' <= c && c <= '9'))
             ;
@@ -573,7 +573,7 @@ static bool match_move_identifier(struct Parser *p, struct Token *t)
         if (!peek_char(&p_, &c))
             break;
 
-        if (('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z') || ('0' <= c && c <= '9') || c == '_' || c == '-' || c == ' ' || c == ',')
+        if (('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z') || ('0' <= c && c <= '9') || c == '_' || c == '-' || c == ' ' || c == ',' || c == '\'')
             ;
         else
             break;
@@ -1581,6 +1581,8 @@ static void fprint_constant(FILE *f, const char *prefix, struct String s)
                 fputc(c, f);
             else if ('a' <= c && c <= 'z')
                 fputc(c - 'a' + 'A', f);
+            else if (c == '\'')
+                ;
             else
                 fputc('_', f);
         }


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
Allows moves like King's Shield and abilities like Mind's Eye to be parsed correctly. 

## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, closes #2222." Remove this section if not applicable.-->
Fixes #6483

<!-- CREDITS -->
<!-- Once your PR is submitted, leave a comment asking the bot to add you to the credits. -->
<!-- If anybody helped with this PR, please encourage them to comment on your PR and ask the bot to add them to the credits. -->
<!-- EVERY contribution matters! -->
<!-- https://github.com/rh-hideout/pokeemerald-expansion/wiki/CREDITS.md-Frequently-Asked-Questions -->



## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
jfb1337