### PR TITLE
Clear Destiny Bond/Grudge bits when not activated

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -4952,6 +4952,8 @@ static void MoveValuesCleanUp(void)
     gBattleScripting.moveEffect = MOVE_EFFECT_NONE;
     gBattleStruct->synchronizeMoveEffect = MOVE_EFFECT_NONE;
     gBattleCommunication[MISS_TYPE] = 0;
+    gBattleStruct->tryDestinyBond = FALSE;
+    gBattleStruct->tryGrudge = FALSE;
 }
 
 static void Cmd_movevaluescleanup(void)
@@ -7031,6 +7033,8 @@ static void Cmd_moveend(void)
             gBattleStruct->additionalEffectsCounter = 0;
             gBattleStruct->poisonPuppeteerConfusion = FALSE;
             gBattleStruct->fickleBeamBoosted = FALSE;
+            gBattleStruct->tryDestinyBond = FALSE;
+            gBattleStruct->tryGrudge = FALSE;
             gBattleStruct->battlerState[gBattlerAttacker].usedMicleBerry = FALSE;
             gBattleStruct->noTargetPresent = FALSE;
             gBattleStruct->toxicChainPriority = FALSE;


### PR DESCRIPTION
Resets Destiny Bond/Grudge activation for every target/hit and in `MOVEEND_CLEAR_BITS` in case it fails to activate (notably when the attacker faints from the attack - Explosion, Final Gambit...)

## Discord contact info
PhallenTree
