### PR TITLE
Fix Persim Berry battle usage

### DIFF
--- a/src/data/items.h
+++ b/src/data/items.h
@@ -9826,7 +9826,7 @@ const struct Item gItemsInfo[] =
             "heals confusion\n"
             "in battle."),
         .pocket = POCKET_BERRIES,
-        .type = ITEM_USE_BAG_MENU,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
         .battleUsage = EFFECT_ITEM_CURE_STATUS,
         .effect = gItemEffect_PersimBerry,


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
Persim Berry had incorrect type, which made it not work as intended in battle.
Using it on a battler that's not statused or on an inactive mon works as expected (error message and return to bag).

Fix originally provided by Wiz1989 in the linked issue

## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, closes #2222." Remove this section if not applicable.-->
Fixes #6094 

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara