### PR TITLE
Fixes speed calculation order

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4699,6 +4699,10 @@ u32 GetBattlerTotalSpeedStatArgs(u32 battler, u32 ability, enum ItemHoldEffect h
 {
     u32 speed = gBattleMons[battler].speed;
 
+    // stat stages
+    speed *= gStatStageRatios[gBattleMons[battler].statStages[STAT_SPEED]][0];
+    speed /= gStatStageRatios[gBattleMons[battler].statStages[STAT_SPEED]][1];
+
     // weather abilities
     if (HasWeatherEffect())
     {
@@ -4725,10 +4729,6 @@ u32 GetBattlerTotalSpeedStatArgs(u32 battler, u32 ability, enum ItemHoldEffect h
         speed = (GetHighestStatId(battler) == STAT_SPEED) ? (speed * 150) / 100 : speed;
     else if (ability == ABILITY_UNBURDEN && gDisableStructs[battler].unburdenActive)
         speed *= 2;
-
-    // stat stages
-    speed *= gStatStageRatios[gBattleMons[battler].statStages[STAT_SPEED]][0];
-    speed /= gStatStageRatios[gBattleMons[battler].statStages[STAT_SPEED]][1];
 
     // player's badge boost
     if (!(gBattleTypeFlags & (BATTLE_TYPE_LINK | BATTLE_TYPE_RECORDED_LINK | BATTLE_TYPE_FRONTIER))


### PR DESCRIPTION
Stat changes are always calculated first. Tested in-game

Pawmot should always be faster (101 speed) then Basculegion (100 speed) but due to the wrong order the calculation for Basc ended in a speed tie with Pawmot   

```
=== DEBUG_TRAINER_PLAYER ===
Name: Player
Class: Pkmn Trainer 1
Pic: Brendan
Gender: Male
Music: Male

Pawmot
Serious Nature
Level: 40
IVs: 31 HP / 31 Atk / 31 Def / 31 SpA / 31 SpD / 31 Spe
- Icy Wind
- Splash

=== DEBUG_TRAINER_AI ===
Name: Debugger
AI: Basic Trainer
Class: Rival
Battle Type: Singles
Pic: Steven
Gender: Male
Music: Male

Basculegion F
Serious Nature
Level: 38
IVs: 31 HP / 31 Atk / 31 Def / 31 SpA / 31 SpD / 31 Spe
- Rain Dance
```
