### PR TITLE
Fix incorrect font width in Dexnav search window hiding some elements

### DIFF
--- a/src/dexnav.c
+++ b/src/dexnav.c
@@ -472,8 +472,8 @@ static void AddSearchWindow(u8 width)
 }
 
 #define WINDOW_COL_0        (SPECIES_ICON_X + 4)
-#define WINDOW_COL_1        (WINDOW_COL_0 + (GetFontAttribute(sDexNavSearchDataPtr->windowId, FONTATTR_MAX_LETTER_WIDTH) * (POKEMON_NAME_LENGTH)))
-#define WINDOW_MOVE_NAME_X  (WINDOW_COL_1 + (GetFontAttribute(sDexNavSearchDataPtr->windowId, FONTATTR_MAX_LETTER_WIDTH) * 6))
+#define WINDOW_COL_1        (WINDOW_COL_0 + (GetFontAttribute(FONT_SMALL, FONTATTR_MAX_LETTER_WIDTH) * (POKEMON_NAME_LENGTH)))
+#define WINDOW_MOVE_NAME_X  (WINDOW_COL_1 + (GetFontAttribute(FONT_SMALL, FONTATTR_MAX_LETTER_WIDTH) * 6))
 #define SEARCH_ARROW_X      (WINDOW_MOVE_NAME_X + 90)
 #define SEARCH_ARROW_Y      0
 


### PR DESCRIPTION
## Description
### Commit 1
I replaced all fontId magic numbers with the appropriate enum value, 0 => FONT_SMALL and 1 => FONT_NORMAL (this doesn't change anything in the compiled ROM)

### Commit 2
GetFontAttribute first argument is supposed to be a fontId but here it takes a windowId. I'm not sure if it's because the function used to work differently or what but changing the argument to the font used in the window allow all elements to appear correctly

## Media
master:
<img width="240" height="160" alt="pokeemerald-4" src="https://github.com/user-attachments/assets/4538f91a-05cd-42a5-bf9d-2a5484265358" />
This commit:
<img width="240" height="160" alt="pokeemerald-3" src="https://github.com/user-attachments/assets/948305a2-3025-45c1-8aa5-ccfcecfb3ccf" />



## Issue(s) that this PR fixes
Fixes #6393 

<!-- CREDITS -->
<!-- Once your PR is submitted, leave a comment asking the bot to add you to the credits. -->
<!-- If anybody helped with this PR, please encourage them to comment on your PR and ask the bot to add them to the credits. -->
<!-- If somebody has contributed at any point and has indicated they wish to be credited, please ask the bot to add them to the credits. If they do not have a known GitHub account, add them to the list at bottom of `CREDITS.md`. -->
<!-- EVERY contribution matters! -->
<!-- https://github.com/rh-hideout/pokeemerald-expansion/wiki/CREDITS.md-Frequently-Asked-Questions -->


## Discord contact info
Jamie
