### PR TITLE
Test to see if AI considers all moves; AI handling for some moves

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -4113,6 +4113,32 @@ static u32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move)
         ADJUST_SCORE(IncreaseStatUpScore(battlerAtk, battlerDef, STAT_CHANGE_ATK));
         ADJUST_SCORE(IncreaseStatUpScore(battlerAtk, battlerDef, STAT_CHANGE_SPATK));
         break;
+    case EFFECT_ROTOTILLER:
+        if (IS_BATTLER_OF_TYPE(battlerAtk, TYPE_GRASS) && IsBattlerGrounded(battlerAtk))
+        {
+            ADJUST_SCORE(IncreaseStatUpScore(battlerAtk, battlerDef, STAT_CHANGE_ATK));
+            ADJUST_SCORE(IncreaseStatUpScore(battlerAtk, battlerDef, STAT_CHANGE_SPATK));
+        }
+        if (hasPartner && IS_BATTLER_OF_TYPE(BATTLE_PARTNER(battlerAtk), TYPE_GRASS) && IsBattlerGrounded(BATTLE_PARTNER(battlerAtk)))
+        {
+            ADJUST_SCORE(IncreaseStatUpScore(BATTLE_PARTNER(battlerAtk), battlerDef, STAT_CHANGE_ATK));
+            ADJUST_SCORE(IncreaseStatUpScore(BATTLE_PARTNER(battlerAtk), battlerDef, STAT_CHANGE_SPATK));
+        }
+        if (IS_BATTLER_OF_TYPE(FOE(battlerAtk), TYPE_GRASS) && IsBattlerGrounded(FOE(battlerAtk)))
+        {
+            if (aiData->abilities[FOE(battlerAtk)] == ABILITY_CONTRARY)
+                ADJUST_SCORE(WEAK_EFFECT);
+            else
+                ADJUST_SCORE(AWFUL_EFFECT);
+        }
+        if (hasTwoOpponents && IS_BATTLER_OF_TYPE(BATTLE_PARTNER(FOE(battlerAtk)), TYPE_GRASS) && IsBattlerGrounded(BATTLE_PARTNER(FOE(battlerAtk))))
+        {
+            if (aiData->abilities[BATTLE_PARTNER(FOE(battlerAtk))] == ABILITY_CONTRARY)
+                ADJUST_SCORE(WEAK_EFFECT);
+            else
+                ADJUST_SCORE(AWFUL_EFFECT);
+        }
+        break;
     case EFFECT_HAZE:
         if (AnyStatIsRaised(BATTLE_PARTNER(battlerAtk))
           || PartnerHasSameMoveEffectWithoutTarget(BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove))

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -2662,6 +2662,16 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
               || PartnerMoveIsSameAsAttacker(BATTLE_PARTNER(battlerAtk), battlerDef, move, aiData->partnerMove))
                 ADJUST_SCORE(-10);
             break;
+        case EFFECT_DARK_VOID:
+            if (B_DARK_VOID_FAIL >= GEN_7 && gBattleMons[battlerAtk].species != SPECIES_DARKRAI)
+                ADJUST_SCORE(-10);
+            if (!AI_CanPutToSleep(battlerAtk, battlerDef, abilityDef, move, aiData->partnerMove))
+                ADJUST_SCORE(-10);
+            break;
+        case EFFECT_HYPERSPACE_FURY:
+            if (gBattleMons[battlerAtk].species != SPECIES_HOOPA_UNBOUND)
+                ADJUST_SCORE(-10);
+            break;
         case EFFECT_HEAL_BLOCK:
             if (gStatuses3[battlerDef] & STATUS3_HEAL_BLOCK
               || PartnerMoveIsSameAsAttacker(BATTLE_PARTNER(battlerAtk), battlerDef, move, aiData->partnerMove))
@@ -5177,6 +5187,9 @@ case EFFECT_GUARD_SPLIT:
         if (HasMoveWithLowAccuracy(battlerAtk, battlerDef, 90, FALSE, aiData->abilities[battlerAtk], aiData->abilities[battlerDef], aiData->holdEffects[battlerAtk], aiData->holdEffects[battlerDef])
           || !IsBattlerGrounded(battlerDef))
             ADJUST_SCORE(DECENT_EFFECT);
+        break;
+    case EFFECT_DARK_VOID:
+        IncreaseSleepScore(battlerAtk, battlerDef, move, &score);
         break;
     case EFFECT_HEAL_BLOCK:
         if (AI_IsFaster(battlerAtk, battlerDef, move, predictedMove, CONSIDER_PRIORITY) && predictedMove != MOVE_NONE && IsHealingMove(predictedMove))

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -2049,12 +2049,16 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             else if (gBattleMons[battlerDef].statStages[STAT_ATK] == MIN_STAT_STAGE && gBattleMons[battlerDef].statStages[STAT_SPATK] == MIN_STAT_STAGE)
                 ADJUST_SCORE(-10);
             break;
-        case EFFECT_FOLLOW_ME:
+        case EFFECT_AROMATIC_MIST:
         case EFFECT_HELPING_HAND:
+            if (gBattleStruct->monToSwitchIntoId[BATTLE_PARTNER(battlerAtk)] != PARTY_SIZE) //Partner is switching out.
+                ADJUST_SCORE(-10);
+            // falls through
+        case EFFECT_FOLLOW_ME:
+        case EFFECT_COACHING:
             if (!hasPartner
               || PartnerHasSameMoveEffectWithoutTarget(BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove)
-              || (aiData->partnerMove != MOVE_NONE && IsBattleMoveStatus(aiData->partnerMove))
-              || gBattleStruct->monToSwitchIntoId[BATTLE_PARTNER(battlerAtk)] != PARTY_SIZE) //Partner is switching out.
+              || (aiData->partnerMove != MOVE_NONE && IsBattleMoveStatus(aiData->partnerMove)))
                 ADJUST_SCORE(-10);
             break;
         case EFFECT_TRICK:
@@ -2131,10 +2135,6 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
         case EFFECT_FLOWER_SHIELD:
             if (!IS_BATTLER_OF_TYPE(battlerAtk, TYPE_GRASS)
               && !(hasPartner && IS_BATTLER_OF_TYPE(BATTLE_PARTNER(battlerAtk), TYPE_GRASS)))
-                ADJUST_SCORE(-10);
-            break;
-        case EFFECT_AROMATIC_MIST:
-            if (!hasPartner || !BattlerStatCanRise(BATTLE_PARTNER(battlerAtk), aiData->abilities[BATTLE_PARTNER(battlerAtk)], STAT_SPDEF))
                 ADJUST_SCORE(-10);
             break;
         case EFFECT_BIDE:
