### PR TITLE
Remove bounds check in IsBattlerAlive

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -1074,9 +1074,7 @@ extern u8 gCategoryIconSpriteId;
 
 static inline bool32 IsBattlerAlive(u32 battler)
 {
-    if (battler >= gBattlersCount)
-        return FALSE;
-    else if (gBattleMons[battler].hp == 0)
+    if (gBattleMons[battler].hp == 0)
         return FALSE;
     else if (gAbsentBattlerFlags & (1u << battler))
         return FALSE;


### PR DESCRIPTION
There is no reason for us to check for `battler > gBattlersCount` since it would return false positives half the time. 

But also `battler > gBattlersCount` can't happen unless something massively terrible happened earlier and if if did then it is harmless because we don't write anything. 

Also we placed asserts in moveend and attackcanceler which will catch those things regardless :sweat_smile: 