### PR TITLE
Separates FRB and FRZ animations

### DIFF
--- a/data/battle_anim_scripts.s
+++ b/data/battle_anim_scripts.s
@@ -31084,6 +31084,17 @@ gBattleAnimStatus_Nightmare::
 	clearmonbg ANIM_DEF_PARTNER
 	end
 
+gBattleAnimStatus_Frostbite::
+	playsewithpan SE_M_ICY_WIND, 0
+	loadspritegfx ANIM_TAG_ICE_CRYSTALS
+	monbg ANIM_DEF_PARTNER
+	splitbgprio ANIM_TARGET
+	call IceCrystalEffectShort
+	createsprite gSimplePaletteBlendSpriteTemplate, ANIM_ATTACKER, 2, F_PAL_TARGET, 5, 7, 0, RGB(0, 20, 31)
+	waitforvisualfinish
+	clearmonbg ANIM_DEF_PARTNER
+	end
+
 gBattleAnimGeneral_StatsChange::
 	createvisualtask AnimTask_StatsChange, 5
 	waitforvisualfinish

--- a/include/battle_anim_scripts.h
+++ b/include/battle_anim_scripts.h
@@ -948,6 +948,7 @@ extern const u8 gBattleAnimStatus_Paralysis[];
 extern const u8 gBattleAnimStatus_Freeze[];
 extern const u8 gBattleAnimStatus_Curse[];
 extern const u8 gBattleAnimStatus_Nightmare[];
+extern const u8 gBattleAnimStatus_Frostbite[];
 
 // general animations
 extern const u8 gBattleAnimGeneral_StatsChange[];

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -308,7 +308,6 @@
 #define B_TRAINER_MON_RANDOM_ABILITY    FALSE      // If this is set to TRUE a random legal ability will be generated for a trainer mon
 #define B_OBEDIENCE_MECHANICS           GEN_LATEST // In PLA+ (here Gen8+), obedience restrictions also apply to non-outsider Pokémon, albeit based on their level met rather than actual level
 #define B_USE_FROSTBITE                 FALSE      // In PLA, Frostbite replaces Freeze. Enabling this flag does the same here. Moves can still be cherry-picked to either Freeze or Frostbite. Freeze-Dry, Secret Power & Tri Attack depend on this config.
-#define B_USE_FROSTBITE_ANIMATION       TRUE       // If set to TRUE, Frostbite will use a different animation to Freeze, otherwise both will use the Freeze animation.
 #define B_TOXIC_REVERSAL                GEN_LATEST // In Gen5+, bad poison will change to regular poison at the end of battles.
 #define B_TRY_CATCH_TRAINER_BALL        GEN_LATEST // In Gen4+, trying to catch a Trainer's Pokémon does not consume the Poké Ball.
 #define B_SLEEP_CLAUSE                  FALSE      // Enables Sleep Clause all the time in every case, overriding B_FLAG_SLEEP_CLAUSE. Use that for modularity.

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -308,6 +308,7 @@
 #define B_TRAINER_MON_RANDOM_ABILITY    FALSE      // If this is set to TRUE a random legal ability will be generated for a trainer mon
 #define B_OBEDIENCE_MECHANICS           GEN_LATEST // In PLA+ (here Gen8+), obedience restrictions also apply to non-outsider Pokémon, albeit based on their level met rather than actual level
 #define B_USE_FROSTBITE                 FALSE      // In PLA, Frostbite replaces Freeze. Enabling this flag does the same here. Moves can still be cherry-picked to either Freeze or Frostbite. Freeze-Dry, Secret Power & Tri Attack depend on this config.
+#define B_USE_FROSTBITE_ANIMATION       TRUE       // If set to TRUE, Frostbite will use a different animation to Freeze, otherwise both will use the Freeze animation.
 #define B_TOXIC_REVERSAL                GEN_LATEST // In Gen5+, bad poison will change to regular poison at the end of battles.
 #define B_TRY_CATCH_TRAINER_BALL        GEN_LATEST // In Gen4+, trying to catch a Trainer's Pokémon does not consume the Poké Ball.
 #define B_SLEEP_CLAUSE                  FALSE      // Enables Sleep Clause all the time in every case, overriding B_FLAG_SLEEP_CLAUSE. Use that for modularity.

--- a/include/constants/battle_anim.h
+++ b/include/constants/battle_anim.h
@@ -616,8 +616,9 @@
 #define B_ANIM_STATUS_FRZ               6
 #define B_ANIM_STATUS_CURSED            7
 #define B_ANIM_STATUS_NIGHTMARE         8
+#define B_ANIM_STATUS_FRB               9
 
-#define NUM_B_ANIMS_STATUS              9
+#define NUM_B_ANIMS_STATUS              10
 
 // Tasks with return values often assign them to gBattleAnimArgs[7].
 #define ARG_RET_ID 7

