### PR TITLE
Prevent moves to be changed when choosing half party

### DIFF
--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -3010,6 +3010,10 @@ static void CB2_ShowPokemonSummaryScreen(void)
         UpdatePartyToBattleOrder();
         ShowPokemonSummaryScreen(SUMMARY_MODE_LOCK_MOVES, gPlayerParty, gPartyMenu.slotId, gPlayerPartyCount - 1, CB2_ReturnToPartyMenuFromSummaryScreen);
     }
+    else if (gPartyMenu.menuType == PARTY_MENU_TYPE_CHOOSE_HALF)
+    {
+        ShowPokemonSummaryScreen(SUMMARY_MODE_LOCK_MOVES, gPlayerParty, gPartyMenu.slotId, gPlayerPartyCount - 1, CB2_ReturnToPartyMenuFromSummaryScreen);
+    }
     else
     {
         ShowPokemonSummaryScreen(SUMMARY_MODE_NORMAL, gPlayerParty, gPartyMenu.slotId, gPlayerPartyCount - 1, CB2_ReturnToPartyMenuFromSummaryScreen);


### PR DESCRIPTION
When canceling after opening a chooseHalfParty screen, the game reloads our previous party and delete any changes we made to moves. We make sure the summary screen open with the locked moves flag set so that the player can't modify their moves then lose their changes

## Media
master:

https://github.com/user-attachments/assets/e44bad20-5205-4d1f-b42f-78b5755fcac1

this commit:

https://github.com/user-attachments/assets/2cf4d0af-6cff-4485-bac9-b183aa894113

## Issue(s) that this PR fixes
Fixes #8242


## Discord contact info
Jamie
