### PR TITLE
Fixes Manaphy egg data blocking compiler with Manaphy disabled

### DIFF
--- a/src/data/pokemon/egg_data.h
+++ b/src/data/pokemon/egg_data.h
@@ -1,3 +1,4 @@
+#if P_FAMILY_MANAPHY
 [EGG_ID_MANAPHY] =
 {
     .eggIcon = gMonEggIcon_Manaphy,
@@ -7,3 +8,4 @@
     .eggHatchPal = gMonHatchPal_Manaphy,
     .eggIconPalIndex = 2,
 },
+#endif //P_FAMILY_MANAPHY


### PR DESCRIPTION
Preproc `#if` block missing around Manaphy egg data was blocking compiling with P_FAMILY_MANAPHY disabled

## Description
Adds preproc block around Manaphy egg data in `src/data/pokemon/egg_data.h`

## Issue(s) that this PR fixes
Fixes #8668

## Credits
@MRLEAKY666 for reporting

## Discord contact info
grintoul