### PR TITLE
Fix build failing with NOOPT=1 due to discarding static data.

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -664,7 +664,7 @@ static const struct DebugMenuOption sDebugMenu_Actions_Flags[] =
     { NULL }
 };
 
-static const u8 *sDebugMenu_Actions_BagUse_Options[] =
+static const u8 *const sDebugMenu_Actions_BagUse_Options[] =
 {
     COMPOUND_STRING("No Bag: {STR_VAR_1}Inactive"),
     COMPOUND_STRING("No Bag: {STR_VAR_1}VS Trainers"),


### PR DESCRIPTION
## Description

Building *without* optimisations, i.e `NOOPT=1` or `-O0`, will fail with:

```
`.data' referenced in section `.text' of src/debug.o: defined in discarded section `.data' of src/debug.o
```

due to missing const modifier on `sDebugMenu_Actions_BagUse_Options`.

## Discord contact info
ultimate_bob
