### PR TITLE
Small fix that prevented TM relearner if `P_ENABLE_ALL_TM_MOVES` was `TRUE`

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -6042,7 +6042,7 @@ bool32 HasRelearnerTMMoves(struct Pokemon *mon)
         if (move == MOVE_NONE)
             continue;
 
-        if (!P_ENABLE_ALL_TM_MOVES || !CheckBagHasItem(item, 1))
+        if (!P_ENABLE_ALL_TM_MOVES && !CheckBagHasItem(item, 1))
             continue;
 
         if (!CanLearnTeachableMove(species, move))


### PR DESCRIPTION
Changing the OR operator to the AND operator fixes the expression. 
If `P_ENABLE_ALL_TM_MOVES` was `TRUE` and the TM wasn't in the bag, it would've considered it as `FALSE` and would've been skipped