### PR TITLE
Make TRUE and 1 behave the same in config/species_enabled.h

### DIFF
--- a/data/sound_data.s
+++ b/data/sound_data.s
@@ -1,5 +1,8 @@
 	.section .rodata
 
+	.include "asm/macros.inc"
+	.include "constants/constants.inc"
+
 	.include "asm/macros/m4a.inc"
 	.include "asm/macros/music_voice.inc"
 	.include "include/config/general.h"

--- a/include/config/species_enabled.h
+++ b/include/config/species_enabled.h
@@ -1,9 +1,6 @@
 #ifndef GUARD_CONFIG_SPECIES_ENABLED_H
 #define GUARD_CONFIG_SPECIES_ENABLED_H
 
-// WARNING: For some reason, using 1/0 instead of TRUE/FALSE causes cry IDs to be shifted.
-// Please use TRUE/FALSE when using the family toggles.
-
 // Modifying the latest generation WILL change the saveblock due to Dex flags and will require a new save file.
 // Generations of Pokémon are defined by the first member introduced,
 // so Pikachu depends on the Gen 1 setting despite Pichu being the lowest member of the evolution tree.


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
`TRUE` and `1` were not behaving the same way in `include/config/species_enabled.h`.
This makes them behave the same way.
There is no change in sha1sum of the compiled ROM before and after this change.
There is no change in sha1sum of the compiled ROM when using `TRUE` or `1`.
Prior to this change `TRUE` or `1` resulted in different ROM checksums.

Fix developed by @Gudf

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara