### PR TITLE
Battle debug menu  now checks correct parties depending on battler side

### DIFF
--- a/src/battle_debug.c
+++ b/src/battle_debug.c
@@ -752,7 +752,8 @@ static void PutMovesPointsText(struct BattleDebugMenu *data)
 
     if (gAiLogicData->shouldSwitch & (1u << data->aiBattlerId))
     {
-        u32 switchMon = GetMonData(&gEnemyParty[gAiLogicData->mostSuitableMonId[data->aiBattlerId]], MON_DATA_SPECIES);
+        struct Pokemon *party = GetBattlerParty(data->aiBattlerId);
+        u32 switchMon = GetMonData(&party[gAiLogicData->mostSuitableMonId[data->aiBattlerId]], MON_DATA_SPECIES);
         AddTextPrinterParameterized(data->aiMovesWindowId, FONT_NORMAL, COMPOUND_STRING("Switching to "), 74, 64, 0, NULL);
         AddTextPrinterParameterized(data->aiMovesWindowId, FONT_NORMAL, gSpeciesInfo[switchMon].speciesName, 74 + 68, 64, 0, NULL);
     }


### PR DESCRIPTION
Amended the Debug Battle menu to check battler party instead of always Enemy party when displaying which mon is being switched in to.

## Description
`PutMovesPointsText` now retrieves relevant party via `GetBattlerParty`

## Media
Previously this would say Morpeko (battler 2) switching to Darumaka (Enemy index 4) instead of Woobat (Player/Partner party index 4).
After change:
<img width="864" height="544" alt="image" src="https://github.com/user-attachments/assets/0fb7a4e0-dac0-4146-8228-23bca3c80341" />

## Discord contact info
grintoul