### PR TITLE
Fix max mushroom unable to be selected when one stat is maxed

### DIFF
--- a/src/item_use.c
+++ b/src/item_use.c
@@ -1293,11 +1293,12 @@ bool32 CannotUseItemsInBattle(u16 itemId, struct Pokemon *mon)
     case EFFECT_ITEM_INCREASE_ALL_STATS:
     {
         u32 ability = GetBattlerAbility(gBattlerInMenuId);
+        cannotUse = TRUE;
         for (i = STAT_ATK; i < NUM_STATS; i++)
         {
-            if (CompareStat(gBattlerInMenuId, i, MAX_STAT_STAGE, CMP_EQUAL, ability))
+            if (!CompareStat(gBattlerInMenuId, i, MAX_STAT_STAGE, CMP_EQUAL, ability))
             {
-                cannotUse = TRUE;
+                cannotUse = FALSE;
                 break;
             }
         }


### PR DESCRIPTION

## Media
master:

https://github.com/user-attachments/assets/a3186a50-e880-4d01-84a0-afbc31cb2fa3

this commit:

https://github.com/user-attachments/assets/91377af7-a3ec-40c3-88da-355caa5201b6



## Issue(s) that this PR fixes
Fixes #8285


## Discord contact info
Jamie