### PR TITLE
fixed-damage-move-ai-calc-fix

### DIFF
--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -280,6 +280,7 @@ u32 CalcRolloutBasePower(u32 battlerAtk, u32 basePower, u32 rolloutTimer);
 u32 CalcFuryCutterBasePower(u32 basePower, u32 furyCutterCounter);
 s32 CalculateMoveDamage(struct DamageContext *ctx);
 s32 CalculateMoveDamageVars(struct DamageContext *ctx);
+s32 DoFixedDamageMoveCalc(struct DamageContext *ctx);
 s32 ApplyModifiersAfterDmgRoll(struct DamageContext *ctx, s32 dmg);
 uq4_12_t CalcTypeEffectivenessMultiplier(struct DamageContext *ctx);
 uq4_12_t CalcPartyMonTypeEffectivenessMultiplier(u16 move, u16 speciesDef, u16 abilityDef);

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -893,7 +893,12 @@ struct SimulatedDamage AI_CalcDamage(u32 move, u32 battlerAtk, u32 battlerDef, u
         AI_StoreBattlerTypes(battlerAtk, types);
         ProteanTryChangeType(battlerAtk, aiData->abilities[battlerAtk], move, ctx.moveType);
 
-        if (moveEffect == EFFECT_TRIPLE_KICK)
+        s32 fixedDamage = DoFixedDamageMoveCalc(&ctx);
+        if (fixedDamage != INT32_MAX)
+        {
+            simDamage.minimum = simDamage.median = simDamage.maximum = fixedDamage;
+        }
+        else if (moveEffect == EFFECT_TRIPLE_KICK)
         {
             for (gMultiHitCounter = GetMoveStrikeCount(move); gMultiHitCounter > 0; gMultiHitCounter--) // The global is used to simulate actual damage done
             {
@@ -913,33 +918,16 @@ struct SimulatedDamage AI_CalcDamage(u32 move, u32 battlerAtk, u32 battlerDef, u
         }
         else
         {
-            u32 damage;
+            u32 damage = CalculateMoveDamageVars(&ctx);
 
-            if (moveEffect == EFFECT_LEVEL_DAMAGE || moveEffect == EFFECT_PSYWAVE || moveEffect == EFFECT_FIXED_HP_DAMAGE 
-                || moveEffect == EFFECT_FIXED_PERCENT_DAMAGE || moveEffect == EFFECT_FINAL_GAMBIT)
-            {
-                if (ctx.typeEffectivenessModifier == UQ_4_12(0.0))
-                    damage = 0;
-                else
-                    damage = CalculateMoveDamageVars(&ctx);
+            simDamage.minimum = GetDamageByRollType(damage, DMG_ROLL_LOWEST);
+            simDamage.minimum = ApplyModifiersAfterDmgRoll(&ctx, simDamage.minimum);
 
-                simDamage.minimum = damage;
-                simDamage.median = damage;
-                simDamage.maximum = damage;
-            }
-            else
-            {
-                damage = CalculateMoveDamageVars(&ctx);
+            simDamage.median = GetDamageByRollType(damage, DMG_ROLL_DEFAULT);
+            simDamage.median = ApplyModifiersAfterDmgRoll(&ctx, simDamage.median);
 
-                simDamage.minimum = GetDamageByRollType(damage, DMG_ROLL_LOWEST);
-                simDamage.minimum = ApplyModifiersAfterDmgRoll(&ctx, simDamage.minimum);
-
-                simDamage.median = GetDamageByRollType(damage, DMG_ROLL_DEFAULT);
-                simDamage.median = ApplyModifiersAfterDmgRoll(&ctx, simDamage.median);
-
-                simDamage.maximum = GetDamageByRollType(damage, DMG_ROLL_HIGHEST);
-                simDamage.maximum = ApplyModifiersAfterDmgRoll(&ctx, simDamage.maximum);
-            }
+            simDamage.maximum = GetDamageByRollType(damage, DMG_ROLL_HIGHEST);
+            simDamage.maximum = ApplyModifiersAfterDmgRoll(&ctx, simDamage.maximum);
         }
 
         if (GetActiveGimmick(battlerAtk) != GIMMICK_Z_MOVE)

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -9392,7 +9392,7 @@ s32 ApplyModifiersAfterDmgRoll(struct DamageContext *ctx, s32 dmg)
     return dmg;
 }
 
-static inline s32 DoFixedDamageMoveCalc(struct DamageContext *ctx)
+s32 DoFixedDamageMoveCalc(struct DamageContext *ctx)
 {
     s32 dmg = 0;
     s32 randDamage;

--- a/src/trainer_see.c
+++ b/src/trainer_see.c
@@ -359,7 +359,7 @@ static const struct SpriteTemplate sSpriteTemplate_Emote =
 // code
 bool8 CheckForTrainersWantingBattle(void)
 {
-    u8 i, k;
+    u8 i;
 
     if (FlagGet(OW_FLAG_NO_TRAINER_SEE))
         return FALSE;
@@ -369,26 +369,14 @@ bool8 CheckForTrainersWantingBattle(void)
 
     for (i = 0; i < OBJECT_EVENTS_COUNT; i++)
     {
-        for (u8 j = 0; j < OBJECT_EVENTS_COUNT; j++)
-        {
-            k = 0;
-            if (gObjectEvents[j].localId == i)
-            {
-                k = j;
-                break;
-            }
-            else
-            {
-                continue;
-            }
-        }       
         u8 numTrainers;
-        if (!gObjectEvents[k].active)
+
+        if (!gObjectEvents[i].active)
             continue;
-        if (gObjectEvents[k].trainerType != TRAINER_TYPE_NORMAL && gObjectEvents[k].trainerType != TRAINER_TYPE_BURIED)
+        if (gObjectEvents[i].trainerType != TRAINER_TYPE_NORMAL && gObjectEvents[i].trainerType != TRAINER_TYPE_BURIED)
             continue;
 
-        numTrainers = CheckTrainer(k);
+        numTrainers = CheckTrainer(i);
         if (numTrainers == 0xFF) // non-trainerbatle script
         {
             u32 objectEventId = gApproachingTrainers[gNoOfApproachingTrainers - 1].objectEventId;

--- a/src/trainer_see.c
+++ b/src/trainer_see.c
@@ -359,7 +359,7 @@ static const struct SpriteTemplate sSpriteTemplate_Emote =
 // code
 bool8 CheckForTrainersWantingBattle(void)
 {
-    u8 i;
+    u8 i, k;
 
     if (FlagGet(OW_FLAG_NO_TRAINER_SEE))
         return FALSE;
@@ -369,14 +369,26 @@ bool8 CheckForTrainersWantingBattle(void)
 
     for (i = 0; i < OBJECT_EVENTS_COUNT; i++)
     {
+        for (u8 j = 0; j < OBJECT_EVENTS_COUNT; j++)
+        {
+            k = 0;
+            if (gObjectEvents[j].localId == i)
+            {
+                k = j;
+                break;
+            }
+            else
+            {
+                continue;
+            }
+        }       
         u8 numTrainers;
-
-        if (!gObjectEvents[i].active)
+        if (!gObjectEvents[k].active)
             continue;
-        if (gObjectEvents[i].trainerType != TRAINER_TYPE_NORMAL && gObjectEvents[i].trainerType != TRAINER_TYPE_BURIED)
+        if (gObjectEvents[k].trainerType != TRAINER_TYPE_NORMAL && gObjectEvents[k].trainerType != TRAINER_TYPE_BURIED)
             continue;
 
-        numTrainers = CheckTrainer(i);
+        numTrainers = CheckTrainer(k);
         if (numTrainers == 0xFF) // non-trainerbatle script
         {
             u32 objectEventId = gApproachingTrainers[gNoOfApproachingTrainers - 1].objectEventId;


### PR DESCRIPTION
AI for switch in and move decisions is factoring in type effectiveness and damage rolls for fixed-damage moves. This PR fixes. 

## Description

## Media
before
https://cdn.discordapp.com/attachments/1077168246555430962/1396601926958714980/image.png?ex=687fffe6&is=687eae66&hm=585890cbcd7c41031de8a197f6d14a049eb925a3d133712d61d0db096c58f847&
after
https://cdn.discordapp.com/attachments/1077168246555430962/1396866813987655751/image.png?ex=687fa518&is=687e5398&hm=ee898cd3f53e2af3589db8f12b8eb21694ab075982e0b161a8fefe0b926f9062&
## Issue(s) that this PR fixes
#7381

## Discord contact info
grintoul

## Credit
@AlexOn1ine for advising a more intelligent solution