### PR TITLE
Fix Air Balloon message happening when another battler switches in

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -196,11 +196,10 @@ struct SpecialStatus
     u8 rototillerAffected:1;  // to be affected by rototiller
     // End of byte
     u8 criticalHit:1;
-    u8 switchInItemDone:1;
     u8 instructedChosenTarget:3;
     u8 berryReduced:1;
     u8 neutralizingGasRemoved:1;    // See VARIOUS_TRY_END_NEUTRALIZING_GAS
-    u8 padding2:1;
+    u8 padding2:2;
     // End of byte
     u8 gemParam:7;
     u8 gemBoost:1;

--- a/src/battle_hold_effects.c
+++ b/src/battle_hold_effects.c
@@ -222,9 +222,8 @@ static enum ItemEffect TryAirBalloon(u32 battler, ActivationTiming timing)
             effect = ITEM_EFFECT_OTHER;
         }
     }
-    else if (!gSpecialStatuses[battler].switchInItemDone)
+    else if (gBattleStruct->battlerState[battler].switchIn)
     {
-        gSpecialStatuses[battler].switchInItemDone = TRUE;
         BattleScriptCall(BattleScript_AirBalloonMsgInRet);
         RecordItemEffectBattle(battler, HOLD_EFFECT_AIR_BALLOON);
         effect = ITEM_EFFECT_OTHER;

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3240,7 +3240,6 @@ void SwitchInClearSetData(u32 battler, struct Volatiles *volatilesCopy)
     gBattleStruct->battlerState[battler].canPickupItem = FALSE;
     gBattleStruct->battlerState[battler].wasAboveHalfHp = gBattleMons[battler].hp > gBattleMons[battler].maxHP / 2;
     gBattleStruct->hazardsCounter = 0;
-    gSpecialStatuses[battler].switchInItemDone = FALSE;
 
     ClearPursuitValuesIfSet(battler);
 

--- a/src/battle_switch_in.c
+++ b/src/battle_switch_in.c
@@ -229,7 +229,6 @@ static bool32 FirstEventBlockEvents(struct BattleContext *ctx)
         else if (EmergencyExitCanBeTriggered(battler))
         {
             gBattleScripting.battler = gBattlerAbility = battler;
-            gSpecialStatuses[battler].switchInItemDone = FALSE;
             gBattleStruct->battlerState[battler].forcedSwitch = FALSE;
             gBattleStruct->eventState.switchIn = 0;
             BattleScriptCall(BattleScript_EmergencyExit);

--- a/test/battle/hold_effect/air_balloon.c
+++ b/test/battle/hold_effect/air_balloon.c
@@ -24,6 +24,20 @@ SINGLE_BATTLE_TEST("Air Balloon prevents the holder from taking damage from grou
     }
 }
 
+SINGLE_BATTLE_TEST("Air Balloon only displays entry message when user switches in")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_AIR_BALLOON); };
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN { SWITCH(opponent, 1); }
+    } SCENE {
+        MESSAGE("Wobbuffet floats in the air with its Air Balloon!");
+        NOT MESSAGE("Wobbuffet floats in the air with its Air Balloon!");
+    }
+}
+
 SINGLE_BATTLE_TEST("Air Balloon pops when the holder is hit by a move that is not ground type")
 {
     GIVEN {


### PR DESCRIPTION
Since the activation was controlled by `gSpecialStatuses[battler].switchInItemDone`, which is cleared after an action finishes, the message could display again when other battlers enter the field.
This was the only use for `gSpecialStatuses[battler].switchInItemDone`.

## Discord contact info
PhallenTree
