### PR TITLE
Fix ShouldPivot overwriting random memory

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -3181,10 +3181,9 @@ enum AIPivot ShouldPivot(u32 battlerAtk, u32 battlerDef, u32 defAbility, u32 mov
         return SHOULD_PIVOT;
 
     battlerToSwitch = gAiLogicData->mostSuitableMonId[battlerAtk];
-    if (battlerToSwitch >= PARTY_SIZE) {
-        // This shouldn't ever happen, but it's there to make sure we don't accidentally read past the gParty array.
+    // This shouldn't ever happen, but it's there to make sure we don't accidentally read past the gParty array.
+    if (battlerToSwitch >= PARTY_SIZE)
         battlerToSwitch = 0;
-    }
     if (PartyBattlerShouldAvoidHazards(battlerAtk, battlerToSwitch))
         return DONT_PIVOT;
 


### PR DESCRIPTION
`gBattleStruct->AI_monToSwitchIntoId[battlerAtk]` was `PARTY_SIZE` which made the `mon` pointer point to `gEnemyParty[6]`.
This was discovered by PCG with LTO on, because it just so conveniently happened that `gBattleMons` were just after `gEnemyParty`. 
Because the battle mon's data was different than pokemon's data, the `GetMonData` treated it like a bad egg and set the bad egg bit, which broke one of the player's battle mon's moves.

Without LTO, I think `gPlayerParty` was the variable after the enemy party. It's possible that the hard-to-reproduce issues where player's party pokemon would randomly turn into bad eggs #2672 were caused by it. Or maybe not, that's just a guess.