### PR TITLE
Fix substitute/defog interactions

### DIFF
--- a/data/battle_anim_scripts.s
+++ b/data/battle_anim_scripts.s
@@ -31100,27 +31100,6 @@ gBattleAnimGeneral_StatsChange::
 	waitforvisualfinish
 	end
 
-gBattleAnimGeneral_StatsChangeBypassSubstitute::
-	createvisualtask AnimTask_IsAttackerBehindSubstitute, 2
-	jumprettrue StatChangeSubstituteForMon
-StatsChangeBypassSubstitute_Continue:
-	createvisualtask AnimTask_StatsChange, 5
-	waitforvisualfinish
-	createvisualtask AnimTask_IsAttackerBehindSubstitute, 2
-	jumprettrue StatChangeSubstituteToMon
-	end
-
-StatChangeSubstituteForMon:
-	createvisualtask AnimTask_SwapMonSpriteToFromSubstitute, 2, TRUE
-	waitforvisualfinish
-	goto StatsChangeBypassSubstitute_Continue
-
-StatChangeSubstituteToMon:
-	createvisualtask AnimTask_SwapMonSpriteToFromSubstitute, 2, FALSE
-	waitforvisualfinish
-	end
-
-
 gBattleAnimGeneral_SubstituteFade::
 	monbg ANIM_ATTACKER
 	createvisualtask AnimTask_SubstituteFadeToInvisible, 5

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -1513,7 +1513,9 @@ BattleScript_DefogWorksAfterSubstituteCheck:
 BattleScript_DefogDoAnim::
 	attackanimation
 	waitanimation
+	call BattleScript_SwapFromSubstitute
 	statbuffchange BS_TARGET, STAT_CHANGE_ALLOW_PTR, BattleScript_DefogTryHazards
+	call BattleScript_SwapToSubstitute
 BattleScript_DefogPrintString::
 	printfromtable gStatDownStringIds
 	waitmessage B_WAIT_TIME_LONG

--- a/src/battle_gfx_sfx_util.c
+++ b/src/battle_gfx_sfx_util.c
@@ -557,7 +557,7 @@ static bool8 ShouldAnimBeDoneRegardlessOfSubstitute(u8 animId)
     case B_ANIM_SNOW_CONTINUES:
     case B_ANIM_FOG_CONTINUES:
     case B_ANIM_SNATCH_MOVE:
-    case B_ANIM_STATS_CHANGE_IGNORE_SUBSTITUTE:
+    case B_ANIM_STATS_CHANGE:
         return TRUE;
     default:
         return FALSE;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -10204,10 +10204,7 @@ static void TryPlayStatChangeAnimation(u32 battler, enum Ability ability, u32 st
 
     if (!gBattleScripting.statAnimPlayed)
     {
-        if (GetConfig(CONFIG_DEFOG_EFFECT_CLEARING) < GEN_5)
-            BtlController_EmitBattleAnimation(battler, B_COMM_TO_CONTROLLER, B_ANIM_STATS_CHANGE_IGNORE_SUBSTITUTE, &gDisableStructs[battler], statAnimId);
-        else
-            BtlController_EmitBattleAnimation(battler, B_COMM_TO_CONTROLLER, B_ANIM_STATS_CHANGE, &gDisableStructs[battler], statAnimId);
+        BtlController_EmitBattleAnimation(battler, B_COMM_TO_CONTROLLER, B_ANIM_STATS_CHANGE, &gDisableStructs[battler], statAnimId);
         MarkBattlerForControllerExec(battler);
         if (changeableStatsCount > 1)
             gBattleScripting.statAnimPlayed = TRUE;

--- a/test/battle/move_effect/defog.c
+++ b/test/battle/move_effect/defog.c
@@ -64,7 +64,7 @@ SINGLE_BATTLE_TEST("Defog lowers evasiveness of target behind Substitute (Gen4-)
         MESSAGE("The opposing Wobbuffet used Substitute!");
         NOT MESSAGE("But it failed!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DEFOG, player);
-        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE_IGNORE_SUBSTITUTE, opponent);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
         MESSAGE("The opposing Wobbuffet's evasiveness fell!");
     }
 }
@@ -83,7 +83,7 @@ SINGLE_BATTLE_TEST("Defog fails if target has minimum evasion stat change behind
     } SCENE {
         MESSAGE("The opposing Wobbuffet used Substitute!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DEFOG, player);
-        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE_IGNORE_SUBSTITUTE, opponent);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
         MESSAGE("The opposing Wobbuffet's evasiveness harshly fell!");
         MESSAGE("But it failed!");
     }


### PR DESCRIPTION
on master Defog was lowering evasion behind substitute if there was stuff on field regardless on gen and I'm fixing that, it will never reduce evasion behind sub in gen5+
Then from my reading of bulbapedia/jp wiki, it seems that it always lowers evasion in gen4 regardless of if there is stuff to remove so I'm going with that for now, it should be easy to change if it's different anyway

I added tests for min stage evasion because I was confused about some stuff but it may not be needed 

## Issue(s) that this PR fixes
Fixes #5386

## Discord contact info
Jamie
