### PR TITLE
Fix no_effect script command overwriting trainer data in trainer script

### DIFF
--- a/src/trainer_see.c
+++ b/src/trainer_see.c
@@ -429,7 +429,7 @@ bool8 CheckForTrainersWantingBattle(void)
 
 static u8 CheckTrainer(u8 objectEventId)
 {
-    const u8 *scriptPtr, *trainerBattlePtr;
+    const u8 *trainerBattlePtr;
     u8 numTrainers = 1;
 
     u8 approachDistance = GetTrainerApproachDistance(&gObjectEvents[objectEventId]);
@@ -438,13 +438,13 @@ static u8 CheckTrainer(u8 objectEventId)
 
     if (InTrainerHill() == TRUE)
     {
-        trainerBattlePtr = scriptPtr = GetTrainerHillTrainerScript();
+        trainerBattlePtr = GetTrainerHillTrainerScript();
     }
     else
     {
-        trainerBattlePtr = scriptPtr = GetObjectEventScriptPointerByObjectEventId(objectEventId);
+        trainerBattlePtr = GetObjectEventScriptPointerByObjectEventId(objectEventId);
         struct ScriptContext ctx;
-        if (RunScriptImmediatelyUntilEffect(SCREFF_V1 | SCREFF_SAVE | SCREFF_HARDWARE | SCREFF_TRAINERBATTLE, scriptPtr, &ctx))
+        if (RunScriptImmediatelyUntilEffect(SCREFF_V1 | SCREFF_SAVE | SCREFF_HARDWARE | SCREFF_TRAINERBATTLE, trainerBattlePtr, &ctx))
         {
             if (*ctx.scriptPtr == 0x5c) // trainerbattle
                 trainerBattlePtr = ctx.scriptPtr;
@@ -492,7 +492,7 @@ static u8 CheckTrainer(u8 objectEventId)
     }
 
     gApproachingTrainers[gNoOfApproachingTrainers].objectEventId = objectEventId;
-    gApproachingTrainers[gNoOfApproachingTrainers].trainerScriptPtr = scriptPtr;
+    gApproachingTrainers[gNoOfApproachingTrainers].trainerScriptPtr = trainerBattlePtr;
     gApproachingTrainers[gNoOfApproachingTrainers].radius = approachDistance;
     InitTrainerApproachTask(&gObjectEvents[objectEventId], approachDistance - 1);
     gNoOfApproachingTrainers++;


### PR DESCRIPTION

## Description
in some cases, the code in trainer_see would assign the wrong pointer as trainerScriptPtr. trainerScriptPtr need to be equal to the pointer of the trainerbattlecommand but it was sommetimes assigned a pointer to the beginning of the trainer script
If the trainer script start with the trainerbattle command, the values would be equal and there would be no effect>
If the trainer script contains a command with an effect (like `msgbox`) before the trainerbattle command. The script would be treated as a non-battle script and there would be no issue
But if the commands before trainerbattle are classified as "no effect", the trainerScriptPtr would point to them instead of the trainerbattle command and read the wrong value

While not necessary for the bugfix, i removed the variable `u8 *scriptPtr` in `static u8 CheckTrainer(u8 objectEventId)` because it was unused. It was supposed to be used to make the distinction between the pointer to the beginning of the script and the pointer to the trainerbattle command but I don't think it made thing clearer.

I use a similar setup as descriped in #6515 for my video examples. Except I used this Youngster script:
```
Route101_EventScript_Youngster::
	goto_if_unset FLAG_BADGE01_GET, Route101_EventScript_Youngster2
	trainerbattle_single TRAINER_CALVIN_1, Route102_Text_CalvinIntro, Route102_Text_CalvinDefeated
	msgbox Route101_Text_TakeTiredPokemonToPokeCenter, MSGBOX_AUTOCLOSE
	end
```
because it modifies trainer data without crashing making recording easier

## Media

https://github.com/user-attachments/assets/9bb8dc16-ba71-4d2d-accc-91e7d27c45bd


https://github.com/user-attachments/assets/4b216239-3a0a-4852-80b3-bd8264799546



## Issue(s) that this PR fixes
Fixes #6515


## Feature(s) this PR does NOT handle:
<!-- If this PR contains any unfinished and non-blocking work, please list them here for clarity. -->
<!--- Remove this section if not applicable. --->

## Things to note in the release changelog:
- Fixes some commands in trainer script causing trainer data to be overwritten (and sometimes making the game crash)

## Discord contact info
Jamie (foster_harmony)
