### PR TITLE
Fix Metronome bans

### DIFF
--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -18193,7 +18193,6 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
         .priority = 0,
         .category = DAMAGE_CATEGORY_PHYSICAL,
         .metronomeBanned = TRUE,
-        .sketchBanned = (B_SKETCH_BANS >= GEN_9),
         .additionalEffects = ADDITIONAL_EFFECTS({
             .moveEffect = MOVE_EFFECT_SPD_PLUS_1,
             .self = TRUE,


### PR DESCRIPTION
## Description
Last Respects, Matcha Gotcha, Syrup Bomb, Ivy Cudgel, and Burning Bulwark have all never been banned from being called by Metronome in the core series.

## Discord contact info
amiosi
