### PR TITLE
Remove shadow and hide follower on stair warp

### DIFF
--- a/include/field_effect.h
+++ b/include/field_effect.h
@@ -37,6 +37,7 @@ bool8 FieldEffectCmd_loadgfx_callnative(u8 **script, u32 *val);
 bool8 FieldEffectCmd_loadtiles_callnative(u8 **script, u32 *val);
 bool8 FieldEffectCmd_loadfadedpal_callnative(u8 **script, u32 *val);
 void FieldCB_FallWarpExit(void);
+void HideFollowerForFieldEffect(void);
 void StartEscalatorWarp(u8 metatileBehavior, u8 priority);
 void StartLavaridgeGymB1FWarp(u8 priority);
 void StartLavaridgeGym1FWarp(u8 priority);

--- a/src/field_effect.c
+++ b/src/field_effect.c
@@ -1650,7 +1650,7 @@ static bool8 FallWarpEffect_End(struct Task *task)
 #define tState   data[0]
 #define tGoingUp data[1]
 
-static void HideFollowerForFieldEffect(void)
+void HideFollowerForFieldEffect(void)
 {
     struct ObjectEvent *followerObj = GetFollowerObject();
     if (!followerObj || followerObj->invisible)

--- a/src/field_screen_effect.c
+++ b/src/field_screen_effect.c
@@ -1570,14 +1570,14 @@ static void Task_ExitStairs(u8 taskId)
         if (!WaitStairExitMovementFinished(&tSpeedX, &tSpeedY, &tOffsetX, &tOffsetY, &tTimer))
             tState++;
         break;
-    }    
+    }
     gObjectEvents[gPlayerAvatar.objectEventId].noShadow = FALSE;
 }
 
 static void ForceStairsMovement(u32 metatileBehavior, s16 *speedX, s16 *speedY)
 {
     ObjectEventForceSetHeldMovement(&gObjectEvents[gPlayerAvatar.objectEventId], GetWalkInPlaceNormalMovementAction(GetPlayerFacingDirection()));
-    GetStairsMovementDirection(metatileBehavior, speedX, speedY);    
+    GetStairsMovementDirection(metatileBehavior, speedX, speedY);
     gObjectEvents[gPlayerAvatar.objectEventId].noShadow = TRUE;
 }
 #undef tSpeedX
@@ -1621,7 +1621,7 @@ static void Task_StairWarp(u8 taskId)
     case 0:
         LockPlayerFieldControls();
         FreezeObjectEvents();
-        CameraObjectFreeze();        
+        CameraObjectFreeze();
         HideFollowerForFieldEffect();
         tState++;
         break;

--- a/src/field_screen_effect.c
+++ b/src/field_screen_effect.c
@@ -1570,13 +1570,15 @@ static void Task_ExitStairs(u8 taskId)
         if (!WaitStairExitMovementFinished(&tSpeedX, &tSpeedY, &tOffsetX, &tOffsetY, &tTimer))
             tState++;
         break;
-    }
+    }    
+    gObjectEvents[gPlayerAvatar.objectEventId].noShadow = FALSE;
 }
 
 static void ForceStairsMovement(u32 metatileBehavior, s16 *speedX, s16 *speedY)
 {
     ObjectEventForceSetHeldMovement(&gObjectEvents[gPlayerAvatar.objectEventId], GetWalkInPlaceNormalMovementAction(GetPlayerFacingDirection()));
-    GetStairsMovementDirection(metatileBehavior, speedX, speedY);
+    GetStairsMovementDirection(metatileBehavior, speedX, speedY);    
+    gObjectEvents[gPlayerAvatar.objectEventId].noShadow = TRUE;
 }
 #undef tSpeedX
 #undef tSpeedY
@@ -1619,7 +1621,8 @@ static void Task_StairWarp(u8 taskId)
     case 0:
         LockPlayerFieldControls();
         FreezeObjectEvents();
-        CameraObjectFreeze();
+        CameraObjectFreeze();        
+        HideFollowerForFieldEffect();
         tState++;
         break;
     case 1:


### PR DESCRIPTION
## Description
Copied the code from the Pokecenter escalators to hide the player's overworld shadow and put follower in pokeball when going up and down sideways stair warps

## Media
![stairwarp-shadows](https://github.com/user-attachments/assets/0601794d-27d8-4b02-970e-c33f37aa44de)

## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, closes #2222." Remove this section if not applicable.-->

<!-- CREDITS -->
<!-- Once your PR is submitted, leave a comment asking the bot to add you to the credits. -->
<!-- If anybody helped with this PR, please encourage them to comment on your PR and ask the bot to add them to the credits. -->
<!-- EVERY contribution matters! -->
<!-- https://github.com/rh-hideout/pokeemerald-expansion/wiki/CREDITS.md-Frequently-Asked-Questions -->

## Feature(s) this PR does NOT handle:
<!-- If this PR contains any unfinished and non-blocking work, please list them here for clarity. -->
<!--- Remove this section if not applicable. --->

## Things to note in the release changelog:
<!-- Add any important details for the release changelog. Must be structed as bullet points. --->
<!--- Remove this section if not applicable. --->

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
