### PR TITLE
Fixes Round and Fusion moves doubling power from previous turn's move

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -12194,7 +12194,7 @@ void BS_RemoveStockpileCounters(void)
 {
     NATIVE_ARGS();
 
-    if (GetMoveEffect(gCurrentMove) == EFFECT_SWALLOW
+    if (GetMoveEffect(gCurrentMove) == EFFECT_SPIT_UP
      && gSpecialStatuses[gBattlerAttacker].parentalBondState == PARENTAL_BOND_1ST_HIT
      && IsBattlerAlive(gBattlerTarget))
     {
@@ -16996,7 +16996,7 @@ static void TryUpdateRoundTurnOrder(void)
         }
 
         // update turn order for round users
-        for (i = 0; roundUsers[i] != 0xFF && i < 3; i++)
+        for (i = 0; i < 3 && roundUsers[i] != 0xFF; i++)
         {
             gBattlerByTurnOrder[currRounder] = roundUsers[i];
             gProtectStructs[roundUsers[i]].quash = TRUE; // Make it so their turn order can't be changed again
@@ -17004,7 +17004,7 @@ static void TryUpdateRoundTurnOrder(void)
         }
 
         // Update turn order for non-round users
-        for (i = 0; nonRoundUsers[i] != 0xFF && i < 3; i++)
+        for (i = 0; i < 3 && nonRoundUsers[i] != 0xFF; i++)
         {
             gBattlerByTurnOrder[currRounder] = nonRoundUsers[i];
             currRounder++;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -6829,6 +6829,7 @@ static void Cmd_moveend(void)
                 UpdateStallMons();
             if ((gBattleStruct->moveResultFlags[gBattlerTarget] & (MOVE_RESULT_FAILED | MOVE_RESULT_DOESNT_AFFECT_FOE))
              || (gBattleMons[gBattlerAttacker].status2 & (STATUS2_FLINCHED))
+             || gBattleStruct->pledgeMove == TRUE // Is the battler that uses the first Pledge move in the combo
              || gProtectStructs[gBattlerAttacker].nonVolatileStatusImmobility)
                 gBattleStruct->battlerState[gBattlerAttacker].stompingTantrumTimer = 2;
 

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -8072,6 +8072,7 @@ static inline u32 CalcMoveBasePower(struct DamageCalculationData *damageCalcData
     u32 battlerAtk = damageCalcData->battlerAtk;
     u32 battlerDef = damageCalcData->battlerDef;
     u32 move = damageCalcData->move;
+    u32 moveEffect = GetMoveEffect(move);
 
     u32 i;
     u32 basePower = GetMovePower(move);
@@ -8083,7 +8084,7 @@ static inline u32 CalcMoveBasePower(struct DamageCalculationData *damageCalcData
     if (GetActiveGimmick(battlerAtk) == GIMMICK_DYNAMAX)
         return GetMaxMovePower(move);
 
-    switch (GetMoveEffect(move))
+    switch (moveEffect)
     {
     case EFFECT_PLEDGE:
         if (gBattleStruct->pledgeMove)
@@ -8242,18 +8243,15 @@ static inline u32 CalcMoveBasePower(struct DamageCalculationData *damageCalcData
             || gDisableStructs[battlerDef].isFirstTurn == 2)
             basePower *= 2;
         break;
-    case EFFECT_ROUND:
-        for (i = 0; i < gBattlersCount; i++)
-        {
-            if (i != battlerAtk && IsBattlerAlive(i) && GetMoveEffect(gLastUsedMove) == EFFECT_ROUND)
-            {
-                basePower *= 2;
-                break;
-            }
-        }
-        break;
     case EFFECT_FUSION_COMBO:
-        if (GetMoveEffect(gLastUsedMove) == EFFECT_FUSION_COMBO && move != gLastUsedMove)
+        if (move == gLastUsedMove)
+            break;
+        // fallthrough
+    case EFFECT_ROUND:
+        // don't double power due to previous turn's Round/Fusion move
+        if (gCurrentTurnActionNumber != 0
+         && gActionsByTurnOrder[gCurrentTurnActionNumber - 1] == B_ACTION_USE_MOVE
+         && GetMoveEffect(gLastUsedMove) == moveEffect)
             basePower *= 2;
         break;
     case EFFECT_LASH_OUT:


### PR DESCRIPTION
- Fixes Round and Fusion Flare/Bolt doubling power from the previous turn's move, since it checked `gLastUsedMove` which isn't cleared at the end of the turn.
Clearing `gLastUsedMove` isn't an option since Copycat also uses it and it can definitely call the previous turn's moves.

- Fixes Stockpile counter removal checking if Swallow would hit twice instead of if Spit Up would hit twice.

- Fixes potential out of bounds check when updating Round turn order.

- Fixes Pledge setup move not doubling Stomping Tantrum's power. [Source](https://wiki.xn--rckteqa2e.com/wiki/%E3%81%98%E3%81%A0%E3%82%93%E3%81%A0#%E6%8A%80%E3%81%AE%E4%BB%95%E6%A7%98)

> When the power doubles
If the previous turn's action failed due to the following reasons, the effect of doubling the power will be applied.
(...)
> - For some combination moves (Grass Pledge, Fire Pledge, Water Pledge), if one move is used first and the combination move is activated, the move itself is considered to have failed, and its power is doubled. This does not affect whether the combination move (commonly known as a "combined move") by an ally was successful.

## Issue(s) that this PR fixes
Fixes #7470

## Discord contact info
PhallenTree
