### PR TITLE
Update mdbook to v0.5.0-beta.1

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - name: Install latest mdbook
         run: |
-          tag="v0.4.35"
+          tag="v0.5.0-beta.1"
           url="https://github.com/rust-lang/mdbook/releases/download/${tag}/mdbook-${tag}-x86_64-unknown-linux-gnu.tar.gz"
           mkdir mdbook
           curl -sSL $url | tar -xz --directory=./mdbook

--- a/docs/fix_links.py
+++ b/docs/fix_links.py
@@ -46,6 +46,6 @@ if __name__ == '__main__':
             sys.exit(0)
 
     context, book = json.load(sys.stdin)
-    proc_items(book['sections'])
+    proc_items(book['items'])
 
     print(json.dumps(book))


### PR DESCRIPTION
## Description
Until #8130, CI automatically determined the latest version of `mdbook` and ran using that latest version. There are breaking changes between the previous latest version of mdbook, `v0.4.52`, and the current latest version of mdbook, `v0.5.0.beta.1`, as described in [the mdBook changelog](https://github.com/rust-lang/mdBook/blob/v0.5.0-beta.1/CHANGELOG.md). #8101, #8105 and #8112 handles one of the breaking changes that affects expansion's docs. This PR handles the other breaking change that affects expansion's docs.

## Feature(s) this PR does NOT handle:

mdbook now warns about a certain bit of invalid html.

```html
        <img src="https://raw.githubusercontent.com/all-contributors/all-contributors-cli/1b8533af435da9854653492b1327a23a4dbd0a10/assets/logo-small.svg">
          <a href="https://all-contributors.js.org/docs/en/bot/usage">Add your contributions</a>
        </img>
```

from `CREDITS.md` is invalid. The `img` tag is auto-closing, which means that the later `</img>` does not correspond to an open `img` tag, and is thus a "stray" closing tag. However, this html is part of the code regenerated by @allcontributors. If I were to change it, allcontributors would change it back the next time allcontributors runs. The code generated by allcontributors has to be fixed upstream.

At least this is currently does not block doc compilation. And mdbook ignores the stray closing tag, which is the expected error-handling in this case.

## Discord contact info
yoshord
