### PR TITLE
make check TESTS="..." support for filenames and infix matches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,7 +300,7 @@ $(TESTELF): $(OBJ_DIR)/ld_script_test.ld $(OBJS) $(TEST_OBJS) libagbsyscall tool
 	@echo "cd $(OBJ_DIR) && $(LD) -T ld_script_test.ld -o ../../$@ <objects> <test-objects> <lib>"
 	@cd $(OBJ_DIR) && $(LD) $(TESTLDFLAGS) -T ld_script_test.ld -o ../../$@ $(OBJS_REL) $(TEST_OBJS_REL) $(LIB)
 	$(FIX) $@ -t"$(TITLE)" -c$(GAME_CODE) -m$(MAKER_CODE) -r$(REVISION) -d0 --silent
-	$(PATCHELF) $(TESTELF) gTestRunnerArgv "$(TESTS)\0"
+	$(PATCHELF) $(TESTELF) gTestRunnerArgv "$(TESTS:%*=%)\0"
 
 ifeq ($(GITHUB_REPOSITORY_OWNER),rh-hideout)
 TEST_SKIP_IS_FAIL := \x01

--- a/include/test/battle.h
+++ b/include/test/battle.h
@@ -2,8 +2,13 @@
  *
  * To run all the tests use:
  *     make check -j
- * To run specific tests, e.g. Spikes ones, use:
+ * To run specific tests, e.g. Spikes ones, use either:
  *     make check TESTS="Spikes"
+ *     make check TESTS="*Spikes*"
+ * The first runs tests with names that start with Spikes, whereas the
+ * second runs tests with names that include Spikes anywhere in them.
+ * To run tests from a specific file, e.g. 'test/battle/move_effect/spikes.c', use:
+ *     make check TESTS="test/battle/move_effect/spikes.c"
  * To build a ROM (pokemerald-test.elf) that can be opened in mgba to
  * view specific tests, e.g. Spikes ones, use:
  *     make pokeemerald-test.elf TESTS="Spikes"

--- a/include/test/test.h
+++ b/include/test/test.h
@@ -37,10 +37,18 @@ struct Test
     u16 sourceLine;
 };
 
+enum TestFilterMode
+{
+    TEST_FILTER_MODE_TEST_NAME_PREFIX,
+    TEST_FILTER_MODE_TEST_NAME_INFIX,
+    TEST_FILTER_MODE_FILENAME_EXACT,
+};
+
 struct TestRunnerState
 {
     u8 state;
     u8 exitCode;
+    enum TestFilterMode filterMode:8;
     const char *skipFilename;
     u32 failedAssumptionsBlockLine;
     const struct Test *test;


### PR DESCRIPTION
`make check TESTS="test/foo.c"` to run all tests from `test/foo.c`.
`make check TESTS="*Illuminate*"` to run all tests with "Illuminate" in the name.

Closes #3485.

Thanks to @SBird1337 for the `strstr` idea.