### PR TITLE
fix: added warning about dns tutorial and triple-layer metatiles tutorial compatibility to the dns tutorial.

### DIFF
--- a/docs/tutorials/dns.md
+++ b/docs/tutorials/dns.md
@@ -12,6 +12,9 @@ If you intend to use vanilla maps and have not already edited them, revert commi
 
 If you _have_ edited vanilla maps, the merge conflicts from reverting that commit will cause problems. If you are using vanilla maps, manually copy some of the tileset changes, `.pal`, and `.pla` files in your branch, and begin rebuilding your metatiles to have windows use the palettes that have a `.pla` for light blending the correct color slots. [Triple-layer metatiles](https://github.com/pret/pokeemerald/wiki/Triple-layer-metatiles) are highly recommended.
 
+WARNING: [As per issue #7034](https://github.com/rh-hideout/pokeemerald-expansion/issues/7034) if you follow this tutorial reverting the previously mentioned commit to use the updated palettes in the Hoenn maps and *after* that you try to follow the [Triple-layer metatiles tutorial](https://github.com/pret/pokeemerald/wiki/Triple-layer-metatiles), you'll encounter an issue when running the script to update old tilesets to support triple-layer metatiles. 
+Follow the band-aid fix proposed in that issue after this tutorial but before following the triple-layer metatiles tutorial if you want everythign to work properly with light-blended palettes and triple-layer metatiles together.
+
 You will also want to add the lighting object events from that commit.
 
 If you are not using Hoenn maps, the primary concern is that you do not use the exact same palette indices for colors you want to be darkened during night time and colors you want to light up. Err towards not light blending a color if you aren't sure how to avoid conflicts.


### PR DESCRIPTION
Updating the DNS tutorial .md file to mention issue 7034

## Description
Added a paragraph that mentions issue #7034 after the line that recommends using triple-layer metatiles in the dns tutorial. 

This is so that people following the dns tutorial can know how to implement the band-aid fix provided in the mentioned issue before going on to follow the triple-layer metatiles tutorial.

## Issue(s) that this PR fixes
Doesn't really address #7034, but helps preventing people following the dns tutorial and then the triple-layer metatiles tutorial from running into the issue of mauville and rustboro's tilesets getting corrupted.

## Discord contact info
vittoriomasia
