### PR TITLE
fix(fanclub): use sText instead of non-existent gText

### DIFF
--- a/src/trainer_fan_club.c
+++ b/src/trainer_fan_club.c
@@ -348,10 +348,10 @@ static void BufferFanClubTrainerName(u8 whichLinkTrainer, u8 whichNPCTrainer)
         break;
 #endif
     case 1:
-        StringCopy(gStringVar1, gText_LtSurge);
+        StringCopy(gStringVar1, sText_LtSurge);
         break;
     case 2:
-        StringCopy(gStringVar1, gText_Koga);
+        StringCopy(gStringVar1, sText_Koga);
         break;
     }
 }


### PR DESCRIPTION
For gText_LtSurge and gText_Koga

<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
Use the right variable name. Code gets compiled only when FREE_LINK_BATTLE is true.


## Discord contact info
kildemal
