### PR TITLE
Clear out parties between battle tests

### DIFF
--- a/test/test_runner_battle.c
+++ b/test/test_runner_battle.c
@@ -1344,13 +1344,8 @@ static void TearDownBattle(void)
     // Zero out the parties, data in them could potentially carry over
     for (u32 i = 0; i < 6; i++)
     {
-        u32 *playerPtr = (u32 *)(&gPlayerParty[i]);
-        u32 *opponentPtr = (u32 *)(&gEnemyParty[i]);
-        for (u32 j = 0; j < sizeof(struct Pokemon)/4; j++)
-        {
-            playerPtr[j] = 0;
-            opponentPtr[j] = 0;
-        }
+        ZeroPlayerPartyMons();
+        ZeroEnemyPartyMons();
     }
 
     FreeMonSpritesGfx();

--- a/test/test_runner_battle.c
+++ b/test/test_runner_battle.c
@@ -1342,11 +1342,8 @@ void TestRunner_Battle_AfterLastTurn(void)
 static void TearDownBattle(void)
 {
     // Zero out the parties, data in them could potentially carry over
-    for (u32 i = 0; i < 6; i++)
-    {
-        ZeroPlayerPartyMons();
-        ZeroEnemyPartyMons();
-    }
+    ZeroPlayerPartyMons();
+    ZeroEnemyPartyMons();
 
     FreeMonSpritesGfx();
     FreeBattleSpritesData();

--- a/test/test_runner_battle.c
+++ b/test/test_runner_battle.c
@@ -1341,6 +1341,18 @@ void TestRunner_Battle_AfterLastTurn(void)
 
 static void TearDownBattle(void)
 {
+    // Zero out the parties, data in them could potentially carry over
+    for (u32 i = 0; i < 6; i++)
+    {
+        u32 *playerPtr = (u32 *)(&gPlayerParty[i]);
+        u32 *opponentPtr = (u32 *)(&gEnemyParty[i]);
+        for (u32 j = 0; j < sizeof(struct Pokemon)/4; j++)
+        {
+            playerPtr[j] = 0;
+            opponentPtr[j] = 0;
+        }
+    }
+
     FreeMonSpritesGfx();
     FreeBattleSpritesData();
     FreeBattleResources();


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
Data in the test parties can potentially carry over between tests.
This makes it so that parties are always zeroed after a battle test.

How to test behaviour.
Run `make check TESTS="Heal Bell" with and without this PR, note that it must be single threaded.

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara