### PR TITLE
Fixes Ice Body healing HP regardless of weather

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4139,7 +4139,8 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
                 }
                 break;
             case ABILITY_ICE_BODY:
-                if (!IsBattlerAtMaxHp(battler)
+                if (IsBattlerWeatherAffected(battler, B_WEATHER_HAIL | B_WEATHER_SNOW)
+                 && !IsBattlerAtMaxHp(battler)
                  && !(gStatuses3[battler] & (STATUS3_UNDERGROUND | STATUS3_UNDERWATER))
                  && !(gStatuses3[battler] & STATUS3_HEAL_BLOCK))
                 {


### PR DESCRIPTION
Ice Body was missing a weather check, so it would function like a "leftovers" Ability. (upcoming issue only)

## Discord contact info
PhallenTree
