### PR TITLE
Improve AI's setup logic

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -1443,6 +1443,25 @@ bool32 CanAIFaintTarget(u32 battlerAtk, u32 battlerDef, u32 numHits)
     return FALSE;
 }
 
+bool32 CanAIKOTargetIfSturdyIgnored(u32 battlerAtk, u32 battlerDef)
+{
+    struct AiLogicData *aiData = gAiLogicData;
+    s32 moveIndex, dmg;
+    u16 *moves = GetMovesArray(battlerAtk);
+    u32 moveLimitations = aiData->moveLimitations[battlerAtk];
+
+    for (moveIndex = 0; moveIndex < MAX_MON_MOVES; moveIndex++)
+    {
+        if (IsMoveUnusable(moveIndex, moves[moveIndex], moveLimitations))
+            continue;
+        dmg = AI_GetDamage(battlerAtk, battlerDef, moveIndex, AI_ATTACKING, aiData);
+
+        if (gBattleMons[battlerDef].hp <= dmg && CanEndureHit(battlerAtk, battlerDef, moves[moveIndex]))
+            return TRUE;
+    }
+    return FALSE;
+}
+
 bool32 CanTargetMoveFaintAi(u32 move, u32 battlerDef, u32 battlerAtk, u32 nHits)
 {
     u32 indexSlot = GetMoveSlot(GetMovesArray(battlerDef), move);
@@ -4220,6 +4239,36 @@ bool32 IsRecycleEncouragedItem(u32 item)
     return FALSE;
 }
 
+bool32 HasMoveThatChangesKOThreshold(u32 battlerId, u32 noOfHitsToFaint, u32 aiIsFaster)
+{
+    s32 i;
+    u16 *moves = GetMovesArray(battlerId);
+
+    for (i = 0; i < MAX_MON_MOVES; i++)
+    {
+        if (moves[i] != MOVE_NONE && moves[i] != MOVE_UNAVAILABLE)
+        {
+            if (noOfHitsToFaint <= 2)
+            {
+                if (GetMovePriority(moves[i]) > 0)
+                    return TRUE;
+
+                switch (gMovesInfo[moves[i]].additionalEffects[i].moveEffect)
+                {
+                    case MOVE_EFFECT_SPD_MINUS_1:
+                    case MOVE_EFFECT_SPD_MINUS_2:
+                    {
+                        if(aiIsFaster)
+                            return TRUE;
+                    }
+                }
+            }
+        }
+    }
+
+    return FALSE;
+}
+
 static enum AIScore IncreaseStatUpScoreInternal(u32 battlerAtk, u32 battlerDef, enum StatChange statId, bool32 considerContrary)
 {
     enum AIScore tempScore = NO_INCREASE;
@@ -4266,6 +4315,14 @@ static enum AIScore IncreaseStatUpScoreInternal(u32 battlerAtk, u32 battlerDef, 
     if (gBattleMons[battlerAtk].statStages[statId] >= MAX_STAT_STAGE - 5 && (HasBattlerSideMoveWithEffect(battlerDef, EFFECT_HAZE)
         || HasBattlerSideMoveWithAdditionalEffect(battlerDef, MOVE_EFFECT_CLEAR_SMOG)
         || HasBattlerSideMoveWithAdditionalEffect(battlerDef, MOVE_EFFECT_HAZE)))
+        return NO_INCREASE;
+
+    // Don't increase stats if AI could KO target through Sturdy effect, as otherwise it always 2HKOs
+    if (CanAIKOTargetIfSturdyIgnored(battlerAtk, battlerDef))
+        return NO_INCREASE;
+
+    // Don't increase stats if player has a move that can change the KO threshold
+    if (HasMoveThatChangesKOThreshold(battlerDef, noOfHitsToFaint, aiIsFaster))
         return NO_INCREASE;
 
     // Predicting switch

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -1456,7 +1456,7 @@ bool32 CanAIKOTargetIfSturdyIgnored(u32 battlerAtk, u32 battlerDef)
             continue;
         dmg = AI_GetDamage(battlerAtk, battlerDef, moveIndex, AI_ATTACKING, aiData);
 
-        if (gBattleMons[battlerDef].hp <= dmg)
+        if (gBattleMons[battlerDef].hp <= dmg && CanEndureHit(battlerAtk, battlerDef, moves[moveIndex]))
             return TRUE;
     }
     return FALSE;

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -1443,7 +1443,8 @@ bool32 CanAIFaintTarget(u32 battlerAtk, u32 battlerDef, u32 numHits)
     return FALSE;
 }
 
