### PR TITLE
Fix berry tree spawning with max yield when OW_BERRY_ALWAYS_WATERABLE is active

### DIFF
--- a/src/berry.c
+++ b/src/berry.c
@@ -1963,7 +1963,7 @@ void PlantBerryTree(u8 id, u8 berry, u8 stage, bool8 allowGrowth)
     tree->moistureLevel = 100;
     if (OW_BERRY_ALWAYS_WATERABLE)
     {
-        // We simulate a tree having grwon without water
+        // We simulate a tree having grown without water
         u32 berryTreeAge = GetBerryTreeAge(id, stage);
         if (GetBerryInfo(berry)->maxYield - berryTreeAge * GetBerryInfo(berry)->maxYield / 5 < GetBerryInfo(berry)->minYield)
             tree->berryYield = GetBerryInfo(berry)->minYield;


### PR DESCRIPTION
When  OW_BERRY_ALWAYS_WATERABLE is active start at max yield when planted and lose yield over time if they are not watered. This cause issues where the tree created in later stage through script (like in enw_game.inc) would stay at max yield forever. This tries to give script generated trees a simulated amount of yield


## Issue(s) that this PR fixes
Fixes #8965



## Discord contact info
Jamie
