### PR TITLE
DMA micro optimization

### DIFF
--- a/include/global.h
+++ b/include/global.h
@@ -85,6 +85,11 @@
 // intended, and a%n for powers of 2 isn't always optimized to use &.
 #define MOD(a, n) (((n) & ((n)-1)) ? ((a) % (n)) : ((a) & ((n)-1)))
 
+// Increments 'a' by 1, wrapping back to 0 when it reaches 'n'. If 'n' is a power of two,
+// the wrap is implemented using a bit mask: (a + 1) & (n - 1), which is slightly faster.
+// This is intended to be used when 'n' is known at compile time.
+#define INCREMENT_OR_WRAP(a, n) ((IS_POW_OF_TWO(n)) ? (((a) + 1) & ((n) - 1)) : (((a) + 1) >= (n) ? 0 : ((a) + 1)))
+
 // Extracts the upper 16 bits of a 32-bit number
 #define HIHALF(n) (((n) & 0xFFFF0000) >> 16)
 

--- a/src/dma3_manager.c
+++ b/src/dma3_manager.c
@@ -88,10 +88,8 @@ void ProcessDma3Requests(void)
         sDma3Requests[sDma3RequestCursor].size = 0;
         sDma3Requests[sDma3RequestCursor].mode = 0;
         sDma3Requests[sDma3RequestCursor].value = 0;
-        sDma3RequestCursor++;
 
-        if (sDma3RequestCursor >= MAX_DMA_REQUESTS) // loop back to the first DMA request
-            sDma3RequestCursor = 0;
+        sDma3RequestCursor = INCREMENT_OR_WRAP(sDma3RequestCursor, MAX_DMA_REQUESTS); // loop back to the first DMA request
     }
 }
 
@@ -119,8 +117,8 @@ s16 RequestDma3Copy(const void *src, void *dest, u16 size, u32 mode)
             sDma3ManagerLocked = FALSE;
             return cursor;
         }
-        if (++cursor >= MAX_DMA_REQUESTS) // loop back to start.
-            cursor = 0;
+
+        cursor = INCREMENT_OR_WRAP(cursor, MAX_DMA_REQUESTS); // loop back to start.
         i++;
     }
     sDma3ManagerLocked = FALSE;
@@ -152,8 +150,8 @@ s16 RequestDma3Fill(s32 value, void *dest, u16 size, u32 mode)
             sDma3ManagerLocked = FALSE;
             return cursor;
         }
-        if (++cursor >= MAX_DMA_REQUESTS) // loop back to start.
-            cursor = 0;
+
+        cursor = INCREMENT_OR_WRAP(cursor, MAX_DMA_REQUESTS); // loop back to start.
         i++;
     }
     sDma3ManagerLocked = FALSE;


### PR DESCRIPTION
## Description
Optimizes 3 searches in a circular array inside the DMA code by using bitwise operations. This saves 8 cycles per call.

Since this optimization depends on `MAX_DMA_REQUESTS` being a power of two and this value is meant to be configurable, the optimization is implemented by using a macro (`INCREMENT_OR_WRAP`), it will switch to the old method on compile if this optimization is no longer possibly.

I left the macro in  `global.h` as it might be useful elsewhere in the code base.

[Here](https://github.com/estellarc/pokeemerald/tree/rhh/dma-micro-optimization-tests) a link to the branch with the code I used for testing performance.

## Logs

Before

Performance by reaching the main menu
```
[WARN] GBA Debug:	Time: 168
[WARN] GBA Debug:	Time: 168
[WARN] GBA Debug:	Time: 202
[WARN] GBA Debug:	Time: 254
[WARN] GBA Debug:	Time: 270
[WARN] GBA Debug:	Time: 168
[WARN] GBA Debug:	Time: 202
```

After

Performance by reaching the main menu
```
[WARN] GBA Debug:	Time: 160
[WARN] GBA Debug:	Time: 160
[WARN] GBA Debug:	Time: 186
[WARN] GBA Debug:	Time: 212
[WARN] GBA Debug:	Time: 238
[WARN] GBA Debug:	Time: 160
[WARN] GBA Debug:	Time: 186
```

## Discord contact info
estellar.cheese
