### PR TITLE
Fix Battle Frontier using Strange Balls

### DIFF
--- a/src/battle_tower.c
+++ b/src/battle_tower.c
@@ -1648,8 +1648,8 @@ void CreateFacilityMon(const struct TrainerMon *fmon, u16 level, u8 fixedIV, u32
         SetMonData(dst, MON_DATA_TERA_TYPE, &data);
     }
 
-
-    SetMonData(dst, MON_DATA_POKEBALL, &ball);
+    if (ball != BALL_STRANGE)
+        SetMonData(dst, MON_DATA_POKEBALL, &ball);
     CalculateMonStats(dst);
 }
 


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
Since the frontier mons didn't have Poké Ball data set, they were defaulting to Strange Balls once they were set as Ball 0.
Figured that since Strange Balls are only meant to be used to represent "invalid" Poké Balls, the Frontier data shouldn't be able to use it.

## Media
Before vs After
<img width="240" height="160" alt="image" src="https://github.com/user-attachments/assets/be121a2c-e465-4be4-880c-1f235cd2a29a" /> <img width="240" height="160" alt="image" src="https://github.com/user-attachments/assets/4dc608ec-355f-47bf-86d7-d205a6ae5d20" />

## Issue(s) that this PR fixes
Fixes #6761

## Discord contact info
AsparagusEduardo