### PR TITLE
feat: add gen 7 config for 1 hp B_HPBAR_COLOR_THRESHOLD interaction

### DIFF
--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -322,7 +322,7 @@
 #define B_ANIMATE_MON_AFTER_KO              TRUE // If set to TRUE, if a Pokémon on the opposite site faints, the non-fainted Pokemon will display a victory animation.
 #define B_ANIMATE_MON_AFTER_FAILED_POKEBALL TRUE  // If set to TRUE, if a Pokémon on the opposite side breaks out of a thrown Poké Ball, the wild Pokémon will display its animation.
 #define B_SHOW_DYNAMAX_MESSAGE              FALSE // If set to TRUE, an additional battle message is shown after completing Dynamaxing/Gigantamaxing.
-#define B_HPBAR_COLOR_THRESHOLD             GEN_LATEST // In Gen 5+, HP bar color thresholds were changed to be based on the actual HP values instead of the pixel length of the HP bar, leading to more accurate HP bar colors. If Gens earlier than 9 are picked, the HP bars of Pokémon with 1 Max HP (ie Shedinja) will turn red before depleting. If Gens 9 or later are picked, they will stay green while depleting.
+#define B_HPBAR_COLOR_THRESHOLD             GEN_LATEST // In Gen 5+, HP bar color thresholds were changed to be based on the actual HP values instead of the pixel length of the HP bar, leading to more accurate HP bar colors. If Gens earlier than 8 are picked, the HP bars of Pokémon with 1 Max HP (ie Shedinja) will turn red before depleting. If Gens 8 or later are picked, they will stay green while depleting.
 
 // Catching settings
 #define B_SEMI_INVULNERABLE_CATCH       GEN_LATEST // In Gen4+, you cannot throw a ball against a Pokemon that is in a semi-invulnerable state (dig/fly/etc)

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -322,7 +322,7 @@
 #define B_ANIMATE_MON_AFTER_KO              TRUE // If set to TRUE, if a Pokémon on the opposite site faints, the non-fainted Pokemon will display a victory animation.
 #define B_ANIMATE_MON_AFTER_FAILED_POKEBALL TRUE  // If set to TRUE, if a Pokémon on the opposite side breaks out of a thrown Poké Ball, the wild Pokémon will display its animation.
 #define B_SHOW_DYNAMAX_MESSAGE              FALSE // If set to TRUE, an additional battle message is shown after completing Dynamaxing/Gigantamaxing.
-#define B_HPBAR_COLOR_THRESHOLD             GEN_LATEST // In Gen 5+, HP bar color thresholds were changed to be based on the actual HP values instead of the pixel length of the HP bar, leading to more accurate HP bar colors.
+#define B_HPBAR_COLOR_THRESHOLD             GEN_LATEST // In Gen 5+, HP bar color thresholds were changed to be based on the actual HP values instead of the pixel length of the HP bar, leading to more accurate HP bar colors. If Gens earlier than 9 are picked, the HP bars of Pokémon with 1 Max HP (ie Shedinja) will turn red before depleting. If Gens 9 or later are picked, they will stay green while depleting.
 
 // Catching settings
 #define B_SEMI_INVULNERABLE_CATCH       GEN_LATEST // In Gen4+, you cannot throw a ball against a Pokemon that is in a semi-invulnerable state (dig/fly/etc)

--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -2117,14 +2117,16 @@ static void MoveBattleBarGraphically(enum BattlerId battler, u8 whichBar)
             break;
         default:
         case HP_BAR_RED:
-            if (maxValue > 1 || B_HPBAR_COLOR_THRESHOLD < GEN_9) // handling for wonder guard
+            if (maxValue > 1)
             {
                 barElementId = HEALTHBOX_GFX_HP_BAR_RED;
             }
-            else
+            else // handling for wonder guard
             {
                 if (B_HPBAR_COLOR_THRESHOLD >= GEN_9)
                     barElementId = HEALTHBOX_GFX_HP_BAR_GREEN;
+                else
+                    barElementId = HEALTHBOX_GFX_HP_BAR_RED;
             }
             break;
         }

--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -2123,7 +2123,7 @@ static void MoveBattleBarGraphically(enum BattlerId battler, u8 whichBar)
             }
             else // handling for mons with 1 max HP, ie Shedinja
             {
-                if (B_HPBAR_COLOR_THRESHOLD >= GEN_9)
+                if (B_HPBAR_COLOR_THRESHOLD >= GEN_8)
                     barElementId = HEALTHBOX_GFX_HP_BAR_GREEN;
                 else
                     barElementId = HEALTHBOX_GFX_HP_BAR_RED;

--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -2121,7 +2121,7 @@ static void MoveBattleBarGraphically(enum BattlerId battler, u8 whichBar)
             {
                 barElementId = HEALTHBOX_GFX_HP_BAR_RED;
             }
-            else // handling for wonder guard
+            else // handling for mons with 1 max HP, ie Shedinja
             {
                 if (B_HPBAR_COLOR_THRESHOLD >= GEN_9)
                     barElementId = HEALTHBOX_GFX_HP_BAR_GREEN;

--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -2118,16 +2118,11 @@ static void MoveBattleBarGraphically(enum BattlerId battler, u8 whichBar)
         default:
         case HP_BAR_RED:
             if (maxValue > 1)
-            {
                 barElementId = HEALTHBOX_GFX_HP_BAR_RED;
-            }
-            else // handling for mons with 1 max HP, ie Shedinja
-            {
-                if (B_HPBAR_COLOR_THRESHOLD >= GEN_8)
-                    barElementId = HEALTHBOX_GFX_HP_BAR_GREEN;
-                else
-                    barElementId = HEALTHBOX_GFX_HP_BAR_RED;
-            }
+            else if (B_HPBAR_COLOR_THRESHOLD >= GEN_8) // handling for mons with 1 max HP, ie Shedinja
+                barElementId = HEALTHBOX_GFX_HP_BAR_GREEN;
+            else
+                barElementId = HEALTHBOX_GFX_HP_BAR_RED;
             break;
         }
 

--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -2117,10 +2117,15 @@ static void MoveBattleBarGraphically(enum BattlerId battler, u8 whichBar)
             break;
         default:
         case HP_BAR_RED:
-            if (maxValue > 1) // handling for wonder guard
+            if (maxValue > 1 || B_HPBAR_COLOR_THRESHOLD < GEN_9) // handling for wonder guard
+            {
                 barElementId = HEALTHBOX_GFX_HP_BAR_RED;
+            }
             else
-                barElementId = HEALTHBOX_GFX_HP_BAR_GREEN;
+            {
+                if (B_HPBAR_COLOR_THRESHOLD >= GEN_9)
+                    barElementId = HEALTHBOX_GFX_HP_BAR_GREEN;
+            }
             break;
         }
 


### PR DESCRIPTION
## Description
adds gen 7 config for 1 hp B_HPBAR_COLOR_THRESHOLD interaction. in gen 7 we know when shedinja is damaged, the hp bar turns red and then depletes; in gen 9 it stays green. 

## Media
https://youtu.be/_pQ8kgHPMT0?t=495: shedinja damaged in (i think gen 7)
https://discord.com/channels/419213663107416084/774393519569502268/1468036246524919809: shedinja damaged in gen 9

## Discord contact info
khbsd
