### PR TITLE
Fix Debug Give Pokémon (Complex) with duplicate moves

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -2853,6 +2853,10 @@ static void DebugAction_Give_Pokemon_ComplexCreateMon(u8 taskId) //https://githu
     //Moves
     for (i = 0; i < MAX_MON_MOVES; i++)
     {
+        // Non-default moveset chosen. Reset moves before setting the chosen moves.
+        if (moves[0] != MOVE_NONE)
+            SetMonMoveSlot(&mon, MOVE_NONE, i);
+
         if (moves[i] == MOVE_NONE || moves[i] >= MOVES_COUNT)
             continue;
 

--- a/test/pokemon.c
+++ b/test/pokemon.c
@@ -288,7 +288,7 @@ TEST("givemon [moves]")
     ZeroPlayerPartyMons();
 
     RUN_OVERWORLD_SCRIPT(
-        givemon SPECIES_WOBBUFFET, 100, move1=MOVE_SCRATCH, move2=MOVE_SPLASH, move3=MOVE_NONE, move4=MOVE_NONE;
+        givemon SPECIES_WOBBUFFET, 100, move1=MOVE_SCRATCH, move2=MOVE_SPLASH, move3=MOVE_NONE;
     );
 
     EXPECT_EQ(GetMonData(&gPlayerParty[0], MON_DATA_SPECIES), SPECIES_WOBBUFFET);


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
Modified Debug option such that when choosing moves, any unchosen moves will now be set to `MOVE_NONE`.

## Media
Before vs After
<img width="240" height="160" alt="image" src="https://github.com/user-attachments/assets/5fa70de3-f431-40d4-9515-dd6d34e34535" /> <img width="240" height="160" alt="image" src="https://github.com/user-attachments/assets/f982d5e2-6c76-483a-95bf-3927513966f5" />

Not choosing moves still works as expected (using Level up moves):
<img width="240" height="160" alt="image" src="https://github.com/user-attachments/assets/81028564-bc93-4fc3-8674-2e99df755b79" />

## Issue(s) that this PR fixes
Fixes #6293

## Discord contact info
AsparagusEduardo
