### PR TITLE
Fix substitute graphic not disappearing after using a pivor move

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -156,7 +156,11 @@ BattleScript_EffectShedTail::
 	waitmessage B_WAIT_TIME_LONG
 	moveendto MOVEEND_ATTACKER_VISIBLE
 	moveendfrom MOVEEND_TARGET_VISIBLE
-	goto BattleScript_MoveSwitchOpenPartyScreen
+	call BattleScript_MoveSwitchOpenPartyScreenReturnWithNoAnim
+	switchinanim BS_ATTACKER, FALSE, TRUE
+	waitstate
+	switchineffects BS_ATTACKER
+	end
 
 BattleScript_EffectPsychicNoise::
 	printstring STRINGID_PKMNPREVENTEDFROMHEALING
@@ -308,6 +312,14 @@ BattleScript_MoveSwitch:
 	printstring STRINGID_PKMNWENTBACK
 	waitmessage B_WAIT_TIME_SHORT
 BattleScript_MoveSwitchOpenPartyScreen::
+	call BattleScript_MoveSwitchOpenPartyScreenReturnWithNoAnim
+	switchinanim BS_ATTACKER, FALSE, FALSE
+	waitstate
+	switchineffects BS_ATTACKER
+BattleScript_MoveSwitchEnd:
+	end
+
+BattleScript_MoveSwitchOpenPartyScreenReturnWithNoAnim:
 	openpartyscreen BS_ATTACKER, BattleScript_MoveSwitchEnd
 	waitstate
 	returntoball BS_ATTACKER, FALSE
@@ -320,11 +332,7 @@ BattleScript_MoveSwitchOpenPartyScreen::
 	printstring STRINGID_EMPTYSTRING3
 	waitmessage 1
 	printstring STRINGID_SWITCHINMON
-	switchinanim BS_ATTACKER, FALSE, TRUE
-	waitstate
-	switchineffects BS_ATTACKER
-BattleScript_MoveSwitchEnd:
-	end
+	return
 
 BattleScript_EffectPledge::
 	attackcanceler


### PR DESCRIPTION
The script used by u_turn and hother hit escape moves calls "switchinanim FALSE, TRUE" The second boolean correspons to "don't clear subsitute" so replacing it with "switchinanim FALSE, FALSE" would properly clear the substitute graphic. However the function is also called by Shed Tail which we don't want to clear the subsitute graphic so I rearrange the scripts so that shed_tail  calls "switchinanim FALSE, TRUE" and the other switch moves call  "switchinanim FALSE, FALSE"

## Media
Video made using the same tests as one described in #6548

https://github.com/user-attachments/assets/0fdef19f-aae7-4741-9b09-cf7f77ac0133



## Issue(s) that this PR fixes
Fixes #6548


## Discord contact info
Jamie
