### PR TITLE
AI handling for similar utility moves

### DIFF
--- a/include/battle_ai_util.h
+++ b/include/battle_ai_util.h
@@ -168,14 +168,14 @@ bool32 HasMove(u32 battlerId, u32 move);
 bool32 HasOnlyMovesWithCategory(u32 battlerId, enum DamageCategory category, bool32 onlyOffensive);
 bool32 HasMoveWithCategory(u32 battler, enum DamageCategory category);
 bool32 HasMoveWithType(u32 battler, u32 type);
-bool32 HasMoveWithEffect(u32 battlerId, enum BattleMoveEffects moveEffect);
+bool32 HasMoveWithEffect(u32 battler, enum BattleMoveEffects moveEffect);
+bool32 HasMoveWithExactEffect(u32 battler, enum BattleMoveEffects moveEffect);
 bool32 HasBattlerSideMoveWithEffect(u32 battler, u32 effect);
 bool32 HasBattlerSideUsedMoveWithEffect(u32 battler, u32 effect);
 bool32 HasNonVolatileMoveEffect(u32 battlerId, u32 effect);
 bool32 IsPowerBasedOnStatus(u32 battlerId, enum BattleMoveEffects effect, u32 argument);
 bool32 HasMoveWithAdditionalEffect(u32 battlerId, u32 moveEffect);
 bool32 HasBattlerSideMoveWithAdditionalEffect(u32 battler, u32 moveEffect);
-bool32 HasBattlerSideUsedMoveWithAdditionalEffect(u32 battler, u32 moveEffect);
 bool32 HasMoveWithCriticalHitChance(u32 battlerId);
 bool32 HasMoveWithMoveEffectExcept(u32 battlerId, u32 moveEffect, enum BattleMoveEffects exception);
 bool32 HasMoveThatLowersOwnStats(u32 battlerId);
@@ -252,11 +252,9 @@ bool32 HasTwoOpponents(u32 battler);
 bool32 HasPartner(u32 battler);
 bool32 HasPartnerIgnoreFlags(u32 battler);
 // HasPartner respects the Attacks Partner AI flag; HasPartnerIgnoreFlags checks only if a live pokemon is adjacent.
+bool32 AreMovesEquivalent(u32 battlerAtk, u32 battlerAtkPartner, u32 move, u32 partnerMove);
 bool32 DoesPartnerHaveSameMoveEffect(u32 battlerAtkPartner, u32 battlerDef, u32 move, u32 partnerMove);
-bool32 PartnerHasSameMoveEffectWithoutTarget(u32 battlerAtkPartner, u32 move, u32 partnerMove);
 bool32 PartnerMoveEffectIsStatusSameTarget(u32 battlerAtkPartner, u32 battlerDef, u32 partnerMove);
-bool32 IsMoveEffectWeather(u32 move);
-bool32 PartnerMoveEffectIsTerrain(u32 battlerAtkPartner, u32 partnerMove);
 bool32 PartnerMoveEffectIs(u32 battlerAtkPartner, u32 partnerMove, enum BattleMoveEffects effectCheck);
 bool32 PartnerMoveIs(u32 battlerAtkPartner, u32 partnerMove, u32 moveCheck);
 bool32 PartnerMoveIsSameAsAttacker(u32 battlerAtkPartner, u32 battlerDef, u32 move, u32 partnerMove);
@@ -300,5 +298,34 @@ bool32 HasLowAccuracyMove(u32 battlerAtk, u32 battlerDef);
 bool32 HasBattlerSideAbility(u32 battlerDef, u32 ability, struct AiLogicData *aiData);
 u32 GetThinkingBattler(u32 battler);
 bool32 IsNaturalEnemy(u32 speciesAttacker, u32 speciesTarget);
+
+enum BattleAIMoveEffects
+{
+    BATTLE_AI_WEATHER,
+    BATTLE_AI_TERRAIN,
+    BATTLE_AI_CLEAR_HAZARDS,
+    BATTLE_AI_BREAK_SCREENS,
+    BATTLE_AI_RESET_STATS,
+    BATTLE_AI_FORCE_SWITCH,
+    BATTLE_AI_TORMENT,
+    BATTLE_AI_LIGHT_SCREEN,
+    BATTLE_AI_REFLECT,
+    BATTLE_AI_GRAVITY,
+};
+// These are for the purpose of not doubling up on moves during double battles.
+// As Aurora Veil effectively is not used alongside Reflect and Light Screen, we are saving the bit.
+
+#define AI_EFFECT_NONE                  0
+#define AI_EFFECT_WEATHER              (1 << BATTLE_AI_WEATHER)
+#define AI_EFFECT_TERRAIN              (1 << BATTLE_AI_TERRAIN)
+#define AI_EFFECT_CLEAR_HAZARDS        (1 << BATTLE_AI_CLEAR_HAZARDS)
+#define AI_EFFECT_BREAK_SCREENS        (1 << BATTLE_AI_BREAK_SCREENS)
+#define AI_EFFECT_RESET_STATS          (1 << BATTLE_AI_RESET_STATS) 
+#define AI_EFFECT_FORCE_SWITCH         (1 << BATTLE_AI_FORCE_SWITCH)
+#define AI_EFFECT_TORMENT              (1 << BATTLE_AI_TORMENT)
+#define AI_EFFECT_LIGHT_SCREEN         (1 << BATTLE_AI_REFLECT)
+#define AI_EFFECT_REFLECT              (1 << BATTLE_AI_REFLECT)
+#define AI_EFFECT_AURORA_VEIL          (AI_EFFECT_LIGHT_SCREEN | AI_EFFECT_REFLECT)
+#define AI_EFFECT_GRAVITY              (1 << BATTLE_AI_GRAVITY)
 
 #endif //GUARD_BATTLE_AI_UTIL_H

--- a/include/battle_ai_util.h
+++ b/include/battle_ai_util.h
@@ -169,8 +169,9 @@ bool32 HasOnlyMovesWithCategory(u32 battlerId, enum DamageCategory category, boo
 bool32 HasMoveWithCategory(u32 battler, enum DamageCategory category);
 bool32 HasMoveWithType(u32 battler, u32 type);
 bool32 HasMoveWithEffect(u32 battler, enum BattleMoveEffects moveEffect);
-bool32 HasMoveWithExactEffect(u32 battler, enum BattleMoveEffects moveEffect);
+bool32 HasMoveWithAIEffect(u32 battler, u32 aiEffect);
 bool32 HasBattlerSideMoveWithEffect(u32 battler, u32 effect);
+bool32 HasBattlerSideMoveWithAIEffect(u32 battler, u32 effect);
 bool32 HasBattlerSideUsedMoveWithEffect(u32 battler, u32 effect);
 bool32 HasNonVolatileMoveEffect(u32 battlerId, u32 effect);
 bool32 IsPowerBasedOnStatus(u32 battlerId, enum BattleMoveEffects effect, u32 argument);

--- a/include/battle_ai_util.h
+++ b/include/battle_ai_util.h
@@ -299,33 +299,22 @@ bool32 HasBattlerSideAbility(u32 battlerDef, u32 ability, struct AiLogicData *ai
 u32 GetThinkingBattler(u32 battler);
 bool32 IsNaturalEnemy(u32 speciesAttacker, u32 speciesTarget);
 
-enum BattleAIMoveEffects
-{
-    BATTLE_AI_WEATHER,
-    BATTLE_AI_TERRAIN,
-    BATTLE_AI_CLEAR_HAZARDS,
-    BATTLE_AI_BREAK_SCREENS,
-    BATTLE_AI_RESET_STATS,
-    BATTLE_AI_FORCE_SWITCH,
-    BATTLE_AI_TORMENT,
-    BATTLE_AI_LIGHT_SCREEN,
-    BATTLE_AI_REFLECT,
-    BATTLE_AI_GRAVITY,
-};
 // These are for the purpose of not doubling up on moves during double battles.
-// As Aurora Veil effectively is not used alongside Reflect and Light Screen, we are saving the bit.
+// Used in GetAIEffectGroup for move effects and GetAIEffectGroupFromMove for additional effects
+#define AI_EFFECT_NONE                        0
+#define AI_EFFECT_WEATHER              (1 <<  0)
+#define AI_EFFECT_TERRAIN              (1 <<  1)
+#define AI_EFFECT_CLEAR_HAZARDS        (1 <<  2)
+#define AI_EFFECT_BREAK_SCREENS        (1 <<  3)
+#define AI_EFFECT_RESET_STATS          (1 <<  4) 
+#define AI_EFFECT_FORCE_SWITCH         (1 <<  5)
+#define AI_EFFECT_TORMENT              (1 <<  6)
+#define AI_EFFECT_LIGHT_SCREEN         (1 <<  7)
+#define AI_EFFECT_REFLECT              (1 <<  8)
+#define AI_EFFECT_GRAVITY              (1 <<  9)
+#define AI_EFFECT_CHANGE_ABILITY       (1 << 10)
 
-#define AI_EFFECT_NONE                  0
-#define AI_EFFECT_WEATHER              (1 << BATTLE_AI_WEATHER)
-#define AI_EFFECT_TERRAIN              (1 << BATTLE_AI_TERRAIN)
-#define AI_EFFECT_CLEAR_HAZARDS        (1 << BATTLE_AI_CLEAR_HAZARDS)
-#define AI_EFFECT_BREAK_SCREENS        (1 << BATTLE_AI_BREAK_SCREENS)
-#define AI_EFFECT_RESET_STATS          (1 << BATTLE_AI_RESET_STATS) 
-#define AI_EFFECT_FORCE_SWITCH         (1 << BATTLE_AI_FORCE_SWITCH)
-#define AI_EFFECT_TORMENT              (1 << BATTLE_AI_TORMENT)
-#define AI_EFFECT_LIGHT_SCREEN         (1 << BATTLE_AI_REFLECT)
-#define AI_EFFECT_REFLECT              (1 << BATTLE_AI_REFLECT)
+// As Aurora Veil should almost never be used alongside the other screens, we save the bit.
 #define AI_EFFECT_AURORA_VEIL          (AI_EFFECT_LIGHT_SCREEN | AI_EFFECT_REFLECT)
-#define AI_EFFECT_GRAVITY              (1 << BATTLE_AI_GRAVITY)
 
 #endif //GUARD_BATTLE_AI_UTIL_H

--- a/src/battle_ai_field_statuses.c
+++ b/src/battle_ai_field_statuses.c
@@ -378,7 +378,8 @@ static enum FieldEffectOutcome BenefitsFromMistyTerrain(u32 battler)
         && (HasDamagingMoveOfType(FOE(battler), TYPE_DRAGON) || HasDamagingMoveOfType(BATTLE_PARTNER(FOE(battler)), TYPE_DRAGON)))
         return FIELD_EFFECT_POSITIVE;
 
-    if ((grounded || allyGrounded) && HasBattlerSideUsedMoveWithAdditionalEffect(FOE(battler), MOVE_EFFECT_SLEEP))
+    if ((grounded || allyGrounded) 
+    && (HasNonVolatileMoveEffect(FOE(battler), MOVE_EFFECT_SLEEP) || HasNonVolatileMoveEffect(BATTLE_PARTNER(FOE(battler)), MOVE_EFFECT_SLEEP)))
         return FIELD_EFFECT_POSITIVE;
 
     if (grounded && ((gBattleMons[battler].status1 & STATUS1_SLEEP) 

--- a/src/battle_ai_field_statuses.c
+++ b/src/battle_ai_field_statuses.c
@@ -375,15 +375,15 @@ static enum FieldEffectOutcome BenefitsFromMistyTerrain(u32 battler)
 
     // harass dragons
     if ((grounded || allyGrounded) 
-        && (HasDamagingMoveOfType(FOE(battler), TYPE_DRAGON) || HasDamagingMoveOfType(BATTLE_PARTNER(FOE(battler)), TYPE_DRAGON)))
+     && (HasDamagingMoveOfType(FOE(battler), TYPE_DRAGON) || HasDamagingMoveOfType(BATTLE_PARTNER(FOE(battler)), TYPE_DRAGON)))
         return FIELD_EFFECT_POSITIVE;
 
     if ((grounded || allyGrounded) 
-    && (HasNonVolatileMoveEffect(FOE(battler), MOVE_EFFECT_SLEEP) || HasNonVolatileMoveEffect(BATTLE_PARTNER(FOE(battler)), MOVE_EFFECT_SLEEP)))
+     && (HasNonVolatileMoveEffect(FOE(battler), MOVE_EFFECT_SLEEP) || HasNonVolatileMoveEffect(BATTLE_PARTNER(FOE(battler)), MOVE_EFFECT_SLEEP)))
         return FIELD_EFFECT_POSITIVE;
 
     if (grounded && ((gBattleMons[battler].status1 & STATUS1_SLEEP) 
-    || (gStatuses3[battler] & STATUS3_YAWN)))
+     || (gStatuses3[battler] & STATUS3_YAWN)))
         return FIELD_EFFECT_POSITIVE;
 
     return FIELD_EFFECT_NEUTRAL;

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -1648,7 +1648,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             break;
     // other
         case EFFECT_HAZE:
-            if (PartnerHasSameMoveEffectWithoutTarget(BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove))
+            if (HasPartner(battlerAtk) && AreMovesEquivalent(battlerAtk, BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove))
             {
                 ADJUST_SCORE(-10);    // partner already using haze
             }
@@ -1707,19 +1707,19 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
                 ADJUST_SCORE(-1);    // may still want to just poison
             //fallthrough
         case EFFECT_LIGHT_SCREEN:
-            if (gSideStatuses[GetBattlerSide(battlerAtk)] & SIDE_STATUS_LIGHTSCREEN
-              || PartnerHasSameMoveEffectWithoutTarget(BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove))
+            if (gSideStatuses[GetBattlerSide(battlerAtk)] & (SIDE_STATUS_LIGHTSCREEN | SIDE_STATUS_AURORA_VEIL)
+             || (HasPartner(battlerAtk) && AreMovesEquivalent(battlerAtk, BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove)))
                 ADJUST_SCORE(-10);
             break;
         case EFFECT_REFLECT:
