### PR TITLE
Remove unused moveEffect variable in MoveEnd_MultihitMove to fix upcoming

### DIFF
--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -776,7 +776,6 @@ static enum MoveEndResult MoveEnd_HpThresholdItemsTarget(void)
 static enum MoveEndResult MoveEnd_MultihitMove(void)
 {
     enum MoveEndResult result = MOVEEND_STEP_CONTINUE;
-    enum BattleMoveEffects moveEffect = GetMoveEffect(gCurrentMove);
 
     if (!(gBattleStruct->moveResultFlags[gBattlerTarget] & MOVE_RESULT_NO_EFFECT)
      && !gBattleStruct->unableToUseMove


### PR DESCRIPTION
Dragon Darts and Present PRs both removed use of `moveEffect` which was not picked up by CI due to timing.

## Description
Remove unused moveEffect variable in MoveEnd_MultihitMove to fix CI

## Discord contact info
grintoul