### PR TITLE
Added Ability TODO tests - Volume C

### DIFF
--- a/test/battle/ability/bad_dreams.c
+++ b/test/battle/ability/bad_dreams.c
@@ -35,6 +35,8 @@ SINGLE_BATTLE_TEST("Bad Dreams causes the sleeping enemy Pokemon to lose 1/8 of 
     }
 }
 
+TO_DO_BATTLE_TEST("Bad Dreams affects Pokémon with Comatose")
+
 DOUBLE_BATTLE_TEST("Bad Dreams does not activate if only the partner Pokemon is sleeping")
 {
     GIVEN {

--- a/test/battle/ability/cheek_pouch.c
+++ b/test/battle/ability/cheek_pouch.c
@@ -1,6 +1,15 @@
 #include "global.h"
 #include "test/battle.h"
 
+TO_DO_BATTLE_TEST("Cheek Pouch restores 33% max HP")
+TO_DO_BATTLE_TEST("Cheek Pouch restores HP after the berry's effect")
+TO_DO_BATTLE_TEST("Cheek Pouch activates via Bug Bite/Pluck if it would trigger an effect")
+TO_DO_BATTLE_TEST("Cheek Pouch activates when receiving from Fling if it would trigger an effect")
+TO_DO_BATTLE_TEST("Cheek Pouch doesn't activate when using Natural Gift")
+TO_DO_BATTLE_TEST("Cheek Pouch doesn't activate when using Fling")
+TO_DO_BATTLE_TEST("Cheek Pouch doesn't activate when using a berry from the bag")
+TO_DO_BATTLE_TEST("Cheek Pouch doesn't activate under Heal Block's effect")
+
 SINGLE_BATTLE_TEST("Cheek Pouch activation doesn't mutate damage when restoring HP mid battle")
 {
     s16 damage;

--- a/test/battle/ability/comatose.c
+++ b/test/battle/ability/comatose.c
@@ -24,7 +24,7 @@ SINGLE_BATTLE_TEST("Comatose prevents status-inducing moves")
     }
 }
 
-SINGLE_BATTLE_TEST("Comatose may be suppressed if pokemon transformed into a pokemon with Comatose ability and was under the effects of Gastro Acid")
+SINGLE_BATTLE_TEST("Comatose may be suppressed if Pokémon transformed into a Pokémon with Comatose ability and was under the effects of Gastro Acid")
 {
     u32 move;
 
@@ -56,7 +56,7 @@ SINGLE_BATTLE_TEST("Comatose may be suppressed if pokemon transformed into a pok
     }
 }
 
-SINGLE_BATTLE_TEST("Comatose pokemon doesn't get poisoned by Toxic Spikes on switch-in")
+SINGLE_BATTLE_TEST("Comatose Pokémon doesn't get poisoned by Toxic Spikes on switch-in")
 {
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);
@@ -72,7 +72,7 @@ SINGLE_BATTLE_TEST("Comatose pokemon doesn't get poisoned by Toxic Spikes on swi
     }
 }
 
-SINGLE_BATTLE_TEST("Comatose pokemon don't get poisoned by Toxic Spikes on switch-in if forced in by phazing with Mold Breaker")
+SINGLE_BATTLE_TEST("Comatose Pokémon don't get poisoned by Toxic Spikes on switch-in if forced in by phazing with Mold Breaker")
 {
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);
@@ -87,3 +87,8 @@ SINGLE_BATTLE_TEST("Comatose pokemon don't get poisoned by Toxic Spikes on switc
         NOT HP_BAR(player);
     }
 }
+
+TO_DO_BATTLE_TEST("Comatose makes Rest fail")
+TO_DO_BATTLE_TEST("Comatose isn't affected by Mold Breaker, Turboblaze or Teravolt")
+TO_DO_BATTLE_TEST("Comatose isn't affected by Poison Touch + Sunsteel Strike")
+TO_DO_BATTLE_TEST("Comatose boosts Dream Ball's multiplier")

