### PR TITLE
Fix substitute follower appearing with dead party

### DIFF
--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -1968,10 +1968,14 @@ u8 CreateVirtualObject(u16 graphicsId, u8 virtualObjId, s16 x, s16 y, u8 elevati
 struct Pokemon *GetFirstLiveMon(void)
 {
     u32 i;
-    for (i = 0; i < gPlayerPartyCount; i++)
+    for (i = 0; i < PARTY_SIZE; i++)
     {
         struct Pokemon *mon = &gPlayerParty[i];
-        if ((OW_FOLLOWERS_ALLOWED_SPECIES && GetMonData(mon, MON_DATA_SPECIES_OR_EGG) != VarGet(OW_FOLLOWERS_ALLOWED_SPECIES))
+        u32 species = GetMonData(mon, MON_DATA_SPECIES_OR_EGG);
+        if (species == SPECIES_NONE)
+            continue;
+
+        if ((OW_FOLLOWERS_ALLOWED_SPECIES && species != VarGet(OW_FOLLOWERS_ALLOWED_SPECIES))
          || (OW_FOLLOWERS_ALLOWED_MET_LVL && GetMonData(mon, MON_DATA_MET_LEVEL) != VarGet(OW_FOLLOWERS_ALLOWED_MET_LVL))
          || (OW_FOLLOWERS_ALLOWED_MET_LOC && GetMonData(mon, MON_DATA_MET_LOCATION) != VarGet(OW_FOLLOWERS_ALLOWED_MET_LOC)))
             continue;


### PR DESCRIPTION
The function that picks a follower from the alive mons in your party can return empty party slots creating the substitute

Video were recorded on upcoming because it was easier to set up tests there

## Media
upcoming:

https://github.com/user-attachments/assets/a81e8a6e-2c5f-4f5e-83e1-57c73b3c4710

after this commit:

https://github.com/user-attachments/assets/a78a74fc-b549-4baa-ac7e-a1fc6282db16


## Issue(s) that this PR fixes
Fixes #9013

## Discord contact info
Jamie
