### PR TITLE
force sGFRomHeader to always be present

### DIFF
--- a/src/rom_header_gf.c
+++ b/src/rom_header_gf.c
@@ -99,7 +99,7 @@ struct GFRomHeader
 // This seems to need to be in the text section for some reason.
 // To avoid a changed section attributes warning it's put in a special .text.consts section.
 __attribute__((section(".text.consts")))
-static const struct GFRomHeader sGFRomHeader = {
+USED static const struct GFRomHeader sGFRomHeader = {
     .version = GAME_VERSION,
     .language = GAME_LANGUAGE,
     .gameName = "pokemon emerald version",


### PR DESCRIPTION
PR body can't be empty