### PR TITLE
fix: add `__attribute__((packed))` to `enum Direction`

### DIFF
--- a/include/constants/global.h
+++ b/include/constants/global.h
@@ -189,7 +189,7 @@ enum Gender
 #define OPTIONS_BATTLE_STYLE_SHIFT 0
 #define OPTIONS_BATTLE_STYLE_SET 1
 
-enum Direction
+enum __attribute__((packed)) Direction
 {
     DIR_NONE,
     DIR_SOUTH,


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
adds `__attribute__((packed))` to `enum Direction`, which fixes a size mismatch causing direction `switch` cases to use the `default` case.

logging from before and after in function `GetOppositeDirection`, `src/event_object_movement.c` line 6768

before:
<img width="412" height="124" alt="image" src="https://github.com/user-attachments/assets/56251702-eaed-4932-9f68-5c952e340734" />

after:
<img width="402" height="129" alt="image" src="https://github.com/user-attachments/assets/e9764b7e-8c15-43f9-80ca-56b95c0acb8f" />

tested with multiple npcs in oldale, littleroot, and route 101.
## Issue(s) that this PR fixes
fixes #8991 

## Discord contact info
khbsd
