### PR TITLE
aiData->partnerMove is MOVE_NONE if the pokemon has not chosen a move this turn.

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -3780,7 +3780,7 @@ u32 GetAllyChosenMove(u32 battlerId)
     if (!IsBattlerAlive(partnerBattler) || !IsAiBattlerAware(partnerBattler))
         return MOVE_NONE;
     else if (partnerBattler > battlerId) // Battler with the lower id chooses the move first.
-        return gLastMoves[partnerBattler];
+        return MOVE_NONE;
     else
         return gBattleMons[partnerBattler].moves[gBattleStruct->chosenMovePositions[partnerBattler]];
 }


### PR DESCRIPTION
The left opponent previously used what the right opponent had chosen the previous turn, which led to a lot of undesirable behavior and did not seem to be in line with any other uses of partnerMove.

I fiddled with Helping Hand slightly but more importantly, it is now possible for the left opponent to use it on turn 2 after the right opponent had used a status move turn 1.

## Discord contact info
wildvenonat