### PR TITLE
Fix dns color transition not applying weather blending

### DIFF
--- a/src/overworld.c
+++ b/src/overworld.c
@@ -1716,7 +1716,7 @@ static void OverworldBasic(void)
          || bld0[1] != bld1[1]
          || bld0[2] != bld1[2])
         {
-            ApplyWeatherColorMapIfIdle(gWeatherPtr->colorMapIndex);
+           ApplyWeatherColorMapIfIdle(gWeatherPtr->colorMapIndex);
         }
     }
 }


### PR DESCRIPTION
Maps with some weather effect like PetalburgWoods with weather_shade would not apply their effects properly when dns was active. It would apply it on map transition but after that, when time has passed to update the color palette, it would not apply the weather effect. This PR makes sure the weather effect is properly applied when DNS is updating the color palette.

## Media
In #7016, you can see a video of the woods suddenly becoming brighter when the palette update. I made a video recreating the situation in this commit where ut's teh evening and the screen become darker when the color transition happen:

https://github.com/user-attachments/assets/2140e52e-c524-40de-874e-4fff35c1dcc7


## Issue(s) that this PR fixes
Fixes #7016 and #7176 

<!-- CREDITS -->
<!-- Once your PR is submitted, leave a comment asking the bot to add you to the credits. -->
<!-- If anybody helped with this PR, please encourage them to comment on your PR and ask the bot to add them to the credits. -->
<!-- EVERY contribution matters! -->
<!-- https://github.com/rh-hideout/pokeemerald-expansion/wiki/CREDITS.md-Frequently-Asked-Questions -->


## Things to note in the release changelog:
- DNS colors should apply properly in maps with weather effects that modify colors (please report any issue you may still find)

## Discord contact info
Jamie (foster_harmony)