-bool32 CanAIKOTargetIfSturdyIgnored(u32 battlerAtk, u32 battlerDef)
+// Can battler KO the target ignoring any Endure effects (Sturdy, Focus Sash, etc.)
+bool32 CanBattlerKOTargetIgnoringSturdy(u32 battlerAtk, u32 battlerDef)
 {
     struct AiLogicData *aiData = gAiLogicData;
     s32 moveIndex, dmg;
@@ -4317,7 +4318,7 @@ static enum AIScore IncreaseStatUpScoreInternal(u32 battlerAtk, u32 battlerDef, 
         return NO_INCREASE;
 
     // Don't increase stats if AI could KO target through Sturdy effect, as otherwise it always 2HKOs
-    if (CanAIKOTargetIfSturdyIgnored(battlerAtk, battlerDef))
+    if (CanBattlerKOTargetIgnoringSturdy(battlerAtk, battlerDef))
         return NO_INCREASE;
 
     // Don't increase stats if player has a move that can change the KO threshold

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -4246,21 +4246,20 @@ bool32 HasMoveThatChangesKOThreshold(u32 battlerId, u32 noOfHitsToFaint, u32 aiI
 
     for (i = 0; i < MAX_MON_MOVES; i++)
     {
-        if (moves[i] != MOVE_NONE && moves[i] != MOVE_UNAVAILABLE)
+        if (moves[i] == MOVE_NONE || moves[i] == MOVE_UNAVAILABLE)
+            continue;
+        if (noOfHitsToFaint <= 2)
         {
-            if (noOfHitsToFaint <= 2)
-            {
-                if (GetMovePriority(moves[i]) > 0)
-                    return TRUE;
+            if (GetMovePriority(moves[i]) > 0)
+                return TRUE;
 
-                switch (gMovesInfo[moves[i]].additionalEffects[i].moveEffect)
+            switch (gMovesInfo[moves[i]].additionalEffects[i].moveEffect)
+            {
+                case MOVE_EFFECT_SPD_MINUS_1:
+                case MOVE_EFFECT_SPD_MINUS_2:
                 {
-                    case MOVE_EFFECT_SPD_MINUS_1:
-                    case MOVE_EFFECT_SPD_MINUS_2:
-                    {
-                        if(aiIsFaster)
-                            return TRUE;
-                    }
+                    if(aiIsFaster)
+                        return TRUE;
                 }
             }
         }

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -1456,7 +1456,7 @@ bool32 CanAIKOTargetIfSturdyIgnored(u32 battlerAtk, u32 battlerDef)
             continue;
         dmg = AI_GetDamage(battlerAtk, battlerDef, moveIndex, AI_ATTACKING, aiData);
 
-        if (gBattleMons[battlerDef].hp <= dmg && CanEndureHit(battlerAtk, battlerDef, moves[moveIndex]))
+        if (gBattleMons[battlerDef].hp <= dmg)
             return TRUE;
     }
     return FALSE;

--- a/test/battle/ai/ai.c
+++ b/test/battle/ai/ai.c
@@ -912,3 +912,25 @@ AI_SINGLE_BATTLE_TEST("AI will see Magnitude damage")
         TURN { MOVE(player, MOVE_MAGNITUDE); EXPECT_SWITCH(opponent, 1); }
     }
 }
+
+AI_SINGLE_BATTLE_TEST("AI won't setup if it can KO through Sturdy effect")
+{
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_OMNISCIENT);
+        PLAYER(SPECIES_SKARMORY) { Ability(ABILITY_STURDY); Moves(MOVE_TACKLE); }
+        OPPONENT(SPECIES_MOLTRES) { Moves(MOVE_FIRE_BLAST, MOVE_AGILITY); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_TACKLE); EXPECT_MOVE(opponent, MOVE_FIRE_BLAST); }
+    }
+}
+
+AI_SINGLE_BATTLE_TEST("AI won't setup if otherwise good scenario is changed by the presence of priority")
+{
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_OMNISCIENT);
+        PLAYER(SPECIES_FLOATZEL) { Speed(2); Moves(MOVE_AQUA_JET, MOVE_SURF); }
+        OPPONENT(SPECIES_DONPHAN) { Speed(5); Moves(MOVE_BULK_UP, MOVE_EARTHQUAKE); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SURF); EXPECT_MOVE(opponent, MOVE_EARTHQUAKE); }
+    }
+}


### PR DESCRIPTION
## Description
This is 100% stealing ideas from @iriv24 after seeing their success in Emerald Imperium. Full credit to iriv for these I've just them into expansion, tweaked some formatting, and added tests.

AI will generally be smarter about when to use setup moves. It won't fall victim to "I outspeed you and you 2HKO me I'm safe (dies to priority move)", and also won't fall victim to infinitely setting up rather than hugely chunking a Sturdy mon that's forcing it to see a 2HKO instead of a OHKO.

## Discord contact info
@Pawkkie 
