### PR TITLE
Fix moves causing errors in Multiplayer due to recoil check in Battle TV

### DIFF
--- a/src/battle_tv.c
+++ b/src/battle_tv.c
@@ -823,6 +823,10 @@ static void AddMovePoints(u8 caseId, u16 arg1, u8 arg2, u8 arg3)
             if (GetMoveReflectDamage_DamageCategories(move) == 1u << DAMAGE_CATEGORY_SPECIAL) // Mirror Coat
                 baseFromEffect++;
             break;
+        case EFFECT_RECOIL:
+            if (GetMoveRecoil(move) > 0)
+                baseFromEffect++;
+            break;
         default:
             break;
         }
@@ -849,9 +853,6 @@ static void AddMovePoints(u8 caseId, u16 arg1, u8 arg2, u8 arg3)
 
         // Guaranteed hit but without negative priority
         if (GetMoveAccuracy(move) == 0 && GetMovePriority(move) >= 0)
-            baseFromEffect++;
-        // User recoil damage
-        if (GetMoveRecoil(move) > 0)
             baseFromEffect++;
         // // Explosion moves get 0 points in vanilla, so we deduct here from EFFECT_HIT's score of 1
         if (IsExplosionMove(move) && baseFromEffect > 0)


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
Battle TV was checking for recoil in a way that was triggering `assertf`.

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara