### PR TITLE
AI Tests: Gimmick Support

### DIFF
--- a/include/test/battle.h
+++ b/include/test/battle.h
@@ -638,7 +638,8 @@ struct BattlerTurn
 
 struct ExpectedAIAction
 {
-    u16 sourceLine;
+    u16 sourceLine:13; // TODO: Avoid stealing these bits.
+    enum Gimmick gimmick:3;
     u8 type:4; // which action
     u8 moveSlots:4; // Expected move(s) to be chosen or not, marked as bits.
     u8 target:4; // move target or id of mon which gets sent out

--- a/include/test_runner.h
+++ b/include/test_runner.h
@@ -7,6 +7,8 @@ extern const bool8 gTestRunnerSkipIsFail;
 
 #if TESTING
 
+enum Gimmick;
+
 void TestRunner_Battle_RecordAbilityPopUp(u32 battlerId, u32 ability);
 void TestRunner_Battle_RecordAnimation(u32 animType, u32 animId);
 void TestRunner_Battle_RecordHP(u32 battlerId, u32 oldHP, u32 newHP);
@@ -14,7 +16,7 @@ void TestRunner_Battle_RecordExp(u32 battlerId, u32 oldExp, u32 newExp);
 void TestRunner_Battle_RecordMessage(const u8 *message);
 void TestRunner_Battle_RecordStatus1(u32 battlerId, u32 status1);
 void TestRunner_Battle_AfterLastTurn(void);
-void TestRunner_Battle_CheckChosenMove(u32 battlerId, u32 moveId, u32 target);
+void TestRunner_Battle_CheckChosenMove(u32 battlerId, u32 moveId, u32 target, enum Gimmick gimmick);
 void TestRunner_Battle_CheckSwitch(u32 battlerId, u32 partyIndex);
 void TestRunner_Battle_CheckAiMoveScores(u32 battlerId);
 void TestRunner_Battle_AISetScore(const char *file, u32 line, u32 battlerId, u32 moveIndex, s32 score);

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4502,7 +4502,10 @@ static void HandleTurnActionSelectionState(void)
 
                             if (gTestRunnerEnabled)
                             {
-                                TestRunner_Battle_CheckChosenMove(battler, gChosenMoveByBattler[battler], gBattleStruct->moveTarget[battler]);
+                                UNUSED enum Gimmick gimmick = GIMMICK_NONE;
+                                if (gBattleResources->bufferB[battler][2] & RET_GIMMICK)
+                                    gimmick = gBattleStruct->gimmick.usableGimmick[battler];
+                                TestRunner_Battle_CheckChosenMove(battler, gChosenMoveByBattler[battler], gBattleStruct->moveTarget[battler], gimmick);
                             }
                         }
                         break;

--- a/test/battle/ai/ai_smart_tera.c
+++ b/test/battle/ai/ai_smart_tera.c
@@ -53,20 +53,19 @@ AI_SINGLE_BATTLE_TEST("AI_FLAG_SMART_TERA: AI will not tera if it gets ko'd by p
     }
 }
 
