### PR TITLE
Mega Gardevoir should always be Fairy-type

### DIFF
--- a/src/data/pokemon/species_info/gen_3_families.h
+++ b/src/data/pokemon/species_info/gen_3_families.h
@@ -2893,7 +2893,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .baseSpeed     = 100,
         .baseSpAttack  = 165,
         .baseSpDefense = 135,
-        .types = MON_TYPES(TYPE_PSYCHIC, RALTS_FAMILY_TYPE2),
+        .types = MON_TYPES(TYPE_PSYCHIC, TYPE_FAIRY),
         .catchRate = 45,
         .expYield = (P_UPDATED_EXP_YIELDS >= GEN_8) ? 309 : 278,
         .evYield_SpAttack = 3,


### PR DESCRIPTION
## Description
as per the discussion and changes made in #8462 Mega Gardevoir shouldn't be pure Psychic when config is set to Gen 5 or earlier. I believe this is the only instance of this type of mistake to slip through the cracks.

## Discord contact info
amiosi
