### PR TITLE
Added line break between Trainer 1 name and Trainer 2 name in sText_TwoTrainersWantToBattle

### DIFF
--- a/src/battle_message.c
+++ b/src/battle_message.c
@@ -1473,7 +1473,7 @@ const u8 gText_Body[] = _("Body");
 const u8 gText_Judgment[] = _("{B_BUFF1}{CLEAR 13}Judgment{CLEAR 13}{B_BUFF2}");
 static const u8 sText_TwoTrainersSentPkmn[] = _("{B_TRAINER1_NAME_WITH_CLASS} sent out {B_OPPONENT_MON1_NAME}!\p{B_TRAINER2_NAME_WITH_CLASS} sent out {B_OPPONENT_MON2_NAME}!");
 static const u8 sText_Trainer2SentOutPkmn[] = _("{B_TRAINER2_NAME_WITH_CLASS} sent out {B_BUFF1}!");
-static const u8 sText_TwoTrainersWantToBattle[] = _("You are challenged by {B_TRAINER1_NAME_WITH_CLASS} and {B_TRAINER2_NAME_WITH_CLASS}!\p");
+static const u8 sText_TwoTrainersWantToBattle[] = _("You are challenged by\n{B_TRAINER1_NAME_WITH_CLASS} and\l{B_TRAINER2_NAME_WITH_CLASS}!\p");
 static const u8 sText_InGamePartnerSentOutZGoN[] = _("{B_PARTNER_NAME_WITH_CLASS} sent out {B_PLAYER_MON2_NAME}! Go, {B_PLAYER_MON1_NAME}!");
 
 const u16 gBattlePalaceFlavorTextTable[] =


### PR DESCRIPTION
Two trainer battle intro text doesn't always display second trainer name. PR fixes this issue.

## Description
Adds defined line breaks into sText_TwoTrainersWantToBattle so both trainer names are always displayed

## Media
Before fix
https://github.com/user-attachments/assets/39ed6539-1bd1-48aa-b19a-1490f3326646

After fix
https://github.com/user-attachments/assets/a0a85ee2-670f-49ac-bef5-917101f504ab

## Issue(s) that this PR fixes
Fixes #6816

## Discord contact info
grintoul