### PR TITLE
Bug fix: clear saved follower NPC door warp when doing dive warp

### DIFF
--- a/src/field_screen_effect.c
+++ b/src/field_screen_effect.c
@@ -528,6 +528,7 @@ void DoDiveWarp(void)
     TryFadeOutOldMapMusic();
     WarpFadeOutScreen();
     PlayRainStoppingSoundEffect();
+    SetFollowerNPCData(FNPC_DATA_COME_OUT_DOOR, FNPC_DOOR_NONE);
     gFieldCallback = FieldCB_DefaultWarpExit;
     CreateTask(Task_WarpAndLoadMap, 10);
 }


### PR DESCRIPTION
## Description
If a dive warp is used while a follower NPC is still set to come out of a doorway, the follower erroneously performs the exit door behavior after the dive warp. This fixes that issue.

## Media
Here's a video showcasing the issue:  
https://cdn.discordapp.com/attachments/1357388177161326834/1379916880671670292/follower_dive_surface.mp4?ex=6841fb3d&is=6840a9bd&hm=07063cd9dfd0971b0923bf0b3519df44d32f8818fb3562dafa07a74be0f60a26&

## Discord contact info
bivurnum
