### PR TITLE
Fix auto-signpost textprinter

### DIFF
--- a/include/text.h
+++ b/include/text.h
@@ -181,6 +181,7 @@ extern u8 gDisableTextPrinters;
 extern struct TextGlyph gCurGlyph;
 
 void DeactivateAllTextPrinters(void);
+void DeactivateSingleTextPrinter(u32 id, enum TextPrinterType type);
 u16 AddTextPrinterParameterized(u8 windowId, u8 fontId, const u8 *str, u8 x, u8 y, u8 speed, void (*callback)(struct TextPrinterTemplate *, u16));
 u16 AddSpriteTextPrinterParametrerized(u8 spriteId, u8 fontId, const u8 *str, u8 x, u8 y, u8 speed, void (*callback)(struct TextPrinterTemplate *, u16));
 void AddSpriteTextPrinterParameterized3(u8 spriteId, u8 fontId, u8 left, u8 top, const u8 *color, s8 speed, const u8 *str);

--- a/src/field_specials.c
+++ b/src/field_specials.c
@@ -4398,8 +4398,7 @@ bool32 CheckPartyHasSpecies(u32 givenSpecies)
 
 void UseBlankMessageToCancelPokemonPic(void)
 {
-    u8 t = EOS;
-    AddTextPrinterParameterized(0, FONT_NORMAL, &t, 0, 1, 0, NULL);
+    DeactivateSingleTextPrinter(0, WINDOW_TEXT_PRINTER);
     ScriptMenu_HidePokemonPic();
 }
 

--- a/src/text.c
+++ b/src/text.c
@@ -2743,3 +2743,38 @@ static void FreeFinishedTextPrinters(void)
         }
     }
 }
+
+void DeactivateSingleTextPrinter(u32 id, enum TextPrinterType type)
+{
+    struct TextPrinter *currentPrinter = sFirstTextPrinter;
+    while (currentPrinter != NULL)
+    {
+        switch (type)
+        {
+        case WINDOW_TEXT_PRINTER:
+            if (currentPrinter->printerTemplate.type == WINDOW_TEXT_PRINTER && currentPrinter->printerTemplate.windowId == id)
+            {
+                currentPrinter->isInUse = FALSE;
+                currentPrinter = NULL;
+            }
+            else
+            {
+                currentPrinter = currentPrinter->nextPrinter;
+            }
+            break;
+        case SPRITE_TEXT_PRINTER:
+            if (currentPrinter->printerTemplate.type == SPRITE_TEXT_PRINTER && currentPrinter->printerTemplate.spriteId == id)
+            {
+                currentPrinter->isInUse = FALSE;
+                currentPrinter = NULL;
+            }
+            else
+            {
+                currentPrinter = currentPrinter->nextPrinter;
+            }
+            break;
+        }
+    }
+
+    FreeFinishedTextPrinters();
+}


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
When text-printers got refactored in #8345 the GF way of stopping single text printers broke due to there no longer being a single text printer assigned to each possible window.
This also adds a way to stop single text printers.

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara