### PR TITLE
Fix `update_text_color_defs.py` on Python < 3.12

### DIFF
--- a/migration_scripts/1.15/update_text_color_defs.py
+++ b/migration_scripts/1.15/update_text_color_defs.py
@@ -1,4 +1,3 @@
-from enum import Enum, auto
 import re
 import tempfile
 


### PR DESCRIPTION
## Description
Reusing a f-strings' string delimiter within a replacement expression is only valid since python 3.12. 
Also removes an unused import.

Properly tested on python 3.10, which is the default on Ubuntu 22.04.

## Discord contact info
Username: gudf
