### PR TITLE
Fix tossing items applying to the wrong stack

### DIFF
--- a/include/item.h
+++ b/include/item.h
@@ -215,6 +215,7 @@ bool32 CheckBagHasSpace(u16 itemId, u16 count);
 u32 GetFreeSpaceForItemInBag(u16 itemId);
 bool32 AddBagItem(u16 itemId, u16 count);
 bool32 RemoveBagItem(u16 itemId, u16 count);
+void RemoveBagItemFromSlot(struct BagPocket *pocket, u16 slotId, u16 count);
 u8 CountUsedPCItemSlots(void);
 bool32 CheckPCHasItem(u16 itemId, u16 count);
 bool32 AddPCItem(u16 itemId, u16 count);

--- a/src/item.c
+++ b/src/item.c
@@ -411,6 +411,13 @@ bool32 RemoveBagItem(u16 itemId, u16 count)
     return BagPocket_RemoveItem(&gBagPockets[GetItemPocket(itemId)], itemId, count);
 }
 
+// Unsafe function: Only use with functions that already check the slot and count are valid
+void RemoveBagItemFromSlot(struct BagPocket *pocket, u16 slotId, u16 count)
+{
+    struct ItemSlot itemSlot = BagPocket_GetSlotData(pocket, slotId);
+    BagPocket_SetSlotItemIdAndCount(pocket, slotId, itemSlot.itemId, itemSlot.quantity - count);
+}
+
 static u8 NONNULL BagPocket_CountUsedItemSlots(struct BagPocket *pocket)
 {
     u8 usedSlots = 0;


### PR DESCRIPTION
I added a function that removes from back by checking the slot instead of the itemId. I made sure to only use this function when tossing items from the bag and not in the pyramid or during other interactions that remove items from the bag

## Media
master:

https://github.com/user-attachments/assets/2adf3011-63c5-42f3-9944-e011512409c5

this commit:

https://github.com/user-attachments/assets/a2afe9ab-2103-48cb-bdde-568544bdf7b5



## Issue(s) that this PR fixes
Fixes #8281


## Feature(s) this PR does NOT handle:
This does not auto combine stack or pick the stack with the lowest amount when you use an item


## Discord contact info
Jamie
