### PR TITLE
Fix winning moves

### DIFF
--- a/src/battle_dome.c
+++ b/src/battle_dome.c
@@ -5104,13 +5104,14 @@ static u16 GetWinningMove(int winnerTournamentId, int loserTournamentId, u8 roun
         for (j = 0; j < MAX_MON_MOVES; j++)
         {
             u32 moveIndex = i * MAX_MON_MOVES + j;
-            enum Move move = moves[moveIndex];
+            enum Move move;
 
             moveScores[moveIndex] = 0;
             if (DOME_TRAINERS[winnerTournamentId].trainerId == TRAINER_FRONTIER_BRAIN)
                 move = GetFrontierBrainMonMove(i, j);
             else
                 move = gFacilityTrainerMons[DOME_MONS[winnerTournamentId][i]].moves[j];
+            moves[moveIndex] = move;
 
             movePower = GetMovePower(move);
             if (IsBattleMoveStatus(move))


### PR DESCRIPTION
Bug introduced in #8612 where the computed moves were not added to the moves array thus rmaking GetWinningMove return MOVE_NONE


## Media

https://github.com/user-attachments/assets/3e30d1ed-0352-4606-966a-de972ff401f8



## Issue(s) that this PR fixes
Fixes #8971



## Discord contact info
Jamie