### PR TITLE
fix id range for object events and multi decrements/increments

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -1866,7 +1866,7 @@ static void ParseObjectEventScript(const u8 *script)
     gPartnerTrainerId = 0;
 }
 
-static void Debug_Display_LocalTrainer(u32 objEventId, u32 digit, u8 windowId)
+static void Debug_Display_LocalTrainer(u32 localId, u32 digit, u8 windowId)
 {
     u32 trainerID = sDebugMenuListData->data[0];
     StringCopy(gStringVar2, gText_DigitIndicator[digit]);
@@ -1877,23 +1877,23 @@ static void Debug_Display_LocalTrainer(u32 objEventId, u32 digit, u8 windowId)
         end = StringCopy(gStringVar1, GetTrainerNameFromId(trainerID));
     WrapFontIdToFit(gStringVar1, end, DEBUG_MENU_FONT, WindowWidthPx(windowId));
     StringCopyPadded(gStringVar1, gStringVar1, CHAR_SPACE, 15);
-    ConvertIntToDecimalStringN(gStringVar3, objEventId, STR_CONV_MODE_LEADING_ZEROS, DEBUG_NUMBER_DIGITS_LOCALID);
-    StringExpandPlaceholders(gStringVar4, COMPOUND_STRING("Object ID: {STR_VAR_3}\n{STR_VAR_1}{CLEAR_TO 90}\n\n{STR_VAR_2}{CLEAR_TO 90}"));
+    ConvertIntToDecimalStringN(gStringVar3, localId, STR_CONV_MODE_LEADING_ZEROS, DEBUG_NUMBER_DIGITS_LOCALID);
+    StringExpandPlaceholders(gStringVar4, COMPOUND_STRING("Local ID: {STR_VAR_3}\n{STR_VAR_1}{CLEAR_TO 90}\n\n{STR_VAR_2}{CLEAR_TO 90}"));
     AddTextPrinterParameterized(windowId, DEBUG_MENU_FONT, gStringVar4, 0, 0, 0, NULL);
 }
 
-static void GetTrainerIdFromObjEventId(u32 objEventId)
+static void GetTrainerIdFromLocalId(u32 localId)
 {
     Debug_Trainers_ResetTrainersData();
-    ParseObjectEventScript(gMapHeader.events->objectEvents[objEventId].script);
+    ParseObjectEventScript(gMapHeader.events->objectEvents[localId - 1].script);
     if (GetTrainerBattleType(sDebugMenuListData->data[0]) == TRAINER_BATTLE_TYPE_DOUBLES)
         sDebugMenuListData->data[5] = TRUE;
 }
 
 #define TRAINER_TAG 0xFDF3
 #define tSpriteId   data[5]
-#define OBJ_EVENT_MIN 0
-#define OBJ_EVENT_MAX (gMapHeader.events->objectEventCount - 1)
+#define LOCAL_ID_MIN 1
+#define LOCAL_ID_MAX (gMapHeader.events->objectEventCount)
 
 static void DebugAction_ChooseFromMap_Select(u8 taskId)
 {
@@ -1903,9 +1903,9 @@ static void DebugAction_ChooseFromMap_Select(u8 taskId)
         u32 previousInput = gTasks[taskId].tInput;
 
         do {
-            Debug_HandleInput_Numeric(taskId, OBJ_EVENT_MIN, OBJ_EVENT_MAX, DEBUG_NUMBER_DIGITS_LOCALID);
-            GetTrainerIdFromObjEventId(gTasks[taskId].tInput);
-        } while (sDebugMenuListData->data[0] == TRAINER_NONE && gTasks[taskId].tInput != OBJ_EVENT_MIN && gTasks[taskId].tInput != OBJ_EVENT_MAX);
+            Debug_HandleInput_Numeric(taskId, LOCAL_ID_MIN, LOCAL_ID_MAX, DEBUG_NUMBER_DIGITS_LOCALID);
+            GetTrainerIdFromLocalId(gTasks[taskId].tInput);
+        } while (sDebugMenuListData->data[0] == TRAINER_NONE && gTasks[taskId].tInput != LOCAL_ID_MIN && gTasks[taskId].tInput != LOCAL_ID_MAX);
 
         if (sDebugMenuListData->data[0] == TRAINER_NONE)
         {
@@ -1916,14 +1916,14 @@ static void DebugAction_ChooseFromMap_Select(u8 taskId)
             while (gTasks[taskId].tInput != previousInput && sDebugMenuListData->data[0] == TRAINER_NONE)
             {
                 gTasks[taskId].tInput += sign;
-                GetTrainerIdFromObjEventId(gTasks[taskId].tInput);
+                GetTrainerIdFromLocalId(gTasks[taskId].tInput);
             }
         }
 
         FreeSpritePaletteByTag(TRAINER_TAG);
         DestroySprite(&gSprites[gTasks[taskId].tSpriteId]);
         Debug_Display_LocalTrainer(gTasks[taskId].tInput, gTasks[taskId].tDigit, gTasks[taskId].tSubWindowId);
