### PR TITLE
Remova faulty battler assignment in BS_CopyFoesStatIncrease

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -15941,7 +15941,6 @@ void BS_CopyFoesStatIncrease(void)
                 SET_STATCHANGER(stat + 1, gQueuedStatBoosts[battler].statChanges[stat], FALSE);
 
             gQueuedStatBoosts[battler].stats &= ~(1 << stat);
-            gBattlerTarget = battler;
             gBattlescriptCurrInstr = cmd->nextInstr;
             return;
         }


### PR DESCRIPTION
Since we now pass an argument to `statbuffchange` we don't need this anymore. It also caused a mutation. 