### PR TITLE
fix poisons absorbing toxic spikes when fainting from other hazards

### DIFF
--- a/asm/macros/battle_script.inc
+++ b/asm/macros/battle_script.inc
@@ -2464,3 +2464,8 @@
 	.byte \gen
 	.4byte \jumpInstr
 	.endm
+
+	@ Absorbs Toxic Spikes when a grounded Poison-type faints to entry hazards.
+	.macro tryabsorbtoxicspikesonfaint
+	callnative BS_TryAbsorbToxicSpikesOnFaint
+	.endm

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -5147,6 +5147,7 @@ BattleScript_DmgHazardsOnAttackerFainted::
 	setbyte sGIVEEXP_STATE, 0
 	getexp BS_ATTACKER
 	moveendall
+	tryabsorbtoxicspikesonfaint
 	goto BattleScript_HandleFaintedMon
 
 BattleScript_DmgHazardsOnTarget::
@@ -5161,6 +5162,7 @@ BattleScript_DmgHazardsOnTargetFainted::
 	setbyte sGIVEEXP_STATE, 0
 	getexp BS_TARGET
 	moveendall
+	tryabsorbtoxicspikesonfaint
 	goto BattleScript_HandleFaintedMon
 
 BattleScript_DmgHazardsOnBattlerScripting::
@@ -5175,6 +5177,7 @@ BattleScript_DmgHazardsOnBattlerScriptingFainted::
 	setbyte sGIVEEXP_STATE, 0
 	getexp BS_SCRIPTING
 	moveendall
+	tryabsorbtoxicspikesonfaint
 	goto BattleScript_HandleFaintedMon
 
 BattleScript_DmgHazardsOnFaintedBattler::
@@ -5189,6 +5192,7 @@ BattleScript_DmgHazardsOnFaintedBattlerFainted::
 	setbyte sGIVEEXP_STATE, 0
 	getexp BS_FAINTED
 	moveendall
+	tryabsorbtoxicspikesonfaint
 	goto BattleScript_HandleFaintedMon
 
 BattleScript_PrintHurtByDmgHazards::

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -18012,3 +18012,29 @@ void BS_JumpIfGenConfigLowerThan(void)
     else
         gBattlescriptCurrInstr = cmd->nextInstr;
 }
+
+// Used when the Pokemon faints before Toxic Spikes would normally be processed in the hazards queue.
+void BS_TryAbsorbToxicSpikesOnFaint(void)
+{
+    NATIVE_ARGS();
+    u32 battler = gBattlerFainted;
+    u32 side = GetBattlerSide(battler);
+
+    if (gSideTimers[side].toxicSpikesAmount == 0)
+    {
+        gBattlescriptCurrInstr = cmd->nextInstr;
+        return;
+    }
+
+    if (IsBattlerGrounded(battler, GetBattlerAbility(battler), GetBattlerHoldEffect(battler))
+     && IS_BATTLER_OF_TYPE(battler, TYPE_POISON))
+    {
+        gSideTimers[side].toxicSpikesAmount = 0;
+        RemoveHazardFromField(side, HAZARDS_TOXIC_SPIKES);
+        gEffectBattler = battler;
+        BattleScriptCall(BattleScript_ToxicSpikesAbsorbed);
+        return;
+    }
+
+    gBattlescriptCurrInstr = cmd->nextInstr;
+}

--- a/test/battle/hazards.c
+++ b/test/battle/hazards.c
@@ -64,8 +64,6 @@ SINGLE_BATTLE_TEST("Hazards are applied correctly after a battler faints")
 
 SINGLE_BATTLE_TEST("Toxic Spikes can be removed after fainting to other hazards")
 {
-    KNOWN_FAILING; // tryfaintmon changes something that doesn't allow other switch-in effects on the battler
-
     GIVEN {
         PLAYER(SPECIES_WYNAUT);
         PLAYER(SPECIES_GRIMER) { HP(1); }


### PR DESCRIPTION
## Description
previously, grounded Poison types couldn't clear Toxic Spikes if they fainted from other hazards. This fixes a KNOWN FAILING test.

## Discord contact info
spindrift64
