### PR TITLE
Fixes Pursuit potentially causing both battlers to switch into the same mon

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -7445,6 +7445,12 @@ static void Cmd_moveend(void)
                 SetActiveGimmick(gBattlerAttacker, GIMMICK_NONE);
             if (B_CHARGE >= GEN_9 && moveType == TYPE_ELECTRIC && (IsBattlerTurnDamaged(gBattlerTarget) || gBattleStruct->moveResultFlags[gBattlerTarget] & MOVE_RESULT_NO_EFFECT))
                 gStatuses3[gBattlerAttacker] &= ~(STATUS3_CHARGED_UP);
+            // check if Stellar type boost should be used up
+            if (GetActiveGimmick(gBattlerAttacker) == GIMMICK_TERA
+             && GetBattlerTeraType(gBattlerAttacker) == TYPE_STELLAR
+             && GetMoveCategory(gCurrentMove) != DAMAGE_CATEGORY_STATUS
+             && IsTypeStellarBoosted(gBattlerAttacker, moveType))
+                ExpendTypeStellarBoost(gBattlerAttacker, moveType);
             memset(gQueuedStatBoosts, 0, sizeof(gQueuedStatBoosts));
 
             for (i = 0; i < gBattlersCount; i++)

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -545,6 +545,16 @@ void HandleAction_UseMove(void)
 void HandleAction_Switch(void)
 {
     gBattlerAttacker = gBattlerByTurnOrder[gCurrentTurnActionNumber];
+
+    // if switching to a mon that is already on field, cancel switch
+    if (!(gAbsentBattlerFlags & (1u << BATTLE_PARTNER(gBattlerAttacker)))
+     && IsBattlerAlive(BATTLE_PARTNER(gBattlerAttacker))
+     && gBattlerPartyIndexes[BATTLE_PARTNER(gBattlerAttacker)] == gBattleStruct->monToSwitchIntoId[gBattlerAttacker])
+    {
+        gCurrentActionFuncId = B_ACTION_FINISHED;
+        return;
+    }
+
     gBattle_BG0_X = 0;
     gBattle_BG0_Y = 0;
     gActionSelectionCursor[gBattlerAttacker] = 0;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -851,7 +851,7 @@ void HandleAction_NothingIsFainted(void)
 
 void HandleAction_ActionFinished(void)
 {
-    u32 i, j, moveType;
+    u32 i, j;
     bool32 afterYouActive = gSpecialStatuses[gBattlerByTurnOrder[gCurrentTurnActionNumber + 1]].afterYou;
     gBattleStruct->monToSwitchIntoId[gBattlerByTurnOrder[gCurrentTurnActionNumber]] = gSelectedMonPartyId = PARTY_SIZE;
     gCurrentTurnActionNumber++;
@@ -862,16 +862,6 @@ void HandleAction_ActionFinished(void)
                     | HITMARKER_OBEYS | HITMARKER_SYNCHRONIZE_EFFECT
                     | HITMARKER_CHARGING | HITMARKER_IGNORE_DISGUISE);
 
-    // check if Stellar type boost should be used up
-    moveType = GetBattleMoveType(gCurrentMove);
-
-    if (GetActiveGimmick(gBattlerAttacker) == GIMMICK_TERA
-        && GetBattlerTeraType(gBattlerAttacker) == TYPE_STELLAR
-        && GetMoveCategory(gCurrentMove) != DAMAGE_CATEGORY_STATUS
-        && IsTypeStellarBoosted(gBattlerAttacker, moveType))
-    {
-        ExpendTypeStellarBoost(gBattlerAttacker, moveType);
-    }
     ClearDamageCalcResults();
     gCurrentMove = 0;
     gBattleScripting.animTurn = 0;

--- a/test/battle/move_effect/pursuit.c
+++ b/test/battle/move_effect/pursuit.c
@@ -673,7 +673,7 @@ SINGLE_BATTLE_TEST("Pursuit user faints to Life Orb and target still switches ou
     }
 }
 
-DOUBLE_BATTLE_TEST("[RS] Pursuit user switches out due to Red Card and partner's switch is cancelled if switching to same Pokémon")
+DOUBLE_BATTLE_TEST("Pursuit user switches out due to Red Card and partner's switch is cancelled if switching to same Pokémon")
 {
     GIVEN {
         ASSUME(GetItemHoldEffect(ITEM_RED_CARD) == HOLD_EFFECT_RED_CARD);

--- a/test/battle/move_effect/pursuit.c
+++ b/test/battle/move_effect/pursuit.c
@@ -673,4 +673,23 @@ SINGLE_BATTLE_TEST("Pursuit user faints to Life Orb and target still switches ou
     }
 }
 
+DOUBLE_BATTLE_TEST("[RS] Pursuit user switches out due to Red Card and partner's switch is cancelled if switching to same Pokémon")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WYNAUT);
+        PLAYER(SPECIES_ARCEUS);
+        OPPONENT(SPECIES_WYNAUT) { Item(ITEM_RED_CARD); }
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_ARCEUS);
+    } WHEN {
+        TURN { SWITCH(opponentLeft, 2); SWITCH(playerRight, 2); MOVE(playerLeft, MOVE_PURSUIT, target: opponentLeft); }
+    } THEN {
+        // playerLeft switches to Arceus
+        EXPECT_EQ(playerLeft->species, SPECIES_ARCEUS);
+        // playerRight has their switch cancelled
+        EXPECT_EQ(playerRight->species, SPECIES_WYNAUT);
+    }
+}
+
 TO_DO_BATTLE_TEST("Baton Pass doesn't cause Pursuit to increase its power or priority");

--- a/test/battle/move_effect/pursuit.c
+++ b/test/battle/move_effect/pursuit.c
@@ -676,6 +676,7 @@ SINGLE_BATTLE_TEST("Pursuit user faints to Life Orb and target still switches ou
 DOUBLE_BATTLE_TEST("[RS] Pursuit user switches out due to Red Card and partner's switch is cancelled if switching to same Pokémon")
 {
     GIVEN {
+        ASSUME(GetItemHoldEffect(ITEM_RED_CARD) == HOLD_EFFECT_RED_CARD);
         PLAYER(SPECIES_WOBBUFFET);
         PLAYER(SPECIES_WYNAUT);
         PLAYER(SPECIES_ARCEUS);


### PR DESCRIPTION
Fixes Pursuit user switching out due to Red Card/Eject Pack and partner switching into the same mon, causing both of the player's (or the opponent's) battlers being the same mon. Source of the fix is Showdown since I couldn't find information on what should happen in this case (in Showdown, the partner's switch is cancelled).

Also moves timing of Tera Stellar boost being used up to `MOVEEND_CLEAR_BITS` since the previous code didn't expend the boost sometimes when Dancer was activated or when the Pursuit cycle ended.

## Issue(s) that this PR fixes
Fixes #6699

## Discord contact info
PhallenTree
