### PR TITLE
Improve debug menu set timeofday aactions and change when color start…

### DIFF
--- a/include/constants/rtc.h
+++ b/include/constants/rtc.h
@@ -18,6 +18,7 @@
 //Morning and evening don't exist in Gen 3
 #if OW_TIMES_OF_DAY == GEN_3
     #define MORNING_HOUR_BEGIN 0
+    #define MORNING_HOUR_MIDDLE 0
     #define MORNING_HOUR_END   0
 
     #define DAY_HOUR_BEGIN     12
@@ -31,6 +32,7 @@
 //Evening doesn't exist in Gen 4
 #elif OW_TIMES_OF_DAY == GEN_4
     #define MORNING_HOUR_BEGIN 4
+    #define MORNING_HOUR_MIDDLE 7 //Used for palette transition but not gameplay
     #define MORNING_HOUR_END   10
 
     #define DAY_HOUR_BEGIN     10
@@ -44,6 +46,7 @@
 //Gen 5 currently not included as the seasons change the times of day
 #elif OW_TIMES_OF_DAY <= GEN_6
     #define MORNING_HOUR_BEGIN 4
+    #define MORNING_HOUR_MIDDLE 7 //Used for palette transition but not gameplay
     #define MORNING_HOUR_END   11
 
     #define DAY_HOUR_BEGIN     11
@@ -57,6 +60,7 @@
 //These are the Sun/Ultra Sun times
 #elif OW_TIMES_OF_DAY == GEN_7
     #define MORNING_HOUR_BEGIN 6
+    #define MORNING_HOUR_MIDDLE 8 //Used for palette transition but not gameplay
     #define MORNING_HOUR_END   10
 
     #define DAY_HOUR_BEGIN     10
@@ -69,6 +73,7 @@
     #define NIGHT_HOUR_END     6
 #elif OW_TIMES_OF_DAY >= GEN_8
     #define MORNING_HOUR_BEGIN 6
+    #define MORNING_HOUR_MIDDLE 8 //Used for palette transition but not gameplay
     #define MORNING_HOUR_END   10
 
     #define DAY_HOUR_BEGIN     10

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -1560,8 +1560,6 @@ const struct BlendSettings gTimeOfDayBlend[] =
 #define DEFAULT_WEIGHT 256
 #define TIME_BLEND_WEIGHT(begin, end) (DEFAULT_WEIGHT - (DEFAULT_WEIGHT * SAFE_DIV(((hours - begin) * MINUTES_PER_HOUR + minutes), ((end - begin) * MINUTES_PER_HOUR))))
 
-#define MORNING_HOUR_MIDDLE (MORNING_HOUR_BEGIN + ((MORNING_HOUR_END - MORNING_HOUR_BEGIN) / 2))
-
 void UpdateTimeOfDay(void)
 {
     s32 hours, minutes;
@@ -1585,19 +1583,19 @@ void UpdateTimeOfDay(void)
         gTimeBlend.altWeight = (DEFAULT_WEIGHT - gTimeBlend.weight) / 2 + (DEFAULT_WEIGHT / 2);
         gTimeOfDay = TIME_MORNING;
     }
-    else if (IsBetweenHours(hours, EVENING_HOUR_BEGIN, EVENING_HOUR_END)) // evening
+    else if (IsBetweenHours(hours, EVENING_HOUR_BEGIN - 1, EVENING_HOUR_BEGIN)) // evening
     {
         gTimeBlend.startBlend = gTimeOfDayBlend[TIME_DAY];
         gTimeBlend.endBlend = gTimeOfDayBlend[TIME_EVENING];
-        gTimeBlend.weight = TIME_BLEND_WEIGHT(EVENING_HOUR_BEGIN, EVENING_HOUR_END);
+        gTimeBlend.weight = TIME_BLEND_WEIGHT(EVENING_HOUR_BEGIN - 1, EVENING_HOUR_BEGIN);
         gTimeBlend.altWeight = gTimeBlend.weight / 2 + (DEFAULT_WEIGHT / 2);
         gTimeOfDay = TIME_EVENING;
     }
-    else if (IsBetweenHours(hours, NIGHT_HOUR_BEGIN, NIGHT_HOUR_BEGIN + 1)) // evening->night
+    else if (IsBetweenHours(hours, EVENING_HOUR_BEGIN, EVENING_HOUR_END)) // evening->night
     {
         gTimeBlend.startBlend = gTimeOfDayBlend[TIME_EVENING];
         gTimeBlend.endBlend = gTimeOfDayBlend[TIME_NIGHT];
-        gTimeBlend.weight = TIME_BLEND_WEIGHT(NIGHT_HOUR_BEGIN, NIGHT_HOUR_BEGIN + 1);
+        gTimeBlend.weight = TIME_BLEND_WEIGHT(EVENING_HOUR_BEGIN, EVENING_HOUR_END);
         gTimeBlend.altWeight = gTimeBlend.weight / 2;
         gTimeOfDay = TIME_NIGHT;
     }


### PR DESCRIPTION
… shifing to evening

People were complaining that using the debug menu functions to set time of day didn't work properly. It did but the colors shown did not match the "peak" of that time of day which is confusing so we made chanegs to alleviate that.

First: if selecting "morning time", the map will be loaded in the middle of morning instead of the beginning so that the map loads in morning color
Second: Time for palette shifting in the evening have ben adjusted: color will shift from day to evening during the hour before evening starts and shift from evening to night during the evening hour. Thus the beginning of evening will be in evening colors and the beginning of night will be in night colors. when selecting to set the time of day to evening or night, colors will match expectations
Third: We added an option to select any hour of the day and actually show what hour the day the different time of options will bring you 
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->

## Media

Before this commit, colors are confusing when going through timeofday options in debug menu

https://github.com/user-attachments/assets/6dcddaba-38f5-44eb-84a3-329a3cc74c06

And here what is changed in this commit

https://github.com/user-attachments/assets/0a3890ac-00f8-4053-aafb-3ff4a2f6447e


<!--- Add relevant images, GIFs, or videos to help reviewers understand the changes. Remove this section if not applicable. --->

## Issue(s) that this PR fixes
Fixes #7433 
<!-- Format: "Fixes #2345, fixes #4523, closes #2222." Remove this section if not applicable.-->

<!-- CREDITS -->
<!-- Once your PR is submitted, leave a comment asking the bot to add you to the credits. -->
<!-- If anybody helped with this PR, please encourage them to comment on your PR and ask the bot to add them to the credits. -->
<!-- EVERY contribution matters! -->
<!-- https://github.com/rh-hideout/pokeemerald-expansion/wiki/CREDITS.md-Frequently-Asked-Questions -->

## Feature(s) this PR does NOT handle:
<!-- If this PR contains any unfinished and non-blocking work, please list them here for clarity. -->
<!--- Remove this section if not applicable. --->

## Things to note in the release changelog:
- Color will now shift from and to evening colors one hour early. In practice, it means the peak of evening color will happen at the beginning of evening instead of the end and night time will start when night colors are fully blended in
- Added a new action in debug menu to set a specific hour of the day

<!-- Add any important details for the release changelog. Must be structed as bullet points. --->
<!--- Remove this section if not applicable. --->

## Discord contact info
Jamie (foster_harmony)
