### PR TITLE
Improve Trick/Bestow AI logic for Toxic/Flame Orb and Utility Umbrella

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -3931,8 +3931,9 @@ static bool32 DoesAbilityBenefitFromSunOrRain(u32 battler, enum Ability ability,
         if (GetItemPocket(gAiLogicData->items[battler]) != POCKET_BERRIES
             && GetItemPocket(gBattleStruct->changedItems[battler]) != POCKET_BERRIES
             && GetItemPocket(GetBattlerPartyState(battler)->usedHeldItem) != POCKET_BERRIES)
+        {
             return FALSE;
-        // fallthrough
+        }
     case ABILITY_CHLOROPHYLL:
     case ABILITY_FLOWER_GIFT:
     case ABILITY_LEAF_GUARD:

--- a/test/battle/ai/ai_doubles.c
+++ b/test/battle/ai/ai_doubles.c
@@ -140,16 +140,16 @@ AI_DOUBLE_BATTLE_TEST("AI skips Trick/Bestow if the target has a Substitute")
 
 AI_DOUBLE_BATTLE_TEST("AI considers status orbs and abilities for Trick/Bestow")
 {
-    u16 move = MOVE_NONE, item = ITEM_NONE, status = STATUS1_NONE;
+    u16 move = MOVE_NONE, item = ITEM_NONE, status = STATUS1_NONE, species = SPECIES_NONE;
     enum Ability ability = ABILITY_NONE;
     u8 turnToTrick = 0;
 
-    PARAMETRIZE { move = MOVE_TRICK;  item = ITEM_TOXIC_ORB; status = STATUS1_NONE;   ability = ABILITY_PRESSURE;    turnToTrick = 1; }
-    PARAMETRIZE { move = MOVE_TRICK;  item = ITEM_FLAME_ORB; status = STATUS1_NONE;   ability = ABILITY_PRESSURE;    turnToTrick = 1; }
-    PARAMETRIZE { move = MOVE_BESTOW; item = ITEM_TOXIC_ORB; status = STATUS1_NONE;   ability = ABILITY_POISON_HEAL; turnToTrick = 2; }
-    PARAMETRIZE { move = MOVE_BESTOW; item = ITEM_FLAME_ORB; status = STATUS1_NONE;   ability = ABILITY_GUTS;        turnToTrick = 2; }
-    PARAMETRIZE { move = MOVE_TRICK;  item = ITEM_TOXIC_ORB; status = STATUS1_POISON; ability = ABILITY_POISON_HEAL; turnToTrick = 1; }
-    PARAMETRIZE { move = MOVE_TRICK;  item = ITEM_FLAME_ORB; status = STATUS1_BURN;   ability = ABILITY_GUTS;        turnToTrick = 1; }
+    PARAMETRIZE { move = MOVE_TRICK;  item = ITEM_TOXIC_ORB; status = STATUS1_NONE;   species = SPECIES_WAILMER; ability = ABILITY_PRESSURE;    turnToTrick = 1; }
+    PARAMETRIZE { move = MOVE_TRICK;  item = ITEM_FLAME_ORB; status = STATUS1_NONE;   species = SPECIES_WAILMER; ability = ABILITY_PRESSURE;    turnToTrick = 1; }
+    PARAMETRIZE { move = MOVE_BESTOW; item = ITEM_TOXIC_ORB; status = STATUS1_NONE;   species = SPECIES_GLISCOR; ability = ABILITY_POISON_HEAL; turnToTrick = 2; }
+    PARAMETRIZE { move = MOVE_BESTOW; item = ITEM_FLAME_ORB; status = STATUS1_NONE;   species = SPECIES_RATTATA; ability = ABILITY_GUTS;        turnToTrick = 2; }
+    PARAMETRIZE { move = MOVE_TRICK;  item = ITEM_TOXIC_ORB; status = STATUS1_POISON; species = SPECIES_GLISCOR; ability = ABILITY_POISON_HEAL; turnToTrick = 1; }
+    PARAMETRIZE { move = MOVE_TRICK;  item = ITEM_FLAME_ORB; status = STATUS1_BURN;   species = SPECIES_RATTATA; ability = ABILITY_GUTS;        turnToTrick = 1; }
 
     GIVEN {
         ASSUME(gItemsInfo[ITEM_TOXIC_ORB].holdEffect == HOLD_EFFECT_TOXIC_ORB);
@@ -157,7 +157,7 @@ AI_DOUBLE_BATTLE_TEST("AI considers status orbs and abilities for Trick/Bestow")
         AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT);
         PLAYER(SPECIES_WOBBUFFET);
         PLAYER(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_WOBBUFFET) { Ability(ability); Item(item); Moves(move, MOVE_SCRATCH); Status1(status); }
+        OPPONENT(species) { Ability(ability); Item(item); Moves(move, MOVE_SCRATCH); Status1(status); }
         OPPONENT(SPECIES_WOBBUFFET) { Moves(MOVE_TACKLE); }
     } WHEN {
         if (turnToTrick == 1)
@@ -178,26 +178,26 @@ AI_DOUBLE_BATTLE_TEST("AI considers status orbs and abilities for Trick/Bestow")
 
 AI_DOUBLE_BATTLE_TEST("AI gifts Utility Umbrella only when it removes the foe's weather benefit")
 {
-    u16 weatherSpecies = SPECIES_NONE;
+    u16 weatherSpecies = SPECIES_NONE, targetSpecies = SPECIES_NONE, attackerSpecies = SPECIES_NONE;
     enum Ability weatherAbility = ABILITY_NONE, targetAbility = ABILITY_NONE, attackerAbility = ABILITY_NONE;
     bool32 expectTrick = FALSE;
 
-    PARAMETRIZE { weatherSpecies = SPECIES_TORKOAL;  weatherAbility = ABILITY_DROUGHT; targetAbility = ABILITY_CHLOROPHYLL;      attackerAbility = ABILITY_DRY_SKIN; expectTrick = FALSE; }
-    PARAMETRIZE { weatherSpecies = SPECIES_TORKOAL;  weatherAbility = ABILITY_DROUGHT; targetAbility = ABILITY_LEAF_GUARD;       attackerAbility = ABILITY_PRESSURE; expectTrick = TRUE; }
-    PARAMETRIZE { weatherSpecies = SPECIES_TORKOAL;  weatherAbility = ABILITY_DROUGHT; targetAbility = ABILITY_FLOWER_GIFT;      attackerAbility = ABILITY_PRESSURE; expectTrick = TRUE; }
-    PARAMETRIZE { weatherSpecies = SPECIES_TORKOAL;  weatherAbility = ABILITY_DROUGHT; targetAbility = ABILITY_SOLAR_POWER;      attackerAbility = ABILITY_PRESSURE; expectTrick = TRUE; }
-    PARAMETRIZE { weatherSpecies = SPECIES_TORKOAL;  weatherAbility = ABILITY_DROUGHT; targetAbility = ABILITY_ORICHALCUM_PULSE; attackerAbility = ABILITY_PRESSURE; expectTrick = TRUE; }
-    PARAMETRIZE { weatherSpecies = SPECIES_POLITOED; weatherAbility = ABILITY_DRIZZLE; targetAbility = ABILITY_SWIFT_SWIM;       attackerAbility = ABILITY_DRY_SKIN; expectTrick = TRUE; }
-    PARAMETRIZE { weatherSpecies = SPECIES_POLITOED; weatherAbility = ABILITY_DRIZZLE; targetAbility = ABILITY_RAIN_DISH;        attackerAbility = ABILITY_PRESSURE; expectTrick = TRUE; }
-    PARAMETRIZE { weatherSpecies = SPECIES_POLITOED; weatherAbility = ABILITY_DRIZZLE; targetAbility = ABILITY_DRY_SKIN;         attackerAbility = ABILITY_PRESSURE; expectTrick = TRUE; }
-    PARAMETRIZE { weatherSpecies = SPECIES_POLITOED; weatherAbility = ABILITY_DRIZZLE; targetAbility = ABILITY_HYDRATION;        attackerAbility = ABILITY_PRESSURE; expectTrick = TRUE; }
+    PARAMETRIZE { weatherSpecies = SPECIES_TORKOAL;  weatherAbility = ABILITY_DROUGHT; targetSpecies = SPECIES_EXEGGCUTE; targetAbility = ABILITY_CHLOROPHYLL;      attackerSpecies = SPECIES_PARAS;   attackerAbility = ABILITY_DRY_SKIN; expectTrick = FALSE; }
+    PARAMETRIZE { weatherSpecies = SPECIES_TORKOAL;  weatherAbility = ABILITY_DROUGHT; targetSpecies = SPECIES_FOMANTIS;  targetAbility = ABILITY_LEAF_GUARD;       attackerSpecies = SPECIES_WAILMER; attackerAbility = ABILITY_PRESSURE; expectTrick = TRUE; }
+    PARAMETRIZE { weatherSpecies = SPECIES_TORKOAL;  weatherAbility = ABILITY_DROUGHT; targetSpecies = SPECIES_CHERRIM;   targetAbility = ABILITY_FLOWER_GIFT;      attackerSpecies = SPECIES_WAILMER; attackerAbility = ABILITY_PRESSURE; expectTrick = TRUE; }
+    PARAMETRIZE { weatherSpecies = SPECIES_TORKOAL;  weatherAbility = ABILITY_DROUGHT; targetSpecies = SPECIES_TROPIUS;   targetAbility = ABILITY_SOLAR_POWER;      attackerSpecies = SPECIES_WAILMER; attackerAbility = ABILITY_PRESSURE; expectTrick = TRUE; }
+    PARAMETRIZE { weatherSpecies = SPECIES_TORKOAL;  weatherAbility = ABILITY_DROUGHT; targetSpecies = SPECIES_KORAIDON;  targetAbility = ABILITY_ORICHALCUM_PULSE; attackerSpecies = SPECIES_WAILMER; attackerAbility = ABILITY_PRESSURE; expectTrick = TRUE; }
+    PARAMETRIZE { weatherSpecies = SPECIES_POLITOED; weatherAbility = ABILITY_DRIZZLE; targetSpecies = SPECIES_LOTAD;     targetAbility = ABILITY_SWIFT_SWIM;       attackerSpecies = SPECIES_PARAS;   attackerAbility = ABILITY_DRY_SKIN; expectTrick = TRUE; }
+    PARAMETRIZE { weatherSpecies = SPECIES_POLITOED; weatherAbility = ABILITY_DRIZZLE; targetSpecies = SPECIES_LOTAD;     targetAbility = ABILITY_RAIN_DISH;        attackerSpecies = SPECIES_WAILMER; attackerAbility = ABILITY_PRESSURE; expectTrick = TRUE; }
+    PARAMETRIZE { weatherSpecies = SPECIES_POLITOED; weatherAbility = ABILITY_DRIZZLE; targetSpecies = SPECIES_PARAS;     targetAbility = ABILITY_DRY_SKIN;         attackerSpecies = SPECIES_WAILMER; attackerAbility = ABILITY_PRESSURE; expectTrick = TRUE; }
+    PARAMETRIZE { weatherSpecies = SPECIES_POLITOED; weatherAbility = ABILITY_DRIZZLE; targetSpecies = SPECIES_WINGULL;   targetAbility = ABILITY_HYDRATION;        attackerSpecies = SPECIES_WAILMER; attackerAbility = ABILITY_PRESSURE; expectTrick = TRUE; }
 
     GIVEN {
         ASSUME(gItemsInfo[ITEM_UTILITY_UMBRELLA].holdEffect == HOLD_EFFECT_UTILITY_UMBRELLA);
         AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_OMNISCIENT);
-        PLAYER(SPECIES_WOBBUFFET) { Ability(targetAbility); }
+        PLAYER(targetSpecies) { Ability(targetAbility); }
         PLAYER(weatherSpecies) { Ability(weatherAbility); }
-        OPPONENT(SPECIES_WOBBUFFET) { Ability(attackerAbility); Item(ITEM_UTILITY_UMBRELLA); Moves(MOVE_TRICK, MOVE_SCRATCH); }
+        OPPONENT(attackerSpecies) { Ability(attackerAbility); Item(ITEM_UTILITY_UMBRELLA); Moves(MOVE_TRICK, MOVE_SCRATCH); }
         OPPONENT(SPECIES_WOBBUFFET) { Moves(MOVE_TACKLE); }
     } WHEN {
         if (expectTrick)
@@ -209,28 +209,28 @@ AI_DOUBLE_BATTLE_TEST("AI gifts Utility Umbrella only when it removes the foe's 
 
 AI_DOUBLE_BATTLE_TEST("AI steals Utility Umbrella to handle sun and Dry Skin but keeps its own weather perks")
 {
-    u16 weatherSpecies = SPECIES_NONE;
+    u16 weatherSpecies = SPECIES_NONE, targetSpecies = SPECIES_NONE, attackerSpecies = SPECIES_NONE;
     enum Ability weatherAbility = ABILITY_NONE, targetAbility = ABILITY_NONE, attackerAbility = ABILITY_NONE;
     bool32 expectTrick = FALSE;
 
-    PARAMETRIZE { weatherSpecies = SPECIES_TORKOAL;  weatherAbility = ABILITY_DROUGHT; targetAbility = ABILITY_PRESSURE; attackerAbility = ABILITY_DRY_SKIN;         expectTrick = TRUE; }
-    PARAMETRIZE { weatherSpecies = SPECIES_TORKOAL;  weatherAbility = ABILITY_DROUGHT; targetAbility = ABILITY_DRY_SKIN; attackerAbility = ABILITY_PRESSURE;         expectTrick = TRUE; }
-    PARAMETRIZE { weatherSpecies = SPECIES_TORKOAL;  weatherAbility = ABILITY_DROUGHT; targetAbility = ABILITY_PRESSURE; attackerAbility = ABILITY_CHLOROPHYLL;      expectTrick = FALSE; }
-    PARAMETRIZE { weatherSpecies = SPECIES_TORKOAL;  weatherAbility = ABILITY_DROUGHT; targetAbility = ABILITY_PRESSURE; attackerAbility = ABILITY_FLOWER_GIFT;      expectTrick = FALSE; }
-    PARAMETRIZE { weatherSpecies = SPECIES_TORKOAL;  weatherAbility = ABILITY_DROUGHT; targetAbility = ABILITY_PRESSURE; attackerAbility = ABILITY_LEAF_GUARD;       expectTrick = FALSE; }
-    PARAMETRIZE { weatherSpecies = SPECIES_TORKOAL;  weatherAbility = ABILITY_DROUGHT; targetAbility = ABILITY_PRESSURE; attackerAbility = ABILITY_SOLAR_POWER;      expectTrick = FALSE; }
-    PARAMETRIZE { weatherSpecies = SPECIES_TORKOAL;  weatherAbility = ABILITY_DROUGHT; targetAbility = ABILITY_PRESSURE; attackerAbility = ABILITY_ORICHALCUM_PULSE; expectTrick = FALSE; }
-    PARAMETRIZE { weatherSpecies = SPECIES_POLITOED; weatherAbility = ABILITY_DRIZZLE; targetAbility = ABILITY_PRESSURE; attackerAbility = ABILITY_SWIFT_SWIM;       expectTrick = FALSE; }
-    PARAMETRIZE { weatherSpecies = SPECIES_POLITOED; weatherAbility = ABILITY_DRIZZLE; targetAbility = ABILITY_PRESSURE; attackerAbility = ABILITY_RAIN_DISH;        expectTrick = FALSE; }
-    PARAMETRIZE { weatherSpecies = SPECIES_POLITOED; weatherAbility = ABILITY_DRIZZLE; targetAbility = ABILITY_PRESSURE; attackerAbility = ABILITY_HYDRATION;        expectTrick = FALSE; }
-    PARAMETRIZE { weatherSpecies = SPECIES_POLITOED; weatherAbility = ABILITY_DRIZZLE; targetAbility = ABILITY_PRESSURE; attackerAbility = ABILITY_DRY_SKIN;         expectTrick = FALSE; }
+    PARAMETRIZE { weatherSpecies = SPECIES_TORKOAL;  weatherAbility = ABILITY_DROUGHT; targetSpecies = SPECIES_WAILMER; targetAbility = ABILITY_PRESSURE; attackerSpecies = SPECIES_PARAS;     attackerAbility = ABILITY_DRY_SKIN;         expectTrick = TRUE; }
+    PARAMETRIZE { weatherSpecies = SPECIES_TORKOAL;  weatherAbility = ABILITY_DROUGHT; targetSpecies = SPECIES_PARAS;   targetAbility = ABILITY_DRY_SKIN; attackerSpecies = SPECIES_WAILMER;   attackerAbility = ABILITY_PRESSURE;         expectTrick = TRUE; }
+    PARAMETRIZE { weatherSpecies = SPECIES_TORKOAL;  weatherAbility = ABILITY_DROUGHT; targetSpecies = SPECIES_WAILMER; targetAbility = ABILITY_PRESSURE; attackerSpecies = SPECIES_EXEGGCUTE; attackerAbility = ABILITY_CHLOROPHYLL;      expectTrick = FALSE; }
+    PARAMETRIZE { weatherSpecies = SPECIES_TORKOAL;  weatherAbility = ABILITY_DROUGHT; targetSpecies = SPECIES_WAILMER; targetAbility = ABILITY_PRESSURE; attackerSpecies = SPECIES_CHERRIM;   attackerAbility = ABILITY_FLOWER_GIFT;      expectTrick = FALSE; }
+    PARAMETRIZE { weatherSpecies = SPECIES_TORKOAL;  weatherAbility = ABILITY_DROUGHT; targetSpecies = SPECIES_WAILMER; targetAbility = ABILITY_PRESSURE; attackerSpecies = SPECIES_FOMANTIS;  attackerAbility = ABILITY_LEAF_GUARD;       expectTrick = FALSE; }
+    PARAMETRIZE { weatherSpecies = SPECIES_TORKOAL;  weatherAbility = ABILITY_DROUGHT; targetSpecies = SPECIES_WAILMER; targetAbility = ABILITY_PRESSURE; attackerSpecies = SPECIES_TROPIUS;   attackerAbility = ABILITY_SOLAR_POWER;      expectTrick = FALSE; }
+    PARAMETRIZE { weatherSpecies = SPECIES_TORKOAL;  weatherAbility = ABILITY_DROUGHT; targetSpecies = SPECIES_WAILMER; targetAbility = ABILITY_PRESSURE; attackerSpecies = SPECIES_KORAIDON;  attackerAbility = ABILITY_ORICHALCUM_PULSE; expectTrick = FALSE; }
+    PARAMETRIZE { weatherSpecies = SPECIES_POLITOED; weatherAbility = ABILITY_DRIZZLE; targetSpecies = SPECIES_WAILMER; targetAbility = ABILITY_PRESSURE; attackerSpecies = SPECIES_LOTAD;     attackerAbility = ABILITY_SWIFT_SWIM;       expectTrick = FALSE; }
+    PARAMETRIZE { weatherSpecies = SPECIES_POLITOED; weatherAbility = ABILITY_DRIZZLE; targetSpecies = SPECIES_WAILMER; targetAbility = ABILITY_PRESSURE; attackerSpecies = SPECIES_LOTAD;     attackerAbility = ABILITY_RAIN_DISH;        expectTrick = FALSE; }
+    PARAMETRIZE { weatherSpecies = SPECIES_POLITOED; weatherAbility = ABILITY_DRIZZLE; targetSpecies = SPECIES_WAILMER; targetAbility = ABILITY_PRESSURE; attackerSpecies = SPECIES_WINGULL;   attackerAbility = ABILITY_HYDRATION;        expectTrick = FALSE; }
+    PARAMETRIZE { weatherSpecies = SPECIES_POLITOED; weatherAbility = ABILITY_DRIZZLE; targetSpecies = SPECIES_WAILMER; targetAbility = ABILITY_PRESSURE; attackerSpecies = SPECIES_PARAS;     attackerAbility = ABILITY_DRY_SKIN;         expectTrick = FALSE; }
 
     GIVEN {
         ASSUME(gItemsInfo[ITEM_UTILITY_UMBRELLA].holdEffect == HOLD_EFFECT_UTILITY_UMBRELLA);
         AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_OMNISCIENT);
-        PLAYER(SPECIES_WOBBUFFET) { Ability(targetAbility); Item(ITEM_UTILITY_UMBRELLA); }
+        PLAYER(targetSpecies) { Ability(targetAbility); Item(ITEM_UTILITY_UMBRELLA); }
         PLAYER(weatherSpecies) { Ability(weatherAbility); }
-        OPPONENT(SPECIES_WOBBUFFET) { Ability(attackerAbility); Item(ITEM_NONE); Moves(MOVE_TRICK, MOVE_SCRATCH); }
+        OPPONENT(attackerSpecies) { Ability(attackerAbility); Item(ITEM_NONE); Moves(MOVE_TRICK, MOVE_SCRATCH); }
         OPPONENT(SPECIES_WOBBUFFET) { Moves(MOVE_TACKLE); }
     } WHEN {
         if (expectTrick)
@@ -246,15 +246,15 @@ AI_DOUBLE_BATTLE_TEST("AI treats Harvest as a sun benefit only when a berry is i
     bool32 expectTrick = FALSE;
 
     PARAMETRIZE { targetItem = ITEM_ORAN_BERRY; expectTrick = TRUE; }
-    PARAMETRIZE { targetItem = ITEM_LEFTOVERS; expectTrick = FALSE; }
+    PARAMETRIZE { targetItem = ITEM_LEFTOVERS;  expectTrick = FALSE; }
 
     GIVEN {
         ASSUME(gItemsInfo[ITEM_UTILITY_UMBRELLA].holdEffect == HOLD_EFFECT_UTILITY_UMBRELLA);
         ASSUME(GetItemPocket(ITEM_ORAN_BERRY) == POCKET_BERRIES);
         AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_OMNISCIENT);
-        PLAYER(SPECIES_WOBBUFFET) { Ability(ABILITY_HARVEST); Item(targetItem); }
+        PLAYER(SPECIES_EXEGGCUTE) { Ability(ABILITY_HARVEST); Item(targetItem); }
         PLAYER(SPECIES_TORKOAL) { Ability(ABILITY_DROUGHT); }
-        OPPONENT(SPECIES_WOBBUFFET) { Ability(ABILITY_PRESSURE); Item(ITEM_UTILITY_UMBRELLA); Moves(MOVE_TRICK, MOVE_SCRATCH); }
+        OPPONENT(SPECIES_WAILMER) { Ability(ABILITY_PRESSURE); Item(ITEM_UTILITY_UMBRELLA); Moves(MOVE_TRICK, MOVE_SCRATCH); }
         OPPONENT(SPECIES_WOBBUFFET) { Moves(MOVE_TACKLE); }
     } WHEN {
         if (expectTrick)


### PR DESCRIPTION
## Description

- Improve Utility Umbrella valuation: prefer giving it when it removes the target’s weather benefit and avoid hurting the AI’s own weather synergies.
- Improve Trick/Bestow scoring for Utility Umbrella and for Toxic/Flame Orb when already statused.
- Add 3 doubles tests covering orb timing and Utility Umbrella swap logic.