### PR TITLE
Running from trainer battles properly handles whiteouts

### DIFF
--- a/src/battle_setup.c
+++ b/src/battle_setup.c
@@ -1469,7 +1469,8 @@ static void CB2_EndTrainerBattle(void)
     }
     else if (DidPlayerForfeitNormalTrainerBattle())
     {
-        if (FlagGet(B_FLAG_NO_WHITEOUT))
+        if (FlagGet(B_FLAG_NO_WHITEOUT) || CurrentBattlePyramidLocation() != PYRAMID_LOCATION_NONE || InTrainerHillChallenge())
+
             SetMainCallback2(CB2_ReturnToFieldContinueScriptPlayMapMusic);
         else
             SetMainCallback2(CB2_WhiteOut);


### PR DESCRIPTION
## Description
Fixes #9226 by reordering the `else if` to handle running from trainer battles first. This is targeting `upcoming` because the issue doesn't impact `master` yet.

## Media
### Broken

https://github.com/user-attachments/assets/951cde7b-36fc-4a61-b195-01a7d4e27b4c

### Fixed

https://github.com/user-attachments/assets/6ae19feb-da0f-4ce6-821f-7f5b65dbc1ec

## Issue(s) that this PR fixes
Fixes #9226 

## Discord contact info
pkmsnfrn