### PR TITLE
Fix Eiscue not resetting back to Ice Face form after battle.

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2802,10 +2802,10 @@ static void Cmd_resultmessage(void)
     if (gDisableStructs[gBattlerTarget].iceFaceActivationPrevention)
     {
         gDisableStructs[gBattlerTarget].iceFaceActivationPrevention = FALSE;
-		u32 side = GetBattlerSide(gBattlerTarget);
+        u32 side = GetBattlerSide(gBattlerTarget);
         if (gBattleStruct->changedSpecies[side][gBattlerPartyIndexes[gBattlerTarget]] == SPECIES_NONE)
             gBattleStruct->changedSpecies[side][gBattlerPartyIndexes[gBattlerTarget]] = gBattleMons[gBattlerTarget].species; 
-		gBattleMons[gBattlerTarget].species = SPECIES_EISCUE_NOICE;
+        gBattleMons[gBattlerTarget].species = SPECIES_EISCUE_NOICE;
         gBattleScripting.battler = gBattlerTarget; // For STRINGID_PKMNTRANSFORMED
         BattleScriptPushCursor();
         gBattlescriptCurrInstr = BattleScript_IceFaceNullsDamage;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2802,7 +2802,10 @@ static void Cmd_resultmessage(void)
     if (gDisableStructs[gBattlerTarget].iceFaceActivationPrevention)
     {
         gDisableStructs[gBattlerTarget].iceFaceActivationPrevention = FALSE;
-        gBattleMons[gBattlerTarget].species = SPECIES_EISCUE_NOICE;
+		u32 side = GetBattlerSide(gBattlerTarget);
+        if (gBattleStruct->changedSpecies[side][gBattlerPartyIndexes[gBattlerTarget]] == SPECIES_NONE)
+            gBattleStruct->changedSpecies[side][gBattlerPartyIndexes[gBattlerTarget]] = gBattleMons[gBattlerTarget].species; 
+		gBattleMons[gBattlerTarget].species = SPECIES_EISCUE_NOICE;
         gBattleScripting.battler = gBattlerTarget; // For STRINGID_PKMNTRANSFORMED
         BattleScriptPushCursor();
         gBattlescriptCurrInstr = BattleScript_IceFaceNullsDamage;


### PR DESCRIPTION
## Description
This PR fixes an issue where Eiscue would stay in Noice Face form after battle. Instead, Eiscue now behaves correctly and resets back to Ice Face outside of combat, similar to Mimikyu.

## Issue(s) that this PR fixes
Fixes #6264.

## Discord contact info
vexedon
