### PR TITLE
Fixes visual glitch after Misty Explosion

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -5839,6 +5839,7 @@ static bool32 HandleMoveEndMoveBlock(u32 moveEffect)
         }
         break;
     case EFFECT_EXPLOSION:
+    case EFFECT_MISTY_EXPLOSION:
         if (!IsAbilityOnField(ABILITY_DAMP))
         {
             gBattleStruct->moveDamage[gBattlerAttacker] = 0;


### PR DESCRIPTION
Before:
<img width="240" height="160" alt="pokeemerald-test-0" src="https://github.com/user-attachments/assets/568ccab0-3f63-45d3-b70d-18bd2ae01b76" />

After:
<img width="240" height="160" alt="pokeemerald-test-1" src="https://github.com/user-attachments/assets/38190a6a-22cd-40bc-80d5-05923443d5bf" />
