### PR TITLE
Fix copyvar instead of setvar causing issue with LTO

### DIFF
--- a/data/scripts/cave_hole.inc
+++ b/data/scripts/cave_hole.inc
@@ -3,7 +3,7 @@ CaveHole_CheckFallDownHole:
 	.2byte 0
 
 CaveHole_FixCrackedGround:
-	copyvar VAR_ICE_STEP_COUNT, 1
+	setvar VAR_ICE_STEP_COUNT, 1
 	end
 
 EventScript_FallDownHole::


### PR DESCRIPTION
copyvar X, 1 makes the gba try to access a null pointer which causes crashes when compile LTO
Thanks to Egg for explaining me how to debug this type of issue

## Issue(s) that this PR fixes
Fixes #8093


## Discord contact info
Jamie
