### PR TITLE
Fix namebox bug when reloading the map mid-script

### DIFF
--- a/include/field_name_box.h
+++ b/include/field_name_box.h
@@ -9,7 +9,7 @@ extern const u8 *const gSpeakerNamesTable[];
 
 void TrySpawnNamebox(u32 tileNum);
 u32 GetNameboxWindowId(void);
-void ResetNameboxId(void);
+void ResetNameboxData(void);
 void DestroyNamebox(void);
 void FillNamebox(void);
 void DrawNamebox(u32 windowId, u32 tileNum, bool32 copyToVram);

--- a/src/field_name_box.c
+++ b/src/field_name_box.c
@@ -94,9 +94,10 @@ u32 GetNameboxWindowId(void)
     return sNameboxWindowId;
 }
 
-void ResetNameboxId(void)
+void ResetNameboxData(void)
 {
     sNameboxWindowId = WINDOW_NONE;
+    gSpeakerName = NULL;
 }
 
 void DestroyNamebox(void)

--- a/src/menu.c
+++ b/src/menu.c
@@ -5,6 +5,7 @@
 #include "decompress.h"
 #include "dma3.h"
 #include "event_data.h"
+#include "field_name_box.h"
 #include "field_weather.h"
 #include "graphics.h"
 #include "main.h"
@@ -146,6 +147,7 @@ static const struct MenuInfoIcon sMenuInfoIcons[] =
 
 void InitStandardTextBoxWindows(void)
 {
+    ResetNameboxData();
     InitWindows(sStandardTextBox_WindowTemplates);
     sStartMenuWindowId = WINDOW_NONE;
     sMapNamePopupWindowId = WINDOW_NONE;

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -16,7 +16,6 @@
 #include "field_effect.h"
 #include "field_effect_helpers.h"
 #include "field_message_box.h"
-#include "field_name_box.h"
 #include "field_player_avatar.h"
 #include "field_screen_effect.h"
 #include "field_special_scene.h"
@@ -1496,7 +1495,6 @@ static void InitOverworldBgs(void)
     SetBgTilemapBuffer(1, gOverworldTilemapBuffer_Bg1);
     SetBgTilemapBuffer(2, gOverworldTilemapBuffer_Bg2);
     SetBgTilemapBuffer(3, gOverworldTilemapBuffer_Bg3);
-    ResetNameboxId();
     InitStandardTextBoxWindows();
 }
 


### PR DESCRIPTION
## Description
When the game waps, the overworld is reloaded and all windows are deeleted/freed but because sNameboxWindowId is not cleared, the namebox code will bug and delete or modify already existing windows. We add a function to reset sNameboxWindowId that is called when loading a new map at the same times windows are freed

## Media
I used the same setup described in #8049

https://github.com/user-attachments/assets/2f73ac21-b28d-4261-b04c-6fbd1c670e0b



## Issue(s) that this PR fixes
Fixes #8049

## Discord contact info
Jamie