### PR TITLE
Bug Fix: Follower NPCs no longer have glitchy bobbing while underwater

### DIFF
--- a/src/follower_npc.c
+++ b/src/follower_npc.c
@@ -1179,10 +1179,6 @@ void FollowerNPC_HandleSprite(void)
         else if (gPlayerAvatar.flags & PLAYER_AVATAR_FLAG_ACRO_BIKE)
             SetFollowerNPCSprite(FOLLOWER_NPC_SPRITE_INDEX_ACRO_BIKE);
     }
-    else if (gMapHeader.mapType == MAP_TYPE_UNDERWATER)
-    {
-        TryUpdateFollowerNPCSpriteUnderwater();
-    }
     else if (gPlayerAvatar.flags & PLAYER_AVATAR_FLAG_ON_FOOT)
     {
         SetFollowerNPCSprite(FOLLOWER_NPC_SPRITE_INDEX_NORMAL);


### PR DESCRIPTION
## Description
Removed an unnecessary extra call to `TryUpdateFollowerNPCSpriteUnderwater` that was causing the normal bobbing behavior of follower NPCs to happen twice.

## Media
Here's a video demonstrating the bugged behavior:  
https://cdn.discordapp.com/attachments/1357388177161326834/1387899299995848734/fnpcunderwater.mp4?ex=685f0573&is=685db3f3&hm=ddab8cf6dbb8cb3bf5cb17eb61284a3a0e97471d57881e1d968c6e51490b63f0&

## Discord contact info
bivurnum
