### PR TITLE
Fixes refusing to replace a move on evolution causing a softlock

### DIFF
--- a/src/evolution_scene.c
+++ b/src/evolution_scene.c
@@ -986,7 +986,7 @@ static void Task_EvolutionScene(u8 taskId)
                 if (var == MAX_MON_MOVES)
                 {
                     // Didn't select move slot
-                    gTasks[taskId].tLearnMoveNoState = (P_ASK_MOVE_CONFIRMATION) ? MVSTATE_ASK_CANCEL : MVSTATE_CANCEL;
+                    gTasks[taskId].tLearnMoveState = (P_ASK_MOVE_CONFIRMATION) ? MVSTATE_ASK_CANCEL : MVSTATE_CANCEL;
                 }
                 else
                 {
@@ -1370,7 +1370,7 @@ static void Task_TradeEvolutionScene(u8 taskId)
                 if (var == MAX_MON_MOVES)
                 {
                     // Didn't select move slot
-                    gTasks[taskId].tLearnMoveNoState = (P_ASK_MOVE_CONFIRMATION) ? T_MVSTATE_ASK_CANCEL : T_MVSTATE_CANCEL;
+                    gTasks[taskId].tLearnMoveState = (P_ASK_MOVE_CONFIRMATION) ? T_MVSTATE_ASK_CANCEL : T_MVSTATE_CANCEL;
                 }
                 else
                 {


### PR DESCRIPTION
Upcoming issue only.

The `MVSTATE` wouldn't change, so the game would softlock with the mon and an empty textbox.
Confirmed that loading a save where this happened after fixing immediately showed "Mon did not learn Move" (with `P_ASK_MOVE_CONFIRMATION` set to false).

## Discord contact info
PhallenTree