### PR TITLE
Adjusted line break substring breaking

### DIFF
--- a/src/line_break.c
+++ b/src/line_break.c
@@ -36,10 +36,10 @@ void BreakStringAutomatic(u8 *src, u32 maxWidth, u32 screenLines, u8 fontId, enu
     {
         if (src[currIndex] == CHAR_PROMPT_CLEAR)
         {
-            u8 replacedChar = src[currIndex + 1];
-            src[currIndex + 1] = EOS;
+            u8 replacedChar = src[currIndex];
+            src[currIndex] = EOS;
             BreakSubStringAutomatic(currSrc, maxWidth, screenLines, fontId, toggleScrollPrompt);
-            src[currIndex + 1] = replacedChar;
+            src[currIndex] = replacedChar;
             currSrc = &src[currIndex + 1];
         }
         currIndex++;


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
The substring breaking function was adding the temporary `EOS` character at `index + 1` instead of directly on the `CHAR_PROMPT_CLEAR`. It makes more sense to replace the `CHAR_PROMPT_CLEAR` before calculating the line breaks for the substring.

Problems came up with the `index + 1` implementation when also using this function to add line breaks to text that can span more than 2 lines with some manual line breaks to distinguish paragraphs.

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara