### PR TITLE
Restore AI: Basic Trainer to PARTNER_STEVEN

### DIFF
--- a/src/battle_tower.c
+++ b/src/battle_tower.c
@@ -25,6 +25,7 @@
 #include "battle_factory.h"
 #include "constants/abilities.h"
 #include "constants/apprentice.h"
+#include "constants/battle_ai.h"
 #include "constants/battle_dome.h"
 #include "constants/battle_frontier.h"
 #include "constants/battle_frontier_mons.h"

--- a/src/data/battle_partners.party
+++ b/src/data/battle_partners.party
@@ -13,6 +13,7 @@ Pic: Steven
 Gender: Male
 Music: Male
 Back Pic: Steven
+AI: Basic Trainer
 
 Metang
 Brave Nature


### PR DESCRIPTION
Historically Partner trainers pulled AI flags from their equivalent define value regular trainer, meaning PARTNER_STEVEN took AI from TRAINER_SAWYER_1. The Partner AI flags PR #7378 broke this link but did not add AI: Basic Trainer to PARTNER_STEVEN, resulting in random AI. PR fixes.

## Description
Added AI: Basic Trainer to PARTNER_STEVEN.
Included "constants/battle_ai.h" to "src/battle_tower.c", which was missed from the original PR.

## Media
Before:
<img width="872" height="575" alt="image" src="https://github.com/user-attachments/assets/4a455805-8316-4038-9564-50ff77c1ad22" />

After:
<img width="872" height="573" alt="image" src="https://github.com/user-attachments/assets/28f8ebd9-3b16-417f-a5ca-ce5195d25762" />

## Discord contact info
grintoul