### PR TITLE
Fix berry blender not computing flavor correctly

### DIFF
--- a/src/berry_blender.c
+++ b/src/berry_blender.c
@@ -2432,6 +2432,7 @@ static void CalculatePokeblock(struct BlenderBerry *berries, struct Pokeblock *p
     }
 
     // Factor in max RPM and round
+    multiuseVar = maxRPM / 333 + 100;
     for (i = 0; i < FLAVOR_COUNT; i++)
     {
         s32 remainder;


### PR DESCRIPTION
## Description
Between pret and expansion, some debug code was removed including this whole line
`sDebug_PokeblockFactorRPM = multiuseVar = maxRPM / 333 + 100;`
this means that multiusevar is not set to a value between 100 and 200 based on RPM but it is set to a values less than 5, this basically cause all the flavors values to become 0 and the pokeblock to become black
Adding the line
`multiuseVar = maxRPM / 333 + 100;`
back fixes the issues as found by FennyBoy

## Media
I used the debug option to make the opponents play perfectly in order to get consistent results

https://github.com/user-attachments/assets/24f60a4f-ffb1-4ebb-91ee-c1b6cf991d85


https://github.com/user-attachments/assets/c4972c3e-f701-4556-9443-c95cfb670ff9



## Issue(s) that this PR fixes
Fixes #8096


## Discord contact info
Jamie
