### PR TITLE
Improve sBattleIntroSlideFuncs bounds check

### DIFF
--- a/src/battle_intro.c
+++ b/src/battle_intro.c
@@ -125,7 +125,8 @@ void HandleIntroSlide(u8 environment)
     }
     else
     {
-        if (environment >= NELEMS(sBattleIntroSlideFuncs))
+        if (environment >= NELEMS(sBattleIntroSlideFuncs)
+         || sBattleIntroSlideFuncs[environment] == NULL)
             environment = BATTLE_ENVIRONMENT_PLAIN;
         taskId = CreateTask(sBattleIntroSlideFuncs[environment], 0);
     }


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
The bounds check for setting the intro slide tasks didn't take into account potentially uninitialized elements in the `sBattleIntroSlideFuncs` array.
This change makes it so that the fallback environment is set in those cases.

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara