### PR TITLE
Block selecting x items when contrary pokemon are at minimum stages

### DIFF
--- a/src/item_use.c
+++ b/src/item_use.c
@@ -1254,7 +1254,8 @@ bool32 CannotUseItemsInBattle(u16 itemId, struct Pokemon *mon)
     switch (battleUsage)
     {
     case EFFECT_ITEM_INCREASE_STAT:
-        if (gBattleMons[gBattlerInMenuId].statStages[GetItemEffect(itemId)[1]] == MAX_STAT_STAGE)
+        u32 ability = GetBattlerAbility(gBattlerInMenuId);
+        if (CompareStat(gBattlerInMenuId, GetItemEffect(itemId)[1], MAX_STAT_STAGE, CMP_EQUAL, ability))
             cannotUse = TRUE;
         break;
     case EFFECT_ITEM_SET_FOCUS_ENERGY:


### PR DESCRIPTION
## Media
master:

https://github.com/user-attachments/assets/f560e0fa-3a20-4ba4-893c-a1a411d3893d

this commit:

https://github.com/user-attachments/assets/52da585b-69b6-4a37-8f51-eb39e69c3d7d



## Discord contact info
Jamie
