### PR TITLE
Flush textbox for Truant Popup

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -8576,7 +8576,7 @@ BattleScript_MoveUsedLoafingAroundMsg::
 	moveendto MOVEEND_NEXT_TARGET
 	end
 BattleScript_TruantLoafingAround::
-    flushtextbox
+	flushtextbox
 	call BattleScript_AbilityPopUp
 	goto BattleScript_MoveUsedLoafingAroundMsg
 

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -8576,6 +8576,7 @@ BattleScript_MoveUsedLoafingAroundMsg::
 	moveendto MOVEEND_NEXT_TARGET
 	end
 BattleScript_TruantLoafingAround::
+    flushtextbox
 	call BattleScript_AbilityPopUp
 	goto BattleScript_MoveUsedLoafingAroundMsg
 


### PR DESCRIPTION
A graphical fix. Truant loafing around script needs to flush the textbox before the popup otherwise the popop will occur while player moves are still displaying