### PR TITLE
fix: split ShouldShowMoveRelearner into smaller checks

### DIFF
--- a/src/pokemon_summary_screen.c
+++ b/src/pokemon_summary_screen.c
@@ -4826,15 +4826,28 @@ static void KeepMoveSelectorVisible(u8 firstSpriteId)
 
 static inline bool32 ShouldShowMoveRelearner(void)
 {
-    return (P_SUMMARY_SCREEN_MOVE_RELEARNER
-         && !sMonSummaryScreen->lockMovesFlag
-         && !sMonSummaryScreen->isBoxMon
-         && sMonSummaryScreen->mode != SUMMARY_MODE_BOX
-         && sMonSummaryScreen->mode != SUMMARY_MODE_BOX_CURSOR
-         && sMonSummaryScreen->hasRelearnableMoves
-         && !InBattleFactory()
-         && !InSlateportBattleTent()
-         && !NoMovesAvailableToRelearn());
+    if (!P_SUMMARY_SCREEN_MOVE_RELEARNER)
+        return FALSE;
+
+    if ((sMonSummaryScreen->lockMovesFlag) || (sMonSummaryScreen->isBoxMon))
+        return FALSE;
+
+    if ((sMonSummaryScreen->mode == SUMMARY_MODE_BOX) || (sMonSummaryScreen->mode == SUMMARY_MODE_BOX_CURSOR))
+        return FALSE;
+
+    if (sMonSummaryScreen->hasRelearnableMoves == FALSE)
+        return FALSE;
+
+    if (InBattleFactory())
+        return FALSE;
+
+    if (InSlateportBattleTent())
+        return FALSE;
+
+    if (NoMovesAvailableToRelearn())
+        return FALSE;
+
+    return TRUE;
 }
 
 static inline bool32 ShouldShowRename(void)


### PR DESCRIPTION
## Description

```c
static inline bool32 ShouldShowMoveRelearner(void)
{
    return (P_SUMMARY_SCREEN_MOVE_RELEARNER
         && !sMonSummaryScreen->lockMovesFlag
         && !sMonSummaryScreen->isBoxMon
         && sMonSummaryScreen->mode != SUMMARY_MODE_BOX
         && sMonSummaryScreen->mode != SUMMARY_MODE_BOX_CURSOR
         && sMonSummaryScreen->hasRelearnableMoves
         && !InBattleFactory()
         && !InSlateportBattleTent()
         && !NoMovesAvailableToRelearn());
}
```
is run every time the player changes places on the Pokemon Summary Screen. The last check, `NoMovesAvailableToRelearn`, runs through all of that mon's level up moves, egg moves, tutor moves, and TM moves. If a game has a lot of TMs, this check is extremely long.

In `ShouldShowMoveRelearner`, all of the checks are run and then if ALL of them are true, the function returns FALSE. This splits up the function into more manageable chunks so that users who have `P_SUMMARY_SCREEN_MOVE_RELEARNER` disabled don't have to do every check.

## Media
These videos are from my game, one with this change and one without the change.

## Before Change
https://github.com/user-attachments/assets/56fb988d-2a44-45eb-905c-d349ef873860

## After Change
https://github.com/user-attachments/assets/bad0b722-5778-4f2c-907d-66245dfd14f2

## Discord contact info
pkmsnfrn