### PR TITLE
Keep removed headers

### DIFF
--- a/include/gba/defines.h
+++ b/include/gba/defines.h
@@ -13,6 +13,7 @@
 #define COMMON_DATA __attribute__((section("common_data")))
 #define UNUSED __attribute__((unused))
 #define USED __attribute__((used))
+#define KEEP_SECTION __attribute__((section(".text.consts")))
 
 #define ARM_FUNC __attribute__((target("arm")))
 

--- a/ld_script_modern.ld
+++ b/ld_script_modern.ld
@@ -53,8 +53,10 @@ SECTIONS {
     .text ORIGIN(ROM) :
     ALIGN(4)
     {
-        src/rom_header.o(.text*);
+        KEEP(src/rom_header.o(.text*));
+        KEEP(src/rom_header_gf.o(.text.consts));
         src/rom_header_gf.o(.text.*);
+        KEEP(src/rom_header_rhh.o(.text.consts));
         src/rom_header_rhh.o(.text.*);
         src/crt0.o(.text);
         *libagbsyscall.a:*.o(.text*);
@@ -62,6 +64,7 @@ SECTIONS {
         *libc.a:*.o(.text*);
         *libnosys.a:*.o(.text*);
         asm/*.o(.text*);
+        KEEP(*.o(.text.consts));
         *.o(.text*);
         *.o(.eh_frame);
     } > ROM =0

--- a/ld_script_modern.ld
+++ b/ld_script_modern.ld
@@ -56,7 +56,6 @@ SECTIONS {
         src/rom_header.o(.text*);
         KEEP(*.o(.text.header_gf));
         KEEP(*.o(.text.header_rhh));
-        src/rom_header_rhh.o(.text.*);
         src/crt0.o(.text);
         *libagbsyscall.a:*.o(.text*);
         *libgcc.a:*.o(.text*);

--- a/ld_script_modern.ld
+++ b/ld_script_modern.ld
@@ -53,10 +53,9 @@ SECTIONS {
     .text ORIGIN(ROM) :
     ALIGN(4)
     {
-        KEEP(src/rom_header.o(.text*));
-        KEEP(src/rom_header_gf.o(.text.consts));
-        src/rom_header_gf.o(.text.*);
-        KEEP(src/rom_header_rhh.o(.text.consts));
+        src/rom_header.o(.text*);
+        KEEP(*.o(.text.header_gf));
+        KEEP(*.o(.text.header_rhh));
         src/rom_header_rhh.o(.text.*);
         src/crt0.o(.text);
         *libagbsyscall.a:*.o(.text*);

--- a/ld_script_test.ld
+++ b/ld_script_test.ld
@@ -75,8 +75,9 @@ SECTIONS {
     ALIGN(4)
     {
         src/rom_header.o(.text);
-        src/rom_header_gf.o(.text.*);
-        src/rom_header_rhh.o(.text.*);
+        KEEP(*.o(.text.header_gf));
+        KEEP(*.o(.text.header_rhh));
+        KEEP(*.o(.text.consts));
         src/*.o(.text);
     } > ROM =0
 

--- a/src/agb_flash_1m.c
+++ b/src/agb_flash_1m.c
@@ -1,7 +1,7 @@
 #include "gba/gba.h"
 #include "gba/flash_internal.h"
 
-USED static const char AgbLibFlashVersion[] = "FLASH1M_V103";
+KEEP_SECTION USED static const char AgbLibFlashVersion[] = "FLASH1M_V103";
 
 static const struct FlashSetupInfo *const sSetupInfos[] =
 {

--- a/src/rom_header.s
+++ b/src/rom_header.s
@@ -7,34 +7,34 @@ Start::
 RomHeaderNintendoLogo::
 	.space 156
 
-RomHeaderGameTitle:
+RomHeaderGameTitle::
 	.space 12
 
 RomHeaderGameCode::
 	.space 4
 
-RomHeaderMakerCode:
+RomHeaderMakerCode::
 	.space 2
 
-RomHeaderMagic:
+RomHeaderMagic::
 	.byte 0
 
-RomHeaderMainUnitCode:
+RomHeaderMainUnitCode::
 	.byte 0
 
-RomHeaderDeviceType:
+RomHeaderDeviceType::
 	.byte 0
 
-RomHeaderReserved1:
+RomHeaderReserved1::
 	.space 7
 
 RomHeaderSoftwareVersion::
 	.byte 0
 
-RomHeaderChecksum:
+RomHeaderChecksum::
 	.byte 0
 
-RomHeaderReserved2:
+RomHeaderReserved2::
 	.space 2
 
 	.word 0

--- a/src/rom_header_gf.c
+++ b/src/rom_header_gf.c
@@ -97,8 +97,8 @@ struct GFRomHeader
 };
 
 // This seems to need to be in the text section for some reason.
-// To avoid a changed section attributes warning it's put in a special .text.consts section.
-KEEP_SECTION USED static const struct GFRomHeader sGFRomHeader = {
+// To avoid a changed section attributes warning it's put in a special .text.header_gf section.
+__attribute__((section(".text.header_gf"))) USED static const struct GFRomHeader sGFRomHeader = {
     .version = GAME_VERSION,
     .language = GAME_LANGUAGE,
     .gameName = "pokemon emerald version",

--- a/src/rom_header_gf.c
+++ b/src/rom_header_gf.c
@@ -98,8 +98,7 @@ struct GFRomHeader
 
 // This seems to need to be in the text section for some reason.
 // To avoid a changed section attributes warning it's put in a special .text.consts section.
-__attribute__((section(".text.consts")))
-USED static const struct GFRomHeader sGFRomHeader = {
+KEEP_SECTION USED static const struct GFRomHeader sGFRomHeader = {
     .version = GAME_VERSION,
     .language = GAME_LANGUAGE,
     .gameName = "pokemon emerald version",

--- a/src/rom_header_rhh.c
+++ b/src/rom_header_rhh.c
@@ -27,7 +27,7 @@ struct RHHRomHeader
     /*0x17*/ u8 padding;
 };
 
-KEEP_SECTION USED static const struct RHHRomHeader sRHHRomHeader =
+__attribute__((section(".text.header_rhh"))) USED static const struct RHHRomHeader sRHHRomHeader =
 {
     .rhh_magic = { 'R', 'H', 'H', 'E', 'X', 'P' },
     .expansionVersionMajor = EXPANSION_VERSION_MAJOR,

--- a/src/rom_header_rhh.c
+++ b/src/rom_header_rhh.c
@@ -27,8 +27,7 @@ struct RHHRomHeader
     /*0x17*/ u8 padding;
 };
 
-__attribute__((section(".text.consts")))
-USED static const struct RHHRomHeader sRHHRomHeader =
+KEEP_SECTION USED static const struct RHHRomHeader sRHHRomHeader =
 {
     .rhh_magic = { 'R', 'H', 'H', 'E', 'X', 'P' },
     .expansionVersionMajor = EXPANSION_VERSION_MAJOR,

--- a/src/siirtc.c
+++ b/src/siirtc.c
@@ -75,7 +75,7 @@ static u8 ReadData();
 static void EnableGpioPortRead();
 static void DisableGpioPortRead();
 
-USED static const char AgbLibRtcVersion[] = "SIIRTC_V001";
+KEEP_SECTION USED static const char AgbLibRtcVersion[] = "SIIRTC_V001";
 
 void SiiRtcUnprotect(void)
 {


### PR DESCRIPTION
## Description
`--gc-sections` removes unused headers/version identifiers even with `USED`. This PR keeps them even with this flag enabled.

credits to @Gudf for the `KEEP` suggestion

## Discord contact info
.cawt