-            if (gSideStatuses[GetBattlerSide(battlerAtk)] & SIDE_STATUS_REFLECT
-              || PartnerHasSameMoveEffectWithoutTarget(BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove))
+            if (gSideStatuses[GetBattlerSide(battlerAtk)] & (SIDE_STATUS_REFLECT | SIDE_STATUS_AURORA_VEIL)
+             || (HasPartner(battlerAtk) && AreMovesEquivalent(battlerAtk, BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove)))
                 ADJUST_SCORE(-10);
             break;
         case EFFECT_AURORA_VEIL:
             if (gSideStatuses[GetBattlerSide(battlerAtk)] & SIDE_STATUS_AURORA_VEIL
-              || PartnerHasSameMoveEffectWithoutTarget(BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove)
-              || !(weather & (B_WEATHER_ICY_ANY)))
+             || (HasPartner(battlerAtk) && AreMovesEquivalent(battlerAtk, BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove))
+             || !(weather & (B_WEATHER_ICY_ANY)))
                 ADJUST_SCORE(-10);
             break;
         case EFFECT_SHEER_COLD:
@@ -1734,7 +1734,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             break;
         case EFFECT_MIST:
             if (gSideStatuses[GetBattlerSide(battlerAtk)] & SIDE_STATUS_MIST
-              || PartnerHasSameMoveEffectWithoutTarget(BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove))
+              || DoesPartnerHaveSameMoveEffect(BATTLE_PARTNER(battlerAtk), battlerDef, move, aiData->partnerMove))
                 ADJUST_SCORE(-10);
             break;
         case EFFECT_FOCUS_ENERGY:
@@ -1742,19 +1742,14 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
                 ADJUST_SCORE(-10);
             break;
         case EFFECT_NON_VOLATILE_STATUS:
-            if (GetBattlerMoveTargetType(battlerAtk, move) & MOVE_TARGET_FOES_AND_ALLY
-              && PartnerHasSameMoveEffectWithoutTarget(BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove))
-                ADJUST_SCORE(-10);
             if (DoesPartnerHaveSameMoveEffect(BATTLE_PARTNER(battlerAtk), battlerDef, move, aiData->partnerMove))
                 ADJUST_SCORE(-10);
             break;
         case EFFECT_CONFUSE:
-            if (GetBattlerMoveTargetType(battlerAtk, move) & MOVE_TARGET_FOES_AND_ALLY
-              && PartnerHasSameMoveEffectWithoutTarget(BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove))
-                ADJUST_SCORE(-10);
         case EFFECT_SWAGGER:
         case EFFECT_FLATTER:
-            if (!AI_CanConfuse(battlerAtk, battlerDef, aiData->abilities[battlerDef], BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove))
+            if (DoesPartnerHaveSameMoveEffect(BATTLE_PARTNER(battlerAtk), battlerDef, move, aiData->partnerMove)
+            || !AI_CanConfuse(battlerAtk, battlerDef, aiData->abilities[battlerDef], BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove))
                 ADJUST_SCORE(-10);
             break;
         case EFFECT_SUBSTITUTE:
@@ -1788,7 +1783,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
                 ADJUST_SCORE(-10);
             else if (gDisableStructs[battlerDef].disableTimer == 0
                 && (B_MENTAL_HERB < GEN_5 || aiData->holdEffects[battlerDef] != HOLD_EFFECT_MENTAL_HERB)
-                && !PartnerHasSameMoveEffectWithoutTarget(BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove))
+                && !DoesPartnerHaveSameMoveEffect(BATTLE_PARTNER(battlerAtk), battlerDef, move, aiData->partnerMove))
             {
                 if (AI_IsFaster(battlerAtk, battlerDef, move, predictedMove, CONSIDER_PRIORITY)) // Attacker should go first
                 {
@@ -1884,7 +1879,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
         case EFFECT_STICKY_WEB:
             if (IsHazardOnSide(GetBattlerSide(battlerDef), HAZARDS_STICKY_WEB))
                 ADJUST_SCORE(-10);
-            if (PartnerHasSameMoveEffectWithoutTarget(BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove))
+            if (DoesPartnerHaveSameMoveEffect(BATTLE_PARTNER(battlerAtk), battlerDef, move, aiData->partnerMove))
                 ADJUST_SCORE(-10); // only one mon needs to set up Sticky Web
             break;
         case EFFECT_FORESIGHT:
@@ -1912,7 +1907,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
                 {
                     ADJUST_SCORE(-10); //Both enemies are perish songed
                 }
-                else if (PartnerHasSameMoveEffectWithoutTarget(BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove))
+                else if (DoesPartnerHaveSameMoveEffect(BATTLE_PARTNER(battlerAtk), battlerDef, move, aiData->partnerMove))
                 {
                     ADJUST_SCORE(-10);
                 }
@@ -1929,23 +1924,23 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             break;
         case EFFECT_SANDSTORM:
             if (weather & (B_WEATHER_SANDSTORM | B_WEATHER_PRIMAL_ANY)
-             || (HasPartner(battlerAtk) && IsMoveEffectWeather(aiData->partnerMove)))
+             || (HasPartner(battlerAtk) && AreMovesEquivalent(battlerAtk, BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove)))
                 ADJUST_SCORE(-8);
             break;
         case EFFECT_SUNNY_DAY:
             if (weather & (B_WEATHER_SUN | B_WEATHER_PRIMAL_ANY)
-             || (HasPartner(battlerAtk) && IsMoveEffectWeather(aiData->partnerMove)))
+             || (HasPartner(battlerAtk) && AreMovesEquivalent(battlerAtk, BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove)))
                 ADJUST_SCORE(-8);
             break;
         case EFFECT_RAIN_DANCE:
             if (weather & (B_WEATHER_RAIN | B_WEATHER_PRIMAL_ANY)
-             || (HasPartner(battlerAtk) && IsMoveEffectWeather(aiData->partnerMove)))
+             || (HasPartner(battlerAtk) && AreMovesEquivalent(battlerAtk, BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove)))
                 ADJUST_SCORE(-8);
             break;
         case EFFECT_HAIL:
         case EFFECT_SNOWSCAPE:
             if (weather & (B_WEATHER_ICY_ANY | B_WEATHER_PRIMAL_ANY)
-             || (HasPartner(battlerAtk) && IsMoveEffectWeather(aiData->partnerMove)))
+             || (HasPartner(battlerAtk) && AreMovesEquivalent(battlerAtk, BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove)))
                 ADJUST_SCORE(-8);
             break;
         case EFFECT_ATTRACT:
@@ -1954,7 +1949,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             break;
         case EFFECT_SAFEGUARD:
             if (gSideStatuses[GetBattlerSide(battlerAtk)] & SIDE_STATUS_SAFEGUARD
-              || PartnerHasSameMoveEffectWithoutTarget(BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove))
+              || DoesPartnerHaveSameMoveEffect(BATTLE_PARTNER(battlerAtk), battlerDef, move, aiData->partnerMove))
                 ADJUST_SCORE(-10);
             break;
         case EFFECT_MAGNITUDE:
@@ -1980,7 +1975,8 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
         case EFFECT_CHILLY_RECEPTION:
             if (CountUsablePartyMons(battlerAtk) == 0)
                 ADJUST_SCORE(-10);
-            else if (weather & (B_WEATHER_ICY_ANY | B_WEATHER_PRIMAL_ANY) || IsMoveEffectWeather(aiData->partnerMove))
+            else if (weather & (B_WEATHER_ICY_ANY | B_WEATHER_PRIMAL_ANY) 
+             || (HasPartner(battlerAtk) && AreMovesEquivalent(battlerAtk, BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove)))
                 ADJUST_SCORE(-8);
             break;
         case EFFECT_BELLY_DRUM:
@@ -2046,7 +2042,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
         case EFFECT_FOLLOW_ME:
         case EFFECT_HELPING_HAND:
             if (!hasPartner
-              || PartnerHasSameMoveEffectWithoutTarget(BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove)
+              || DoesPartnerHaveSameMoveEffect(BATTLE_PARTNER(battlerAtk), battlerDef, move, aiData->partnerMove)
               || (aiData->partnerMove != MOVE_NONE && IsBattleMoveStatus(aiData->partnerMove))
               || gBattleStruct->monToSwitchIntoId[BATTLE_PARTNER(battlerAtk)] != PARTY_SIZE) //Partner is switching out.
                 ADJUST_SCORE(-10);
@@ -2096,13 +2092,13 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
         case EFFECT_MUD_SPORT:
             if (gFieldStatuses & STATUS_FIELD_MUDSPORT
               || gBattleMons[battlerAtk].volatiles.mudSport
-              || PartnerHasSameMoveEffectWithoutTarget(BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove))
+              || DoesPartnerHaveSameMoveEffect(BATTLE_PARTNER(battlerAtk), battlerDef, move, aiData->partnerMove))
                 ADJUST_SCORE(-10);
             break;
         case EFFECT_WATER_SPORT:
             if (gFieldStatuses & STATUS_FIELD_WATERSPORT
               || gBattleMons[battlerAtk].volatiles.waterSport
-              || PartnerHasSameMoveEffectWithoutTarget(BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove))
+              || DoesPartnerHaveSameMoveEffect(BATTLE_PARTNER(battlerAtk), battlerDef, move, aiData->partnerMove))
                 ADJUST_SCORE(-10);
             break;
         case EFFECT_ABSORB:
@@ -2239,7 +2235,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
                 ADJUST_SCORE(-10);
             break;
         case EFFECT_HEAL_BELL:
-            if (!AnyPartyMemberStatused(battlerAtk, IsSoundMove(move)) || PartnerHasSameMoveEffectWithoutTarget(BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove))
+            if (!AnyPartyMemberStatused(battlerAtk, IsSoundMove(move)) || DoesPartnerHaveSameMoveEffect(BATTLE_PARTNER(battlerAtk), battlerDef, move, aiData->partnerMove))
                 ADJUST_SCORE(-10);
             break;
         case EFFECT_ENDURE:
@@ -2336,7 +2332,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             if (gSideStatuses[GetBattlerSide(battlerDef)] & (SIDE_STATUS_SCREEN_ANY | SIDE_STATUS_SAFEGUARD | SIDE_STATUS_MIST)
              || AreAnyHazardsOnSide(GetBattlerSide(battlerAtk)))
             {
-                if (PartnerHasSameMoveEffectWithoutTarget(BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove))
+                if (HasPartner(battlerAtk) && AreMovesEquivalent(battlerAtk, BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove))
                 {
                     ADJUST_SCORE(-10); //Only need one hazards removal
                     break;
@@ -2445,7 +2441,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             break;
         case EFFECT_SNATCH:
             if (!HasMoveWithFlag(battlerDef, MoveCanBeSnatched)
-             || PartnerHasSameMoveEffectWithoutTarget(BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove))
+             || DoesPartnerHaveSameMoveEffect(BATTLE_PARTNER(battlerAtk), battlerDef, move, aiData->partnerMove))
                 ADJUST_SCORE(-10);
             break;
         case EFFECT_POWER_TRICK:
@@ -2542,23 +2538,28 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
                 ADJUST_SCORE(-10);
             break;
         case EFFECT_GRASSY_TERRAIN:
-            if (PartnerMoveEffectIsTerrain(BATTLE_PARTNER(battlerAtk), aiData->partnerMove) || gFieldStatuses & STATUS_FIELD_GRASSY_TERRAIN)
+            if (gFieldStatuses & STATUS_FIELD_GRASSY_TERRAIN
+             || (HasPartner(battlerAtk) && AreMovesEquivalent(battlerAtk, BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove)))
                 ADJUST_SCORE(-10);
             break;
         case EFFECT_ELECTRIC_TERRAIN:
-            if (PartnerMoveEffectIsTerrain(BATTLE_PARTNER(battlerAtk), aiData->partnerMove) || gFieldStatuses & STATUS_FIELD_ELECTRIC_TERRAIN)
+            if (gFieldStatuses & STATUS_FIELD_ELECTRIC_TERRAIN
+             || (HasPartner(battlerAtk) && AreMovesEquivalent(battlerAtk, BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove)))
                 ADJUST_SCORE(-10);
             break;
         case EFFECT_PSYCHIC_TERRAIN:
-            if (PartnerMoveEffectIsTerrain(BATTLE_PARTNER(battlerAtk), aiData->partnerMove) || gFieldStatuses & STATUS_FIELD_PSYCHIC_TERRAIN)
+            if (gFieldStatuses & STATUS_FIELD_PSYCHIC_TERRAIN
+             || (HasPartner(battlerAtk) && AreMovesEquivalent(battlerAtk, BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove)))
                 ADJUST_SCORE(-10);
             break;
         case EFFECT_MISTY_TERRAIN:
-            if (PartnerMoveEffectIsTerrain(BATTLE_PARTNER(battlerAtk), aiData->partnerMove) || gFieldStatuses & STATUS_FIELD_MISTY_TERRAIN)
+            if (gFieldStatuses & STATUS_FIELD_MISTY_TERRAIN
+             || (HasPartner(battlerAtk) && AreMovesEquivalent(battlerAtk, BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove)))
                 ADJUST_SCORE(-10);
             break;
         case EFFECT_STEEL_ROLLER:
-            if (!(gFieldStatuses & STATUS_FIELD_TERRAIN_ANY))
+            if (!(gFieldStatuses & STATUS_FIELD_TERRAIN_ANY)
+             || (HasPartner(battlerAtk) && AreMovesEquivalent(battlerAtk, BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove)))
                 ADJUST_SCORE(-10);
             break;
         case EFFECT_PLEDGE:
@@ -2888,7 +2889,7 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             break;
         case EFFECT_COURT_CHANGE:
         case EFFECT_TEATIME:
-            if (PartnerHasSameMoveEffectWithoutTarget(BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove))
+            if (DoesPartnerHaveSameMoveEffect(BATTLE_PARTNER(battlerAtk), battlerDef, move, aiData->partnerMove))
                 ADJUST_SCORE(-10);
             break;
         case EFFECT_PLACEHOLDER:
@@ -3009,6 +3010,10 @@ static s32 AI_DoubleBattle(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
     // check what effect partner is using
     if (aiData->partnerMove != 0 && hasPartner)
     {
+        // This catches weather, terrain, screens, etc
+        if (AreMovesEquivalent(battlerAtk, battlerAtkPartner, move, aiData->partnerMove))
+            ADJUST_SCORE(-10);
+
         switch (partnerEffect)
         {
         case EFFECT_HELPING_HAND:
@@ -3021,16 +3026,6 @@ static s32 AI_DoubleBattle(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
                 if (IsTrappingMove(aiData->partnerMove) || predictedMove == MOVE_INGRAIN)
                     ADJUST_SCORE(WEAK_EFFECT);
             }
-            break;
-        // Don't change weather if ally already decided to do so.
-        case EFFECT_SUNNY_DAY:
-        case EFFECT_HAIL:
-        case EFFECT_SNOWSCAPE:
-        case EFFECT_RAIN_DANCE:
-        case EFFECT_SANDSTORM:
-        case EFFECT_CHILLY_RECEPTION:
-            if (IsMoveEffectWeather(move))
-                ADJUST_SCORE(-10);
             break;
         case EFFECT_AFTER_YOU:
             if (effect == EFFECT_TRICK_ROOM && !(gFieldStatuses & STATUS_FIELD_TRICK_ROOM) && ShouldSetFieldStatus(battlerAtk, STATUS_FIELD_TRICK_ROOM))
@@ -4110,7 +4105,7 @@ static u32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move)
         break;
     case EFFECT_HAZE:
         if (AnyStatIsRaised(BATTLE_PARTNER(battlerAtk))
-          || PartnerHasSameMoveEffectWithoutTarget(BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove))
+          || DoesPartnerHaveSameMoveEffect(BATTLE_PARTNER(battlerAtk), battlerDef, move, aiData->partnerMove))
             break;
         score += AI_TryToClearStats(battlerAtk, battlerDef, moveTargetsBothOpponents);
         break;
@@ -4234,7 +4229,7 @@ static u32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move)
     case EFFECT_LEECH_SEED:
         if (IS_BATTLER_OF_TYPE(battlerDef, TYPE_GRASS)
           || gStatuses3[battlerDef] & STATUS3_LEECHSEED
-          || HasMoveWithEffect(battlerDef, EFFECT_RAPID_SPIN)
+          || HasMoveWithExactEffect(battlerDef, EFFECT_RAPID_SPIN)
           || aiData->abilities[battlerDef] == ABILITY_LIQUID_OOZE
           || aiData->abilities[battlerDef] == ABILITY_MAGIC_GUARD)
             break;
@@ -5241,6 +5236,7 @@ case EFFECT_GUARD_SPLIT:
         if ((AreAnyHazardsOnSide(GetBattlerSide(battlerAtk)) && CountUsablePartyMons(battlerAtk) != 0)
          || (gStatuses3[battlerAtk] & STATUS3_LEECHSEED || gBattleMons[battlerAtk].volatiles.wrapped))
             ADJUST_SCORE(GOOD_EFFECT);
+        break;
     case EFFECT_SPECTRAL_THIEF:
         ADJUST_SCORE(AI_ShouldCopyStatChanges(battlerAtk, battlerDef));
         break;
@@ -5495,7 +5491,7 @@ case EFFECT_GUARD_SPLIT:
                 }
                 break;
             case MOVE_EFFECT_WRAP:
-                if (!HasMoveWithEffect(battlerDef, EFFECT_RAPID_SPIN) && ShouldTrap(battlerAtk, battlerDef, move))
+                if (!HasMoveWithExactEffect(battlerDef, EFFECT_RAPID_SPIN) && ShouldTrap(battlerAtk, battlerDef, move))
                     ADJUST_SCORE(BEST_EFFECT);
                 break;
             case MOVE_EFFECT_SALT_CURE:

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -4230,7 +4230,7 @@ static u32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move)
     case EFFECT_LEECH_SEED:
         if (IS_BATTLER_OF_TYPE(battlerDef, TYPE_GRASS)
           || gStatuses3[battlerDef] & STATUS3_LEECHSEED
-          || HasMoveWithExactEffect(battlerDef, EFFECT_RAPID_SPIN)
+          || HasMoveWithEffect(battlerDef, EFFECT_RAPID_SPIN)
           || aiData->abilities[battlerDef] == ABILITY_LIQUID_OOZE
           || aiData->abilities[battlerDef] == ABILITY_MAGIC_GUARD)
             break;
@@ -5484,7 +5484,7 @@ case EFFECT_GUARD_SPLIT:
                 }
                 break;
             case MOVE_EFFECT_WRAP:
-                if (!HasMoveWithExactEffect(battlerDef, EFFECT_RAPID_SPIN) && ShouldTrap(battlerAtk, battlerDef, move))
+                if (!HasMoveWithEffect(battlerDef, EFFECT_RAPID_SPIN) && ShouldTrap(battlerAtk, battlerDef, move))
                     ADJUST_SCORE(BEST_EFFECT);
                 break;
             case MOVE_EFFECT_SALT_CURE:

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -2436,7 +2436,8 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
         case EFFECT_SIMPLE_BEAM:
         case EFFECT_SKILL_SWAP:
         case EFFECT_WORRY_SEED:
-            if (!CanEffectChangeAbility(battlerAtk, battlerDef, moveEffect, aiData))
+            if (!CanEffectChangeAbility(battlerAtk, battlerDef, moveEffect, aiData)
+             || DoesPartnerHaveSameMoveEffect(BATTLE_PARTNER(battlerAtk), battlerDef, move, aiData->partnerMove))
                 ADJUST_AND_RETURN_SCORE(NO_DAMAGE_OR_FAILS);
             break;
         case EFFECT_SNATCH:

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -24,6 +24,9 @@
 #include "constants/moves.h"
 #include "constants/items.h"
 
+static u32 GetAIEffectGroup(enum BattleMoveEffects effect);
+static u32 GetAIEffectGroupFromMove(u32 battler, u32 move);
+
 // Functions
 static bool32 AI_IsDoubleSpreadMove(u32 battlerAtk, u32 move)
 {
@@ -2206,15 +2209,38 @@ bool32 HasMoveWithType(u32 battler, u32 type)
     return FALSE;
 }
 
-bool32 HasMoveWithEffect(u32 battlerId, enum BattleMoveEffects effect)
+bool32 HasMoveWithEffect(u32 battler, enum BattleMoveEffects effect)
 {
+    u32 aiEffect = GetAIEffectGroup(effect);
     s32 i;
-    u16 *moves = GetMovesArray(battlerId);
+    u16 *moves = GetMovesArray(battler);
 
     for (i = 0; i < MAX_MON_MOVES; i++)
     {
-        if (moves[i] != MOVE_NONE && moves[i] != MOVE_UNAVAILABLE
-            && GetMoveEffect(moves[i]) == effect)
+        if (moves[i] != MOVE_NONE && moves[i] != MOVE_UNAVAILABLE)
+        {
+            if (GetMoveEffect(moves[i]) == effect)
+                return TRUE;
+
+            if (aiEffect != AI_EFFECT_NONE)
+            {
+                if (GetAIEffectGroupFromMove(battler, moves[i]) & aiEffect)
+                    return TRUE;
+            }
+        }
+    }
+
+    return FALSE;
+}
+
+bool32 HasMoveWithExactEffect(u32 battler, enum BattleMoveEffects effect)
+{
+    s32 i;
+    u16 *moves = GetMovesArray(battler);
+
+    for (i = 0; i < MAX_MON_MOVES; i++)
+    {
+        if (moves[i] != MOVE_NONE && moves[i] != MOVE_UNAVAILABLE && GetMoveEffect(moves[i]) == effect)
             return TRUE;
     }
 
@@ -2235,13 +2261,30 @@ bool32 HasBattlerSideMoveWithEffect(u32 battler, u32 effect)
 // The former acts the same way as the latter if AI_FLAG_OMNISCIENT isn't used.
 bool32 HasBattlerSideUsedMoveWithEffect(u32 battler, u32 effect)
 {
+    u32 aiEffect = GetAIEffectGroup(effect);
     u32 i;
     for (i = 0; i < MAX_MON_MOVES; i++)
     {
         if (GetMoveEffect(gBattleHistory->usedMoves[battler][i]) == effect)
             return TRUE;
-        if (HasPartnerIgnoreFlags(battler) && GetMoveEffect(gBattleHistory->usedMoves[BATTLE_PARTNER(battler)][i]) == effect)
-            return TRUE;
+
+        if (aiEffect != AI_EFFECT_NONE)
+        {
+            if (GetAIEffectGroupFromMove(battler, gBattleHistory->usedMoves[battler][i]) & aiEffect)
+                return TRUE;
+        }
+
+        if (HasPartnerIgnoreFlags(battler))
+        {
+            if (GetMoveEffect(gBattleHistory->usedMoves[BATTLE_PARTNER(battler)][i]) == effect)
+                return TRUE;
+
+            if (aiEffect != AI_EFFECT_NONE)
+            {
+                if (GetAIEffectGroupFromMove(battler, gBattleHistory->usedMoves[BATTLE_PARTNER(battler)][i]) & aiEffect)
+                    return TRUE;
+            }
+        }
     }
     return FALSE;
 }
@@ -2297,22 +2340,6 @@ bool32 HasBattlerSideMoveWithAdditionalEffect(u32 battler, u32 moveEffect)
         return TRUE;
     if (HasPartnerIgnoreFlags(battler) && HasMoveWithAdditionalEffect(BATTLE_PARTNER(battler), moveEffect))
         return TRUE;
-    return FALSE;
-}
-
-// HasBattlerSideMoveWithAdditionalEffect checks if the AI knows a side has a move effect,
-// while HasBattlerSideUsedMoveWithAdditionalEffect checks if the side has ever used a move effect.
-// The former acts the same way as the latter if AI_FLAG_OMNISCIENT isn't used.
-bool32 HasBattlerSideUsedMoveWithAdditionalEffect(u32 battler, u32 moveEffect)
-{
-    u32 i;
-    for (i = 0; i < MAX_MON_MOVES; i++)
-    {
-        if (MoveHasAdditionalEffect(gBattleHistory->usedMoves[battler][i], moveEffect))
-            return TRUE;
-        if (HasPartnerIgnoreFlags(battler) && MoveHasAdditionalEffect(gBattleHistory->usedMoves[BATTLE_PARTNER(battler)][i], moveEffect))
-            return TRUE;
-    }
     return FALSE;
 }
 
@@ -3716,8 +3743,7 @@ bool32 ShouldSetScreen(u32 battlerAtk, u32 battlerDef, enum BattleMoveEffects mo
     u32 atkSide = GetBattlerSide(battlerAtk);
 
     // Don't waste a turn if screens will be broken
-    if (HasMoveWithEffect(battlerDef, EFFECT_BRICK_BREAK)
-     || HasMoveWithEffect(battlerDef, EFFECT_RAGING_BULL))
+    if (HasMoveWithEffect(battlerDef, EFFECT_BRICK_BREAK))
         return FALSE;
 
     switch (moveEffect)
@@ -3805,6 +3831,151 @@ u32 GetAllyChosenMove(u32 battlerId)
         return gBattleMons[partnerBattler].moves[gBattleStruct->chosenMovePositions[partnerBattler]];
 }
 
