### PR TITLE
Fix Vs Seeker Trainer Battle script issue

### DIFF
--- a/src/vs_seeker.c
+++ b/src/vs_seeker.c
@@ -529,7 +529,6 @@ void ClearRematchMovementByTrainerId(void)
 
         TryGetObjectEventIdByLocalIdAndMap(objectEventTemplates[i].localId, gSaveBlock1Ptr->location.mapNum, gSaveBlock1Ptr->location.mapGroup, &objEventId);
         objectEvent = &gObjectEvents[objEventId];
-        GetRandomFaceDirectionMovementType(&objectEventTemplates[i]);
         TryOverrideTemplateCoordsForObjectEvent(objectEvent, sFaceDirectionMovementTypeByFacingDirection[objectEvent->facingDirection]);
 
         if (gSelectedObjectEvent == objEventId)
@@ -705,11 +704,9 @@ static u8 GetResponseMovementTypeFromTrainerGraphicsId(u8 graphicsId)
 #endif //FREE_MATCH_CALL
 
 static u16 GetTrainerFlagFromScript(const u8 *script)
-    /*
-     * The trainer flag is a located 3 bytes (command + flags + localIdA) from the script pointer, assuming the trainerbattle command is first in the script.
-     * Because scripts are unaligned, and because the ARM processor requires shorts to be 16-bit aligned, this function needs to perform explicit bitwise operations to get the correct flag.
-     */
 {
+    // The trainer flag is a located 3 bytes (command + flags + localIdA) from the script pointer, assuming the trainerbattle command is first in the script.
+    // Because scripts are unaligned, and because the ARM processor requires shorts to be 16-bit aligned, this function needs to perform explicit bitwise operations to get the correct flag.
     script += 3;
     u16 trainerFlag = script[0];
     trainerFlag |= script[1] << 8;

--- a/src/vs_seeker.c
+++ b/src/vs_seeker.c
@@ -706,21 +706,12 @@ static u8 GetResponseMovementTypeFromTrainerGraphicsId(u8 graphicsId)
 
 static u16 GetTrainerFlagFromScript(const u8 *script)
     /*
- * The trainer flag is a little-endian short located +2 from
- * the script pointer, assuming the trainerbattle command is
- * first in the script.  Because scripts are unaligned, and
- * because the ARM processor requires shorts to be 16-bit
- * aligned, this function needs to perform explicit bitwise
- * operations to get the correct flag.
- *
- * 5c XX YY ZZ ...
- *       -- --
+     * The trainer flag is a located 3 bytes (command + flags + localIdA) from the script pointer, assuming the trainerbattle command is first in the script.
+     * Because scripts are unaligned, and because the ARM processor requires shorts to be 16-bit aligned, this function needs to perform explicit bitwise operations to get the correct flag.
      */
 {
-    u16 trainerFlag;
-
-    script += 2;
-    trainerFlag = script[0];
+    script += 3;
+    u16 trainerFlag = script[0];
     trainerFlag |= script[1] << 8;
     return trainerFlag;
 }

--- a/src/vs_seeker.c
+++ b/src/vs_seeker.c
@@ -705,7 +705,7 @@ static u8 GetResponseMovementTypeFromTrainerGraphicsId(u8 graphicsId)
 
 static u16 GetTrainerFlagFromScript(const u8 *script)
 {
-    // The trainer flag is a located 3 bytes (command + flags + localIdA) from the script pointer, assuming the trainerbattle command is first in the script.
+    // The trainer flag is located 3 bytes (command + flags + localIdA) from the script pointer, assuming the trainerbattle command is first in the script.
     // Because scripts are unaligned, and because the ARM processor requires shorts to be 16-bit aligned, this function needs to perform explicit bitwise operations to get the correct flag.
     script += 3;
     u16 trainerFlag = script[0];


### PR DESCRIPTION
# Description
![Image of Brendan using the Vs Seeker and Calvin responding with rematch](https://files.catbox.moe/b5z7p3.png)

This PR 
* Fixes https://github.com/rh-hideout/pokeemerald-expansion/issues/6928
* Fixes https://github.com/rh-hideout/pokeemerald-expansion/issues/6919

## Details

## 6928
The Vs. Seeker has been broken since #5982. This PR changes `GetTrainerFlagFromScript` by looking at the 3rd byte instead of the 2nd in the `trainerbattle` command.

# Testing
## Clean Branch
You can recreate this branch by applying a patch or pulling the repo. From a clean version of expansion's `master`, you can either:

### Patch
`wget https://files.catbox.moe/pi08q5.patch ; git apply pi08q5.patch ; rm pi08q5.patch`

### Repo
`git remote add psf-expansion https://github.com/PokemonSanFran/pokeemerald-expansion/ ; git pull psf-expansion vsSeekerFix`

## Manual Tests
After replicating the branch, to recreate my testing environment, you can either directly download the config file and debug script, or manually create the changes.

### Download
* [`data/scripts/debug.inc`](https://files.catbox.moe/6leydt.inc)
* [`include/config/item.h`](https://files.catbox.moe/30rpzt.h)

### Manual Testing
* Compile the game
* Start a new save
* Run Script 1
* Run Utilities > Cheat Start
* Leave Truck
* Go to Route 102
* Battle Trainer Calvin
* Leave Route 102
* Walk 100 steps
* Return to Route 102
* Use Vs Seeker
* If fixed, Calvin will respond with a rematch, otherwise, Calvin will respond as if they have never been battled

https://github.com/user-attachments/assets/60b408dc-9884-4176-a21d-ff03f5f524f8

# Features this PR does NOT handle:
- This PR **DOES NOT** handle any other Vs Seeker functionality.

# Discord Contact Info

I am `pkmnsnfrn` on Discord.