### PR TITLE
Fixes incorrect battler used in STRINGID_USEDINSTRUCTEDMOVE

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -1542,9 +1542,9 @@ BattleScript_EffectInstruct::
 	attackanimation
 	waitanimation
 	printstring STRINGID_USEDINSTRUCTEDMOVE
+	waitmessage B_WAIT_TIME_LONG
 	copybyte gBattlerAttacker, gBattlerTarget
 	copybyte gBattlerTarget, gEffectBattler
-	waitmessage B_WAIT_TIME_LONG
 	jumptocalledmove TRUE
 
 BattleScript_EffectAutotomize::

--- a/test/battle/battle_message.c
+++ b/test/battle/battle_message.c
@@ -46,28 +46,3 @@ TO_DO_BATTLE_TEST("Battle Message: Switch-out message changes based on condition
             MESSAGE("Wynaut, good! Come back!");
     }
 }*/
-
-DOUBLE_BATTLE_TEST("Battle Message: Instruct message references the correct battlers")
-{
-    GIVEN {
-        PLAYER(SPECIES_TREECKO);
-        PLAYER(SPECIES_SCEPTILE);
-        OPPONENT(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_WYNAUT);
-    } WHEN {
-        TURN {
-            MOVE(playerLeft, MOVE_CELEBRATE);
-            MOVE(playerRight, MOVE_SCRATCH, target: opponentLeft);
-            MOVE(opponentLeft, MOVE_DRAGON_DARTS, target:playerLeft);
-            MOVE(opponentRight, MOVE_INSTRUCT, target: playerRight);
-        }
-    } SCENE {
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, playerRight);
-        MESSAGE("The opposing Wynaut used Instruct!");
-        NONE_OF {
-            MESSAGE("Sceptile followed the opposing Wobbuffet's instructions!");
-        }
-        MESSAGE("Sceptile followed the opposing Wynaut's instructions!");
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, playerRight);
-    }
-}

--- a/test/battle/move_effect/instruct.c
+++ b/test/battle/move_effect/instruct.c
@@ -322,3 +322,28 @@ DOUBLE_BATTLE_TEST("Instructed move will be redirected by Rage Powder after inst
         HP_BAR(opponentLeft);
     }
 }
+
+DOUBLE_BATTLE_TEST("Instruct message references the correct battlers")
+{
+    GIVEN {
+        PLAYER(SPECIES_TREECKO);
+        PLAYER(SPECIES_SCEPTILE);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN {
+            MOVE(playerLeft, MOVE_CELEBRATE);
+            MOVE(playerRight, MOVE_SCRATCH, target: opponentLeft);
+            MOVE(opponentLeft, MOVE_DRAGON_DARTS, target:playerLeft);
+            MOVE(opponentRight, MOVE_INSTRUCT, target: playerRight);
+        }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, playerRight);
+        MESSAGE("The opposing Wynaut used Instruct!");
+        NONE_OF {
+            MESSAGE("Sceptile followed the opposing Wobbuffet's instructions!");
+        }
+        MESSAGE("Sceptile followed the opposing Wynaut's instructions!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, playerRight);
+    }
+}


### PR DESCRIPTION
## Description
`STRINGID_USEDINSTRUCTEDMOVE` using `B_SCR_NAME_WITH_PREFIX2` instead of `B_EFF_NAME_WITH_PREFIX2`

## CREDITS 
@FosterProgramming for finding issue and informing correction
@PhallenTree for final solution

## Discord contact info
grintoul