### PR TITLE
[DRAFT] Fix Normalize not boosting Normal type moves if they were already Normal type

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -6012,7 +6012,9 @@ u32 GetDynamicMoveType(struct Pokemon *mon, u32 move, u32 battler, enum MonState
             gBattleStruct->ateBoost[battler] = TRUE;
         return ateType;
     }
-    else if (moveType != TYPE_NORMAL
+    else if (moveEffect != EFFECT_CHANGE_TYPE_ON_ITEM // Judgment, Techno Blast, Multi-Attack
+          && moveEffect != EFFECT_TERRAIN_PULSE
+          && moveEffect != EFFECT_NATURAL_GIFT
           && moveEffect != EFFECT_HIDDEN_POWER
           && moveEffect != EFFECT_WEATHER_BALL
           && ability == ABILITY_NORMALIZE


### PR DESCRIPTION
Includes a catch to make sure certain move effects never get a boost

## Description
As per Bulbapedia, in Gen 7+, Normalize boosts all Normal-type moves even if they were Normal type from the start.

## Feature(s) this PR does NOT handle:
Generation configuration for the move effects Normalize doesn't boost.

## Discord contact info
i0brendan0
