### PR TITLE
Power Construct test fix

### DIFF
--- a/test/battle/ability/power_construct.c
+++ b/test/battle/ability/power_construct.c
@@ -50,7 +50,7 @@ WILD_BATTLE_TEST("Power Construct Zygarde reverts to its original form upon catc
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_POWER_CONSTRUCT, opponent);
 
         // Turn 2
-        ANIMATION(ANIM_TYPE_SPECIAL, B_ANIM_BALL_THROW, player);
+        MESSAGE("You used Master Ball!"); // Removed ANIMATION check as seems to fail if run in same thread as daycare ditto test
     } THEN {
         EXPECT_EQ(GetMonData(&gPlayerParty[1], MON_DATA_SPECIES), baseSpecies);
     }


### PR DESCRIPTION
Daycare Ditto test is causing tests that run in the same thread to fail if the use `ANIMATION(ANIM_TYPE_SPECIAL, B_ANIM_BALL_THROW, player);`. PR changes the `WILD_BATTLE_TEST("Power Construct Zygarde reverts to its original form upon catching")` test to check for message on T2 rather than the animation.

Note this doesn't address the underlying issue causing the failure, but changes the test to stop it being impacted by the daycare test. I have trialled changing the test to not reference Zygarde or Power Construct at all by changing the mon to a Zigzagoon and it still fails.

## Discord contact info
grintoul