### PR TITLE
Updated gPlayerParty to no longer use encryption

### DIFF
--- a/include/gba/defines.h
+++ b/include/gba/defines.h
@@ -26,6 +26,7 @@
 #define ALIGNED(n) __attribute__((aligned(n)))
 #define PACKED __attribute__((packed))
 #define TRANSPARENT __attribute__ ((__transparent_union__))
+#define ALWAYS_INLINE inline __attribute__((always_inline))
 
 #define SOUND_INFO_PTR (*(struct SoundInfo **)0x3007FF0)
 #define INTR_CHECK     (*(u16 *)0x3007FF8)

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -16,7 +16,7 @@
 #define FORM_SPECIES_END (0xffff)
 
 // Property labels for Get(Box)MonData / Set(Box)MonData
-enum {
+enum MonData {
     MON_DATA_PERSONALITY,
     MON_DATA_STATUS,
     MON_DATA_OT_ID,
@@ -185,42 +185,52 @@ struct PokemonSubstruct3
     u16 metGame:4;
     u16 dynamaxLevel:4;
     u16 otGender:1;
-    u32 hpIV:5;
-    u32 attackIV:5;
-    u32 defenseIV:5;
-    u32 speedIV:5;
-    u32 spAttackIV:5;
-    u32 spDefenseIV:5;
-    u32 isEgg:1;
-    u32 gigantamaxFactor:1;
-    u32 coolRibbon:3;     // Stores the highest contest rank achieved in the Cool category.
-    u32 beautyRibbon:3;   // Stores the highest contest rank achieved in the Beauty category.
-    u32 cuteRibbon:3;     // Stores the highest contest rank achieved in the Cute category.
-    u32 smartRibbon:3;    // Stores the highest contest rank achieved in the Smart category.
-    u32 toughRibbon:3;    // Stores the highest contest rank achieved in the Tough category.
-    u32 championRibbon:1; // Given when defeating the Champion. Because both RSE and FRLG use it, later generations don't specify from which region it comes from.
-    u32 winningRibbon:1;  // Given at the Battle Tower's Level 50 challenge by winning a set of seven battles that extends the current streak to 56 or more.
-    u32 victoryRibbon:1;  // Given at the Battle Tower's Level 100 challenge by winning a set of seven battles that extends the current streak to 56 or more.
-    u32 artistRibbon:1;   // Given at the Contest Hall by winning a Master Rank contest with at least 800 points, and agreeing to have the Pokémon's portrait placed in the museum after being offered.
-    u32 effortRibbon:1;   // Given at Slateport's market to Pokémon with maximum EVs.
-    u32 marineRibbon:1;   // Never distributed.
-    u32 landRibbon:1;     // Never distributed.
-    u32 skyRibbon:1;      // Never distributed.
-    u32 countryRibbon:1;  // Distributed during Pokémon Festa '04 and '05 to tournament winners.
-    u32 nationalRibbon:1; // Given to purified Shadow Pokémon in Colosseum/XD.
-    u32 earthRibbon:1;    // Given to teams that have beaten Mt. Battle's 100-battle challenge in Colosseum/XD.
-    u32 worldRibbon:1;    // Distributed during Pokémon Festa '04 and '05 to tournament winners.
-    u32 isShadow:1;
-    u32 unused_0B:1;
-    u32 abilityNum:2;
+    union {
+        u32 ivs:30;
+        struct {
+            u32 hpIV:5;
+            u32 attackIV:5;
+            u32 defenseIV:5;
+            u32 speedIV:5;
+            u32 spAttackIV:5;
+            u32 spDefenseIV:5;
+            u32 isEgg:1;
+            u32 gigantamaxFactor:1;
+        };
+    };
+    union {
+        u32 ribbons:27;
+        struct {
+            u32 coolRibbon:3;     // Stores the highest contest rank achieved in the Cool category.
+            u32 beautyRibbon:3;   // Stores the highest contest rank achieved in the Beauty category.
+            u32 cuteRibbon:3;     // Stores the highest contest rank achieved in the Cute category.
+            u32 smartRibbon:3;    // Stores the highest contest rank achieved in the Smart category.
+            u32 toughRibbon:3;    // Stores the highest contest rank achieved in the Tough category.
+            u32 championRibbon:1; // Given when defeating the Champion. Because both RSE and FRLG use it, later generations don't specify from which region it comes from.
+            u32 winningRibbon:1;  // Given at the Battle Tower's Level 50 challenge by winning a set of seven battles that extends the current streak to 56 or more.
+            u32 victoryRibbon:1;  // Given at the Battle Tower's Level 100 challenge by winning a set of seven battles that extends the current streak to 56 or more.
+            u32 artistRibbon:1;   // Given at the Contest Hall by winning a Master Rank contest with at least 800 points, and agreeing to have the Pokémon's portrait placed in the museum after being offered.
+            u32 effortRibbon:1;   // Given at Slateport's market to Pokémon with maximum EVs.
+            u32 marineRibbon:1;   // Never distributed.
+            u32 landRibbon:1;     // Never distributed.
+            u32 skyRibbon:1;      // Never distributed.
+            u32 countryRibbon:1;  // Distributed during Pokémon Festa '04 and '05 to tournament winners.
+            u32 nationalRibbon:1; // Given to purified Shadow Pokémon in Colosseum/XD.
+            u32 earthRibbon:1;    // Given to teams that have beaten Mt. Battle's 100-battle challenge in Colosseum/XD.
+            u32 worldRibbon:1;    // Distributed during Pokémon Festa '04 and '05 to tournament winners.
+            u32 isShadow:1;
+            u32 unused_0B:1;
+            u32 abilityNum:2;
 
-    // The functionality of this bit changed in FRLG:
-    // In RS, this bit does nothing, is never set, & is accidentally unset when hatching Eggs.
-    // In FRLG & Emerald, this controls Mew & Deoxys obedience and whether they can be traded.
-    // If set, a Pokémon is a fateful encounter in FRLG's summary screen if hatched & for all Pokémon in Gen 4+ summary screens.
-    // Set for in-game event island legendaries, events distributed after a certain date, & Pokémon from XD: Gale of Darkness.
-    // Not to be confused with METLOC_FATEFUL_ENCOUNTER.
-    u32 modernFatefulEncounter:1;
+            // The functionality of this bit changed in FRLG:
+            // In RS, this bit does nothing, is never set, & is accidentally unset when hatching Eggs.
+            // In FRLG & Emerald, this controls Mew & Deoxys obedience and whether they can be traded.
+            // If set, a Pokémon is a fateful encounter in FRLG's summary screen if hatched & for all Pokémon in Gen 4+ summary screens.
+            // Set for in-game event island legendaries, events distributed after a certain date, & Pokémon from XD: Gale of Darkness.
+            // Not to be confused with METLOC_FATEFUL_ENCOUNTER.
+            u32 modernFatefulEncounter:1;
+        };
+    };
 };
 
 // Number of bytes in the largest Pokémon substruct.

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -232,6 +232,14 @@ struct PokemonSubstruct3
                              max(sizeof(struct PokemonSubstruct2),     \
                                  sizeof(struct PokemonSubstruct3)))))
 
