### PR TITLE
lto support

### DIFF
--- a/ld_script_modern.ld
+++ b/ld_script_modern.ld
@@ -26,7 +26,7 @@ SECTIONS {
     .ewram.sbss (NOLOAD) :
     ALIGN(4)
     {
-        src/*.o(.sbss);
+        *.o(.sbss);
     } > EWRAM
 
     .iwram ORIGIN(IWRAM) : AT (__iwram_lma)
@@ -41,14 +41,8 @@ SECTIONS {
     .iwram.bss (NOLOAD) :
     ALIGN(4)
     {
-        src/*.o(.bss);
-        data/*.o(.bss);
-        *libc.a:*.o(.bss*);
-        *libnosys.a:*.o(.bss*);
-
-        src/m4a.o(.bss.code);
-
-        src/*.o(common_data);
+        *.o(.bss*);
+        *.o(common_data);
         src/*.o(COMMON);
         *libc.a:*.o(COMMON);
         *libnosys.a:*.o(COMMON);
@@ -63,9 +57,13 @@ SECTIONS {
         src/rom_header_gf.o(.text.*);
         src/rom_header_rhh.o(.text.*);
         src/crt0.o(.text);
-        src/main.o(.text);
-        src/*.o(.text*);
+        *libagbsyscall.a:*.o(.text*);
+        *libgcc.a:*.o(.text*);
+        *libc.a:*.o(.text*);
+        *libnosys.a:*.o(.text*);
         asm/*.o(.text*);
+        *.o(.text*);
+        *.o(.eh_frame);
     } > ROM =0
 
     script_data :
@@ -74,69 +72,14 @@ SECTIONS {
 		data/*.o(script_data);
     } > ROM =0
 
-    lib_text :
-    ALIGN(4)
-    {
-        src/libgcnmultiboot.o(.text);
-        src/m4a_1.o(.text);
-        src/m4a.o(.text);
-        src/agb_flash.o(.text);
-        src/agb_flash_1m.o(.text);
-        src/agb_flash_mx.o(.text);
-        src/siirtc.o(.text);
-        src/librfu_stwi.o(.text);
-        src/librfu_intr.o(.text);
-        src/librfu_rfu.o(.text);
-        src/librfu_sio32id.o(.text);
-        *libagbsyscall.a:*.o(.text*);
-        *libgcc.a:*.o(.text*);
-        *libc.a:*.o(.text*);
-        *libnosys.a:*.o(.text*);
-        src/libisagbprn.o(.text);
-    } > ROM =0
-
     .rodata :
     ALIGN(4)
     {
-        src/*.o(.rodata*);
-        data/*.o(.rodata*);
-    } > ROM =0
-
-    song_data :
-    ALIGN(4)
-    {
-        sound/songs/*.o(.rodata);
-    } > ROM =0
-
-    lib_rodata :
-    SUBALIGN(4)
-    {
-        src/m4a.o(.rodata);
-        src/agb_flash.o(.rodata);
-        src/agb_flash_1m.o(.rodata);
-        src/agb_flash_mx.o(.rodata);
-        src/agb_flash_le.o(.rodata);
-        src/siirtc.o(.rodata);
-        src/librfu_rfu.o(.rodata);
-        src/librfu_sio32id.o(.rodata);
+        *.o(.rodata*);
         *libgcc.a:*.o(.rodata*);
         *libc.a:*.o(.rodata*);
         *libc.a:*.o(.data*);
-        src/libisagbprn.o(.rodata);
-    } > ROM =0
-
-    multiboot_data :
-    ALIGN(4)
-    {
-        data/multiboot_ereader.o(.rodata);
-        data/multiboot_berry_glitch_fix.o(.rodata);
-        data/multiboot_pokemon_colosseum.o(.rodata);
-    } > ROM =0
-
-    gfx_data :
-    ALIGN(4)
-    {
-        src/graphics.o(.rodata);
+        sound/songs/*.o(.rodata);
     } > ROM =0
 
     .data.iwram :


### PR DESCRIPTION
Followup to #6392

Some notes:
- There are some warnings when building with -lto, but they're generally harmless
- I didn't encounter any issues, but `-lto` with `-O3` or `-Ofast` freezes the game in pokemon summary screen in battles, so there's a potential issue there
- I didn't add lto to workflow, but maybe it would be a good idea to add it?
- usage is `make LTO=1`. LTO has to be in uppercase

Credits to SBird for his original implementation [here ](https://github.com/SBird1337/pokeemerald/commit/b2c8a1741bf61ac838c7d4c40ce0eb3a4e27f1ea)