### PR TITLE
Fixed Aura Wheel `KNOWN_FAILING` test

### DIFF
--- a/test/battle/move_effect/aura_wheel.c
+++ b/test/battle/move_effect/aura_wheel.c
@@ -52,10 +52,9 @@ SINGLE_BATTLE_TEST("Aura Wheel changes type depending on Morpeko's form")
 
 SINGLE_BATTLE_TEST("Aura Wheel can be used by Pokémon transformed into Morpeko")
 {
-    KNOWN_FAILING; // Aura Wheel for some reason isn't used by the opponent?
     GIVEN {
-        PLAYER(SPECIES_MORPEKO) { Ability(ABILITY_HUNGER_SWITCH); }
-        OPPONENT(SPECIES_DITTO) { Ability(ABILITY_IMPOSTER); }
+        PLAYER(SPECIES_MORPEKO) { Moves(MOVE_AURA_WHEEL, MOVE_CELEBRATE); Ability(ABILITY_HUNGER_SWITCH); }
+        OPPONENT(SPECIES_DITTO) { Moves(MOVE_AURA_WHEEL, MOVE_CELEBRATE); Ability(ABILITY_IMPOSTER); }
     } WHEN {
         TURN { MOVE(opponent, MOVE_AURA_WHEEL); }
     } SCENE {


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
Like documented previously, Transform moves are bugging up in tests. Fixed test by matching Ditto moves with Morpeko

## Discord contact info
AsparagusEduardo