--- a/src/battle_anim.c
+++ b/src/battle_anim.c
@@ -195,6 +195,7 @@ static const u8* const sBattleAnims_StatusConditions[NUM_B_ANIMS_STATUS] =
     [B_ANIM_STATUS_FRZ]         = gBattleAnimStatus_Freeze,
     [B_ANIM_STATUS_CURSED]      = gBattleAnimStatus_Curse,
     [B_ANIM_STATUS_NIGHTMARE]   = gBattleAnimStatus_Nightmare,
+    [B_ANIM_STATUS_FRB]         = (B_USE_FROSTBITE_ANIMATION ? gBattleAnimStatus_Frostbite: gBattleAnimStatus_Freeze),
 };
 
 static const u8* const sBattleAnims_General[NUM_B_ANIMS_GENERAL] =

--- a/src/battle_anim.c
+++ b/src/battle_anim.c
@@ -195,7 +195,7 @@ static const u8* const sBattleAnims_StatusConditions[NUM_B_ANIMS_STATUS] =
     [B_ANIM_STATUS_FRZ]         = gBattleAnimStatus_Freeze,
     [B_ANIM_STATUS_CURSED]      = gBattleAnimStatus_Curse,
     [B_ANIM_STATUS_NIGHTMARE]   = gBattleAnimStatus_Nightmare,
-    [B_ANIM_STATUS_FRB]         = (B_USE_FROSTBITE_ANIMATION ? gBattleAnimStatus_Frostbite: gBattleAnimStatus_Freeze),
+    [B_ANIM_STATUS_FRB]         = gBattleAnimStatus_Frostbite,
 };
 
 static const u8* const sBattleAnims_General[NUM_B_ANIMS_GENERAL] =

--- a/src/battle_gfx_sfx_util.c
+++ b/src/battle_gfx_sfx_util.c
@@ -464,8 +464,10 @@ void InitAndLaunchChosenStatusAnimation(u32 battler, bool32 isVolatile, u32 stat
     gBattleSpritesDataPtr->healthBoxesData[battler].statusAnimActive = 1;
     if (!isVolatile)
     {
-        if (status == STATUS1_FREEZE || status == STATUS1_FROSTBITE)
+        if (status == STATUS1_FREEZE)
             LaunchStatusAnimation(battler, B_ANIM_STATUS_FRZ);
+        else if (status == STATUS1_FROSTBITE)
+            LaunchStatusAnimation(battler, B_ANIM_STATUS_FRB);
         else if (status == STATUS1_POISON || status & STATUS1_TOXIC_POISON)
             LaunchStatusAnimation(battler, B_ANIM_STATUS_PSN);
         else if (status == STATUS1_BURN)

--- a/test/battle/hold_effect/cure_status.c
+++ b/test/battle/hold_effect/cure_status.c
@@ -87,7 +87,7 @@ SINGLE_BATTLE_TEST("Aspear and Lum Berries cure freeze or frostbite")
         TURN { MOVE(player, MOVE_ICE_PUNCH); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ICE_PUNCH, player);
-        ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_FRZ, opponent);
+        ANIMATION(ANIM_TYPE_STATUS, (B_USE_FROSTBITE ? B_ANIM_STATUS_FRB : B_ANIM_STATUS_FRZ), opponent);
         FREEZE_OR_FROSTBURN_STATUS(opponent, TRUE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
         FREEZE_OR_FROSTBURN_STATUS(opponent, FALSE);

--- a/test/battle/move_effect_secondary/freeze.c
+++ b/test/battle/move_effect_secondary/freeze.c
@@ -20,7 +20,7 @@ SINGLE_BATTLE_TEST("Powder Snow inflicts freeze")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_POWDER_SNOW, player);
         HP_BAR(opponent);
-        ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_FRZ, opponent);
+        ANIMATION(ANIM_TYPE_STATUS, (B_USE_FROSTBITE ? B_ANIM_STATUS_FRB : B_ANIM_STATUS_FRZ), opponent);
         FREEZE_OR_FROSTBURN_STATUS(opponent, TRUE);
     }
 }
@@ -85,11 +85,11 @@ SINGLE_BATTLE_TEST("Freezing Glare shouldn't freeze Psychic-types")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_FREEZING_GLARE, player);
         HP_BAR(opponent);
         #if B_STATUS_TYPE_IMMUNITY > GEN_1
-            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_FRZ, opponent);
+            ANIMATION(ANIM_TYPE_STATUS, (B_USE_FROSTBITE ? B_ANIM_STATUS_FRB : B_ANIM_STATUS_FRZ), opponent);
             FREEZE_OR_FROSTBURN_STATUS(opponent, TRUE);
         #else
             NONE_OF {
-                ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_FRZ, opponent);
+                ANIMATION(ANIM_TYPE_STATUS, (B_USE_FROSTBITE ? B_ANIM_STATUS_FRB : B_ANIM_STATUS_FRZ), opponent);
                 FREEZE_OR_FROSTBURN_STATUS(opponent, TRUE);
             }
         #endif

