### PR TITLE
Ally Switch swap gLastX values

### DIFF
--- a/src/battle_anim_effects_1.c
+++ b/src/battle_anim_effects_1.c
@@ -6864,6 +6864,25 @@ static void TrySwapWishBattlerIds(u32 battlerAtk, u32 battlerPartner)
         SWAP(gWishFutureKnock.wishPartyId[battlerAtk], gWishFutureKnock.wishPartyId[battlerPartner], temp);
 }
 
+static void SwapBattlerMoveData(u32 battler1, u32 battler2)
+{
+    u32 temp;
+    SWAP(gBattleStruct->chosenMovePositions[battler1], gBattleStruct->chosenMovePositions[battler2], temp);
+    SWAP(gChosenMoveByBattler[battler1], gChosenMoveByBattler[battler2], temp);
+    SWAP(gBattleStruct->moveTarget[battler1], gBattleStruct->moveTarget[battler2], temp);
+    SWAP(gMoveSelectionCursor[battler1], gMoveSelectionCursor[battler2], temp);
+    SWAP(gLockedMoves[battler1], gLockedMoves[battler2], temp);
+    
+    // update last moves
+    SWAP(gLastPrintedMoves[battler1],   gLastPrintedMoves[battler2], temp);
+    SWAP(gLastMoves[battler1],          gLastMoves[battler2], temp);
+    SWAP(gLastLandedMoves[battler1],    gLastLandedMoves[battler2], temp);
+    SWAP(gLastHitByType[battler1],      gLastHitByType[battler2], temp);
+    SWAP(gLastUsedMoveType[battler1],   gLastUsedMoveType[battler2], temp);
+    SWAP(gLastResultingMoves[battler1], gLastResultingMoves[battler2], temp);
+    SWAP(gLastHitBy[battler1],          gLastHitBy[battler2], temp);
+}
+
 static void AnimTask_AllySwitchDataSwap(u8 taskId)
 {
     s32 i, j;
@@ -6890,11 +6909,9 @@ static void AnimTask_AllySwitchDataSwap(u8 taskId)
     SWAP(gTransformedShininess[battlerAtk], gTransformedShininess[battlerPartner], temp);
     SWAP(gStatuses3[battlerAtk], gStatuses3[battlerPartner], temp);
     SWAP(gStatuses4[battlerAtk], gStatuses4[battlerPartner], temp);
-    SWAP(gBattleStruct->chosenMovePositions[battlerAtk], gBattleStruct->chosenMovePositions[battlerPartner], temp);
-    SWAP(gChosenMoveByBattler[battlerAtk], gChosenMoveByBattler[battlerPartner], temp);
-    SWAP(gLockedMoves[battlerAtk], gLockedMoves[battlerPartner], temp);
-    SWAP(gBattleStruct->moveTarget[battlerAtk], gBattleStruct->moveTarget[battlerPartner], temp);
-    SWAP(gMoveSelectionCursor[battlerAtk], gMoveSelectionCursor[battlerPartner], temp);
+    
+    SwapBattlerMoveData(battlerAtk, battlerPartner);
+    
     // Swap turn order, so that all the battlers take action
     SWAP(gChosenActionByBattler[battlerAtk], gChosenActionByBattler[battlerPartner], temp);
     for (i = 0; i < gBattlersCount; i++)

--- a/test/battle/move_effect/ally_switch.c
+++ b/test/battle/move_effect/ally_switch.c
@@ -311,5 +311,27 @@ DOUBLE_BATTLE_TEST("Ally Switch swaps Illusion data")
     }
 }
 
+DOUBLE_BATTLE_TEST("Ally switch updates last used moves for Mimic")
+{
+    GIVEN {
+        PLAYER(SPECIES_XATU)     { Speed(100); }
+        PLAYER(SPECIES_RIOLU)    { Speed(150); }
+        OPPONENT(SPECIES_FEAROW) { Speed(20); }
+        OPPONENT(SPECIES_ARON)   { Speed(30); }
+    } WHEN {
+        TURN { MOVE(playerRight, MOVE_FAKE_OUT, target: opponentRight); MOVE(playerLeft, MOVE_ALLY_SWITCH); 
+               MOVE(opponentLeft, MOVE_MIMIC, target: playerLeft);
+             }
+    } SCENE {
+        MESSAGE("Riolu used Fake Out!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FAKE_OUT, playerRight);
+        MESSAGE("Xatu used Ally Switch!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ALLY_SWITCH, playerLeft);
+        MESSAGE("Xatu and Riolu switched places!");
+        MESSAGE("The opposing Fearow used Mimic!");
+        MESSAGE("The opposing Fearow learned Fake Out!");
+    }
+}
+
 // Triple Battles required to test
 //TO_DO_BATTLE_TEST("Ally Switch fails if the user is in the middle of the field in a Triple Battle");


### PR DESCRIPTION
gLastUsedMove, for example, needed to be updated with Ally Switch for proper future references. A mimic example test is added

Added a SwapBattlerMoveData function to help group swapped data a bit more