### PR TITLE
Expand usage of FaintedActions enum in HandleFaintedMonActions

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -1854,7 +1854,7 @@ bool32 HandleFaintedMonActions(void)
             break;
         case FAINTED_ACTIONS_SET_ABSENT_FLAGS:
             OpponentSwitchInResetSentPokesToOpponentValue(gBattlerFainted);
-            if (gBattleStruct->eventState.faintedActionBattler == gBattlersCount - 1)
+            if (++gBattleStruct->eventState.faintedActionBattler == gBattlersCount)
                 gBattleStruct->eventState.faintedAction = FAINTED_ACTIONS_WAIT_STATE;
             else
                 gBattleStruct->eventState.faintedAction = FAINTED_ACTIONS_GIVE_EXP;


### PR DESCRIPTION
#8131 added the `FaintedActions` enum, but didn't change all the values given to `gBattleStruct->eventState.faintedAction` to values of this enum.

## Discord contact info
PhallenTree