-// AI_SINGLE_BATTLE_TEST("AI_FLAG_SMART_TERA: AI might tera if it gets saved from a ko")
-// {
-//     KNOWN_FAILING; // Tests don't currently give the AI the capability to tera, even with a tera type set.
-//     PASSES_RANDOMLY(90, 100, RNG_AI_CONSERVE_TERA);
-//     GIVEN {
-//         ASSUME(GetMovePower(MOVE_SEED_BOMB) == 80);
-//         AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_SMART_TERA | AI_FLAG_OMNISCIENT );
-//         PLAYER(SPECIES_WOBBUFFET) { HP(47); Speed(100); Moves(MOVE_SEED_BOMB); }
-//         PLAYER(SPECIES_WOBBUFFET) { Speed(100); }
-//         OPPONENT(SPECIES_WOBBUFFET) { Speed(100); HP(30); Moves(MOVE_SEED_BOMB); TeraType(TYPE_FIRE); }
-//         OPPONENT(SPECIES_WOBBUFFET) { Speed(100); TeraType(TYPE_FIRE); }
-//     } WHEN {
-//         TURN { MOVE(player, MOVE_SEED_BOMB); }
-//     } SCENE {
-//         MESSAGE("The opposing Wobbuffet terastallized into the Fire type!");
-//     }
-// }
+AI_SINGLE_BATTLE_TEST("AI_FLAG_SMART_TERA: AI might tera if it gets saved from a ko")
+{
+    PASSES_RANDOMLY(90, 100, RNG_AI_CONSERVE_TERA);
+    GIVEN {
+        ASSUME(GetMovePower(MOVE_SEED_BOMB) == 80);
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_SMART_TERA | AI_FLAG_OMNISCIENT );
+        PLAYER(SPECIES_WOBBUFFET) { HP(47); Speed(100); Moves(MOVE_SEED_BOMB); }
+        PLAYER(SPECIES_WOBBUFFET) { Speed(100); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(100); HP(30); Moves(MOVE_SEED_BOMB); TeraType(TYPE_FIRE); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(100); TeraType(TYPE_FIRE); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SEED_BOMB); }
+    } SCENE {
+        MESSAGE("The opposing Wobbuffet terastallized into the Fire type!");
+    }
+}

--- a/test/battle/ai/ai_smart_tera.c
+++ b/test/battle/ai/ai_smart_tera.c
@@ -4,7 +4,6 @@
 
 AI_SINGLE_BATTLE_TEST("AI_FLAG_SMART_TERA: AI will tera if it enables a ko")
 {
-    KNOWN_FAILING; // Tests don't currently give the AI the capability to tera, even with a tera type set.
     GIVEN {
         ASSUME(GetMovePower(MOVE_SEED_BOMB) == 80);
         ASSUME(GetMovePower(MOVE_AQUA_TAIL) == 90);
@@ -14,9 +13,9 @@ AI_SINGLE_BATTLE_TEST("AI_FLAG_SMART_TERA: AI will tera if it enables a ko")
         OPPONENT(SPECIES_WOBBUFFET) { Speed(1); Moves(MOVE_AQUA_TAIL, MOVE_SEED_BOMB); TeraType(TYPE_GRASS); }
         OPPONENT(SPECIES_WOBBUFFET) { HP(1); Speed(100); TeraType(TYPE_FIRE); }
     } WHEN {
-        TURN { EXPECT_MOVE(opponent, MOVE_SEED_BOMB); }
+        TURN { EXPECT_MOVE(opponent, MOVE_SEED_BOMB, gimmick: GIMMICK_TERA); SEND_OUT(player, 1); }
     } SCENE {
-        MESSAGE("The opposing Wobbuffet terastilized into the Grass type!");
+        MESSAGE("The opposing Wobbuffet terastallized into the Grass type!");
         MESSAGE("Wobbuffet fainted!");
     }
 }
@@ -34,7 +33,7 @@ AI_SINGLE_BATTLE_TEST("AI_FLAG_SMART_TERA: AI will not tera if it gets outsped a
     } WHEN {
         TURN { }
     } SCENE {
-        NOT MESSAGE("The opposing Wobbuffet terastilized into the Grass type!");
+        NOT MESSAGE("The opposing Wobbuffet terastallized into the Grass type!");
     }
 }
 
@@ -50,7 +49,7 @@ AI_SINGLE_BATTLE_TEST("AI_FLAG_SMART_TERA: AI will not tera if it gets ko'd by p
     } WHEN {
         TURN {  }
     } SCENE {
-        NOT MESSAGE("The opposing Wobbuffet terastilized into the Grass type!");
+        NOT MESSAGE("The opposing Wobbuffet terastallized into the Grass type!");
     }
 }
 
