### PR TITLE
Fix Cheek Pouch to trigger only on actual berry consumption not historical ateBerry

### DIFF
--- a/asm/macros/battle_script.inc
+++ b/asm/macros/battle_script.inc
@@ -625,9 +625,10 @@
 	.4byte \failInstr
 	.endm
 
-	.macro removeitem battler:req
+	.macro removeitem battler:req, consumedBerry=FALSE
 	.byte 0x6a
 	.byte \battler
+	.byte \consumedBerry
 	.endm
 
 	.macro atknameinbuff1

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -506,7 +506,7 @@ BattleScript_TeatimeLoop:
 	setbyte sBERRY_OVERRIDE, TRUE   @ override the requirements for eating berries
 	consumeberry BS_TARGET, TRUE  @ consume the berry, then restore the item from changedItems
 	setbyte sBERRY_OVERRIDE, FALSE
-	removeitem BS_TARGET
+	removeitem BS_TARGET, TRUE
 	moveendto MOVEEND_NEXT_TARGET
 	jumpifnexttargetvalid BattleScript_TeatimeLoop
 	moveendcase MOVEEND_CLEAR_BITS
@@ -857,7 +857,7 @@ BattleScript_EffectStuffCheeks::
 	consumeberry BS_ATTACKER, TRUE
 	bicword gHitMarker, HITMARKER_DISABLE_ANIMATION
 	setbyte sBERRY_OVERRIDE, 0
-	removeitem BS_ATTACKER
+	removeitem BS_ATTACKER, TRUE
 	setstatchanger STAT_DEF, 2, FALSE
 	statbuffchange BS_ATTACKER, STAT_CHANGE_ALLOW_PTR, BattleScript_StuffCheeksEnd
 	printfromtable gStatUpStringIds
@@ -7651,7 +7651,7 @@ BattleScript_BerryCureStatusRet::
 	printfromtable CureStatusBerryEffectStringID
 	waitmessage B_WAIT_TIME_LONG
 	updatestatusicon BS_SCRIPTING
-	removeitem BS_SCRIPTING
+	removeitem BS_SCRIPTING, TRUE
 	return
 
 BattleScript_GemActivates::
@@ -7669,7 +7669,7 @@ BattleScript_BerryReduceDmg::
 	setlastuseditem BS_SCRIPTING
 	printstring STRINGID_BERRYDMGREDUCES
 	waitmessage B_WAIT_TIME_LONG
-	removeitem BS_SCRIPTING
+	removeitem BS_SCRIPTING, TRUE
 	return
 
 BattleScript_BerryCureConfusionEnd2::
@@ -7680,7 +7680,7 @@ BattleScript_BerryCureConfusionRet::
 	playanimation BS_SCRIPTING, B_ANIM_HELD_ITEM_EFFECT
 	printstring STRINGID_PKMNSITEMSNAPPEDOUT
 	waitmessage B_WAIT_TIME_LONG
-	removeitem BS_SCRIPTING
+	removeitem BS_SCRIPTING, TRUE
 	return
 
 BattleScript_MentalHerbCureRet::
@@ -7717,7 +7717,7 @@ BattleScript_ItemHealHP_RemoveItemRet_Anim:
 	waitmessage B_WAIT_TIME_LONG
 	healthbarupdate BS_SCRIPTING, PASSIVE_HP_UPDATE
 	datahpupdate BS_SCRIPTING, PASSIVE_HP_UPDATE
-	removeitem BS_SCRIPTING
+	removeitem BS_SCRIPTING, TRUE
 	return
 
 BattleScript_ItemHealHP_RemoveItemEnd2::
@@ -7731,7 +7731,7 @@ BattleScript_ItemHealHP_RemoveItemEnd2_Anim:
 	waitmessage B_WAIT_TIME_LONG
 	healthbarupdate BS_ATTACKER, PASSIVE_HP_UPDATE
 	datahpupdate BS_ATTACKER, PASSIVE_HP_UPDATE
-	removeitem BS_ATTACKER
+	removeitem BS_ATTACKER, TRUE
 	end2
 
 BattleScript_BerryPPHealRet::
@@ -7743,7 +7743,7 @@ BattleScript_BerryPPHeal_Anim:
 	playanimation BS_SCRIPTING, B_ANIM_HELD_ITEM_EFFECT
 	printstring STRINGID_PKMNSITEMRESTOREDPP
 	waitmessage B_WAIT_TIME_LONG
