### PR TITLE
Fixes Razor Wind not activating after hit effects after the first target

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -3529,6 +3529,7 @@ BattleScript_PowerHerbActivation:
 BattleScript_EffectTwoTurnsAttack::
 	jumpifstatus2 BS_ATTACKER, STATUS2_MULTIPLETURNS, BattleScript_TwoTurnMovesSecondTurn
 	jumpifword CMP_COMMON_BITS, gHitMarker, HITMARKER_NO_ATTACKSTRING, BattleScript_TwoTurnMovesSecondTurn
+	jumpifword CMP_COMMON_BITS, gHitMarker, HITMARKER_ATTACKSTRING_PRINTED, BattleScript_EffectHit @ if it's not the first hit
 	tryfiretwoturnmovewithoutcharging BS_ATTACKER, BattleScript_EffectHit @ e.g. Solar Beam
 	call BattleScript_FirstChargingTurn
 	tryfiretwoturnmoveaftercharging BS_ATTACKER, BattleScript_TwoTurnMovesSecondTurn @ e.g. Electro Shot

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -6975,10 +6975,7 @@ static void Cmd_moveend(void)
                     MoveValuesCleanUp();
                     gBattleScripting.moveEffect = gBattleScripting.savedMoveEffect;
 
-                    if (moveEffect == EFFECT_EXPLOSION
-                     || moveEffect == EFFECT_TWO_TURNS_ATTACK
-                     || moveEffect == EFFECT_SOLAR_BEAM
-                     || moveEffect == EFFECT_SEMI_INVULNERABLE)
+                    if (moveEffect == EFFECT_EXPLOSION)
                         BattleScriptPush(gBattleMoveEffects[EFFECT_HIT].battleScript); // Edge case for Explosion not changing targets
                     else
                         BattleScriptPush(GetMoveBattleScript(gCurrentMove));


### PR DESCRIPTION
Fixes Razor Wind not activating after hit effects after the first target.
This happened due to `STATUS2_MULTIPLE_TURNS` being removed when executing for the first target, instead causing a new Razor Wind to charge (when reaching `MOVEEND_NEXT_TARGET` to call the BattleScript again).

Bugged behavior:

https://github.com/user-attachments/assets/3ed1e986-1965-496b-9ddd-44ee02e2a27a

## Discord contact info
PhallenTree
