### PR TITLE
Fixes AI selecting unusable moves in Single Battles

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -682,6 +682,12 @@ static u32 ChooseMoveOrAction_Singles(u32 battler)
     u32 opposingBattler = GetOppositeBattler(battler);
 
     gAiLogicData->partnerMove = 0;   // no ally
+
+    if (gBattleTypeFlags & BATTLE_TYPE_PALACE)
+        BattleAI_SetupAIData(gBattleStruct->palaceFlags >> 4, battler);
+    else
+        BattleAI_SetupAIData(0xF, battler);
+
     while (flags != 0)
     {
         if (flags & 1)
@@ -741,6 +747,11 @@ static u32 ChooseMoveOrAction_Doubles(u32 battler)
     u32 mostViableMovesNo;
     s32 mostMovePoints;
 
+    if (gBattleTypeFlags & BATTLE_TYPE_PALACE)
+        BattleAI_SetupAIData(gBattleStruct->palaceFlags >> 4, battler);
+    else
+        BattleAI_SetupAIData(0xF, battler);
+
     for (i = 0; i < MAX_BATTLERS_COUNT; i++)
     {
         if (i == battler || gBattleMons[i].hp == 0)
@@ -750,11 +761,6 @@ static u32 ChooseMoveOrAction_Doubles(u32 battler)
         }
         else
         {
-            if (gBattleTypeFlags & BATTLE_TYPE_PALACE)
-                BattleAI_SetupAIData(gBattleStruct->palaceFlags >> 4, battler);
-            else
-                BattleAI_SetupAIData(0xF, battler);
-
             gBattlerTarget = i;
 
             gAiLogicData->partnerMove = GetAllyChosenMove(battler);


### PR DESCRIPTION
Fixes AI selecting unusable moves in Single Battles and makes the function setting AI score for unusable moves to 0 run less in Double Battles.

Tested in-game with Encore and Torment.

## Issue(s) that this PR fixes
Fixes #7421 

## Discord contact info
PhallenTree
