### PR TITLE
Fix OW_POPUP_BW_TIME_MODE burning a lot of cycles due to RTC queries.

### DIFF
--- a/src/map_name_popup.c
+++ b/src/map_name_popup.c
@@ -424,7 +424,6 @@ static void Task_MapNamePopUpWindow(u8 taskId)
         break;
     case STATE_WAIT:
         // Wait while the window is fully onscreen.
-        UpdateSecondaryPopUpWindow(GetSecondaryPopUpWindowId());
         if (++task->tOnscreenTimer > 120)
         {
             task->tOnscreenTimer = 0;


### PR DESCRIPTION
## Description
Removes the update to the popup window every frame that queries the RTC chip. This burns a lot of cycles due to the siirtc being slow and the code accounting for it in a busy wait.

## Things to note in the release changelog:
- Fixed an issue that causes the game to lag in some configurations that involve `OW_POPUP_BW_TIME_MODE`.

## Discord contact info
karathan
