### PR TITLE
Jaboca berry triggers instead of being stolen by bug bite

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -3800,7 +3800,12 @@ void SetMoveEffect(bool32 primary, bool32 certain)
                 }
                 break;
             case MOVE_EFFECT_BUG_BITE:
-                if (GetItemPocket(gBattleMons[gEffectBattler].item) == POCKET_BERRIES
+                if (GetBattlerHoldEffect(gEffectBattler, TRUE) == HOLD_EFFECT_JABOCA_BERRY)
+                {
+                    // jaboca berry triggers instead of being stolen
+                    gBattlescriptCurrInstr++;
+                }
+                else if (GetItemPocket(gBattleMons[gEffectBattler].item) == POCKET_BERRIES
                     && battlerAbility != ABILITY_STICKY_HOLD)
                 {
                     // target loses their berry

--- a/test/battle/hold_effect/jaboca_berry.c
+++ b/test/battle/hold_effect/jaboca_berry.c
@@ -42,7 +42,6 @@ SINGLE_BATTLE_TEST("Jaboca Berry causes the attacker to lose 1/8 of its max HP i
 
 SINGLE_BATTLE_TEST("Jaboca Berry triggers before Bug Bite can steal it")
 {
-    KNOWN_FAILING;
     GIVEN {
         ASSUME(GetMoveCategory(MOVE_BUG_BITE) == DAMAGE_CATEGORY_PHYSICAL);
         PLAYER(SPECIES_WYNAUT);


### PR DESCRIPTION
Jaboca berry not stolen by bug bite so it can trigger at end of move (more efficient than adding entirely new ITEMEFFECT just for jaboca)

Re: https://bulbapedia.bulbagarden.net/wiki/Bug_Bite_(move)#Generation_V_onwards

didn't think it was worth an entire gen 4 vs. 5 config to avoid config bloat wherever possible