### PR TITLE
Fix move description prompt window not appear when choosing a move after canceling target selection

### DIFF
--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -460,6 +460,7 @@ void HandleInputChooseTarget(u32 battler)
             gBattleStruct->zmove.viewing = TRUE;
             ReloadMoveNames(battler);
         }
+        TryToAddMoveInfoWindow();
         DoBounceEffect(battler, BOUNCE_HEALTHBOX, 7, 1);
         DoBounceEffect(battler, BOUNCE_MON, 7, 1);
         EndBounceEffect(gMultiUsePlayerCursor, BOUNCE_HEALTHBOX);


### PR DESCRIPTION
## Media
Master:

https://github.com/user-attachments/assets/d9f2cdcf-57e4-4857-aad4-e10f32a930f1

This commit:

https://github.com/user-attachments/assets/03a30d0c-acb7-423f-b6b9-3a10f0cf11c5



## Issue(s) that this PR fixes
Fixes #7877

## Discord contact info
Jamie
