### PR TITLE
Fixes Neutralizing Gas / Mold Breaker / Dragon Darts interaction

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -667,7 +667,7 @@ struct BattleStruct
     u8 multipleSwitchInState:2;
     u8 multipleSwitchInCursor:3;
     u8 sleepClauseNotBlocked:1;
-    u8 padding1:1;
+    u8 moldBreakerActive:1;
     u8 multipleSwitchInSortedBattlers[MAX_BATTLERS_COUNT];
     void (*savedCallback)(void);
     u16 usedHeldItems[PARTY_SIZE][NUM_BATTLE_SIDES]; // For each party member and side. For harvest, recycle

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -7020,6 +7020,7 @@ static void Cmd_moveend(void)
             gSpecialStatuses[gBattlerTarget].berryReduced = FALSE;
             gSpecialStatuses[gBattlerTarget].distortedTypeMatchups = FALSE;
             gBattleScripting.moveEffect = MOVE_EFFECT_NONE;
+            gBattleStruct->moldBreakerActive = FALSE;
             gBattleStruct->isAtkCancelerForCalledMove = FALSE;
             gBattleStruct->swapDamageCategory = FALSE;
             gBattleStruct->categoryOverride = FALSE;

--- a/test/battle/ability/neutralizing_gas.c
+++ b/test/battle/ability/neutralizing_gas.c
@@ -353,3 +353,45 @@ SINGLE_BATTLE_TEST("Neutralizing Gas only displays exiting message for the last 
         NOT MESSAGE("The effects of the neutralizing gas wore off!");
     }
 }
+
+DOUBLE_BATTLE_TEST("Neutralizing Gas is active for the duration of a Spread Move even if Neutralizing Gas is no longer on the field")
+{
+    GIVEN {
+        ASSUME(GetMoveTarget(MOVE_ORIGIN_PULSE) == MOVE_TARGET_BOTH);
+        PLAYER(SPECIES_WEEZING) { HP(1); Ability(ABILITY_NEUTRALIZING_GAS); }
+        PLAYER(SPECIES_GOLEM) { Ability(ABILITY_STURDY); }
+        OPPONENT(SPECIES_BASCULEGION) { Ability(ABILITY_MOLD_BREAKER); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponentLeft, MOVE_ORIGIN_PULSE); }
+    } SCENE {
+        ABILITY_POPUP(playerLeft, ABILITY_NEUTRALIZING_GAS);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ORIGIN_PULSE, opponentLeft);
+        HP_BAR(playerLeft);
+        HP_BAR(playerRight);
+        MESSAGE("Weezing fainted!");
+        MESSAGE("Golem fainted!");
+        NOT ABILITY_POPUP(playerRight, ABILITY_STURDY);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Neutralizing Gas is active until the last Dragon Darts hit even if Neutralizing Gas is no longer on the field")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_DRAGON_DARTS) == EFFECT_DRAGON_DARTS);
+        PLAYER(SPECIES_WEEZING) { HP(1); Ability(ABILITY_NEUTRALIZING_GAS); }
+        PLAYER(SPECIES_GOLEM) { HP(2); MaxHP(2); Ability(ABILITY_STURDY); }
+        OPPONENT(SPECIES_BASCULEGION) { Ability(ABILITY_MOLD_BREAKER); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponentLeft, MOVE_DRAGON_DARTS, target: playerLeft); }
+    } SCENE {
+        ABILITY_POPUP(playerLeft, ABILITY_NEUTRALIZING_GAS);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DARTS, opponentLeft);
+        HP_BAR(playerLeft);
+        MESSAGE("Weezing fainted!");
+        HP_BAR(playerRight);
+        NOT MESSAGE("Golem fainted!");
+        ABILITY_POPUP(playerRight, ABILITY_STURDY);
+    }
+}


### PR DESCRIPTION
Neutralizing Gas is active for the duration of the move even if the mon with the ability faints in the middle of an attack such as Dragon Darts.  The second hit will still be unaffected by Mold Breaker. 