### PR TITLE
Corrected Stone Axe and Ceaseless Edge descriptions

### DIFF
--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -19328,8 +19328,8 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
     {
         .name = COMPOUND_STRING("Stone Axe"),
         .description = COMPOUND_STRING(
-            "Sets sharp rocks that\n"
-            "hurt the foe."),
+            "Sets sharp rocks that hurt\n"
+            "the foe."),
         .effect = EFFECT_STONE_AXE,
         .power = 65,
         .type = TYPE_ROCK,
@@ -19665,7 +19665,8 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
     {
         .name = COMPOUND_STRING("Ceaseless Edge"),
         .description = COMPOUND_STRING(
-            "Sets Spikes that hurt the foe."),
+            "Sets Spikes that hurt the\n"
+            "foe."),
         .effect = EFFECT_CEASELESS_EDGE,
         .power = 65,
         .type = TYPE_DARK,


### PR DESCRIPTION
## Description
Stone Axe and Ceaseless Edge's descriptions incorrectly stated that they have an increased critical hit ratio. They also mention splinters which were a Legends: Arceus-exclusive feature

## Discord contact info
Frankfurter0