### PR TITLE
Fixes Magnet Rise when user is Rooted/Smacked Down

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -2601,6 +2601,8 @@ BattleScript_EffectMagnetRise::
 	attackcanceler
 	attackstring
 	ppreduce
+	jumpifstatus3 BS_ATTACKER, STATUS3_ROOTED, BattleScript_ButItFailed
+	jumpifstatus3 BS_ATTACKER, STATUS3_SMACKED_DOWN, BattleScript_ButItFailed
 	setuserstatus3 STATUS3_MAGNET_RISE, BattleScript_ButItFailed
 	attackanimation
 	waitanimation

--- a/test/battle/move_effect/magic_room.c
+++ b/test/battle/move_effect/magic_room.c
@@ -35,3 +35,5 @@ DOUBLE_BATTLE_TEST("Magic Room prevents item hold effects")
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponentRight);
     }
 }
+
+TO_DO_BATTLE_TEST("TODO: Write Magic Room (Move Effect) test titles")

--- a/test/battle/move_effect/magnet_rise.c
+++ b/test/battle/move_effect/magnet_rise.c
@@ -1,4 +1,57 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Magic Room (Move Effect) test titles")
+ASSUMPTIONS
+{
+    ASSUME(GetMoveEffect(MOVE_MAGNET_RISE) == EFFECT_MAGNET_RISE);
+}
+
+SINGLE_BATTLE_TEST("Magnet Rise rises the user into the air, avoiding Ground-type attacks")
+{
+    GIVEN {
+        ASSUME(GetMoveType(MOVE_EARTHQUAKE) == TYPE_GROUND);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN { MOVE(player, MOVE_MAGNET_RISE); MOVE(opponent, MOVE_EARTHQUAKE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_MAGNET_RISE, player);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
+            HP_BAR(player);
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Magnet Rise fails if the user is Rooted")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_INGRAIN) == EFFECT_INGRAIN);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN { MOVE(player, MOVE_INGRAIN); }
+        TURN { MOVE(player, MOVE_MAGNET_RISE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_INGRAIN, player);
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_MAGNET_RISE, player);
+    }
+}
+
+SINGLE_BATTLE_TEST("Magnet Rise fails if the user is Grounded by Smack Down")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_SMACK_DOWN) == EFFECT_SMACK_DOWN);
+        ASSUME(gSpeciesInfo[SPECIES_XATU].types[0] == TYPE_FLYING || gSpeciesInfo[SPECIES_XATU].types[1] == TYPE_FLYING);
+        PLAYER(SPECIES_XATU);
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SMACK_DOWN); MOVE(player, MOVE_MAGNET_RISE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SMACK_DOWN, opponent);
+        MESSAGE("Xatu fell straight down!");
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_MAGNET_RISE, player);
+    }
+}
+
+TO_DO_BATTLE_TEST("TODO: Write Magnet Rise (Move Effect) test titles")

--- a/test/battle/move_effect_secondary/will_o_wisp.c
+++ b/test/battle/move_effect_secondary/will_o_wisp.c
@@ -1,4 +1,0 @@
-#include "global.h"
-#include "test/battle.h"
-
-TO_DO_BATTLE_TEST("TODO: Write Will-O-Wisp (Move Effect) test titles")


### PR DESCRIPTION
Prevents Magnet Rise from working when user is Rooted or Smacked Down.
Added tests and removed extra test file for Will-o-Wisp in `test/battle/move_effect_secondary` (`test/battle/move_effect_secondary/burn.c` already exists).

## Issue(s) that this PR fixes
Fixes #7447

## Discord contact info
PhallenTree
