### PR TITLE
Fixed broken friendship from items in battle test and added new test for opposite case

### DIFF
--- a/include/constants/item_effects.h
+++ b/include/constants/item_effects.h
@@ -93,6 +93,9 @@
 #define ITEM_EFFECT_HEAL_PP 21
 #define ITEM_EFFECT_NONE 22
 
+#define ITEM_FRIENDSHIP_MAPSEC_BONUS  1   // The amount of bonus friendship gained when an item is used on a Pokémon whose met location matches the current map section.
+#define ITEM_FRIENDSHIP_LUXURY_BONUS  1   // The amount of bonus friendship gained when a Pokémon is in the Luxury Ball.
+
 // Since X item stat increases are now handled by battle scripts, the friendship increase effect is now handled by the battle controller in HandleAction_UseItem.
 #define X_ITEM_FRIENDSHIP_INCREASE    1   // The amount of friendship gained by using an X item on a Pokémon in battle.
 #define X_ITEM_MAX_FRIENDSHIP         200 // Friendship threshold at which Pokémon stop receiving a friendship increase from using X items on them in battle.

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -83,6 +83,7 @@ static void EncryptBoxMon(struct BoxPokemon *boxMon);
 static void DecryptBoxMon(struct BoxPokemon *boxMon);
 static void Task_PlayMapChosenOrBattleBGM(u8 taskId);
 void TrySpecialOverworldEvo();
+static void ApplyFriendshipBonuses(struct Pokemon *mon, s32 *friendship);
 
 EWRAM_DATA static u8 sLearningMoveTableID = 0;
 EWRAM_DATA u8 gPlayerPartyCount = 0;
@@ -3709,10 +3710,7 @@ bool8 ExecuteTableBasedItemEffect(struct Pokemon *mon, u16 item, u8 partyIndex, 
             friendship += friendshipChange;                                                             \
         if (friendshipChange > 0)                                                                       \
         {                                                                                               \
-            if (GetMonData(mon, MON_DATA_POKEBALL, NULL) == ITEM_LUXURY_BALL)                           \
-                friendship++;                                                                           \
-            if (GetMonData(mon, MON_DATA_MET_LOCATION, NULL) == GetCurrentRegionMapSectionId())         \
-                friendship++;                                                                           \
+            ApplyFriendshipBonuses(mon,&friendship);                                                    \
         }                                                                                               \
         if (friendship < 0)                                                                             \
             friendship = 0;                                                                             \
@@ -5242,7 +5240,7 @@ void AdjustFriendship(struct Pokemon *mon, u8 event)
     if (species && species != SPECIES_EGG)
     {
         u8 friendshipLevel = 0;
-        s16 friendship = GetMonData(mon, MON_DATA_FRIENDSHIP, 0);
+        s32 friendship = GetMonData(mon, MON_DATA_FRIENDSHIP, 0);
         enum TrainerClassID opponentTrainerClass = GetTrainerClassFromId(TRAINER_BATTLE_PARAM.opponentA);
 
         if (friendship > 99)
@@ -5275,10 +5273,7 @@ void AdjustFriendship(struct Pokemon *mon, u8 event)
         friendship += mod;
         if (mod > 0)
         {
-            if (GetMonData(mon, MON_DATA_POKEBALL, NULL) == ITEM_LUXURY_BALL)
-                friendship++;
-            if (GetMonData(mon, MON_DATA_MET_LOCATION, NULL) == GetCurrentRegionMapSectionId())
-                friendship++;
+            ApplyFriendshipBonuses(mon,&friendship);
         }
 
         if (friendship < 0)
@@ -5288,6 +5283,15 @@ void AdjustFriendship(struct Pokemon *mon, u8 event)
 
         SetMonData(mon, MON_DATA_FRIENDSHIP, &friendship);
     }
+}
+
+static void ApplyFriendshipBonuses(struct Pokemon *mon, s32 *friendship)
+{
+    if (GetMonData(mon, MON_DATA_POKEBALL, NULL) == ITEM_LUXURY_BALL)
+        *friendship += ITEM_FRIENDSHIP_LUXURY_BONUS;
+
+    if (GetMonData(mon, MON_DATA_MET_LOCATION, NULL) == GetCurrentRegionMapSectionId())
+        *friendship += ITEM_FRIENDSHIP_MAPSEC_BONUS;
 }
 
 void MonGainEVs(struct Pokemon *mon, u16 defeatedSpecies)

