### PR TITLE
Increased heap by 768 bytes

### DIFF
--- a/include/malloc.h
+++ b/include/malloc.h
@@ -41,7 +41,7 @@ struct MemBlock
     u8 data[0];
 };
 
-#define HEAP_SIZE 0x1C000
+#define HEAP_SIZE 0x1C300
 extern u8 gHeap[HEAP_SIZE];
 
 #if TESTING || !defined(NDEBUG)


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
The new `.smol` compression scheme makes it so that some decompressions in battle would overflow the heap.
Increasing the heap by 592 bytes would be enough, but increasing by 768 makes the declaration a bit more even and leaves a buffer.

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara