### PR TITLE
NO_WHITEOUT now prevent forfeits from B_RUN_TRAINER_BATTLE 

### DIFF
--- a/src/battle_setup.c
+++ b/src/battle_setup.c
@@ -940,6 +940,7 @@ static bool32 IsPlayerDefeated(u32 battleOutcome)
     {
     case B_OUTCOME_LOST:
     case B_OUTCOME_DREW:
+    case B_OUTCOME_FORFEITED:
         return TRUE;
     case B_OUTCOME_WON:
     case B_OUTCOME_RAN:


### PR DESCRIPTION
## Description
Fixes #9104 by adding `B_PLAYER_FORFEITED` to the list of battle outcomes that trigger a "loss". WRitten by @wiz1989

## Media
[video](https://github.com/user-attachments/assets/6aca2b43-abd3-4356-a673-bee2438ed7ee)

## Issue(s) that this PR fixes
Fixes #9104

## Discord contact info
pkmnsnfrn