### PR TITLE
Update .gitignore to add heal locations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ prefabs.json
 *.js
 /pokeemerald-*.png
 src/data/map_group_count.h
+include/constants/heal_locations.h
 tools/trainerproc/trainerproc
 tools/compresSmol/compresSmol
 tools/compresSmol/compresSmolTilemap


### PR DESCRIPTION
``make clean`` on upcoming currently results in the apparent deletion of ``heal_locations.h``, which is fully automatically generated and can/should thus be safely gitignored