### PR TITLE
Make sure grass effect palette ignore fog when time blended

### DIFF
--- a/include/field_effect_helpers.h
+++ b/include/field_effect_helpers.h
@@ -43,4 +43,6 @@ void UpdateSparkleFieldEffect(struct Sprite *sprite);
 void SetSpriteInvisible(u8 spriteId);
 void ShowWarpArrowSprite(u8 spriteId, u8 direction, s16 x, s16 y);
 
+u32 FldEff_TallGrass(void);
+
 #endif //GUARD_FIELD_EFFECT_HELPERS_H

--- a/src/field_effect.c
+++ b/src/field_effect.c
@@ -803,14 +803,22 @@ void FieldEffectScript_LoadTiles(u8 **script)
     (*script) += 4;
 }
 
+static bool32 ShouldFieldEffectBeFogBlended(u8 *script)
+{
+    u32 ptr = FieldEffectScript_ReadWord(&script);
+    if (ptr == (u32)FldEff_TallGrass)
+        return FALSE;
+    return TRUE;
+}
+
 void FieldEffectScript_LoadFadedPalette(u8 **script)
 {
     struct SpritePalette *palette = (struct SpritePalette *)FieldEffectScript_ReadWord(script);
     u32 paletteSlot = LoadSpritePalette(palette);
     (*script) += 4;
     SetPaletteColorMapType(paletteSlot + 16, T1_READ_8(*script));
-    UpdateSpritePaletteWithWeather(paletteSlot, TRUE);
     (*script)++;
+    UpdateSpritePaletteWithWeather(paletteSlot, ShouldFieldEffectBeFogBlended(*script));
 }
 
 void FieldEffectScript_LoadPalette(u8 **script)


### PR DESCRIPTION
The fog + night blending combination has some specific rules on which sprites it should apply because it looks weid on some sprites. It was applying the same to all field effect sprites but I'm changing it so that it applies differently to the tall grass field effect

## Media

https://github.com/user-attachments/assets/e9ceff71-c3d0-41f4-a3bb-3faa47dc3944


## Issue(s) that this PR fixes
Fixes #9220


## Discord contact info
Jamie
