### PR TITLE
Fix Crafty Shield consecutive-use failure

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -9753,7 +9753,8 @@ static void Cmd_setprotectlike(void)
 
     if ((sProtectSuccessRates[gDisableStructs[gBattlerAttacker].protectUses] >= RandomUniform(RNG_PROTECT_FAIL, 0, USHRT_MAX) && notLastTurn)
      || (protectMethod == PROTECT_WIDE_GUARD && GetConfig(CONFIG_WIDE_GUARD) >= GEN_6)
-     || (protectMethod == PROTECT_QUICK_GUARD && GetConfig(CONFIG_QUICK_GUARD) >= GEN_6))
+     || (protectMethod == PROTECT_QUICK_GUARD && GetConfig(CONFIG_QUICK_GUARD) >= GEN_6)
+     || (protectMethod == PROTECT_CRAFTY_SHIELD))
     {
         if (GetMoveEffect(gCurrentMove) == EFFECT_ENDURE)
         {


### PR DESCRIPTION
## Description
**Bulba:**
> [Crafty Shield](https://bulbapedia.bulbagarden.net/wiki/Crafty_Shield_(move)) can be used consecutively without failing.