### PR TITLE
Fix scroll prompt sometimes being off-screen with automatic line breaks

### DIFF
--- a/src/line_break.c
+++ b/src/line_break.c
@@ -176,7 +176,6 @@ void BreakSubStringNaive(u8 *src, u32 maxWidth, u32 screenLines, u8 fontId, enum
 
     Free(allWords);
 }
-#undef SCROLL_PROMPT_WIDTH
 
 void BreakSubStringAutomatic(u8 *src, u32 maxWidth, u32 screenLines, u8 fontId, enum ToggleScrollPrompt toggleScrollPrompt)
 {
@@ -246,6 +245,9 @@ void BreakSubStringAutomatic(u8 *src, u32 maxWidth, u32 screenLines, u8 fontId, 
     for (u32 i = 1; i < numWords; i++)
         totalWidth += allWords[i].width + spaceWidth;
 
+    if (toggleScrollPrompt == SHOW_SCROLL_PROMPT)
+        totalWidth += SCROLL_PROMPT_WIDTH;
+
     //  If it doesn't fit on 1 line, do fancy line break calculation
     //  NOTE: Currently the line break calculation isn't fancy
     if (totalWidth > maxWidth)
@@ -256,6 +258,8 @@ void BreakSubStringAutomatic(u8 *src, u32 maxWidth, u32 screenLines, u8 fontId, 
         bool32 shouldTryAgain;
         for (currWordIndex = 0; currWordIndex < numWords; currWordIndex++)
         {
+            if (toggleScrollPrompt == SHOW_SCROLL_PROMPT && currWordIndex + 1 == numWords)
+                currLineWidth += SCROLL_PROMPT_WIDTH;
             if (currLineWidth + allWords[currWordIndex].length > maxWidth)
             {
                 totalLines++;
@@ -266,6 +270,10 @@ void BreakSubStringAutomatic(u8 *src, u32 maxWidth, u32 screenLines, u8 fontId, 
                 currLineWidth += allWords[currWordIndex].width + spaceWidth;
             }
         }
+
+        if (currLineWidth > maxWidth)
+            totalLines++;
+
         //  LINE LAYOUT STARTS HERE
         struct StringLine *stringLines;
         do
@@ -424,3 +432,4 @@ bool32 StringHasManualBreaks(u8 *src)
     }
     return FALSE;
 }
+#undef SCROLL_PROMPT_WIDTH


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
The "fancy" line breaker wasn't taking into account the scroll prompt icon when calculating number of line breaks to insert.

## Media
<img width="240" height="160" alt="pokeemerald-24" src="https://github.com/user-attachments/assets/e8d9da72-de79-4f28-ba9f-194db40fd718" />


## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, closes #2222." Remove this section if not applicable.-->
Fixes #8134 

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara