### PR TITLE
Turn `OW_FRLG_WHITEOUT` into `OW_WHITEOUT_CUTSCENE` and make it generational

### DIFF
--- a/include/config/overworld.h
+++ b/include/config/overworld.h
@@ -9,7 +9,7 @@
 #define OW_POISON_DAMAGE                GEN_LATEST // In Gen4, Pokémon no longer faint from Poison in the overworld. In Gen5+, they no longer take damage at all.
 #define OW_DOUBLE_APPROACH_WITH_ONE_MON FALSE      // If enabled, you can be spotted by two trainers at the same time even if you only have one eligible Pokémon in your party.
 #define OW_HIDE_REPEAT_MAP_POPUP        FALSE      // If enabled, map popups will not appear if entering a map with the same Map Section Id as the last.
-#define OW_FRLG_WHITEOUT                FALSE      // If enabled, shows an additional whiteout message and post whiteout event script with healing NPC.
+#define OW_WHITEOUT_CUTSCENE            GEN_LATEST // In Gen4+, whiting out shows an additional message and post whiteout event script cutscene with a healing NPC. (While this change was also in FRLG, for the sake of simplicity, setting this to GEN_3 will result in RSE behavior.)
 #define OW_DEFOG_FIELD_MOVE             FALSE      // If enabled, Defog can be used as a Field Move as seen in DPPt.
 
 // Item Obtain Description Box

--- a/src/field_screen_effect.c
+++ b/src/field_screen_effect.c
@@ -1382,10 +1382,10 @@ static bool32 PrintWhiteOutRecoveryMessage(u8 taskId, const u8 *text, u32 x, u32
 }
 
 enum {
-    FRLG_WHITEOUT_ENTER_MSG_SCREEN,
-    FRLG_WHITEOUT_PRINT_MSG,
-    FRLG_WHITEOUT_LEAVE_MSG_SCREEN,
-    FRLG_WHITEOUT_HEAL_SCRIPT,
+    WHITEOUT_CUTSCENE_ENTER_MSG_SCREEN,
+    WHITEOUT_CUTSCENE_PRINT_MSG,
+    WHITEOUT_CUTSCENE_LEAVE_MSG_SCREEN,
+    WHITEOUT_CUTSCENE_HEAL_SCRIPT,
 };
 
 static const u8 *GenerateRecoveryMessage(u8 taskId)
@@ -1409,7 +1409,7 @@ static void Task_RushInjuredPokemonToCenter(u8 taskId)
 
     switch (gTasks[taskId].tState)
     {
-    case FRLG_WHITEOUT_ENTER_MSG_SCREEN:
+    case WHITEOUT_CUTSCENE_ENTER_MSG_SCREEN:
         windowId = AddWindow(&sWindowTemplate_WhiteoutText);
         gTasks[taskId].tWindowId = windowId;
         Menu_LoadStdPalAt(BG_PLTT_ID(15));
@@ -1418,28 +1418,28 @@ static void Task_RushInjuredPokemonToCenter(u8 taskId)
         CopyWindowToVram(windowId, COPYWIN_FULL);
 
         gTasks[taskId].tIsPlayerHouse = IsLastHealLocationPlayerHouse();
-        gTasks[taskId].tState = FRLG_WHITEOUT_PRINT_MSG;
+        gTasks[taskId].tState = WHITEOUT_CUTSCENE_PRINT_MSG;
         break;
-    case FRLG_WHITEOUT_PRINT_MSG:
+    case WHITEOUT_CUTSCENE_PRINT_MSG:
     {
         const u8 *recoveryMessage = GenerateRecoveryMessage(taskId);
 
         if (PrintWhiteOutRecoveryMessage(taskId, recoveryMessage, 2, 8))
         {
             ObjectEventTurn(&gObjectEvents[gPlayerAvatar.objectEventId], DIR_NORTH);
-            gTasks[taskId].tState = FRLG_WHITEOUT_LEAVE_MSG_SCREEN;
+            gTasks[taskId].tState = WHITEOUT_CUTSCENE_LEAVE_MSG_SCREEN;
         }
         break;
     }
-    case FRLG_WHITEOUT_LEAVE_MSG_SCREEN:
+    case WHITEOUT_CUTSCENE_LEAVE_MSG_SCREEN:
         windowId = gTasks[taskId].tWindowId;
         ClearWindowTilemap(windowId);
         CopyWindowToVram(windowId, COPYWIN_MAP);
         RemoveWindow(windowId);
         FadeInFromBlack();
-        gTasks[taskId].tState = FRLG_WHITEOUT_HEAL_SCRIPT;
+        gTasks[taskId].tState = WHITEOUT_CUTSCENE_HEAL_SCRIPT;
         break;
-    case FRLG_WHITEOUT_HEAL_SCRIPT:
+    case WHITEOUT_CUTSCENE_HEAL_SCRIPT:
         if (WaitForWeatherFadeIn() == TRUE)
         {
             DestroyTask(taskId);
@@ -1459,7 +1459,7 @@ void FieldCB_RushInjuredPokemonToCenter(void)
     LockPlayerFieldControls();
     FillPalBufferBlack();
     taskId = CreateTask(Task_RushInjuredPokemonToCenter, 10);
-    gTasks[taskId].tState = FRLG_WHITEOUT_ENTER_MSG_SCREEN;
+    gTasks[taskId].tState = WHITEOUT_CUTSCENE_ENTER_MSG_SCREEN;
 }
 
 static void GetStairsMovementDirection(u32 metatileBehavior, s16 *speedX, s16 *speedY)

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -708,16 +708,16 @@ void SetWarpDestinationToHealLocation(u8 healLocationId)
         SetWarpDestination(healLocation->group, healLocation->map, WARP_ID_NONE, healLocation->x, healLocation->y);
 }
 
-static bool32 IsFRLGWhiteout(void)
+static bool32 IsWhiteoutCutscene(void)
 {
-    if (!OW_FRLG_WHITEOUT)
+    if (OW_WHITEOUT_CUTSCENE < GEN_4)
         return FALSE;
     return GetHealNpcLocalId(GetHealLocationIndexByWarpData(&gSaveBlock1Ptr->lastHealLocation)) > 0;
 }
 
 void SetWarpDestinationToLastHealLocation(void)
 {
-    if (IsFRLGWhiteout())
+    if (IsWhiteoutCutscene())
         SetWhiteoutRespawnWarpAndHealerNPC(&sWarpDestination);
     else
         sWarpDestination = gSaveBlock1Ptr->lastHealLocation;
@@ -1811,7 +1811,7 @@ void CB2_WhiteOut(void)
         ResetInitialPlayerAvatarState();
         ScriptContext_Init();
         UnlockPlayerFieldControls();
-        if (IsFRLGWhiteout())
+        if (IsWhiteoutCutscene())
             gFieldCallback = FieldCB_RushInjuredPokemonToCenter;
         else
             gFieldCallback = FieldCB_WarpExitFadeFromBlack;


### PR DESCRIPTION
## Description
The config and name was misleading, this is actually the behavior of every game after FRLG, so it should be generational and enabled by default.

## Discord contact info
kittenchilly
