### PR TITLE
CI runs tests on all branches.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,6 @@ name: CI
 
 on:
   push:
-    branches:
-      - master
-      - upcoming
   pull_request:
 
 jobs:


### PR DESCRIPTION
I would like to suggest having CI run tests on all branches so that it's easier to have CI run tests on PRs before they're submitted as PRs. It isn't realistic for me to run more than a handful of tests on my personal machine, and it would cut down on my draft PR submissions.

If the concern is the deluge of emails downstream, I suggest only having this apply to upcoming.

## Discord contact info
wildvenonat