### PR TITLE
Fix Rare Candy reviving fainted level 100 Pokémon

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -3725,6 +3725,9 @@ bool8 PokemonUseItemEffects(struct Pokemon *mon, u16 item, u8 partyIndex, u8 mov
     u8 effectFlags;
     s8 evChange;
     u16 evCount;
+    u8 levelBefore;
+    bool8 didLevelUp = FALSE;
+    bool8 isLevelUpItem;
 
     // Determine the EV cap to use
     u32 maxAllowedEVs = !B_EV_ITEMS_CAP ? MAX_TOTAL_EVS : GetCurrentEVCap();
@@ -3746,6 +3749,8 @@ bool8 PokemonUseItemEffects(struct Pokemon *mon, u16 item, u8 partyIndex, u8 mov
 
     // Get item effect
     itemEffect = GetItemEffect(item);
+    isLevelUpItem = (itemEffect[3] & ITEM3_LEVEL_UP) != 0;
+    levelBefore = GetMonData(mon, MON_DATA_LEVEL, NULL);
 
     // Do item effect
     for (i = 0; i < ITEM_EFFECT_ARG_START; i++)
@@ -3800,6 +3805,8 @@ bool8 PokemonUseItemEffects(struct Pokemon *mon, u16 item, u8 partyIndex, u8 mov
                 {
                     SetMonData(mon, MON_DATA_EXP, &dataUnsigned);
                     CalculateMonStats(mon);
+                    if (GetMonData(mon, MON_DATA_LEVEL, NULL) > levelBefore)
+                        didLevelUp = TRUE;
                     retVal = FALSE;
                 }
             }
@@ -3918,6 +3925,11 @@ bool8 PokemonUseItemEffects(struct Pokemon *mon, u16 item, u8 partyIndex, u8 mov
                     {
                         u32 currentHP = GetMonData(mon, MON_DATA_HP, NULL);
                         u32 maxHP = GetMonData(mon, MON_DATA_MAX_HP, NULL);
+                        if (isLevelUpItem && !didLevelUp && (effectFlags & (ITEM4_REVIVE >> 2)))
+                        {
+                            itemEffectParam++;
+                            break;
+                        }
                         // Check use validity.
                         if ((effectFlags & (ITEM4_REVIVE >> 2) && currentHP != 0)
                               || (!(effectFlags & (ITEM4_REVIVE >> 2)) && currentHP == 0))


### PR DESCRIPTION
## Description

**[Rare Candy](https://bulbapedia.bulbagarden.net/wiki/Rare_Candy)**

> If used on a fainted Pokémon, it will be revived. When Rare Candy is used to **revive and level up** a Pokémon, it will have either 2 HP remaining or its remaining HP will equal to the amount its maximum HP increased (except Shedinja), which will always be revived with its maximum 1 HP prior to Generation VI).

Revive and leveling up must occur simultaneously (or is Revive accompanied by leveling up?)

> If a Rare Candy is used on a level 100 Pokémon that is able to evolve when leveling up(including those that evolve at a certain level, or with high friendship, or knowing a certain move, among other Evolution methods) and currently meets its Evolution requirements, this Pokémon will evolve without gaining a level; **fainted Pokémon will not be revived if evolved this way**.

## Media
**Before fixing**
![before fixing](https://github.com/user-attachments/assets/b333159c-2384-48ce-8c0a-a8b15c94ef3b)

**After fixing**
![after fix](https://github.com/user-attachments/assets/bad87b3d-4edd-4a23-be3f-03fd92c3783c)

## Issue(s) that this PR fixes
Fixes #9114 

## Feature(s) this PR does NOT handle:
Some old generation configs is missing
> Generation III onwards
> The Rare Candy also increases the Pokémon's [friendship](https://bulbapedia.bulbagarden.net/wiki/Friendship) a little.

> Generation VI onwards
> Using a Rare Candy on a fainted Shedinja no longer recovers it from fainting.
