### PR TITLE
correct move flags/data

### DIFF
--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -8969,7 +8969,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
         .priority = 0,
         .category = DAMAGE_CATEGORY_STATUS,
         .zMove = { .effect = Z_EFFECT_DEF_UP_1 },
-        .ignoresProtect = B_UPDATED_MOVE_FLAGS >= GEN_6,
+        .ignoresProtect = (B_UPDATED_MOVE_FLAGS >= GEN_6 || B_UPDATED_MOVE_FLAGS < GEN_3),
         .magicCoatAffected = TRUE,
         .contestEffect = CONTEST_EFFECT_MAKE_FOLLOWING_MONS_NERVOUS,
         .contestCategory = CONTEST_CATEGORY_CUTE,


### PR DESCRIPTION
## Description
Razor Wind dioes not have a high crit rate in gen 1
Counter and Mirror Coat are actually not blocked by Protect in at least vanilla pokeemerald. other gens are unknown, but likely the same prior to gen 5 (no change just addresses the issue)
Spider Web does not ignore Protect in gen 6+
Conversion 2 ignores Protect prior to gen 3
Protect ignores itself and cannot be called by Mirror Move
Mirror Move ignores Protect and cannot be called by itself
Nature Power ignores Protect and cannot be called by Mirror Move
Sntach ignores Protect and cannot be called by Mirror Move
Swords Dance ignores Protect and cannot be called by Mirror Move

## Issue(s) that this PR fixes
Closes #8855

## Discord contact info
amiosi
