### PR TITLE
Fix Gen 4 Taunt for upcoming

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -10181,7 +10181,7 @@ static void Cmd_settaunt(void)
         }
         else if (B_TAUNT_TURNS >= GEN_4)
         {
-            turns = RandomUniform(RNG_TAUNT, 2, B_TAUNT_TIMER);
+            turns = RandomUniform(RNG_TAUNT, 3, B_TAUNT_TIMER);
         }
         else
         {


### PR DESCRIPTION
## Description
On upcoming only, Gen 4 Taunt is set to last 2-5 turns, rather than 3-5. This issue does not exist on master.

## Discord contact info
amiosi
