### PR TITLE
Suppress trainerproc compile warning for unused func

### DIFF
--- a/tools/trainerproc/main.c
+++ b/tools/trainerproc/main.c
@@ -178,13 +178,11 @@ static bool is_literal_string(struct String s1, const char *s2)
     }
 }
 
-#if 0
-static bool starts_with(struct String s, const char *prefix)
+static bool __attribute__((unused)) starts_with(struct String s, const char *prefix)
 {
     int n = strlen(prefix);
     return strncmp((const char *)s.string, prefix, n) == 0;
 }
-#endif
 
 static bool ends_with(struct String s, const char *suffix)
 {

--- a/tools/trainerproc/main.c
+++ b/tools/trainerproc/main.c
@@ -178,11 +178,13 @@ static bool is_literal_string(struct String s1, const char *s2)
     }
 }
 
+#if 0
 static bool starts_with(struct String s, const char *prefix)
 {
     int n = strlen(prefix);
     return strncmp((const char *)s.string, prefix, n) == 0;
 }
+#endif
 
 static bool ends_with(struct String s, const char *suffix)
 {


### PR DESCRIPTION
Since the function can be useful but still shows up during compile time I think we should ifdef it.