### PR TITLE
Fix follower NPC not reappearing after Mossdeep gym warp

### DIFF
--- a/src/field_screen_effect.c
+++ b/src/field_screen_effect.c
@@ -593,6 +593,7 @@ void DoMossdeepGymWarp(void)
     SaveObjectEvents();
     TryFadeOutOldMapMusic();
     WarpFadeOutScreen();
+    SetFollowerNPCData(FNPC_DATA_WARP_END, FNPC_WARP_REAPPEAR);
     PlaySE(SE_WARP_IN);
     CreateTask(Task_WarpAndLoadMap, 10);
     gFieldCallback = FieldCB_MossdeepGymWarpExit;


### PR DESCRIPTION
## Description
Mossdeep gym warps now set the follower NPC to reappear.

## Media
A video showcasing the issue:  
https://discord.com/channels/419213663107416084/1357388177161326834/1376678372498870412

## Discord contact info
bivurnum
