### PR TITLE
Fix hit escape switching hardcode

### DIFF
--- a/src/battle_controller_opponent.c
+++ b/src/battle_controller_opponent.c
@@ -635,7 +635,7 @@ static void OpponentHandleChoosePokemon(u32 battler)
     {
         if (IsSwitchOutEffect(GetMoveEffect(gCurrentMove)) || gAiLogicData->ejectButtonSwitch || gAiLogicData->ejectPackSwitch)
             switchType = SWITCH_MID_BATTLE;
-        chosenMonId = GetMostSuitableMonToSwitchInto(battler, SWITCH_AFTER_KO);
+        chosenMonId = GetMostSuitableMonToSwitchInto(battler, switchType);
         if (chosenMonId == PARTY_SIZE)
         {
             s32 battler1, battler2, firstId, lastId;

--- a/src/battle_controller_opponent.c
+++ b/src/battle_controller_opponent.c
@@ -623,6 +623,7 @@ static void OpponentHandleChoosePokemon(u32 battler)
 {
     s32 chosenMonId;
     s32 pokemonInBattle = 1;
+    enum SwitchType switchType = SWITCH_AFTER_KO;
 
     // Choosing Revival Blessing target
     if ((gBattleResources->bufferA[battler][1] & 0xF) == PARTY_ACTION_CHOOSE_FAINTED_MON)
@@ -632,6 +633,8 @@ static void OpponentHandleChoosePokemon(u32 battler)
     // Switching out
     else if (gBattleStruct->AI_monToSwitchIntoId[battler] == PARTY_SIZE)
     {
+        if (IsSwitchOutEffect(GetMoveEffect(gCurrentMove)) || gAiLogicData->ejectButtonSwitch || gAiLogicData->ejectPackSwitch)
+            switchType = SWITCH_MID_BATTLE;
         chosenMonId = GetMostSuitableMonToSwitchInto(battler, SWITCH_AFTER_KO);
         if (chosenMonId == PARTY_SIZE)
         {


### PR DESCRIPTION
## Description
Any calls through to `GetBestMonIntegrated` from `OpponentHandleChoosePokemon` were hardcoded to use `SWITCH_AFTER_KO`, which breaks handling for hit escape effects like U-Turn that also call the switchin selection code from this function. This PR adds the exact same clause used to identify these cases in `GetBestMonIntegrated` so mon selection after hit escape effects is handled correctly instead of hardcoded.

Thanks to @iriv24 for finding this!

## Discord contact info
@Pawkkie 
