### PR TITLE
The original attacker wasn't restored for Doodle

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -221,12 +221,13 @@ BattleScript_EffectDoodle::
 	attackstring
 	ppreduce
 	trycopyability BS_ATTACKER, BattleScript_ButItFailed
+	saveattacker
 	attackanimation
 	waitanimation
 	setbyte gBattleCommunication, 0
 	goto BattleScript_EffectDoodle_AfterCopy
 BattleScript_EffectDoodle_CopyAbility:
-	trycopyability BS_ATTACKER, BattleScript_MoveEnd
+	trycopyability BS_ATTACKER, BattleScript_EffectDoodleMoveEnd
 BattleScript_EffectDoodle_AfterCopy:
 .if B_ABILITY_POP_UP == TRUE
 	copybyte gBattlerAbility, gBattlerAttacker
@@ -238,10 +239,14 @@ BattleScript_EffectDoodle_AfterCopy:
 	switchinabilities BS_ATTACKER
 	jumpifbyte CMP_NOT_EQUAL, gBattleCommunication, 0x0, BattleScript_MoveEnd
 	addbyte gBattleCommunication, 1
-	jumpifnoally BS_ATTACKER, BattleScript_MoveEnd
+	jumpifnoally BS_ATTACKER, BattleScript_EffectDoodleMoveEnd
 	setallytonextattacker BattleScript_EffectDoodle_CopyAbility
-	goto BattleScript_MoveEnd
+	goto BattleScript_EffectDoodleMoveEnd
 
+BattleScript_EffectDoodleMoveEnd:
+	restoreattacker
+	goto BattleScript_MoveEnd
+ 
 BattleScript_EffectGlaiveRush::
 	call BattleScript_EffectHit_Ret
 	jumpifmoveresultflags MOVE_RESULT_DOESNT_AFFECT_FOE, BattleScript_TryFaintMon

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -244,7 +244,7 @@ BattleScript_EffectDoodle_AfterCopy:
 BattleScript_EffectDoodleMoveEnd:
 	restoreattacker
 	goto BattleScript_MoveEnd
- 
+
 BattleScript_EffectGlaiveRush::
 	call BattleScript_EffectHit_Ret
 	jumpifmoveresultflags MOVE_RESULT_DOESNT_AFFECT_FOE, BattleScript_TryFaintMon

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -241,8 +241,6 @@ BattleScript_EffectDoodle_AfterCopy:
 	addbyte gBattleCommunication, 1
 	jumpifnoally BS_ATTACKER, BattleScript_EffectDoodleMoveEnd
 	setallytonextattacker BattleScript_EffectDoodle_CopyAbility
-	goto BattleScript_EffectDoodleMoveEnd
-
 BattleScript_EffectDoodleMoveEnd:
 	restoreattacker
 	goto BattleScript_MoveEnd


### PR DESCRIPTION
When going into `moveend` the original attacker for doodle wasn't restored.
