### PR TITLE
Fix failing test for B_PREFERRED_ICE_WEATHER = B_ICE_WEATHER_SNOW

### DIFF
--- a/test/battle/ability/overcoat.c
+++ b/test/battle/ability/overcoat.c
@@ -40,6 +40,7 @@ DOUBLE_BATTLE_TEST("Overcoat blocks damage from sandstorm")
 DOUBLE_BATTLE_TEST("Overcoat blocks damage from hail")
 {
     GIVEN {
+        ASSUME(GetMoveEffect(MOVE_HAIL) == EFFECT_HAIL);
         PLAYER(SPECIES_WYNAUT)    { Speed(50); Ability(ABILITY_SNOW_CLOAK); } 
         PLAYER(SPECIES_SOLOSIS)   { Speed(40); Ability(ABILITY_RUN_AWAY); }
         OPPONENT(SPECIES_PINECO)  { Speed(30); Ability(ABILITY_OVERCOAT); }

--- a/test/battle/ability/slush_rush.c
+++ b/test/battle/ability/slush_rush.c
@@ -54,6 +54,7 @@ SINGLE_BATTLE_TEST("Slush Rush doesn't prevent non-Ice types from taking damage 
     GIVEN {
         ASSUME(GetSpeciesType(SPECIES_WOBBUFFET, 0) != TYPE_ICE);
         ASSUME(GetSpeciesType(SPECIES_WOBBUFFET, 1) != TYPE_ICE);
+        ASSUME(GetMoveEffect(MOVE_HAIL) == EFFECT_HAIL);
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_CETITAN) { Ability(ABILITY_SLUSH_RUSH); }
     } WHEN {

--- a/test/battle/ai/can_use_all_moves.c
+++ b/test/battle/ai/can_use_all_moves.c
@@ -249,7 +249,11 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 201-300")
         case EFFECT_HEAL_BELL:
         case EFFECT_SUNNY_DAY:
         case EFFECT_RAIN_DANCE:
+    #if B_PREFERRED_ICE_WEATHER == B_ICE_WEATHER_SNOW
+        case EFFECT_SNOWSCAPE:
+    #else
         case EFFECT_HAIL:
+    #endif
         case EFFECT_ROLE_PLAY:
         case EFFECT_REFRESH:
 

--- a/test/battle/gimmick/dynamax.c
+++ b/test/battle/gimmick/dynamax.c
@@ -838,7 +838,11 @@ SINGLE_BATTLE_TEST("Dynamax: Max Geyser sets up heavy rain")
     }
 }
 
+#if B_PREFERRED_ICE_WEATHER == B_ICE_WEATHER_SNOW
+SINGLE_BATTLE_TEST("Dynamax: Max Hailstorm sets up snow")
+#else
 SINGLE_BATTLE_TEST("Dynamax: Max Hailstorm sets up hail")
+#endif
 {
     GIVEN {
         ASSUME(MoveHasAdditionalEffect(MOVE_MAX_HAILSTORM, MOVE_EFFECT_HAIL));
@@ -848,9 +852,15 @@ SINGLE_BATTLE_TEST("Dynamax: Max Hailstorm sets up hail")
         TURN { MOVE(player, MOVE_POWDER_SNOW, gimmick: GIMMICK_DYNAMAX); MOVE(opponent, MOVE_CELEBRATE); }
     } SCENE {
         MESSAGE("Wobbuffet used Max Hailstorm!");
+#if B_PREFERRED_ICE_WEATHER == B_ICE_WEATHER_SNOW
+        MESSAGE("It started to snow!");
+        MESSAGE("The opposing Wobbuffet used Celebrate!");
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_SNOW_CONTINUES);
+#else
         MESSAGE("It started to hail!");
         MESSAGE("The opposing Wobbuffet used Celebrate!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HAIL_CONTINUES);
+#endif        
     }
 }
 


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
Setting B_PREFERRED_ICE_WEATHER config to B_ICE_WEATHER_SNOW caused the following 4 tests to fail.

Updated to assume hail because of hail damage being tested:
- Overcoat blocks damage from hail
- Slush Rush doesn't prevent non-Ice types from taking damage in Hail

Updated to check for and work with snow preferred:
- Dynamax: Max Hailstorm sets up snow/hail
- AI can use all moves, 201-300

<!-- CREDITS -->
<!-- Once your PR is submitted, leave a comment asking the bot to add you to the credits. -->
<!-- If anybody helped with this PR, please encourage them to comment on your PR and ask the bot to add them to the credits. -->
<!-- EVERY contribution matters! -->
<!-- https://github.com/rh-hideout/pokeemerald-expansion/wiki/CREDITS.md-Frequently-Asked-Questions -->

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
phexi

