### PR TITLE
No bag use flag changed to a varable

### DIFF
--- a/data/scripts/debug.inc
+++ b/data/scripts/debug.inc
@@ -87,6 +87,15 @@ Debug_FlagsNotSetBattleConfigMessage_Text:
 	.string "Please define a usable flag in:\l"
 	.string "'include/config/battle.h'!$"
 
+Debug_VarsNotSetBattleConfigMessage::
+	message Debug_VarsNotSetBattleConfigMessage_Text
+	goto Debug_MessageEnd
+
+Debug_VarsNotSetBattleConfigMessage_Text:
+	.string "Feature unavailable!\n"
+	.string "Please define a usable var in:\l"
+	.string "'include/config/battle.h'!$"
+
 Debug_BoxFilledMessage::
 	message Debug_BoxFilledMessage_Text
 	goto Debug_MessageEnd

--- a/include/battle_controllers.h
+++ b/include/battle_controllers.h
@@ -437,4 +437,5 @@ void BtlController_HandleSwitchInTryShinyAnim(u32 battler);
 void BtlController_HandleSwitchInSoundAndEnd(u32 battler);
 void BtlController_HandleSwitchInShowSubstitute(u32 battler);
 
+bool32 ShouldBattleRestrictionsApply(u32 battler);
 #endif // GUARD_BATTLE_CONTROLLERS_H

--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -432,5 +432,6 @@ u32 GetNaturePowerMove(u32 battler);
 u32 GetNaturePowerMove(u32 battler);
 void RemoveAbilityFlags(u32 battler);
 bool32 IsDazzlingAbility(enum Ability ability);
+bool32 IsAllowedToUseBag(void);
 
 #endif // GUARD_BATTLE_UTIL_H

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -234,7 +234,7 @@
 #define NO_BAG_AGAINST_TRAINER   1
 #define NO_BAG_IN_BATTLE         2
 
-#define B_VAR_NO_BAG_USE            0     // If 1, the ability to use the bag in battle is disabled in trainer battles. If 2, it is also disabled in wild battles.
+#define B_VAR_NO_BAG_USE         0     // If 1, the ability to use the bag in battle is disabled in trainer battles. If 2, it is also disabled in wild battles.
 
 // Sky Battles
 #define B_FLAG_SKY_BATTLE                 0     // If this flag has a value, the player will be able to engage in scripted Sky Battles.

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -208,7 +208,6 @@
 #define B_FLAG_INVERSE_BATTLE       0     // If this flag is set, the battle's type effectiveness are inversed. For example, fire is super effective against water.
 #define B_FLAG_FORCE_DOUBLE_WILD    0     // If this flag is set, all land and surfing wild battles will be double battles.
 #define B_SMART_WILD_AI_FLAG        0     // If this flag is set, wild Pokémon will become smart, with all AI flags enabled.
-#define B_FLAG_NO_BAG_USE           0     // If this flag is set, the ability to use the bag in battle is disabled.
 #define B_FLAG_NO_CATCHING          0     // If this flag is set, the ability to catch wild Pokémon is disabled.
 #define B_FLAG_NO_RUNNING           0     // If this flag is set, the ability to escape from wild battles is disabled. Also makes Roar/Whirlwind and Teleport (under Gen8) fail.
 #define B_FLAG_AI_VS_AI_BATTLE      0     // If this flag is set, the player's mons will be controlled by the ai next battles.
@@ -229,6 +228,13 @@
                                           // For better wild AI handling, edit GetWildAiFlags() in src/battle_ai_main.c
 
 #define B_VAR_DIFFICULTY            0     // If not 0, you can use this var to control which difficulty version of a Trainer is loaded. This should be manually set by the developer using Script_SetDifficulty AFTER NewGameInitData has run.
+
+// No bag settings
+#define NO_BAG_RESTRICTION       0
+#define NO_BAG_AGAINST_TRAINER   1
+#define NO_BAG_IN_BATTLE         2
+
+#define B_VAR_NO_BAG_USE            0     // If 1, the ability to use the bag in battle is disabled in trainer battles. If 2, it is also disabled in wild battles.
 
 // Sky Battles
 #define B_FLAG_SKY_BATTLE                 0     // If this flag has a value, the player will be able to engage in scripted Sky Battles.

--- a/src/battle_controllers.c
+++ b/src/battle_controllers.c
@@ -3124,3 +3124,8 @@ void UpdateFriendshipFromXItem(u32 battler)
         SetBattlerMonData(battler, GetBattlerParty(battler), gBattlerPartyIndexes[battler]);
     }
 }
+
+bool32 ShouldBattleRestrictionsApply(u32 battler)
+{
+    return IsControllerPlayer(battler);
+}

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4298,7 +4298,7 @@ static void HandleTurnActionSelectionState(void)
                     }
                     break;
                 case B_ACTION_USE_ITEM:
