### PR TITLE
Fix shell side arm rng in battle tests moves

### DIFF
--- a/include/test/battle.h
+++ b/include/test/battle.h
@@ -701,6 +701,7 @@ struct BattleTestData
     u8 moveBattlers;
     bool8 hasAI:1;
     bool8 logAI:1;
+    u16 multipleShellSideArm;
 
     struct RecordedBattleSave recordedBattle;
     u8 battleRecordTypes[MAX_BATTLERS_COUNT][BATTLER_RECORD_SIZE];

--- a/include/test/battle.h
+++ b/include/test/battle.h
@@ -701,7 +701,6 @@ struct BattleTestData
     u8 moveBattlers;
     bool8 hasAI:1;
     bool8 logAI:1;
-    u16 multipleShellSideArm;
 
     struct RecordedBattleSave recordedBattle;
     u8 battleRecordTypes[MAX_BATTLERS_COUNT][BATTLER_RECORD_SIZE];

--- a/test/test_runner_battle.c
+++ b/test/test_runner_battle.c
@@ -48,8 +48,6 @@ static inline bool32 RngSeedNotDefault(const rng_value_t *seed)
 struct BattleTestRunnerState *const gBattleTestRunnerState = (void *)sBackupMapData;
 STATIC_ASSERT(sizeof(struct BattleTestRunnerState) <= sizeof(sBackupMapData), sBackupMapDataSpace);
 
-STATIC_ASSERT(MAX_TURNS <= 8 * sizeof(DATA.multipleShellSideArm), NeedBiggerIntegerSizeForMultipleShellSideArm);
-
 static void CB2_BattleTest_NextParameter(void);
 static void CB2_BattleTest_NextTrial(void);
 static void PushBattlerAction(u32 sourceLine, s32 battlerId, u32 actionType, u32 byte);
@@ -2216,14 +2214,17 @@ void Move(u32 sourceLine, struct BattlePokemon *battler, struct MoveContext ctx)
         DATA.battleRecordTurns[DATA.turns][battlerId].criticalHit = 1 + ctx.criticalHit;
     if (ctx.explicitSecondaryEffect)
         DATA.battleRecordTurns[DATA.turns][battlerId].secondaryEffect = 1 + ctx.secondaryEffect;
-    if (ctx.explicitRNG) {
+    if (ctx.explicitRNG)
         DATA.battleRecordTurns[DATA.turns][battlerId].rng = ctx.rng;
-        if (ctx.rng.tag == RNG_SHELL_SIDE_ARM)
+    
+    u32 shellSideArmCount = 0;
+    for (u32 i = 0; i < STATE->battlersCount; i++)
+    {
+        if (DATA.battleRecordTurns[DATA.turns][i].rng.tag == RNG_SHELL_SIDE_ARM)
         {
-            if (DATA.multipleShellSideArm & (1 << DATA.turns))
+            shellSideArmCount++;
+            if (shellSideArmCount > 1)
                 Test_ExitWithResult(TEST_RESULT_ERROR, SourceLine(0), ":L Tried to use fixed RNG for multiple Shell Side Arm moves in the same turn");
-            else
-                DATA.multipleShellSideArm |= (1 << DATA.turns);
         }
     }
 

--- a/test/test_runner_battle.c
+++ b/test/test_runner_battle.c
@@ -48,6 +48,8 @@ static inline bool32 RngSeedNotDefault(const rng_value_t *seed)
 struct BattleTestRunnerState *const gBattleTestRunnerState = (void *)sBackupMapData;
 STATIC_ASSERT(sizeof(struct BattleTestRunnerState) <= sizeof(sBackupMapData), sBackupMapDataSpace);
 
+STATIC_ASSERT(MAX_TURNS <= 8 * sizeof(DATA.multipleShellSideArm), NeedBiggerIntegerSizeForMultipleShellSideArm);
+
 static void CB2_BattleTest_NextParameter(void);
 static void CB2_BattleTest_NextTrial(void);
 static void PushBattlerAction(u32 sourceLine, s32 battlerId, u32 actionType, u32 byte);
@@ -444,7 +446,7 @@ u32 RandomWeightedArray(enum RandomTag tag, u32 sum, u32 n, const u8 *weights)
     if (sum == 0)
         Test_ExitWithResult(TEST_RESULT_ERROR, SourceLine(0), ":LRandomWeightedArray called with zero sum");
 
-    if (gCurrentTurnActionNumber < gBattlersCount)
+    if (gCurrentTurnActionNumber < gBattlersCount || tag == RNG_SHELL_SIDE_ARM)
     {
         u32 battlerId = gBattlerByTurnOrder[gCurrentTurnActionNumber];
         turn = &DATA.battleRecordTurns[gBattleResults.battleTurnCounter][battlerId];
@@ -2214,8 +2216,16 @@ void Move(u32 sourceLine, struct BattlePokemon *battler, struct MoveContext ctx)
         DATA.battleRecordTurns[DATA.turns][battlerId].criticalHit = 1 + ctx.criticalHit;
     if (ctx.explicitSecondaryEffect)
         DATA.battleRecordTurns[DATA.turns][battlerId].secondaryEffect = 1 + ctx.secondaryEffect;
-    if (ctx.explicitRNG)
+    if (ctx.explicitRNG) {
         DATA.battleRecordTurns[DATA.turns][battlerId].rng = ctx.rng;
+        if (ctx.rng.tag == RNG_SHELL_SIDE_ARM)
+        {
+            if (DATA.multipleShellSideArm & (1 << DATA.turns))
+                Test_ExitWithResult(TEST_RESULT_ERROR, SourceLine(0), ":L Tried to use fixed RNG for multiple Shell Side Arm moves in the same turn");
+            else
+                DATA.multipleShellSideArm |= (1 << DATA.turns);
+        }
+    }
 
     if (!(DATA.actionBattlers & (1 << battlerId)))
     {


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

MOVE(SHELL_SIDE_ARM, target, WITH_RNG(RNG_SHELL_SIDE_ARM, fixed_rng)
will only properly fix the RNG on the very first turn on battle. This is because SHELL_SIDE_ARM damage type is determined at the beginning of combat for the first turn and at the end of the previous turn for every turn after that.

I fixed it by making sure `SetShellSideArmCategory` properly reads fixed rng even if it occurs during end of turn but it means multiple uses of shell side arm in the same turn will use the same fixed RNG. A check has been added to make sure the test will fail if someone try to fix the rng of multiple shell side arm moves in the same turn.
 
Move rng is decided at the beginning of the test creation before the battle start so I needed to store the information of the number of shell side arm used on every turn. Because the MAX_TURN_COUNT is 16, I used a u16 and added a static_assert in case MAX_TURN_COUNT is changed in the future.

## Issue(s) that this PR fixes
I'm closing #7547 that I created to describe the problem this is fixing

## Discord contact info
Jamie (foster_harmony)
