### PR TITLE
Fix UB when using time menu

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -1922,20 +1922,24 @@ static void DebugAction_Util_OpenTimeMenu(u8 taskId)
 
 static void DebugAction_TimeMenu_TimesOfDay(u8 taskId)
 {
-    Debug_DestroyMenu_Full(taskId);
     if (!OW_USE_FAKE_RTC)
         Debug_DestroyMenu_Full_Script(taskId, Debug_EventScript_FakeRTCNotEnabled);
     else
+    {
+        Debug_DestroyMenu_Full(taskId);
         Debug_ShowMenu(DebugTask_HandleMenuInput_TimeMenu_TimesOfDay, sDebugMenu_ListTemplate_TimeMenu_TimesOfDay);
+    }
 }
 
 static void DebugAction_TimeMenu_Weekdays(u8 taskId)
 {
-    Debug_DestroyMenu_Full(taskId);
     if (!OW_USE_FAKE_RTC)
         Debug_DestroyMenu_Full_Script(taskId, Debug_EventScript_FakeRTCNotEnabled);
     else
+    {
+        Debug_DestroyMenu_Full(taskId);
         Debug_ShowMenu(DebugTask_HandleMenuInput_TimeMenu_Weekdays, sDebugMenu_ListTemplate_TimeMenu_Weekdays);
+    }
 }
 
 static void DebugAction_OpenPlayerMenu(u8 taskId)
@@ -2384,7 +2388,6 @@ void BufferExpansionVersion(struct ScriptContext *ctx)
 
 static void DebugAction_TimeMenu_PrintTime(u8 taskId)
 {
-    Debug_DestroyMenu_Full(taskId);
     LockPlayerFieldControls();
     Debug_DestroyMenu_Full_Script(taskId, Debug_EventScript_TellTheTime);
 }
@@ -2410,7 +2413,6 @@ void DebugMenu_CalculateTime(struct ScriptContext *ctx)
 
 static void DebugAction_TimeMenu_PrintTimeOfDay(u8 taskId)
 {
-    Debug_DestroyMenu_Full(taskId);
     LockPlayerFieldControls();
     Debug_DestroyMenu_Full_Script(taskId, Debug_EventScript_PrintTimeOfDay);
 }

--- a/src/debug.c
+++ b/src/debug.c
@@ -1923,7 +1923,9 @@ static void DebugAction_Util_OpenTimeMenu(u8 taskId)
 static void DebugAction_TimeMenu_TimesOfDay(u8 taskId)
 {
     if (!OW_USE_FAKE_RTC)
+    {
         Debug_DestroyMenu_Full_Script(taskId, Debug_EventScript_FakeRTCNotEnabled);
+    }
     else
     {
         Debug_DestroyMenu_Full(taskId);
@@ -1934,7 +1936,9 @@ static void DebugAction_TimeMenu_TimesOfDay(u8 taskId)
 static void DebugAction_TimeMenu_Weekdays(u8 taskId)
 {
     if (!OW_USE_FAKE_RTC)
+    {
         Debug_DestroyMenu_Full_Script(taskId, Debug_EventScript_FakeRTCNotEnabled);
+    }
     else
     {
         Debug_DestroyMenu_Full(taskId);


### PR DESCRIPTION
## Description
`Debug_DestroyMenu_Full` is called twice in a row, when `FAKE_RTC` is disabled, causing free to be called twice on the same pointer.

## Discord contact info
.cawt
