### PR TITLE
Fixes Wonder Room interactions with Defense/Special Defense boosting effects

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -8957,29 +8957,37 @@ static inline u32 CalcDefenseStat(struct DamageCalculationData *damageCalcData, 
     u32 move = damageCalcData->move;
     enum BattleMoveEffects moveEffect = GetMoveEffect(move);
 
-    if (gFieldStatuses & STATUS_FIELD_WONDER_ROOM) // the defense stats are swapped
-    {
-        def = gBattleMons[battlerDef].spDefense;
-        spDef = gBattleMons[battlerDef].defense;
-    }
-    else
-    {
-        def = gBattleMons[battlerDef].defense;
-        spDef = gBattleMons[battlerDef].spDefense;
-    }
+    def = gBattleMons[battlerDef].defense;
+    spDef = gBattleMons[battlerDef].spDefense;
 
     if (moveEffect == EFFECT_PSYSHOCK || IsBattleMovePhysical(move)) // uses defense stat instead of sp.def
     {
-        defStat = def;
+        if (gFieldStatuses & STATUS_FIELD_WONDER_ROOM) // the defense stats are swapped
+        {
+            defStat = spDef;
+            usesDefStat = FALSE;
+        }
+        else
+        {
+            defStat = def;
+            usesDefStat = TRUE;
+        }
         defStage = gBattleMons[battlerDef].statStages[STAT_DEF];
     }
     else // is special
     {
-        defStat = spDef;
+        if (gFieldStatuses & STATUS_FIELD_WONDER_ROOM) // the defense stats are swapped
+        {
+            defStat = def;
+            usesDefStat = TRUE;
+        }
+        else
+        {
+            defStat = spDef;
+            usesDefStat = FALSE;
+        }
         defStage = gBattleMons[battlerDef].statStages[STAT_SPDEF];
     }
-
-    usesDefStat = defStat == gBattleMons[battlerDef].defense;
 
     // Self-destruct / Explosion cut defense in half
     if (B_EXPLOSION_DEFENSE < GEN_5 && moveEffect == EFFECT_EXPLOSION)


### PR DESCRIPTION
Fixes Wonder Room interactions with Defense/Special Defense boosting effects. [Source](https://wiki.xn--rckteqa2e.com/wiki/%E3%83%AF%E3%83%B3%E3%83%80%E3%83%BC%E3%83%AB%E3%83%BC%E3%83%A0_(%E5%A0%B4%E3%81%AE%E7%8A%B6%E6%85%8B)#%E8%A9%B3%E7%B4%B0%E3%81%AA%E4%BB%95%E6%A7%98) (The difference is that they should boost Def/Sp. Def based on whether Def/Sp. Def were used for damage calculation instead of whether the move was physical or special)
Also moved Purifying Salt damage halving to `CalcAttackStat` [Source 1](https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/page-27#post-9469856), [Source 2](https://wiki.xn--rckteqa2e.com/wiki/%E3%81%8D%E3%82%88%E3%82%81%E3%81%AE%E3%81%97%E3%81%8A)

## Discord contact info
PhallenTree
