### PR TITLE
Fix wrong gimmick spite showing when inputting too fast

### DIFF
--- a/include/battle_gimmick.h
+++ b/include/battle_gimmick.h
@@ -35,6 +35,7 @@ void SetGimmickAsActivated(u32 battler, enum Gimmick gimmick);
 void ChangeGimmickTriggerSprite(u32 spriteId, u32 animId);
 void CreateGimmickTriggerSprite(u32 battler);
 bool32 IsGimmickTriggerSpriteActive(void);
+bool32 IsGimmickTriggerSpriteMatchingBattler(u32 battler);
 void HideGimmickTriggerSprite(void);
 void DestroyGimmickTriggerSprite(void);
 

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -2090,6 +2090,8 @@ void PlayerHandleChooseMove(u32 battler)
 
         if (!IsGimmickTriggerSpriteActive())
             gBattleStruct->gimmick.triggerSpriteId = 0xFF;
+        else if (!IsGimmickTriggerSpriteMatchingBattler(battler))
+            DestroyGimmickTriggerSprite();
         if (!(gBattleStruct->gimmick.usableGimmick[battler] == GIMMICK_Z_MOVE && !gBattleStruct->zmove.viable))
             CreateGimmickTriggerSprite(battler);
 

--- a/src/battle_gimmick.c
+++ b/src/battle_gimmick.c
@@ -178,6 +178,13 @@ bool32 IsGimmickTriggerSpriteActive(void)
         return FALSE;
 }
 
+bool32 IsGimmickTriggerSpriteMatchingBattler(u32 battler)
+{
+    if (battler == gSprites[gBattleStruct->gimmick.triggerSpriteId].tBattler)
+        return TRUE;
+    return FALSE;
+}
+
 void HideGimmickTriggerSprite(void)
 {
     if (gBattleStruct->gimmick.triggerSpriteId != 0xFF)


### PR DESCRIPTION
If the gimmick sprite doesn't match the current battler when opening the move window, I delete the sprite early instead of waiting for the animation to finish

## Media
master:

https://github.com/user-attachments/assets/243c520f-72cc-4f52-bfdc-dceeadeda272

this commit:

https://github.com/user-attachments/assets/67b56018-a899-495c-a931-67b18715d60c


## Issue(s) that this PR fixes
Fixes #7078

## Discord contact info
Jamie
