### PR TITLE
Remove player party shiny bit setting in CreateFrontierBrainPokemon

### DIFF
--- a/src/frontier_util.c
+++ b/src/frontier_util.c
@@ -2612,8 +2612,6 @@ void CreateFrontierBrainPokemon(void)
                 friendship = 0;
         }
         SetMonData(&gEnemyParty[monPartyId], MON_DATA_FRIENDSHIP, &friendship);
-        j = FALSE;
-        SetMonData(&gPlayerParty[MULTI_PARTY_SIZE + i], MON_DATA_IS_SHINY, &j);
         CalculateMonStats(&gEnemyParty[monPartyId]);
         monPartyId++;
     }


### PR DESCRIPTION
## Description
Removes setting of player slots 3-5 as non-shiny in CreateFrontierBrainPokemon. Not present in pret and makes no sense being here afaict

## Discord contact info
grintoul