### PR TITLE
Clear Selection Scripts to prevents consequent fails

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3020,7 +3020,8 @@ static void BattleStartClearSetData(void)
         gLastHitBy[i] = 0xFF;
         gLockedMoves[i] = MOVE_NONE;
         gLastPrintedMoves[i] = MOVE_NONE;
-        gPalaceSelectionBattleScripts[i] = 0;
+        gSelectionBattleScripts[i] = NULL;
+        gPalaceSelectionBattleScripts[i] = NULL;
         gBattleStruct->lastTakenMove[i] = MOVE_NONE;
         gBattleStruct->choicedMove[i] = MOVE_NONE;
         gBattleStruct->changedItems[i] = 0;


### PR DESCRIPTION
After #9018, if a test failed while in the selection script, all consequent tests on the same proc would fail since `gSelectionBattleScripts[battler] != NULL`.

## Discord contact info
PhallenTree
