### PR TITLE
 Fix AI_FLAG_DOUBLE_ACE_POKEMON sending duplicate Pokémon in doubles

### DIFF
--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -2414,6 +2414,7 @@ u32 GetMostSuitableMonToSwitchInto(u32 battler, enum SwitchType switchType)
                 aliveCount++;
             }
         }
+
         bestMonId = GetBestMonBatonPass(party, firstId, lastId, invalidMons, aliveCount, battler, opposingBattler);
         if (bestMonId != PARTY_SIZE)
             return bestMonId;
@@ -2425,6 +2426,9 @@ u32 GetMostSuitableMonToSwitchInto(u32 battler, enum SwitchType switchType)
         bestMonId = GetBestMonDmg(party, firstId, lastId, invalidMons, battler, opposingBattler);
         if (bestMonId != PARTY_SIZE)
             return bestMonId;
+
+        if (aceMonId != PARTY_SIZE && aliveCount == 0)
+            return aceMonId;
 
         // If ace mon is the last available Pokemon and U-Turn/Volt Switch or Eject Pack/Button was used - switch to the mon.
         if (aceMonId != PARTY_SIZE && CountUsablePartyMons(battler) <= aceMonCount

--- a/src/battle_controller_opponent.c
+++ b/src/battle_controller_opponent.c
@@ -534,13 +534,57 @@ static inline bool32 IsAcePokemon(u32 chosenMonId, u32 pokemonInBattle, u32 batt
         && CountAIAliveNonEggMonsExcept(PARTY_SIZE) != pokemonInBattle;
 }
 
+static inline bool32 IsDoubleAceSlot(u32 battler, u32 partyId)
+{
+    u32 partyCountEnd;
+
+    if (!(gAiThinkingStruct->aiFlags[battler] & AI_FLAG_DOUBLE_ACE_POKEMON))
+        return FALSE;
+
+    partyCountEnd = CalculateEnemyPartyCountInSide(battler);
+    if (partyCountEnd == 0)
+        return FALSE;
+
+    if (partyId == partyCountEnd - 1)
+        return TRUE;
+    if (partyCountEnd > 1 && partyId == partyCountEnd - 2)
+        return TRUE;
+
+    return FALSE;
+}
+
 static inline bool32 IsDoubleAcePokemon(u32 chosenMonId, u32 pokemonInBattle, u32 battler)
 {
-    return gAiThinkingStruct->aiFlags[battler] & AI_FLAG_DOUBLE_ACE_POKEMON
-        && (chosenMonId == CalculateEnemyPartyCountInSide(battler) - 1)
-        && (chosenMonId == CalculateEnemyPartyCountInSide(battler) - 2)
-        && CountAIAliveNonEggMonsExcept(PARTY_SIZE) != pokemonInBattle
-        && CountAIAliveNonEggMonsExcept(PARTY_SIZE-1) != pokemonInBattle;
+    s32 battler1, battler2, firstId, lastId;
+    s32 i;
+
+    if (!IsDoubleAceSlot(battler, chosenMonId))
+        return FALSE;
+
+    if (!IsDoubleBattle())
+    {
+        battler2 = battler1 = GetBattlerAtPosition(B_POSITION_OPPONENT_LEFT);
+    }
+    else
+    {
+        battler1 = GetBattlerAtPosition(B_POSITION_OPPONENT_LEFT);
+        battler2 = GetBattlerAtPosition(B_POSITION_OPPONENT_RIGHT);
+    }
+
+    GetAIPartyIndexes(battler, &firstId, &lastId);
+    for (i = firstId; i < lastId; i++)
+    {
+        if (!IsValidForBattle(&gEnemyParty[i])
+         || i == gBattlerPartyIndexes[battler1]
+         || i == gBattlerPartyIndexes[battler2]
+         || i == chosenMonId)
+            continue;
+
+        if (!IsAcePokemon(i, pokemonInBattle, battler) && !IsDoubleAceSlot(battler, i))
+            return TRUE;
+    }
+
+    return FALSE;
 }
 
 static void OpponentHandleChoosePokemon(u32 battler)

--- a/test/battle/ai/ai_double_ace.c
+++ b/test/battle/ai/ai_double_ace.c
@@ -94,3 +94,35 @@ AI_DOUBLE_BATTLE_TEST("AI_FLAG_DOUBLE_ACE_POKEMON: Ace mons won't be switched in
         TURN { EXPECT_SWITCH(opponentLeft, 2); }
     }
 }