-	removeitem BS_SCRIPTING
+	removeitem BS_SCRIPTING, TRUE
 	return
 
 BattleScript_BerryPPHealEnd2::
@@ -7845,7 +7845,7 @@ BattleScript_BerryConfuseHealEnd2_Anim:
 	healthbarupdate BS_SCRIPTING, PASSIVE_HP_UPDATE
 	datahpupdate BS_SCRIPTING, PASSIVE_HP_UPDATE
 	seteffectprimary BS_SCRIPTING, BS_SCRIPTING, MOVE_EFFECT_CONFUSION
-	removeitem BS_SCRIPTING
+	removeitem BS_SCRIPTING, TRUE
 	end2
 
 BattleScript_BerryConfuseHealRet::
@@ -7860,7 +7860,7 @@ BattleScript_BerryConfuseHealRet_Anim:
 	healthbarupdate BS_SCRIPTING, PASSIVE_HP_UPDATE
 	datahpupdate BS_SCRIPTING, PASSIVE_HP_UPDATE
 	seteffectprimary BS_SCRIPTING, BS_SCRIPTING, MOVE_EFFECT_CONFUSION
-	removeitem BS_SCRIPTING
+	removeitem BS_SCRIPTING, TRUE
 	return
 
 BattleScript_ConsumableStatRaiseEnd2::
@@ -7882,7 +7882,7 @@ BattleScript_ConsumableStatRaiseRet_Anim:
 	copybyte gBattlerTarget, sBATTLER @ BattleScript_StatUp uses target as a message arg
 	call BattleScript_StatUp
 	restoretarget
-	removeitem BS_SCRIPTING
+	removeitem BS_SCRIPTING, TRUE
 BattleScript_ConsumableStatRaiseRet_End:
 	return
 
@@ -7890,7 +7890,7 @@ BattleScript_BerryFocusEnergyRet::
 	playanimation BS_SCRIPTING, B_ANIM_HELD_ITEM_EFFECT
 	printstring STRINGID_PKMNUSEDXTOGETPUMPED
 	waitmessage B_WAIT_TIME_LONG
-	removeitem BS_SCRIPTING
+	removeitem BS_SCRIPTING, TRUE
 	return
 
 BattleScript_BerryFocusEnergyEnd2::
@@ -8148,7 +8148,7 @@ BattleScript_CustapBerryActivation::
 	waitanimation
 	printstring STRINGID_CANACTFASTERTHANKSTO
 	waitmessage B_WAIT_TIME_LONG
-	removeitem BS_ATTACKER
+	removeitem BS_ATTACKER, TRUE
 	end2
 
 BattleScript_MicleBerryActivateEnd2::
@@ -8160,7 +8160,7 @@ BattleScript_MicleBerryActivateEnd2_Anim:
 	playanimation BS_ATTACKER, B_ANIM_HELD_ITEM_EFFECT
 	printstring STRINGID_MICLEBERRYACTIVATES
 	waitmessage B_WAIT_TIME_LONG
-	removeitem BS_ATTACKER
+	removeitem BS_ATTACKER, TRUE
 	end2
 
 BattleScript_MicleBerryActivateRet::
@@ -8172,7 +8172,7 @@ BattleScript_MicleBerryActivateRet_Anim:
 	playanimation BS_SCRIPTING, B_ANIM_HELD_ITEM_EFFECT
 	printstring STRINGID_MICLEBERRYACTIVATES
 	waitmessage B_WAIT_TIME_LONG
-	removeitem BS_SCRIPTING
+	removeitem BS_SCRIPTING, TRUE
 	return
 
 BattleScript_JabocaRowapBerryActivates::
@@ -8186,7 +8186,7 @@ BattleScript_JabocaRowapBerryActivate_Anim:
 	waitanimation
 BattleScript_JabocaRowapBerryActivate_Dmg:
 	call BattleScript_HurtAttacker
-	removeitem BS_TARGET
+	removeitem BS_TARGET, TRUE
 	return
 
 @ z moves / effects

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -7717,7 +7717,11 @@ BattleScript_ItemHealHP_RemoveItemRet_Anim:
 	waitmessage B_WAIT_TIME_LONG
 	healthbarupdate BS_SCRIPTING, PASSIVE_HP_UPDATE
 	datahpupdate BS_SCRIPTING, PASSIVE_HP_UPDATE
