### PR TITLE
Update mdbook to v0.5.1

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - name: Install latest mdbook
         run: |
-          tag="v0.5.0-beta.1"
+          tag="v0.5.1"
           url="https://github.com/rust-lang/mdbook/releases/download/${tag}/mdbook-${tag}-x86_64-unknown-linux-gnu.tar.gz"
           mkdir mdbook
           curl -sSL $url | tar -xz --directory=./mdbook

--- a/docs/changelogs/1.12.x/1.12.0.md
+++ b/docs/changelogs/1.12.x/1.12.0.md
@@ -121,7 +121,7 @@
     - Added option to disable object event shadows
     - Added option to turn DNS on or off, `OW_ENABLE_DNS`
     - Added option to for vanilla shadow behaviour, `OW_OBJECT_VANILLA_SHADOWS`
-    - Scripts containing consecutive `removeobject <object> and `addobject <object>` needs a `delay 1` between the commands.
+    - Scripts containing consecutive `removeobject <object>` and `addobject <object>` needs a `delay 1` between the commands.
     ```diff
     removeobject MY_OBJECT
     + delay 1


### PR DESCRIPTION
The change to the 1.12.0 changelog resolves a new warning:
```
WARN unclosed HTML tag `<object>` found in `changelogs/1.12.x/1.12.0.md` while exiting Item
```

A code block was unclosed, which meant that everything in the rest of that line that was supposed to be inside a code span was outside the code span and thus interpreted instead of treated as plaintext

## Discord contact info
yoshord
