### PR TITLE
Fixes Mold Breaker and Dondozo edge cases

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -708,7 +708,7 @@ struct BattleStruct
     u8 calculatedSpreadMoveAccuracy:1;
     u8 printedStrongWindsWeakenedAttack:1;
     u8 numSpreadTargets:3;
-    u8 moldBreakerActive:1;
+    u8 padding4:1;
     struct MessageStatus slideMessageStatus;
     u8 trainerSlideSpriteIds[MAX_BATTLERS_COUNT];
     u8 hazardsQueue[NUM_BATTLE_SIDES][HAZARDS_MAX_COUNT];
@@ -721,7 +721,7 @@ struct BattleStruct
     u8 incrementEchoedVoice:1;
     u8 echoedVoiceCounter:3;
     u8 preAttackAnimPlayed:1;
-    u8 padding4:1;
+    u8 padding5:1;
     u8 magicCoatActive:1;
     u8 magicBounceActive:1;
     u8 moveBouncer;

--- a/include/constants/battle.h
+++ b/include/constants/battle.h
@@ -286,7 +286,8 @@ enum VolatileFlags
     F(VOLATILE_TRY_EJECT_PACK,              tryEjectPack,                  (u32, 1)) \
     F(VOLATILE_OCTOLOCKED_BY,               octolockedBy,                  (enum BattlerId, MAX_BITS(MAX_BATTLERS_COUNT))) \
     F(VOLATILE_PARADOX_BOOSTED_STAT,        paradoxBoostedStat,            (enum Stat, NUM_STATS - 1)) \
-    F(VOLATILE_UNABLE_TO_USE_MOVE,          unableToUseMove,               (u32, 1))
+    F(VOLATILE_UNABLE_TO_USE_MOVE,          unableToUseMove,               (u32, 1)) \
+    F(VOLATILE_MOLD_BREAKER_ACTIVE,         moldBreakerActive,             (u32, 1))
 
 
 /* Use within a macro to get the maximum allowed value for a volatile. Requires _typeMaxValue as input. */

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4808,6 +4808,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, u32 battler, enum Ability ab
         case ABILITY_COMMANDER:
             if (IsBattlerAlive(partner)
              && IsBattlerAlive(battler)
+             && gChosenActionByBattler[partner] != B_ACTION_SWITCH
              && gBattleStruct->battlerState[partner].commanderSpecies == SPECIES_NONE
              && gBattleMons[partner].species == SPECIES_DONDOZO
              && GET_BASE_SPECIES_ID(GetMonData(GetBattlerMon(battler), MON_DATA_SPECIES)) == SPECIES_TATSUGIRI)
@@ -4997,7 +4998,7 @@ static inline bool32 CanBreakThroughAbility(u32 battlerAtk, u32 battlerDef, bool
 {
     if (hasAbilityShield || ignoreMoldBreaker || battlerDef == battlerAtk)
         return FALSE;
-    return gBattleStruct->moldBreakerActive && gAbilitiesInfo[gBattleMons[battlerDef].ability].breakable;
+    return gBattleMons[battlerAtk].volatiles.moldBreakerActive && gAbilitiesInfo[gBattleMons[battlerDef].ability].breakable;
 }
 
 enum Ability GetBattlerAbilityNoAbilityShield(u32 battler)
@@ -10029,9 +10030,9 @@ void ClearDamageCalcResults(void)
 	gBattleStruct->preAttackAnimPlayed = FALSE;
     gBattleScripting.savedDmg = 0;
     if (gCurrentMove != MOVE_NONE)
-        gBattleStruct->moldBreakerActive = IsMoldBreakerTypeAbility(gBattlerAttacker, GetBattlerAbility(gBattlerAttacker)) || MoveIgnoresTargetAbility(gCurrentMove);
+        gBattleMons[gBattlerAttacker].volatiles.moldBreakerActive = IsMoldBreakerTypeAbility(gBattlerAttacker, GetBattlerAbility(gBattlerAttacker)) || MoveIgnoresTargetAbility(gCurrentMove);
     else
-        gBattleStruct->moldBreakerActive = FALSE;
+        gBattleMons[gBattlerAttacker].volatiles.moldBreakerActive = FALSE;
 }
 
 bool32 DoesDestinyBondFail(u32 battler)

--- a/test/battle/ability/commander.c
+++ b/test/battle/ability/commander.c
@@ -455,3 +455,23 @@ DOUBLE_BATTLE_TEST("Commander prevent Dondozo from switch out by Dragon Tail")
         NOT MESSAGE("Wobbuffet was dragged out!");
     }
 }
+
+DOUBLE_BATTLE_TEST("Commander will not activate if partner Dondozo is about to switch out")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_DONDOZO);
+        PLAYER(SPECIES_TATSUGIRI) { Ability(ABILITY_COMMANDER); }
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN {
+            SWITCH(playerLeft, 2);
+            SWITCH(playerRight, 3);
+        }
+    } SCENE {
+        NOT ABILITY_POPUP(playerRight, ABILITY_COMMANDER);
+    }
+}
+

--- a/test/battle/ability/mold_breaker.c
+++ b/test/battle/ability/mold_breaker.c
@@ -19,4 +19,17 @@ SINGLE_BATTLE_TEST("Mold Breaker cancels damage reduction from Ice Scales", s16 
     }
 }
 
+SINGLE_BATTLE_TEST("Mold Breaker will be inactive if user faints due to recoil")
+{
+    GIVEN {
+        PLAYER(SPECIES_PINSIR) { HP(1); Ability(ABILITY_MOLD_BREAKER); }
+        OPPONENT(SPECIES_KECLEON) { Ability(ABILITY_COLOR_CHANGE); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_FLARE_BLITZ); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FLARE_BLITZ, player);
+        ABILITY_POPUP(opponent, ABILITY_COLOR_CHANGE);
+    }
+}
+
 TO_DO_BATTLE_TEST("TODO: Write more Mold Breaker (Ability) test titles")


### PR DESCRIPTION
Fixes #8236

According to ingame tests, Mold Breaker will be inactive if a mon faints during it's attack https://discord.com/channels/419213663107416084/1368163973366681712/1461537056739033158

Also fixes Commander activating when partner Dondozo is about to switch out

By accident I based in on upcoming. Will rebase later. 