### PR TITLE
Fix gimmick icon not appearing correctly in 1v2

### DIFF
--- a/src/battle_gimmick.c
+++ b/src/battle_gimmick.c
@@ -147,7 +147,7 @@ void CreateGimmickTriggerSprite(u32 battler)
 
     if (gBattleStruct->gimmick.triggerSpriteId == 0xFF)
     {
-        if (IsDoubleBattle())
+        if (GetBattlerCoordsIndex(battler) == BATTLE_COORDS_DOUBLES)
             gBattleStruct->gimmick.triggerSpriteId = CreateSprite(gimmick->triggerTemplate,
                                                                   gSprites[gHealthboxSpriteIds[battler]].x - DOUBLES_GIMMICK_TRIGGER_POS_X_SLIDE,
                                                                   gSprites[gHealthboxSpriteIds[battler]].y - DOUBLES_GIMMICK_TRIGGER_POS_Y_DIFF, 0);
@@ -204,7 +204,7 @@ static void SpriteCb_GimmickTrigger(struct Sprite *sprite)
     s32 yDiff;
     s32 xHealthbox = gSprites[gHealthboxSpriteIds[sprite->tBattler]].x;
 
-    if (IsDoubleBattle())
+    if (GetBattlerCoordsIndex(sprite->tBattler) == BATTLE_COORDS_DOUBLES)
     {
         xSlide = DOUBLES_GIMMICK_TRIGGER_POS_X_SLIDE;
         xPriority = DOUBLES_GIMMICK_TRIGGER_POS_X_PRIORITY;


### PR DESCRIPTION
## Media
Master:

<img width="240" height="160" alt="pokeemerald-10" src="https://github.com/user-attachments/assets/f9dd3726-a903-45b3-a854-81366c2a3d33" />

This commit:
<img width="240" height="160" alt="pokeemerald-11" src="https://github.com/user-attachments/assets/0fa5e21f-4eda-4d06-88f1-8969c4a5e6b6" />

## Issue(s) that this PR fixes
Fixes #8447


## Discord contact info
Jamie