### PR TITLE
Refactor Endeavor to use DoFixedDamageMoveCalc func

### DIFF
--- a/asm/macros/battle_script.inc
+++ b/asm/macros/battle_script.inc
@@ -1162,9 +1162,8 @@
 	.4byte \failInstr
 	.endm
 
-	.macro setdamagetohealthdifference failInstr:req
+	.macro Cmd_unused0xd8
 	.byte 0xd8
-	.4byte \failInstr
 	.endm
 
 	.macro setroom

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -4082,16 +4082,6 @@ BattleScript_PrintAbilityMadeIneffective::
 	waitmessage B_WAIT_TIME_LONG
 	goto BattleScript_MoveEnd
 
-BattleScript_EffectEndeavor::
-	attackcanceler
-	setdamagetohealthdifference BattleScript_ButItFailed
-	accuracycheck BattleScript_MoveMissedPause, ACC_CURR_MOVE
-	typecalc
-	jumpifmovehadnoeffect BattleScript_HitFromAtkAnimation
-	clearmoveresultflags MOVE_RESULT_SUPER_EFFECTIVE | MOVE_RESULT_NOT_VERY_EFFECTIVE
-	adjustdamage
-	goto BattleScript_HitFromAtkAnimation
-
 BattleScript_EffectSkillSwap::
 	attackcanceler
 	accuracycheck BattleScript_ButItFailed, NO_ACC_CALC_CHECK_LOCK_ON

--- a/include/battle_scripts.h
+++ b/include/battle_scripts.h
@@ -671,7 +671,6 @@ extern const u8 BattleScript_EffectMagicCoat[];
 extern const u8 BattleScript_EffectRecycle[];
 extern const u8 BattleScript_EffectBrickBreak[];
 extern const u8 BattleScript_EffectYawn[];
-extern const u8 BattleScript_EffectEndeavor[];
 extern const u8 BattleScript_EffectSkillSwap[];
 extern const u8 BattleScript_EffectImprison[];
 extern const u8 BattleScript_EffectRefresh[];

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -759,12 +759,8 @@ static inline void CalcDynamicMoveDamage(struct BattleContext *ctx, u16 *medianD
     u16 maximum = *maximumDamage;
 
     u32 strikeCount = GetMoveStrikeCount(ctx->move);
-    if (effect == EFFECT_ENDEAVOR)
-    {
-        // If target has less HP than user, Endeavor does no damage
-        median = maximum = minimum = max(0, gBattleMons[ctx->battlerDef].hp - gBattleMons[ctx->battlerAtk].hp);
-    }
-    else if (effect == EFFECT_BEAT_UP && GetConfig(CONFIG_BEAT_UP) >= GEN_5)
+
+    if (effect == EFFECT_BEAT_UP && GetConfig(CONFIG_BEAT_UP) >= GEN_5)
     {
         u32 partyCount = CalculatePartyCount(GetBattlerParty(ctx->battlerAtk));
         u32 i;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -557,7 +557,7 @@ static void Cmd_trywish(void);
 static void Cmd_settoxicspikes(void);
 static void Cmd_setgastroacid(void);
 static void Cmd_setyawn(void);
-static void Cmd_setdamagetohealthdifference(void);
+static void Cmd_unused0xd8(void);
 static void Cmd_setroom(void);
 static void Cmd_tryswapabilities(void);
 static void Cmd_tryimprison(void);
@@ -816,7 +816,7 @@ void (*const gBattleScriptingCommandsTable[])(void) =
     Cmd_settoxicspikes,                          //0xD5
     Cmd_setgastroacid,                           //0xD6
     Cmd_setyawn,                                 //0xD7
-    Cmd_setdamagetohealthdifference,             //0xD8
+    Cmd_unused0xd8,                              //0xD8
     Cmd_setroom,                                 //0xD9
     Cmd_tryswapabilities,                        //0xDA
     Cmd_tryimprison,                             //0xDB
@@ -12408,19 +12408,8 @@ static void Cmd_setyawn(void)
     }
 }
 
-static void Cmd_setdamagetohealthdifference(void)
+static void Cmd_unused0xd8(void)
 {
-    CMD_ARGS(const u8 *failInstr);
-
-    if (GetNonDynamaxHP(gBattlerTarget) <= gBattleMons[gBattlerAttacker].hp)
-    {
-        gBattlescriptCurrInstr = cmd->failInstr;
-    }
-    else
-    {
-        gBattleStruct->moveDamage[gBattlerTarget] = GetNonDynamaxHP(gBattlerTarget) - gBattleMons[gBattlerAttacker].hp;
-        gBattlescriptCurrInstr = cmd->nextInstr;
-    }
 }
 
 static void HandleRoomMove(u32 statusFlag, u16 *timer, u8 stringId)

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -422,7 +422,7 @@ bool32 HandleMoveTargetRedirection(void)
     if (moveEffect == EFFECT_REFLECT_DAMAGE)
     {
         enum DamageCategory reflectCategory = GetReflectDamageMoveDamageCategory(gBattlerAttacker, gCurrentMove);
-        
+
         if (reflectCategory == DAMAGE_CATEGORY_PHYSICAL)
             gBattleStruct->moveTarget[gBattlerAttacker] = gProtectStructs[gBattlerAttacker].physicalBattlerId;
         else
@@ -8769,13 +8769,24 @@ s32 DoFixedDamageMoveCalc(struct BattleContext *ctx)
             u32 percentMultiplier = GetMoveReflectDamage_DamagePercent(ctx->move);
             enum DamageCategory reflectCategory = GetReflectDamageMoveDamageCategory(ctx->battlerAtk, ctx->move);
             s32 baseDamage;
-            
+
             if (reflectCategory == DAMAGE_CATEGORY_PHYSICAL)
                 baseDamage = gProtectStructs[ctx->battlerAtk].physicalDmg;
             else
                 baseDamage = gProtectStructs[ctx->battlerAtk].specialDmg;
-        
+
             dmg = (baseDamage - 1) * percentMultiplier / 100;
+        }
+        break;
+    case EFFECT_ENDEAVOR:
+        if (GetNonDynamaxHP(ctx->battlerDef) <= gBattleMons[ctx->battlerAtk].hp)
+        {
+            dmg = 0;
+            gBattleStruct->moveResultFlags[ctx->battlerDef] |= MOVE_RESULT_DOESNT_AFFECT_FOE;
+        }
+        else
+        {
+            dmg = GetNonDynamaxHP(ctx->battlerDef) - gBattleMons[ctx->battlerAtk].hp;
         }
         break;
     default:
@@ -9085,10 +9096,6 @@ s32 CalculateMoveDamage(struct BattleContext *ctx)
 // for AI so that typeEffectivenessModifier, weather, abilities and holdEffects are calculated only once
 s32 CalculateMoveDamageVars(struct BattleContext *ctx)
 {
-    s32 dmg = DoFixedDamageMoveCalc(ctx);
-    if (dmg != INT32_MAX)
-        return dmg;
-
     return DoMoveDamageCalcVars(ctx);
 }
 

--- a/src/data/battle_move_effects.h
+++ b/src/data/battle_move_effects.h
@@ -1102,7 +1102,7 @@ const struct BattleMoveEffect gBattleMoveEffects[NUM_BATTLE_MOVE_EFFECTS] =
 
     [EFFECT_ENDEAVOR] =
     {
-        .battleScript = BattleScript_EffectEndeavor,
+        .battleScript = BattleScript_EffectHit,
         .battleTvScore = 1,
     },
 

--- a/test/battle/move_effect/endeavor.c
+++ b/test/battle/move_effect/endeavor.c
@@ -19,5 +19,27 @@ SINGLE_BATTLE_TEST("Endeavor causes the target's HP to equal the user's current 
         EXPECT_EQ(player->hp, opponent->hp);
     }
 }
-TO_DO_BATTLE_TEST("Endeavor does not change HP if the target has less HP than the user, but still plays the animation")
-TO_DO_BATTLE_TEST("Endeavor fails on Ghost-type Pokémon");
+
+SINGLE_BATTLE_TEST("Endeavor fails on Ghost-type Pokémon")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { HP(1); }
+        OPPONENT(SPECIES_GASTLY);
+    } WHEN {
+        TURN { MOVE(player, MOVE_ENDEAVOR); }
+    } SCENE {
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_ENDEAVOR, player);
+    }
+}
+
+SINGLE_BATTLE_TEST("Endeavor fails to change HP if the target has less HP than the user")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { HP(10); }
+        OPPONENT(SPECIES_WOBBUFFET) { HP(9); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_ENDEAVOR); }
+    } SCENE {
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_ENDEAVOR, player);
+    }
+}


### PR DESCRIPTION
This change let's it work with correctly if it was a spread move and parity with AI calcs. 

Also there was some leftover in `CalculateMoveDamageVars` that was removed due to it being done in the caller function 