### PR TITLE
Fix using town map as registered item

### DIFF
--- a/src/item_use.c
+++ b/src/item_use.c
@@ -1609,8 +1609,7 @@ void ItemUseOutOfBattle_TownMap(u8 taskId)
     }
     else
     {
-        // TODO: handle key items with callbacks to menus allow to be used by registering them.
-        DisplayDadsAdviceCannotUseItemMessage(taskId, gTasks[taskId].tUsingRegisteredKeyItem);
+        gTasks[taskId].func = ItemUseOnFieldCB_TownMap;
     }
 }
 


### PR DESCRIPTION
## Description
- Changes it so that you can actually use the town map as a registered item. 
- Related to #7481, but I decided to make this one separate since it's not a party menu item...and it turned out to be vastly more simple than I was anticipating

## Media
https://github.com/user-attachments/assets/d8914a7f-3a3e-4140-b6ef-e5f393187d04

## Feature(s) this PR does NOT handle:
- Adding the fancy map opening animation from FRLG or something

## Discord contact info
ravepossum
