### PR TITLE
Fix misaligned shadows of transformed mons when `B_ENEMY_MON_SHADOW_STYLE <= GEN_3`

### DIFF
--- a/src/battle_gfx_sfx_util.c
+++ b/src/battle_gfx_sfx_util.c
@@ -1268,9 +1268,12 @@ void SpriteCB_EnemyShadow(struct Sprite *shadowSprite)
     }
     else if (transformSpecies != SPECIES_NONE)
     {
-        xOffset = gSpeciesInfo[transformSpecies].enemyShadowXOffset + (shadowSprite->tSpriteSide == SPRITE_SIDE_LEFT ? -16 : 16);
+        xOffset = gSpeciesInfo[transformSpecies].enemyShadowXOffset;
         yOffset = gSpeciesInfo[transformSpecies].enemyShadowYOffset + 16;
         size = gSpeciesInfo[transformSpecies].enemyShadowSize;
+
+        if (B_ENEMY_MON_SHADOW_STYLE >= GEN_4)
+            xOffset += (shadowSprite->tSpriteSide == SPRITE_SIDE_LEFT ? -16 : 16);
 
         invisible = (B_ENEMY_MON_SHADOW_STYLE >= GEN_4 && P_GBA_STYLE_SPECIES_GFX == FALSE)
                   ? gSpeciesInfo[transformSpecies].suppressEnemyShadow


### PR DESCRIPTION
## Description
This PR fixes a bug where transformed mons would have their shadow misaligned when `B_ENEMY_MON_SHADOW_STYLE <= GEN_3`.

## Media
| Before      | After      |
|---------------|-------------|
| <!-- Detail the changes made, why they were made, and any important context. -->
<img width="480" height="320" alt="pokeemerald-2" src="https://github.com/user-attachments/assets/bdb13164-b163-4132-a282-7c009f4187a9" /> | <img width="480" height="320" alt="pokeemerald-1" src="https://github.com/user-attachments/assets/6e88f9cb-5e3f-404d-9c14-b7bc389a4330" /> |

## Issue(s) that this PR fixes
Closes #8670

## Discord contact info
estellar.cheese