### PR TITLE
waitmovementall

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -641,6 +641,10 @@
 		.endif
 	.endm
 
+	.macro waitmovementall
+	callnative Script_waitmovementall, requests_effects=1
+	.endm
+
 	@ Attempts to despawn the specified (localId) object on the specified map.
 	@ It also sets the object's visibility flag if it has one.
 	@ If no map is specified, then the current map is used.

--- a/include/script.h
+++ b/include/script.h
@@ -11,7 +11,8 @@ struct ScriptContext
     u8 stackDepth;
     u8 mode;
     u8 comparisonResult;
-    bool8 breakOnTrainerBattle;
+    bool8 breakOnTrainerBattle:1;
+    bool8 waitAfterCallNative:1;
     u8 (*nativePtr)(void);
     const u8 *scriptPtr;
     const u8 *stack[20];

--- a/include/script_movement.h
+++ b/include/script_movement.h
@@ -3,6 +3,7 @@
 
 bool8 ScriptMovement_StartObjectMovementScript(u8 localId, u8 mapNum, u8 mapGroup, const u8 *movementScript);
 bool8 ScriptMovement_IsObjectMovementFinished(u8 localId, u8 mapNum, u8 mapGroup);
+bool32 ScriptMovement_IsAllObjectMovementFinished(void);
 void ScriptMovement_UnfreezeObjectEvents(void);
 
 #endif // GUARD_SCRIPT_MOVEMENT_H

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -171,8 +171,9 @@ bool8 ScrCmd_callnative(struct ScriptContext *ctx)
     Script_RequestEffects(SCREFF_V1);
     Script_CheckEffectInstrumentedCallNative(func);
 
+    ctx->waitAfterCallNative = FALSE;
     func(ctx);
-    return FALSE;
+    return ctx->waitAfterCallNative;
 }
 
 bool8 ScrCmd_waitstate(struct ScriptContext *ctx)
@@ -1371,6 +1372,18 @@ bool8 ScrCmd_waitmovementat(struct ScriptContext *ctx)
     sMovingNpcMapNum = mapNum;
     SetupNativeScript(ctx, WaitForMovementFinish);
     return TRUE;
+}
+
+static bool8 WaitForAllMovementFinish(void)
+{
+    return ScriptMovement_IsAllObjectMovementFinished();
+}
+
+void Script_waitmovementall(struct ScriptContext *ctx)
+{
+    Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
+    SetupNativeScript(ctx, WaitForAllMovementFinish);
+    ctx->waitAfterCallNative = TRUE;
 }
 
 bool8 ScrCmd_removeobject(struct ScriptContext *ctx)

--- a/src/script_movement.c
+++ b/src/script_movement.c
@@ -45,6 +45,22 @@ bool8 ScriptMovement_IsObjectMovementFinished(u8 localId, u8 mapNum, u8 mapGroup
     return IsMovementScriptFinished(taskId, moveScrId);
 }
 
+bool32 ScriptMovement_IsAllObjectMovementFinished(void)
+{
+    u8 taskId = GetMoveObjectsTaskId();
+    if (taskId != TASK_NONE)
+    {
+        u32 finishedMovements = gTasks[taskId].data[0];
+        const u8 *objEventIds = (u8 *)&gTasks[taskId].data[1];
+        for (u32 i = 0; i < OBJECT_EVENTS_COUNT; i++)
+        {
+            if (objEventIds[i] != 0xFF && !(finishedMovements & (1 << i)))
+                return FALSE;
+        }
+    }
+    return TRUE;
+}
+
 void ScriptMovement_UnfreezeObjectEvents(void)
 {
     u8 taskId;


### PR DESCRIPTION
Adds `waitmovementall` which is like `waitmovement X` where `X` is whichever local ID will finish moving last.

Separated from #8196 because this command could be generally useful. Technically it's not strictly necessary for #8196 because I could also use `waitmovement X` with an explicit ID, but I think it's kinda cleaner to say `waitmovementall` when there are multiple movements and the intention is to wait for them all to finish.

It would have been nice to make `waitmovement 0` wait for all movements to finish, but people could (and probably do) use that to wait for the most recent movement.

Also adds `waitAfterCallNative` to `ScriptContext` because previously there was no way for a `callnative` that sets up a native script to function. On merrp's branches `callnative` is extended to return a `bool8` like script commands, but we can't really do that—all existing code would continue to compile without any warnings but the return value will be whatever happens to be in `r0`.