### PR TITLE
Fix right player position battle partner target display

### DIFF
--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -2002,7 +2002,7 @@ static void PlayerHandleChooseAction(u32 battler)
             else if (gAiBattleData->chosenTarget[B_POSITION_PLAYER_RIGHT] == B_POSITION_PLAYER_LEFT)
                 StringAppend(gStringVar1, COMPOUND_STRING(" {DOWN_ARROW}-"));
             else if (gAiBattleData->chosenTarget[B_POSITION_PLAYER_RIGHT] == B_POSITION_PLAYER_RIGHT)
-                StringAppend(gStringVar1, COMPOUND_STRING(" {DOWN_ARROW}-"));
+                StringAppend(gStringVar1, COMPOUND_STRING(" -{DOWN_ARROW}"));
         }
         else if (moveTarget == MOVE_TARGET_BOTH)
         {


### PR DESCRIPTION
## Description
- Fixes a partner's battle target selection of `B_POSITION_PLAYER_RIGHT` to reflect the correct target when displayed.
- As you can tell from the mon targeting itself with Flame Wheel in the screenshot, I did have to fudge the code a bit to get the partner to select itself. I'm not aware of any vanilla moves that have this functionality, so I didn't think it was possible to test without fudging the move code a bit. If I'm wrong, let me know and I'll re-test,

## Media
<img width="240" height="160" alt="pokeemerald-2" src="https://github.com/user-attachments/assets/537dc501-ec2b-48ac-bd8c-b75957cda4b5" />


## Issue(s) that this PR fixes
Fixes #7491 

## Discord contact info
ravepossum
