### PR TITLE
Fixes follower NPC not changing state with player after warp

### DIFF
--- a/src/follower_npc.c
+++ b/src/follower_npc.c
@@ -1284,7 +1284,15 @@ void FollowerNPC_WarpSetEnd(void)
     }
 
     if (gPlayerAvatar.flags & PLAYER_AVATAR_FLAG_ON_FOOT)
+    {
         SetFollowerNPCSprite(FOLLOWER_NPC_SPRITE_INDEX_NORMAL);
+        SetFollowerNPCData(FNPC_DATA_SURF_BLOB, FNPC_SURF_BLOB_NONE);
+    }
+    else if (gPlayerAvatar.flags & PLAYER_AVATAR_FLAG_SURFING)
+    {
+        SetFollowerNPCSprite(FOLLOWER_NPC_SPRITE_INDEX_SURF);
+        SetFollowerNPCData(FNPC_DATA_SURF_BLOB, FNPC_SURF_BLOB_RECREATE);
+    }
 
     follower->facingDirection = player->facingDirection;
     follower->movementDirection = player->movementDirection;


### PR DESCRIPTION
## Description
Added logic to the `FollowerNPC_WarpSetEnd` function that makes sure the follower will have the same state as the player after a warp. For example, when surfing into a warp that leads to a non-surfing destination the follower would erroneously retain the surf blob on land. This fixes that issue.

## Media
Here is a video showcasing the bug:  
https://discord.com/channels/419213663107416084/1357388177161326834/1377337293433471148

## Discord contact info
bivurnum
