### PR TITLE
Fix wrong battler argument in `GetBattleMovePriority` call

### DIFF
--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -238,7 +238,7 @@ static bool32 ShouldSwitchIfHasBadOdds(u32 battler)
                 maxDamageTaken = damageTaken;
                 bestPlayerMove = playerMove;
             }
-            if (GetBattleMovePriority(opposingBattler, gAiLogicData->abilities[battler], playerMove) > 0 && damageTaken > maxDamageTakenPriority && !AI_DoesChoiceEffectBlockMove(opposingBattler, playerMove))
+            if (GetBattleMovePriority(opposingBattler, gAiLogicData->abilities[opposingBattler], playerMove) > 0 && damageTaken > maxDamageTakenPriority && !AI_DoesChoiceEffectBlockMove(opposingBattler, playerMove))
             {
                 maxDamageTakenPriority = damageTaken;
                 bestPlayerPriorityMove = playerMove;


### PR DESCRIPTION
## Description
A `battler` should have been an `opposingBattler`

## Discord contact info
@Pawkkie 
