### PR TITLE
Fixes difficulty not being restored after tests

### DIFF
--- a/test/battle/trainer_control.c
+++ b/test/battle/trainer_control.c
@@ -188,6 +188,7 @@ TEST("Difficulty default to Normal is the trainer doesn't have a member for the 
     CreateNPCTrainerPartyFromTrainer(testParty, &sTestTrainers[GetTrainerDifficultyLevelTest(currTrainer)][currTrainer], TRUE, BATTLE_TYPE_TRAINER);
     EXPECT(GetMonData(&testParty[0], MON_DATA_SPECIES) == SPECIES_MEWTWO);
     Free(testParty);
+    SetCurrentDifficultyLevel(DIFFICULTY_NORMAL);
 }
 
 TEST("Difficulty changes which party if used for NPCs if defined for the difficulty (EASY)")
@@ -199,6 +200,7 @@ TEST("Difficulty changes which party if used for NPCs if defined for the difficu
     EXPECT(GetMonData(&testParty[0], MON_DATA_SPECIES) == SPECIES_METAPOD);
     EXPECT(GetMonData(&testParty[0], MON_DATA_LEVEL) == 1);
     Free(testParty);
+    SetCurrentDifficultyLevel(DIFFICULTY_NORMAL);
 }
 
 TEST("Difficulty changes which party if used for NPCs if defined for the difficulty (HARD)")
@@ -210,6 +212,7 @@ TEST("Difficulty changes which party if used for NPCs if defined for the difficu
     EXPECT(GetMonData(&testParty[0], MON_DATA_SPECIES) == SPECIES_ARCEUS);
     EXPECT(GetMonData(&testParty[0], MON_DATA_LEVEL) == 99);
     Free(testParty);
+    SetCurrentDifficultyLevel(DIFFICULTY_NORMAL);
 }
 
 TEST("Difficulty changes which party if used for NPCs if defined for the difficulty (NORMAL)")

--- a/test/test_runner_battle.c
+++ b/test/test_runner_battle.c
@@ -1344,6 +1344,7 @@ static void TearDownBattle(void)
     // Zero out the parties, data in them could potentially carry over
     ZeroPlayerPartyMons();
     ZeroEnemyPartyMons();
+    SetCurrentDifficultyLevel(DIFFICULTY_NORMAL);
 
     FreeMonSpritesGfx();
     FreeBattleSpritesData();


### PR DESCRIPTION
Battle test tear-down does not restore difficulty to `DIFFICULTY_NORMAL` as standard. Added to the tear-down function to safeguard against future issues. Also added to 3 non-battle tests that change difficulty so they revert to normal at the end of the tests.

## Discord contact info
grintoul