### PR TITLE
Fix ball cycling not working properly when the same ball take multiple bag slots

### DIFF
--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -198,16 +198,16 @@ static void CompleteOnBattlerSpritePosX_0(u32 battler)
 static u16 GetPrevBall(u16 ballId)
 {
     s32 i;
-    s32 index;
-    for (i = 1; i < ITEMS_COUNT; i++)
+    s32 index = ItemIdToBallId(ballId);
+    u32 newBall = 0;
+     for (i = 0; i < POKEBALL_COUNT; i++)
     {
-        index = ballId - i;
-        if (index < 1)
-            index = index + ITEMS_COUNT - 1;
-        if (gItemsInfo[index].pocket != POCKET_POKE_BALLS)
-            continue;
-        if (CheckBagHasItem(index, 1))
-            return index;
+        index--;
+        if (index == -1)
+            index = POKEBALL_COUNT - 1;
+        newBall = gBallItemIds[index];
+        if (CheckBagHasItem(newBall, 1))
+            return newBall;
     }
     return ballId;
 }
@@ -215,16 +215,16 @@ static u16 GetPrevBall(u16 ballId)
 static u32 GetNextBall(u32 ballId)
 {
     s32 i;
-    s32 index;
-    for (i = 1; i < ITEMS_COUNT; i++)
+    s32 index = ItemIdToBallId(ballId);
+    u32 newBall = 0;
+    for (i = 0; i < POKEBALL_COUNT; i++)
     {
-        index = ballId + i;
-        if (index >= ITEMS_COUNT)
-            index = index - ITEMS_COUNT + 1;
-        if (gItemsInfo[index].pocket != POCKET_POKE_BALLS)
-            continue;
-        if (CheckBagHasItem(index, 1))
-            return index;
+        index++;
+        if (index == POKEBALL_COUNT)
+            index = 0;
+        newBall = gBallItemIds[index];
+        if (CheckBagHasItem(newBall, 1))
+            return newBall;
     }
     return ballId;
 }


### PR DESCRIPTION
I loop through the ball ids instead of looping through the items in the bag .This solution works but it assumes all usable ball items have consecutive indexes


## Media
In the video examples, I'm pressing right when I'm hovering over the bag command and i'm pressing left when hovering over the battle command
master:

https://github.com/user-attachments/assets/4df64ea4-496b-44e1-b4ba-270ac1ea2028

this commit:

https://github.com/user-attachments/assets/8cf00823-fa97-42d7-804b-043c8c168b85



## Issue(s) that this PR fixes
Fixes #5555

## Things to note in the release changelog:
- Two new defines added to items.h `FIRST_BALL_INDEX` and `LAST_BALL_INDEX`
- We now assume the indexes of all regular ball usable in wild battle have consecutive indexes and some features (throw ball shortcut in battle) might break if not true

## Discord contact info
Jamie
