### PR TITLE
Fix Memento and Block regressions

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -12512,7 +12512,7 @@ static void Cmd_trymemento(void)
 {
     CMD_ARGS(const u8 *failInstr);
 
-    if (B_MEMENTO_FAIL >= GEN_5
+    if (B_MEMENTO_FAIL >= GEN_4
       && (gBattleCommunication[MISS_TYPE] == B_MSG_PROTECTED
         || IsSemiInvulnerable(gBattlerTarget, CHECK_ALL)
         || IsBattlerProtected(gBattlerAttacker, gBattlerTarget, gCurrentMove)

--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -8959,7 +8959,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
         .priority = 0,
         .category = DAMAGE_CATEGORY_STATUS,
         .zMove = { .effect = Z_EFFECT_DEF_UP_1 },
-        .ignoresProtect = (B_UPDATED_MOVE_FLAGS >= GEN_6 || B_UPDATED_MOVE_FLAGS < GEN_3),
+        .ignoresProtect = B_UPDATED_MOVE_FLAGS >= GEN_6,
         .magicCoatAffected = TRUE,
         .contestEffect = CONTEST_EFFECT_MAKE_FOLLOWING_MONS_NERVOUS,
         .contestCategory = CONTEST_CATEGORY_CUTE,


### PR DESCRIPTION
## Description
My previous PRs made regressions in two areas:
B_MEMENTO_FAIL was made to apply to gen 5 and onward, when it should also apply to gen 4.
Block was given the ability to bypass protection in gen 1 and 2, where it did not exist to determine this data.

## Discord contact info
amiosi
