### PR TITLE
Fix accuracy bypass

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1097,7 +1097,7 @@ static bool32 ShouldSkipAccuracyCalcPastFirstHit(enum BattlerId battlerAtk, enum
 
 	if (abilityAtk == ABILITY_SKILL_LINK || holdEffectAtk == HOLD_EFFECT_LOADED_DICE)
         return TRUE;
-	
+
     if (moveEffect == EFFECT_TRIPLE_KICK || moveEffect == EFFECT_POPULATION_BOMB)
         return FALSE;
 
@@ -1117,7 +1117,7 @@ static bool32 ShouldBypassAccuracyCheckFrlg(void)
         return TRUE;
     }
 
-    if (gBattleTypeFlags & BATTLE_TYPE_POKEDUDE);
+    if (gBattleTypeFlags & BATTLE_TYPE_POKEDUDE)
         return TRUE;
 
     return FALSE;


### PR DESCRIPTION
## Description
Always returns `TRUE` for FRLG.

## Discord contact info
.cawt