### PR TITLE
Fix statement after label issue in chooseboxmon

### DIFF
--- a/src/chooseboxmon.c
+++ b/src/chooseboxmon.c
@@ -273,7 +273,7 @@ s32 LearnMove(const struct MoveLearnUI *ui, u8 taskId)
         ui->printMessage(gText_12PoofForgotMove);
         return REPLACE_MOVE_1;
     case REPLACE_MOVE_1:
-        ; // On some compilers, declaring a variable right after case is not allowed
+    {
         u32 slot = GetMoveSlotToReplace();
         RemoveBoxMonPPBonus(boxmon, slot);
         u32 pp = GetMovePP(move);
@@ -284,6 +284,7 @@ s32 LearnMove(const struct MoveLearnUI *ui, u8 taskId)
         gSpecialVar_Result = TRUE;
         ui->printMessage(gText_PkmnLearnedMove4);
         return LEARN_MOVE_END;
+    }
     case DID_NOT_LEARN_1:
         GetBoxMonNickname(boxmon, gStringVar1);
         StringCopy(gStringVar2, GetMoveName(move));


### PR DESCRIPTION
I'm not sure if it's the right way to do fix this, I think putting things in brackets would work too:
```c
case REPLACE_MOVE_1:
{
u32 slot = GetMoveSlotToReplace();
RemoveBoxMonPPBonus(boxmon, slot);
...
}
```
but I'm not familiar enough with C to know exactly what's up. Cle-bit confirmed this commit fixed the issue tho
I'm adding a 1.15.0 milestone to make sure we make a decision/fix this before major release

## Issue(s) that this PR fixes
Fixes #9089

## Discord contact info
Jamie