--- a/test/battle/move_effect_secondary/tri_attack.c
+++ b/test/battle/move_effect_secondary/tri_attack.c
@@ -15,7 +15,7 @@ SINGLE_BATTLE_TEST("Tri Attack can inflict paralysis, burn or freeze")
     u8 statusAnim;
     PARAMETRIZE { statusAnim = B_ANIM_STATUS_PRZ; }
     PARAMETRIZE { statusAnim = B_ANIM_STATUS_BRN; }
-    PARAMETRIZE { statusAnim = B_ANIM_STATUS_FRZ; }
+    PARAMETRIZE { statusAnim = (B_USE_FROSTBITE ? B_ANIM_STATUS_FRB : B_ANIM_STATUS_FRZ); }
     PASSES_RANDOMLY(1, 3, RNG_TRI_ATTACK);
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);
@@ -29,7 +29,7 @@ SINGLE_BATTLE_TEST("Tri Attack can inflict paralysis, burn or freeze")
         ANIMATION(ANIM_TYPE_STATUS, statusAnim, opponent);
         if (statusAnim == B_ANIM_STATUS_BRN) {
             STATUS_ICON(opponent, burn: TRUE);
-        } else if (statusAnim == B_ANIM_STATUS_FRZ) {
+        } else if (statusAnim == (B_USE_FROSTBITE ? B_ANIM_STATUS_FRB : B_ANIM_STATUS_FRZ)) {
             FREEZE_OR_FROSTBURN_STATUS(opponent, TRUE);
         } else if (statusAnim == B_ANIM_STATUS_PRZ) {
             STATUS_ICON(opponent, paralysis: TRUE);

--- a/test/battle/move_effects_combined/flinch_status.c
+++ b/test/battle/move_effects_combined/flinch_status.c
@@ -32,7 +32,7 @@ SINGLE_BATTLE_TEST("Thunder, Ice and Fire Fang inflict status 10% of the time")
             ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PRZ, opponent);
             STATUS_ICON(opponent, paralysis: TRUE);
         } if (move == MOVE_ICE_FANG) {
-            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_FRZ, opponent);
+            ANIMATION(ANIM_TYPE_STATUS, (B_USE_FROSTBITE ? B_ANIM_STATUS_FRB : B_ANIM_STATUS_FRZ), opponent);
             FREEZE_OR_FROSTBURN_STATUS(opponent, TRUE);
         } if (move == MOVE_FIRE_FANG) {
             ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, opponent);

--- a/test/battle/status1/frostbite.c
+++ b/test/battle/status1/frostbite.c
@@ -34,7 +34,7 @@ SINGLE_BATTLE_TEST("Frostbite deals 1/16th (Gen7+) or 1/8th damage to affected p
         TURN {}
     } SCENE {
         MESSAGE("The opposing Wobbuffet was hurt by its frostbite!");
-        ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_FRZ, opponent);
+        ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_FRB, opponent);
         HP_BAR(opponent, captureDamage: &frostbiteDamage);
    } THEN { EXPECT_EQ(frostbiteDamage, opponent->maxHP / ((B_BURN_DAMAGE >= GEN_7) ? 16 : 8)); }
 }
@@ -86,11 +86,11 @@ SINGLE_BATTLE_TEST("Frostbite is healed when the user uses a thawing move")
         HP_BAR(opponent);
         if (move == MOVE_EMBER) {
             MESSAGE("Wobbuffet was hurt by its frostbite!");
-            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_FRZ, player);
+            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_FRB, player);
         } else {
             NONE_OF {
                 MESSAGE("Wobbuffet was hurt by its frostbite!");
-                ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_FRZ, player);
+                ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_FRB, player);
             }
         }
    }


### PR DESCRIPTION
Adds a separate animation for Frostbite with a config to toggle whether to use it or the FRZ animation, defaulting to FRB for when FRB is enabled

## Description
Current setup uses FRZ animation for both FRZ and FRB. New FRB animation feels more suitable for what the status condition is and enables the two to be distinguished if users wish to use both conditions. 

Changes:
1. Added `gBattleAnimStatus_Frostbite`
2. Added `B_USE_FROSTBITE_ANIMATION` in `include/config/battle.h`, defaulting to `TRUE`.
3. Defined `B_ANIM_STATUS_FRB`, which returns `gBattleAnimStatus_Frostbite` or `gBattleAnimStatus_Freeze` depending on config
4. Separated animations launched for `STATUS1_FREEZE` and `STATUS1_FROSTBITE` in `InitAndLaunchChosenStatusAnimation`. (3) means FRZ will be used for FRB if config set to FALSE
5. Updated tests to accommodate `B_ANIM_STATUS_FRB` depending on `B_USE_FROSTBITE` config

## Media
FRB anim with `B_USE_FROSTBITE_ANIMATION` set `TRUE`:
https://github.com/user-attachments/assets/4c88b776-4fb0-4cfa-81f8-f54d88e2289e

FRB anim with `B_USE_FROSTBITE_ANIMATION` set `FALSE`:
https://github.com/user-attachments/assets/8b704574-13ee-414b-b49a-7a6e37f11187

## Discord contact info
grintoul