### PR TITLE
fix: better area mons handling, no longer duplicates `hiddenMons` field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ ALL_LEARNABLES_JSON := $(LEARNSET_HELPERS_BUILD_DIR)/all_learnables.json
 WILD_ENCOUNTERS_TOOL_DIR := $(TOOLS_DIR)/wild_encounters
 AUTO_GEN_TARGETS += $(DATA_SRC_SUBDIR)/wild_encounters.h
 
-$(DATA_SRC_SUBDIR)/wild_encounters.h: $(DATA_SRC_SUBDIR)/wild_encounters.json $(WILD_ENCOUNTERS_TOOL_DIR)/wild_encounters_to_header.py $(INCLUDE_DIRS)/config/overworld.h
+$(DATA_SRC_SUBDIR)/wild_encounters.h: $(DATA_SRC_SUBDIR)/wild_encounters.json $(WILD_ENCOUNTERS_TOOL_DIR)/wild_encounters_to_header.py $(INCLUDE_DIRS)/config/overworld.h $(INCLUDE_DIRS)/config/dexnav.h
 	python3 $(WILD_ENCOUNTERS_TOOL_DIR)/wild_encounters_to_header.py > $@
 
 $(C_BUILDDIR)/wild_encounter.o: c_dep += $(DATA_SRC_SUBDIR)/wild_encounters.h

--- a/tools/wild_encounters/wild_encounters_to_header.py
+++ b/tools/wild_encounters/wild_encounters_to_header.py
@@ -179,7 +179,7 @@ def ImportWildEncounterFile():
                 """
                 hidden_mons = "hidden_mons"
                 if (fieldCounter == len(wFields) - 1) and not CheckFieldDataDupes(hidden_mons):
-                    hidden_dummy_rates = [0, 0]
+                    hidden_dummy_rates = [1, 0]
                     AddFieldData(fieldCounter + 1, hidden_mons, hidden_dummy_rates)
 
                 fieldCounter += 1

--- a/tools/wild_encounters/wild_encounters_to_header.py
+++ b/tools/wild_encounters/wild_encounters_to_header.py
@@ -54,8 +54,6 @@ hLabel       = ""
 hForMaps     = True
 headersArray = [headerIndex]
 
-
-
 # debug output control
 mainSwitch                      = True
 printWarningAndInclude          = mainSwitch
@@ -175,11 +173,12 @@ def ImportWildEncounterFile():
                 if "groups" in field:
                     fieldData[fieldCounter]["groups"] = field["groups"]
 
-                if fieldCounter == len(wFields) - 1:
+                hidden_mons = "hidden_mons"
+                if (fieldCounter == len(wFields) - 1) and (fieldData[fieldCounter]["name"] != hidden_mons):
                     fieldData.append({})
-                    fieldData[fieldCounter + 1]["name"] = "hidden_mons"
-                    fieldData[fieldCounter + 1]["pascalName"] = GetPascalCase("hidden_mons")
-                    fieldData[fieldCounter + 1]["snakeName"] = GetSnakeCase("hidden_mons")
+                    fieldData[fieldCounter + 1]["name"] = hidden_mons
+                    fieldData[fieldCounter + 1]["pascalName"] = GetPascalCase(hidden_mons)
+                    fieldData[fieldCounter + 1]["snakeName"] = GetSnakeCase(hidden_mons)
 
                 fieldCounter += 1
 

--- a/tools/wild_encounters/wild_encounters_to_header.py
+++ b/tools/wild_encounters/wild_encounters_to_header.py
@@ -445,7 +445,7 @@ def PrintEncounterRateMacros():
                 for percent in fieldData[fieldCounter]["encounter_rates"]:
                     if not DEXNAV_ENABLED and tempName == "HIDDEN_MONS":
                         break
-                    
+
                     if rateCount == 0:
                         print(f"{define} {ENCOUNTER_CHANCE}_{tempName}_{SLOT}_{rateCount} {percent}")
                     else:
@@ -677,7 +677,10 @@ if __name__ == "__main__":
 #define ENCOUNTER_CHANCE_FISHING_MONS_SUPER_ROD_SLOT_8 ENCOUNTER_CHANCE_FISHING_MONS_SUPER_ROD_SLOT_7 + 4
 #define ENCOUNTER_CHANCE_FISHING_MONS_SUPER_ROD_SLOT_9 ENCOUNTER_CHANCE_FISHING_MONS_SUPER_ROD_SLOT_8 + 1
 #define ENCOUNTER_CHANCE_FISHING_MONS_SUPER_ROD_TOTAL (ENCOUNTER_CHANCE_FISHING_MONS_SUPER_ROD_SLOT_9)
-#define ENCOUNTER_CHANCE_HIDDEN_MONS_SLOT_0 100
+
+- if DEXNAV_ENABLED is TRUE
+- these macros are all 0 if hidden_mons isn't in the encounter rate list
+#define ENCOUNTER_CHANCE_HIDDEN_MONS_SLOT_0 0
 #define ENCOUNTER_CHANCE_HIDDEN_MONS_SLOT_1 ENCOUNTER_CHANCE_HIDDEN_MONS_SLOT_0 + 0
 #define ENCOUNTER_CHANCE_HIDDEN_MONS_TOTAL (ENCOUNTER_CHANCE_HIDDEN_MONS_SLOT_1)
 

--- a/tools/wild_encounters/wild_encounters_to_header.py
+++ b/tools/wild_encounters/wild_encounters_to_header.py
@@ -4,6 +4,7 @@ import os
 
 
 IS_ENABLED            = False
+DEXNAV_ENABLED        = False
 
 # C string vars
 define                = "#define"
@@ -113,6 +114,9 @@ def ImportWildEncounterFile():
     if IsConfigEnabled():
         IS_ENABLED = True
         TIMES_OF_DAY_COUNT = len(TIME_OF_DAY)
+    
+    global DEXNAV_ENABLED
+    DEXNAV_ENABLED = IsDexnavEnabled()
 
     global fieldInfoStrings
     global fieldStrings
@@ -174,7 +178,7 @@ def ImportWildEncounterFile():
                 """
                 hidden_mons = "hidden_mons"
                 if (fieldCounter == len(wFields) - 1) and not CheckFieldDataDupes(hidden_mons):
