### PR TITLE
Fix Knock Off not being restored and Wild Battles

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -5694,6 +5694,7 @@ static bool32 HandleMoveEndMoveBlock(u32 moveEffect)
         return FALSE;
 
     u32 effect = FALSE;
+    u32 side = GetBattlerSide(gBattlerTarget);
     switch (moveEffect)
     {
     case EFFECT_KNOCK_OFF:
@@ -5701,9 +5702,8 @@ static bool32 HandleMoveEndMoveBlock(u32 moveEffect)
          && gBattleMons[gBattlerTarget].item != ITEM_NONE
          && IsBattlerTurnDamaged(gBattlerTarget)
          && IsBattlerAlive(gBattlerAttacker)
-         && !(B_KNOCK_OFF_REMOVAL >= GEN_5 && !(gBattleTypeFlags & BATTLE_TYPE_TRAINER)))
+         && !(B_KNOCK_OFF_REMOVAL >= GEN_5 && side == B_SIDE_PLAYER && !(gBattleTypeFlags & BATTLE_TYPE_TRAINER)))
         {
-            u32 side = GetBattlerSide(gBattlerTarget);
             gLastUsedItem = gBattleMons[gBattlerTarget].item;
             gBattleMons[gBattlerTarget].item = 0;
             if (gBattleMons[gBattlerTarget].ability != ABILITY_GORILLA_TACTICS)
@@ -5878,7 +5878,7 @@ static bool32 HandleMoveEndMoveBlock(u32 moveEffect)
         }
         break;
     case EFFECT_STONE_AXE:
-        if (!IsHazardOnSide(GetBattlerSide(gBattlerTarget), HAZARDS_STEALTH_ROCK)
+        if (!IsHazardOnSide(side, HAZARDS_STEALTH_ROCK)
          && IsBattlerTurnDamaged(gBattlerTarget)
          && IsBattlerAlive(gBattlerAttacker))
         {
@@ -5889,7 +5889,7 @@ static bool32 HandleMoveEndMoveBlock(u32 moveEffect)
         }
         break;
     case EFFECT_CEASELESS_EDGE:
-        if (gSideTimers[GetBattlerSide(gBattlerTarget)].spikesAmount < 3
+        if (gSideTimers[side].spikesAmount < 3
          && IsBattlerTurnDamaged(gBattlerTarget)
          && IsBattlerAlive(gBattlerAttacker))
         {

--- a/test/battle/move_effect/knock_off.c
+++ b/test/battle/move_effect/knock_off.c
@@ -10,17 +10,26 @@ WILD_BATTLE_TEST("Knock Off does not remove item when used by Wild Pokemon (Gen 
 {
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_LEFTOVERS); }
-        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_EVIOLITE); }
     } WHEN {
         TURN { MOVE(opponent, MOVE_KNOCK_OFF); }
+        TURN { MOVE(player, MOVE_KNOCK_OFF); }
     } SCENE {
+        // Turn 1
         ANIMATION(ANIM_TYPE_MOVE, MOVE_KNOCK_OFF, opponent);
         if (B_KNOCK_OFF_REMOVAL >= GEN_5)
             NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ITEM_KNOCKOFF, player);
         else
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ITEM_KNOCKOFF, player);
+        // Turn 2
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_KNOCK_OFF, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ITEM_KNOCKOFF, opponent);
     } THEN {
         EXPECT(player->item == ITEM_LEFTOVERS);
+        if (B_KNOCK_OFF_REMOVAL >= GEN_5)
+            EXPECT(opponent->item == ITEM_NONE);
+        else
+            EXPECT(opponent->item == ITEM_EVIOLITE);
     }
 }
 


### PR DESCRIPTION
Fixes #7914 by:
1. Wild Pokemon cannot knock off player items (Gen 5+)
2. Knocked off items are restored after battle regardless of `B_RESTORE_HELD_BATTLE_ITEMS` value