### PR TITLE
Fixed an issue where double targeting a Pokemon on a single mon party causes animation issues

### DIFF
--- a/src/battle_anim_mons.c
+++ b/src/battle_anim_mons.c
@@ -813,6 +813,8 @@ bool32 InitSpritePosToAnimBattler(u32 animBattlerId, struct Sprite *sprite, bool
 
 bool8 IsBattlerSpritePresent(u8 battler)
 {
+    if (GetMonData(GetBattlerMon(battler), MON_DATA_SPECIES) == SPECIES_NONE)
+        return FALSE;
     if (IsContest())
     {
         if (gBattleAnimAttacker == battler)


### PR DESCRIPTION
This PR addresses #8890. This is going to upcoming due to this only being seen on upcoming branch.

## Media

https://github.com/user-attachments/assets/23fb3399-16b4-4a45-a9a1-33f1d315f66c

## Issue(s) that this PR fixes
Fixes #8890.

## Discord contact info
linathan
