### PR TITLE
Change ShouldSwitchIfAllScoresBad to switch at all 90, not all 89; fix toxic thread AI

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -1698,7 +1698,9 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
         case EFFECT_TOXIC_THREAD:
             if (!CanLowerStat(battlerAtk, battlerDef, aiData, STAT_SPEED))
                 ADJUST_SCORE(-1);    // may still want to just poison
-            //fallthrough
+            if (!AI_CanPoison(battlerAtk, battlerDef, aiData->abilities[battlerDef], move, aiData->partnerMove))
+                ADJUST_SCORE(-10);
+            break;
         case EFFECT_LIGHT_SCREEN:
             if (gSideStatuses[GetBattlerSide(battlerAtk)] & (SIDE_STATUS_LIGHTSCREEN | SIDE_STATUS_AURORA_VEIL)
              || (HasPartner(battlerAtk) && AreMovesEquivalent(battlerAtk, BATTLE_PARTNER(battlerAtk), move, aiData->partnerMove)))

--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -1222,7 +1222,7 @@ bool32 ShouldSwitchIfAllScoresBad(u32 battler)
     for (i = 0; i < MAX_MON_MOVES; i++)
     {
         score = gAiBattleData->finalScore[battler][opposingBattler][i];
-        if (score > AI_BAD_SCORE_THRESHOLD)
+        if (score >= AI_BAD_SCORE_THRESHOLD)
             return FALSE;
     }
     if (RandomPercentage(RNG_AI_SWITCH_ALL_SCORES_BAD, GetSwitchChance(SHOULD_SWITCH_ALL_SCORES_BAD)))


### PR DESCRIPTION
A lot of literally useless, cannot do anything at all, moves in CheckBadMove only land on a -10, not a -20.  -11 is the threshold at which a pokemon switches.  Ergo, moves that are truly, absolutely, pointless in this situation should trigger switching.

## Discord contact info
wildvenonat