### PR TITLE
Fixes wrong Future Sight indexing

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -9582,8 +9582,13 @@ bool32 IsFutureSightAttackerInParty(u32 battlerAtk, u32 battlerDef, u32 move)
         return FALSE;
 
     struct Pokemon *party = GetBattlerParty(battlerAtk);
-    return &party[gWishFutureKnock.futureSightPartyIndex[battlerDef]] != &party[gBattlerPartyIndexes[battlerAtk]]
-        && &party[gWishFutureKnock.futureSightPartyIndex[battlerDef]] != &party[BATTLE_PARTNER(gBattlerPartyIndexes[battlerAtk])];
+    if (IsDoubleBattle())
+    {
+        return &party[gWishFutureKnock.futureSightPartyIndex[battlerDef]] != &party[gBattlerPartyIndexes[battlerAtk]]
+            && &party[gWishFutureKnock.futureSightPartyIndex[battlerDef]] != &party[gBattlerPartyIndexes[BATTLE_PARTNER(battlerAtk)]];
+    }
+
+    return &party[gWishFutureKnock.futureSightPartyIndex[battlerDef]] != &party[gBattlerPartyIndexes[battlerAtk]];
 }
 
 s32 CalculateMoveDamage(struct DamageCalculationData *damageCalcData, u32 fixedBasePower)


### PR DESCRIPTION
Fixes:

1. In singles it would return false because the second index is being checked.
2. The index for the partner was wrongly retrieved

Not sure why tests didn't catch that.

To repro in-game: Use future sight on a mon, switch out. In my case I tested against a Hariyama with a Gardevoir and a really weak switch in. Future Sight was supposed to faint the Hariyama.