### PR TITLE
Fix LTO breaking with FREE_MYSTERY_GIFT set to TRUE

### DIFF
--- a/src/easy_chat.c
+++ b/src/easy_chat.c
@@ -5851,16 +5851,23 @@ static u8 IsEasyChatWordUnlocked(u16 easyChatWord)
 void InitializeEasyChatWordArray(u16 *words, u16 length)
 {
     u16 i;
-    for (i = length - 1; i != EC_EMPTY_WORD; i--)
-        *(words++) = EC_EMPTY_WORD;
+    if (words != NULL)
+    {
+        for (i = length - 1; i != EC_EMPTY_WORD; i--)
+            *(words++) = EC_EMPTY_WORD;
+    }
 }
 
 void InitQuestionnaireWords(void)
 {
     int i;
     u16 *words = GetQuestionnaireWordsPtr();
-    for (i = 0; i < NUM_QUESTIONNAIRE_WORDS; i++)
-        words[i] = EC_EMPTY_WORD;
+
+    if (words != NULL)
+    {
+        for (i = 0; i < NUM_QUESTIONNAIRE_WORDS; i++)
+            words[i] = EC_EMPTY_WORD;
+    }
 }
 
 bool32 IsEasyChatAnswerUnlocked(int easyChatWord)


### PR DESCRIPTION
When FREE_MYSTERY_GIFT is set to TRUE, `GetQuestionnaireWordsPtr` returns NULL, and gcc decides that writing to NULL is an UB and crashes the rom. I thought it was MyBoy-only issue at first, but no, it was happening in all emulators.

Discovered thanks to PCG who brought attention to this issue.