### PR TITLE
Do not add padding to end of smol file when smol is natually word-sized

### DIFF
--- a/tools/compresSmol/compressAlgo.cpp
+++ b/tools/compresSmol/compressAlgo.cpp
@@ -970,7 +970,7 @@ void getUIntVecFromData(CompressedImage *pImage, std::vector<unsigned int> *pOut
             }
         }
     }
-    if (currOffset != 0)
+    if (currOffset % 4 != 0)
         pOutput->push_back(currInt);
 }
 


### PR DESCRIPTION
## Description

When the smol compressor writes the not-tans-encoded part of a file, it will write the bytes to a 32-bit-sized buffer and then write the buffer to the file either when the buffer is full or when the end of file is reached. Before this change, the encoder would write the buffer at the end of the file even if the buffer was effectively empty. After this change, the encoder only writes that final word at the end-of-file if that word contains any data. This reduces the size of affected files by 4 bytes each.

Saves sightly over 1000 bytes of rom, suggesting slightly over 250 affected files.

Some affected files are checked by `test/smol.c`. Aside from that, item icons contain a decent mix of affected and not-affected files, and scrolling though the "Give Item" debug menu didn't have any graphical glitches, as far as I could tell.

## Discord contact info
yoshord
