### PR TITLE
`sPlayerAvatarGfxToStateFlag`'s graphics id to `u16`

### DIFF
--- a/src/field_player_avatar.c
+++ b/src/field_player_avatar.c
@@ -277,9 +277,9 @@ static const u8 sRSAvatarGfxIds[GENDER_COUNT] =
     [FEMALE] = OBJ_EVENT_GFX_LINK_RS_MAY
 };
 
-static const struct __attribute__((packed))
+static const struct PACKED
 {
-    u8 graphicsId;
+    u16 graphicsId;
     u8 playerFlag;
 } sPlayerAvatarGfxToStateFlag[GENDER_COUNT][5] =
 {


### PR DESCRIPTION
## Description
Sets `sPlayerAvatarGfxToStateFlag`'s `graphicsId` member to `u16`. This in order to fix a possible issue when adding new objects events as a playable character.

## Discord contact info
estellar.cheese
