### PR TITLE
Fix Wish healing even if the target is Heal Blocked

### DIFF
--- a/asm/macros/battle_script.inc
+++ b/asm/macros/battle_script.inc
@@ -1140,10 +1140,11 @@
 	.4byte \failInstr
 	.endm
 
-	.macro trywish turnNumber:req, failInstr:req
+	.macro trywish turnNumber:req, failInstr:req, blockedInstr:req
 	.byte 0xd4
 	.byte \turnNumber
 	.4byte \failInstr
+	.4byte \blockedInstr
 	.endm
 
 	.macro settoxicspikes failInstr:req

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -5033,7 +5033,7 @@ BattleScript_EffectWish::
 	attackcanceler
 	attackstring
 	ppreduce
-	trywish 0, BattleScript_ButItFailed
+	trywish 0, BattleScript_ButItFailed, BattleScript_ButItFailed
 	attackanimation
 	waitanimation
 	goto BattleScript_MoveEnd
@@ -6675,7 +6675,7 @@ BattleScript_SelectingNotAllowedCurrentMoveInPalace::
 	goto BattleScript_SelectingUnusableMoveInPalace
 
 BattleScript_WishComesTrue::
-	trywish 1, BattleScript_WishButFullHp
+	trywish 1, BattleScript_WishButFullHp, BattleScript_WishButHealBlocked
 	playanimation BS_TARGET, B_ANIM_WISH_HEAL
 	printstring STRINGID_PKMNWISHCAMETRUE
 	waitmessage B_WAIT_TIME_LONG
@@ -6691,6 +6691,14 @@ BattleScript_WishButFullHp::
 	waitmessage B_WAIT_TIME_LONG
 	pause B_WAIT_TIME_SHORT
 	printstring STRINGID_PKMNHPFULL
+	waitmessage B_WAIT_TIME_LONG
+	end2
+
+BattleScript_WishButHealBlocked::
+	printstring STRINGID_PKMNWISHCAMETRUE
+	waitmessage B_WAIT_TIME_LONG
+	pause B_WAIT_TIME_SHORT
+	printstring STRINGID_HEALBLOCKPREVENTSUSAGE
 	waitmessage B_WAIT_TIME_LONG
 	end2
 

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -15150,7 +15150,7 @@ static void Cmd_trycopyability(void)
 
 static void Cmd_trywish(void)
 {
-    CMD_ARGS(u8 turnNumber, const u8 *failInstr);
+    CMD_ARGS(u8 turnNumber, const u8 *failInstr, const u8 *healBlockedInstr);
 
     switch (cmd->turnNumber)
     {
@@ -15174,7 +15174,9 @@ static void Cmd_trywish(void)
             gBattleStruct->moveDamage[gBattlerTarget] = max(1, GetNonDynamaxMaxHP(gBattlerAttacker) / 2);
 
         gBattleStruct->moveDamage[gBattlerTarget] *= -1;
-        if (gBattleMons[gBattlerTarget].hp == gBattleMons[gBattlerTarget].maxHP)
+	if (gStatuses3[gBattlerTarget] & STATUS3_HEAL_BLOCK)
+	    gBattlescriptCurrInstr = cmd->healBlockedInstr;
+	else if (gBattleMons[gBattlerTarget].hp == gBattleMons[gBattlerTarget].maxHP)
             gBattlescriptCurrInstr = cmd->failInstr;
         else
             gBattlescriptCurrInstr = cmd->nextInstr;

--- a/test/battle/move_effect/wish.c
+++ b/test/battle/move_effect/wish.c
@@ -1,4 +1,29 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Wish (Move Effect) test titles")
+SINGLE_BATTLE_TEST("Wish heals")
+{
+	GIVEN {
+		PLAYER(SPECIES_TOGETIC);
+		OPPONENT(SPECIES_LUNATONE);
+	} WHEN {
+		TURN { MOVE(player, MOVE_WISH); MOVE(opponent, MOVE_TACKLE); }
+		TURN { MOVE(player, MOVE_SPLASH); MOVE(opponent, MOVE_TACKLE); }
+	} SCENE {
+		HP_BAR(player);
+	}
+}
+
+SINGLE_BATTLE_TEST("Wish is blocked by Heal Block")
+{
+	GIVEN {
+		PLAYER(SPECIES_TOGETIC);
+		OPPONENT(SPECIES_LUNATONE);
+	} WHEN {
+		TURN { MOVE(player, MOVE_WISH); MOVE(opponent, MOVE_TACKLE); }
+		TURN { MOVE(player, MOVE_SPLASH); MOVE(opponent, MOVE_HEAL_BLOCK); }
+	} SCENE {
+		MESSAGE("Togetic was prevented from healing!");
+		NOT HP_BAR(player);
+	}
+}	


### PR DESCRIPTION
## Description
This PR fixes the issue where, if a Wish comes true and the target of the healing is Heal Blocked, the target pokemon would still heal. Now, if the target has Heal Block, the Wish no longer heals and correctly displays Heal Blocked trigger text.
This is my first PR, so let me know if this method of solving the problem isn't optimal, or anything else that should be changed.

## Issue(s) that this PR fixes
Fixes #6649

## Things to note in the release changelog:
- Fixed Heal Block not applying to Wish moves that had already been used

## Discord contact info
vexedon
