### PR TITLE
Bug fix: clear follower npc surf blob on white out

### DIFF
--- a/src/follower_npc.c
+++ b/src/follower_npc.c
@@ -1183,7 +1183,7 @@ void FollowerNPC_HandleSprite(void)
     {
         TryUpdateFollowerNPCSpriteUnderwater();
     }
-    else
+    else if (gPlayerAvatar.flags & PLAYER_AVATAR_FLAG_ON_FOOT)
     {
         SetFollowerNPCSprite(FOLLOWER_NPC_SPRITE_INDEX_NORMAL);
     }

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -1816,6 +1816,7 @@ void CB2_WhiteOut(void)
         else
             gFieldCallback = FieldCB_WarpExitFadeFromBlack;
         state = 0;
+        SetFollowerNPCData(FNPC_DATA_SURF_BLOB, FNPC_SURF_BLOB_NONE);
         DoMapLoadLoop(&state);
         SetFieldVBlankCallback();
         SetMainCallback1(CB1_Overworld);


### PR DESCRIPTION
## Description
If the player whites out while surfing, the follower NPC will now have their surf blob cleared upon map reload.

## Media
![](https://cdn.discordapp.com/attachments/1357388177161326834/1384825230521929728/image.png?ex=6853d67f&is=685284ff&hm=1bf2e1817026270eec7df7e9425eaffb11ef2058bd31404b0043ddbe16070403&)

## Discord contact info
bivurnum
