### PR TITLE
Fix volt tackle not inflicting recoil

### DIFF
--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -9079,7 +9079,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
             "A life-risking tackle that\n"
             "slightly hurts the user."),
         #endif
-        .effect = EFFECT_HIT,
+        .effect = EFFECT_RECOIL,
         .power = 120,
         .type = TYPE_ELECTRIC,
         .accuracy = 100,


### PR DESCRIPTION
Test used
```
SINGLE_BATTLE_TEST("Volt tackle")
{
    GIVEN {
        PLAYER(SPECIES_PIKACHU);
        OPPONENT(SPECIES_WOBBUFFET);
    } WHEN {
        TURN { MOVE(player, MOVE_VOLT_TACKLE); }
    } THEN {
        EXPECT_LT(player->hp, player->maxHP);
    }
}
```

## Description
<!-- Detail the changes made, why they were made, and any important context. -->

## Media
Master (same video as issue):

https://github.com/user-attachments/assets/b310ee31-bcfa-4e36-8166-3f4c1fbf0fa1

This commit:

https://github.com/user-attachments/assets/9869e4ad-eb40-4c37-bc88-e629343f45b8



## Issue(s) that this PR fixes
Fixes #7943


## Discord contact info
Jamie
