### PR TITLE
Add setmetatileinrange Script Command

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -1439,6 +1439,18 @@
 	.2byte \metatileId
 	.2byte \impassable
 	.endm
+    
+    @ Set a metatile at all tiles within the bounds [xmin,ymin] to [xmax,ymax] inclusive with desired elevation
+    .macro setmetatileinrange xmin:req, ymin:req, xmax:req, ymax:req, tileid:req, collision=FALSE, elevation=0xFF
+    callnative ScriptSetMetatileInRange
+    .byte \xmin
+    .byte \ymin
+    .byte \xmax
+    .byte \ymax
+    .2byte \tileid
+    .byte \collision
+    .byte \elevation
+    .endm
 
 	@ Queues a weather change to the default weather for the map.
 	.macro resetweather

--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -1439,18 +1439,18 @@
 	.2byte \metatileId
 	.2byte \impassable
 	.endm
-    
-    @ Set a metatile at all tiles within the bounds [xmin,ymin] to [xmax,ymax] inclusive with desired elevation
-    .macro setmetatileinrange xmin:req, ymin:req, xmax:req, ymax:req, tileid:req, collision=FALSE, elevation=0xFF
-    callnative ScriptSetMetatileInRange
-    .byte \xmin
-    .byte \ymin
-    .byte \xmax
-    .byte \ymax
-    .2byte \tileid
-    .byte \collision
-    .byte \elevation
-    .endm
+
+	@ Set a metatile at all tiles within the bounds [xmin,ymin] to [xmax,ymax] inclusive with desired elevation
+	.macro setmetatileinrange xmin:req, ymin:req, xmax:req, ymax:req, metatileId:req, collision=FALSE, elevation=0xFF
+	callnative NativeFunc_SetMetatileInRange
+	.byte \xmin
+	.byte \ymin
+	.byte \xmax
+	.byte \ymax
+	.2byte \metatileId
+	.byte \collision
+	.byte \elevation
+	.endm
 
 	@ Queues a weather change to the default weather for the map.
 	.macro resetweather

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -2755,6 +2755,43 @@ bool8 ScrCmd_setmetatile(struct ScriptContext *ctx)
     return FALSE;
 }
 
+void NativeFunc_SetMetatileInRange(struct ScriptContext *ctx)
+{
+    u8 xmin = ScriptReadByte(ctx);
+    u8 ymin = ScriptReadByte(ctx);
+    u8 xmax = ScriptReadByte(ctx);
+    u8 ymax = ScriptReadByte(ctx);
+    u16 tileId = VarGet(ScriptReadHalfword(ctx));
+    bool8 hasCollision = ScriptReadByte(ctx);
+    u8 elevation = ScriptReadByte(ctx);
+    u32 i, j;
+    
+    if (xmin > xmax)
+        SWAP(xmin, xmax, i);
+
+    if (ymin > ymax)
+        SWAP(ymin, ymax, i);
+    
+    xmin += MAP_OFFSET;
+    ymin += MAP_OFFSET;
+    xmax += MAP_OFFSET;
+    ymax += MAP_OFFSET;
+
+    // try set impassable
+    if (hasCollision)
+        tileId |= MAPGRID_COLLISION_MASK;
+
+    // set elevation
+    if (elevation < 15)
+        tileId |= (elevation << MAPGRID_ELEVATION_SHIFT);
+
+    for (i = xmin; i <= xmax; i++)
+    {
+        for (j = ymin; j <= ymax; j++)
+            MapGridSetMetatileEntryAt(i, j, tileId);
+    }
+}
+
 bool8 ScrCmd_opendoor(struct ScriptContext *ctx)
 {
     u16 x = VarGet(ScriptReadHalfword(ctx));

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -2778,7 +2778,7 @@ void NativeFunc_SetMetatileInRange(struct ScriptContext *ctx)
 
     // try set impassable
     if (hasCollision)
-        tileId |= MAPGRID_COLLISION_MASK;
+        metatileId |= MAPGRID_COLLISION_MASK;
 
     // set elevation
     if (elevation < 15)

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -2761,17 +2761,16 @@ void NativeFunc_SetMetatileInRange(struct ScriptContext *ctx)
     u8 ymin = ScriptReadByte(ctx);
     u8 xmax = ScriptReadByte(ctx);
     u8 ymax = ScriptReadByte(ctx);
-    u16 tileId = VarGet(ScriptReadHalfword(ctx));
+    u16 metatileId = VarGet(ScriptReadHalfword(ctx));
     bool8 hasCollision = ScriptReadByte(ctx);
     u8 elevation = ScriptReadByte(ctx);
-    u32 i, j;
+    u32 temp;
     
     if (xmin > xmax)
-        SWAP(xmin, xmax, i);
+        SWAP(xmin, xmax, temp);
 
     if (ymin > ymax)
-        SWAP(ymin, ymax, i);
-    
+        SWAP(ymin, ymax, temp);
     xmin += MAP_OFFSET;
     ymin += MAP_OFFSET;
     xmax += MAP_OFFSET;
@@ -2783,12 +2782,12 @@ void NativeFunc_SetMetatileInRange(struct ScriptContext *ctx)
 
     // set elevation
     if (elevation < 15)
-        tileId |= (elevation << MAPGRID_ELEVATION_SHIFT);
+        metatileId |= (elevation << MAPGRID_ELEVATION_SHIFT);
 
-    for (i = xmin; i <= xmax; i++)
+    for (u32 i = xmin; i <= xmax; i++)
     {
-        for (j = ymin; j <= ymax; j++)
-            MapGridSetMetatileEntryAt(i, j, tileId);
+        for (u32 j = ymin; j <= ymax; j++)
+            MapGridSetMetatileEntryAt(i, j, metatileId);
     }
 }
 


### PR DESCRIPTION
Adds a new script command to allow setting a single metatile across an entire map range. Useful for puzzles where rocks/walls disappear and all the tile changes are the same metatile ID.