### PR TITLE
Minor hpOnSwitchOut refactor

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -589,6 +589,7 @@ struct BattlerState
     u32 commanderSpecies:11;
     u32 padding:4;
     // End of Word
+    u16 hpOnSwitchout;
 };
 
 struct PartyState
@@ -671,7 +672,6 @@ struct BattleStruct
     u8 wallyWaitFrames;
     u8 wallyMoveFrames;
     u16 lastTakenMove[MAX_BATTLERS_COUNT]; // Last move that a battler was hit with.
-    u16 hpOnSwitchout[NUM_BATTLE_SIDES];
     u32 savedBattleTypeFlags;
     u16 abilityPreventingSwitchout;
     u8 hpScale;

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3489,7 +3489,7 @@ static void DoBattleIntro(void)
                 gBattleMons[battler].types[1] = GetSpeciesType(gBattleMons[battler].species, 1);
                 gBattleMons[battler].types[2] = TYPE_MYSTERY;
                 gBattleMons[battler].ability = GetAbilityBySpecies(gBattleMons[battler].species, gBattleMons[battler].abilityNum);
-                gBattleStruct->hpOnSwitchout[GetBattlerSide(battler)] = gBattleMons[battler].hp;
+                gBattleStruct->battlerState[battler].hpOnSwitchout = gBattleMons[battler].hp;
                 memset(&gBattleMons[battler].volatiles, 0, sizeof(struct Volatiles));
                 for (i = 0; i < NUM_BATTLE_STATS; i++)
                     gBattleMons[battler].statStages[i] = DEFAULT_STAT_STAGE;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -7958,7 +7958,7 @@ static bool32 DoSwitchInEffectsForBattler(u32 battler)
             if (gBattlerByTurnOrder[i] == battler)
                 gActionsByTurnOrder[i] = B_ACTION_CANCEL_PARTNER;
 
-            gBattleStruct->hpOnSwitchout[GetBattlerSide(i)] = gBattleMons[i].hp;
+            gBattleStruct->battlerState[i].hpOnSwitchout = gBattleMons[i].hp;
         }
 
         gSpecialStatuses[battler].switchInItemDone = FALSE;
@@ -9147,7 +9147,7 @@ static void Cmd_hpthresholds2(void)
     {
         u32 battler = GetBattlerForBattleScript(cmd->battler);
         u32 opposingBattler = BATTLE_OPPOSITE(battler);
-        u8 hpSwitchout = gBattleStruct->hpOnSwitchout[GetBattlerSide(opposingBattler)];
+        u32 hpSwitchout = gBattleStruct->battlerState[opposingBattler].hpOnSwitchout;
         s32 result = (hpSwitchout - gBattleMons[opposingBattler].hp) * 100 / hpSwitchout;
 
         if (gBattleMons[opposingBattler].hp >= hpSwitchout)


### PR DESCRIPTION
Instead of storing one hp value per side, it stores it for every battler now. Needed for #8128. 