### PR TITLE
Fix battler side status check in CalcCritChanceStage

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1613,7 +1613,7 @@ s32 CalcCritChanceStage(u32 battlerAtk, u32 battlerDef, u32 move, bool32 recordA
 {
     s32 critChance = 0;
 
-    if (gSideStatuses[battlerDef] & SIDE_STATUS_LUCKY_CHANT)
+    if (gSideStatuses[GetBattlerSide(battlerDef)] & SIDE_STATUS_LUCKY_CHANT)
     {
         critChance = CRITICAL_HIT_BLOCKED;
     }


### PR DESCRIPTION
I have no idea how this never caused an issue but I think it has been there forever like that.
