### PR TITLE
Add AI_FLAG_RANDOMIZE_PARTY_INDICES

### DIFF
--- a/docs/tutorials/ai_flags.md
+++ b/docs/tutorials/ai_flags.md
@@ -207,3 +207,6 @@ This flag aims to prevent the player from PP stalling the AI by switching betwee
 
 ## `AI_FLAG_RANDOMIZE_SWITCHIN`
 AI will randomly choose between eligible switchin candidates rather than always picking the last one in the party. For example, if the AI has two mons that can revenge kill the player's mon after a KO, by default the AI will only track the most recent eligible candidate, and will always send in the last one in party order as a result. With this flag, it will instead track all of the eligible mons, and randomly choose between them when deciding which to send out.
+
+## `AI_FLAG_RANDOMIZE_PARTY_INDICES`
+AI will randomize the order of the mons in their party before battle starts. This means that lead choice is randommized, but so is the last mon for things like Illusion or the Ace flag, so be mindful when using it.

--- a/include/constants/battle_ai.h
+++ b/include/constants/battle_ai.h
@@ -40,6 +40,7 @@
 #define AI_FLAG_ATTACKS_PARTNER             AI_FLAG(30)  // AI specific to double battles; AI can deliberately attack its 'partner.'
 #define AI_FLAG_KNOW_OPPONENT_PARTY         AI_FLAG(31)  // AI knows all the species in the player's party, but not moves/items/abilities unless they've been seen.
 #define AI_FLAG_RANDOMIZE_SWITCHIN          AI_FLAG(32)  // AI will randomly choose between eligible switchin candidates of a given category instead of picking the last one in the party.
+#define AI_FLAG_RANDOMIZE_PARTY_INDICES     AI_FLAG(33)  // AI will randomize the order of the mons in its party, including the lead. Not an AI flag really, just a way to trigger TPP functionality
 
 // The following options are enough to have a basic/smart trainer. Any other addtion could make the trainer worse/better depending on the flag
 #define AI_FLAG_BASIC_TRAINER         (AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY)

--- a/src/trainer_pools.c
+++ b/src/trainer_pools.c
@@ -6,6 +6,7 @@
 #include "random.h"
 #include "trainer_pools.h"
 #include "constants/battle.h"
+#include "constants/battle_ai.h"
 #include "constants/items.h"
 
 #include "data/battle_pool_rules.h"
@@ -370,6 +371,14 @@ void DoTrainerPartyPool(const struct Trainer *trainer, u32 *monIndices, u8 monsC
 {
         bool32 usingPool = FALSE;
         struct PoolRules rules = defaultPoolRules;
+        struct Trainer tempTrainer;
+        if (trainer->poolSize == 0 && (trainer->aiFlags & AI_FLAG_RANDOMIZE_PARTY_INDICES))
+        {
+            tempTrainer = *trainer;
+            tempTrainer.poolSize = tempTrainer.partySize;
+            trainer = &tempTrainer;
+        }
+
         if (trainer->poolSize != 0)
         {
             usingPool = TRUE;


### PR DESCRIPTION
## Description
Went to make this today, got chatting with hedara, turns out trainer party pools can already do this if you specify that a trainer should use pools and then don't put anything extra in its pools. That's not especially intuitive, so we've repackaged it as an AI flag, which is what our users are familiar with using and should be readily discoverable.

The flag randomizes all party indices of the AI trainer before battle starts. This functionally means that their lead will always be random, as will abilities like Illusion that reference the last mon in the party.

This is hedara's implementation, I'm just PRing it :)

You can test this out with our best friend Tiana by loading into a battle with her as follows:
```
=== TRAINER_TIANA ===
Name: TIANA
Class: Lass
Pic: Lass
Gender: Female
Music: Female
Double Battle: No
AI: Check Bad Move / Randomize Party Indices

Zigzagoon
Level: 4
IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe

Shroomish
Level: 4
IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe

Eevee
Level: 4
IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe

Wailmer
Level: 4
IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe

Spheal
Level: 4
IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe

Sentret
Level: 4
IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
```

## Discord contact info
@Pawkkie 
