### PR TITLE
Fix battle arena counting all judges loss for the opponent

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -17100,11 +17100,14 @@ void BS_ArenaJudgmentWindow(void)
     gBattlescriptCurrInstr = cmd->nextInstr;
 }
 
-static void SetArenMonLostValues(u32 battler)
+static void SetArenMonLostValues(u32 battler, u32 side)
 {
     gBattleMons[battler].hp = 0;
     gHitMarker |= HITMARKER_FAINTED(battler);
-    gBattleStruct->arenaLostOpponentMons |= 1u << gBattlerPartyIndexes[battler];
+    if (side == B_SIDE_PLAYER)
+        gBattleStruct->arenaLostPlayerMons |= 1u << gBattlerPartyIndexes[battler];
+    else
+        gBattleStruct->arenaLostOpponentMons |= 1u << gBattlerPartyIndexes[battler];
     gDisableStructs[battler].truantSwitchInHack = TRUE;
 }
 
@@ -17113,22 +17116,22 @@ static void SetArenMonLostValues(u32 battler)
 void BS_ArenaOpponentMonLost(void)
 {
     NATIVE_ARGS();
-    SetArenMonLostValues(opponentMon);
+    SetArenMonLostValues(opponentMon, B_SIDE_OPPONENT);
     gBattlescriptCurrInstr = cmd->nextInstr;
 }
 
 void BS_ArenaPlayerMonLost(void)
 {
     NATIVE_ARGS();
-    SetArenMonLostValues(playerMon);
+    SetArenMonLostValues(playerMon, B_SIDE_PLAYER);
     gBattlescriptCurrInstr = cmd->nextInstr;
 }
 
 void BS_ArenaBothMonsLost(void)
 {
     NATIVE_ARGS();
-    SetArenMonLostValues(playerMon);
-    SetArenMonLostValues(opponentMon);
+    SetArenMonLostValues(playerMon, B_SIDE_PLAYER);
+    SetArenMonLostValues(opponentMon, B_SIDE_OPPONENT);
     gBattlescriptCurrInstr = cmd->nextInstr;
 }
 #undef playerMon


### PR DESCRIPTION
The function that records which pokemon did the referee gave a loss to didn't take into account the pokemon side thus always recording the loss for the non-player pokemon. 

## Media
Both videos are done with both my other mons dead and should result in victory for the opponent
Master:

https://github.com/user-attachments/assets/efd4ab0f-b2f9-4f3d-b52f-81ae71d811b9

This commit:

https://github.com/user-attachments/assets/a32a3da8-4493-4527-9709-e190edada03e

## Issue(s) that this PR fixes
Fixes #8044

## Things to note in the release changelog:
- Fix battle arena referees giving undeserved wins to the player

## Discord contact info
Jamie