+
+AI_DOUBLE_BATTLE_TEST("AI_FLAG_DOUBLE_ACE_POKEMON: sends out Ace mons when no other options remain mid-battle")
+{
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_SMART_SWITCHING | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_SMART_MON_CHOICES | AI_FLAG_DOUBLE_ACE_POKEMON);
+
+        PLAYER(SPECIES_WOBBUFFET) { Level(50); Speed(200); Moves(MOVE_THUNDERBOLT, MOVE_CELEBRATE); SpAttack(200); }
+        PLAYER(SPECIES_WOBBUFFET) { Level(50); Speed(150); Moves(MOVE_THUNDERBOLT, MOVE_CELEBRATE); SpAttack(200); }
+
+        OPPONENT(SPECIES_ZIGZAGOON) { Level(5); HP(1); Speed(1); Moves(MOVE_SPLASH); }
+        OPPONENT(SPECIES_POOCHYENA) { Level(5); HP(1); Speed(1); Moves(MOVE_SPLASH); }
+
+        // Aces
+        OPPONENT(SPECIES_MIGHTYENA) { Level(50); Speed(10); Moves(MOVE_CRUNCH); }
+        OPPONENT(SPECIES_GENGAR) { Level(50); Speed(10); Moves(MOVE_SPLASH); }
+    } WHEN {
+        TURN {
+            MOVE(playerLeft, MOVE_THUNDERBOLT, target: opponentLeft);
+            MOVE(playerRight, MOVE_CELEBRATE);
+            EXPECT_MOVE(opponentLeft, MOVE_SPLASH);
+            EXPECT_MOVE(opponentRight, MOVE_SPLASH);
+            EXPECT_SEND_OUT(opponentLeft, 3);
+        }
+        TURN {
+            MOVE(playerLeft, MOVE_CELEBRATE);
+            MOVE(playerRight, MOVE_THUNDERBOLT, target: opponentRight);
+            EXPECT_MOVE(opponentLeft, MOVE_SPLASH);
+            EXPECT_MOVE(opponentRight, MOVE_SPLASH);
+            EXPECT_SEND_OUT(opponentRight, 2);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Trainers that use `AI_FLAG_DOUBLE_ACE_POKEMON` were sending out a duplicate of the surviving Pokémon after a KO instead of bringing in one of their two Aces (see #7989). 

The old guard logic in `IsDoubleAcePokemon` was:

  ```c
  return gAiThinkingStruct->aiFlags[battler] & AI_FLAG_DOUBLE_ACE_POKEMON
      && (chosenMonId == CalculateEnemyPartyCountInSide(battler) - 1)
      && (chosenMonId == CalculateEnemyPartyCountInSide(battler) - 2)
      && CountAIAliveNonEggMonsExcept(PARTY_SIZE) != pokemonInBattle
      && CountAIAliveNonEggMonsExcept(PARTY_SIZE - 1) != pokemonInBattle;
```

The combination of ``chosenMonId == last`` and ``chosenMonId == secondLast`` can never be true, so every ace slot was permanently blocked. When the AI tried to switch after a KO, it returned that there was no choice, which the battle engine interpreted as 'reuse slot 0', resulting in the duplicate Pokémon on the field.

This PR fixes the flow:

  - `src/battle_controller_opponent.c`: Added `IsDoubleAceSlot` to detect the last two party indices for whichever
    opponent battler is switching. `IsDoubleAcePokemon` now allows those slots as soon as there are no valid non‑Ace
    choices remaining, so a KO never results in there being no switch when only the aces are left.
  - `src/battle_ai_switch_items.c`: `GetMostSuitableMonToSwitchInto` still keeps ace Pokémon reserved while other candidates
    exist, but if every usable party member is flagged as an Ace it now returns one of them immediately. Pivoting
    (U‑turn/Volt Switch/Eject Pack/Button) retains its previous behaviour.
  - `test/battle/ai/ai_double_ace.c`: Added a regression test that reproduces the reported 4‑Pokémon double battle with two
    regular Pokemon and two Ace bench slots. The test asserts each KO brings out a different Ace, preventing the regression
    from returning.

With these changes the AI always picks an Ace when they are the only remaining bench Pokémon so that the controller never returns that there is no choice in this instance.

## Media

Not applicable.

## Issue(s) that this PR fixes

  Fixes #7644 and #7989

## Feature(s) this PR does NOT handle:

  N/A

## Things to note in the release changelog:

  - Fixed AI_FLAG_DOUBLE_ACE_POKEMON trainers resending the same Pokémon after a KO instead of their two Ace Pokémon in double battles.

## Discord contact info

viridian.