### PR TITLE
Allow people to create custom README without conflicting with expansion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ src/data/debug_trainers.h
 test/battle/trainer_control.h
 tools/compresSmol/compresSmol
 tools/compresSmol/compresSmolTilemap
+.github/README.md
 *.Identifier
 *.smol
 *.fastSmol


### PR DESCRIPTION
A readme placed in `.github/README.md` will take priority over the main directory README on github.
Adding the file to the .gitignore allow people making feature branches to make custome README without cerating additional conflicts for users 

## Things to note in the release changelog:
You can now add REAME for your project or feature branch without conflicting with Expansion by adding a `.github/README.md` file to your project or branch

## Discord contact info
Jamie
