### PR TITLE
Fix light flickering when different types of light sprite are present

### DIFF
--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -2627,37 +2627,29 @@ void UpdateLightSprite(struct Sprite *sprite)
         return;
     }
 
-    // Note: Don't set window registers during hardware fade!
-    switch (sprite->sLightType)
+    if (sprite->sLightType == LIGHT_TYPE_BALL)
     {
-    default:
-    case LIGHT_TYPE_BALL:
         if (gPaletteFade.active) // if palette fade is active, don't flicker since the timer won't be updated
         {
-            Weather_SetBlendCoeffs(7, BASE_SHADOW_INTENSITY);
             sprite->invisible = FALSE;
         }
         else if (gPlayerAvatar.tileTransitionState)
         {
-            Weather_SetBlendCoeffs(7, BASE_SHADOW_INTENSITY); // As long as the second coefficient stays 12, shadows will not change
             sprite->invisible = FALSE;
             if (GetSpritePaletteTagByPaletteNum(sprite->oam.paletteNum) == OBJ_EVENT_PAL_TAG_LIGHT_2)
                 LoadSpritePaletteInSlot(&sObjectEventSpritePalettes[FindObjectEventPaletteIndexByTag(OBJ_EVENT_PAL_TAG_LIGHT)], sprite->oam.paletteNum);
         }
         else if ((sprite->invisible = gTimeUpdateCounter & 1))
         {
-            Weather_SetBlendCoeffs(7, BASE_SHADOW_INTENSITY);
             sprite->invisible = FALSE;
             if (GetSpritePaletteTagByPaletteNum(sprite->oam.paletteNum) == OBJ_EVENT_PAL_TAG_LIGHT_2)
                 LoadSpritePaletteInSlot(&sObjectEventSpritePalettes[FindObjectEventPaletteIndexByTag(OBJ_EVENT_PAL_TAG_LIGHT)], sprite->oam.paletteNum);
         }
-        break;
-    case LIGHT_TYPE_PKMN_CENTER_SIGN:
-    case LIGHT_TYPE_POKE_MART_SIGN:
-        Weather_SetBlendCoeffs(12, BASE_SHADOW_INTENSITY);
+    } else {
         sprite->invisible = FALSE;
-        break;
     }
+    // Note: Don't set window registers during hardware fade!
+    Weather_SetBlendCoeffs(7, BASE_SHADOW_INTENSITY);
 }
 
 // Spawn a light at a map coordinate


### PR DESCRIPTION
Light intensity is determined by the alpha value set in the GBA registers. When two light sprites with different light intensity appear on the same screen, it creates some flickering so we set all light sprites to the same intensity to avoid that.

Alternative solutions:
https://discord.com/channels/419213663107416084/774393519569502268/1431481573894656151

## Media
Master:

https://github.com/user-attachments/assets/f939a10e-11ae-474d-9312-8d12dcab9c94

This commit:

https://github.com/user-attachments/assets/fb1ad077-f056-4df7-a732-94d8cd8a1f5f


## Issue(s) that this PR fixes
Fix #7088


## Things to note in the release changelog:
- Light intensity of neon signs was reduced to avoid conflicts with other light sources
- Fix flickering when both neon signs and light ball are present on screen

## Discord contact info
Jamie
