### PR TITLE
Fix Beak Blast burning fire types

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -6009,7 +6009,7 @@ static void Cmd_moveend(void)
 
                 // Not strictly a protect effect, but works the same way
                 if (gProtectStructs[gBattlerTarget].beakBlastCharge
-                 && CanBeBurned(gBattlerAttacker, gBattlerTarget, GetBattlerAbility(gBattlerAttacker))
+                 && CanBeBurned(gBattlerAttacker, gBattlerAttacker, GetBattlerAbility(gBattlerAttacker))
                  && !(gBattleStruct->moveResultFlags[gBattlerTarget] & MOVE_RESULT_NO_EFFECT))
                 {
                     gProtectStructs[gBattlerAttacker].touchedProtectLike = FALSE;

--- a/test/battle/move_effect/beak_blast.c
+++ b/test/battle/move_effect/beak_blast.c
@@ -112,6 +112,21 @@ SINGLE_BATTLE_TEST("Beak Blast burns only when contact moves are used")
     }
 }
 
+SINGLE_BATTLE_TEST("Beak Blast doesn't burn fire types")
+{
+    GIVEN {
+        ASSUME(gSpeciesInfo[SPECIES_ARCANINE].types[0] == TYPE_FIRE || gSpeciesInfo[SPECIES_ARCANINE].types[1]);
+        PLAYER(SPECIES_ARCANINE);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_BEAK_BLAST); MOVE(player, MOVE_SCRATCH); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        NOT STATUS_ICON(player, burn: TRUE);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BEAK_BLAST, opponent);
+    }
+}
+
 TO_DO_BATTLE_TEST("Beak Blast's charging message is shown regardless if it would've missed");
 TO_DO_BATTLE_TEST("Beak Blast fails if it's forced by Encore after choosing a different move");
 TO_DO_BATTLE_TEST("Bulletproof is immune to Beak Blast but not to the burn it causes");


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
Beak Blast had an incorrect `CanBeBurned` check which resulted in fire type being burned when attacking into Beak Blast.
Discovered by Kumatora on the TAH discord.

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara