### PR TITLE
Fix not enough memory being allocated when moves load background in contests

### DIFF
--- a/src/battle_anim.c
+++ b/src/battle_anim.c
@@ -13,6 +13,7 @@
 #include "graphics.h"
 #include "main.h"
 #include "malloc.h"
+#include "menu.h"
 #include "m4a.h"
 #include "palette.h"
 #include "pokemon.h"
@@ -1568,10 +1569,7 @@ void LoadMoveBg(u16 bgId)
 {
     if (IsContest())
     {
-        void *decompressionBuffer = Alloc(0x4000);
-        const u32 *tilemap = gBattleAnimBackgroundTable[bgId].tilemap;
-
-        DecompressDataWithHeaderWram(tilemap, decompressionBuffer);
+        void *decompressionBuffer = malloc_and_decompress(gBattleAnimBackgroundTable[bgId].tilemap, NULL);
         RelocateBattleBgPal(GetBattleBgPaletteNum(), decompressionBuffer, 0x100, FALSE);
         DmaCopy32(3, decompressionBuffer, (void *)BG_SCREEN_ADDR(26), 0x800);
         DecompressDataWithHeaderVram(gBattleAnimBackgroundTable[bgId].image, (void *)BG_SCREEN_ADDR(4));


### PR DESCRIPTION
In vanilla emerald, a global decompression buffer of size 0x4000 is used in the function that loads background in contests but this was changed at some point in expansion to use a local buffer of smaller size. However the smaller buffer results in arbitrary data being read which cause freezes (or for me when I was testing, just threw a lot of error in the logs but worked fine). 
I restored the buffer to its original size to avoid the issue. I tested intermediate sizes of buffers between 0x800 and 0x4000 and they seem to work for the fissure background but I prefer to keep the original pret one in case some background require more memory. (The memory is freed almost immediately anyway)  


## Issue(s) that this PR fixes
Fixes #8266


## Discord contact info
Jamie
