### PR TITLE
Fix mirage tower ceiling crumble color

### DIFF
--- a/src/mirage_tower.c
+++ b/src/mirage_tower.c
@@ -98,12 +98,6 @@ static const struct SpriteSheet sCeilingCrumbleSpriteSheets[] =
     {}
 };
 
-static const struct SpritePalette sCeilingCrumbleSpritePalettes[] =
-{
-    {sMirageTowerCrumbles_Palette,     TAG_CEILING_CRUMBLE},
-    {},
-};
-
 static const struct MetatileCoords sInvisibleMirageTowerMetatiles[] =
 {
     {18, 53, METATILE_Mauville_DeepSand_Center},
@@ -426,7 +420,7 @@ static void IncrementCeilingCrumbleFinishedCount(void)
 
 void DoMirageTowerCeilingCrumble(void)
 {
-    LoadSpritePalettes(sCeilingCrumbleSpritePalettes);
+    LoadSpritePaletteWithTag(sMirageTowerCrumbles_Palette, TAG_CEILING_CRUMBLE);
     LoadSpriteSheets(sCeilingCrumbleSpriteSheets);
     CreateCeilingCrumbleSprites();
     CreateTask(WaitCeilingCrumble, 8);


### PR DESCRIPTION
Normally, the ceiling crumble sprites don't use their own palette and just use colors that are part of the player palette. I'm not sure why but at some point in expansion life, this turned the sprite purple. To fix this, I simply load the already existing palette file. This does not match the original color in vanilla emerald which was more green-ish but it arguably looks better

## Media
Master:

https://github.com/user-attachments/assets/0ef09af9-4577-4c4d-92d2-b18960667f9f

This commit:

https://github.com/user-attachments/assets/3f76d6c6-efdd-449e-8b92-6ec843264ae7



## Issue(s) that this PR fixes
Fixes #6566


## Discord contact info
Jamie
