### PR TITLE
Allow Max Hailstorm to summon snow if the config is set for it

### DIFF
--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -22035,7 +22035,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
         .category = DAMAGE_CATEGORY_PHYSICAL,
         .battleAnimScript = gBattleAnimMove_MaxHailstorm,
         .additionalEffects = ADDITIONAL_EFFECTS({
-            .moveEffect = (B_PREFERRED_ICE_WEATHER == B_ICE_WEATHER_SNOW) ? MOVE_EFFECT_SNOW : MOVE_EFFECT_HAIL,
+            .moveEffect = (B_PREFERRED_ICE_WEATHER == B_ICE_WEATHER_SNOW) ? MOVE_EFFECT_SNOWSCAPE : MOVE_EFFECT_HAIL,
         }),
     },
 


### PR DESCRIPTION
## Description
Max Hailstorm currently always summons hail, even if B_PREFERRED_ICE_WEATHER == B_ICE_WEATHER_SNOW. Quick and simple PR to allow it to summon snow if the user chooses to do so.

## Discord contact info
amiosi
