### PR TITLE
AI uses Tailwind with Wind Rider and Wind Power

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -46,6 +46,7 @@ static inline void BattleAI_DoAIProcessing_PredictedSwitchin(struct AiThinkingSt
 static bool32 IsPinchBerryItemEffect(enum HoldEffect holdEffect);
 static bool32 DoesAbilityBenefitFromSunOrRain(u32 battler, enum Ability ability, u32 weather);
 static void AI_CompareDamagingMoves(u32 battlerAtk, u32 battlerDef);
+static u32 GetWindAbilityScore(u32 battlerAtk, u32 battlerDef, struct AiLogicData *aiData);
 
 // ewram
 EWRAM_DATA const u8 *gAIScriptPtr = NULL;   // Still used in contests
@@ -3948,6 +3949,26 @@ static bool32 DoesAbilityBenefitFromSunOrRain(u32 battler, enum Ability ability,
     return FALSE;
 }
 
+static u32 GetWindAbilityScore(u32 battlerAtk, u32 battlerDef, struct AiLogicData *aiData)
+{
+    u32 score = 0;
+
+    if (aiData->abilities[battlerAtk] == ABILITY_WIND_RIDER)
+    {
+        score = IncreaseStatUpScore(battlerAtk, battlerDef, STAT_CHANGE_ATK);
+    }
+    else if (aiData->abilities[battlerAtk] == ABILITY_WIND_POWER)
+    {
+        if (gBattleMons[battlerAtk].volatiles.chargeTimer == 0
+         && HasDamagingMoveOfType(battlerAtk, TYPE_ELECTRIC))
+        {
+            score = DECENT_EFFECT;
+        }
+    }
+
+    return score;
+}
+
 static enum MoveComparisonResult CompareMoveAccuracies(u32 battlerAtk, u32 battlerDef, u32 moveSlot1, u32 moveSlot2)
 {
     u32 acc1 = gAiLogicData->moveAccuracy[battlerAtk][battlerDef][moveSlot1];
@@ -5604,6 +5625,14 @@ static s32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, enum Move move
 
             if (CountUsablePartyMons(battlerAtk) != 0)
                 ADJUST_SCORE(WEAK_EFFECT);
+
+            if (!(gSideStatuses[GetBattlerSide(battlerAtk)] & SIDE_STATUS_TAILWIND))
+            {
+                u32 windAbilityScore = GetWindAbilityScore(battlerAtk, battlerDef, aiData);
+
+                if (windAbilityScore > 0)
+                    ADJUST_SCORE(windAbilityScore);
+            }
         }
         else
         {
@@ -5627,21 +5656,15 @@ static s32 AI_CalcMoveEffectScore(u32 battlerAtk, u32 battlerDef, enum Move move
 
             ADJUST_SCORE(tailwindScore);
 
-            if (IsBattlerAlive(BATTLE_PARTNER(battlerAtk))
-             && !(gSideStatuses[GetBattlerSide(battlerAtk)] & SIDE_STATUS_TAILWIND))
+            if (!(gSideStatuses[GetBattlerSide(battlerAtk)] & SIDE_STATUS_TAILWIND))
             {
-                if (aiData->abilities[BATTLE_PARTNER(battlerAtk)] == ABILITY_WIND_RIDER)
-                {
-                    ADJUST_SCORE(IncreaseStatUpScore(BATTLE_PARTNER(battlerAtk), battlerDef, STAT_CHANGE_ATK));
-                }
-                else if (aiData->abilities[BATTLE_PARTNER(battlerAtk)] == ABILITY_WIND_POWER)
-                {
-                    if (gBattleMons[BATTLE_PARTNER(battlerAtk)].volatiles.chargeTimer == 0
-                     && HasDamagingMoveOfType(BATTLE_PARTNER(battlerAtk), TYPE_ELECTRIC))
-                    {
-                        ADJUST_SCORE(GOOD_EFFECT);
-                    }
-                }
+                u32 windAbilityScore = GetWindAbilityScore(battlerAtk, battlerDef, aiData);
+
+                if (IsBattlerAlive(BATTLE_PARTNER(battlerAtk)))
+                    windAbilityScore += GetWindAbilityScore(BATTLE_PARTNER(battlerAtk), battlerDef, aiData);
+
+                if (windAbilityScore > 0)
+                    ADJUST_SCORE(windAbilityScore);
             }
         }
         break;

--- a/test/battle/ai/ai_check_viability.c
+++ b/test/battle/ai/ai_check_viability.c
@@ -397,6 +397,51 @@ AI_SINGLE_BATTLE_TEST("AI uses Trick Room (singles)")
     }
 }
 
