### PR TITLE
Hacky support for enums in C asm statements

### DIFF
--- a/include/test/overworld_script.h
+++ b/include/test/overworld_script.h
@@ -51,7 +51,6 @@ asm(".set FALSE, 0\n"
     ".set VARS_END, " STR(VARS_END) "\n"
     ".set SPECIAL_VARS_START, " STR(SPECIAL_VARS_START) "\n"
     ".set SPECIAL_VARS_END, " STR(SPECIAL_VARS_END) "\n");
-asm(".include \"constants/gba_constants.inc\"\n");
 
 // Make overworld script macros available.
 asm(".include \"constants/gba_constants.inc\"\n"

--- a/tools/preproc/asm_file.cpp
+++ b/tools/preproc/asm_file.cpp
@@ -620,6 +620,10 @@ bool AsmFile::ParseEnum()
                 }
                 enumCounter = 0;
             }
+            // HACK(#7394): Make the definitions global so that C 'asm'
+            // statements are able to reference them (if they happen to
+            // be available in an assembled object file).
+            std::printf(".global %s; ", currentIdentName.c_str());
             std::printf(".equiv %s, (%s) + %ld\n", currentIdentName.c_str(), enumBase.c_str(), enumCounter);
             enumCounter++;
             symbolCount++;


### PR DESCRIPTION
## Things to note in the release changelog:
- WARNING: If an `enum` is not present in an assembled object file, it will not be available in C. This is not a problem for `OVERWORLD_SCRIPT` because you would not use an `enum` value that is not available in `data/event_scripts.s` in those scripts.

Closes #7394