### PR TITLE
Fix: Sticky Hold does not block user's own Bestow

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -2526,7 +2526,6 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, enum Move move, s32 s
               || aiData->items[battlerDef] != ITEM_NONE
               || !CanBattlerGetOrLoseItem(battlerAtk, battlerDef, gBattleMons[battlerAtk].item)    // AI knows its own item
               || !CanBattlerGetOrLoseItem(battlerDef, battlerAtk, gBattleMons[battlerAtk].item)
-              || aiData->abilities[battlerAtk] == ABILITY_STICKY_HOLD
               || DoesSubstituteBlockMove(battlerAtk, battlerDef, move))
                 ADJUST_SCORE(-10);
             break;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -15009,7 +15009,6 @@ void BS_TryBestow(void)
         || gBattleMons[gBattlerTarget].item != ITEM_NONE
         || !CanBattlerGetOrLoseItem(gBattlerAttacker, gBattlerTarget, gBattleMons[gBattlerAttacker].item)
         || !CanBattlerGetOrLoseItem(gBattlerTarget, gBattlerAttacker, gBattleMons[gBattlerAttacker].item)
-        || GetBattlerAbility(gBattlerAttacker) == ABILITY_STICKY_HOLD
         || GetBattlerPartyState(gBattlerTarget)->knockedOffItem)
     {
         gBattlescriptCurrInstr = cmd->failInstr;

--- a/test/battle/ai/ai_doubles.c
+++ b/test/battle/ai/ai_doubles.c
@@ -98,23 +98,16 @@ AI_DOUBLE_BATTLE_TEST("AI skips Trick/Bestow with unexchangeable items")
     }
 }
 
-AI_DOUBLE_BATTLE_TEST("AI skips Trick/Bestow around Sticky Hold")
+AI_DOUBLE_BATTLE_TEST("AI skips Trick around Sticky Hold")
 {
-    enum Move move = MOVE_NONE;
-    u32 atkItem = ITEM_ORAN_BERRY, targetItem = ITEM_NONE;
-    enum Ability atkAbility = ABILITY_PRESSURE, targetAbility = ABILITY_PRESSURE;
-
-    PARAMETRIZE { move = MOVE_TRICK;  atkAbility = ABILITY_PRESSURE;  targetAbility = ABILITY_STICKY_HOLD; targetItem = ITEM_LEFTOVERS; }
-    PARAMETRIZE { move = MOVE_BESTOW; atkAbility = ABILITY_STICKY_HOLD; targetAbility = ABILITY_PRESSURE;  targetItem = ITEM_NONE; }
-
     GIVEN {
         AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT);
-        PLAYER(SPECIES_WOBBUFFET) { Ability(targetAbility); Item(targetItem); }
+        PLAYER(SPECIES_WOBBUFFET) { Ability(ABILITY_STICKY_HOLD); Item(ITEM_LEFTOVERS); }
         PLAYER(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_WOBBUFFET) { Ability(atkAbility); Item(atkItem); Moves(move, MOVE_SCRATCH); }
+        OPPONENT(SPECIES_WOBBUFFET) { Ability(ABILITY_PRESSURE); Item(ITEM_ORAN_BERRY); Moves(MOVE_TRICK, MOVE_SCRATCH); }
         OPPONENT(SPECIES_WOBBUFFET) { Moves(MOVE_TACKLE); }
     } WHEN {
-        TURN { NOT_EXPECT_MOVE(opponentLeft, move); }
+        TURN { NOT_EXPECT_MOVE(opponentLeft, MOVE_TRICK); }
     }
 }
 

--- a/test/battle/move_effect/bestow.c
+++ b/test/battle/move_effect/bestow.c
@@ -92,7 +92,7 @@ SINGLE_BATTLE_TEST("Bestow fails if the user's held item is a Z-Crystal")
     }
 }
 
-SINGLE_BATTLE_TEST("Bestow fails if the user has Sticky Hold")
+SINGLE_BATTLE_TEST("Bestow doesn't fail if the user has Sticky Hold")
 {
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET) { Ability(ABILITY_STICKY_HOLD); Item(ITEM_SITRUS_BERRY); }
@@ -100,10 +100,10 @@ SINGLE_BATTLE_TEST("Bestow fails if the user has Sticky Hold")
     } WHEN {
         TURN { MOVE(player, MOVE_BESTOW); }
     } SCENE {
-        MESSAGE("But it failed!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BESTOW, player);
     } THEN {
-        EXPECT(player->item == ITEM_SITRUS_BERRY);
-        EXPECT(opponent->item == ITEM_NONE);
+        EXPECT(player->item == ITEM_NONE);
+        EXPECT(opponent->item == ITEM_SITRUS_BERRY);
     }
 }
 


### PR DESCRIPTION
## Description
**[Japanese Wiki Source](https://wiki.xn--rckteqa2e.com/wiki/%E3%81%AD%E3%82%93%E3%81%A1%E3%82%83%E3%81%8F):**
ねんちゃくのポケモンがトリック・すりかえ・ギフトパスを使用して道具を渡すことはできる。

_English Translation:_
A Pokémon with Sticky Hold can use Trick, Switcheroo, or Bestow to pass an item to another Pokémon.

Fixes the interaction for #8516 regarding Bestow and Sticky Hold, specifically when the user has the Sticky Hold ability. 