### PR TITLE
Fix incorrect type input

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -212,7 +212,7 @@ static uq4_12_t CalcTypeEffectivenessMultiplierHelper(u32 move, u32 moveType, u3
     ctx.battlerAtk = battlerAtk;
     ctx.battlerDef = battlerDef;
     ctx.move = move;
-    ctx.moveType = GetBattleMoveType(gCurrentMove);
+    ctx.moveType = moveType;
     ctx.updateFlags = recordAbilities;
     ctx.abilityAtk = GetBattlerAbility(battlerAtk);
     ctx.abilityDef = defAbility;


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
`CalcTypeEffectivenessMultiplierHelper` was taking `moveType` as input, but didn't use it and used the actual type of the input move instead.

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara