### PR TITLE
Smarter Doubles Fake Out AI + EFFECT_FIRST_TURN_ONLY tests

### DIFF
--- a/include/config/ai.h
+++ b/include/config/ai.h
@@ -72,6 +72,7 @@
 #define EXPLOSION_MAXIMUM_CHANCE                                90 // Highest possible percent chance of the AI using explosion based on its current HP
 #define FINAL_GAMBIT_CHANCE                                     50 // Chance for AI to consider using Final Gambit if it outspeeds the player and thinks it has more HP
 #define SHOULD_PIVOT_BREAK_SASH_CHANCE                          50 // Chance for ShouldPivot to return true when trying to break Multiscale and Focus Sash type effects while having a good switchin
+#define FAKE_OUT_SAVE_ALLY_CHANCE                               50 // Chance for AI to Fake Out to save its ally when ally is fast KO'd by both opponents
 
 // AI damage calc considerations
 #define RISKY_AI_CRIT_STAGE_THRESHOLD                           2   // Stat stages at which Risky will assume it gets a crit

--- a/include/random.h
+++ b/include/random.h
@@ -235,6 +235,7 @@ enum RandomTag
     RNG_FISHING_BITE,
     RNG_FISHING_GEN3_STICKY,
     RNG_TAUNT,
+    RNG_AI_FAKE_OUT_SAVE_ALLY,
 };
 
 #define RandomWeighted(tag, ...) \

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -4995,14 +4995,20 @@ static s32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move, stru
                  && AI_WhoStrikesFirst(battlerAtk, battlerDef, MOVE_FAKE_OUT, MOVE_FAKE_OUT, CONSIDER_PRIORITY) == AI_IS_FASTER)
                  || (HasMove(BATTLE_PARTNER(battlerDef), MOVE_FAKE_OUT) && gBattleStruct->battlerState[BATTLE_PARTNER(battlerDef)].isFirstTurn
                  && AI_WhoStrikesFirst(battlerAtk, BATTLE_PARTNER(battlerDef), MOVE_FAKE_OUT, MOVE_FAKE_OUT, CONSIDER_PRIORITY) == AI_IS_FASTER))
+                    ADJUST_SCORE(GOOD_EFFECT);
+                // If ally has KO on target's partner, but target can fast KO ally (checking move and priority combinations for everything likely gets a bit complicated)
+                else if (hasPartner
+                 && CanAIFaintTarget(BATTLE_PARTNER(battlerAtk), BATTLE_PARTNER(battlerDef), 1)
+                 && (CanAIFaintTarget(battlerDef, BATTLE_PARTNER(battlerAtk), 1) && AI_WhoStrikesFirst(BATTLE_PARTNER(battlerAtk), battlerDef, gBattleMons[BATTLE_PARTNER(battlerAtk)].moves[gAiBattleData->chosenMoveIndex[BATTLE_PARTNER(battlerAtk)]], predictedMoveSpeedCheck, CONSIDER_PRIORITY) == AI_IS_SLOWER)
+                 && !(CanAIFaintTarget(battlerAtk, battlerDef, 1) && AI_WhoStrikesFirst(battlerAtk, battlerDef, move, predictedMoveSpeedCheck, DONT_CONSIDER_PRIORITY) == AI_IS_FASTER))
                     ADJUST_SCORE(BEST_EFFECT);
-                // If ally has slow KO with their chosen move, user sees no KOs while outspeeding (checking move and priority combinations gets a bit complicated)
+                // If ally has slow KO with their chosen move, user sees no KOs while outspeeding (checking move and priority combinations for everything likely gets a bit complicated)
                 else if (hasPartner 
-                 && (AI_WhoStrikesFirst(BATTLE_PARTNER(battlerAtk), battlerDef, gBattleMons[BATTLE_PARTNER(battlerAtk)].moves[gAiBattleData->chosenMoveIndex[BATTLE_PARTNER(battlerAtk)]], MOVE_SCRATCH, CONSIDER_PRIORITY) == AI_IS_SLOWER)
+                 && (AI_WhoStrikesFirst(BATTLE_PARTNER(battlerAtk), battlerDef, gBattleMons[BATTLE_PARTNER(battlerAtk)].moves[gAiBattleData->chosenMoveIndex[BATTLE_PARTNER(battlerAtk)]], predictedMoveSpeedCheck, CONSIDER_PRIORITY) == AI_IS_SLOWER)
                  && CanAIFaintTarget(BATTLE_PARTNER(battlerAtk), battlerDef, 1) 
                  && !(CanAIFaintTarget(battlerAtk, battlerDef, 1) && AI_WhoStrikesFirst(battlerAtk, battlerDef, move, predictedMoveSpeedCheck, DONT_CONSIDER_PRIORITY) == AI_IS_FASTER)
                  && !(CanAIFaintTarget(battlerAtk, BATTLE_PARTNER(battlerDef), 1) && AI_WhoStrikesFirst(battlerAtk, BATTLE_PARTNER(battlerDef), move, MOVE_SCRATCH, DONT_CONSIDER_PRIORITY) == AI_IS_FASTER))
-                    ADJUST_SCORE(BEST_EFFECT);
+                    ADJUST_SCORE(GOOD_EFFECT);
                 else
                     ADJUST_SCORE(DECENT_EFFECT);
             }

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -4987,33 +4987,49 @@ static s32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move, stru
     case EFFECT_FIRST_TURN_ONLY:
         if (gBattleStruct->battlerState[battlerAtk].isFirstTurn && !IsTargetingPartner(battlerAtk, battlerDef))
         {
-            // Fake Out in doubles
-            if (IsDoubleBattle() && IsFlinchGuaranteed(battlerAtk, battlerDef, move))
+            // Fake Out in doubles - don't incentivise if ally fast KO'd by both opponents
+            if (IsDoubleBattle() && IsFlinchGuaranteed(battlerAtk, battlerDef, move)
+             && !((CanAIFaintTarget(battlerDef, BATTLE_PARTNER(battlerAtk), 1) && AI_WhoStrikesFirst(BATTLE_PARTNER(battlerAtk), battlerDef, gBattleMons[BATTLE_PARTNER(battlerAtk)].moves[gAiBattleData->chosenMoveIndex[BATTLE_PARTNER(battlerAtk)]], predictedMoveSpeedCheck, CONSIDER_PRIORITY) == AI_IS_SLOWER)
+             && (CanAIFaintTarget(BATTLE_PARTNER(battlerDef), BATTLE_PARTNER(battlerAtk), 1) && AI_WhoStrikesFirst(BATTLE_PARTNER(battlerAtk), BATTLE_PARTNER(battlerDef), gBattleMons[BATTLE_PARTNER(battlerAtk)].moves[gAiBattleData->chosenMoveIndex[BATTLE_PARTNER(battlerAtk)]], MOVE_SCRATCH, CONSIDER_PRIORITY) == AI_IS_SLOWER)))
             {
-                // If either opponent has Fake out, it's their first turn but user is faster - incentivise Fake Out on both
+                // If either opponent has Fake Out, it's their first turn but user is faster - incentivise Fake Out on both
                 if ((HasMove(battlerDef, MOVE_FAKE_OUT) && gBattleStruct->battlerState[battlerDef].isFirstTurn
                  && AI_WhoStrikesFirst(battlerAtk, battlerDef, MOVE_FAKE_OUT, MOVE_FAKE_OUT, CONSIDER_PRIORITY) == AI_IS_FASTER)
                  || (HasMove(BATTLE_PARTNER(battlerDef), MOVE_FAKE_OUT) && gBattleStruct->battlerState[BATTLE_PARTNER(battlerDef)].isFirstTurn
                  && AI_WhoStrikesFirst(battlerAtk, BATTLE_PARTNER(battlerDef), MOVE_FAKE_OUT, MOVE_FAKE_OUT, CONSIDER_PRIORITY) == AI_IS_FASTER))
+                {    
                     ADJUST_SCORE(GOOD_EFFECT);
+                }
                 // If ally has KO on target's partner, but target can fast KO ally (checking move and priority combinations for everything likely gets a bit complicated)
                 else if (hasPartner
                  && CanAIFaintTarget(BATTLE_PARTNER(battlerAtk), BATTLE_PARTNER(battlerDef), 1)
                  && (CanAIFaintTarget(battlerDef, BATTLE_PARTNER(battlerAtk), 1) && AI_WhoStrikesFirst(BATTLE_PARTNER(battlerAtk), battlerDef, gBattleMons[BATTLE_PARTNER(battlerAtk)].moves[gAiBattleData->chosenMoveIndex[BATTLE_PARTNER(battlerAtk)]], predictedMoveSpeedCheck, CONSIDER_PRIORITY) == AI_IS_SLOWER)
                  && !(CanAIFaintTarget(battlerAtk, battlerDef, 1) && AI_WhoStrikesFirst(battlerAtk, battlerDef, move, predictedMoveSpeedCheck, DONT_CONSIDER_PRIORITY) == AI_IS_FASTER))
-                    ADJUST_SCORE(BEST_EFFECT);
+                {
+                    if (AI_WhoStrikesFirst(BATTLE_PARTNER(battlerAtk), BATTLE_PARTNER(battlerDef), gBattleMons[BATTLE_PARTNER(battlerAtk)].moves[gAiBattleData->chosenMoveIndex[BATTLE_PARTNER(battlerAtk)]], predictedMoveSpeedCheck, CONSIDER_PRIORITY) == AI_IS_FASTER)
+                        ADJUST_SCORE(FAST_KILL + 2); // No point fast KOing target's partner when user can save ally who will do it anyway
+                    else
+                        ADJUST_SCORE(SLOW_KILL + 2); // No point saving ally if target's partner also fast KOs them
+                    // No else case as assume if both opponents have fast KO on user's ally, then user probably better off not using Fake Out
+                }
                 // If ally has slow KO with their chosen move, user sees no KOs while outspeeding (checking move and priority combinations for everything likely gets a bit complicated)
                 else if (hasPartner 
                  && (AI_WhoStrikesFirst(BATTLE_PARTNER(battlerAtk), battlerDef, gBattleMons[BATTLE_PARTNER(battlerAtk)].moves[gAiBattleData->chosenMoveIndex[BATTLE_PARTNER(battlerAtk)]], predictedMoveSpeedCheck, CONSIDER_PRIORITY) == AI_IS_SLOWER)
                  && CanAIFaintTarget(BATTLE_PARTNER(battlerAtk), battlerDef, 1) 
                  && !(CanAIFaintTarget(battlerAtk, battlerDef, 1) && AI_WhoStrikesFirst(battlerAtk, battlerDef, move, predictedMoveSpeedCheck, DONT_CONSIDER_PRIORITY) == AI_IS_FASTER)
                  && !(CanAIFaintTarget(battlerAtk, BATTLE_PARTNER(battlerDef), 1) && AI_WhoStrikesFirst(battlerAtk, BATTLE_PARTNER(battlerDef), move, MOVE_SCRATCH, DONT_CONSIDER_PRIORITY) == AI_IS_FASTER))
+                {
                     ADJUST_SCORE(GOOD_EFFECT);
+                }
                 else
+                {    
                     ADJUST_SCORE(DECENT_EFFECT);
+                }
             }
             else if (IsBestDmgMove(battlerAtk, battlerDef, AI_ATTACKING, move))
+            {
                 ADJUST_SCORE(BEST_EFFECT);
+            }
         }
         break;
     case EFFECT_STOCKPILE:

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -4238,6 +4238,8 @@ static s32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move, stru
     bool32 isBattle1v1 = IsBattle1v1();
     bool32 hasTwoOpponents = HasTwoOpponents(battlerAtk);
     bool32 hasPartner = HasPartner(battlerAtk);
+    enum BattlerId battlerAtkPartner = BATTLE_PARTNER(battlerAtk);
+    enum BattlerId battlerDefPartner = BATTLE_PARTNER(battlerDef);
     enum MoveTarget moveTarget = AI_GetBattlerMoveTargetType(battlerAtk, move);
     bool32 moveTargetsBothOpponents = hasTwoOpponents && (IsSpreadMove(moveTarget, IGNORE_BATTLE_TYPE) || moveTarget == TARGET_ALL_BATTLERS || moveTarget == TARGET_FIELD);
 
