### PR TITLE
Fix bug with IF_GENDER evolution condition

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -4477,7 +4477,7 @@ bool32 DoesMonMeetAdditionalConditions(struct Pokemon *mon, const struct Evoluti
         {
         // Gen 2
         case IF_GENDER:
-            if (gender == GetMonGender(mon))
+            if (gender == params[i].arg1)
                 currentCondition = TRUE;
             break;
         case IF_MIN_FRIENDSHIP:


### PR DESCRIPTION
The If_gender always returns TRUE because it checks if a pokemon's gender is equal to its gender. This PR fixes this

Thanks to Charlie III in TAH for noticing the issue
Before:

https://github.com/user-attachments/assets/637f84f7-ccf6-4909-bc8a-a0f974797125

After:
https://github.com/user-attachments/assets/92f8ec59-55b9-4cc8-a247-aed91833a1e5

## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, closes #2222." Remove this section if not applicable.-->

## Things to note in the release changelog:
<!-- Add any important details for the release changelog. Must be structed as bullet points. --->
<!--- Remove this section if not applicable. --->

## Discord contact info
Jamie (foster_harmony)
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
