### PR TITLE
Only test if move name fits on the bag screen for moves names within a TM/HM

### DIFF
--- a/test/text.c
+++ b/test/text.c
@@ -73,7 +73,7 @@ TEST("Move names fit on TMs & HMs Bag Screen")
     for (enum TMHMIndex tm = 1; tm <= NUM_ALL_MACHINES; tm++)
     {
         u32 tmMove = GetTMHMMoveId(tm);
-        PARAMETRIZE_LABEL("%S", GetMoveName(move)) { move = tmMove; }
+        PARAMETRIZE_LABEL("%S", GetMoveName(tmMove)) { move = tmMove; }
     }
     EXPECT_LE(GetStringWidth(fontId, GetMoveName(move), 0), widthPx);
 }


### PR DESCRIPTION


## Description
<!-- Detail the changes made, why they were made, and any important context. -->

This PR make the test `Move names fit on TMs & HMs Bag Screen` to only test for move names within a TM or HM.

Currently for TMs/HMs all move are tested, however this information can be misleading for any theoretical translation of expansion, since a translator would only care for the cases that can happen in game.

[Here](https://github.com/estellarc/pokeemerald/blob/estellar/multi-language/src/data/moves_info.h) an example of the situation, where `Clangorous Soul`, `Last Respects` and `Alluring Voice` do not pass the test when translated.

Any feedback is welcome, due my lack of experience with the test suit.

## Discord contact info
estellar.cheese
