### PR TITLE
[FIX]  Prevent caught Pokémon loss in NPC partner battles

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -16027,7 +16027,7 @@ static void Cmd_givecaughtmon(void)
     CMD_ARGS(const u8 *passInstr);
     enum GiveCaughtMonStates state = gBattleCommunication[MULTIUSE_STATE];
     // Restore players party in order to handle properly the case when a wild mon is caught.
-    if (IsDoubleBattle() && IsNPCFollowerWildBattle())
+    if (IsNPCFollowerWildBattle())
         LoadPlayerParty();
 
     switch (state)
@@ -16167,7 +16167,7 @@ static void Cmd_givecaughtmon(void)
         break;
     }
     // Save the player's party again to not interferes with RestorePartyAfterFollowerNPCBattle() called after battle.
-    if (IsDoubleBattle() && IsNPCFollowerWildBattle())
+    if (IsNPCFollowerWildBattle())
         SavePlayerParty();
 }
 

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -66,6 +66,8 @@
 #include "constants/pokemon.h"
 #include "config/battle.h"
 #include "data/battle_move_effects.h"
+#include "follower_npc.h"
+#include "load_save.h"
 
 // table to avoid ugly powing on gba (courtesy of doesnt)
 // this returns (i^2.5)/4
@@ -16024,6 +16026,9 @@ static void Cmd_givecaughtmon(void)
 {
     CMD_ARGS(const u8 *passInstr);
     enum GiveCaughtMonStates state = gBattleCommunication[MULTIUSE_STATE];
+    // Restore players party in order to handle properly the case when a wild mon is caught.
+    if (IsDoubleBattle() && IsNPCFollowerWildBattle())
+        LoadPlayerParty();
 
     switch (state)
     {
@@ -16161,6 +16166,9 @@ static void Cmd_givecaughtmon(void)
             gBattlescriptCurrInstr = cmd->nextInstr;
         break;
     }
+    // Save the player's party again to not interferes with RestorePartyAfterFollowerNPCBattle() called after battle.
+    if (IsDoubleBattle() && IsNPCFollowerWildBattle())
+        SavePlayerParty();
 }
 
 static void Cmd_trysetcaughtmondexflags(void)


### PR DESCRIPTION
## Description
Fixes a bug where Pokémon caught during follower NPC partner battles would disappear instead of being added to the party or PC. The issue occurred because the temporary battle party would overwrite captures before the player's original party was restored.

Changes:
- Restores the player's real party before adding caught Pokémon
- Saves the party again after capture to prevent overwrites
- Maintains vanilla behavior for non-follower battles

## Issue(s) that this PR fixes
[(link to Discord discussion)](https://discord.com/channels/419213663107416084/419214240277200898/1385935682886963310)

## Feature(s) this PR does NOT handle:
- Does not modify behavior for regular partner battles (e.g., Steven double battles)
- Does not affect PC storage logic beyond this specific case

## Things to note in the release changelog:

## Discord contact info
juanjo4540


<!-- CREDITS -->
@all-contributors please add @J2M2 for code, bug, and test