### PR TITLE
Fix mew sprite not appearing correctly

### DIFF
--- a/src/faraway_island.c
+++ b/src/faraway_island.c
@@ -393,6 +393,7 @@ void SetMewAboveGrass(void)
 
         LoadSpritePalette(&gSpritePalette_GeneralFieldEffect1);
         UpdateSpritePaletteWithWeather(IndexOfSpritePaletteTag(gSpritePalette_GeneralFieldEffect1.tag), FALSE);
+        gSprites[mew->spriteId].subspriteTableNum = 1;
 
         x = mew->currentCoords.x;
         y = mew->currentCoords.y;


### PR DESCRIPTION
I'm not sure what's caused the problem in the first place but updating the subsprite table fixes it. Mew is a 16x32 sprite so the GF sprite abstraction class is actually composed of two 16x16 oam gba sprite. The subsprites can have different priorities, that's how the lower part appear below the grass while the upper part apear above it. By changing the subsprite table to 1, I forced both subsprites to have the same priority of 1 putting them above the grass. 

## Media
master:

https://github.com/user-attachments/assets/3cba0a67-1182-4216-a4b1-1b6f69ed051e

this commit:

https://github.com/user-attachments/assets/2583332e-14d5-44a6-b107-f2b9585b85a6




## Issue(s) that this PR fixes
Fixes #8202



## Discord contact info
Jamie 