+AI_SINGLE_BATTLE_TEST("AI uses Tailwind to trigger Wind Rider (Single)")
+{
+    bool32 expectTailwind;
+    u16 tailwindSpecies;
+    enum Ability tailwindAbility;
+
+    PARAMETRIZE { tailwindSpecies = SPECIES_BRAMBLEGHAST; tailwindAbility = ABILITY_WIND_RIDER;  expectTailwind = TRUE; }
+    PARAMETRIZE { tailwindSpecies = SPECIES_BRAMBLEGHAST; tailwindAbility = ABILITY_INFILTRATOR; expectTailwind = FALSE; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_TAILWIND) == EFFECT_TAILWIND);
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(20); }
+        OPPONENT(tailwindSpecies) { Ability(tailwindAbility); Speed(9); Moves(MOVE_TAILWIND, MOVE_HEADBUTT); }
+    } WHEN {
+        if (expectTailwind)
+            TURN { EXPECT_MOVE(opponent, MOVE_TAILWIND); }
+        else
+            TURN { NOT_EXPECT_MOVE(opponent, MOVE_TAILWIND); }
+    }
+}
+
+AI_SINGLE_BATTLE_TEST("AI uses Tailwind to trigger Wind Power (Single)")
+{
+    bool32 expectTailwind;
+    u16 tailwindSpecies;
+    enum Ability tailwindAbility;
+
+    PARAMETRIZE { tailwindSpecies = SPECIES_KILOWATTREL; tailwindAbility = ABILITY_WIND_POWER;  expectTailwind = TRUE; }
+    PARAMETRIZE { tailwindSpecies = SPECIES_KILOWATTREL; tailwindAbility = ABILITY_COMPETITIVE; expectTailwind = FALSE; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_TAILWIND) == EFFECT_TAILWIND);
+        ASSUME(GetMoveType(MOVE_THUNDERSHOCK) == TYPE_ELECTRIC);
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(20); }
+        OPPONENT(tailwindSpecies) { Ability(tailwindAbility); Speed(9); Moves(MOVE_TAILWIND, MOVE_THUNDERSHOCK); }
+    } WHEN {
+        if (expectTailwind)
+            TURN { EXPECT_MOVE(opponent, MOVE_TAILWIND); }
+        else
+            TURN { NOT_EXPECT_MOVE(opponent, MOVE_TAILWIND); }
+    }
+}
+
 AI_SINGLE_BATTLE_TEST("AI uses Quick Guard against Quick Attack when opponent would take poison damage")
 {
     PASSES_RANDOMLY(PREDICT_MOVE_CHANCE, 100, RNG_AI_PREDICT_MOVE);

--- a/test/battle/ai/ai_doubles.c
+++ b/test/battle/ai/ai_doubles.c
@@ -973,21 +973,24 @@ AI_DOUBLE_BATTLE_TEST("AI uses Tailwind")
     }
 }
 
-AI_DOUBLE_BATTLE_TEST("AI uses Tailwind to trigger Wind Rider ally")
+AI_DOUBLE_BATTLE_TEST("AI uses Tailwind to trigger Wind Rider (Doubles)")
 {
     bool32 expectTailwind;
-    u32 ability;
+    u16 tailwindSpecies, partnerSpecies;
+    enum Ability tailwindAbility, partnerAbility;
 
-    PARAMETRIZE { ability = ABILITY_WIND_RIDER; expectTailwind = TRUE; }
-    PARAMETRIZE { ability = ABILITY_INFILTRATOR; expectTailwind = FALSE; }
+    PARAMETRIZE { tailwindSpecies = SPECIES_BRAMBLEGHAST; tailwindAbility = ABILITY_WIND_RIDER;  partnerSpecies = SPECIES_BRAMBLEGHAST; partnerAbility = ABILITY_WIND_RIDER;  expectTailwind = TRUE; }
+    PARAMETRIZE { tailwindSpecies = SPECIES_BRAMBLEGHAST; tailwindAbility = ABILITY_WIND_RIDER;  partnerSpecies = SPECIES_BRAMBLEGHAST; partnerAbility = ABILITY_INFILTRATOR; expectTailwind = TRUE; }
+    PARAMETRIZE { tailwindSpecies = SPECIES_BRAMBLEGHAST; tailwindAbility = ABILITY_INFILTRATOR; partnerSpecies = SPECIES_BRAMBLEGHAST; partnerAbility = ABILITY_WIND_RIDER;  expectTailwind = TRUE; }
+    PARAMETRIZE { tailwindSpecies = SPECIES_BRAMBLEGHAST; tailwindAbility = ABILITY_INFILTRATOR; partnerSpecies = SPECIES_BRAMBLEGHAST; partnerAbility = ABILITY_INFILTRATOR; expectTailwind = FALSE; }
 
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_TAILWIND) == EFFECT_TAILWIND);
         AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_DOUBLE_BATTLE);
         PLAYER(SPECIES_WOBBUFFET) { Speed(20); }
         PLAYER(SPECIES_WOBBUFFET) { Speed(20); }
