### PR TITLE
Show convergent evolution to Gholdengo in HGSS dex

### DIFF
--- a/src/pokedex_plus_hgss.c
+++ b/src/pokedex_plus_hgss.c
@@ -6311,11 +6311,15 @@ static void HandlePreEvolutionSpeciesPrint(u8 taskId, u16 preSpecies, u16 specie
     }
 }
 
-static bool32 HasMultiplePreEvolutions(u32 species)
+static bool32 HasTwoPreEvolutions(u32 species)
 {
-    if (species == SPECIES_GHOLDENGO)
-        return TRUE;
-    return FALSE;
+    switch (species)
+    {
+        case SPECIES_GHOLDENGO:
+            return TRUE;
+        default:
+            return FALSE;
+    }
 }
 
 static u8 PrintPreEvolutions(u8 taskId, u16 species)
@@ -6373,7 +6377,7 @@ static u8 PrintPreEvolutions(u8 taskId, u16 species)
                 {
                     preEvolutionOne = i;
                     numPreEvolutions += 1;
-                    if (!HasMultiplePreEvolutions(species))
+                    if (!HasTwoPreEvolutions(species))
                         break;
                 }
                 else
@@ -6386,7 +6390,7 @@ static u8 PrintPreEvolutions(u8 taskId, u16 species)
         }
     }
 
-    if (HasMultiplePreEvolutions(species))
+    if (HasTwoPreEvolutions(species))
     {
         CreateCaughtBallEvolutionScreen(preEvolutionOne, base_x - 9, base_y + base_y_offset*0, 0);
         HandlePreEvolutionSpeciesPrint(taskId, preEvolutionOne, species, base_x, base_y, base_y_offset, 0);


### PR DESCRIPTION
HGSS dex didn't show both ghimiggoul forms as gholdengo pre-evolutions.
I added some support to show an additional pre-evolution but the code is very catered to Gholdengo case.
This is because full-fledge support for convergent evolution feel out of scope for a bugfix around a vanilla mechanic

## Media
<img width="240" height="160" alt="pokeemerald-2" src="https://github.com/user-attachments/assets/81df49e5-0137-4754-8b0b-543c0df0ccda" />


## Issue(s) that this PR fixes
Fix #6084 

## Feature(s) this PR does NOT handle:
Convergent evolutions are not fully supported but so are evo lines with more than 3 members.
There is a discussion to be had about the extent to which we want to support more complex evolution families that what exists in official games.
Detecting non-supported evolution families could be added to a test to warn developpers


## Things to note in the release changelog:
<!-- Add any important details for the release changelog. Must be structed as bullet points. --->
<!--- Remove this section if not applicable. --->

## Discord contact info
Jame