--- a/test/battle/ability/competitive.c
+++ b/test/battle/ability/competitive.c
@@ -1,4 +1,337 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Competitive (Ability) test titles")
+DOUBLE_BATTLE_TEST("Competitive sharply raises player's Attack after Intimidate")
+{
+    u32 abilityLeft, abilityRight;
+
+    PARAMETRIZE { abilityLeft = ABILITY_FRIEND_GUARD; abilityRight = ABILITY_FRIEND_GUARD; }
+    PARAMETRIZE { abilityLeft = ABILITY_FRIEND_GUARD; abilityRight = ABILITY_COMPETITIVE; }
+    PARAMETRIZE { abilityLeft = ABILITY_COMPETITIVE; abilityRight = ABILITY_FRIEND_GUARD; }
+    PARAMETRIZE { abilityLeft = ABILITY_COMPETITIVE; abilityRight = ABILITY_COMPETITIVE; }
+
+    GIVEN {
+        PLAYER(SPECIES_IGGLYBUFF) { Ability(abilityLeft); }
+        PLAYER(SPECIES_JIGGLYPUFF) { Ability(abilityRight); }
+        OPPONENT(SPECIES_GYARADOS) { Ability(ABILITY_INTIMIDATE); }
+        OPPONENT(SPECIES_ARBOK) { Ability(ABILITY_INTIMIDATE); }
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_SCRATCH, target:opponentLeft); MOVE(playerRight, MOVE_SCRATCH, target:opponentRight); }
+    } SCENE {
+        //1st mon Intimidate
+        ABILITY_POPUP(opponentLeft, ABILITY_INTIMIDATE);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
+        MESSAGE("The opposing Gyarados's Intimidate cuts Igglybuff's Attack!");
+        if (abilityLeft == ABILITY_COMPETITIVE) {
+            ABILITY_POPUP(playerLeft, ABILITY_COMPETITIVE);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
+            MESSAGE("Igglybuff's Sp. Atk sharply rose!");
+        }
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerRight);
+        MESSAGE("The opposing Gyarados's Intimidate cuts Jigglypuff's Attack!");
+        if (abilityRight == ABILITY_COMPETITIVE) {
+            ABILITY_POPUP(playerRight, ABILITY_COMPETITIVE);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerRight);
+            MESSAGE("Jigglypuff's Sp. Atk sharply rose!");
+        }
+
+        //2nd mon Intimidate
+        ABILITY_POPUP(opponentRight, ABILITY_INTIMIDATE);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
+        MESSAGE("The opposing Arbok's Intimidate cuts Igglybuff's Attack!");
+        if (abilityLeft == ABILITY_COMPETITIVE) {
+            ABILITY_POPUP(playerLeft, ABILITY_COMPETITIVE);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
+            MESSAGE("Igglybuff's Sp. Atk sharply rose!");
+        }
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerRight);
+        MESSAGE("The opposing Arbok's Intimidate cuts Jigglypuff's Attack!");
+        if (abilityRight == ABILITY_COMPETITIVE) {
+            ABILITY_POPUP(playerRight, ABILITY_COMPETITIVE);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerRight);
+            MESSAGE("Jigglypuff's Sp. Atk sharply rose!");
+        }
+    } FINALLY {
+        // -2 from Intimidates and +4 from Defiants gets +2 total
+        EXPECT_EQ(playerLeft->statStages[STAT_SPATK], (abilityLeft == ABILITY_COMPETITIVE) ? DEFAULT_STAT_STAGE + 4 : DEFAULT_STAT_STAGE - 2);
+        EXPECT_EQ(playerRight->statStages[STAT_SPATK], (abilityRight == ABILITY_COMPETITIVE) ? DEFAULT_STAT_STAGE + 4 : DEFAULT_STAT_STAGE - 2);
+    }
+}
+
+// Same as above, but for opponent.
+DOUBLE_BATTLE_TEST("Competitive sharply raises opponent's Attack after Intimidate")
+{
+    u32 abilityLeft, abilityRight;
+
+    PARAMETRIZE { abilityLeft = ABILITY_FRIEND_GUARD; abilityRight = ABILITY_FRIEND_GUARD; }
+    PARAMETRIZE { abilityLeft = ABILITY_FRIEND_GUARD; abilityRight = ABILITY_COMPETITIVE; }
+    PARAMETRIZE { abilityLeft = ABILITY_COMPETITIVE; abilityRight = ABILITY_FRIEND_GUARD; }
+    PARAMETRIZE { abilityLeft = ABILITY_COMPETITIVE; abilityRight = ABILITY_COMPETITIVE; }
+
+    GIVEN {
+        OPPONENT(SPECIES_IGGLYBUFF) { Ability(abilityLeft); }
+        OPPONENT(SPECIES_JIGGLYPUFF) { Ability(abilityRight); }
+        PLAYER(SPECIES_GYARADOS) { Ability(ABILITY_INTIMIDATE); }
+        PLAYER(SPECIES_ARBOK) { Ability(ABILITY_INTIMIDATE); }
+    } WHEN {
+        TURN { MOVE(opponentLeft, MOVE_SCRATCH, target:playerLeft); MOVE(opponentRight, MOVE_SCRATCH, target:playerRight); }
+    } SCENE {
+        //1st mon Intimidate
+        ABILITY_POPUP(playerLeft, ABILITY_INTIMIDATE);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
+        MESSAGE("Gyarados's Intimidate cuts the opposing Igglybuff's Attack!");
+        if (abilityLeft == ABILITY_COMPETITIVE) {
+            ABILITY_POPUP(opponentLeft, ABILITY_COMPETITIVE);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
+            MESSAGE("The opposing Igglybuff's Sp. Atk sharply rose!");
+        }
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);
+        MESSAGE("Gyarados's Intimidate cuts the opposing Jigglypuff's Attack!");
+        if (abilityRight == ABILITY_COMPETITIVE) {
+            ABILITY_POPUP(opponentRight, ABILITY_COMPETITIVE);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);
+            MESSAGE("The opposing Jigglypuff's Sp. Atk sharply rose!");
+        }
+
+        //2nd mon Intimidate
+        ABILITY_POPUP(playerRight, ABILITY_INTIMIDATE);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
+        MESSAGE("Arbok's Intimidate cuts the opposing Igglybuff's Attack!");
+        if (abilityLeft == ABILITY_COMPETITIVE) {
+            ABILITY_POPUP(opponentLeft, ABILITY_COMPETITIVE);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
+            MESSAGE("The opposing Igglybuff's Sp. Atk sharply rose!");
+        }
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);
+        MESSAGE("Arbok's Intimidate cuts the opposing Jigglypuff's Attack!");
+        if (abilityRight == ABILITY_COMPETITIVE) {
+            ABILITY_POPUP(opponentRight, ABILITY_COMPETITIVE);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);
+            MESSAGE("The opposing Jigglypuff's Sp. Atk sharply rose!");
+        }
+    } FINALLY {
+        // -2 from Intimidates and +4 from Defiants gets +2 total
+        EXPECT_EQ(opponentLeft->statStages[STAT_SPATK], (abilityLeft == ABILITY_COMPETITIVE) ? DEFAULT_STAT_STAGE + 4 : DEFAULT_STAT_STAGE - 2);
+        EXPECT_EQ(opponentRight->statStages[STAT_SPATK], (abilityRight == ABILITY_COMPETITIVE) ? DEFAULT_STAT_STAGE + 4 : DEFAULT_STAT_STAGE - 2);
+    }
+}
+
+SINGLE_BATTLE_TEST("Competitive activates after Sticky Web lowers Speed")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_IGGLYBUFF) { Ability(ABILITY_COMPETITIVE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_STICKY_WEB); }
+        TURN { SWITCH(player, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_STICKY_WEB, opponent);
+        // Switch-in - Sticky Web activates
+        SEND_IN_MESSAGE("Igglybuff");
+        MESSAGE("Igglybuff was caught in a sticky web!");
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        MESSAGE("Igglybuff's Speed fell!");
+        // Competitive activates
+        ABILITY_POPUP(player, ABILITY_COMPETITIVE);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        MESSAGE("Igglybuff's Sp. Atk sharply rose!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Competitive doesn't activate after Sticky Web lowers Speed if Court Changed")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_IGGLYBUFF) { Ability(ABILITY_COMPETITIVE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_STICKY_WEB); MOVE(opponent, MOVE_COURT_CHANGE); }
+        TURN { SWITCH(player, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_STICKY_WEB, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_COURT_CHANGE, opponent);
+        // Switch-in - Sticky Web activates
+        SEND_IN_MESSAGE("Igglybuff");
+        MESSAGE("Igglybuff was caught in a sticky web!");
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        MESSAGE("Igglybuff's Speed fell!");
+        // Competitive doesn't activate
+        NONE_OF {
+            ABILITY_POPUP(player, ABILITY_COMPETITIVE);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+            MESSAGE("Igglybuff's Sp. Atk sharply rose!");
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Competitive correctly activates after Sticky Web lowers Speed if Court Changed")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_IGGLYBUFF) { Ability(ABILITY_COMPETITIVE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_STICKY_WEB); MOVE(opponent, MOVE_COURT_CHANGE); }
+        TURN { SWITCH(player, 1); }
+        TURN { MOVE(opponent, MOVE_GROWL);}
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_STICKY_WEB, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_COURT_CHANGE, opponent);
+        // Switch-in - Sticky Web activates
+        SEND_IN_MESSAGE("Igglybuff");
+        MESSAGE("Igglybuff was caught in a sticky web!");
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        MESSAGE("Igglybuff's Speed fell!");
+        // Competitive doesn't activate
+        NONE_OF {
+            ABILITY_POPUP(player, ABILITY_COMPETITIVE);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+            MESSAGE("Igglybuff's Sp. Atk sharply rose!");
+        }
+        // Competitive triggers correctly after Sticky Web
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_GROWL, opponent);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        MESSAGE("Igglybuff's Attack fell!");
+        ABILITY_POPUP(player, ABILITY_COMPETITIVE);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        MESSAGE("Igglybuff's Sp. Atk sharply rose!");
+    }
+}
+
+DOUBLE_BATTLE_TEST("Competitive is activated by Cotton Down for non-ally pokemon")
+{
+    GIVEN {
+        PLAYER(SPECIES_IGGLYBUFF) { Ability(ABILITY_COMPETITIVE); }
+        PLAYER(SPECIES_IGGLYBUFF) { Ability(ABILITY_COMPETITIVE); }
+        OPPONENT(SPECIES_ELDEGOSS) { Ability(ABILITY_COTTON_DOWN); }
+        OPPONENT(SPECIES_IGGLYBUFF) { Ability(ABILITY_COMPETITIVE); }
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_SCRATCH, target: opponentLeft); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, playerLeft);
+        ABILITY_POPUP(opponentLeft, ABILITY_COTTON_DOWN);
+
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
+        MESSAGE("Igglybuff's Speed fell!");
+        ABILITY_POPUP(playerLeft, ABILITY_COMPETITIVE);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
+        MESSAGE("Igglybuff's Sp. Atk sharply rose!");
+
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerRight);
+        MESSAGE("Igglybuff's Speed fell!");
+        ABILITY_POPUP(playerRight, ABILITY_COMPETITIVE);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerRight);
+        MESSAGE("Igglybuff's Sp. Atk sharply rose!");
+
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);
+        MESSAGE("The opposing Igglybuff's Speed fell!");
+    } THEN {
+        EXPECT_EQ(playerLeft->statStages[STAT_SPEED], DEFAULT_STAT_STAGE - 1);
+        EXPECT_EQ(playerRight->statStages[STAT_SPEED], DEFAULT_STAT_STAGE - 1);
+        EXPECT_EQ(opponentRight->statStages[STAT_SPEED], DEFAULT_STAT_STAGE - 1);
+        EXPECT_EQ(playerLeft->statStages[STAT_SPATK], DEFAULT_STAT_STAGE + 2);
+        EXPECT_EQ(playerRight->statStages[STAT_SPATK], DEFAULT_STAT_STAGE + 2);
+    }
+}
+
+SINGLE_BATTLE_TEST("Competitive activates before White Herb")
+{
+    u32 move;
+
+    PARAMETRIZE { move = MOVE_LEER; }
+    PARAMETRIZE { move = MOVE_CONFIDE; }
+
+    GIVEN {
+        PLAYER(SPECIES_IGGLYBUFF) { Ability(ABILITY_COMPETITIVE); Item(ITEM_WHITE_HERB); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, move); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, opponent);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+
+        ABILITY_POPUP(player, ABILITY_COMPETITIVE);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        MESSAGE("Igglybuff's Sp. Atk sharply rose!");
+
+        if (move == MOVE_LEER) {
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+            MESSAGE("Igglybuff returned its stats to normal using its White Herb!");
+        } else {
+            NONE_OF {
+                ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+                MESSAGE("Igglybuff returned its stats to normal using its White Herb!");
+            }
+        }
+    } THEN {
+        if (move == MOVE_LEER) {
+            EXPECT_EQ(player->statStages[STAT_DEF], DEFAULT_STAT_STAGE);
+            EXPECT_EQ(player->statStages[STAT_SPATK], DEFAULT_STAT_STAGE + 2);
+        } else {
+            EXPECT_EQ(player->statStages[STAT_SPATK], DEFAULT_STAT_STAGE + 1);
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Competitive activates for each stat that is lowered")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_TICKLE) == EFFECT_TICKLE);
+        PLAYER(SPECIES_IGGLYBUFF) { Ability(ABILITY_COMPETITIVE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_TICKLE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TICKLE, opponent);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+
+        MESSAGE("Igglybuff's Attack fell!");
+        ABILITY_POPUP(player, ABILITY_COMPETITIVE);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        MESSAGE("Igglybuff's Sp. Atk sharply rose!");
+
+        MESSAGE("Igglybuff's Defense fell!");
+        ABILITY_POPUP(player, ABILITY_COMPETITIVE);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        MESSAGE("Igglybuff's Sp. Atk sharply rose!");
+
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_SPATK], DEFAULT_STAT_STAGE + 4);
+    }
+}
+
+SINGLE_BATTLE_TEST("Competitive doesn't activate if the pokemon lowers it's own stats")
+{
+    u32 move;
+
+    PARAMETRIZE { move = MOVE_SUPERPOWER; }
+    PARAMETRIZE { move = MOVE_CLOSE_COMBAT; }
+    PARAMETRIZE { move = MOVE_MAKE_IT_RAIN; }
+    PARAMETRIZE { move = MOVE_SPIN_OUT; }
+
+    GIVEN {
+        ASSUME(MoveHasAdditionalEffectSelf(MOVE_SUPERPOWER, MOVE_EFFECT_ATK_DEF_DOWN));
+        ASSUME(MoveHasAdditionalEffectSelf(MOVE_CLOSE_COMBAT, MOVE_EFFECT_DEF_SPDEF_DOWN));
+        ASSUME(MoveHasAdditionalEffectSelf(MOVE_MAKE_IT_RAIN, MOVE_EFFECT_SP_ATK_MINUS_1));
+        ASSUME(MoveHasAdditionalEffectSelf(MOVE_SPIN_OUT, MOVE_EFFECT_SPD_MINUS_2));
+        PLAYER(SPECIES_IGGLYBUFF) { Ability(ABILITY_COMPETITIVE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, move); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+
+        NONE_OF {
+            ABILITY_POPUP(player, ABILITY_COMPETITIVE);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+            MESSAGE("Igglybuff's Sp. Atk sharply rose!");
+        }
+    } THEN {
+        if (move == MOVE_SUPERPOWER)
+            EXPECT_EQ(player->statStages[STAT_ATK], DEFAULT_STAT_STAGE - 1);
+        else
+            EXPECT_EQ(player->statStages[STAT_ATK], DEFAULT_STAT_STAGE);
+    }
+}

--- a/test/battle/ability/competitive.c
+++ b/test/battle/ability/competitive.c
@@ -52,9 +52,8 @@ DOUBLE_BATTLE_TEST("Competitive sharply raises player's Attack after Intimidate"
             MESSAGE("Jigglypuff's Sp. Atk sharply rose!");
         }
     } FINALLY {
-        // -2 from Intimidates and +4 from Defiants gets +2 total
-        EXPECT_EQ(playerLeft->statStages[STAT_SPATK], (abilityLeft == ABILITY_COMPETITIVE) ? DEFAULT_STAT_STAGE + 4 : DEFAULT_STAT_STAGE - 2);
-        EXPECT_EQ(playerRight->statStages[STAT_SPATK], (abilityRight == ABILITY_COMPETITIVE) ? DEFAULT_STAT_STAGE + 4 : DEFAULT_STAT_STAGE - 2);
+        EXPECT_EQ(playerLeft->statStages[STAT_SPATK], DEFAULT_STAT_STAGE + (abilityLeft == ABILITY_COMPETITIVE ? 4 : 0));
+        EXPECT_EQ(playerRight->statStages[STAT_SPATK], DEFAULT_STAT_STAGE + (abilityRight == ABILITY_COMPETITIVE ? 4 : 0));
     }
 }
 
