### PR TITLE
Bug fix for Grassy Terrain incorrectly healing non-grounded Pokemon

### DIFF
--- a/src/battle_end_turn.c
+++ b/src/battle_end_turn.c
@@ -473,7 +473,7 @@ static bool32 HandleEndTurnFirstEventBlock(u32 battler)
         gBattleStruct->eventBlockCounter++;
         break;
     case FIRST_EVENT_BLOCK_GRASSY_TERRAIN_HEAL:
-        if (gFieldStatuses & STATUS_FIELD_GRASSY_TERRAIN && IsBattlerAlive(battler) && !IsBattlerAtMaxHp(battler))
+        if (gFieldStatuses & STATUS_FIELD_GRASSY_TERRAIN && IsBattlerAlive(battler) && !IsBattlerAtMaxHp(battler) && !IsBattlerAtMaxHp(battler) && IsBattlerGrounded(battler))
         {
             gBattlerAttacker = battler;
             gBattleStruct->moveDamage[battler] = -(GetNonDynamaxMaxHP(battler) / 16);

--- a/src/battle_end_turn.c
+++ b/src/battle_end_turn.c
@@ -473,7 +473,7 @@ static bool32 HandleEndTurnFirstEventBlock(u32 battler)
         gBattleStruct->eventBlockCounter++;
         break;
     case FIRST_EVENT_BLOCK_GRASSY_TERRAIN_HEAL:
-        if (gFieldStatuses & STATUS_FIELD_GRASSY_TERRAIN && IsBattlerAlive(battler) && !IsBattlerAtMaxHp(battler) && !IsBattlerAtMaxHp(battler) && IsBattlerGrounded(battler))
+        if (gFieldStatuses & STATUS_FIELD_GRASSY_TERRAIN && IsBattlerAlive(battler) && !IsBattlerAtMaxHp(battler) && IsBattlerGrounded(battler))
         {
             gBattlerAttacker = battler;
             gBattleStruct->moveDamage[battler] = -(GetNonDynamaxMaxHP(battler) / 16);


### PR DESCRIPTION
Title. Grassy Terrain heals non-grounded Pokemon when it shouldn't. This PR fixes #7057.

## Description
In `battle_end_turn.c`, the `FIRST_EVENT_BLOCK_GRASSY_TERRAIN_HEAL` needs `IsBattlerGrounded(battler)` in its activation conditional.

## **Discord contact info**
linathan