### PR TITLE
Fix abilities that should not reactivate when they are changed

### DIFF
--- a/asm/macros/battle_script.inc
+++ b/asm/macros/battle_script.inc
@@ -1729,8 +1729,8 @@
 	1:
 	.endm
 
-	.macro jumpifabilitycantbereactivated battler:req, jumpInstr:req
-	callnative BS_JumpIfAbilityCantBeReactivated
+	.macro jumpifabilitycantbesuppressed battler:req, jumpInstr:req
+	callnative BS_JumpIfAbilityCantBeSuppressed
 	.byte \battler
 	.4byte \jumpInstr
 	.endm

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -7815,7 +7815,7 @@ BattleScript_NeutralizingGasExits::
 	sortbattlers
 BattleScript_NeutralizingGasExitsLoop:
 	copyarraywithindex gBattlerTarget, gBattlersBySpeed, gBattlerAttacker, 1
-	jumpifabilitycantbereactivated BS_TARGET, BattleScript_NeutralizingGasExitsLoopIncrement
+	jumpifabilitycantbesuppressed BS_TARGET, BattleScript_NeutralizingGasExitsLoopIncrement
 	saveattacker
 	switchinabilities BS_TARGET
 	restoreattacker

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -13895,9 +13895,12 @@ void BS_StatTextBuffer(void)
 void BS_SwitchinAbilities(void)
 {
     NATIVE_ARGS(u8 battler);
+
     enum BattlerId battler = GetBattlerForBattleScript(cmd->battler);
-    u32 ability = GetBattlerAbility(battler);
+    enum Ability ability = GetBattlerAbility(battler);
+
     gBattlescriptCurrInstr = cmd->nextInstr;
+
     switch (ability)
     {
     case ABILITY_IMPOSTER:
@@ -13905,7 +13908,10 @@ void BS_SwitchinAbilities(void)
     case ABILITY_AIR_LOCK:
     case ABILITY_CLOUD_NINE:
         return;
+    default:
+        break;
     }
+
     AbilityBattleEffects(ABILITYEFFECT_TERA_SHIFT, battler, ability, MOVE_NONE, TRUE);
     AbilityBattleEffects(ABILITYEFFECT_NEUTRALIZINGGAS, battler, ability, MOVE_NONE, TRUE);
     AbilityBattleEffects(ABILITYEFFECT_UNNERVE, battler, ability, MOVE_NONE, TRUE);

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -13347,27 +13347,15 @@ void BS_TryBoosterEnergy(void)
     gBattlescriptCurrInstr = cmd->nextInstr;
 }
 
-void BS_JumpIfAbilityCantBeReactivated(void)
+void BS_JumpIfAbilityCantBeSuppressed(void)
 {
     NATIVE_ARGS(u8 battler, const u8 *jumpInstr);
     enum BattlerId battler = GetBattlerForBattleScript(cmd->battler);
     u32 ability = gBattleMons[battler].ability;
-
-    switch (ability)
-    {
-    case ABILITY_IMPOSTER:
-    case ABILITY_NEUTRALIZING_GAS:
-    case ABILITY_AIR_LOCK:
-    case ABILITY_CLOUD_NINE:
+    if (gAbilitiesInfo[ability].cantBeSuppressed)
         gBattlescriptCurrInstr = cmd->jumpInstr;
-        break;
-    default:
-        if (gAbilitiesInfo[ability].cantBeSuppressed)
-            gBattlescriptCurrInstr = cmd->jumpInstr;
-        else
-            gBattlescriptCurrInstr = cmd->nextInstr;
-        break;
-    }
+    else
+        gBattlescriptCurrInstr = cmd->nextInstr;
 }
 
 void BS_TryActivateAbilityShield(void)
@@ -13910,6 +13898,14 @@ void BS_SwitchinAbilities(void)
     enum BattlerId battler = GetBattlerForBattleScript(cmd->battler);
     u32 ability = GetBattlerAbility(battler);
     gBattlescriptCurrInstr = cmd->nextInstr;
+    switch (ability)
+    {
+    case ABILITY_IMPOSTER:
+    case ABILITY_NEUTRALIZING_GAS:
+    case ABILITY_AIR_LOCK:
+    case ABILITY_CLOUD_NINE:
+        return;
+    }
     AbilityBattleEffects(ABILITYEFFECT_TERA_SHIFT, battler, ability, MOVE_NONE, TRUE);
     AbilityBattleEffects(ABILITYEFFECT_NEUTRALIZINGGAS, battler, ability, MOVE_NONE, TRUE);
     AbilityBattleEffects(ABILITYEFFECT_UNNERVE, battler, ability, MOVE_NONE, TRUE);

--- a/test/battle/ability/cloud_nine.c
+++ b/test/battle/ability/cloud_nine.c
@@ -31,6 +31,19 @@ SINGLE_BATTLE_TEST("Cloud Nine/Air Lock prevent basic weather effects, but witho
     }
 }
 
+SINGLE_BATTLE_TEST("Cloud Nine does not reactivate if it is skill swapped")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_PSYDUCK) { Ability(ABILITY_CLOUD_NINE); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SKILL_SWAP); }
+    } SCENE {
+        ABILITY_POPUP(opponent, ABILITY_CLOUD_NINE);
+        NOT ABILITY_POPUP(player, ABILITY_CLOUD_NINE);
+    }
+}
+
 TO_DO_BATTLE_TEST("Cloud Nine/Air Lock prevent basic weather effects, but without them disappearing - Sun");
 TO_DO_BATTLE_TEST("Cloud Nine/Air Lock prevent basic weather effects, but without them disappearing - Rain");
 TO_DO_BATTLE_TEST("Cloud Nine/Air Lock prevent basic weather effects, but without them disappearing - Hail");

--- a/test/battle/ability/cloud_nine.c
+++ b/test/battle/ability/cloud_nine.c
@@ -31,7 +31,7 @@ SINGLE_BATTLE_TEST("Cloud Nine/Air Lock prevent basic weather effects, but witho
     }
 }
 
-SINGLE_BATTLE_TEST("Cloud Nine does not reactivate if it is skill swapped")
+SINGLE_BATTLE_TEST("Cloud Nine does not reactivate when obtained via Skill Swap")
 {
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);


### PR DESCRIPTION
Cloud Nine, Air Lock, Imposter and Neutralizing Gas don't reactive if it's not actually a switch in.