### PR TITLE
Fixes multi battle party re-order

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4651,7 +4651,7 @@ static void HandleTurnActionSelectionState(void)
             for (i = 0; i < gBattlersCount; i++)
             {
                 if (gChosenActionByBattler[i] == B_ACTION_SWITCH)
-                    SwitchPartyOrderInGameMulti(i, gBattleStruct->monToSwitchIntoId[battler]);
+                    SwitchPartyOrderInGameMulti(i, gBattleStruct->monToSwitchIntoId[i]);
             }
         }
     }


### PR DESCRIPTION
When a pokemon switched out in a multi battle, the partner pokemon would occupy a slot from partner