### PR TITLE
Fixes Knock Off/Smack Down effect on immune target/protect

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -6559,6 +6559,7 @@ static void Cmd_moveend(void)
             break;
         case MOVEEND_FIRST_MOVE_BLOCK:
             if ((gSpecialStatuses[gBattlerAttacker].parentalBondState == PARENTAL_BOND_1ST_HIT && IsBattlerAlive(gBattlerTarget))
+             || gBattleStruct->moveResultFlags[gBattlerTarget] & MOVE_RESULT_NO_EFFECT
              || gHitMarker & HITMARKER_UNABLE_TO_USE_MOVE)
             {
                 gBattleScripting.moveendState++;
@@ -6575,8 +6576,7 @@ static void Cmd_moveend(void)
                 if (IsBattlerTurnDamaged(gBattlerTarget)
                  && IsBattlerAlive(gBattlerTarget)
                  && IsBattlerAlive(gBattlerAttacker)
-                 && !(gStatuses3[BATTLE_PARTNER(gBattlerTarget)] & STATUS3_COMMANDER)
-                 && gSpecialStatuses[gBattlerAttacker].parentalBondState != PARENTAL_BOND_1ST_HIT)
+                 && !(gStatuses3[BATTLE_PARTNER(gBattlerTarget)] & STATUS3_COMMANDER))
                 {
                     u32 targetAbility = GetBattlerAbility(gBattlerTarget);
                     if (targetAbility == ABILITY_GUARD_DOG)

--- a/test/battle/move_effect/knock_off.c
+++ b/test/battle/move_effect/knock_off.c
@@ -90,11 +90,46 @@ SINGLE_BATTLE_TEST("Knock Off does not remove items through Substitute")
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_LEFTOVERS); };
     } WHEN {
-        TURN { MOVE(opponent, MOVE_SUBSTITUTE);
-               MOVE(player, MOVE_KNOCK_OFF); }
+        TURN { MOVE(opponent, MOVE_SUBSTITUTE); MOVE(player, MOVE_KNOCK_OFF); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_KNOCK_OFF, player);
         NOT { ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ITEM_KNOCKOFF); }
+    } THEN {
+        EXPECT(opponent->item == ITEM_LEFTOVERS);
+    }
+}
+
+SINGLE_BATTLE_TEST("Knock Off does not remove items through Protect")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_LEFTOVERS); };
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_PROTECT); MOVE(player, MOVE_KNOCK_OFF); }
+    } SCENE {
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_KNOCK_OFF, player);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ITEM_KNOCKOFF);
+        }
+    } THEN {
+        EXPECT(opponent->item == ITEM_LEFTOVERS);
+    }
+}
+
+SINGLE_BATTLE_TEST("Knock Off does not remove items if target is immune")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_ELECTRIFY) == EFFECT_ELECTRIFY);
+        ASSUME(gSpeciesInfo[SPECIES_DONPHAN].types[0] == TYPE_GROUND || gSpeciesInfo[SPECIES_DONPHAN].types[1] == TYPE_GROUND);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_DONPHAN) { Item(ITEM_LEFTOVERS); };
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_ELECTRIFY); MOVE(player, MOVE_KNOCK_OFF); }
+    } SCENE {
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_KNOCK_OFF, player);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ITEM_KNOCKOFF);
+        }
     } THEN {
         EXPECT(opponent->item == ITEM_LEFTOVERS);
     }

--- a/test/battle/move_effect/smack_down.c
+++ b/test/battle/move_effect/smack_down.c
@@ -17,3 +17,30 @@ SINGLE_BATTLE_TEST("Smack Down does not ground mons behind substitutes")
         NOT MESSAGE("The opposing Skarmory fell straight down!");
     }
 }
+
+SINGLE_BATTLE_TEST("Smack Down does not ground mons through Protect")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_SKARMORY);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_PROTECT); MOVE(player, MOVE_SMACK_DOWN); }
+    } SCENE {
+        NOT MESSAGE("The opposing Skarmory fell straight down!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Smack Down does not ground target if target is immune")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_ELECTRIFY) == EFFECT_ELECTRIFY);
+        ASSUME(gSpeciesInfo[SPECIES_GLISCOR].types[0] == TYPE_GROUND || gSpeciesInfo[SPECIES_GLISCOR].types[1] == TYPE_GROUND);
+        ASSUME(gSpeciesInfo[SPECIES_GLISCOR].types[0] == TYPE_FLYING || gSpeciesInfo[SPECIES_GLISCOR].types[1] == TYPE_FLYING);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_GLISCOR);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_ELECTRIFY); MOVE(player, MOVE_SMACK_DOWN); }
+    } SCENE {
+        NOT MESSAGE("The opposing Gliscor fell straight down!");
+    }
+}


### PR DESCRIPTION
Fixes Knock Off and Smack Down applying their effects even if the move had no effect (immune, protected, ...).

Removed a redundant check for Switch Target moves.

## Discord contact info
PhallenTree
