### PR TITLE
Clear gScanlineEffect to fix timeout in acid downpour animation

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -487,10 +487,9 @@ static void CB2_InitBattleInternal(void)
     else
     {
         gBattle_WIN0V = WIN_RANGE(DISPLAY_HEIGHT / 2, DISPLAY_HEIGHT / 2 + 1);
+        ScanlineEffect_Clear();
         if (B_FAST_INTRO_NO_SLIDE == FALSE && !gTestRunnerHeadless)
         {
-            ScanlineEffect_Clear();
-
             for (i = 0; i < DISPLAY_HEIGHT / 2; i++)
             {
                 gScanlineEffectRegBuffers[0][i] = 0xF0;


### PR DESCRIPTION
I was running some animation tests and the Z-move Acid Downpour will timeout/softlock if the gScanlineEffect is not cleared.
The exact process is not clear but one of the visual tasks of the animations get destroyed by an unknown process instead of clearing itself properly. When ended this way, the visual task counter is not decreased and waitforvisualfinish never ends causing the move to softlock.
This change fixes the issue.
