### PR TITLE
Fix bug causing hgss dex to freeze

### DIFF
--- a/src/pokedex_plus_hgss.c
+++ b/src/pokedex_plus_hgss.c
@@ -2421,6 +2421,8 @@ static bool8 LoadPokedexListPage(u8 page)
             // when returning to search results after selecting an evo, we have to restore
             // the original dexNum because the search results page doesn't rebuild the list
             sPokedexListItem->dexNum = sPokedexView->originalSearchSelectionNum;
+            sPokedexListItem->seen   = GetSetPokedexFlag(sPokedexView->originalSearchSelectionNum, FLAG_GET_SEEN);
+            sPokedexListItem->owned  = GetSetPokedexFlag(sPokedexView->originalSearchSelectionNum, FLAG_GET_CAUGHT);
             sPokedexView->originalSearchSelectionNum = 0;
         }
         CreateMonSpritesAtPos(sPokedexView->selectedPokemon, 0xE);


### PR DESCRIPTION
## Description
When checking an evolution info in the evo screen. The pointer the currently selected list item is modified so that it can show info about the right pokemon. There was a piece of code supposed to put back the selected item list to the right value but it didn't change the seen and caught flags. So if you moved from a caught mon to a seen mon, it would "remove" the caught flag from the pokemon (thus causing the pokeball disappear)

Normally the area screen doesn't let you move to the stats screen if a mon is seen but not caught but different parts of are screen code checks different version of the flags, one recalculate the flag based on the species and one checks the value of the listitem. Because the two flags don't match, it cuses the freeze bug where the area screen is allowed to fadeout but the stats screen is not allowed to fade in.

I simply make the seen and caught flags of the selected item pointer are resetted to their proper value which prevents the bug from happening 

## Media
I reproduced the steps in the issue and it works now:

https://github.com/user-attachments/assets/42fbb397-d4ac-40c9-bd17-543d1cd7abd4



## Issue(s) that this PR fixes
Fixes #6546


## Feature(s) this PR does NOT handle:
<!-- If this PR contains any unfinished and non-blocking work, please list them here for clarity. -->
<!--- Remove this section if not applicable. --->

## Things to note in the release changelog:
- Fix a bug when checking evolutions info screen while search mode is active in the hgss dex

## Discord contact info
Jamie