@@ -110,9 +109,8 @@ DOUBLE_BATTLE_TEST("Competitive sharply raises opponent's Attack after Intimidat
             MESSAGE("The opposing Jigglypuff's Sp. Atk sharply rose!");
         }
     } FINALLY {
-        // -2 from Intimidates and +4 from Defiants gets +2 total
-        EXPECT_EQ(opponentLeft->statStages[STAT_SPATK], (abilityLeft == ABILITY_COMPETITIVE) ? DEFAULT_STAT_STAGE + 4 : DEFAULT_STAT_STAGE - 2);
-        EXPECT_EQ(opponentRight->statStages[STAT_SPATK], (abilityRight == ABILITY_COMPETITIVE) ? DEFAULT_STAT_STAGE + 4 : DEFAULT_STAT_STAGE - 2);
+        EXPECT_EQ(opponentLeft->statStages[STAT_SPATK], DEFAULT_STAT_STAGE + (abilityLeft == ABILITY_COMPETITIVE ? 4 : 0));
+        EXPECT_EQ(opponentRight->statStages[STAT_SPATK], DEFAULT_STAT_STAGE + (abilityRight == ABILITY_COMPETITIVE ? 4 : 0));
     }
 }
 

--- a/test/battle/ability/competitive.c
+++ b/test/battle/ability/competitive.c
@@ -1,7 +1,7 @@
 #include "global.h"
 #include "test/battle.h"
 
