### PR TITLE
Make the ROM headers used to stop them disappearing from the ROM

### DIFF
--- a/include/global.h
+++ b/include/global.h
@@ -1177,4 +1177,7 @@ struct MapPosition
 extern bool32 gLoadFail;
 #endif // T_SHOULD_RUN_MOVE_ANIM
 
+u32 CalcGFHeader();
+u32 CalcRHHHeader();
+
 #endif // GUARD_GLOBAL_H

--- a/src/main.c
+++ b/src/main.c
@@ -115,7 +115,7 @@ void AgbMain(void)
 
     gSoftResetDisabled = FALSE;
 
-    if (gFlashMemoryPresent != TRUE)
+    if (gFlashMemoryPresent != TRUE || CalcGFHeader() < 1 || CalcRHHHeader() < 1)
         SetMainCallback2((SAVE_TYPE_ERROR_SCREEN) ? CB2_FlashNotDetectedScreen : NULL);
 
     gLinkTransferringData = FALSE;

--- a/src/rom_header_gf.c
+++ b/src/rom_header_gf.c
@@ -178,3 +178,12 @@ USED static const struct GFRomHeader sGFRomHeader = {
     .moveDescriptions = NULL,
     .unk20 = 0x00000000, // 0xFFFFFFFF in FRLG
 };
+
+u32 CalcGFHeader()
+{
+    u32 size = sizeof(struct GFRomHeader) / 4;
+    u32 returnVal = 0;
+    for (u32 i = 0; i < size; i++)
+        returnVal += ((u32 *)&sGFRomHeader)[i];
+    return returnVal;
+}

--- a/src/rom_header_rhh.c
+++ b/src/rom_header_rhh.c
@@ -42,3 +42,12 @@ USED static const struct RHHRomHeader sRHHRomHeader =
     .itemsCount = ITEMS_COUNT,
     .itemNameLength = ITEM_NAME_LENGTH,
 };
+
+u32 CalcRHHHeader()
+{
+    u32 size = sizeof(struct RHHRomHeader) / 4;
+    u32 returnVal = 0;
+    for (u32 i = 0; i < size; i++)
+        returnVal += ((u32 *)&sRHHRomHeader)[i];
+    return returnVal;
+}


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
This is a very stupid way to prevent the ROM headers from being excluded from the compiled ROM.

## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, closes #2222." Remove this section if not applicable.-->
The ROM headers being removed all the time

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara