### PR TITLE
Bag sorting cleanup

### DIFF
--- a/src/item_menu.c
+++ b/src/item_menu.c
@@ -2887,12 +2887,19 @@ static void MergeSort(struct BagPocket *pocket, s32 (*comparator)(enum Pocket, s
 {
     struct ItemSlot *dummySlots = AllocZeroed(sizeof(struct ItemSlot) * pocket->capacity);
 
-    for (u32 width = 1; width < pocket->capacity; width *= 2)
+    u32 usedCapacity;
+    for (usedCapacity = 0; usedCapacity < pocket->capacity; usedCapacity++)
     {
-        for (u32 i = 0; i < pocket->capacity; i += 2 * width)
-            Merge(pocket, i, min(i + width, pocket->capacity), min(i + 2 * width, pocket->capacity), dummySlots, comparator);
+        if (BagPocket_GetSlotData(pocket, usedCapacity).itemId == ITEM_NONE)
+            break;
+    }
 
-        for (u32 j = 0; j < pocket->capacity; j++)
+    for (u32 width = 1; width < usedCapacity; width *= 2)
+    {
+        for (u32 i = 0; i < usedCapacity; i += 2 * width)
+            Merge(pocket, i, min(i + width, usedCapacity), min(i + 2 * width, usedCapacity), dummySlots, comparator);
+
+        for (u32 j = 0; j < usedCapacity; j++)
             BagPocket_SetSlotData(pocket, j, dummySlots[j]);
     }
 

--- a/src/item_menu.c
+++ b/src/item_menu.c
@@ -2926,22 +2926,7 @@ static s32 CompareItemsAlphabetically(enum Pocket pocketId, struct ItemSlot item
         name2 = GetItemName(item2.itemId);
     }
 
-    for (u32 i = 0; ; ++i)
-    {
-        if (name1[i] == EOS && name2[i] != EOS)
-            return -1;
-        else if (name1[i] != EOS && name2[i] == EOS)
-            return 1;
-        else if (name1[i] == EOS && name2[i] == EOS)
-            return 0;
-
-        if (name1[i] < name2[i])
-            return -1;
-        else if (name1[i] > name2[i])
-            return 1;
-    }
-
-    return 0; // Will never be reached
+    return StringCompare(name1, name2);
 }
 
 static s32 CompareItemsByMost(enum Pocket pocketId, struct ItemSlot item1, struct ItemSlot item2)


### PR DESCRIPTION
Amusingly 33bde02 is also a fix for #7436. But mostly the purpose of that change is performance, for pockets with few items we avoid sorting the whole pocket.

I don't think either of these changes are necessary.

Whoever reviews this, please double-check my assumption that the bag pockets are non-`ITEM_NONE`s followed by `ITEM_NONE`s. I'm pretty sure all the non-empty slots get shuffled to the front, but if I'm wrong I'll have broken all the pockets.