### PR TITLE
Gorilla Tactics fix and White Herb Typo fix

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -12745,7 +12745,7 @@ static void Cmd_tryswapitems(void)
 
             if (GetBattlerAbility(gBattlerTarget) != ABILITY_GORILLA_TACTICS)
                 gBattleStruct->choicedMove[gBattlerTarget] = MOVE_NONE;
-            if (GetBattlerAbility(gBattlerTarget) != ABILITY_GORILLA_TACTICS)
+            if (GetBattlerAbility(gBattlerAttacker) != ABILITY_GORILLA_TACTICS)
                 gBattleStruct->choicedMove[gBattlerAttacker] = MOVE_NONE;
 
             gBattlescriptCurrInstr = cmd->nextInstr;

--- a/test/battle/hold_effect/restore_stats.c
+++ b/test/battle/hold_effect/restore_stats.c
@@ -176,7 +176,7 @@ SINGLE_BATTLE_TEST("White Herb wont have time to activate if Magician steals it"
         MESSAGE("The opposing Fennekin stole Slugma's White Herb!");
         NONE_OF {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-            MESSAGE("Wobbuffet returned its stats to normal using its White Herb!");
+            MESSAGE("Slugma returned its stats to normal using its White Herb!");
         }
     } THEN {
         EXPECT(player->statStages[STAT_DEF] = DEFAULT_STAT_STAGE - 1);


### PR DESCRIPTION
Looks like a Gorilla Tactics check targets the attacker twice instead of the attacker and then the defender when resetting non-Gorilla Tactics Choice during an item swap.
Updated a typo in the White Herb checks where an old "Wobbuffet" should be Slugma.