### PR TITLE
Fixed surf blob binding to invisible follower NPC on map reload

### DIFF
--- a/src/follower_npc.c
+++ b/src/follower_npc.c
@@ -1357,7 +1357,7 @@ void FollowerNPC_BindToSurfBlobOnReloadScreen(void)
     follower = &gObjectEvents[GetFollowerNPCObjectId()];
     TryUpdateFollowerNPCSpriteUnderwater();
 
-    if (GetFollowerNPCData(FNPC_DATA_SURF_BLOB) != FNPC_SURF_BLOB_RECREATE && GetFollowerNPCData(FNPC_DATA_SURF_BLOB) != FNPC_SURF_BLOB_DESTROY)
+    if (follower->invisible || (GetFollowerNPCData(FNPC_DATA_SURF_BLOB) != FNPC_SURF_BLOB_RECREATE && GetFollowerNPCData(FNPC_DATA_SURF_BLOB) != FNPC_SURF_BLOB_DESTROY))
         return;
 
     // Spawn the surf blob under the follower.


### PR DESCRIPTION
## Description
The surf blob would get created for the follower NPC on map reload even if they were invisible, causing a second surf blob to be created when the follower is revealed. This fixes that issue.

## Media
Video showcasing the bug:  
https://discord.com/channels/419213663107416084/1357388177161326834/1377337293433471148

## Discord contact info
bivurnum