### PR TITLE
Fixing crash from Last Resort with Normalium Z in certain damage thresholds

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -5241,6 +5241,9 @@ bool32 ShouldUseZMove(u32 battlerAtk, u32 battlerDef, u32 chosenMove)
             return FALSE;
         }
 
+        if (GetMoveEffect(chosenMove) == EFFECT_LAST_RESORT && !CanUseLastResort(battlerAtk))
+            return TRUE;
+
         uq4_12_t effectiveness;
         struct SimulatedDamage dmg;
 

--- a/test/battle/ai/gimmick_z_move.c
+++ b/test/battle/ai/gimmick_z_move.c
@@ -47,6 +47,18 @@ AI_SINGLE_BATTLE_TEST("AI uses Z-Moves -- Extreme Evoboost")
     }
 }
 
+AI_SINGLE_BATTLE_TEST("AI uses Z-Moves to bypass move limitations")
+{
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_OMNISCIENT );
+        ASSUME(GetMoveType(MOVE_QUICK_ATTACK) == TYPE_NORMAL);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_NORMALIUM_Z); Moves(MOVE_POUND, MOVE_LAST_RESORT); }
+    } WHEN {
+        TURN { EXPECT_MOVE(opponent, MOVE_LAST_RESORT, gimmick: GIMMICK_Z_MOVE); }
+    }
+}
+
 AI_SINGLE_BATTLE_TEST("AI uses Z-Moves -- 10,000,000 Volt Thunderbolt")
 {
     GIVEN {


### PR DESCRIPTION
Test fails without the change, passes with.

## Discord contact info
wildvenonat