### PR TITLE
Add missing inst call in Cmd_setnonvolatilestatus

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -16526,6 +16526,7 @@ static void Cmd_setnonvolatilestatus(void)
 {
     CMD_ARGS();
     gEffectBattler = gBattlerTarget;
+    gBattlescriptCurrInstr = cmd->nextInstr - 1;
     SetNonVolatileStatusCondition(gBattlerTarget, GetMoveNonVolatileStatus(gCurrentMove));
 }
 


### PR DESCRIPTION
I'm pretty sure this is a bug that never manifested.
