### PR TITLE
Fix game freeze when trainers try to walk on sideway stairs

### DIFF
--- a/src/trainer_see.c
+++ b/src/trainer_see.c
@@ -522,6 +522,9 @@ static u8 GetTrainerApproachDistance(struct ObjectEvent *trainerObj)
     PlayerGetDestCoords(&x, &y);
     if (trainerObj->trainerType == TRAINER_TYPE_NORMAL)  // can only see in one direction
     {
+        // Disable trainer approach while moving diagonally (usually moving on sideway stairs)
+        if (trainerObj->facingDirection > DIR_EAST)
+            return 0;
         approachDistance = sDirectionalApproachDistanceFuncs[trainerObj->facingDirection - 1](trainerObj, trainerObj->trainerRange_berryTreeId, x, y);
         return CheckPathBetweenTrainerAndPlayer(trainerObj, approachDistance, trainerObj->facingDirection);
     }


### PR DESCRIPTION
Pokemon trainer have a function to test for if the player is in range for each cardinal direction.
When moving on sideway stairs, their direction become diagonal and there is no detection function which causes a freeze
I disable the "player search" when a trainer is moving diagonally and this fixes the issue

## Media

https://github.com/user-attachments/assets/db6c3543-d85a-4aa9-a97b-59539a88f0b4


## Issue(s) that this PR fixes
Fixes #8296

## Discord contact info
Jamie