@@ -4989,35 +4991,36 @@ static s32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move, stru
         {
             // Fake Out in doubles - don't incentivise if ally fast KO'd by both opponents
             if (IsDoubleBattle() && IsFlinchGuaranteed(battlerAtk, battlerDef, move)
-             && !((CanAIFaintTarget(battlerDef, BATTLE_PARTNER(battlerAtk), 1) && AI_WhoStrikesFirst(BATTLE_PARTNER(battlerAtk), battlerDef, gBattleMons[BATTLE_PARTNER(battlerAtk)].moves[gAiBattleData->chosenMoveIndex[BATTLE_PARTNER(battlerAtk)]], predictedMoveSpeedCheck, CONSIDER_PRIORITY) == AI_IS_SLOWER)
-             && (CanAIFaintTarget(BATTLE_PARTNER(battlerDef), BATTLE_PARTNER(battlerAtk), 1) && AI_WhoStrikesFirst(BATTLE_PARTNER(battlerAtk), BATTLE_PARTNER(battlerDef), gBattleMons[BATTLE_PARTNER(battlerAtk)].moves[gAiBattleData->chosenMoveIndex[BATTLE_PARTNER(battlerAtk)]], MOVE_SCRATCH, CONSIDER_PRIORITY) == AI_IS_SLOWER)))
+             && !((CanAIFaintTarget(battlerDef, battlerAtkPartner, 1) && AI_WhoStrikesFirst(battlerAtkPartner, battlerDef, gBattleMons[battlerAtkPartner].moves[gAiBattleData->chosenMoveIndex[battlerAtkPartner]], predictedMoveSpeedCheck, CONSIDER_PRIORITY) == AI_IS_SLOWER)
+             && (CanAIFaintTarget(battlerDefPartner, battlerAtkPartner, 1) && AI_WhoStrikesFirst(battlerAtkPartner, battlerDefPartner, gBattleMons[battlerAtkPartner].moves[gAiBattleData->chosenMoveIndex[battlerAtkPartner]], MOVE_SCRATCH, CONSIDER_PRIORITY) == AI_IS_SLOWER)))
             {
                 // If either opponent has Fake Out, it's their first turn but user is faster - incentivise Fake Out on both
                 if ((HasMove(battlerDef, MOVE_FAKE_OUT) && gBattleStruct->battlerState[battlerDef].isFirstTurn
                  && AI_WhoStrikesFirst(battlerAtk, battlerDef, MOVE_FAKE_OUT, MOVE_FAKE_OUT, CONSIDER_PRIORITY) == AI_IS_FASTER)
-                 || (HasMove(BATTLE_PARTNER(battlerDef), MOVE_FAKE_OUT) && gBattleStruct->battlerState[BATTLE_PARTNER(battlerDef)].isFirstTurn
-                 && AI_WhoStrikesFirst(battlerAtk, BATTLE_PARTNER(battlerDef), MOVE_FAKE_OUT, MOVE_FAKE_OUT, CONSIDER_PRIORITY) == AI_IS_FASTER))
+                 || (HasMove(battlerDefPartner, MOVE_FAKE_OUT) && gBattleStruct->battlerState[battlerDefPartner].isFirstTurn
+                 && AI_WhoStrikesFirst(battlerAtk, battlerDefPartner, MOVE_FAKE_OUT, MOVE_FAKE_OUT, CONSIDER_PRIORITY) == AI_IS_FASTER))
                 {    
                     ADJUST_SCORE(GOOD_EFFECT);
                 }
                 // If ally has KO on target's partner, but target can fast KO ally (checking move and priority combinations for everything likely gets a bit complicated)
                 else if (hasPartner
-                 && CanAIFaintTarget(BATTLE_PARTNER(battlerAtk), BATTLE_PARTNER(battlerDef), 1)
-                 && (CanAIFaintTarget(battlerDef, BATTLE_PARTNER(battlerAtk), 1) && AI_WhoStrikesFirst(BATTLE_PARTNER(battlerAtk), battlerDef, gBattleMons[BATTLE_PARTNER(battlerAtk)].moves[gAiBattleData->chosenMoveIndex[BATTLE_PARTNER(battlerAtk)]], predictedMoveSpeedCheck, CONSIDER_PRIORITY) == AI_IS_SLOWER)
+                 && CanAIFaintTarget(battlerAtkPartner, battlerDefPartner, 1)
+                 && (CanAIFaintTarget(battlerDef, battlerAtkPartner, 1) && AI_WhoStrikesFirst(battlerAtkPartner, battlerDef, gBattleMons[battlerAtkPartner].moves[gAiBattleData->chosenMoveIndex[battlerAtkPartner]], predictedMoveSpeedCheck, CONSIDER_PRIORITY) == AI_IS_SLOWER)
                  && !(CanAIFaintTarget(battlerAtk, battlerDef, 1) && AI_WhoStrikesFirst(battlerAtk, battlerDef, move, predictedMoveSpeedCheck, DONT_CONSIDER_PRIORITY) == AI_IS_FASTER))
                 {
-                    if (AI_WhoStrikesFirst(BATTLE_PARTNER(battlerAtk), BATTLE_PARTNER(battlerDef), gBattleMons[BATTLE_PARTNER(battlerAtk)].moves[gAiBattleData->chosenMoveIndex[BATTLE_PARTNER(battlerAtk)]], predictedMoveSpeedCheck, CONSIDER_PRIORITY) == AI_IS_FASTER)
+                    if (AI_WhoStrikesFirst(battlerAtkPartner, battlerDefPartner, gBattleMons[battlerAtkPartner].moves[gAiBattleData->chosenMoveIndex[battlerAtkPartner]], predictedMoveSpeedCheck, CONSIDER_PRIORITY) == AI_IS_FASTER)
                         ADJUST_SCORE(FAST_KILL + 2); // No point fast KOing target's partner when user can save ally who will do it anyway
+                    else if (RandomPercentage(RNG_AI_FAKE_OUT_SAVE_ALLY, FAKE_OUT_SAVE_ALLY_CHANCE))
+                        ADJUST_SCORE(FAST_KILL + 2); // Still Fake Out in case the ally is not double targeted
                     else
                         ADJUST_SCORE(SLOW_KILL + 2); // No point saving ally if target's partner also fast KOs them
-                    // No else case as assume if both opponents have fast KO on user's ally, then user probably better off not using Fake Out
                 }
                 // If ally has slow KO with their chosen move, user sees no KOs while outspeeding (checking move and priority combinations for everything likely gets a bit complicated)
                 else if (hasPartner 
-                 && (AI_WhoStrikesFirst(BATTLE_PARTNER(battlerAtk), battlerDef, gBattleMons[BATTLE_PARTNER(battlerAtk)].moves[gAiBattleData->chosenMoveIndex[BATTLE_PARTNER(battlerAtk)]], predictedMoveSpeedCheck, CONSIDER_PRIORITY) == AI_IS_SLOWER)
-                 && CanAIFaintTarget(BATTLE_PARTNER(battlerAtk), battlerDef, 1) 
+                 && (AI_WhoStrikesFirst(battlerAtkPartner, battlerDef, gBattleMons[battlerAtkPartner].moves[gAiBattleData->chosenMoveIndex[battlerAtkPartner]], predictedMoveSpeedCheck, CONSIDER_PRIORITY) == AI_IS_SLOWER)
+                 && CanAIFaintTarget(battlerAtkPartner, battlerDef, 1) 
                  && !(CanAIFaintTarget(battlerAtk, battlerDef, 1) && AI_WhoStrikesFirst(battlerAtk, battlerDef, move, predictedMoveSpeedCheck, DONT_CONSIDER_PRIORITY) == AI_IS_FASTER)
-                 && !(CanAIFaintTarget(battlerAtk, BATTLE_PARTNER(battlerDef), 1) && AI_WhoStrikesFirst(battlerAtk, BATTLE_PARTNER(battlerDef), move, MOVE_SCRATCH, DONT_CONSIDER_PRIORITY) == AI_IS_FASTER))
+                 && !(CanAIFaintTarget(battlerAtk, battlerDefPartner, 1) && AI_WhoStrikesFirst(battlerAtk, battlerDefPartner, move, MOVE_SCRATCH, DONT_CONSIDER_PRIORITY) == AI_IS_FASTER))
                 {
                     ADJUST_SCORE(GOOD_EFFECT);
                 }

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -4989,38 +4989,50 @@ static s32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, u32 move, stru
     case EFFECT_FIRST_TURN_ONLY:
         if (gBattleStruct->battlerState[battlerAtk].isFirstTurn && !IsTargetingPartner(battlerAtk, battlerDef))
         {
-            // Fake Out in doubles - don't incentivise if ally fast KO'd by both opponents
-            if (IsDoubleBattle() && IsFlinchGuaranteed(battlerAtk, battlerDef, move)
-             && !((CanAIFaintTarget(battlerDef, battlerAtkPartner, 1) && AI_WhoStrikesFirst(battlerAtkPartner, battlerDef, gBattleMons[battlerAtkPartner].moves[gAiBattleData->chosenMoveIndex[battlerAtkPartner]], predictedMoveSpeedCheck, CONSIDER_PRIORITY) == AI_IS_SLOWER)
-             && (CanAIFaintTarget(battlerDefPartner, battlerAtkPartner, 1) && AI_WhoStrikesFirst(battlerAtkPartner, battlerDefPartner, gBattleMons[battlerAtkPartner].moves[gAiBattleData->chosenMoveIndex[battlerAtkPartner]], MOVE_SCRATCH, CONSIDER_PRIORITY) == AI_IS_SLOWER)))
+            // Fake Out in doubles
+            if (IsDoubleBattle() && IsFlinchGuaranteed(battlerAtk, battlerDef, move))
             {
+                bool32 atkKoDef = CanAIFaintTarget(battlerAtk, battlerDef, 1);
+                bool32 atkKoDefPartner = CanAIFaintTarget(battlerAtk, battlerDefPartner, 1);
+                bool32 defKoAtkPartner = CanAIFaintTarget(battlerDef, battlerAtkPartner, 1);
+                bool32 atkPartnerKoDef = CanAIFaintTarget(battlerAtkPartner, battlerDef, 1);
+                bool32 atkPartnerKoDefPartner = CanAIFaintTarget(battlerAtkPartner, battlerDefPartner, 1);
+                bool32 defPartnerKoAtkPartner = CanAIFaintTarget(battlerDefPartner, battlerAtkPartner, 1);
+                bool32 atkPartnerDoubleFastKOd = (defKoAtkPartner && AI_WhoStrikesFirst(battlerAtkPartner, battlerDef, gBattleMons[battlerAtkPartner].moves[gAiBattleData->chosenMoveIndex[battlerAtkPartner]], predictedMoveSpeedCheck, CONSIDER_PRIORITY) == AI_IS_SLOWER)
+                 && (defPartnerKoAtkPartner && AI_WhoStrikesFirst(battlerAtkPartner, battlerDefPartner, gBattleMons[battlerAtkPartner].moves[gAiBattleData->chosenMoveIndex[battlerAtkPartner]], MOVE_SCRATCH, CONSIDER_PRIORITY) == AI_IS_SLOWER);
+
                 // If either opponent has Fake Out, it's their first turn but user is faster - incentivise Fake Out on both
                 if ((HasMove(battlerDef, MOVE_FAKE_OUT) && gBattleStruct->battlerState[battlerDef].isFirstTurn
                  && AI_WhoStrikesFirst(battlerAtk, battlerDef, MOVE_FAKE_OUT, MOVE_FAKE_OUT, CONSIDER_PRIORITY) == AI_IS_FASTER)
                  || (HasMove(battlerDefPartner, MOVE_FAKE_OUT) && gBattleStruct->battlerState[battlerDefPartner].isFirstTurn
                  && AI_WhoStrikesFirst(battlerAtk, battlerDefPartner, MOVE_FAKE_OUT, MOVE_FAKE_OUT, CONSIDER_PRIORITY) == AI_IS_FASTER))
                 {    
-                    ADJUST_SCORE(GOOD_EFFECT);
+                    ADJUST_SCORE(FAST_KILL + 2);
                 }
                 // If ally has KO on target's partner, but target can fast KO ally (checking move and priority combinations for everything likely gets a bit complicated)
-                else if (hasPartner
-                 && CanAIFaintTarget(battlerAtkPartner, battlerDefPartner, 1)
-                 && (CanAIFaintTarget(battlerDef, battlerAtkPartner, 1) && AI_WhoStrikesFirst(battlerAtkPartner, battlerDef, gBattleMons[battlerAtkPartner].moves[gAiBattleData->chosenMoveIndex[battlerAtkPartner]], predictedMoveSpeedCheck, CONSIDER_PRIORITY) == AI_IS_SLOWER)
-                 && !(CanAIFaintTarget(battlerAtk, battlerDef, 1) && AI_WhoStrikesFirst(battlerAtk, battlerDef, move, predictedMoveSpeedCheck, DONT_CONSIDER_PRIORITY) == AI_IS_FASTER))
+                else if (hasPartner && atkPartnerKoDefPartner
+                 && (defKoAtkPartner && AI_WhoStrikesFirst(battlerAtkPartner, battlerDef, gBattleMons[battlerAtkPartner].moves[gAiBattleData->chosenMoveIndex[battlerAtkPartner]], predictedMoveSpeedCheck, CONSIDER_PRIORITY) == AI_IS_SLOWER)
+                 && !(atkKoDef && AI_WhoStrikesFirst(battlerAtk, battlerDef, move, predictedMoveSpeedCheck, DONT_CONSIDER_PRIORITY) == AI_IS_FASTER))
                 {
                     if (AI_WhoStrikesFirst(battlerAtkPartner, battlerDefPartner, gBattleMons[battlerAtkPartner].moves[gAiBattleData->chosenMoveIndex[battlerAtkPartner]], predictedMoveSpeedCheck, CONSIDER_PRIORITY) == AI_IS_FASTER)
                         ADJUST_SCORE(FAST_KILL + 2); // No point fast KOing target's partner when user can save ally who will do it anyway
-                    else if (RandomPercentage(RNG_AI_FAKE_OUT_SAVE_ALLY, FAKE_OUT_SAVE_ALLY_CHANCE))
-                        ADJUST_SCORE(FAST_KILL + 2); // Still Fake Out in case the ally is not double targeted
+                    else if (atkPartnerDoubleFastKOd)
+                    {
+                        if (RandomPercentage(RNG_AI_FAKE_OUT_SAVE_ALLY, FAKE_OUT_SAVE_ALLY_CHANCE))
+                            ADJUST_SCORE(FAST_KILL + 2); // Still Fake Out in case the ally is not double targeted
+                        else
+                            ADJUST_SCORE(SLOW_KILL + 2); // Prioritize fast KO
+                    }
                     else
-                        ADJUST_SCORE(SLOW_KILL + 2); // No point saving ally if target's partner also fast KOs them
+                    {
+                        ADJUST_SCORE(SLOW_KILL + 2);
+                    }
                 }
                 // If ally has slow KO with their chosen move, user sees no KOs while outspeeding (checking move and priority combinations for everything likely gets a bit complicated)
                 else if (hasPartner 
-                 && (AI_WhoStrikesFirst(battlerAtkPartner, battlerDef, gBattleMons[battlerAtkPartner].moves[gAiBattleData->chosenMoveIndex[battlerAtkPartner]], predictedMoveSpeedCheck, CONSIDER_PRIORITY) == AI_IS_SLOWER)
-                 && CanAIFaintTarget(battlerAtkPartner, battlerDef, 1) 
-                 && !(CanAIFaintTarget(battlerAtk, battlerDef, 1) && AI_WhoStrikesFirst(battlerAtk, battlerDef, move, predictedMoveSpeedCheck, DONT_CONSIDER_PRIORITY) == AI_IS_FASTER)
-                 && !(CanAIFaintTarget(battlerAtk, battlerDefPartner, 1) && AI_WhoStrikesFirst(battlerAtk, battlerDefPartner, move, MOVE_SCRATCH, DONT_CONSIDER_PRIORITY) == AI_IS_FASTER))
+                 && (atkPartnerKoDef && AI_WhoStrikesFirst(battlerAtkPartner, battlerDef, gBattleMons[battlerAtkPartner].moves[gAiBattleData->chosenMoveIndex[battlerAtkPartner]], predictedMoveSpeedCheck, CONSIDER_PRIORITY) == AI_IS_SLOWER)
+                 && !(atkKoDef && AI_WhoStrikesFirst(battlerAtk, battlerDef, move, predictedMoveSpeedCheck, DONT_CONSIDER_PRIORITY) == AI_IS_FASTER)
+                 && !(atkKoDefPartner && AI_WhoStrikesFirst(battlerAtk, battlerDefPartner, move, MOVE_SCRATCH, DONT_CONSIDER_PRIORITY) == AI_IS_FASTER))
                 {
                     ADJUST_SCORE(GOOD_EFFECT);
                 }

--- a/test/battle/move_effect/first_turn_only.c
+++ b/test/battle/move_effect/first_turn_only.c
@@ -58,8 +58,8 @@ AI_DOUBLE_BATTLE_TEST("AI will Fake Out either opponent if one has a slower Fake
     } WHEN {
         TURN { MOVE(playerLeft, MOVE_CELEBRATE); MOVE(playerRight, MOVE_CELEBRATE);
             EXPECT_MOVE(opponentLeft, MOVE_FAKE_OUT, target:playerRight);
-            SCORE_EQ_VAL(opponentLeft, MOVE_FAKE_OUT, AI_SCORE_DEFAULT + BEST_EFFECT, target:playerLeft);
-            SCORE_EQ_VAL(opponentLeft, MOVE_FAKE_OUT, AI_SCORE_DEFAULT + BEST_EFFECT, target:playerRight);
+            SCORE_EQ_VAL(opponentLeft, MOVE_FAKE_OUT, AI_SCORE_DEFAULT + GOOD_EFFECT, target:playerLeft);
+            SCORE_EQ_VAL(opponentLeft, MOVE_FAKE_OUT, AI_SCORE_DEFAULT + GOOD_EFFECT, target:playerRight);
             SCORE_EQ_VAL(opponentLeft, MOVE_SEISMIC_TOSS, AI_SCORE_DEFAULT + BEST_DAMAGE_MOVE, target:playerLeft);
             SCORE_EQ_VAL(opponentLeft, MOVE_SEISMIC_TOSS, AI_SCORE_DEFAULT + BEST_DAMAGE_MOVE, target:playerRight);
         }
@@ -68,11 +68,30 @@ AI_DOUBLE_BATTLE_TEST("AI will Fake Out either opponent if one has a slower Fake
     }
 }
 
+AI_DOUBLE_BATTLE_TEST("AI will Fake Out a target that its ally has slow KO on the target's partner and the user cannot fast KO the target")
+{
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_DOUBLE_BATTLE | AI_FLAG_OMNISCIENT);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); Moves(MOVE_CELEBRATE); HP(40); }
+        PLAYER(SPECIES_WOBBUFFET) { Speed(3); Moves(MOVE_DRAGON_RAGE, MOVE_CELEBRATE); HP(100); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); Moves(MOVE_DRAGON_RAGE, MOVE_CELEBRATE); HP(40); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(4); Level(39); Moves(MOVE_SEISMIC_TOSS, MOVE_FAKE_OUT); }
+    } WHEN {
+        TURN { EXPECT_MOVE(opponentRight, MOVE_FAKE_OUT, target:playerRight);
+            SCORE_EQ_VAL(opponentRight, MOVE_SEISMIC_TOSS, AI_SCORE_DEFAULT + BEST_DAMAGE_MOVE, target:playerLeft);
+            SCORE_EQ_VAL(opponentRight, MOVE_SEISMIC_TOSS, AI_SCORE_DEFAULT + BEST_DAMAGE_MOVE, target:playerRight);
+            SCORE_EQ_VAL(opponentRight, MOVE_FAKE_OUT, AI_SCORE_DEFAULT + GOOD_EFFECT, target:playerLeft); 
+            SCORE_EQ_VAL(opponentRight, MOVE_FAKE_OUT, AI_SCORE_DEFAULT + BEST_EFFECT, target:playerRight);
+        }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FAKE_OUT, opponentRight);
+    }
+}
+
 AI_DOUBLE_BATTLE_TEST("AI will Fake Out a target that its ally has slow KO on when seeing no fast KOs")
 {
     GIVEN {
         AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_DOUBLE_BATTLE | AI_FLAG_OMNISCIENT);
-        TIE_BREAK_TARGET(TARGET_TIE_RANDOM, 0);
         PLAYER(SPECIES_WOBBUFFET) { Speed(2); Moves(MOVE_DRAGON_RAGE, MOVE_CELEBRATE); HP(40); }
         PLAYER(SPECIES_WOBBUFFET) { Speed(2); Moves(MOVE_DRAGON_RAGE, MOVE_CELEBRATE); HP(100); }
         OPPONENT(SPECIES_WOBBUFFET) { Speed(1); Moves(MOVE_DRAGON_RAGE, MOVE_CELEBRATE); }
@@ -81,7 +100,7 @@ AI_DOUBLE_BATTLE_TEST("AI will Fake Out a target that its ally has slow KO on wh
         TURN { EXPECT_MOVE(opponentRight, MOVE_FAKE_OUT, target:playerLeft);
             SCORE_EQ_VAL(opponentRight, MOVE_SEISMIC_TOSS, AI_SCORE_DEFAULT + BEST_DAMAGE_MOVE, target:playerLeft);
             SCORE_EQ_VAL(opponentRight, MOVE_SEISMIC_TOSS, AI_SCORE_DEFAULT + BEST_DAMAGE_MOVE, target:playerRight);
-            SCORE_EQ_VAL(opponentRight, MOVE_FAKE_OUT, AI_SCORE_DEFAULT + BEST_EFFECT, target:playerLeft);
+            SCORE_EQ_VAL(opponentRight, MOVE_FAKE_OUT, AI_SCORE_DEFAULT + GOOD_EFFECT, target:playerLeft);
             SCORE_EQ_VAL(opponentRight, MOVE_FAKE_OUT, AI_SCORE_DEFAULT + DECENT_EFFECT, target:playerRight); 
         }
     } SCENE {
@@ -93,7 +112,6 @@ AI_DOUBLE_BATTLE_TEST("AI will not Fake Out a target that its ally has slow KO o
 {
     GIVEN {
         AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_DOUBLE_BATTLE | AI_FLAG_OMNISCIENT);
-        TIE_BREAK_TARGET(TARGET_TIE_RANDOM, 0);
         PLAYER(SPECIES_WOBBUFFET) { Speed(2); Moves(MOVE_DRAGON_RAGE, MOVE_CELEBRATE); HP(40); }
         PLAYER(SPECIES_WOBBUFFET) { Speed(2); Moves(MOVE_DRAGON_RAGE, MOVE_CELEBRATE); HP(100); }
         OPPONENT(SPECIES_WOBBUFFET) { Speed(1); Moves(MOVE_SEISMIC_TOSS, MOVE_CELEBRATE); }

--- a/test/battle/move_effect/first_turn_only.c
+++ b/test/battle/move_effect/first_turn_only.c
@@ -1,8 +1,152 @@
 #include "global.h"
 #include "test/battle.h"
+#include "battle_ai_util.h"
 
-TO_DO_BATTLE_TEST("Fake Out can only be used on the user's first turn")
-TO_DO_BATTLE_TEST("Fake Out fails if it's called via Instruct")
+SINGLE_BATTLE_TEST("Fake Out can only be used on the user's first turn")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Speed(1); }
+        PLAYER(SPECIES_WOBBUFFET) { Speed(1); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(2); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_FAKE_OUT); SWITCH(player, 1); }
+        TURN { MOVE(player, MOVE_FAKE_OUT); MOVE(opponent, MOVE_FAKE_OUT); }
+        TURN { MOVE(player, MOVE_FAKE_OUT); MOVE(opponent, MOVE_FAKE_OUT); }
+    } SCENE {
+        MESSAGE("The opposing Wobbuffet used Fake Out!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FAKE_OUT, opponent);
+        MESSAGE("The opposing Wobbuffet used Fake Out!");
+        NONE_OF { ANIMATION(ANIM_TYPE_MOVE, MOVE_FAKE_OUT, opponent); }
+        MESSAGE("Wobbuffet used Fake Out!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FAKE_OUT, player);
+        MESSAGE("The opposing Wobbuffet used Fake Out!");
+        NONE_OF { ANIMATION(ANIM_TYPE_MOVE, MOVE_FAKE_OUT, opponent); }
+        MESSAGE("Wobbuffet used Fake Out!");
+        NONE_OF { ANIMATION(ANIM_TYPE_MOVE, MOVE_FAKE_OUT, player); }
+    }
+}
 
-TO_DO_BATTLE_TEST("First Impression can only be used on the user's first turn")
-TO_DO_BATTLE_TEST("First Impression fails if it's called via Instruct")
+SINGLE_BATTLE_TEST("Fake Out fails if it's called via Instruct")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_ORANGURU) { Ability(ABILITY_INNER_FOCUS); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_FAKE_OUT); MOVE(opponent, MOVE_INSTRUCT); }
+    } SCENE {
+        MESSAGE("Wobbuffet used Fake Out!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FAKE_OUT, player);
+        ABILITY_POPUP(opponent, ABILITY_INNER_FOCUS);
+        NONE_OF { MESSAGE("The opposing Oranguru flinched and couldn't move!"); }
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_INSTRUCT, opponent);
+        MESSAGE("Wobbuffet used Fake Out!");
+        NONE_OF { ANIMATION(ANIM_TYPE_MOVE, MOVE_FAKE_OUT, player); }
+    }
+}
+
+AI_DOUBLE_BATTLE_TEST("AI will Fake Out either opponent if one has a slower Fake Out")
+{
+    PASSES_RANDOMLY(50, 100, RNG_AI_SCORE_TIE_DOUBLES_TARGET);
+
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_DOUBLE_BATTLE | AI_FLAG_OMNISCIENT);
+        TIE_BREAK_TARGET(TARGET_TIE_RANDOM, 0);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(1); }
+        PLAYER(SPECIES_WOBBUFFET) { Speed(1); Moves(MOVE_SEISMIC_TOSS, MOVE_FAKE_OUT, MOVE_CELEBRATE); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(2); Moves(MOVE_SEISMIC_TOSS, MOVE_FAKE_OUT); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(2); }
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_CELEBRATE); MOVE(playerRight, MOVE_CELEBRATE);
+            EXPECT_MOVE(opponentLeft, MOVE_FAKE_OUT, target:playerRight);
+            SCORE_EQ_VAL(opponentLeft, MOVE_FAKE_OUT, AI_SCORE_DEFAULT + BEST_EFFECT, target:playerLeft);
+            SCORE_EQ_VAL(opponentLeft, MOVE_FAKE_OUT, AI_SCORE_DEFAULT + BEST_EFFECT, target:playerRight);
+            SCORE_EQ_VAL(opponentLeft, MOVE_SEISMIC_TOSS, AI_SCORE_DEFAULT + BEST_DAMAGE_MOVE, target:playerLeft);
+            SCORE_EQ_VAL(opponentLeft, MOVE_SEISMIC_TOSS, AI_SCORE_DEFAULT + BEST_DAMAGE_MOVE, target:playerRight);
+        }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FAKE_OUT, opponentLeft);
+    }
+}
+
+AI_DOUBLE_BATTLE_TEST("AI will Fake Out a target that its ally has slow KO on when seeing no fast KOs")
+{
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_DOUBLE_BATTLE | AI_FLAG_OMNISCIENT);
+        TIE_BREAK_TARGET(TARGET_TIE_RANDOM, 0);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); Moves(MOVE_DRAGON_RAGE, MOVE_CELEBRATE); HP(40); }
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); Moves(MOVE_DRAGON_RAGE, MOVE_CELEBRATE); HP(100); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); Moves(MOVE_DRAGON_RAGE, MOVE_CELEBRATE); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(3); Level(39); Moves(MOVE_SEISMIC_TOSS, MOVE_FAKE_OUT); }
+    } WHEN {
+        TURN { EXPECT_MOVE(opponentRight, MOVE_FAKE_OUT, target:playerLeft);
+            SCORE_EQ_VAL(opponentRight, MOVE_SEISMIC_TOSS, AI_SCORE_DEFAULT + BEST_DAMAGE_MOVE, target:playerLeft);
+            SCORE_EQ_VAL(opponentRight, MOVE_SEISMIC_TOSS, AI_SCORE_DEFAULT + BEST_DAMAGE_MOVE, target:playerRight);
+            SCORE_EQ_VAL(opponentRight, MOVE_FAKE_OUT, AI_SCORE_DEFAULT + BEST_EFFECT, target:playerLeft);
+            SCORE_EQ_VAL(opponentRight, MOVE_FAKE_OUT, AI_SCORE_DEFAULT + DECENT_EFFECT, target:playerRight); 
+        }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FAKE_OUT, opponentRight);
+    }
+}
+
+AI_DOUBLE_BATTLE_TEST("AI will not Fake Out a target that its ally has slow KO on when seeing fast KO")
+{
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_DOUBLE_BATTLE | AI_FLAG_OMNISCIENT);
+        TIE_BREAK_TARGET(TARGET_TIE_RANDOM, 0);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); Moves(MOVE_DRAGON_RAGE, MOVE_CELEBRATE); HP(40); }
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); Moves(MOVE_DRAGON_RAGE, MOVE_CELEBRATE); HP(100); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); Moves(MOVE_SEISMIC_TOSS, MOVE_CELEBRATE); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(3); Level(40); Moves(MOVE_SEISMIC_TOSS, MOVE_FAKE_OUT); }
+    } WHEN {
+        TURN { EXPECT_MOVE(opponentRight, MOVE_SEISMIC_TOSS, target:playerLeft);
+            SCORE_EQ_VAL(opponentRight, MOVE_SEISMIC_TOSS, AI_SCORE_DEFAULT + BEST_DAMAGE_MOVE + FAST_KILL, target:playerLeft);
+            SCORE_EQ_VAL(opponentRight, MOVE_SEISMIC_TOSS, AI_SCORE_DEFAULT + BEST_DAMAGE_MOVE, target:playerRight);
+            SCORE_EQ_VAL(opponentRight, MOVE_FAKE_OUT, AI_SCORE_DEFAULT + DECENT_EFFECT, target:playerLeft);
+            SCORE_EQ_VAL(opponentRight, MOVE_FAKE_OUT, AI_SCORE_DEFAULT + DECENT_EFFECT, target:playerRight); 
+        }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SEISMIC_TOSS, opponentRight);
+    }
+}
+
+SINGLE_BATTLE_TEST("First Impression can only be used on the user's first turn")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Speed(1); }
+        PLAYER(SPECIES_WOBBUFFET) { Speed(1); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(2); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_FIRST_IMPRESSION); SWITCH(player, 1); }
+        TURN { MOVE(player, MOVE_FIRST_IMPRESSION); MOVE(opponent, MOVE_FIRST_IMPRESSION); }
+        TURN { MOVE(player, MOVE_FIRST_IMPRESSION); MOVE(opponent, MOVE_FIRST_IMPRESSION); }
+    } SCENE {
+        MESSAGE("The opposing Wobbuffet used First Impression!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FIRST_IMPRESSION, opponent);
+        MESSAGE("The opposing Wobbuffet used First Impression!");
+        NONE_OF { ANIMATION(ANIM_TYPE_MOVE, MOVE_FIRST_IMPRESSION, opponent); }
+        MESSAGE("Wobbuffet used First Impression!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FIRST_IMPRESSION, player);
+        MESSAGE("The opposing Wobbuffet used First Impression!");
+        NONE_OF { ANIMATION(ANIM_TYPE_MOVE, MOVE_FIRST_IMPRESSION, opponent); }
+        MESSAGE("Wobbuffet used First Impression!");
+        NONE_OF { ANIMATION(ANIM_TYPE_MOVE, MOVE_FIRST_IMPRESSION, player); }
+    }
+}
+
+SINGLE_BATTLE_TEST("First Impression fails if it's called via Instruct")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_ORANGURU);
+    } WHEN {
+        TURN { MOVE(player, MOVE_FIRST_IMPRESSION); MOVE(opponent, MOVE_INSTRUCT); }
+    } SCENE {
+        MESSAGE("Wobbuffet used First Impression!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FIRST_IMPRESSION, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_INSTRUCT, opponent);
+        MESSAGE("Wobbuffet used First Impression!");
+        NONE_OF { ANIMATION(ANIM_TYPE_MOVE, MOVE_FIRST_IMPRESSION, player); }
+    }
+}
+

