### PR TITLE
Fix image links in doc site

### DIFF
--- a/docs/fix_links.py
+++ b/docs/fix_links.py
@@ -36,6 +36,7 @@ def proc_items(items):
             s = s.replace('](README.md)', '](./)')
             s = s.replace('](/INSTALL.md', '](INSTALL.md')
             s = s.replace('](docs/', '](')
+            s = s.replace('](/docs/', '](/')
             s = URL_RE.sub(handle_url, s)
             item['Chapter']['content'] = ANCHOR_RE.sub(handle_anchor, s)
             proc_items(item['Chapter']['sub_items'])


### PR DESCRIPTION
## Description
Several documentation tutorials are intended to have images. These images are correctly linked when viewing in the github code tree. However, since the root of the doc site is not the same as the root of the repository, those root-relative links do not point to existing images in the docs site.

This adds a rule to the `fix_links.py` preprocessor to also modify these these root-relative image links to account for the different root.

## Media

### Before

![In the dns faq, immediately after the "How do I make lightbulbs glow" header, is text - the alt text of two images](https://github.com/user-attachments/assets/a0abe6d4-1dd6-41fd-9421-d7951be090d0)

### After

![In the dns faq, immediately after the "How do I make lightbulbs glow" header, are a pair of images](https://github.com/user-attachments/assets/cb6c004f-3c4a-4983-be6f-e286ffc7a0ee)

## Discord contact info
yoshord
