### PR TITLE
Lock mdbook to v0.4.35 to fix docs not building

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - name: Install latest mdbook
         run: |
-          tag=$(curl 'https://api.github.com/repos/rust-lang/mdbook/releases/latest' | jq -r '.tag_name')
+          tag="v0.4.35"
           url="https://github.com/rust-lang/mdbook/releases/download/${tag}/mdbook-${tag}-x86_64-unknown-linux-gnu.tar.gz"
           mkdir mdbook
           curl -sSL $url | tar -xz --directory=./mdbook


### PR DESCRIPTION
Locks the mdbook version in the docs build to v0.4.35 which is the last version before the "anstream" feature was added, which is causing the latest version to not work for us

Worked in my repo so assuming it will work here
<img width="1849" height="560" alt="image" src="https://github.com/user-attachments/assets/4069d875-f9ea-49bb-97ce-0356fb22a3a4" />

## Discord contact info
grintoul