### PR TITLE
Removed extra period in Pokéshi Doll description

### DIFF
--- a/src/data/items.h
+++ b/src/data/items.h
@@ -15048,7 +15048,7 @@ const struct Item gItemsInfo[] =
         .price = 2000,
         .description = COMPOUND_STRING(
             "A wooden toy\n"
-            "resembling a Poké-.\n"
+            "resembling a Poké-\n"
             "mon. Can be sold."),
         .pocket = POCKET_ITEMS,
         .sortType = ITEM_TYPE_SELLABLE,


### PR DESCRIPTION
## Description
<!-- Detail the changes made, why they were made, and any important context. -->
Removed an extra period in `ITEM_POKESHI_DOLL` description.

## Media

upcoming:

<img width="240" height="160" alt="pokeemerald-0" src="https://github.com/user-attachments/assets/0a8b9ce1-2f77-498e-9c19-9cfcc03ee930" />

this commit:

<img width="240" height="160" alt="pokeemerald-1" src="https://github.com/user-attachments/assets/47d7bba4-cfd2-4b3f-a91b-979f6926acd0" />

## Discord contact info
Montblanc
