### PR TITLE
Tie Break failsafe correction

### DIFF
--- a/test/test_runner_battle.c
+++ b/test/test_runner_battle.c
@@ -679,7 +679,9 @@ static u32 BattleTest_RandomUniform(enum RandomTag tag, u32 lo, u32 hi, bool32 (
         }
     }
 
-    SanitizeTieCounts();
+    if (IsTieBreakTag(tag))
+        SanitizeTieCounts();
+
     //trials
     switch (tag)
     {


### PR DESCRIPTION
## Description
`TIE_BREAK_SCORE` and `TIE_BREAK_TARGET` had insufficient fail-safes in place. 

Changes:
1. Tie counts are cleansed to be between 1 and expected upper limit
2. Tie break RNG tags excluded from `RandomUniformTrials` error check as they do not necessarily run for every trial

## Discord contact info
grintoul