### PR TITLE
Fix Apricorns with OW_SHOW_ITEM_DESCRIPTIONS not off

### DIFF
--- a/data/scripts/apricorn_tree.inc
+++ b/data/scripts/apricorn_tree.inc
@@ -30,7 +30,7 @@ ApricornTree_EventScript_PickApricorn::
 .endif
 	delay 10
 .if OW_SHOW_ITEM_DESCRIPTIONS != OW_ITEM_DESCRIPTIONS_OFF
-	showberrydesc
+	showberrydescription
 .endif
 	playfanfare MUS_OBTAIN_BERRY
 	waitmessage
@@ -40,7 +40,7 @@ ApricornTree_EventScript_PickApricorn::
 	waitmessage
 	waitbuttonpress
 .if OW_SHOW_ITEM_DESCRIPTIONS != OW_ITEM_DESCRIPTIONS_OFF
-	hideitemdesc
+	hideitemdescription
 .endif
 	release
 	end


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
When `OW_SHOW_ITEM_DESCRIPTIONS` is set to something that's not `OW_ITEM_DESCRIPTIONS_OFF`, compilation fails due to misspelled scripts.

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara