### PR TITLE
Fix target cancelling not working properly with z-move

### DIFF
--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -454,6 +454,12 @@ void HandleInputChooseTarget(u32 battler)
         PlaySE(SE_SELECT);
         gSprites[gBattlerSpriteIds[gMultiUsePlayerCursor]].callback = SpriteCB_HideAsMoveTarget;
         gBattlerControllerFuncs[battler] = HandleInputChooseMove;
+        if (gBattleStruct->gimmick.playerSelect == 1 && gBattleStruct->gimmick.usableGimmick[battler] == GIMMICK_Z_MOVE)
+        {
+            gBattleStruct->gimmick.playerSelect = 0;
+            gBattleStruct->zmove.viewing = TRUE;
+            ReloadMoveNames(battler);
+        }
         DoBounceEffect(battler, BOUNCE_HEALTHBOX, 7, 1);
         DoBounceEffect(battler, BOUNCE_MON, 7, 1);
         EndBounceEffect(gMultiUsePlayerCursor, BOUNCE_HEALTHBOX);


### PR DESCRIPTION
When canceling target while zmove is active, I make sure to disable z-move and when moving back to move selection

## Media
master:

https://github.com/user-attachments/assets/5efbd70a-44f7-4113-88c8-43637ad2e5a2

This commit:

https://github.com/user-attachments/assets/976a12a9-0539-4b92-9d10-5fcc582d74a5



## Issue(s) that this PR fixes
Fixes #6688

## Discord contact info
Jamie