### PR TITLE
Fix pc turning on/off animation not working in battle frontier

### DIFF
--- a/src/field_specials.c
+++ b/src/field_specials.c
@@ -61,7 +61,6 @@
 #include "constants/field_specials.h"
 #include "constants/items.h"
 #include "constants/heal_locations.h"
-#include "constants/metatile_behaviors.h"
 #include "constants/mystery_gift.h"
 #include "constants/slot_machine.h"
 #include "constants/songs.h"


### PR DESCRIPTION
I replaced the code to detect if a pc is in front of the player from something that only look for a specific pc tile to something that looks at the MB_PC metatile behavior

## Media

https://github.com/user-attachments/assets/77e290bf-5957-443d-bd6b-d1d3ede8b7f4

## Issue(s) that this PR fixes
Fixes #8047


## Discord contact info
Jamie