### PR TITLE
Fix AI unusable move scoring freeze

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -290,7 +290,7 @@ void BattleAI_SetupAIData(u8 defaultScoreMoves, u32 battler)
     {
         if (moveLimitations & (1u << moveIndex))
             SET_SCORE(battler, moveIndex, 0);
-        if (defaultScoreMoves & 1)
+        else if (defaultScoreMoves & 1)
             SET_SCORE(battler, moveIndex, AI_SCORE_DEFAULT);
         else
             SET_SCORE(battler, moveIndex, 0);


### PR DESCRIPTION
## Description
Thanks to zeluzao and hedara for finding / helping debug this one!

The structure of the conditional statement that initializatzes AI moves scores was missing an `else if` rather than an `if` for the second line. This means that moves that are unusable (such as any move other than one that is choice-locked) that should be getting set to 0 AI score were instead receiving the default AI score.

This means the AI can still choose these moves, and if it does the game freezes.

This PR fixes the conditional such that unusable moves are correctly given a score of 0.

## Discord contact info
@Pawkkie 
