### PR TITLE
Fix crashing tests looping

### DIFF
--- a/include/test/battle.h
+++ b/include/test/battle.h
@@ -219,6 +219,17 @@
  *     {
  *         KNOWN_FAILING; // #2596.
  *
+ * KNOWN_CRASHING
+ * Marks a test as crashing due to a bug. If there is an issue number
+ * associated with the bug it should be included in a comment. If the
+ * test passes the developer will be notified to remove KNOWN_CRASHING.
+ * For example:
+ *     TEST("Crashes")
+ *     {
+ *         KNOWN_CRASHING; // #7255
+ *         void (*f)(void) = NULL;
+ *         f(); // Crashes!
+ *
  * PARAMETRIZE
  * Runs a test multiple times. i will be set to which parameter is
  * running, and results will contain an entry for each parameter, e.g.:

--- a/include/test/test.h
+++ b/include/test/test.h
@@ -54,6 +54,14 @@ struct TestRunnerState
     u32 timeoutSeconds;
 };
 
+struct PersistentTestRunnerState
+{
+    u32 address:28;
+    u32 state:1;
+    u32 expectCrash:1;
+    u32 unused_30:2;
+};
+
 extern const u8 gTestRunnerN;
 extern const u8 gTestRunnerI;
 extern const char gTestRunnerArgv[256];
@@ -71,11 +79,13 @@ extern const struct TestRunner gFunctionTestRunner;
 extern struct FunctionTestRunnerState *gFunctionTestRunnerState;
 
 extern struct TestRunnerState gTestRunnerState;
+extern struct PersistentTestRunnerState gPersistentTestRunnerState;
 
 void CB2_TestRunner(void);
 
 void Test_ExpectedResult(enum TestResult);
 void Test_ExpectLeaks(bool32);
+void Test_ExpectCrash(bool32);
 void Test_ExitWithResult(enum TestResult, u32 stopLine, const char *fmt, ...);
 u32 SourceLine(u32 sourceLineOffset);
 u32 SourceLineOffset(u32 sourceLine);
@@ -219,6 +229,9 @@ static inline struct Benchmark BenchmarkStop(void)
 
 #define KNOWN_LEAKING \
     Test_ExpectLeaks(TRUE)
+
+#define KNOWN_CRASHING \
+    Test_ExpectCrash(TRUE)
 
 #define PARAMETRIZE if (gFunctionTestRunnerState->parameters++ == gFunctionTestRunnerState->runParameter)
 

--- a/ld_script_test.ld
+++ b/ld_script_test.ld
@@ -6,9 +6,10 @@ gInitialMainCB2 = CB2_TestRunner;
 
 MEMORY
 {
-    EWRAM (rwx) : ORIGIN = 0x2000000, LENGTH = 256K
-    IWRAM (rwx) : ORIGIN = 0x3000000, LENGTH = 32K
-    ROM    (rx) : ORIGIN = 0x8000000, LENGTH = 32M
+    EWRAM            (rwx) : ORIGIN = 0x2000000, LENGTH = 256K
+    IWRAM            (rwx) : ORIGIN = 0x3000000, LENGTH = 0x7F00
+    IWRAM_PERSISTENT (rwx) : ORIGIN = 0x3007F00, LENGTH = 0x100
+    ROM               (rx) : ORIGIN = 0x8000000, LENGTH = 32M
 }
 
 SECTIONS {
@@ -60,13 +61,11 @@ SECTIONS {
     /* .persistent starts at 0x3007F00 */
     /* WARNING: This is the end of the IRQ stack, if there's too
      * much data it WILL be overwritten. */
-
-    . = 0x03007F00;
     .iwram.persistent (NOLOAD) :
     ALIGN(4)
     {
         test/*.o(.persistent);
-    } > IWRAM
+    } > IWRAM_PERSISTENT
 
     /* BEGIN ROM DATA */
     . = 0x8000000;
@@ -135,6 +134,7 @@ SECTIONS {
     ALIGN(4)
     {
         __start_tests = .;
+        test/test_test_runner.o(.tests); /* Sanity checks first. */
         test/*.o(.tests);
         __stop_tests = .;
         test/*.o(.text);

--- a/test/test_test_runner.c
+++ b/test/test_test_runner.c
@@ -1,0 +1,9 @@
+#include "global.h"
+#include "test/test.h"
+
+TEST("Tests resume after CRASH")
+{
+    KNOWN_CRASHING;
+    void (*f)(void) = NULL;
+    f();
+}


### PR DESCRIPTION
`.persistent` was incorrectly positioned in the linker script which meant that the `RegisterRamReset(RESET_ALL)` in `src/crt0.s` zeroed `sCurrentTest`, causing the crashing test to re-run.

## Issue(s) that this PR fixes
Fixes #7255