### PR TITLE
Miscellaneous Item Changes

### DIFF
--- a/src/data/items.h
+++ b/src/data/items.h
@@ -9343,6 +9343,7 @@ const struct Item gItemsInfo[] =
         .holdEffect = HOLD_EFFECT_EXP_SHARE,
         #if I_EXP_SHARE_ITEM >= GEN_6
             .price = 0,
+            .importance = 1,
             .description = COMPOUND_STRING(
                 "This device gives\n"
                 "exp. to other\n"
@@ -13462,6 +13463,7 @@ const struct Item gItemsInfo[] =
     {
         .name = ITEM_NAME("Dynamax Band"),
         .price = 0,
+        .importance = 1,
         .description = COMPOUND_STRING(
             "A band carrying a\n"
             "Wishing Star that\n"


### PR DESCRIPTION
## Description
* Plurals matched to the official games (normal, not quantified)
* Bicycle -> Bike (as in BDSP)
* Fresh Start Mochi -> Fresh-Start Mochi (missed dash)
* Gen 3 Sport Ball: $300 -> $0
* Gen 5 Big Nugget: $20,000 -> $0
* Gen 5 Balm Mushroom: $12,500 -> $0
* Gen 5 Pearl String: $15,000 -> $0
* Gen 8+ Pearl String: $15,000 -> $20,000
* Gen 6+ Relic Gold: $0 -> $60,000
* Gen 1/2 Moon Stone: $2,100 -> $1
* Gen 3 Moon Stone: $2,100 -> $0
* Gen 1 Exp. Share: $3000 -> $1
* Pre-Gen 8 Big Nugget Fling Power: 130 -> 80
* Gen 5/6 Honey: $300 -> $100

## Discord contact info
amiosi