@@ -3113,7 +3113,14 @@ static s32 AI_DoubleBattle(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
     {
     case EFFECT_AROMATIC_MIST:
         if (hasPartner)
-            ADJUST_SCORE(IncreaseStatUpScore(battlerAtkPartner, battlerDef, STAT_CHANGE_SPDEF));
+            ADJUST_SCORE(IncreaseStatUpScore(battlerAtkPartner, FOE(battlerAtk), STAT_CHANGE_SPDEF));
+        break;
+    case EFFECT_COACHING:
+        if (hasPartner)
+        {
+            ADJUST_SCORE(IncreaseStatUpScore(BATTLE_PARTNER(battlerAtk), FOE(battlerAtk), STAT_CHANGE_ATK));
+            ADJUST_SCORE(IncreaseStatUpScore(BATTLE_PARTNER(battlerAtk), FOE(battlerAtk), STAT_CHANGE_DEF));
+        }
         break;
     case EFFECT_HELPING_HAND:
         if (!hasPartner || !HasDamagingMove(battlerAtkPartner))
@@ -3525,6 +3532,14 @@ static s32 AI_DoubleBattle(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
 
             switch (effect)
             {
+            case EFFECT_ACUPRESSURE:
+                if (atkPartnerAbility == ABILITY_CONTRARY)
+                    ADJUST_SCORE(AWFUL_EFFECT);
+                else if (atkPartnerAbility == ABILITY_SIMPLE)
+                    ADJUST_SCORE(GOOD_EFFECT);
+                else
+                    ADJUST_SCORE(WEAK_EFFECT);
+                break;
             case EFFECT_DOODLE:
             case EFFECT_ENTRAINMENT:
             case EFFECT_GASTRO_ACID:
@@ -4158,7 +4173,7 @@ static u32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move)
             ADJUST_SCORE(-2); // Should be either removed or turned into increasing score
     case EFFECT_ACUPRESSURE:
     {
-        u32 ability = aiData->abilities[battlerDef];
+        u32 ability = aiData->abilities[battlerAtk];
         if (ability == ABILITY_CONTRARY)
             ADJUST_SCORE(AWFUL_EFFECT);
         else if (ability == ABILITY_SIMPLE)

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -2337,8 +2337,27 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
               || DoesPartnerHaveSameMoveEffect(BATTLE_PARTNER(battlerAtk), battlerDef, move, aiData->partnerMove))
                 ADJUST_SCORE(-9);
             break;
+        case EFFECT_COURT_CHANGE:
+            if (gSideStatuses[GetBattlerSide(FOE(battlerAtk))] & SIDE_STATUS_BAD_COURT)
+                ADJUST_SCORE(BAD_EFFECT);
+            if (gSideStatuses[GetBattlerSide(battlerAtk)] & SIDE_STATUS_GOOD_COURT)
+                ADJUST_SCORE(BAD_EFFECT);
+            if (AreAnyHazardsOnSide(GetBattlerSide(FOE(battlerAtk))) && CountUsablePartyMons(battlerAtk) != 0)
+                ADJUST_SCORE(WORST_EFFECT);
+
+
+            if (hasPartner)
+            {
+                if (IsHazardMove(aiData->partnerMove) // partner is going to set up hazards
+                  && AI_IsFaster(BATTLE_PARTNER(battlerAtk), battlerAtk, aiData->partnerMove, predictedMove, CONSIDER_PRIORITY)) // partner is going to set up before the Court Change
+                {
+                    ADJUST_SCORE(-10);
+                    break; // Don't use Defog if partner is going to set up hazards
+                }
+            }
+            break;
         case EFFECT_DEFOG:
-            if (gSideStatuses[GetBattlerSide(battlerDef)] & (SIDE_STATUS_SCREEN_ANY | SIDE_STATUS_SAFEGUARD | SIDE_STATUS_MIST)
+            if (gSideStatuses[GetBattlerSide(battlerDef)] & SIDE_STATUS_GOOD_FOG
              || AreAnyHazardsOnSide(GetBattlerSide(battlerAtk)))
             {
                 if (PartnerHasSameMoveEffectWithoutTarget(BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove))
@@ -2643,6 +2662,13 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
                 }*/
             }
             break;
+        case EFFECT_TEATIME:
+            if (!(GetItemPocket(aiData->items[battlerAtk]) == POCKET_BERRIES 
+            || (hasPartner && GetItemPocket(aiData->items[BATTLE_PARTNER(battlerAtk)]) == POCKET_BERRIES)))
+                ADJUST_SCORE(-10);
+            if (PartnerHasSameMoveEffectWithoutTarget(BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove))
+                ADJUST_SCORE(-10);
+            break;
         case EFFECT_EMBARGO:
             if (!IsBattlerItemEnabled(battlerAtk)
              || gStatuses3[battlerDef] & STATUS3_EMBARGO
@@ -2842,11 +2868,11 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             ||  GetBattlerWeight(battlerDef) >= 2000) //200.0 kg
                 ADJUST_SCORE(-10);
             break;
-        /*case EFFECT_NO_RETREAT:
-            if (TrappedByNoRetreat(battlerAtk))
+        case EFFECT_NO_RETREAT:
+            if (gDisableStructs[battlerAtk].noRetreat)
                 ADJUST_SCORE(-10);
             break;
-        case EFFECT_EXTREME_EVOBOOST:
+        /*case EFFECT_EXTREME_EVOBOOST:
             if (MainStatsMaxed(battlerAtk))
                 ADJUST_SCORE(-10);
             break;
@@ -2896,11 +2922,6 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
                  || defPrio > 3) // Opponent going first or not using priority move
                     ADJUST_SCORE(-10);
             }
-            break;
-        case EFFECT_COURT_CHANGE:
-        case EFFECT_TEATIME:
-            if (PartnerHasSameMoveEffectWithoutTarget(BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove))
-                ADJUST_SCORE(-10);
             break;
         case EFFECT_PLACEHOLDER:
             return 0;   // cannot even select
@@ -4717,6 +4738,27 @@ static u32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move)
         //if (CountUsablePartyMons(battlerDef) != 0)
             //ADJUST_SCORE(8);
         break;
+    case EFFECT_COURT_CHANGE:
+        if (gSideStatuses[GetBattlerSide(FOE(battlerAtk))] & SIDE_STATUS_GOOD_COURT)
+            ADJUST_SCORE(WEAK_EFFECT);
+        if (gSideStatuses[GetBattlerSide(battlerAtk)] & SIDE_STATUS_BAD_COURT)
+            ADJUST_SCORE(WEAK_EFFECT);
+
+        if (AreAnyHazardsOnSide(GetBattlerSide(battlerAtk)) && CountUsablePartyMons(battlerAtk) != 0)
+        {
+            ADJUST_SCORE(DECENT_EFFECT);
+        }
+
+        if (hasPartner)
+        {
+            if (IsHazardMove(aiData->partnerMove) // partner is going to set up hazards
+              && AI_IsFaster(BATTLE_PARTNER(battlerAtk), battlerAtk, aiData->partnerMove, predictedMove, CONSIDER_PRIORITY)) // partner is going to set up before the Court Change
+            {
+                ADJUST_SCORE(-10);
+                break;
+            }
+        }
+        break;
     case EFFECT_DEFOG:
         if ((AreAnyHazardsOnSide(GetBattlerSide(battlerAtk)) && CountUsablePartyMons(battlerAtk) != 0)
             || (gSideStatuses[GetBattlerSide(battlerDef)] & SIDE_STATUS_GOOD_FOG))
@@ -4760,6 +4802,23 @@ static u32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move)
         else if (HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_STATUS))
             ADJUST_SCORE(DECENT_EFFECT);
         break;
+    case EFFECT_TEATIME:
+    {
+        u32 item = aiData->items[battlerAtk];
+        if (IsStatBoostingBerry(item))
+            ADJUST_SCORE(DECENT_EFFECT);
+        if (ShouldRestoreHpBerry(battlerAtk, item))
+            ADJUST_SCORE(DECENT_EFFECT);
+        if (hasPartner)
+        {
+            u32 item = aiData->items[BATTLE_PARTNER(battlerAtk)];
+            if (IsStatBoostingBerry(item))
+                ADJUST_SCORE(DECENT_EFFECT);
+            if (ShouldRestoreHpBerry(BATTLE_PARTNER(battlerAtk), item))
+                ADJUST_SCORE(DECENT_EFFECT);
+        } 
+        break;
+    }
     case EFFECT_TRICK:
     case EFFECT_BESTOW:
         switch (aiData->holdEffects[battlerAtk])
@@ -5329,8 +5388,10 @@ case EFFECT_GUARD_SPLIT:
         //break;
     //case EFFECT_CLANGOROUS_SOUL:  // TODO
         //break;
-    //case EFFECT_NO_RETREAT:       // TODO
-        //break;
+    case EFFECT_NO_RETREAT:
+        if (!(gDisableStructs[battlerAtk].noRetreat) && aiData->hpPercents[battlerAtk] >= 90)
+            ADJUST_SCORE(BEST_EFFECT);
+        break;
     //case EFFECT_SKY_DROP
         //break;
     case EFFECT_JUNGLE_HEALING:

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -2168,6 +2168,22 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             else if (aiData->hpPercents[battlerAtk] >= 90)
                 ADJUST_SCORE(-9); //No point in healing, but should at least do it if nothing better
             break;
+        case EFFECT_LIFE_DEW:
+            if (AI_BattlerAtMaxHp(battlerAtk))
+            {
+                if (hasPartner)
+                {
+                    if (AI_BattlerAtMaxHp(BATTLE_PARTNER(battlerAtk)))
+                        ADJUST_SCORE(-10);
+                    else
+                        break;
+                }
+                else
+                {
+                    ADJUST_SCORE(-10);
+                }
+            }
+            break;
         case EFFECT_MORNING_SUN:
         case EFFECT_SYNTHESIS:
         case EFFECT_MOONLIGHT:
@@ -4293,6 +4309,12 @@ static u32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move)
     case EFFECT_SYNTHESIS:
     case EFFECT_MOONLIGHT:
         if (ShouldRecover(battlerAtk, battlerDef, move, 50))
+            ADJUST_SCORE(GOOD_EFFECT);
+        break;
+    case EFFECT_LIFE_DEW:
+        if (ShouldRecover(battlerAtk, battlerDef, move, 25))
+            ADJUST_SCORE(GOOD_EFFECT);
+        if (hasPartner && ShouldRecover(BATTLE_PARTNER(battlerAtk), battlerDef, move, 25))
             ADJUST_SCORE(GOOD_EFFECT);
         break;
     case EFFECT_LIGHT_SCREEN:

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -4023,8 +4023,12 @@ static u32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move)
             return AI_CheckViability(battlerAtk, battlerDef, predictedMove, score);
         break;
     case EFFECT_ATTACK_UP:
+        ADJUST_SCORE(IncreaseStatUpScore(battlerAtk, battlerDef, STAT_CHANGE_ATK));
+        break;
     case EFFECT_ATTACK_UP_USER_ALLY:
         ADJUST_SCORE(IncreaseStatUpScore(battlerAtk, battlerDef, STAT_CHANGE_ATK));
+        if (hasPartner)
+            ADJUST_SCORE(IncreaseStatUpScore(BATTLE_PARTNER(battlerAtk), battlerDef, STAT_CHANGE_ATK));
         break;
     case EFFECT_ATTACK_UP_2:
         ADJUST_SCORE(IncreaseStatUpScore(battlerAtk, battlerDef, STAT_CHANGE_ATK_2));

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -1988,6 +1988,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
                 ADJUST_SCORE(-8);
             break;
         case EFFECT_BELLY_DRUM:
+        case EFFECT_CLANGOROUS_SOUL:
         case EFFECT_FILLET_AWAY:
             if (HasBattlerSideAbility(battlerDef, ABILITY_UNAWARE, aiData))
                 ADJUST_SCORE(-10);
@@ -4666,6 +4667,10 @@ static u32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move)
         && aiData->abilities[battlerAtk] != ABILITY_CONTRARY)
             ADJUST_SCORE(BEST_EFFECT);
         break;
+    case EFFECT_CLANGOROUS_SOUL:
+        if (!CanTargetFaintAi(battlerDef, battlerAtk) && aiData->abilities[battlerAtk] != ABILITY_CONTRARY)
+            ADJUST_SCORE(BEST_EFFECT);
+        break;
     case EFFECT_PSYCH_UP:
         score += AI_ShouldCopyStatChanges(battlerAtk, battlerDef);
         break;
@@ -5386,8 +5391,6 @@ case EFFECT_GUARD_SPLIT:
         break;
     //case EFFECT_EXTREME_EVOBOOST: // TODO
         //break;
-    //case EFFECT_CLANGOROUS_SOUL:  // TODO
-        //break;
     case EFFECT_NO_RETREAT:
         if (!(gDisableStructs[battlerAtk].noRetreat) && aiData->hpPercents[battlerAtk] >= 90)
             ADJUST_SCORE(BEST_EFFECT);
@@ -5849,6 +5852,8 @@ static s32 AI_Risky(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             ADJUST_SCORE(AVERAGE_RISKY_EFFECT);
         break;
     case EFFECT_BELLY_DRUM:
+    case EFFECT_CLANGOROUS_SOUL:
+    case EFFECT_FILLET_AWAY:
         if (aiData->hpPercents[battlerAtk] >= 90)
             ADJUST_SCORE(AVERAGE_RISKY_EFFECT);
         break;

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -4044,6 +4044,7 @@ static u32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move)
         ADJUST_SCORE(IncreaseStatUpScore(battlerAtk, battlerDef, STAT_CHANGE_SPEED));
         break;
     case EFFECT_SPEED_UP_2:
+    case EFFECT_AUTOTOMIZE:
         ADJUST_SCORE(IncreaseStatUpScore(battlerAtk, battlerDef, STAT_CHANGE_SPEED_2));
         break;
     case EFFECT_SPECIAL_ATTACK_UP:

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -4052,6 +4052,7 @@ static u32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move)
     case EFFECT_DEFENSE_UP_3:
         ADJUST_SCORE(IncreaseStatUpScore(battlerAtk, battlerDef, STAT_CHANGE_DEF));
         break;
+    case EFFECT_STUFF_CHEEKS:
     case EFFECT_DEFENSE_UP_2:
         ADJUST_SCORE(IncreaseStatUpScore(battlerAtk, battlerDef, STAT_CHANGE_DEF_2));
         break;

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -1832,6 +1832,10 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             if (IsWakeupTurn(battlerAtk) || !AI_IsBattlerAsleepOrComatose(battlerAtk))
                 ADJUST_SCORE(-10);    // if mon will wake up, is not asleep, or is not comatose
             break;
+        case EFFECT_FAIRY_LOCK:
+            if ((gFieldStatuses & STATUS_FIELD_FAIRY_LOCK) || PartnerMoveIsSameNoTarget(BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove))
+                ADJUST_SCORE(-10);
+            // fall through
         case EFFECT_MEAN_LOOK:
             if (AI_CanBattlerEscape(battlerDef)
                 || IsBattlerTrapped(battlerAtk, battlerDef)
@@ -2715,10 +2719,6 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
                 else if (targetNegativeStages < targetPositiveStages)
                     ADJUST_SCORE(-5); //More stages would be made positive than negative
             }
-            break;
-        case EFFECT_FAIRY_LOCK:
-            if ((gFieldStatuses & STATUS_FIELD_FAIRY_LOCK) || PartnerMoveIsSameNoTarget(BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove))
-                ADJUST_SCORE(-10);
             break;
         case EFFECT_DO_NOTHING:
         case EFFECT_HOLD_HANDS:
@@ -4260,6 +4260,7 @@ static u32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move)
         else if (gStatuses3[battlerAtk] & STATUS3_ALWAYS_HITS)
             ADJUST_SCORE(BEST_EFFECT);
         break;
+    case EFFECT_FAIRY_LOCK:
     case EFFECT_MEAN_LOOK:
         if (ShouldTrap(battlerAtk, battlerDef, move))
             ADJUST_SCORE(GOOD_EFFECT);
@@ -5202,10 +5203,6 @@ case EFFECT_GUARD_SPLIT:
     case EFFECT_TOPSY_TURVY:
         if (CountPositiveStatStages(battlerDef) > CountNegativeStatStages(battlerDef))
             ADJUST_SCORE(DECENT_EFFECT);
-        break;
-    case EFFECT_FAIRY_LOCK:
-        if (ShouldTrap(battlerAtk, battlerDef, move))
-            ADJUST_SCORE(BEST_EFFECT);
         break;
     case EFFECT_QUASH:
         if (hasPartner && AI_IsSlower(BATTLE_PARTNER(battlerAtk), battlerDef, aiData->partnerMove, predictedMove, CONSIDER_PRIORITY))
@@ -6302,6 +6299,7 @@ static s32 AI_PredictSwitch(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
     case EFFECT_TAUNT:
     case EFFECT_INGRAIN:
     case EFFECT_NO_RETREAT:
+    case EFFECT_FAIRY_LOCK:
     case EFFECT_MEAN_LOOK:
         ADJUST_SCORE(AWFUL_EFFECT);
         break;

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -2924,9 +2924,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
         case EFFECT_SPICY_EXTRACT:
             if (battlerAtk != BATTLE_PARTNER(battlerDef)
              && (HasMoveWithCategory(battlerDef, DAMAGE_CATEGORY_PHYSICAL)
-              || aiData->abilities[battlerDef] == ABILITY_CLEAR_BODY
-              || aiData->abilities[battlerDef] == ABILITY_GOOD_AS_GOLD
-              || aiData->holdEffects[battlerDef] == HOLD_EFFECT_CLEAR_AMULET))
+              || !CanLowerStat(battlerAtk, battlerDef, aiData->abilities[battlerDef], STAT_DEF)))
                 ADJUST_SCORE(-10);
             break;
         case EFFECT_UPPER_HAND:
@@ -4166,7 +4164,10 @@ static u32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move)
         ADJUST_SCORE(IncreaseStatDownScore(battlerAtk, battlerDef, STAT_EVASION));
         break;
     case EFFECT_SPICY_EXTRACT:
-        // TODO: Make IncreaseStatDownScore function, just like IncreaseStatUpScore
+        if (HasBattlerSideMoveWithEffect(battlerAtk, EFFECT_FOUL_PLAY)
+         || HasBattlerSideMoveWithEffect(battlerAtk, EFFECT_SPECTRAL_THIEF))
+            ADJUST_SCORE(WEAK_EFFECT);
+        ADJUST_SCORE(IncreaseStatDownScore(battlerAtk, battlerDef, STAT_DEF));
         break;
     case EFFECT_BIDE:
         if (aiData->hpPercents[battlerAtk] < 90)

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -3063,6 +3063,10 @@ static s32 AI_DoubleBattle(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
     // consider our move effect relative to partner state
     switch (effect)
     {
+    case EFFECT_AROMATIC_MIST:
+        if (hasPartner)
+            ADJUST_SCORE(IncreaseStatUpScore(battlerAtkPartner, battlerDef, STAT_CHANGE_SPDEF));
+        break;
     case EFFECT_HELPING_HAND:
         if (!hasPartner || !HasDamagingMove(battlerAtkPartner))
             ADJUST_SCORE(-20);

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -4139,6 +4139,30 @@ static u32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move)
                 ADJUST_SCORE(AWFUL_EFFECT);
         }
         break;
+    case EFFECT_FLOWER_SHIELD:
+        if (IS_BATTLER_OF_TYPE(battlerAtk, TYPE_GRASS))
+        {
+            ADJUST_SCORE(IncreaseStatUpScore(battlerAtk, battlerDef, STAT_CHANGE_DEF));
+        }
+        if (hasPartner && IS_BATTLER_OF_TYPE(BATTLE_PARTNER(battlerAtk), TYPE_GRASS))
+        {
+            ADJUST_SCORE(IncreaseStatUpScore(BATTLE_PARTNER(battlerAtk), battlerDef, STAT_CHANGE_DEF));
+        }
+        if (IS_BATTLER_OF_TYPE(FOE(battlerAtk), TYPE_GRASS))
+        {
+            if (aiData->abilities[FOE(battlerAtk)] == ABILITY_CONTRARY)
+                ADJUST_SCORE(WEAK_EFFECT);
+            else
+                ADJUST_SCORE(AWFUL_EFFECT);
+        }
+        if (hasTwoOpponents && IS_BATTLER_OF_TYPE(BATTLE_PARTNER(FOE(battlerAtk)), TYPE_GRASS))
+        {
+            if (aiData->abilities[BATTLE_PARTNER(FOE(battlerAtk))] == ABILITY_CONTRARY)
+                ADJUST_SCORE(WEAK_EFFECT);
+            else
+                ADJUST_SCORE(AWFUL_EFFECT);
+        }
+        break;
     case EFFECT_HAZE:
         if (AnyStatIsRaised(BATTLE_PARTNER(battlerAtk))
           || PartnerHasSameMoveEffectWithoutTarget(BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove))

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -4118,6 +4118,38 @@ static u32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move)
         if (aiData->hpPercents[battlerAtk] < 90)
             ADJUST_SCORE(-2); // Should be either removed or turned into increasing score
     case EFFECT_ACUPRESSURE:
+    {
+        u32 ability = aiData->abilities[battlerDef];
+        if (ability == ABILITY_CONTRARY)
+            ADJUST_SCORE(AWFUL_EFFECT);
+        else if (ability == ABILITY_SIMPLE)
+            ADJUST_SCORE(GOOD_EFFECT);
+        else
+            ADJUST_SCORE(WEAK_EFFECT);
+    }
+    case EFFECT_MAGNETIC_FLUX:
+        if (aiData->abilities[battlerAtk] == ABILITY_PLUS || aiData->abilities[battlerAtk] == ABILITY_MINUS)
+        {
+            ADJUST_SCORE(IncreaseStatUpScore(battlerAtk, battlerDef, STAT_CHANGE_DEF));
+            ADJUST_SCORE(IncreaseStatUpScore(battlerAtk, battlerDef, STAT_CHANGE_SPDEF));
+        }
+        if (hasPartner && (aiData->abilities[BATTLE_PARTNER(battlerAtk)] == ABILITY_PLUS || aiData->abilities[BATTLE_PARTNER(battlerAtk)] == ABILITY_MINUS))
+        {
+            ADJUST_SCORE(IncreaseStatUpScore(BATTLE_PARTNER(battlerAtk), battlerDef, STAT_CHANGE_DEF));
+            ADJUST_SCORE(IncreaseStatUpScore(BATTLE_PARTNER(battlerAtk), battlerDef, STAT_CHANGE_SPDEF));
+        }
+        break;
+    case EFFECT_GEAR_UP:
+        if (aiData->abilities[battlerAtk] == ABILITY_PLUS || aiData->abilities[battlerAtk] == ABILITY_MINUS)
+        {
+            ADJUST_SCORE(IncreaseStatUpScore(battlerAtk, battlerDef, STAT_CHANGE_ATK));
+            ADJUST_SCORE(IncreaseStatUpScore(battlerAtk, battlerDef, STAT_CHANGE_SPATK));
+        }
+        if (hasPartner && (aiData->abilities[BATTLE_PARTNER(battlerAtk)] == ABILITY_PLUS || aiData->abilities[BATTLE_PARTNER(battlerAtk)] == ABILITY_MINUS))
+        {
+            ADJUST_SCORE(IncreaseStatUpScore(BATTLE_PARTNER(battlerAtk), battlerDef, STAT_CHANGE_ATK));
+            ADJUST_SCORE(IncreaseStatUpScore(BATTLE_PARTNER(battlerAtk), battlerDef, STAT_CHANGE_SPATK));
+        }
         break;
     case EFFECT_ATTACK_ACCURACY_UP: // hone claws
         ADJUST_SCORE(IncreaseStatUpScore(battlerAtk, battlerDef, STAT_CHANGE_ATK));

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -2000,7 +2000,8 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
                 ADJUST_SCORE(GOOD_EFFECT);
             break;
         case EFFECT_TELEPORT:
-            ADJUST_SCORE(-10);
+            if (B_TELEPORT_BEHAVIOR < GEN_8)
+                ADJUST_SCORE(-10);
             break;
         case EFFECT_FIRST_TURN_ONLY:
             if (!gDisableStructs[battlerAtk].isFirstTurn)
@@ -4306,7 +4307,7 @@ static u32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move)
         //todo - check z splash, z celebrate, z happy hour (lol)
         break;
     case EFFECT_TELEPORT: // Either remove or add better logic
-        if (!(gBattleTypeFlags & BATTLE_TYPE_TRAINER) || !IsOnPlayerSide(battlerAtk))
+        if (B_TELEPORT_BEHAVIOR < GEN_8)
             break;
         //fallthrough
     case EFFECT_HIT_ESCAPE:

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -2533,6 +2533,7 @@ bool32 IsAttackBoostMoveEffect(enum BattleMoveEffects effect)
     {
     case EFFECT_ATTACK_UP:
     case EFFECT_ATTACK_UP_2:
+    case EFFECT_ATTACK_UP_USER_ALLY:
     case EFFECT_ATTACK_ACCURACY_UP:
     case EFFECT_ATTACK_SPATK_UP:
     case EFFECT_DRAGON_DANCE:
@@ -2553,6 +2554,7 @@ bool32 IsStatRaisingEffect(enum BattleMoveEffects effect)
     {
     case EFFECT_ATTACK_UP:
     case EFFECT_ATTACK_UP_2:
+    case EFFECT_ATTACK_UP_USER_ALLY:
     case EFFECT_DEFENSE_UP:
     case EFFECT_DEFENSE_UP_2:
     case EFFECT_DEFENSE_UP_3:

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -2536,12 +2536,13 @@ bool32 IsAttackBoostMoveEffect(enum BattleMoveEffects effect)
     case EFFECT_ATTACK_UP_USER_ALLY:
     case EFFECT_ATTACK_ACCURACY_UP:
     case EFFECT_ATTACK_SPATK_UP:
-    case EFFECT_DRAGON_DANCE:
-    case EFFECT_COIL:
     case EFFECT_BELLY_DRUM:
     case EFFECT_BULK_UP:
-    case EFFECT_GROWTH:
+    case EFFECT_DRAGON_DANCE:
+    case EFFECT_CLANGOROUS_SOUL:
+    case EFFECT_COIL:
     case EFFECT_FILLET_AWAY:
+    case EFFECT_GROWTH:
         return TRUE;
     default:
         return FALSE;
@@ -2574,24 +2575,27 @@ bool32 IsStatRaisingEffect(enum BattleMoveEffects effect)
     case EFFECT_EVASION_UP:
     case EFFECT_EVASION_UP_2:
     case EFFECT_MINIMIZE:
-    case EFFECT_CALM_MIND:
-    case EFFECT_COSMIC_POWER:
-    case EFFECT_MAGNETIC_FLUX:
-    case EFFECT_DRAGON_DANCE:
-    case EFFECT_ACUPRESSURE:
-    case EFFECT_SHELL_SMASH:
-    case EFFECT_SHIFT_GEAR:
     case EFFECT_ATTACK_ACCURACY_UP:
     case EFFECT_ATTACK_SPATK_UP:
-    case EFFECT_GEAR_UP:
-    case EFFECT_GROWTH:
-    case EFFECT_COIL:
-    case EFFECT_QUIVER_DANCE:
+    case EFFECT_ACUPRESSURE:
+    case EFFECT_BELLY_DRUM:
     case EFFECT_BULK_UP:
+    case EFFECT_CALM_MIND:
+    case EFFECT_CLANGOROUS_SOUL:
+    case EFFECT_COIL:
+    case EFFECT_COSMIC_POWER:
+    case EFFECT_DRAGON_DANCE:
+    case EFFECT_FILLET_AWAY:
+    case EFFECT_GEAR_UP:
     case EFFECT_GEOMANCY:
+    case EFFECT_GROWTH:
+    case EFFECT_MAGNETIC_FLUX:
+    case EFFECT_NO_RETREAT:
+    case EFFECT_QUIVER_DANCE:
+    case EFFECT_SHELL_SMASH:
+    case EFFECT_SHIFT_GEAR:
     case EFFECT_STOCKPILE:
     case EFFECT_VICTORY_DANCE:
-    case EFFECT_NO_RETREAT:
         return TRUE;
     case EFFECT_CHARGE:
         return B_CHARGE_SPDEF_RAISE >= GEN_5;

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -2575,12 +2575,14 @@ bool32 IsStatRaisingEffect(enum BattleMoveEffects effect)
     case EFFECT_MINIMIZE:
     case EFFECT_CALM_MIND:
     case EFFECT_COSMIC_POWER:
+    case EFFECT_MAGNETIC_FLUX:
     case EFFECT_DRAGON_DANCE:
     case EFFECT_ACUPRESSURE:
     case EFFECT_SHELL_SMASH:
     case EFFECT_SHIFT_GEAR:
     case EFFECT_ATTACK_ACCURACY_UP:
     case EFFECT_ATTACK_SPATK_UP:
+    case EFFECT_GEAR_UP:
     case EFFECT_GROWTH:
     case EFFECT_COIL:
     case EFFECT_QUIVER_DANCE:

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -2591,6 +2591,7 @@ bool32 IsStatRaisingEffect(enum BattleMoveEffects effect)
     case EFFECT_GEOMANCY:
     case EFFECT_STOCKPILE:
     case EFFECT_VICTORY_DANCE:
+    case EFFECT_NO_RETREAT:
         return TRUE;
     case EFFECT_CHARGE:
         return B_CHARGE_SPDEF_RAISE >= GEN_5;

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -2556,9 +2556,10 @@ bool32 IsStatRaisingEffect(enum BattleMoveEffects effect)
     case EFFECT_ATTACK_UP_2:
     case EFFECT_ATTACK_UP_USER_ALLY:
     case EFFECT_DEFENSE_UP:
-    case EFFECT_DEFENSE_CURL:
     case EFFECT_DEFENSE_UP_2:
     case EFFECT_DEFENSE_UP_3:
+    case EFFECT_DEFENSE_CURL:
+    case EFFECT_FLOWER_SHIELD:
     case EFFECT_SPEED_UP:
     case EFFECT_SPEED_UP_2:
     case EFFECT_AUTOTOMIZE:

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -2543,6 +2543,7 @@ bool32 IsAttackBoostMoveEffect(enum BattleMoveEffects effect)
     case EFFECT_COIL:
     case EFFECT_FILLET_AWAY:
     case EFFECT_GROWTH:
+    case EFFECT_TIDY_UP:
         return TRUE;
     default:
         return FALSE;
@@ -2595,6 +2596,7 @@ bool32 IsStatRaisingEffect(enum BattleMoveEffects effect)
     case EFFECT_SHELL_SMASH:
     case EFFECT_SHIFT_GEAR:
     case EFFECT_STOCKPILE:
+    case EFFECT_TIDY_UP:
     case EFFECT_VICTORY_DANCE:
         return TRUE;
     case EFFECT_CHARGE:

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -2559,6 +2559,7 @@ bool32 IsStatRaisingEffect(enum BattleMoveEffects effect)
     case EFFECT_DEFENSE_UP_2:
     case EFFECT_DEFENSE_UP_3:
     case EFFECT_DEFENSE_CURL:
+    case EFFECT_STUFF_CHEEKS:
     case EFFECT_FLOWER_SHIELD:
     case EFFECT_SPEED_UP:
     case EFFECT_SPEED_UP_2:

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -2556,10 +2556,12 @@ bool32 IsStatRaisingEffect(enum BattleMoveEffects effect)
     case EFFECT_ATTACK_UP_2:
     case EFFECT_ATTACK_UP_USER_ALLY:
     case EFFECT_DEFENSE_UP:
+    case EFFECT_DEFENSE_CURL:
     case EFFECT_DEFENSE_UP_2:
     case EFFECT_DEFENSE_UP_3:
     case EFFECT_SPEED_UP:
     case EFFECT_SPEED_UP_2:
+    case EFFECT_AUTOTOMIZE:
     case EFFECT_SPECIAL_ATTACK_UP:
     case EFFECT_SPECIAL_ATTACK_UP_2:
     case EFFECT_SPECIAL_ATTACK_UP_3:
@@ -2570,7 +2572,6 @@ bool32 IsStatRaisingEffect(enum BattleMoveEffects effect)
     case EFFECT_EVASION_UP:
     case EFFECT_EVASION_UP_2:
     case EFFECT_MINIMIZE:
-    case EFFECT_DEFENSE_CURL:
     case EFFECT_CALM_MIND:
     case EFFECT_COSMIC_POWER:
     case EFFECT_DRAGON_DANCE:

--- a/test/battle/ai/ai_doubles.c
+++ b/test/battle/ai/ai_doubles.c
@@ -2,6 +2,158 @@
 #include "test/battle.h"
 #include "battle_ai_util.h"
 
+AI_DOUBLE_BATTLE_TEST("AI considers all moves; TODO: first group of move effects")
+{
+    s32 j;
+    u32 move = MOVE_NONE;
+    enum BattleMoveEffects moveEffect;
+
+    for (j = MOVE_NONE + 1; j < MOVES_COUNT; j++)
+    {
+        // Damaging moves are universally usable.
+        if (GetMoveCategory(j) != DAMAGE_CATEGORY_STATUS)
+            continue;
+        if (IsMoveEffectWeather(j))
+            continue;
+
+        moveEffect = GetMoveEffect(j);
+
+        if (IsStatRaisingEffect(moveEffect))
+            continue;
+        if (IsStatRaisingEffect(moveEffect))
+            continue;
+
+        switch (moveEffect)
+        {
+        // These move effects are problematic or missing entirely
+        case EFFECT_MIST:
+        case EFFECT_TELEPORT:
+        case EFFECT_LIGHT_SCREEN:
+        case EFFECT_REFLECT:
+        case EFFECT_AURORA_VEIL:
+        case EFFECT_SKETCH:
+        case EFFECT_PROTECT:
+        case EFFECT_HEAL_BELL:
+        case EFFECT_REFRESH:
+        case EFFECT_SAFEGUARD:
+        case EFFECT_FOLLOW_ME:
+        case EFFECT_WISH:
+        case EFFECT_MUD_SPORT:
+        case EFFECT_WATER_SPORT:
+        case EFFECT_HEALING_WISH:
+        case EFFECT_TAILWIND:
+        case EFFECT_PSYCHO_SHIFT:
+        case EFFECT_LUCKY_CHANT:
+        case EFFECT_ME_FIRST:
+        case EFFECT_COPYCAT:
+        case EFFECT_AQUA_RING:
+        case EFFECT_MAGNET_RISE:
+        case EFFECT_CAPTIVATE:
+        case EFFECT_WONDER_ROOM:
+        case EFFECT_MAGIC_ROOM:
+        case EFFECT_ALLY_SWITCH:
+        case EFFECT_MAT_BLOCK:
+        case EFFECT_POWDER:
+        case EFFECT_PURIFY:
+        case EFFECT_INSTRUCT:
+        case EFFECT_TEATIME:
+        case EFFECT_JUNGLE_HEALING:
+        case EFFECT_TAKE_HEART:
+        case EFFECT_REVIVAL_BLESSING:
+
+        // These all should be usable under circumstances unrelated to this test.
+        // If there is not an AI test to see if it works, make one yourself!
+        case EFFECT_COURT_CHANGE:
+        case EFFECT_DRAGON_CHEER:
+        case EFFECT_LIFE_DEW:
+        case EFFECT_FAIRY_LOCK:
+        case EFFECT_ELECTRIFY:
+        case EFFECT_GRASSY_TERRAIN:
+        case EFFECT_MISTY_TERRAIN:
+        case EFFECT_ELECTRIC_TERRAIN:
+        case EFFECT_PSYCHIC_TERRAIN:
+        case EFFECT_NON_VOLATILE_STATUS:
+        case EFFECT_TOPSY_TURVY:
+        case EFFECT_ION_DELUGE:
+        case EFFECT_LASER_FOCUS:
+        case EFFECT_ROTOTILLER:
+        case EFFECT_HEAL_PULSE:
+        case EFFECT_BESTOW:
+        case EFFECT_AFTER_YOU:
+        case EFFECT_SHORE_UP:
+        case EFFECT_TRICK_ROOM:
+        case EFFECT_HEART_SWAP:
+        case EFFECT_POWER_SWAP:
+        case EFFECT_GUARD_SWAP:
+        case EFFECT_POWER_TRICK:
+        case EFFECT_POWER_SPLIT:
+        case EFFECT_GUARD_SPLIT:
+        case EFFECT_GRAVITY:
+        case EFFECT_CAMOUFLAGE:
+        case EFFECT_SNATCH:
+        case EFFECT_IMPRISON:
+        case EFFECT_GRUDGE:
+        case EFFECT_RECYCLE:
+        case EFFECT_MAGIC_COAT:
+        case EFFECT_INGRAIN:
+        case EFFECT_ROLE_PLAY:
+        case EFFECT_SKILL_SWAP:
+        case EFFECT_DOODLE:
+        case EFFECT_ENTRAINMENT:
+        case EFFECT_SIMPLE_BEAM:
+        case EFFECT_WORRY_SEED:
+        case EFFECT_BATON_PASS:
+        case EFFECT_ENCORE:
+        case EFFECT_SWALLOW:
+        case EFFECT_PERISH_SONG:
+        case EFFECT_DESTINY_BOND:
+        case EFFECT_SLEEP_TALK:
+        case EFFECT_CURSE:
+        case EFFECT_ENDURE:
+        case EFFECT_SPITE:
+        case EFFECT_SUBSTITUTE:
+        case EFFECT_SHED_TAIL:
+        case EFFECT_HAZE:
+        case EFFECT_RESTORE_HP:
+        case EFFECT_SOFTBOILED:
+        case EFFECT_ROOST:
+        case EFFECT_MORNING_SUN:
+        case EFFECT_SYNTHESIS:
+        case EFFECT_MOONLIGHT:
+        case EFFECT_REST:
+        case EFFECT_CONVERSION:
+        case EFFECT_CONVERSION_2:
+        case EFFECT_MIMIC:
+        case EFFECT_DISABLE:
+        case EFFECT_HELPING_HAND:
+        case EFFECT_FOCUS_ENERGY:
+        case EFFECT_MIRROR_MOVE:
+
+        // Skipped on purpose.
+        case EFFECT_DO_NOTHING:
+        case EFFECT_HOLD_HANDS:
+        case EFFECT_CELEBRATE:
+        case EFFECT_HAPPY_HOUR:
+            break;
+        default:
+            PARAMETRIZE { move = j; }
+        }
+    }
+
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_HP_AWARE | AI_FLAG_OMNISCIENT);
+        PLAYER(SPECIES_ZIGZAGOON) { Status1(STATUS1_POISON); }
+        PLAYER(SPECIES_ZIGZAGOON);
+        PLAYER(SPECIES_ZIGZAGOON);
+        OPPONENT(SPECIES_ZIGZAGOON) { Moves(MOVE_SPLASH, move); Status1(STATUS1_BURN); Item(ITEM_STARF_BERRY); }
+        OPPONENT(SPECIES_ZIGZAGOON) { Moves(MOVE_POUND, move); Item(ITEM_STARF_BERRY); }
+        OPPONENT(SPECIES_ZIGZAGOON) { Status1(STATUS1_BURN); }
+        OPPONENT(SPECIES_ZIGZAGOON);
+    } WHEN {
+        TURN {  EXPECT_MOVE(opponentLeft, move); }
+    }
+}
+
 AI_DOUBLE_BATTLE_TEST("AI won't use a Weather changing move if partner already chose such move")
 {
     u32 j, k;
@@ -661,3 +813,69 @@ AI_DOUBLE_BATTLE_TEST("AI prefers to Fake Out the opponent vulnerable to flinchi
         TURN { EXPECT_MOVE(opponentLeft, MOVE_FAKE_OUT, target:playerRight); }
     }
 }
+
+AI_DOUBLE_BATTLE_TEST("AI can use Flower Shield")
+{
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_OMNISCIENT);
+        PLAYER(SPECIES_WOBBUFFET) { Moves(MOVE_POUND, MOVE_CELEBRATE); }
+        PLAYER(SPECIES_WOBBUFFET) { Moves(MOVE_POUND, MOVE_CELEBRATE); }
+        OPPONENT(SPECIES_BULBASAUR) { Moves(MOVE_FLOWER_SHIELD, MOVE_POUND); }
+        OPPONENT(SPECIES_BULBASAUR);
+    } WHEN {
+        TURN {  EXPECT_MOVE(opponentLeft, MOVE_FLOWER_SHIELD); }
+    }
+}
+
+AI_DOUBLE_BATTLE_TEST("AI can use Rototiller")
+{
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_OMNISCIENT);
+        PLAYER(SPECIES_WOBBUFFET) { Moves(MOVE_POUND, MOVE_CELEBRATE); }
+        PLAYER(SPECIES_WOBBUFFET) { Moves(MOVE_POUND, MOVE_CELEBRATE); }
+        OPPONENT(SPECIES_BULBASAUR) { Moves(MOVE_ROTOTILLER, MOVE_POUND); }
+        OPPONENT(SPECIES_BULBASAUR);
+    } WHEN {
+        TURN {  EXPECT_MOVE(opponentLeft, MOVE_ROTOTILLER); }
+    }
+}
+
+AI_DOUBLE_BATTLE_TEST("AI can use Dragon Cheer")
+{
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_OMNISCIENT);
+        PLAYER(SPECIES_WOBBUFFET) { Moves(MOVE_POUND, MOVE_CELEBRATE); }
+        PLAYER(SPECIES_WOBBUFFET) { Moves(MOVE_POUND, MOVE_CELEBRATE); }
+        OPPONENT(SPECIES_DRATINI) { Moves(MOVE_DRAGON_CHEER, MOVE_POUND); }
+        OPPONENT(SPECIES_DRATINI) { Moves(MOVE_DRAGON_CHEER, MOVE_POUND); }
+    } WHEN {
+        TURN {  EXPECT_MOVE(opponentLeft, MOVE_DRAGON_CHEER); }
+    }
+}
+
+AI_DOUBLE_BATTLE_TEST("AI can use Magnetic Flux")
+{
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_OMNISCIENT);
+        PLAYER(SPECIES_WOBBUFFET) { Moves(MOVE_POUND, MOVE_CELEBRATE); }
+        PLAYER(SPECIES_WOBBUFFET) { Moves(MOVE_POUND, MOVE_CELEBRATE); }
+        OPPONENT(SPECIES_KLINK) { Ability(ABILITY_PLUS); Moves(MOVE_MAGNETIC_FLUX, MOVE_POUND); }
+        OPPONENT(SPECIES_KLINK) { Ability(ABILITY_PLUS); Moves(MOVE_MAGNETIC_FLUX, MOVE_POUND); }
+    } WHEN {
+        TURN {  EXPECT_MOVE(opponentLeft, MOVE_MAGNETIC_FLUX); }
+    }
+}
+
+AI_DOUBLE_BATTLE_TEST("AI can use Gear Up")
+{
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_OMNISCIENT);
+        PLAYER(SPECIES_WOBBUFFET) { Moves(MOVE_POUND, MOVE_CELEBRATE); }
+        PLAYER(SPECIES_WOBBUFFET) { Moves(MOVE_POUND, MOVE_CELEBRATE); }
+        OPPONENT(SPECIES_KLINKLANG) { Ability(ABILITY_PLUS); Moves(MOVE_GEAR_UP, MOVE_WATER_GUN, MOVE_POUND); }
+        OPPONENT(SPECIES_KLINKLANG) { Ability(ABILITY_PLUS); Moves(MOVE_GEAR_UP, MOVE_WATER_GUN, MOVE_POUND); }
+    } WHEN {
+        TURN {  EXPECT_MOVE(opponentLeft, MOVE_GEAR_UP); }
+    }
+}
+


### PR DESCRIPTION
AI_DOUBLE_BATTLE_TEST("AI considers all moves; TODO: first group of move effects") is a test that runs through all status moves to see if they score higher than Splash.

The first segment in the case statement is of move effects where it scores equivalently to doing literally nothing where it probably should not have for some reason or another.

The second segment is of move effects that I understood why it did not work.

The full list of moves I believe something is wrong for is: Ally Switch, Aqua Ring, Aurora Veil, Captivate, Copycat, Follow Me, Heal Bell, Healing Wish, Instruct, Jungle Healing, Light Screen, Lucky Chant, Magic Room, Magnet Rise, Mat Block, Me First, Mist, Mud Sport, Powder, Protect, Psycho Shift, Purify, Reflect, Refresh, Revival Blessing, Safeguard, Sketch, Tailwind, Take Heart, Teatime.

Moves with effects added or corrected in some way in this PR:
Acupressure
Aromatic Mist (tested)
Automotize
Clangorous Soul (tested; failed; suspect Belly Drum might also be broken)
Coaching (tested)
Court Change
Dark Void
Fairy Lock
Flower Shield (tested)
Gear Up (tested)
Howl
Hyperspace Fury
Life Dew
Magnetic Flux (tested)
No Retreat
Rototiller (tested)
Spicy Extract (tested)
Stuff Cheeks
Teatime (tested; failed)
Teleport
Tidy Up

## Discord contact info
wildvenonat