+bool32 AreMovesEquivalent(u32 battlerAtk, u32 battlerAtkPartner, u32 move, u32 partnerMove)
+{
+    if (!IsBattlerAlive(battlerAtkPartner) || partnerMove == MOVE_NONE)
+        return FALSE;
+
+    u32 battlerDef = gBattleStruct->moveTarget[battlerAtk];
+    
+    // We don't care the effect is basically the same; we would use this move anyway.
+    if (GetBestDmgMoveFromBattler(battlerAtk, battlerDef, AI_ATTACKING) == move)
+        return FALSE;
+
+    u32 atkEffect = GetAIEffectGroupFromMove(battlerAtk, move);
+    u32 partnerEffect = GetAIEffectGroupFromMove(battlerAtkPartner, partnerMove);
+
+    // shared bits indicate they're meaningfully the same in some way
+    if (atkEffect & partnerEffect)
+    {
+        if (gMovesInfo[move].target == MOVE_TARGET_SELECTED && gMovesInfo[partnerMove].target == MOVE_TARGET_SELECTED)
+        {
+            if (battlerDef == gBattleStruct->moveTarget[battlerAtkPartner])
+                return TRUE;
+            else
+                return FALSE;
+        }
+        return TRUE;
+    }
+    return FALSE;
+}
+
+static u32 GetAIEffectGroup(enum BattleMoveEffects effect)
+{
+    u32 aiEffect = AI_EFFECT_NONE;
+
+    switch (effect)
+    {
+    case EFFECT_SUNNY_DAY:
+    case EFFECT_RAIN_DANCE:
+    case EFFECT_SANDSTORM:
+    case EFFECT_HAIL:
+    case EFFECT_SNOWSCAPE:
+    case EFFECT_CHILLY_RECEPTION:
+        aiEffect |= AI_EFFECT_WEATHER;
+        break;
+    case EFFECT_ELECTRIC_TERRAIN:
+    case EFFECT_GRASSY_TERRAIN:
+    case EFFECT_MISTY_TERRAIN:
+    case EFFECT_PSYCHIC_TERRAIN:
+    case EFFECT_STEEL_ROLLER:
+    case EFFECT_ICE_SPINNER:
+        aiEffect |= AI_EFFECT_TERRAIN;
+        break;
+    case EFFECT_COURT_CHANGE:
+        aiEffect |= AI_EFFECT_CLEAR_HAZARDS | AI_EFFECT_AURORA_VEIL | AI_EFFECT_BREAK_SCREENS;
+        break;
+    case EFFECT_DEFOG:
+        aiEffect |= AI_EFFECT_CLEAR_HAZARDS | AI_EFFECT_BREAK_SCREENS;
+        break;
+    case EFFECT_RAPID_SPIN:
+    case EFFECT_TIDY_UP:
+        aiEffect |= AI_EFFECT_CLEAR_HAZARDS;
+        break;
+    case EFFECT_BRICK_BREAK:
+    case EFFECT_RAGING_BULL:
+        aiEffect |= AI_EFFECT_BREAK_SCREENS;
+        break;
+    case EFFECT_HAZE:
+        aiEffect |= AI_EFFECT_RESET_STATS;
+        break;
+    case EFFECT_HIT_SWITCH_TARGET:
+    case EFFECT_ROAR:
+        aiEffect |= AI_EFFECT_FORCE_SWITCH;
+        break;
+    case EFFECT_TORMENT:
+        aiEffect |= AI_EFFECT_TORMENT;
+        break;
+    case EFFECT_AURORA_VEIL:
+        aiEffect |= AI_EFFECT_AURORA_VEIL;
+        break;
+    case EFFECT_LIGHT_SCREEN:
+        aiEffect |= AI_EFFECT_LIGHT_SCREEN;
+        break;
+    case EFFECT_REFLECT:
+        aiEffect |= AI_EFFECT_REFLECT;
+        break;
+    case EFFECT_GRAVITY:
+        aiEffect |= AI_EFFECT_GRAVITY;
+        break;
+    default:
+        break;
+    }
+    return aiEffect;
+}
+
+static u32 GetAIEffectGroupFromMove(u32 battler, u32 move)
+{
+    u32 aiEffect = GetAIEffectGroup(GetMoveEffect(move));
+
+    u32 i;
+    u32 additionalEffectCount = GetMoveAdditionalEffectCount(move);
+    for (i = 0; i < additionalEffectCount; i++)
+    {
+        switch (GetMoveAdditionalEffectById(move, i)->moveEffect)
+        {
+        case MOVE_EFFECT_SUN:
+        case MOVE_EFFECT_RAIN:
+        case MOVE_EFFECT_SANDSTORM:
+        case MOVE_EFFECT_HAIL:
+            aiEffect |= AI_EFFECT_WEATHER;
+            break;
+        case MOVE_EFFECT_ELECTRIC_TERRAIN:
+        case MOVE_EFFECT_GRASSY_TERRAIN:
+        case MOVE_EFFECT_MISTY_TERRAIN:
+        case MOVE_EFFECT_PSYCHIC_TERRAIN:
+            aiEffect |= AI_EFFECT_TERRAIN;
+            break;
+        case MOVE_EFFECT_DEFOG:
+            aiEffect |= AI_EFFECT_CLEAR_HAZARDS | AI_EFFECT_BREAK_SCREENS;
+            break;
+        case MOVE_EFFECT_CLEAR_SMOG:
+        case MOVE_EFFECT_HAZE:
+            aiEffect |= AI_EFFECT_RESET_STATS;
+            break;
+        case MOVE_EFFECT_TORMENT_SIDE:
+            aiEffect |= AI_EFFECT_TORMENT;
+            break;
+        case MOVE_EFFECT_LIGHT_SCREEN:
+            aiEffect |= AI_EFFECT_LIGHT_SCREEN;
+            break;
+        case MOVE_EFFECT_REFLECT:
+            aiEffect |= AI_EFFECT_REFLECT;
+            break;
+        case MOVE_EFFECT_AURORA_VEIL:
+            aiEffect |= AI_EFFECT_AURORA_VEIL;
+            break;
+        case MOVE_EFFECT_GRAVITY:
+            aiEffect |= AI_EFFECT_GRAVITY;
+            break;
+        default:
+            break;
+        }
+    }
+
+    return aiEffect;
+}
+
 //PARTNER_MOVE_EFFECT_IS_SAME
 bool32 DoesPartnerHaveSameMoveEffect(u32 battlerAtkPartner, u32 battlerDef, u32 move, u32 partnerMove)
 {
@@ -3812,23 +3983,17 @@ bool32 DoesPartnerHaveSameMoveEffect(u32 battlerAtkPartner, u32 battlerDef, u32 
         return FALSE;
 
     if (GetMoveEffect(move) == GetMoveEffect(partnerMove)
-      && partnerMove != MOVE_NONE
-      && gBattleStruct->moveTarget[battlerAtkPartner] == battlerDef)
+      && partnerMove != MOVE_NONE)
     {
+        if (gMovesInfo[move].target == MOVE_TARGET_SELECTED && gMovesInfo[partnerMove].target == MOVE_TARGET_SELECTED)
+        {
+            if (gBattleStruct->moveTarget[battlerAtkPartner] == battlerDef)
+                return TRUE;
+            else
+                return FALSE;
+        }
         return TRUE;
     }
-    return FALSE;
-}
-
-//PARTNER_MOVE_EFFECT_IS_SAME_NO_TARGET
-bool32 PartnerHasSameMoveEffectWithoutTarget(u32 battlerAtkPartner, u32 move, u32 partnerMove)
-{
-    if (!HasPartner(battlerAtkPartner))
-        return FALSE;
-
-    if (GetMoveEffect(move) == GetMoveEffect(partnerMove)
-      && partnerMove != MOVE_NONE)
-        return TRUE;
     return FALSE;
 }
 
@@ -3849,37 +4014,6 @@ bool32 PartnerMoveEffectIsStatusSameTarget(u32 battlerAtkPartner, u32 battlerDef
        || nonVolatileStatus == MOVE_EFFECT_BURN
        || partnerEffect == EFFECT_YAWN))
         return TRUE;
-    return FALSE;
-}
-
-bool32 IsMoveEffectWeather(u32 move)
-{
-    enum BattleMoveEffects effect = GetMoveEffect(move);
-    if (move != MOVE_NONE
-     && (effect == EFFECT_SUNNY_DAY
-      || effect == EFFECT_RAIN_DANCE
-      || effect == EFFECT_SANDSTORM
-      || effect == EFFECT_HAIL
-      || effect == EFFECT_SNOWSCAPE
-      || effect == EFFECT_CHILLY_RECEPTION))
-        return TRUE;
-    return FALSE;
-}
-
-//PARTNER_MOVE_EFFECT_IS_TERRAIN
-bool32 PartnerMoveEffectIsTerrain(u32 battlerAtkPartner, u32 partnerMove)
-{
-    if (!HasPartner(battlerAtkPartner))
-        return FALSE;
-
-    enum BattleMoveEffects partnerEffect = GetMoveEffect(partnerMove);
-    if (partnerMove != MOVE_NONE
-     && (partnerEffect == EFFECT_GRASSY_TERRAIN
-      || partnerEffect == EFFECT_MISTY_TERRAIN
-      || partnerEffect == EFFECT_ELECTRIC_TERRAIN
-      || partnerEffect == EFFECT_PSYCHIC_TERRAIN))
-        return TRUE;
-
     return FALSE;
 }
 
