### PR TITLE
Added missing 'coolness' string

### DIFF
--- a/src/contest.c
+++ b/src/contest.c
@@ -715,7 +715,7 @@ const struct ContestCategory gContestCategoryInfo[CONTEST_CATEGORIES_COUNT + 1] 
     [CONTEST_CATEGORY_COOL] =
     {
         .name = COMPOUND_STRING("COOL"),
-        .condition = COMPOUND_STRING(""),
+        .condition = COMPOUND_STRING("coolness"),
         .generic = COMPOUND_STRING("COOL Move"),
         .negativeTrait = COMPOUND_STRING("shyness"),
         .palette = 13,


### PR DESCRIPTION
This was accidentally removed when consolidating the strings in #8178 

## Discord contact info
Frankfurter0
