### PR TITLE
fix: IsDoubleBattle() return value

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -1210,7 +1210,7 @@ static inline struct PartyState *GetBattlerPartyState(u32 battler)
 
 static inline bool32 IsDoubleBattle(void)
 {
-    return (gBattleTypeFlags & BATTLE_TYPE_MORE_THAN_TWO_BATTLERS);
+    return !!(gBattleTypeFlags & BATTLE_TYPE_MORE_THAN_TWO_BATTLERS);
 }
 
 static inline bool32 IsSpreadMove(u32 moveTarget)


### PR DESCRIPTION
## Description
`IsDoubleBattle()` doesnt appear to always return a 1 or 0, so using it with `== TRUE` would result in a `FALSE` in some cases; adding the `!!` makes it a 1 or 0.

## Issue(s) that this PR fixes
#8907, maybe others

## Discord contact info
khbsd