### PR TITLE
Fixes Aura Wheel + Normalize and Hunger Switch while Transformed/Terastallized

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -6002,7 +6002,9 @@ u32 GetDynamicMoveType(struct Pokemon *mon, u32 move, u32 battler, enum MonState
     {
         return TYPE_WATER;
     }
-    else if (moveEffect == EFFECT_AURA_WHEEL && species == SPECIES_MORPEKO_HANGRY)
+    else if (moveEffect == EFFECT_AURA_WHEEL
+          && species == SPECIES_MORPEKO_HANGRY
+          && ability != ABILITY_NORMALIZE)
     {
         return TYPE_DARK;
     }

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4320,7 +4320,9 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
                 }
                 break;
             case ABILITY_HUNGER_SWITCH:
-                if (TryBattleFormChange(battler, FORM_CHANGE_BATTLE_TURN_END))
+                if (!(gBattleMons[battler].status2 & STATUS2_TRANSFORMED)
+                 && GetActiveGimmick(battler) != GIMMICK_TERA
+                 && TryBattleFormChange(battler, FORM_CHANGE_BATTLE_TURN_END))
                 {
                     gBattlerAttacker = battler;
                     BattleScriptPushCursorAndCallback(BattleScript_AttackerFormChangeEnd3NoPopup);

--- a/test/battle/ability/hunger_switch.c
+++ b/test/battle/ability/hunger_switch.c
@@ -22,3 +22,52 @@ SINGLE_BATTLE_TEST("Hunger Switch switches Morpeko's forms at the end of the tur
             EXPECT_EQ(player->species, SPECIES_MORPEKO_FULL_BELLY);
     }
 }
+
+SINGLE_BATTLE_TEST("Hunger Switch does not switch a mon transformed into Morpeko's form")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_TRANSFORM) == EFFECT_TRANSFORM);
+        PLAYER(SPECIES_MORPEKO) { Ability(ABILITY_HUNGER_SWITCH); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_TRANSFORM); }
+    } SCENE {
+        NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, opponent);
+    }
+}
+
+SINGLE_BATTLE_TEST("Hunger Switch does not switch Morpeko's form when Terastallized")
+{
+    GIVEN {
+        PLAYER(SPECIES_MORPEKO) { Ability(ABILITY_HUNGER_SWITCH); TeraType(TYPE_NORMAL); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { }
+        TURN { MOVE(player, MOVE_SCRATCH, gimmick: GIMMICK_TERA); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
+    }
+}
+
+SINGLE_BATTLE_TEST("Hunger Switch does not switch Morpeko's form after switching out while Terastallized")
+{
+    KNOWN_FAILING;
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_ROAR) == EFFECT_ROAR);
+        PLAYER(SPECIES_MORPEKO) { Ability(ABILITY_HUNGER_SWITCH); TeraType(TYPE_NORMAL); }
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { }
+        TURN { MOVE(player, MOVE_SCRATCH, gimmick: GIMMICK_TERA); MOVE(opponent, MOVE_ROAR); }
+        TURN { SWITCH(player, 0); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
+    } THEN {
+        EXPECT_EQ(player->species, SPECIES_MORPEKO_HANGRY);
+    }
+}

--- a/test/battle/move_effect/aura_wheel.c
+++ b/test/battle/move_effect/aura_wheel.c
@@ -50,4 +50,42 @@ SINGLE_BATTLE_TEST("Aura Wheel changes type depending on Morpeko's form")
     }
 }
 
-TO_DO_BATTLE_TEST("Aura Wheel can be used by Pokémon transformed into Morpeko");
+SINGLE_BATTLE_TEST("Aura Wheel can be used by Pokémon transformed into Morpeko")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_TRANSFORM) == EFFECT_TRANSFORM);
+        PLAYER(SPECIES_MORPEKO) { Ability(ABILITY_HUNGER_SWITCH); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_TRANSFORM); }
+        TURN { MOVE(opponent, MOVE_AURA_WHEEL); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_AURA_WHEEL, opponent);
+    }
+}
+
+SINGLE_BATTLE_TEST("Aura Wheel can be turned into a Normal-type move after Morpeko gains Normalize")
+{
+    bool32 hangryMode;
+    PARAMETRIZE { hangryMode = FALSE; }
+    PARAMETRIZE { hangryMode = TRUE; }
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_ENTRAINMENT) == EFFECT_ENTRAINMENT);
+        ASSUME(gSpeciesInfo[SPECIES_DUSKULL].types[0] == TYPE_GHOST || gSpeciesInfo[SPECIES_DUSKULL].types[1] == TYPE_GHOST);
+        PLAYER(SPECIES_MORPEKO) { Ability(ABILITY_HUNGER_SWITCH); }
+        OPPONENT(SPECIES_DELCATTY) { Ability(ABILITY_NORMALIZE); }
+        OPPONENT(SPECIES_DUSKULL);
+    } WHEN {
+        if (hangryMode)
+            TURN { }
+        TURN { MOVE(opponent, MOVE_ENTRAINMENT); }
+        TURN { MOVE(player, MOVE_AURA_WHEEL); SWITCH(opponent, 1); }
+    } SCENE {
+        if (hangryMode)
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_FORM_CHANGE, player);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_AURA_WHEEL, player);
+            HP_BAR(opponent);
+        }
+    }
+}


### PR DESCRIPTION
- Fixes Aura Wheel ignoring Normalize when Morpeko is in Hangry Form (would still be Dark-type)
- Fixes Hunger Switch switching Morpeko's form while Transformed or Terastallized.
- Adds a Known Failing test for Terastallized Morpeko not keeping its form when switching back in ([source](https://www.smogon.com/forums/threads/hunger-switch-terastallization-mechanics.3735480/)).

## Discord contact info
PhallenTree