+	jumpifnotberry BS_SCRIPTING, BattleScript_ItemHealHP_RemoveItemRet_RemoveNonBerry
 	removeitem BS_SCRIPTING, TRUE
+	return
+BattleScript_ItemHealHP_RemoveItemRet_RemoveNonBerry:
+	removeitem BS_SCRIPTING
 	return
 
 BattleScript_ItemHealHP_RemoveItemEnd2::
@@ -7731,7 +7735,11 @@ BattleScript_ItemHealHP_RemoveItemEnd2_Anim:
 	waitmessage B_WAIT_TIME_LONG
 	healthbarupdate BS_ATTACKER, PASSIVE_HP_UPDATE
 	datahpupdate BS_ATTACKER, PASSIVE_HP_UPDATE
+	jumpifnotberry BS_ATTACKER, BattleScript_ItemHealHP_RemoveItemEnd2_RemoveNonBerry
 	removeitem BS_ATTACKER, TRUE
+	end2
+BattleScript_ItemHealHP_RemoveItemEnd2_RemoveNonBerry:
+	removeitem BS_ATTACKER
 	end2
 
 BattleScript_BerryPPHealRet::
@@ -7882,7 +7890,11 @@ BattleScript_ConsumableStatRaiseRet_Anim:
 	copybyte gBattlerTarget, sBATTLER @ BattleScript_StatUp uses target as a message arg
 	call BattleScript_StatUp
 	restoretarget
+	jumpifnotberry BS_SCRIPTING, BattleScript_ConsumableStatRaiseRet_RemoveNonBerry
 	removeitem BS_SCRIPTING, TRUE
+	return
+BattleScript_ConsumableStatRaiseRet_RemoveNonBerry:
+	removeitem BS_SCRIPTING
 BattleScript_ConsumableStatRaiseRet_End:
 	return
 

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -354,7 +354,7 @@ static u32 GetNextTarget(u32 moveTarget, bool32 excludeCurrent);
 static void TryUpdateEvolutionTracker(u32 evolutionCondition, u32 upAmount, u16 usedMove);
 static void AccuracyCheck(bool32 recalcDragonDarts, const u8 *nextInstr, const u8 *failInstr, u16 move);
 static void ResetValuesForCalledMove(void);
-static bool32 TrySymbiosis(u32 battler, u32 itemId, bool32 moveEnd);
+static bool32 TrySymbiosis(u32 battler, u32 itemId, bool32 moveEnd, const u8 *nextInstr);
 static bool32 CanAbilityShieldActivateForBattler(u32 battler);
 static void TryClearChargeVolatile(u32 moveType);
 static bool32 IsAnyTargetAffected(void);
@@ -7114,7 +7114,7 @@ static void Cmd_moveend(void)
                     MarkBattlerForControllerExec(gBattlerAttacker);
                     ClearBattlerItemEffectHistory(gBattlerAttacker);
 
-                    if (!TrySymbiosis(gBattlerAttacker, item, TRUE))
+                    if (!TrySymbiosis(gBattlerAttacker, item, TRUE, NULL))
                         effect = TRUE;
                 }
             default:
@@ -8855,7 +8855,6 @@ static bool32 TryCheekPouch(u32 battler, u32 itemId, const u8 *nextInstr)
     if (GetItemPocket(itemId) == POCKET_BERRIES
         && GetBattlerAbility(battler) == ABILITY_CHEEK_POUCH
         && !gBattleMons[battler].volatiles.healBlock
-        && GetBattlerPartyState(battler)->ateBerry
         && !IsBattlerAtMaxHp(battler))
     {
         gBattlerAbility = battler;
@@ -8884,7 +8883,7 @@ static void BestowItem(u32 battlerAtk, u32 battlerDef)
 }
 
 // Called by Cmd_removeitem. itemId represents the item that was removed, not being given.
-static bool32 TrySymbiosis(u32 battler, u32 itemId, bool32 moveEnd)
+static bool32 TrySymbiosis(u32 battler, u32 itemId, bool32 moveEnd, const u8 *nextInstr)
 {
     if (!gBattleStruct->itemLost[B_SIDE_PLAYER][gBattlerPartyIndexes[battler]].stolen
         && gBattleStruct->changedItems[battler] == ITEM_NONE
@@ -8902,7 +8901,7 @@ static bool32 TrySymbiosis(u32 battler, u32 itemId, bool32 moveEnd)
         if (moveEnd)
             BattleScriptPushCursor();
         else
-            BattleScriptPush(gBattlescriptCurrInstr + 2);
+            BattleScriptPush(nextInstr);
         gBattlescriptCurrInstr = BattleScript_SymbiosisActivates;
         return TRUE;
     }
@@ -8911,7 +8910,7 @@ static bool32 TrySymbiosis(u32 battler, u32 itemId, bool32 moveEnd)
 
 static void Cmd_removeitem(void)
 {
-    CMD_ARGS(u8 battler);
+    CMD_ARGS(u8 battler, bool8 consumedBerry);
 
     u32 battler;
     u16 itemId = 0;
@@ -8940,7 +8939,8 @@ static void Cmd_removeitem(void)
     MarkBattlerForControllerExec(battler);
 
     ClearBattlerItemEffectHistory(battler);
-    if (!TryCheekPouch(battler, itemId, cmd->nextInstr) && !TrySymbiosis(battler, itemId, FALSE))
+    if ((!cmd->consumedBerry || !TryCheekPouch(battler, itemId, cmd->nextInstr))
+        && !TrySymbiosis(battler, itemId, FALSE, cmd->nextInstr))
         gBattlescriptCurrInstr = cmd->nextInstr;
 }
 

--- a/test/battle/ability/cheek_pouch.c
+++ b/test/battle/ability/cheek_pouch.c
@@ -1,14 +1,18 @@
 #include "global.h"
 #include "test/battle.h"
 
+ASSUMPTIONS
+{
+    ASSUME(gItemsInfo[ITEM_ORAN_BERRY].holdEffect == HOLD_EFFECT_RESTORE_HP);
+    ASSUME(gItemsInfo[ITEM_ORAN_BERRY].holdEffectParam == 10);
+    ASSUME(GetMoveEffect(MOVE_SUPER_FANG) == EFFECT_FIXED_PERCENT_DAMAGE);
+}
+
 SINGLE_BATTLE_TEST("Cheek Pouch restores 33% max HP")
 {
     s16 berryHeal, cheekPouchHeal;
 
     GIVEN {
-        ASSUME(GetMoveEffect(MOVE_SUPER_FANG) == EFFECT_FIXED_PERCENT_DAMAGE);
-        ASSUME(gItemsInfo[ITEM_ORAN_BERRY].holdEffect == HOLD_EFFECT_RESTORE_HP);
-        ASSUME(gItemsInfo[ITEM_ORAN_BERRY].holdEffectParam == 10);
         PLAYER(SPECIES_GREEDENT) { Ability(ABILITY_CHEEK_POUCH); MaxHP(60); HP(31); Item(ITEM_ORAN_BERRY); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
@@ -31,9 +35,6 @@ SINGLE_BATTLE_TEST("Cheek Pouch restores HP after the berry's effect")
     u16 hpAfterBerry, hpAfterCheekPouch;
 
     GIVEN {
-        ASSUME(GetMoveEffect(MOVE_SUPER_FANG) == EFFECT_FIXED_PERCENT_DAMAGE);
-        ASSUME(gItemsInfo[ITEM_ORAN_BERRY].holdEffect == HOLD_EFFECT_RESTORE_HP);
-        ASSUME(gItemsInfo[ITEM_ORAN_BERRY].holdEffectParam == 10);
         PLAYER(SPECIES_GREEDENT) { Ability(ABILITY_CHEEK_POUCH); MaxHP(60); HP(31); Item(ITEM_ORAN_BERRY); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
@@ -60,8 +61,6 @@ SINGLE_BATTLE_TEST("Cheek Pouch activates via Bug Bite/Pluck if it would trigger
 
     GIVEN {
         ASSUME(MoveHasAdditionalEffect(move, MOVE_EFFECT_BUG_BITE));
-        ASSUME(gItemsInfo[ITEM_ORAN_BERRY].holdEffect == HOLD_EFFECT_RESTORE_HP);
-        ASSUME(gItemsInfo[ITEM_ORAN_BERRY].holdEffectParam == 10);
         PLAYER(SPECIES_GREEDENT) { Ability(ABILITY_CHEEK_POUCH); MaxHP(60); HP(30); }
         OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_ORAN_BERRY); }
     } WHEN {
@@ -85,8 +84,6 @@ SINGLE_BATTLE_TEST("Cheek Pouch activates when receiving from Fling if it would 
 
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_FLING) == EFFECT_FLING);
-        ASSUME(gItemsInfo[ITEM_ORAN_BERRY].holdEffect == HOLD_EFFECT_RESTORE_HP);
-        ASSUME(gItemsInfo[ITEM_ORAN_BERRY].holdEffectParam == 10);
         PLAYER(SPECIES_WOBBUFFET) { Attack(1); Item(ITEM_ORAN_BERRY); }
         OPPONENT(SPECIES_GREEDENT) { Ability(ABILITY_CHEEK_POUCH); MaxHP(60); HP(30); }
     } WHEN {
@@ -137,8 +134,6 @@ SINGLE_BATTLE_TEST("Cheek Pouch doesn't activate when user uses Fling")
 SINGLE_BATTLE_TEST("Cheek Pouch doesn't activate when using a berry from the bag")
 {
     GIVEN {
-        ASSUME(gItemsInfo[ITEM_ORAN_BERRY].holdEffect == HOLD_EFFECT_RESTORE_HP);
-        ASSUME(gItemsInfo[ITEM_ORAN_BERRY].holdEffectParam == 10);
         PLAYER(SPECIES_GREEDENT) { Ability(ABILITY_CHEEK_POUCH); MaxHP(60); HP(20); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
@@ -152,9 +147,6 @@ SINGLE_BATTLE_TEST("Cheek Pouch doesn't activate under Heal Block's effect")
 {
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_HEAL_BLOCK) == EFFECT_HEAL_BLOCK);
-        ASSUME(GetMoveEffect(MOVE_SUPER_FANG) == EFFECT_FIXED_PERCENT_DAMAGE);
-        ASSUME(gItemsInfo[ITEM_ORAN_BERRY].holdEffect == HOLD_EFFECT_RESTORE_HP);
-        ASSUME(gItemsInfo[ITEM_ORAN_BERRY].holdEffectParam == 10);
         PLAYER(SPECIES_GREEDENT) { Ability(ABILITY_CHEEK_POUCH); MaxHP(60); HP(31); Item(ITEM_ORAN_BERRY); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
@@ -173,11 +165,8 @@ SINGLE_BATTLE_TEST("Cheek Pouch doesn't activate under Heal Block's effect")
 SINGLE_BATTLE_TEST("Cheek Pouch doesn't activate on Corrosive Gas after previously eating a berry")
 {
     GIVEN {
-        ASSUME(GetMoveEffect(MOVE_SUPER_FANG) == EFFECT_FIXED_PERCENT_DAMAGE);
         ASSUME(GetMoveEffect(MOVE_CORROSIVE_GAS) == EFFECT_CORROSIVE_GAS);
         ASSUME(GetMoveEffect(MOVE_RECYCLE) == EFFECT_RECYCLE);
-        ASSUME(gItemsInfo[ITEM_ORAN_BERRY].holdEffect == HOLD_EFFECT_RESTORE_HP);
-        ASSUME(gItemsInfo[ITEM_ORAN_BERRY].holdEffectParam == 10);
         PLAYER(SPECIES_GREEDENT) { Ability(ABILITY_CHEEK_POUCH); MaxHP(60); HP(31); Item(ITEM_ORAN_BERRY); Speed(5); }
         OPPONENT(SPECIES_WOBBUFFET) { Speed(10); }
     } WHEN {
@@ -199,11 +188,8 @@ SINGLE_BATTLE_TEST("Cheek Pouch doesn't activate on Corrosive Gas after previous
 SINGLE_BATTLE_TEST("Cheek Pouch doesn't activate when user flings a berry restored by Recycle")
 {
     GIVEN {
-        ASSUME(GetMoveEffect(MOVE_SUPER_FANG) == EFFECT_FIXED_PERCENT_DAMAGE);
         ASSUME(GetMoveEffect(MOVE_FLING) == EFFECT_FLING);
         ASSUME(GetMoveEffect(MOVE_RECYCLE) == EFFECT_RECYCLE);
-        ASSUME(gItemsInfo[ITEM_ORAN_BERRY].holdEffect == HOLD_EFFECT_RESTORE_HP);
-        ASSUME(gItemsInfo[ITEM_ORAN_BERRY].holdEffectParam == 10);
         PLAYER(SPECIES_GREEDENT) { Ability(ABILITY_CHEEK_POUCH); MaxHP(60); HP(31); Item(ITEM_ORAN_BERRY); Speed(10); }
         OPPONENT(SPECIES_WOBBUFFET) { Speed(5); }
     } WHEN {
@@ -227,6 +213,9 @@ SINGLE_BATTLE_TEST("Cheek Pouch activation doesn't mutate damage when restoring 
     s16 damage, healing;
 
     GIVEN {
+        ASSUME(GetMoveType(MOVE_KARATE_CHOP) == TYPE_FIGHTING);
+        ASSUME(GetItemHoldEffect(ITEM_CHOPLE_BERRY) == HOLD_EFFECT_RESIST_BERRY);
+        ASSUME(GetItemHoldEffectParam(ITEM_CHOPLE_BERRY) == TYPE_FIGHTING);
         PLAYER(SPECIES_GREEDENT) { Ability(ABILITY_CHEEK_POUCH); Item(ITEM_CHOPLE_BERRY); HP(100); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {

--- a/test/battle/ability/cheek_pouch.c
+++ b/test/battle/ability/cheek_pouch.c
@@ -170,6 +170,58 @@ SINGLE_BATTLE_TEST("Cheek Pouch doesn't activate under Heal Block's effect")
     }
 }
 
+SINGLE_BATTLE_TEST("Cheek Pouch doesn't activate on Corrosive Gas after previously eating a berry")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_SUPER_FANG) == EFFECT_FIXED_PERCENT_DAMAGE);
+        ASSUME(GetMoveEffect(MOVE_CORROSIVE_GAS) == EFFECT_CORROSIVE_GAS);
+        ASSUME(GetMoveEffect(MOVE_RECYCLE) == EFFECT_RECYCLE);
+        ASSUME(gItemsInfo[ITEM_ORAN_BERRY].holdEffect == HOLD_EFFECT_RESTORE_HP);
+        ASSUME(gItemsInfo[ITEM_ORAN_BERRY].holdEffectParam == 10);
+        PLAYER(SPECIES_GREEDENT) { Ability(ABILITY_CHEEK_POUCH); MaxHP(60); HP(31); Item(ITEM_ORAN_BERRY); Speed(5); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(10); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SUPER_FANG); }
+        TURN { MOVE(player, MOVE_RECYCLE); }
+        TURN { MOVE(opponent, MOVE_CORROSIVE_GAS); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SUPER_FANG, opponent);
+        ABILITY_POPUP(player, ABILITY_CHEEK_POUCH);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_RECYCLE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CORROSIVE_GAS, opponent);
+        NOT ABILITY_POPUP(player, ABILITY_CHEEK_POUCH);
+    } THEN {
+        EXPECT_EQ(player->hp, 46);
+        EXPECT_EQ(player->item, ITEM_NONE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Cheek Pouch doesn't activate when user flings a berry restored by Recycle")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_SUPER_FANG) == EFFECT_FIXED_PERCENT_DAMAGE);
+        ASSUME(GetMoveEffect(MOVE_FLING) == EFFECT_FLING);
+        ASSUME(GetMoveEffect(MOVE_RECYCLE) == EFFECT_RECYCLE);
+        ASSUME(gItemsInfo[ITEM_ORAN_BERRY].holdEffect == HOLD_EFFECT_RESTORE_HP);
+        ASSUME(gItemsInfo[ITEM_ORAN_BERRY].holdEffectParam == 10);
+        PLAYER(SPECIES_GREEDENT) { Ability(ABILITY_CHEEK_POUCH); MaxHP(60); HP(31); Item(ITEM_ORAN_BERRY); Speed(10); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(5); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SUPER_FANG); }
+        TURN { MOVE(player, MOVE_RECYCLE); }
+        TURN { MOVE(player, MOVE_FLING); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SUPER_FANG, opponent);
+        ABILITY_POPUP(player, ABILITY_CHEEK_POUCH);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_RECYCLE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FLING, player);
+        NOT ABILITY_POPUP(player, ABILITY_CHEEK_POUCH);
+    } THEN {
+        EXPECT_EQ(player->hp, 46);
+        EXPECT_EQ(player->item, ITEM_NONE);
+    }
+}
+
 SINGLE_BATTLE_TEST("Cheek Pouch activation doesn't mutate damage when restoring HP mid battle")
 {
     s16 damage, healing;


### PR DESCRIPTION
## Description
Fixed Cheek Pouch activation to depend on whether the current `removeitem` path actually consumed a berry (instead of persistent `ateBerry` state), though I’m not sure this is the best possible solution.

## Issue(s) that this PR fixes
Fixes #7624 