--- a/test/battle/item_effect/increase_stat.c
+++ b/test/battle/item_effect/increase_stat.c
@@ -282,3 +282,25 @@ SINGLE_BATTLE_TEST("Using X items in battle raises Friendship", s16 damage)
             EXPECT_EQ(player->friendship, X_ITEM_FRIENDSHIP_INCREASE);
     }
 }
+
+SINGLE_BATTLE_TEST("Using X items in battle where Pokemon was met raises Friendship with a bonus", s16 damage)
+{
+    u32 startingFriendship;
+    u8 metLocation = GetCurrentRegionMapSectionId();
+
+    PARAMETRIZE { startingFriendship = 0; }
+    PARAMETRIZE { startingFriendship = X_ITEM_MAX_FRIENDSHIP; }
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Friendship(startingFriendship); };
+        // Set met location to currentMapSec to get the friendship boost
+        SetMonData(&PLAYER_PARTY[0], MON_DATA_MET_LOCATION, &metLocation);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { USE_ITEM(player, ITEM_X_ACCURACY); MOVE(opponent, MOVE_CELEBRATE); }
+    } THEN {
+        if (startingFriendship == X_ITEM_MAX_FRIENDSHIP)
+            EXPECT_EQ(player->friendship, X_ITEM_MAX_FRIENDSHIP);
+        else
+            EXPECT_EQ(player->friendship, (ITEM_FRIENDSHIP_MAPSEC_BONUS + X_ITEM_FRIENDSHIP_INCREASE));
+    }
+}

--- a/test/battle/item_effect/increase_stat.c
+++ b/test/battle/item_effect/increase_stat.c
@@ -1,4 +1,5 @@
 #include "global.h"
+#include "overworld.h"
 #include "test/battle.h"
 #include "constants/item_effects.h"
 
@@ -262,12 +263,13 @@ SINGLE_BATTLE_TEST("Max Mushrooms raises battler's Speed stat", s16 damage)
 SINGLE_BATTLE_TEST("Using X items in battle raises Friendship", s16 damage)
 {
     u32 startingFriendship;
-    u8 metLocation = MAPSEC_NONE;
+    u8 metLocation = GetCurrentRegionMapSectionId() + 1;
+
     PARAMETRIZE { startingFriendship = 0; }
     PARAMETRIZE { startingFriendship = X_ITEM_MAX_FRIENDSHIP; }
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET) { Friendship(startingFriendship); };
-        // Set met location to MAPSEC_NONE to avoid getting the friendship boost
+        // Set met location to currentMapSec + 1 to avoid getting the friendship boost
         // from being met in the current map section
         SetMonData(&PLAYER_PARTY[0], MON_DATA_MET_LOCATION, &metLocation);
         OPPONENT(SPECIES_WOBBUFFET);


### PR DESCRIPTION
## Description
* Fixes #7871 
* Adds a test for the opposite situation - pokemon DOES get the friendship boost
* Removed some duplicate code

## Issue(s) that this PR fixes
* Fixes #7871 

<!-- CREDITS -->
<!-- Once your PR is submitted, leave a comment asking the bot to add you to the credits. -->
<!-- If anybody helped with this PR, please encourage them to comment on your PR and ask the bot to add them to the credits. -->
<!-- EVERY contribution matters! -->
<!-- https://github.com/rh-hideout/pokeemerald-expansion/wiki/CREDITS.md-Frequently-Asked-Questions -->

## Feature(s) this PR does NOT handle:
<!-- If this PR contains any unfinished and non-blocking work, please list them here for clarity. -->
<!--- Remove this section if not applicable. --->
This does not perform any extra friendship cleanup.

## Discord contact info
pkmnsnfrn - discussion started here: https://discord.com/channels/419213663107416084/1077009799293710357/1425133513136541757
