### PR TITLE
CheckForTrainersWantingBattle trainerObjects array now initialized to zero and all loops now start at zero

### DIFF
--- a/src/trainer_see.c
+++ b/src/trainer_see.c
@@ -360,7 +360,7 @@ static const struct SpriteTemplate sSpriteTemplate_Emote =
 bool8 CheckForTrainersWantingBattle(void)
 {
     u8 i;
-    u8 trainerObjects[OBJECT_EVENTS_COUNT];
+    u8 trainerObjects[OBJECT_EVENTS_COUNT] = {0};
     u8 trainerObjectsCount = 0;
 
     if (FlagGet(OW_FLAG_NO_TRAINER_SEE))
@@ -376,11 +376,12 @@ bool8 CheckForTrainersWantingBattle(void)
             continue;
         if (gObjectEvents[i].trainerType != TRAINER_TYPE_NORMAL && gObjectEvents[i].trainerType != TRAINER_TYPE_BURIED)
             continue;
-        trainerObjects[trainerObjectsCount++] = i;
+        trainerObjects[trainerObjectsCount] = i;
+        trainerObjectsCount++;
     }
 
     // Sorts array by localId
-    for (i = 1; i <= trainerObjectsCount; i++)
+    for (i = 0; i <= trainerObjectsCount; i++)
     {
         u8 x = trainerObjects[i];
         u8 j = i;
@@ -392,7 +393,7 @@ bool8 CheckForTrainersWantingBattle(void)
         trainerObjects[j] = x;
     }
 
-    for (i = 1; i <= trainerObjectsCount; i++)
+    for (i = 0; i <= trainerObjectsCount; i++)
     {
         u8 numTrainers;
         numTrainers = CheckTrainer(trainerObjects[i]);


### PR DESCRIPTION
## Description
trainerObjects array now initializes to zero, preventing unexpected object events triggering. All three loops now start at index zero as previous assumption that starting at 1 would be okay due to localIds beginning at 1 appeared to cause an issue in Fortree gym where a trainer could not see the player. Appeared to be the case that the player localID was ending up in the array causing the trainer localID to sort to array index zero, meaning the trainer was not checked. PR changes should mean even if there are instances of player/other unexpected object events ending up in the array, all array positions are checked for triggerable trainers. I think should not happen now however because the array is now filling from position zero instead of position 1.

## CREDITS
@TerraPrograms for highlighting the missing array initializing
@PhallenTree for notifying of the Fortree issue case

## Discord contact info
grintoul