### PR TITLE
Fix some ai action check happening before the logic was computed

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -319,7 +319,7 @@ void BattleAI_SetupAIData(u8 defaultScoreMoves, u32 battler)
     gAiBattleData->chosenTarget[battler] = gBattlerTarget;
 }
 
-bool32 BattlerChooseNonMoveAction()
+bool32 BattlerChooseNonMoveAction(void)
 {
     if (gAiThinkingStruct->aiAction & AI_ACTION_FLEE)
     {


### PR DESCRIPTION
To limit AI computation the check for flee and watch actions was put early but compltely bypass computing the logic for fleeing or watching, resulting in those happening a turn later.
I made sure run only the AI computations regarding fleeing and watching before checking thus fixing the issue of roamer not fleeing in the first turn.

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->

## Media

https://github.com/user-attachments/assets/520fc072-b9a6-4d17-9ccc-da20a96a7288

## Issue(s) that this PR fixes
Fixes #7118 

<!-- CREDITS -->
<!-- Once your PR is submitted, leave a comment asking the bot to add you to the credits. -->
<!-- If anybody helped with this PR, please encourage them to comment on your PR and ask the bot to add them to the credits. -->
<!-- EVERY contribution matters! -->
<!-- https://github.com/rh-hideout/pokeemerald-expansion/wiki/CREDITS.md-Frequently-Asked-Questions -->

## Feature(s) this PR does NOT handle:
<!-- If this PR contains any unfinished and non-blocking work, please list them here for clarity. -->
<!--- Remove this section if not applicable. --->

## Things to note in the release changelog:
- Roamers will now flee in the first turn of battle

## Discord contact info
Jamie
