### PR TITLE
Add wav2agb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 *.fwjpnfont
 sound/**/*.bin
 sound/songs/midi/*.s
+sound/direct_sound_samples/**/*.s
 tools/agbcc
 *.map
 *.bat
@@ -51,6 +52,7 @@ src/data/debug_trainers.h
 test/battle/trainer_control.h
 tools/compresSmol/compresSmol
 tools/compresSmol/compresSmolTilemap
+tools/wav2agb/wav2agb
 *.Identifier
 *.smol
 *.fastSmol

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tools/wav2agb"]
+	path = tools/wav2agb
+	url = https://github.com/ipatix/wav2agb

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,8 @@ C_SUBDIR = src
 ASM_SUBDIR = asm
 DATA_SRC_SUBDIR = src/data
 DATA_ASM_SUBDIR = data
+SAMPLE_SUBDIR = sound/direct_sound_samples
+CRY_SUBDIR := $(SAMPLE_SUBDIR)/cries
 SONG_SUBDIR = sound/songs
 MID_SUBDIR = sound/songs/midi
 TEST_SUBDIR = test
@@ -101,6 +103,8 @@ TEST_SUBDIR = test
 C_BUILDDIR = $(OBJ_DIR)/$(C_SUBDIR)
 ASM_BUILDDIR = $(OBJ_DIR)/$(ASM_SUBDIR)
 DATA_ASM_BUILDDIR = $(OBJ_DIR)/$(DATA_ASM_SUBDIR)
+SAMPLE_BUILDDIR = $(OBJ_DIR)/$(SAMPLE_SUBDIR)
+CRY_BUILDDIR := $(OBJ_DIR)/$(CRY_SUBDIR)
 SONG_BUILDDIR = $(OBJ_DIR)/$(SONG_SUBDIR)
 MID_BUILDDIR = $(OBJ_DIR)/$(MID_SUBDIR)
 TEST_BUILDDIR = $(OBJ_DIR)/$(TEST_SUBDIR)
@@ -165,6 +169,7 @@ SMOLTM       := $(TOOLS_DIR)/compresSmol/compresSmolTilemap$(EXE)
 SMOL         := $(TOOLS_DIR)/compresSmol/compresSmol$(EXE)
 GFX          := $(TOOLS_DIR)/gbagfx/gbagfx$(EXE)
 AIF          := $(TOOLS_DIR)/aif2pcm/aif2pcm$(EXE)
+WAV          := $(TOOLS_DIR)/wav2agb/wav2agb$(EXE)
 MID          := $(TOOLS_DIR)/mid2agb/mid2agb$(EXE)
 SCANINC      := $(TOOLS_DIR)/scaninc/scaninc$(EXE)
 PREPROC      := $(TOOLS_DIR)/preproc/preproc$(EXE)
@@ -271,10 +276,13 @@ DATA_ASM_OBJS := $(patsubst $(DATA_ASM_SUBDIR)/%.s,$(DATA_ASM_BUILDDIR)/%.o,$(DA
 SONG_SRCS := $(wildcard $(SONG_SUBDIR)/*.s)
 SONG_OBJS := $(patsubst $(SONG_SUBDIR)/%.s,$(SONG_BUILDDIR)/%.o,$(SONG_SRCS))
 
+SAMPLE_SRCS := $(wildcard $(SAMPLE_SUBDIR)/*.wav $(CRY_SUBDIR)/*.wav)
+SAMPLE_OBJS := $(patsubst $(SAMPLE_SUBDIR)/%.wav,$(SAMPLE_BUILDDIR)/%.o,$(SAMPLE_SRCS))
+
 MID_SRCS := $(wildcard $(MID_SUBDIR)/*.mid)
 MID_OBJS := $(patsubst $(MID_SUBDIR)/%.mid,$(MID_BUILDDIR)/%.o,$(MID_SRCS))
 
-OBJS     := $(C_OBJS) $(C_ASM_OBJS) $(ASM_OBJS) $(DATA_ASM_OBJS) $(SONG_OBJS) $(MID_OBJS)
+OBJS     := $(C_OBJS) $(C_ASM_OBJS) $(ASM_OBJS) $(DATA_ASM_OBJS) $(SONG_OBJS) $(MID_OBJS) $(SAMPLE_OBJS)
 OBJS_REL := $(patsubst $(OBJ_DIR)/%,%,$(OBJS))
 
 SUBDIRS  := $(sort $(dir $(OBJS) $(dir $(TEST_OBJS))))
@@ -326,6 +334,8 @@ clean: tidy clean-tools clean-check-tools clean-generated clean-assets
 
 clean-assets:
 	rm -f $(MID_SUBDIR)/*.s
+	rm -f $(SAMPLE_SUBDIR)/*.s
+	rm -f $(CRY_SUBDIR)/*.s
 	rm -f $(DATA_ASM_SUBDIR)/layouts/layouts.inc $(DATA_ASM_SUBDIR)/layouts/layouts_table.inc
 	rm -f $(DATA_ASM_SUBDIR)/maps/connections.inc $(DATA_ASM_SUBDIR)/maps/events.inc $(DATA_ASM_SUBDIR)/maps/groups.inc $(DATA_ASM_SUBDIR)/maps/headers.inc $(DATA_SRC_SUBDIR)/map_group_count.h
 	find sound -iname '*.bin' -exec rm {} +
@@ -363,6 +373,7 @@ generated: $(AUTO_GEN_TARGETS)
 %.png: ;
 %.pal: ;
 %.aif: ;
+%.wav: ;
 
 %.1bpp:     %.png  ; $(GFX) $< $@
 %.4bpp:     %.png  ; $(GFX) $< $@

--- a/audio_rules.mk
+++ b/audio_rules.mk
@@ -9,7 +9,7 @@ SOUND_BIN_DIR := sound
 # Needs to recompile for B_NUM_LOW_HEALTH_BEEPS in battle.h
 EXPANSION_BATTLE_CONFIG := include/config/battle.h
 
-SPECIAL_OUTDIRS := $(MID_ASM_DIR) $(CRY_BIN_DIR) 
+SPECIAL_OUTDIRS := $(MID_ASM_DIR) $(CRY_BIN_DIR) $(CRY_BUILDDIR) 
 SPECIAL_OUTDIRS += $(SOUND_BIN_DIR) $(SOUND_BIN_DIR)/direct_sound_samples/phonemes $(SOUND_BIN_DIR)/direct_sound_samples/cries
 $(shell mkdir -p $(SPECIAL_OUTDIRS) )
 
@@ -30,6 +30,24 @@ $(CRY_BIN_DIR)/uncomp_%.bin: $(CRY_SUBDIR)/uncomp_%.aif
 # Uncompressed sounds
 $(SOUND_BIN_DIR)/%.bin: sound/%.aif 
 	$(AIF) $< $@
+
+# Compressed wav cries
+$(CRY_BUILDDIR)/%.o: $(CRY_SUBDIR)/%.s
+	$(AS) $(ASFLAGS) -I sound -o $@ $<
+$(CRY_SUBDIR)/%.s: $(CRY_SUBDIR)/%.wav 
+	$(WAV) $< $@ -c -s $(patsubst $(CRY_SUBDIR)/%.wav,Cry_%,$<)
+
+# Uncompressed wav cries
+$(CRY_BUILDDIR)/uncomp_%.o: $(CRY_SUBDIR)/uncomp_%.s
+	$(AS) $(ASFLAGS) -I sound -o $@ $<
+$(CRY_SUBDIR)/uncomp_%.s: $(CRY_SUBDIR)/uncomp_%.wav
+	$(WAV) $< $@ -s $(patsubst $(CRY_SUBDIR)/%.wav,Cry_%,$<)
+
+# Uncompressed wav sounds
+$(SAMPLE_BUILDDIR)/%.o: $(SAMPLE_SUBDIR)/%.s 
+	$(AS) $(ASFLAGS) -I sound -o $@ $<
+$(SAMPLE_SUBDIR)/%.s: $(SAMPLE_SUBDIR)/%.wav 
+	$(WAV) $< $@ -s $(patsubst $(CRY_SUBDIR)/%.wav,DirectSoundWaveData_%,$<)
 
 # For each line in midi.cfg, we do some trickery to convert it into a make rule for the `.mid` file described on the line
 # Data following the colon in said file corresponds to arguments passed into mid2agb

--- a/ld_script_modern.ld
+++ b/ld_script_modern.ld
@@ -81,6 +81,7 @@ SECTIONS {
         *libc.a:*.o(.rodata*);
         *libc.a:*.o(.data*);
         sound/songs/*.o(.rodata);
+        sound/direct_sound_samples/*.o(.rodata);
     } > ROM =0
 
     .data.iwram :

--- a/ld_script_test.ld
+++ b/ld_script_test.ld
@@ -108,6 +108,12 @@ SECTIONS {
         sound/songs/*.o(.rodata);
     } > ROM =0
 
+    sample_data :
+    ALIGN(4)
+    {
+        sound/direct_sound_samples/*.o(.rodata);
+    } > ROM =0
+
     lib_rodata :
     SUBALIGN(4)
     {

--- a/make_tools.mk
+++ b/make_tools.mk
@@ -5,7 +5,7 @@ MAKEFLAGS += --no-print-directory
 
 # Inclusive list. If you don't want a tool to be built, don't add it here.
 TOOLS_DIR := tools
-TOOL_NAMES := aif2pcm bin2c gbafix gbagfx jsonproc mapjson mid2agb preproc ramscrgen rsfont scaninc trainerproc compresSmol
+TOOL_NAMES := aif2pcm bin2c gbafix gbagfx jsonproc mapjson mid2agb preproc ramscrgen rsfont scaninc trainerproc compresSmol wav2agb
 CHECK_TOOL_NAMES = patchelf mgba-rom-test-hydra
 
 TOOLDIRS := $(TOOL_NAMES:%=$(TOOLS_DIR)/%)


### PR DESCRIPTION
## Description
Adds [ipatix](https://github.com/ipatix)'s [wav2agb](https://github.com/ipatix/wav2agb) tool, as well as the necessary makefile and linker script changes, to enable inserting audio samples in .wav format. With this, developers are no longer restricted to the relatively esoteric .aif format, and can instead use the much more widely supported .wav format, which has much better (free!) tooling (such as [wavosaur](https://www.wavosaur.com/)), as well as root note functionality, which is useful if you are inserting new instruments with keysplits.

## Feature(s) this PR does NOT handle:
- Enabling or disabling a .wav sample through defines

## Things to note in the release changelog:
- Audio samples can now be inserted in .wav format

## Discord contact info
veloscocity
