### PR TITLE
Pokemon Legends ZA DLC moveset changes (za.json changes) V2

### DIFF
--- a/tools/learnset_helpers/porymoves_files/za.json
+++ b/tools/learnset_helpers/porymoves_files/za.json
@@ -63,19 +63,33 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_BULLET_SEED",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_GIGA_DRAIN",
+      "MOVE_TOXIC",
       "MOVE_LIGHT_SCREEN",
       "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_BULLET_SEED",
+      "MOVE_GIGA_DRAIN",
       "MOVE_SAFEGUARD",
       "MOVE_SLUDGE_BOMB",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_SOLAR_BEAM",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWORDS_DANCE",
-      "MOVE_TOXIC",
-      "MOVE_WORK_UP"
+      "MOVE_WORK_UP",
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_TRAILBLAZE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_SEED_BOMB",
+      "MOVE_PETAL_DANCE",
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_TRAILBLAZE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_SEED_BOMB",
+      "MOVE_PETAL_DANCE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -144,20 +158,33 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_BULLET_SEED",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_GIGA_DRAIN",
+      "MOVE_ROAR",
+      "MOVE_TOXIC",
       "MOVE_LIGHT_SCREEN",
       "MOVE_PROTECT",
-      "MOVE_ROAR",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_BULLET_SEED",
+      "MOVE_GIGA_DRAIN",
       "MOVE_SAFEGUARD",
       "MOVE_SLUDGE_BOMB",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_SOLAR_BEAM",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWORDS_DANCE",
-      "MOVE_TOXIC",
-      "MOVE_WORK_UP"
+      "MOVE_WORK_UP",
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_TRAILBLAZE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_SEED_BOMB",
+      "MOVE_PETAL_DANCE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_TRAILBLAZE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_SEED_BOMB",
+      "MOVE_PETAL_DANCE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -226,25 +253,34 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_BULLET_SEED",
-      "MOVE_EARTHQUAKE",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_GIGA_DRAIN",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_OUTRAGE",
-      "MOVE_PROTECT",
       "MOVE_ROAR",
-      "MOVE_SAFEGUARD",
-      "MOVE_SLUDGE_BOMB",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SWORDS_DANCE",
       "MOVE_TOXIC",
-      "MOVE_WORK_UP"
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_BULLET_SEED",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_HYPER_BEAM",
+      "MOVE_SAFEGUARD",
+      "MOVE_EARTH_POWER",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_EARTHQUAKE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_OUTRAGE",
+      "MOVE_WORK_UP",
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_TRAILBLAZE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_SEED_BOMB",
+      "MOVE_PETAL_DANCE",
+      "MOVE_FRENZY_PLANT"
     ],
     "TutorMoves": [
       "MOVE_POWER_WHIP"
@@ -299,30 +335,38 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_BRICK_BREAK",
-      "MOVE_CRUNCH",
-      "MOVE_DIG",
       "MOVE_DRAGON_CLAW",
-      "MOVE_DRAGON_PULSE",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_BLAST",
+      "MOVE_ROAR",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_FIRE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_CRUNCH",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
       "MOVE_FIRE_PUNCH",
-      "MOVE_FOCUS_BLAST",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_FIRE_BLAST",
+      "MOVE_OVERHEAT",
+      "MOVE_WILL-O-WISP",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_FLAMETHROWER",
       "MOVE_HEAT_WAVE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_SUBSTITUTE",
       "MOVE_IRON_TAIL",
       "MOVE_OUTRAGE",
-      "MOVE_OVERHEAT",
-      "MOVE_PROTECT",
-      "MOVE_ROAR",
-      "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SHADOW_CLAW",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_SWORDS_DANCE",
-      "MOVE_THUNDER_PUNCH",
-      "MOVE_WILL_O_WISP"
+      "MOVE_FOCUS_BLAST",
+      "MOVE_FLARE_BLITZ",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_FALSE_SWIPE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -375,30 +419,38 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_BRICK_BREAK",
-      "MOVE_CRUNCH",
-      "MOVE_DIG",
       "MOVE_DRAGON_CLAW",
-      "MOVE_DRAGON_PULSE",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_BLAST",
+      "MOVE_ROAR",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_FIRE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_CRUNCH",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
       "MOVE_FIRE_PUNCH",
-      "MOVE_FOCUS_BLAST",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_FIRE_BLAST",
+      "MOVE_OVERHEAT",
+      "MOVE_WILL-O-WISP",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_FLAMETHROWER",
       "MOVE_HEAT_WAVE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_SUBSTITUTE",
       "MOVE_IRON_TAIL",
       "MOVE_OUTRAGE",
-      "MOVE_OVERHEAT",
-      "MOVE_PROTECT",
-      "MOVE_ROAR",
-      "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SHADOW_CLAW",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_SWORDS_DANCE",
-      "MOVE_THUNDER_PUNCH",
-      "MOVE_WILL_O_WISP"
+      "MOVE_FOCUS_BLAST",
+      "MOVE_FLARE_BLITZ",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_FALSE_SWIPE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -455,35 +507,53 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
+      "MOVE_DRAGON_CLAW",
+      "MOVE_ROAR",
       "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_FIRE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_PUNCH",
       "MOVE_CRUNCH",
+      "MOVE_SWIFT",
       "MOVE_DIG",
-      "MOVE_DOUBLE_EDGE",
-      "MOVE_DRAGON_PULSE",
-      "MOVE_EARTHQUAKE",
-      "MOVE_ENDURE",
       "MOVE_FIRE_PUNCH",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_FIRE_BLAST",
       "MOVE_FLY",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HEAT_WAVE",
-      "MOVE_HURRICANE",
       "MOVE_HYPER_BEAM",
+      "MOVE_OVERHEAT",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_WILL-O-WISP",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_FLAMETHROWER",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_HEAT_WAVE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_HURRICANE",
+      "MOVE_SUBSTITUTE",
       "MOVE_IRON_TAIL",
       "MOVE_OUTRAGE",
-      "MOVE_OVERHEAT",
-      "MOVE_PROTECT",
-      "MOVE_ROAR",
-      "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SHADOW_CLAW",
-      "MOVE_SOLAR_BEAM",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_SWORDS_DANCE",
-      "MOVE_THUNDER_PUNCH",
-      "MOVE_WILL_O_WISP"
+      "MOVE_FOCUS_BLAST",
+      "MOVE_FLARE_BLITZ",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_BLAZE_KICK",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_SCALE_SHOT",
+      "MOVE_SKULL_BASH",
+      "MOVE_FISSURE",
+      "MOVE_BLAST_BURN"
     ],
     "TutorMoves": [
       "MOVE_AIR_SLASH",
@@ -535,31 +605,39 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AURA_SPHERE",
-      "MOVE_BLIZZARD",
-      "MOVE_BODY_SLAM",
-      "MOVE_BRICK_BREAK",
-      "MOVE_DIG",
-      "MOVE_DOUBLE_EDGE",
-      "MOVE_DRAGON_PULSE",
-      "MOVE_ENDURE",
-      "MOVE_FLIP_TURN",
       "MOVE_HEADBUTT",
-      "MOVE_HYDRO_PUMP",
+      "MOVE_FLIP_TURN",
+      "MOVE_BRICK_BREAK",
       "MOVE_ICE_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_IRON_HEAD",
-      "MOVE_IRON_TAIL",
-      "MOVE_MUD_SHOT",
       "MOVE_PROTECT",
+      "MOVE_ICE_PUNCH",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
-      "MOVE_WATERFALL",
       "MOVE_WATER_PULSE",
+      "MOVE_MUD_SHOT",
+      "MOVE_ICY_WIND",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
       "MOVE_WHIRLPOOL",
+      "MOVE_SURF",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_LIQUIDATION",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
       "MOVE_WORK_UP",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_MUDDY_WATER",
+      "MOVE_FAKE_OUT",
+      "MOVE_SKULL_BASH",
+      "MOVE_SCALD"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -608,31 +686,39 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AURA_SPHERE",
-      "MOVE_BLIZZARD",
-      "MOVE_BODY_SLAM",
-      "MOVE_BRICK_BREAK",
-      "MOVE_DIG",
-      "MOVE_DOUBLE_EDGE",
-      "MOVE_DRAGON_PULSE",
-      "MOVE_ENDURE",
-      "MOVE_FLIP_TURN",
       "MOVE_HEADBUTT",
-      "MOVE_HYDRO_PUMP",
+      "MOVE_FLIP_TURN",
+      "MOVE_BRICK_BREAK",
       "MOVE_ICE_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_IRON_HEAD",
-      "MOVE_IRON_TAIL",
-      "MOVE_MUD_SHOT",
       "MOVE_PROTECT",
+      "MOVE_ICE_PUNCH",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
-      "MOVE_WATERFALL",
       "MOVE_WATER_PULSE",
+      "MOVE_MUD_SHOT",
+      "MOVE_ICY_WIND",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
       "MOVE_WHIRLPOOL",
+      "MOVE_SURF",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_LIQUIDATION",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
       "MOVE_WORK_UP",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_MUDDY_WATER",
+      "MOVE_FAKE_OUT",
+      "MOVE_SKULL_BASH",
+      "MOVE_SCALD"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -681,39 +767,51 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AURA_SPHERE",
-      "MOVE_BLIZZARD",
-      "MOVE_BODY_SLAM",
-      "MOVE_BRICK_BREAK",
-      "MOVE_CRUNCH",
-      "MOVE_DARK_PULSE",
-      "MOVE_DIG",
-      "MOVE_DOUBLE_EDGE",
-      "MOVE_DRAGON_PULSE",
-      "MOVE_EARTHQUAKE",
-      "MOVE_ENDURE",
-      "MOVE_FLIP_TURN",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
       "MOVE_HEADBUTT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_ICE_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_IRON_HEAD",
-      "MOVE_IRON_TAIL",
-      "MOVE_MUD_SHOT",
-      "MOVE_OUTRAGE",
-      "MOVE_PROTECT",
       "MOVE_ROAR",
+      "MOVE_FLIP_TURN",
+      "MOVE_BRICK_BREAK",
       "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_ICE_PUNCH",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
-      "MOVE_WATERFALL",
       "MOVE_WATER_PULSE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_MUD_SHOT",
+      "MOVE_ICY_WIND",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_EARTHQUAKE",
       "MOVE_WHIRLPOOL",
+      "MOVE_SURF",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_LIQUIDATION",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_DARK_PULSE",
+      "MOVE_OUTRAGE",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_FOCUS_BLAST",
       "MOVE_WORK_UP",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_MUDDY_WATER",
+      "MOVE_FAKE_OUT",
+      "MOVE_SKULL_BASH",
+      "MOVE_SCALD",
+      "MOVE_HYDRO_CANNON"
     ],
     "TutorMoves": [
       "MOVE_FLASH_CANNON",
@@ -733,7 +831,8 @@
       }
     ],
     "TMMoves": [
-      "MOVE_ELECTROWEB"
+      "MOVE_ELECTROWEB",
+      "MOVE_FACADE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -755,7 +854,8 @@
     ],
     "TMMoves": [
       "MOVE_ELECTROWEB",
-      "MOVE_IRON_DEFENSE"
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FACADE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -808,24 +908,32 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
-      "MOVE_AGILITY",
+      "MOVE_ROCK_SMASH",
+      "MOVE_TOXIC",
       "MOVE_BRICK_BREAK",
-      "MOVE_ELECTROWEB",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_SWORDS_DANCE",
       "MOVE_ENDURE",
       "MOVE_GIGA_DRAIN",
-      "MOVE_GIGA_IMPACT",
       "MOVE_HYPER_BEAM",
-      "MOVE_IRON_DEFENSE",
-      "MOVE_OUTRAGE",
-      "MOVE_PROTECT",
-      "MOVE_ROCK_SMASH",
+      "MOVE_AGILITY",
       "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
       "MOVE_SOLAR_BEAM",
+      "MOVE_POISON_JAB",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_X-SCISSOR",
+      "MOVE_U-TURN",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWORDS_DANCE",
-      "MOVE_TOXIC",
-      "MOVE_U_TURN"
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_OUTRAGE",
+      "MOVE_ELECTROWEB",
+      "MOVE_FACADE",
+      "MOVE_SILVER_WIND",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_DOUBLE_HIT",
+      "MOVE_DUAL_WINGBEAT"
     ],
     "TutorMoves": [
       "MOVE_PIN_MISSILE"
@@ -884,17 +992,32 @@
       }
     ],
     "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_PROTECT",
       "MOVE_AERIAL_ACE",
+      "MOVE_REFLECT",
       "MOVE_DOUBLE_TEAM",
       "MOVE_ENDURE",
       "MOVE_FLY",
-      "MOVE_HEADBUTT",
+      "MOVE_AGILITY",
       "MOVE_HEAT_WAVE",
-      "MOVE_PROTECT",
-      "MOVE_REFLECT",
+      "MOVE_HURRICANE",
+      "MOVE_U-TURN",
       "MOVE_SUBSTITUTE",
-      "MOVE_U_TURN",
-      "MOVE_WORK_UP"
+      "MOVE_WHIRLWIND",
+      "MOVE_WORK_UP",
+      "MOVE_FACADE",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_U-TURN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_OUTRAGE",
+      "MOVE_ELECTROWEB",
+      "MOVE_FACADE",
+      "MOVE_SILVER_WIND",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_DOUBLE_HIT",
+      "MOVE_DUAL_WINGBEAT"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -951,17 +1074,25 @@
       }
     ],
     "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_PROTECT",
       "MOVE_AERIAL_ACE",
+      "MOVE_REFLECT",
       "MOVE_DOUBLE_TEAM",
       "MOVE_ENDURE",
       "MOVE_FLY",
-      "MOVE_HEADBUTT",
+      "MOVE_AGILITY",
       "MOVE_HEAT_WAVE",
-      "MOVE_PROTECT",
-      "MOVE_REFLECT",
+      "MOVE_HURRICANE",
+      "MOVE_U-TURN",
       "MOVE_SUBSTITUTE",
-      "MOVE_U_TURN",
-      "MOVE_WORK_UP"
+      "MOVE_WHIRLWIND",
+      "MOVE_WORK_UP",
+      "MOVE_FACADE",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_RAZOR_WIND",
+      "MOVE_SKY_ATTACK"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -1018,19 +1149,27 @@
       }
     ],
     "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_PROTECT",
       "MOVE_AERIAL_ACE",
+      "MOVE_REFLECT",
       "MOVE_DOUBLE_TEAM",
       "MOVE_ENDURE",
       "MOVE_FLY",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HEADBUTT",
-      "MOVE_HEAT_WAVE",
       "MOVE_HYPER_BEAM",
-      "MOVE_PROTECT",
-      "MOVE_REFLECT",
+      "MOVE_AGILITY",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_HEAT_WAVE",
+      "MOVE_HURRICANE",
+      "MOVE_U-TURN",
       "MOVE_SUBSTITUTE",
-      "MOVE_U_TURN",
-      "MOVE_WORK_UP"
+      "MOVE_WHIRLWIND",
+      "MOVE_WORK_UP",
+      "MOVE_FACADE",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_RAZOR_WIND",
+      "MOVE_SKY_ATTACK"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -1087,24 +1226,34 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_BULLDOZE",
-      "MOVE_DARK_PULSE",
-      "MOVE_DIG",
-      "MOVE_EARTHQUAKE",
-      "MOVE_ENDURE",
+      "MOVE_TOXIC",
+      "MOVE_ROCK_SLIDE",
       "MOVE_FIRE_FANG",
-      "MOVE_GIGA_DRAIN",
       "MOVE_ICE_FANG",
-      "MOVE_IRON_TAIL",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_FANG",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_GIGA_DRAIN",
       "MOVE_KNOCK_OFF",
       "MOVE_MUD_SHOT",
-      "MOVE_PROTECT",
-      "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
       "MOVE_SLUDGE_BOMB",
+      "MOVE_EARTHQUAKE",
+      "MOVE_POISON_JAB",
+      "MOVE_BULLDOZE",
       "MOVE_SUBSTITUTE",
-      "MOVE_THUNDER_FANG"
+      "MOVE_IRON_TAIL",
+      "MOVE_DARK_PULSE",
+      "MOVE_GUNK_SHOT",
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_TRAILBLAZE",
+      "MOVE_POISON_FANG",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_SEED_BOMB",
+      "MOVE_SCALE_SHOT"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -1161,27 +1310,38 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_BULLDOZE",
-      "MOVE_DARK_PULSE",
-      "MOVE_DIG",
-      "MOVE_DOUBLE_EDGE",
-      "MOVE_EARTHQUAKE",
-      "MOVE_ENDURE",
+      "MOVE_TOXIC",
+      "MOVE_ROCK_SLIDE",
       "MOVE_FIRE_FANG",
-      "MOVE_GIGA_DRAIN",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
       "MOVE_ICE_FANG",
-      "MOVE_IRON_TAIL",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_FANG",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_HYPER_BEAM",
       "MOVE_KNOCK_OFF",
       "MOVE_MUD_SHOT",
-      "MOVE_PROTECT",
-      "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
       "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_POISON_JAB",
+      "MOVE_BULLDOZE",
       "MOVE_SUBSTITUTE",
-      "MOVE_THUNDER_FANG"
+      "MOVE_IRON_TAIL",
+      "MOVE_DARK_PULSE",
+      "MOVE_GUNK_SHOT",
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_TRAILBLAZE",
+      "MOVE_POISON_FANG",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_SEED_BOMB",
+      "MOVE_SCALE_SHOT"
     ],
     "TutorMoves": [
       "MOVE_CRUNCH"
@@ -1244,27 +1404,38 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
-      "MOVE_BODY_SLAM",
+      "MOVE_THUNDER_WAVE",
       "MOVE_BRICK_BREAK",
-      "MOVE_DIG",
-      "MOVE_DISCHARGE",
-      "MOVE_DOUBLE_TEAM",
-      "MOVE_ELECTROWEB",
-      "MOVE_ENDURE",
-      "MOVE_IRON_TAIL",
-      "MOVE_NASTY_PLOT",
-      "MOVE_PLAY_ROUGH",
+      "MOVE_LIGHT_SCREEN",
       "MOVE_PROTECT",
-      "MOVE_REFLECT",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
-      "MOVE_SWIFT",
+      "MOVE_PLAY_ROUGH",
       "MOVE_THUNDER_PUNCH",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_REFLECT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_DISCHARGE",
+      "MOVE_AGILITY",
       "MOVE_VOLT_SWITCH",
-      "MOVE_WILD_CHARGE"
+      "MOVE_THUNDERBOLT",
+      "MOVE_SURF",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WILD_CHARGE",
+      "MOVE_IRON_TAIL",
+      "MOVE_ELECTROWEB",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_FAKE_OUT",
+      "MOVE_SKULL_BASH"
     ],
-    "TutorMoves": [],
+    "TutorMoves": [
+      "MOVE_DRAINING_KISS"
+    ],
     "EggMoves": []
   },
   "RAICHU": {
@@ -1323,30 +1494,45 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
-      "MOVE_BODY_SLAM",
+      "MOVE_THUNDER_WAVE",
       "MOVE_BRICK_BREAK",
-      "MOVE_DIG",
-      "MOVE_DISCHARGE",
-      "MOVE_DOUBLE_TEAM",
-      "MOVE_ELECTROWEB",
-      "MOVE_ENDURE",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_IRON_TAIL",
-      "MOVE_NASTY_PLOT",
-      "MOVE_PLAY_ROUGH",
+      "MOVE_LIGHT_SCREEN",
       "MOVE_PROTECT",
-      "MOVE_REFLECT",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_THUNDER_PUNCH",
       "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_REFLECT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_DISCHARGE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_GIGA_IMPACT",
       "MOVE_VOLT_SWITCH",
-      "MOVE_WILD_CHARGE"
+      "MOVE_THUNDERBOLT",
+      "MOVE_SURF",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WILD_CHARGE",
+      "MOVE_IRON_TAIL",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_ELECTROWEB",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_FAKE_OUT",
+      "MOVE_SKULL_BASH"
     ],
     "TutorMoves": [
       "MOVE_EERIE_IMPULSE",
-      "MOVE_THUNDER_PUNCH"
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_DRAINING_KISS"
     ],
     "EggMoves": []
   },
@@ -1406,33 +1592,47 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
-      "MOVE_BODY_SLAM",
-      "MOVE_BRICK_BREAK",
-      "MOVE_CALM_MIND",
-      "MOVE_DIG",
-      "MOVE_DISCHARGE",
-      "MOVE_DOUBLE_TEAM",
-      "MOVE_ELECTROWEB",
-      "MOVE_ENDURE",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_IRON_TAIL",
-      "MOVE_NASTY_PLOT",
-      "MOVE_PLAY_ROUGH",
-      "MOVE_PROTECT",
       "MOVE_PSYSHOCK",
-      "MOVE_REFLECT",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
-      "MOVE_SWIFT",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
       "MOVE_THUNDER_PUNCH",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_REFLECT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_DISCHARGE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_PSYCHIC",
       "MOVE_VOLT_SWITCH",
-      "MOVE_WILD_CHARGE"
+      "MOVE_THUNDERBOLT",
+      "MOVE_SURF",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WILD_CHARGE",
+      "MOVE_IRON_TAIL",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_ELECTROWEB",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_FAKE_OUT",
+      "MOVE_SKULL_BASH"
     ],
     "TutorMoves": [
       "MOVE_EERIE_IMPULSE",
-      "MOVE_PSYCHIC"
+      "MOVE_PSYCHIC",
+      "MOVE_DRAINING_KISS"
     ],
     "EggMoves": []
   },
@@ -1500,38 +1700,50 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BLIZZARD",
-      "MOVE_BODY_SLAM",
-      "MOVE_CALM_MIND",
-      "MOVE_DIG",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FLAMETHROWER",
       "MOVE_HEADBUTT",
-      "MOVE_HEAL_BLOCK",
-      "MOVE_HYPER_VOICE",
-      "MOVE_ICE_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_IRON_TAIL",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_PLAY_ROUGH",
-      "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
       "MOVE_PSYSHOCK",
-      "MOVE_REFLECT",
-      "MOVE_SAFEGUARD",
-      "MOVE_SHADOW_BALL",
-      "MOVE_SOLAR_BEAM",
-      "MOVE_STEALTH_ROCK",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_THUNDER",
-      "MOVE_THUNDERBOLT",
-      "MOVE_THUNDER_PUNCH",
+      "MOVE_CALM_MIND",
       "MOVE_THUNDER_WAVE",
+      "MOVE_ICE_BEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_FIRE_BLAST",
+      "MOVE_SAFEGUARD",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FLAMETHROWER",
+      "MOVE_PSYCHIC",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_METRONOME",
       "MOVE_WORK_UP",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_SING",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_TRI_ATTACK",
+      "MOVE_METEOR_BEAM"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -1604,41 +1816,1277 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BLIZZARD",
-      "MOVE_BODY_SLAM",
-      "MOVE_CALM_MIND",
-      "MOVE_DIG",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FLAMETHROWER",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
       "MOVE_HEADBUTT",
-      "MOVE_HEAL_BLOCK",
-      "MOVE_HYPER_BEAM",
-      "MOVE_HYPER_VOICE",
-      "MOVE_ICE_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_IRON_TAIL",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_PLAY_ROUGH",
-      "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
       "MOVE_PSYSHOCK",
-      "MOVE_REFLECT",
-      "MOVE_SAFEGUARD",
-      "MOVE_SHADOW_BALL",
-      "MOVE_SOLAR_BEAM",
-      "MOVE_STEALTH_ROCK",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_THUNDER",
-      "MOVE_THUNDERBOLT",
-      "MOVE_THUNDER_PUNCH",
+      "MOVE_CALM_MIND",
       "MOVE_THUNDER_WAVE",
+      "MOVE_ICE_BEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_FIRE_BLAST",
+      "MOVE_HYPER_BEAM",
+      "MOVE_SAFEGUARD",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FLAMETHROWER",
+      "MOVE_PSYCHIC",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_METRONOME",
+      "MOVE_FOCUS_BLAST",
       "MOVE_WORK_UP",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_SING",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_TRI_ATTACK",
+      "MOVE_METEOR_BEAM"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "JIGGLYPUFF": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_SING"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_CHARM"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_DISARMING_VOICE"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_ROLLOUT"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_DRAINING_KISS"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_FAKE_TEARS"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_CONFUSION"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_FACADE"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_BODY_SLAM"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_MIMIC"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_HYPER_VOICE"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_WISH"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_DOUBLE_EDGE"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_PERISH_SONG"
+      },
+      {
+        "Level": "53",
+        "Move": "MOVE_MOONBLAST"
+      }
+    ],
+    "TMMoves": [  
+      "MOVE_HEADBUTT",
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ICE_BEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_FIRE_BLAST",
+      "MOVE_WATER_PULSE",
+      "MOVE_KNOCK_OFF",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_ICY_WIND",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FLAMETHROWER",
+      "MOVE_PSYCHIC",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WILD_CHARGE",
+      "MOVE_DARK_PULSE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_TAUNT",
+      "MOVE_METRONOME",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_SING",
+      "MOVE_TRAILBLAZE",
+      "MOVE_MIMIC",
+      "MOVE_DREAM_EATER",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_FAKE_OUT",
+      "MOVE_TRI_ATTACK"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "WIGGLYTUFF": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_SING"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_CHARM"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_DISARMING_VOICE"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_ROLLOUT"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_DRAINING_KISS"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_FAKE_TEARS"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_CONFUSION"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_FACADE"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_BODY_SLAM"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_MIMIC"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_HYPER_VOICE"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_WISH"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_DOUBLE_EDGE"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_PERISH_SONG"
+      },
+      {
+        "Level": "53",
+        "Move": "MOVE_MOONBLAST"
+      }
+    ],
+    "TMMoves": [  
+      "MOVE_HEADBUTT",
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ICE_BEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_FIRE_BLAST",
+      "MOVE_WATER_PULSE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_ICY_WIND",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FLAMETHROWER",
+      "MOVE_PSYCHIC",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WILD_CHARGE",
+      "MOVE_DARK_PULSE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_TAUNT",
+      "MOVE_METRONOME",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_SING",
+      "MOVE_TRAILBLAZE",
+      "MOVE_MIMIC",
+      "MOVE_DREAM_EATER",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_FAKE_OUT",
+      "MOVE_TRI_ATTACK"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "ZUBAT": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_SUPERSONIC"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_ABSORB"
+      },
+      {
+        "Level": "5",
+        "Move": "MOVE_GUST"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_WING_ATTACK"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_WHIRLWIND"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_HYPNOSIS"
+      },
+      {
+        "Level": "26",
+        "Move": "MOVE_HAZE"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_POISON_FANG"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_AIR_SLASH"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_LEECH_LIFE"
+      }
+    ],
+    "TMMoves": [  
+      "MOVE_PROTECT",
+      "MOVE_CRUNCH",
+      "MOVE_SWIFT",
+      "MOVE_ENDURE",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_FLY",
+      "MOVE_AGILITY",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_HEAT_WAVE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_U-TURN",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CURSE",
+      "MOVE_WHIRLWIND",
+      "MOVE_TAUNT",
+      "MOVE_FACADE",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_POISON_FANG",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_SWAGGER",
+      "MOVE_RAZOR_WIND"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "GOLBAT": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_SUPERSONIC"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_ABSORB"
+      },
+      {
+        "Level": "5",
+        "Move": "MOVE_GUST"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_WING_ATTACK"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_WHIRLWIND"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_HYPNOSIS"
+      },
+      {
+        "Level": "26",
+        "Move": "MOVE_HAZE"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_POISON_FANG"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_AIR_SLASH"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_LEECH_LIFE"
+      }
+    ],
+    "TMMoves": [  
+      "MOVE_TOXIC",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_CRUNCH",
+      "MOVE_SWIFT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_ENDURE",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_FLY",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_HEAT_WAVE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_X-SCISSOR",
+      "MOVE_U-TURN",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CURSE",
+      "MOVE_WHIRLWIND",
+      "MOVE_TAUNT",
+      "MOVE_FACADE",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_POISON_FANG",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_SWAGGER",
+      "MOVE_RAZOR_WIND",
+      "MOVE_SKY_ATTACK"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "MEOWTH": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_PAY_DAY"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_TAIL_WHIP"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "13",
+        "Move": "MOVE_TAUNT"
+      },
+      {
+        "Level": "17",
+        "Move": "MOVE_SCREECH"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_SLASH"
+      },
+      {
+        "Level": "27",
+        "Move": "MOVE_NASTY_PLOT"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_HYPNOSIS"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "37",
+        "Move": "MOVE_CHARM"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_FAKE_TEARS"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_PLAY_ROUGH"
+      }
+    ],
+    "TMMoves": [  
+      "MOVE_HEADBUTT",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_PROTECT",
+      "MOVE_POWER_GEM",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_AERIAL_ACE",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_WATER_PULSE",
+      "MOVE_KNOCK_OFF",
+      "MOVE_AGILITY",
+      "MOVE_ICY_WIND",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_U-TURN",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_SPIKES",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_TAUNT",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_METRONOME",
+      "MOVE_GUNK_SHOT",
+      "MOVE_WORK_UP",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_TRAILBLAZE",
+      "MOVE_PAY_DAY",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_MIMIC",
+      "MOVE_SEED_BOMB",
+      "MOVE_FAKE_OUT"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "MEOWTH_ALOLA": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_PAY_DAY"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_TAIL_WHIP"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_SNARL"
+      },
+      {
+        "Level": "6",
+        "Move": "MOVE_PARTING_SHOT"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "13",
+        "Move": "MOVE_TAUNT"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_METAL_CLAW"
+      },
+      {
+        "Level": "17",
+        "Move": "MOVE_SCREECH"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_NIGHT_SLASH"
+      },
+      {
+        "Level": "27",
+        "Move": "MOVE_NASTY_PLOT"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_HYPNOSIS"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "37",
+        "Move": "MOVE_CHARM"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_FAKE_TEARS"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_PLAY_ROUGH"
+      }
+    ],
+    "TMMoves": [  
+      "MOVE_HEADBUTT",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_PROTECT",
+      "MOVE_POWER_GEM",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_AERIAL_ACE",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_BODY_SLAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_WATER_PULSE",
+      "MOVE_KNOCK_OFF",
+      "MOVE_AGILITY",
+      "MOVE_ICY_WIND",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_U-TURN",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_SPIKES",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_TAUNT",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_METRONOME",
+      "MOVE_GUNK_SHOT",
+      "MOVE_WORK_UP",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_TRAILBLAZE",
+      "MOVE_PAY_DAY",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_MIMIC",
+      "MOVE_SEED_BOMB",
+      "MOVE_FAKE_OUT"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "MEOWTH_GALAR": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_PAY_DAY"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "6",
+        "Move": "MOVE_TAIL_WHIP"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "13",
+        "Move": "MOVE_TAUNT"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_METAL_CLAW"
+      },
+      {
+        "Level": "17",
+        "Move": "MOVE_SCREECH"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_SLASH"
+      },
+      {
+        "Level": "27",
+        "Move": "MOVE_NASTY_PLOT"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_HYPNOSIS"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "37",
+        "Move": "MOVE_CHARM"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_METAL_SOUND"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_MIMIC"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_OUTRAGE"
+      }
+    ],
+    "TMMoves": [  
+      "MOVE_HEADBUTT",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_AERIAL_ACE",
+      "MOVE_CRUNCH",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_WATER_PULSE",
+      "MOVE_KNOCK_OFF",
+      "MOVE_ICY_WIND",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_X-SCISSOR",
+      "MOVE_U-TURN",
+      "MOVE_NASTY_PLOT",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_SPIKES",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_OUTRAGE",
+      "MOVE_TAUNT",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_METRONOME",
+      "MOVE_GUNK_SHOT",
+      "MOVE_WORK_UP",
+      "MOVE_THUNDER",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_PAY_DAY",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_MIMIC",
+      "MOVE_SEED_BOMB",
+      "MOVE_SWAGGER",
+      "MOVE_FAKE_OUT",
+      "MOVE_STEEL_BEAM"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "PERSIAN": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_PAY_DAY"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_TAIL_WHIP"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "13",
+        "Move": "MOVE_TAUNT"
+      },
+      {
+        "Level": "17",
+        "Move": "MOVE_SCREECH"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_SLASH"
+      },
+      {
+        "Level": "27",
+        "Move": "MOVE_NASTY_PLOT"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_HYPNOSIS"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "37",
+        "Move": "MOVE_CHARM"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_FAKE_TEARS"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_PLAY_ROUGH"
+      }
+    ],
+    "TMMoves": [  
+      "MOVE_HEADBUTT",
+      "MOVE_ROAR",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_PROTECT",
+      "MOVE_POWER_GEM",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_AERIAL_ACE",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_WATER_PULSE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_AGILITY",
+      "MOVE_ICY_WIND",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_U-TURN",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_SPIKES",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_TAUNT",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_METRONOME",
+      "MOVE_GUNK_SHOT",
+      "MOVE_WORK_UP",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_TRAILBLAZE",
+      "MOVE_PAY_DAY",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_MIMIC",
+      "MOVE_SEED_BOMB",
+      "MOVE_FAKE_OUT",
+      "MOVE_SKULL_BASH"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "PERSIAN_ALOLA": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_PAY_DAY"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_TAIL_WHIP"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_SNARL"
+      },
+      {
+        "Level": "6",
+        "Move": "MOVE_PARTING_SHOT"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "13",
+        "Move": "MOVE_TAUNT"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_METAL_CLAW"
+      },
+      {
+        "Level": "17",
+        "Move": "MOVE_SCREECH"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_NIGHT_SLASH"
+      },
+      {
+        "Level": "27",
+        "Move": "MOVE_NASTY_PLOT"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_HYPNOSIS"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "37",
+        "Move": "MOVE_CHARM"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_FAKE_TEARS"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_PLAY_ROUGH"
+      }
+    ],
+    "TMMoves": [  
+      "MOVE_HEADBUTT",
+      "MOVE_ROAR",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_PROTECT",
+      "MOVE_POWER_GEM",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_AERIAL_ACE",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_BODY_SLAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_WATER_PULSE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_AGILITY",
+      "MOVE_ICY_WIND",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_U-TURN",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_SPIKES",
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_TAUNT",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_METRONOME",
+      "MOVE_GUNK_SHOT",
+      "MOVE_WORK_UP",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_TRAILBLAZE",
+      "MOVE_PAY_DAY",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_MIMIC",
+      "MOVE_SEED_BOMB",
+      "MOVE_FAKE_OUT"
+    ],
+    "TutorMoves": [
+      "MOVE_POWER_GEM"
+    ],
+    "EggMoves": []
+  },
+  "MANKEY": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_FOCUS_ENERGY"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_ROCK_THROW"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_ROCK_SMASH"
+      },
+      {
+        "Level": "13",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_LOW_SWEEP"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_KNOCK_OFF"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_BULLDOZE"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_BRICK_BREAK"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_FACADE"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_SCREECH"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_CLOSE_COMBAT"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_OUTRAGE"
+      },
+      {
+        "Level": "54",
+        "Move": "MOVE_DYNAMIC_PUNCH"
+      }
+    ],
+    "TMMoves": [  
+      "MOVE_HEADBUTT",
+      "MOVE_ROCK_SMASH",
+      "MOVE_ROAR",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_BODY_SLAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_KNOCK_OFF",
+      "MOVE_OVERHEAT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_STONE_EDGE",
+      "MOVE_THUNDERBOLT",
+      "MOVE_EARTHQUAKE",
+      "MOVE_POISON_JAB",
+      "MOVE_BULLDOZE",
+      "MOVE_U-TURN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CURSE",
+      "MOVE_OUTRAGE",
+      "MOVE_TAUNT",
+      "MOVE_METRONOME",
+      "MOVE_GUNK_SHOT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_PAY_DAY",
+      "MOVE_TORMENT",
+      "MOVE_SEED_BOMB",
+      "MOVE_CIRCLE_THROW",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_DUAL_CHOP",
+      "MOVE_STORM_THROW",
+      "MOVE_SWAGGER"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "PRIMEAPE": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_FOCUS_ENERGY"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_ROCK_THROW"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_ROCK_SMASH"
+      },
+      {
+        "Level": "13",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_LOW_SWEEP"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_KNOCK_OFF"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_BULLDOZE"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_BRICK_BREAK"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_FACADE"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_RAGE_FIST"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_SCREECH"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_CLOSE_COMBAT"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_OUTRAGE"
+      },
+      {
+        "Level": "54",
+        "Move": "MOVE_DYNAMIC_PUNCH"
+      }
+    ],
+    "TMMoves": [  
+      "MOVE_HEADBUTT",
+      "MOVE_ROCK_SMASH",
+      "MOVE_ROAR",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_BODY_SLAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_OVERHEAT",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_STONE_EDGE",
+      "MOVE_THUNDERBOLT",
+      "MOVE_EARTHQUAKE",
+      "MOVE_POISON_JAB",
+      "MOVE_BULLDOZE",
+      "MOVE_U-TURN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CURSE",
+      "MOVE_OUTRAGE",
+      "MOVE_TAUNT",
+      "MOVE_METRONOME",
+      "MOVE_GUNK_SHOT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_THUNDER",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_PAY_DAY",
+      "MOVE_TORMENT",
+      "MOVE_SEED_BOMB",
+      "MOVE_CIRCLE_THROW",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_DUAL_CHOP",
+      "MOVE_STORM_THROW",
+      "MOVE_SWAGGER",
+      "MOVE_VACUUM_WAVE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -1651,28 +3099,32 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
       "MOVE_CALM_MIND",
-      "MOVE_DAZZLING_GLEAM",
-      "MOVE_DOUBLE_TEAM",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_ICE_PUNCH",
-      "MOVE_IRON_TAIL",
+      "MOVE_THUNDER_WAVE",
       "MOVE_LIGHT_SCREEN",
-      "MOVE_METRONOME",
       "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_FIRE_PUNCH",
       "MOVE_REFLECT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_SAFEGUARD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_PSYCHIC",
       "MOVE_SHADOW_BALL",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
+      "MOVE_IRON_TAIL",
+      "MOVE_DAZZLING_GLEAM",
       "MOVE_TAUNT",
-      "MOVE_THUNDER_PUNCH",
-      "MOVE_THUNDER_WAVE",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_METRONOME",
+      "MOVE_FACADE",
+      "MOVE_DREAM_EATER",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_TRI_ATTACK"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -1721,24 +3173,35 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_DAZZLING_GLEAM",
-      "MOVE_DOUBLE_TEAM",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_ICE_PUNCH",
-      "MOVE_IRON_TAIL",
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
       "MOVE_LIGHT_SCREEN",
-      "MOVE_METRONOME",
       "MOVE_PROTECT",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_REFLECT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_SAFEGUARD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_PSYCHIC",
       "MOVE_SHADOW_BALL",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
+      "MOVE_IRON_TAIL",
+      "MOVE_DAZZLING_GLEAM",
       "MOVE_TAUNT",
-      "MOVE_THUNDER_PUNCH",
-      "MOVE_THUNDER_WAVE",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_METRONOME",
+      "MOVE_FACADE",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_TRI_ATTACK"
     ],
     "TutorMoves": [
       "MOVE_CONFUSION"
@@ -1789,27 +3252,38 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_DAZZLING_GLEAM",
-      "MOVE_DOUBLE_TEAM",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_HYPER_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_IRON_TAIL",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_METRONOME",
-      "MOVE_NASTY_PLOT",
-      "MOVE_PROTECT",
-      "MOVE_SHADOW_BALL",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_TAUNT",
-      "MOVE_THUNDER_PUNCH",
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
       "MOVE_THUNDER_WAVE",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_REFLECT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_SAFEGUARD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_PSYCHIC",
+      "MOVE_SHADOW_BALL",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_TAUNT",
+      "MOVE_METRONOME",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_FACADE",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_TRI_ATTACK"
     ],
     "TutorMoves": [
       "MOVE_CONFUSION"
@@ -1872,25 +3346,38 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_CLOSE_COMBAT",
-      "MOVE_DIG",
-      "MOVE_EARTHQUAKE",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FLAMETHROWER",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_ICE_PUNCH",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_METRONOME",
-      "MOVE_POISON_JAB",
-      "MOVE_PROTECT",
+      "MOVE_ROCK_SMASH",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SUBSTITUTE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
       "MOVE_THUNDER_PUNCH",
-      "MOVE_WORK_UP"
+      "MOVE_ICE_PUNCH",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_FIRE_BLAST",
+      "MOVE_KNOCK_OFF",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_FLAMETHROWER",
+      "MOVE_EARTHQUAKE",
+      "MOVE_POISON_JAB",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_METRONOME",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_DUAL_CHOP",
+      "MOVE_FISSURE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -1951,25 +3438,38 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_CLOSE_COMBAT",
-      "MOVE_DIG",
-      "MOVE_EARTHQUAKE",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FLAMETHROWER",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_ICE_PUNCH",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_METRONOME",
-      "MOVE_POISON_JAB",
-      "MOVE_PROTECT",
+      "MOVE_ROCK_SMASH",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SUBSTITUTE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
       "MOVE_THUNDER_PUNCH",
-      "MOVE_WORK_UP"
+      "MOVE_ICE_PUNCH",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_FIRE_BLAST",
+      "MOVE_KNOCK_OFF",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_FLAMETHROWER",
+      "MOVE_EARTHQUAKE",
+      "MOVE_POISON_JAB",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_METRONOME",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_DUAL_CHOP",
+      "MOVE_FISSURE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -2034,28 +3534,42 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_CLOSE_COMBAT",
-      "MOVE_DIG",
-      "MOVE_EARTHQUAKE",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FLAMETHROWER",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_METRONOME",
-      "MOVE_POISON_JAB",
-      "MOVE_PROTECT",
+      "MOVE_ROCK_SMASH",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_STONE_EDGE",
-      "MOVE_SUBSTITUTE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
       "MOVE_THUNDER_PUNCH",
-      "MOVE_WORK_UP"
+      "MOVE_ICE_PUNCH",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_FIRE_BLAST",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_FLAMETHROWER",
+      "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_POISON_JAB",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_METRONOME",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_DUAL_CHOP",
+      "MOVE_STORM_THROW",
+      "MOVE_FISSURE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -2124,16 +3638,23 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BULLET_SEED",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_GIGA_DRAIN",
+      "MOVE_TOXIC",
       "MOVE_PROTECT",
-      "MOVE_REFLECT",
-      "MOVE_SOLAR_BEAM",
-      "MOVE_SUBSTITUTE",
+      "MOVE_ENERGY_BALL",
       "MOVE_SWORDS_DANCE",
-      "MOVE_TOXIC"
+      "MOVE_REFLECT",
+      "MOVE_ENDURE",
+      "MOVE_BULLET_SEED",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_KNOCK_OFF",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_POISON_JAB",
+      "MOVE_SUBSTITUTE",
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_TRAILBLAZE",
+      "MOVE_SEED_BOMB"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -2202,16 +3723,23 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BULLET_SEED",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_GIGA_DRAIN",
+      "MOVE_TOXIC",
       "MOVE_PROTECT",
-      "MOVE_REFLECT",
-      "MOVE_SOLAR_BEAM",
-      "MOVE_SUBSTITUTE",
+      "MOVE_ENERGY_BALL",
       "MOVE_SWORDS_DANCE",
-      "MOVE_TOXIC"
+      "MOVE_REFLECT",
+      "MOVE_ENDURE",
+      "MOVE_BULLET_SEED",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_KNOCK_OFF",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_POISON_JAB",
+      "MOVE_SUBSTITUTE",
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_TRAILBLAZE",
+      "MOVE_SEED_BOMB"
     ],
     "TutorMoves": [
       "MOVE_LUNGE"
@@ -2286,18 +3814,26 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BULLET_SEED",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_GIGA_DRAIN",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
+      "MOVE_TOXIC",
       "MOVE_PROTECT",
-      "MOVE_REFLECT",
-      "MOVE_SOLAR_BEAM",
-      "MOVE_SUBSTITUTE",
+      "MOVE_ENERGY_BALL",
       "MOVE_SWORDS_DANCE",
-      "MOVE_TOXIC"
+      "MOVE_REFLECT",
+      "MOVE_ENDURE",
+      "MOVE_BULLET_SEED",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_POISON_JAB",
+      "MOVE_SUBSTITUTE",
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_TRAILBLAZE",
+      "MOVE_SEED_BOMB"
     ],
     "TutorMoves": [
       "MOVE_SLUDGE_BOMB"
@@ -2356,30 +3892,133 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BLIZZARD",
-      "MOVE_BODY_SLAM",
+      "MOVE_HEADBUTT",
+      "MOVE_PSYSHOCK",
       "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_ICE_BEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_SWIFT",
       "MOVE_DIG",
-      "MOVE_EARTHQUAKE",
+      "MOVE_BODY_SLAM",
       "MOVE_ENDURE",
       "MOVE_FIRE_BLAST",
-      "MOVE_FLAMETHROWER",
-      "MOVE_HYDRO_PUMP",
-      "MOVE_ICE_BEAM",
-      "MOVE_ICY_WIND",
-      "MOVE_IRON_TAIL",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_LIQUIDATION",
+      "MOVE_WATER_PULSE",
       "MOVE_MUD_SHOT",
-      "MOVE_PROTECT",
-      "MOVE_PSYSHOCK",
+      "MOVE_ICY_WIND",
       "MOVE_SAFEGUARD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FLAMETHROWER",
+      "MOVE_PSYCHIC",
+      "MOVE_EARTHQUAKE",
+      "MOVE_WHIRLPOOL",
+      "MOVE_SURF",
       "MOVE_SHADOW_BALL",
+      "MOVE_LIQUIDATION",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_THUNDER_WAVE",
+      "MOVE_IRON_TAIL",
+      "MOVE_CURSE",
+      "MOVE_HYDRO_PUMP",
       "MOVE_WATERFALL",
-      "MOVE_WHIRLPOOL"
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_DREAM_EATER",
+      "MOVE_SKULL_BASH",
+      "MOVE_TRI_ATTACK",
+      "MOVE_SCALD"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "SLOWPOKE_GALAR": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_CONFUSION"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_CURSE"
+      },
+      {
+        "Level": "3",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "6",
+        "Move": "MOVE_WATER_GUN"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_PSYBEAM"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_WATER_PULSE"
+      },
+      {
+        "Level": "21",
+        "Move": "MOVE_HEADBUTT"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_ZEN_HEADBUTT"
+      },
+      {
+        "Level": "27",
+        "Move": "MOVE_AMNESIA"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_SURF"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_PSYCHIC"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_ICE_BEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_FIRE_BLAST",
+      "MOVE_WATER_PULSE",
+      "MOVE_MUD_SHOT",
+      "MOVE_ICY_WIND",
+      "MOVE_SAFEGUARD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FLAMETHROWER",
+      "MOVE_PSYCHIC",
+      "MOVE_EARTHQUAKE",
+      "MOVE_WHIRLPOOL",
+      "MOVE_SURF",
+      "MOVE_SHADOW_BALL",
+      "MOVE_LIQUIDATION",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_CURSE",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_DREAM_EATER",
+      "MOVE_SKULL_BASH",
+      "MOVE_TRI_ATTACK"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -2440,38 +4079,54 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BLIZZARD",
-      "MOVE_BODY_SLAM",
+      "MOVE_HEADBUTT",
+      "MOVE_PSYSHOCK",
       "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_ICE_BEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_POWER_GEM",
+      "MOVE_ICE_PUNCH",
+      "MOVE_SWIFT",
       "MOVE_DIG",
-      "MOVE_EARTHQUAKE",
+      "MOVE_BODY_SLAM",
       "MOVE_ENDURE",
       "MOVE_FIRE_BLAST",
-      "MOVE_FLAMETHROWER",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HEAL_BLOCK",
-      "MOVE_HYDRO_PUMP",
+      "MOVE_WATER_PULSE",
       "MOVE_HYPER_BEAM",
-      "MOVE_ICE_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_ICY_WIND",
-      "MOVE_IRON_TAIL",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_LIQUIDATION",
-      "MOVE_METRONOME",
       "MOVE_MUD_SHOT",
-      "MOVE_NASTY_PLOT",
-      "MOVE_POWER_GEM",
-      "MOVE_PROTECT",
-      "MOVE_PSYSHOCK",
+      "MOVE_ICY_WIND",
       "MOVE_SAFEGUARD",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_FLAMETHROWER",
+      "MOVE_PSYCHIC",
+      "MOVE_EARTHQUAKE",
+      "MOVE_WHIRLPOOL",
+      "MOVE_SURF",
       "MOVE_SHADOW_BALL",
+      "MOVE_LIQUIDATION",
+      "MOVE_NASTY_PLOT",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_THUNDER_WAVE",
+      "MOVE_IRON_TAIL",
+      "MOVE_CURSE",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_HEAL_BLOCK",
       "MOVE_WATERFALL",
-      "MOVE_WHIRLPOOL"
+      "MOVE_METRONOME",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_DREAM_EATER",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_MUDDY_WATER",
+      "MOVE_SKULL_BASH",
+      "MOVE_TRI_ATTACK",
+      "MOVE_SCALD"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -2540,42 +4195,271 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BLIZZARD",
-      "MOVE_BODY_SLAM",
+      "MOVE_HEADBUTT",
+      "MOVE_PSYSHOCK",
       "MOVE_CALM_MIND",
+      "MOVE_TOXIC",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_ICE_BEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_SWIFT",
       "MOVE_DIG",
-      "MOVE_DOUBLE_EDGE",
-      "MOVE_EARTHQUAKE",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_BODY_SLAM",
       "MOVE_ENDURE",
       "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FLAMETHROWER",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_GUNK_SHOT",
-      "MOVE_HEAL_BLOCK",
-      "MOVE_HYDRO_PUMP",
+      "MOVE_WATER_PULSE",
       "MOVE_HYPER_BEAM",
-      "MOVE_ICE_BEAM",
-      "MOVE_ICY_WIND",
-      "MOVE_IRON_TAIL",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_LIQUIDATION",
-      "MOVE_METRONOME",
       "MOVE_MUD_SHOT",
-      "MOVE_NASTY_PLOT",
-      "MOVE_PROTECT",
-      "MOVE_PSYSHOCK",
+      "MOVE_ICY_WIND",
       "MOVE_SAFEGUARD",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_FLAMETHROWER",
+      "MOVE_PSYCHIC",
+      "MOVE_EARTHQUAKE",
+      "MOVE_WHIRLPOOL",
+      "MOVE_SURF",
       "MOVE_SHADOW_BALL",
+      "MOVE_LIQUIDATION",
+      "MOVE_POISON_JAB",
+      "MOVE_NASTY_PLOT",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_THUNDER_PUNCH",
-      "MOVE_THUNDER_WAVE",
-      "MOVE_TOXIC",
+      "MOVE_IRON_TAIL",
       "MOVE_TOXIC_SPIKES",
+      "MOVE_CURSE",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_HEAL_BLOCK",
       "MOVE_WATERFALL",
-      "MOVE_WHIRLPOOL"
+      "MOVE_METRONOME",
+      "MOVE_GUNK_SHOT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_ACID_SPRAY",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_DREAM_EATER",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_MUDDY_WATER",
+      "MOVE_SKULL_BASH",
+      "MOVE_TRI_ATTACK",
+      "MOVE_SCALD"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "FARFETCHD": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_PECK"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_GUST"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_STEEL_WING"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_AERIAL_ACE"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_KNOCK_OFF"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_BRUTAL_SWING"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_FALSE_SWIPE"
+      },
+      {
+        "Level": "27",
+        "Move": "MOVE_FOCUS_ENERGY"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_SLASH"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_SWORDS_DANCE"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_FEATHER_DANCE"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_AIR_SLASH"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_LEAF_BLADE"
+      },
+      {
+        "Level": "47",
+        "Move": "MOVE_AGILITY"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_BRAVE_BIRD"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_SWIFT",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_FLY",
+      "MOVE_KNOCK_OFF",
+      "MOVE_AGILITY",
+      "MOVE_HEAT_WAVE",
+      "MOVE_POISON_JAB",
+      "MOVE_U-TURN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_CURSE",
+      "MOVE_WORK_UP",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_FIRST_IMPRESSION",
+      "MOVE_RAZOR_WIND",
+      "MOVE_SOLAR_BLADE",
+      "MOVE_SKY_ATTACK"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "FARFETCHD_GALAR": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_PECK"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_DETECT"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_ROCK_SMASH"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_STEEL_WING"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_AERIAL_ACE"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_KNOCK_OFF"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_BRUTAL_SWING"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_FALSE_SWIPE"
+      },
+      {
+        "Level": "27",
+        "Move": "MOVE_FOCUS_ENERGY"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_SLASH"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_SWORDS_DANCE"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_FEATHER_DANCE"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_BRICK_BREAK"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_LEAF_BLADE"
+      },
+      {
+        "Level": "47",
+        "Move": "MOVE_AGILITY"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_BRAVE_BIRD"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ROCK_SMASH",
+      "MOVE_BRICK_BREAK",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_SWIFT",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_FLY",
+      "MOVE_KNOCK_OFF",
+      "MOVE_AGILITY",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_POISON_JAB",
+      "MOVE_U-TURN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_CURSE",
+      "MOVE_WORK_UP",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_FIRST_IMPRESSION",
+      "MOVE_RAZOR_WIND",
+      "MOVE_VACUUM_WAVE",
+      "MOVE_SOLAR_BLADE",
+      "MOVE_SKY_ATTACK"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -2628,23 +4512,30 @@
       }
     ],
     "TMMoves": [
-      "MOVE_DAZZLING_GLEAM",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_GIGA_DRAIN",
-      "MOVE_GUNK_SHOT",
-      "MOVE_NASTY_PLOT",
-      "MOVE_POISON_JAB",
-      "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
-      "MOVE_SELF_DESTRUCT",
-      "MOVE_SLUDGE_BOMB",
-      "MOVE_SUBSTITUTE",
-      "MOVE_TAUNT",
-      "MOVE_THUNDER",
-      "MOVE_THUNDERBOLT",
       "MOVE_TOXIC",
-      "MOVE_WILL_O_WISP"
+      "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
+      "MOVE_ENDURE",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_ICY_WIND",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_WILL-O-WISP",
+      "MOVE_PSYCHIC",
+      "MOVE_THUNDERBOLT",
+      "MOVE_SHADOW_BALL",
+      "MOVE_POISON_JAB",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_TAUNT",
+      "MOVE_GUNK_SHOT",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_DREAM_EATER"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -2709,28 +4600,37 @@
       }
     ],
     "TMMoves": [
-      "MOVE_DAZZLING_GLEAM",
-      "MOVE_ENDURE",
+      "MOVE_TOXIC",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
       "MOVE_ENERGY_BALL",
       "MOVE_FIRE_PUNCH",
+      "MOVE_ENDURE",
       "MOVE_GIGA_DRAIN",
-      "MOVE_GUNK_SHOT",
-      "MOVE_ICE_PUNCH",
-      "MOVE_METRONOME",
-      "MOVE_NASTY_PLOT",
-      "MOVE_POISON_JAB",
-      "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
-      "MOVE_SELF_DESTRUCT",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_ICY_WIND",
       "MOVE_SLUDGE_BOMB",
-      "MOVE_SUBSTITUTE",
-      "MOVE_TAUNT",
-      "MOVE_THUNDER",
+      "MOVE_WILL-O-WISP",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_PSYCHIC",
       "MOVE_THUNDERBOLT",
-      "MOVE_THUNDER_PUNCH",
-      "MOVE_TOXIC",
+      "MOVE_SHADOW_BALL",
+      "MOVE_POISON_JAB",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
       "MOVE_TOXIC_SPIKES",
-      "MOVE_WILL_O_WISP"
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_TAUNT",
+      "MOVE_METRONOME",
+      "MOVE_GUNK_SHOT",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_SHADOW_PUNCH",
+      "MOVE_DREAM_EATER"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -2795,32 +4695,43 @@
       }
     ],
     "TMMoves": [
-      "MOVE_DAZZLING_GLEAM",
-      "MOVE_ENDURE",
+      "MOVE_TOXIC",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
       "MOVE_ENERGY_BALL",
       "MOVE_FIRE_PUNCH",
-      "MOVE_FOCUS_BLAST",
+      "MOVE_ENDURE",
       "MOVE_GIGA_DRAIN",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_GUNK_SHOT",
       "MOVE_HYPER_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_METRONOME",
-      "MOVE_NASTY_PLOT",
-      "MOVE_POISON_JAB",
-      "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
-      "MOVE_SELF_DESTRUCT",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_ICY_WIND",
       "MOVE_SLUDGE_BOMB",
-      "MOVE_SUBSTITUTE",
-      "MOVE_TAUNT",
-      "MOVE_THUNDER",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_WILL-O-WISP",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_PSYCHIC",
       "MOVE_THUNDERBOLT",
-      "MOVE_THUNDER_PUNCH",
-      "MOVE_THUNDER_WAVE",
-      "MOVE_TOXIC",
+      "MOVE_SHADOW_BALL",
+      "MOVE_POISON_JAB",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
       "MOVE_TOXIC_SPIKES",
-      "MOVE_WILL_O_WISP"
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_TAUNT",
+      "MOVE_METRONOME",
+      "MOVE_GUNK_SHOT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_SHADOW_PUNCH",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_DREAM_EATER",
+      "MOVE_DRAIN_PUNCH"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -2889,18 +4800,347 @@
       }
     ],
     "TMMoves": [
-      "MOVE_DRAGON_PULSE",
-      "MOVE_EARTHQUAKE",
-      "MOVE_ENDURE",
-      "MOVE_IRON_HEAD",
+      "MOVE_ROCK_SLIDE",
       "MOVE_PROTECT",
-      "MOVE_ROCK_BLAST",
+      "MOVE_DIG",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
-      "MOVE_SELF_DESTRUCT",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_DRAGON_PULSE",
       "MOVE_SUBSTITUTE",
-      "MOVE_TAUNT"
+      "MOVE_IRON_TAIL",
+      "MOVE_CURSE",
+      "MOVE_TAUNT",
+      "MOVE_FACADE",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_METEOR_BEAM"
+    ],
+    "TutorMoves": [
+      "MOVE_ROCK_BLAST"
+    ],
+    "EggMoves": []
+  },
+  "CUBONE": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "4",
+        "Move": "MOVE_TAIL_WHIP"
+      },
+      {
+        "Level": "7",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_FALSE_SWIPE"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_HEADBUTT"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_DETECT"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_BULLDOZE"
+      },
+      {
+        "Level": "29",
+        "Move": "MOVE_BRUTAL_SWING"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_FOCUS_ENERGY"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_BONEMERANG"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_SWORDS_DANCE"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_DOUBLE_EDGE"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_PERISH_SONG"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_FIRE_BLAST",
+      "MOVE_ICY_WIND",
+      "MOVE_EARTH_POWER",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_FLAMETHROWER",
+      "MOVE_EARTHQUAKE",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_CURSE",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_SKULL_BASH"
     ],
     "TutorMoves": [],
+    "EggMoves": []
+  },
+  "MAROWAK": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "4",
+        "Move": "MOVE_TAIL_WHIP"
+      },
+      {
+        "Level": "7",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_FALSE_SWIPE"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_HEADBUTT"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_DETECT"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_BULLDOZE"
+      },
+      {
+        "Level": "29",
+        "Move": "MOVE_BRUTAL_SWING"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_FOCUS_ENERGY"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_BONEMERANG"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_SWORDS_DANCE"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_DOUBLE_EDGE"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_PERISH_SONG"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_FIRE_BLAST",
+      "MOVE_HYPER_BEAM",
+      "MOVE_ICY_WIND",
+      "MOVE_EARTH_POWER",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_FLAMETHROWER",
+      "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_CURSE",
+      "MOVE_OUTRAGE",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_SKULL_BASH",
+      "MOVE_FISSURE"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "MAROWAK_ALOLA": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "4",
+        "Move": "MOVE_TAIL_WHIP"
+      },
+      {
+        "Level": "7",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_FALSE_SWIPE"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_HEADBUTT"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_DETECT"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_BULLDOZE"
+      },
+      {
+        "Level": "29",
+        "Move": "MOVE_BRUTAL_SWING"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_FOCUS_ENERGY"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_BONEMERANG"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_SWORDS_DANCE"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_DOUBLE_EDGE"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_PERISH_SONG"
+      },
+      {
+        "Level": "58",
+        "Move": "MOVE_FLARE_BLITZ"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_FIRE_BLAST",
+      "MOVE_HYPER_BEAM",
+      "MOVE_ICY_WIND",
+      "MOVE_EARTH_POWER",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_WILL-O-WISP",
+      "MOVE_IRON_HEAD",
+      "MOVE_FLAMETHROWER",
+      "MOVE_STONE_EDGE",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HEAT_WAVE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_SHADOW_BALL",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_OUTRAGE",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_FLARE_BLITZ",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_SKULL_BASH",
+      "MOVE_FISSURE"
+    ],
+    "TutorMoves": [
+      "MOVE_FLAME_WHEEL",
+      "MOVE_SHADOW_BONE"
+    ],
     "EggMoves": []
   },
   "KANGASKHAN": {
@@ -2951,40 +5191,51 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
-      "MOVE_BLIZZARD",
-      "MOVE_BODY_SLAM",
-      "MOVE_BRICK_BREAK",
-      "MOVE_BULLDOZE",
-      "MOVE_DIG",
-      "MOVE_DOUBLE_EDGE",
-      "MOVE_EARTHQUAKE",
-      "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FLAMETHROWER",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYDRO_PUMP",
-      "MOVE_HYPER_BEAM",
-      "MOVE_ICE_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_IRON_TAIL",
-      "MOVE_POWER_UP_PUNCH",
-      "MOVE_PROTECT",
+      "MOVE_HEADBUTT",
       "MOVE_ROAR",
+      "MOVE_BRICK_BREAK",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SAFEGUARD",
-      "MOVE_SHADOW_BALL",
-      "MOVE_SHADOW_CLAW",
-      "MOVE_SOLAR_BEAM",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
-      "MOVE_THUNDER",
-      "MOVE_THUNDERBOLT",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_AERIAL_ACE",
       "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_FIRE_BLAST",
+      "MOVE_HYPER_BEAM",
+      "MOVE_SAFEGUARD",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_FLAMETHROWER",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_THUNDERBOLT",
+      "MOVE_EARTHQUAKE",
       "MOVE_WHIRLPOOL",
-      "MOVE_WORK_UP"
+      "MOVE_SURF",
+      "MOVE_SHADOW_BALL",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_OUTRAGE",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_CIRCLE_THROW",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_DOUBLE_HIT",
+      "MOVE_DUAL_CHOP",
+      "MOVE_FAKE_OUT"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -3049,24 +5300,33 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BLIZZARD",
-      "MOVE_DAZZLING_GLEAM",
-      "MOVE_ENDURE",
-      "MOVE_FLASH_CANNON",
+      "MOVE_THUNDER_WAVE",
       "MOVE_FLIP_TURN",
       "MOVE_ICE_BEAM",
-      "MOVE_ICY_WIND",
+      "MOVE_LIGHT_SCREEN",
       "MOVE_PROTECT",
+      "MOVE_POWER_GEM",
+      "MOVE_SWIFT",
       "MOVE_REFLECT",
-      "MOVE_SAFEGUARD",
-      "MOVE_SELF_DESTRUCT",
-      "MOVE_SUBSTITUTE",
-      "MOVE_THUNDER",
-      "MOVE_THUNDERBOLT",
-      "MOVE_THUNDER_WAVE",
-      "MOVE_WATERFALL",
+      "MOVE_ENDURE",
       "MOVE_WATER_PULSE",
-      "MOVE_WHIRLPOOL"
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_ICY_WIND",
+      "MOVE_SAFEGUARD",
+      "MOVE_PSYCHIC",
+      "MOVE_THUNDERBOLT",
+      "MOVE_WHIRLPOOL",
+      "MOVE_SURF",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_TRI_ATTACK",
+      "MOVE_SCALD"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -3139,35 +5399,310 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
-      "MOVE_BLIZZARD",
-      "MOVE_BULK_UP",
-      "MOVE_DAZZLING_GLEAM",
-      "MOVE_DOUBLE_EDGE",
-      "MOVE_ENDURE",
-      "MOVE_FLASH_CANNON",
-      "MOVE_FLIP_TURN",
-      "MOVE_GIGA_IMPACT",
       "MOVE_HEADBUTT",
-      "MOVE_HEAL_BLOCK",
-      "MOVE_HYPER_BEAM",
-      "MOVE_ICE_BEAM",
-      "MOVE_ICY_WIND",
-      "MOVE_PROTECT",
       "MOVE_PSYSHOCK",
-      "MOVE_REFLECT",
-      "MOVE_SAFEGUARD",
-      "MOVE_SELF_DESTRUCT",
-      "MOVE_SUBSTITUTE",
-      "MOVE_THUNDER",
-      "MOVE_THUNDERBOLT",
       "MOVE_THUNDER_WAVE",
-      "MOVE_WATERFALL",
+      "MOVE_FLIP_TURN",
+      "MOVE_BULK_UP",
+      "MOVE_ICE_BEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_POWER_GEM",
+      "MOVE_SWIFT",
+      "MOVE_REFLECT",
+      "MOVE_ENDURE",
       "MOVE_WATER_PULSE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_ICY_WIND",
+      "MOVE_SAFEGUARD",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_PSYCHIC",
+      "MOVE_THUNDERBOLT",
       "MOVE_WHIRLPOOL",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_SURF",
+      "MOVE_LIQUIDATION",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_WATERFALL",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_TRIPLE_AXEL",
+      "MOVE_SKULL_BASH",
+      "MOVE_TRI_ATTACK",
+      "MOVE_SCALD",
+      "MOVE_METEOR_BEAM"
     ],
     "TutorMoves": [],
+    "EggMoves": []
+  },
+  "MR_MIME": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_HYPNOSIS"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_CHARM"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_CONFUSION"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_DREAM_EATER"
+      },
+      {
+        "Level": "17",
+        "Move": "MOVE_INFESTATION"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_PROTECT"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_STEALTH_ROCK"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_PSYBEAM"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_MIMIC"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_LIGHT_SCREEN"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_REFLECT"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_SAFEGUARD"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_MYSTICAL_FIRE"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_DAZZLING_GLEAM"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_PSYCHIC"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_HYPER_BEAM",
+      "MOVE_ICY_WIND",
+      "MOVE_SAFEGUARD",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_PSYCHIC",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_THUNDERBOLT",
+      "MOVE_SHADOW_BALL",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_TAUNT",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_METRONOME",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_THUNDER",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_TORMENT",
+      "MOVE_MIMIC",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_SWAGGER",
+      "MOVE_FAKE_OUT",
+      "MOVE_FIRST_IMPRESSION",
+      "MOVE_TRIPLE_AXEL"
+    ],
+    "TutorMoves": [
+      "MOVE_MIST",
+      "MOVE_SMOKESCREEN",
+      "MOVE_HAZE"
+    ],
+    "EggMoves": []
+  },
+  "MR_MIME_GALAR": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_HYPNOSIS"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_CHARM"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_CONFUSION"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_DREAM_EATER"
+      },
+      {
+        "Level": "17",
+        "Move": "MOVE_INFESTATION"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_PROTECT"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_STEALTH_ROCK"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_PSYBEAM"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_MIMIC"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_LIGHT_SCREEN"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_REFLECT"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_SAFEGUARD"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_MYSTICAL_FIRE"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_DAZZLING_GLEAM"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_PSYCHIC"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ICE_BEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_HYPER_BEAM",
+      "MOVE_ICY_WIND",
+      "MOVE_SAFEGUARD",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_PSYCHIC",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_THUNDERBOLT",
+      "MOVE_SHADOW_BALL",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_TAUNT",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_METRONOME",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_TORMENT",
+      "MOVE_MIMIC",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_FROST_BREATH",
+      "MOVE_SWAGGER",
+      "MOVE_FAKE_OUT",
+      "MOVE_FIRST_IMPRESSION",
+      "MOVE_TRIPLE_AXEL",
+      "MOVE_ICICLE_SPEAR",
+      "MOVE_SHEER_COLD"
+    ],
+    "TutorMoves": [
+      "MOVE_MIST",
+      "MOVE_SMOKESCREEN",
+      "MOVE_HAZE"
+    ],
     "EggMoves": []
   },
   "SCYTHER": {
@@ -3222,21 +5757,33 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
-      "MOVE_AGILITY",
       "MOVE_BRICK_BREAK",
-      "MOVE_CLOSE_COMBAT",
-      "MOVE_DOUBLE_EDGE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_SWIFT",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_NIGHT_SLASH",
       "MOVE_ENDURE",
-      "MOVE_GIGA_IMPACT",
       "MOVE_HYPER_BEAM",
       "MOVE_KNOCK_OFF",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_NIGHT_SLASH",
-      "MOVE_PROTECT",
+      "MOVE_AGILITY",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_X-SCISSOR",
+      "MOVE_U-TURN",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_U_TURN"
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_SILVER_WIND",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_DOUBLE_HIT",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_DUAL_CHOP",
+      "MOVE_RAZOR_WIND",
+      "MOVE_VACUUM_WAVE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -3289,23 +5836,33 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
+      "MOVE_ROCK_SMASH",
       "MOVE_BRICK_BREAK",
       "MOVE_BULK_UP",
-      "MOVE_DIG",
-      "MOVE_EARTHQUAKE",
-      "MOVE_ENDURE",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_IRON_DEFENSE",
-      "MOVE_OUTRAGE",
-      "MOVE_PROTECT",
       "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_DIG",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
       "MOVE_STEALTH_ROCK",
+      "MOVE_HYPER_BEAM",
+      "MOVE_GIGA_IMPACT",
       "MOVE_STONE_EDGE",
-      "MOVE_SUBSTITUTE"
+      "MOVE_EARTHQUAKE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_X-SCISSOR",
+      "MOVE_SUBSTITUTE",
+      "MOVE_OUTRAGE",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_CIRCLE_THROW",
+      "MOVE_DOUBLE_HIT",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_STORM_THROW"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -3322,7 +5879,8 @@
       }
     ],
     "TMMoves": [
-      "MOVE_HYDRO_PUMP"
+      "MOVE_HYDRO_PUMP",
+      "MOVE_FACADE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -3379,32 +5937,46 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BLIZZARD",
-      "MOVE_BODY_SLAM",
-      "MOVE_BULLDOZE",
-      "MOVE_DARK_PULSE",
-      "MOVE_DOUBLE_EDGE",
-      "MOVE_DRAGON_PULSE",
-      "MOVE_EARTHQUAKE",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_BLAST",
-      "MOVE_FLAMETHROWER",
-      "MOVE_GIGA_IMPACT",
+      "MOVE_ROAR",
+      "MOVE_THUNDER_WAVE",
       "MOVE_ICE_BEAM",
       "MOVE_ICE_FANG",
-      "MOVE_ICY_WIND",
-      "MOVE_IRON_TAIL",
-      "MOVE_OUTRAGE",
       "MOVE_PROTECT",
-      "MOVE_ROAR",
+      "MOVE_CRUNCH",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_FIRE_BLAST",
+      "MOVE_WATER_PULSE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_ICY_WIND",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_FLAMETHROWER",
       "MOVE_STONE_EDGE",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
-      "MOVE_TAUNT",
-      "MOVE_THUNDER",
       "MOVE_THUNDERBOLT",
-      "MOVE_THUNDER_WAVE",
-      "MOVE_WATER_PULSE"
+      "MOVE_EARTHQUAKE",
+      "MOVE_WHIRLPOOL",
+      "MOVE_SURF",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_BULLDOZE",
+      "MOVE_HURRICANE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_DARK_PULSE",
+      "MOVE_OUTRAGE",
+      "MOVE_TAUNT",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_SWAGGER",
+      "MOVE_MUDDY_WATER",
+      "MOVE_SCALE_SHOT",
+      "MOVE_SKULL_BASH",
+      "MOVE_SCALD"
     ],
     "TutorMoves": [
       "MOVE_BITE",
@@ -3461,16 +6033,21 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_CALM_MIND",
-      "MOVE_DIG",
-      "MOVE_ENDURE",
-      "MOVE_HYPER_VOICE",
-      "MOVE_IRON_TAIL",
-      "MOVE_PROTECT",
       "MOVE_ROAR",
+      "MOVE_CALM_MIND",
+      "MOVE_PROTECT",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_HYPER_VOICE",
       "MOVE_SHADOW_BALL",
-      "MOVE_SUBSTITUTE"
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_MIMIC"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -3531,27 +6108,39 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BLIZZARD",
-      "MOVE_BODY_SLAM",
-      "MOVE_CALM_MIND",
-      "MOVE_DIG",
-      "MOVE_ENDURE",
-      "MOVE_FLIP_TURN",
-      "MOVE_GIGA_IMPACT",
       "MOVE_HEADBUTT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_HYPER_VOICE",
-      "MOVE_ICE_BEAM",
-      "MOVE_IRON_TAIL",
-      "MOVE_LIQUIDATION",
-      "MOVE_PROTECT",
       "MOVE_ROAR",
-      "MOVE_SHADOW_BALL",
-      "MOVE_SUBSTITUTE",
-      "MOVE_TAUNT",
-      "MOVE_WATERFALL",
+      "MOVE_CALM_MIND",
+      "MOVE_FLIP_TURN",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_WATER_PULSE",
-      "MOVE_WHIRLPOOL"
+      "MOVE_HYPER_BEAM",
+      "MOVE_ICY_WIND",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_WHIRLPOOL",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SURF",
+      "MOVE_SHADOW_BALL",
+      "MOVE_LIQUIDATION",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_TAUNT",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_TRAILBLAZE",
+      "MOVE_MIMIC",
+      "MOVE_MUDDY_WATER",
+      "MOVE_SKULL_BASH",
+      "MOVE_SCALD"
     ],
     "TutorMoves": [
       "MOVE_CHARM",
@@ -3619,24 +6208,37 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
-      "MOVE_BODY_SLAM",
+      "MOVE_HEADBUTT",
+      "MOVE_ROAR",
       "MOVE_CALM_MIND",
-      "MOVE_DIG",
-      "MOVE_DISCHARGE",
-      "MOVE_ELECTROWEB",
-      "MOVE_ENDURE",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_HYPER_VOICE",
-      "MOVE_IRON_TAIL",
+      "MOVE_THUNDER_WAVE",
       "MOVE_LIGHT_SCREEN",
       "MOVE_PROTECT",
-      "MOVE_ROAR",
+      "MOVE_THUNDER_FANG",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_DISCHARGE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_VOLT_SWITCH",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HYPER_VOICE",
       "MOVE_SHADOW_BALL",
       "MOVE_SUBSTITUTE",
-      "MOVE_VOLT_SWITCH",
-      "MOVE_WILD_CHARGE"
+      "MOVE_WILD_CHARGE",
+      "MOVE_IRON_TAIL",
+      "MOVE_ELECTROWEB",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_MIMIC",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_SKULL_BASH"
     ],
     "TutorMoves": [
       "MOVE_CHARM",
@@ -3701,25 +6303,36 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
+      "MOVE_HEADBUTT",
+      "MOVE_ROAR",
       "MOVE_CALM_MIND",
+      "MOVE_FIRE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_SWIFT",
       "MOVE_DIG",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
       "MOVE_ENDURE",
       "MOVE_FIRE_BLAST",
-      "MOVE_FLAMETHROWER",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HEADBUTT",
-      "MOVE_HEAT_WAVE",
       "MOVE_HYPER_BEAM",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_WILL-O-WISP",
+      "MOVE_FLAMETHROWER",
+      "MOVE_HEAT_WAVE",
       "MOVE_HYPER_VOICE",
-      "MOVE_IRON_TAIL",
-      "MOVE_PROTECT",
-      "MOVE_ROAR",
+      "MOVE_FIRE_SPIN",
       "MOVE_SHADOW_BALL",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWORDS_DANCE",
+      "MOVE_IRON_TAIL",
       "MOVE_TAUNT",
-      "MOVE_WILL_O_WISP"
+      "MOVE_FLARE_BLITZ",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_MIMIC",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_SKULL_BASH"
     ],
     "TutorMoves": [
       "MOVE_CHARM",
@@ -3729,6 +6342,103 @@
       "MOVE_TAKE_DOWN",
       "MOVE_WISH"
     ],
+    "EggMoves": []
+  },
+  "PORYGON": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_CONVERSION"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_CHARGE"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_EERIE_IMPULSE"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_THUNDER_SHOCK"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_PSYBEAM"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_CONVERSION_2"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_AGILITY"
+      },
+      {
+        "Level": "35",
+        "Move": "MOVE_RECOVER"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_DISCHARGE"
+      },
+      {
+        "Level": "45",
+        "Move": "MOVE_METAL_SOUND"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_SELF_DESTRUCT"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_ZAP_CANNON"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_PSYSHOCK",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_SWIFT",
+      "MOVE_REFLECT",
+      "MOVE_ENDURE",
+      "MOVE_DISCHARGE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_ICY_WIND",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_PSYCHIC",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_VOLT_SWITCH",
+      "MOVE_THUNDERBOLT",
+      "MOVE_SHADOW_BALL",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_ELECTROWEB",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_SKULL_BASH",
+      "MOVE_TRI_ATTACK"
+    ],
+    "TutorMoves": [],
     "EggMoves": []
   },
   "AERODACTYL": {
@@ -3787,28 +6497,43 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
       "MOVE_DRAGON_CLAW",
-      "MOVE_DRAGON_PULSE",
-      "MOVE_EARTHQUAKE",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_BLAST",
+      "MOVE_ROAR",
+      "MOVE_ROCK_SLIDE",
       "MOVE_FIRE_FANG",
-      "MOVE_FLAMETHROWER",
-      "MOVE_FLY",
-      "MOVE_HEAT_WAVE",
-      "MOVE_HURRICANE",
       "MOVE_ICE_FANG",
-      "MOVE_IRON_TAIL",
       "MOVE_PROTECT",
+      "MOVE_THUNDER_FANG",
+      "MOVE_CRUNCH",
+      "MOVE_SWIFT",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
       "MOVE_STEALTH_ROCK",
+      "MOVE_FIRE_BLAST",
+      "MOVE_FLY",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_EARTH_POWER",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_IRON_HEAD",
+      "MOVE_FLAMETHROWER",
+      "MOVE_STONE_EDGE",
+      "MOVE_HEAT_WAVE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_HURRICANE",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
+      "MOVE_IRON_TAIL",
+      "MOVE_WHIRLWIND",
       "MOVE_TAUNT",
-      "MOVE_THUNDER_FANG",
-      "MOVE_WHIRLWIND"
+      "MOVE_FACADE",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_SWAGGER",
+      "MOVE_SKY_ATTACK",
+      "MOVE_METEOR_BEAM"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -3865,28 +6590,35 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
-      "MOVE_BLIZZARD",
-      "MOVE_DRACO_METEOR",
-      "MOVE_DRAGON_PULSE",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_SPIN",
-      "MOVE_FLAMETHROWER",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYDRO_PUMP",
+      "MOVE_THUNDER_WAVE",
       "MOVE_ICE_BEAM",
-      "MOVE_IRON_HEAD",
       "MOVE_LIGHT_SCREEN",
       "MOVE_PROTECT",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
       "MOVE_SWIFT",
-      "MOVE_THUNDER",
-      "MOVE_THUNDERBOLT",
-      "MOVE_WATERFALL",
+      "MOVE_ENDURE",
+      "MOVE_FIRE_BLAST",
       "MOVE_WATER_PULSE",
-      "MOVE_WHIRLPOOL"
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_SAFEGUARD",
+      "MOVE_DRACO_METEOR",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_IRON_HEAD",
+      "MOVE_FLAMETHROWER",
+      "MOVE_THUNDERBOLT",
+      "MOVE_WHIRLPOOL",
+      "MOVE_FIRE_SPIN",
+      "MOVE_SURF",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_OUTRAGE",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_SCALE_SHOT"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -3943,28 +6675,35 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
-      "MOVE_BLIZZARD",
-      "MOVE_DRACO_METEOR",
-      "MOVE_DRAGON_PULSE",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_SPIN",
-      "MOVE_FLAMETHROWER",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYDRO_PUMP",
+      "MOVE_THUNDER_WAVE",
       "MOVE_ICE_BEAM",
-      "MOVE_IRON_HEAD",
       "MOVE_LIGHT_SCREEN",
       "MOVE_PROTECT",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
       "MOVE_SWIFT",
-      "MOVE_THUNDER",
-      "MOVE_THUNDERBOLT",
-      "MOVE_WATERFALL",
+      "MOVE_ENDURE",
+      "MOVE_FIRE_BLAST",
       "MOVE_WATER_PULSE",
-      "MOVE_WHIRLPOOL"
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_SAFEGUARD",
+      "MOVE_DRACO_METEOR",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_IRON_HEAD",
+      "MOVE_FLAMETHROWER",
+      "MOVE_THUNDERBOLT",
+      "MOVE_WHIRLPOOL",
+      "MOVE_FIRE_SPIN",
+      "MOVE_SURF",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_OUTRAGE",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_SCALE_SHOT"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -4025,42 +6764,56 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
-      "MOVE_AGILITY",
-      "MOVE_BLIZZARD",
-      "MOVE_BRICK_BREAK",
-      "MOVE_DRACO_METEOR",
       "MOVE_DRAGON_CLAW",
-      "MOVE_DRAGON_PULSE",
-      "MOVE_EARTHQUAKE",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_SPIN",
-      "MOVE_FLAMETHROWER",
-      "MOVE_FLY",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HEAT_WAVE",
-      "MOVE_HYDRO_PUMP",
-      "MOVE_ICE_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_IRON_HEAD",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_METRONOME",
-      "MOVE_PROTECT",
       "MOVE_ROAR",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_STONE_EDGE",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
+      "MOVE_ICE_BEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
       "MOVE_SWIFT",
-      "MOVE_THUNDER",
-      "MOVE_THUNDERBOLT",
-      "MOVE_WATERFALL",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_FIRE_BLAST",
       "MOVE_WATER_PULSE",
+      "MOVE_FLY",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_SAFEGUARD",
+      "MOVE_DRACO_METEOR",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_IRON_HEAD",
+      "MOVE_FLAMETHROWER",
+      "MOVE_STONE_EDGE",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HEAT_WAVE",
+      "MOVE_EARTHQUAKE",
       "MOVE_WHIRLPOOL",
-      "MOVE_WHIRLWIND"
+      "MOVE_FIRE_SPIN",
+      "MOVE_SURF",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_HURRICANE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_OUTRAGE",
+      "MOVE_WHIRLWIND",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_METRONOME",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_SCALE_SHOT",
+      "MOVE_RAZOR_WIND",
+      "MOVE_SKULL_BASH",
+      "MOVE_VACUUM_WAVE"
     ],
     "TutorMoves": [
       "MOVE_FIRE_PUNCH",
@@ -4122,54 +6875,68 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
-      "MOVE_AGILITY",
-      "MOVE_BLIZZARD",
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_TOXIC",
+      "MOVE_THUNDER_WAVE",
       "MOVE_BRICK_BREAK",
       "MOVE_BULK_UP",
-      "MOVE_CALM_MIND",
-      "MOVE_DARK_PULSE",
-      "MOVE_DISCHARGE",
-      "MOVE_DOUBLE_EDGE",
-      "MOVE_EARTHQUAKE",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FLAMETHROWER",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HEAL_BLOCK",
-      "MOVE_HURRICANE",
-      "MOVE_HYPER_BEAM",
-      "MOVE_ICE_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_IRON_TAIL",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_METRONOME",
-      "MOVE_NASTY_PLOT",
-      "MOVE_POISON_JAB",
-      "MOVE_POWER_GEM",
-      "MOVE_PROTECT",
-      "MOVE_PSYSHOCK",
-      "MOVE_REFLECT",
       "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_POWER_GEM",
+      "MOVE_AERIAL_ACE",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_REFLECT",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
-      "MOVE_SELF_DESTRUCT",
-      "MOVE_SHADOW_BALL",
+      "MOVE_FIRE_BLAST",
+      "MOVE_DISCHARGE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_SAFEGUARD",
+      "MOVE_EARTH_POWER",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_WILL-O-WISP",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_FLAMETHROWER",
+      "MOVE_PSYCHIC",
       "MOVE_SOLAR_BEAM",
       "MOVE_STONE_EDGE",
-      "MOVE_SUBSTITUTE",
-      "MOVE_TAKE_DOWN",
-      "MOVE_TAUNT",
-      "MOVE_THUNDER",
       "MOVE_THUNDERBOLT",
-      "MOVE_THUNDER_PUNCH",
-      "MOVE_THUNDER_WAVE",
-      "MOVE_TOXIC",
-      "MOVE_WILL_O_WISP",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_EARTHQUAKE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_POISON_JAB",
+      "MOVE_HURRICANE",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_DARK_PULSE",
+      "MOVE_TAUNT",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_METRONOME",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_LOW_SWEEP",
+      "MOVE_TRAILBLAZE",
+      "MOVE_PAY_DAY",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_DREAM_EATER",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_TRI_ATTACK",
+      "MOVE_VACUUM_WAVE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -4230,22 +6997,32 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BULLDOZE",
+      "MOVE_HEADBUTT",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_REFLECT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_BULLET_SEED",
+      "MOVE_KNOCK_OFF",
+      "MOVE_SAFEGUARD",
+      "MOVE_EARTH_POWER",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
       "MOVE_CURSE",
       "MOVE_DAZZLING_GLEAM",
-      "MOVE_DOUBLE_EDGE",
-      "MOVE_DOUBLE_TEAM",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_HEADBUTT",
-      "MOVE_IRON_TAIL",
-      "MOVE_KNOCK_OFF",
-      "MOVE_PROTECT",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SWORDS_DANCE",
-      "MOVE_WORK_UP"
+      "MOVE_WORK_UP",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_SEED_BOMB",
+      "MOVE_SOLAR_BLADE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -4306,23 +7083,34 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BULLDOZE",
+      "MOVE_HEADBUTT",
+      "MOVE_ROCK_SMASH",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_REFLECT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_BULLET_SEED",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_KNOCK_OFF",
+      "MOVE_SAFEGUARD",
+      "MOVE_EARTH_POWER",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
       "MOVE_CURSE",
       "MOVE_DAZZLING_GLEAM",
-      "MOVE_DOUBLE_EDGE",
-      "MOVE_DOUBLE_TEAM",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_HEADBUTT",
-      "MOVE_IRON_TAIL",
-      "MOVE_KNOCK_OFF",
-      "MOVE_PROTECT",
-      "MOVE_ROCK_SMASH",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SWORDS_DANCE",
-      "MOVE_WORK_UP"
+      "MOVE_WORK_UP",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_SEED_BOMB",
+      "MOVE_SOLAR_BLADE"
     ],
     "TutorMoves": [
       "MOVE_GIGA_DRAIN"
@@ -4385,27 +7173,40 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BULLDOZE",
+      "MOVE_HEADBUTT",
+      "MOVE_ROCK_SMASH",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_REFLECT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_BULLET_SEED",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_SAFEGUARD",
+      "MOVE_EARTH_POWER",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_EARTHQUAKE",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
       "MOVE_CURSE",
       "MOVE_DAZZLING_GLEAM",
-      "MOVE_DOUBLE_EDGE",
-      "MOVE_DOUBLE_TEAM",
-      "MOVE_EARTHQUAKE",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HEADBUTT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_IRON_TAIL",
-      "MOVE_KNOCK_OFF",
       "MOVE_OUTRAGE",
-      "MOVE_PROTECT",
-      "MOVE_ROCK_SMASH",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SWORDS_DANCE",
-      "MOVE_WORK_UP"
+      "MOVE_WORK_UP",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_SEED_BOMB",
+      "MOVE_PETAL_DANCE",
+      "MOVE_SOLAR_BLADE",
+      "MOVE_FRENZY_PLANT"
     ],
     "TutorMoves": [
       "MOVE_GIGA_DRAIN",
@@ -4461,28 +7262,37 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BLIZZARD",
-      "MOVE_BRICK_BREAK",
-      "MOVE_BULLDOZE",
-      "MOVE_CURSE",
-      "MOVE_DIG",
-      "MOVE_DOUBLE_TEAM",
       "MOVE_DRAGON_CLAW",
-      "MOVE_ENDURE",
       "MOVE_FLIP_TURN",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
       "MOVE_ICE_BEAM",
       "MOVE_ICE_FANG",
-      "MOVE_ICY_WIND",
       "MOVE_PROTECT",
-      "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
+      "MOVE_DIG",
       "MOVE_SWORDS_DANCE",
-      "MOVE_WATERFALL",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
       "MOVE_WATER_PULSE",
+      "MOVE_ICY_WIND",
       "MOVE_WHIRLPOOL",
-      "MOVE_WORK_UP"
+      "MOVE_SURF",
+      "MOVE_LIQUIDATION",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CURSE",
+      "MOVE_OUTRAGE",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_WORK_UP",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_TRAILBLAZE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_MUDDY_WATER"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -4535,30 +7345,39 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BLIZZARD",
-      "MOVE_BRICK_BREAK",
-      "MOVE_BULLDOZE",
-      "MOVE_CURSE",
-      "MOVE_DIG",
-      "MOVE_DOUBLE_TEAM",
       "MOVE_DRAGON_CLAW",
-      "MOVE_ENDURE",
+      "MOVE_ROCK_SMASH",
+      "MOVE_ROAR",
       "MOVE_FLIP_TURN",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
       "MOVE_ICE_BEAM",
       "MOVE_ICE_FANG",
-      "MOVE_ICY_WIND",
       "MOVE_PROTECT",
-      "MOVE_ROAR",
-      "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_SMASH",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
+      "MOVE_DIG",
       "MOVE_SWORDS_DANCE",
-      "MOVE_WATERFALL",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
       "MOVE_WATER_PULSE",
+      "MOVE_ICY_WIND",
       "MOVE_WHIRLPOOL",
-      "MOVE_WORK_UP"
+      "MOVE_SURF",
+      "MOVE_LIQUIDATION",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CURSE",
+      "MOVE_OUTRAGE",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_WORK_UP",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_TRAILBLAZE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_MUDDY_WATER"
     ],
     "TutorMoves": [
       "MOVE_SLASH"
@@ -4617,35 +7436,50 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
-      "MOVE_BLIZZARD",
-      "MOVE_BRICK_BREAK",
-      "MOVE_BULLDOZE",
-      "MOVE_CURSE",
-      "MOVE_DIG",
-      "MOVE_DOUBLE_EDGE",
-      "MOVE_DOUBLE_TEAM",
       "MOVE_DRAGON_CLAW",
-      "MOVE_EARTHQUAKE",
-      "MOVE_ENDURE",
+      "MOVE_ROCK_SMASH",
+      "MOVE_ROAR",
       "MOVE_FLIP_TURN",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
       "MOVE_ICE_BEAM",
       "MOVE_ICE_FANG",
-      "MOVE_ICY_WIND",
       "MOVE_PROTECT",
-      "MOVE_ROAR",
-      "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_SMASH",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
       "MOVE_SWORDS_DANCE",
-      "MOVE_WATERFALL",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
       "MOVE_WATER_PULSE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_ICY_WIND",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_EARTHQUAKE",
       "MOVE_WHIRLPOOL",
-      "MOVE_WORK_UP"
+      "MOVE_SURF",
+      "MOVE_LIQUIDATION",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CURSE",
+      "MOVE_OUTRAGE",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_WORK_UP",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_TRAILBLAZE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_MUDDY_WATER",
+      "MOVE_SCALE_SHOT",
+      "MOVE_RAZOR_WIND",
+      "MOVE_SCALD",
+      "MOVE_ICICLE_SPEAR",
+      "MOVE_HYDRO_CANNON"
     ],
     "TutorMoves": [
       "MOVE_CRUNCH"
@@ -4716,20 +7550,26 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
-      "MOVE_BODY_SLAM",
+      "MOVE_HEADBUTT",
+      "MOVE_TOXIC",
+      "MOVE_PROTECT",
       "MOVE_DIG",
-      "MOVE_ELECTROWEB",
+      "MOVE_BODY_SLAM",
       "MOVE_ENDURE",
       "MOVE_GIGA_DRAIN",
-      "MOVE_HEADBUTT",
       "MOVE_KNOCK_OFF",
-      "MOVE_PROTECT",
+      "MOVE_AGILITY",
       "MOVE_SLUDGE_BOMB",
+      "MOVE_PSYCHIC",
       "MOVE_SOLAR_BEAM",
+      "MOVE_POISON_JAB",
+      "MOVE_X-SCISSOR",
       "MOVE_SUBSTITUTE",
-      "MOVE_TOXIC",
-      "MOVE_TOXIC_SPIKES"
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_ELECTROWEB",
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_TRAILBLAZE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -4802,26 +7642,136 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
-      "MOVE_BODY_SLAM",
+      "MOVE_HEADBUTT",
+      "MOVE_TOXIC",
+      "MOVE_PROTECT",
       "MOVE_DIG",
-      "MOVE_ELECTROWEB",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
       "MOVE_ENDURE",
       "MOVE_GIGA_DRAIN",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HEADBUTT",
       "MOVE_HYPER_BEAM",
       "MOVE_KNOCK_OFF",
-      "MOVE_PROTECT",
+      "MOVE_AGILITY",
       "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_PSYCHIC",
       "MOVE_SOLAR_BEAM",
+      "MOVE_POISON_JAB",
+      "MOVE_X-SCISSOR",
       "MOVE_SUBSTITUTE",
-      "MOVE_TOXIC",
-      "MOVE_TOXIC_SPIKES"
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_ELECTROWEB",
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_TRAILBLAZE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_FIRST_IMPRESSION"
     ],
     "TutorMoves": [
       "MOVE_SWORDS_DANCE"
     ],
+    "EggMoves": []
+  },
+  "CROBAT": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_SUPERSONIC"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_ABSORB"
+      },
+      {
+        "Level": "5",
+        "Move": "MOVE_GUST"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_WING_ATTACK"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_WHIRLWIND"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_HYPNOSIS"
+      },
+      {
+        "Level": "26",
+        "Move": "MOVE_HAZE"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_POISON_FANG"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_AIR_SLASH"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_LEECH_LIFE"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_BRAVE_BIRD"
+      }
+    ],
+    "TMMoves": [  
+      "MOVE_TOXIC",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_CRUNCH",
+      "MOVE_SWIFT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_FLY",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_AGILITY",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_HEAT_WAVE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_HURRICANE",
+      "MOVE_X-SCISSOR",
+      "MOVE_U-TURN",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_WHIRLWIND",
+      "MOVE_TAUNT",
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_POISON_FANG",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_DOUBLE_HIT",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_SWAGGER",
+      "MOVE_RAZOR_WIND",
+      "MOVE_SKY_ATTACK"
+    ],
+    "TutorMoves": [],
     "EggMoves": []
   },
   "PICHU": {
@@ -4880,24 +7830,31 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
+      "MOVE_THUNDER_WAVE",
       "MOVE_BRICK_BREAK",
-      "MOVE_DIG",
-      "MOVE_DISCHARGE",
-      "MOVE_DOUBLE_TEAM",
-      "MOVE_ELECTROWEB",
-      "MOVE_ENDURE",
-      "MOVE_IRON_TAIL",
-      "MOVE_NASTY_PLOT",
-      "MOVE_PLAY_ROUGH",
+      "MOVE_LIGHT_SCREEN",
       "MOVE_PROTECT",
-      "MOVE_REFLECT",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
-      "MOVE_SWIFT",
+      "MOVE_PLAY_ROUGH",
       "MOVE_THUNDER_PUNCH",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_REFLECT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_DISCHARGE",
       "MOVE_VOLT_SWITCH",
-      "MOVE_WILD_CHARGE"
+      "MOVE_THUNDERBOLT",
+      "MOVE_SURF",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WILD_CHARGE",
+      "MOVE_IRON_TAIL",
+      "MOVE_ELECTROWEB",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_FAKE_OUT"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -4962,35 +7919,129 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BLIZZARD",
-      "MOVE_BODY_SLAM",
-      "MOVE_CALM_MIND",
-      "MOVE_DAZZLING_GLEAM",
-      "MOVE_DIG",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_BLAST",
-      "MOVE_FLAMETHROWER",
       "MOVE_HEADBUTT",
-      "MOVE_HYPER_VOICE",
-      "MOVE_ICE_BEAM",
-      "MOVE_IRON_TAIL",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_PLAY_ROUGH",
-      "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
       "MOVE_PSYSHOCK",
-      "MOVE_REFLECT",
-      "MOVE_SAFEGUARD",
-      "MOVE_SHADOW_BALL",
-      "MOVE_SOLAR_BEAM",
-      "MOVE_STEALTH_ROCK",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_THUNDER",
-      "MOVE_THUNDERBOLT",
+      "MOVE_CALM_MIND",
       "MOVE_THUNDER_WAVE",
+      "MOVE_ICE_BEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_FIRE_BLAST",
+      "MOVE_SAFEGUARD",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FLAMETHROWER",
+      "MOVE_PSYCHIC",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_METRONOME",
       "MOVE_WORK_UP",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_SING"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "IGGLYBUFF": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_SING"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_CHARM"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_DISARMING_VOICE"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_ROLLOUT"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_DRAINING_KISS"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_FAKE_TEARS"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_CONFUSION"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_FACADE"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_MIMIC"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_WISH"
+      }
+    ],
+    "TMMoves": [  
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_FIRE_BLAST",
+      "MOVE_WATER_PULSE",
+      "MOVE_ICY_WIND",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FLAMETHROWER",
+      "MOVE_PSYCHIC",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WILD_CHARGE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_TAUNT",
+      "MOVE_FACADE",
+      "MOVE_SING",
+      "MOVE_TRAILBLAZE",
+      "MOVE_MIMIC"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -5043,18 +8094,26 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_DAZZLING_GLEAM",
-      "MOVE_DIG",
-      "MOVE_DISCHARGE",
-      "MOVE_ELECTROWEB",
-      "MOVE_ENDURE",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_LIGHT_SCREEN",
       "MOVE_PROTECT",
-      "MOVE_REFLECT",
-      "MOVE_SUBSTITUTE",
+      "MOVE_POWER_GEM",
       "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_DISCHARGE",
       "MOVE_VOLT_SWITCH",
-      "MOVE_WILD_CHARGE"
+      "MOVE_THUNDERBOLT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WILD_CHARGE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_ELECTROWEB",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_CHARGE_BEAM"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -5107,22 +8166,30 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
-      "MOVE_BODY_SLAM",
-      "MOVE_DAZZLING_GLEAM",
-      "MOVE_DIG",
-      "MOVE_DISCHARGE",
-      "MOVE_ELECTROWEB",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_ICE_PUNCH",
-      "MOVE_PROTECT",
-      "MOVE_REFLECT",
       "MOVE_ROAR",
-      "MOVE_SUBSTITUTE",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_POWER_GEM",
+      "MOVE_ICE_PUNCH",
       "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_DISCHARGE",
+      "MOVE_AGILITY",
       "MOVE_VOLT_SWITCH",
-      "MOVE_WILD_CHARGE"
+      "MOVE_THUNDERBOLT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WILD_CHARGE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_ELECTROWEB",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_CHARGE_BEAM"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -5183,30 +8250,42 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
-      "MOVE_BODY_SLAM",
-      "MOVE_BRICK_BREAK",
-      "MOVE_DAZZLING_GLEAM",
-      "MOVE_DIG",
-      "MOVE_DISCHARGE",
-      "MOVE_DOUBLE_EDGE",
-      "MOVE_DRAGON_PULSE",
-      "MOVE_ELECTROWEB",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FLASH_CANNON",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_OUTRAGE",
-      "MOVE_PROTECT",
-      "MOVE_REFLECT",
       "MOVE_ROAR",
-      "MOVE_SUBSTITUTE",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_POWER_GEM",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
       "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_DISCHARGE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
       "MOVE_VOLT_SWITCH",
-      "MOVE_WILD_CHARGE"
+      "MOVE_THUNDERBOLT",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WILD_CHARGE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_OUTRAGE",
+      "MOVE_ELECTROWEB",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_THUNDER",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_DUAL_CHOP",
+      "MOVE_METEOR_BEAM"
     ],
     "TutorMoves": [
       "MOVE_EERIE_IMPULSE",
@@ -5266,25 +8345,36 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_CALM_MIND",
-      "MOVE_DAZZLING_GLEAM",
-      "MOVE_DIG",
-      "MOVE_ENDURE",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_HYPER_VOICE",
-      "MOVE_IRON_TAIL",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_POWER_GEM",
-      "MOVE_PROTECT",
       "MOVE_PSYSHOCK",
-      "MOVE_REFLECT",
       "MOVE_ROAR",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_POWER_GEM",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_HYPER_BEAM",
       "MOVE_SAFEGUARD",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_PSYCHIC",
+      "MOVE_HYPER_VOICE",
       "MOVE_SHADOW_BALL",
       "MOVE_SUBSTITUTE",
-      "MOVE_THUNDER_WAVE"
+      "MOVE_IRON_TAIL",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_MIMIC",
+      "MOVE_DREAM_EATER",
+      "MOVE_SKULL_BASH"
     ],
     "TutorMoves": [
       "MOVE_CHARM",
@@ -5348,25 +8438,39 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
+      "MOVE_ROAR",
       "MOVE_CALM_MIND",
-      "MOVE_CURSE",
-      "MOVE_DIG",
-      "MOVE_ENDURE",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_HYPER_VOICE",
-      "MOVE_IRON_TAIL",
+      "MOVE_TOXIC",
+      "MOVE_THUNDER_WAVE",
       "MOVE_LIGHT_SCREEN",
       "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
+      "MOVE_CRUNCH",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
       "MOVE_REFLECT",
-      "MOVE_ROAR",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_PSYCHIC",
+      "MOVE_HYPER_VOICE",
       "MOVE_SHADOW_BALL",
       "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
       "MOVE_TAUNT",
-      "MOVE_THUNDER_WAVE",
-      "MOVE_TOXIC"
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_TORMENT",
+      "MOVE_MIMIC",
+      "MOVE_DREAM_EATER",
+      "MOVE_SWAGGER",
+      "MOVE_RAZOR_WIND",
+      "MOVE_SKULL_BASH"
     ],
     "TutorMoves": [
       "MOVE_CHARM",
@@ -5438,37 +8542,56 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BLIZZARD",
-      "MOVE_BODY_SLAM",
+      "MOVE_HEADBUTT",
+      "MOVE_PSYSHOCK",
       "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_ICE_BEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_POWER_GEM",
+      "MOVE_ICE_PUNCH",
+      "MOVE_SWIFT",
       "MOVE_DIG",
-      "MOVE_EARTHQUAKE",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
       "MOVE_ENDURE",
       "MOVE_FIRE_BLAST",
-      "MOVE_FLAMETHROWER",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HEAL_BLOCK",
-      "MOVE_HYDRO_PUMP",
+      "MOVE_WATER_PULSE",
       "MOVE_HYPER_BEAM",
-      "MOVE_ICE_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_ICY_WIND",
-      "MOVE_IRON_TAIL",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_LIQUIDATION",
-      "MOVE_METRONOME",
       "MOVE_MUD_SHOT",
-      "MOVE_PROTECT",
-      "MOVE_PSYSHOCK",
-      "MOVE_REFLECT",
+      "MOVE_ICY_WIND",
       "MOVE_SAFEGUARD",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_FLAMETHROWER",
+      "MOVE_PSYCHIC",
+      "MOVE_EARTHQUAKE",
+      "MOVE_WHIRLPOOL",
+      "MOVE_SURF",
       "MOVE_SHADOW_BALL",
+      "MOVE_LIQUIDATION",
+      "MOVE_NASTY_PLOT",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_THUNDER_WAVE",
+      "MOVE_IRON_TAIL",
+      "MOVE_CURSE",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_HEAL_BLOCK",
       "MOVE_WATERFALL",
-      "MOVE_WHIRLPOOL"
+      "MOVE_METRONOME",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_DREAM_EATER",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_SWAGGER",
+      "MOVE_MUDDY_WATER",
+      "MOVE_SKULL_BASH",
+      "MOVE_TRI_ATTACK",
+      "MOVE_SCALD"
     ],
     "TutorMoves": [
       "MOVE_CONFUSION"
@@ -5539,42 +8662,64 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BLIZZARD",
-      "MOVE_BODY_SLAM",
+      "MOVE_HEADBUTT",
+      "MOVE_PSYSHOCK",
       "MOVE_CALM_MIND",
+      "MOVE_TOXIC",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_ICE_BEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_POWER_GEM",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_SWIFT",
       "MOVE_DIG",
-      "MOVE_EARTHQUAKE",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_BODY_SLAM",
       "MOVE_ENDURE",
       "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FLAMETHROWER",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_GUNK_SHOT",
-      "MOVE_HEAL_BLOCK",
-      "MOVE_HYDRO_PUMP",
+      "MOVE_WATER_PULSE",
       "MOVE_HYPER_BEAM",
-      "MOVE_ICE_BEAM",
-      "MOVE_ICY_WIND",
-      "MOVE_IRON_TAIL",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_LIQUIDATION",
-      "MOVE_METRONOME",
       "MOVE_MUD_SHOT",
-      "MOVE_POISON_JAB",
-      "MOVE_PROTECT",
-      "MOVE_PSYSHOCK",
+      "MOVE_ICY_WIND",
       "MOVE_SAFEGUARD",
-      "MOVE_SHADOW_BALL",
       "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_FLAMETHROWER",
+      "MOVE_PSYCHIC",
+      "MOVE_EARTHQUAKE",
+      "MOVE_WHIRLPOOL",
+      "MOVE_SURF",
+      "MOVE_SHADOW_BALL",
+      "MOVE_LIQUIDATION",
+      "MOVE_POISON_JAB",
+      "MOVE_NASTY_PLOT",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_TAUNT",
-      "MOVE_THUNDER_PUNCH",
-      "MOVE_THUNDER_WAVE",
+      "MOVE_IRON_TAIL",
       "MOVE_TOXIC_SPIKES",
+      "MOVE_CURSE",
+      "MOVE_TAUNT",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_HEAL_BLOCK",
       "MOVE_WATERFALL",
-      "MOVE_WHIRLPOOL"
+      "MOVE_METRONOME",
+      "MOVE_GUNK_SHOT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_ACID_SPRAY",
+      "MOVE_LOW_SWEEP",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_DREAM_EATER",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_SWAGGER",
+      "MOVE_MUDDY_WATER",
+      "MOVE_SKULL_BASH",
+      "MOVE_TRI_ATTACK"
     ],
     "TutorMoves": [
       "MOVE_CONFUSION",
@@ -5650,30 +8795,242 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_DARK_PULSE",
-      "MOVE_DRAGON_PULSE",
-      "MOVE_EARTHQUAKE",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
+      "MOVE_ROCK_SLIDE",
       "MOVE_FIRE_FANG",
-      "MOVE_FLASH_CANNON",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
       "MOVE_ICE_FANG",
-      "MOVE_IRON_DEFENSE",
-      "MOVE_IRON_HEAD",
       "MOVE_PROTECT",
-      "MOVE_ROCK_BLAST",
+      "MOVE_THUNDER_FANG",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
-      "MOVE_SELF_DESTRUCT",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_HYPER_BEAM",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_EARTH_POWER",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
       "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
       "MOVE_TAUNT",
-      "MOVE_THUNDER_FANG"
+      "MOVE_FACADE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_FISSURE",
+      "MOVE_METEOR_BEAM",
+      "MOVE_STEEL_BEAM"
     ],
     "TutorMoves": [
-      "MOVE_IRON_TAIL"
+      "MOVE_IRON_TAIL",
+      "MOVE_ROCK_BLAST"
     ],
+    "EggMoves": []
+  },
+  "QUILFISH": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_POISON_STING"
+      },
+      {
+        "Level": "4",
+        "Move": "MOVE_HARDEN"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_WATER_GUN"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_BUBBLE_BEAM"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_HAZE"
+      },
+      {
+        "Level": "17",
+        "Move": "MOVE_AQUA_JET"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_SPIKES"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_BARB_BARRAGE"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_POISON_JAB"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_PIN_MISSILE"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_TOXIC_SPIKES"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_TOXIC"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_GUNK_SHOT"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_TOXIC",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_FLIP_TURN",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_CRUNCH",
+      "MOVE_SWIFT",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_ENDURE",
+      "MOVE_WATER_PULSE",
+      "MOVE_MUD_SHOT",
+      "MOVE_AGILITY",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_ICY_WIND",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_WHIRLPOOL",
+      "MOVE_SURF",
+      "MOVE_SHADOW_BALL",
+      "MOVE_LIQUIDATION",
+      "MOVE_POISON_JAB",
+      "MOVE_SUBSTITUTE",
+      "MOVE_SPIKES",
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_CURSE",
+      "MOVE_TAUNT",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_GUNK_SHOT",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_ACID_SPRAY",
+      "MOVE_SCALE_SHOT"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "QWILFISH_HISUI": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_POISON_STING"
+      },
+      {
+        "Level": "4",
+        "Move": "MOVE_HARDEN"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_WATER_GUN"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_BUBBLE_BEAM"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_HAZE"
+      },
+      {
+        "Level": "17",
+        "Move": "MOVE_AQUA_JET"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_SPIKES"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_BARB_BARRAGE"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_POISON_JAB"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_PIN_MISSILE"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_TOXIC_SPIKES"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_TOXIC"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_GUNK_SHOT"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_TOXIC",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_CRUNCH",
+      "MOVE_SWIFT",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_ENDURE",
+      "MOVE_WATER_PULSE",
+      "MOVE_MUD_SHOT",
+      "MOVE_AGILITY",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_ICY_WIND",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_SURF",
+      "MOVE_SHADOW_BALL",
+      "MOVE_LIQUIDATION",
+      "MOVE_POISON_JAB",
+      "MOVE_SUBSTITUTE",
+      "MOVE_SPIKES",
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_TAUNT",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_GUNK_SHOT",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_ACID_SPRAY",
+      "MOVE_SCALE_SHOT"
+    ],
+    "TutorMoves": [],
     "EggMoves": []
   },
   "SCIZOR": {
@@ -5740,24 +9097,40 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
-      "MOVE_AGILITY",
       "MOVE_BRICK_BREAK",
-      "MOVE_CLOSE_COMBAT",
-      "MOVE_CURSE",
-      "MOVE_DOUBLE_EDGE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_SWIFT",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_NIGHT_SLASH",
       "MOVE_ENDURE",
-      "MOVE_FLASH_CANNON",
-      "MOVE_GIGA_IMPACT",
       "MOVE_HYPER_BEAM",
       "MOVE_KNOCK_OFF",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_NIGHT_SLASH",
-      "MOVE_PROTECT",
+      "MOVE_AGILITY",
       "MOVE_SAFEGUARD",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_X-SCISSOR",
+      "MOVE_U-TURN",
+      "MOVE_FLASH_CANNON",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_U_TURN"
+      "MOVE_CURSE",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_SILVER_WIND",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_DOUBLE_HIT",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_DUAL_CHOP",
+      "MOVE_RAZOR_WIND",
+      "MOVE_VACUUM_WAVE",
+      "MOVE_STEEL_BEAM"
     ],
     "TutorMoves": [
       "MOVE_BULLET_PUNCH"
@@ -5824,31 +9197,43 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_BULK_UP",
-      "MOVE_BULLDOZE",
-      "MOVE_BULLET_SEED",
-      "MOVE_CURSE",
-      "MOVE_DIG",
-      "MOVE_EARTHQUAKE",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
       "MOVE_HEADBUTT",
+      "MOVE_ROCK_SMASH",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_DIG",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_BULLET_SEED",
       "MOVE_HYPER_BEAM",
-      "MOVE_IRON_DEFENSE",
       "MOVE_KNOCK_OFF",
       "MOVE_MUD_SHOT",
-      "MOVE_NIGHT_SLASH",
-      "MOVE_OUTRAGE",
-      "MOVE_PROTECT",
-      "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_SMASH",
-      "MOVE_ROCK_TOMB",
+      "MOVE_GIGA_IMPACT",
       "MOVE_SHADOW_CLAW",
-      "MOVE_SPIKES",
       "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
       "MOVE_SUBSTITUTE",
-      "MOVE_WORK_UP"
+      "MOVE_SPIKES",
+      "MOVE_CURSE",
+      "MOVE_OUTRAGE",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_SILVER_WIND",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_CIRCLE_THROW",
+      "MOVE_SKULL_BASH",
+      "MOVE_VACUUM_WAVE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -5893,20 +9278,35 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
-      "MOVE_BODY_SLAM",
       "MOVE_BRICK_BREAK",
-      "MOVE_ENDURE",
-      "MOVE_FLY",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_GUNK_SHOT",
-      "MOVE_HYPER_BEAM",
       "MOVE_ICE_BEAM",
       "MOVE_PROTECT",
-      "MOVE_SPIKES",
-      "MOVE_SUBSTITUTE",
+      "MOVE_AERIAL_ACE",
+      "MOVE_ICE_PUNCH",
       "MOVE_SWIFT",
-      "MOVE_WATER_PULSE"
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_WATER_PULSE",
+      "MOVE_FLY",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_ICY_WIND",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_SPIKES",
+      "MOVE_GUNK_SHOT",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_TRAILBLAZE",
+      "MOVE_SEED_BOMB",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_FROST_BREATH",
+      "MOVE_FAKE_OUT",
+      "MOVE_TRIPLE_AXEL",
+      "MOVE_RAZOR_WIND",
+      "MOVE_ICICLE_SPEAR",
+      "MOVE_SHEER_COLD"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -5967,29 +9367,40 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
-      "MOVE_AGILITY",
-      "MOVE_CURSE",
-      "MOVE_DARK_PULSE",
-      "MOVE_DOUBLE_TEAM",
-      "MOVE_ENDURE",
-      "MOVE_FLASH_CANNON",
-      "MOVE_FLY",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HURRICANE",
-      "MOVE_HYPER_BEAM",
-      "MOVE_IRON_HEAD",
-      "MOVE_PROTECT",
       "MOVE_ROAR",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_STEALTH_ROCK",
-      "MOVE_SUBSTITUTE",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
       "MOVE_SWIFT",
       "MOVE_SWORDS_DANCE",
-      "MOVE_TAUNT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_FLY",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_IRON_HEAD",
+      "MOVE_HURRICANE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_X-SCISSOR",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_SPIKES",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
       "MOVE_WHIRLWIND",
-      "MOVE_X_SCISSOR"
+      "MOVE_TAUNT",
+      "MOVE_FACADE",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_SCALE_SHOT",
+      "MOVE_RAZOR_WIND",
+      "MOVE_SKULL_BASH",
+      "MOVE_SKY_ATTACK",
+      "MOVE_STEEL_BEAM"
     ],
     "TutorMoves": [
       "MOVE_AIR_SLASH"
@@ -6040,25 +9451,35 @@
       }
     ],
     "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_ROAR",
+      "MOVE_FIRE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_CRUNCH",
       "MOVE_BODY_SLAM",
-      "MOVE_DARK_PULSE",
-      "MOVE_DOUBLE_EDGE",
       "MOVE_ENDURE",
       "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_SPIN",
-      "MOVE_FLARE_BLITZ",
-      "MOVE_HEADBUTT",
-      "MOVE_HEAT_WAVE",
-      "MOVE_HYPER_VOICE",
       "MOVE_MUD_SHOT",
       "MOVE_OVERHEAT",
-      "MOVE_PROTECT",
-      "MOVE_SHADOW_BALL",
       "MOVE_SLUDGE_BOMB",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_WILL-O-WISP",
+      "MOVE_FLAMETHROWER",
       "MOVE_SOLAR_BEAM",
+      "MOVE_HEAT_WAVE",
+      "MOVE_HYPER_VOICE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_SHADOW_BALL",
+      "MOVE_NASTY_PLOT",
       "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
       "MOVE_TAUNT",
-      "MOVE_WILL_O_WISP"
+      "MOVE_FLARE_BLITZ",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_TORMENT",
+      "MOVE_PSYCHIC_FANGS"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -6119,27 +9540,142 @@
       }
     ],
     "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_ROAR",
+      "MOVE_TOXIC",
+      "MOVE_FIRE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_FANG",
+      "MOVE_CRUNCH",
       "MOVE_BODY_SLAM",
-      "MOVE_DOUBLE_EDGE",
       "MOVE_ENDURE",
       "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_SPIN",
-      "MOVE_FLARE_BLITZ",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HEADBUTT",
-      "MOVE_HEAT_WAVE",
       "MOVE_HYPER_BEAM",
-      "MOVE_HYPER_VOICE",
       "MOVE_MUD_SHOT",
-      "MOVE_PROTECT",
-      "MOVE_SHADOW_BALL",
+      "MOVE_OVERHEAT",
       "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_WILL-O-WISP",
+      "MOVE_FLAMETHROWER",
       "MOVE_SOLAR_BEAM",
+      "MOVE_HEAT_WAVE",
+      "MOVE_HYPER_VOICE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_SHADOW_BALL",
+      "MOVE_NASTY_PLOT",
       "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
       "MOVE_TAUNT",
-      "MOVE_THUNDER_FANG",
-      "MOVE_TOXIC",
-      "MOVE_WILL_O_WISP"
+      "MOVE_FLARE_BLITZ",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_TORMENT",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_DREAM_EATER",
+      "MOVE_SWAGGER"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "PORYGON2": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_CONVERSION"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_CHARGE"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_EERIE_IMPULSE"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_THUNDER_SHOCK"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_PSYBEAM"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_CONVERSION_2"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_AGILITY"
+      },
+      {
+        "Level": "35",
+        "Move": "MOVE_RECOVER"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_DISCHARGE"
+      },
+      {
+        "Level": "45",
+        "Move": "MOVE_METAL_SOUND"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_SELF_DESTRUCT"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_ZAP_CANNON"
+      },
+      {
+        "Level": "60",
+        "Move": "MOVE_HYPER_BEAM"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_PSYSHOCK",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_SWIFT",
+      "MOVE_REFLECT",
+      "MOVE_ENDURE",
+      "MOVE_DISCHARGE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_ICY_WIND",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_PSYCHIC",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_VOLT_SWITCH",
+      "MOVE_THUNDERBOLT",
+      "MOVE_SHADOW_BALL",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_ELECTROWEB",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_SKULL_BASH",
+      "MOVE_TRI_ATTACK"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -6196,26 +9732,33 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_BRICK_BREAK",
-      "MOVE_BULLDOZE",
-      "MOVE_CURSE",
-      "MOVE_DARK_PULSE",
-      "MOVE_DIG",
-      "MOVE_DOUBLE_EDGE",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
-      "MOVE_GIGA_IMPACT",
       "MOVE_HEADBUTT",
-      "MOVE_IRON_DEFENSE",
-      "MOVE_IRON_HEAD",
-      "MOVE_MUD_SHOT",
-      "MOVE_OUTRAGE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
       "MOVE_PROTECT",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
       "MOVE_STEALTH_ROCK",
+      "MOVE_HYPER_BEAM",
+      "MOVE_MUD_SHOT",
+      "MOVE_EARTH_POWER",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
       "MOVE_SUBSTITUTE",
-      "MOVE_TAUNT"
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_OUTRAGE",
+      "MOVE_TAUNT",
+      "MOVE_FACADE",
+      "MOVE_ANCIENT_POWER"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -6272,26 +9815,34 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
-      "MOVE_BODY_SLAM",
-      "MOVE_BRICK_BREAK",
-      "MOVE_BULLDOZE",
-      "MOVE_CURSE",
-      "MOVE_DARK_PULSE",
-      "MOVE_DIG",
-      "MOVE_DOUBLE_EDGE",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
-      "MOVE_GIGA_IMPACT",
       "MOVE_HEADBUTT",
-      "MOVE_IRON_HEAD",
-      "MOVE_MUD_SHOT",
-      "MOVE_OUTRAGE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
       "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
       "MOVE_STEALTH_ROCK",
+      "MOVE_HYPER_BEAM",
+      "MOVE_MUD_SHOT",
+      "MOVE_EARTH_POWER",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
       "MOVE_SUBSTITUTE",
-      "MOVE_TAUNT"
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_OUTRAGE",
+      "MOVE_TAUNT",
+      "MOVE_FACADE",
+      "MOVE_ANCIENT_POWER"
     ],
     "TutorMoves": [
       "MOVE_IRON_DEFENSE"
@@ -6358,48 +9909,1002 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
-      "MOVE_BLIZZARD",
-      "MOVE_BODY_SLAM",
-      "MOVE_BRICK_BREAK",
-      "MOVE_BULLDOZE",
-      "MOVE_CURSE",
-      "MOVE_DIG",
-      "MOVE_DOUBLE_EDGE",
-      "MOVE_DRAGON_CLAW",
-      "MOVE_DRAGON_PULSE",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_FANG",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FLAMETHROWER",
       "MOVE_HEADBUTT",
-      "MOVE_HYDRO_PUMP",
+      "MOVE_DRAGON_CLAW",
+      "MOVE_ROAR",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
       "MOVE_ICE_BEAM",
+      "MOVE_FIRE_FANG",
       "MOVE_ICE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_POWER_GEM",
+      "MOVE_THUNDER_FANG",
+      "MOVE_AERIAL_ACE",
+      "MOVE_THUNDER_PUNCH",
       "MOVE_ICE_PUNCH",
-      "MOVE_IRON_HEAD",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_FIRE_BLAST",
+      "MOVE_HYPER_BEAM",
       "MOVE_KNOCK_OFF",
       "MOVE_MUD_SHOT",
-      "MOVE_OUTRAGE",
-      "MOVE_POWER_GEM",
-      "MOVE_PROTECT",
-      "MOVE_ROAR",
-      "MOVE_ROCK_TOMB",
+      "MOVE_EARTH_POWER",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
       "MOVE_SHADOW_CLAW",
-      "MOVE_STEALTH_ROCK",
-      "MOVE_SUBSTITUTE",
-      "MOVE_TAUNT",
-      "MOVE_THUNDER",
+      "MOVE_FLAMETHROWER",
+      "MOVE_STONE_EDGE",
       "MOVE_THUNDERBOLT",
-      "MOVE_THUNDER_FANG",
-      "MOVE_THUNDER_PUNCH",
-      "MOVE_THUNDER_WAVE"
+      "MOVE_EARTHQUAKE",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_OUTRAGE",
+      "MOVE_TAUNT",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_SWAGGER",
+      "MOVE_MUDDY_WATER",
+      "MOVE_SCALE_SHOT"
     ],
     "TutorMoves": [
       "MOVE_DARK_PULSE",
       "MOVE_IRON_DEFENSE"
+    ],
+    "EggMoves": []
+  },
+  "TREECKO": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "3",
+        "Move": "MOVE_LEAFAGE"
+      },
+      {
+        "Level": "6",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "9",
+        "Move": "MOVE_ABSORB"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_DETECT"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_LEECH_SEED"
+      },
+      {
+        "Level": "21",
+        "Move": "MOVE_GIGA_DRAIN"
+      },
+      {
+        "Level": "27",
+        "Move": "MOVE_DRAGON_BREATH"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_DOUBLE_TEAM"
+      },
+      {
+        "Level": "33",
+        "Move": "MOVE_ENERGY_BALL"
+      },
+      {
+        "Level": "35",
+        "Move": "MOVE_SLASH"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_SCREECH"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_SYNTHESIS"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_LEAF_STORM"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_CRUNCH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_BODY_SLAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_BULLET_SEED",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_AGILITY",
+      "MOVE_SAFEGUARD",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_WORK_UP",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_SEED_BOMB",
+      "MOVE_DRAIN_PUNCH"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "GROVYLE": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "3",
+        "Move": "MOVE_LEAFAGE"
+      },
+      {
+        "Level": "6",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "9",
+        "Move": "MOVE_ABSORB"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_DETECT"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_LEECH_SEED"
+      },
+      {
+        "Level": "21",
+        "Move": "MOVE_GIGA_DRAIN"
+      },
+      {
+        "Level": "27",
+        "Move": "MOVE_DRAGON_BREATH"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_DOUBLE_TEAM"
+      },
+      {
+        "Level": "33",
+        "Move": "MOVE_ENERGY_BALL"
+      },
+      {
+        "Level": "35",
+        "Move": "MOVE_SLASH"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_SCREECH"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_SYNTHESIS"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_LEAF_STORM"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_DRAGON_CLAW",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_CRUNCH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_BODY_SLAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_BULLET_SEED",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_AGILITY",
+      "MOVE_SAFEGUARD",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_X-SCISSOR",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_WORK_UP",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_TRAILBLAZE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_SEED_BOMB",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_VACUUM_WAVE",
+      "MOVE_SOLAR_BLADE"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "SCEPTILE": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "3",
+        "Move": "MOVE_LEAFAGE"
+      },
+      {
+        "Level": "6",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "9",
+        "Move": "MOVE_ABSORB"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_DETECT"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_LEECH_SEED"
+      },
+      {
+        "Level": "21",
+        "Move": "MOVE_GIGA_DRAIN"
+      },
+      {
+        "Level": "27",
+        "Move": "MOVE_DRAGON_BREATH"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_DOUBLE_TEAM"
+      },
+      {
+        "Level": "33",
+        "Move": "MOVE_ENERGY_BALL"
+      },
+      {
+        "Level": "35",
+        "Move": "MOVE_SLASH"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_SCREECH"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_SYNTHESIS"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_LEAF_STORM"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_DRAGON_CLAW",
+      "MOVE_ROAR",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_CRUNCH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_BODY_SLAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_BULLET_SEED",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_SAFEGUARD",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_EARTHQUAKE",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_BULLDOZE",
+      "MOVE_X-SCISSOR",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_OUTRAGE",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_TRAILBLAZE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_SEED_BOMB",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_DUAL_CHOP",
+      "MOVE_SCALE_SHOT",
+      "MOVE_RAZOR_WIND",
+      "MOVE_VACUUM_WAVE",
+      "MOVE_SOLAR_BLADE",
+      "MOVE_FRENZY_PLANT"
+    ],
+    "TutorMoves": [
+      "MOVE_SHED_TAIL"
+    ],
+    "EggMoves": []
+  },
+  "TORCHIC": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_PECK"
+      },
+      {
+        "Level": "3",
+        "Move": "MOVE_EMBER"
+      },
+      {
+        "Level": "6",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "9",
+        "Move": "MOVE_FLAME_CHARGE"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_DETECT"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_AERIAL_ACE"
+      },
+      {
+        "Level": "21",
+        "Move": "MOVE_SLASH"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_BOUNCE"
+      },
+      {
+        "Level": "27",
+        "Move": "MOVE_FOCUS_ENERGY"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_FLAMETHROWER"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_FLARE_BLITZ"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_FIRE_BLAST",
+      "MOVE_AGILITY",
+      "MOVE_OVERHEAT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_WILL-O-WISP",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_FLAMETHROWER",
+      "MOVE_HEAT_WAVE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CURSE",
+      "MOVE_WORK_UP",
+      "MOVE_FLARE_BLITZ",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "COMBUSKEN": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_PECK"
+      },
+      {
+        "Level": "3",
+        "Move": "MOVE_EMBER"
+      },
+      {
+        "Level": "6",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "9",
+        "Move": "MOVE_FLAME_CHARGE"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_DETECT"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_AERIAL_ACE"
+      },
+      {
+        "Level": "21",
+        "Move": "MOVE_SLASH"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_BOUNCE"
+      },
+      {
+        "Level": "27",
+        "Move": "MOVE_FOCUS_ENERGY"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_FLAMETHROWER"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_FLARE_BLITZ"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_AERIAL_ACE",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_FIRE_BLAST",
+      "MOVE_AGILITY",
+      "MOVE_OVERHEAT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_WILL-O-WISP",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_FLAMETHROWER",
+      "MOVE_HEAT_WAVE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_POISON_JAB",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CURSE",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_FLARE_BLITZ",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_CIRCLE_THROW",
+      "MOVE_BLAZE_KICK",
+      "MOVE_DUAL_CHOP",
+      "MOVE_VACUUM_WAVE"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "BLAZIKEN": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_PECK"
+      },
+      {
+        "Level": "3",
+        "Move": "MOVE_EMBER"
+      },
+      {
+        "Level": "6",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "9",
+        "Move": "MOVE_FLAME_CHARGE"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_DETECT"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_AERIAL_ACE"
+      },
+      {
+        "Level": "21",
+        "Move": "MOVE_SLASH"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_BOUNCE"
+      },
+      {
+        "Level": "27",
+        "Move": "MOVE_FOCUS_ENERGY"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_FLAMETHROWER"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_FLARE_BLITZ"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ROAR",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_AERIAL_ACE",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_FIRE_BLAST",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_AGILITY",
+      "MOVE_OVERHEAT",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_WILL-O-WISP",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_FLAMETHROWER",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_STONE_EDGE",
+      "MOVE_HEAT_WAVE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_POISON_JAB",
+      "MOVE_BULLDOZE",
+      "MOVE_U-TURN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CURSE",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_FLARE_BLITZ",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_CIRCLE_THROW",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_BLAZE_KICK",
+      "MOVE_DUAL_CHOP",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_VACUUM_WAVE",
+      "MOVE_BLAST_BURN"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "MUDKIP": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "3",
+        "Move": "MOVE_WATER_GUN"
+      },
+      {
+        "Level": "6",
+        "Move": "MOVE_ROCK_SMASH"
+      },
+      {
+        "Level": "11",
+        "Move": "MOVE_ROCK_THROW"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_PROTECT"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_SUPERSONIC"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_BUBBLE_BEAM"
+      },
+      {
+        "Level": "26",
+        "Move": "MOVE_ROCK_SLIDE"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_AMNESIA"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_SURF"
+      },
+      {
+        "Level": "38",
+        "Move": "MOVE_SCREECH"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_SLUDGE_BOMB"
+      },
+      {
+        "Level": "46",
+        "Move": "MOVE_MUDDY_WATER"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_HYDRO_PUMP"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ROCK_SMASH",
+      "MOVE_ROAR",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_WATER_PULSE",
+      "MOVE_MUD_SHOT",
+      "MOVE_ICY_WIND",
+      "MOVE_EARTH_POWER",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_WHIRLPOOL",
+      "MOVE_SURF",
+      "MOVE_LIQUIDATION",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_CURSE",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_WORK_UP",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_MUDDY_WATER",
+      "MOVE_SCALD"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "MARSHTOMP": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "3",
+        "Move": "MOVE_WATER_GUN"
+      },
+      {
+        "Level": "6",
+        "Move": "MOVE_ROCK_SMASH"
+      },
+      {
+        "Level": "11",
+        "Move": "MOVE_ROCK_THROW"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_PROTECT"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_SUPERSONIC"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_BUBBLE_BEAM"
+      },
+      {
+        "Level": "26",
+        "Move": "MOVE_ROCK_SLIDE"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_AMNESIA"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_SURF"
+      },
+      {
+        "Level": "38",
+        "Move": "MOVE_SCREECH"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_SLUDGE_BOMB"
+      },
+      {
+        "Level": "46",
+        "Move": "MOVE_MUDDY_WATER"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_HYDRO_PUMP"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ROCK_SMASH",
+      "MOVE_ROAR",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_ICE_PUNCH",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_WATER_PULSE",
+      "MOVE_MUD_SHOT",
+      "MOVE_ICY_WIND",
+      "MOVE_EARTH_POWER",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_WHIRLPOOL",
+      "MOVE_SURF",
+      "MOVE_LIQUIDATION",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_CURSE",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_WORK_UP",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_MUDDY_WATER",
+      "MOVE_SCALD"
+    ],
+    "TutorMoves": [
+      "MOVE_SAND_TOMB"
+    ],
+    "EggMoves": []
+  },
+  "SWAMPERT": {
+    "LevelMoves": [
+       {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "3",
+        "Move": "MOVE_WATER_GUN"
+      },
+      {
+        "Level": "6",
+        "Move": "MOVE_ROCK_SMASH"
+      },
+      {
+        "Level": "11",
+        "Move": "MOVE_ROCK_THROW"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_PROTECT"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_SUPERSONIC"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_BUBBLE_BEAM"
+      },
+      {
+        "Level": "26",
+        "Move": "MOVE_ROCK_SLIDE"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_AMNESIA"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_SURF"
+      },
+      {
+        "Level": "38",
+        "Move": "MOVE_SCREECH"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_SLUDGE_BOMB"
+      },
+      {
+        "Level": "46",
+        "Move": "MOVE_MUDDY_WATER"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_HYDRO_PUMP"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ROCK_SMASH",
+      "MOVE_ROAR",
+      "MOVE_FLIP_TURN",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_ICE_PUNCH",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_WATER_PULSE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_MUD_SHOT",
+      "MOVE_ICY_WIND",
+      "MOVE_EARTH_POWER",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_WHIRLPOOL",
+      "MOVE_SURF",
+      "MOVE_LIQUIDATION",
+      "MOVE_POISON_JAB",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_CURSE",
+      "MOVE_OUTRAGE",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_MUDDY_WATER",
+      "MOVE_SCALD",
+      "MOVE_FISSURE",
+      "MOVE_HYDRO_CANNON"
+    ],
+    "TutorMoves": [
+      "MOVE_SAND_TOMB",
+      "MOVE_MUD_SHOT"
     ],
     "EggMoves": []
   },
@@ -6467,26 +10972,33 @@
       }
     ],
     "TMMoves": [
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_SWIFT",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_REFLECT",
+      "MOVE_DOUBLE_TEAM",
       "MOVE_BODY_SLAM",
       "MOVE_ENDURE",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_HYPER_VOICE",
-      "MOVE_ICE_PUNCH",
       "MOVE_ICY_WIND",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_METRONOME",
-      "MOVE_PROTECT",
-      "MOVE_PSYSHOCK",
-      "MOVE_REFLECT",
+      "MOVE_WILL-O-WISP",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_PSYCHIC",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HYPER_VOICE",
       "MOVE_SHADOW_BALL",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
       "MOVE_TAUNT",
-      "MOVE_THUNDERBOLT",
-      "MOVE_THUNDER_PUNCH",
-      "MOVE_THUNDER_WAVE",
-      "MOVE_WILL_O_WISP",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_METRONOME",
+      "MOVE_FACADE",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -6555,27 +11067,36 @@
       }
     ],
     "TMMoves": [
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_SWIFT",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_REFLECT",
+      "MOVE_DOUBLE_TEAM",
       "MOVE_BODY_SLAM",
       "MOVE_ENDURE",
-      "MOVE_FIRE_PUNCH",
       "MOVE_HYPER_BEAM",
-      "MOVE_HYPER_VOICE",
-      "MOVE_ICE_PUNCH",
       "MOVE_ICY_WIND",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_METRONOME",
-      "MOVE_PROTECT",
-      "MOVE_PSYSHOCK",
-      "MOVE_REFLECT",
+      "MOVE_WILL-O-WISP",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_PSYCHIC",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HYPER_VOICE",
       "MOVE_SHADOW_BALL",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
       "MOVE_TAUNT",
-      "MOVE_THUNDERBOLT",
-      "MOVE_THUNDER_PUNCH",
-      "MOVE_THUNDER_WAVE",
-      "MOVE_WILL_O_WISP",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_METRONOME",
+      "MOVE_FACADE",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_TRIPLE_AXEL",
+      "MOVE_VACUUM_WAVE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -6652,32 +11173,44 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AURA_SPHERE",
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_REFLECT",
+      "MOVE_DOUBLE_TEAM",
       "MOVE_BODY_SLAM",
       "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
       "MOVE_HYPER_BEAM",
-      "MOVE_HYPER_VOICE",
-      "MOVE_ICE_PUNCH",
       "MOVE_ICY_WIND",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_METRONOME",
-      "MOVE_PROTECT",
-      "MOVE_PSYSHOCK",
-      "MOVE_REFLECT",
       "MOVE_SAFEGUARD",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_WILL-O-WISP",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_PSYCHIC",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HYPER_VOICE",
       "MOVE_SHADOW_BALL",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
+      "MOVE_DAZZLING_GLEAM",
       "MOVE_TAUNT",
-      "MOVE_THUNDERBOLT",
-      "MOVE_THUNDER_PUNCH",
-      "MOVE_THUNDER_WAVE",
-      "MOVE_WILL_O_WISP",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_METRONOME",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_FACADE",
+      "MOVE_TORMENT",
+      "MOVE_MIMIC",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_SWAGGER",
+      "MOVE_TRIPLE_AXEL",
+      "MOVE_VACUUM_WAVE"
     ],
     "TutorMoves": [
       "MOVE_DAZZLING_GLEAM"
@@ -6752,38 +11285,52 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
-      "MOVE_BODY_SLAM",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
       "MOVE_BRICK_BREAK",
       "MOVE_BULK_UP",
-      "MOVE_CALM_MIND",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_POWER_GEM",
+      "MOVE_AERIAL_ACE",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_MUD_SHOT",
+      "MOVE_SAFEGUARD",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_WILL-O-WISP",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_PSYCHIC",
+      "MOVE_SHADOW_BALL",
+      "MOVE_POISON_JAB",
+      "MOVE_X-SCISSOR",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
       "MOVE_DARK_PULSE",
       "MOVE_DAZZLING_GLEAM",
-      "MOVE_DIG",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_GIGA_DRAIN",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HEAL_BLOCK",
-      "MOVE_HYPER_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_METRONOME",
-      "MOVE_MUD_SHOT",
-      "MOVE_NASTY_PLOT",
-      "MOVE_POISON_JAB",
-      "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
-      "MOVE_REFLECT",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SAFEGUARD",
-      "MOVE_SUBSTITUTE",
       "MOVE_TAUNT",
-      "MOVE_THUNDER_PUNCH",
-      "MOVE_THUNDER_WAVE",
-      "MOVE_WILL_O_WISP",
-      "MOVE_X_SCISSOR"
+      "MOVE_HEAL_BLOCK",
+      "MOVE_METRONOME",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_SHADOW_PUNCH",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_TORMENT",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_SWAGGER",
+      "MOVE_FAKE_OUT"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -6840,38 +11387,52 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
+      "MOVE_HEADBUTT",
+      "MOVE_ROCK_SMASH",
       "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_FIRE_FANG",
+      "MOVE_ICE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_THUNDER_FANG",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_CRUNCH",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_FIRE_BLAST",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_FLAMETHROWER",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_STONE_EDGE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
       "MOVE_DARK_PULSE",
       "MOVE_DAZZLING_GLEAM",
-      "MOVE_DOUBLE_EDGE",
-      "MOVE_DOUBLE_TEAM",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_FANG",
-      "MOVE_FLAMETHROWER",
-      "MOVE_FLASH_CANNON",
+      "MOVE_TAUNT",
       "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HEADBUTT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_ICE_BEAM",
-      "MOVE_ICE_FANG",
-      "MOVE_ICE_PUNCH",
-      "MOVE_POWER_UP_PUNCH",
-      "MOVE_PROTECT",
-      "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_SMASH",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SHADOW_BALL",
-      "MOVE_SLUDGE_BOMB",
-      "MOVE_SOLAR_BEAM",
-      "MOVE_STEALTH_ROCK",
-      "MOVE_STONE_EDGE",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SWORDS_DANCE",
-      "MOVE_THUNDER_FANG",
-      "MOVE_THUNDER_PUNCH"
+      "MOVE_FACADE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_POISON_FANG",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_SWAGGER",
+      "MOVE_STEEL_BEAM"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -6948,16 +11509,27 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_BULLDOZE",
+      "MOVE_HEADBUTT",
+      "MOVE_ROAR",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
       "MOVE_DIG",
-      "MOVE_EARTHQUAKE",
-      "MOVE_EARTH_POWER",
+      "MOVE_BODY_SLAM",
       "MOVE_ENDURE",
-      "MOVE_MUD_SHOT",
-      "MOVE_SHADOW_CLAW",
+      "MOVE_ROCK_TOMB",
       "MOVE_STEALTH_ROCK",
-      "MOVE_SUBSTITUTE"
+      "MOVE_MUD_SHOT",
+      "MOVE_EARTH_POWER",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_EARTHQUAKE",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_FACADE",
+      "MOVE_STEEL_BEAM"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -7034,17 +11606,28 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_BULLDOZE",
+      "MOVE_HEADBUTT",
+      "MOVE_ROAR",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
       "MOVE_DIG",
-      "MOVE_EARTHQUAKE",
-      "MOVE_EARTH_POWER",
+      "MOVE_BODY_SLAM",
       "MOVE_ENDURE",
-      "MOVE_MUD_SHOT",
-      "MOVE_SHADOW_CLAW",
+      "MOVE_ROCK_TOMB",
       "MOVE_STEALTH_ROCK",
+      "MOVE_MUD_SHOT",
+      "MOVE_EARTH_POWER",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_SHADOW_CLAW",
       "MOVE_STONE_EDGE",
-      "MOVE_SUBSTITUTE"
+      "MOVE_EARTHQUAKE",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_FACADE",
+      "MOVE_STEEL_BEAM"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -7121,40 +11704,57 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BLIZZARD",
-      "MOVE_BODY_SLAM",
-      "MOVE_BRICK_BREAK",
-      "MOVE_BULLDOZE",
-      "MOVE_CRUNCH",
-      "MOVE_DARK_PULSE",
-      "MOVE_DIG",
+      "MOVE_HEADBUTT",
       "MOVE_DRAGON_CLAW",
-      "MOVE_DRAGON_PULSE",
-      "MOVE_EARTHQUAKE",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FLAMETHROWER",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYDRO_PUMP",
-      "MOVE_HYPER_BEAM",
-      "MOVE_ICE_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_MUD_SHOT",
-      "MOVE_OUTRAGE",
-      "MOVE_SHADOW_CLAW",
-      "MOVE_SOLAR_BEAM",
-      "MOVE_STEALTH_ROCK",
-      "MOVE_STONE_EDGE",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
-      "MOVE_THUNDER",
-      "MOVE_THUNDERBOLT",
-      "MOVE_THUNDER_PUNCH",
+      "MOVE_ROAR",
       "MOVE_THUNDER_WAVE",
-      "MOVE_WHIRLPOOL"
+      "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_FIRE_BLAST",
+      "MOVE_HYPER_BEAM",
+      "MOVE_MUD_SHOT",
+      "MOVE_EARTH_POWER",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_FLAMETHROWER",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_STONE_EDGE",
+      "MOVE_THUNDERBOLT",
+      "MOVE_EARTHQUAKE",
+      "MOVE_WHIRLPOOL",
+      "MOVE_SURF",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_DARK_PULSE",
+      "MOVE_OUTRAGE",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_SWAGGER",
+      "MOVE_METEOR_BEAM",
+      "MOVE_STEEL_BEAM"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -7211,29 +11811,39 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
-      "MOVE_BODY_SLAM",
+      "MOVE_PSYSHOCK",
+      "MOVE_ROCK_SMASH",
+      "MOVE_CALM_MIND",
       "MOVE_BRICK_BREAK",
       "MOVE_BULK_UP",
-      "MOVE_CLOSE_COMBAT",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_ICE_PUNCH",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_METRONOME",
-      "MOVE_POISON_JAB",
-      "MOVE_POWER_UP_PUNCH",
-      "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
-      "MOVE_PSYSHOCK",
-      "MOVE_REFLECT",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SHADOW_BALL",
-      "MOVE_SUBSTITUTE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_AERIAL_ACE",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
       "MOVE_SWIFT",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_PSYCHIC",
+      "MOVE_SHADOW_BALL",
+      "MOVE_POISON_JAB",
+      "MOVE_SUBSTITUTE",
       "MOVE_TAUNT",
-      "MOVE_THUNDER_PUNCH"
+      "MOVE_METRONOME",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_TRAILBLAZE",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_FAKE_OUT"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -7294,28 +11904,45 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
-      "MOVE_BODY_SLAM",
+      "MOVE_PSYSHOCK",
+      "MOVE_ROCK_SMASH",
+      "MOVE_CALM_MIND",
       "MOVE_BRICK_BREAK",
       "MOVE_BULK_UP",
-      "MOVE_CLOSE_COMBAT",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_METRONOME",
-      "MOVE_POISON_JAB",
-      "MOVE_POWER_UP_PUNCH",
-      "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
-      "MOVE_PSYSHOCK",
-      "MOVE_REFLECT",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SHADOW_BALL",
-      "MOVE_SUBSTITUTE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_AERIAL_ACE",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
       "MOVE_SWIFT",
-      "MOVE_TAUNT"
+      "MOVE_FIRE_PUNCH",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_PSYCHIC",
+      "MOVE_SHADOW_BALL",
+      "MOVE_POISON_JAB",
+      "MOVE_SUBSTITUTE",
+      "MOVE_TAUNT",
+      "MOVE_METRONOME",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_TRAILBLAZE",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_BLAZE_KICK",
+      "MOVE_FAKE_OUT",
+      "MOVE_VACUUM_WAVE"
     ],
     "TutorMoves": [
       "MOVE_FIRE_PUNCH",
@@ -7388,21 +12015,29 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
-      "MOVE_BODY_SLAM",
-      "MOVE_CRUNCH",
-      "MOVE_CURSE",
-      "MOVE_DISCHARGE",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_FANG",
-      "MOVE_FLAMETHROWER",
       "MOVE_HEADBUTT",
+      "MOVE_ROAR",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_FIRE_FANG",
       "MOVE_ICE_FANG",
       "MOVE_LIGHT_SCREEN",
       "MOVE_PROTECT",
-      "MOVE_SUBSTITUTE",
+      "MOVE_THUNDER_FANG",
+      "MOVE_CRUNCH",
       "MOVE_SWIFT",
-      "MOVE_VOLT_SWITCH"
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_DISCHARGE",
+      "MOVE_AGILITY",
+      "MOVE_FLAMETHROWER",
+      "MOVE_VOLT_SWITCH",
+      "MOVE_THUNDERBOLT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WILD_CHARGE",
+      "MOVE_CURSE",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_PSYCHIC_FANGS"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -7475,24 +12110,37 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
-      "MOVE_BODY_SLAM",
-      "MOVE_CRUNCH",
-      "MOVE_CURSE",
-      "MOVE_DISCHARGE",
-      "MOVE_ENDURE",
-      "MOVE_FLAMETHROWER",
-      "MOVE_GIGA_IMPACT",
       "MOVE_HEADBUTT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_HYPER_VOICE",
+      "MOVE_ROAR",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_FIRE_FANG",
       "MOVE_ICE_FANG",
       "MOVE_LIGHT_SCREEN",
-      "MOVE_OVERHEAT",
       "MOVE_PROTECT",
-      "MOVE_SUBSTITUTE",
+      "MOVE_THUNDER_FANG",
+      "MOVE_CRUNCH",
       "MOVE_SWIFT",
-      "MOVE_VOLT_SWITCH"
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_DISCHARGE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_OVERHEAT",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_FLAMETHROWER",
+      "MOVE_VOLT_SWITCH",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WILD_CHARGE",
+      "MOVE_CURSE",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_RAZOR_WIND"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -7561,24 +12209,225 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_BULLET_SEED",
-      "MOVE_DAZZLING_GLEAM",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_MUD_SHOT",
+      "MOVE_TOXIC",
       "MOVE_PROTECT",
-      "MOVE_SHADOW_BALL",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_BULLET_SEED",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_MUD_SHOT",
       "MOVE_SLUDGE_BOMB",
       "MOVE_SOLAR_BEAM",
-      "MOVE_SPIKES",
+      "MOVE_SHADOW_BALL",
+      "MOVE_POISON_JAB",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_SWORDS_DANCE"
+      "MOVE_SPIKES",
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_FACADE",
+      "MOVE_SEED_BOMB",
+      "MOVE_PETAL_DANCE"
     ],
     "TutorMoves": [
       "MOVE_POISON_STING"
     ],
+    "EggMoves": []
+  },
+  "GULPIN": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_SMOKESCREEN"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_AMNESIA"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_ACID_ARMOR"
+      },
+      {
+        "Level": "17",
+        "Move": "MOVE_POISON_JAB"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_KNOCK_OFF"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_ROLLOUT"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_BODY_SLAM"
+      },
+      {
+        "Level": "35",
+        "Move": "MOVE_TOXIC"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_SLUDGE_BOMB"
+      },
+      {
+        "Level": "49",
+        "Move": "MOVE_GUNK_SHOT"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_SLUDGE_WAVE"
+      },
+      {
+        "Level": "60",
+        "Move": "MOVE_EXPLOSION"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_TOXIC",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_BULLET_SEED",
+      "MOVE_WATER_PULSE",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_KNOCK_OFF",
+      "MOVE_MUD_SHOT",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_SHADOW_BALL",
+      "MOVE_POISON_JAB",
+      "MOVE_SUBSTITUTE",
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_CURSE",
+      "MOVE_GUNK_SHOT",
+      "MOVE_FACADE",
+      "MOVE_SING",
+      "MOVE_ACID_SPRAY",
+      "MOVE_DREAM_EATER",
+      "MOVE_SEED_BOMB"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "SWALOT": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_SMOKESCREEN"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_AMNESIA"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_ACID_ARMOR"
+      },
+      {
+        "Level": "17",
+        "Move": "MOVE_POISON_JAB"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_KNOCK_OFF"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_ROLLOUT"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_BODY_SLAM"
+      },
+      {
+        "Level": "35",
+        "Move": "MOVE_TOXIC"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_SLUDGE_BOMB"
+      },
+      {
+        "Level": "49",
+        "Move": "MOVE_GUNK_SHOT"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_SLUDGE_WAVE"
+      },
+      {
+        "Level": "60",
+        "Move": "MOVE_EXPLOSION"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_TOXIC",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_BULLET_SEED",
+      "MOVE_WATER_PULSE",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_MUD_SHOT",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_EARTHQUAKE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_POISON_JAB",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_CURSE",
+      "MOVE_METRONOME",
+      "MOVE_GUNK_SHOT",
+      "MOVE_FACADE",
+      "MOVE_SING",
+      "MOVE_ACID_SPRAY",
+      "MOVE_DREAM_EATER",
+      "MOVE_SEED_BOMB"
+    ],
+    "TutorMoves": [],
     "EggMoves": []
   },
   "CARVANHA": {
@@ -7629,22 +12478,33 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
-      "MOVE_BLIZZARD",
-      "MOVE_DARK_PULSE",
-      "MOVE_ENDURE",
-      "MOVE_HYDRO_PUMP",
+      "MOVE_FLIP_TURN",
       "MOVE_ICE_BEAM",
       "MOVE_ICE_FANG",
-      "MOVE_ICY_WIND",
       "MOVE_PROTECT",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
+      "MOVE_CRUNCH",
       "MOVE_SWIFT",
-      "MOVE_TAUNT",
-      "MOVE_WATERFALL",
+      "MOVE_ENDURE",
+      "MOVE_AGILITY",
+      "MOVE_ICY_WIND",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_ZEN_HEADBUTT",
       "MOVE_WHIRLPOOL",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_SURF",
+      "MOVE_LIQUIDATION",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_TAUNT",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_POISON_FANG",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_SWAGGER",
+      "MOVE_SCALE_SHOT",
+      "MOVE_SCALD"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -7705,27 +12565,41 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BLIZZARD",
-      "MOVE_CLOSE_COMBAT",
-      "MOVE_DARK_PULSE",
-      "MOVE_EARTHQUAKE",
-      "MOVE_ENDURE",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYDRO_PUMP",
-      "MOVE_HYPER_BEAM",
+      "MOVE_FLIP_TURN",
       "MOVE_ICE_BEAM",
       "MOVE_ICE_FANG",
-      "MOVE_ICY_WIND",
-      "MOVE_POISON_JAB",
       "MOVE_PROTECT",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
+      "MOVE_CRUNCH",
       "MOVE_SWIFT",
-      "MOVE_TAUNT",
-      "MOVE_WATERFALL",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_ICY_WIND",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_EARTHQUAKE",
       "MOVE_WHIRLPOOL",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_SURF",
+      "MOVE_LIQUIDATION",
+      "MOVE_POISON_JAB",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_TAUNT",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_BLIZZARD",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_POISON_FANG",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_SWAGGER",
+      "MOVE_SCALE_SHOT",
+      "MOVE_SKULL_BASH",
+      "MOVE_SCALD"
     ],
     "TutorMoves": [
       "MOVE_SLASH"
@@ -7792,26 +12666,37 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_DIG",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_SPIN",
-      "MOVE_FLARE_BLITZ",
-      "MOVE_FLASH_CANNON",
       "MOVE_HEADBUTT",
-      "MOVE_HEAT_WAVE",
-      "MOVE_IRON_HEAD",
-      "MOVE_OVERHEAT",
-      "MOVE_PROTECT",
       "MOVE_ROAR",
       "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
       "MOVE_STEALTH_ROCK",
+      "MOVE_FIRE_BLAST",
+      "MOVE_OVERHEAT",
+      "MOVE_EARTH_POWER",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_WILL-O-WISP",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FLAMETHROWER",
       "MOVE_STONE_EDGE",
+      "MOVE_HEAT_WAVE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_BULLDOZE",
+      "MOVE_FLASH_CANNON",
       "MOVE_SUBSTITUTE",
-      "MOVE_WILL_O_WISP",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_CURSE",
+      "MOVE_FLARE_BLITZ",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_SCORCHING_SANDS"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -7876,32 +12761,240 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_DIG",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_SPIN",
-      "MOVE_FLARE_BLITZ",
-      "MOVE_FLASH_CANNON",
-      "MOVE_GIGA_IMPACT",
       "MOVE_HEADBUTT",
-      "MOVE_HEAT_WAVE",
-      "MOVE_HYPER_BEAM",
-      "MOVE_IRON_HEAD",
-      "MOVE_OVERHEAT",
-      "MOVE_PROTECT",
       "MOVE_ROAR",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
-      "MOVE_SELF_DESTRUCT",
       "MOVE_STEALTH_ROCK",
+      "MOVE_FIRE_BLAST",
+      "MOVE_HYPER_BEAM",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_OVERHEAT",
+      "MOVE_EARTH_POWER",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_WILL-O-WISP",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FLAMETHROWER",
       "MOVE_STONE_EDGE",
+      "MOVE_HEAT_WAVE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_BULLDOZE",
+      "MOVE_FLASH_CANNON",
       "MOVE_SUBSTITUTE",
-      "MOVE_WILL_O_WISP",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_CURSE",
+      "MOVE_FLARE_BLITZ",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_FISSURE"
     ],
     "TutorMoves": [
       "MOVE_ROCK_SLIDE"
     ],
+    "EggMoves": []
+  },
+  "SPOINK": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_SPLASH"
+      },
+      {
+        "Level": "7",
+        "Move": "MOVE_CONFUSION"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_PSYBEAM"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_HYPNOSIS"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_WHIRLWIND"
+      },
+      {
+        "Level": "29",
+        "Move": "MOVE_POWER_GEM"
+      },
+      {
+        "Level": "33",
+        "Move": "MOVE_AMNESIA"
+      },
+      {
+        "Level": "38",
+        "Move": "MOVE_PSYSHOCK"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_PSYCHIC"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_BOUNCE"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_FUTURE_SIGHT"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_POWER_GEM",
+      "MOVE_SWIFT",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_MUD_SHOT",
+      "MOVE_ICY_WIND",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_PSYCHIC",
+      "MOVE_SHADOW_BALL",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_WHIRLWIND",
+      "MOVE_TAUNT",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_TRAILBLAZE",
+      "MOVE_PAY_DAY",
+      "MOVE_SHADOW_PUNCH",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "GRUMPIG": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_SPLASH"
+      },
+      {
+        "Level": "7",
+        "Move": "MOVE_CONFUSION"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_PSYBEAM"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_HYPNOSIS"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_WHIRLWIND"
+      },
+      {
+        "Level": "29",
+        "Move": "MOVE_POWER_GEM"
+      },
+      {
+        "Level": "33",
+        "Move": "MOVE_AMNESIA"
+      },
+      {
+        "Level": "38",
+        "Move": "MOVE_PSYSHOCK"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_PSYCHIC"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_BOUNCE"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_FUTURE_SIGHT"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_POWER_GEM",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_MUD_SHOT",
+      "MOVE_ICY_WIND",
+      "MOVE_EARTH_POWER",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_PSYCHIC",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_BULLDOZE",
+      "MOVE_NASTY_PLOT",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_WHIRLWIND",
+      "MOVE_TAUNT",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_METRONOME",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_LOW_SWEEP",
+      "MOVE_TRAILBLAZE",
+      "MOVE_PAY_DAY",
+      "MOVE_SHADOW_PUNCH",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_DREAM_EATER",
+      "MOVE_SEED_BOMB",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_DRAIN_PUNCH"
+    ],
+    "TutorMoves": [],
     "EggMoves": []
   },
   "SWABLU": {
@@ -7964,23 +13057,29 @@
       }
     ],
     "TMMoves": [
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
       "MOVE_AERIAL_ACE",
-      "MOVE_AGILITY",
+      "MOVE_SWIFT",
       "MOVE_BODY_SLAM",
-      "MOVE_DAZZLING_GLEAM",
-      "MOVE_DRAGON_PULSE",
       "MOVE_ENDURE",
       "MOVE_FLY",
-      "MOVE_HEAT_WAVE",
-      "MOVE_HURRICANE",
-      "MOVE_HYPER_VOICE",
-      "MOVE_ICE_BEAM",
-      "MOVE_OUTRAGE",
-      "MOVE_PLAY_ROUGH",
-      "MOVE_PROTECT",
+      "MOVE_AGILITY",
+      "MOVE_SAFEGUARD",
       "MOVE_SOLAR_BEAM",
+      "MOVE_HEAT_WAVE",
+      "MOVE_HYPER_VOICE",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_HURRICANE",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT"
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_OUTRAGE",
+      "MOVE_FACADE",
+      "MOVE_SING",
+      "MOVE_TRAILBLAZE",
+      "MOVE_DREAM_EATER",
+      "MOVE_DUAL_WINGBEAT"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -8045,36 +13144,510 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
-      "MOVE_AGILITY",
-      "MOVE_BODY_SLAM",
-      "MOVE_BULLDOZE",
-      "MOVE_DAZZLING_GLEAM",
-      "MOVE_DRACO_METEOR",
       "MOVE_DRAGON_CLAW",
-      "MOVE_EARTHQUAKE",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_SPIN",
-      "MOVE_FLAMETHROWER",
-      "MOVE_FLY",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HEAT_WAVE",
-      "MOVE_HURRICANE",
-      "MOVE_HYPER_BEAM",
-      "MOVE_HYPER_VOICE",
-      "MOVE_ICE_BEAM",
-      "MOVE_OUTRAGE",
-      "MOVE_PLAY_ROUGH",
-      "MOVE_PROTECT",
       "MOVE_ROAR",
-      "MOVE_SOLAR_BEAM",
-      "MOVE_SUBSTITUTE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_AERIAL_ACE",
       "MOVE_SWIFT",
-      "MOVE_WILL_O_WISP"
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_FLY",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_SAFEGUARD",
+      "MOVE_DRACO_METEOR",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_WILL-O-WISP",
+      "MOVE_FLAMETHROWER",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_HEAT_WAVE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_HYPER_VOICE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_BULLDOZE",
+      "MOVE_HURRICANE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_OUTRAGE",
+      "MOVE_FACADE",
+      "MOVE_SING",
+      "MOVE_TRAILBLAZE",
+      "MOVE_SILVER_WIND",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_DREAM_EATER",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_PETAL_DANCE",
+      "MOVE_SKY_ATTACK"
     ],
     "TutorMoves": [
       "MOVE_DRAGON_PULSE"
     ],
+    "EggMoves": []
+  },
+  "ZANGOOSE": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "5",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_METAL_CLAW"
+      },
+      {
+        "Level": "19",
+        "Move": "MOVE_SLASH"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_NIGHT_SLASH"
+      },
+      {
+        "Level": "29",
+        "Move": "MOVE_FALSE_SWIPE"
+      },
+      {
+        "Level": "33",
+        "Move": "MOVE_DIG"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_DETECT"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_X_SCISSOR"
+      },
+      {
+        "Level": "43",
+        "Move": "MOVE_TAUNT"
+      },
+      {
+        "Level": "47",
+        "Move": "MOVE_SWORDS_DANCE"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_CLOSE_COMBAT"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_ROAR",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_FIRE_BLAST",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_AGILITY",
+      "MOVE_ICY_WIND",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_FLAMETHROWER",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_THUNDERBOLT",
+      "MOVE_SURF",
+      "MOVE_SHADOW_BALL",
+      "MOVE_POISON_JAB",
+      "MOVE_X-SCISSOR",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_CURSE",
+      "MOVE_TAUNT",
+      "MOVE_GUNK_SHOT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_SEED_BOMB",
+      "MOVE_DOUBLE_HIT",
+      "MOVE_FAKE_OUT",
+      "MOVE_RAZOR_WIND",
+      "MOVE_SKULL_BASH"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "SEVIPER": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_LICK"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "6",
+        "Move": "MOVE_LICK"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_SCREECH"
+      },
+      {
+        "Level": "17",
+        "Move": "MOVE_SNARL"
+      },
+      {
+        "Level": "19",
+        "Move": "MOVE_GLARE"
+      },
+      {
+        "Level": "21",
+        "Move": "MOVE_POISON_FANG"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_BREAKING_SWIPE"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_NIGHT_SLASH"
+      },
+      {
+        "Level": "31",
+        "Move": "MOVE_POISON_JAB"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_HAZE"
+      },
+      {
+        "Level": "39",
+        "Move": "MOVE_CRUNCH"
+      },
+      {
+        "Level": "46",
+        "Move": "MOVE_SLUDGE_BOMB"
+      },
+      {
+        "Level": "52",
+        "Move": "MOVE_GUNK_SHOT"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_TOXIC",
+      "MOVE_BRICK_BREAK",
+      "MOVE_FIRE_FANG",
+      "MOVE_ICE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_FANG",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FLAMETHROWER",
+      "MOVE_EARTHQUAKE",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_POISON_JAB",
+      "MOVE_BULLDOZE",
+      "MOVE_X-SCISSOR",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_TAUNT",
+      "MOVE_GUNK_SHOT",
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_TRAILBLAZE",
+      "MOVE_POISON_FANG",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_SEED_BOMB",
+      "MOVE_SWAGGER",
+      "MOVE_SCALE_SHOT"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "FEEBAS": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_SPLASH"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_TACKLE"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ICE_BEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_SWIFT",
+      "MOVE_ENDURE",
+      "MOVE_WATER_PULSE",
+      "MOVE_MUD_SHOT",
+      "MOVE_ICY_WIND",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_WHIRLPOOL",
+      "MOVE_SURF",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_WATERFALL",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_MUDDY_WATER",
+      "MOVE_SCALE_SHOT",
+      "MOVE_SCALD"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "MILOTIC": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_WATER_GUN"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_SPLASH"
+      },
+      {
+        "Level": "4",
+        "Move": "MOVE_DISARMING_VOICE"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_TWISTER"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_AQUA_RING"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_WHIRLPOOL"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_BREAKING_SWIPE"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_DRAINING_KISS"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_HYPNOSIS"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_RECOVER"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_SAFEGUARD"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_SURF"
+      },
+      {
+        "Level": "52",
+        "Move": "MOVE_HYDRO_PUMP"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_CALM_MIND",
+      "MOVE_FLIP_TURN",
+      "MOVE_ICE_BEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_SWIFT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_WATER_PULSE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_MUD_SHOT",
+      "MOVE_ICY_WIND",
+      "MOVE_SAFEGUARD",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_WHIRLPOOL",
+      "MOVE_SURF",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_LIQUIDATION",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_MIMIC",
+      "MOVE_MUDDY_WATER",
+      "MOVE_SCALE_SHOT",
+      "MOVE_TRIPLE_AXEL",
+      "MOVE_SCALD"
+    ],
+    "TutorMoves": [
+      "MOVE_WATER_PULSE",
+      "MOVE_MIST",
+      "MOVE_HAZE"
+    ],
+    "EggMoves": []
+  },
+  "KECLEON": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TAIL_WHIP"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_LICK"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_CONVERSION"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_SUBSTITUTE"
+      },
+      {
+        "Level": "7",
+        "Move": "MOVE_SHADOW_SNEAK"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_SHED_TAIL"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_KNOCK_OFF"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_PSYBEAM"
+      },
+      {
+        "Level": "21",
+        "Move": "MOVE_ROCK_SLIDE"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_SLASH"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_STEALTH_ROCK"
+      },
+      {
+        "Level": "33",
+        "Move": "MOVE_SHADOW_CLAW"
+      },
+      {
+        "Level": "38",
+        "Move": "MOVE_SCREECH"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_CONVERSION_2"
+      },
+      {
+        "Level": "53",
+        "Move": "MOVE_POWER_WHIP"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_AERIAL_ACE",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_FIRE_BLAST",
+      "MOVE_KNOCK_OFF",
+      "MOVE_ICY_WIND",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_FLAMETHROWER",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_THUNDERBOLT",
+      "MOVE_SHADOW_BALL",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_METRONOME",
+      "MOVE_WORK_UP",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_FAKE_OUT",
+      "MOVE_FIRST_IMPRESSION",
+      "MOVE_SCALE_SHOT"
+    ],
+    "TutorMoves": [],
     "EggMoves": []
   },
   "SHUPPET": {
@@ -8129,22 +13702,32 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_CALM_MIND",
-      "MOVE_DARK_PULSE",
-      "MOVE_DAZZLING_GLEAM",
-      "MOVE_ENDURE",
       "MOVE_HEADBUTT",
-      "MOVE_METRONOME",
-      "MOVE_NASTY_PLOT",
-      "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
-      "MOVE_SUBSTITUTE",
-      "MOVE_TAUNT",
-      "MOVE_THUNDER",
-      "MOVE_THUNDERBOLT",
+      "MOVE_CALM_MIND",
       "MOVE_THUNDER_WAVE",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_PROTECT",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_KNOCK_OFF",
+      "MOVE_WILL-O-WISP",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_PSYCHIC",
+      "MOVE_THUNDERBOLT",
+      "MOVE_SHADOW_BALL",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_TAUNT",
+      "MOVE_METRONOME",
+      "MOVE_GUNK_SHOT",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -8205,31 +13788,150 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_CALM_MIND",
-      "MOVE_DARK_PULSE",
-      "MOVE_DAZZLING_GLEAM",
-      "MOVE_ENDURE",
-      "MOVE_GIGA_IMPACT",
       "MOVE_HEADBUTT",
-      "MOVE_HEAL_BLOCK",
-      "MOVE_HYPER_BEAM",
-      "MOVE_METRONOME",
-      "MOVE_NASTY_PLOT",
-      "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
-      "MOVE_SUBSTITUTE",
-      "MOVE_TAUNT",
-      "MOVE_THUNDER",
-      "MOVE_THUNDERBOLT",
+      "MOVE_CALM_MIND",
       "MOVE_THUNDER_WAVE",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_PROTECT",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_WILL-O-WISP",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_PSYCHIC",
+      "MOVE_THUNDERBOLT",
+      "MOVE_SHADOW_BALL",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_TAUNT",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_METRONOME",
+      "MOVE_GUNK_SHOT",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_SHADOW_PUNCH",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_TORMENT",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_SWAGGER",
+      "MOVE_RAZOR_WIND",
+      "MOVE_ICICLE_SPEAR",
+      "MOVE_VACUUM_WAVE"
     ],
     "TutorMoves": [],
     "EggMoves": []
   },
+  "CHIMECHO": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "7",
+        "Move": "MOVE_CONFUSION"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_DISARMING_VOICE"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_SUPERSONIC"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_SCREECH"
+      },
+      {
+        "Level": "23",
+        "Move": "MOVE_AMNESIA"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_WISH"
+      },
+      {
+        "Level": "29",
+        "Move": "MOVE_METAL_SOUND"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_PSYCHIC"
+      },
+      {
+        "Level": "38",
+        "Move": "MOVE_DOUBLE_EDGE"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_BOOMBURST"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_REFLECT",
+      "MOVE_ENDURE",
+      "MOVE_WATER_PULSE",
+      "MOVE_KNOCK_OFF",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_ICY_WIND",
+      "MOVE_SAFEGUARD",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_PSYCHIC",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CURSE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_TAUNT",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_FACADE",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_METEOR_BEAM"
+    ],
+    "TutorMoves": [
+      "MOVE_PSYBEAM"
+    ],
+    "EggMoves": []
+  },
   "ABSOL": {
     "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_SHADOW_SNEAK"
+      },
       {
         "Level": "1",
         "Move": "MOVE_LEER"
@@ -8288,35 +13990,49 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
-      "MOVE_BLIZZARD",
-      "MOVE_BODY_SLAM",
       "MOVE_CALM_MIND",
-      "MOVE_CLOSE_COMBAT",
-      "MOVE_DARK_PULSE",
-      "MOVE_DOUBLE_EDGE",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_BLAST",
-      "MOVE_FLAMETHROWER",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_ICE_BEAM",
-      "MOVE_PLAY_ROUGH",
-      "MOVE_PROTECT",
-      "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SHADOW_BALL",
-      "MOVE_STONE_EDGE",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_THUNDER",
-      "MOVE_THUNDERBOLT",
       "MOVE_THUNDER_WAVE",
-      "MOVE_WILL_O_WISP",
-      "MOVE_X_SCISSOR",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_AERIAL_ACE",
+      "MOVE_SWIFT",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_BODY_SLAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_FIRE_BLAST",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_WILL-O-WISP",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_FLAMETHROWER",
+      "MOVE_STONE_EDGE",
+      "MOVE_THUNDERBOLT",
+      "MOVE_SHADOW_BALL",
+      "MOVE_X-SCISSOR",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_TAUNT",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_RAZOR_WIND"
     ],
-    "TutorMoves": [],
+    "TutorMoves": [    
+      "MOVE_SNARL",
+      "MOVE_PHANTOM_FORCE"
+      ],
     "EggMoves": []
   },
   "SNORUNT": {
@@ -8371,14 +14087,26 @@
       }
     ],
     "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_ICE_BEAM",
+      "MOVE_ICE_FANG",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_CRUNCH",
+      "MOVE_DOUBLE_TEAM",
       "MOVE_BODY_SLAM",
       "MOVE_ENDURE",
-      "MOVE_ICE_BEAM",
-      "MOVE_LIGHT_SCREEN",
+      "MOVE_WATER_PULSE",
+      "MOVE_ICY_WIND",
       "MOVE_SHADOW_BALL",
-      "MOVE_SPIKES",
       "MOVE_SUBSTITUTE",
-      "MOVE_WATER_PULSE"
+      "MOVE_SPIKES",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_TRAILBLAZE",
+      "MOVE_FROST_BREATH",
+      "MOVE_ICICLE_SPEAR"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -8439,20 +14167,35 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_DARK_PULSE",
-      "MOVE_EARTHQUAKE",
-      "MOVE_ENDURE",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
+      "MOVE_HEADBUTT",
       "MOVE_ICE_BEAM",
-      "MOVE_IRON_HEAD",
+      "MOVE_ICE_FANG",
       "MOVE_LIGHT_SCREEN",
-      "MOVE_SELF_DESTRUCT",
+      "MOVE_PROTECT",
+      "MOVE_CRUNCH",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_WATER_PULSE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_ICY_WIND",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_IRON_HEAD",
+      "MOVE_EARTHQUAKE",
       "MOVE_SHADOW_BALL",
-      "MOVE_SPIKES",
       "MOVE_SUBSTITUTE",
-      "MOVE_WATER_PULSE"
+      "MOVE_SPIKES",
+      "MOVE_DARK_PULSE",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_TRAILBLAZE",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_FROST_BREATH",
+      "MOVE_SKULL_BASH",
+      "MOVE_ICICLE_SPEAR",
+      "MOVE_SHEER_COLD"
     ],
     "TutorMoves": [
       "MOVE_FREEZE_DRY"
@@ -8511,25 +14254,33 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_BRICK_BREAK",
-      "MOVE_DRACO_METEOR",
-      "MOVE_DRAGON_PULSE",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_FANG",
-      "MOVE_FIRE_SPIN",
-      "MOVE_HYDRO_PUMP",
-      "MOVE_HYPER_VOICE",
-      "MOVE_IRON_DEFENSE",
-      "MOVE_IRON_HEAD",
-      "MOVE_PROTECT",
+      "MOVE_HEADBUTT",
+      "MOVE_DRAGON_CLAW",
       "MOVE_ROAR",
+      "MOVE_BRICK_BREAK",
       "MOVE_ROCK_SLIDE",
+      "MOVE_FIRE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_FANG",
+      "MOVE_CRUNCH",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
+      "MOVE_FIRE_BLAST",
+      "MOVE_DRACO_METEOR",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
       "MOVE_SHADOW_CLAW",
+      "MOVE_FLAMETHROWER",
+      "MOVE_HYPER_VOICE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_IRON_DEFENSE",
       "MOVE_SUBSTITUTE",
-      "MOVE_THUNDER_FANG"
+      "MOVE_OUTRAGE",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_FACADE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -8586,24 +14337,33 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_BRICK_BREAK",
-      "MOVE_DRACO_METEOR",
-      "MOVE_DRAGON_PULSE",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_FANG",
-      "MOVE_FIRE_SPIN",
-      "MOVE_HYDRO_PUMP",
-      "MOVE_HYPER_VOICE",
-      "MOVE_IRON_DEFENSE",
-      "MOVE_IRON_HEAD",
+      "MOVE_HEADBUTT",
+      "MOVE_DRAGON_CLAW",
       "MOVE_ROAR",
+      "MOVE_BRICK_BREAK",
       "MOVE_ROCK_SLIDE",
+      "MOVE_FIRE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_FANG",
+      "MOVE_CRUNCH",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
+      "MOVE_FIRE_BLAST",
+      "MOVE_DRACO_METEOR",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
       "MOVE_SHADOW_CLAW",
+      "MOVE_FLAMETHROWER",
+      "MOVE_HYPER_VOICE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_IRON_DEFENSE",
       "MOVE_SUBSTITUTE",
-      "MOVE_THUNDER_FANG"
+      "MOVE_OUTRAGE",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_FACADE"
     ],
     "TutorMoves": [
       "MOVE_PROTECT"
@@ -8670,31 +14430,46 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
-      "MOVE_BODY_SLAM",
-      "MOVE_BRICK_BREAK",
-      "MOVE_DRACO_METEOR",
-      "MOVE_DRAGON_PULSE",
-      "MOVE_EARTHQUAKE",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_FANG",
-      "MOVE_FIRE_SPIN",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HURRICANE",
-      "MOVE_HYDRO_PUMP",
-      "MOVE_HYPER_BEAM",
-      "MOVE_HYPER_VOICE",
-      "MOVE_IRON_DEFENSE",
-      "MOVE_IRON_HEAD",
+      "MOVE_HEADBUTT",
+      "MOVE_DRAGON_CLAW",
       "MOVE_ROAR",
+      "MOVE_BRICK_BREAK",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SHADOW_CLAW",
-      "MOVE_STONE_EDGE",
-      "MOVE_SUBSTITUTE",
+      "MOVE_FIRE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_FANG",
+      "MOVE_AERIAL_ACE",
+      "MOVE_CRUNCH",
       "MOVE_SWIFT",
-      "MOVE_THUNDER_FANG"
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_FIRE_BLAST",
+      "MOVE_FLY",
+      "MOVE_HYPER_BEAM",
+      "MOVE_DRACO_METEOR",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_FLAMETHROWER",
+      "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_HYPER_VOICE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_HURRICANE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_OUTRAGE",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_SCALE_SHOT",
+      "MOVE_SKULL_BASH"
     ],
     "TutorMoves": [
       "MOVE_FLY"
@@ -8709,11 +14484,13 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
       "MOVE_HEADBUTT",
-      "MOVE_IRON_DEFENSE",
+      "MOVE_AGILITY",
       "MOVE_IRON_HEAD",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FACADE",
+      "MOVE_STEEL_BEAM"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -8762,28 +14539,39 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
-      "MOVE_BODY_SLAM",
-      "MOVE_BRICK_BREAK",
-      "MOVE_DOUBLE_EDGE",
-      "MOVE_EARTHQUAKE",
-      "MOVE_ENDURE",
       "MOVE_HEADBUTT",
-      "MOVE_ICE_PUNCH",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_POWER_UP_PUNCH",
-      "MOVE_PROTECT",
       "MOVE_PSYSHOCK",
-      "MOVE_REFLECT",
+      "MOVE_BRICK_BREAK",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SELF_DESTRUCT",
-      "MOVE_SHADOW_BALL",
-      "MOVE_SLUDGE_BOMB",
-      "MOVE_STEALTH_ROCK",
-      "MOVE_SUBSTITUTE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
       "MOVE_SWIFT",
-      "MOVE_THUNDER_PUNCH"
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_PSYCHIC",
+      "MOVE_EARTHQUAKE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_METEOR_BEAM",
+      "MOVE_STEEL_BEAM"
     ],
     "TutorMoves": [
       "MOVE_CONFUSION",
@@ -8847,35 +14635,882 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
-      "MOVE_BODY_SLAM",
-      "MOVE_BRICK_BREAK",
-      "MOVE_DOUBLE_EDGE",
-      "MOVE_EARTHQUAKE",
-      "MOVE_ENDURE",
-      "MOVE_GIGA_IMPACT",
       "MOVE_HEADBUTT",
-      "MOVE_ICE_PUNCH",
-      "MOVE_KNOCK_OFF",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_POWER_UP_PUNCH",
-      "MOVE_PROTECT",
       "MOVE_PSYSHOCK",
-      "MOVE_REFLECT",
+      "MOVE_BRICK_BREAK",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SELF_DESTRUCT",
-      "MOVE_SHADOW_BALL",
-      "MOVE_SLUDGE_BOMB",
-      "MOVE_STEALTH_ROCK",
-      "MOVE_STONE_EDGE",
-      "MOVE_SUBSTITUTE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
       "MOVE_SWIFT",
-      "MOVE_THUNDER_PUNCH"
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_AGILITY",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_PSYCHIC",
+      "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_SHADOW_PUNCH",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_SWAGGER",
+      "MOVE_SKULL_BASH",
+      "MOVE_METEOR_BEAM",
+      "MOVE_STEEL_BEAM"
     ],
     "TutorMoves": [
       "MOVE_EXPLOSION",
       "MOVE_HEAVY_SLAM"
+    ],
+    "EggMoves": []
+  },
+  "LATIAS": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_CHARM"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_MIST_BALL"
+      },
+      {
+        "Level": "5",
+        "Move": "MOVE_DRAINING_KISS"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_RECOVER"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_CONFUSION"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_PSYBEAM"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_DRAGON_BREATH"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_WISH"
+      },
+      {
+        "Level": "35",
+        "Move": "MOVE_WATER_PULSE"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_ZEN_HEADBUTT"
+      },
+      {
+        "Level": "45",
+        "Move": "MOVE_DRAGON_PULSE"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_AURA_SPHERE"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_MYSTICAL_FIRE"
+      },
+      {
+        "Level": "60",
+        "Move": "MOVE_AIR_SLASH"
+      },
+      {
+        "Level": "65",
+        "Move": "MOVE_PSYCHIC"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_DRAGON_CLAW",
+      "MOVE_PSYSHOCK",
+      "MOVE_ROAR",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_ICE_BEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_WATER_PULSE",
+      "MOVE_FLY",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_ICY_WIND",
+      "MOVE_SAFEGUARD",
+      "MOVE_DRACO_METEOR",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_PSYCHIC",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_THUNDERBOLT",
+      "MOVE_EARTHQUAKE",
+      "MOVE_WHIRLPOOL",
+      "MOVE_SURF",
+      "MOVE_SHADOW_BALL",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_LIQUIDATION",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_OUTRAGE",
+      "MOVE_WATERFALL",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_SCALE_SHOT",
+      "MOVE_RAZOR_WIND",
+      "MOVE_TRI_ATTACK"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "LATIOS": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_WORK_UP"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_LUSTER_PURGE"
+      },
+      {
+        "Level": "5",
+        "Move": "MOVE_TWISTER"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_RECOVER"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_CONFUSION"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_PSYBEAM"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_DRAGON_BREATH"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_WISH"
+      },
+      {
+        "Level": "35",
+        "Move": "MOVE_WATER_PULSE"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_ZEN_HEADBUTT"
+      },
+      {
+        "Level": "45",
+        "Move": "MOVE_DRAGON_PULSE"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_AURA_SPHERE"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_MYSTICAL_FIRE"
+      },
+      {
+        "Level": "60",
+        "Move": "MOVE_PSYCHIC"
+      },
+      {
+        "Level": "65",
+        "Move": "MOVE_AIR_SLASH"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_DRAGON_CLAW",
+      "MOVE_PSYSHOCK",
+      "MOVE_ROAR",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_FLIP_TURN",
+      "MOVE_ICE_BEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_WATER_PULSE",
+      "MOVE_FLY",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_ICY_WIND",
+      "MOVE_SAFEGUARD",
+      "MOVE_DRACO_METEOR",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_PSYCHIC",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_THUNDERBOLT",
+      "MOVE_EARTHQUAKE",
+      "MOVE_WHIRLPOOL",
+      "MOVE_SURF",
+      "MOVE_SHADOW_BALL",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_LIQUIDATION",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_OUTRAGE",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_WATERFALL",
+      "MOVE_WORK_UP",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_SCALE_SHOT",
+      "MOVE_RAZOR_WIND",
+      "MOVE_TRI_ATTACK"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "KYOGRE": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_BODY_SLAM"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_ANCIENT_POWER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_WATER_PULSE"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_WHIRLPOOL"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_CALM_MIND"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_HEAVY_SLAM"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_ICE_BEAM"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_SURF"
+      },
+      {
+        "Level": "45",
+        "Move": "MOVE_SHEER_COLD"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_ORIGIN_PULSE"
+      },
+      {
+        "Level": "54",
+        "Move": "MOVE_AQUA_RING"
+      },
+      {
+        "Level": "58",
+        "Move": "MOVE_BLIZZARD"
+      },
+      {
+        "Level": "64",
+        "Move": "MOVE_DOUBLE_EDGE"
+      },
+      {
+        "Level": "72",
+        "Move": "MOVE_HYDRO_PUMP"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_ROCK_SMASH",
+      "MOVE_ROAR",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_SWIFT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_WATER_PULSE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_ICY_WIND",
+      "MOVE_SAFEGUARD",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_THUNDERBOLT",
+      "MOVE_EARTHQUAKE",
+      "MOVE_WHIRLPOOL",
+      "MOVE_SURF",
+      "MOVE_LIQUIDATION",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_SWAGGER",
+      "MOVE_MUDDY_WATER",
+      "MOVE_SCALD",
+      "MOVE_ICICLE_SPEAR",
+      "MOVE_SHEER_COLD"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "GROUDON": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_ANCIENT_POWER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_SAND_TOMB"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_MUD_SHOT"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_LAVA_PLUME"
+      },
+      {
+        "Level": "9",
+        "Move": "MOVE_EARTH_POWER"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_BULK_UP"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_ROCK_BLAST"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_FIRE_SPIN"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_EARTHQUAKE"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_HEAVY_SLAM"
+      },
+      {
+        "Level": "43",
+        "Move": "MOVE_STONE_EDGE"
+      },
+      {
+        "Level": "45",
+        "Move": "MOVE_FISSURE"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_PRECIPICE_BLADES"
+      },
+      {
+        "Level": "62",
+        "Move": "MOVE_DYNAMIC_PUNCH"
+      },
+      {
+        "Level": "68",
+        "Move": "MOVE_FIRE_BLAST"
+      },
+      {
+        "Level": "75",
+        "Move": "MOVE_HEAT_CRASH"
+      },
+      {
+        "Level": "81",
+        "Move": "MOVE_SOLAR_BEAM"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_DRAGON_CLAW",
+      "MOVE_ROAR",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_FIRE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_POWER_GEM",
+      "MOVE_AERIAL_ACE",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_FIRE_BLAST",
+      "MOVE_HYPER_BEAM",
+      "MOVE_MUD_SHOT",
+      "MOVE_OVERHEAT",
+      "MOVE_SAFEGUARD",
+      "MOVE_EARTH_POWER",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_WILL-O-WISP",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_FLAMETHROWER",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_STONE_EDGE",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HEAT_WAVE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_SPIKES",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_FISSURE"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "RAYQUAZA": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TWISTER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_AIR_SLASH"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_DRAGON_ASCENT"
+      },
+      {
+        "Level": "9",
+        "Move": "MOVE_CRUNCH"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_BRUTAL_SWING"
+      },
+      {
+        "Level": "27",
+        "Move": "MOVE_EXTREME_SPEED"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_DRAGON_PULSE"
+      },
+      {
+        "Level": "45",
+        "Move": "MOVE_HYPER_VOICE"
+      },
+      {
+        "Level": "58",
+        "Move": "MOVE_DRAGON_RUSH"
+      },
+      {
+        "Level": "63",
+        "Move": "MOVE_FLY"
+      },
+      {
+        "Level": "81",
+        "Move": "MOVE_OUTRAGE"
+      },
+      {
+        "Level": "90",
+        "Move": "MOVE_HYPER_BEAM"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_DRAGON_CLAW",
+      "MOVE_ROAR",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_CRUNCH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_FIRE_BLAST",
+      "MOVE_FLY",
+      "MOVE_HYPER_BEAM",
+      "MOVE_ICY_WIND",
+      "MOVE_OVERHEAT",
+      "MOVE_EARTH_POWER",
+      "MOVE_DRACO_METEOR",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_FLAMETHROWER",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_STONE_EDGE",
+      "MOVE_THUNDERBOLT",
+      "MOVE_EARTHQUAKE",
+      "MOVE_WHIRLPOOL",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SURF",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_BULLDOZE",
+      "MOVE_HURRICANE",
+      "MOVE_U-TURN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WILD_CHARGE",
+      "MOVE_IRON_TAIL",
+      "MOVE_OUTRAGE",
+      "MOVE_WHIRLWIND",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_SCALE_SHOT",
+      "MOVE_METEOR_BEAM"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "STARLY": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_PECK"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_GUST"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_WING_ATTACK"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_DOUBLE_TEAM"
+      },
+      {
+        "Level": "19",
+        "Move": "MOVE_FEATHER_DANCE"
+      },
+      {
+        "Level": "23",
+        "Move": "MOVE_WHIRLWIND"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_AERIAL_ACE"
+      },
+      {
+        "Level": "33",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "41",
+        "Move": "MOVE_AGILITY"
+      },
+      {
+        "Level": "49",
+        "Move": "MOVE_BRAVE_BIRD"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_SWIFT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_ENDURE",
+      "MOVE_FLY",
+      "MOVE_KNOCK_OFF",
+      "MOVE_AGILITY",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_HEAT_WAVE",
+      "MOVE_HURRICANE",
+      "MOVE_U-TURN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WHIRLWIND",
+      "MOVE_WORK_UP",
+      "MOVE_FACADE",
+      "MOVE_DUAL_WINGBEAT"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "STARAVIA": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_PECK"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_GUST"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_WING_ATTACK"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_DOUBLE_TEAM"
+      },
+      {
+        "Level": "19",
+        "Move": "MOVE_FEATHER_DANCE"
+      },
+      {
+        "Level": "23",
+        "Move": "MOVE_WHIRLWIND"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_AERIAL_ACE"
+      },
+      {
+        "Level": "33",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "41",
+        "Move": "MOVE_AGILITY"
+      },
+      {
+        "Level": "49",
+        "Move": "MOVE_BRAVE_BIRD"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_SWIFT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_ENDURE",
+      "MOVE_FLY",
+      "MOVE_KNOCK_OFF",
+      "MOVE_AGILITY",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_HEAT_WAVE",
+      "MOVE_HURRICANE",
+      "MOVE_U-TURN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WHIRLWIND",
+      "MOVE_WORK_UP",
+      "MOVE_FACADE",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_SKULL_BASH",
+      "MOVE_VACUUM_WAVE",
+      "MOVE_SKY_ATTACK"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "STARAPROR": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_PECK"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_GUST"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_WING_ATTACK"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_DOUBLE_TEAM"
+      },
+      {
+        "Level": "19",
+        "Move": "MOVE_FEATHER_DANCE"
+      },
+      {
+        "Level": "23",
+        "Move": "MOVE_WHIRLWIND"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_AERIAL_ACE"
+      },
+      {
+        "Level": "33",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "41",
+        "Move": "MOVE_AGILITY"
+      },
+      {
+        "Level": "49",
+        "Move": "MOVE_BRAVE_BIRD"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_SWIFT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_ENDURE",
+      "MOVE_FLY",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_AGILITY",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_HEAT_WAVE",
+      "MOVE_HURRICANE",
+      "MOVE_U-TURN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_OUTRAGE",
+      "MOVE_WHIRLWIND",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_TORMENT",
+      "MOVE_BLAZE_KICK",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_SWAGGER",
+      "MOVE_RAZOR_WIND",
+      "MOVE_SKULL_BASH",
+      "MOVE_VACUUM_WAVE",
+      "MOVE_SKY_ATTACK"
+    ],
+    "TutorMoves": [    
+      "MOVE_CLOSE_COMBAT"
     ],
     "EggMoves": []
   },
@@ -8899,20 +15534,22 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_BULLET_SEED",
-      "MOVE_DAZZLING_GLEAM",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_MUD_SHOT",
       "MOVE_PROTECT",
-      "MOVE_SHADOW_BALL",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_BULLET_SEED",
+      "MOVE_MUD_SHOT",
       "MOVE_SLUDGE_BOMB",
       "MOVE_SOLAR_BEAM",
-      "MOVE_SPIKES",
+      "MOVE_SHADOW_BALL",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_SWORDS_DANCE"
+      "MOVE_SPIKES",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_FACADE",
+      "MOVE_SEED_BOMB"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -8981,25 +15618,34 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_BULLET_SEED",
-      "MOVE_DAZZLING_GLEAM",
-      "MOVE_ENDURE",
+      "MOVE_TOXIC",
+      "MOVE_PROTECT",
       "MOVE_ENERGY_BALL",
-      "MOVE_GIGA_IMPACT",
+      "MOVE_SWIFT",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_BULLET_SEED",
+      "MOVE_GIGA_DRAIN",
       "MOVE_HYPER_BEAM",
       "MOVE_MUD_SHOT",
-      "MOVE_PROTECT",
-      "MOVE_SHADOW_BALL",
       "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
       "MOVE_SOLAR_BEAM",
-      "MOVE_SPIKES",
+      "MOVE_SHADOW_BALL",
+      "MOVE_POISON_JAB",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_SWORDS_DANCE"
+      "MOVE_SPIKES",
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_FACADE",
+      "MOVE_SEED_BOMB",
+      "MOVE_RAZOR_WIND",
+      "MOVE_PETAL_DANCE"
     ],
     "TutorMoves": [
-      "MOVE_POISON_STING"
+      "MOVE_POISON_STING",
+      "MOVE_MORTAL_SPIN"
     ],
     "EggMoves": []
   },
@@ -9051,25 +15697,34 @@
       }
     ],
     "TMMoves": [
-      "MOVE_CLOSE_COMBAT",
-      "MOVE_DIG",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_HYPER_VOICE",
-      "MOVE_ICE_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_IRON_TAIL",
-      "MOVE_PLAY_ROUGH",
-      "MOVE_POWER_UP_PUNCH",
-      "MOVE_PROTECT",
-      "MOVE_SHADOW_BALL",
-      "MOVE_SOLAR_BEAM",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_THUNDERBOLT",
-      "MOVE_THUNDER_PUNCH",
+      "MOVE_HEADBUTT",
       "MOVE_THUNDER_WAVE",
-      "MOVE_WORK_UP"
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_ENDURE",
+      "MOVE_AGILITY",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_WORK_UP",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_CIRCLE_THROW",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_DOUBLE_HIT",
+      "MOVE_FAKE_OUT",
+      "MOVE_TRIPLE_AXEL"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -9138,32 +15793,230 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BLIZZARD",
-      "MOVE_CLOSE_COMBAT",
-      "MOVE_DIG",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_HYPER_VOICE",
-      "MOVE_ICE_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_PLAY_ROUGH",
-      "MOVE_PROTECT",
-      "MOVE_SHADOW_BALL",
-      "MOVE_SOLAR_BEAM",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_SWORDS_DANCE",
-      "MOVE_THUNDER",
-      "MOVE_THUNDERBOLT",
-      "MOVE_THUNDER_PUNCH",
+      "MOVE_HEADBUTT",
       "MOVE_THUNDER_WAVE",
-      "MOVE_U_TURN",
-      "MOVE_WORK_UP"
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_ENDURE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_U-TURN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_CIRCLE_THROW",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_DOUBLE_HIT",
+      "MOVE_FAKE_OUT",
+      "MOVE_TRIPLE_AXEL"
     ],
     "TutorMoves": [],
+    "EggMoves": []
+  },
+  "CHINGLING": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "7",
+        "Move": "MOVE_CONFUSION"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_DISARMING_VOICE"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_SUPERSONIC"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_SCREECH"
+      },
+      {
+        "Level": "23",
+        "Move": "MOVE_AMNESIA"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_WISH"
+      },
+      {
+        "Level": "29",
+        "Move": "MOVE_METAL_SOUND"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_PSYCHIC"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
+      "MOVE_REFLECT",
+      "MOVE_ENDURE",
+      "MOVE_WATER_PULSE",
+      "MOVE_KNOCK_OFF",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_ICY_WIND",
+      "MOVE_SAFEGUARD",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_PSYCHIC",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CURSE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_TAUNT",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_FACADE",
+      "MOVE_CHARGE_BEAM"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "MIME_JR": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_HYPNOSIS"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_CHARM"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_CONFUSION"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_DREAM_EATER"
+      },
+      {
+        "Level": "17",
+        "Move": "MOVE_INFESTATION"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_PROTECT"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_STEALTH_ROCK"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_PSYBEAM"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_MIMIC"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_LIGHT_SCREEN"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_REFLECT"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_SAFEGUARD"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_DAZZLING_GLEAM"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_PSYCHIC"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
+      "MOVE_REFLECT",
+      "MOVE_ENDURE",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_ICY_WIND",
+      "MOVE_SAFEGUARD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_PSYCHIC",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_THUNDERBOLT",
+      "MOVE_SHADOW_BALL",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_TAUNT",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_MIMIC",
+      "MOVE_DREAM_EATER",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_FAKE_OUT",
+      "MOVE_FIRST_IMPRESSION"
+    ],
+    "TutorMoves": [
+      "MOVE_MIST",
+      "MOVE_SMOKESCREEN",
+      "MOVE_HAZE"
+    ],
     "EggMoves": []
   },
   "GIBLE": {
@@ -9210,27 +16063,34 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_DRACO_METEOR",
-      "MOVE_DRAGON_PULSE",
-      "MOVE_EARTHQUAKE",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_FANG",
-      "MOVE_FLAMETHROWER",
-      "MOVE_IRON_HEAD",
-      "MOVE_OUTRAGE",
-      "MOVE_PROTECT",
+      "MOVE_DRAGON_CLAW",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SHADOW_CLAW",
-      "MOVE_STEALTH_ROCK",
-      "MOVE_STONE_EDGE",
-      "MOVE_SUBSTITUTE",
+      "MOVE_FIRE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_FANG",
       "MOVE_SWIFT",
+      "MOVE_DIG",
       "MOVE_SWORDS_DANCE",
-      "MOVE_THUNDER_FANG"
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_FIRE_BLAST",
+      "MOVE_EARTH_POWER",
+      "MOVE_DRACO_METEOR",
+      "MOVE_IRON_HEAD",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_FLAMETHROWER",
+      "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_OUTRAGE",
+      "MOVE_FACADE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_SCALE_SHOT"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -9279,32 +16139,39 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
-      "MOVE_BODY_SLAM",
+      "MOVE_DRAGON_CLAW",
       "MOVE_BRICK_BREAK",
-      "MOVE_CRUNCH",
-      "MOVE_DRACO_METEOR",
-      "MOVE_DRAGON_PULSE",
-      "MOVE_EARTHQUAKE",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_FANG",
-      "MOVE_FLAMETHROWER",
-      "MOVE_IRON_HEAD",
-      "MOVE_OUTRAGE",
-      "MOVE_POISON_JAB",
-      "MOVE_PROTECT",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SHADOW_CLAW",
-      "MOVE_SPIKES",
-      "MOVE_STEALTH_ROCK",
-      "MOVE_STONE_EDGE",
-      "MOVE_SUBSTITUTE",
+      "MOVE_FIRE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_FANG",
+      "MOVE_AERIAL_ACE",
+      "MOVE_CRUNCH",
       "MOVE_SWIFT",
+      "MOVE_DIG",
       "MOVE_SWORDS_DANCE",
-      "MOVE_THUNDER_FANG"
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_FIRE_BLAST",
+      "MOVE_EARTH_POWER",
+      "MOVE_DRACO_METEOR",
+      "MOVE_IRON_HEAD",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_FLAMETHROWER",
+      "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_POISON_JAB",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_SPIKES",
+      "MOVE_OUTRAGE",
+      "MOVE_FACADE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_SCALE_SHOT"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -9353,36 +16220,49 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
-      "MOVE_BODY_SLAM",
+      "MOVE_DRAGON_CLAW",
       "MOVE_BRICK_BREAK",
-      "MOVE_DRACO_METEOR",
-      "MOVE_DRAGON_PULSE",
-      "MOVE_EARTHQUAKE",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_FANG",
-      "MOVE_FLAMETHROWER",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_IRON_HEAD",
-      "MOVE_IRON_TAIL",
-      "MOVE_LIQUIDATION",
-      "MOVE_OUTRAGE",
-      "MOVE_POISON_JAB",
-      "MOVE_PROTECT",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SHADOW_CLAW",
-      "MOVE_SPIKES",
-      "MOVE_STEALTH_ROCK",
-      "MOVE_STONE_EDGE",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
+      "MOVE_FIRE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_POWER_GEM",
+      "MOVE_THUNDER_FANG",
+      "MOVE_AERIAL_ACE",
+      "MOVE_CRUNCH",
       "MOVE_SWIFT",
+      "MOVE_DIG",
       "MOVE_SWORDS_DANCE",
-      "MOVE_THUNDER_FANG"
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_FIRE_BLAST",
+      "MOVE_HYPER_BEAM",
+      "MOVE_EARTH_POWER",
+      "MOVE_DRACO_METEOR",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_IRON_HEAD",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_FLAMETHROWER",
+      "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_SURF",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_LIQUIDATION",
+      "MOVE_POISON_JAB",
+      "MOVE_BULLDOZE",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_SPIKES",
+      "MOVE_OUTRAGE",
+      "MOVE_FACADE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_DUAL_CHOP",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_SCALE_SHOT",
+      "MOVE_RAZOR_WIND",
+      "MOVE_VACUUM_WAVE"
     ],
     "TutorMoves": [
       "MOVE_CRUNCH"
@@ -9433,26 +16313,37 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
-      "MOVE_AGILITY",
+      "MOVE_ROCK_SMASH",
       "MOVE_BRICK_BREAK",
       "MOVE_BULK_UP",
-      "MOVE_CLOSE_COMBAT",
-      "MOVE_CRUNCH",
-      "MOVE_DIG",
-      "MOVE_EARTHQUAKE",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_ICE_PUNCH",
-      "MOVE_NASTY_PLOT",
-      "MOVE_POISON_JAB",
-      "MOVE_PROTECT",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SHADOW_CLAW",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
       "MOVE_THUNDER_PUNCH",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_ICE_PUNCH",
+      "MOVE_CRUNCH",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_AGILITY",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_EARTHQUAKE",
+      "MOVE_POISON_JAB",
+      "MOVE_BULLDOZE",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_TRAILBLAZE",
+      "MOVE_CIRCLE_THROW",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_VACUUM_WAVE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -9521,38 +16412,55 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
-      "MOVE_AGILITY",
+      "MOVE_ROCK_SMASH",
+      "MOVE_ROAR",
+      "MOVE_CALM_MIND",
       "MOVE_BRICK_BREAK",
       "MOVE_BULK_UP",
-      "MOVE_CALM_MIND",
-      "MOVE_CRUNCH",
-      "MOVE_DARK_PULSE",
-      "MOVE_DIG",
-      "MOVE_EARTHQUAKE",
-      "MOVE_FLASH_CANNON",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_IRON_DEFENSE",
-      "MOVE_IRON_TAIL",
-      "MOVE_METRONOME",
-      "MOVE_NASTY_PLOT",
-      "MOVE_POISON_JAB",
-      "MOVE_POWER_UP_PUNCH",
-      "MOVE_PSYCHIC",
-      "MOVE_ROAR",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SHADOW_BALL",
-      "MOVE_SHADOW_CLAW",
-      "MOVE_STONE_EDGE",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_AERIAL_ACE",
       "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_CRUNCH",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
       "MOVE_WATER_PULSE",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_PSYCHIC",
+      "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_POISON_JAB",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_NASTY_PLOT",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_DARK_PULSE",
+      "MOVE_METRONOME",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_TRAILBLAZE",
+      "MOVE_CIRCLE_THROW",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_BLAZE_KICK",
+      "MOVE_DUAL_CHOP",
+      "MOVE_VACUUM_WAVE",
+      "MOVE_STEEL_BEAM"
     ],
     "TutorMoves": [
       "MOVE_DETECT"
@@ -9607,19 +16515,29 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
+      "MOVE_ROAR",
+      "MOVE_ROCK_SLIDE",
       "MOVE_FIRE_FANG",
       "MOVE_ICE_FANG",
       "MOVE_PROTECT",
-      "MOVE_ROCK_SLIDE",
+      "MOVE_THUNDER_FANG",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
       "MOVE_STEALTH_ROCK",
+      "MOVE_EARTH_POWER",
+      "MOVE_DOUBLE-EDGE",
       "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
       "MOVE_SUBSTITUTE",
-      "MOVE_THUNDER_FANG",
-      "MOVE_WHIRLWIND"
+      "MOVE_CURSE",
+      "MOVE_WHIRLWIND",
+      "MOVE_FACADE",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_MUDDY_WATER",
+      "MOVE_FISSURE" 
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -9672,24 +16590,33 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_CURSE",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_FANG",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_HYPER_VOICE",
-      "MOVE_ICE_FANG",
-      "MOVE_IRON_HEAD",
-      "MOVE_PROTECT",
+      "MOVE_ROAR",
       "MOVE_ROCK_SLIDE",
+      "MOVE_FIRE_FANG",
+      "MOVE_ICE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_FANG",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
       "MOVE_STEALTH_ROCK",
+      "MOVE_HYPER_BEAM",
+      "MOVE_EARTH_POWER",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
       "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_HYPER_VOICE",
       "MOVE_SUBSTITUTE",
-      "MOVE_THUNDER_FANG",
-      "MOVE_WHIRLWIND"
+      "MOVE_CURSE",
+      "MOVE_WHIRLWIND",
+      "MOVE_FACADE",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_MUDDY_WATER",
+      "MOVE_FISSURE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -9742,19 +16669,27 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_BULLET_SEED",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_GIGA_DRAIN",
       "MOVE_ICE_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_MAGICAL_LEAF",
       "MOVE_PROTECT",
+      "MOVE_ICE_PUNCH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_BULLET_SEED",
+      "MOVE_WATER_PULSE",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_ICY_WIND",
       "MOVE_SOLAR_BEAM",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWORDS_DANCE",
-      "MOVE_WATER_PULSE"
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_TRAILBLAZE",
+      "MOVE_SEED_BOMB",
+      "MOVE_SWAGGER",
+      "MOVE_ICICLE_SPEAR",
+      "MOVE_SHEER_COLD"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -9807,32 +16742,43 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
       "MOVE_BRICK_BREAK",
-      "MOVE_BULLET_SEED",
-      "MOVE_CURSE",
-      "MOVE_DOUBLE_EDGE",
-      "MOVE_EARTHQUAKE",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_DRAIN",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_ICE_BEAM",
-      "MOVE_MAGICAL_LEAF",
-      "MOVE_OUTRAGE",
-      "MOVE_PROTECT",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SOLAR_BEAM",
-      "MOVE_SUBSTITUTE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_ICE_PUNCH",
+      "MOVE_ENERGY_BALL",
       "MOVE_SWORDS_DANCE",
-      "MOVE_WATER_PULSE"
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_BULLET_SEED",
+      "MOVE_WATER_PULSE",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_HYPER_BEAM",
+      "MOVE_ICY_WIND",
+      "MOVE_EARTH_POWER",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_EARTHQUAKE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CURSE",
+      "MOVE_OUTRAGE",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_TRAILBLAZE",
+      "MOVE_SEED_BOMB",
+      "MOVE_FROST_BREATH",
+      "MOVE_SWAGGER",
+      "MOVE_ICICLE_SPEAR",
+      "MOVE_SHEER_COLD"
     ],
     "TutorMoves": [
-      "MOVE_ICE_PUNCH"
+      "MOVE_ICE_PUNCH",
+      "MOVE_ICE_HAMMER"
     ],
     "EggMoves": []
   },
@@ -9892,24 +16838,35 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
-      "MOVE_BODY_SLAM",
-      "MOVE_BULLET_SEED",
-      "MOVE_CALM_MIND",
-      "MOVE_DIG",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_HYPER_VOICE",
-      "MOVE_IRON_TAIL",
-      "MOVE_PROTECT",
       "MOVE_ROAR",
-      "MOVE_SHADOW_BALL",
+      "MOVE_CALM_MIND",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_BULLET_SEED",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_HYPER_BEAM",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
       "MOVE_SOLAR_BEAM",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_X-SCISSOR",
       "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
       "MOVE_TAUNT",
-      "MOVE_X_SCISSOR"
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_MIMIC",
+      "MOVE_SEED_BOMB",
+      "MOVE_SKULL_BASH",
+      "MOVE_PETAL_DANCE",
+      "MOVE_SOLAR_BLADE"
     ],
     "TutorMoves": [
       "MOVE_CHARM",
@@ -9973,19 +16930,34 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_CALM_MIND",
-      "MOVE_DIG",
-      "MOVE_ENDURE",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_HYPER_VOICE",
-      "MOVE_IRON_TAIL",
-      "MOVE_PROTECT",
       "MOVE_ROAR",
+      "MOVE_CALM_MIND",
+      "MOVE_ICE_BEAM",
+      "MOVE_ICE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_ICY_WIND",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_HYPER_VOICE",
       "MOVE_SHADOW_BALL",
       "MOVE_SUBSTITUTE",
-      "MOVE_TAUNT"
+      "MOVE_IRON_TAIL",
+      "MOVE_TAUNT",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_TRAILBLAZE",
+      "MOVE_MIMIC",
+      "MOVE_FROST_BREATH",
+      "MOVE_TRIPLE_AXEL",
+      "MOVE_SKULL_BASH",
+      "MOVE_ICICLE_SPEAR",
+      "MOVE_SHEER_COLD"
     ],
     "TutorMoves": [
       "MOVE_CHARM",
@@ -9997,8 +16969,116 @@
     ],
     "EggMoves": []
   },
+  "PORYGONZ": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_CONVERSION"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_CHARGE"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_EERIE_IMPULSE"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_THUNDER_SHOCK"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_PSYBEAM"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_CONVERSION_2"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_AGILITY"
+      },
+      {
+        "Level": "35",
+        "Move": "MOVE_RECOVER"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_DISCHARGE"
+      },
+      {
+        "Level": "45",
+        "Move": "MOVE_METAL_SOUND"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_SELF_DESTRUCT"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_ZAP_CANNON"
+      },
+      {
+        "Level": "60",
+        "Move": "MOVE_HYPER_BEAM"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_PSYSHOCK",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_SWIFT",
+      "MOVE_REFLECT",
+      "MOVE_ENDURE",
+      "MOVE_DISCHARGE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_ICY_WIND",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_PSYCHIC",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_VOLT_SWITCH",
+      "MOVE_THUNDERBOLT",
+      "MOVE_SHADOW_BALL",
+      "MOVE_NASTY_PLOT",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_DARK_PULSE",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_ELECTROWEB",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_SKULL_BASH",
+      "MOVE_TRI_ATTACK"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
   "GALLADE": {
     "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_SACRED_SWORD"
+      },
       {
         "Level": "1",
         "Move": "MOVE_GROWL"
@@ -10053,40 +17133,60 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
-      "MOVE_AURA_SPHERE",
-      "MOVE_BODY_SLAM",
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
       "MOVE_BRICK_BREAK",
       "MOVE_BULK_UP",
-      "MOVE_DAZZLING_GLEAM",
-      "MOVE_EARTHQUAKE",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_HYPER_VOICE",
-      "MOVE_ICE_PUNCH",
-      "MOVE_ICY_WIND",
-      "MOVE_KNOCK_OFF",
       "MOVE_LIGHT_SCREEN",
-      "MOVE_METRONOME",
-      "MOVE_PSYSHOCK",
-      "MOVE_REFLECT",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SAFEGUARD",
-      "MOVE_SHADOW_BALL",
-      "MOVE_SHADOW_CLAW",
-      "MOVE_STONE_EDGE",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_TAUNT",
-      "MOVE_THUNDERBOLT",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
       "MOVE_THUNDER_PUNCH",
-      "MOVE_THUNDER_WAVE",
-      "MOVE_WILL_O_WISP",
-      "MOVE_X_SCISSOR",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_ICE_PUNCH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_REFLECT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_BODY_SLAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_AGILITY",
+      "MOVE_ICY_WIND",
+      "MOVE_SAFEGUARD",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_WILL-O-WISP",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_PSYCHIC",
+      "MOVE_STONE_EDGE",
+      "MOVE_THUNDERBOLT",
+      "MOVE_EARTHQUAKE",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_X-SCISSOR",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_TAUNT",
+      "MOVE_METRONOME",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_DUAL_CHOP",
+      "MOVE_TRIPLE_AXEL",
+      "MOVE_RAZOR_WIND",
+      "MOVE_VACUUM_WAVE",
+      "MOVE_SOLAR_BLADE"
     ],
     "TutorMoves": [
       "MOVE_CALM_MIND",
@@ -10166,23 +17266,42 @@
       }
     ],
     "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_ICE_BEAM",
+      "MOVE_ICE_FANG",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_ICE_PUNCH",
+      "MOVE_CRUNCH",
+      "MOVE_REFLECT",
+      "MOVE_DOUBLE_TEAM",
       "MOVE_BODY_SLAM",
       "MOVE_ENDURE",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HEAL_BLOCK",
+      "MOVE_WATER_PULSE",
       "MOVE_HYPER_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_NASTY_PLOT",
+      "MOVE_ICY_WIND",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_WILL-O-WISP",
       "MOVE_PSYCHIC",
-      "MOVE_REFLECT",
-      "MOVE_SPIKES",
-      "MOVE_SUBSTITUTE",
-      "MOVE_TAUNT",
-      "MOVE_THUNDER",
       "MOVE_THUNDERBOLT",
-      "MOVE_THUNDER_WAVE",
-      "MOVE_WATER_PULSE"
+      "MOVE_SHADOW_BALL",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_SPIKES",
+      "MOVE_CURSE",
+      "MOVE_TAUNT",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_TRAILBLAZE",
+      "MOVE_FROST_BREATH",
+      "MOVE_TRIPLE_AXEL",
+      "MOVE_ICICLE_SPEAR",
+      "MOVE_PETAL_DANCE",
+      "MOVE_SHEER_COLD"
     ],
     "TutorMoves": [
       "MOVE_CRUNCH",
@@ -10191,6 +17310,801 @@
       "MOVE_ICICLE_CRASH",
       "MOVE_PROTECT"
     ],
+    "EggMoves": []
+  },
+  "ROTOM": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_THUNDER_SHOCK"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_DOUBLE_TEAM"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_CHARGE"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_PARABOLIC_CHARGE"
+      },
+      {
+        "Level": "17",
+        "Move": "MOVE_PARTING_SHOT"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_THUNDER_WAVE"
+      },
+      {
+        "Level": "23",
+        "Move": "MOVE_PSYBEAM"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_EERIE_IMPULSE"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_SHADOW_BALL"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_TAUNT"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_SUBSTITUTE"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_LIGHT_SCREEN"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_DISCHARGE"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_THUNDER_WAVE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_SWIFT",
+      "MOVE_REFLECT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_ENDURE",
+      "MOVE_DISCHARGE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_WILL-O-WISP",
+      "MOVE_VOLT_SWITCH",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_TAUNT",
+      "MOVE_ELECTROWEB",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "ROTOM_HEAT": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_THUNDER_SHOCK"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_DOUBLE_TEAM"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_OVERHEAT"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_CHARGE"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_PARABOLIC_CHARGE"
+      },
+      {
+        "Level": "17",
+        "Move": "MOVE_PARTING_SHOT"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_THUNDER_WAVE"
+      },
+      {
+        "Level": "23",
+        "Move": "MOVE_PSYBEAM"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_EERIE_IMPULSE"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_SHADOW_BALL"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_TAUNT"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_SUBSTITUTE"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_LIGHT_SCREEN"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_DISCHARGE"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_THUNDER_WAVE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_SWIFT",
+      "MOVE_REFLECT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_ENDURE",
+      "MOVE_DISCHARGE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_WILL-O-WISP",
+      "MOVE_VOLT_SWITCH",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_TAUNT",
+      "MOVE_ELECTROWEB",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "ROTOM_MOW": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_THUNDER_SHOCK"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_DOUBLE_TEAM"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_LEAF_STORM"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_CHARGE"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_PARABOLIC_CHARGE"
+      },
+      {
+        "Level": "17",
+        "Move": "MOVE_PARTING_SHOT"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_THUNDER_WAVE"
+      },
+      {
+        "Level": "23",
+        "Move": "MOVE_PSYBEAM"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_EERIE_IMPULSE"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_SHADOW_BALL"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_TAUNT"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_SUBSTITUTE"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_LIGHT_SCREEN"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_DISCHARGE"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_THUNDER_WAVE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_SWIFT",
+      "MOVE_REFLECT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_ENDURE",
+      "MOVE_DISCHARGE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_WILL-O-WISP",
+      "MOVE_VOLT_SWITCH",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_TAUNT",
+      "MOVE_ELECTROWEB",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "ROTOM_FROST": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_THUNDER_SHOCK"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_DOUBLE_TEAM"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_BLIZZARD"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_CHARGE"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_PARABOLIC_CHARGE"
+      },
+      {
+        "Level": "17",
+        "Move": "MOVE_PARTING_SHOT"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_THUNDER_WAVE"
+      },
+      {
+        "Level": "23",
+        "Move": "MOVE_PSYBEAM"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_EERIE_IMPULSE"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_SHADOW_BALL"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_TAUNT"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_SUBSTITUTE"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_LIGHT_SCREEN"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_DISCHARGE"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_THUNDER_WAVE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_SWIFT",
+      "MOVE_REFLECT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_ENDURE",
+      "MOVE_DISCHARGE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_WILL-O-WISP",
+      "MOVE_VOLT_SWITCH",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_TAUNT",
+      "MOVE_ELECTROWEB",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "ROTOM_WASH": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_THUNDER_SHOCK"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_DOUBLE_TEAM"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_HYDRO_PUMP"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_CHARGE"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_PARABOLIC_CHARGE"
+      },
+      {
+        "Level": "17",
+        "Move": "MOVE_PARTING_SHOT"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_THUNDER_WAVE"
+      },
+      {
+        "Level": "23",
+        "Move": "MOVE_PSYBEAM"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_EERIE_IMPULSE"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_SHADOW_BALL"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_TAUNT"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_SUBSTITUTE"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_LIGHT_SCREEN"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_DISCHARGE"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_THUNDER_WAVE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_SWIFT",
+      "MOVE_REFLECT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_ENDURE",
+      "MOVE_DISCHARGE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_WILL-O-WISP",
+      "MOVE_VOLT_SWITCH",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_TAUNT",
+      "MOVE_ELECTROWEB",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "ROTOM_FAN": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_THUNDER_SHOCK"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_DOUBLE_TEAM"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_AIR_SLASH"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_CHARGE"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_PARABOLIC_CHARGE"
+      },
+      {
+        "Level": "17",
+        "Move": "MOVE_PARTING_SHOT"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_THUNDER_WAVE"
+      },
+      {
+        "Level": "23",
+        "Move": "MOVE_PSYBEAM"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_EERIE_IMPULSE"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_SHADOW_BALL"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_TAUNT"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_SUBSTITUTE"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_LIGHT_SCREEN"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_DISCHARGE"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_THUNDER_WAVE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_SWIFT",
+      "MOVE_REFLECT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_ENDURE",
+      "MOVE_DISCHARGE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_WILL-O-WISP",
+      "MOVE_VOLT_SWITCH",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_TAUNT",
+      "MOVE_ELECTROWEB",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "HEATRAN": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_FIRE_SPIN"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_HEAT_CRASH"
+      },
+      {
+        "Level": "6",
+        "Move": "MOVE_METAL_CLAW"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_ROCK_BLAST"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_FIRE_FANG"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_IRON_HEAD"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_CRUNCH"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_LAVA_PLUME"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_METAL_SOUND"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_HEAVY_SLAM"
+      },
+      {
+        "Level": "54",
+        "Move": "MOVE_EARTH_POWER"
+      },
+      {
+        "Level": "59",
+        "Move": "MOVE_LUNGE"
+      },
+      {
+        "Level": "64",
+        "Move": "MOVE_HEAT_WAVE"
+      },
+      {
+        "Level": "66",
+        "Move": "MOVE_STONE_EDGE"
+      },
+      {
+        "Level": "72",
+        "Move": "MOVE_MAGMA_STORM"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ROCK_SLIDE",
+      "MOVE_FIRE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_POWER_GEM",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_FIRE_BLAST",
+      "MOVE_HYPER_BEAM",
+      "MOVE_OVERHEAT",
+      "MOVE_EARTH_POWER",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_WILL-O-WISP",
+      "MOVE_IRON_HEAD",
+      "MOVE_FLAMETHROWER",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_STONE_EDGE",
+      "MOVE_HEAT_WAVE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_TAUNT",
+      "MOVE_FLARE_BLITZ",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_FIRST_IMPRESSION",
+      "MOVE_STEEL_BEAM"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "DARKRAI": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_CONFUSION"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_SHADOW_SNEAK"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_BRUTAL_SWING"
+      },
+      {
+        "Level": "11",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_SNARL"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_HYPNOSIS"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_PSYBEAM"
+      },
+      {
+        "Level": "47",
+        "Move": "MOVE_DOUBLE_TEAM"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_FUTURE_SIGHT"
+      },
+      {
+        "Level": "57",
+        "Move": "MOVE_HAZE"
+      },
+      {
+        "Level": "66",
+        "Move": "MOVE_DARK_VOID"
+      },
+      {
+        "Level": "70",
+        "Move": "MOVE_PHANTOM_FORCE"
+      },
+      {
+        "Level": "75",
+        "Move": "MOVE_NASTY_PLOT"
+      },
+      {
+        "Level": "84",
+        "Move": "MOVE_DREAM_EATER"
+      },
+      {
+        "Level": "93",
+        "Move": "MOVE_DARK_PULSE"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_CRUNCH",
+      "MOVE_SWIFT",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_ICY_WIND",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_WILL-O-WISP",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_PSYCHIC",
+      "MOVE_THUNDERBOLT",
+      "MOVE_SHADOW_BALL",
+      "MOVE_POISON_JAB",
+      "MOVE_X-SCISSOR",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_TAUNT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_SHADOW_PUNCH",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_TORMENT",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_RAZOR_WIND",
+      "MOVE_ICICLE_SPEAR",
+      "MOVE_VACUUM_WAVE"
+    ],
+    "TutorMoves": [],
     "EggMoves": []
   },
   "TEPIG": {
@@ -10245,20 +18159,26 @@
       }
     ],
     "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_ROAR",
+      "MOVE_PROTECT",
       "MOVE_DIG",
       "MOVE_DOUBLE_TEAM",
       "MOVE_ENDURE",
       "MOVE_FIRE_BLAST",
-      "MOVE_HEADBUTT",
-      "MOVE_HEAT_WAVE",
       "MOVE_OVERHEAT",
-      "MOVE_PROTECT",
-      "MOVE_ROAR",
+      "MOVE_WILL-O-WISP",
+      "MOVE_FLAMETHROWER",
+      "MOVE_HEAT_WAVE",
+      "MOVE_FIRE_SPIN",
       "MOVE_SUBSTITUTE",
-      "MOVE_TAUNT",
       "MOVE_WILD_CHARGE",
-      "MOVE_WILL_O_WISP",
-      "MOVE_WORK_UP"
+      "MOVE_TAUNT",
+      "MOVE_WORK_UP",
+      "MOVE_FLARE_BLITZ",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_TRAILBLAZE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -10319,31 +18239,41 @@
       }
     ],
     "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_ROCK_SMASH",
+      "MOVE_ROAR",
       "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
       "MOVE_DIG",
-      "MOVE_DOUBLE_EDGE",
+      "MOVE_FIRE_PUNCH",
       "MOVE_DOUBLE_TEAM",
       "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
       "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_HEADBUTT",
-      "MOVE_HEAT_WAVE",
       "MOVE_KNOCK_OFF",
       "MOVE_OVERHEAT",
-      "MOVE_POISON_JAB",
-      "MOVE_PROTECT",
-      "MOVE_ROAR",
-      "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_SMASH",
-      "MOVE_ROCK_TOMB",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_WILL-O-WISP",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FLAMETHROWER",
       "MOVE_STONE_EDGE",
+      "MOVE_HEAT_WAVE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_POISON_JAB",
       "MOVE_SUBSTITUTE",
-      "MOVE_TAUNT",
       "MOVE_WILD_CHARGE",
-      "MOVE_WILL_O_WISP",
+      "MOVE_TAUNT",
+      "MOVE_FOCUS_BLAST",
       "MOVE_WORK_UP",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_FLARE_BLITZ",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_DRAIN_PUNCH"
     ],
     "TutorMoves": [
       "MOVE_POWER_UP_PUNCH"
@@ -10410,37 +18340,56 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BRICK_BREAK",
-      "MOVE_CURSE",
-      "MOVE_DIG",
-      "MOVE_DOUBLE_EDGE",
-      "MOVE_DOUBLE_TEAM",
-      "MOVE_EARTHQUAKE",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
       "MOVE_HEADBUTT",
-      "MOVE_HEAT_WAVE",
+      "MOVE_ROCK_SMASH",
+      "MOVE_ROAR",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_FIRE_BLAST",
       "MOVE_HYPER_BEAM",
-      "MOVE_IRON_HEAD",
       "MOVE_KNOCK_OFF",
       "MOVE_OVERHEAT",
-      "MOVE_POISON_JAB",
-      "MOVE_PROTECT",
-      "MOVE_ROAR",
-      "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_SMASH",
-      "MOVE_ROCK_TOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_WILL-O-WISP",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FLAMETHROWER",
       "MOVE_STONE_EDGE",
+      "MOVE_HEAT_WAVE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_POISON_JAB",
       "MOVE_SUBSTITUTE",
-      "MOVE_TAUNT",
-      "MOVE_THUNDER_PUNCH",
       "MOVE_WILD_CHARGE",
-      "MOVE_WILL_O_WISP",
+      "MOVE_CURSE",
+      "MOVE_TAUNT",
+      "MOVE_FOCUS_BLAST",
       "MOVE_WORK_UP",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_FLARE_BLITZ",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_CIRCLE_THROW",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_DUAL_CHOP",
+      "MOVE_STORM_THROW",
+      "MOVE_SCALD",
+      "MOVE_VACUUM_WAVE",
+      "MOVE_SOLAR_BLADE",
+      "MOVE_BLAST_BURN"
     ],
     "TutorMoves": [
       "MOVE_HEAT_CRASH",
@@ -10492,19 +18441,24 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BULLET_SEED",
+      "MOVE_TOXIC",
+      "MOVE_PROTECT",
+      "MOVE_CRUNCH",
       "MOVE_DIG",
+      "MOVE_SWORDS_DANCE",
       "MOVE_DOUBLE_TEAM",
       "MOVE_ENDURE",
-      "MOVE_GUNK_SHOT",
+      "MOVE_BULLET_SEED",
       "MOVE_MUD_SHOT",
-      "MOVE_PROTECT",
-      "MOVE_SHADOW_BALL",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SWORDS_DANCE",
+      "MOVE_ZEN_HEADBUTT",
       "MOVE_THUNDERBOLT",
-      "MOVE_TOXIC",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_SHADOW_BALL",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_GUNK_SHOT",
+      "MOVE_WORK_UP",
+      "MOVE_FACADE",
+      "MOVE_SEED_BOMB"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -10565,33 +18519,240 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BULLET_SEED",
+      "MOVE_ROCK_SMASH",
+      "MOVE_TOXIC",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_CRUNCH",
+      "MOVE_SWIFT",
       "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_SWORDS_DANCE",
       "MOVE_DOUBLE_TEAM",
       "MOVE_ENDURE",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FLAMETHROWER",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_GUNK_SHOT",
+      "MOVE_BULLET_SEED",
       "MOVE_HYPER_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_LIGHT_SCREEN",
       "MOVE_MUD_SHOT",
-      "MOVE_POWER_UP_PUNCH",
-      "MOVE_PROTECT",
-      "MOVE_ROCK_SMASH",
-      "MOVE_SHADOW_BALL",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_SWORDS_DANCE",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FLAMETHROWER",
       "MOVE_THUNDERBOLT",
-      "MOVE_THUNDER_PUNCH",
-      "MOVE_THUNDER_WAVE",
-      "MOVE_TOXIC",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_SHADOW_BALL",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_GUNK_SHOT",
+      "MOVE_WORK_UP",
+      "MOVE_FACADE",
+      "MOVE_SEED_BOMB",
+      "MOVE_SKULL_BASH"
     ],
     "TutorMoves": [
       "MOVE_CONFUSE_RAY"
+    ],
+    "EggMoves": []
+  },
+  "PURRLOIN": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_SNARL"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_MIMIC"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_FAKE_OUT"
+      },
+      {
+        "Level": "9",
+        "Move": "MOVE_LICK"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_TORMENT"
+      },
+      {
+        "Level": "19",
+        "Move": "MOVE_FAKE_TEARS"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_SLASH"
+      },
+      {
+        "Level": "26",
+        "Move": "MOVE_SCREECH"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_NASTY_PLOT"
+      },
+      {
+        "Level": "38",
+        "Move": "MOVE_NIGHT_SLASH"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_PARTING_SHOT"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_PLAY_ROUGH"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_THUNDER_WAVE",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_SWIFT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_KNOCK_OFF",
+      "MOVE_AGILITY",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_U-TURN",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_DARK_PULSE",
+      "MOVE_TAUNT",
+      "MOVE_GUNK_SHOT",
+      "MOVE_FACADE",
+      "MOVE_PAY_DAY",
+      "MOVE_TORMENT",
+      "MOVE_MIMIC",
+      "MOVE_SEED_BOMB",
+      "MOVE_DOUBLE_HIT",
+      "MOVE_SWAGGER",
+      "MOVE_FAKE_OUT",
+      "MOVE_FIRST_IMPRESSION"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "LIEPARD": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_MIMIC"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_FAKE_OUT"
+      },
+      {
+        "Level": "9",
+        "Move": "MOVE_LICK"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_TORMENT"
+      },
+      {
+        "Level": "19",
+        "Move": "MOVE_FAKE_TEARS"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_SLASH"
+      },
+      {
+        "Level": "26",
+        "Move": "MOVE_SCREECH"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_NASTY_PLOT"
+      },
+      {
+        "Level": "38",
+        "Move": "MOVE_NIGHT_SLASH"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_PARTING_SHOT"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_PLAY_ROUGH"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_THUNDER_WAVE",
+      "MOVE_FIRE_FANG",
+      "MOVE_ICE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_THUNDER_FANG",
+      "MOVE_CRUNCH",
+      "MOVE_SWIFT",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_AGILITY",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_X-SCISSOR",
+      "MOVE_U-TURN",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_DARK_PULSE",
+      "MOVE_TAUNT",
+      "MOVE_GUNK_SHOT",
+      "MOVE_FACADE",
+      "MOVE_PAY_DAY",
+      "MOVE_TORMENT",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_MIMIC",
+      "MOVE_SEED_BOMB",
+      "MOVE_DOUBLE_HIT",
+      "MOVE_SWAGGER",
+      "MOVE_FAKE_OUT",
+      "MOVE_FIRST_IMPRESSION"
+    ],
+    "TutorMoves": [
+      "MOVE_SNARL"
     ],
     "EggMoves": []
   },
@@ -10651,25 +18812,35 @@
       }
     ],
     "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_TOXIC",
       "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_CRUNCH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
       "MOVE_DIG",
       "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_GIGA_DRAIN",
-      "MOVE_GUNK_SHOT",
-      "MOVE_IRON_TAIL",
-      "MOVE_MUD_SHOT",
-      "MOVE_NASTY_PLOT",
-      "MOVE_POWER_UP_PUNCH",
-      "MOVE_PROTECT",
-      "MOVE_ROCK_SLIDE",
       "MOVE_ROCK_TOMB",
+      "MOVE_BULLET_SEED",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_MUD_SHOT",
       "MOVE_SHADOW_CLAW",
       "MOVE_SOLAR_BEAM",
+      "MOVE_NASTY_PLOT",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
+      "MOVE_IRON_TAIL",
       "MOVE_TAUNT",
-      "MOVE_TOXIC"
+      "MOVE_GUNK_SHOT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_TRAILBLAZE",
+      "MOVE_TORMENT",
+      "MOVE_SEED_BOMB"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -10730,27 +18901,40 @@
       }
     ],
     "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_TOXIC",
       "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_CRUNCH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
       "MOVE_DIG",
       "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_GIGA_DRAIN",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_GUNK_SHOT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_IRON_TAIL",
-      "MOVE_MUD_SHOT",
-      "MOVE_NASTY_PLOT",
-      "MOVE_POWER_UP_PUNCH",
-      "MOVE_PROTECT",
-      "MOVE_ROCK_SLIDE",
       "MOVE_ROCK_TOMB",
+      "MOVE_BULLET_SEED",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_HYPER_BEAM",
+      "MOVE_MUD_SHOT",
+      "MOVE_GIGA_IMPACT",
       "MOVE_SHADOW_CLAW",
       "MOVE_SOLAR_BEAM",
+      "MOVE_NASTY_PLOT",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
+      "MOVE_IRON_TAIL",
       "MOVE_TAUNT",
-      "MOVE_TOXIC"
+      "MOVE_GUNK_SHOT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_TRAILBLAZE",
+      "MOVE_TORMENT",
+      "MOVE_SEED_BOMB",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_FAKE_OUT",
+      "MOVE_SOLAR_BLADE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -10811,28 +18995,36 @@
       }
     ],
     "TMMoves": [
+      "MOVE_HEADBUTT",
       "MOVE_BRICK_BREAK",
-      "MOVE_DIG",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FLAMETHROWER",
-      "MOVE_FLARE_BLITZ",
-      "MOVE_GUNK_SHOT",
-      "MOVE_HEAT_WAVE",
-      "MOVE_IRON_TAIL",
-      "MOVE_MUD_SHOT",
-      "MOVE_NASTY_PLOT",
-      "MOVE_OVERHEAT",
-      "MOVE_POWER_UP_PUNCH",
-      "MOVE_PROTECT",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SHADOW_CLAW",
-      "MOVE_SOLAR_BEAM",
-      "MOVE_SUBSTITUTE",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_CRUNCH",
       "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_FIRE_BLAST",
+      "MOVE_MUD_SHOT",
+      "MOVE_OVERHEAT",
+      "MOVE_WILL-O-WISP",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_FLAMETHROWER",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_HEAT_WAVE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
       "MOVE_TAUNT",
-      "MOVE_WILL_O_WISP"
+      "MOVE_GUNK_SHOT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_FLARE_BLITZ",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -10893,30 +19085,42 @@
       }
     ],
     "TMMoves": [
+      "MOVE_HEADBUTT",
       "MOVE_BRICK_BREAK",
-      "MOVE_DIG",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FLAMETHROWER",
-      "MOVE_FLARE_BLITZ",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_GUNK_SHOT",
-      "MOVE_HEAT_WAVE",
-      "MOVE_HYPER_BEAM",
-      "MOVE_IRON_TAIL",
-      "MOVE_MUD_SHOT",
-      "MOVE_NASTY_PLOT",
-      "MOVE_OVERHEAT",
-      "MOVE_POWER_UP_PUNCH",
-      "MOVE_PROTECT",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SHADOW_CLAW",
-      "MOVE_SOLAR_BEAM",
-      "MOVE_SUBSTITUTE",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_CRUNCH",
       "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_FIRE_BLAST",
+      "MOVE_HYPER_BEAM",
+      "MOVE_MUD_SHOT",
+      "MOVE_OVERHEAT",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_WILL-O-WISP",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_FLAMETHROWER",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_HEAT_WAVE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
       "MOVE_TAUNT",
-      "MOVE_WILL_O_WISP"
+      "MOVE_GUNK_SHOT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_FLARE_BLITZ",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_BLAZE_KICK",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_FAKE_OUT"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -10977,27 +19181,37 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BLIZZARD",
+      "MOVE_HEADBUTT",
+      "MOVE_FLIP_TURN",
       "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_CRUNCH",
+      "MOVE_SWIFT",
       "MOVE_DIG",
       "MOVE_ENDURE",
-      "MOVE_FLIP_TURN",
-      "MOVE_GUNK_SHOT",
-      "MOVE_ICE_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_ICY_WIND",
-      "MOVE_IRON_TAIL",
-      "MOVE_MUD_SHOT",
-      "MOVE_NASTY_PLOT",
-      "MOVE_POWER_UP_PUNCH",
-      "MOVE_PROTECT",
-      "MOVE_ROCK_SLIDE",
       "MOVE_ROCK_TOMB",
+      "MOVE_MUD_SHOT",
+      "MOVE_ICY_WIND",
       "MOVE_SHADOW_CLAW",
-      "MOVE_SUBSTITUTE",
       "MOVE_SURF",
-      "MOVE_SWIFT",
-      "MOVE_WATERFALL"
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_TAUNT",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_GUNK_SHOT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_LOW_SWEEP",
+      "MOVE_SCALD"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -11058,30 +19272,200 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BLIZZARD",
+      "MOVE_HEADBUTT",
+      "MOVE_FLIP_TURN",
       "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_CRUNCH",
+      "MOVE_SWIFT",
       "MOVE_DIG",
       "MOVE_ENDURE",
-      "MOVE_FLIP_TURN",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_GUNK_SHOT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_ICE_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_ICY_WIND",
-      "MOVE_IRON_TAIL",
-      "MOVE_LIQUIDATION",
-      "MOVE_MUD_SHOT",
-      "MOVE_NASTY_PLOT",
-      "MOVE_POWER_UP_PUNCH",
-      "MOVE_PROTECT",
-      "MOVE_ROCK_SLIDE",
       "MOVE_ROCK_TOMB",
+      "MOVE_HYPER_BEAM",
+      "MOVE_MUD_SHOT",
+      "MOVE_ICY_WIND",
+      "MOVE_GIGA_IMPACT",
       "MOVE_SHADOW_CLAW",
-      "MOVE_SUBSTITUTE",
       "MOVE_SURF",
+      "MOVE_LIQUIDATION",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_TAUNT",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_GUNK_SHOT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_LOW_SWEEP",
+      "MOVE_FAKE_OUT",
+      "MOVE_SCALD"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "MUNNA": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_HYPNOSIS"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_PSYBEAM"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_AMNESIA"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_MOONLIGHT"
+      },
+      {
+        "Level": "21",
+        "Move": "MOVE_CHARM"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_ZEN_HEADBUTT"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_DREAM_EATER"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_CALM_MIND"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_PSYCHIC"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_MOONBLAST"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_FUTURE_SIGHT"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
       "MOVE_SWIFT",
-      "MOVE_WATERFALL"
+      "MOVE_REFLECT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_SAFEGUARD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_PSYCHIC",
+      "MOVE_SHADOW_BALL",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CURSE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_FACADE",
+      "MOVE_SILVER_WIND",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_DREAM_EATER",
+      "MOVE_TRI_ATTACK"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "MUSHARNA": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_HYPNOSIS"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_PSYBEAM"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_AMNESIA"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_MOONLIGHT"
+      },
+      {
+        "Level": "21",
+        "Move": "MOVE_CHARM"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_ZEN_HEADBUTT"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_DREAM_EATER"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_CALM_MIND"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_PSYCHIC"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_MOONBLAST"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_FUTURE_SIGHT"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_REFLECT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_HYPER_BEAM",
+      "MOVE_SAFEGUARD",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_PSYCHIC",
+      "MOVE_SHADOW_BALL",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CURSE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_FACADE",
+      "MOVE_SILVER_WIND",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_TRI_ATTACK"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -11138,18 +19522,27 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
-      "MOVE_BRICK_BREAK",
-      "MOVE_DOUBLE_EDGE",
-      "MOVE_ENDURE",
-      "MOVE_IRON_DEFENSE",
-      "MOVE_POISON_JAB",
-      "MOVE_PROTECT",
       "MOVE_ROCK_SMASH",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_DIG",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
+      "MOVE_MUD_SHOT",
+      "MOVE_AGILITY",
       "MOVE_SLUDGE_BOMB",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_POISON_JAB",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_X-SCISSOR",
       "MOVE_SUBSTITUTE",
-      "MOVE_X_SCISSOR"
+      "MOVE_FACADE",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_FISSURE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -11218,23 +19611,35 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
-      "MOVE_BRICK_BREAK",
-      "MOVE_DOUBLE_EDGE",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_IRON_DEFENSE",
-      "MOVE_IRON_HEAD",
-      "MOVE_POISON_JAB",
-      "MOVE_PROTECT",
       "MOVE_ROCK_SMASH",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_DIG",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
-      "MOVE_SLUDGE_BOMB",
       "MOVE_STEALTH_ROCK",
-      "MOVE_SUBSTITUTE"
+      "MOVE_HYPER_BEAM",
+      "MOVE_MUD_SHOT",
+      "MOVE_AGILITY",
+      "MOVE_EARTH_POWER",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_EARTHQUAKE",
+      "MOVE_POISON_JAB",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_X-SCISSOR",
+      "MOVE_SUBSTITUTE",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_FACADE",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_SKULL_BASH",
+      "MOVE_FISSURE",
+      "MOVE_STEEL_BEAM"
     ],
     "TutorMoves": [
       "MOVE_METAL_SOUND"
@@ -11289,37 +19694,240 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BLIZZARD",
-      "MOVE_BODY_SLAM",
+      "MOVE_PSYSHOCK",
       "MOVE_CALM_MIND",
-      "MOVE_DAZZLING_GLEAM",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_ICE_BEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
       "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
       "MOVE_ENDURE",
       "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FLAMETHROWER",
-      "MOVE_GIGA_IMPACT",
       "MOVE_HYPER_BEAM",
-      "MOVE_ICE_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_IRON_TAIL",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_POWER_UP_PUNCH",
-      "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
-      "MOVE_PSYSHOCK",
-      "MOVE_REFLECT",
+      "MOVE_ICY_WIND",
       "MOVE_SAFEGUARD",
-      "MOVE_SHADOW_BALL",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FLAMETHROWER",
+      "MOVE_PSYCHIC",
       "MOVE_SOLAR_BEAM",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
-      "MOVE_THUNDER",
       "MOVE_THUNDERBOLT",
-      "MOVE_THUNDER_PUNCH",
-      "MOVE_THUNDER_WAVE",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SURF",
+      "MOVE_SHADOW_BALL",
+      "MOVE_SUBSTITUTE",
       "MOVE_WILD_CHARGE",
-      "MOVE_WORK_UP"
+      "MOVE_IRON_TAIL",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_WORK_UP",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_TRI_ATTACK"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "THROH": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_CIRCLE_THROW"
+      },
+      {
+        "Level": "5",
+        "Move": "MOVE_FOCUS_ENERGY"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_BRUTAL_SWING"
+      },
+      {
+        "Level": "13",
+        "Move": "MOVE_ROLLOUT"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_ROCK_BLAST"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_BULK_UP"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_LOW_SWEEP"
+      },
+      {
+        "Level": "33",
+        "Move": "MOVE_BRICK_BREAK"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_ENDURE"
+      },
+      {
+        "Level": "41",
+        "Move": "MOVE_AMNESIA"
+      },
+      {
+        "Level": "43",
+        "Move": "MOVE_OUTRAGE"
+      },
+      {
+        "Level": "52",
+        "Move": "MOVE_STORM_THROW"
+      },
+      {
+        "Level": "58",
+        "Move": "MOVE_DYNAMIC_PUNCH"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ROCK_SMASH",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_POISON_JAB",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_OUTRAGE",
+      "MOVE_TAUNT",
+      "MOVE_GUNK_SHOT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_SEED_BOMB",
+      "MOVE_CIRCLE_THROW",
+      "MOVE_STORM_THROW",
+      "MOVE_SKULL_BASH"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "SAWK": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_ROCK_SMASH"
+      },
+      {
+        "Level": "5",
+        "Move": "MOVE_FOCUS_ENERGY"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_DETECT"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_MACH_PUNCH"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_KNOCK_OFF"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_POWER_UP_PUNCH"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_LOW_SWEEP"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_BULK_UP"
+      },
+      {
+        "Level": "33",
+        "Move": "MOVE_BRICK_BREAK"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_ENDURE"
+      },
+      {
+        "Level": "43",
+        "Move": "MOVE_OUTRAGE"
+      },
+      {
+        "Level": "52",
+        "Move": "MOVE_CLOSE_COMBAT"
+      },
+      {
+        "Level": "58",
+        "Move": "MOVE_DYNAMIC_PUNCH"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ROCK_SMASH",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_KNOCK_OFF",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_POISON_JAB",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_OUTRAGE",
+      "MOVE_TAUNT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_BLAZE_KICK",
+      "MOVE_DUAL_CHOP"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -11376,14 +19984,20 @@
       }
     ],
     "TMMoves": [
+      "MOVE_TOXIC",
+      "MOVE_PROTECT",
       "MOVE_ENDURE",
-      "MOVE_IRON_DEFENSE",
       "MOVE_ROCK_TOMB",
+      "MOVE_AGILITY",
       "MOVE_SLUDGE_BOMB",
+      "MOVE_DOUBLE-EDGE",
       "MOVE_SOLAR_BEAM",
-      "MOVE_SPIKES",
+      "MOVE_POISON_JAB",
+      "MOVE_IRON_DEFENSE",
       "MOVE_SUBSTITUTE",
-      "MOVE_TOXIC_SPIKES"
+      "MOVE_SPIKES",
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_FACADE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -11440,16 +20054,24 @@
       }
     ],
     "TMMoves": [
+      "MOVE_TOXIC",
+      "MOVE_PROTECT",
       "MOVE_ENDURE",
-      "MOVE_IRON_DEFENSE",
       "MOVE_ROCK_TOMB",
+      "MOVE_AGILITY",
       "MOVE_SLUDGE_BOMB",
+      "MOVE_DOUBLE-EDGE",
       "MOVE_SOLAR_BEAM",
-      "MOVE_SPIKES",
+      "MOVE_POISON_JAB",
+      "MOVE_IRON_DEFENSE",
       "MOVE_SUBSTITUTE",
-      "MOVE_TOXIC_SPIKES"
+      "MOVE_SPIKES",
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_FACADE"
     ],
-    "TutorMoves": [],
+    "TutorMoves": [
+      "MOVE_MORTAL_SPIN"
+    ],
     "EggMoves": []
   },
   "SCOLIPEDE": {
@@ -11520,23 +20142,39 @@
       }
     ],
     "TMMoves": [
-      "MOVE_DIG",
-      "MOVE_EARTHQUAKE",
-      "MOVE_ENDURE",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_GUNK_SHOT",
-      "MOVE_HYPER_BEAM",
+      "MOVE_TOXIC",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SLUDGE_BOMB",
-      "MOVE_SOLAR_BEAM",
-      "MOVE_SPIKES",
-      "MOVE_SUBSTITUTE",
+      "MOVE_PROTECT",
+      "MOVE_DIG",
       "MOVE_SWORDS_DANCE",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_EARTHQUAKE",
+      "MOVE_POISON_JAB",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_X-SCISSOR",
+      "MOVE_U-TURN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_SPIKES",
       "MOVE_TOXIC_SPIKES",
-      "MOVE_U_TURN"
+      "MOVE_GUNK_SHOT",
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_TRAILBLAZE",
+      "MOVE_DOUBLE_HIT",
+      "MOVE_FIRST_IMPRESSION",
+      "MOVE_SKULL_BASH"
     ],
-    "TutorMoves": [],
+    "TutorMoves": [
+      "MOVE_MORTAL_SPIN"
+    ],
     "EggMoves": []
   },
   "SANDILE": {
@@ -11583,26 +20221,35 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
-      "MOVE_BODY_SLAM",
-      "MOVE_BRICK_BREAK",
-      "MOVE_BULLDOZE",
-      "MOVE_DARK_PULSE",
       "MOVE_DRAGON_CLAW",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
+      "MOVE_ROAR",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
       "MOVE_FIRE_FANG",
       "MOVE_PROTECT",
-      "MOVE_ROAR",
-      "MOVE_ROCK_SLIDE",
+      "MOVE_THUNDER_FANG",
+      "MOVE_AERIAL_ACE",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
-      "MOVE_SHADOW_CLAW",
-      "MOVE_SLUDGE_BOMB",
       "MOVE_STEALTH_ROCK",
+      "MOVE_EARTH_POWER",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_SHADOW_CLAW",
       "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_BULLDOZE",
       "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_DARK_PULSE",
       "MOVE_TAUNT",
-      "MOVE_THUNDER_FANG"
+      "MOVE_FACADE",
+      "MOVE_TORMENT",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_SWAGGER"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -11651,28 +20298,39 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
-      "MOVE_BODY_SLAM",
-      "MOVE_BRICK_BREAK",
-      "MOVE_BULLDOZE",
-      "MOVE_CURSE",
-      "MOVE_DARK_PULSE",
       "MOVE_DRAGON_CLAW",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_FANG",
-      "MOVE_KNOCK_OFF",
-      "MOVE_PROTECT",
       "MOVE_ROAR",
+      "MOVE_BRICK_BREAK",
       "MOVE_ROCK_SLIDE",
+      "MOVE_FIRE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_FANG",
+      "MOVE_AERIAL_ACE",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
-      "MOVE_SHADOW_CLAW",
-      "MOVE_SLUDGE_BOMB",
       "MOVE_STEALTH_ROCK",
+      "MOVE_KNOCK_OFF",
+      "MOVE_EARTH_POWER",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_SHADOW_CLAW",
       "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_BULLDOZE",
       "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
       "MOVE_TAUNT",
-      "MOVE_THUNDER_FANG"
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_TORMENT",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_SWAGGER",
+      "MOVE_SCALE_SHOT"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -11725,35 +20383,48 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
-      "MOVE_BODY_SLAM",
+      "MOVE_DRAGON_CLAW",
+      "MOVE_ROAR",
       "MOVE_BRICK_BREAK",
       "MOVE_BULK_UP",
-      "MOVE_BULLDOZE",
-      "MOVE_CLOSE_COMBAT",
-      "MOVE_CURSE",
-      "MOVE_DARK_PULSE",
-      "MOVE_DRAGON_CLAW",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_FANG",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_GUNK_SHOT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_IRON_HEAD",
-      "MOVE_KNOCK_OFF",
-      "MOVE_PROTECT",
-      "MOVE_ROAR",
       "MOVE_ROCK_SLIDE",
+      "MOVE_FIRE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_FANG",
+      "MOVE_AERIAL_ACE",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
-      "MOVE_SHADOW_CLAW",
-      "MOVE_SLUDGE_BOMB",
       "MOVE_STEALTH_ROCK",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_EARTH_POWER",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_SHADOW_CLAW",
       "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_BULLDOZE",
       "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_OUTRAGE",
       "MOVE_TAUNT",
-      "MOVE_THUNDER_FANG"
+      "MOVE_GUNK_SHOT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_TORMENT",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_SWAGGER",
+      "MOVE_SCALE_SHOT",
+      "MOVE_FISSURE"
     ],
     "TutorMoves": [
       "MOVE_BREAKING_SWIPE"
@@ -11816,28 +20487,43 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BULK_UP",
-      "MOVE_CURSE",
-      "MOVE_DARK_PULSE",
-      "MOVE_DIG",
+      "MOVE_HEADBUTT",
       "MOVE_DRAGON_CLAW",
-      "MOVE_DRAGON_PULSE",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_ICE_PUNCH",
-      "MOVE_IRON_DEFENSE",
-      "MOVE_IRON_HEAD",
-      "MOVE_POISON_JAB",
       "MOVE_ROAR",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
       "MOVE_ROCK_SLIDE",
-      "MOVE_SLUDGE_BOMB",
-      "MOVE_STONE_EDGE",
-      "MOVE_SUBSTITUTE",
-      "MOVE_TAUNT",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
       "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_STONE_EDGE",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_POISON_JAB",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_TAUNT",
+      "MOVE_FOCUS_BLAST",
       "MOVE_WORK_UP",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_LOW_SWEEP",
+      "MOVE_TRAILBLAZE",
+      "MOVE_TORMENT",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_SWAGGER",
+      "MOVE_FAKE_OUT"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -11898,39 +20584,327 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BULK_UP",
-      "MOVE_CLOSE_COMBAT",
-      "MOVE_CURSE",
-      "MOVE_DARK_PULSE",
-      "MOVE_DIG",
-      "MOVE_DOUBLE_EDGE",
+      "MOVE_HEADBUTT",
       "MOVE_DRAGON_CLAW",
-      "MOVE_DRAGON_PULSE",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_IRON_DEFENSE",
-      "MOVE_IRON_HEAD",
-      "MOVE_KNOCK_OFF",
-      "MOVE_METRONOME",
-      "MOVE_OUTRAGE",
-      "MOVE_POISON_JAB",
-      "MOVE_ROAR",
-      "MOVE_ROCK_SLIDE",
       "MOVE_ROCK_SMASH",
-      "MOVE_SLUDGE_BOMB",
-      "MOVE_STONE_EDGE",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SWORDS_DANCE",
-      "MOVE_TAUNT",
+      "MOVE_ROAR",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
       "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_STONE_EDGE",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_POISON_JAB",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_OUTRAGE",
+      "MOVE_TAUNT",
+      "MOVE_METRONOME",
+      "MOVE_FOCUS_BLAST",
       "MOVE_WORK_UP",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_LOW_SWEEP",
+      "MOVE_TRAILBLAZE",
+      "MOVE_TORMENT",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_DUAL_CHOP",
+      "MOVE_SWAGGER",
+      "MOVE_FAKE_OUT",
+      "MOVE_SKULL_BASH"
     ],
     "TutorMoves": [],
+    "EggMoves": []
+  },
+  "YAMASK": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_CONFUSION"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_PROTECT"
+      },
+      {
+        "Level": "4",
+        "Move": "MOVE_HAZE"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_FAKE_TEARS"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_WILL_O_WISP"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_INFESTATION"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_PSYSHOCK"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_CURSE"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_SHADOW_BALL"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_DARK_PULSE"
+      },
+      {
+        "Level": "46",
+        "Move": "MOVE_PHANTOM_FORCE"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_PARTING_SHOT"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
+      "MOVE_ENDURE",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_KNOCK_OFF",
+      "MOVE_MUD_SHOT",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_SAFEGUARD",
+      "MOVE_WILL-O-WISP",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_PSYCHIC",
+      "MOVE_SHADOW_BALL",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_FACADE",
+      "MOVE_SHADOW_PUNCH",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_DREAM_EATER"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "YAMASK_GALAR": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_CONFUSION"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_PROTECT"
+      },
+      {
+        "Level": "4",
+        "Move": "MOVE_HAZE"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_FAKE_TEARS"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_BRUTAL_SWING"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_INFESTATION"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_PSYSHOCK"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_CURSE"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_SHADOW_BALL"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_EARTHQUAKE"
+      },
+      {
+        "Level": "46",
+        "Move": "MOVE_PHANTOM_FORCE"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_PARTING_SHOT"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_KNOCK_OFF",
+      "MOVE_MUD_SHOT",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_SAFEGUARD",
+      "MOVE_EARTH_POWER",
+      "MOVE_WILL-O-WISP",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_PSYCHIC",
+      "MOVE_EARTHQUAKE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_FACADE",
+      "MOVE_SHADOW_PUNCH",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_DREAM_EATER"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "COFAGRIGUS": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_CONFUSION"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_PROTECT"
+      },
+      {
+        "Level": "4",
+        "Move": "MOVE_HAZE"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_FAKE_TEARS"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_WILL_O_WISP"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_INFESTATION"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_PSYSHOCK"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_CURSE"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_SHADOW_BALL"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_DARK_PULSE"
+      },
+      {
+        "Level": "46",
+        "Move": "MOVE_PHANTOM_FORCE"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_PARTING_SHOT"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
+      "MOVE_ENDURE",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_MUD_SHOT",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_ICY_WIND",
+      "MOVE_SAFEGUARD",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_WILL-O-WISP",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_PSYCHIC",
+      "MOVE_SHADOW_BALL",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_FACADE",
+      "MOVE_SHADOW_PUNCH",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_DREAM_EATER"
+    ],
+    "TutorMoves": [
+      "MOVE_SHADOW_CLAW"
+    ],
     "EggMoves": []
   },
   "TRUBBISH": {
@@ -11993,15 +20967,25 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BULLET_SEED",
-      "MOVE_DARK_PULSE",
+      "MOVE_HEADBUTT",
+      "MOVE_TOXIC",
+      "MOVE_PROTECT",
       "MOVE_ENDURE",
+      "MOVE_BULLET_SEED",
       "MOVE_GIGA_DRAIN",
       "MOVE_MUD_SHOT",
-      "MOVE_PROTECT",
-      "MOVE_ROCK_BLAST",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_POISON_JAB",
+      "MOVE_SUBSTITUTE",
       "MOVE_SPIKES",
-      "MOVE_SUBSTITUTE"
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_DARK_PULSE",
+      "MOVE_GUNK_SHOT",
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_SEED_BOMB",
+      "MOVE_DRAIN_PUNCH"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -12070,23 +21054,35 @@
       }
     ],
     "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_TOXIC",
+      "MOVE_PROTECT",
       "MOVE_BODY_SLAM",
-      "MOVE_BULLET_SEED",
-      "MOVE_DARK_PULSE",
       "MOVE_ENDURE",
-      "MOVE_FOCUS_BLAST",
+      "MOVE_BULLET_SEED",
       "MOVE_GIGA_DRAIN",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HEAL_BLOCK",
       "MOVE_HYPER_BEAM",
       "MOVE_MUD_SHOT",
-      "MOVE_PROTECT",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
       "MOVE_PSYCHIC",
-      "MOVE_ROCK_BLAST",
       "MOVE_SOLAR_BEAM",
-      "MOVE_SPIKES",
+      "MOVE_THUNDERBOLT",
+      "MOVE_POISON_JAB",
       "MOVE_SUBSTITUTE",
-      "MOVE_THUNDERBOLT"
+      "MOVE_SPIKES",
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_DARK_PULSE",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_GUNK_SHOT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_SEED_BOMB",
+      "MOVE_DRAIN_PUNCH"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -12139,13 +21135,22 @@
       }
     ],
     "TMMoves": [
-      "MOVE_ENDURE",
-      "MOVE_FLASH_CANNON",
-      "MOVE_HYPER_VOICE",
-      "MOVE_IRON_DEFENSE",
+      "MOVE_ICE_BEAM",
       "MOVE_LIGHT_SCREEN",
       "MOVE_PROTECT",
-      "MOVE_SUBSTITUTE"
+      "MOVE_ENDURE",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_ICY_WIND",
+      "MOVE_HYPER_VOICE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_TAUNT",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_FROST_BREATH",
+      "MOVE_ICICLE_SPEAR",
+      "MOVE_SHEER_COLD"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -12198,13 +21203,22 @@
       }
     ],
     "TMMoves": [
-      "MOVE_ENDURE",
-      "MOVE_FLASH_CANNON",
-      "MOVE_HYPER_VOICE",
-      "MOVE_IRON_DEFENSE",
+      "MOVE_ICE_BEAM",
       "MOVE_LIGHT_SCREEN",
       "MOVE_PROTECT",
-      "MOVE_SUBSTITUTE"
+      "MOVE_ENDURE",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_ICY_WIND",
+      "MOVE_HYPER_VOICE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_TAUNT",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_FROST_BREATH",
+      "MOVE_ICICLE_SPEAR",
+      "MOVE_SHEER_COLD"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -12261,15 +21275,25 @@
       }
     ],
     "TMMoves": [
-      "MOVE_ENDURE",
-      "MOVE_FLASH_CANNON",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_HYPER_VOICE",
-      "MOVE_IRON_DEFENSE",
+      "MOVE_ICE_BEAM",
       "MOVE_LIGHT_SCREEN",
       "MOVE_PROTECT",
-      "MOVE_SUBSTITUTE"
+      "MOVE_ENDURE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_ICY_WIND",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_HYPER_VOICE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_TAUNT",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_FROST_BREATH",
+      "MOVE_ICICLE_SPEAR",
+      "MOVE_SHEER_COLD"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -12334,21 +21358,183 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
-      "MOVE_ELECTROWEB",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_IRON_TAIL",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_LIGHT_SCREEN",
       "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_ENDURE",
+      "MOVE_DISCHARGE",
+      "MOVE_AGILITY",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_VOLT_SWITCH",
+      "MOVE_THUNDERBOLT",
+      "MOVE_U-TURN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WILD_CHARGE",
+      "MOVE_IRON_TAIL",
+      "MOVE_TAUNT",
+      "MOVE_ELECTROWEB",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_RAZOR_WIND"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "FOONGUS": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_ABSORB"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWTH"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_STUN_SPORE"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_ROLLOUT"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_MAGICAL_LEAF"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_SYNTHESIS"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_TOXIC_SPIKES"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_GIGA_DRAIN"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_TOXIC"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_SOLAR_BEAM"
+      },
+      {
+        "Level": "54",
+        "Move": "MOVE_SPORE"
+      },
+      {
+        "Level": "62",
+        "Move": "MOVE_LEAF_STORM"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_TOXIC",
+      "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_BULLET_SEED",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_MUD_SHOT",
+      "MOVE_SLUDGE_BOMB",
       "MOVE_SOLAR_BEAM",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_TAUNT",
-      "MOVE_THUNDER",
-      "MOVE_THUNDERBOLT",
-      "MOVE_THUNDER_WAVE",
-      "MOVE_U_TURN",
-      "MOVE_WILD_CHARGE"
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_FACADE",
+      "MOVE_MIMIC",
+      "MOVE_SEED_BOMB",
+      "MOVE_FIRST_IMPRESSION",
+      "MOVE_SKULL_BASH"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "AMOONGUSS": {
+    "LevelMoves": [
+     {
+        "Level": "1",
+        "Move": "MOVE_ABSORB"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWTH"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_STUN_SPORE"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_ROLLOUT"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_MAGICAL_LEAF"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_SYNTHESIS"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_TOXIC_SPIKES"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_GIGA_DRAIN"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_TOXIC"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_SOLAR_BEAM"
+      },
+      {
+        "Level": "54",
+        "Move": "MOVE_SPORE"
+      },
+      {
+        "Level": "62",
+        "Move": "MOVE_LEAF_STORM"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_TOXIC",
+      "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_BULLET_SEED",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_HYPER_BEAM",
+      "MOVE_MUD_SHOT",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_SUBSTITUTE",
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_FACADE",
+      "MOVE_TORMENT",
+      "MOVE_MIMIC",
+      "MOVE_SEED_BOMB",
+      "MOVE_SWAGGER",
+      "MOVE_FIRST_IMPRESSION",
+      "MOVE_SKULL_BASH"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -12369,7 +21555,10 @@
       }
     ],
     "TMMoves": [
-      "MOVE_PROTECT"
+      "MOVE_THUNDER_WAVE",
+      "MOVE_PROTECT",
+      "MOVE_FACADE",
+      "MOVE_CHARGE_BEAM"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -12426,17 +21615,26 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_ENDURE",
-      "MOVE_FLASH_CANNON",
-      "MOVE_GIGA_DRAIN",
+      "MOVE_HEADBUTT",
+      "MOVE_THUNDER_WAVE",
       "MOVE_LIGHT_SCREEN",
       "MOVE_PROTECT",
-      "MOVE_SUBSTITUTE",
-      "MOVE_THUNDER",
       "MOVE_THUNDER_FANG",
-      "MOVE_U_TURN",
-      "MOVE_VOLT_SWITCH"
+      "MOVE_CRUNCH",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_DISCHARGE",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_VOLT_SWITCH",
+      "MOVE_THUNDERBOLT",
+      "MOVE_U-TURN",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WILD_CHARGE",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_CHARGE_BEAM"
     ],
     "TutorMoves": [
       "MOVE_CRUNCH"
@@ -12503,34 +21701,48 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_BULK_UP",
-      "MOVE_BULLDOZE",
-      "MOVE_CLOSE_COMBAT",
+      "MOVE_HEADBUTT",
       "MOVE_DRAGON_CLAW",
-      "MOVE_DRAGON_PULSE",
-      "MOVE_ELECTROWEB",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FLAMETHROWER",
-      "MOVE_FLASH_CANNON",
-      "MOVE_GIGA_DRAIN",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_OUTRAGE",
-      "MOVE_PROTECT",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BULK_UP",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SUBSTITUTE",
-      "MOVE_THUNDER",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
       "MOVE_THUNDER_FANG",
       "MOVE_THUNDER_PUNCH",
-      "MOVE_THUNDER_WAVE",
-      "MOVE_U_TURN",
+      "MOVE_CRUNCH",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_DISCHARGE",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_HYPER_BEAM",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FLAMETHROWER",
       "MOVE_VOLT_SWITCH",
+      "MOVE_THUNDERBOLT",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_LIQUIDATION",
+      "MOVE_BULLDOZE",
+      "MOVE_U-TURN",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WILD_CHARGE",
+      "MOVE_OUTRAGE",
       "MOVE_WATERFALL",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_ELECTROWEB",
+      "MOVE_THUNDER",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_POISON_FANG",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_MUDDY_WATER" 
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -12592,18 +21804,27 @@
     ],
     "TMMoves": [
       "MOVE_CALM_MIND",
-      "MOVE_DARK_PULSE",
+      "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
       "MOVE_DOUBLE_TEAM",
       "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
       "MOVE_FIRE_BLAST",
-      "MOVE_HEAT_WAVE",
-      "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
+      "MOVE_OVERHEAT",
       "MOVE_SAFEGUARD",
+      "MOVE_WILL-O-WISP",
+      "MOVE_FLAMETHROWER",
+      "MOVE_PSYCHIC",
       "MOVE_SOLAR_BEAM",
+      "MOVE_HEAT_WAVE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_SHADOW_BALL",
       "MOVE_SUBSTITUTE",
-      "MOVE_TAUNT"
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_TAUNT",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -12665,18 +21886,28 @@
     ],
     "TMMoves": [
       "MOVE_CALM_MIND",
-      "MOVE_DARK_PULSE",
+      "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
       "MOVE_DOUBLE_TEAM",
       "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
       "MOVE_FIRE_BLAST",
-      "MOVE_HEAT_WAVE",
-      "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
+      "MOVE_OVERHEAT",
       "MOVE_SAFEGUARD",
+      "MOVE_WILL-O-WISP",
+      "MOVE_FLAMETHROWER",
+      "MOVE_PSYCHIC",
       "MOVE_SOLAR_BEAM",
+      "MOVE_HEAT_WAVE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_SHADOW_BALL",
       "MOVE_SUBSTITUTE",
-      "MOVE_TAUNT"
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_TAUNT",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_OMINOUS_WIND"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -12738,21 +21969,130 @@
     ],
     "TMMoves": [
       "MOVE_CALM_MIND",
-      "MOVE_DARK_PULSE",
+      "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
       "MOVE_DOUBLE_TEAM",
       "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
       "MOVE_FIRE_BLAST",
-      "MOVE_FLARE_BLITZ",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HEAT_WAVE",
       "MOVE_HYPER_BEAM",
-      "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
+      "MOVE_OVERHEAT",
       "MOVE_SAFEGUARD",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_WILL-O-WISP",
+      "MOVE_FLAMETHROWER",
+      "MOVE_PSYCHIC",
       "MOVE_SOLAR_BEAM",
+      "MOVE_HEAT_WAVE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_SHADOW_BALL",
       "MOVE_SUBSTITUTE",
-      "MOVE_TAUNT"
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_TAUNT",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_FLARE_BLITZ",
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_OMINOUS_WIND"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "CRYOGONAL": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_ICE_SHARD"
+      },
+      {
+        "Level": "4",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_ICY_WIND"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_MIST"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_HAZE"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_SLASH"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_NIGHT_SLASH"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_FREEZE_DRY"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_LIGHT_SCREEN"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_REFLECT"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_RECOVER"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_ICE_BEAM"
+      },
+      {
+        "Level": "52",
+        "Move": "MOVE_ACID_ARMOR"
+      },
+      {
+        "Level": "56",
+        "Move": "MOVE_SOLAR_BEAM"
+      },
+      {
+        "Level": "60",
+        "Move": "MOVE_EXPLOSION"
+      },
+      {
+        "Level": "65",
+        "Move": "MOVE_SHEER_COLD"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ICE_BEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_WATER_PULSE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_ICY_WIND",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_POISON_JAB",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_FROST_BREATH",
+      "MOVE_TRIPLE_AXEL",
+      "MOVE_ICICLE_SPEAR",
+      "MOVE_SHEER_COLD"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -12813,21 +22153,30 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BULLDOZE",
-      "MOVE_CURSE",
-      "MOVE_DIG",
-      "MOVE_EARTH_POWER",
-      "MOVE_ELECTROWEB",
-      "MOVE_PROTECT",
+      "MOVE_THUNDER_WAVE",
       "MOVE_ROCK_SLIDE",
-      "MOVE_SLUDGE_BOMB",
+      "MOVE_PROTECT",
+      "MOVE_DIG",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
       "MOVE_STEALTH_ROCK",
+      "MOVE_DISCHARGE",
+      "MOVE_MUD_SHOT",
+      "MOVE_EARTH_POWER",
+      "MOVE_SLUDGE_BOMB",
       "MOVE_STONE_EDGE",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
-      "MOVE_THUNDER",
       "MOVE_THUNDERBOLT",
-      "MOVE_THUNDER_WAVE"
+      "MOVE_EARTHQUAKE",
+      "MOVE_SURF",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CURSE",
+      "MOVE_ELECTROWEB",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_MUDDY_WATER",
+      "MOVE_SCALD",
+      "MOVE_FISSURE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -12892,20 +22241,871 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BULLDOZE",
-      "MOVE_CURSE",
-      "MOVE_DIG",
-      "MOVE_EARTH_POWER",
-      "MOVE_FLASH_CANNON",
+      "MOVE_TOXIC",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_ROCK_SLIDE",
       "MOVE_ICE_FANG",
       "MOVE_PROTECT",
-      "MOVE_ROCK_SLIDE",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_MUD_SHOT",
+      "MOVE_EARTH_POWER",
       "MOVE_SLUDGE_BOMB",
       "MOVE_STONE_EDGE",
-      "MOVE_SUBSTITUTE",
+      "MOVE_EARTHQUAKE",
       "MOVE_SURF",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CURSE",
+      "MOVE_FACADE",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_MUDDY_WATER",
+      "MOVE_SCALD",
+      "MOVE_FISSURE",
+      "MOVE_STEEL_BEAM"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "GOLETT": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_HARDEN"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_SHADOW_PUNCH"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_CURSE"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_ROLLOUT"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_BULLDOZE"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_IRON_DEFENSE"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_SHADOW_BALL"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_HEAVY_SLAM"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_PHANTOM_FORCE"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_EARTHQUAKE"
+      },
+      {
+        "Level": "65",
+        "Move": "MOVE_DYNAMIC_PUNCH"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_KNOCK_OFF",
+      "MOVE_MUD_SHOT",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_ICY_WIND",
+      "MOVE_SAFEGUARD",
+      "MOVE_EARTH_POWER",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_PSYCHIC",
+      "MOVE_EARTHQUAKE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CURSE",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_SHADOW_PUNCH",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_SCORCHING_SANDS"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "GOLURK": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_HARDEN"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_SHADOW_PUNCH"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_CURSE"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_ROLLOUT"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_BULLDOZE"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_IRON_DEFENSE"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_SHADOW_BALL"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_HEAVY_SLAM"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_PHANTOM_FORCE"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_EARTHQUAKE"
+      },
+      {
+        "Level": "65",
+        "Move": "MOVE_DYNAMIC_PUNCH"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_FLY",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_MUD_SHOT",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_ICY_WIND",
+      "MOVE_SAFEGUARD",
+      "MOVE_EARTH_POWER",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_PSYCHIC",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_STONE_EDGE",
+      "MOVE_THUNDERBOLT",
+      "MOVE_EARTHQUAKE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CURSE",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_SHADOW_PUNCH",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_SKULL_BASH",
+      "MOVE_FISSURE"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "COBALION": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_WORK_UP"
+      },
+      {
+        "Level": "7",
+        "Move": "MOVE_METAL_CLAW"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_BODY_SLAM"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "26",
+        "Move": "MOVE_BOUNCE"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_AURA_SPHERE"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_HEAVY_SLAM"
+      },
+      {
+        "Level": "38",
+        "Move": "MOVE_AIR_SLASH"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_MEGAHORN"
+      },
+      {
+        "Level": "49",
+        "Move": "MOVE_SACRED_SWORD"
+      },
+      {
+        "Level": "56",
+        "Move": "MOVE_SWORDS_DANCE"
+      },
+      {
+        "Level": "63",
+        "Move": "MOVE_IRON_HEAD"
+      },
+      {
+        "Level": "70",
+        "Move": "MOVE_CLOSE_COMBAT"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_ROAR",
+      "MOVE_CALM_MIND",
       "MOVE_THUNDER_WAVE",
-      "MOVE_TOXIC"
+      "MOVE_BRICK_BREAK",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_SWIFT",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_HYPER_BEAM",
+      "MOVE_SAFEGUARD",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_STONE_EDGE",
+      "MOVE_VOLT_SWITCH",
+      "MOVE_POISON_JAB",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_X-SCISSOR",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_TAUNT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_SKULL_BASH",
+      "MOVE_VACUUM_WAVE",
+      "MOVE_STEEL_BEAM"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "TERRAKION": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_WORK_UP"
+      },
+      {
+        "Level": "7",
+        "Move": "MOVE_ROCK_THROW"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_BODY_SLAM"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "26",
+        "Move": "MOVE_HEAVY_SLAM"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_AURA_SPHERE"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_ROCK_BLAST"
+      },
+      {
+        "Level": "38",
+        "Move": "MOVE_ROCK_SLIDE"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_MEGAHORN"
+      },
+      {
+        "Level": "49",
+        "Move": "MOVE_SACRED_SWORD"
+      },
+      {
+        "Level": "56",
+        "Move": "MOVE_SWORDS_DANCE"
+      },
+      {
+        "Level": "63",
+        "Move": "MOVE_STONE_EDGE"
+      },
+      {
+        "Level": "70",
+        "Move": "MOVE_CLOSE_COMBAT"
+      },
+      {
+        "Level": "78",
+        "Move": "MOVE_HEAD_SMASH"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_ROAR",
+      "MOVE_CALM_MIND",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_SWIFT",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_HYPER_BEAM",
+      "MOVE_SAFEGUARD",
+      "MOVE_EARTH_POWER",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_POISON_JAB",
+      "MOVE_BULLDOZE",
+      "MOVE_X-SCISSOR",
+      "MOVE_SUBSTITUTE",
+      "MOVE_TAUNT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_SKULL_BASH"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "VIRIZION": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_WORK_UP"
+      },
+      {
+        "Level": "7",
+        "Move": "MOVE_MAGICAL_LEAF"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_BODY_SLAM"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "26",
+        "Move": "MOVE_BOUNCE"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_AURA_SPHERE"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_AIR_SLASH"
+      },
+      {
+        "Level": "38",
+        "Move": "MOVE_HORN_LEECH"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_MEGAHORN"
+      },
+      {
+        "Level": "49",
+        "Move": "MOVE_SACRED_SWORD"
+      },
+      {
+        "Level": "56",
+        "Move": "MOVE_SWORDS_DANCE"
+      },
+      {
+        "Level": "63",
+        "Move": "MOVE_LEAF_BLADE"
+      },
+      {
+        "Level": "70",
+        "Move": "MOVE_CLOSE_COMBAT"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_ROAR",
+      "MOVE_CALM_MIND",
+      "MOVE_BRICK_BREAK",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_BULLET_SEED",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_HYPER_BEAM",
+      "MOVE_SAFEGUARD",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_STONE_EDGE",
+      "MOVE_POISON_JAB",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_X-SCISSOR",
+      "MOVE_SUBSTITUTE",
+      "MOVE_TAUNT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_SEED_BOMB",
+      "MOVE_SKULL_BASH",
+      "MOVE_VACUUM_WAVE",
+      "MOVE_SOLAR_BLADE"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "KELDIO": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_AQUA_JET"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_WORK_UP"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_SACRED_SWORD"
+      },
+      {
+        "Level": "7",
+        "Move": "MOVE_BUBBLE_BEAM"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_BODY_SLAM"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "26",
+        "Move": "MOVE_BOUNCE"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_AURA_SPHERE"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_EARTH_POWER"
+      },
+      {
+        "Level": "38",
+        "Move": "MOVE_AIR_SLASH"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_MEGAHORN"
+      },
+      {
+        "Level": "49",
+        "Move": "MOVE_SACRED_SWORD"
+      },
+      {
+        "Level": "56",
+        "Move": "MOVE_SWORDS_DANCE"
+      },
+      {
+        "Level": "63",
+        "Move": "MOVE_HYDRO_PUMP"
+      },
+      {
+        "Level": "70",
+        "Move": "MOVE_CLOSE_COMBAT"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_ROAR",
+      "MOVE_CALM_MIND",
+      "MOVE_FLIP_TURN",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ICE_BEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_SWIFT",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_WATER_PULSE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_ICY_WIND",
+      "MOVE_SAFEGUARD",
+      "MOVE_EARTH_POWER",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_STONE_EDGE",
+      "MOVE_WHIRLPOOL",
+      "MOVE_SURF",
+      "MOVE_LIQUIDATION",
+      "MOVE_POISON_JAB",
+      "MOVE_X-SCISSOR",
+      "MOVE_SUBSTITUTE",
+      "MOVE_TAUNT",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_TRAILBLAZE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_MUDDY_WATER",
+      "MOVE_SKULL_BASH",
+      "MOVE_SCALD",
+      "MOVE_VACUUM_WAVE"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "MELOETTA": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_SING"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_CONFUSION"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "11",
+        "Move": "MOVE_DISARMING_VOICE"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_FAKE_TEARS"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_SWORDS_DANCE"
+      },
+      {
+        "Level": "31",
+        "Move": "MOVE_PSYBEAM"
+      },
+      {
+        "Level": "43",
+        "Move": "MOVE_U_TURN"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_RELIC_SONG"
+      },
+      {
+        "Level": "57",
+        "Move": "MOVE_PSYCHIC"
+      },
+      {
+        "Level": "64",
+        "Move": "MOVE_HYPER_VOICE"
+      },
+      {
+        "Level": "78",
+        "Move": "MOVE_CLOSE_COMBAT"
+      },
+      {
+        "Level": "85",
+        "Move": "MOVE_PERISH_SONG"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_FLIP_TURN",
+      "MOVE_BRICK_BREAK",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_POWER_GEM",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_ENDURE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_AGILITY",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_PSYCHIC",
+      "MOVE_STONE_EDGE",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_U-TURN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_METRONOME",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_THUNDER",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_SING",
+      "MOVE_LOW_SWEEP",
+      "MOVE_MIMIC",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_TRIPLE_AXEL",
+      "MOVE_PETAL_DANCE"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "GENESECT": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_TECHNO_BLAST"
+      },
+      {
+        "Level": "7",
+        "Move": "MOVE_SCREECH"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_METAL_CLAW"
+      },
+      {
+        "Level": "21",
+        "Move": "MOVE_X_SCISSOR"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_FLAME_CHARGE"
+      },
+      {
+        "Level": "35",
+        "Move": "MOVE_METAL_SOUND"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_LUNGE"
+      },
+      {
+        "Level": "45",
+        "Move": "MOVE_FLASH_CANNON"
+      },
+      {
+        "Level": "49",
+        "Move": "MOVE_LEECH_LIFE"
+      },
+      {
+        "Level": "56",
+        "Move": "MOVE_BUG_BUZZ"
+      },
+      {
+        "Level": "62",
+        "Move": "MOVE_IRON_HEAD"
+      },
+      {
+        "Level": "70",
+        "Move": "MOVE_ZAP_CANNON"
+      },
+      {
+        "Level": "91",
+        "Move": "MOVE_SELF_DESTRUCT"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_THUNDER_WAVE",
+      "MOVE_ICE_BEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_REFLECT",
+      "MOVE_ENDURE",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_FLY",
+      "MOVE_HYPER_BEAM",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_FLAMETHROWER",
+      "MOVE_PSYCHIC",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_THUNDERBOLT",
+      "MOVE_SHADOW_BALL",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_X-SCISSOR",
+      "MOVE_U-TURN",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_GUNK_SHOT",
+      "MOVE_ELECTROWEB",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_BLAZE_KICK",
+      "MOVE_SKULL_BASH",
+      "MOVE_TRI_ATTACK",
+      "MOVE_STEEL_BEAM"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -12958,30 +23158,36 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
-      "MOVE_BULLDOZE",
-      "MOVE_BULLET_SEED",
-      "MOVE_CURSE",
-      "MOVE_DIG",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_GIGA_DRAIN",
       "MOVE_HEADBUTT",
-      "MOVE_IRON_HEAD",
-      "MOVE_MUD_SHOT",
-      "MOVE_POISON_JAB",
-      "MOVE_PROTECT",
-      "MOVE_REFLECT",
       "MOVE_ROAR",
+      "MOVE_BRICK_BREAK",
       "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
+      "MOVE_BULLET_SEED",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_MUD_SHOT",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
       "MOVE_SHADOW_CLAW",
       "MOVE_SOLAR_BEAM",
-      "MOVE_SPIKES",
+      "MOVE_POISON_JAB",
+      "MOVE_BULLDOZE",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_THUNDER_PUNCH",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_SPIKES",
+      "MOVE_CURSE",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_SEED_BOMB",
+      "MOVE_DRAIN_PUNCH"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -13034,32 +23240,39 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
-      "MOVE_BULK_UP",
-      "MOVE_BULLDOZE",
-      "MOVE_BULLET_SEED",
-      "MOVE_CURSE",
-      "MOVE_DIG",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_GIGA_DRAIN",
       "MOVE_HEADBUTT",
-      "MOVE_IRON_HEAD",
-      "MOVE_MUD_SHOT",
-      "MOVE_POISON_JAB",
-      "MOVE_PROTECT",
-      "MOVE_REFLECT",
-      "MOVE_ROAR",
-      "MOVE_ROCK_SLIDE",
       "MOVE_ROCK_SMASH",
+      "MOVE_ROAR",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
+      "MOVE_BULLET_SEED",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_MUD_SHOT",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
       "MOVE_SHADOW_CLAW",
       "MOVE_SOLAR_BEAM",
-      "MOVE_SPIKES",
+      "MOVE_POISON_JAB",
+      "MOVE_BULLDOZE",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_THUNDER_PUNCH",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_SPIKES",
+      "MOVE_CURSE",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_TRAILBLAZE",
+      "MOVE_SEED_BOMB",
+      "MOVE_DRAIN_PUNCH"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -13124,40 +23337,54 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
-      "MOVE_BULLDOZE",
-      "MOVE_BULLET_SEED",
-      "MOVE_CRUNCH",
-      "MOVE_CURSE",
-      "MOVE_DIG",
-      "MOVE_DOUBLE_EDGE",
-      "MOVE_DRAGON_CLAW",
-      "MOVE_EARTHQUAKE",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_GIGA_DRAIN",
       "MOVE_HEADBUTT",
+      "MOVE_DRAGON_CLAW",
+      "MOVE_ROCK_SMASH",
+      "MOVE_ROAR",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_CRUNCH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_BULLET_SEED",
+      "MOVE_GIGA_DRAIN",
       "MOVE_HYPER_BEAM",
-      "MOVE_IRON_DEFENSE",
-      "MOVE_IRON_HEAD",
       "MOVE_KNOCK_OFF",
       "MOVE_MUD_SHOT",
-      "MOVE_POISON_JAB",
-      "MOVE_PROTECT",
-      "MOVE_REFLECT",
-      "MOVE_ROAR",
-      "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_SMASH",
-      "MOVE_ROCK_TOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
       "MOVE_SHADOW_CLAW",
       "MOVE_SOLAR_BEAM",
-      "MOVE_SPIKES",
       "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_POISON_JAB",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_SWORDS_DANCE",
-      "MOVE_THUNDER_PUNCH",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_SPIKES",
+      "MOVE_CURSE",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_TRAILBLAZE",
+      "MOVE_SEED_BOMB",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_DUAL_CHOP",
+      "MOVE_SKULL_BASH",
+      "MOVE_SOLAR_BLADE",
+      "MOVE_FRENZY_PLANT"
     ],
     "TutorMoves": [
       "MOVE_SPIKY_SHIELD"
@@ -13216,15 +23443,24 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
+      "MOVE_PSYSHOCK",
       "MOVE_CALM_MIND",
-      "MOVE_ENDURE",
-      "MOVE_FLARE_BLITZ",
-      "MOVE_OVERHEAT",
+      "MOVE_LIGHT_SCREEN",
       "MOVE_PROTECT",
+      "MOVE_SWIFT",
+      "MOVE_ENDURE",
+      "MOVE_FIRE_BLAST",
+      "MOVE_AGILITY",
+      "MOVE_OVERHEAT",
+      "MOVE_WILL-O-WISP",
+      "MOVE_FLAMETHROWER",
+      "MOVE_PSYCHIC",
       "MOVE_SOLAR_BEAM",
+      "MOVE_FIRE_SPIN",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT"
+      "MOVE_FLARE_BLITZ",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -13285,17 +23521,27 @@
       }
     ],
     "TMMoves": [
+      "MOVE_PSYSHOCK",
       "MOVE_CALM_MIND",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FLARE_BLITZ",
-      "MOVE_HEAT_WAVE",
-      "MOVE_OVERHEAT",
+      "MOVE_LIGHT_SCREEN",
       "MOVE_PROTECT",
-      "MOVE_SOLAR_BEAM",
-      "MOVE_SUBSTITUTE",
+      "MOVE_THUNDER_PUNCH",
       "MOVE_SWIFT",
-      "MOVE_THUNDER_PUNCH"
+      "MOVE_FIRE_PUNCH",
+      "MOVE_ENDURE",
+      "MOVE_FIRE_BLAST",
+      "MOVE_AGILITY",
+      "MOVE_OVERHEAT",
+      "MOVE_WILL-O-WISP",
+      "MOVE_FLAMETHROWER",
+      "MOVE_PSYCHIC",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_HEAT_WAVE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_FLARE_BLITZ",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -13356,28 +23602,47 @@
       }
     ],
     "TMMoves": [
+      "MOVE_PSYSHOCK",
       "MOVE_CALM_MIND",
-      "MOVE_DAZZLING_GLEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_SWIFT",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_REFLECT",
       "MOVE_DOUBLE_TEAM",
       "MOVE_ENDURE",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FLARE_BLITZ",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_HEAL_BLOCK",
-      "MOVE_HEAT_WAVE",
+      "MOVE_FIRE_BLAST",
       "MOVE_HYPER_BEAM",
-      "MOVE_HYPER_VOICE",
-      "MOVE_METRONOME",
-      "MOVE_NASTY_PLOT",
+      "MOVE_AGILITY",
       "MOVE_OVERHEAT",
-      "MOVE_PROTECT",
-      "MOVE_REFLECT",
       "MOVE_SAFEGUARD",
+      "MOVE_WILL-O-WISP",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_FLAMETHROWER",
+      "MOVE_PSYCHIC",
       "MOVE_SOLAR_BEAM",
+      "MOVE_HEAT_WAVE",
+      "MOVE_HYPER_VOICE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_SHADOW_BALL",
+      "MOVE_NASTY_PLOT",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_THUNDER_PUNCH",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_METRONOME",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_FLARE_BLITZ",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_SILVER_WIND",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_RAZOR_WIND",
+      "MOVE_BLAST_BURN"
     ],
     "TutorMoves": [
       "MOVE_FUTURE_SIGHT",
@@ -13438,24 +23703,32 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
-      "MOVE_BLIZZARD",
-      "MOVE_DIG",
-      "MOVE_ENDURE",
-      "MOVE_ICE_BEAM",
-      "MOVE_ICY_WIND",
-      "MOVE_LIQUIDATION",
-      "MOVE_PROTECT",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SPIKES",
-      "MOVE_SURF",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
       "MOVE_SWIFT",
-      "MOVE_TAUNT",
+      "MOVE_DIG",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_WATER_PULSE",
+      "MOVE_ICY_WIND",
+      "MOVE_SURF",
+      "MOVE_LIQUIDATION",
+      "MOVE_U-TURN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_SPIKES",
       "MOVE_TOXIC_SPIKES",
-      "MOVE_U_TURN",
+      "MOVE_TAUNT",
+      "MOVE_HYDRO_PUMP",
       "MOVE_WATERFALL",
-      "MOVE_WATER_PULSE"
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_TRAILBLAZE",
+      "MOVE_FALSE_SWIPE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -13520,31 +23793,40 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BLIZZARD",
-      "MOVE_BRICK_BREAK",
-      "MOVE_DARK_PULSE",
-      "MOVE_DIG",
-      "MOVE_ENDURE",
-      "MOVE_FLIP_TURN",
-      "MOVE_GUNK_SHOT",
       "MOVE_HEADBUTT",
-      "MOVE_ICE_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_ICY_WIND",
-      "MOVE_LIQUIDATION",
-      "MOVE_NASTY_PLOT",
-      "MOVE_PROTECT",
+      "MOVE_FLIP_TURN",
+      "MOVE_BRICK_BREAK",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SPIKES",
-      "MOVE_SURF",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_ICE_PUNCH",
       "MOVE_SWIFT",
+      "MOVE_DIG",
       "MOVE_SWORDS_DANCE",
-      "MOVE_TAUNT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_WATER_PULSE",
+      "MOVE_ICY_WIND",
+      "MOVE_SURF",
+      "MOVE_LIQUIDATION",
+      "MOVE_U-TURN",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_SPIKES",
       "MOVE_TOXIC_SPIKES",
-      "MOVE_U_TURN",
+      "MOVE_DARK_PULSE",
+      "MOVE_TAUNT",
+      "MOVE_HYDRO_PUMP",
       "MOVE_WATERFALL",
-      "MOVE_WATER_PULSE"
+      "MOVE_GUNK_SHOT",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_TRAILBLAZE",
+      "MOVE_FALSE_SWIPE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -13609,34 +23891,47 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BLIZZARD",
-      "MOVE_BRICK_BREAK",
-      "MOVE_DARK_PULSE",
-      "MOVE_DIG",
-      "MOVE_ENDURE",
-      "MOVE_FLIP_TURN",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_GUNK_SHOT",
       "MOVE_HEADBUTT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_ICE_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_ICY_WIND",
-      "MOVE_LIQUIDATION",
-      "MOVE_NASTY_PLOT",
-      "MOVE_PROTECT",
       "MOVE_PSYSHOCK",
+      "MOVE_FLIP_TURN",
+      "MOVE_BRICK_BREAK",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SPIKES",
-      "MOVE_SURF",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_ICE_PUNCH",
       "MOVE_SWIFT",
+      "MOVE_DIG",
       "MOVE_SWORDS_DANCE",
-      "MOVE_TAUNT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_WATER_PULSE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_ICY_WIND",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_SURF",
+      "MOVE_LIQUIDATION",
+      "MOVE_U-TURN",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_SPIKES",
       "MOVE_TOXIC_SPIKES",
-      "MOVE_U_TURN",
+      "MOVE_DARK_PULSE",
+      "MOVE_TAUNT",
+      "MOVE_HYDRO_PUMP",
       "MOVE_WATERFALL",
-      "MOVE_WATER_PULSE"
+      "MOVE_GUNK_SHOT",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_LOW_SWEEP",
+      "MOVE_TRAILBLAZE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_RAZOR_WIND",
+      "MOVE_VACUUM_WAVE",
+      "MOVE_HYDRO_CANNON"
     ],
     "TutorMoves": [
       "MOVE_WATER_SHURIKEN"
@@ -13687,26 +23982,30 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
+      "MOVE_HEADBUTT",
+      "MOVE_ROCK_SMASH",
       "MOVE_BRICK_BREAK",
       "MOVE_BULK_UP",
-      "MOVE_BULLDOZE",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
-      "MOVE_HEADBUTT",
-      "MOVE_IRON_HEAD",
-      "MOVE_PROTECT",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_SMASH",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SLUDGE_BOMB",
-      "MOVE_SPIKES",
-      "MOVE_STONE_EDGE",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
+      "MOVE_PROTECT",
+      "MOVE_DIG",
       "MOVE_SWORDS_DANCE",
-      "MOVE_U_TURN",
-      "MOVE_WILD_CHARGE"
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_MUD_SHOT",
+      "MOVE_AGILITY",
+      "MOVE_EARTH_POWER",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_IRON_HEAD",
+      "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_SURF",
+      "MOVE_BULLDOZE",
+      "MOVE_U-TURN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WILD_CHARGE",
+      "MOVE_SPIKES",
+      "MOVE_FACADE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -13755,32 +24054,43 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
-      "MOVE_BODY_SLAM",
+      "MOVE_HEADBUTT",
+      "MOVE_ROCK_SMASH",
       "MOVE_BRICK_BREAK",
       "MOVE_BULK_UP",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_GUNK_SHOT",
-      "MOVE_HEADBUTT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_IRON_HEAD",
-      "MOVE_PROTECT",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_SMASH",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SLUDGE_BOMB",
-      "MOVE_SPIKES",
-      "MOVE_STONE_EDGE",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
-      "MOVE_SWORDS_DANCE",
+      "MOVE_PROTECT",
       "MOVE_THUNDER_PUNCH",
-      "MOVE_U_TURN",
-      "MOVE_WILD_CHARGE"
+      "MOVE_ICE_PUNCH",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_HYPER_BEAM",
+      "MOVE_MUD_SHOT",
+      "MOVE_AGILITY",
+      "MOVE_EARTH_POWER",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_IRON_HEAD",
+      "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_SURF",
+      "MOVE_BULLDOZE",
+      "MOVE_U-TURN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WILD_CHARGE",
+      "MOVE_SPIKES",
+      "MOVE_GUNK_SHOT",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_CIRCLE_THROW",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_SKULL_BASH",
+      "MOVE_FISSURE"
     ],
     "TutorMoves": [
       "MOVE_BULLDOZE"
@@ -13835,19 +24145,25 @@
       }
     ],
     "TMMoves": [
+      "MOVE_PROTECT",
       "MOVE_AERIAL_ACE",
+      "MOVE_SWIFT",
+      "MOVE_SWORDS_DANCE",
       "MOVE_DOUBLE_TEAM",
       "MOVE_ENDURE",
       "MOVE_FLY",
+      "MOVE_AGILITY",
+      "MOVE_OVERHEAT",
+      "MOVE_WILL-O-WISP",
       "MOVE_HEAT_WAVE",
       "MOVE_HURRICANE",
-      "MOVE_OVERHEAT",
-      "MOVE_PROTECT",
+      "MOVE_U-TURN",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_SWORDS_DANCE",
-      "MOVE_U_TURN",
-      "MOVE_WILL_O_WISP"
+      "MOVE_WHIRLWIND",
+      "MOVE_FLARE_BLITZ",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_DUAL_WINGBEAT"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -13900,23 +24216,30 @@
       }
     ],
     "TMMoves": [
+      "MOVE_PROTECT",
       "MOVE_AERIAL_ACE",
-      "MOVE_DOUBLE_EDGE",
+      "MOVE_SWIFT",
+      "MOVE_SWORDS_DANCE",
       "MOVE_DOUBLE_TEAM",
       "MOVE_ENDURE",
       "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_SPIN",
-      "MOVE_FLAMETHROWER",
       "MOVE_FLY",
-      "MOVE_HEAT_WAVE",
-      "MOVE_HURRICANE",
+      "MOVE_AGILITY",
       "MOVE_OVERHEAT",
-      "MOVE_PROTECT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_WILL-O-WISP",
+      "MOVE_FLAMETHROWER",
+      "MOVE_HEAT_WAVE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_HURRICANE",
+      "MOVE_U-TURN",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_SWORDS_DANCE",
-      "MOVE_U_TURN",
-      "MOVE_WILL_O_WISP"
+      "MOVE_WHIRLWIND",
+      "MOVE_FLARE_BLITZ",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_VACUUM_WAVE"
     ],
     "TutorMoves": [
       "MOVE_WING_ATTACK"
@@ -13975,27 +24298,36 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
       "MOVE_BULK_UP",
-      "MOVE_DOUBLE_EDGE",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_SWIFT",
+      "MOVE_SWORDS_DANCE",
       "MOVE_DOUBLE_TEAM",
       "MOVE_ENDURE",
       "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_SPIN",
-      "MOVE_FLAMETHROWER",
       "MOVE_FLY",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HEAT_WAVE",
-      "MOVE_HURRICANE",
       "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
       "MOVE_OVERHEAT",
-      "MOVE_PROTECT",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_WILL-O-WISP",
+      "MOVE_FLAMETHROWER",
       "MOVE_SOLAR_BEAM",
+      "MOVE_HEAT_WAVE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_HURRICANE",
+      "MOVE_U-TURN",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_SWORDS_DANCE",
-      "MOVE_U_TURN",
-      "MOVE_WILL_O_WISP"
+      "MOVE_WHIRLWIND",
+      "MOVE_FLARE_BLITZ",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_BLAZE_KICK",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_VACUUM_WAVE",
+      "MOVE_SKY_ATTACK"
     ],
     "TutorMoves": [
       "MOVE_BRAVE_BIRD"
@@ -14018,7 +24350,9 @@
       }
     ],
     "TMMoves": [
-      "MOVE_PROTECT"
+      "MOVE_PROTECT",
+      "MOVE_ENDURE",
+      "MOVE_FACADE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -14051,7 +24385,10 @@
       }
     ],
     "TMMoves": [
-      "MOVE_IRON_DEFENSE"
+      "MOVE_PROTECT",
+      "MOVE_ENDURE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FACADE"
     ],
     "TutorMoves": [
       "MOVE_PROTECT"
@@ -14118,17 +24455,28 @@
       }
     ],
     "TMMoves": [
-      "MOVE_DAZZLING_GLEAM",
-      "MOVE_ENDURE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
       "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_ENDURE",
       "MOVE_GIGA_DRAIN",
-      "MOVE_GIGA_IMPACT",
       "MOVE_HYPER_BEAM",
-      "MOVE_IRON_DEFENSE",
+      "MOVE_SAFEGUARD",
+      "MOVE_GIGA_IMPACT",
       "MOVE_PSYCHIC",
       "MOVE_SOLAR_BEAM",
+      "MOVE_HURRICANE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_U-TURN",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT"
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_WHIRLWIND",
+      "MOVE_FACADE",
+      "MOVE_SILVER_WIND",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_PETAL_DANCE"
     ],
     "TutorMoves": [
       "MOVE_GUST",
@@ -14195,23 +24543,35 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
+      "MOVE_HEADBUTT",
+      "MOVE_ROAR",
+      "MOVE_FIRE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_FANG",
+      "MOVE_CRUNCH",
+      "MOVE_SWIFT",
       "MOVE_DIG",
-      "MOVE_DOUBLE_EDGE",
+      "MOVE_BODY_SLAM",
       "MOVE_ENDURE",
       "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_SPIN",
-      "MOVE_FLARE_BLITZ",
-      "MOVE_HEAT_WAVE",
       "MOVE_OVERHEAT",
-      "MOVE_PROTECT",
+      "MOVE_EARTH_POWER",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_WILL-O-WISP",
+      "MOVE_FLAMETHROWER",
       "MOVE_SOLAR_BEAM",
+      "MOVE_HEAT_WAVE",
+      "MOVE_HYPER_VOICE",
+      "MOVE_FIRE_SPIN",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_TAUNT",
-      "MOVE_THUNDER_FANG",
       "MOVE_WILD_CHARGE",
-      "MOVE_WILL_O_WISP"
+      "MOVE_TAUNT",
+      "MOVE_WORK_UP",
+      "MOVE_FLARE_BLITZ",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_PSYCHIC_FANGS"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -14272,24 +24632,38 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_DARK_PULSE",
+      "MOVE_HEADBUTT",
+      "MOVE_ROAR",
+      "MOVE_FIRE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_FANG",
+      "MOVE_CRUNCH",
+      "MOVE_SWIFT",
       "MOVE_DIG",
-      "MOVE_DOUBLE_EDGE",
+      "MOVE_BODY_SLAM",
       "MOVE_ENDURE",
       "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_SPIN",
-      "MOVE_FLARE_BLITZ",
+      "MOVE_HYPER_BEAM",
+      "MOVE_OVERHEAT",
+      "MOVE_EARTH_POWER",
       "MOVE_GIGA_IMPACT",
-      "MOVE_HEAT_WAVE",
-      "MOVE_PROTECT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_WILL-O-WISP",
+      "MOVE_FLAMETHROWER",
       "MOVE_SOLAR_BEAM",
+      "MOVE_HEAT_WAVE",
+      "MOVE_HYPER_VOICE",
+      "MOVE_FIRE_SPIN",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_TAUNT",
-      "MOVE_THUNDER_FANG",
       "MOVE_WILD_CHARGE",
-      "MOVE_WILL_O_WISP"
+      "MOVE_DARK_PULSE",
+      "MOVE_TAUNT",
+      "MOVE_WORK_UP",
+      "MOVE_FLARE_BLITZ",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_PSYCHIC_FANGS"
     ],
     "TutorMoves": [
       "MOVE_HYPER_BEAM",
@@ -14350,15 +24724,23 @@
     ],
     "TMMoves": [
       "MOVE_CALM_MIND",
-      "MOVE_DAZZLING_GLEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
       "MOVE_DOUBLE_TEAM",
       "MOVE_ENDURE",
       "MOVE_GIGA_DRAIN",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_PROTECT",
+      "MOVE_SAFEGUARD",
       "MOVE_PSYCHIC",
+      "MOVE_SOLAR_BEAM",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT"
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_TRAILBLAZE",
+      "MOVE_SEED_BOMB",
+      "MOVE_PETAL_DANCE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -14416,16 +24798,27 @@
     ],
     "TMMoves": [
       "MOVE_CALM_MIND",
-      "MOVE_DAZZLING_GLEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
       "MOVE_DOUBLE_TEAM",
       "MOVE_ENDURE",
       "MOVE_GIGA_DRAIN",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_METRONOME",
-      "MOVE_PROTECT",
+      "MOVE_SAFEGUARD",
       "MOVE_PSYCHIC",
+      "MOVE_SOLAR_BEAM",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT"
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_METRONOME",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_TRAILBLAZE",
+      "MOVE_SILVER_WIND",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_SEED_BOMB",
+      "MOVE_PETAL_DANCE",
+      "MOVE_SOLAR_BLADE"
     ],
     "TutorMoves": [
       "MOVE_MOONBLAST"
@@ -14489,17 +24882,28 @@
     ],
     "TMMoves": [
       "MOVE_CALM_MIND",
-      "MOVE_DAZZLING_GLEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
       "MOVE_DOUBLE_TEAM",
       "MOVE_ENDURE",
       "MOVE_GIGA_DRAIN",
       "MOVE_HYPER_BEAM",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_METRONOME",
-      "MOVE_PROTECT",
+      "MOVE_SAFEGUARD",
       "MOVE_PSYCHIC",
+      "MOVE_SOLAR_BEAM",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT"
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_METRONOME",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_TRAILBLAZE",
+      "MOVE_SILVER_WIND",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_SEED_BOMB",
+      "MOVE_PETAL_DANCE",
+      "MOVE_SOLAR_BLADE"
     ],
     "TutorMoves": [
       "MOVE_MOONBLAST"
@@ -14563,17 +24967,28 @@
     ],
     "TMMoves": [
       "MOVE_CALM_MIND",
-      "MOVE_DAZZLING_GLEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
       "MOVE_DOUBLE_TEAM",
       "MOVE_ENDURE",
       "MOVE_GIGA_DRAIN",
       "MOVE_HYPER_BEAM",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_METRONOME",
-      "MOVE_PROTECT",
+      "MOVE_SAFEGUARD",
       "MOVE_PSYCHIC",
+      "MOVE_SOLAR_BEAM",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT"
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_METRONOME",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_TRAILBLAZE",
+      "MOVE_SILVER_WIND",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_SEED_BOMB",
+      "MOVE_PETAL_DANCE",
+      "MOVE_SOLAR_BLADE"
     ],
     "TutorMoves": [
       "MOVE_DISARMING_VOICE"
@@ -14644,24 +25059,29 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_BRICK_BREAK",
-      "MOVE_BULLET_SEED",
-      "MOVE_DIG",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_GIGA_DRAIN",
-      "MOVE_LEAF_STORM",
-      "MOVE_MAGICAL_LEAF",
-      "MOVE_PLAY_ROUGH",
-      "MOVE_PROTECT",
       "MOVE_ROAR",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
       "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_BULLET_SEED",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_MUD_SHOT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_ZEN_HEADBUTT",
       "MOVE_SOLAR_BEAM",
-      "MOVE_SUBSTITUTE",
       "MOVE_SURF",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
       "MOVE_WILD_CHARGE",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_SEED_BOMB"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -14734,26 +25154,35 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_BRICK_BREAK",
-      "MOVE_BULLET_SEED",
-      "MOVE_DIG",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_GIGA_DRAIN",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_LEAF_STORM",
-      "MOVE_MAGICAL_LEAF",
-      "MOVE_PLAY_ROUGH",
-      "MOVE_PROTECT",
       "MOVE_ROAR",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
       "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_AERIAL_ACE",
+      "MOVE_ENERGY_BALL",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_BULLET_SEED",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_HYPER_BEAM",
+      "MOVE_MUD_SHOT",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_ZEN_HEADBUTT",
       "MOVE_SOLAR_BEAM",
-      "MOVE_SUBSTITUTE",
+      "MOVE_EARTHQUAKE",
       "MOVE_SURF",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
       "MOVE_WILD_CHARGE",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_SEED_BOMB",
+      "MOVE_SKULL_BASH",
+      "MOVE_SOLAR_BLADE"
     ],
     "TutorMoves": [
       "MOVE_AERIAL_ACE"
@@ -14804,23 +25233,35 @@
       }
     ],
     "TMMoves": [
+      "MOVE_BRICK_BREAK",
       "MOVE_BULK_UP",
-      "MOVE_BULLDOZE",
-      "MOVE_DIG",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_HYPER_VOICE",
-      "MOVE_ICE_PUNCH",
-      "MOVE_PROTECT",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SHADOW_CLAW",
-      "MOVE_SLUDGE_BOMB",
-      "MOVE_STONE_EDGE",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
       "MOVE_SWORDS_DANCE",
-      "MOVE_THUNDER_PUNCH"
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_STONE_EDGE",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SURF",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_TAUNT",
+      "MOVE_WORK_UP",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_CIRCLE_THROW",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_STORM_THROW"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -14889,37 +25330,53 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BULK_UP",
-      "MOVE_BULLDOZE",
-      "MOVE_DARK_PULSE",
-      "MOVE_DIG",
       "MOVE_DRAGON_CLAW",
-      "MOVE_EARTHQUAKE",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_DRAIN",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_GUNK_SHOT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_HYPER_VOICE",
-      "MOVE_ICE_PUNCH",
-      "MOVE_IRON_HEAD",
-      "MOVE_KNOCK_OFF",
-      "MOVE_POISON_JAB",
-      "MOVE_POWER_UP_PUNCH",
-      "MOVE_PROTECT",
-      "MOVE_ROCK_SLIDE",
       "MOVE_ROCK_SMASH",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SHADOW_CLAW",
-      "MOVE_SLUDGE_BOMB",
-      "MOVE_STONE_EDGE",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
-      "MOVE_SWORDS_DANCE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
       "MOVE_THUNDER_PUNCH",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_ICE_PUNCH",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SURF",
+      "MOVE_POISON_JAB",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_OUTRAGE",
+      "MOVE_TAUNT",
+      "MOVE_GUNK_SHOT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_CIRCLE_THROW",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_DUAL_CHOP",
+      "MOVE_STORM_THROW"
     ],
     "TutorMoves": [
       "MOVE_NIGHT_SLASH"
@@ -14982,31 +25439,47 @@
       }
     ],
     "TMMoves": [
-      "MOVE_DARK_PULSE",
+      "MOVE_HEADBUTT",
+      "MOVE_ROCK_SMASH",
+      "MOVE_ROAR",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_FIRE_FANG",
+      "MOVE_ICE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_FANG",
+      "MOVE_CRUNCH",
       "MOVE_DIG",
       "MOVE_DOUBLE_TEAM",
       "MOVE_ENDURE",
-      "MOVE_FIRE_FANG",
-      "MOVE_GIGA_IMPACT",
       "MOVE_HYPER_BEAM",
-      "MOVE_ICE_FANG",
-      "MOVE_IRON_TAIL",
-      "MOVE_PROTECT",
-      "MOVE_ROCK_SMASH",
-      "MOVE_SUBSTITUTE",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_HYPER_VOICE",
       "MOVE_SURF",
-      "MOVE_THUNDER_FANG",
-      "MOVE_THUNDER_WAVE",
-      "MOVE_U_TURN",
+      "MOVE_U-TURN",
+      "MOVE_SUBSTITUTE",
       "MOVE_WILD_CHARGE",
+      "MOVE_IRON_TAIL",
+      "MOVE_DARK_PULSE",
       "MOVE_WORK_UP",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_FACADE",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_MIMIC",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_DOUBLE_HIT",
+      "MOVE_SKULL_BASH",
+      "MOVE_TRI_ATTACK"
     ],
     "TutorMoves": [],
     "EggMoves": []
   },
   "ESPURR": {
     "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TELEPORT"
+      },
       {
         "Level": "1",
         "Move": "MOVE_TACKLE"
@@ -15049,27 +25522,38 @@
       }
     ],
     "TMMoves": [
+      "MOVE_PSYSHOCK",
       "MOVE_CALM_MIND",
-      "MOVE_DARK_PULSE",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_NASTY_PLOT",
-      "MOVE_PLAY_ROUGH",
-      "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
-      "MOVE_SAFEGUARD",
-      "MOVE_SHADOW_BALL",
-      "MOVE_SUBSTITUTE",
-      "MOVE_THUNDERBOLT",
       "MOVE_THUNDER_WAVE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_REFLECT",
+      "MOVE_ENDURE",
+      "MOVE_SAFEGUARD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_PSYCHIC",
+      "MOVE_THUNDERBOLT",
+      "MOVE_SHADOW_BALL",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
       "MOVE_WORK_UP",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_FACADE",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_FAKE_OUT"
     ],
     "TutorMoves": [],
     "EggMoves": []
   },
   "MEOWSTIC_M": {
     "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TELEPORT"
+      },
       {
         "Level": "1",
         "Move": "MOVE_TACKLE"
@@ -15128,34 +25612,53 @@
       }
     ],
     "TMMoves": [
+      "MOVE_PSYSHOCK",
       "MOVE_CALM_MIND",
-      "MOVE_DARK_PULSE",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
       "MOVE_DIG",
+      "MOVE_REFLECT",
       "MOVE_DOUBLE_TEAM",
       "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_NASTY_PLOT",
-      "MOVE_PLAY_ROUGH",
-      "MOVE_PROTECT",
-      "MOVE_SAFEGUARD",
-      "MOVE_SHADOW_BALL",
-      "MOVE_SPIKES",
       "MOVE_STEALTH_ROCK",
-      "MOVE_SUBSTITUTE",
-      "MOVE_TAUNT",
+      "MOVE_HYPER_BEAM",
+      "MOVE_SAFEGUARD",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_PSYCHIC",
       "MOVE_THUNDERBOLT",
-      "MOVE_THUNDER_WAVE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_SPIKES",
       "MOVE_TOXIC_SPIKES",
+      "MOVE_DARK_PULSE",
+      "MOVE_TAUNT",
+      "MOVE_HEAL_BLOCK",
       "MOVE_WORK_UP",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_PAY_DAY",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_FAKE_OUT",
+      "MOVE_TRI_ATTACK"
     ],
-    "TutorMoves": [],
+    "TutorMoves": [
+      "MOVE_MOONBLAST"
+    ],
     "EggMoves": []
   },
   "MEOWSTIC_F": {
     "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TELEPORT"
+      },
       {
         "Level": "1",
         "Move": "MOVE_TACKLE"
@@ -15218,25 +25721,42 @@
       }
     ],
     "TMMoves": [
+      "MOVE_PSYSHOCK",
       "MOVE_CALM_MIND",
-      "MOVE_DIG",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_NASTY_PLOT",
-      "MOVE_PLAY_ROUGH",
-      "MOVE_PROTECT",
-      "MOVE_SAFEGUARD",
-      "MOVE_SUBSTITUTE",
-      "MOVE_THUNDERBOLT",
       "MOVE_THUNDER_WAVE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_REFLECT",
+      "MOVE_ENDURE",
       "MOVE_WATER_PULSE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_SAFEGUARD",
+      "MOVE_EARTH_POWER",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_PSYCHIC",
+      "MOVE_THUNDERBOLT",
+      "MOVE_SHADOW_BALL",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
       "MOVE_WORK_UP",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_PAY_DAY",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_FAKE_OUT",
+      "MOVE_TRI_ATTACK"
     ],
-    "TutorMoves": [],
+    "TutorMoves": [
+      "MOVE_MOONBLAST"
+    ],
     "EggMoves": []
   },
   "HONEDGE": {
@@ -15287,17 +25807,28 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BRICK_BREAK",
-      "MOVE_CLOSE_COMBAT",
-      "MOVE_FLASH_CANNON",
       "MOVE_HEADBUTT",
-      "MOVE_NIGHT_SLASH",
-      "MOVE_PROTECT",
-      "MOVE_REFLECT",
+      "MOVE_BRICK_BREAK",
       "MOVE_ROCK_SLIDE",
-      "MOVE_SUBSTITUTE"
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_REFLECT",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_IRON_HEAD",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_SOLAR_BLADE",
+      "MOVE_STEEL_BEAM"
     ],
-    "TutorMoves": [],
+    "TutorMoves": [
+      "MOVE_SACRED_SWORD"
+    ],
     "EggMoves": []
   },
   "DOUBLADE": {
@@ -15348,23 +25879,41 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BRICK_BREAK",
-      "MOVE_CLOSE_COMBAT",
-      "MOVE_ENDURE",
-      "MOVE_FLASH_CANNON",
       "MOVE_HEADBUTT",
-      "MOVE_NIGHT_SLASH",
-      "MOVE_PROTECT",
-      "MOVE_REFLECT",
+      "MOVE_BRICK_BREAK",
       "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_REFLECT",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
       "MOVE_SUBSTITUTE",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_DOUBLE_HIT",
+      "MOVE_DUAL_CHOP",
+      "MOVE_RAZOR_WIND",
+      "MOVE_SOLAR_BLADE",
+      "MOVE_STEEL_BEAM"
     ],
-    "TutorMoves": [],
+    "TutorMoves": [
+      "MOVE_SACRED_SWORD"
+    ],
     "EggMoves": []
   },
   "AEGISLASH": {
     "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_SACRED_SWORD"
+      },
       {
         "Level": "1",
         "Move": "MOVE_TACKLE"
@@ -15415,23 +25964,37 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BRICK_BREAK",
-      "MOVE_CLOSE_COMBAT",
-      "MOVE_ENDURE",
-      "MOVE_FLASH_CANNON",
-      "MOVE_GIGA_IMPACT",
       "MOVE_HEADBUTT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_NIGHT_SLASH",
-      "MOVE_PROTECT",
-      "MOVE_REFLECT",
+      "MOVE_BRICK_BREAK",
       "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_REFLECT",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_SHADOW_CLAW",
       "MOVE_SHADOW_BALL",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
       "MOVE_SUBSTITUTE",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_DOUBLE_HIT",
+      "MOVE_DUAL_CHOP",
+      "MOVE_RAZOR_WIND",
+      "MOVE_SOLAR_BLADE",
+      "MOVE_STEEL_BEAM"
     ],
     "TutorMoves": [
-      "MOVE_KINGS_SHIELD"
+      "MOVE_KINGS_SHIELD",
+      "MOVE_SACRED_SWORD"
     ],
     "EggMoves": []
   },
@@ -15491,15 +26054,20 @@
       }
     ],
     "TMMoves": [
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_FLASH_CANNON",
+      "MOVE_CALM_MIND",
       "MOVE_LIGHT_SCREEN",
-      "MOVE_NASTY_PLOT",
       "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
       "MOVE_REFLECT",
+      "MOVE_ENDURE",
+      "MOVE_PSYCHIC",
+      "MOVE_THUNDERBOLT",
+      "MOVE_NASTY_PLOT",
+      "MOVE_FLASH_CANNON",
       "MOVE_SUBSTITUTE",
-      "MOVE_THUNDERBOLT"
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_FACADE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -15560,19 +26128,29 @@
       }
     ],
     "TMMoves": [
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_FLASH_CANNON",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_METRONOME",
-      "MOVE_NASTY_PLOT",
-      "MOVE_PROTECT",
       "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
       "MOVE_REFLECT",
+      "MOVE_ENDURE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_PSYCHIC",
+      "MOVE_THUNDERBOLT",
+      "MOVE_NASTY_PLOT",
+      "MOVE_FLASH_CANNON",
       "MOVE_SUBSTITUTE",
-      "MOVE_THUNDERBOLT"
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_METRONOME",
+      "MOVE_FACADE",
+      "MOVE_SILVER_WIND",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_DRAIN_PUNCH"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -15630,18 +26208,21 @@
     ],
     "TMMoves": [
       "MOVE_CALM_MIND",
-      "MOVE_DAZZLING_GLEAM",
-      "MOVE_ENDURE",
-      "MOVE_FLAMETHROWER",
       "MOVE_LIGHT_SCREEN",
       "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
-      "MOVE_SAFEGUARD",
-      "MOVE_SELF_DESTRUCT",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_ENERGY_BALL",
       "MOVE_SWORDS_DANCE",
-      "MOVE_THUNDERBOLT"
+      "MOVE_ENDURE",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_SAFEGUARD",
+      "MOVE_FLAMETHROWER",
+      "MOVE_PSYCHIC",
+      "MOVE_THUNDERBOLT",
+      "MOVE_SURF",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_FACADE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -15699,21 +26280,28 @@
     ],
     "TMMoves": [
       "MOVE_CALM_MIND",
-      "MOVE_DAZZLING_GLEAM",
-      "MOVE_ENDURE",
-      "MOVE_FLAMETHROWER",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
       "MOVE_LIGHT_SCREEN",
-      "MOVE_METRONOME",
       "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
-      "MOVE_SAFEGUARD",
-      "MOVE_SELF_DESTRUCT",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_ENERGY_BALL",
       "MOVE_SWORDS_DANCE",
-      "MOVE_THUNDERBOLT"
+      "MOVE_ENDURE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_SAFEGUARD",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_FLAMETHROWER",
+      "MOVE_PSYCHIC",
+      "MOVE_THUNDERBOLT",
+      "MOVE_SURF",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_METRONOME",
+      "MOVE_FACADE",
+      "MOVE_SILVER_WIND",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_DREAM_EATER",
+      "MOVE_DRAIN_PUNCH"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -15770,23 +26358,30 @@
       }
     ],
     "TMMoves": [
-      "MOVE_CALM_MIND",
-      "MOVE_DARK_PULSE",
-      "MOVE_ENDURE",
-      "MOVE_FLAMETHROWER",
-      "MOVE_FUTURE_SIGHT",
       "MOVE_HEADBUTT",
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_ROCK_SLIDE",
       "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_REFLECT",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_KNOCK_OFF",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_FLAMETHROWER",
+      "MOVE_PSYCHIC",
+      "MOVE_THUNDERBOLT",
       "MOVE_LIQUIDATION",
       "MOVE_NASTY_PLOT",
-      "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
-      "MOVE_REFLECT",
-      "MOVE_ROCK_SLIDE",
       "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
       "MOVE_TAUNT",
-      "MOVE_THUNDERBOLT",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_MIMIC",
+      "MOVE_SWAGGER"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -15843,32 +26438,46 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BULK_UP",
-      "MOVE_CALM_MIND",
-      "MOVE_DARK_PULSE",
-      "MOVE_DOUBLE_TEAM",
-      "MOVE_ENDURE",
-      "MOVE_FLAMETHROWER",
-      "MOVE_FUTURE_SIGHT",
-      "MOVE_GIGA_IMPACT",
       "MOVE_HEADBUTT",
-      "MOVE_HEAL_BLOCK",
-      "MOVE_HYPER_BEAM",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_LIQUIDATION",
-      "MOVE_NASTY_PLOT",
-      "MOVE_POISON_JAB",
-      "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
-      "MOVE_REFLECT",
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_BULK_UP",
       "MOVE_ROCK_SLIDE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_REFLECT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
       "MOVE_STEALTH_ROCK",
-      "MOVE_SUBSTITUTE",
-      "MOVE_TAUNT",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_FLAMETHROWER",
+      "MOVE_PSYCHIC",
       "MOVE_THUNDERBOLT",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_LIQUIDATION",
+      "MOVE_POISON_JAB",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_TAUNT",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_TORMENT",
+      "MOVE_MIMIC",
+      "MOVE_CIRCLE_THROW",
+      "MOVE_DOUBLE_HIT",
+      "MOVE_SWAGGER"
     ],
-    "TutorMoves": [],
+    "TutorMoves": [
+      "MOVE_OCTOLOCK"
+    ],
     "EggMoves": []
   },
   "BINACLE": {
@@ -15923,28 +26532,37 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BLIZZARD",
       "MOVE_BRICK_BREAK",
-      "MOVE_DIG",
-      "MOVE_EARTHQUAKE",
-      "MOVE_ENDURE",
-      "MOVE_ICE_BEAM",
-      "MOVE_MUD_SHOT",
-      "MOVE_POISON_JAB",
-      "MOVE_POWER_UP_PUNCH",
-      "MOVE_PROTECT",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SAFEGUARD",
-      "MOVE_SHADOW_CLAW",
-      "MOVE_SLUDGE_BOMB",
-      "MOVE_STEALTH_ROCK",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_DIG",
       "MOVE_SWORDS_DANCE",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_MUD_SHOT",
+      "MOVE_SAFEGUARD",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_SURF",
+      "MOVE_LIQUIDATION",
+      "MOVE_POISON_JAB",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_X-SCISSOR",
+      "MOVE_SUBSTITUTE",
       "MOVE_TAUNT",
       "MOVE_WATERFALL",
-      "MOVE_X_SCISSOR"
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_SCALD"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -16009,32 +26627,49 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BLIZZARD",
-      "MOVE_BULK_UP",
-      "MOVE_DIG",
       "MOVE_DRAGON_CLAW",
-      "MOVE_EARTHQUAKE",
-      "MOVE_ENDURE",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_ICE_BEAM",
-      "MOVE_MUD_SHOT",
-      "MOVE_POISON_JAB",
-      "MOVE_POWER_UP_PUNCH",
-      "MOVE_PROTECT",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SAFEGUARD",
-      "MOVE_SHADOW_CLAW",
-      "MOVE_SLUDGE_BOMB",
-      "MOVE_STEALTH_ROCK",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_DIG",
       "MOVE_SWORDS_DANCE",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_HYPER_BEAM",
+      "MOVE_MUD_SHOT",
+      "MOVE_SAFEGUARD",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_SURF",
+      "MOVE_LIQUIDATION",
+      "MOVE_POISON_JAB",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_X-SCISSOR",
+      "MOVE_SUBSTITUTE",
       "MOVE_TAUNT",
       "MOVE_WATERFALL",
-      "MOVE_X_SCISSOR"
+      "MOVE_FOCUS_BLAST",
+      "MOVE_BLIZZARD",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_DOUBLE_HIT",
+      "MOVE_DUAL_CHOP",
+      "MOVE_MUDDY_WATER",
+      "MOVE_SKULL_BASH",
+      "MOVE_SCALD",
+      "MOVE_METEOR_BEAM"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -16099,19 +26734,33 @@
       }
     ],
     "TMMoves": [
-      "MOVE_ENDURE",
+      "MOVE_TOXIC",
       "MOVE_FLIP_TURN",
-      "MOVE_GUNK_SHOT",
-      "MOVE_LIQUIDATION",
-      "MOVE_OUTRAGE",
-      "MOVE_PLAY_ROUGH",
       "MOVE_PROTECT",
-      "MOVE_SHADOW_BALL",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_ENDURE",
+      "MOVE_WATER_PULSE",
+      "MOVE_MUD_SHOT",
+      "MOVE_SLUDGE_BOMB",
       "MOVE_THUNDERBOLT",
+      "MOVE_SURF",
+      "MOVE_SHADOW_BALL",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_LIQUIDATION",
+      "MOVE_POISON_JAB",
+      "MOVE_SUBSTITUTE",
       "MOVE_TOXIC_SPIKES",
-      "MOVE_WATERFALL"
+      "MOVE_OUTRAGE",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_GUNK_SHOT",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_ACID_SPRAY",
+      "MOVE_MUDDY_WATER",
+      "MOVE_SCALE_SHOT",
+      "MOVE_SCALD"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -16176,22 +26825,36 @@
       }
     ],
     "TMMoves": [
-      "MOVE_DRACO_METEOR",
-      "MOVE_ENDURE",
+      "MOVE_TOXIC",
       "MOVE_FLIP_TURN",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GUNK_SHOT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_LIQUIDATION",
-      "MOVE_OUTRAGE",
-      "MOVE_PLAY_ROUGH",
       "MOVE_PROTECT",
-      "MOVE_SHADOW_BALL",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_ENDURE",
+      "MOVE_WATER_PULSE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_MUD_SHOT",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_DRACO_METEOR",
       "MOVE_THUNDERBOLT",
+      "MOVE_SURF",
+      "MOVE_SHADOW_BALL",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_LIQUIDATION",
+      "MOVE_POISON_JAB",
+      "MOVE_SUBSTITUTE",
       "MOVE_TOXIC_SPIKES",
-      "MOVE_WATERFALL"
+      "MOVE_OUTRAGE",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_GUNK_SHOT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_ACID_SPRAY",
+      "MOVE_MUDDY_WATER",
+      "MOVE_SCALE_SHOT",
+      "MOVE_SCALD"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -16248,18 +26911,27 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BLIZZARD",
-      "MOVE_ENDURE",
-      "MOVE_FLASH_CANNON",
       "MOVE_FLIP_TURN",
-      "MOVE_ICE_BEAM",
-      "MOVE_LIQUIDATION",
-      "MOVE_PROTECT",
       "MOVE_ROCK_SLIDE",
-      "MOVE_SUBSTITUTE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_ENDURE",
+      "MOVE_WATER_PULSE",
+      "MOVE_MUD_SHOT",
       "MOVE_SURF",
-      "MOVE_U_TURN",
-      "MOVE_WATERFALL"
+      "MOVE_DRAGON_PULSE",
+      "MOVE_LIQUIDATION",
+      "MOVE_U-TURN",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_MUDDY_WATER"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -16320,20 +26992,32 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BLIZZARD",
-      "MOVE_ENDURE",
-      "MOVE_FLASH_CANNON",
       "MOVE_FLIP_TURN",
-      "MOVE_HYPER_BEAM",
-      "MOVE_ICE_BEAM",
-      "MOVE_LIQUIDATION",
-      "MOVE_PROTECT",
       "MOVE_ROCK_SLIDE",
-      "MOVE_SHADOW_BALL",
-      "MOVE_SUBSTITUTE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_ENDURE",
+      "MOVE_WATER_PULSE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_MUD_SHOT",
       "MOVE_SURF",
-      "MOVE_U_TURN",
-      "MOVE_WATERFALL"
+      "MOVE_SHADOW_BALL",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_LIQUIDATION",
+      "MOVE_U-TURN",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_ACID_SPRAY",
+      "MOVE_MUDDY_WATER",
+      "MOVE_SCALD"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -16394,20 +27078,30 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
-      "MOVE_DARK_PULSE",
-      "MOVE_DIG",
-      "MOVE_DISCHARGE",
-      "MOVE_ELECTROWEB",
-      "MOVE_ENDURE",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_ROCK_SLIDE",
       "MOVE_LIGHT_SCREEN",
       "MOVE_PROTECT",
-      "MOVE_ROCK_SLIDE",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
-      "MOVE_SUBSTITUTE",
+      "MOVE_DISCHARGE",
+      "MOVE_AGILITY",
+      "MOVE_VOLT_SWITCH",
+      "MOVE_THUNDERBOLT",
       "MOVE_SURF",
-      "MOVE_U_TURN",
-      "MOVE_WILD_CHARGE"
+      "MOVE_BULLDOZE",
+      "MOVE_U-TURN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WILD_CHARGE",
+      "MOVE_DARK_PULSE",
+      "MOVE_ELECTROWEB",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_SEED_BOMB",
+      "MOVE_SCALE_SHOT"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -16468,31 +27162,45 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
-      "MOVE_DARK_PULSE",
-      "MOVE_DIG",
-      "MOVE_DISCHARGE",
-      "MOVE_DRAGON_PULSE",
-      "MOVE_ELECTROWEB",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_HYPER_VOICE",
-      "MOVE_IRON_TAIL",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_ROCK_SLIDE",
       "MOVE_LIGHT_SCREEN",
       "MOVE_PROTECT",
-      "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SOLAR_BEAM",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
       "MOVE_THUNDER_PUNCH",
-      "MOVE_U_TURN",
-      "MOVE_WILD_CHARGE"
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_DISCHARGE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_VOLT_SWITCH",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SURF",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_BULLDOZE",
+      "MOVE_U-TURN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WILD_CHARGE",
+      "MOVE_IRON_TAIL",
+      "MOVE_DARK_PULSE",
+      "MOVE_ELECTROWEB",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_SEED_BOMB",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_SCALE_SHOT",
+      "MOVE_RAZOR_WIND"
     ],
-    "TutorMoves": [],
+    "TutorMoves": [
+      "MOVE_SHED_TAIL"
+    ],
     "EggMoves": []
   },
   "TYRUNT": {
@@ -16543,30 +27251,41 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
+      "MOVE_DRAGON_CLAW",
+      "MOVE_ROAR",
       "MOVE_BRICK_BREAK",
-      "MOVE_BULLDOZE",
-      "MOVE_CLOSE_COMBAT",
-      "MOVE_DARK_PULSE",
-      "MOVE_DIG",
-      "MOVE_DRACO_METEOR",
-      "MOVE_DRAGON_PULSE",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
+      "MOVE_ROCK_SLIDE",
       "MOVE_FIRE_FANG",
-      "MOVE_HYPER_VOICE",
       "MOVE_ICE_FANG",
-      "MOVE_IRON_DEFENSE",
-      "MOVE_IRON_HEAD",
-      "MOVE_OUTRAGE",
-      "MOVE_PLAY_ROUGH",
       "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_THUNDER_FANG",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
       "MOVE_STEALTH_ROCK",
+      "MOVE_EARTH_POWER",
+      "MOVE_DRACO_METEOR",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
       "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_HYPER_VOICE",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
       "MOVE_SUBSTITUTE",
-      "MOVE_THUNDER_FANG",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_DARK_PULSE",
+      "MOVE_OUTRAGE",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_POISON_FANG",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_SCALE_SHOT",
+      "MOVE_METEOR_BEAM"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -16631,32 +27350,44 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
+      "MOVE_DRAGON_CLAW",
+      "MOVE_ROAR",
       "MOVE_BRICK_BREAK",
-      "MOVE_BULLDOZE",
-      "MOVE_CLOSE_COMBAT",
-      "MOVE_DARK_PULSE",
-      "MOVE_DIG",
-      "MOVE_DRACO_METEOR",
-      "MOVE_DRAGON_PULSE",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
+      "MOVE_ROCK_SLIDE",
       "MOVE_FIRE_FANG",
-      "MOVE_HYPER_BEAM",
-      "MOVE_HYPER_VOICE",
       "MOVE_ICE_FANG",
-      "MOVE_IRON_DEFENSE",
-      "MOVE_IRON_HEAD",
-      "MOVE_IRON_TAIL",
-      "MOVE_OUTRAGE",
-      "MOVE_PLAY_ROUGH",
       "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_THUNDER_FANG",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
       "MOVE_STEALTH_ROCK",
+      "MOVE_HYPER_BEAM",
+      "MOVE_EARTH_POWER",
+      "MOVE_DRACO_METEOR",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
       "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_HYPER_VOICE",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
       "MOVE_SUBSTITUTE",
-      "MOVE_THUNDER_FANG",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_IRON_TAIL",
+      "MOVE_DARK_PULSE",
+      "MOVE_OUTRAGE",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_POISON_FANG",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_SCALE_SHOT",
+      "MOVE_METEOR_BEAM"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -16717,27 +27448,36 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_BULLDOZE",
       "MOVE_CALM_MIND",
-      "MOVE_DARK_PULSE",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
-      "MOVE_FLASH_CANNON",
-      "MOVE_HYPER_VOICE",
-      "MOVE_IRON_DEFENSE",
-      "MOVE_IRON_HEAD",
-      "MOVE_OUTRAGE",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_LIGHT_SCREEN",
       "MOVE_PROTECT",
       "MOVE_REFLECT",
-      "MOVE_ROCK_SLIDE",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
-      "MOVE_SAFEGUARD",
       "MOVE_STEALTH_ROCK",
+      "MOVE_HYPER_BEAM",
+      "MOVE_ICY_WIND",
+      "MOVE_SAFEGUARD",
+      "MOVE_EARTH_POWER",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
       "MOVE_STONE_EDGE",
-      "MOVE_SUBSTITUTE",
       "MOVE_THUNDERBOLT",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_HYPER_VOICE",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_OUTRAGE",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_METEOR_BEAM"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -16798,34 +27538,49 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_BULLDOZE",
       "MOVE_CALM_MIND",
-      "MOVE_DARK_PULSE",
-      "MOVE_EARTHQUAKE",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
-      "MOVE_FLASH_CANNON",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_VOICE",
-      "MOVE_IRON_DEFENSE",
-      "MOVE_IRON_HEAD",
-      "MOVE_IRON_TAIL",
-      "MOVE_OUTRAGE",
-      "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
-      "MOVE_REFLECT",
+      "MOVE_THUNDER_WAVE",
       "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
-      "MOVE_SAFEGUARD",
       "MOVE_STEALTH_ROCK",
+      "MOVE_HYPER_BEAM",
+      "MOVE_ICY_WIND",
+      "MOVE_SAFEGUARD",
+      "MOVE_EARTH_POWER",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_PSYCHIC",
       "MOVE_STONE_EDGE",
-      "MOVE_SUBSTITUTE",
-      "MOVE_THUNDER",
       "MOVE_THUNDERBOLT",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_EARTHQUAKE",
+      "MOVE_HYPER_VOICE",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_DARK_PULSE",
+      "MOVE_OUTRAGE",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_ICICLE_SPEAR",
+      "MOVE_SHEER_COLD",
+      "MOVE_METEOR_BEAM"
     ],
-    "TutorMoves": [],
+    "TutorMoves": [
+      "MOVE_ICE_HAMMER"
+    ],
     "EggMoves": []
   },
   "SYLVEON": {
@@ -16880,22 +27635,31 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_CALM_MIND",
-      "MOVE_CURSE",
-      "MOVE_DIG",
-      "MOVE_ENDURE",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_IRON_TAIL",
-      "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
       "MOVE_PSYSHOCK",
-      "MOVE_REFLECT",
       "MOVE_ROAR",
+      "MOVE_CALM_MIND",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_PSYCHIC",
+      "MOVE_HYPER_VOICE",
       "MOVE_SHADOW_BALL",
       "MOVE_SUBSTITUTE",
-      "MOVE_TAUNT"
+      "MOVE_IRON_TAIL",
+      "MOVE_CURSE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_TAUNT",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_MIMIC",
+      "MOVE_SKULL_BASH"
     ],
     "TutorMoves": [
       "MOVE_CHARM",
@@ -16962,29 +27726,43 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
-      "MOVE_BODY_SLAM",
+      "MOVE_BRICK_BREAK",
       "MOVE_BULK_UP",
-      "MOVE_CLOSE_COMBAT",
-      "MOVE_DIG",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FLY",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_IRON_HEAD",
-      "MOVE_POISON_JAB",
-      "MOVE_PROTECT",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_STONE_EDGE",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
       "MOVE_THUNDER_PUNCH",
-      "MOVE_U_TURN",
-      "MOVE_X_SCISSOR",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_FLY",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_STONE_EDGE",
+      "MOVE_POISON_JAB",
+      "MOVE_X-SCISSOR",
+      "MOVE_U-TURN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_TAUNT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_TRAILBLAZE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_DUAL_CHOP",
+      "MOVE_SKULL_BASH",
+      "MOVE_SKY_ATTACK"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -17045,21 +27823,31 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
-      "MOVE_DAZZLING_GLEAM",
-      "MOVE_DIG",
-      "MOVE_DISCHARGE",
-      "MOVE_ENDURE",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
+      "MOVE_THUNDER_WAVE",
       "MOVE_LIGHT_SCREEN",
       "MOVE_PROTECT",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
+      "MOVE_PLAY_ROUGH",
       "MOVE_THUNDER_PUNCH",
-      "MOVE_THUNDER_WAVE",
-      "MOVE_U_TURN",
-      "MOVE_WILD_CHARGE"
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_ENDURE",
+      "MOVE_DISCHARGE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_VOLT_SWITCH",
+      "MOVE_THUNDERBOLT",
+      "MOVE_U-TURN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WILD_CHARGE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_SEED_BOMB",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_FAKE_OUT"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -17120,22 +27908,33 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
       "MOVE_CALM_MIND",
-      "MOVE_DOUBLE_EDGE",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_IRON_HEAD",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_LIGHT_SCREEN",
       "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
+      "MOVE_POWER_GEM",
       "MOVE_REFLECT",
-      "MOVE_ROCK_BLAST",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
-      "MOVE_SELF_DESTRUCT",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_HYPER_BEAM",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_EARTH_POWER",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_PSYCHIC",
+      "MOVE_STONE_EDGE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
       "MOVE_SPIKES",
-      "MOVE_SUBSTITUTE"
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_FACADE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_METEOR_BEAM"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -17196,14 +27995,24 @@
       }
     ],
     "TMMoves": [
-      "MOVE_DRACO_METEOR",
-      "MOVE_ENDURE",
-      "MOVE_OUTRAGE",
+      "MOVE_TOXIC",
       "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_WATER_PULSE",
+      "MOVE_MUD_SHOT",
       "MOVE_SLUDGE_BOMB",
-      "MOVE_SUBSTITUTE",
+      "MOVE_DRACO_METEOR",
       "MOVE_THUNDERBOLT",
-      "MOVE_TOXIC"
+      "MOVE_SURF",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CURSE",
+      "MOVE_OUTRAGE",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_MUDDY_WATER"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -17268,17 +28077,28 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BLIZZARD",
-      "MOVE_DRACO_METEOR",
-      "MOVE_ENDURE",
-      "MOVE_ICE_BEAM",
-      "MOVE_OUTRAGE",
+      "MOVE_TOXIC",
       "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_WATER_PULSE",
+      "MOVE_MUD_SHOT",
       "MOVE_SLUDGE_BOMB",
-      "MOVE_SUBSTITUTE",
-      "MOVE_THUNDER",
+      "MOVE_DRACO_METEOR",
       "MOVE_THUNDERBOLT",
-      "MOVE_TOXIC"
+      "MOVE_SURF",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CURSE",
+      "MOVE_OUTRAGE",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_ACID_SPRAY",
+      "MOVE_MUDDY_WATER"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -17343,19 +28163,33 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BLIZZARD",
-      "MOVE_DRACO_METEOR",
-      "MOVE_ENDURE",
-      "MOVE_ICE_BEAM",
-      "MOVE_IRON_HEAD",
-      "MOVE_OUTRAGE",
+      "MOVE_TOXIC",
       "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
+      "MOVE_WATER_PULSE",
+      "MOVE_MUD_SHOT",
       "MOVE_SLUDGE_BOMB",
-      "MOVE_SUBSTITUTE",
-      "MOVE_THUNDER",
+      "MOVE_DRACO_METEOR",
+      "MOVE_IRON_HEAD",
       "MOVE_THUNDERBOLT",
-      "MOVE_TOXIC"
+      "MOVE_SURF",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CURSE",
+      "MOVE_OUTRAGE",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_ACID_SPRAY",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_MUDDY_WATER",
+      "MOVE_STEEL_BEAM"
     ],
     "TutorMoves": [
       "MOVE_IRON_DEFENSE"
@@ -17430,30 +28264,42 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BLIZZARD",
-      "MOVE_BULLDOZE",
-      "MOVE_DRACO_METEOR",
       "MOVE_DRAGON_CLAW",
-      "MOVE_EARTHQUAKE",
+      "MOVE_TOXIC",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_BODY_SLAM",
       "MOVE_ENDURE",
       "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FLAMETHROWER",
-      "MOVE_FOCUS_BLAST",
+      "MOVE_WATER_PULSE",
       "MOVE_GIGA_DRAIN",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYDRO_PUMP",
       "MOVE_HYPER_BEAM",
-      "MOVE_ICE_BEAM",
       "MOVE_KNOCK_OFF",
-      "MOVE_OUTRAGE",
-      "MOVE_ROCK_SLIDE",
+      "MOVE_MUD_SHOT",
       "MOVE_SLUDGE_BOMB",
-      "MOVE_SUBSTITUTE",
-      "MOVE_THUNDER",
+      "MOVE_DRACO_METEOR",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_FLAMETHROWER",
       "MOVE_THUNDERBOLT",
-      "MOVE_THUNDER_PUNCH",
-      "MOVE_TOXIC"
+      "MOVE_EARTHQUAKE",
+      "MOVE_SURF",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CURSE",
+      "MOVE_OUTRAGE",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_ACID_SPRAY",
+      "MOVE_MUDDY_WATER",
+      "MOVE_SCALD"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -17534,31 +28380,47 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BLIZZARD",
-      "MOVE_BULLDOZE",
-      "MOVE_DRACO_METEOR",
       "MOVE_DRAGON_CLAW",
-      "MOVE_EARTHQUAKE",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FLAMETHROWER",
-      "MOVE_FLASH_CANNON",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYDRO_PUMP",
-      "MOVE_HYPER_BEAM",
-      "MOVE_ICE_BEAM",
-      "MOVE_IRON_HEAD",
-      "MOVE_KNOCK_OFF",
-      "MOVE_OUTRAGE",
+      "MOVE_TOXIC",
       "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SLUDGE_BOMB",
-      "MOVE_SUBSTITUTE",
-      "MOVE_THUNDER",
-      "MOVE_THUNDERBOLT",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
       "MOVE_THUNDER_PUNCH",
-      "MOVE_TOXIC"
+      "MOVE_FIRE_PUNCH",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_FIRE_BLAST",
+      "MOVE_WATER_PULSE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_MUD_SHOT",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_DRACO_METEOR",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_IRON_HEAD",
+      "MOVE_FLAMETHROWER",
+      "MOVE_THUNDERBOLT",
+      "MOVE_EARTHQUAKE",
+      "MOVE_SURF",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_CURSE",
+      "MOVE_OUTRAGE",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_ACID_SPRAY",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_MUDDY_WATER",
+      "MOVE_STEEL_BEAM"
     ],
     "TutorMoves": [
       "MOVE_BREAKING_SWIPE"
@@ -17605,22 +28467,30 @@
       }
     ],
     "TMMoves": [
+      "MOVE_PSYSHOCK",
       "MOVE_CALM_MIND",
-      "MOVE_DOUBLE_TEAM",
-      "MOVE_ENDURE",
-      "MOVE_FUTURE_SIGHT",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_IRON_DEFENSE",
+      "MOVE_THUNDER_WAVE",
       "MOVE_LIGHT_SCREEN",
       "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
-      "MOVE_PSYSHOCK",
-      "MOVE_REFLECT",
-      "MOVE_SPIKES",
-      "MOVE_SUBSTITUTE",
+      "MOVE_PLAY_ROUGH",
       "MOVE_SWIFT",
-      "MOVE_THUNDER_WAVE"
+      "MOVE_REFLECT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_ENDURE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_PSYCHIC",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_SPIKES",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_FACADE",
+      "MOVE_TORMENT",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_STEEL_BEAM"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -17669,23 +28539,27 @@
       }
     ],
     "TMMoves": [
-      "MOVE_DARK_PULSE",
-      "MOVE_DIG",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_GIGA_DRAIN",
-      "MOVE_HEAL_BLOCK",
-      "MOVE_MAGICAL_LEAF",
-      "MOVE_POISON_JAB",
-      "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
-      "MOVE_REFLECT",
       "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
+      "MOVE_DIG",
+      "MOVE_REFLECT",
+      "MOVE_ENDURE",
+      "MOVE_GIGA_DRAIN",
       "MOVE_SAFEGUARD",
-      "MOVE_SHADOW_BALL",
+      "MOVE_WILL-O-WISP",
       "MOVE_SHADOW_CLAW",
+      "MOVE_PSYCHIC",
       "MOVE_SOLAR_BEAM",
-      "MOVE_SUBSTITUTE"
+      "MOVE_SHADOW_BALL",
+      "MOVE_POISON_JAB",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_SEED_BOMB"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -17739,27 +28613,36 @@
     ],
     "TMMoves": [
       "MOVE_CALM_MIND",
-      "MOVE_DARK_PULSE",
-      "MOVE_DIG",
-      "MOVE_EARTHQUAKE",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_DRAIN",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HEAL_BLOCK",
-      "MOVE_HYPER_BEAM",
-      "MOVE_MAGICAL_LEAF",
-      "MOVE_POISON_JAB",
-      "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
-      "MOVE_REFLECT",
       "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
+      "MOVE_DIG",
+      "MOVE_REFLECT",
+      "MOVE_ENDURE",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_HYPER_BEAM",
       "MOVE_SAFEGUARD",
-      "MOVE_SHADOW_BALL",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_WILL-O-WISP",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_PSYCHIC",
       "MOVE_SOLAR_BEAM",
+      "MOVE_EARTHQUAKE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_POISON_JAB",
+      "MOVE_X-SCISSOR",
       "MOVE_SUBSTITUTE",
-      "MOVE_X_SCISSOR"
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_SHADOW_PUNCH",
+      "MOVE_DREAM_EATER",
+      "MOVE_SEED_BOMB",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_SWAGGER"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -17816,24 +28699,28 @@
       }
     ],
     "TMMoves": [
-      "MOVE_CURSE",
-      "MOVE_DARK_PULSE",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_SPIN",
-      "MOVE_FLAMETHROWER",
-      "MOVE_GIGA_DRAIN",
+      "MOVE_ROCK_SLIDE",
       "MOVE_LIGHT_SCREEN",
       "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
-      "MOVE_ROCK_SLIDE",
+      "MOVE_ENERGY_BALL",
+      "MOVE_ENDURE",
+      "MOVE_FIRE_BLAST",
+      "MOVE_BULLET_SEED",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_SELF-DESTRUCT",
       "MOVE_SAFEGUARD",
-      "MOVE_SELF_DESTRUCT",
       "MOVE_SLUDGE_BOMB",
+      "MOVE_WILL-O-WISP",
+      "MOVE_FLAMETHROWER",
+      "MOVE_PSYCHIC",
       "MOVE_SOLAR_BEAM",
+      "MOVE_FIRE_SPIN",
+      "MOVE_SHADOW_BALL",
       "MOVE_SUBSTITUTE",
-      "MOVE_WILL_O_WISP"
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_FACADE",
+      "MOVE_SEED_BOMB"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -17902,28 +28789,35 @@
       }
     ],
     "TMMoves": [
-      "MOVE_CURSE",
-      "MOVE_DARK_PULSE",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_SPIN",
-      "MOVE_FLAMETHROWER",
-      "MOVE_GIGA_DRAIN",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_LIGHT_SCREEN",
-      "MOVE_NASTY_PLOT",
-      "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
       "MOVE_ROCK_SLIDE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
+      "MOVE_ENDURE",
+      "MOVE_FIRE_BLAST",
+      "MOVE_BULLET_SEED",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_HYPER_BEAM",
+      "MOVE_SELF-DESTRUCT",
       "MOVE_SAFEGUARD",
-      "MOVE_SELF_DESTRUCT",
-      "MOVE_SHADOW_CLAW",
       "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_WILL-O-WISP",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_FLAMETHROWER",
+      "MOVE_PSYCHIC",
       "MOVE_SOLAR_BEAM",
+      "MOVE_FIRE_SPIN",
+      "MOVE_SHADOW_BALL",
+      "MOVE_NASTY_PLOT",
       "MOVE_SUBSTITUTE",
-      "MOVE_WILL_O_WISP"
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_SILVER_WIND",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_SEED_BOMB"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -17984,14 +28878,25 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_BULLDOZE",
-      "MOVE_ENDURE",
-      "MOVE_ICE_BEAM",
       "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_ICE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_CRUNCH",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
+      "MOVE_ICY_WIND",
+      "MOVE_DOUBLE-EDGE",
       "MOVE_STONE_EDGE",
-      "MOVE_SUBSTITUTE"
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CURSE",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_ICICLE_SPEAR"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -18060,20 +28965,34 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_BULLDOZE",
-      "MOVE_EARTHQUAKE",
-      "MOVE_ENDURE",
-      "MOVE_FLASH_CANNON",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYDRO_PUMP",
-      "MOVE_HYPER_BEAM",
-      "MOVE_ICE_BEAM",
       "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_ICE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_CRUNCH",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
+      "MOVE_HYPER_BEAM",
+      "MOVE_ICY_WIND",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
       "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_SURF",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
       "MOVE_SUBSTITUTE",
-      "MOVE_SURF"
+      "MOVE_CURSE",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_FROST_BREATH",
+      "MOVE_SKULL_BASH",
+      "MOVE_ICICLE_SPEAR",
+      "MOVE_SHEER_COLD"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -18150,21 +29069,38 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_BULLDOZE",
-      "MOVE_DIG",
-      "MOVE_EARTHQUAKE",
-      "MOVE_ENDURE",
-      "MOVE_FLASH_CANNON",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYDRO_PUMP",
-      "MOVE_HYPER_BEAM",
-      "MOVE_ICE_BEAM",
       "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_ICE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
       "MOVE_STEALTH_ROCK",
+      "MOVE_HYPER_BEAM",
+      "MOVE_ICY_WIND",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_SURF",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
       "MOVE_SUBSTITUTE",
-      "MOVE_SURF"
+      "MOVE_CURSE",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_SKULL_BASH",
+      "MOVE_ICICLE_SPEAR",
+      "MOVE_SHEER_COLD",
+      "MOVE_METEOR_BEAM"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -18225,28 +29161,33 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
-      "MOVE_AGILITY",
-      "MOVE_BRICK_BREAK",
-      "MOVE_DARK_PULSE",
-      "MOVE_DRACO_METEOR",
       "MOVE_DRAGON_CLAW",
-      "MOVE_DRAGON_PULSE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_SWIFT",
+      "MOVE_DOUBLE_TEAM",
       "MOVE_ENDURE",
       "MOVE_FLY",
+      "MOVE_AGILITY",
+      "MOVE_DRACO_METEOR",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_PSYCHIC",
+      "MOVE_SOLAR_BEAM",
       "MOVE_HEAT_WAVE",
       "MOVE_HYPER_VOICE",
-      "MOVE_OUTRAGE",
-      "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
       "MOVE_SHADOW_BALL",
-      "MOVE_SHADOW_CLAW",
-      "MOVE_SOLAR_BEAM",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_HURRICANE",
+      "MOVE_U-TURN",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
+      "MOVE_WILD_CHARGE",
+      "MOVE_DARK_PULSE",
+      "MOVE_OUTRAGE",
+      "MOVE_WHIRLWIND",
       "MOVE_TAUNT",
-      "MOVE_U_TURN",
-      "MOVE_WILD_CHARGE"
+      "MOVE_FACADE",
+      "MOVE_DUAL_WINGBEAT"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -18315,34 +29256,44 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AERIAL_ACE",
-      "MOVE_AGILITY",
-      "MOVE_BODY_SLAM",
-      "MOVE_BRICK_BREAK",
-      "MOVE_DARK_PULSE",
-      "MOVE_DRACO_METEOR",
       "MOVE_DRAGON_CLAW",
-      "MOVE_ENDURE",
-      "MOVE_FLAMETHROWER",
-      "MOVE_FLY",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HEAT_WAVE",
-      "MOVE_HYPER_BEAM",
-      "MOVE_HYPER_VOICE",
-      "MOVE_IRON_TAIL",
-      "MOVE_OUTRAGE",
+      "MOVE_BRICK_BREAK",
       "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
-      "MOVE_SHADOW_BALL",
-      "MOVE_SHADOW_CLAW",
-      "MOVE_SOLAR_BEAM",
-      "MOVE_SUBSTITUTE",
+      "MOVE_AERIAL_ACE",
       "MOVE_SWIFT",
-      "MOVE_TAUNT",
-      "MOVE_U_TURN",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_WATER_PULSE",
-      "MOVE_WILD_CHARGE"
+      "MOVE_FLY",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_DRACO_METEOR",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_FLAMETHROWER",
+      "MOVE_PSYCHIC",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_HEAT_WAVE",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_HURRICANE",
+      "MOVE_U-TURN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WILD_CHARGE",
+      "MOVE_IRON_TAIL",
+      "MOVE_DARK_PULSE",
+      "MOVE_OUTRAGE",
+      "MOVE_WHIRLWIND",
+      "MOVE_TAUNT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_FACADE",
+      "MOVE_TORMENT",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_SCALE_SHOT",
+      "MOVE_RAZOR_WIND",
+      "MOVE_SKY_ATTACK"
     ],
     "TutorMoves": [
       "MOVE_DRAGON_PULSE"
@@ -18397,26 +29348,37 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_CALM_MIND",
-      "MOVE_DAZZLING_GLEAM",
-      "MOVE_ENDURE",
-      "MOVE_FLASH_CANNON",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_HYPER_BEAM",
-      "MOVE_HYPER_VOICE",
-      "MOVE_PLAY_ROUGH",
-      "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
       "MOVE_PSYSHOCK",
-      "MOVE_REFLECT",
-      "MOVE_ROCK_SLIDE",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_THUNDER",
-      "MOVE_THUNDERBOLT",
+      "MOVE_CALM_MIND",
       "MOVE_THUNDER_WAVE",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_ROCK_SLIDE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_SWIFT",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_PSYCHIC",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HYPER_VOICE",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_OUTRAGE",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_THUNDER",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_SILVER_WIND",
+      "MOVE_SEED_BOMB",
+      "MOVE_PETAL_DANCE",
+      "MOVE_SOLAR_BLADE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -18477,22 +29439,36 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
       "MOVE_DRAGON_CLAW",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_SWIFT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_BODY_SLAM",
       "MOVE_ENDURE",
       "MOVE_FLY",
+      "MOVE_HYPER_BEAM",
       "MOVE_GIGA_IMPACT",
-      "MOVE_HEAL_BLOCK",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_PSYCHIC",
       "MOVE_HEAT_WAVE",
       "MOVE_HYPER_VOICE",
-      "MOVE_PROTECT",
-      "MOVE_ROCK_SLIDE",
       "MOVE_SHADOW_BALL",
-      "MOVE_SHADOW_CLAW",
+      "MOVE_HURRICANE",
+      "MOVE_U-TURN",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_U_TURN",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_DARK_PULSE",
+      "MOVE_TAUNT",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_FACADE",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_DREAM_EATER",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_RAZOR_WIND",
+      "MOVE_VACUUM_WAVE",
+      "MOVE_SKY_ATTACK"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -18573,22 +29549,37 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
       "MOVE_BRICK_BREAK",
-      "MOVE_DRACO_METEOR",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_HYPER_VOICE",
-      "MOVE_IRON_HEAD",
-      "MOVE_PROTECT",
       "MOVE_ROCK_SLIDE",
-      "MOVE_STONE_EDGE",
-      "MOVE_SUBSTITUTE",
+      "MOVE_PROTECT",
+      "MOVE_CRUNCH",
       "MOVE_SWIFT",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_SAFEGUARD",
+      "MOVE_EARTH_POWER",
+      "MOVE_DRACO_METEOR",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_HYPER_VOICE",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_OUTRAGE",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_FACADE",
+      "MOVE_POISON_FANG",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_SCALE_SHOT",
+      "MOVE_TRI_ATTACK",
+      "MOVE_FISSURE"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -18649,26 +29640,37 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_CALM_MIND",
-      "MOVE_DAZZLING_GLEAM",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
-      "MOVE_FLASH_CANNON",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HYPER_BEAM",
-      "MOVE_IRON_DEFENSE",
-      "MOVE_METRONOME",
-      "MOVE_PLAY_ROUGH",
-      "MOVE_PROTECT",
-      "MOVE_PSYCHIC",
       "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_POWER_GEM",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_SWIFT",
       "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_HYPER_BEAM",
       "MOVE_SAFEGUARD",
-      "MOVE_SPIKES",
+      "MOVE_EARTH_POWER",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_PSYCHIC",
+      "MOVE_STONE_EDGE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
       "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT"
+      "MOVE_SPIKES",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_METRONOME",
+      "MOVE_FACADE",
+      "MOVE_SILVER_WIND",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_METEOR_BEAM"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -18717,30 +29719,43 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BRICK_BREAK",
-      "MOVE_CALM_MIND",
-      "MOVE_DARK_PULSE",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_FUTURE_SIGHT",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_GUNK_SHOT",
-      "MOVE_HEAL_BLOCK",
-      "MOVE_HYPER_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_PROTECT",
       "MOVE_PSYSHOCK",
-      "MOVE_REFLECT",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_TAKE_DOWN",
-      "MOVE_TAUNT",
-      "MOVE_THUNDERBOLT",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
       "MOVE_THUNDER_PUNCH",
-      "MOVE_THUNDER_WAVE"
+      "MOVE_ICE_PUNCH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_REFLECT",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_PSYCHIC",
+      "MOVE_THUNDERBOLT",
+      "MOVE_SHADOW_BALL",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_TAUNT",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_GUNK_SHOT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_FACADE",
+      "MOVE_SILVER_WIND",
+      "MOVE_SHADOW_PUNCH",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_DRAIN_PUNCH"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -18789,30 +29804,43 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BRICK_BREAK",
-      "MOVE_CALM_MIND",
-      "MOVE_DARK_PULSE",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_FIRE_PUNCH",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_FUTURE_SIGHT",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_GUNK_SHOT",
-      "MOVE_HEAL_BLOCK",
-      "MOVE_HYPER_BEAM",
-      "MOVE_ICE_PUNCH",
-      "MOVE_PROTECT",
       "MOVE_PSYSHOCK",
-      "MOVE_REFLECT",
-      "MOVE_ROCK_TOMB",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SWIFT",
-      "MOVE_TAKE_DOWN",
-      "MOVE_TAUNT",
-      "MOVE_THUNDERBOLT",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
       "MOVE_THUNDER_PUNCH",
-      "MOVE_THUNDER_WAVE"
+      "MOVE_ICE_PUNCH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_REFLECT",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_PSYCHIC",
+      "MOVE_THUNDERBOLT",
+      "MOVE_SHADOW_BALL",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_TAUNT",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_GUNK_SHOT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_FACADE",
+      "MOVE_SILVER_WIND",
+      "MOVE_SHADOW_PUNCH",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_DRAIN_PUNCH"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -18881,34 +29909,620 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BODY_SLAM",
-      "MOVE_BRICK_BREAK",
-      "MOVE_DIG",
-      "MOVE_EARTHQUAKE",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
-      "MOVE_FIRE_BLAST",
-      "MOVE_FIRE_FANG",
-      "MOVE_FLAMETHROWER",
-      "MOVE_FLASH_CANNON",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HEAT_WAVE",
-      "MOVE_HYPER_BEAM",
-      "MOVE_LIQUIDATION",
-      "MOVE_PROTECT",
       "MOVE_ROAR",
+      "MOVE_BRICK_BREAK",
       "MOVE_ROCK_SLIDE",
+      "MOVE_FIRE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_FANG",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
       "MOVE_ROCK_TOMB",
-      "MOVE_SELF_DESTRUCT",
+      "MOVE_FIRE_BLAST",
+      "MOVE_WATER_PULSE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_MUD_SHOT",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_OVERHEAT",
+      "MOVE_EARTH_POWER",
       "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_WILL-O-WISP",
+      "MOVE_FLAMETHROWER",
       "MOVE_SOLAR_BEAM",
       "MOVE_STONE_EDGE",
+      "MOVE_HEAT_WAVE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_LIQUIDATION",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WILD_CHARGE",
+      "MOVE_TAUNT",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_FLARE_BLITZ",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_SCALD"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "CRABRAWLER": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_HARDEN"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_ROCK_SMASH"
+      },
+      {
+        "Level": "9",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "13",
+        "Move": "MOVE_BUBBLE_BEAM"
+      },
+      {
+        "Level": "17",
+        "Move": "MOVE_PROTECT"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_BRICK_BREAK"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_BULK_UP"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_MACH_PUNCH"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_IRON_DEFENSE"
+      },
+      {
+        "Level": "45",
+        "Move": "MOVE_DYNAMIC_PUNCH"
+      },
+      {
+        "Level": "49",
+        "Move": "MOVE_CLOSE_COMBAT"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ROCK_SMASH",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_KNOCK_OFF",
+      "MOVE_MUD_SHOT",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_EARTHQUAKE",
+      "MOVE_LIQUIDATION",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
       "MOVE_SUBSTITUTE",
       "MOVE_TAUNT",
-      "MOVE_THUNDER_FANG",
-      "MOVE_WILD_CHARGE",
-      "MOVE_WILL_O_WISP"
+      "MOVE_GUNK_SHOT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_TORMENT",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_SWAGGER",
+      "MOVE_FIRST_IMPRESSION"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "CRABOMINABLE": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_HARDEN"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_ROCK_SMASH"
+      },
+      {
+        "Level": "9",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "13",
+        "Move": "MOVE_BUBBLE_BEAM"
+      },
+      {
+        "Level": "17",
+        "Move": "MOVE_PROTECT"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_BRICK_BREAK"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_BULK_UP"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_MACH_PUNCH"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_IRON_DEFENSE"
+      },
+      {
+        "Level": "45",
+        "Move": "MOVE_DYNAMIC_PUNCH"
+      },
+      {
+        "Level": "49",
+        "Move": "MOVE_CLOSE_COMBAT"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ROCK_SMASH",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_MUD_SHOT",
+      "MOVE_ICY_WIND",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_EARTHQUAKE",
+      "MOVE_LIQUIDATION",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_TAUNT",
+      "MOVE_GUNK_SHOT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_BLIZZARD",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_TORMENT",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_SWAGGER",
+      "MOVE_FIRST_IMPRESSION",
+      "MOVE_ICICLE_SPEAR",
+      "MOVE_SHEER_COLD"
+    ],
+    "TutorMoves": [
+      "MOVE_ICE_PUNCH"
+    ],
+    "EggMoves": []
+  },
+  "WHIMPOD": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_HARDEN"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_ROLLOUT"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_PROTECT",
+      "MOVE_SWIFT",
+      "MOVE_ENDURE",
+      "MOVE_MUD_SHOT",
+      "MOVE_SURF",
+      "MOVE_SUBSTITUTE",
+      "MOVE_SPIKES",
+      "MOVE_TAUNT",
+      "MOVE_WATERFALL",
+      "MOVE_FACADE",
+      "MOVE_SCALD"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "GOLISOPOD": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_HARDEN"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_ROLLOUT"
+      },
+      {
+        "Level": "4",
+        "Move": "MOVE_ROCK_SMASH"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_MUD_SHOT"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_AQUA_JET"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_IRON_DEFENSE"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_METAL_CLAW"
+      },
+      {
+        "Level": "26",
+        "Move": "MOVE_SCREECH"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_SLASH"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_DRILL_RUN"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_LEECH_LIFE"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_IRON_HEAD"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_PIN_MISSILE"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_SWORDS_DANCE"
+      },
+      {
+        "Level": "53",
+        "Move": "MOVE_LIQUIDATION"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ROCK_SMASH",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_SWIFT",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_HYPER_BEAM",
+      "MOVE_MUD_SHOT",
+      "MOVE_AGILITY",
+      "MOVE_ICY_WIND",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_IRON_HEAD",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_SURF",
+      "MOVE_LIQUIDATION",
+      "MOVE_POISON_JAB",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_X-SCISSOR",
+      "MOVE_U-TURN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_SPIKES",
+      "MOVE_DARK_PULSE",
+      "MOVE_TAUNT",
+      "MOVE_WATERFALL",
+      "MOVE_GUNK_SHOT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_BLIZZARD",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_DOUBLE_HIT",
+      "MOVE_DUAL_CHOP",
+      "MOVE_MUDDY_WATER",
+      "MOVE_FIRST_IMPRESSION",
+      "MOVE_SCALD"
+    ],
+    "TutorMoves": [
+      "MOVE_FIRST_IMPRESSION"
+    ],
+    "EggMoves": []
+  },
+  "SANDYGAST": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_ABSORB"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_HARDEN"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_SAND_TOMB"
+      },
+      {
+        "Level": "13",
+        "Move": "MOVE_INFESTATION"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_BULLDOZE"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_HYPNOSIS"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_IRON_DEFENSE"
+      },
+      {
+        "Level": "35",
+        "Move": "MOVE_GIGA_DRAIN"
+      },
+      {
+        "Level": "41",
+        "Move": "MOVE_SHADOW_BALL"
+      },
+      {
+        "Level": "46",
+        "Move": "MOVE_DARK_PULSE"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_EARTH_POWER"
+      },
+      {
+        "Level": "52",
+        "Move": "MOVE_SHORE_UP"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_POWER_GEM",
+      "MOVE_ENERGY_BALL",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_MUD_SHOT",
+      "MOVE_EARTH_POWER",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_PSYCHIC",
+      "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_NASTY_PLOT",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_SCORCHING_SANDS"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "PALOSSAND": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_ABSORB"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_HARDEN"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_SAND_TOMB"
+      },
+      {
+        "Level": "13",
+        "Move": "MOVE_INFESTATION"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_BULLDOZE"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_HYPNOSIS"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_IRON_DEFENSE"
+      },
+      {
+        "Level": "35",
+        "Move": "MOVE_GIGA_DRAIN"
+      },
+      {
+        "Level": "41",
+        "Move": "MOVE_SHADOW_BALL"
+      },
+      {
+        "Level": "46",
+        "Move": "MOVE_DARK_PULSE"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_EARTH_POWER"
+      },
+      {
+        "Level": "52",
+        "Move": "MOVE_SHORE_UP"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_POWER_GEM",
+      "MOVE_ENERGY_BALL",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_HYPER_BEAM",
+      "MOVE_MUD_SHOT",
+      "MOVE_EARTH_POWER",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_PSYCHIC",
+      "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_NASTY_PLOT",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_TORMENT",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_FAKE_OUT",
+      "MOVE_FISSURE"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "MIMIKYU": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_SPLASH"
+      },
+      {
+        "Level": "6",
+        "Move": "MOVE_SHADOW_SNEAK"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_DOUBLE_TEAM"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_MIMIC"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_SLASH"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_SHADOW_CLAW"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_WOOD_HAMMER"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_CHARM"
+      },
+      {
+        "Level": "54",
+        "Move": "MOVE_PLAY_ROUGH"
+      },
+      {
+        "Level": "60",
+        "Move": "MOVE_PHANTOM_FORCE"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BULK_UP",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_HYPER_BEAM",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_WILL-O-WISP",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_PSYCHIC",
+      "MOVE_THUNDERBOLT",
+      "MOVE_SHADOW_BALL",
+      "MOVE_X-SCISSOR",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_TAUNT",
+      "MOVE_WORK_UP",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_MIMIC",
+      "MOVE_DRAIN_PUNCH"
     ],
     "TutorMoves": [],
     "EggMoves": []
@@ -18977,38 +30591,1859 @@
       }
     ],
     "TMMoves": [
-      "MOVE_BLIZZARD",
-      "MOVE_CALM_MIND",
-      "MOVE_DRACO_METEOR",
       "MOVE_DRAGON_CLAW",
-      "MOVE_EARTHQUAKE",
-      "MOVE_EARTH_POWER",
-      "MOVE_ENDURE",
-      "MOVE_ENERGY_BALL",
-      "MOVE_FIRE_BLAST",
-      "MOVE_FLAMETHROWER",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
-      "MOVE_HEAT_WAVE",
-      "MOVE_HURRICANE",
-      "MOVE_HYDRO_PUMP",
-      "MOVE_HYPER_BEAM",
-      "MOVE_ICE_BEAM",
-      "MOVE_PLAY_ROUGH",
-      "MOVE_ROCK_SLIDE",
-      "MOVE_SHADOW_BALL",
-      "MOVE_SHADOW_CLAW",
-      "MOVE_SOLAR_BEAM",
-      "MOVE_SUBSTITUTE",
-      "MOVE_SURF",
-      "MOVE_SWIFT",
-      "MOVE_THUNDER",
-      "MOVE_THUNDERBOLT",
+      "MOVE_CALM_MIND",
       "MOVE_THUNDER_WAVE",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_FIRE_BLAST",
+      "MOVE_FLY",
+      "MOVE_HYPER_BEAM",
+      "MOVE_ICY_WIND",
+      "MOVE_SAFEGUARD",
+      "MOVE_EARTH_POWER",
+      "MOVE_DRACO_METEOR",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_FLAMETHROWER",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HEAT_WAVE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SURF",
+      "MOVE_SHADOW_BALL",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_HURRICANE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_OUTRAGE",
       "MOVE_WHIRLWIND",
-      "MOVE_WORK_UP"
+      "MOVE_HYDRO_PUMP",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_SCALE_SHOT",
+      "MOVE_RAZOR_WIND",
+      "MOVE_TRI_ATTACK"
     ],
     "TutorMoves": [],
+    "EggMoves": []
+  },
+  "MAGEARNA": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_METAL_SOUND"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_DISARMING_VOICE"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_ROLLOUT"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_DRAINING_KISS"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_IRON_DEFENSE"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_CHARGE_BEAM"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_EERIE_IMPULSE"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_PSYBEAM"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_TRI_ATTACK"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_MAGNET_BOMB"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_PSYSHOCK"
+      },
+      {
+        "Level": "60",
+        "Move": "MOVE_IRON_HEAD"
+      },
+      {
+        "Level": "66",
+        "Move": "MOVE_AURA_SPHERE"
+      },
+      {
+        "Level": "72",
+        "Move": "MOVE_FLASH_CANNON"
+      },
+      {
+        "Level": "80",
+        "Move": "MOVE_FLEUR_CANNON"
+      },
+      {
+        "Level": "84",
+        "Move": "MOVE_ZAP_CANNON"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ICE_BEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_POWER_GEM",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_PSYCHIC",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_VOLT_SWITCH",
+      "MOVE_THUNDERBOLT",
+      "MOVE_SHADOW_BALL",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_SPIKES",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_ELECTROWEB",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_FACADE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_SKULL_BASH",
+      "MOVE_TRI_ATTACK",
+      "MOVE_VACUUM_WAVE",
+      "MOVE_PETAL_DANCE",
+      "MOVE_SOLAR_BLADE",
+      "MOVE_STEEL_BEAM"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "MARSHADOW": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_FIRE_PUNCH"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_ICE_PUNCH"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_THUNDER_PUNCH"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_SHADOW_SNEAK"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_POWER_UP_PUNCH"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_SHADOW_PUNCH"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_MACH_PUNCH"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_BRUTAL_SWING"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_AURA_SPHERE"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_DUAL_CHOP"
+      },
+      {
+        "Level": "54",
+        "Move": "MOVE_DRAIN_PUNCH"
+      },
+      {
+        "Level": "64",
+        "Move": "MOVE_PHANTOM_FORCE"
+      },
+      {
+        "Level": "72",
+        "Move": "MOVE_SPECTRAL_THIEF"
+      },
+      {
+        "Level": "80",
+        "Move": "MOVE_CLOSE_COMBAT"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_CALM_MIND",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_SWIFT",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_AGILITY",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_WILL-O-WISP",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_STONE_EDGE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_POISON_JAB",
+      "MOVE_SUBSTITUTE",
+      "MOVE_OUTRAGE",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_SHADOW_PUNCH",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_BLAZE_KICK",
+      "MOVE_DUAL_CHOP",
+      "MOVE_VACUUM_WAVE"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "ZERAORA": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_SPARK"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_FAKE_OUT"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_SNARL"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_POWER_UP_PUNCH"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_BRUTAL_SWING"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_SLASH"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_VOLT_SWITCH"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_CHARGE"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_THUNDER_PUNCH"
+      },
+      {
+        "Level": "56",
+        "Move": "MOVE_DYNAMIC_PUNCH"
+      },
+      {
+        "Level": "64",
+        "Move": "MOVE_DISCHARGE"
+      },
+      {
+        "Level": "72",
+        "Move": "MOVE_WILD_CHARGE"
+      },
+      {
+        "Level": "80",
+        "Move": "MOVE_AGILITY"
+      },
+      {
+        "Level": "84",
+        "Move": "MOVE_PLASMA_FISTS"
+      },
+      {
+        "Level": "96",
+        "Move": "MOVE_CLOSE_COMBAT"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_AERIAL_ACE",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_SWIFT",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_ENDURE",
+      "MOVE_DISCHARGE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_VOLT_SWITCH",
+      "MOVE_THUNDERBOLT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WILD_CHARGE",
+      "MOVE_IRON_TAIL",
+      "MOVE_OUTRAGE",
+      "MOVE_TAUNT",
+      "MOVE_ELECTROWEB",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_THUNDER",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_PAY_DAY",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_BLAZE_KICK",
+      "MOVE_FAKE_OUT",
+      "MOVE_RAZOR_WIND",
+      "MOVE_VACUUM_WAVE"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "MELTAN": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_THUNDER_SHOCK"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_HARDEN"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_TAIL_WHIP"
+      },
+      {
+        "Level": "11",
+        "Move": "MOVE_BRUTAL_SWING"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_HEADBUTT"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_THUNDER_WAVE"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_ACID_ARMOR"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_FLASH_CANNON"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_PROTECT",
+      "MOVE_ENDURE",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_IRON_HEAD",
+      "MOVE_THUNDERBOLT",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_FACADE",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_STEEL_BEAM"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "MELMETAL": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_THUNDER_SHOCK"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_HARDEN"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_TAIL_WHIP"
+      },
+      {
+        "Level": "11",
+        "Move": "MOVE_BRUTAL_SWING"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_HEADBUTT"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_THUNDER_WAVE"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_ACID_ARMOR"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_FLASH_CANNON"
+      },
+      {
+        "Level": "64",
+        "Move": "MOVE_DISCHARGE"
+      },
+      {
+        "Level": "72",
+        "Move": "MOVE_DYNAMIC_PUNCH"
+      },
+      {
+        "Level": "80",
+        "Move": "MOVE_DOUBLE_IRON_BASH"
+      },
+      {
+        "Level": "96",
+        "Move": "MOVE_HYPER_BEAM"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_DISCHARGE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_IRON_HEAD",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_THUNDERBOLT",
+      "MOVE_EARTHQUAKE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_STEEL_BEAM"
+    ],
+    "TutorMoves": [
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_HEAVY_SLAM"
+    ],
+    "EggMoves": []
+  },
+  "ROOKIDEE": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_PECK"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_GUST"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_WING_ATTACK"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_TAUNT"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_AIR_SLASH"
+      },
+      {
+        "Level": "27",
+        "Move": "MOVE_FEATHER_DANCE"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_SWAGGER"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_SLASH"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_DUAL_WINGBEAT"
+      },
+      {
+        "Level": "47",
+        "Move": "MOVE_BRAVE_BIRD"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ROCK_SMASH",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_SWIFT",
+      "MOVE_ENDURE",
+      "MOVE_FLY",
+      "MOVE_AGILITY",
+      "MOVE_U-TURN",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_TAUNT",
+      "MOVE_FACADE",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_SWAGGER",
+      "MOVE_RAZOR_WIND",
+      "MOVE_SKY_ATTACK"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "CORVISQUIRE": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_PECK"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_GUST"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_WING_ATTACK"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_TAUNT"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_AIR_SLASH"
+      },
+      {
+        "Level": "27",
+        "Move": "MOVE_FEATHER_DANCE"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_SWAGGER"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_SLASH"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_DUAL_WINGBEAT"
+      },
+      {
+        "Level": "47",
+        "Move": "MOVE_BRAVE_BIRD"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ROCK_SMASH",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_SWIFT",
+      "MOVE_ENDURE",
+      "MOVE_FLY",
+      "MOVE_AGILITY",
+      "MOVE_HURRICANE",
+      "MOVE_U-TURN",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_TAUNT",
+      "MOVE_WORK_UP",
+      "MOVE_FACADE",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_SWAGGER",
+      "MOVE_RAZOR_WIND",
+      "MOVE_SKY_ATTACK"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "CORVIKNIGHT": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_PECK"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_SCREECH"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_IRON_DEFENSE"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_GUST"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_WING_ATTACK"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_TAUNT"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_AIR_SLASH"
+      },
+      {
+        "Level": "27",
+        "Move": "MOVE_FEATHER_DANCE"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_SWAGGER"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_SLASH"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_DUAL_WINGBEAT"
+      },
+      {
+        "Level": "47",
+        "Move": "MOVE_BRAVE_BIRD"
+      },
+      {
+        "Level": "53",
+        "Move": "MOVE_HEAVY_SLAM"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ROCK_SMASH",
+      "MOVE_BULK_UP",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_SWIFT",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_FLY",
+      "MOVE_HYPER_BEAM",
+      "MOVE_AGILITY",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_HURRICANE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_U-TURN",
+      "MOVE_NASTY_PLOT",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CURSE",
+      "MOVE_TAUNT",
+      "MOVE_WORK_UP",
+      "MOVE_FACADE",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_SWAGGER",
+      "MOVE_RAZOR_WIND",
+      "MOVE_SKY_ATTACK",
+      "MOVE_STEEL_BEAM"
+    ],
+    "TutorMoves": [
+      "MOVE_STEEL_WING",
+      "MOVE_METAL_SOUND",
+      "MOVE_METAL_CLAW"
+    ],
+    "EggMoves": []
+  },
+  "NICKIT": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TAIL_WHIP"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_ROAR"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_SNARL"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_KNOCK_OFF"
+      },
+      {
+        "Level": "17",
+        "Move": "MOVE_FAKE_TEARS"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_NASTY_PLOT"
+      },
+      {
+        "Level": "26",
+        "Move": "MOVE_MIMIC"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_NIGHT_SLASH"
+      },
+      {
+        "Level": "38",
+        "Move": "MOVE_DARK_PULSE"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_DOUBLE_TEAM"
+      },
+      {
+        "Level": "52",
+        "Move": "MOVE_PARTING_SHOT"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ROAR",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_KNOCK_OFF",
+      "MOVE_MUD_SHOT",
+      "MOVE_AGILITY",
+      "MOVE_ICY_WIND",
+      "MOVE_WILL-O-WISP",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_TAUNT",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_TORMENT",
+      "MOVE_MIMIC",
+      "MOVE_FAKE_OUT",
+      "MOVE_FIRST_IMPRESSION",
+      "MOVE_RAZOR_WIND"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "THIEVUL": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TAIL_WHIP"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_ROAR"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_SNARL"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_KNOCK_OFF"
+      },
+      {
+        "Level": "17",
+        "Move": "MOVE_FAKE_TEARS"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_NASTY_PLOT"
+      },
+      {
+        "Level": "26",
+        "Move": "MOVE_MIMIC"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_NIGHT_SLASH"
+      },
+      {
+        "Level": "38",
+        "Move": "MOVE_DARK_PULSE"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_DOUBLE_TEAM"
+      },
+      {
+        "Level": "52",
+        "Move": "MOVE_PARTING_SHOT"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ROAR",
+      "MOVE_FIRE_FANG",
+      "MOVE_ICE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_THUNDER_FANG",
+      "MOVE_CRUNCH",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_MUD_SHOT",
+      "MOVE_AGILITY",
+      "MOVE_ICY_WIND",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_WILL-O-WISP",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_PSYCHIC",
+      "MOVE_SHADOW_BALL",
+      "MOVE_U-TURN",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_TAUNT",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_TORMENT",
+      "MOVE_MIMIC",
+      "MOVE_FAKE_OUT",
+      "MOVE_FIRST_IMPRESSION",
+      "MOVE_RAZOR_WIND"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "TOXEL": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_NUZZLE"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_PROTECT",
+      "MOVE_ENDURE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_FACADE"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "TOXTRICITY_AMPED": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_NUZZLE"
+      },
+      {
+        "Level": "4",
+        "Move": "MOVE_CHARGE"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_SNARL"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_ACID_SPRAY"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_TAUNT"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_SCREECH"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_SWAGGER"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_DISCHARGE"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_TOXIC"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_EERIE_IMPULSE"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_POISON_JAB"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_OVERDRIVE"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_BOOMBURST"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_ZAP_CANNON"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_TOXIC",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_FANG",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_SWIFT",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_ENDURE",
+      "MOVE_DISCHARGE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_VOLT_SWITCH",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HYPER_VOICE",
+      "MOVE_POISON_JAB",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WILD_CHARGE",
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_TAUNT",
+      "MOVE_METRONOME",
+      "MOVE_GUNK_SHOT",
+      "MOVE_ELECTROWEB",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_TRAILBLAZE",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_SWAGGER"
+    ],
+    "TutorMoves": [
+      "MOVE_SPARK",
+      "MOVE_SLUDGE_WAVE",
+      "MOVE_THUNDER_SHOCK",
+      "MOVE_METAL_SOUND"
+    ],
+    "EggMoves": []
+  },
+  "TOXTRICITY_LOW_KEY": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_NUZZLE"
+      },
+      {
+        "Level": "4",
+        "Move": "MOVE_CHARGE"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_SNARL"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_ACID_SPRAY"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_TAUNT"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_SCREECH"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_SWAGGER"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_DISCHARGE"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_TOXIC"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_EERIE_IMPULSE"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_POISON_JAB"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_OVERDRIVE"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_BOOMBURST"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_PARABOLIC_CHARGE"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_TOXIC",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_FANG",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_SWIFT",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_ENDURE",
+      "MOVE_DISCHARGE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_VOLT_SWITCH",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HYPER_VOICE",
+      "MOVE_POISON_JAB",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WILD_CHARGE",
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_TAUNT",
+      "MOVE_METRONOME",
+      "MOVE_GUNK_SHOT",
+      "MOVE_ELECTROWEB",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_TRAILBLAZE",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_SWAGGER"
+    ],
+    "TutorMoves": [
+      "MOVE_SPARK",
+      "MOVE_SLUDGE_WAVE",
+      "MOVE_THUNDER_SHOCK",
+      "MOVE_METAL_SOUND"
+    ],
+    "EggMoves": []
+  },
+  "CLOBBOPUS": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_ROCK_SMASH"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_POWER_UP_PUNCH"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_BULLET_PUNCH"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_DETECT"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_MACH_PUNCH"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_CIRCLE_THROW"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_BRICK_BREAK"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_BULK_UP"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_KNOCK_OFF"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_DOUBLE_HIT"
+      },
+      {
+        "Level": "35",
+        "Move": "MOVE_TAUNT"
+      },
+      {
+        "Level": "46",
+        "Move": "MOVE_CLOSE_COMBAT"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ROCK_SMASH",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_KNOCK_OFF",
+      "MOVE_MUD_SHOT",
+      "MOVE_WHIRLPOOL",
+      "MOVE_LIQUIDATION",
+      "MOVE_SUBSTITUTE",
+      "MOVE_TAUNT",
+      "MOVE_WATERFALL",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_CIRCLE_THROW",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_DOUBLE_HIT",
+      "MOVE_DUAL_CHOP",
+      "MOVE_STORM_THROW",
+      "MOVE_MUDDY_WATER",
+      "MOVE_VACUUM_WAVE"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "GRAPPLOCT": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_ROCK_SMASH"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_POWER_UP_PUNCH"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_BULLET_PUNCH"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_DETECT"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_MACH_PUNCH"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_CIRCLE_THROW"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_BRICK_BREAK"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_BULK_UP"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_KNOCK_OFF"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_DOUBLE_HIT"
+      },
+      {
+        "Level": "35",
+        "Move": "MOVE_TAUNT"
+      },
+      {
+        "Level": "46",
+        "Move": "MOVE_CLOSE_COMBAT"
+      },
+      {
+        "Level": "53",
+        "Move": "MOVE_TOPSY_TURVY"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ROCK_SMASH",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_MUD_SHOT",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_WHIRLPOOL",
+      "MOVE_SURF",
+      "MOVE_LIQUIDATION",
+      "MOVE_SUBSTITUTE",
+      "MOVE_TAUNT",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_CIRCLE_THROW",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_DOUBLE_HIT",
+      "MOVE_DUAL_CHOP",
+      "MOVE_STORM_THROW",
+      "MOVE_MUDDY_WATER",
+      "MOVE_VACUUM_WAVE"
+    ],
+    "TutorMoves": [
+      "MOVE_OCTOLOCK"
+    ],
+    "EggMoves": []
+  },
+  "PERRSERKER": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_PAY_DAY"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "6",
+        "Move": "MOVE_TAIL_WHIP"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "13",
+        "Move": "MOVE_TAUNT"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_METAL_CLAW"
+      },
+      {
+        "Level": "17",
+        "Move": "MOVE_SCREECH"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_SLASH"
+      },
+      {
+        "Level": "27",
+        "Move": "MOVE_NASTY_PLOT"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_HYPNOSIS"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "37",
+        "Move": "MOVE_CHARM"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_METAL_SOUND"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_MIMIC"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_OUTRAGE"
+      }
+    ],
+    "TMMoves": [  
+      "MOVE_HEADBUTT",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_AERIAL_ACE",
+      "MOVE_CRUNCH",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_WATER_PULSE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_ICY_WIND",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_LIQUIDATION",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_X-SCISSOR",
+      "MOVE_U-TURN",
+      "MOVE_NASTY_PLOT",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_SPIKES",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_OUTRAGE",
+      "MOVE_TAUNT",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_METRONOME",
+      "MOVE_GUNK_SHOT",
+      "MOVE_WORK_UP",
+      "MOVE_THUNDER",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_TRAILBLAZE",
+      "MOVE_PAY_DAY",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_MIMIC",
+      "MOVE_SEED_BOMB",
+      "MOVE_DUAL_CHOP",
+      "MOVE_SWAGGER",
+      "MOVE_FAKE_OUT",
+      "MOVE_SKULL_BASH",
+      "MOVE_STEEL_BEAM"
+    ],
+    "TutorMoves": [
+      "MOVE_IRON_HEAD"
+    ],
+    "EggMoves": []
+  },
+  "SIRFETCHD": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_PECK"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_DETECT"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_ROCK_SMASH"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_STEEL_WING"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_AERIAL_ACE"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_KNOCK_OFF"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_BRUTAL_SWING"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_FALSE_SWIPE"
+      },
+      {
+        "Level": "27",
+        "Move": "MOVE_FOCUS_ENERGY"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_SLASH"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_SWORDS_DANCE"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_FEATHER_DANCE"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_BRICK_BREAK"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_LEAF_BLADE"
+      },
+      {
+        "Level": "47",
+        "Move": "MOVE_AGILITY"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_BRAVE_BIRD"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_METEOR_ASSAULT"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ROCK_SMASH",
+      "MOVE_BRICK_BREAK",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_SWIFT",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_FLY",
+      "MOVE_KNOCK_OFF",
+      "MOVE_AGILITY",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_POISON_JAB",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_U-TURN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_CURSE",
+      "MOVE_WORK_UP",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_FIRST_IMPRESSION",
+      "MOVE_RAZOR_WIND",
+      "MOVE_SKULL_BASH",
+      "MOVE_VACUUM_WAVE",
+      "MOVE_SOLAR_BLADE",
+      "MOVE_SKY_ATTACK"
+    ],
+    "TutorMoves": [
+      "MOVE_IRON_DEFENSE"
+    ],
+    "EggMoves": []
+  },
+  "MR_RIME": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_HYPNOSIS"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_ICE_SHARD"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_CHARM"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_CONFUSION"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_DREAM_EATER"
+      },
+      {
+        "Level": "17",
+        "Move": "MOVE_INFESTATION"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_PROTECT"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_STEALTH_ROCK"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_PSYBEAM"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_MIMIC"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_LIGHT_SCREEN"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_REFLECT"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_SAFEGUARD"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_FREEZE_DRY"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_DAZZLING_GLEAM"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_PSYCHIC"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ICE_BEAM",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_REFLECT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_HYPER_BEAM",
+      "MOVE_ICY_WIND",
+      "MOVE_SAFEGUARD",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_PSYCHIC",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_THUNDERBOLT",
+      "MOVE_SHADOW_BALL",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_TAUNT",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_METRONOME",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_BLIZZARD",
+      "MOVE_THUNDER",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_TORMENT",
+      "MOVE_MIMIC",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_FROST_BREATH",
+      "MOVE_SWAGGER",
+      "MOVE_FAKE_OUT",
+      "MOVE_FIRST_IMPRESSION",
+      "MOVE_TRIPLE_AXEL",
+      "MOVE_ICICLE_SPEAR",
+      "MOVE_SHEER_COLD"
+    ],
+    "TutorMoves": [
+      "MOVE_MIST",
+      "MOVE_SMOKESCREEN",
+      "MOVE_HAZE",
+      "MOVE_FAKE_TEARS"
+    ],
+    "EggMoves": []
+  },
+  "RUNERIGUS": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_CONFUSION"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_PROTECT"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_SAND_TOMB"
+      },
+      {
+        "Level": "4",
+        "Move": "MOVE_HAZE"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_ROCK_TOMB"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_FAKE_TEARS"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_BRUTAL_SWING"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_ROCK_BLAST"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_INFESTATION"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_PSYSHOCK"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_CURSE"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_SHADOW_BALL"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_EARTHQUAKE"
+      },
+      {
+        "Level": "46",
+        "Move": "MOVE_PHANTOM_FORCE"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_PARTING_SHOT"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_MUD_SHOT",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_ICY_WIND",
+      "MOVE_SAFEGUARD",
+      "MOVE_EARTH_POWER",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_WILL-O-WISP",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_PSYCHIC",
+      "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_TAUNT",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_FACADE",
+      "MOVE_SHADOW_PUNCH",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_DREAM_EATER",
+      "MOVE_FISSURE"
+    ],
+    "TutorMoves": [
+      "MOVE_SHADOW_CLAW"
+    ],
     "EggMoves": []
   },
   "FALINKS": {
@@ -19067,18 +32502,3386 @@
       }
     ],
     "TMMoves": [
-      "MOVE_AGILITY",
+      "MOVE_HEADBUTT",
+      "MOVE_ROCK_SMASH",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_SWORDS_DANCE",
       "MOVE_BODY_SLAM",
-      "MOVE_FOCUS_BLAST",
-      "MOVE_GIGA_IMPACT",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
       "MOVE_HYPER_BEAM",
       "MOVE_KNOCK_OFF",
+      "MOVE_AGILITY",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
       "MOVE_POISON_JAB",
-      "MOVE_ROCK_SLIDE",
-      "MOVE_ROCK_TOMB",
+      "MOVE_IRON_DEFENSE",
       "MOVE_SUBSTITUTE",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_TRAILBLAZE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_SEED_BOMB",
+      "MOVE_DOUBLE_HIT",
+      "MOVE_FAKE_OUT",
+      "MOVE_FIRST_IMPRESSION",
+      "MOVE_SKULL_BASH"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "INDEEDEE_M": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_DRAINING_KISS"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_DISARMING_VOICE"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_MAGICAL_LEAF"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_PSYBEAM"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_MOONLIGHT"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_TRI_ATTACK"
+      },
+      {
+        "Level": "35",
+        "Move": "MOVE_PSYCHIC"
+      },
+      {
+        "Level": "38",
+        "Move": "MOVE_WISH"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_CALM_MIND"
+      },
+      {
+        "Level": "52",
+        "Move": "MOVE_MOONBLAST"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_PSYCHIC",
+      "MOVE_HEAT_WAVE",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_METRONOME",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_MIMIC",
+      "MOVE_DREAM_EATER",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_FAKE_OUT",
+      "MOVE_RAZOR_WIND",
+      "MOVE_TRI_ATTACK",
+      "MOVE_VACUUM_WAVE"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "INDEEDEE_F": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_DRAINING_KISS"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_DISARMING_VOICE"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_MAGICAL_LEAF"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_PSYBEAM"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_MOONLIGHT"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_TRI_ATTACK"
+      },
+      {
+        "Level": "35",
+        "Move": "MOVE_PSYCHIC"
+      },
+      {
+        "Level": "38",
+        "Move": "MOVE_WISH"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_CALM_MIND"
+      },
+      {
+        "Level": "52",
+        "Move": "MOVE_MOONBLAST"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_SWIFT",
+      "MOVE_REFLECT",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_SAFEGUARD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_PSYCHIC",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_METRONOME",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_SING",
+      "MOVE_DREAM_EATER",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_FAKE_OUT",
+      "MOVE_TRI_ATTACK"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "MORPEKO": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TAIL_WHIP"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_THUNDER_SHOCK"
+      },
+      {
+        "Level": "5",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "7",
+        "Move": "MOVE_SWAGGER"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_CHARGE"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_SPARK"
+      },
+      {
+        "Level": "33",
+        "Move": "MOVE_PARTING_SHOT"
+      },
+      {
+        "Level": "38",
+        "Move": "MOVE_SUPER_FANG"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_TORMENT"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_AGILITY"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_BULLET_SEED"
+      },
+      {
+        "Level": "52",
+        "Move": "MOVE_CRUNCH"
+      },
+      {
+        "Level": "57",
+        "Move": "MOVE_AURA_WHEEL"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_FIRE_FANG",
+      "MOVE_ICE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_FANG",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_CRUNCH",
+      "MOVE_SWIFT",
+      "MOVE_ENDURE",
+      "MOVE_BULLET_SEED",
+      "MOVE_KNOCK_OFF",
+      "MOVE_AGILITY",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_VOLT_SWITCH",
+      "MOVE_THUNDERBOLT",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WILD_CHARGE",
+      "MOVE_DARK_PULSE",
+      "MOVE_OUTRAGE",
+      "MOVE_TAUNT",
+      "MOVE_ELECTROWEB",
+      "MOVE_THUNDER",
+      "MOVE_FACADE",
+      "MOVE_TORMENT",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_SEED_BOMB",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_SWAGGER",
+      "MOVE_FAKE_OUT",
+      "MOVE_SKULL_BASH"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "KLEAVOR": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_WING_ATTACK"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_DOUBLE_TEAM"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_BRUTAL_SWING"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_SLASH"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_FOCUS_ENERGY"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_X_SCISSOR"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_BUG_BUZZ"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_AIR_SLASH"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_SWORDS_DANCE"
+      },
+      {
+        "Level": "46",
+        "Move": "MOVE_LUNGE"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_ROCK_BLAST"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ROCK_SMASH",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_SWIFT",
       "MOVE_SWORDS_DANCE",
-      "MOVE_ZEN_HEADBUTT"
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_AGILITY",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_STONE_EDGE",
+      "MOVE_X-SCISSOR",
+      "MOVE_U-TURN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_SILVER_WIND",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_DOUBLE_HIT",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_DUAL_CHOP",
+      "MOVE_RAZOR_WIND",
+      "MOVE_VACUUM_WAVE"
+    ],
+    "TutorMoves": [
+      "MOVE_STONE_AXE"
+    ],
+    "EggMoves": []
+  },
+  "OVERQWIL": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_POISON_STING"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "4",
+        "Move": "MOVE_HARDEN"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_WATER_GUN"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_BUBBLE_BEAM"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_HAZE"
+      },
+      {
+        "Level": "17",
+        "Move": "MOVE_AQUA_JET"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_SPIKES"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_BARB_BARRAGE"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_POISON_JAB"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_PIN_MISSILE"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_TOXIC_SPIKES"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_TOXIC"
+      },
+      {
+        "Level": "46",
+        "Move": "MOVE_CRUNCH"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_GUNK_SHOT"
+      },
+      {
+        "Level": "53",
+        "Move": "MOVE_MORTAL_SPIN"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_TOXIC",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_CRUNCH",
+      "MOVE_SWIFT",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_ENDURE",
+      "MOVE_WATER_PULSE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_MUD_SHOT",
+      "MOVE_AGILITY",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_ICY_WIND",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_SURF",
+      "MOVE_SHADOW_BALL",
+      "MOVE_LIQUIDATION",
+      "MOVE_POISON_JAB",
+      "MOVE_SUBSTITUTE",
+      "MOVE_SPIKES",
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_TAUNT",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_GUNK_SHOT",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_ACID_SPRAY",
+      "MOVE_SCALE_SHOT"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "FIDOUGH": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "3",
+        "Move": "MOVE_LICK"
+      },
+      {
+        "Level": "6",
+        "Move": "MOVE_TAIL_WHIP"
+      },
+      {
+        "Level": "11",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_DRAINING_KISS"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_PLAY_ROUGH"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_WORK_UP"
+      },
+      {
+        "Level": "26",
+        "Move": "MOVE_SNARL"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_BOUNCE"
+      },
+      {
+        "Level": "33",
+        "Move": "MOVE_DOUBLE_EDGE"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_CHARM"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_ROAR"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_CRUNCH"
+      },
+      {
+        "Level": "47",
+        "Move": "MOVE_WISH"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ROAR",
+      "MOVE_FIRE_FANG",
+      "MOVE_ICE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_THUNDER_FANG",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_MUD_SHOT",
+      "MOVE_AGILITY",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_WORK_UP",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_PSYCHIC_FANGS"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "DACHSBUN": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "3",
+        "Move": "MOVE_LICK"
+      },
+      {
+        "Level": "6",
+        "Move": "MOVE_TAIL_WHIP"
+      },
+      {
+        "Level": "11",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_DRAINING_KISS"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_PLAY_ROUGH"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_WORK_UP"
+      },
+      {
+        "Level": "26",
+        "Move": "MOVE_SNARL"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_BOUNCE"
+      },
+      {
+        "Level": "33",
+        "Move": "MOVE_DOUBLE_EDGE"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_CHARM"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_ROAR"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_CRUNCH"
+      },
+      {
+        "Level": "47",
+        "Move": "MOVE_WISH"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ROAR",
+      "MOVE_FIRE_FANG",
+      "MOVE_ICE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_THUNDER_FANG",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_MUD_SHOT",
+      "MOVE_AGILITY",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_WORK_UP",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_SEED_BOMB"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "SQUAWKABILLY": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_PECK"
+      },
+      {
+        "Level": "6",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_TORMENT"
+      },
+      {
+        "Level": "13",
+        "Move": "MOVE_AERIAL_ACE"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_TAUNT"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_FEATHER_DANCE"
+      },
+      {
+        "Level": "27",
+        "Move": "MOVE_MIMIC"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_FLY"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_FACADE"
+      },
+      {
+        "Level": "38",
+        "Move": "MOVE_SWAGGER"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_LUNGE"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_BRAVE_BIRD"
+      },
+      {
+        "Level": "46",
+        "Move": "MOVE_AIR_SLASH"
+      },
+      {
+        "Level": "52",
+        "Move": "MOVE_PARTING_SHOT"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_BULK_UP",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_ENDURE",
+      "MOVE_FLY",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_HEAT_WAVE",
+      "MOVE_HYPER_VOICE",
+      "MOVE_HURRICANE",
+      "MOVE_U-TURN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_TAUNT",
+      "MOVE_WORK_UP",
+      "MOVE_FACADE",
+      "MOVE_TORMENT",
+      "MOVE_MIMIC",
+      "MOVE_SEED_BOMB",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_SWAGGER",
+      "MOVE_SKULL_BASH",
+      "MOVE_SKY_ATTACK"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "NACLI": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_HARDEN"
+      },
+      {
+        "Level": "5",
+        "Move": "MOVE_ROCK_THROW"
+      },
+      {
+        "Level": "7",
+        "Move": "MOVE_MUD_SHOT"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_HEADBUTT"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_ANCIENT_POWER"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_IRON_DEFENSE"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_RECOVER"
+      },
+      {
+        "Level": "35",
+        "Move": "MOVE_ROCK_SLIDE"
+      },
+      {
+        "Level": "38",
+        "Move": "MOVE_STEALTH_ROCK"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_HEAVY_SLAM"
+      },
+      {
+        "Level": "47",
+        "Move": "MOVE_EARTHQUAKE"
+      },
+      {
+        "Level": "54",
+        "Move": "MOVE_STONE_EDGE"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_POWER_GEM",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_MUD_SHOT",
+      "MOVE_EARTH_POWER",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CURSE",
+      "MOVE_FACADE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_SKULL_BASH",
+      "MOVE_FISSURE",
+      "MOVE_METEOR_BEAM"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "NACLSTACK": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_HARDEN"
+      },
+      {
+        "Level": "5",
+        "Move": "MOVE_ROCK_THROW"
+      },
+      {
+        "Level": "7",
+        "Move": "MOVE_MUD_SHOT"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_HEADBUTT"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_ANCIENT_POWER"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_IRON_DEFENSE"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_RECOVER"
+      },
+      {
+        "Level": "35",
+        "Move": "MOVE_ROCK_SLIDE"
+      },
+      {
+        "Level": "38",
+        "Move": "MOVE_STEALTH_ROCK"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_HEAVY_SLAM"
+      },
+      {
+        "Level": "47",
+        "Move": "MOVE_EARTHQUAKE"
+      },
+      {
+        "Level": "54",
+        "Move": "MOVE_STONE_EDGE"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_POWER_GEM",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_HYPER_BEAM",
+      "MOVE_MUD_SHOT",
+      "MOVE_EARTH_POWER",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CURSE",
+      "MOVE_FACADE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_SKULL_BASH",
+      "MOVE_FISSURE",
+      "MOVE_METEOR_BEAM"
+    ],
+    "TutorMoves": [
+      "MOVE_SALT_CURE"
+    ],
+    "EggMoves": []
+  },
+  "GARGANACL": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_HARDEN"
+      },
+      {
+        "Level": "5",
+        "Move": "MOVE_ROCK_THROW"
+      },
+      {
+        "Level": "7",
+        "Move": "MOVE_MUD_SHOT"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_HEADBUTT"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_ANCIENT_POWER"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_IRON_DEFENSE"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_RECOVER"
+      },
+      {
+        "Level": "35",
+        "Move": "MOVE_ROCK_SLIDE"
+      },
+      {
+        "Level": "38",
+        "Move": "MOVE_STEALTH_ROCK"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_HEAVY_SLAM"
+      },
+      {
+        "Level": "47",
+        "Move": "MOVE_EARTHQUAKE"
+      },
+      {
+        "Level": "54",
+        "Move": "MOVE_STONE_EDGE"
+      },
+      {
+        "Level": "60",
+        "Move": "MOVE_EXPLOSION"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_POWER_GEM",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_HYPER_BEAM",
+      "MOVE_MUD_SHOT",
+      "MOVE_EARTH_POWER",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_STONE_EDGE",
+      "MOVE_EARTHQUAKE",
+      "MOVE_BULLDOZE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CURSE",
+      "MOVE_FACADE",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_SKULL_BASH",
+      "MOVE_FISSURE",
+      "MOVE_METEOR_BEAM"
+    ],
+    "TutorMoves": [
+      "MOVE_SALT_CURE",
+      "MOVE_ROCK_BLAST",
+      "MOVE_DYNAMIC_PUNCH"
+    ],
+    "EggMoves": []
+  },
+  "CHARCADET": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "EMBER"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_SMOKESCREEN"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_FIRE_SPIN"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_WILL_O_WISP"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_FLAME_CHARGE"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_LAVA_PLUME"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_PROTECT",
+      "MOVE_ENDURE",
+      "MOVE_FIRE_BLAST",
+      "MOVE_OVERHEAT",
+      "MOVE_WILL-O-WISP",
+      "MOVE_FLAMETHROWER",
+      "MOVE_HEAT_WAVE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_FLARE_BLITZ",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_OMINOUS_WIND"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "ARMAROUGE": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_EMBER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_MYSTICAL_FIRE"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_SMOKESCREEN"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_FIRE_SPIN"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_WILL_O_WISP"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_PSYBEAM"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_FLAME_CHARGE"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_LAVA_PLUME"
+      },
+      {
+        "Level": "37",
+        "Move": "MOVE_CALM_MIND"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_ARMOR_CANNON"
+      },
+      {
+        "Level": "54",
+        "Move": "MOVE_FLAMETHROWER"
+      },
+      {
+        "Level": "62",
+        "Move": "MOVE_AURA_SPHERE"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_PSYSHOCK",
+      "MOVE_CALM_MIND",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_ENERGY_BALL",
+      "MOVE_REFLECT",
+      "MOVE_ENDURE",
+      "MOVE_FIRE_BLAST",
+      "MOVE_HYPER_BEAM",
+      "MOVE_OVERHEAT",
+      "MOVE_WILL-O-WISP",
+      "MOVE_FUTURE_SIGHT",
+      "MOVE_FLAMETHROWER",
+      "MOVE_PSYCHIC",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_HEAT_WAVE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_SHADOW_BALL",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_TAUNT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_FLARE_BLITZ",
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_SCORCHING_SANDS",
+      "MOVE_METEOR_BEAM"
+    ],
+    "TutorMoves": [
+      "MOVE_PSYSHOCK"
+    ],
+    "EggMoves": []
+  },
+  "CERULEDGE": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_EMBER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_MYSTICAL_FIRE"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_SMOKESCREEN"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_FIRE_SPIN"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_WILL_O_WISP"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_FLAME_CHARGE"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_LAVA_PLUME"
+      },
+      {
+        "Level": "37",
+        "Move": "MOVE_SWORDS_DANCE"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_SOLAR_BLADE"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_BITTER_BLADE"
+      },
+      {
+        "Level": "54",
+        "Move": "MOVE_PSYCHO_CUT"
+      },
+      {
+        "Level": "58",
+        "Move": "MOVE_PHANTOM_FORCE"
+      },
+      {
+        "Level": "62",
+        "Move": "MOVE_FLARE_BLITZ"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_DRAGON_CLAW",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_REFLECT",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_FIRE_BLAST",
+      "MOVE_OVERHEAT",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_WILL-O-WISP",
+      "MOVE_IRON_HEAD",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_FLAMETHROWER",
+      "MOVE_STONE_EDGE",
+      "MOVE_HEAT_WAVE",
+      "MOVE_FIRE_SPIN",
+      "MOVE_SHADOW_BALL",
+      "MOVE_POISON_JAB",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_X-SCISSOR",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CURSE",
+      "MOVE_TAUNT",
+      "MOVE_FLARE_BLITZ",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_RAZOR_WIND",
+      "MOVE_VACUUM_WAVE",
+      "MOVE_SOLAR_BLADE"
+    ],
+    "TutorMoves": [
+      "MOVE_SHADOW_SNEAK",
+      "MOVE_SHADOW_CLAW"
+    ],
+    "EggMoves": []
+  },
+  "MASCHIFF": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_LICK"
+      },
+      {
+        "Level": "4",
+        "Move": "MOVE_SNARL"
+      },
+      {
+        "Level": "7",
+        "Move": "MOVE_CHARM"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_ROAR"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_HEADBUTT"
+      },
+      {
+        "Level": "27",
+        "Move": "MOVE_FOCUS_ENERGY"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_TAUNT"
+      },
+      {
+        "Level": "35",
+        "Move": "MOVE_SWAGGER"
+      },
+      {
+        "Level": "38",
+        "Move": "MOVE_BOUNCE"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_CRUNCH"
+      },
+      {
+        "Level": "45",
+        "Move": "MOVE_LUNGE"
+      },
+      {
+        "Level": "49",
+        "Move": "MOVE_DOUBLE_EDGE"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_ROCK_SMASH",
+      "MOVE_ROAR",
+      "MOVE_FIRE_FANG",
+      "MOVE_ICE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_THUNDER_FANG",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_KNOCK_OFF",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_TAUNT",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_SEED_BOMB",
+      "MOVE_SWAGGER"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "MABOSSTIFF": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_LICK"
+      },
+      {
+        "Level": "4",
+        "Move": "MOVE_SNARL"
+      },
+      {
+        "Level": "7",
+        "Move": "MOVE_CHARM"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_ROAR"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_HEADBUTT"
+      },
+      {
+        "Level": "27",
+        "Move": "MOVE_FOCUS_ENERGY"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_TAUNT"
+      },
+      {
+        "Level": "35",
+        "Move": "MOVE_SWAGGER"
+      },
+      {
+        "Level": "38",
+        "Move": "MOVE_BOUNCE"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_CRUNCH"
+      },
+      {
+        "Level": "45",
+        "Move": "MOVE_LUNGE"
+      },
+      {
+        "Level": "49",
+        "Move": "MOVE_DOUBLE_EDGE"
+      },
+      {
+        "Level": "56",
+        "Move": "MOVE_OUTRAGE"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_ROCK_SMASH",
+      "MOVE_ROAR",
+      "MOVE_FIRE_FANG",
+      "MOVE_ICE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_THUNDER_FANG",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_HYPER_VOICE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WILD_CHARGE",
+      "MOVE_DARK_PULSE",
+      "MOVE_CURSE",
+      "MOVE_OUTRAGE",
+      "MOVE_TAUNT",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_SEED_BOMB",
+      "MOVE_SWAGGER",
+      "MOVE_SKULL_BASH"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "SHROODLE": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "5",
+        "Move": "MOVE_ACID_SPRAY"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_PIN_MISSILE"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_POISON_FANG"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_SUPER_FANG"
+      },
+      {
+        "Level": "21",
+        "Move": "MOVE_SLASH"
+      },
+      {
+        "Level": "23",
+        "Move": "MOVE_PARTING_SHOT"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_U_TURN"
+      },
+      {
+        "Level": "29",
+        "Move": "MOVE_POISON_JAB"
+      },
+      {
+        "Level": "33",
+        "Move": "MOVE_TAUNT"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_SUBSTITUTE"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_KNOCK_OFF"
+      },
+      {
+        "Level": "54",
+        "Move": "MOVE_GUNK_SHOT"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_TOXIC",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_DIG",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_REFLECT",
+      "MOVE_ENDURE",
+      "MOVE_KNOCK_OFF",
+      "MOVE_MUD_SHOT",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_POISON_JAB",
+      "MOVE_U-TURN",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_TAUNT",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_METRONOME",
+      "MOVE_GUNK_SHOT",
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_TRAILBLAZE",
+      "MOVE_POISON_FANG",
+      "MOVE_MIMIC",
+      "MOVE_SWAGGER"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "GRAFAIAI": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "5",
+        "Move": "MOVE_ACID_SPRAY"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_PIN_MISSILE"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_POISON_FANG"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_SUPER_FANG"
+      },
+      {
+        "Level": "21",
+        "Move": "MOVE_SLASH"
+      },
+      {
+        "Level": "23",
+        "Move": "MOVE_PARTING_SHOT"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_U_TURN"
+      },
+      {
+        "Level": "29",
+        "Move": "MOVE_POISON_JAB"
+      },
+      {
+        "Level": "33",
+        "Move": "MOVE_TAUNT"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_SUBSTITUTE"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_KNOCK_OFF"
+      },
+      {
+        "Level": "54",
+        "Move": "MOVE_GUNK_SHOT"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_TOXIC",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_DIG",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_REFLECT",
+      "MOVE_ENDURE",
+      "MOVE_KNOCK_OFF",
+      "MOVE_MUD_SHOT",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_POISON_JAB",
+      "MOVE_X-SCISSOR",
+      "MOVE_U-TURN",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_TAUNT",
+      "MOVE_HEAL_BLOCK",
+      "MOVE_METRONOME",
+      "MOVE_GUNK_SHOT",
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_LOW_SWEEP",
+      "MOVE_TRAILBLAZE",
+      "MOVE_POISON_FANG",
+      "MOVE_MIMIC",
+      "MOVE_SEED_BOMB",
+      "MOVE_SWAGGER",
+      "MOVE_FIRST_IMPRESSION",
+      "MOVE_RAZOR_WIND",
+      "MOVE_TRI_ATTACK"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "CAPSAKID": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_LEAFAGE"
+      },
+      {
+        "Level": "4",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_ROLLOUT"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_GROWTH"
+      },
+      {
+        "Level": "13",
+        "Move": "MOVE_RAZOR_LEAF"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_LEECH_SEED"
+      },
+      {
+        "Level": "21",
+        "Move": "MOVE_BULLET_SEED"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_HEADBUTT"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_ZEN_HEADBUTT"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_MAGICAL_LEAF"
+      },
+      {
+        "Level": "35",
+        "Move": "MOVE_SUPER_FANG"
+      },
+      {
+        "Level": "38",
+        "Move": "MOVE_CRUNCH"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_SEED_BOMB"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_SOLAR_BEAM"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_PROTECT",
+      "MOVE_CRUNCH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_ENDURE",
+      "MOVE_BULLET_SEED",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_SUBSTITUTE",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_SEED_BOMB"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "SCOVILLAIN": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_LEAFAGE"
+      },
+      {
+        "Level": "4",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_ROLLOUT"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_GROWTH"
+      },
+      {
+        "Level": "13",
+        "Move": "MOVE_RAZOR_LEAF"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_LEECH_SEED"
+      },
+      {
+        "Level": "21",
+        "Move": "MOVE_BULLET_SEED"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_HEADBUTT"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_ZEN_HEADBUTT"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_MAGICAL_LEAF"
+      },
+      {
+        "Level": "35",
+        "Move": "MOVE_SUPER_FANG"
+      },
+      {
+        "Level": "38",
+        "Move": "MOVE_CRUNCH"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_SEED_BOMB"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_SOLAR_BEAM"
+      },
+      {
+        "Level": "48",
+        "Move": "MOVE_OVERHEAT"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_FIRE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_FANG",
+      "MOVE_CRUNCH",
+      "MOVE_ENERGY_BALL",
+      "MOVE_ENDURE",
+      "MOVE_FIRE_BLAST",
+      "MOVE_BULLET_SEED",
+      "MOVE_GIGA_DRAIN",
+      "MOVE_HYPER_BEAM",
+      "MOVE_OVERHEAT",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_WILL-O-WISP",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_FLAMETHROWER",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_FIRE_SPIN",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_OUTRAGE",
+      "MOVE_FLARE_BLITZ",
+      "MOVE_FACADE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_SEED_BOMB",
+      "MOVE_DOUBLE_HIT",
+      "MOVE_SWAGGER"
+    ],
+    "TutorMoves": [
+      "MOVE_FLAMETHROWER",
+      "MOVE_SPICY_EXTRACT"
+    ],
+    "EggMoves": []
+  },
+  "TINKATINK": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_FAIRY_WIND"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_METAL_CLAW"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_ROCK_THROW"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_ROCK_SMASH"
+      },
+      {
+        "Level": "17",
+        "Move": "MOVE_DRAINING_KISS"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_SCREECH"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_BRUTAL_SWING"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_FAKE_TEARS"
+      },
+      {
+        "Level": "31",
+        "Move": "MOVE_FLASH_CANNON"
+      },
+      {
+        "Level": "35",
+        "Move": "MOVE_PLAY_ROUGH"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_KNOCK_OFF"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ROCK_SMASH",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_REFLECT",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_KNOCK_OFF",
+      "MOVE_STONE_EDGE",
+      "MOVE_BULLDOZE",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_METRONOME",
+      "MOVE_FACADE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_FAKE_OUT",
+      "MOVE_STEEL_BEAM"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "TINKATUFF": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_FAIRY_WIND"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_METAL_CLAW"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_ROCK_THROW"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_ROCK_SMASH"
+      },
+      {
+        "Level": "17",
+        "Move": "MOVE_DRAINING_KISS"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_SCREECH"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_BRUTAL_SWING"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_FAKE_TEARS"
+      },
+      {
+        "Level": "31",
+        "Move": "MOVE_FLASH_CANNON"
+      },
+      {
+        "Level": "35",
+        "Move": "MOVE_PLAY_ROUGH"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_KNOCK_OFF"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ROCK_SMASH",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_REFLECT",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_KNOCK_OFF",
+      "MOVE_STONE_EDGE",
+      "MOVE_BULLDOZE",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_METRONOME",
+      "MOVE_FACADE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_FAKE_OUT",
+      "MOVE_STEEL_BEAM"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "TINKATON": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_FAIRY_WIND"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_METAL_CLAW"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_ROCK_THROW"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_ROCK_SMASH"
+      },
+      {
+        "Level": "17",
+        "Move": "MOVE_DRAINING_KISS"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_SCREECH"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_BRUTAL_SWING"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_FAKE_TEARS"
+      },
+      {
+        "Level": "31",
+        "Move": "MOVE_FLASH_CANNON"
+      },
+      {
+        "Level": "35",
+        "Move": "MOVE_PLAY_ROUGH"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_KNOCK_OFF"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_HEAVY_SLAM"
+      }      
+    ],
+    "TMMoves": [
+      "MOVE_ROCK_SMASH",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_REFLECT",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_STONE_EDGE",
+      "MOVE_BULLDOZE",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_METRONOME",
+      "MOVE_FACADE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_FAKE_OUT",
+      "MOVE_STEEL_BEAM"
+    ],
+    "TutorMoves": [
+      "MOVE_GIGATON_HAMMER",
+      "MOVE_ICE_HAMMER",
+      "MOVE_WOOD_HAMMER"
+    ],
+    "EggMoves": []
+  },
+  "CYCLIZAR": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "11",
+        "Move": "MOVE_TAUNT"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_BREAKING_SWIPE"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_QUICK_ATTACK"
+      },
+      {
+        "Level": "23",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "27",
+        "Move": "MOVE_U_TURN"
+      },
+      {
+        "Level": "31",
+        "Move": "MOVE_SHED_TAIL"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_DRAGON_CLAW"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_IRON_TAIL"
+      },
+      {
+        "Level": "45",
+        "Move": "MOVE_DRAGON_PULSE"
+      },
+      {
+        "Level": "51",
+        "Move": "MOVE_DOUBLE_EDGE"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_POWER_WHIP"
+      },
+      {
+        "Level": "57",
+        "Move": "MOVE_DRAGON_RUSH"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_DRAGON_CLAW",
+      "MOVE_FIRE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_FANG",
+      "MOVE_AERIAL_ACE",
+      "MOVE_CRUNCH",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_MUD_SHOT",
+      "MOVE_AGILITY",
+      "MOVE_OVERHEAT",
+      "MOVE_DRACO_METEOR",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_THUNDERBOLT",
+      "MOVE_HYPER_VOICE",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_U-TURN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WILD_CHARGE",
+      "MOVE_IRON_TAIL",
+      "MOVE_OUTRAGE",
+      "MOVE_TAUNT",
+      "MOVE_FACADE",
+      "MOVE_FLAME_CHARGE",
+      "MOVE_TRAILBLAZE",
+      "MOVE_SCALE_SHOT",
+      "MOVE_SKULL_BASH"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "GLIMMET": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_ROCK_THROW"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_HARDEN"
+      },
+      {
+        "Level": "7",
+        "Move": "MOVE_ACID_SPRAY"
+      },
+      {
+        "Level": "11",
+        "Move": "MOVE_ANCIENT_POWER"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_STEALTH_ROCK"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_ROCK_BLAST"
+      },
+      {
+        "Level": "29",
+        "Move": "MOVE_SELF_DESTRUCT"
+      },
+      {
+        "Level": "33",
+        "Move": "MOVE_ROCK_SLIDE"
+      },
+      {
+        "Level": "37",
+        "Move": "MOVE_POWER_GEM"
+      },
+      {
+        "Level": "41",
+        "Move": "MOVE_ACID_ARMOR"
+      },
+      {
+        "Level": "46",
+        "Move": "MOVE_SLUDGE_WAVE"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_EXPLOSION"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_TOXIC",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_POWER_GEM",
+      "MOVE_REFLECT",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_MUD_SHOT",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_STONE_EDGE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_SPIKES",
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_GUNK_SHOT",
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_METEOR_BEAM"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "GLIMMORA": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_ROCK_THROW"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_HARDEN"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_SPIKY_SHIELD"
+      },
+      {
+        "Level": "7",
+        "Move": "MOVE_ACID_SPRAY"
+      },
+      {
+        "Level": "11",
+        "Move": "MOVE_ANCIENT_POWER"
+      },
+      {
+        "Level": "14",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_STEALTH_ROCK"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_ROCK_BLAST"
+      },
+      {
+        "Level": "29",
+        "Move": "MOVE_SELF_DESTRUCT"
+      },
+      {
+        "Level": "33",
+        "Move": "MOVE_ROCK_SLIDE"
+      },
+      {
+        "Level": "37",
+        "Move": "MOVE_POWER_GEM"
+      },
+      {
+        "Level": "41",
+        "Move": "MOVE_ACID_ARMOR"
+      },
+      {
+        "Level": "46",
+        "Move": "MOVE_SLUDGE_WAVE"
+      },
+      {
+        "Level": "55",
+        "Move": "MOVE_EXPLOSION"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_TOXIC",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_POWER_GEM",
+      "MOVE_ENERGY_BALL",
+      "MOVE_REFLECT",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_HYPER_BEAM",
+      "MOVE_MUD_SHOT",
+      "MOVE_SELF-DESTRUCT",
+      "MOVE_EARTH_POWER",
+      "MOVE_SLUDGE_BOMB",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_SOLAR_BEAM",
+      "MOVE_STONE_EDGE",
+      "MOVE_IRON_DEFENSE",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_SPIKES",
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_GUNK_SHOT",
+      "MOVE_FACADE",
+      "MOVE_ACID_SPRAY",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_METEOR_BEAM"
+    ],
+    "TutorMoves": [
+      "MOVE_TOXIC_SPIKES",
+      "MOVE_METEOR_BEAM",
+      "MOVE_MORTAL_SPIN"
+    ],
+    "EggMoves": []
+  },
+  "GREAVARD": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_SMOKESCREEN"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_SHADOW_SNEAK"
+      },
+      {
+        "Level": "3",
+        "Move": "MOVE_LICK"
+      },
+      {
+        "Level": "6",
+        "Move": "MOVE_TAIL_WHIP"
+      },
+      {
+        "Level": "6",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "9",
+        "Move": "MOVE_ROAR"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_HEADBUTT"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_DIG"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_SNARL"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_CRUNCH"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_PLAY_ROUGH"
+      },
+      {
+        "Level": "41",
+        "Move": "MOVE_PHANTOM_FORCE"
+      },
+      {
+        "Level": "46",
+        "Move": "MOVE_CHARM"
+      },
+      {
+        "Level": "52",
+        "Move": "MOVE_DOUBLE_EDGE"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_ROAR",
+      "MOVE_FIRE_FANG",
+      "MOVE_ICE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_THUNDER_FANG",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_ENDURE",
+      "MOVE_MUD_SHOT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_WILL-O-WISP",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_SHADOW_BALL",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_FACADE",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_DREAM_EATER",
+      "MOVE_SWAGGER"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "HOUNDSTONE": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_GROWL"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_SMOKESCREEN"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_SHADOW_SNEAK"
+      },
+      {
+        "Level": "3",
+        "Move": "MOVE_LICK"
+      },
+      {
+        "Level": "6",
+        "Move": "MOVE_TAIL_WHIP"
+      },
+      {
+        "Level": "6",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "9",
+        "Move": "MOVE_ROAR"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_HEADBUTT"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_DIG"
+      },
+      {
+        "Level": "20",
+        "Move": "MOVE_SNARL"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_CRUNCH"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_PLAY_ROUGH"
+      },
+      {
+        "Level": "41",
+        "Move": "MOVE_PHANTOM_FORCE"
+      },
+      {
+        "Level": "46",
+        "Move": "MOVE_CHARM"
+      },
+      {
+        "Level": "52",
+        "Move": "MOVE_DOUBLE_EDGE"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_HEADBUTT",
+      "MOVE_ROAR",
+      "MOVE_FIRE_FANG",
+      "MOVE_ICE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_PLAY_ROUGH",
+      "MOVE_THUNDER_FANG",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_ENDURE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_MUD_SHOT",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_WILL-O-WISP",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_SHADOW_BALL",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WORK_UP",
+      "MOVE_FACADE",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_DREAM_EATER",
+      "MOVE_SEED_BOMB",
+      "MOVE_SWAGGER"
+    ],
+    "TutorMoves": [
+      "MOVE_LAST_RESPECTS"
+    ],
+    "EggMoves": []
+  },
+  "FLAMIGO": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_PECK"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_MIMIC"
+      },
+      {
+        "Level": "9",
+        "Move": "MOVE_DETECT"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_WING_ATTACK"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_FOCUS_ENERGY"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_LUNGE"
+      },
+      {
+        "Level": "21",
+        "Move": "MOVE_BRUTAL_SWING"
+      },
+      {
+        "Level": "26",
+        "Move": "MOVE_DUAL_WINGBEAT"
+      },
+      {
+        "Level": "30",
+        "Move": "MOVE_FEATHER_DANCE"
+      },
+      {
+        "Level": "35",
+        "Move": "MOVE_AIR_SLASH"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_BRICK_BREAK"
+      },
+      {
+        "Level": "47",
+        "Move": "MOVE_FLY"
+      },
+      {
+        "Level": "54",
+        "Move": "MOVE_BRAVE_BIRD"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ROCK_SMASH",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_DOUBLE_TEAM",
+      "MOVE_ENDURE",
+      "MOVE_WATER_PULSE",
+      "MOVE_FLY",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_AGILITY",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_LIQUIDATION",
+      "MOVE_HURRICANE",
+      "MOVE_U-TURN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_WHIRLWIND",
+      "MOVE_TAUNT",
+      "MOVE_WATERFALL",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_LOW_SWEEP",
+      "MOVE_MIMIC",
+      "MOVE_DUAL_WINGBEAT",
+      "MOVE_TRIPLE_AXEL",
+      "MOVE_SKY_ATTACK"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "DONDOZO": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_SUPERSONIC"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_WATER_GUN"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_LICK"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_CURSE"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_BODY_SLAM"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_LIQUIDATION"
+      },
+      {
+        "Level": "38",
+        "Move": "MOVE_DOUBLE_EDGE"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_HEAVY_SLAM"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_ORDER_UP"
+      },
+      {
+        "Level": "56",
+        "Move": "MOVE_EARTHQUAKE"
+      },
+      {
+        "Level": "67",
+        "Move": "MOVE_FISSURE"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_ROCK_SLIDE",
+      "MOVE_ICE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_CRUNCH",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_WATER_PULSE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_MUD_SHOT",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_EARTHQUAKE",
+      "MOVE_WHIRLPOOL",
+      "MOVE_SURF",
+      "MOVE_LIQUIDATION",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_IRON_TAIL",
+      "MOVE_CURSE",
+      "MOVE_OUTRAGE",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_MUDDY_WATER",
+      "MOVE_FISSURE"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "TATSUGIRI": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_WATER_GUN"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_SPLASH"
+      },
+      {
+        "Level": "6",
+        "Move": "MOVE_HARDEN"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_RAZOR_WIND"
+      },
+      {
+        "Level": "17",
+        "Move": "MOVE_WATER_PULSE"
+      },
+      {
+        "Level": "21",
+        "Move": "MOVE_WHIRLPOOL"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_MUD_SHOT"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_TAUNT"
+      },
+      {
+        "Level": "34",
+        "Move": "MOVE_MIMIC"
+      },
+      {
+        "Level": "39",
+        "Move": "MOVE_MUDDY_WATER"
+      },
+      {
+        "Level": "43",
+        "Move": "MOVE_NASTY_PLOT"
+      },
+      {
+        "Level": "47",
+        "Move": "MOVE_DRAGON_RUSH"
+      },
+      {
+        "Level": "52",
+        "Move": "MOVE_DRAGON_PULSE"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_CALM_MIND",
+      "MOVE_FLIP_TURN",
+      "MOVE_ICE_BEAM",
+      "MOVE_PROTECT",
+      "MOVE_ENDURE",
+      "MOVE_WATER_PULSE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_MUD_SHOT",
+      "MOVE_ICY_WIND",
+      "MOVE_DRACO_METEOR",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_WHIRLPOOL",
+      "MOVE_SURF",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DARK_PULSE",
+      "MOVE_OUTRAGE",
+      "MOVE_TAUNT",
+      "MOVE_HYDRO_PUMP",
+      "MOVE_WATERFALL",
+      "MOVE_FACADE",
+      "MOVE_CHILLING_WATER",
+      "MOVE_ANCIENT_POWER",
+      "MOVE_MIMIC",
+      "MOVE_MUDDY_WATER",
+      "MOVE_TRIPLE_AXEL",
+      "MOVE_RAZOR_WIND",
+      "MOVE_SCALD"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "ANNIHILAPE": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_FOCUS_ENERGY"
+      },
+      {
+        "Level": "8",
+        "Move": "MOVE_ROCK_THROW"
+      },
+      {
+        "Level": "10",
+        "Move": "MOVE_ROCK_SMASH"
+      },
+      {
+        "Level": "13",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "16",
+        "Move": "MOVE_LOW_SWEEP"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_KNOCK_OFF"
+      },
+      {
+        "Level": "22",
+        "Move": "MOVE_BULLDOZE"
+      },
+      {
+        "Level": "25",
+        "Move": "MOVE_BRICK_BREAK"
+      },
+      {
+        "Level": "28",
+        "Move": "MOVE_FACADE"
+      },
+      {
+        "Level": "35",
+        "Move": "MOVE_RAGE_FIST"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_SCREECH"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_CLOSE_COMBAT"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_OUTRAGE"
+      },
+      {
+        "Level": "54",
+        "Move": "MOVE_DYNAMIC_PUNCH"
+      }
+    ],
+    "TMMoves": [  
+      "MOVE_HEADBUTT",
+      "MOVE_ROCK_SMASH",
+      "MOVE_ROAR",
+      "MOVE_BRICK_BREAK",
+      "MOVE_BULK_UP",
+      "MOVE_ROCK_SLIDE",
+      "MOVE_PROTECT",
+      "MOVE_POWER-UP_PUNCH",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_ICE_PUNCH",
+      "MOVE_SWIFT",
+      "MOVE_DIG",
+      "MOVE_FIRE_PUNCH",
+      "MOVE_BODY_SLAM",
+      "MOVE_NIGHT_SLASH",
+      "MOVE_ENDURE",
+      "MOVE_ROCK_TOMB",
+      "MOVE_STEALTH_ROCK",
+      "MOVE_HYPER_BEAM",
+      "MOVE_KNOCK_OFF",
+      "MOVE_OVERHEAT",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_SHADOW_CLAW",
+      "MOVE_STONE_EDGE",
+      "MOVE_THUNDERBOLT",
+      "MOVE_EARTHQUAKE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_POISON_JAB",
+      "MOVE_BULLDOZE",
+      "MOVE_U-TURN",
+      "MOVE_SUBSTITUTE",
+      "MOVE_CURSE",
+      "MOVE_OUTRAGE",
+      "MOVE_TAUNT",
+      "MOVE_METRONOME",
+      "MOVE_GUNK_SHOT",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_WORK_UP",
+      "MOVE_THUNDER",
+      "MOVE_CLOSE_COMBAT",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_PAY_DAY",
+      "MOVE_SHADOW_PUNCH",
+      "MOVE_TORMENT",
+      "MOVE_SEED_BOMB",
+      "MOVE_CIRCLE_THROW",
+      "MOVE_DRAIN_PUNCH",
+      "MOVE_DUAL_CHOP",
+      "MOVE_STORM_THROW",
+      "MOVE_SWAGGER",
+      "MOVE_VACUUM_WAVE"
+    ],
+    "TutorMoves": [
+      "MOVE_SHADOW_PUNCH",
+      "MOVE_PHANTOM_FORCE"
+    ],
+    "EggMoves": []
+  },
+  "FRIGIBAX": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "6",
+        "Move": "MOVE_ICY_WIND"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_DRAGON_BREATH"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_FOCUS_ENERGY"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "29",
+        "Move": "MOVE_ICE_FANG"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_DRAGON_CLAW"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_ICE_BEAM"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_CRUNCH"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_FREEZE_DRY"
+      },
+      {
+        "Level": "54",
+        "Move": "MOVE_ICICLE_CRASH"
+      },
+      {
+        "Level": "60",
+        "Move": "MOVE_DRAGON_RUSH"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_DRAGON_CLAW",
+      "MOVE_ICE_BEAM",
+      "MOVE_ICE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ICY_WIND",
+      "MOVE_DRACO_METEOR",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_OUTRAGE",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_ICICLE_SPEAR"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "ARCTIBAX": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "6",
+        "Move": "MOVE_ICY_WIND"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_DRAGON_BREATH"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_FOCUS_ENERGY"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "29",
+        "Move": "MOVE_ICE_FANG"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_DRAGON_CLAW"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_ICE_BEAM"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_CRUNCH"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_FREEZE_DRY"
+      },
+      {
+        "Level": "54",
+        "Move": "MOVE_ICICLE_CRASH"
+      },
+      {
+        "Level": "60",
+        "Move": "MOVE_DRAGON_RUSH"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_DRAGON_CLAW",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ICE_BEAM",
+      "MOVE_ICE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_AERIAL_ACE",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_ICY_WIND",
+      "MOVE_DRACO_METEOR",
+      "MOVE_IRON_HEAD",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_OUTRAGE",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_FROST_BREATH",
+      "MOVE_ICICLE_SPEAR"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "BAXCALIBUR": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_LEER"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_BREAKING_SWIPE"
+      },
+      {
+        "Level": "6",
+        "Move": "MOVE_ICY_WIND"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_DRAGON_BREATH"
+      },
+      {
+        "Level": "18",
+        "Move": "MOVE_FOCUS_ENERGY"
+      },
+      {
+        "Level": "24",
+        "Move": "MOVE_BITE"
+      },
+      {
+        "Level": "29",
+        "Move": "MOVE_ICE_FANG"
+      },
+      {
+        "Level": "32",
+        "Move": "MOVE_DRAGON_CLAW"
+      },
+      {
+        "Level": "36",
+        "Move": "MOVE_TAKE_DOWN"
+      },
+      {
+        "Level": "40",
+        "Move": "MOVE_ICE_BEAM"
+      },
+      {
+        "Level": "44",
+        "Move": "MOVE_CRUNCH"
+      },
+      {
+        "Level": "50",
+        "Move": "MOVE_FREEZE_DRY"
+      },
+      {
+        "Level": "54",
+        "Move": "MOVE_ICICLE_CRASH"
+      },
+      {
+        "Level": "60",
+        "Move": "MOVE_DRAGON_RUSH"
+      },
+      {
+        "Level": "65",
+        "Move": "MOVE_ICE_HAMMER"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_DRAGON_CLAW",
+      "MOVE_BRICK_BREAK",
+      "MOVE_ICE_BEAM",
+      "MOVE_ICE_FANG",
+      "MOVE_PROTECT",
+      "MOVE_THUNDER_FANG",
+      "MOVE_AERIAL_ACE",
+      "MOVE_CRUNCH",
+      "MOVE_DIG",
+      "MOVE_SWORDS_DANCE",
+      "MOVE_BODY_SLAM",
+      "MOVE_ENDURE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_ICY_WIND",
+      "MOVE_DRACO_METEOR",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_DOUBLE-EDGE",
+      "MOVE_IRON_HEAD",
+      "MOVE_ZEN_HEADBUTT",
+      "MOVE_EARTHQUAKE",
+      "MOVE_DRAGON_PULSE",
+      "MOVE_BULLDOZE",
+      "MOVE_SUBSTITUTE",
+      "MOVE_OUTRAGE",
+      "MOVE_BLIZZARD",
+      "MOVE_FACADE",
+      "MOVE_FALSE_SWIPE",
+      "MOVE_PSYCHIC_FANGS",
+      "MOVE_FROST_BREATH",
+      "MOVE_SCALE_SHOT",
+      "MOVE_ICICLE_SPEAR",
+      "MOVE_SHEER_COLD"
+    ],
+    "TutorMoves": [
+      "MOVE_GLAIVE_RUSH",
+      "MOVE_ICE_SHARD"
+    ],
+    "EggMoves": []
+  },
+  "GIMMIGHOUL": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_CONFUSE_RAY"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_POWER_GEM",
+      "MOVE_REFLECT",
+      "MOVE_ENDURE",
+      "MOVE_SHADOW_BALL",
+      "MOVE_NASTY_PLOT",
+      "MOVE_SUBSTITUTE",
+      "MOVE_FACADE"
+    ],
+    "TutorMoves": [],
+    "EggMoves": []
+  },
+  "GHOLDENGO": {
+    "LevelMoves": [
+      {
+        "Level": "1",
+        "Move": "MOVE_TACKLE"
+      },
+      {
+        "Level": "1",
+        "Move": "MOVE_CONFUSE_RAY"
+      },
+      {
+        "Level": "12",
+        "Move": "MOVE_SHADOW_PUNCH"
+      },
+      {
+        "Level": "15",
+        "Move": "MOVE_SUBSTITUTE"
+      },
+      {
+        "Level": "23",
+        "Move": "MOVE_METAL_SOUND"
+      },
+      {
+        "Level": "27",
+        "Move": "MOVE_OMINOUS_WIND"
+      },
+      {
+        "Level": "33",
+        "Move": "MOVE_SHADOW_BALL"
+      },
+      {
+        "Level": "38",
+        "Move": "MOVE_FLASH_CANNON"
+      },
+      {
+        "Level": "42",
+        "Move": "MOVE_RECOVER"
+      },
+      {
+        "Level": "49",
+        "Move": "MOVE_POWER_GEM"
+      },
+      {
+        "Level": "56",
+        "Move": "MOVE_MAKE_IT_RAIN"
+      },
+      {
+        "Level": "63",
+        "Move": "MOVE_NASTY_PLOT"
+      }
+    ],
+    "TMMoves": [
+      "MOVE_PSYSHOCK",
+      "MOVE_THUNDER_WAVE",
+      "MOVE_LIGHT_SCREEN",
+      "MOVE_PROTECT",
+      "MOVE_POWER_GEM",
+      "MOVE_THUNDER_PUNCH",
+      "MOVE_REFLECT",
+      "MOVE_ENDURE",
+      "MOVE_HYPER_BEAM",
+      "MOVE_GIGA_IMPACT",
+      "MOVE_IRON_HEAD",
+      "MOVE_PSYCHIC",
+      "MOVE_THUNDERBOLT",
+      "MOVE_SURF",
+      "MOVE_SHADOW_BALL",
+      "MOVE_NASTY_PLOT",
+      "MOVE_FLASH_CANNON",
+      "MOVE_SUBSTITUTE",
+      "MOVE_DAZZLING_GLEAM",
+      "MOVE_METRONOME",
+      "MOVE_FOCUS_BLAST",
+      "MOVE_THUNDER",
+      "MOVE_COMET_PUNCH",
+      "MOVE_FACADE",
+      "MOVE_LOW_SWEEP",
+      "MOVE_SHADOW_PUNCH",
+      "MOVE_OMINOUS_WIND",
+      "MOVE_MAGNET_BOMB",
+      "MOVE_CHARGE_BEAM",
+      "MOVE_STEEL_BEAM"
     ],
     "TutorMoves": [],
     "EggMoves": []


### PR DESCRIPTION
## Description
This Pull Request is a repeat of my previous one. I have created an new one to allow it to be merged with the 'upcoming' branch instead of 'master' branch.   The First one was #8640.

Makes changes to the za.json file in tools/learnset_helpers/porymoves_files to bring it up to date with the changes in the ZA DLC update.  This is currently a work in progress, changes are tracked below. I will  update this pr as i finish each gen. The game compiles currently but i dont know how to change where the move sets generate from.

Initial Additions | Checked | Pokemon Game Gen
[Done]                     [Checked]                          Gen 1
[Done]                     [Checked]                          Gen 2
[Done]                     [Checked]                          Gen 3
[Done]                     [Checked]                          Gen 4
[Done]                     [Checked]                          Gen 5
[Done]                     [Checked]                          Gen 6
[Done]                     [Checked]                          Gen 7
[Done]                     [Checked]                          Gen 8
[Done]                     [Checked]                          Gen 9
* za.json can be checked as i have finished with the edits.  i just want to test and make sure it compiles and is usable in game
* Game Compiles and new moves populate teachable_learnsets.h if they are apart of the tm or tutor list. Video of weedle learning the move Facade (ZA moveset has it as a tm)


https://github.com/user-attachments/assets/eb209c76-5ef6-4cbf-aab4-3e8db0a07a17



Sorry about the speed, not sure why its so slow)

<!-- CREDITS -->
All move set information is pulled from serebii.net

## Feature(s) this PR does NOT handle:
Anything else related to Legends ZA

## Discord contact info
Liamjd14
