### PR TITLE
Ensure last used ball and move description window sprites don't free palette too early

### DIFF
--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -2970,7 +2970,8 @@ void TryAddLastUsedBallItemSprites(void)
 static void DestroyLastUsedBallWinGfx(struct Sprite *sprite)
 {
     FreeSpriteTilesByTag(TAG_LAST_BALL_WINDOW);
-    FreeSpritePaletteByTag(TAG_ABILITY_POP_UP);
+    if (GetSpriteTileStartByTag(MOVE_INFO_WINDOW_TAG) == 0xFFFF)
+        FreeSpritePaletteByTag(TAG_ABILITY_POP_UP);
     DestroySprite(sprite);
     gBattleStruct->ballSpriteIds[1] = MAX_SPRITES;
 }
@@ -3007,7 +3008,8 @@ void TryToHideMoveInfoWindow(void)
 static void DestroyMoveInfoWinGfx(struct Sprite *sprite)
 {
     FreeSpriteTilesByTag(MOVE_INFO_WINDOW_TAG);
-    FreeSpritePaletteByTag(TAG_ABILITY_POP_UP);
+    if (GetSpriteTileStartByTag(TAG_LAST_BALL_WINDOW) == 0xFFFF)
+        FreeSpritePaletteByTag(TAG_ABILITY_POP_UP);
     DestroySprite(sprite);
     gBattleStruct->moveInfoSpriteId = MAX_SPRITES;
 }


### PR DESCRIPTION
## Description
- The last used ball window and the move description window share a palette and can appear on-screen at the same time. 
- When the move description window sprite is hidden and destroyed, it frees its palette, which shares a palette tag with the last used ball window. 
- This causes the palette to incorrectly change for the last used ball window when the move description window reappears and loads the palette in a new slot.
- I've changed the functions that destroy the two windows to avoid freeing the palette if the other window's spritesheet is loaded. The palette will then be freed by the other one being destroyed later.


## Media

https://github.com/user-attachments/assets/944a144e-7da7-487d-9cf9-ed30697c620a


## Issue(s) that this PR fixes
Fixes #6428 

## Feature(s) this PR does NOT handle:
- Unrelated - I noticed a small graphical glitch with type icons can occur when spamming A and B. Making a separate issue for this.

## Discord contact info
ravepossum
