### PR TITLE
Fix truck fade being cancelled

### DIFF
--- a/src/overworld.c
+++ b/src/overworld.c
@@ -1716,11 +1716,12 @@ static void OverworldBasic(void)
         gTimeUpdateCounter = (SECONDS_PER_MINUTE * 60 / FakeRtc_GetSecondsRatio());
         UpdateTimeOfDay();
         FormChangeTimeUpdate();
-        if (bld0[0] != bld1[0]
+        if (MapHasNaturalLight(gMapHeader.mapType) &&
+           (bld0[0] != bld1[0]
          || bld0[1] != bld1[1]
-         || bld0[2] != bld1[2])
+         || bld0[2] != bld1[2]))
         {
-           ApplyWeatherColorMapIfIdle(gWeatherPtr->colorMapIndex);
+            ApplyWeatherColorMapIfIdle(gWeatherPtr->colorMapIndex);
         }
     }
 }


### PR DESCRIPTION
The pallete update code that applies to map with weather/natural light can sometimes overwrite a black or white transition screen. Before #7883, there was some code to only do the palette calculations for map with natural light, I'm adding the condition map to at least fix the issue for inside map like the truck while I look for a proper solution

## Media
master:

https://github.com/user-attachments/assets/32b87f03-20e4-48cf-9f98-aaf180d30f85

this commit:

https://github.com/user-attachments/assets/1256ffbf-dcb2-4411-96a6-ab2e7cb117c8




## Issue(s) that this PR fixes
partially fixes #8616 (don't close issue yet)


## Discord contact info
Jamie
