### PR TITLE
Replace all usages of rl compression with smol

### DIFF
--- a/migration_scripts/1.13/convert_compressed_files.py
+++ b/migration_scripts/1.13/convert_compressed_files.py
@@ -9,9 +9,10 @@ if not os.path.exists("Makefile"):
 
 primaryTileset_pattern = re.compile(r"(.*\"data/tilesets/primary/.+\.4bpp\.)lz(\".*)")
 secondaryTileset_pattern = re.compile(r"(.*\"data/tilesets/secondary/.+\.4bpp\.)lz(\".*)")
-tilemap_pattern = re.compile(r"(.*\"graphics/.+\.bin\.)lz(\".*)")
+tilemap_pattern = re.compile(r"(.*\"graphics/.+\.bin\.)(?:lz|rl)(\".*)")
 lzuncomp_pattern = re.compile(r"(.*)\bLZ77UnComp([WV])ram\b(\(.*)")
 lzdecomp_pattern = re.compile(r"(.*)\bLZDecompress([WV])ram\b(\(.*)")
+rluncomp_pattern = re.compile(r"(.*)\bRLUnComp([WV])ram\b(\(.*)")
 
 def handle_file(fileInput):
     fileTest = Path(fileInput)
@@ -33,13 +34,20 @@ def handle_file(fileInput):
                 line = match.group(1) + "smolTM" + match.group(2) + "\n"
             elif ".4bpp.lz" in line:
                 line = line.replace(".4bpp.lz", ".4bpp.smol")
+            elif ".4bpp.rl" in line:
+                line = line.replace(".4bpp.rl", ".4bpp.smol")
             elif ".8bpp.lz" in line:
                 line = line.replace(".8bpp.lz", ".8bpp.smol")
+            elif ".8bpp.rl" in line:
+                line = line.replace(".8bpp.rl", ".8bpp.smol")
             elif match := lzuncomp_pattern.match(line):
                 if allLines[-1].strip() != "case MODE_LZ77:": # do not modify DecompressDataWithHeader itself
                     line = match.group(1) + "DecompressDataWithHeader" + match.group(2) + "ram" + match.group(3) + "\n"
                     needs_decompress_h = True
             elif match := lzdecomp_pattern.match(line):
+                line = match.group(1) + "DecompressDataWithHeader" + match.group(2) + "ram" + match.group(3) + "\n"
+                needs_decompress_h = True
+            elif match := rluncomp_pattern.match(line):
                 line = match.group(1) + "DecompressDataWithHeader" + match.group(2) + "ram" + match.group(3) + "\n"
                 needs_decompress_h = True
             else:

--- a/src/contest_painting.c
+++ b/src/contest_painting.c
@@ -70,18 +70,18 @@ extern const u8 gContestPaintingTough2[];
 extern const u8 gContestPaintingTough3[];
 
 static const u16 sPictureFramePalettes[]          = INCBIN_U16("graphics/picture_frame/bg.gbapal");
