### PR TITLE
Fix bug with enterCode default value

### DIFF
--- a/src/field_specials.c
+++ b/src/field_specials.c
@@ -4356,6 +4356,7 @@ void UseBlankMessageToCancelPokemonPic(void)
 
 void EnterCode(void)
 {
+    StringCopy(gStringVar2, COMPOUND_STRING(""));
     DoNamingScreen(NAMING_SCREEN_CODE, gStringVar2, 0, 0, 0, CB2_ReturnToFieldContinueScript);
 }
 


### PR DESCRIPTION
If you press start immediately on the naming screen when using the entercode special, the game will consider the inputted code (stored in gStringVar2) to be equal to the previous value stored in gStringVar2 instead of ""
(see video for example)
This commit fixes that

## Media
master:

https://github.com/user-attachments/assets/7912e861-2398-4d78-947f-028035d4f33d

this commit:

https://github.com/user-attachments/assets/1d910e84-7a90-4e29-8d48-7afb56ecfa0c



## Discord contact info
Jamie
