### PR TITLE
Fix unhandled config in hgss dex

### DIFF
--- a/src/pokedex_plus_hgss.c
+++ b/src/pokedex_plus_hgss.c
@@ -5106,7 +5106,14 @@ static bool8 CalculateMoves(void)
 static u16 GetSelectedMove(u32 species, u32 selected)
 {
     if (selected < sPokedexView->numEggMoves)
-        return GetSpeciesEggMoves(species)[selected];
+    {
+        if (!HGSS_SHOW_EGG_MOVES_FOR_EVOS)
+            return GetSpeciesEggMoves(species)[selected];
+        u16 preSpecies = species;
+        while (GetSpeciesPreEvolution(preSpecies) != SPECIES_NONE)
+            preSpecies = GetSpeciesPreEvolution(preSpecies);
+        return GetSpeciesEggMoves(preSpecies)[selected];
+    }
     selected -= sPokedexView->numEggMoves;
     if (selected < sPokedexView->numLevelUpMoves)
         return GetSpeciesLevelUpLearnset(species)[selected].move;


### PR DESCRIPTION
I forgot to handle the `HGSS_SHOW_EGG_MOVES_FOR_EVOS` config when refactoring hgss dex movelist so this adds it back.

Thanks to PCG for noticing and helping with the fix.

## Discord contact info
Jamie