### PR TITLE
Fix save text colors arg order

### DIFF
--- a/src/text.c
+++ b/src/text.c
@@ -531,7 +531,7 @@ void GenerateFontHalfRowLookupTable(union TextColor color)
     }
 }
 
-void SaveTextColors(u8 *bgColor, u8 *fgColor, u8 *shadowColor, u8 *accentColor) 
+void SaveTextColors(u8 *bgColor, u8 *fgColor, u8 *shadowColor, u8 *accentColor)
 {
     *bgColor = sLastTextColor.background;
     *fgColor = sLastTextColor.foreground;


### PR DESCRIPTION
## Description
Changed the order in the definition of `SaveTextColors`, but not `RestoreTextColors`, resulting in the foreground and background colors getting swapped with each pair or `SaveTextColors` then `RestoreTextColors` call.

Found by @khbsd 

## Discord contact info
Username: gudf