### PR TITLE
Fixed follower NPC changing to surf sprite when choosing not to surface from dive

### DIFF
--- a/data/scripts/field_move_scripts.inc
+++ b/data/scripts/field_move_scripts.inc
@@ -354,7 +354,7 @@ EventScript_UseDiveUnderwater::
 	setfieldeffectargument 0, VAR_RESULT
 	setfieldeffectargument 1, 1
 	msgbox Text_WantToSurface, MSGBOX_YESNO
-	goto_if_eq VAR_RESULT, NO, EventScript_EndSurface
+	goto_if_eq VAR_RESULT, NO, EventScript_NoSurface
 	msgbox Text_MonUsedDive, MSGBOX_DEFAULT
 	hidefollowernpc
 	dofieldeffect FLDEFF_USE_DIVE
@@ -369,6 +369,7 @@ EventScript_CantSurface::
 
 EventScript_EndSurface::
 	callnative SetFollowerNPCSurfSpriteAfterDive
+EventScript_NoSurface::
 	releaseall
 	end
 


### PR DESCRIPTION
## Description
Selecting "No" when asked if you want to surface from underwater will no longer change the follower NPC to the regular surf sprite.

## Media
A video showcasing the bug:  
https://discord.com/channels/419213663107416084/1357388177161326834/1376995585411907724

## Discord contact info
bivurnum