### PR TITLE
Fix immunity ability status sync to avoid persisting Toxic counter when only volatile conditions are cured

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -9703,8 +9703,11 @@ u32 TryImmunityAbilityHealStatus(u32 battler, enum AbilityEffect caseID)
         }
 
         gBattleScripting.battler = gBattlerAbility = battler;
-        BtlController_EmitSetMonData(battler, B_COMM_TO_CONTROLLER, REQUEST_STATUS_BATTLE, 0, 4, &gBattleMons[battler].status1);
-        MarkBattlerForControllerExec(battler);
+        if (effect == 1) // Only primary status changes should sync party status.
+        {
+            BtlController_EmitSetMonData(battler, B_COMM_TO_CONTROLLER, REQUEST_STATUS_BATTLE, 0, 4, &gBattleMons[battler].status1);
+            MarkBattlerForControllerExec(battler);
+        }
         return effect;
     }
 

--- a/test/battle/ability/oblivious.c
+++ b/test/battle/ability/oblivious.c
@@ -99,3 +99,29 @@ SINGLE_BATTLE_TEST("Oblivious prevents Intimidate (Gen8+)")
         MESSAGE("Slowpoke's Oblivious prevents stat loss!");
     }
 }
+
+SINGLE_BATTLE_TEST("Oblivious cured infatuation should not persist toxic counter after switching")
+{
+    s16 firstTick, secondTick, postSwitchTick;
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_ATTRACT) == EFFECT_ATTRACT);
+        ASSUME(GetMoveEffect(MOVE_SKILL_SWAP) == EFFECT_SKILL_SWAP);
+        PLAYER(SPECIES_WOBBUFFET) { Gender(MON_MALE); Status1(STATUS1_TOXIC_POISON); MaxHP(160); HP(160); Speed(100); }
+        PLAYER(SPECIES_WYNAUT) { Speed(90); }
+        OPPONENT(SPECIES_SLOWPOKE) { Gender(MON_FEMALE); Ability(ABILITY_OBLIVIOUS); Speed(80); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_ATTRACT); }
+        TURN { MOVE(opponent, MOVE_SKILL_SWAP); }
+        TURN { SWITCH(player, 1); }
+        TURN { SWITCH(player, 0); }
+    } SCENE {
+        HP_BAR(player, captureDamage: &firstTick);
+        HP_BAR(player, captureDamage: &secondTick);
+        HP_BAR(player, captureDamage: &postSwitchTick);
+    } THEN {
+        EXPECT_EQ(firstTick, 10);
+        EXPECT_EQ(secondTick, 20);
+        EXPECT_EQ(postSwitchTick, 10);
+    }
+}

--- a/test/battle/ability/own_tempo.c
+++ b/test/battle/ability/own_tempo.c
@@ -143,3 +143,29 @@ SINGLE_BATTLE_TEST("Own Tempo prevents confusion from items")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
     }
 }
+
+SINGLE_BATTLE_TEST("Own Tempo cured confusion should not persist toxic counter after switching")
+{
+    s16 firstTick, secondTick, postSwitchTick;
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_CONFUSE_RAY) == EFFECT_CONFUSE);
+        ASSUME(GetMoveEffect(MOVE_SKILL_SWAP) == EFFECT_SKILL_SWAP);
+        PLAYER(SPECIES_WOBBUFFET) { Status1(STATUS1_TOXIC_POISON); MaxHP(160); HP(160); Speed(100); }
+        PLAYER(SPECIES_WYNAUT) { Speed(90); }
+        OPPONENT(SPECIES_SLOWPOKE) { Ability(ABILITY_OWN_TEMPO); Speed(80); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_CONFUSE_RAY); }
+        TURN { MOVE(opponent, MOVE_SKILL_SWAP); MOVE(player, MOVE_CELEBRATE, WITH_RNG(RNG_CONFUSION, FALSE)); }
+        TURN { SWITCH(player, 1); }
+        TURN { SWITCH(player, 0); }
+    } SCENE {
+        HP_BAR(player, captureDamage: &firstTick);
+        HP_BAR(player, captureDamage: &secondTick);
+        HP_BAR(player, captureDamage: &postSwitchTick);
+    } THEN {
+        EXPECT_EQ(firstTick, 10);
+        EXPECT_EQ(secondTick, 20);
+        EXPECT_EQ(postSwitchTick, 10);
+    }
+}


### PR DESCRIPTION
## Description
Restrict `REQUEST_STATUS_BATTLE` syncing in `TryImmunityAbilityHealStatus` to primary status cures only, preventing Own Tempo/Oblivious volatile cures from writing Toxic counter back to party data.

## Issue(s) that this PR fixes
Fixes #9149 
