### PR TITLE
Add make release target

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -1,0 +1,2 @@
+# Enable LTO when making a release build. Disable by setting to 0.
+USE_LTO_ON_RELEASE ?= 1

--- a/include/config/debug.h
+++ b/include/config/debug.h
@@ -2,16 +2,16 @@
 #define GUARD_CONFIG_DEBUG_H
 
 // Overworld Debug
-#define DEBUG_OVERWORLD_MENU            TRUE                // Enables an overworld debug menu to change flags, variables, giving pokemon and more, accessed by holding R and pressing START while in the overworld by default.
+#define DEBUG_OVERWORLD_MENU            DISABLED_ON_RELEASE // Enables an overworld debug menu to change flags, variables, giving pokemon and more, accessed by holding R and pressing START while in the overworld by default.
 #define DEBUG_OVERWORLD_HELD_KEYS       (R_BUTTON)          // The keys required to be held to open the debug menu.
 #define DEBUG_OVERWORLD_TRIGGER_EVENT   pressedStartButton  // The event that opens the menu when holding the key(s) defined in DEBUG_OVERWORLD_HELD_KEYS.
 #define DEBUG_OVERWORLD_IN_MENU         FALSE               // Replaces the overworld debug menu button combination with a start menu entry (above Pokédex).
 
 // Battle Debug Menu
-#define DEBUG_BATTLE_MENU               TRUE    // If set to TRUE, enables a debug menu to use in battles by pressing the Select button.
+#define DEBUG_BATTLE_MENU               DISABLED_ON_RELEASE // If set to TRUE, enables a debug menu to use in battles by pressing the Select button.
 #define DEBUG_AI_DELAY_TIMER            FALSE   // If set to TRUE, displays the number of frames it takes for the AI to choose a move. Replaces the "What will PKMN do" text. Useful for devs or anyone who modifies the AI code and wants to see if it doesn't take too long to run.
 
 // Pokémon Debug
-#define DEBUG_POKEMON_SPRITE_VISUALIZER TRUE    // Enables a debug menu for Pokémon sprites and icons, accessed by pressing Select in the summary screen.
+#define DEBUG_POKEMON_SPRITE_VISUALIZER DISABLED_ON_RELEASE // Enables a debug menu for Pokémon sprites and icons, accessed by pressing Select in the summary screen.
 
 #endif // GUARD_CONFIG_DEBUG_H

--- a/include/config/general.h
+++ b/include/config/general.h
@@ -6,11 +6,16 @@
 // still has them in the ROM. This is because the developers forgot
 // to define NDEBUG before release, however this has been changed as
 // Ruby's actual debug build does not use the AGBPrint features.
+// 
+// Use `make release` to automatically enable NDEBUG.
+#ifdef RELEASE
 #define NDEBUG
+#endif
 
-// To enable printf debugging, comment out "#define NDEBUG". This allows
+// printf debugging is now enabled by default. This allows
 // the various AGBPrint functions to be used. (See include/gba/isagbprint.h).
 // See below for enabling different pretty printing versions.
+// To disable printf debugging, build a release build using `make release`.
 
 #ifndef NDEBUG
 

--- a/include/constants/global.h
+++ b/include/constants/global.h
@@ -1,6 +1,21 @@
 #ifndef GUARD_CONSTANTS_GLOBAL_H
 #define GUARD_CONSTANTS_GLOBAL_H
 
+// You can use the ENABLED_ON_RELEASE and DISABLED_ON_RELEASE macros to
+// control whether a feature is enabled or disabled when making a release build.
+// 
+// For example, the overworld debug menu is enabled by default, but when using
+// `make release`, it will be automatically disabled.
+// 
+// #define DEBUG_OVERWORLD_MENU DISABLED_ON_RELEASE
+#ifdef RELEASE
+#define ENABLED_ON_RELEASE TRUE
+#define DISABLED_ON_RELEASE FALSE
+#else
+#define ENABLED_ON_RELEASE FALSE
+#define DISABLED_ON_RELEASE TRUE
+#endif
+
 #include "config/general.h"
 #include "config/battle.h"
 #include "config/debug.h"


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
Adds a `release` target to the Makefile, with functionality to disable debugging features automatically. Enables LTO by default for release builds.

Building with the `release` target will use a separate `build/modern-release` directory. The output binaries and map files will also be set to have `-release` appended to their names.

Also adds `ENABLED_ON_RELEASE` and `DISABLED_ON_RELEASE` macros to allow for easy enabling/disabling of features depending on whether the current build is a release build or not. This PR only changes the following macros to be automatically disabled for release builds:
- `DEBUG_OVERWORLD_MENU`
- `DEBUG_BATTLE_MENU`
- `DEBUG_POKEMON_SPRITE_VISUALIZER`

This PR also changes `NDEBUG` to no longer be defined by default. Instead, it will automatically be defined only when making a release build.

I also created a `config.mk` file to allow customizing whether `make release` also enables LTO. Currently there's only one config option there, but if we decide on keeping the `config.mk` file, there's probably other config options that could be moved there from the Makefile.

The reasons I decided on `config.mk`:
1. The place where LTO is enabled on RELEASE is deep in the Makefile, so it would be tricker to modify there, especially for those less experience with GNU make or the Makefile
2. Avoids extra clutter at the top of the Makefile with config options
3. Few people enjoy merge conflicts in the Makefile (or having to open it in general), so this is an attempt to minimize that

<!-- CREDITS -->
<!-- Once your PR is submitted, leave a comment asking the bot to add you to the credits. -->
<!-- If anybody helped with this PR, please encourage them to comment on your PR and ask the bot to add them to the credits. -->
<!-- EVERY contribution matters! -->
<!-- https://github.com/rh-hideout/pokeemerald-expansion/wiki/CREDITS.md-Frequently-Asked-Questions -->

## Discord contact info
te_on
Discussion thread: https://discord.com/channels/419213663107416084/1390796454645465088
