### PR TITLE
Corrects ONE_VS_TWO_BATTLE_TEST to use BATTLE_TEST_ARGS_ONE_VS_TWO

### DIFF
--- a/include/test/battle.h
+++ b/include/test/battle.h
@@ -918,8 +918,8 @@ extern struct BattleTestRunnerState *const gBattleTestRunnerState;
 #define TWO_VS_ONE_BATTLE_TEST(_name, ...) BATTLE_TEST_ARGS_TWO_VS_ONE(_name, BATTLE_TEST_TWO_VS_ONE, __VA_ARGS__)
 #define AI_TWO_VS_ONE_BATTLE_TEST(_name, ...) BATTLE_TEST_ARGS_TWO_VS_ONE(_name, BATTLE_TEST_AI_TWO_VS_ONE, __VA_ARGS__)
 
-#define ONE_VS_TWO_BATTLE_TEST(_name, ...) BATTLE_TEST_ARGS_TWO_VS_ONE(_name, BATTLE_TEST_ONE_VS_TWO, __VA_ARGS__)
-#define AI_ONE_VS_TWO_BATTLE_TEST(_name, ...) BATTLE_TEST_ARGS_TWO_VS_ONE(_name, BATTLE_TEST_AI_ONE_VS_TWO, __VA_ARGS__)
+#define ONE_VS_TWO_BATTLE_TEST(_name, ...) BATTLE_TEST_ARGS_ONE_VS_TWO(_name, BATTLE_TEST_ONE_VS_TWO, __VA_ARGS__)
+#define AI_ONE_VS_TWO_BATTLE_TEST(_name, ...) BATTLE_TEST_ARGS_ONE_VS_TWO(_name, BATTLE_TEST_AI_ONE_VS_TWO, __VA_ARGS__)
 
 /* Parametrize */
 


### PR DESCRIPTION
Corrects `ONE_VS_TWO_BATTLE_TEST` to use `BATTLE_TEST_ARGS_ONE_VS_TWO` instead of `BATTLE_TEST_ARGS_TWO_VS_ONE`. Likely inconsequential but worth correcting.

## Discord contact info
grintoul