### PR TITLE
Fixed Acc value shadow cut off when Accuracy = 100

### DIFF
--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -1739,7 +1739,7 @@ static void MoveSelectionDisplayMoveDescription(u32 battler)
     u8 acc_desc[7] = _("ACC: ");
     u8 cat_start[] = _("{CLEAR_TO 0x03}");
     u8 pwr_start[] = _("{CLEAR_TO 0x38}");
-    u8 acc_start[] = _("{CLEAR_TO 0x6D}");
+    u8 acc_start[] = _("{CLEAR_TO 0x6C}");
     LoadMessageBoxAndBorderGfx();
     DrawStdWindowFrame(B_WIN_MOVE_DESCRIPTION, FALSE);
     if (pwr < 2)


### PR DESCRIPTION
## Description

When `acc_num` is 100, current `acc_start` causes the last 0 to have its right-edge shadow cut off.  There is plenty of space to the left so just moving `acc_start` 1 pixel left to allow for the full shadow.

## Media

upcoming:

<img width="400" alt="image" src="https://github.com/user-attachments/assets/8eba74c0-6e1f-45d3-85be-8b17447e332f" />

this commit:

<img width="400" alt="image" src="https://github.com/user-attachments/assets/6de2c412-7bb0-4f3f-95ed-4e3db536cff6" />

## Discord contact info

Montblanc