### PR TITLE
Fix non-battle trainer script not running properly

### DIFF
--- a/src/trainer_see.c
+++ b/src/trainer_see.c
@@ -380,6 +380,7 @@ bool8 CheckForTrainersWantingBattle(void)
         if (numTrainers == 0xFF) // non-trainerbatle script
         {
             u32 objectEventId = gApproachingTrainers[gNoOfApproachingTrainers - 1].objectEventId;
+            gApproachingTrainers[gNoOfApproachingTrainers - 1].trainerScriptPtr = GetObjectEventScriptPointerByObjectEventId(objectEventId);
             gSelectedObjectEvent = objectEventId;
             gSpecialVar_LastTalked = gObjectEvents[objectEventId].localId;
             ScriptContext_SetupScript(EventScript_ObjectApproachPlayer);


### PR DESCRIPTION
Fixes back to expected behavior according to mGriifin. I'm not sure where the regression is from (possibly #7978 ?)

## Media
Master:

https://github.com/user-attachments/assets/fea44422-1a15-49df-a4ff-be0b8fb7f820

This commit:

https://github.com/user-attachments/assets/91e59011-dd89-4b51-b9a2-8a7b8dc32bfe


## Discord contact info
Jamie
