### PR TITLE
Fix Sticky Hold blocking user's own Trick or Bestow

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -2069,7 +2069,6 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
               || !CanBattlerGetOrLoseItem(battlerAtk, aiData->items[battlerDef])
               || !CanBattlerGetOrLoseItem(battlerDef, aiData->items[battlerDef])
               || !CanBattlerGetOrLoseItem(battlerDef, gBattleMons[battlerAtk].item)
-              || aiData->abilities[battlerAtk] == ABILITY_STICKY_HOLD
               || aiData->abilities[battlerDef] == ABILITY_STICKY_HOLD
               || DoesSubstituteBlockMove(battlerAtk, battlerDef, move))
                 ADJUST_SCORE(-10);
@@ -2470,7 +2469,6 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, u32 move, s32 score)
               || aiData->items[battlerDef] != ITEM_NONE
               || !CanBattlerGetOrLoseItem(battlerAtk, gBattleMons[battlerAtk].item)    // AI knows its own item
               || !CanBattlerGetOrLoseItem(battlerDef, gBattleMons[battlerAtk].item)
-              || aiData->abilities[battlerAtk] == ABILITY_STICKY_HOLD
               || DoesSubstituteBlockMove(battlerAtk, battlerDef, move))
                 ADJUST_SCORE(-10);
             break;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -12717,10 +12717,6 @@ static void Cmd_tryswapitems(void)
             gBattlescriptCurrInstr = cmd->failInstr;
         }
         // check if ability prevents swapping
-        else if (GetBattlerAbility(gBattlerAttacker) == ABILITY_STICKY_HOLD)
-        {
-            gBattlescriptCurrInstr = cmd->failInstr;
-        }
         else if (GetBattlerAbility(gBattlerTarget) == ABILITY_STICKY_HOLD)
         {
             gBattlescriptCurrInstr = BattleScript_StickyHoldActivates;
@@ -17479,7 +17475,6 @@ void BS_TryBestow(void)
         || gBattleMons[gBattlerTarget].item != ITEM_NONE
         || !CanBattlerGetOrLoseItem(gBattlerAttacker, gBattleMons[gBattlerAttacker].item)
         || !CanBattlerGetOrLoseItem(gBattlerTarget, gBattleMons[gBattlerAttacker].item)
-        || GetBattlerAbility(gBattlerAttacker) == ABILITY_STICKY_HOLD
         || gWishFutureKnock.knockedOffMons[GetBattlerSide(gBattlerTarget)] & (1u << gBattlerPartyIndexes[gBattlerTarget]))
     {
         gBattlescriptCurrInstr = cmd->failInstr;

--- a/test/battle/ai/ai_doubles.c
+++ b/test/battle/ai/ai_doubles.c
@@ -96,23 +96,16 @@ AI_DOUBLE_BATTLE_TEST("AI skips Trick/Bestow with unexchangeable items")
     }
 }
 
-AI_DOUBLE_BATTLE_TEST("AI skips Trick/Bestow around Sticky Hold")
+AI_DOUBLE_BATTLE_TEST("AI skips Trick around Sticky Hold")
 {
-    u16 move = MOVE_NONE, atkItem = ITEM_ORAN_BERRY, targetItem = ITEM_NONE;
-    enum Ability atkAbility = ABILITY_PRESSURE, targetAbility = ABILITY_PRESSURE;
-
-    PARAMETRIZE { move = MOVE_TRICK;  atkAbility = ABILITY_STICKY_HOLD; targetAbility = ABILITY_PRESSURE; targetItem = ITEM_LEFTOVERS; }
-    PARAMETRIZE { move = MOVE_TRICK;  atkAbility = ABILITY_PRESSURE;  targetAbility = ABILITY_STICKY_HOLD; targetItem = ITEM_LEFTOVERS; }
-    PARAMETRIZE { move = MOVE_BESTOW; atkAbility = ABILITY_STICKY_HOLD; targetAbility = ABILITY_PRESSURE;  targetItem = ITEM_NONE; }
-
     GIVEN {
         AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT);
-        PLAYER(SPECIES_WOBBUFFET) { Ability(targetAbility); Item(targetItem); }
+        PLAYER(SPECIES_WOBBUFFET) { Ability(ABILITY_STICKY_HOLD); Item(ITEM_LEFTOVERS); }
         PLAYER(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_WOBBUFFET) { Ability(atkAbility); Item(atkItem); Moves(move, MOVE_SCRATCH); }
+        OPPONENT(SPECIES_WOBBUFFET) { Ability(ABILITY_PRESSURE); Item(ITEM_ORAN_BERRY); Moves(MOVE_TRICK, MOVE_SCRATCH); }
         OPPONENT(SPECIES_WOBBUFFET) { Moves(MOVE_TACKLE); }
     } WHEN {
-        TURN { NOT_EXPECT_MOVE(opponentLeft, move); }
+        TURN { NOT_EXPECT_MOVE(opponentLeft, MOVE_TRICK); }
     }
 }
 

--- a/test/battle/move_effect/bestow.c
+++ b/test/battle/move_effect/bestow.c
@@ -92,7 +92,7 @@ SINGLE_BATTLE_TEST("Bestow fails if the user's held item is a Z-Crystal")
     }
 }
 
-SINGLE_BATTLE_TEST("Bestow fails if the user has Sticky Hold")
+SINGLE_BATTLE_TEST("Bestow doesn't fail if the user has Sticky Hold")
 {
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET) { Ability(ABILITY_STICKY_HOLD); Item(ITEM_SITRUS_BERRY); }
@@ -100,10 +100,10 @@ SINGLE_BATTLE_TEST("Bestow fails if the user has Sticky Hold")
     } WHEN {
         TURN { MOVE(player, MOVE_BESTOW); }
     } SCENE {
-        MESSAGE("But it failed!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BESTOW, player);
     } THEN {
-        EXPECT(player->item == ITEM_SITRUS_BERRY);
-        EXPECT(opponent->item == ITEM_NONE);
+        EXPECT(player->item == ITEM_NONE);
+        EXPECT(opponent->item == ITEM_SITRUS_BERRY);
     }
 }
 

--- a/test/battle/move_effect/trick.c
+++ b/test/battle/move_effect/trick.c
@@ -139,7 +139,7 @@ SINGLE_BATTLE_TEST("Trick fails if an item changes the holder's form")
     }
 }
 
-SINGLE_BATTLE_TEST("Trick fails if the user has Sticky Hold")
+SINGLE_BATTLE_TEST("Trick doesn't fail if the user has Sticky Hold")
 {
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET) { Ability(ABILITY_STICKY_HOLD); Item(ITEM_SITRUS_BERRY); }
@@ -147,10 +147,10 @@ SINGLE_BATTLE_TEST("Trick fails if the user has Sticky Hold")
     } WHEN {
         TURN { MOVE(player, MOVE_TRICK); }
     } SCENE {
-        MESSAGE("But it failed!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TRICK, player);
     } THEN {
-        EXPECT(player->item == ITEM_SITRUS_BERRY);
-        EXPECT(opponent->item == ITEM_LUM_BERRY);
+        EXPECT(player->item == ITEM_LUM_BERRY);
+        EXPECT(opponent->item == ITEM_SITRUS_BERRY);
     }
 }
 


### PR DESCRIPTION
## Description
Fixes the interaction for #8516 regarding Trick/Bestow and Sticky Hold, specifically when the user has the Sticky Hold ability(The modifications regarding Trick have been merged into _upcoming_). The mistake caused by wiki differences taught me a lesson.
