### PR TITLE
fix (choice lock): Gorilla Tactics interactions with choice item removal

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2861,7 +2861,7 @@ void StealTargetItem(u8 battlerStealer, u8 battlerItem)
     BtlController_EmitSetMonData(battlerItem, B_COMM_TO_CONTROLLER, REQUEST_HELDITEM_BATTLE, 0, sizeof(gBattleMons[gBattlerTarget].item), &gBattleMons[battlerItem].item);  // remove target item
     MarkBattlerForControllerExec(battlerItem);
 
-    if (gBattleMons[gBattlerTarget].ability != ABILITY_GORILLA_TACTICS)
+    if (GetBattlerAbility(gBattlerTarget) != ABILITY_GORILLA_TACTICS)
         gBattleStruct->choicedMove[gBattlerTarget] = MOVE_NONE;
 
     TrySaveExchangedItem(battlerItem, gLastUsedItem);

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -12866,7 +12866,7 @@ static void Cmd_tryswapitems(void)
             BtlController_EmitSetMonData(gBattlerTarget, B_COMM_TO_CONTROLLER, REQUEST_HELDITEM_BATTLE, 0, sizeof(gBattleMons[gBattlerTarget].item), &gBattleMons[gBattlerTarget].item);
             MarkBattlerForControllerExec(gBattlerTarget);
 
-            if (gBattleMons[gBattlerTarget].ability != ABILITY_GORILLA_TACTICS)
+            if (GetBattlerAbility(gBattlerTarget) != ABILITY_GORILLA_TACTICS)
                 gBattleStruct->choicedMove[gBattlerTarget] = MOVE_NONE;
             if (gBattleMons[gBattlerAttacker].ability != ABILITY_GORILLA_TACTICS)
                 gBattleStruct->choicedMove[gBattlerAttacker] = MOVE_NONE;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -12868,7 +12868,7 @@ static void Cmd_tryswapitems(void)
 
             if (GetBattlerAbility(gBattlerTarget) != ABILITY_GORILLA_TACTICS)
                 gBattleStruct->choicedMove[gBattlerTarget] = MOVE_NONE;
-            if (gBattleMons[gBattlerAttacker].ability != ABILITY_GORILLA_TACTICS)
+            if (GetBattlerAbility(gBattlerTarget) != ABILITY_GORILLA_TACTICS)
                 gBattleStruct->choicedMove[gBattlerAttacker] = MOVE_NONE;
 
             gBattlescriptCurrInstr = cmd->nextInstr;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2861,7 +2861,8 @@ void StealTargetItem(u8 battlerStealer, u8 battlerItem)
     BtlController_EmitSetMonData(battlerItem, B_COMM_TO_CONTROLLER, REQUEST_HELDITEM_BATTLE, 0, sizeof(gBattleMons[gBattlerTarget].item), &gBattleMons[battlerItem].item);  // remove target item
     MarkBattlerForControllerExec(battlerItem);
 
-    gBattleStruct->choicedMove[battlerItem] = 0;
+    if (gBattleMons[gBattlerTarget].ability != ABILITY_GORILLA_TACTICS)
+        gBattleStruct->choicedMove[gBattlerTarget] = MOVE_NONE;
 
     TrySaveExchangedItem(battlerItem, gLastUsedItem);
 }
@@ -5705,7 +5706,7 @@ static bool32 HandleMoveEndMoveBlock(u32 moveEffect)
             gLastUsedItem = gBattleMons[gBattlerTarget].item;
             gBattleMons[gBattlerTarget].item = 0;
             if (gBattleMons[gBattlerTarget].ability != ABILITY_GORILLA_TACTICS)
-                gBattleStruct->choicedMove[gBattlerTarget] = 0;
+                gBattleStruct->choicedMove[gBattlerTarget] = MOVE_NONE;
             CheckSetUnburden(gBattlerTarget);
 
             // In Gen 5+, Knock Off removes the target's item rather than rendering it unusable.
@@ -12865,8 +12866,10 @@ static void Cmd_tryswapitems(void)
             BtlController_EmitSetMonData(gBattlerTarget, B_COMM_TO_CONTROLLER, REQUEST_HELDITEM_BATTLE, 0, sizeof(gBattleMons[gBattlerTarget].item), &gBattleMons[gBattlerTarget].item);
             MarkBattlerForControllerExec(gBattlerTarget);
 
-            gBattleStruct->choicedMove[gBattlerTarget] = MOVE_NONE;
-            gBattleStruct->choicedMove[gBattlerAttacker] = MOVE_NONE;
+            if (gBattleMons[gBattlerTarget].ability != ABILITY_GORILLA_TACTICS)
+                gBattleStruct->choicedMove[gBattlerTarget] = MOVE_NONE;
+            if (gBattleMons[gBattlerAttacker].ability != ABILITY_GORILLA_TACTICS)
+                gBattleStruct->choicedMove[gBattlerAttacker] = MOVE_NONE;
 
             gBattlescriptCurrInstr = cmd->nextInstr;
 


### PR DESCRIPTION
## Description
Knock Off correctly handled overlapping choice lock with Sage Power/Gorilla Tactics, but this was never applied to the battle scripts for thief or trick effects. I also adjusted all three to reference MOVE_NONE for the choice lock move replacement instead of 0, hopefully improving AI behavior consistency, though if that is incorrect (I'm not a C/romhack expert by any means!), feel free to revert those instances of MOVE_NONE to 0.
This issue was discovered in Pokemon Emerald Imperium v 1.3.1, link to the PR for the fix for that romhack and supporting bug documentation located [here](https://github.com/iriv24/pokeemerald-expansion/pull/94), including a save file (inside the associated Discord thread) and steps to reproduce in that romhack.

## Media
VOD link for instance of bug happening (in Pokemon Emerald Imperium v 1.3.1 https://youtu.be/USLapASkYzo?t=1326 )

## Things to note in the release changelog:
- Fixed interactions with choice items and Gorilla Tactics both present when choice item is removed by a thief effect or item swap effect.

## Discord contact info
ghostyboyy97
