### PR TITLE
Fix progbits flags for iwram asm functions

### DIFF
--- a/src/crt0.s
+++ b/src/crt0.s
@@ -37,7 +37,7 @@ sp_irq: .word IWRAM_END - 0x60
 	.pool
 
 	.arm
-	.section .iwram.code
+	.section .iwram.code, "ax", %progbits
 	.align 2, 0
 IntrMain::
 	mov r3, #REG_BASE

--- a/src/decompress_asm.s
+++ b/src/decompress_asm.s
@@ -1,7 +1,7 @@
     .syntax unified
 
     .arm
-    .section .iwram.code
+    .section .iwram.code, "ax", %progbits
     .align 2
 
 .global FastUnsafeCopy32

--- a/src/m4a_1.s
+++ b/src/m4a_1.s
@@ -85,7 +85,7 @@ lt_o_SoundInfo_pcmBuffer: .word o_SoundInfo_pcmBuffer
 lt_PCM_DMA_BUF_SIZE:      .word PCM_DMA_BUF_SIZE
 	thumb_func_end SoundMain
 
-	.section .iwram.code
+	.section .iwram.code, "ax", %progbits
 	thumb_func_start SoundMainRAM
 SoundMainRAM:
 	ldrb r3, [r0, o_SoundInfo_reverb]


### PR DESCRIPTION
Originally found by Cawt.
Repro steps: Try these first, your game should freeze at boot-up. Then apply the changes from this PR, and the game should run smoothly.

```
Cawt — 15:38
with these changes the game gets stuck on start-up. Is that expected?
--- a/src/load_save.c
+++ b/src/load_save.c
-IWRAM_INIT struct SaveBlock3 *gSaveBlock3Ptr = &gSaveblock3;
+EWRAM_INIT struct SaveBlock3 *gSaveBlock3Ptr = &gSaveblock3;

--- a/src/decompress.c
+++ b/src/decompress.c
-ARM_FUNC __attribute__((section(".iwram.code"))) __attribute__((noinline)) static void CopyTable(u32 *dst, const u32 *src, u32 size, u32 orrVal)
+ARM_FUNC __attribute__((noinline)) static void CopyTable(u32 *dst, const u32 *src, u32 size, u32 orrVal)
```

From what I understand the missing flags basically tell the compiler what type of data it is, so it updates the location counter correctly. The compiler does that automatically for `IWRAM_INIT`.