### PR TITLE
Fix wrong palette for types sprites in hgss dex after catching mon

### DIFF
--- a/src/pokedex_plus_hgss.c
+++ b/src/pokedex_plus_hgss.c
@@ -4089,8 +4089,8 @@ static void UNUSED HighlightScreenSelectBarItem(u8 selectedScreen, u16 unused)
 #define tPersonalityHi data[15]
 
 // Types palettes need to be loaded at a different slot than anticipated by gTypesInfo
-// to avoid overlapping with caught mon sprite palatte slot
-// Normal type info palette slots: 13 ,14 and 15
+// to avoid overlapping with caught mon sprite palette slot
+// Normal type info palette slots: 13, 14 and 15
 // Caught mon palette slot: 15
 #define TYPE_INFO_PALETTE_NUM_OFFSET -1
 


### PR DESCRIPTION
When showing hgss dex after capturing a mon
the caught mon would use palette slot 15 while the types sprites would use palette slots 13, 14 15
causing the wrong palette to load for some of the types
I changed the types sprites palettes to be 12, 13, 14 instead


## Media

master:

https://github.com/user-attachments/assets/e2f41f29-3848-47ce-9711-158d662789c5

this commit:

https://github.com/user-attachments/assets/ff9532f3-9f67-428a-b13c-47e35d05e54a



## Issue(s) that this PR fixes
Fixes #8120


## Discord contact info
Jamie