### PR TITLE
Fix Magic Coat reflecting hazard moves incorrectly when used by a partner

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1170,6 +1170,7 @@ static void Cmd_attackcanceler(void)
     bool32 bounceActive = (gProtectStructs[gBattlerTarget].bounceMove && IsBattlerAlive(gBattlerTarget));
 
     if (!bounceActive
+        && !gBattleStruct->bouncedMoveIsUsed
         && isBounceable
         && GetBattlerMoveTargetType(gBattlerAttacker, gCurrentMove) == MOVE_TARGET_OPPONENTS_FIELD)
     {

--- a/test/battle/move_effect/magic_coat.c
+++ b/test/battle/move_effect/magic_coat.c
@@ -4,8 +4,6 @@
 ASSUMPTIONS
 {
     ASSUME(GetMoveEffect(MOVE_MAGIC_COAT) == EFFECT_MAGIC_COAT);
-    ASSUME(GetMoveEffect(MOVE_SPIKES) == EFFECT_SPIKES);
-    ASSUME(GetMoveEffect(MOVE_STEALTH_ROCK) == EFFECT_STEALTH_ROCK);
 }
 
 SINGLE_BATTLE_TEST("Magic Coat prints the correct message when bouncing back a move")
@@ -40,6 +38,8 @@ DOUBLE_BATTLE_TEST("Magic Coat reflects hazards regardless of the user's positio
     struct BattlePokemon *coatUser = NULL;
     PARAMETRIZE { coatUser = playerLeft; }
     PARAMETRIZE { coatUser = playerRight; }
+    ASSUME(GetMoveEffect(MOVE_SPIKES) == EFFECT_SPIKES);
+    ASSUME(GetMoveEffect(MOVE_STEALTH_ROCK) == EFFECT_STEALTH_ROCK);
 
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);


### PR DESCRIPTION
## Description
  <!-- Detail the changes made, why they were made, and any important context. -->

  - Updated `Cmd_attackcanceler` to detect active Magic Coat on an ally in doubles so hazard moves (and other bounceable
    moves) get redirected and reflected correctly even when the targeted Pokémon is already fainted.
  - Ensured the bounceability check now works for opponent-field targeting moves, covering hazards like Spikes and
    Stealth Rock.
  - Added a new double battle test verifying hazards are reflected when either player position uses Magic Coat,
    alongside new assumptions for hazard effects (based off hedara's original verification test)

  ## Media

  N/A

  ## Issue(s) that this PR fixes

  Fixes #8195
  <!-- CREDITS -->
  <!-- Once your PR is submitted, leave a comment asking the bot to add you to the credits. -->
  <!-- If anybody helped with this PR, please encourage them to comment on your PR and ask the bot to add them to the
  credits. If somebody has contributed at any point and has indicated they wish to be credited, please ask the bot to
  add them to the credits. If they do not have a known GitHub account, add them to the list at bottom of `CREDITS.md`.
  -->
  <!-- EVERY contribution matters! -->
  <!-- https://github.com/rh-hideout/pokeemerald-expansion/wiki/CREDITS.md-Frequently-Asked-Questions -->

  ## Feature(s) this PR does NOT handle:

  None.

  ## Things to note in the release changelog:

  - Magic Coat now properly reflects hazard moves from either slot in double battles.

  ## Discord contact info

viridian.