-                    hidden_dummy_rates = [100, 0]
+                    hidden_dummy_rates = [0, 0]
                     AddFieldData(fieldCounter + 1, hidden_mons, hidden_dummy_rates)
 
                 fieldCounter += 1
@@ -439,6 +443,9 @@ def PrintEncounterRateMacros():
             rateCount = 0
             if fieldData[fieldCounter]["encounter_rates"]:
                 for percent in fieldData[fieldCounter]["encounter_rates"]:
+                    if not DEXNAV_ENABLED and tempName == "HIDDEN_MONS":
+                        break
+                    
                     if rateCount == 0:
                         print(f"{define} {ENCOUNTER_CHANCE}_{tempName}_{SLOT}_{rateCount} {percent}")
                     else:
@@ -508,7 +515,7 @@ def GetMapGroupEnum(string, index = 0):
 
 """
 get copied lhea :^ ) 
-- next three functions copied almost verbatim from @lhearachel's python scripts in tools/learnset_helpers
+- next four functions copied almost verbatim from @lhearachel's python scripts in tools/learnset_helpers
 """
 def PrintGeneratedWarningText():
     print("//")
@@ -521,6 +528,15 @@ def IsConfigEnabled():
     CONFIG_ENABLED_PAT = re.compile(r"#define OW_TIME_OF_DAY_ENCOUNTERS\s+(?P<cfg_val>[^ ]*)")
 
     with open("./include/config/overworld.h", "r") as overworld_config_file:
+        config_overworld = overworld_config_file.read()
+        config_setting = CONFIG_ENABLED_PAT.search(config_overworld)
+        return config_setting is not None and config_setting.group("cfg_val") in ("TRUE", "1")
+
+
+def IsDexnavEnabled():
+    CONFIG_ENABLED_PAT = re.compile(r"#define DEXNAV_ENABLED\s+(?P<cfg_val>[^ ]*)")
+
+    with open("./include/config/dexnav.h", "r") as overworld_config_file:
         config_overworld = overworld_config_file.read()
         config_setting = CONFIG_ENABLED_PAT.search(config_overworld)
         return config_setting is not None and config_setting.group("cfg_val") in ("TRUE", "1")

--- a/tools/wild_encounters/wild_encounters_to_header.py
+++ b/tools/wild_encounters/wild_encounters_to_header.py
@@ -173,7 +173,8 @@ def ImportWildEncounterFile():
                 if "groups" in field:
                     fieldData[fieldCounter]["groups"] = field["groups"]
 
-                """ hidden mons need a special bit of logic since they're not in the vanilla
+                """ 
+                    hidden mons need a special bit of logic since they're not in the vanilla
                     wild_encounters.json file, but the game expects them to be there
                 """
                 hidden_mons = "hidden_mons"

--- a/tools/wild_encounters/wild_encounters_to_header.py
+++ b/tools/wild_encounters/wild_encounters_to_header.py
@@ -682,7 +682,7 @@ if __name__ == "__main__":
 - if DEXNAV_ENABLED is TRUE
 - these macros are 1 and 0, respectively if hidden_mons isn't in the encounter 
   rate list at the top of wild_encounters.json
-#define ENCOUNTER_CHANCE_HIDDEN_MONS_SLOT_0 0
+#define ENCOUNTER_CHANCE_HIDDEN_MONS_SLOT_0 1
 #define ENCOUNTER_CHANCE_HIDDEN_MONS_SLOT_1 ENCOUNTER_CHANCE_HIDDEN_MONS_SLOT_0 + 0
 #define ENCOUNTER_CHANCE_HIDDEN_MONS_TOTAL (ENCOUNTER_CHANCE_HIDDEN_MONS_SLOT_1)
 

--- a/tools/wild_encounters/wild_encounters_to_header.py
+++ b/tools/wild_encounters/wild_encounters_to_header.py
@@ -680,7 +680,8 @@ if __name__ == "__main__":
 #define ENCOUNTER_CHANCE_FISHING_MONS_SUPER_ROD_TOTAL (ENCOUNTER_CHANCE_FISHING_MONS_SUPER_ROD_SLOT_9)
 
 - if DEXNAV_ENABLED is TRUE
-- these macros are all 0 if hidden_mons isn't in the encounter rate list at the top of wild_encounters.json
+- these macros are 1 and 0, respectively if hidden_mons isn't in the encounter 
+  rate list at the top of wild_encounters.json
 #define ENCOUNTER_CHANCE_HIDDEN_MONS_SLOT_0 0
 #define ENCOUNTER_CHANCE_HIDDEN_MONS_SLOT_1 ENCOUNTER_CHANCE_HIDDEN_MONS_SLOT_0 + 0
 #define ENCOUNTER_CHANCE_HIDDEN_MONS_TOTAL (ENCOUNTER_CHANCE_HIDDEN_MONS_SLOT_1)

--- a/tools/wild_encounters/wild_encounters_to_header.py
+++ b/tools/wild_encounters/wild_encounters_to_header.py
@@ -679,7 +679,7 @@ if __name__ == "__main__":
 #define ENCOUNTER_CHANCE_FISHING_MONS_SUPER_ROD_TOTAL (ENCOUNTER_CHANCE_FISHING_MONS_SUPER_ROD_SLOT_9)
 
 - if DEXNAV_ENABLED is TRUE
-- these macros are all 0 if hidden_mons isn't in the encounter rate list
+- these macros are all 0 if hidden_mons isn't in the encounter rate list at the top of wild_encounters.json
 #define ENCOUNTER_CHANCE_HIDDEN_MONS_SLOT_0 0
 #define ENCOUNTER_CHANCE_HIDDEN_MONS_SLOT_1 ENCOUNTER_CHANCE_HIDDEN_MONS_SLOT_0 + 0
 #define ENCOUNTER_CHANCE_HIDDEN_MONS_TOTAL (ENCOUNTER_CHANCE_HIDDEN_MONS_SLOT_1)

--- a/tools/wild_encounters/wild_encounters_to_header.py
+++ b/tools/wild_encounters/wild_encounters_to_header.py
@@ -175,7 +175,7 @@ def ImportWildEncounterFile():
 
                 """ 
                     hidden mons need a special bit of logic since they're not in the vanilla
-                    wild_encounters.json file, but the game expects them to be there
+                    wild_encounters.json file, but the code expects them to be there
                 """
                 hidden_mons = "hidden_mons"
                 if (fieldCounter == len(wFields) - 1) and not CheckFieldDataDupes(hidden_mons):


### PR DESCRIPTION
## Description
@/spargel on discord brought this up:
https://discord.com/channels/419213663107416084/1077168246555430962/1374503502243696650
this handles the fields better and checks for duplicate entries, as well as reading from `dexnav.h` to determine whether hidden mon macros should be generated.

<!-- CREDITS -->
@/spargel on discord for alerting me to the problem