### PR TITLE
Fixes shadows and mon animations for Illusioned battlers

### DIFF
--- a/src/battle_controllers.c
+++ b/src/battle_controllers.c
@@ -2172,9 +2172,7 @@ void StartSendOutAnim(u32 battler, bool32 dontClearTransform, bool32 dontClearSu
 
     ClearTemporarySpeciesSpriteData(battler, dontClearTransform, dontClearSubstituteBit);
     gBattlerPartyIndexes[battler] = gBattleResources->bufferA[battler][1];
-    species = GetIllusionMonSpecies(battler);
-    if (species == SPECIES_NONE)
-        species = GetMonData(mon, MON_DATA_SPECIES);
+    species = GetBattlerVisualSpecies(battler);
     gBattleControllerData[battler] = CreateInvisibleSpriteWithCallback(SpriteCB_WaitForBattlerBallReleaseAnim);
     // Load sprite for opponent only, player sprite is expected to be already loaded.
     if (!IsOnPlayerSide(battler))
@@ -2490,7 +2488,7 @@ void BtlController_HandleSetRawMonData(u32 battler)
 void BtlController_HandleLoadMonSprite(u32 battler, void (*controllerCallback)(u32 battler))
 {
     struct Pokemon *mon = GetBattlerMon(battler);
-    u16 species = GetMonData(mon, MON_DATA_SPECIES);
+    u16 species = GetBattlerVisualSpecies(battler);
 
     BattleLoadMonSpriteGfx(mon, battler);
     SetMultiuseSpriteTemplateToPokemon(species, GetBattlerPosition(battler));
@@ -3153,7 +3151,7 @@ void TrySetBattlerShadowSpriteCallback(u32 battler)
     if (gSprites[gBattleSpritesDataPtr->healthBoxesData[battler].shadowSpriteIdPrimary].callback == SpriteCallbackDummy
      && (B_ENEMY_MON_SHADOW_STYLE <= GEN_3 || P_GBA_STYLE_SPECIES_GFX == TRUE
       || gSprites[gBattleSpritesDataPtr->healthBoxesData[battler].shadowSpriteIdSecondary].callback == SpriteCallbackDummy))
-        SetBattlerShadowSpriteCallback(battler, GetMonData(GetBattlerMon(battler), MON_DATA_SPECIES));
+        SetBattlerShadowSpriteCallback(battler, GetBattlerVisualSpecies(battler));
 }
 
 bool32 TryShinyAnimAfterMonAnimUtil(u32 battler)
@@ -3256,7 +3254,7 @@ bool32 SwitchIn_TryShinyAnimUtil(u32 battler)
     DestroySprite(&gSprites[gBattleControllerData[battler]]);
 
     if (GetBattlerSide(battler) == B_SIDE_OPPONENT)
-        SetBattlerShadowSpriteCallback(battler, GetMonData(GetBattlerMon(battler), MON_DATA_SPECIES));
+        SetBattlerShadowSpriteCallback(battler, GetBattlerVisualSpecies(battler));
 
     return TRUE;
 }

--- a/src/battle_gfx_sfx_util.c
+++ b/src/battle_gfx_sfx_util.c
@@ -1168,7 +1168,7 @@ void CreateEnemyShadowSprite(u32 battler)
 {
     if (B_ENEMY_MON_SHADOW_STYLE >= GEN_4 && P_GBA_STYLE_SPECIES_GFX == FALSE)
     {
-        u16 species = SanitizeSpeciesId(gBattleMons[battler].species);
+        u16 species = GetBattlerVisualSpecies(battler);
         u8 size = gSpeciesInfo[species].enemyShadowSize;
 
         gBattleSpritesDataPtr->healthBoxesData[battler].shadowSpriteIdPrimary = CreateSprite(&gSpriteTemplate_EnemyShadow,
@@ -1282,7 +1282,7 @@ void SpriteCB_EnemyShadow(struct Sprite *shadowSprite)
     }
     else if (B_ENEMY_MON_SHADOW_STYLE >= GEN_4 && P_GBA_STYLE_SPECIES_GFX == FALSE)
     {
-        u16 species = SanitizeSpeciesId(gBattleMons[battler].species);
+        u16 species = GetBattlerVisualSpecies(battler);
         xOffset = gSpeciesInfo[species].enemyShadowXOffset + (shadowSprite->tSpriteSide == SPRITE_SIDE_LEFT ? -16 : 16);
         yOffset = gSpeciesInfo[species].enemyShadowYOffset + 16;
         size = gSpeciesInfo[species].enemyShadowSize;


### PR DESCRIPTION
Fixes shadows on Illusioned battlers using some values from the original species, causing the shadows to be placed in the wrong position and/or having the wrong size.
Fixes some animations, like the mon entry animation, using the animation from the original species instead of the one it's disguised as.

(GetBattlerVisualSpecies returns GetIllusionMonSpecies if `!= SPECIES_NONE`, otherwise `gBattleMons[battler].species`)

## Feature(s) this PR does NOT handle:
Does not fix 7068 but I believe it changes the shape of the shadows (but they're still not right) since it gets the species from the battler instead of from the mon.

## Discord contact info
PhallenTree
