### PR TITLE
Add test for BoxPokemon integrity

### DIFF
--- a/test/pokemon.c
+++ b/test/pokemon.c
@@ -4,6 +4,7 @@
 #include "pokemon.h"
 #include "test/overworld_script.h"
 #include "test/test.h"
+#include "constants/characters.h"
 
 TEST("Nature independent from Hidden Nature")
 {
@@ -449,4 +450,100 @@ TEST("Pokémon level up learnsets fit within MAX_LEVEL_UP_MOVES and MAX_RELEARNE
         count++;
     EXPECT_LT(count, MAX_LEVEL_UP_MOVES);
     EXPECT_LT(count, MAX_RELEARNER_MOVES - 1); // - 1 because at least one move is already known
+}
+
+TEST("BoxPokemon encryption works")
+{
+    u32 raw[20] =
+    {
+        990384375,
+        2948624514,
+        3907508686,
+        14410461,
+        35316705,
+        3907508686,
+        64742109,
+        718729,
+        3102307966,
+        2160206402,
+        49956971,
+        2495766612,
+        1424318580,
+        273408756,
+        2371630199,
+        2708871082,
+        3059937332,
+        2529190026,
+        2290634828,
+        2870614922
+    };
+
+    struct Pokemon mon;
+    BoxMonToMon((struct BoxPokemon *)&raw, &mon);
+
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_SPECIES), SPECIES_TORCHIC);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_MARKINGS), 3);
+    const u8 *actualNickname = COMPOUND_STRING("Testing mon");
+    u8 nickname[12];
+    GetMonData(&mon, MON_DATA_NICKNAME, nickname);
+    u32 charIndex = 0;
+    while (actualNickname[charIndex] != EOS)
+    {
+        EXPECT_EQ(actualNickname[charIndex], nickname[charIndex]);
+        charIndex++;
+    }
+    EXPECT_EQ(GetNature(&mon), NATURE_HARDY);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_HIDDEN_NATURE), NATURE_ADAMANT);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_HP_LOST), 10);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_HELD_ITEM), ITEM_ORAN_BERRY);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_MOVE1), MOVE_TACKLE);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_MOVE2), MOVE_SCRATCH);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_MOVE3), MOVE_POUND);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_MOVE4), MOVE_GROWL);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_PP1), 1);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_PP2), 2);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_PP3), 3);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_PP4), 4);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_PP_BONUSES), 255);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_COOL), 10);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_BEAUTY), 20);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_CUTE), 30);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_SMART), 40);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_TOUGH), 50);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_SHEEN), 150);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_EXP), 12345);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_MET_LEVEL), 20);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_HP_EV), 11);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_ATK_EV), 22);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_DEF_EV), 33);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_SPEED_EV), 44);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_SPATK_EV), 55);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_SPDEF_EV), 66);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_FRIENDSHIP), 123);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_POKERUS), 2);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_POKEBALL), BALL_FRIEND);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_HP_IV), 31);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_ATK_IV), 30);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_DEF_IV), 29);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_SPEED_IV), 28);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_SPATK_IV), 27);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_SPDEF_IV), 26);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_CUTE_RIBBON), 1);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_BEAUTY_RIBBON), 0);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_TOUGH_RIBBON), 1);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_SMART_RIBBON), 0);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_CHAMPION_RIBBON), 1);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_VICTORY_RIBBON), 1);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_EFFORT_RIBBON), 1);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_LAND_RIBBON), 1);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_COUNTRY_RIBBON), 1);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_EARTH_RIBBON), 1);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_HYPER_TRAINED_HP), 1);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_HYPER_TRAINED_ATK), 1);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_HYPER_TRAINED_DEF), 1);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_HYPER_TRAINED_SPEED), 1);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_HYPER_TRAINED_SPATK), 1);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_HYPER_TRAINED_SPDEF), 1);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_DYNAMAX_LEVEL), 3);
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_OT_GENDER), 0);
 }

--- a/test/pokemon.c
+++ b/test/pokemon.c
@@ -481,6 +481,7 @@ TEST("BoxPokemon encryption works")
     struct Pokemon mon;
     BoxMonToMon((struct BoxPokemon *)&raw, &mon);
 
+    EXPECT_EQ(GetMonData(&mon, MON_DATA_SANITY_IS_BAD_EGG), 0);
     EXPECT_EQ(GetMonData(&mon, MON_DATA_SPECIES), SPECIES_TORCHIC);
     EXPECT_EQ(GetMonData(&mon, MON_DATA_MARKINGS), 3);
     const u8 *actualNickname = COMPOUND_STRING("Testing mon");


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
Adds a test for `struct BoxPokemon` integrity.
Most things that can be checked with `GetMonData` is checked.
This test fails on #7313, but passes after the fix.

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara