### PR TITLE
Set correct Instruction

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -16445,7 +16445,8 @@ static void Cmd_jumpifcaptivateaffected(void)
 static void Cmd_setnonvolatilestatus(void)
 {
     CMD_ARGS(u8 trigger);
-
+    gBattlescriptCurrInstr = cmd->nextInstr - 1;
+    
     switch (cmd->trigger)
     {
     case TRIGGER_ON_ABILITY:


### PR DESCRIPTION
Since we now pass arguments to the macro we need to advance the instruction by the correct amount.

This was wrong regardless but only manifested after #7051 was merged.