--- a/test/battle/move_effect/first_turn_only.c
+++ b/test/battle/move_effect/first_turn_only.c
@@ -88,7 +88,7 @@ AI_DOUBLE_BATTLE_TEST("AI will Fake Out a target if its ally has slow KO on the 
             if (speed == 2)
             {
                 SCORE_EQ_VAL(opponentRight, MOVE_FAKE_OUT, AI_SCORE_DEFAULT + GOOD_EFFECT, target:playerLeft); 
-                SCORE_EQ_VAL(opponentRight, MOVE_FAKE_OUT, AI_SCORE_DEFAULT + SLOW_KILL + 2, target:playerRight);
+                SCORE_EQ_VAL(opponentRight, MOVE_FAKE_OUT, AI_SCORE_DEFAULT + FAST_KILL + 2, target:playerRight);
             }
             else
             {

--- a/test/battle/move_effect/first_turn_only.c
+++ b/test/battle/move_effect/first_turn_only.c
@@ -58,8 +58,8 @@ AI_DOUBLE_BATTLE_TEST("AI will Fake Out either opponent if one has a slower Fake
     } WHEN {
         TURN { MOVE(playerLeft, MOVE_CELEBRATE); MOVE(playerRight, MOVE_CELEBRATE);
             EXPECT_MOVE(opponentLeft, MOVE_FAKE_OUT, target:playerRight);
-            SCORE_EQ_VAL(opponentLeft, MOVE_FAKE_OUT, AI_SCORE_DEFAULT + GOOD_EFFECT, target:playerLeft);
-            SCORE_EQ_VAL(opponentLeft, MOVE_FAKE_OUT, AI_SCORE_DEFAULT + GOOD_EFFECT, target:playerRight);
+            SCORE_EQ_VAL(opponentLeft, MOVE_FAKE_OUT, AI_SCORE_DEFAULT + FAST_KILL + 2, target:playerLeft);
+            SCORE_EQ_VAL(opponentLeft, MOVE_FAKE_OUT, AI_SCORE_DEFAULT + FAST_KILL + 2, target:playerRight);
             SCORE_EQ_VAL(opponentLeft, MOVE_SEISMIC_TOSS, AI_SCORE_DEFAULT + BEST_DAMAGE_MOVE, target:playerLeft);
             SCORE_EQ_VAL(opponentLeft, MOVE_SEISMIC_TOSS, AI_SCORE_DEFAULT + BEST_DAMAGE_MOVE, target:playerRight);
         }
@@ -88,7 +88,7 @@ AI_DOUBLE_BATTLE_TEST("AI will Fake Out a target if its ally has slow KO on the 
             if (speed == 2)
             {
                 SCORE_EQ_VAL(opponentRight, MOVE_FAKE_OUT, AI_SCORE_DEFAULT + GOOD_EFFECT, target:playerLeft); 
-                SCORE_EQ_VAL(opponentRight, MOVE_FAKE_OUT, AI_SCORE_DEFAULT + FAST_KILL + 2, target:playerRight);
+                SCORE_EQ_VAL(opponentRight, MOVE_FAKE_OUT, AI_SCORE_DEFAULT + SLOW_KILL + 2, target:playerRight);
             }
             else
             {
@@ -101,24 +101,25 @@ AI_DOUBLE_BATTLE_TEST("AI will Fake Out a target if its ally has slow KO on the 
     }
 }
 
-AI_DOUBLE_BATTLE_TEST("AI will not Fake Out a target if its ally has slow KO on the target's partner where its ally is fast KO'd by both target and target's partner")
+AI_DOUBLE_BATTLE_TEST("AI may prioritize Fake Out over fast KO when its ally is fast KO'd by both opponents but has a slow KO on target's partner")
 {
+    PASSES_RANDOMLY(FAKE_OUT_SAVE_ALLY_CHANCE, 100, RNG_AI_FAKE_OUT_SAVE_ALLY);
     GIVEN {
         AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_DOUBLE_BATTLE | AI_FLAG_OMNISCIENT);
         TIE_BREAK_TARGET(TARGET_TIE_HI, 0);
         PLAYER(SPECIES_WOBBUFFET) { Speed(3); Moves(MOVE_DRAGON_RAGE, MOVE_CELEBRATE); HP(40); }
         PLAYER(SPECIES_WOBBUFFET) { Speed(3); Moves(MOVE_DRAGON_RAGE, MOVE_CELEBRATE); HP(100); }
         OPPONENT(SPECIES_WOBBUFFET) { Speed(2); Moves(MOVE_DRAGON_RAGE, MOVE_CELEBRATE); HP(40); }
-        OPPONENT(SPECIES_WOBBUFFET) { Speed(4); Level(39); Moves(MOVE_SEISMIC_TOSS, MOVE_FAKE_OUT); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(4); Level(40); Moves(MOVE_SEISMIC_TOSS, MOVE_FAKE_OUT); }
     } WHEN {
-        TURN { EXPECT_MOVE(opponentRight, MOVE_SEISMIC_TOSS, target:playerRight);
-            SCORE_EQ_VAL(opponentRight, MOVE_SEISMIC_TOSS, AI_SCORE_DEFAULT + BEST_DAMAGE_MOVE, target:playerLeft);
+        TURN { EXPECT_MOVE(opponentRight, MOVE_FAKE_OUT, target:playerRight);
+            SCORE_EQ_VAL(opponentRight, MOVE_SEISMIC_TOSS, AI_SCORE_DEFAULT + BEST_DAMAGE_MOVE + FAST_KILL, target:playerLeft);
             SCORE_EQ_VAL(opponentRight, MOVE_SEISMIC_TOSS, AI_SCORE_DEFAULT + BEST_DAMAGE_MOVE, target:playerRight);
-            SCORE_EQ_VAL(opponentRight, MOVE_FAKE_OUT, AI_SCORE_DEFAULT, target:playerLeft); 
-            SCORE_EQ_VAL(opponentRight, MOVE_FAKE_OUT, AI_SCORE_DEFAULT, target:playerRight);
+            SCORE_EQ_VAL(opponentRight, MOVE_FAKE_OUT, AI_SCORE_DEFAULT + DECENT_EFFECT, target:playerLeft); 
+            SCORE_EQ_VAL(opponentRight, MOVE_FAKE_OUT, AI_SCORE_DEFAULT + FAST_KILL + 2, target:playerRight);
         }
     } SCENE {
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_SEISMIC_TOSS, opponentRight);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FAKE_OUT, opponentRight);
     }
 }
 


### PR DESCRIPTION
Smarter Doubles Fake Out AI + EFFECT_FIRST_TURN_ONLY tests

## Description
Adds Fake Out incentives for the following cases in Doubles

1. Target or target's partner has Fake Out and it's their first turn, but user has a faster Fake Out -> incentivise Fake Out on both target and target's partner
2. User's ally has slow KO on target's partner, but target will fast KO user's ally first -> incentivise Fake Out on target to secure KO for ally.
3. User's ally has a slow KO on target, and user sees no fast KOs themselves on either target/target's partner -> incentivise Fake Out on target to secure the KO for ally.
4. Else DECENT_EFFECT

Adds EFFECT_FIRST_TURN_ONLY mechanic tests for Fake Out and First Impression

## Issue(s) that this PR fixes
#8469

## Credits
@Pawkkie / @FosterProgramming for reviewing my original Fake Out code and recommending improvements

## Discord contact info
grintoul