### PR TITLE
Fix Form Change Item Task Data and Clean Up Field Use Funcs

### DIFF
--- a/src/item_use.c
+++ b/src/item_use.c
@@ -1527,7 +1527,7 @@ static void Task_DisplayPokeFluteMessage(u8 taskId)
 {
     if (WaitFanfare(FALSE))
     {
-        if (gTasks[taskId].data[3] == 0)
+        if (!gTasks[taskId].tUsingRegisteredKeyItem)
             DisplayItemMessage(taskId, FONT_NORMAL, sText_PokeFluteAwakenedMon, CloseItemMessage);
         else
             DisplayItemMessageOnField(taskId, sText_PokeFluteAwakenedMon, Task_CloseCantUseKeyItemMessage);
@@ -1553,14 +1553,14 @@ void ItemUseOutOfBattle_PokeFlute(u8 taskId)
 
     if (wokeSomeoneUp)
     {
-        if (gTasks[taskId].data[3] == 0)
+        if (!gTasks[taskId].tUsingRegisteredKeyItem)
             DisplayItemMessage(taskId, FONT_NORMAL, sText_PlayedPokeFlute, Task_PlayPokeFlute);
         else
             DisplayItemMessageOnField(taskId, sText_PlayedPokeFlute, Task_PlayPokeFlute);
     }
     else
     {
-        if (gTasks[taskId].data[3] == 0)
+        if (!gTasks[taskId].tUsingRegisteredKeyItem)
             DisplayItemMessage(taskId, FONT_NORMAL, sText_PlayedPokeFluteCatchy, CloseItemMessage);
         else
             DisplayItemMessageOnField(taskId, sText_PlayedPokeFluteCatchy, Task_CloseCantUseKeyItemMessage);

--- a/src/item_use.c
+++ b/src/item_use.c
@@ -1431,7 +1431,6 @@ void ItemUseOutOfBattle_Fusion(u8 taskId)
 
 void Task_UseHoneyOnField(u8 taskId)
 {
-    //ResetInitialPlayerAvatarState();
     StartSweetScentFieldEffect();
     DestroyTask(taskId);
 }
@@ -1442,7 +1441,6 @@ static void ItemUseOnFieldCB_Honey(u8 taskId)
     RemoveBagItem(gSpecialVar_ItemId, 1);
     CopyItemName(gSpecialVar_ItemId, gStringVar2);
     StringExpandPlaceholders(gStringVar4, gText_PlayerUsedVar2);
-    gTasks[taskId].data[0] = 0;
     DisplayItemMessageOnField(taskId, gStringVar4, Task_UseHoneyOnField);
 }
 

--- a/src/item_use.c
+++ b/src/item_use.c
@@ -1402,35 +1402,30 @@ void ItemUseOutOfBattle_EnigmaBerry(u8 taskId)
 void ItemUseOutOfBattle_FormChange(u8 taskId)
 {
     gItemUseCB = ItemUseCB_FormChange;
-    gTasks[taskId].data[0] = FALSE;
     SetUpItemUseCallback(taskId);
 }
 
 void ItemUseOutOfBattle_FormChange_ConsumedOnUse(u8 taskId)
 {
     gItemUseCB = ItemUseCB_FormChange_ConsumedOnUse;
-    gTasks[taskId].data[0] = TRUE;
     SetUpItemUseCallback(taskId);
 }
 
 void ItemUseOutOfBattle_RotomCatalog(u8 taskId)
 {
     gItemUseCB = ItemUseCB_RotomCatalog;
-    gTasks[taskId].data[0] = TRUE;
     SetUpItemUseCallback(taskId);
 }
 
 void ItemUseOutOfBattle_ZygardeCube(u8 taskId)
 {
     gItemUseCB = ItemUseCB_ZygardeCube;
-    gTasks[taskId].data[0] = TRUE;
     SetUpItemUseCallback(taskId);
 }
 
 void ItemUseOutOfBattle_Fusion(u8 taskId)
 {
     gItemUseCB = ItemUseCB_Fusion;
-    gTasks[taskId].data[0] = FALSE;
     SetUpItemUseCallback(taskId);
 }
 


### PR DESCRIPTION
## Description
- It appears the lines that were setting `gTasks[taskId].data[0]` for the form change item field use funcs were not used at all. I can't see anywhere they're actually used, and deleting them does not appear to alter functionality. I've deleted the lines to fix issue #4544.
- The Poke Flute field use funcs had some references to `data[3]` that were not using the `tUsingRegisteredKeyItem` alias. I've fixed these.
- The honey item field use func had a comment left in and a line setting task data that does nothing as well. I've removed those.

## Issue(s) that this PR fixes
- Fixes #4544 

## Feature(s) this PR does NOT handle:
- Remaining references to `data[X]` without an alias that are from upstream pret

## Discord contact info
ravepossum
