### PR TITLE
Expanded macros to untangle TMHMs from itemIds

### DIFF
--- a/include/constants/items.h
+++ b/include/constants/items.h
@@ -1027,9 +1027,6 @@
 #define MAIL_NONE 0xFF
 #define ITEM_TO_MULCH(itemId)(((itemId) - ITEM_GROWTH_MULCH) + 1)
 
-#define NUM_TECHNICAL_MACHINES 100
-#define NUM_HIDDEN_MACHINES 8
-
 #define MAX_BAG_ITEM_CAPACITY         999
 #define MAX_PC_ITEM_CAPACITY          999
 #define MAX_PYRAMID_BAG_ITEM_CAPACITY  99 // Values higher than 255 require free SaveBlock2 space.

--- a/include/metaprogram.h
+++ b/include/metaprogram.h
@@ -26,8 +26,9 @@
 #define STR(...) STR_(__VA_ARGS__)
 #define STR_(...) #__VA_ARGS__
 
-/* You'll never guess what this one does */
+/* You'll never guess what these do */
 #define APPEND_SEMICOLON(a) a;
+#define APPEND_COMMA(a) a,
 
 /* Converts a string to a compound literal, essentially making it a pointer to const u8 */
 #define COMPOUND_STRING(str) (const u8[]) _(str)
@@ -170,5 +171,8 @@ Input must be of the form (upper << lower) where upper can be up to 3, lower up 
 
 /* Finds the required digits to display the number (maximum 4) */
 #define MAX_DIGITS(_num) 1 + !!(_num / 10) + !!(_num / 100) + !!(_num / 1000)
+
+/* Converts a number with leading zeroes to a normal int*/
+#define REMOVE_LEADING_ZEROES(_num) (((0x##_num / 16) * 10) + (0x##_num % 16))
 
 #endif

--- a/src/apprentice.c
+++ b/src/apprentice.c
@@ -353,13 +353,11 @@ static u16 GetRandomAlternateMove(u8 monId)
                 // NOTE: Below is an infinite loop if a species which cannot learn TMs is assigned to an Apprentice
                 do
                 {
-                    id = Random() % (NUM_TECHNICAL_MACHINES + NUM_HIDDEN_MACHINES);
-                    shouldUseMove = CanLearnTeachableMove(species, ItemIdToBattleMoveId(ITEM_TM01 + id));
+                    id = Random() % (NUM_ALL_MACHINES);
+                    move = ItemIdToBattleMoveId(GetTMHMId(id));
+                    shouldUseMove = CanLearnTeachableMove(species, move);
                 }
                 while (!shouldUseMove);
-
-                move = ItemIdToBattleMoveId(ITEM_TM01 + id);
-                shouldUseMove = TRUE;
 
                 if (numLearnsetMoves <= MAX_MON_MOVES)
                     j = 0;

--- a/src/battle_dome.c
+++ b/src/battle_dome.c
@@ -27,6 +27,7 @@
 #include "sound.h"
 #include "pokemon_icon.h"
 #include "data.h"
+#include "item.h"
 #include "international_string_util.h"
 #include "trainer_pokemon_sprites.h"
 #include "scanline_effect.h"
@@ -3976,12 +3977,12 @@ static bool32 IsDomeLuckyMove(u32 move)
 static bool32 IsDomePopularMove(u32 move)
 {
     u8 i;
-    for (i = 0; i < NUM_TECHNICAL_MACHINES + NUM_HIDDEN_MACHINES; i++)
+    for (i = 0; i < NUM_ALL_MACHINES; i++)
     {
-        if (ItemIdToBattleMoveId(ITEM_TM01 + i) == move)
+        if (ItemIdToBattleMoveId(GetTMHMId(i)) == move)
             return TRUE;
     }
-    if (i == NUM_TECHNICAL_MACHINES + NUM_HIDDEN_MACHINES)
+    if (i == NUM_ALL_MACHINES)
         return FALSE;
     // Filter in TMs/HMs
     if (GetMovePower(move) >= 90)

--- a/src/data/items.h
+++ b/src/data/items.h
@@ -10444,97 +10444,85 @@ const struct Item gItemsInfo[] =
 
     [ITEM_TM_FOCUS_PUNCH] =
     {
-        .name = _("TM01"),
+        DEFINE_TM(01),
         .price = 3000,
         .description = COMPOUND_STRING(
             "Powerful, but makes\n"
             "the user flinch if\n"
             "hit by the foe."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_FOCUS_PUNCH,
     },
 
     [ITEM_TM_DRAGON_CLAW] =
     {
-        .name = _("TM02"),
+        DEFINE_TM(02),
         .price = 3000,
         .description = COMPOUND_STRING(
             "Hooks and slashes\n"
             "the foe with long,\n"
             "sharp claws."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_DRAGON_CLAW,
     },
 
     [ITEM_TM_WATER_PULSE] =
     {
-        .name = _("TM03"),
+        DEFINE_TM(03),
         .price = 3000,
         .description = COMPOUND_STRING(
             "Generates an\n"
             "ultrasonic wave\n"
             "that may confuse."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_WATER_PULSE,
     },
 
     [ITEM_TM_CALM_MIND] =
     {
-        .name = _("TM04"),
+        DEFINE_TM(04),
         .price = 3000,
         .description = COMPOUND_STRING(
             "Raises Sp. Atk and\n"
             "Sp. Def by focusing\n"
             "the mind."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_CALM_MIND,
     },
 
     [ITEM_TM_ROAR] =
     {
-        .name = _("TM05"),
+        DEFINE_TM(05),
         .price = 1000,
         .description = COMPOUND_STRING(
             "A savage roar that\n"
             "makes the foe flee \n"
             "to end the battle."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_ROAR,
     },
 
     [ITEM_TM_TOXIC] =
     {
-        .name = _("TM06"),
+        DEFINE_TM(06),
         .price = 3000,
         .description = COMPOUND_STRING(
             "Poisons the foe\n"
             "with a toxin that\n"
             "gradually worsens."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_TOXIC,
     },
 
     [ITEM_TM_HAIL] =
     {
-        .name = _("TM07"),
+        DEFINE_TM(07),
         .price = 3000,
         #if B_PREFERRED_ICE_WEATHER == B_ICE_WEATHER_SNOW
         .description = COMPOUND_STRING(
@@ -10548,90 +10536,78 @@ const struct Item gItemsInfo[] =
             "types except Ice."),
         #endif
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_HAIL,
     },
 
     [ITEM_TM_BULK_UP] =
     {
-        .name = _("TM08"),
+        DEFINE_TM(08),
         .price = 3000,
         .description = COMPOUND_STRING(
             "Bulks up the body\n"
             "to boost both\n"
             "Attack & Defense."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_BULK_UP,
     },
 
     [ITEM_TM_BULLET_SEED] =
     {
-        .name = _("TM09"),
+        DEFINE_TM(09),
         .price = 3000,
         .description = COMPOUND_STRING(
             "Shoots 2 to 5 seeds\n"
             "in a row to strike\n"
             "the foe."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_BULLET_SEED,
     },
 
     [ITEM_TM_HIDDEN_POWER] =
     {
-        .name = _("TM10"),
+        DEFINE_TM(10),
         .price = 3000,
         .description = COMPOUND_STRING(
             "The attack power\n"
             "varies among\n"
             "different Pokémon."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_HIDDEN_POWER,
     },
 
     [ITEM_TM_SUNNY_DAY] =
     {
-        .name = _("TM11"),
+        DEFINE_TM(11),
         .price = 2000,
         .description = COMPOUND_STRING(
             "Raises the power of\n"
             "Fire-type moves\n"
             "for 5 turns."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_SUNNY_DAY,
     },
 
     [ITEM_TM_TAUNT] =
     {
-        .name = _("TM12"),
+        DEFINE_TM(12),
         .price = 3000,
         .description = COMPOUND_STRING(
             "Enrages the foe so\n"
             "it can only use\n"
             "attack moves."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_TAUNT,
     },
 
     [ITEM_TM_ICE_BEAM] =
     {
-        .name = _("TM13"),
+        DEFINE_TM(13),
         .price = 3000,
         .description = COMPOUND_STRING(
             "Fires an icy cold\n"
@@ -10642,15 +10618,13 @@ const struct Item gItemsInfo[] =
             "freeze the foe."),
         #endif
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_ICE_BEAM,
     },
 
     [ITEM_TM_BLIZZARD] =
     {
-        .name = _("TM14"),
+        DEFINE_TM(14),
         .price = 5500,
         .description = COMPOUND_STRING(
         #if B_USE_FROSTBITE == TRUE
@@ -10663,550 +10637,476 @@ const struct Item gItemsInfo[] =
             "may freeze the foe."),
         #endif
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_BLIZZARD,
     },
 
     [ITEM_TM_HYPER_BEAM] =
     {
-        .name = _("TM15"),
+        DEFINE_TM(15),
         .price = 7500,
         .description = COMPOUND_STRING(
             "Powerful, but needs\n"
             "recharging the\n"
             "next turn."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_HYPER_BEAM,
     },
 
     [ITEM_TM_LIGHT_SCREEN] =
     {
-        .name = _("TM16"),
+        DEFINE_TM(16),
         .price = 3000,
         .description = COMPOUND_STRING(
             "Creates a wall of\n"
             "light that lowers\n"
             "Sp. Atk damage."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_LIGHT_SCREEN,
     },
 
     [ITEM_TM_PROTECT] =
     {
-        .name = _("TM17"),
+        DEFINE_TM(17),
         .price = 3000,
         .description = COMPOUND_STRING(
             "Negates all damage,\n"
             "but may fail if used\n"
             "in succession."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_PROTECT,
     },
 
     [ITEM_TM_RAIN_DANCE] =
     {
-        .name = _("TM18"),
+        DEFINE_TM(18),
         .price = 2000,
         .description = COMPOUND_STRING(
             "Raises the power of\n"
             "Water-type moves\n"
             "for 5 turns."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_RAIN_DANCE,
     },
 
     [ITEM_TM_GIGA_DRAIN] =
     {
-        .name = _("TM19"),
+        DEFINE_TM(19),
         .price = 3000,
         .description = COMPOUND_STRING(
             "Recovers half the\n"
             "HP of the damage \n"
             "this move inflicts."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_GIGA_DRAIN,
     },
 
     [ITEM_TM_SAFEGUARD] =
     {
-        .name = _("TM20"),
+        DEFINE_TM(20),
         .price = 3000,
         .description = COMPOUND_STRING(
             "Prevents status\n"
             "abnormality with a\n"
             "mystical power."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_SAFEGUARD,
     },
 
     [ITEM_TM_FRUSTRATION] =
     {
-        .name = _("TM21"),
+        DEFINE_TM(21),
         .price = 1000,
         .description = COMPOUND_STRING(
             "The less the user\n"
             "likes you, the more\n"
             "powerful this move."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_FRUSTRATION,
     },
 
     [ITEM_TM_SOLAR_BEAM] =
     {
-        .name = _("TM22"),
+        DEFINE_TM(22),
         .price = 3000,
         .description = COMPOUND_STRING(
             "Absorbs sunlight in\n"
             "the 1st turn, then\n"
             "attacks next turn."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_SOLAR_BEAM,
     },
 
     [ITEM_TM_IRON_TAIL] =
     {
-        .name = _("TM23"),
+        DEFINE_TM(23),
         .price = 3000,
         .description = COMPOUND_STRING(
             "Slams the foe with\n"
             "a hard tail. It may\n"
             "lower Defense."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_IRON_TAIL,
     },
 
     [ITEM_TM_THUNDERBOLT] =
     {
-        .name = _("TM24"),
+        DEFINE_TM(24),
         .price = 3000,
         .description = COMPOUND_STRING(
             "A powerful electric\n"
             "attack that may\n"
             "cause paralysis."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_THUNDERBOLT,
     },
 
     [ITEM_TM_THUNDER] =
     {
-        .name = _("TM25"),
+        DEFINE_TM(25),
         .price = 5500,
         .description = COMPOUND_STRING(
             "Strikes the foe\n"
             "with a thunderbolt.\n"
             "It may paralyze."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_THUNDER,
     },
 
     [ITEM_TM_EARTHQUAKE] =
     {
-        .name = _("TM26"),
+        DEFINE_TM(26),
         .price = 3000,
         .description = COMPOUND_STRING(
             "Causes a quake\n"
             "that has no effect\n"
             "on flying foes."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_EARTHQUAKE,
     },
 
     [ITEM_TM_RETURN] =
     {
-        .name = _("TM27"),
+        DEFINE_TM(27),
         .price = 1000,
         .description = COMPOUND_STRING(
             "The more the user\n"
             "likes you, the more\n"
             "powerful this move."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_RETURN,
     },
 
     [ITEM_TM_DIG] =
     {
-        .name = _("TM28"),
+        DEFINE_TM(28),
         .price = 2000,
         .description = COMPOUND_STRING(
             "Digs underground\n"
             "the 1st turn, then\n"
             "strikes next turn."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_DIG,
     },
 
     [ITEM_TM_PSYCHIC] =
     {
-        .name = _("TM29"),
+        DEFINE_TM(29),
         .price = 2000,
         .description = COMPOUND_STRING(
             "A powerful psychic\n"
             "attack that may\n"
             "lower Sp. Def."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_PSYCHIC,
     },
 
     [ITEM_TM_SHADOW_BALL] =
     {
-        .name = _("TM30"),
+        DEFINE_TM(30),
         .price = 3000,
         .description = COMPOUND_STRING(
             "Hurls a dark lump\n"
             "at the foe. It may\n"
             "lower Sp. Def."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_SHADOW_BALL,
     },
 
     [ITEM_TM_BRICK_BREAK] =
     {
-        .name = _("TM31"),
+        DEFINE_TM(31),
         .price = 3000,
         .description = COMPOUND_STRING(
             "Destroys barriers\n"
             "like Light Screen\n"
             "and causes damage."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_BRICK_BREAK,
     },
 
     [ITEM_TM_DOUBLE_TEAM] =
     {
-        .name = _("TM32"),
+        DEFINE_TM(32),
         .price = 2000,
         .description = COMPOUND_STRING(
             "Creates illusory\n"
             "copies to enhance\n"
             "elusiveness."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_DOUBLE_TEAM,
     },
 
     [ITEM_TM_REFLECT] =
     {
-        .name = _("TM33"),
+        DEFINE_TM(33),
         .price = 3000,
         .description = COMPOUND_STRING(
             "Creates a wall of\n"
             "light that weakens\n"
             "physical attacks."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_REFLECT,
     },
 
     [ITEM_TM_SHOCK_WAVE] =
     {
-        .name = _("TM34"),
+        DEFINE_TM(34),
         .price = 3000,
         .description = COMPOUND_STRING(
             "Zaps the foe with a\n"
             "jolt of electricity\n"
             "that never misses."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_SHOCK_WAVE,
     },
 
     [ITEM_TM_FLAMETHROWER] =
     {
-        .name = _("TM35"),
+        DEFINE_TM(35),
         .price = 3000,
         .description = COMPOUND_STRING(
             "Looses a stream of\n"
             "fire that may burn\n"
             "the foe."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_FLAMETHROWER,
     },
 
     [ITEM_TM_SLUDGE_BOMB] =
     {
-        .name = _("TM36"),
+        DEFINE_TM(36),
         .price = 1000,
         .description = COMPOUND_STRING(
             "Hurls sludge at the\n"
             "foe. It may poison\n"
             "the foe."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_SLUDGE_BOMB,
     },
 
     [ITEM_TM_SANDSTORM] =
     {
-        .name = _("TM37"),
+        DEFINE_TM(37),
         .price = 2000,
         .description = COMPOUND_STRING(
             "Causes a sandstorm\n"
             "that hits the foe\n"
             "over several turns."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_SANDSTORM,
     },
 
     [ITEM_TM_FIRE_BLAST] =
     {
-        .name = _("TM38"),
+        DEFINE_TM(38),
         .price = 5500,
         .description = COMPOUND_STRING(
             "A powerful fire\n"
             "attack that may\n"
             "burn the foe."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_FIRE_BLAST,
     },
 
     [ITEM_TM_ROCK_TOMB] =
     {
-        .name = _("TM39"),
+        DEFINE_TM(39),
         .price = 3000,
         .description = COMPOUND_STRING(
             "Stops the foe from\n"
             "moving with rocks.\n"
             "May lower Speed."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_ROCK_TOMB,
     },
 
     [ITEM_TM_AERIAL_ACE] =
     {
-        .name = _("TM40"),
+        DEFINE_TM(40),
         .price = 3000,
         .description = COMPOUND_STRING(
             "An extremely fast\n"
             "attack that can't\n"
             "be avoided."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_AERIAL_ACE,
     },
 
     [ITEM_TM_TORMENT] =
     {
-        .name = _("TM41"),
+        DEFINE_TM(41),
         .price = 3000,
         .description = COMPOUND_STRING(
             "Prevents the foe\n"
             "from using the same\n"
             "move in a row."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_TORMENT,
     },
 
     [ITEM_TM_FACADE] =
     {
-        .name = _("TM42"),
+        DEFINE_TM(42),
         .price = 3000,
         .description = COMPOUND_STRING(
             "Raises Attack when\n"
             "poisoned, burned,\n"
             "or paralyzed."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_FACADE,
     },
 
     [ITEM_TM_SECRET_POWER] =
     {
-        .name = _("TM43"),
+        DEFINE_TM(43),
         .price = 3000,
         .description = COMPOUND_STRING(
             "Adds an effect to\n"
             "attack depending\n"
             "on the location."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_SECRET_POWER,
     },
 
     [ITEM_TM_REST] =
     {
-        .name = _("TM44"),
+        DEFINE_TM(44),
         .price = 3000,
         .description = COMPOUND_STRING(
             "The user sleeps for\n"
             "2 turns to restore\n"
             "health and status."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_REST,
     },
 
     [ITEM_TM_ATTRACT] =
     {
-        .name = _("TM45"),
+        DEFINE_TM(45),
         .price = 3000,
         .description = COMPOUND_STRING(
             "Makes it tough to\n"
             "attack a foe of the\n"
             "opposite gender."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_ATTRACT,
     },
 
     [ITEM_TM_THIEF] =
     {
-        .name = _("TM46"),
+        DEFINE_TM(46),
         .price = 3000,
         .description = COMPOUND_STRING(
             "While attacking,\n"
             "it may steal the\n"
             "foe's held item."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_THIEF,
     },
 
     [ITEM_TM_STEEL_WING] =
     {
-        .name = _("TM47"),
+        DEFINE_TM(47),
         .price = 3000,
         .description = COMPOUND_STRING(
             "Spreads hard-\n"
             "edged wings and\n"
             "slams into the foe."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_STEEL_WING,
     },
 
     [ITEM_TM_SKILL_SWAP] =
     {
-        .name = _("TM48"),
+        DEFINE_TM(48),
         .price = 3000,
         .description = COMPOUND_STRING(
             "Switches abilities\n"
             "with the foe on the\n"
             "turn this is used."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_SKILL_SWAP,
     },
 
     [ITEM_TM_SNATCH] =
     {
-        .name = _("TM49"),
+        DEFINE_TM(49),
         .price = 3000,
         .description = COMPOUND_STRING(
             "Steals the effects\n"
             "of the move the foe\n"
             "is trying to use."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_SNATCH,
     },
 
     [ITEM_TM_OVERHEAT] =
     {
-        .name = _("TM50"),
+        DEFINE_TM(50),
         .price = 3000,
         .description = COMPOUND_STRING(
             "Enables full-power\n"
             "attack, but sharply\n"
             "lowers Sp. Atk."),
         .importance = I_REUSABLE_TMS,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_OVERHEAT,
     },
 
     [ITEM_TM51] =
@@ -11811,122 +11711,106 @@ const struct Item gItemsInfo[] =
 
     [ITEM_HM_CUT] =
     {
-        .name = _("HM01"),
+        DEFINE_HM(01),
         .price = 0,
         .description = COMPOUND_STRING(
             "Attacks the foe\n"
             "with sharp blades\n"
             "or claws."),
         .importance = 1,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_CUT,
     },
 
     [ITEM_HM_FLY] =
     {
-        .name = _("HM02"),
+        DEFINE_HM(02),
         .price = 0,
         .description = COMPOUND_STRING(
             "Flies up on the\n"
             "first turn, then\n"
             "attacks next turn."),
         .importance = 1,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_FLY,
     },
 
     [ITEM_HM_SURF] =
     {
-        .name = _("HM03"),
+        DEFINE_HM(03),
         .price = 0,
         .description = COMPOUND_STRING(
             "Creates a huge\n"
             "wave, then crashes\n"
             "it down on the foe."),
         .importance = 1,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_SURF,
     },
 
     [ITEM_HM_STRENGTH] =
     {
-        .name = _("HM04"),
+        DEFINE_HM(04),
         .price = 0,
         .description = COMPOUND_STRING(
             "Builds enormous\n"
             "power, then slams\n"
             "the foe."),
         .importance = 1,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_STRENGTH,
     },
 
     [ITEM_HM_FLASH] =
     {
-        .name = _("HM05"),
+        DEFINE_HM(05),
         .price = 0,
         .description = COMPOUND_STRING(
             "Looses a powerful\n"
             "blast of light that\n"
             "reduces accuracy."),
         .importance = 1,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_FLASH,
     },
 
     [ITEM_HM_ROCK_SMASH] =
     {
-        .name = _("HM06"),
+        DEFINE_HM(06),
         .price = 0,
         .description = COMPOUND_STRING(
             "A rock-crushingly\n"
             "tough attack that\n"
             "may lower Defense."),
         .importance = 1,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_ROCK_SMASH,
     },
 
     [ITEM_HM_WATERFALL] =
     {
-        .name = _("HM07"),
+        DEFINE_HM(07),
         .price = 0,
         .description = COMPOUND_STRING(
             "Attacks the foe\n"
             "with enough power\n"
             "to climb waterfalls."),
         .importance = 1,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_WATERFALL,
     },
 
     [ITEM_HM_DIVE] =
     {
-        .name = _("HM08"),
+        DEFINE_HM(08),
         .price = 0,
         .description = COMPOUND_STRING(
             "Dives underwater\n"
             "the 1st turn, then\n"
             "attacks next turn."),
         .importance = 1,
-        .pocket = POCKET_TM_HM,
         .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = MOVE_DIVE,
     },
 
 

--- a/src/daycare.c
+++ b/src/daycare.c
@@ -895,9 +895,9 @@ static void BuildEggMoveset(struct Pokemon *egg, struct BoxPokemon *father, stru
         {
             if (sHatchedEggFatherMoves[i] != MOVE_NONE)
             {
-                for (j = 0; j < NUM_TECHNICAL_MACHINES + NUM_HIDDEN_MACHINES; j++)
+                for (j = 0; j < NUM_ALL_MACHINES; j++)
                 {
-                    u16 moveId = ItemIdToBattleMoveId(ITEM_TM01 + j);
+                    u16 moveId = ItemIdToBattleMoveId(GetTMHMId(j));
                     if (sHatchedEggFatherMoves[i] == moveId && CanLearnTeachableMove(GetMonData(egg, MON_DATA_SPECIES_OR_EGG), moveId))
                     {
                         if (GiveMoveToMon(egg, sHatchedEggFatherMoves[i]) == MON_HAS_MAX_MOVES)

--- a/src/item.c
+++ b/src/item.c
@@ -31,6 +31,15 @@ EWRAM_DATA struct BagPocket gBagPockets[POCKETS_COUNT] = {0};
 #include "data/pokemon/item_effects.h"
 #include "data/items.h"
 
+#define UNPACK_TM_ITEM_ID(_tm) [CAT(ENUM_TM_HM_, _tm)] = CAT(ITEM_TM_, _tm),
+#define UNPACK_HM_ITEM_ID(_hm) [CAT(ENUM_TM_HM_, _hm)] = CAT(ITEM_HM_, _hm),
+
+const u16 gTMHMItemIds[NUM_ALL_MACHINES] =
+{
+    FOREACH_TM(UNPACK_TM_ITEM_ID)
+    FOREACH_HM(UNPACK_HM_ITEM_ID)
+};
+
 static inline u16 GetBagItemIdPocket(struct BagPocket *pocket, u32 pocketPos)
 {
     return pocket->itemSlots[pocketPos].itemId;

--- a/src/item_icon.c
+++ b/src/item_icon.c
@@ -166,11 +166,11 @@ const void *GetItemIconPic(u16 itemId)
         return gItemIcon_ReturnToFieldArrow; // Use last icon, the "return to field" arrow
     if (itemId >= ITEMS_COUNT)
         return gItemsInfo[0].iconPic;
-    if (itemId >= ITEM_TM01 && itemId < ITEM_HM01 + NUM_HIDDEN_MACHINES)
+    if (gItemsInfo[itemId].pocket == POCKET_TM_HM)
     {
-        if (itemId < ITEM_TM01 + NUM_TECHNICAL_MACHINES)
-            return gItemIcon_TM;
-        return gItemIcon_HM;
+        if (gItemsInfo[itemId].index >= NUM_TECHNICAL_MACHINES)
+            return gItemIcon_HM;
+        return gItemIcon_TM;
     }
 
     return gItemsInfo[itemId].iconPic;
@@ -182,7 +182,7 @@ const u16 *GetItemIconPalette(u16 itemId)
         return gItemIconPalette_ReturnToFieldArrow;
     if (itemId >= ITEMS_COUNT)
         return gItemsInfo[0].iconPalette;
-    if (itemId >= ITEM_TM01 && itemId < ITEM_HM01 + NUM_HIDDEN_MACHINES)
+    if (gItemsInfo[itemId].pocket == POCKET_TM_HM && gItemsInfo[itemId].index >= NUM_TECHNICAL_MACHINES)
         return gTypesInfo[GetMoveType(gItemsInfo[itemId].secondaryId)].paletteTMHM;
 
     return gItemsInfo[itemId].iconPalette;

--- a/src/item_menu.c
+++ b/src/item_menu.c
@@ -916,16 +916,16 @@ static void GetItemNameFromPocket(u8 *dest, u16 itemId)
     case POCKET_TM_HM:
         end = StringCopy(gStringVar2, GetMoveName(ItemIdToBattleMoveId(itemId)));
         PrependFontIdToFit(gStringVar2, end, FONT_NARROW, 61);
-        if (itemId >= ITEM_HM01)
+        if (gItemsInfo[itemId].index >= NUM_TECHNICAL_MACHINES)
         {
             // Get HM number
-            ConvertIntToDecimalStringN(gStringVar1, itemId - ITEM_HM01 + 1, STR_CONV_MODE_LEADING_ZEROS, 1);
+            ConvertIntToDecimalStringN(gStringVar1, gItemsInfo[itemId].index - NUM_TECHNICAL_MACHINES, STR_CONV_MODE_LEADING_ZEROS, 1);
             StringExpandPlaceholders(dest, gText_NumberItem_HM);
         }
         else
         {
             // Get TM number
-            ConvertIntToDecimalStringN(gStringVar1, itemId - ITEM_TM01 + 1, STR_CONV_MODE_LEADING_ZEROS, 2);
+            ConvertIntToDecimalStringN(gStringVar1, gItemsInfo[itemId].index, STR_CONV_MODE_LEADING_ZEROS, 2);
             StringExpandPlaceholders(dest, gText_NumberItem_TMBerry);
         }
         break;

--- a/src/pokedex_plus_hgss.c
+++ b/src/pokedex_plus_hgss.c
@@ -290,9 +290,9 @@ static EWRAM_DATA u16 sLastSelectedPokemon = 0;
 static EWRAM_DATA u8 sPokeBallRotation = 0;
 static EWRAM_DATA struct PokedexListItem *sPokedexListItem = NULL;
 //Pokedex Plus HGSS_Ui
-#define MOVES_COUNT_TOTAL (EGG_MOVES_ARRAY_COUNT + MAX_LEVEL_UP_MOVES + NUM_TECHNICAL_MACHINES + NUM_HIDDEN_MACHINES)
+#define MOVES_COUNT_TOTAL (EGG_MOVES_ARRAY_COUNT + MAX_LEVEL_UP_MOVES + NUM_ALL_MACHINES)
 EWRAM_DATA static u16 sStatsMoves[MOVES_COUNT_TOTAL] = {0};
-EWRAM_DATA static u16 sStatsMovesTMHM_ID[NUM_TECHNICAL_MACHINES + NUM_HIDDEN_MACHINES] = {0};
+EWRAM_DATA static u16 sStatsMovesTMHM_ID[NUM_ALL_MACHINES] = {0};
 
 
 struct SearchOptionText
@@ -5054,13 +5054,13 @@ static u16 AddTMTutorMoves(u16 species, u16 movesTotal, u8 *numTMHMMoves, u8 *nu
     // TM Moves
     if (HGSS_SORT_TMS_BY_NUM)
     {
-        for (i = 0; i < NUM_TECHNICAL_MACHINES + NUM_HIDDEN_MACHINES; i++)
+        for (i = 0; i < NUM_ALL_MACHINES; i++)
         {
-            move = ItemIdToBattleMoveId(ITEM_TM01 + i);
+            move = ItemIdToBattleMoveId(GetTMHMId(i));
             if (move != MOVE_NONE && CanLearnTeachableMove(species, move))
             {
                 isTMMove[move] = TRUE;
-                sStatsMovesTMHM_ID[*numTMHMMoves] = ITEM_TM01 + i;
+                sStatsMovesTMHM_ID[*numTMHMMoves] = GetTMHMId(i);
                 (*numTMHMMoves)++;
                 sStatsMoves[movesTotal] = move;
                 movesTotal++;
@@ -5072,12 +5072,12 @@ static u16 AddTMTutorMoves(u16 species, u16 movesTotal, u8 *numTMHMMoves, u8 *nu
         for (i = 0; teachableLearnset[i] != MOVE_UNAVAILABLE; i++)
         {
             move = teachableLearnset[i];
-            for (u16 j = 0; j < NUM_TECHNICAL_MACHINES + NUM_HIDDEN_MACHINES; j++)
+            for (u16 j = 0; j < NUM_ALL_MACHINES; j++)
             {
-                if (ItemIdToBattleMoveId(ITEM_TM01 + j) == move)
+                if (ItemIdToBattleMoveId(GetTMHMId(j)) == move)
                 {
                     isTMMove[move] = TRUE;
-                    sStatsMovesTMHM_ID[*numTMHMMoves] = ITEM_TM01 + j;
+                    sStatsMovesTMHM_ID[*numTMHMMoves] = GetTMHMId(j);
                     (*numTMHMMoves)++;
                     sStatsMoves[movesTotal] = move;
                     movesTotal++;


### PR DESCRIPTION
Simply had another crack at #6237 since I found it rather tricky to understand...

## Description
Every TM/HM simply has an index, and the index->item id table is in item.c (gTMHMItemIds). Macros automatically generate a TM's name, index, secondary Id. Only requirement is modifying the header, modifying values in tms_hms_.h. Might need validation to make sure numbers line up?

## Media
<!--- Add relevant images, GIFs, or videos to help reviewers understand the changes. Remove this section if not applicable. --->

## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, closes #2222." Remove this section if not applicable.-->

<!-- CREDITS -->
<!-- Once your PR is submitted, leave a comment asking the bot to add you to the credits. -->
<!-- If anybody helped with this PR, please encourage them to comment on your PR and ask the bot to add them to the credits. -->
<!-- EVERY contribution matters! -->
<!-- https://github.com/rh-hideout/pokeemerald-expansion/wiki/CREDITS.md-Frequently-Asked-Questions -->

## Feature(s) this PR does NOT handle:
<!-- If this PR contains any unfinished and non-blocking work, please list them here for clarity. -->
<!--- Remove this section if not applicable. --->

## Things to note in the release changelog:
<!-- Add any important details for the release changelog. Must be structed as bullet points. --->
<!--- Remove this section if not applicable. --->

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
