### PR TITLE
Fix preproc not correctly reading skipped lines symbols inside enum

### DIFF
--- a/tools/preproc/asm_file.cpp
+++ b/tools/preproc/asm_file.cpp
@@ -633,7 +633,11 @@ bool AsmFile::ParseEnum()
             RaiseError("%s:%ld: empty enum is invalid", headerFilename.c_str(), currentHeaderLine);
         }
 
-        if (m_buffer[m_pos] != ',')
+        if (m_buffer[m_pos] == '#')
+        {
+            currentHeaderLine = ParseLineSkipInEnum();
+        }
+        else if (m_buffer[m_pos] != ',')
         {
             currentHeaderLine += SkipWhitespaceAndEol();
             if (m_buffer[m_pos++] == '}' && m_buffer[m_pos++] == ';')
@@ -735,6 +739,50 @@ int AsmFile::SkipWhitespaceAndEol()
         m_pos++;
     }
     return newlines;
+}
+
+int AsmFile::ParseLineSkipInEnum(void)
+{
+    m_pos++;
+    while (m_buffer[m_pos] == ' ' || m_buffer[m_pos] == '\t')
+        m_pos++;
+
+     if (!IsAsciiDigit(m_buffer[m_pos]))
+        RaiseError("malformatted line indicator found inside `enum`, expected line number");
+
+    unsigned n = 0;
+    int digit = 0;
+    while ((digit = ConvertDigit(m_buffer[m_pos++], 10)) != -1)
+        n = 10 * n + digit;
+
+    while (m_buffer[m_pos] == ' ' || m_buffer[m_pos] == '\t')
+        m_pos++;
+
+    if (m_buffer[m_pos++] != '"')
+        RaiseError("malformatted line indicator found before `enum`, expected filename");
+
+    while (m_buffer[m_pos] != '"')
+    {
+        unsigned char c = m_buffer[m_pos++];
+
+        if (c == 0)
+        {
+            if (m_pos >= m_size)
+                RaiseError("unexpected EOF in line indicator");
+            else
+                RaiseError("unexpected null character in line indicator");
+        }
+
+        if (!IsAsciiPrintable(c))
+            RaiseError("unexpected character '\\x%02X' in line indicator", c);
+
+        if (c == '\\')
+        {
+            c = m_buffer[m_pos];
+            RaiseError("unexpected escape '\\%c' in line indicator", c);
+        }
+    }
+    return n - 1;
 }
 
 // returns the last line indicator and its corresponding file name without modifying the token index

--- a/tools/preproc/asm_file.h
+++ b/tools/preproc/asm_file.h
@@ -73,6 +73,7 @@ private:
     void VerifyStringLength(int length);
     int SkipWhitespaceAndEol();
     int FindLastLineNumber(std::string& filename);
+    int ParseLineSkipInEnum(void);
     std::string ReadIdentifier();
     long ReadInteger(std::string filename, long line);
 };


### PR DESCRIPTION
When you have a lot of newlines in an enum like this:
```
enum Test_preproc {
  Test_Preproc_A,
  Test_Preproc_B,








  Test_Preproc_C,
  
};
```
the compiler will convert it into something like this
```
enum Test_preproc {
  Test_Preproc_A,
  Test_Preproc_B,
# 13 "include/constants/coins.h"
  Test_Preproc_C,
};
```
and preproc wasn't coded to handle this kind of comment inside an enum, this PR fixes that

## Issue(s) that this PR fixes
Fixes #6985



## Discord contact info
Jamie
