### PR TITLE
Fix B_ANIMATE_MON_AFTER_KO with a new counter

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -5232,6 +5232,7 @@ BattleScript_FaintAttacker::
 	dofaintanimation BS_ATTACKER
 	printstring STRINGID_ATTACKERFAINTED
 	cleareffectsonfaint BS_ATTACKER
+	waitanimation
 	tryactivatesoulheart
 	tryactivatereceiver BS_ATTACKER
 	trytrainerslidefirstdownmsg BS_ATTACKER
@@ -5246,6 +5247,7 @@ BattleScript_FaintTarget::
 	dofaintanimation BS_TARGET
 	printstring STRINGID_TARGETFAINTED
 	cleareffectsonfaint BS_TARGET
+	waitanimation
 	tryactivatesoulheart
 	tryactivatereceiver BS_TARGET
 	trytrainerslidefirstdownmsg BS_TARGET
@@ -8979,6 +8981,7 @@ BattleScript_ArenaDoJudgment::
 	waitcry BS_ATTACKER
 	dofaintanimation BS_OPPONENT1
 	cleareffectsonfaint BS_OPPONENT1
+	waitanimation
 	arenaopponentmonlost
 	end2
 
@@ -8993,6 +8996,7 @@ BattleScript_ArenaJudgmentPlayerLoses:
 	waitcry BS_ATTACKER
 	dofaintanimation BS_PLAYER1
 	cleareffectsonfaint BS_PLAYER1
+	waitanimation
 	arenaplayermonlost
 	end2
 
@@ -9007,10 +9011,12 @@ BattleScript_ArenaJudgmentDraw:
 	waitcry BS_ATTACKER
 	dofaintanimation BS_PLAYER1
 	cleareffectsonfaint BS_PLAYER1
+	waitanimation
 	playfaintcry BS_OPPONENT1
 	waitcry BS_ATTACKER
 	dofaintanimation BS_OPPONENT1
 	cleareffectsonfaint BS_OPPONENT1
+	waitanimation
 	arenabothmonlost
 	end2
 

--- a/include/battle.h
+++ b/include/battle.h
@@ -687,7 +687,7 @@ struct BattleStruct
     u8 startingStatusDone:1;
     u8 terrainDone:1;
     u8 overworldWeatherDone:1;
-    u8 animsRunning:3;
+    u8 battlerKOAnimsRunning:3;
     u8 isAtkCancelerForCalledMove:1; // Certain cases in atk canceler should only be checked once, when the original move is called, however others need to be checked the twice.
     u8 friskedAbility:1; // If identifies two mons, show the ability pop-up only once.
     u8 fickleBeamBoosted:1;

--- a/include/battle.h
+++ b/include/battle.h
@@ -687,7 +687,7 @@ struct BattleStruct
     u8 startingStatusDone:1;
     u8 terrainDone:1;
     u8 overworldWeatherDone:1;
-    u8 unused:3;
+    u8 animsRunning:3;
     u8 isAtkCancelerForCalledMove:1; // Certain cases in atk canceler should only be checked once, when the original move is called, however others need to be checked the twice.
     u8 friskedAbility:1; // If identifies two mons, show the ability pop-up only once.
     u8 fickleBeamBoosted:1;

--- a/src/battle_controllers.c
+++ b/src/battle_controllers.c
@@ -3122,7 +3122,7 @@ static void LaunchKOAnimation(u32 battlerId, u16 animId, bool32 isFront)
     u32 species = GetBattlerVisualSpecies(battlerId);
     u32 spriteId = gBattlerSpriteIds[battlerId];
 
-    gBattleStruct->animsRunning++;
+    gBattleStruct->battlerKOAnimsRunning++;
 
     if (isFront)
     {

--- a/src/battle_controllers.c
+++ b/src/battle_controllers.c
@@ -3122,6 +3122,8 @@ static void LaunchKOAnimation(u32 battlerId, u16 animId, bool32 isFront)
     u32 species = GetBattlerVisualSpecies(battlerId);
     u32 spriteId = gBattlerSpriteIds[battlerId];
 
+    gBattleStruct->animsRunning++;
+
     if (isFront)
     {
         LaunchAnimationTaskForFrontSprite(&gSprites[spriteId], animId);

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2558,7 +2558,7 @@ static void Cmd_waitanimation(void)
 {
     CMD_ARGS();
 
-    if (gBattleControllerExecFlags == 0)
+    if (gBattleControllerExecFlags == 0 && gBattleStruct->animsRunning == 0)
         gBattlescriptCurrInstr = cmd->nextInstr;
 }
 

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2558,7 +2558,7 @@ static void Cmd_waitanimation(void)
 {
     CMD_ARGS();
 
-    if (gBattleControllerExecFlags == 0 && gBattleStruct->animsRunning == 0)
+    if (gBattleControllerExecFlags == 0 && gBattleStruct->battlerKOAnimsRunning == 0)
         gBattlescriptCurrInstr = cmd->nextInstr;
 }
 

--- a/src/pokemon_animation.c
+++ b/src/pokemon_animation.c
@@ -523,6 +523,8 @@ static void Task_HandleMonAnimation(u8 taskId)
         sprite->data[2] = gTasks[taskId].tSpeciesId;
         sprite->data[1] = 0;
 
+        if (gBattleStruct->animsRunning > 0)
+            gBattleStruct->animsRunning--;
         DestroyTask(taskId);
     }
 }

--- a/src/pokemon_animation.c
+++ b/src/pokemon_animation.c
@@ -523,8 +523,8 @@ static void Task_HandleMonAnimation(u8 taskId)
         sprite->data[2] = gTasks[taskId].tSpeciesId;
         sprite->data[1] = 0;
 
-        if (gBattleStruct->animsRunning > 0)
-            gBattleStruct->animsRunning--;
+        if (gBattleStruct->battlerKOAnimsRunning > 0)
+            gBattleStruct->battlerKOAnimsRunning--;
         DestroyTask(taskId);
     }
 }

--- a/src/pokemon_animation.c
+++ b/src/pokemon_animation.c
@@ -523,6 +523,9 @@ static void Task_HandleMonAnimation(u8 taskId)
         sprite->data[2] = gTasks[taskId].tSpeciesId;
         sprite->data[1] = 0;
 
+        // Task_HandleMonAnimation handles more than just KO animations,
+        // but if the counter is non-zero then only KO animations are running.
+        // This assumption is not checked.
         if (gBattleStruct->battlerKOAnimsRunning > 0)
             gBattleStruct->battlerKOAnimsRunning--;
         DestroyTask(taskId);


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
Animations can potentially break because the animations for `B_ANIMATE_MON_AFTER_KO` could still be running when new animations start.

https://github.com/user-attachments/assets/5966a5d3-687f-40ae-88ee-41b34ec0c7a3

This adds another counter that `waitanimation` checks before continuing.

https://github.com/user-attachments/assets/ead1989f-8b97-423e-94db-9092ac16f312



## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara