### PR TITLE
Fix Synchronoise typeless behavior in Gen7+

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -9409,19 +9409,23 @@ bool32 TryBattleFormChange(u32 battler, enum FormChanges method)
 bool32 DoBattlersShareType(u32 battler1, u32 battler2)
 {
     s32 i;
+    s32 j;
     enum Type types1[3], types2[3];
     GetBattlerTypes(battler1, FALSE, types1);
     GetBattlerTypes(battler2, FALSE, types2);
 
-    if (types1[2] == TYPE_MYSTERY)
-        types1[2] = types1[0];
-    if (types2[2] == TYPE_MYSTERY)
-        types2[2] = types2[0];
-
     for (i = 0; i < 3; i++)
     {
-        if (types1[i] == types2[0] || types1[i] == types2[1] || types1[i] == types2[2])
-            return TRUE;
+        if (types1[i] == TYPE_MYSTERY)
+            continue;
+
+        for (j = 0; j < 3; j++)
+        {
+            if (types2[j] == TYPE_MYSTERY)
+                continue;
+            if (types1[i] == types2[j])
+                return TRUE;
+        }
     }
 
     return FALSE;

--- a/test/battle/move_effect/synchronoise.c
+++ b/test/battle/move_effect/synchronoise.c
@@ -1,6 +1,17 @@
 #include "global.h"
 #include "test/battle.h"
 
+ASSUMPTIONS
+{
+    ASSUME(GetMoveEffect(MOVE_SYNCHRONOISE) == EFFECT_SYNCHRONOISE);
+    ASSUME(GetSpeciesType(SPECIES_WOBBUFFET, 0) == TYPE_PSYCHIC);
+    ASSUME(GetSpeciesType(SPECIES_WOBBUFFET, 1) == TYPE_PSYCHIC);
+    ASSUME(GetSpeciesType(SPECIES_BULBASAUR, 0) == TYPE_GRASS);
+    ASSUME(GetSpeciesType(SPECIES_BULBASAUR, 1) == TYPE_POISON);
+    ASSUME(GetSpeciesType(SPECIES_ARCANINE, 0) == TYPE_FIRE);
+    ASSUME(GetSpeciesType(SPECIES_ARCANINE, 1) == TYPE_FIRE);
+}
+
 DOUBLE_BATTLE_TEST("Synchronoise hits all Pokemon that share a type with the attacker")
 {
     GIVEN {
@@ -68,6 +79,37 @@ DOUBLE_BATTLE_TEST("Synchronoise will fail if the corresponding typing mon prote
         TURN { MOVE(opponentLeft, MOVE_PROTECT); MOVE(playerLeft, MOVE_SYNCHRONOISE); }
     } SCENE {
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_SYNCHRONOISE, playerLeft);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Synchronoise will fail for a typeless user even if a target is typeless")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_BURN_UP) == EFFECT_FAIL_IF_NOT_ARG_TYPE);
+        PLAYER(SPECIES_ARCANINE) { Moves(MOVE_BURN_UP, MOVE_SYNCHRONOISE); }
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_ARCANINE) { Moves(MOVE_BURN_UP, MOVE_CELEBRATE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN {
+            MOVE(playerLeft, MOVE_BURN_UP, target: opponentRight);
+            MOVE(opponentLeft, MOVE_BURN_UP, target: playerRight);
+            MOVE(playerRight, MOVE_CELEBRATE);
+            MOVE(opponentRight, MOVE_CELEBRATE);
+        }
+        TURN {
+            MOVE(playerLeft, MOVE_SYNCHRONOISE);
+            MOVE(opponentLeft, MOVE_CELEBRATE);
+            MOVE(playerRight, MOVE_CELEBRATE);
+            MOVE(opponentRight, MOVE_CELEBRATE);
+        }
+    } SCENE {
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_SYNCHRONOISE, playerLeft);
+        MESSAGE("Arcanine used Synchronoise!");
+        MESSAGE("It doesn't affect the opposing Arcanine…");
+        MESSAGE("It doesn't affect Wobbuffet…");
+        MESSAGE("It doesn't affect the opposing Wobbuffet…");
+        NOT MESSAGE("But it failed!");
     }
 }
 


### PR DESCRIPTION
## Description

- Treat TYPE_MYSTERY as non‑type when checking shared types.
- Ensure Synchronoise never affects targets if the user is typeless (e.g., after Burn Up).

## Issue(s) that this PR fixes
Fix #8505