### PR TITLE
Free the allocated buffer before the second decompression call (hopefully helps)

### DIFF
--- a/src/battle_anim.c
+++ b/src/battle_anim.c
@@ -1572,9 +1572,9 @@ void LoadMoveBg(u16 bgId)
         void *decompressionBuffer = malloc_and_decompress(gBattleAnimBackgroundTable[bgId].tilemap, NULL);
         RelocateBattleBgPal(GetBattleBgPaletteNum(), decompressionBuffer, 0x100, FALSE);
         DmaCopy32(3, decompressionBuffer, (void *)BG_SCREEN_ADDR(26), 0x800);
+        Free(decompressionBuffer);
         DecompressDataWithHeaderVram(gBattleAnimBackgroundTable[bgId].image, (void *)BG_SCREEN_ADDR(4));
         LoadPalette(gBattleAnimBackgroundTable[bgId].palette, BG_PLTT_ID(GetBattleBgPaletteNum()), PLTT_SIZE_4BPP);
-        Free(decompressionBuffer);
     }
     else
     {


### PR DESCRIPTION
Even after #8284, the issue #8266  still happen inconsistently on others move (but not fissure). I'm freeing the buffer early hoping it may alleviate the issue


## Discord contact info
Jamie
