### PR TITLE
Add a cleaner way to reset all_learnables.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,7 +273,7 @@ MAKEFLAGS += --no-print-directory
 # Delete files that weren't built properly
 .DELETE_ON_ERROR:
 
-RULES_NO_SCAN += libagbsyscall clean clean-assets tidy tidymodern tidycheck tidyrelease generated clean-generated
+RULES_NO_SCAN += libagbsyscall clean clean-assets tidy tidymodern tidycheck tidyrelease generated clean-generated clean-teachables clean-teachables_intermediates
 .PHONY: all rom agbcc modern compare check debug release
 .PHONY: $(RULES_NO_SCAN)
 
@@ -445,11 +445,19 @@ generated: $(AUTO_GEN_TARGETS)
 %.smol:     %      ; $(SMOL) -w $< $@
 %.rl:       %      ; $(GFX) $< $@
 
-clean-generated:
-	@rm -f $(AUTO_GEN_TARGETS)
-	@echo "rm -f <AUTO_GEN_TARGETS>"
+clean-teachables_intermediates:
+	rm -f $(DATA_SRC_SUBDIR)/tutor_moves.h
+	rm -f $(DATA_SRC_SUBDIR)/pokemon/teachable_learnsets.h
 	@rm -Rf $(LEARNSET_HELPERS_BUILD_DIR)
 	@echo "rm -Rf <LEARNSET_HELPERS_BUILD_DIR>"
+
+clean-generated: clean-teachables_intermediates
+	@rm -f $(AUTO_GEN_TARGETS)
+	@echo "rm -f <AUTO_GEN_TARGETS>"
+
+clean-teachables: clean-teachables_intermediates
+	rm -f $(ALL_LEARNABLES_JSON)
+	@touch $(C_SUBDIR)/pokemon.c
 
 $(C_BUILDDIR)/librfu_intr.o: CFLAGS := -mthumb-interwork -O2 -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -fno-toplevel-reorder -Wno-pointer-to-int-cast
 $(C_BUILDDIR)/berry_crush.o: override CFLAGS += -Wno-address-of-packed-member

--- a/docs/tutorials/teachable_learnsets.md
+++ b/docs/tutorials/teachable_learnsets.md
@@ -21,7 +21,7 @@ When you `make`, a file will be generated in `src/data/pokemon/teachable_learnse
 
 The potential moveset of each pokemon is defined in `src/data/pokemon/all_learnables.json`. If you don't have the file yet, a version will be generated automatically after you run `make`. 
 On its first creation, the file is based on the list of moves a pokemon can learn in official Pokemon games. Those lists are found in `tools/learnset_helpers/porymoves_files`, if a Pokemon learned a move in any way in the game (from level-up, egg move, tm or tutor), it will be added to its teachable learnset. You can delete some of the files mix-and-match from different games list. This is justa  tool to help you quickly generate a vanilla-ish etachable learnset.
-After `src/data/pokemon/all_learnables.json` has been created, this file will NEVER be modified by running `make` so you don't have to worry abour your changes being reverted. However you can choose to remake the file by using a different set of game move list by deleting `src/data/pokemon/all_learnables.json` and running `make` again.
+After `src/data/pokemon/all_learnables.json` has been created, this file will NEVER be modified by running `make` so you don't have to worry abour your changes being reverted. However you can choose to remake the file by using a different set of game move list by running `make clean-teachables` and then running `make` again.
 
 ## Teaching Types
 


### PR DESCRIPTION
Adds a new makefile command `make clean-teachbales` that properly reset the all_learnables.json file

(I updated the changelog of te previous PR instead to make sure less confusing in changelog)
## Things to note in the release changelog:
<!-- Add any important details for the release changelog. Must be structed as bullet points. --->
<!--- Remove this section if not applicable. --->

## Discord contact info
Jamie
