### PR TITLE
Fix AI Permanently Switching When the Player Has a Choice Item

### DIFF
--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -261,7 +261,7 @@ static bool32 ShouldSwitchIfHasBadOdds(u32 battler)
             damageTaken = AI_GetDamage(opposingBattler, battler, i, AI_DEFENDING, gAiLogicData);
             if (playerMove == gBattleStruct->choicedMove[opposingBattler]) // If player is choiced, only care about the choice locked move
             {
-                return maxDamageTaken = damageTaken;
+                maxDamageTaken = damageTaken;
                 break;
             }
             if (damageTaken > maxDamageTaken)


### PR DESCRIPTION
Fix AI Permanently Switching When the Player Has a Choice Item
#7199 

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

## Issue(s) that this PR fixes
Fixes #7199

## Discord contact info
iriv24
