### PR TITLE
Consolidate `GetIndexMove`

### DIFF
--- a/include/battle_ai_util.h
+++ b/include/battle_ai_util.h
@@ -186,7 +186,6 @@ uq4_12_t AI_GetMoveEffectiveness(u32 move, u32 battlerAtk, u32 battlerDef);
 u16 *GetMovesArray(u32 battler);
 bool32 IsConfusionMoveEffect(enum BattleMoveEffects moveEffect);
 bool32 HasMove(u32 battlerId, u32 move);
-u32 GetIndexInMoveArray(u32 battler, u32 move);
 u32 GetBattlerMoveIndexWithEffect(u32 battler, enum BattleMoveEffects effect);
 bool32 HasPhysicalBestMove(u32 battlerAtk, u32 battlerDef, enum DamageCalcContext calcContext);
 bool32 HasOnlyMovesWithCategory(u32 battlerId, enum DamageCategory category, bool32 onlyOffensive);

--- a/src/battle_ai_switch.c
+++ b/src/battle_ai_switch.c
@@ -825,7 +825,7 @@ static bool32 GetHitEscapeTransformState(u32 battlerAtk, u32 move)
     if (GetMoveEffect(move) != EFFECT_HIT_ESCAPE)
         return FALSE;
 
-    moveIndex = GetIndexInMoveArray(battlerAtk, move);
+    moveIndex = GetMoveIndex(battlerAtk, move);
     if (moveIndex >= MAX_MON_MOVES)
         return FALSE;
 
@@ -1140,7 +1140,7 @@ static bool32 ShouldSwitchIfEncored(u32 battler)
         return SetSwitchinAndSwitch(battler, PARTY_SIZE);
 
     // Stay in if effective move
-    else if (gAiLogicData->effectiveness[battler][opposingBattler][GetIndexInMoveArray(battler, encoredMove)] >= UQ_4_12(2.0))
+    else if (gAiLogicData->effectiveness[battler][opposingBattler][GetMoveIndex(battler, encoredMove)] >= UQ_4_12(2.0))
         return FALSE;
 
     // Switch out 50% of the time otherwise

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -2515,18 +2515,6 @@ u16 *GetMovesArray(u32 battler)
         return gBattleHistory->usedMoves[battler];
 }
 
-u32 GetIndexInMoveArray(u32 battler, u32 move)
-{
-    u16 *moves = GetMovesArray(battler);
-    u32 i;
-    for (i = 0; i < MAX_MON_MOVES; i++)
-    {
-        if (moves[i] == move)
-            return i;
-    }
-    return MAX_MON_MOVES;
-}
-
 u32 GetBattlerMoveIndexWithEffect(u32 battler, enum BattleMoveEffects effect)
 {
     u16 *moves = GetMovesArray(battler);


### PR DESCRIPTION
## Description
We ended up with `GetMoveIndex` and `GetIndexInMoveArray` both doing exactly the same thing, probably because the latter didn't show up in searching at some point. Don't need two identical functions, and Alex and I agreed that the former name was clearer than the latter, so it's been replaced.

## Discord contact info
@Pawkkie 
