### PR TITLE
fix (hazards): ghosty used rapid spin! ghosty blew the semicolon away!

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -5855,7 +5855,7 @@ static s32 AI_CalcAdditionalEffectScore(u32 battlerAtk, u32 battlerDef, u32 move
                     ADJUST_SCORE(DECENT_EFFECT);
                 break;
             case MOVE_EFFECT_STEALTH_ROCK:
-                if (AI_ShouldSetUpHazards(battlerAtk, battlerDef, move, aiData));
+                if (AI_ShouldSetUpHazards(battlerAtk, battlerDef, move, aiData))
                 {
                     if (gDisableStructs[battlerAtk].isFirstTurn)
                         ADJUST_SCORE(BEST_EFFECT);


### PR DESCRIPTION
## Description
Bug discovered in EI 1.3.1, not as critical upstream here since Stone Axe is handled via a direct effect and not an additional effect - but in AI_CalcMoveEffectScore() additional guaranteed effect handling, a nefarious load-bearing semicolon prevented the AI from correctly recognizing hazard prevention and would default to either +4 on the first turn or +2 on subsequent turns for those moves.

## Things to note in the release changelog:
- The AI will now correctly see if the player can prevent hazards on moves with a secondary Stealth Rock effect.

## Discord contact info
ghostyboyy97