+enum SubstructType
+{
+    SUBSTRUCT_TYPE_0,
+    SUBSTRUCT_TYPE_1,
+    SUBSTRUCT_TYPE_2,
+    SUBSTRUCT_TYPE_3,
+};
+
 union PokemonSubstruct
 {
     struct PokemonSubstruct0 type0;
@@ -260,7 +268,7 @@ struct BoxPokemon
     u16 checksum;
     u16 hpLost:14; // 16383 HP.
     u16 shinyModifier:1;
-    u16 unused_1E:1;
+    u16 unencrypted:1; // Saved mons always encrypted - gPlayerParty etc mons are not
 
     union
     {
@@ -879,6 +887,7 @@ u32 GetRegionalFormByRegion(u32 species, u32 region);
 bool32 IsSpeciesForeignRegionalForm(u32 species, u32 currentRegion);
 u32 GetTeraTypeFromPersonality(struct Pokemon *mon);
 struct Pokemon *GetSavedPlayerPartyMon(u32 index);
+void LoadSavedPlayerPartyMon(u32 index);
 u8 *GetSavedPlayerPartyCount(void);
 void SavePlayerPartyMon(u32 index, struct Pokemon *mon);
 

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -756,8 +756,16 @@ u32 GetMonData2(struct Pokemon *mon, s32 field);
 u32 GetBoxMonData3(struct BoxPokemon *boxMon, s32 field, u8 *data);
 u32 GetBoxMonData2(struct BoxPokemon *boxMon, s32 field);
 
-void SetMonData(struct Pokemon *mon, s32 field, const void *dataArg);
-void SetBoxMonData(struct BoxPokemon *boxMon, s32 field, const void *dataArg);
+union TRANSPARENT SetMonDataArg
+{
+    const void *any;
+    u8 *byte;
+    u16 *hWord;
+    u32 *word;
+};
+
+void SetMonData(struct Pokemon *mon, s32 field, union SetMonDataArg dataArg);
+void SetBoxMonData(struct BoxPokemon *boxMon, s32 field, union SetMonDataArg dataArg);
 void CopyMon(void *dest, void *src, size_t size);
 u8 GiveMonToPlayer(struct Pokemon *mon);
 u8 CopyMonToPC(struct Pokemon *mon);

--- a/src/load_save.c
+++ b/src/load_save.c
@@ -184,7 +184,7 @@ void LoadPlayerParty(void)
     for (i = 0; i < PARTY_SIZE; i++)
     {
         u32 data;
-        gPlayerParty[i] = *GetSavedPlayerPartyMon(i);
+        LoadSavedPlayerPartyMon(i);
 
         // TODO: Turn this into a save migration once those are available.
         // At which point we can remove hp and status from Pokemon entirely.

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -1663,34 +1663,17 @@ static u16 CalculateBoxMonChecksum(struct BoxPokemon *boxMon)
     union PokemonSubstruct *substruct3 = GetSubstruct(boxMon, boxMon->personality, 3);
     s32 i;
 
-    if (boxMon->unencrypted)
-    {
-        for (i = 0; i < (s32)ARRAY_COUNT(substruct0->raw); i++)
-            checksum += (substruct0->raw[i] ^ boxMon->personality) ^ boxMon->otId;
+    for (i = 0; i < (s32)ARRAY_COUNT(substruct0->raw); i++)
+        checksum += substruct0->raw[i];
 
-        for (i = 0; i < (s32)ARRAY_COUNT(substruct1->raw); i++)
-            checksum += (substruct1->raw[i] ^ boxMon->personality) ^ boxMon->otId;
+    for (i = 0; i < (s32)ARRAY_COUNT(substruct1->raw); i++)
+        checksum += substruct1->raw[i];
 
-        for (i = 0; i < (s32)ARRAY_COUNT(substruct2->raw); i++)
-            checksum += (substruct2->raw[i] ^ boxMon->personality) ^ boxMon->otId;
+    for (i = 0; i < (s32)ARRAY_COUNT(substruct2->raw); i++)
+        checksum += substruct2->raw[i];
 
-        for (i = 0; i < (s32)ARRAY_COUNT(substruct3->raw); i++)
-            checksum += (substruct3->raw[i] ^ boxMon->personality) ^ boxMon->otId;
-    }
-    else
-    {
-        for (i = 0; i < (s32)ARRAY_COUNT(substruct0->raw); i++)
-            checksum += substruct0->raw[i];
-
-        for (i = 0; i < (s32)ARRAY_COUNT(substruct1->raw); i++)
-            checksum += substruct1->raw[i];
-
-        for (i = 0; i < (s32)ARRAY_COUNT(substruct2->raw); i++)
-            checksum += substruct2->raw[i];
-
-        for (i = 0; i < (s32)ARRAY_COUNT(substruct3->raw); i++)
-            checksum += substruct3->raw[i];
-    }
+    for (i = 0; i < (s32)ARRAY_COUNT(substruct3->raw); i++)
+        checksum += substruct3->raw[i];
 
     return checksum;
 }

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -2393,7 +2393,7 @@ static bool32 IsBadEgg(struct BoxPokemon *boxMon)
 
 static ALWAYS_INLINE bool32 IsEggOrBadEgg(struct BoxPokemon *boxMon)
 {
-    return IsBadEgg(boxMon) || GetSubstruct3(boxMon)->isEgg;
+    return GetSubstruct3(boxMon)->isEgg || IsBadEgg(boxMon);
 }
 
 /* GameFreak called GetBoxMonData with either 2 or 3 arguments, for type
@@ -2486,7 +2486,7 @@ u32 GetBoxMonData3(struct BoxPokemon *boxMon, s32 field, u8 *data)
             break;
         }
         case MON_DATA_SPECIES:
-            retVal = boxMon->isBadEgg ? SPECIES_EGG : GetSubstruct0(boxMon)->species;
+            retVal = IsBadEgg(boxMon) ? SPECIES_EGG : GetSubstruct0(boxMon)->species;
             break;
         case MON_DATA_HELD_ITEM:
             retVal = GetSubstruct0(boxMon)->heldItem;
@@ -2793,7 +2793,7 @@ u32 GetBoxMonData3(struct BoxPokemon *boxMon, s32 field, u8 *data)
             retVal = boxMon->language;
             break;
         case MON_DATA_SANITY_IS_BAD_EGG:
-            retVal = boxMon->isBadEgg;
+            retVal = IsBadEgg(boxMon);
             break;
         case MON_DATA_SANITY_HAS_SPECIES:
             retVal = boxMon->hasSpecies;

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -2844,14 +2844,12 @@ u32 GetBoxMonData2(struct BoxPokemon *boxMon, s32 field)
     return GetBoxMonData3(boxMon, field, NULL);
 }
 
-#define SET8(lhs) (lhs) = *data
-#define SET16(lhs) (lhs) = data[0] + (data[1] << 8)
-#define SET32(lhs) (lhs) = data[0] + (data[1] << 8) + (data[2] << 16) + (data[3] << 24)
+#define SET8(lhs) (lhs) = *dataArg.byte
+#define SET16(lhs) (lhs) = *dataArg.hWord
+#define SET32(lhs) (lhs) = *dataArg.word
 
-void SetMonData(struct Pokemon *mon, s32 field, const void *dataArg)
+void SetMonData(struct Pokemon *mon, s32 field, union SetMonDataArg dataArg)
 {
-    const u8 *data = dataArg;
-
     switch (field)
     {
     case MON_DATA_STATUS:
@@ -2901,15 +2899,13 @@ void SetMonData(struct Pokemon *mon, s32 field, const void *dataArg)
     case MON_DATA_SPECIES_OR_EGG:
         break;
     default:
-        SetBoxMonData(&mon->box, field, data);
+        SetBoxMonData(&mon->box, field, dataArg);
         break;
     }
 }
 
-void SetBoxMonData(struct BoxPokemon *boxMon, s32 field, const void *dataArg)
+void SetBoxMonData(struct BoxPokemon *boxMon, s32 field, union SetMonDataArg dataArg)
 {
-    const u8 *data = dataArg;
-
     if (field > MON_DATA_ENCRYPT_SEPARATOR)
     {
         if (!boxMon->unencrypted)
@@ -2933,13 +2929,13 @@ void SetBoxMonData(struct BoxPokemon *boxMon, s32 field, const void *dataArg)
             s32 i;
             struct PokemonSubstruct0 *substruct0 = GetSubstruct0(boxMon);
             for (i = 0; i < min(sizeof(boxMon->nickname), POKEMON_NAME_LENGTH); i++)
-                boxMon->nickname[i] = data[i];
+                boxMon->nickname[i] = dataArg.byte[i];
             if (field != MON_DATA_NICKNAME10)
             {
                 if (POKEMON_NAME_LENGTH >= 11)
-                    substruct0->nickname11 = data[10];
+                    substruct0->nickname11 = dataArg.byte[10];
                 if (POKEMON_NAME_LENGTH >= 12)
-                    substruct0->nickname12 = data[11];
+                    substruct0->nickname12 = dataArg.byte[11];
             }
             else
             {
@@ -3211,7 +3207,7 @@ void SetBoxMonData(struct BoxPokemon *boxMon, s32 field, const void *dataArg)
         {
             s32 i;
             for (i = 0; i < PLAYER_NAME_LENGTH; i++)
-                boxMon->otName[i] = data[i];
+                boxMon->otName[i] = dataArg.byte[i];
             break;
         }
         case MON_DATA_MARKINGS:

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -1654,26 +1654,19 @@ void CreateEnemyEventMon(void)
     }
 }
 
+struct WordIn2
+{
+    u16 hWord1;
+    u16 hWord2;
+};
+
 static u16 CalculateBoxMonChecksum(struct BoxPokemon *boxMon)
 {
     u16 checksum = 0;
-    union PokemonSubstruct *substruct0 = GetSubstruct(boxMon, boxMon->personality, 0);
-    union PokemonSubstruct *substruct1 = GetSubstruct(boxMon, boxMon->personality, 1);
-    union PokemonSubstruct *substruct2 = GetSubstruct(boxMon, boxMon->personality, 2);
-    union PokemonSubstruct *substruct3 = GetSubstruct(boxMon, boxMon->personality, 3);
-    s32 i;
+    struct WordIn2 *raw = (struct WordIn2 *)boxMon->secure.raw;
 
-    for (i = 0; i < (s32)ARRAY_COUNT(substruct0->raw); i++)
-        checksum += substruct0->raw[i];
-
-    for (i = 0; i < (s32)ARRAY_COUNT(substruct1->raw); i++)
-        checksum += substruct1->raw[i];
-
-    for (i = 0; i < (s32)ARRAY_COUNT(substruct2->raw); i++)
-        checksum += substruct2->raw[i];
-
-    for (i = 0; i < (s32)ARRAY_COUNT(substruct3->raw); i++)
-        checksum += substruct3->raw[i];
+    for (u32 i = 0; i < ARRAY_COUNT(boxMon->secure.raw); i++, raw++)
+        checksum += (raw->hWord1 + raw->hWord2);
 
     return checksum;
 }
@@ -2359,22 +2352,22 @@ union EvolutionTracker
 
 static ALWAYS_INLINE struct PokemonSubstruct0 *GetSubstruct0(struct BoxPokemon *boxMon)
 {
-    return &GetSubstruct(boxMon, boxMon->personality, 0)->type0;
+    return boxMon->unencrypted ? &boxMon->secure.substructs[SUBSTRUCT_TYPE_0].type0 : &(GetSubstruct(boxMon, boxMon->personality, SUBSTRUCT_TYPE_0))->type0;
 }
 
 static ALWAYS_INLINE struct PokemonSubstruct1 *GetSubstruct1(struct BoxPokemon *boxMon)
 {
-    return &GetSubstruct(boxMon, boxMon->personality, 1)->type1;
+    return boxMon->unencrypted ? &boxMon->secure.substructs[SUBSTRUCT_TYPE_1].type1 : &(GetSubstruct(boxMon, boxMon->personality, SUBSTRUCT_TYPE_1))->type1;
 }
 
 static ALWAYS_INLINE struct PokemonSubstruct2 *GetSubstruct2(struct BoxPokemon *boxMon)
 {
-    return &GetSubstruct(boxMon, boxMon->personality, 2)->type2;
+    return boxMon->unencrypted ? &boxMon->secure.substructs[SUBSTRUCT_TYPE_2].type2 : &(GetSubstruct(boxMon, boxMon->personality, SUBSTRUCT_TYPE_2))->type2;
 }
 
 static ALWAYS_INLINE struct PokemonSubstruct3 *GetSubstruct3(struct BoxPokemon *boxMon)
 {
-    return &GetSubstruct(boxMon, boxMon->personality, 3)->type3;
+    return boxMon->unencrypted ? &boxMon->secure.substructs[SUBSTRUCT_TYPE_3].type3 : &(GetSubstruct(boxMon, boxMon->personality, SUBSTRUCT_TYPE_3))->type3;
 }
 
 static bool32 IsBadEgg(struct BoxPokemon *boxMon)

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -2910,26 +2910,18 @@ void SetBoxMonData(struct BoxPokemon *boxMon, s32 field, const void *dataArg)
 {
     const u8 *data = dataArg;
 
-    struct PokemonSubstruct0 *substruct0 = NULL;
-    struct PokemonSubstruct1 *substruct1 = NULL;
-    struct PokemonSubstruct2 *substruct2 = NULL;
-    struct PokemonSubstruct3 *substruct3 = NULL;
-
     if (field > MON_DATA_ENCRYPT_SEPARATOR)
     {
-        substruct0 = &(GetSubstruct(boxMon, boxMon->personality, 0)->type0);
-        substruct1 = &(GetSubstruct(boxMon, boxMon->personality, 1)->type1);
-        substruct2 = &(GetSubstruct(boxMon, boxMon->personality, 2)->type2);
-        substruct3 = &(GetSubstruct(boxMon, boxMon->personality, 3)->type3);
-
-        DecryptBoxMon(boxMon);
+        if (!boxMon->unencrypted)
+            DecryptBoxMon(boxMon);
 
         if (CalculateBoxMonChecksum(boxMon) != boxMon->checksum)
         {
             boxMon->isBadEgg = TRUE;
             boxMon->isEgg = TRUE;
-            substruct3->isEgg = TRUE;
-            EncryptBoxMon(boxMon);
+            GetSubstruct3(boxMon)->isEgg = TRUE;
+            if (!boxMon->unencrypted)
+                EncryptBoxMon(boxMon);
             return;
         }
 
@@ -2939,6 +2931,7 @@ void SetBoxMonData(struct BoxPokemon *boxMon, s32 field, const void *dataArg)
         case MON_DATA_NICKNAME10:
         {
             s32 i;
+            struct PokemonSubstruct0 *substruct0 = GetSubstruct0(boxMon);
             for (i = 0; i < min(sizeof(boxMon->nickname), POKEMON_NAME_LENGTH); i++)
                 boxMon->nickname[i] = data[i];
             if (field != MON_DATA_NICKNAME10)
@@ -2957,6 +2950,7 @@ void SetBoxMonData(struct BoxPokemon *boxMon, s32 field, const void *dataArg)
         }
         case MON_DATA_SPECIES:
         {
+            struct PokemonSubstruct0 *substruct0 = GetSubstruct0(boxMon);
             SET16(substruct0->species);
             if (substruct0->species)
                 boxMon->hasSpecies = TRUE;
@@ -2965,222 +2959,211 @@ void SetBoxMonData(struct BoxPokemon *boxMon, s32 field, const void *dataArg)
             break;
         }
         case MON_DATA_HELD_ITEM:
-            SET16(substruct0->heldItem);
+            SET16(GetSubstruct0(boxMon)->heldItem);
             break;
         case MON_DATA_EXP:
-            SET32(substruct0->experience);
+            SET32(GetSubstruct0(boxMon)->experience);
             break;
         case MON_DATA_PP_BONUSES:
-            SET8(substruct0->ppBonuses);
+            SET8(GetSubstruct0(boxMon)->ppBonuses);
             break;
         case MON_DATA_FRIENDSHIP:
-            SET8(substruct0->friendship);
+            SET8(GetSubstruct0(boxMon)->friendship);
             break;
         case MON_DATA_MOVE1:
-            SET16(substruct1->move1);
+            SET16(GetSubstruct1(boxMon)->move1);
             break;
         case MON_DATA_MOVE2:
-            SET16(substruct1->move2);
+            SET16(GetSubstruct1(boxMon)->move2);
             break;
         case MON_DATA_MOVE3:
-            SET16(substruct1->move3);
+            SET16(GetSubstruct1(boxMon)->move3);
             break;
         case MON_DATA_MOVE4:
-            SET16(substruct1->move4);
+            SET16(GetSubstruct1(boxMon)->move4);
             break;
         case MON_DATA_PP1:
-            SET8(substruct1->pp1);
+            SET8(GetSubstruct1(boxMon)->pp1);
             break;
         case MON_DATA_PP2:
-            SET8(substruct1->pp2);
+            SET8(GetSubstruct1(boxMon)->pp2);
             break;
         case MON_DATA_PP3:
-            SET8(substruct1->pp3);
+            SET8(GetSubstruct1(boxMon)->pp3);
             break;
         case MON_DATA_PP4:
-            SET8(substruct1->pp4);
+            SET8(GetSubstruct1(boxMon)->pp4);
             break;
         case MON_DATA_HP_EV:
-            SET8(substruct2->hpEV);
+            SET8(GetSubstruct2(boxMon)->hpEV);
             break;
         case MON_DATA_ATK_EV:
-            SET8(substruct2->attackEV);
+            SET8(GetSubstruct2(boxMon)->attackEV);
             break;
         case MON_DATA_DEF_EV:
-            SET8(substruct2->defenseEV);
+            SET8(GetSubstruct2(boxMon)->defenseEV);
             break;
         case MON_DATA_SPEED_EV:
-            SET8(substruct2->speedEV);
+            SET8(GetSubstruct2(boxMon)->speedEV);
             break;
         case MON_DATA_SPATK_EV:
-            SET8(substruct2->spAttackEV);
+            SET8(GetSubstruct2(boxMon)->spAttackEV);
             break;
         case MON_DATA_SPDEF_EV:
-            SET8(substruct2->spDefenseEV);
+            SET8(GetSubstruct2(boxMon)->spDefenseEV);
             break;
         case MON_DATA_COOL:
-            SET8(substruct2->cool);
+            SET8(GetSubstruct2(boxMon)->cool);
             break;
         case MON_DATA_BEAUTY:
-            SET8(substruct2->beauty);
+            SET8(GetSubstruct2(boxMon)->beauty);
             break;
         case MON_DATA_CUTE:
-            SET8(substruct2->cute);
+            SET8(GetSubstruct2(boxMon)->cute);
             break;
         case MON_DATA_SMART:
-            SET8(substruct2->smart);
+            SET8(GetSubstruct2(boxMon)->smart);
             break;
         case MON_DATA_TOUGH:
-            SET8(substruct2->tough);
+            SET8(GetSubstruct2(boxMon)->tough);
             break;
         case MON_DATA_SHEEN:
-            SET8(substruct2->sheen);
+            SET8(GetSubstruct2(boxMon)->sheen);
             break;
         case MON_DATA_POKERUS:
-            SET8(substruct3->pokerus);
+            SET8(GetSubstruct3(boxMon)->pokerus);
             break;
         case MON_DATA_MET_LOCATION:
-            SET8(substruct3->metLocation);
+            SET8(GetSubstruct3(boxMon)->metLocation);
             break;
         case MON_DATA_MET_LEVEL:
-            SET8(substruct3->metLevel);
+            SET8(GetSubstruct3(boxMon)->metLevel);
             break;
         case MON_DATA_MET_GAME:
-            SET8(substruct3->metGame);
+            SET8(GetSubstruct3(boxMon)->metGame);
             break;
         case MON_DATA_POKEBALL:
-            SET8(substruct0->pokeball);
+            SET8(GetSubstruct0(boxMon)->pokeball);
             break;
         case MON_DATA_OT_GENDER:
-            SET8(substruct3->otGender);
+            SET8(GetSubstruct3(boxMon)->otGender);
             break;
         case MON_DATA_HP_IV:
-            SET8(substruct3->hpIV);
+            SET8(GetSubstruct3(boxMon)->hpIV);
             break;
         case MON_DATA_ATK_IV:
-            SET8(substruct3->attackIV);
+            SET8(GetSubstruct3(boxMon)->attackIV);
             break;
         case MON_DATA_DEF_IV:
-            SET8(substruct3->defenseIV);
+            SET8(GetSubstruct3(boxMon)->defenseIV);
             break;
         case MON_DATA_SPEED_IV:
-            SET8(substruct3->speedIV);
+            SET8(GetSubstruct3(boxMon)->speedIV);
             break;
         case MON_DATA_SPATK_IV:
-            SET8(substruct3->spAttackIV);
+            SET8(GetSubstruct3(boxMon)->spAttackIV);
             break;
         case MON_DATA_SPDEF_IV:
-            SET8(substruct3->spDefenseIV);
+            SET8(GetSubstruct3(boxMon)->spDefenseIV);
             break;
         case MON_DATA_IS_EGG:
-            SET8(substruct3->isEgg);
-            if (substruct3->isEgg)
-                boxMon->isEgg = TRUE;
-            else
-                boxMon->isEgg = FALSE;
+            SET8(GetSubstruct3(boxMon)->isEgg);
+            SET8(boxMon->isEgg);
             break;
         case MON_DATA_ABILITY_NUM:
-            SET8(substruct3->abilityNum);
+            SET8(GetSubstruct3(boxMon)->abilityNum);
             break;
         case MON_DATA_COOL_RIBBON:
-            SET8(substruct3->coolRibbon);
+            SET8(GetSubstruct3(boxMon)->coolRibbon);
             break;
         case MON_DATA_BEAUTY_RIBBON:
-            SET8(substruct3->beautyRibbon);
+            SET8(GetSubstruct3(boxMon)->beautyRibbon);
             break;
         case MON_DATA_CUTE_RIBBON:
-            SET8(substruct3->cuteRibbon);
+            SET8(GetSubstruct3(boxMon)->cuteRibbon);
             break;
         case MON_DATA_SMART_RIBBON:
-            SET8(substruct3->smartRibbon);
+            SET8(GetSubstruct3(boxMon)->smartRibbon);
             break;
         case MON_DATA_TOUGH_RIBBON:
-            SET8(substruct3->toughRibbon);
+            SET8(GetSubstruct3(boxMon)->toughRibbon);
             break;
         case MON_DATA_CHAMPION_RIBBON:
-            SET8(substruct3->championRibbon);
+            SET8(GetSubstruct3(boxMon)->championRibbon);
             break;
         case MON_DATA_WINNING_RIBBON:
-            SET8(substruct3->winningRibbon);
+            SET8(GetSubstruct3(boxMon)->winningRibbon);
             break;
         case MON_DATA_VICTORY_RIBBON:
-            SET8(substruct3->victoryRibbon);
+            SET8(GetSubstruct3(boxMon)->victoryRibbon);
             break;
         case MON_DATA_ARTIST_RIBBON:
-            SET8(substruct3->artistRibbon);
+            SET8(GetSubstruct3(boxMon)->artistRibbon);
             break;
         case MON_DATA_EFFORT_RIBBON:
-            SET8(substruct3->effortRibbon);
+            SET8(GetSubstruct3(boxMon)->effortRibbon);
             break;
         case MON_DATA_MARINE_RIBBON:
-            SET8(substruct3->marineRibbon);
+            SET8(GetSubstruct3(boxMon)->marineRibbon);
             break;
         case MON_DATA_LAND_RIBBON:
-            SET8(substruct3->landRibbon);
+            SET8(GetSubstruct3(boxMon)->landRibbon);
             break;
         case MON_DATA_SKY_RIBBON:
-            SET8(substruct3->skyRibbon);
+            SET8(GetSubstruct3(boxMon)->skyRibbon);
             break;
         case MON_DATA_COUNTRY_RIBBON:
-            SET8(substruct3->countryRibbon);
+            SET8(GetSubstruct3(boxMon)->countryRibbon);
             break;
         case MON_DATA_NATIONAL_RIBBON:
-            SET8(substruct3->nationalRibbon);
+            SET8(GetSubstruct3(boxMon)->nationalRibbon);
             break;
         case MON_DATA_EARTH_RIBBON:
-            SET8(substruct3->earthRibbon);
+            SET8(GetSubstruct3(boxMon)->earthRibbon);
             break;
         case MON_DATA_WORLD_RIBBON:
-            SET8(substruct3->worldRibbon);
+            SET8(GetSubstruct3(boxMon)->worldRibbon);
             break;
         case MON_DATA_MODERN_FATEFUL_ENCOUNTER:
-            SET8(substruct3->modernFatefulEncounter);
+            SET8(GetSubstruct3(boxMon)->modernFatefulEncounter);
             break;
         case MON_DATA_IVS:
-        {
-            u32 ivs;
-            SET32(ivs);
-            substruct3->hpIV = ivs & MAX_IV_MASK;
-            substruct3->attackIV = (ivs >> 5) & MAX_IV_MASK;
-            substruct3->defenseIV = (ivs >> 10) & MAX_IV_MASK;
-            substruct3->speedIV = (ivs >> 15) & MAX_IV_MASK;
-            substruct3->spAttackIV = (ivs >> 20) & MAX_IV_MASK;
-            substruct3->spDefenseIV = (ivs >> 25) & MAX_IV_MASK;
+            SET32(GetSubstruct3(boxMon)->ivs);
             break;
-        }
         case MON_DATA_HYPER_TRAINED_HP:
-            SET8(substruct1->hyperTrainedHP);
+            SET8(GetSubstruct1(boxMon)->hyperTrainedHP);
             break;
         case MON_DATA_HYPER_TRAINED_ATK:
-            SET8(substruct1->hyperTrainedAttack);
+            SET8(GetSubstruct1(boxMon)->hyperTrainedAttack);
             break;
         case MON_DATA_HYPER_TRAINED_DEF:
-            SET8(substruct1->hyperTrainedDefense);
+            SET8(GetSubstruct1(boxMon)->hyperTrainedDefense);
             break;
         case MON_DATA_HYPER_TRAINED_SPEED:
-            SET8(substruct1->hyperTrainedSpeed);
+            SET8(GetSubstruct1(boxMon)->hyperTrainedSpeed);
             break;
         case MON_DATA_HYPER_TRAINED_SPATK:
-            SET8(substruct1->hyperTrainedSpAttack);
+            SET8(GetSubstruct1(boxMon)->hyperTrainedSpAttack);
             break;
         case MON_DATA_HYPER_TRAINED_SPDEF:
-            SET8(substruct1->hyperTrainedSpDefense);
+            SET8(GetSubstruct1(boxMon)->hyperTrainedSpDefense);
             break;
         case MON_DATA_IS_SHADOW:
-            SET8(substruct3->isShadow);
+            SET8(GetSubstruct3(boxMon)->isShadow);
             break;
         case MON_DATA_DYNAMAX_LEVEL:
-            SET8(substruct3->dynamaxLevel);
+            SET8(GetSubstruct3(boxMon)->dynamaxLevel);
             break;
         case MON_DATA_GIGANTAMAX_FACTOR:
-            SET8(substruct3->gigantamaxFactor);
+            SET8(GetSubstruct3(boxMon)->gigantamaxFactor);
             break;
         case MON_DATA_TERA_TYPE:
-            SET8(substruct0->teraType);
+            SET8(GetSubstruct0(boxMon)->teraType);
             break;
         case MON_DATA_EVOLUTION_TRACKER:
         {
             union EvolutionTracker evoTracker;
+            struct PokemonSubstruct1 *substruct1 = GetSubstruct1(boxMon);
             u32 evoTrackerValue;
             SET32(evoTrackerValue);
             evoTracker.value = evoTrackerValue;


### PR DESCRIPTION
## Description
As the title suggests, updated loading/saving player party info to decrypt and re-encrypt respectively. Involves NO changes to the Pokemon struct other than repurposing an unused bit to mark encrypted and unencrypted data and no other optimisations. For the sake of type checking, introduces SUBSTRUCT_TYPE_N enums.

Draft for now as besides saving and loading, I have done no testing whatsoever.

## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, closes #2222." Remove this section if not applicable.-->

## Feature(s) this PR does NOT handle:
Does absolutely no refactoring of the Pokemon struct, but it does present a golden opportunity to do so since it breaks encryption.

## Discord contact info
Cringe Fairy/thechurchofcage