-        OPPONENT(SPECIES_WOBBUFFET) { Speed(5); Moves(MOVE_TAILWIND, MOVE_HEADBUTT); }
-        OPPONENT(SPECIES_BRAMBLEGHAST) { Ability(ability); Speed(5); Moves(MOVE_HEADBUTT); }
+        OPPONENT(tailwindSpecies) { Ability(tailwindAbility); Speed(9); Moves(MOVE_TAILWIND, MOVE_HEADBUTT); }
+        OPPONENT(partnerSpecies) { Ability(partnerAbility); Speed(9); Moves(MOVE_HEADBUTT); }
     } WHEN {
         if (expectTailwind)
             TURN { EXPECT_MOVE(opponentLeft, MOVE_TAILWIND); }
@@ -996,13 +999,16 @@ AI_DOUBLE_BATTLE_TEST("AI uses Tailwind to trigger Wind Rider ally")
     }
 }
 
-AI_DOUBLE_BATTLE_TEST("AI uses Tailwind to trigger Wind Power ally")
+AI_DOUBLE_BATTLE_TEST("AI uses Tailwind to trigger Wind Power (Doubles)")
 {
     bool32 expectTailwind;
-    u32 ability;
+    u16 tailwindSpecies, partnerSpecies;
+    enum Ability tailwindAbility, partnerAbility;
 
-    PARAMETRIZE { ability = ABILITY_WIND_POWER; expectTailwind = TRUE; }
-    PARAMETRIZE { ability = ABILITY_COMPETITIVE; expectTailwind = FALSE; }
+    PARAMETRIZE { tailwindSpecies = SPECIES_KILOWATTREL; tailwindAbility = ABILITY_WIND_POWER;  partnerSpecies = SPECIES_KILOWATTREL; partnerAbility = ABILITY_WIND_POWER;  expectTailwind = TRUE; }
+    PARAMETRIZE { tailwindSpecies = SPECIES_KILOWATTREL; tailwindAbility = ABILITY_WIND_POWER;  partnerSpecies = SPECIES_KILOWATTREL; partnerAbility = ABILITY_COMPETITIVE; expectTailwind = TRUE; }
+    PARAMETRIZE { tailwindSpecies = SPECIES_KILOWATTREL; tailwindAbility = ABILITY_COMPETITIVE; partnerSpecies = SPECIES_KILOWATTREL; partnerAbility = ABILITY_WIND_POWER;  expectTailwind = TRUE; }
+    PARAMETRIZE { tailwindSpecies = SPECIES_KILOWATTREL; tailwindAbility = ABILITY_COMPETITIVE; partnerSpecies = SPECIES_KILOWATTREL; partnerAbility = ABILITY_COMPETITIVE; expectTailwind = FALSE; }
 
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_TAILWIND) == EFFECT_TAILWIND);
@@ -1010,8 +1016,8 @@ AI_DOUBLE_BATTLE_TEST("AI uses Tailwind to trigger Wind Power ally")
         AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_DOUBLE_BATTLE);
         PLAYER(SPECIES_WOBBUFFET) { Speed(20); }
         PLAYER(SPECIES_WOBBUFFET) { Speed(20); }
-        OPPONENT(SPECIES_WOBBUFFET) { Speed(5); Moves(MOVE_TAILWIND, MOVE_HEADBUTT); }
-        OPPONENT(SPECIES_KILOWATTREL) { Ability(ability); Speed(5); Moves(MOVE_THUNDERSHOCK); }
+        OPPONENT(tailwindSpecies) { Ability(tailwindAbility); Speed(21); Moves(MOVE_TAILWIND, MOVE_THUNDERSHOCK); }
+        OPPONENT(partnerSpecies) { Ability(partnerAbility); Speed(21); Moves(MOVE_THUNDERSHOCK); }
     } WHEN {
         if (expectTailwind)
             TURN { EXPECT_MOVE(opponentLeft, MOVE_TAILWIND); }


### PR DESCRIPTION
## Description
Improve Tailwind AI scoring to account for Wind Rider and Wind Power on the user or its partner in singles and doubles.

## Note
Tailwind speed scoring for the AI was fixed in #8968 and merged into master (the adjustment here simply ensures the new test’s speed calculation is correct)