### PR TITLE
Clean up follow up for AtkCanceller refactor

### DIFF
--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -173,8 +173,9 @@ struct BattleContext
     u32 battlerAtk:3;
     u32 battlerDef:3;
     u32 currentMove:16;
-    enum BattleMoveEffects moveEffect:10;
-    enum Ability ability[MAX_BATTLERS_COUNT];
+    u32 padding:10;
+    enum Ability abilities[MAX_BATTLERS_COUNT];
+    enum HoldEffect holdEffects[MAX_BATTLERS_COUNT];
 };
 
 enum SleepClauseBlock


### PR DESCRIPTION
Clean up follow up for #7698

I've noticed that all our ability arrays are named `abilities` so I changed that, included holdEffects already since they will be needed and remove the `moveEffect` field because it's pointless. It's free to get the move effect and it is only needed in a few cases. 