-                    if (FlagGet(B_FLAG_NO_BAG_USE))
+                    if (ShouldBattleRestrictionsApply(battler) && !IsAllowedToUseBag())
                     {
                         RecordedBattle_ClearBattlerAction(battler, 1);
                         gSelectionBattleScripts[battler] = BattleScript_ActionSelectionItemsCantBeUsed;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -12447,3 +12447,18 @@ void RemoveAbilityFlags(u32 battler)
        break;
     }
 }
+
+bool32 IsAllowedToUseBag(void)
+{
+    switch(VarGet(B_VAR_NO_BAG_USE))
+    {
+        case NO_BAG_RESTRICTION:
+            return TRUE;
+        case NO_BAG_AGAINST_TRAINER: //True in wild battle; False in trainer battle
+            return (!(gBattleTypeFlags & BATTLE_TYPE_TRAINER));
+        case NO_BAG_IN_BATTLE:
+            return FALSE;
+        default:
+            return TRUE; // Undefined Behavior
+    }
+}

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -12452,13 +12452,13 @@ bool32 IsAllowedToUseBag(void)
 {
     switch(VarGet(B_VAR_NO_BAG_USE))
     {
-        case NO_BAG_RESTRICTION:
-            return TRUE;
-        case NO_BAG_AGAINST_TRAINER: //True in wild battle; False in trainer battle
-            return (!(gBattleTypeFlags & BATTLE_TYPE_TRAINER));
-        case NO_BAG_IN_BATTLE:
-            return FALSE;
-        default:
-            return TRUE; // Undefined Behavior
+    case NO_BAG_RESTRICTION:
+        return TRUE;
+    case NO_BAG_AGAINST_TRAINER: //True in wild battle; False in trainer battle
+        return (!(gBattleTypeFlags & BATTLE_TYPE_TRAINER));
+    case NO_BAG_IN_BATTLE:
+        return FALSE;
+    default:
+        return TRUE; // Undefined Behavior
     }
 }

--- a/src/item_use.c
+++ b/src/item_use.c
@@ -1133,7 +1133,7 @@ static u32 GetBallThrowableState(void)
         return BALL_THROW_UNABLE_NO_ROOM;
     else if (B_SEMI_INVULNERABLE_CATCH >= GEN_4 &&  IsSemiInvulnerable(GetCatchingBattler(), CHECK_ALL))
         return BALL_THROW_UNABLE_SEMI_INVULNERABLE;
-    else if (FlagGet(B_FLAG_NO_CATCHING))
+    else if (FlagGet(B_FLAG_NO_CATCHING) || !IsAllowedToUseBag())
         return BALL_THROW_UNABLE_DISABLED_FLAG;
 
     return BALL_THROW_ABLE;

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -429,10 +429,13 @@ void Overworld_ResetBattleFlagsAndVars(void)
         VarSet(B_VAR_WILD_AI_FLAGS,0);
     #endif
 
+    #if B_VAR_NO_BAG_USE != 0
+        VarSet(B_VAR_NO_BAG_USE, 0);
+    #endif
+
     FlagClear(B_FLAG_INVERSE_BATTLE);
     FlagClear(B_FLAG_FORCE_DOUBLE_WILD);
     FlagClear(B_SMART_WILD_AI_FLAG);
-    FlagClear(B_FLAG_NO_BAG_USE);
     FlagClear(B_FLAG_NO_CATCHING);
     FlagClear(B_FLAG_NO_RUNNING);
     FlagClear(B_FLAG_DYNAMAX_BATTLE);


### PR DESCRIPTION
  No bag use flag changed to a variable:
   - It only applies to player controller
   - It has 3 mode, no bag, no bag against trainer and available bag
   - Update debug menu to allow switching between modes if var is set
   - Prevent ball to be thrown when bag is disabled for wild battles

## Description
<!-- Detail the changes made, why they were made, and any important context. -->

## Media

https://github.com/user-attachments/assets/c4b12369-c95c-4dbf-bd94-f6d343b108b9

Wally Tutorial issue that has been fixed (uses early version of the PR)
Before:
https://github.com/user-attachments/assets/dfc00041-959d-49fa-a1f2-389ff218dfd7
After:
https://github.com/user-attachments/assets/51ce6157-bf44-41b4-8211-f3f295b9fc4d

## Issue(s) that this PR fixes
Fixes #6571

## Things to note in the release changelog:
<!-- Add any important details for the release changelog. Must be structed as bullet points. --->
<!--- Remove this section if not applicable. --->
- IMPORTANT: The config flag B_FLAG_NO_BAG_USE has been removed
- A config var B_VAR_NO_BAG_USE has been added to replace it. It allows you to choose between:
bag available in battle, bag available in wild battle only, and unavailable bag

## Discord contact info
Jamie (foster_harmony)
