### PR TITLE
Adjust label workflow to only run if PR is approved

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -3,10 +3,12 @@ name: Labels
 on:
   pull_request:
     types: [opened, synchronize, labeled, unlabeled]
+  pull_request_review:
+    types: [submitted]
 
 jobs:
   label:
-    if: github.actor != 'allcontributors[bot]'
+    if: ${{ github.actor != 'allcontributors[bot]' && github.event.review.state == 'approved' }}
     runs-on: ubuntu-latest
     steps:
       - name: check labels


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
This should make the label workflow only run when the PR is approved, and therefore not send failure emails before that.

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara