### PR TITLE
Reworking Battler Benefits From Nonvolatile Status checks

### DIFF
--- a/include/battle_ai_util.h
+++ b/include/battle_ai_util.h
@@ -113,7 +113,7 @@ bool32 CanTargetFaintAiWithMod(u32 battlerDef, u32 battlerAtk, s32 hpMod, s32 dm
 s32 AI_DecideKnownAbilityForTurn(u32 battlerId);
 enum ItemHoldEffect AI_DecideHoldEffectForTurn(u32 battlerId);
 bool32 DoesBattlerIgnoreAbilityChecks(u32 battlerAtk, u32 atkAbility, u32 move);
-bool32 DoesBattlerBenefitFromStatus(u32 battler, u32 ability, u32 status);
+bool32 DoesBattlerBenefitFromNonvolatileStatus(u32 battler, u32 ability, u32 status);
 u32 AI_GetWeather(void);
 u32 AI_GetSwitchinWeather(struct BattlePokemon battleMon);
 enum WeatherState IsWeatherActive(u32 flags);

--- a/include/battle_ai_util.h
+++ b/include/battle_ai_util.h
@@ -113,6 +113,7 @@ bool32 CanTargetFaintAiWithMod(u32 battlerDef, u32 battlerAtk, s32 hpMod, s32 dm
 s32 AI_DecideKnownAbilityForTurn(u32 battlerId);
 enum ItemHoldEffect AI_DecideHoldEffectForTurn(u32 battlerId);
 bool32 DoesBattlerIgnoreAbilityChecks(u32 battlerAtk, u32 atkAbility, u32 move);
+bool32 DoesBattlerBenefitFromStatus(u32 battler, u32 ability, u32 status);
 u32 AI_GetWeather(void);
 u32 AI_GetSwitchinWeather(struct BattlePokemon battleMon);
 enum WeatherState IsWeatherActive(u32 flags);

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -3367,7 +3367,7 @@ bool32 AI_CanPutToSleep(u32 battlerAtk, u32 battlerDef, u32 defAbility, u32 move
     return TRUE;
 }
 
-bool32 DoesBattlerBenefitFromStatus(u32 battler, u32 ability, u32 status)
+bool32 DoesBattlerBenefitFromNonvolatileStatus(u32 battler, u32 ability, u32 status)
 {
     if (status & STATUS1_SLEEP)
     {
@@ -3426,7 +3426,7 @@ bool32 ShouldPoison(u32 battlerAtk, u32 battlerDef)
     u32 abilityDef = gAiLogicData->abilities[battlerDef];
     // Battler can be poisoned and has move/ability that synergizes with being poisoned
     if (CanBePoisoned(battlerAtk, battlerDef, gAiLogicData->abilities[battlerAtk], abilityDef)
-     && DoesBattlerBenefitFromStatus(battlerDef, abilityDef, STATUS1_PSN_ANY))
+     && DoesBattlerBenefitFromNonvolatileStatus(battlerDef, abilityDef, STATUS1_PSN_ANY))
     {
         if (battlerAtk == battlerDef) // Targeting self
             return TRUE;
@@ -3443,7 +3443,7 @@ bool32 ShouldBurn(u32 battlerAtk, u32 battlerDef, u32 abilityDef)
 {
     // Battler can be burned and has move/ability that synergizes with being burned
     if (CanBeBurned(battlerAtk, battlerDef, abilityDef)
-     && DoesBattlerBenefitFromStatus(battlerDef, abilityDef, STATUS1_BURN))
+     && DoesBattlerBenefitFromNonvolatileStatus(battlerDef, abilityDef, STATUS1_BURN))
     {
         if (battlerAtk == battlerDef) // Targeting self
             return TRUE;
@@ -3474,7 +3474,7 @@ bool32 ShouldFreezeOrFrostbite(u32 battlerAtk, u32 battlerDef, u32 abilityDef)
     {
         // Battler can be frostbitten and has move/ability that synergizes with being frostbitten
         if (CanBeFrozen(battlerAtk, battlerDef, abilityDef)
-            && DoesBattlerBenefitFromStatus(battlerDef, abilityDef, STATUS1_FROSTBITE))
+            && DoesBattlerBenefitFromNonvolatileStatus(battlerDef, abilityDef, STATUS1_FROSTBITE))
         {
             if (battlerAtk == battlerDef) // Targeting self
                 return TRUE;
@@ -3493,7 +3493,7 @@ bool32 ShouldParalyze(u32 battlerAtk, u32 battlerDef, u32 abilityDef)
 {
     // Battler can be paralyzed and has move/ability that synergizes with being paralyzed
     if (CanBeParalyzed(battlerAtk, battlerDef, abilityDef)
-     && DoesBattlerBenefitFromStatus(battlerDef, abilityDef, STATUS1_PARALYSIS))
+     && DoesBattlerBenefitFromNonvolatileStatus(battlerDef, abilityDef, STATUS1_PARALYSIS))
     {
         if (battlerAtk == battlerDef) // Targeting self
             return TRUE;

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -3367,13 +3367,25 @@ bool32 AI_CanPutToSleep(u32 battlerAtk, u32 battlerDef, u32 defAbility, u32 move
     return TRUE;
 }
 
-static inline bool32 DoesBattlerBenefitFromStatus(u32 battler, u32 ability, u32 status)
+bool32 DoesBattlerBenefitFromStatus(u32 battler, u32 ability, u32 status)
 {
-    if (!(status & STATUS1_CAN_MOVE))
-        return FALSE;
+    if (status & STATUS1_SLEEP)
+    {
+        if (HasMoveWithEffect(battler, EFFECT_SLEEP_TALK) || HasMoveWithEffect(battler, EFFECT_SNORE))
+            return TRUE;
+        else
+            return FALSE;
+    }
 
-    if (HasMoveWithEffect(battler, EFFECT_FACADE)
-     || HasMoveWithEffect(battler, EFFECT_PSYCHO_SHIFT))
+    if (status & STATUS1_FREEZE)
+    {
+        if (HasThawingMove(battler))
+            return TRUE;
+        else
+            return FALSE;
+    }
+
+    if (HasMoveWithEffect(battler, EFFECT_FACADE) || HasMoveWithEffect(battler, EFFECT_PSYCHO_SHIFT))
         return TRUE;
 
     switch (ability)
@@ -3383,6 +3395,8 @@ static inline bool32 DoesBattlerBenefitFromStatus(u32 battler, u32 ability, u32 
     case ABILITY_QUICK_FEET:
         if (status & STATUS1_BURN)
             return !HasMoveWithCategory(battler, DAMAGE_CATEGORY_PHYSICAL);
+        if (status & STATUS1_FROSTBITE)
+            return !HasMoveWithCategory(battler, DAMAGE_CATEGORY_SPECIAL);
         return TRUE;
     case ABILITY_GUTS:
         return HasMoveWithCategory(battler, DAMAGE_CATEGORY_PHYSICAL);


### PR DESCRIPTION
Moving some of the checks out of the individual Should Burn, Should Poison, Should Paralyze etc functions into an overall handler that takes the status as an arg. This also reworks the previous check if a battler benefits from all nonvolatile status.

The intention here is to put all of the "powers up while x" checks in the same place for readability, and to make it easier to determine when to NOT cure a pokemon's status ailment. I have a followup pr drafted for, e.g., not using Burn Heal on a Guts pokemon. 

## Discord contact info
wildvenonat