@@ -4348,16 +4482,13 @@ static enum AIScore IncreaseStatUpScoreInternal(u32 battlerAtk, u32 battlerDef, 
         return NO_INCREASE;
 
     // Don't increase stats if opposing battler has used Haze effect
-    if (!RandomPercentage(RNG_AI_BOOST_INTO_HAZE, BOOST_INTO_HAZE_CHANCE) &&
-        (HasBattlerSideUsedMoveWithEffect(battlerDef, EFFECT_HAZE)
-        || HasBattlerSideUsedMoveWithAdditionalEffect(battlerDef, MOVE_EFFECT_CLEAR_SMOG)
-        || HasBattlerSideUsedMoveWithAdditionalEffect(battlerDef, MOVE_EFFECT_HAZE)))
+    if (!RandomPercentage(RNG_AI_BOOST_INTO_HAZE, BOOST_INTO_HAZE_CHANCE)
+      && HasBattlerSideUsedMoveWithEffect(battlerDef, EFFECT_HAZE))
         return NO_INCREASE;
 
     // Don't increase if AI is at +1 and opponent has Haze effect
-    if (gBattleMons[battlerAtk].statStages[statId] >= MAX_STAT_STAGE - 5 && (HasBattlerSideMoveWithEffect(battlerDef, EFFECT_HAZE)
-        || HasBattlerSideMoveWithAdditionalEffect(battlerDef, MOVE_EFFECT_CLEAR_SMOG)
-        || HasBattlerSideMoveWithAdditionalEffect(battlerDef, MOVE_EFFECT_HAZE)))
+    if (gBattleMons[battlerAtk].statStages[statId] >= MAX_STAT_STAGE - 5
+      && HasBattlerSideMoveWithEffect(battlerDef, EFFECT_HAZE))
         return NO_INCREASE;
 
     // Don't increase stats if AI could KO target through Sturdy effect, as otherwise it always 2HKOs
@@ -4962,9 +5093,6 @@ bool32 AI_ShouldSetUpHazards(u32 battlerAtk, u32 battlerDef, struct AiLogicData 
     if (aiData->abilities[battlerDef] == ABILITY_MAGIC_BOUNCE
      || CountUsablePartyMons(battlerDef) == 0
      || HasMoveWithEffect(battlerDef, EFFECT_RAPID_SPIN)
-     || HasMoveWithEffect(battlerDef, EFFECT_TIDY_UP)
-     || HasMoveWithEffect(battlerDef, EFFECT_DEFOG)
-     || HasMoveWithAdditionalEffect(battlerDef, MOVE_EFFECT_DEFOG)
      || HasMoveWithEffect(battlerDef, EFFECT_MAGIC_COAT))
         return FALSE;
 

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -4014,7 +4014,7 @@ bool32 DoesPartnerHaveSameMoveEffect(u32 battlerAtkPartner, u32 battlerDef, u32 
     {
         if (gMovesInfo[move].target == MOVE_TARGET_SELECTED && gMovesInfo[partnerMove].target == MOVE_TARGET_SELECTED)
         {
-            return gBattleStruct->moveTarget[battlerAtkPartner] == battlerDef);
+            return gBattleStruct->moveTarget[battlerAtkPartner] == battlerDef;
         }
         return TRUE;
     }

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -3918,6 +3918,15 @@ static u32 GetAIEffectGroup(enum BattleMoveEffects effect)
     case EFFECT_GRAVITY:
         aiEffect |= AI_EFFECT_GRAVITY;
         break;
+    case EFFECT_DOODLE:
+    case EFFECT_ENTRAINMENT:
+    case EFFECT_GASTRO_ACID:
+    case EFFECT_ROLE_PLAY:
+    case EFFECT_SIMPLE_BEAM:
+    case EFFECT_SKILL_SWAP:
+    case EFFECT_WORRY_SEED:
+        aiEffect |= AI_EFFECT_CHANGE_ABILITY;
+        break;
     default:
         break;
     }

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -4014,10 +4014,7 @@ bool32 DoesPartnerHaveSameMoveEffect(u32 battlerAtkPartner, u32 battlerDef, u32 
     {
         if (gMovesInfo[move].target == MOVE_TARGET_SELECTED && gMovesInfo[partnerMove].target == MOVE_TARGET_SELECTED)
         {
-            if (gBattleStruct->moveTarget[battlerAtkPartner] == battlerDef)
-                return TRUE;
-            else
-                return FALSE;
+            return gBattleStruct->moveTarget[battlerAtkPartner] == battlerDef);
         }
         return TRUE;
     }

--- a/test/battle/ai/ai_doubles.c
+++ b/test/battle/ai/ai_doubles.c
@@ -90,7 +90,7 @@ TO_DO_BATTLE_TEST("AI understands Instruct")
 TO_DO_BATTLE_TEST("AI understands Quick Guard")
 TO_DO_BATTLE_TEST("AI understands Wide Guard")
 
-AI_DOUBLE_BATTLE_TEST("AI will not use the same nondamaging move as its partner for no reason")
+AI_DOUBLE_BATTLE_TEST("AI won't use the same nondamaging move as its partner for no reason")
 {
     u32 move;
     PARAMETRIZE { move = MOVE_AROMATHERAPY; }


### PR DESCRIPTION
The intention here is to reduce the number of places that need to be updated every time a new move effect is added.

AI Effects is a bitfield of major utility traits of a move.  Sets weather, sets terrain, removes stat changes, removes the opponent's screens, sets your own screens, that sort of thing. The goal here is that if you add a new move effect that's like if Court Change also removed items, you add it to the case statement in GetAIEffectGroup, and if you decide it should also have the Clear Smog move effect, then it won't be used at the same time as Defog, Aurora Veil, Reflect, Light Screen, Brick Break, Haze, Clear Smog, or Freezy Frost, without having to update every AI reference to any of those moves. Similarly, you shouldn't set a terrain effect the same turn you plan on using Ice Spinner; that's kind of silly.

The equivalent moves check includes "actually, yeah, let's double Ice Spinner" if it's your best damaging move.

HasMoveWithAIEffect checks if the effect has anything in the bitfield, and if so it checks for any moves with the same bit set as well. 

Supercedes #7508

DoesPartnerHaveSameMoveEffect and HasBattlerSideUsedMoveWithEffect will fuzzy match between both EFFECT and AI_EFFECT and have a comment explaining it above the function.  DoesPartnerHaveSameMoveEffect includes targeting checks, as well. There are a few cases this may cause odd behavior -- both pokemon may end up using Rapid Spin to cleanse hazards if they're targeting different opponents, for example -- but they should NOT both Rapid Spin and Tidy Up on the same turn, and using Rapid Spin on both opponents isn't really bad behavior anyway because you might be predicting a Protect or a switch into immunity.

## Discord contact info
wildvenonat