### PR TITLE
Sheer force test fix

### DIFF
--- a/test/battle/ability/sheer_force.c
+++ b/test/battle/ability/sheer_force.c
@@ -1371,8 +1371,8 @@ AI_SINGLE_BATTLE_TEST("AI sees Sheer Force skips additional effects")
 
     GIVEN {
         AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT);
-        PLAYER(SPECIES_DRUDDIGON);
-        OPPONENT(SPECIES_WOBBUFFET) { Ability(ability); Moves(MOVE_POWER_UP_PUNCH, move); }
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_DRUDDIGON) { Ability(ability); Moves(MOVE_POWER_UP_PUNCH, move); }
     } WHEN {
         TURN { EXPECT_MOVE(opponent, expectedMove); }
     }


### PR DESCRIPTION
Changes in master cause this test to fail when attempting master -> upcoming merge. Existing test _should_ fail as run 2 AI should see Power-Up Punch Sheer Force boosted to 40 x 1.3 = 52BP vs Karate Chop 50BP, but it doesn't for some reason. Changes in Master result in PUP being chosen on run two which appears correct. PR changes second move to Brick Break to correctly test Sheer Force mon choosing highest damage move when PUP does not offer Atk boost.

## Discord contact info
grintoul