### PR TITLE
Turn Sheer Cold effect into fail on same type

### DIFF
--- a/include/constants/battle_move_effects.h
+++ b/include/constants/battle_move_effects.h
@@ -33,7 +33,7 @@ enum __attribute__((packed)) BattleMoveEffects
     EFFECT_LIGHT_SCREEN,
     EFFECT_REST,
     EFFECT_OHKO,
-    EFFECT_SHEER_COLD, // Same as EFFECT_OHKO but Ice-types are immune to it and has decreased accuracy for non Ice-type users.
+    EFFECT_OHKO_FAIL_ON_TYPE, // Same as EFFECT_OHKO but targets of the same type as the move immune to it and has decreased accuracy for users that aren't the same type as the move.
     EFFECT_FUSION_COMBO,
     EFFECT_FIXED_PERCENT_DAMAGE,
     EFFECT_FIXED_HP_DAMAGE,

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -1787,8 +1787,8 @@ static s32 AI_CheckBadMove(u32 battlerAtk, u32 battlerDef, enum Move move, s32 s
              || !(weather & (B_WEATHER_ICY_ANY)))
                 ADJUST_SCORE(-10);
             break;
-        case EFFECT_SHEER_COLD:
-            if (GetConfig(CONFIG_SHEER_COLD_IMMUNITY) >= GEN_7 && IS_BATTLER_OF_TYPE(battlerDef, TYPE_ICE))
+        case EFFECT_OHKO_FAIL_ON_TYPE:
+            if (GetConfig(CONFIG_SHEER_COLD_IMMUNITY) >= GEN_7 && IS_BATTLER_OF_TYPE(battlerDef, GetMoveType(move)))
                 RETURN_SCORE_MINUS(20);
             // fallthrough
         case EFFECT_OHKO:
@@ -4608,7 +4608,7 @@ static s32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, enum Move move
         }
         break;
     case EFFECT_OHKO:
-    case EFFECT_SHEER_COLD:
+    case EFFECT_OHKO_FAIL_ON_TYPE:
         if (GetActiveGimmick(battlerDef) == GIMMICK_DYNAMAX)
             break;
         else if (gBattleMons[battlerAtk].volatiles.lockOn)
@@ -4728,7 +4728,7 @@ static s32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, enum Move move
             ADJUST_SCORE(BEST_EFFECT);
         break;
     case EFFECT_LOCK_ON:
-        if (HasMoveWithEffect(battlerAtk, EFFECT_OHKO) || HasMoveWithEffect(battlerAtk, EFFECT_SHEER_COLD))
+        if (HasMoveWithEffect(battlerAtk, EFFECT_OHKO) || HasMoveWithEffect(battlerAtk, EFFECT_OHKO_FAIL_ON_TYPE))
             ADJUST_SCORE(GOOD_EFFECT);
         else if (HasMoveWithLowAccuracy(battlerAtk, battlerDef, 85, TRUE))
             ADJUST_SCORE(GOOD_EFFECT);
@@ -6310,7 +6310,7 @@ static s32 AI_Risky(u32 battlerAtk, u32 battlerDef, enum Move move, s32 score)
     case EFFECT_FLATTER:
     case EFFECT_ATTRACT:
     case EFFECT_OHKO:
-    case EFFECT_SHEER_COLD:
+    case EFFECT_OHKO_FAIL_ON_TYPE:
         ADJUST_SCORE(AVERAGE_RISKY_EFFECT);
         break;
     case EFFECT_HIT:

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -2156,7 +2156,7 @@ bool32 ShouldTryOHKO(u32 battlerAtk, u32 battlerDef, enum Ability atkAbility, en
     else    // test the odds
     {
         u32 odds = accuracy + (gBattleMons[battlerAtk].level - gBattleMons[battlerDef].level);
-        if (B_SHEER_COLD_ACC >= GEN_7 && GetMoveEffect(move) == EFFECT_SHEER_COLD && !IS_BATTLER_OF_TYPE(gBattlerAttacker, TYPE_ICE))
+        if (B_SHEER_COLD_ACC >= GEN_7 && GetMoveEffect(move) == EFFECT_OHKO_FAIL_ON_TYPE && !IS_BATTLER_OF_TYPE(battlerAtk, GetMoveType(move)))
             odds -= 10;
         if (Random() % 100 + 1 < odds && gBattleMons[battlerAtk].level >= gBattleMons[battlerDef].level)
             return TRUE;

--- a/src/battle_dome.c
+++ b/src/battle_dome.c
@@ -3945,7 +3945,7 @@ static bool32 IsDomeLuckyMove(enum Move move)
             return FALSE;
         // fallthrough
     case EFFECT_OHKO:
-    case EFFECT_SHEER_COLD:
+    case EFFECT_OHKO_FAIL_ON_TYPE:
     case EFFECT_METRONOME:
     case EFFECT_MIRROR_MOVE:
     case EFFECT_SKETCH:

--- a/src/battle_dynamax.c
+++ b/src/battle_dynamax.c
@@ -403,7 +403,7 @@ static u32 GetMaxPowerTier(enum Move move)
         case EFFECT_FINAL_GAMBIT:
             return MAX_POWER_TIER_2;
         case EFFECT_OHKO:
-        case EFFECT_SHEER_COLD:
+        case EFFECT_OHKO_FAIL_ON_TYPE:
         case EFFECT_RETURN:
         case EFFECT_FRUSTRATION:
         case EFFECT_HEAT_CRASH:

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -6029,7 +6029,7 @@ void SetTypeBeforeUsingMove(enum Move move, u32 battler)
         && GetBattleMoveType(move) == GetItemSecondaryId(heldItem)
         && effect != EFFECT_PLEDGE
         && effect != EFFECT_OHKO
-        && effect != EFFECT_SHEER_COLD)
+        && effect != EFFECT_OHKO_FAIL_ON_TYPE)
     {
         gSpecialStatuses[battler].gemParam = GetBattlerHoldEffectParam(battler);
         gSpecialStatuses[battler].gemBoost = TRUE;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2086,7 +2086,11 @@ static void MoveDamageDataHpUpdate(u32 battler, u32 scriptBattler, const u8 *nex
         gBattlescriptCurrInstr = nextInstr;
         return;
     }
-    else if (DoesSubstituteBlockMove(gBattlerAttacker, battler, gCurrentMove) && gBattleMons[battler].volatiles.substituteHP)
+
+    u32 moveEffect = GetMoveEffect(gCurrentMove);
+    bool32 isOneHitKOMove = moveEffect == EFFECT_OHKO || moveEffect == EFFECT_OHKO_FAIL_ON_TYPE;
+
+    if (DoesSubstituteBlockMove(gBattlerAttacker, battler, gCurrentMove) && gBattleMons[battler].volatiles.substituteHP)
     {
         if (gBattleMons[battler].volatiles.substituteHP >= gBattleStruct->moveDamage[battler])
         {
@@ -2117,7 +2121,7 @@ static void MoveDamageDataHpUpdate(u32 battler, u32 scriptBattler, const u8 *nex
         gBattleScripting.battler = battler;
         gBattleStruct->moveDamage[battler] = 0;
         gBattleStruct->moveResultFlags[battler] &= ~(MOVE_RESULT_NOT_VERY_EFFECTIVE | MOVE_RESULT_SUPER_EFFECTIVE);
-        if (GetMoveEffect(gCurrentMove) == EFFECT_OHKO)
+        if (isOneHitKOMove)
             gProtectStructs[battler].survivedOHKO = TRUE;
         if (GetBattlerPartyState(battler)->changedSpecies == SPECIES_NONE)
             GetBattlerPartyState(battler)->changedSpecies = gBattleMons[battler].species;
@@ -2147,7 +2151,7 @@ static void MoveDamageDataHpUpdate(u32 battler, u32 scriptBattler, const u8 *nex
             // Deal damage to the battler
             if (gBattleMons[battler].hp > gBattleStruct->moveDamage[battler])
             {
-                if (GetMoveEffect(gCurrentMove) == EFFECT_OHKO && gBattleStruct->moveResultFlags[gBattlerTarget] & MOVE_RESULT_FOE_HUNG_ON)
+                if (isOneHitKOMove && gBattleStruct->moveResultFlags[gBattlerTarget] & MOVE_RESULT_FOE_HUNG_ON)
                 {
                     gProtectStructs[battler].survivedOHKO = TRUE;
                 }
@@ -8801,7 +8805,7 @@ static void Cmd_tryKO(void)
         if (lands == CALC_ACC)
         {
             u16 odds = GetMoveAccuracy(gCurrentMove) + (gBattleMons[gBattlerAttacker].level - gBattleMons[gBattlerTarget].level);
-            if (B_SHEER_COLD_ACC >= GEN_7 && effect == EFFECT_SHEER_COLD && !IS_BATTLER_OF_TYPE(gBattlerAttacker, TYPE_ICE))
+            if (B_SHEER_COLD_ACC >= GEN_7 && effect == EFFECT_OHKO_FAIL_ON_TYPE && !IS_BATTLER_OF_TYPE(gBattlerAttacker, GetMoveType(gCurrentMove)))
                 odds -= 10;
             if (RandomPercentage(RNG_ACCURACY, odds) && gBattleMons[gBattlerAttacker].level >= gBattleMons[gBattlerTarget].level)
                 lands = SURE_HIT;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3445,7 +3445,7 @@ static void ForewarnChooseMove(u32 battler)
                 switch (GetMoveEffect(data[count].moveId))
                 {
                 case EFFECT_OHKO:
-                case EFFECT_SHEER_COLD:
+                case EFFECT_OHKO_FAIL_ON_TYPE:
                     data[count].power = 150;
                     break;
                 case EFFECT_REFLECT_DAMAGE:
@@ -4482,7 +4482,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, u32 battler, enum Ability ab
 
                             if (modifier >= UQ_4_12(2.0)
                              || moveEffect == EFFECT_OHKO
-                             || moveEffect == EFFECT_SHEER_COLD)
+                             || moveEffect == EFFECT_OHKO_FAIL_ON_TYPE)
                             {
                                 effect++;
                                 break;
@@ -9552,7 +9552,7 @@ static inline uq4_12_t CalcTypeEffectivenessMultiplierInternal(struct BattleCont
             RecordAbilityBattle(ctx->battlerDef, ABILITY_LEVITATE);
         }
     }
-    else if (GetConfig(CONFIG_SHEER_COLD_IMMUNITY) >= GEN_7 && GetMoveEffect(ctx->move) == EFFECT_SHEER_COLD && IS_BATTLER_OF_TYPE(ctx->battlerDef, TYPE_ICE))
+    else if (GetConfig(CONFIG_SHEER_COLD_IMMUNITY) >= GEN_7 && GetMoveEffect(ctx->move) == EFFECT_OHKO_FAIL_ON_TYPE && IS_BATTLER_OF_TYPE(ctx->battlerDef, GetMoveType(ctx->move)))
     {
         modifier = UQ_4_12(0.0);
     }
@@ -11626,7 +11626,7 @@ bool32 CanMoveSkipAccuracyCalc(u32 battlerAtk, u32 battlerDef, enum Ability abil
     else if (gBattleMons[battlerDef].volatiles.telekinesis
           && !IsSemiInvulnerable(battlerDef, CHECK_ALL)
           && moveEffect != EFFECT_OHKO
-          && moveEffect != EFFECT_SHEER_COLD)
+          && moveEffect != EFFECT_OHKO_FAIL_ON_TYPE)
     {
         effect = TRUE;
     }

--- a/src/battle_z_move.c
+++ b/src/battle_z_move.c
@@ -548,7 +548,7 @@ u32 GetZMovePower(enum Move move)
     if (GetMoveCategory(move) == DAMAGE_CATEGORY_STATUS)
         return 0;
     enum BattleMoveEffects moveEffect = GetMoveEffect(move);
-    if (moveEffect == EFFECT_OHKO || moveEffect == EFFECT_SHEER_COLD)
+    if (moveEffect == EFFECT_OHKO || moveEffect == EFFECT_OHKO_FAIL_ON_TYPE)
         return 180;
 
     u32 power = GetMoveZPowerOverride(move);

--- a/src/data/battle_move_effects.h
+++ b/src/data/battle_move_effects.h
@@ -221,7 +221,7 @@ const struct BattleMoveEffect gBattleMoveEffects[NUM_BATTLE_MOVE_EFFECTS] =
         .battleFactoryStyle = FACTORY_STYLE_HIGH_RISK,
     },
 
-    [EFFECT_SHEER_COLD] =
+    [EFFECT_OHKO_FAIL_ON_TYPE] =
     {
         .battleScript = BattleScript_EffectOHKO,
         .battleTvScore = 7,

--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -8839,7 +8839,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
         .description = COMPOUND_STRING(
             "A chilling attack that\n"
             "causes fainting if it hits."),
-        .effect = EFFECT_SHEER_COLD,
+        .effect = EFFECT_OHKO_FAIL_ON_TYPE,
         .power = 1,
         .type = TYPE_ICE,
         .accuracy = 30,

--- a/test/battle/ai/can_use_all_moves.c
+++ b/test/battle/ai/can_use_all_moves.c
@@ -299,7 +299,7 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 301-400")
         switch (effect)
         {
         //TODO: AI HANDLING
-        case EFFECT_SHEER_COLD: // Guillotine is crashing the test entirely.
+        case EFFECT_OHKO_FAIL_ON_TYPE: // Guillotine is crashing the test entirely.
         case EFFECT_WATER_SPORT:
         case EFFECT_LUCKY_CHANT:
         case EFFECT_ME_FIRST:

--- a/test/battle/move_animations/all_anims.c
+++ b/test/battle/move_animations/all_anims.c
@@ -310,7 +310,7 @@ static void WhenSingles(enum Move move, struct BattlePokemon *attacker, struct B
             MOVE(attacker, move);
             MOVE(defender, MOVE_SWORDS_DANCE);
         }
-        else if (effect == EFFECT_OHKO || effect == EFFECT_SHEER_COLD)
+        else if (effect == EFFECT_OHKO || effect == EFFECT_OHKO_FAIL_ON_TYPE)
         { // defender needs to send out a different team member
             MOVE(attacker, move);
             SEND_OUT(defender, 1);
@@ -526,7 +526,7 @@ static void DoublesWhen(enum Move move, struct BattlePokemon *attacker, struct B
             MOVE(attacker, move, target: target);
             MOVE(target, MOVE_SWORDS_DANCE);
         }
-        else if (effect == EFFECT_OHKO || effect == EFFECT_SHEER_COLD)
+        else if (effect == EFFECT_OHKO || effect == EFFECT_OHKO_FAIL_ON_TYPE)
         { // Opponent needs to send out a different team member
             MOVE(attacker, move, target: target);
             SEND_OUT(target, 2);

--- a/test/battle/move_effect/sheer_cold.c
+++ b/test/battle/move_effect/sheer_cold.c
@@ -3,7 +3,7 @@
 
 ASSUMPTIONS
 {
-    ASSUME(GetMoveEffect(MOVE_SHEER_COLD) == EFFECT_SHEER_COLD);
+    ASSUME(GetMoveEffect(MOVE_SHEER_COLD) == EFFECT_OHKO_FAIL_ON_TYPE);
 }
 
 SINGLE_BATTLE_TEST("Sheer Cold doesn't affect Ice-type Pokémon (Gen3-6)")


### PR DESCRIPTION
Took some liberty in optimizing the Sheer Cold effect. Instead of failing on Ice Types, it will fail if target is of the same type as the move. 

I think that is a fair assumption to make considering users can use the normal ohko effect if they don't want this. 