### PR TITLE
Adds missing breakable flag for Bulletproof

### DIFF
--- a/src/data/abilities.h
+++ b/src/data/abilities.h
@@ -1286,7 +1286,7 @@ const struct Ability gAbilitiesInfo[ABILITIES_COUNT] =
     {
         .name = _("Bulletproof"),
         .description = COMPOUND_STRING("Avoids some projectiles."),
-        .breakable = TRUE
+        .breakable = TRUE,
         .aiRating = 7,
     },
 


### PR DESCRIPTION
The flag was missing. We should cross check this with official sources at some point. 

I think Game Freak uses an `unbreakable` flag which we should honestly switch to, to make things easier.