-static const u32 sPictureFrameTiles_Cool[]        = INCBIN_U32("graphics/picture_frame/cool.4bpp.rl");
-static const u32 sPictureFrameTiles_Beauty[]      = INCBIN_U32("graphics/picture_frame/beauty.4bpp.rl");
-static const u32 sPictureFrameTiles_Cute[]        = INCBIN_U32("graphics/picture_frame/cute.4bpp.rl");
-static const u32 sPictureFrameTiles_Smart[]       = INCBIN_U32("graphics/picture_frame/smart.4bpp.rl");
-static const u32 sPictureFrameTiles_Tough[]       = INCBIN_U32("graphics/picture_frame/tough.4bpp.rl");
-static const u32 sPictureFrameTiles_HallLobby[]   = INCBIN_U32("graphics/picture_frame/lobby.4bpp.rl");
-static const u32 sPictureFrameTilemap_Cool[]      = INCBIN_U32("graphics/picture_frame/cool_map.bin.rl");
-static const u32 sPictureFrameTilemap_Beauty[]    = INCBIN_U32("graphics/picture_frame/beauty_map.bin.rl");
-static const u32 sPictureFrameTilemap_Cute[]      = INCBIN_U32("graphics/picture_frame/cute_map.bin.rl");
-static const u32 sPictureFrameTilemap_Smart[]     = INCBIN_U32("graphics/picture_frame/smart_map.bin.rl");
-static const u32 sPictureFrameTilemap_Tough[]     = INCBIN_U32("graphics/picture_frame/tough_map.bin.rl");
-static const u32 sPictureFrameTilemap_HallLobby[] = INCBIN_U32("graphics/picture_frame/lobby_map.bin.rl");
+static const u32 sPictureFrameTiles_Cool[]        = INCBIN_U32("graphics/picture_frame/cool.4bpp.smol");
+static const u32 sPictureFrameTiles_Beauty[]      = INCBIN_U32("graphics/picture_frame/beauty.4bpp.smol");
+static const u32 sPictureFrameTiles_Cute[]        = INCBIN_U32("graphics/picture_frame/cute.4bpp.smol");
+static const u32 sPictureFrameTiles_Smart[]       = INCBIN_U32("graphics/picture_frame/smart.4bpp.smol");
+static const u32 sPictureFrameTiles_Tough[]       = INCBIN_U32("graphics/picture_frame/tough.4bpp.smol");
+static const u32 sPictureFrameTiles_HallLobby[]   = INCBIN_U32("graphics/picture_frame/lobby.4bpp.smol");
+static const u32 sPictureFrameTilemap_Cool[]      = INCBIN_U32("graphics/picture_frame/cool_map.bin.smolTM");
+static const u32 sPictureFrameTilemap_Beauty[]    = INCBIN_U32("graphics/picture_frame/beauty_map.bin.smolTM");
+static const u32 sPictureFrameTilemap_Cute[]      = INCBIN_U32("graphics/picture_frame/cute_map.bin.smolTM");
+static const u32 sPictureFrameTilemap_Smart[]     = INCBIN_U32("graphics/picture_frame/smart_map.bin.smolTM");
+static const u32 sPictureFrameTilemap_Tough[]     = INCBIN_U32("graphics/picture_frame/tough_map.bin.smolTM");
+static const u32 sPictureFrameTilemap_HallLobby[] = INCBIN_U32("graphics/picture_frame/lobby_map.bin.smolTM");
 
 static const u8 *const sContestCategoryNames_Unused[] =
 {
@@ -424,24 +424,24 @@ static void LoadContestPaintingFrame(u8 contestWinnerId, bool8 isForArtist)
         switch (gContestPaintingWinner->contestCategory / NUM_PAINTING_CAPTIONS)
         {
         case CONTEST_CATEGORY_COOL:
-            RLUnCompVram(sPictureFrameTiles_Cool, (void *)VRAM);
-            RLUnCompWram(sPictureFrameTilemap_Cool, gContestMonPixels);
+            DecompressDataWithHeaderVram(sPictureFrameTiles_Cool, (void *)VRAM);
+            DecompressDataWithHeaderWram(sPictureFrameTilemap_Cool, gContestMonPixels);
             break;
         case CONTEST_CATEGORY_BEAUTY:
-            RLUnCompVram(sPictureFrameTiles_Beauty, (void *)VRAM);
-            RLUnCompWram(sPictureFrameTilemap_Beauty, gContestMonPixels);
+            DecompressDataWithHeaderVram(sPictureFrameTiles_Beauty, (void *)VRAM);
+            DecompressDataWithHeaderWram(sPictureFrameTilemap_Beauty, gContestMonPixels);
             break;
         case CONTEST_CATEGORY_CUTE:
-            RLUnCompVram(sPictureFrameTiles_Cute, (void *)VRAM);
-            RLUnCompWram(sPictureFrameTilemap_Cute, gContestMonPixels);
+            DecompressDataWithHeaderVram(sPictureFrameTiles_Cute, (void *)VRAM);
+            DecompressDataWithHeaderWram(sPictureFrameTilemap_Cute, gContestMonPixels);
             break;
         case CONTEST_CATEGORY_SMART:
-            RLUnCompVram(sPictureFrameTiles_Smart, (void *)VRAM);
-            RLUnCompWram(sPictureFrameTilemap_Smart, gContestMonPixels);
+            DecompressDataWithHeaderVram(sPictureFrameTiles_Smart, (void *)VRAM);
+            DecompressDataWithHeaderWram(sPictureFrameTilemap_Smart, gContestMonPixels);
             break;
         case CONTEST_CATEGORY_TOUGH:
-            RLUnCompVram(sPictureFrameTiles_Tough, (void *)VRAM);
-            RLUnCompWram(sPictureFrameTilemap_Tough, gContestMonPixels);
+            DecompressDataWithHeaderVram(sPictureFrameTiles_Tough, (void *)VRAM);
+            DecompressDataWithHeaderWram(sPictureFrameTilemap_Tough, gContestMonPixels);
             break;
         }
 
@@ -466,8 +466,8 @@ static void LoadContestPaintingFrame(u8 contestWinnerId, bool8 isForArtist)
     else if (contestWinnerId < MUSEUM_CONTEST_WINNERS_START)
     {
         // Load Contest Hall lobby frame
-        RLUnCompVram(sPictureFrameTiles_HallLobby, (void *)VRAM);
-        RLUnCompVram(sPictureFrameTilemap_HallLobby, (void *)(BG_SCREEN_ADDR(12)));
+        DecompressDataWithHeaderVram(sPictureFrameTiles_HallLobby, (void *)VRAM);
+        DecompressDataWithHeaderVram(sPictureFrameTilemap_HallLobby, (void *)(BG_SCREEN_ADDR(12)));
     }
     else
     {
@@ -475,24 +475,24 @@ static void LoadContestPaintingFrame(u8 contestWinnerId, bool8 isForArtist)
         switch (gContestPaintingWinner->contestCategory / NUM_PAINTING_CAPTIONS)
         {
         case CONTEST_CATEGORY_COOL:
-            RLUnCompVram(sPictureFrameTiles_Cool, (void *)VRAM);
-            RLUnCompVram(sPictureFrameTilemap_Cool, (void *)(BG_SCREEN_ADDR(12)));
+            DecompressDataWithHeaderVram(sPictureFrameTiles_Cool, (void *)VRAM);
+            DecompressDataWithHeaderVram(sPictureFrameTilemap_Cool, (void *)(BG_SCREEN_ADDR(12)));
             break;
         case CONTEST_CATEGORY_BEAUTY:
-            RLUnCompVram(sPictureFrameTiles_Beauty, (void *)VRAM);
-            RLUnCompVram(sPictureFrameTilemap_Beauty, (void *)(BG_SCREEN_ADDR(12)));
+            DecompressDataWithHeaderVram(sPictureFrameTiles_Beauty, (void *)VRAM);
+            DecompressDataWithHeaderVram(sPictureFrameTilemap_Beauty, (void *)(BG_SCREEN_ADDR(12)));
             break;
         case CONTEST_CATEGORY_CUTE:
-            RLUnCompVram(sPictureFrameTiles_Cute, (void *)VRAM);
-            RLUnCompVram(sPictureFrameTilemap_Cute, (void *)(BG_SCREEN_ADDR(12)));
+            DecompressDataWithHeaderVram(sPictureFrameTiles_Cute, (void *)VRAM);
+            DecompressDataWithHeaderVram(sPictureFrameTilemap_Cute, (void *)(BG_SCREEN_ADDR(12)));
             break;
         case CONTEST_CATEGORY_SMART:
-            RLUnCompVram(sPictureFrameTiles_Smart, (void *)VRAM);
-            RLUnCompVram(sPictureFrameTilemap_Smart, (void *)(BG_SCREEN_ADDR(12)));
+            DecompressDataWithHeaderVram(sPictureFrameTiles_Smart, (void *)VRAM);
+            DecompressDataWithHeaderVram(sPictureFrameTilemap_Smart, (void *)(BG_SCREEN_ADDR(12)));
             break;
         case CONTEST_CATEGORY_TOUGH:
-            RLUnCompVram(sPictureFrameTiles_Tough, (void *)VRAM);
-            RLUnCompVram(sPictureFrameTilemap_Tough, (void *)(BG_SCREEN_ADDR(12)));
+            DecompressDataWithHeaderVram(sPictureFrameTiles_Tough, (void *)VRAM);
+            DecompressDataWithHeaderVram(sPictureFrameTilemap_Tough, (void *)(BG_SCREEN_ADDR(12)));
             break;
         }
     }


### PR DESCRIPTION
## Description
The first commit modifies the smol conversion script so that it also converts `rl` compression to `smol` compression.    
The second commit is the result of running the conversion script

Size before replacement: `74.02%`    
 Size after replacement: `73.98%`

## Media
When I was checking this, I used [museum_painting.patch.gz](https://github.com/user-attachments/files/21552432/museum_painting.patch.gz) to populate the museum paintings during a new game, for the purpose of inspecting the museum paintings

## Discord contact info
yoshord