@@ -68,6 +67,6 @@ AI_SINGLE_BATTLE_TEST("AI_FLAG_SMART_TERA: AI will not tera if it gets ko'd by p
 //     } WHEN {
 //         TURN { MOVE(player, MOVE_SEED_BOMB); }
 //     } SCENE {
-//         MESSAGE("The opposing Wobbuffet terastilized into the Fire type!");
+//         MESSAGE("The opposing Wobbuffet terastallized into the Fire type!");
 //     }
 // }

--- a/test/battle/ai/gimmick_dynamax.c
+++ b/test/battle/ai/gimmick_dynamax.c
@@ -1,0 +1,15 @@
+#include "global.h"
+#include "test/battle.h"
+#include "battle_ai_util.h"
+
+AI_SINGLE_BATTLE_TEST("AI uses Dynamax")
+{
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_OMNISCIENT );
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { Moves(MOVE_SCRATCH); DynamaxLevel(10); }
+    } WHEN {
+        TURN { EXPECT_MOVE(opponent, MOVE_SCRATCH, gimmick: GIMMICK_DYNAMAX); }
+    }
+}
+

--- a/test/battle/ai/gimmick_mega.c
+++ b/test/battle/ai/gimmick_mega.c
@@ -1,0 +1,19 @@
+#include "global.h"
+#include "test/battle.h"
+#include "battle_ai_util.h"
+
+AI_SINGLE_BATTLE_TEST("AI uses Mega Evolution")
+{
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_OMNISCIENT );
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_VENUSAUR) { Item(ITEM_VENUSAURITE); Moves(MOVE_SLUDGE_BOMB); }
+    } WHEN {
+        TURN { EXPECT_MOVE(opponent, MOVE_SLUDGE_BOMB, gimmick: GIMMICK_MEGA); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MEGA_EVOLUTION, opponent);
+    } THEN {
+        EXPECT_EQ(opponent->species, SPECIES_VENUSAUR_MEGA);
+    }
+}
+

--- a/test/battle/ai/gimmick_z_move.c
+++ b/test/battle/ai/gimmick_z_move.c
@@ -1,0 +1,34 @@
+#include "global.h"
+#include "test/battle.h"
+#include "battle_ai_util.h"
+#include "constants/battle_z_move_effects.h"
+
+AI_SINGLE_BATTLE_TEST("AI uses Z-moves.")
+{
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_OMNISCIENT );
+        ASSUME(GetMoveType(MOVE_QUICK_ATTACK) == TYPE_NORMAL);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_NORMALIUM_Z); Moves(MOVE_QUICK_ATTACK); }
+    } WHEN {
+        TURN { EXPECT_MOVE(opponent, MOVE_QUICK_ATTACK, gimmick: GIMMICK_Z_MOVE); }
+    }
+}
+
+AI_SINGLE_BATTLE_TEST("AI does not use damaging Z-moves if the player would faint anyway.")
+{
+    u32 currentHP;
+    PARAMETRIZE { currentHP = 1; }
+    PARAMETRIZE { currentHP = 500; }
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_OMNISCIENT );
+        ASSUME(GetMoveType(MOVE_QUICK_ATTACK) == TYPE_NORMAL);
+        PLAYER(SPECIES_WOBBUFFET) { HP(currentHP); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_NORMALIUM_Z); Moves(MOVE_QUICK_ATTACK); }
+    } WHEN {
+    if (currentHP != 1)
+        TURN { EXPECT_MOVE(opponent, MOVE_QUICK_ATTACK, gimmick: GIMMICK_Z_MOVE); }
+    else
+        TURN { EXPECT_MOVE(opponent, MOVE_QUICK_ATTACK, gimmick: GIMMICK_NONE); }
+    }
+}


### PR DESCRIPTION
Sets up `chosenGimmick` as appropriate so that the AI is able to see that it can use those gimmicks.

Untested, except for the `KNOWN_FAILING` Tera test which now passes. @surskitty, can you review this?