### PR TITLE
Bug fix: Follower NPC no longer retains bike sprite after white out

### DIFF
--- a/src/follower_npc.c
+++ b/src/follower_npc.c
@@ -1172,7 +1172,7 @@ void CreateFollowerNPCAvatar(void)
 
 void FollowerNPC_HandleSprite(void)
 {
-    if (CheckFollowerNPCFlag(FOLLOWER_NPC_FLAG_CAN_BIKE))
+    if (TestPlayerAvatarFlags(PLAYER_AVATAR_FLAG_BIKE) && CheckFollowerNPCFlag(FOLLOWER_NPC_FLAG_CAN_BIKE))
     {
         if (gPlayerAvatar.flags & PLAYER_AVATAR_FLAG_MACH_BIKE)
             SetFollowerNPCSprite(FOLLOWER_NPC_SPRITE_INDEX_MACH_BIKE);


### PR DESCRIPTION
## Description
Previously, the `FollowerNPC_HandleSprite` function erroneously set the npc follower's bike sprite upon map init, without checking to see if the follower *should* be biking. This caused the follower to remain biking after some white out respawns. This fixes the issue.

## Media
![](https://cdn.discordapp.com/attachments/1357388177161326834/1382805661997596742/image.png?ex=684e77e1&is=684d2661&hm=e5e17cb923edb7d60e561cb0a85b57c85b7e6ffc688a50a74dd091b91dfbe575&)

## Discord contact info
bivurnum
