### PR TITLE
Added comment in event.inc for simple menus in dynmultichoice

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -1875,6 +1875,7 @@
 	@ Displays a multichoice box from which the user can choose a selection, and blocks script execution until a selection is made.
 	@ Lists of options are provided in argv.
 	@ If ignoreBPress is set to a non-zero value, then the user will not be allowed to back out of the multichoice with the B button.
+	@ For a simple menu supply DYN_MULTICHOICE_CB_NONE in callbacks.
 	.macro dynmultichoice left:req, top:req, ignoreBPress:req, maxBeforeScroll:req, initialSelected:req, callbacks:req argv:vararg
 	_dynmultichoice \left, \top, \ignoreBPress, \maxBeforeScroll, FALSE, \initialSelected, \callbacks, \argv
 	.endm


### PR DESCRIPTION
## Description
Adds a comment in event.inc for what callback to use when no callbacks are used for dynmultichoice macro.

## Discord
rubyraven