### PR TITLE
Fix transform shininess in link battles

### DIFF
--- a/src/battle_gfx_sfx_util.c
+++ b/src/battle_gfx_sfx_util.c
@@ -961,8 +961,8 @@ void HandleSpeciesGfxDataChange(u8 battlerAtk, u8 battlerDef, u8 changeType)
         }
         else
         {
-            personalityValue = gTransformedPersonalities[battlerAtk];
-            isShiny = gTransformedShininess[battlerAtk];
+            personalityValue = GetMonData(monAtk, MON_DATA_PERSONALITY);
+            isShiny = GetMonData(monAtk, MON_DATA_IS_SHINY);
         }
         HandleLoadSpecialPokePic(!IsOnPlayerSide(battlerAtk),
                                  gMonSpritesGfxPtr->spritesGfx[position],


### PR DESCRIPTION
#8552 follow up. The branches are the same now but I've kept them since Ditto needs a config for the gen3 and lower behavior.

<img width="1313" height="448" alt="image" src="https://github.com/user-attachments/assets/6f1b2e1e-22a5-449f-a0a6-5013382038ed" />
