### PR TITLE
Fixes ability activation on first turn if mon is dead

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3861,6 +3861,9 @@ static void TryDoEventsBeforeFirstTurn(void)
         {
             i = gBattlerByTurnOrder[gBattleStruct->switchInBattlerCounter++];
 
+            if (!IsBattlerAlive(i))
+                continue;
+
             if (TryPrimalReversion(i))
                 return;
             if (AbilityBattleEffects(ABILITYEFFECT_ON_SWITCHIN, i, 0, 0, 0) != 0)

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -5238,7 +5238,9 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
         // Prints message only. separate from ABILITYEFFECT_ON_SWITCHIN bc activates before entry hazards
         for (i = 0; i < gBattlersCount; i++)
         {
-            if (gBattleMons[i].ability == ABILITY_NEUTRALIZING_GAS && !gDisableStructs[i].neutralizingGas)
+            if (gBattleMons[i].ability == ABILITY_NEUTRALIZING_GAS
+             && !gDisableStructs[i].neutralizingGas
+             && IsBattlerAlive(i))
             {
                 gDisableStructs[i].neutralizingGas = TRUE;
                 gBattlerAbility = i;


### PR DESCRIPTION
Needs to be tested in-game. 

When you go into a double battle with one mon and everything else fainted, the ability of the fainted mon will activate on the first turn. 