### PR TITLE
Fix random function in testing trying to run trials when rng tag is 0/RNG_NONE

### DIFF
--- a/test/test_runner_battle.c
+++ b/test/test_runner_battle.c
@@ -650,7 +650,7 @@ static u32 BattleTest_RandomUniform(enum RandomTag tag, u32 lo, u32 hi, bool32 (
         }
     }
     //trials
-    if (tag == STATE->rngTag)
+    if (tag && tag == STATE->rngTag)
         return RandomUniformTrials(tag, lo, hi, reject, caller);
 
     //default
@@ -670,7 +670,7 @@ static u32 BattleTest_RandomWeightedArray(enum RandomTag tag, u32 sum, u32 n, co
     }
 
     //trials
-    if (tag == STATE->rngTag)
+    if (tag && tag == STATE->rngTag)
         return RandomWeightedArrayTrials(tag, sum, n, weights, caller);
 
     //default
@@ -725,7 +725,7 @@ static const void *BattleTest_RandomElementArray(enum RandomTag tag, const void 
 
 
     //trials
-    if (tag == STATE->rngTag)
+    if (tag && tag == STATE->rngTag)
         return RandomElementArrayTrials(tag, array, size, count, caller);
 
     //default


### PR DESCRIPTION
When calling a randomness function with tag RNG_NONE (0), the test engine would compare to the value to STATE->rngTag to check if should run trials. But STATE->rngTag  is equal to 0 when are not running trials which is causing issue.
So I added acondition to make sure the tag is not 0/RNG_NONE

## Discord contact info
Jamie