### PR TITLE
Fix ShouldSkipAccuracyCalcPastFirstHit wrong return val

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1101,7 +1101,7 @@ static bool32 ShouldSkipAccuracyCalcPastFirstHit(enum BattlerId battlerAtk, enum
     if (moveEffect == EFFECT_TRIPLE_KICK || moveEffect == EFFECT_POPULATION_BOMB)
         return FALSE;
 
-    return TRUE;
+    return TRUE; // multiHitOn is set so skip Acc check for everything else
 }
 
 static bool32 ShouldBypassAccuracyCheckFrlg(void)


### PR DESCRIPTION
This should return TRUE. For comparison here is the old code 

```C
    if (gSpecialStatuses[gBattlerAttacker].parentalBondState == PARENTAL_BOND_2ND_HIT
        || (gSpecialStatuses[gBattlerAttacker].multiHitOn
        && (abilityAtk == ABILITY_SKILL_LINK || holdEffectAtk == HOLD_EFFECT_LOADED_DICE
        || !(effect == EFFECT_TRIPLE_KICK || effect == EFFECT_POPULATION_BOMB))))
```

When `gSpecialStatuses[gBattlerAttacker].multiHitOn` is active we skip the acc calc for everything unless it is Triple Kick/Population Bomb and user does not have Skill Link/Loaded Dice.
