### PR TITLE
Fixes AI seeing Last Resort as unusable when usable and vice-versa

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -416,7 +416,7 @@ u32 BattleAI_ChooseMoveIndex(u32 battler)
     if (gBattleStruct->gimmick.usableGimmick[battler] == GIMMICK_TERA && (gAiThinkingStruct->aiFlags[battler] & AI_FLAG_SMART_TERA))
         DecideTerastal(battler);
 
-    chosenMoveIndex = ChooseMoveOrAction(battler);
+    gCurrMovePos = gChosenMovePos = chosenMoveIndex = ChooseMoveOrAction(battler);
 
     if (gBattleStruct->gimmick.usableGimmick[battler] != GIMMICK_NONE)
         ReconsiderGimmick(battler, gBattlerTarget, gBattleMons[battler].moves[chosenMoveIndex]);
@@ -603,6 +603,7 @@ static void CalcBattlerAiMovesData(struct AiLogicData *aiData, u32 battlerAtk, u
         if (IsMoveUnusable(moveIndex, move, moveLimitations))
             continue;
 
+        gCurrMovePos = gChosenMovePos = moveIndex;
         // Also get effectiveness of status moves
         dmg = AI_CalcDamage(move, battlerAtk, battlerDef, &effectiveness, USE_GIMMICK, NO_GIMMICK, weather);
         aiData->moveAccuracy[battlerAtk][battlerDef][moveIndex] = Ai_SetMoveAccuracy(aiData, battlerAtk, battlerDef, move);

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -4913,6 +4913,7 @@ void DecideTerastal(u32 battler)
 
     for (int i = 0; i < MAX_MON_MOVES; i++)
     {
+        gCurrMovePos = gChosenMovePos = i;
         if (!IsMoveUnusable(i, aiMoves[i], gAiLogicData->moveLimitations[battler]) && !IsBattleMoveStatus(aiMoves[i]))
             altCalcs.dealtWithoutTera[i] = AI_CalcDamage(aiMoves[i], battler, opposingBattler, &effectiveness, NO_GIMMICK, NO_GIMMICK, AI_GetWeather());
         else


### PR DESCRIPTION
Since `gCurrMovePos` was not updated in the AI calcs, it would use the last battler's values. This would result in a random move being skipped when checking if Last Resort can be used in `CanUseLastResort` (in `battle_script_commands.c`), instead of skipping Last Resort's move slot. Therefore the AI could potentially see Last Resort as an unusable move after using all moves.

Might fix some Known Failing tests in `upcoming`, but the issue also exists in `master`.

## Issue(s) that this PR fixes
Fixes #7920

## Discord contact info
PhallenTree