### PR TITLE
Setitng wallclock time now properly sets fakeRTC 

### DIFF
--- a/src/overworld.c
+++ b/src/overworld.c
@@ -1795,6 +1795,10 @@ void CB2_NewGame(void)
     SetFieldVBlankCallback();
     SetMainCallback1(CB1_Overworld);
     SetMainCallback2(CB2_Overworld);
+    #if OW_USE_FAKE_RTC
+        //Wall clock now track local time so we set it to 10AM to match intial wall clock time
+        RtcCalcLocalTimeOffset(0, 10, 0, 0);
+    #endif
 }
 
 void CB2_WhiteOut(void)

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -348,6 +348,7 @@ void RtcCalcLocalTimeOffset(s32 days, s32 hours, s32 minutes, s32 seconds)
     gLocalTime.hours = hours;
     gLocalTime.minutes = minutes;
     gLocalTime.seconds = seconds;
+    FakeRtc_ManuallySetTime(gLocalTime.days, gLocalTime.hours, gLocalTime.minutes, seconds);
     RtcGetInfo(&sRtc);
     RtcCalcTimeDifference(&sRtc, &gSaveBlock2Ptr->localTimeOffset, &gLocalTime);
 }

--- a/src/wallclock.c
+++ b/src/wallclock.c
@@ -692,13 +692,13 @@ void CB2_StartWallClock(void)
     DecompressDataWithHeaderVram(gWallClockStart_Tilemap, (u16 *)BG_SCREEN_ADDR(7));
 
     taskId = CreateTask(Task_SetClock_WaitFadeIn, 0);
-    gTasks[taskId].tHours = 10;
-    gTasks[taskId].tMinutes = 0;
+    gTasks[taskId].tHours = gLocalTime.hours;
+    gTasks[taskId].tMinutes = gLocalTime.minutes;
     gTasks[taskId].tMoveDir = 0;
-    gTasks[taskId].tPeriod = 0;
+    gTasks[taskId].tPeriod = gTasks[taskId].tHours / 12;
     gTasks[taskId].tMoveSpeed = 0;
-    gTasks[taskId].tMinuteHandAngle = 0;
-    gTasks[taskId].tHourHandAngle = 300;
+    gTasks[taskId].tMinuteHandAngle = gTasks[taskId].tMinutes * 6;
+    gTasks[taskId].tHourHandAngle = (gTasks[taskId].tHours % 12) * 30 + (gTasks[taskId].tMinutes / 10) * 5;
 
     spriteId = CreateSprite(&sSpriteTemplate_MinuteHand, 120, 80, 1);
     gSprites[spriteId].sTaskId = taskId;


### PR DESCRIPTION
Setting wallclock time now properly sets fakeRTC and other misc wallclock changes
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
#7433 reported some issues with fakertc and wallclock. Setting wallclock time would change local time but not fakeRTC leading to weird effects. This fixes it. 
I also added minor changes: when trying to set the wall clock, it now starts at the current time.
And to compensate, if FakeRtc is activated, new game will start on 10AM 

<!-- Detail the changes made, why they were made, and any important context. -->

## Media
<!--- Add relevant images, GIFs, or videos to help reviewers understand the changes. Remove this section if not applicable. --->

## Issue(s) that this PR fixes
Fixes #7433 (at least the errors I was able to reproduce)
<!-- Format: "Fixes #2345, fixes #4523, closes #2222." Remove this section if not applicable.-->

<!-- CREDITS -->
<!-- Once your PR is submitted, leave a comment asking the bot to add you to the credits. -->
<!-- If anybody helped with this PR, please encourage them to comment on your PR and ask the bot to add them to the credits. -->
<!-- EVERY contribution matters! -->
<!-- https://github.com/rh-hideout/pokeemerald-expansion/wiki/CREDITS.md-Frequently-Asked-Questions -->

## Feature(s) this PR does NOT handle:
I'm not sure if there are no other issues described in #7433 that people experienced but I wasn't able to reproduce anything

## Things to note in the release changelog:
- Fix time bug when setting wallclock in fakeRTC mode
- When setting the wall clock, it will start on current time instead of 10AM
- If FakeRTC is active, new game will start at 10AM

## Discord contact info
Jamie (foster_harmony)
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
