### PR TITLE
Remove unnecessary EWRAM allocation for cable car animation

### DIFF
--- a/src/cable_car.c
+++ b/src/cable_car.c
@@ -69,12 +69,6 @@ struct CableCar
 };
 
 static EWRAM_DATA struct CableCar *sCableCar = NULL;
-static EWRAM_DATA u8 sGroundX_Up = 0;
-static EWRAM_DATA u8 sGroundY_Up = 0;
-static EWRAM_DATA u8 sGroundSegmentY_Up = 0;
-static EWRAM_DATA u8 sGroundX_Down = 0;
-static EWRAM_DATA u8 sGroundY_Down = 0;
-static EWRAM_DATA u8 sGroundSegmentY_Down = 0;
 
 static void CB2_LoadCableCar(void);
 static void SetBgRegs(bool8);
@@ -965,61 +959,67 @@ static void AnimateGroundGoingDown(void)
 static void DrawNextGroundSegmentGoingUp(void)
 {
     u8 i = 0;
+    u8 groundX_Up = 0;
+    u8 groundY_Up = 0;
+    u8 groundSegmentY_Up = 0;
 
     sCableCar->groundXOffset = sCableCar->groundYOffset = 0;
     sCableCar->groundXBase = sCableCar->bg0HorizontalOffset;
     sCableCar->groundYBase = sCableCar->bg0VerticalOffset;
     sCableCar->groundSegmentXStart = (sCableCar->groundSegmentXStart + 30) % 32;
     sCableCar->groundTileIdx -= 2;
-    sGroundSegmentY_Up = (sCableCar->groundSegmentYStart + 23) % 32;
+    groundSegmentY_Up = (sCableCar->groundSegmentYStart + 23) % 32;
 
     // Draw next segment
     for (i = 0; i < ARRAY_COUNT(sCableCar->groundTileBuffer); i++)
     {
-        sGroundX_Up = sCableCar->groundSegmentXStart;
-        sGroundY_Up = (sGroundSegmentY_Up + i) % 32;
-        FillBgTilemapBufferRect(0, sCableCar->groundTileBuffer[i][sCableCar->groundTileIdx], sGroundX_Up, sGroundY_Up, 1, 1, 17);
-        sGroundX_Up = (sGroundX_Up + 1) % 32;
-        FillBgTilemapBufferRect(0, sCableCar->groundTileBuffer[i][sCableCar->groundTileIdx + 1], sGroundX_Up, sGroundY_Up, 1, 1, 17);
+        groundX_Up = sCableCar->groundSegmentXStart;
+        groundY_Up = (groundSegmentY_Up + i) % 32;
+        FillBgTilemapBufferRect(0, sCableCar->groundTileBuffer[i][sCableCar->groundTileIdx], groundX_Up, groundY_Up, 1, 1, 17);
+        groundX_Up = (groundX_Up + 1) % 32;
+        FillBgTilemapBufferRect(0, sCableCar->groundTileBuffer[i][sCableCar->groundTileIdx + 1], groundX_Up, groundY_Up, 1, 1, 17);
     }
 
     // Erase old segment
-    sGroundX_Up = (sCableCar->groundSegmentXStart + 30) % 32;
-    FillBgTilemapBufferRect(0, 0, sGroundX_Up, 0, 2, 32, 17);
+    groundX_Up = (sCableCar->groundSegmentXStart + 30) % 32;
+    FillBgTilemapBufferRect(0, 0, groundX_Up, 0, 2, 32, 17);
     if (sCableCar->groundTileIdx == 0)
     {
         sCableCar->groundSegmentYStart = (sCableCar->groundSegmentYStart + 29) % 32;
         sCableCar->groundTileIdx = 12;
         BufferNextGroundSegment();
-        sGroundX_Up = (sCableCar->groundSegmentYStart + 1) % 32;
-        FillBgTilemapBufferRect(0, 0, 0, sGroundX_Up, 32, 9, 17);
+        groundX_Up = (sCableCar->groundSegmentYStart + 1) % 32;
+        FillBgTilemapBufferRect(0, 0, 0, groundX_Up, 32, 9, 17);
     }
 }
 
 static void DrawNextGroundSegmentGoingDown(void)
 {
     u8 i = 0;
+    u8 groundX_Down = 0;
+    u8 groundY_Down = 0;
+    u8 groundSegmentY_Down = 0;
 
     sCableCar->groundXOffset = sCableCar->groundYOffset = 0;
     sCableCar->groundXBase = sCableCar->bg0HorizontalOffset;
     sCableCar->groundYBase = sCableCar->bg0VerticalOffset;
     sCableCar->groundSegmentXStart = (sCableCar->groundSegmentXStart + 2) % 32;
     sCableCar->groundTileIdx += 2;
-    sGroundSegmentY_Down = sCableCar->groundSegmentYStart;
+    groundSegmentY_Down = sCableCar->groundSegmentYStart;
 
     // Draw next segment
     for (i = 0; i < ARRAY_COUNT(sCableCar->groundTileBuffer); i++)
     {
-        sGroundX_Down = sCableCar->groundSegmentXStart;
-        sGroundY_Down = (sGroundSegmentY_Down + i) % 32;
-        FillBgTilemapBufferRect(0, sCableCar->groundTileBuffer[i][sCableCar->groundTileIdx], sGroundX_Down, sGroundY_Down, 1, 1, 17);
-        sGroundX_Down = (sGroundX_Down + 1) % 32;
-        FillBgTilemapBufferRect(0, sCableCar->groundTileBuffer[i][sCableCar->groundTileIdx + 1], sGroundX_Down, sGroundY_Down, 1, 1, 17);
+        groundX_Down = sCableCar->groundSegmentXStart;
+        groundY_Down = (groundSegmentY_Down + i) % 32;
+        FillBgTilemapBufferRect(0, sCableCar->groundTileBuffer[i][sCableCar->groundTileIdx], groundX_Down, groundY_Down, 1, 1, 17);
+        groundX_Down = (groundX_Down + 1) % 32;
+        FillBgTilemapBufferRect(0, sCableCar->groundTileBuffer[i][sCableCar->groundTileIdx + 1], groundX_Down, groundY_Down, 1, 1, 17);
     }
 
     // Erase old segment
-    sGroundY_Down = (sCableCar->groundSegmentYStart + 23) % 32;
-    FillBgTilemapBufferRect(0, 0, sCableCar->groundSegmentXStart, sGroundY_Down, 2, 9, 17);
+    groundY_Down = (sCableCar->groundSegmentYStart + 23) % 32;
+    FillBgTilemapBufferRect(0, 0, sCableCar->groundSegmentXStart, groundY_Down, 2, 9, 17);
     if (sCableCar->groundTileIdx == 10)
     {
         sCableCar->groundSegmentYStart = (sCableCar->groundSegmentYStart + 3) % 32;


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
For some reason the cable car animation uses `EWRAM` variables for things only used in single functions and are assigned before usage, no data is saved between invocations of the functions.

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara