### PR TITLE
Make `gTestRunnerHeadless`  into a constant outside of tests

### DIFF
--- a/include/test_runner.h
+++ b/include/test_runner.h
@@ -2,7 +2,11 @@
 #define GUARD_TEST_RUNNER_H
 
 extern const bool8 gTestRunnerEnabled;
+#if TESTING
 extern const bool8 gTestRunnerHeadless;
+#else
+#define gTestRunnerHeadless FALSE
+#endif
 extern const bool8 gTestRunnerSkipIsFail;
 
 #if TESTING

--- a/src/test_runner_stub.c
+++ b/src/test_runner_stub.c
@@ -7,5 +7,7 @@ const bool8 gTestRunnerEnabled = FALSE;
 // The Makefile patches gTestRunnerHeadless as part of make test.
 // This allows us to open the ROM in an mgba with a UI and see the
 // animations and messages play, which helps when debugging a test.
+#if TESTING
 const bool8 gTestRunnerHeadless = FALSE;
+#endif
 const bool8 gTestRunnerSkipIsFail = FALSE;


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
Adds a preproc switch for `gTestRunnerHeadless` which makes it into an actual constant outside of tests, allowing the compiler to do more optimizations.

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara