### PR TITLE
Uncommenting out No Retreat, Clangorous Soul, and Extreme Evoboost from CheckBadMove

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -2853,18 +2853,18 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
             ||  GetBattlerWeight(battlerDef) >= 2000) //200.0 kg
                 ADJUST_SCORE(-10);
             break;
-        /*case EFFECT_NO_RETREAT:
-            if (TrappedByNoRetreat(battlerAtk))
+        case EFFECT_NO_RETREAT:
+            if (gDisableStructs[battlerAtk].noRetreat)
                 ADJUST_SCORE(-10);
             break;
         case EFFECT_EXTREME_EVOBOOST:
-            if (MainStatsMaxed(battlerAtk))
+            if (AreBattlersStatsMaxed(battlerAtk))
                 ADJUST_SCORE(-10);
             break;
         case EFFECT_CLANGOROUS_SOUL:
             if (gBattleMons[battlerAtk].hp <= gBattleMons[battlerAtk].maxHP / 3)
                 ADJUST_SCORE(-10);
-            break;*/
+            break;
         case EFFECT_REVIVAL_BLESSING:
             if (GetFirstFaintedPartyIndex(battlerAtk) == PARTY_SIZE)
                 ADJUST_SCORE(-10);


### PR DESCRIPTION
This does NOT include handling for the AI to ever pick any of those three moves; two of those need to go in CheckViability and the third needs a complete rework for a number of reasons.  This is only updating the commented out segments to current standards and uncommenting them.

## Discord contact info
wildvenonat