### PR TITLE
Remove unnecessary EWRAM and IWRAM variables from the Window code

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -5,8 +5,6 @@
 #include "blit.h"
 #include "decompress.h"
 
-// This global is set to 0 and never changed.
-COMMON_DATA u8 gTransparentTileNumber = 0;
 COMMON_DATA void *gWindowBgTilemapBuffers[NUM_BACKGROUNDS] = {0};
 extern u32 gWindowTileAutoAllocEnabled;
 
@@ -101,7 +99,6 @@ bool32 InitWindows(const struct WindowTemplate *templates)
         }
     }
 
-    gTransparentTileNumber = 0;
     return TRUE;
 }
 
@@ -373,7 +370,7 @@ void ClearWindowTilemap(u32 windowId)
 
     FillBgTilemapBufferRect(
         windowLocal.window.bg,
-        gTransparentTileNumber,
+        0,
         windowLocal.window.tilemapLeft,
         windowLocal.window.tilemapTop,
         windowLocal.window.width,


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
Removes a few variables whose values weren't used or they didn't needed to be on the static memory at all.

`CopyWindowToVram8Bit` is only used by the multi selection option in the PC, functionality which seems to be working fine after the changes. 

This reduces Ewram y usage by 4 bytes and Iwram usage by 1 byte.
Ain't much but it's honest work.

## Media
![pc](https://github.com/user-attachments/assets/943c294c-fa9d-482c-87ac-516cbb9e806a)

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
estellar.cheese
