### PR TITLE
Use `argument.type` for `EFFECT_SOAK`

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -2660,10 +2660,11 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
         case EFFECT_SOAK:
         {
             u32 types[3];
+            u32 typeArg = GetMoveArgType(move);
+
             GetBattlerTypes(battlerDef, FALSE, types);
-            // TODO: Use the type of the move like 'VARIOUS_TRY_SOAK'?
             if (PartnerMoveIsSameAsAttacker(BATTLE_PARTNER(battlerAtk), battlerDef, move, aiData->partnerMove)
-              || (types[0] == TYPE_WATER && types[1] == TYPE_WATER && types[2] == TYPE_MYSTERY))
+              || (types[0] == typeArg && types[1] == typeArg && types[2] == TYPE_MYSTERY))
                 ADJUST_SCORE(-10);    // target is already water-only
             break;
         }

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -10751,16 +10751,16 @@ static void Cmd_various(void)
         VARIOUS_ARGS(const u8 *failInstr);
         u32 types[3];
         GetBattlerTypes(gBattlerTarget, FALSE, types);
-        u32 moveType = GetMoveType(gCurrentMove);
-        if ((types[0] == moveType && types[1] == moveType)
+        u32 typeToSet = GetMoveArgType(gCurrentMove);
+        if ((types[0] == typeToSet && types[1] == typeToSet)
          || GetActiveGimmick(gBattlerTarget) == GIMMICK_TERA)
         {
             gBattlescriptCurrInstr = cmd->failInstr;
         }
         else
         {
-            SET_BATTLER_TYPE(gBattlerTarget, moveType);
-            PREPARE_TYPE_BUFFER(gBattleTextBuff1, moveType);
+            SET_BATTLER_TYPE(gBattlerTarget, typeToSet);
+            PREPARE_TYPE_BUFFER(gBattleTextBuff1, typeToSet);
             gBattlescriptCurrInstr = cmd->nextInstr;
         }
         return;

--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -12571,6 +12571,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
         .category = DAMAGE_CATEGORY_STATUS,
+        .argument = { .type = TYPE_WATER },
         .zMove = { .effect = Z_EFFECT_SPATK_UP_1 },
         .magicCoatAffected = TRUE,
         .contestEffect = CONTEST_EFFECT_WORSEN_CONDITION_OF_PREV_MONS,

--- a/test/battle/move_effect/soak.c
+++ b/test/battle/move_effect/soak.c
@@ -1,9 +1,15 @@
 #include "global.h"
 #include "test/battle.h"
 
+ASSUMPTIONS
+{
+    ASSUME(GetMoveEffect(MOVE_SOAK) == EFFECT_SOAK);
+    ASSUME(GetMoveEffect(MOVE_MAGIC_POWDER) == EFFECT_SOAK);
+}
+
 TO_DO_BATTLE_TEST("Soak/Magic Powder changes the target's type to pure Water/Psychic");
 
-SINGLE_BATTLE_TEST("Soak/Magic Powder's type change overritten if the target changes form")
+SINGLE_BATTLE_TEST("Soak/Magic Powder's type change is overwitten if the target changes form")
 {
     u32 move;
     PARAMETRIZE { move = MOVE_SOAK; }

--- a/test/battle/move_effect/soak.c
+++ b/test/battle/move_effect/soak.c
@@ -1,4 +1,39 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Soak (Move Effect) test titles")
+TO_DO_BATTLE_TEST("Soak/Magic Powder changes the target's type to pure Water/Psychic");
+
+SINGLE_BATTLE_TEST("Soak/Magic Powder's type change overritten if the target changes form")
+{
+    u32 move;
+    PARAMETRIZE { move = MOVE_SOAK; }
+    PARAMETRIZE { move = MOVE_MAGIC_POWDER; }
+    GIVEN {
+        ASSUME(GetMoveType(MOVE_SCRATCH) == TYPE_NORMAL);
+        PLAYER(SPECIES_MIMIKYU_DISGUISED) { Ability(ABILITY_DISGUISE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, move); }
+        TURN { MOVE(opponent, MOVE_SCRATCH); }
+        TURN { MOVE(opponent, MOVE_SCRATCH); }
+    } SCENE {
+        // Turn 1
+        ANIMATION(ANIM_TYPE_MOVE, move, opponent);
+        switch (move) {
+            case MOVE_SOAK:         MESSAGE("Mimikyu transformed into the Water type!"); break;
+            case MOVE_MAGIC_POWDER: MESSAGE("Mimikyu transformed into the Psychic type!"); break;
+        }
+        // Turn 2
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
+        NOT MESSAGE("It doesn't affect Mimikyu…");
+        ABILITY_POPUP(player, ABILITY_DISGUISE);
+        // Turn 3
+        MESSAGE("It doesn't affect Mimikyu…");
+    }
+}
+
+TO_DO_BATTLE_TEST("Soak/Magic Powder's type change overritten if the target transforms");
+TO_DO_BATTLE_TEST("(TERA) Soak/Magic Powder's type change overritten if the target Terastalizes");
+TO_DO_BATTLE_TEST("Soak/Magic Powder fails if the target is behind a Substitute");
+TO_DO_BATTLE_TEST("Soak/Magic Powder fails if the target is already Water/Psychic");
+TO_DO_BATTLE_TEST("Soak/Magic Powder fails if the target has Multitype or RKS System");


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
Before, it used the move's actual type.
Also fixed inconsistency in the data itself.

## Discord contact info
AsparagusEduardo
