### PR TITLE
Fix EWRAM_INIT in tests and add a default state to test runner main loop

### DIFF
--- a/ld_script_test.ld
+++ b/ld_script_test.ld
@@ -19,6 +19,7 @@ SECTIONS {
     {
         __ewram_start = .;
         *(.ewram*)
+        . = ALIGN(4);
         __ewram_end = .;
     } > EWRAM
 

--- a/test/test_runner.c
+++ b/test/test_runner.c
@@ -446,6 +446,11 @@ top:
     case STATE_EXIT:
         MgbaExit_(gTestRunnerState.exitCode);
         break;
+    default:
+        MgbaOpen_();
+        Test_MgbaPrintf("\e[31mInvalid TestRunner state, exiting\e[0m");
+        gTestRunnerState.exitCode = 1;
+        gTestRunnerState.state = STATE_EXIT;
     }
 
     if (gMain.callback2 == CB2_TestRunner)


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
The test runner didn't have `default` case in the main loop which was causing infinite stalls if the state was ever outside of the allowed range of states. Now states outside of the allowed range causes an immediate exit.

Also changed the linker script for tests to not misbehave if less than 4 bytes of variables use `EWRAM_INIT`.
<img width="776" height="632" alt="20250906_16h55m41s_grim" src="https://github.com/user-attachments/assets/9f201198-8e2b-447f-9a96-11befb97fb7e" />


## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara