### PR TITLE
Fixed test "Revival Blessing cannot revive a partner's party member"

### DIFF
--- a/test/battle/move_effect/revival_blessing.c
+++ b/test/battle/move_effect/revival_blessing.c
@@ -71,7 +71,7 @@ AI_MULTI_BATTLE_TEST("Revival Blessing cannot revive a partner's party member")
         MULTI_OPPONENT_B(SPECIES_WYNAUT) { HP(0); }
         MULTI_OPPONENT_B(SPECIES_WYNAUT);
     } WHEN {
-            TURN { EXPECT_MOVE(playerRight, move2); } // EXPECT_MOVE makes battler2 AI-controlled
+        TURN { EXPECT_MOVE(playerRight, move2); } // EXPECT_MOVE makes battler2 AI-controlled
     } SCENE {
         if (user == opponentLeft) {
             MESSAGE("The opposing Wobbuffet used Revival Blessing!");


### PR DESCRIPTION
Fixes `DOUBLE_BATTLE_TEST("Revival Blessing cannot revive a partner's party member")` by using `AI_MULTI_BATTLE_TEST("Revival Blessing cannot revive a partner's party member")`. 

## Description
Previous test setup failed due to trying to force an illegal action. Rewritten as an AI multi test to implicitly prove case based on move failures and chosen index when successful

## Discord contact info
grintoul