### PR TITLE
Battle debug menu: highlight chosen action and change separator

### DIFF
--- a/src/battle_debug.c
+++ b/src/battle_debug.c
@@ -722,14 +722,11 @@ void CB2_BattleDebugMenu(void)
 
 enum {
     COLORID_RED,
-    COLORID_BLUE,
-    COLORID_COUNT,
 };
 
 static const u8 sTextColorTable[][3] =
 {
     [COLORID_RED]        = {TEXT_COLOR_WHITE,       TEXT_COLOR_RED,        TEXT_COLOR_LIGHT_RED},
-    [COLORID_BLUE]       = {TEXT_COLOR_WHITE,       TEXT_COLOR_BLUE,       TEXT_COLOR_LIGHT_BLUE},
 };
 
 static void PutMovesPointsText(struct BattleDebugMenu *data)
@@ -738,7 +735,7 @@ static void PutMovesPointsText(struct BattleDebugMenu *data)
     u8 *text = Alloc(0x50);
 
     FillWindowPixelBuffer(data->aiMovesWindowId, 0x11);
-    AddTextPrinterParameterized3(data->aiMovesWindowId, FONT_NORMAL, 3, 0, sTextColorTable[COLORID_BLUE], 0, COMPOUND_STRING("Score/Dmg"));
+    AddTextPrinterParameterized(data->aiMovesWindowId, FONT_NORMAL, COMPOUND_STRING("Score/Dmg"), 3, 0, 0, NULL);
     for (i = 0; i < MAX_MON_MOVES; i++)
     {
         text[0] = CHAR_SPACE;


### PR DESCRIPTION
## Description
Highlights chosen action red and changes separator to `/`

## Media
<img width="870" height="571" alt="image" src="https://github.com/user-attachments/assets/c5d94c05-4000-4083-8689-b33739c57c9e" />

<img width="870" height="572" alt="image" src="https://github.com/user-attachments/assets/2821f9d9-60bd-445b-9bc1-256a0bf071da" />

<img width="873" height="576" alt="image" src="https://github.com/user-attachments/assets/91565780-51ae-46a9-afb3-ec6b40e7b701" />

## Credits
@ghoulslash for idea and example layout

## Discord contact info
grintoul