-        u32 graphicsId = gMapHeader.events->objectEvents[gTasks[taskId].tInput].graphicsId;
+        u32 graphicsId = gMapHeader.events->objectEvents[gTasks[taskId].tInput - 1].graphicsId;
         gTasks[taskId].tSpriteId = CreateObjectGraphicsSprite(graphicsId, SpriteCallbackDummy, DEBUG_NUMBER_ICON_X, DEBUG_NUMBER_ICON_Y, 4);
         StartSpriteAnim(&gSprites[gTasks[taskId].tSpriteId], ANIM_STD_GO_SOUTH);
         gSprites[gTasks[taskId].tSpriteId].oam.priority = 0;
@@ -1963,17 +1963,17 @@ static void DebugAction_Trainers_ChooseFromMap(u8 taskId)
     CopyWindowToVram(windowId, COPYWIN_FULL);
 
     // Display initial object event
-    u32 objEventId = OBJ_EVENT_MIN;
-    GetTrainerIdFromObjEventId(objEventId);
-    Debug_Display_LocalTrainer(objEventId, 0, windowId);
+    u32 localId = LOCAL_ID_MIN;
+    GetTrainerIdFromLocalId(localId);
+    Debug_Display_LocalTrainer(localId, 0, windowId);
 
     //Set task data
     gTasks[taskId].func = DebugAction_ChooseFromMap_Select;
     gTasks[taskId].tSubWindowId = windowId;
-    gTasks[taskId].tInput = objEventId;
+    gTasks[taskId].tInput = localId;
     gTasks[taskId].tDigit = 0;
 
-    u32 graphicsId = gMapHeader.events->objectEvents[objEventId].graphicsId;
+    u32 graphicsId = gMapHeader.events->objectEvents[localId - 1].graphicsId;
     u32 spriteId = CreateObjectGraphicsSprite(graphicsId, SpriteCallbackDummy, DEBUG_NUMBER_ICON_X, DEBUG_NUMBER_ICON_Y, 4);
     StartSpriteAnim(&gSprites[spriteId], ANIM_STD_GO_SOUTH);
     gSprites[spriteId].oam.priority = 0;
@@ -1983,8 +1983,8 @@ static void DebugAction_Trainers_ChooseFromMap(u8 taskId)
 
 #undef TRAINER_TAG
 #undef tSpriteId
-#undef OBJ_EVENT_MIN
-#undef OBJ_EVENT_MAX
+#undef LOCAL_ID_MIN
+#undef LOCAL_ID_MAX
 
 #define tSelection  data[5]
 #define tInitial    data[6]


### PR DESCRIPTION
## Description
Fix 1: Interval of possible ids is currently [1, objectEventCount], while it should be [0, objectEventCount - 1] (same as in e.g. `SetDecoration`).
Fix 2: If max/min is not a trainer backwards search the closest. Example on Route 102, decrementing by 10 from ID 8 now finds ID 1.

## Discord contact info
.cawt