-DOUBLE_BATTLE_TEST("Competitive sharply raises player's Attack after Intimidate")
+DOUBLE_BATTLE_TEST("Competitive sharply raises player's Sp. Atk after Intimidate")
 {
     u32 abilityLeft, abilityRight;
 
@@ -58,7 +58,7 @@ DOUBLE_BATTLE_TEST("Competitive sharply raises player's Attack after Intimidate"
 }
 
 // Same as above, but for opponent.
-DOUBLE_BATTLE_TEST("Competitive sharply raises opponent's Attack after Intimidate")
+DOUBLE_BATTLE_TEST("Competitive sharply raises opponent's Sp. Atk after Intimidate")
 {
     u32 abilityLeft, abilityRight;
 

--- a/test/battle/ability/competitive.c
+++ b/test/battle/ability/competitive.c
@@ -51,7 +51,7 @@ DOUBLE_BATTLE_TEST("Competitive sharply raises player's Sp. Atk after Intimidate
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerRight);
             MESSAGE("Jigglypuff's Sp. Atk sharply rose!");
         }
-    } FINALLY {
+    } THEN {
         EXPECT_EQ(playerLeft->statStages[STAT_SPATK], DEFAULT_STAT_STAGE + (abilityLeft == ABILITY_COMPETITIVE ? 4 : 0));
         EXPECT_EQ(playerRight->statStages[STAT_SPATK], DEFAULT_STAT_STAGE + (abilityRight == ABILITY_COMPETITIVE ? 4 : 0));
     }
