### PR TITLE
AI should use at least a few z-status moves.

### DIFF
--- a/include/config/ai.h
+++ b/include/config/ai.h
@@ -110,4 +110,8 @@
 #define POWER_SPLIT_ALLY_PERCENTAGE     150
 #define POWER_SPLIT_ENEMY_PERCENTAGE    50
 
+// HP threshold to use Z-Destiny Bond or Z-Grudge in a double battle.
+#define Z_EFFECT_FOLLOW_ME_THRESHOLD    50
+// HP threshold to use Z-Belly Drum or Z-Curse (ghost version)
+#define Z_EFFECT_RESTORE_HP_THRESHOLD   33   
 #endif // GUARD_CONFIG_AI_H


### PR DESCRIPTION
From looking at the code, it was straight up impossible for the AI to ever use a status Z-move.  This fixes it for a handful that are consistently relevant: Z-Conversion, Z-Splash, Extreme Evoboost, Z-Happy Hour, Z-Celebrate, Z-Hold Hands.  It also includes some basic handling for Z-Curse (ghost), Z-Belly Drum, Z-Destiny Bond, and Z-Grudge.

I tested it compiles but I have not tested to make sure it works.  It looks like it ought to, though.

## Discord contact info
wildvenonat