### PR TITLE
Fix wrong ditto sprite on capture

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -14253,13 +14253,16 @@ static void Cmd_displaydexinfo(void)
 {
     CMD_ARGS();
 
-    struct Pokemon *mon = GetBattlerMon(GetCatchingBattler());
+    u32 caughtBattler = GetCatchingBattler();
+    struct Pokemon *mon = GetBattlerMon(caughtBattler);
     u16 species = GetMonData(mon, MON_DATA_SPECIES, NULL);
 
     switch (gBattleCommunication[0])
     {
     case 0:
         BeginNormalPaletteFade(PALETTES_ALL, 0, 0, 16, RGB_BLACK);
+        ClearTemporarySpeciesSpriteData(caughtBattler, FALSE, FALSE);
+        BattleLoadMonSpriteGfx(mon, caughtBattler);
         gBattleCommunication[0]++;
         break;
     case 1:


### PR DESCRIPTION
Fixes a regression introduced in #7884 when we started reusing the sprite instead of loading a new one when using pokedex. The code now clears transformations and reloads the battler sprite before proceeding to the dex screen. Because we replace the sprite instead of adding a new one, it doesn't cause issue when terrain is active.

## Media
master:

https://github.com/user-attachments/assets/33894350-cff1-40a9-b672-169e9560aa16

this commit:

https://github.com/user-attachments/assets/eba75af3-fee3-4c23-9b43-54051cd09977

with terrain:

https://github.com/user-attachments/assets/d5be9e5e-cdcd-4872-a398-dc1d5c15c0d3


## Issue(s) that this PR fixes
Fixes #8201

## Discord contact info
Jamie