@@ -108,7 +108,7 @@ DOUBLE_BATTLE_TEST("Competitive sharply raises opponent's Sp. Atk after Intimida
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);
             MESSAGE("The opposing Jigglypuff's Sp. Atk sharply rose!");
         }
-    } FINALLY {
+    } THEN {
         EXPECT_EQ(opponentLeft->statStages[STAT_SPATK], DEFAULT_STAT_STAGE + (abilityLeft == ABILITY_COMPETITIVE ? 4 : 0));
         EXPECT_EQ(opponentRight->statStages[STAT_SPATK], DEFAULT_STAT_STAGE + (abilityRight == ABILITY_COMPETITIVE ? 4 : 0));
     }

--- a/test/battle/ability/contrary.c
+++ b/test/battle/ability/contrary.c
@@ -241,3 +241,5 @@ SINGLE_BATTLE_TEST("Sticky Web raises Speed by 1 for Contrary mon on switch-in")
         MESSAGE("The opposing Snivy's Speed rose!");
     }
 }
+
+TO_DO_BATTLE_TEST("Contrary does not invert stat changes that have been Baton-passed")

--- a/test/battle/ability/corrosion.c
+++ b/test/battle/ability/corrosion.c
@@ -238,3 +238,10 @@ SINGLE_BATTLE_TEST("Corrosion's effect is lost if the move used by the Pokémon 
         }
     }
 }
+
+TO_DO_BATTLE_TEST("Corrosion can poison Poison/Steel types if the Pokémon uses Baneful Bunker")
+TO_DO_BATTLE_TEST("Corrosion can poison Poison/Steel types if the Pokémon uses Psycho Shift while poisoned")
+TO_DO_BATTLE_TEST("Corrosion can poison Poison/Steel types if the Pokémon uses Fling while holding a Toxic Orb")
+TO_DO_BATTLE_TEST("Corrosion can poison Poison/Steel types if the Pokémon uses Fling while holding a Poison Barb")
+TO_DO_BATTLE_TEST("Dynamax: Corrosion can poison Poison/Steel types if the Pokémon uses G-Max Malodor")
+TO_DO_BATTLE_TEST("Corrosion does not affect Poison Spikes")

--- a/test/battle/ability/costar.c
+++ b/test/battle/ability/costar.c
@@ -28,3 +28,5 @@ DOUBLE_BATTLE_TEST("Costar copies an ally's stat stages upon entering battle")
 // Copy from Ruin ability tests
 TO_DO_BATTLE_TEST("Costar's message displays correctly after all battlers fainted - Player");
 TO_DO_BATTLE_TEST("Costar's message displays correctly after all battlers fainted - Opponent");
+
+TO_DO_BATTLE_TEST("Costar can copy an ally's critical hit ratio");

--- a/test/battle/ability/cud_chew.c
+++ b/test/battle/ability/cud_chew.c
@@ -47,3 +47,5 @@ SINGLE_BATTLE_TEST("Cud Chew will activate Oran Berry effect again on the next t
         EXPECT_EQ(opponent->hp, 40);
     }
 }
+
+TO_DO_BATTLE_TEST("Cud Chew will activate Lum Berry effect again on the next turn")

--- a/test/battle/ability/cursed_body.c
+++ b/test/battle/ability/cursed_body.c
@@ -15,3 +15,11 @@ SINGLE_BATTLE_TEST("Cursed Body triggers 30% of the time")
         MESSAGE("Wobbuffet's Aqua Jet was disabled by the opposing Frillish's Cursed Body!");
     }
 }
+
+TO_DO_BATTLE_TEST("Cursed Body cannot disable Struggle")
+TO_DO_BATTLE_TEST("Cursed Body can trigger if the attacker is behind a Substitute")
+TO_DO_BATTLE_TEST("Cursed Body cannot trigger if the target is behind a Substitute")
+TO_DO_BATTLE_TEST("Cursed Body does not stop a multistrike move mid-execution")
+TO_DO_BATTLE_TEST("Cursed Body disables the move that called another move instead of the called move")
+TO_DO_BATTLE_TEST("Cursed Body disables damaging Z-Moves, but not the base move") // Rotom Powers can restore Z-Moves
+TO_DO_BATTLE_TEST("Cursed Body disables the base move of a status Z-Move")

--- a/test/battle/ability/cute_charm.c
+++ b/test/battle/ability/cute_charm.c
@@ -46,7 +46,11 @@ SINGLE_BATTLE_TEST("Cute Charm cannot infatuate same gender")
     }
 }
 
-SINGLE_BATTLE_TEST("Cute Charm triggers 30% of the time")
+TO_DO_BATTLE_TEST("Cute Charm cannot infatuate if either Pokémon are Gender-unknown")
+
+TO_DO_BATTLE_TEST("Cute Charm triggers 1/3 of the time (Gen 3)")
+
+SINGLE_BATTLE_TEST("Cute Charm triggers 30% of the time (Gen 4+)")
 {
     PASSES_RANDOMLY(3, 10, RNG_CUTE_CHARM);
     GIVEN {

--- a/test/battle/ability/defiant.c
+++ b/test/battle/ability/defiant.c
@@ -51,7 +51,7 @@ DOUBLE_BATTLE_TEST("Defiant sharply raises player's Attack after Intimidate")
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerRight);
             MESSAGE("Primeape's Attack sharply rose!");
         }
-    } FINALLY {
+    } THEN {
         // -2 from Intimidates and +4 from Defiants gets +2 total
         EXPECT_EQ(playerLeft->statStages[STAT_ATK], (abilityLeft == ABILITY_DEFIANT) ? DEFAULT_STAT_STAGE + 2 : DEFAULT_STAT_STAGE - 2);
         EXPECT_EQ(playerRight->statStages[STAT_ATK], (abilityRight == ABILITY_DEFIANT) ? DEFAULT_STAT_STAGE + 2 : DEFAULT_STAT_STAGE - 2);
@@ -109,7 +109,7 @@ DOUBLE_BATTLE_TEST("Defiant sharply raises opponent's Attack after Intimidate")
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);
             MESSAGE("The opposing Primeape's Attack sharply rose!");
         }
-    } FINALLY {
+    } THEN {
         // -2 from Intimidates and +4 from Defiants gets +2 total
         EXPECT_EQ(opponentLeft->statStages[STAT_ATK], (abilityLeft == ABILITY_DEFIANT) ? DEFAULT_STAT_STAGE + 2 : DEFAULT_STAT_STAGE - 2);
         EXPECT_EQ(opponentRight->statStages[STAT_ATK], (abilityRight == ABILITY_DEFIANT) ? DEFAULT_STAT_STAGE + 2 : DEFAULT_STAT_STAGE - 2);

--- a/test/battle/ability/flower_veil.c
+++ b/test/battle/ability/flower_veil.c
@@ -62,3 +62,5 @@ DOUBLE_BATTLE_TEST("Flower Veil prevents Toxic bad poison on partner - left targ
         MESSAGE("The opposing Chikorita surrounded itself with a veil of petals!");
     }
 }
+
+TO_DO_BATTLE_TEST("Flower Veil's stat reduction protection considers Contrary") // Eg. If a move would reduce stats due to Contrary, it will be protected by Mist.

--- a/test/battle/ability/insomnia.c
+++ b/test/battle/ability/insomnia.c
@@ -40,7 +40,7 @@ SINGLE_BATTLE_TEST("Insomnia prevents yawn")
     }
 }
 
-SINGLE_BATTLE_TEST("Insomnia prevents rest")
+SINGLE_BATTLE_TEST("Insomnia prevents Rest")
 {
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_REST) == EFFECT_REST);

--- a/test/battle/ability/moxie.c
+++ b/test/battle/ability/moxie.c
@@ -4,8 +4,8 @@
 DOUBLE_BATTLE_TEST("Moxie/Chilling Neigh raises Attack by one stage after directly causing a Pokemon to faint")
 {
     u32 species = 0, ability = 0, abilityPopUp = 0;
-    PARAMETRIZE { species = SPECIES_SALAMENCE;         ability = ABILITY_MOXIE;            abilityPopUp = ABILITY_MOXIE;          }
-    PARAMETRIZE { species = SPECIES_GLASTRIER;         ability = ABILITY_CHILLING_NEIGH;   abilityPopUp = ABILITY_CHILLING_NEIGH; }
+    PARAMETRIZE { species = SPECIES_SALAMENCE;   ability = ABILITY_MOXIE;            abilityPopUp = ABILITY_MOXIE;          }
+    PARAMETRIZE { species = SPECIES_GLASTRIER;   ability = ABILITY_CHILLING_NEIGH;   abilityPopUp = ABILITY_CHILLING_NEIGH; }
     PARAMETRIZE { species = SPECIES_CALYREX_ICE; ability = ABILITY_AS_ONE_ICE_RIDER; abilityPopUp = ABILITY_CHILLING_NEIGH; }
     GIVEN {
         ASSUME(GetMoveTarget(MOVE_EARTHQUAKE) == MOVE_TARGET_FOES_AND_ALLY);
@@ -37,8 +37,8 @@ DOUBLE_BATTLE_TEST("Moxie/Chilling Neigh raises Attack by one stage after direct
 DOUBLE_BATTLE_TEST("Moxie/Chilling Neigh does not trigger if Pokemon faint to indirect damage or damage from other Pokemon")
 {
     u32 species = 0, ability = 0, abilityPopUp = 0;
-    PARAMETRIZE { species = SPECIES_SALAMENCE;         ability = ABILITY_MOXIE;            abilityPopUp = ABILITY_MOXIE;          }
-    PARAMETRIZE { species = SPECIES_GLASTRIER;         ability = ABILITY_CHILLING_NEIGH;   abilityPopUp = ABILITY_CHILLING_NEIGH; }
+    PARAMETRIZE { species = SPECIES_SALAMENCE;   ability = ABILITY_MOXIE;            abilityPopUp = ABILITY_MOXIE;          }
+    PARAMETRIZE { species = SPECIES_GLASTRIER;   ability = ABILITY_CHILLING_NEIGH;   abilityPopUp = ABILITY_CHILLING_NEIGH; }
     PARAMETRIZE { species = SPECIES_CALYREX_ICE; ability = ABILITY_AS_ONE_ICE_RIDER; abilityPopUp = ABILITY_CHILLING_NEIGH; }
     GIVEN {
         PLAYER(species) { Ability(ability); }
@@ -74,8 +74,8 @@ DOUBLE_BATTLE_TEST("Moxie/Chilling Neigh does not trigger if Pokemon faint to in
 SINGLE_BATTLE_TEST("Moxie/Chilling Neigh does not trigger when already at maximum Attack stage")
 {
     u32 species = 0, ability = 0, abilityPopUp = 0;
-    PARAMETRIZE { species = SPECIES_SALAMENCE;         ability = ABILITY_MOXIE;            abilityPopUp = ABILITY_MOXIE;          }
-    PARAMETRIZE { species = SPECIES_GLASTRIER;         ability = ABILITY_CHILLING_NEIGH;   abilityPopUp = ABILITY_CHILLING_NEIGH; }
+    PARAMETRIZE { species = SPECIES_SALAMENCE;   ability = ABILITY_MOXIE;            abilityPopUp = ABILITY_MOXIE;          }
+    PARAMETRIZE { species = SPECIES_GLASTRIER;   ability = ABILITY_CHILLING_NEIGH;   abilityPopUp = ABILITY_CHILLING_NEIGH; }
     PARAMETRIZE { species = SPECIES_CALYREX_ICE; ability = ABILITY_AS_ONE_ICE_RIDER; abilityPopUp = ABILITY_CHILLING_NEIGH; }
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_BELLY_DRUM) == EFFECT_BELLY_DRUM);
@@ -112,9 +112,9 @@ DOUBLE_BATTLE_TEST("Moxie/Chilling Neigh does not increase damage done by the sa
 {
     s16 damage[2];
     u32 species = 0, ability = 0, abilityPopUp = 0;
-    PARAMETRIZE { species = SPECIES_SALAMENCE;         ability = ABILITY_MOXIE;            abilityPopUp = ABILITY_MOXIE;          }
-    PARAMETRIZE { species = SPECIES_GLASTRIER;         ability = ABILITY_CHILLING_NEIGH;   abilityPopUp = ABILITY_CHILLING_NEIGH; }
-    PARAMETRIZE { species = SPECIES_CALYREX_ICE;       ability = ABILITY_AS_ONE_ICE_RIDER; abilityPopUp = ABILITY_CHILLING_NEIGH; }
+    PARAMETRIZE { species = SPECIES_SALAMENCE;   ability = ABILITY_MOXIE;            abilityPopUp = ABILITY_MOXIE;          }
+    PARAMETRIZE { species = SPECIES_GLASTRIER;   ability = ABILITY_CHILLING_NEIGH;   abilityPopUp = ABILITY_CHILLING_NEIGH; }
+    PARAMETRIZE { species = SPECIES_CALYREX_ICE; ability = ABILITY_AS_ONE_ICE_RIDER; abilityPopUp = ABILITY_CHILLING_NEIGH; }
 
     GIVEN {
         ASSUME(GetMoveTarget(MOVE_EARTHQUAKE) == MOVE_TARGET_FOES_AND_ALLY);

--- a/test/battle/gimmick/dynamax.c
+++ b/test/battle/gimmick/dynamax.c
@@ -1660,3 +1660,6 @@ SINGLE_BATTLE_TEST("Dynamax: Destiny Bond fails if a dynamaxed battler is presen
         MESSAGE("The move was blocked by the power of Dynamax!");
     }
 }
+
+TO_DO_BATTLE_TEST("Dynamax: Contrary inverts stat-lowering Max Moves, without showing a message")
+TO_DO_BATTLE_TEST("Dynamax: Contrary inverts stat-increasing Max Moves, without showing a message")

--- a/test/battle/gimmick/zmove.c
+++ b/test/battle/gimmick/zmove.c
@@ -679,3 +679,7 @@ SINGLE_BATTLE_TEST("(Z-MOVE) Z-Revelation Dance always transforms into Breakneck
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BREAKNECK_BLITZ, player);
     }
 }
+
+TO_DO_BATTLE_TEST("(Z-MOVE) Stat changes from status Z-Moves are not inverted by Contrary")
+TO_DO_BATTLE_TEST("(Z-MOVE) Stat changes from Extreme Evoboost are inverted by Contrary")
+TO_DO_BATTLE_TEST("(Z-MOVE) Stat changes from Clangorous Soulblaze are inverted by Contrary")

--- a/test/battle/hold_effect/cure_status.c
+++ b/test/battle/hold_effect/cure_status.c
@@ -116,6 +116,8 @@ SINGLE_BATTLE_TEST("Chesto and Lum Berries cure sleep")
     }
 }
 
+TO_DO_BATTLE_TEST("Chesto and Lum Berries don't trigger if the holder has Comatose")
+
 SINGLE_BATTLE_TEST("Cheri and Lum Berries cure paralysis")
 {
     u16 item;
@@ -289,6 +291,5 @@ DOUBLE_BATTLE_TEST("Lum Berry correctly cures all battlers if multiple fainted t
         EXPECT_EQ(playerLeft->status1, STATUS1_NONE);
         EXPECT_EQ(playerRight->status1, STATUS1_NONE);
         EXPECT_EQ(opponentLeft->status1, STATUS1_NONE);
-
     }
 }

--- a/test/battle/move_effect/beat_up.c
+++ b/test/battle/move_effect/beat_up.c
@@ -3,6 +3,7 @@
 
 // General
 TO_DO_BATTLE_TEST("Beat Up hits the target for each non-fainted, non-statused member in the party");
+TO_DO_BATTLE_TEST("Beat Up doesn't consider Comatose as a status")
 TO_DO_BATTLE_TEST("Beat Up's strikes have each an independent chance of a critical hit");
 
 // B_BEAT_UP Gen2-4

--- a/test/battle/move_effect/double_power_on_arg_status.c
+++ b/test/battle/move_effect/double_power_on_arg_status.c
@@ -29,6 +29,8 @@ SINGLE_BATTLE_TEST("Hex deals double damage to foes with a status", s16 damage)
     }
 }
 
+TO_DO_BATTLE_TEST("Hex deals double damage to Pokémon with Comatose")
+
 SINGLE_BATTLE_TEST("Venoshock's power doubles if the target is poisoned/badly poisoned", s16 damage)
 {
     u32 status1;

--- a/test/battle/move_effect/mist.c
+++ b/test/battle/move_effect/mist.c
@@ -2,3 +2,5 @@
 #include "test/battle.h"
 
 TO_DO_BATTLE_TEST("TODO: Write Mist (Move Effect) test titles")
+
+TO_DO_BATTLE_TEST("Mist's protection considers Contrary") // Eg. If a move would reduce stats due to Contrary, it will be protected by Mist.

--- a/test/battle/move_effect/nightmare.c
+++ b/test/battle/move_effect/nightmare.c
@@ -2,3 +2,5 @@
 #include "test/battle.h"
 
 TO_DO_BATTLE_TEST("TODO: Write Nightmare (Move Effect) test titles")
+
+TO_DO_BATTLE_TEST("Nightmare affects Pokémon with Comatose")

--- a/test/battle/move_effect/purify.c
+++ b/test/battle/move_effect/purify.c
@@ -2,3 +2,5 @@
 #include "test/battle.h"
 
 TO_DO_BATTLE_TEST("TODO: Write Purify (Move Effect) test titles")
+
+TO_DO_BATTLE_TEST("Purify doesn't heal HP if the target has Comatose")

--- a/test/battle/move_effect/strength_sap.c
+++ b/test/battle/move_effect/strength_sap.c
@@ -141,6 +141,8 @@ SINGLE_BATTLE_TEST("Strength Sap fails if target is at -6 Atk")
     }
 }
 
+TO_DO_BATTLE_TEST("Strength Sap doesn't fail if target has Contrary and is at +6 Atk, restoring HP based on +5 Atk")
+
 SINGLE_BATTLE_TEST("Strength Sap restores more HP if Big Root is held", s16 hp)
 {
     u32 item;

--- a/test/battle/move_effect_secondary/remove_status.c
+++ b/test/battle/move_effect_secondary/remove_status.c
@@ -113,6 +113,8 @@ SINGLE_BATTLE_TEST("Wake-Up Slap gets increased power against sleeping targets")
     }
 }
 
+TO_DO_BATTLE_TEST("Wake-Up Slap gets increased power against Pokémon with Comatose")
+
 DOUBLE_BATTLE_TEST("Sparkling Aria cures burns from all Pokemon on the field and behind substitutes")
 {
     GIVEN {


### PR DESCRIPTION
## Description
Added TODO tests for abilities that start with C.
Also, filled Competitive tests based on Defiant's.

## Feature(s) this PR does NOT handle:
Besides Competitive, it only writes the titles for tests.

## Discord contact info
AsparagusEduardo