### PR TITLE
Fixes Rapid Spin description (#7178)

### DIFF
--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -6050,11 +6050,11 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
     {
         .name = COMPOUND_STRING("Rapid Spin"),
         .description = COMPOUND_STRING(
-            "Spins attack that removes\n"
+            "User spins and removes some\n"
         #if B_SPEED_BUFFING_RAPID_SPIN >= GEN_8
-            "some effects and ups speed."),
+            "effects, while upping speed."),
         #else 
-            "certain effects."),
+            "effects."),
         #endif
         .effect = EFFECT_RAPID_SPIN,
         .power = B_UPDATED_MOVE_DATA >= GEN_8 ? 50 : 20,


### PR DESCRIPTION
Fixes Rapid Spin description which contained incorrect grammar. Previously said "Spins attack that removes certain effects / Spins attack that removes some effects and ups speed"


## Media
![Screenshot 2025-06-22 102111](https://github.com/user-attachments/assets/0514e3c8-23c2-4b82-aa5a-696911daf24d)
![Screenshot 2025-06-22 102127](https://github.com/user-attachments/assets/7eccd6a0-faa2-48f9-b2ea-0eff364be349)


## Issue(s) that this PR fixes
Fixes #7178

## Discord contact info
grintoul
