### PR TITLE
Unify Follow Me behavior with wiki and add related tests

### DIFF
--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -126,7 +126,7 @@
 #define B_IMPRISON                  GEN_LATEST // In Gen5+, Imprison doesn't fail if opposing pokemon don't have any moves the user knows.
 #define B_TAUNT_ME_FIRST            GEN_LATEST // In Gen5+, Taunt does not block Me First.
 #define B_FOLLOW_ME_FUTURE_SIGHT    GEN_LATEST // In Gen6+, Follow Me does not redirect Future Sight/Doom Desire. In Gen3-5, it can redirect only on the turn they are selected.
-#define B_FOLLOW_ME_SINGLES_FAIL    TRUE       // TRUE: Follow Me fails in Single Battles (BDSP+). FALSE: Follow Me works in Single Battles (Gen3-SwSh).
+#define B_FOLLOW_ME_SINGLES_FAIL    GEN_LATEST // In Gen8+, Follow Me fails in Single Battles.
 #define B_ALLY_SWITCH_FAIL_CHANCE   GEN_LATEST // In Gen9+, using Ally Switch consecutively decreases the chance of success for each consecutive use.
 #define B_SKETCH_BANS               GEN_LATEST // In Gen9+, Sketch is unable to copy more moves than in previous generations.
 #define B_KNOCK_OFF_REMOVAL         GEN_LATEST // In Gen5+, Knock Off removes the foe's item instead of rendering it unusable.

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -125,7 +125,8 @@
 #define B_QUICK_GUARD               GEN_LATEST // In Gen5 only, Quick Guard has a chance to fail if used consecutively.
 #define B_IMPRISON                  GEN_LATEST // In Gen5+, Imprison doesn't fail if opposing pokemon don't have any moves the user knows.
 #define B_TAUNT_ME_FIRST            GEN_LATEST // In Gen5+, Taunt does not block Me First.
-#define B_FOLLOW_ME_FUTURE_SIGHT    GEN_LATEST // In Gen6+, Follow Me does not redirect Future Sight/Doom Desire.
+#define B_FOLLOW_ME_FUTURE_SIGHT    GEN_LATEST // In Gen6+, Follow Me does not redirect Future Sight/Doom Desire. In Gen3-5, it can redirect only on the turn they are selected.
+#define B_FOLLOW_ME_SINGLES_FAIL    TRUE       // TRUE: Follow Me fails in Single Battles (BDSP+). FALSE: Follow Me works in Single Battles (Gen3-SwSh).
 #define B_ALLY_SWITCH_FAIL_CHANCE   GEN_LATEST // In Gen9+, using Ally Switch consecutively decreases the chance of success for each consecutive use.
 #define B_SKETCH_BANS               GEN_LATEST // In Gen9+, Sketch is unable to copy more moves than in previous generations.
 #define B_KNOCK_OFF_REMOVAL         GEN_LATEST // In Gen5+, Knock Off removes the foe's item instead of rendering it unusable.

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -125,6 +125,7 @@
 #define B_QUICK_GUARD               GEN_LATEST // In Gen5 only, Quick Guard has a chance to fail if used consecutively.
 #define B_IMPRISON                  GEN_LATEST // In Gen5+, Imprison doesn't fail if opposing pokemon don't have any moves the user knows.
 #define B_TAUNT_ME_FIRST            GEN_LATEST // In Gen5+, Taunt does not block Me First.
+#define B_FOLLOW_ME_FUTURE_SIGHT    GEN_LATEST // In Gen6+, Follow Me does not redirect Future Sight/Doom Desire.
 #define B_ALLY_SWITCH_FAIL_CHANCE   GEN_LATEST // In Gen9+, using Ally Switch consecutively decreases the chance of success for each consecutive use.
 #define B_SKETCH_BANS               GEN_LATEST // In Gen9+, Sketch is unable to copy more moves than in previous generations.
 #define B_KNOCK_OFF_REMOVAL         GEN_LATEST // In Gen5+, Knock Off removes the foe's item instead of rendering it unusable.

--- a/include/constants/generational_changes.h
+++ b/include/constants/generational_changes.h
@@ -117,7 +117,7 @@
     F(B_IMPRISON,                  imprison,                (u32, GEN_COUNT - 1)) /* TODO: use in tests */ \
     F(B_TAUNT_ME_FIRST,            tauntMeFirst,            (u32, GEN_COUNT - 1)) \
     F(B_FOLLOW_ME_FUTURE_SIGHT,    followMeFutureSight,     (u32, GEN_COUNT - 1)) \
-    F(B_FOLLOW_ME_SINGLES_FAIL,    followMeSinglesFail,     (u32, TRUE)) \
+    F(B_FOLLOW_ME_SINGLES_FAIL,    followMeSinglesFail,     (u32, GEN_COUNT - 1)) \
     F(B_ALLY_SWITCH_FAIL_CHANCE,   allySwitchFailChance,    (u32, GEN_COUNT - 1)) \
     F(B_SKETCH_BANS,               sketchBans,              (u32, GEN_COUNT - 1)) /* TODO: use in tests */ \
     F(B_KNOCK_OFF_REMOVAL,         knockOffRemoval,         (u32, GEN_COUNT - 1)) /* TODO: use in tests */ \

--- a/include/constants/generational_changes.h
+++ b/include/constants/generational_changes.h
@@ -116,6 +116,7 @@
     F(B_QUICK_GUARD,               quickGuard,              (u32, GEN_COUNT - 1)) \
     F(B_IMPRISON,                  imprison,                (u32, GEN_COUNT - 1)) /* TODO: use in tests */ \
     F(B_TAUNT_ME_FIRST,            tauntMeFirst,            (u32, GEN_COUNT - 1)) \
+    F(B_FOLLOW_ME_FUTURE_SIGHT,    followMeFutureSight,     (u32, GEN_COUNT - 1)) \
     F(B_ALLY_SWITCH_FAIL_CHANCE,   allySwitchFailChance,    (u32, GEN_COUNT - 1)) \
     F(B_SKETCH_BANS,               sketchBans,              (u32, GEN_COUNT - 1)) /* TODO: use in tests */ \
     F(B_KNOCK_OFF_REMOVAL,         knockOffRemoval,         (u32, GEN_COUNT - 1)) /* TODO: use in tests */ \

--- a/include/constants/generational_changes.h
+++ b/include/constants/generational_changes.h
@@ -117,6 +117,7 @@
     F(B_IMPRISON,                  imprison,                (u32, GEN_COUNT - 1)) /* TODO: use in tests */ \
     F(B_TAUNT_ME_FIRST,            tauntMeFirst,            (u32, GEN_COUNT - 1)) \
     F(B_FOLLOW_ME_FUTURE_SIGHT,    followMeFutureSight,     (u32, GEN_COUNT - 1)) \
+    F(B_FOLLOW_ME_SINGLES_FAIL,    followMeSinglesFail,     (u32, TRUE)) \
     F(B_ALLY_SWITCH_FAIL_CHANCE,   allySwitchFailChance,    (u32, GEN_COUNT - 1)) \
     F(B_SKETCH_BANS,               sketchBans,              (u32, GEN_COUNT - 1)) /* TODO: use in tests */ \
     F(B_KNOCK_OFF_REMOVAL,         knockOffRemoval,         (u32, GEN_COUNT - 1)) /* TODO: use in tests */ \

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -12624,9 +12624,21 @@ static void Cmd_setforcedtarget(void)
 {
     CMD_ARGS();
 
-    gSideTimers[GetBattlerSide(gBattlerTarget)].followmeTimer = 1;
-    gSideTimers[GetBattlerSide(gBattlerTarget)].followmeTarget = gBattlerTarget;
-    gSideTimers[GetBattlerSide(gBattlerTarget)].followmePowder = IsPowderMove(gCurrentMove);
+    u32 side = GetBattlerSide(gBattlerTarget);
+    bool32 shouldSet = TRUE;
+
+    if (gSideTimers[side].followmeTimer != 0 && IsBattlerAlive(gSideTimers[side].followmeTarget))
+    {
+        if (GetBattlerTurnOrderNum(gSideTimers[side].followmeTarget) <= GetBattlerTurnOrderNum(gBattlerTarget))
+            shouldSet = FALSE;
+    }
+
+    if (shouldSet)
+    {
+        gSideTimers[side].followmeTimer = 1;
+        gSideTimers[side].followmeTarget = gBattlerTarget;
+        gSideTimers[side].followmePowder = IsPowderMove(gCurrentMove);
+    }
     gBattlescriptCurrInstr = cmd->nextInstr;
 }
 

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -401,7 +401,9 @@ bool32 HandleMoveTargetRedirection(void)
     enum Ability ability = GetBattlerAbility(gBattleStruct->moveTarget[gBattlerAttacker]);
 
     if (IsAffectedByFollowMe(gBattlerAttacker, side, gCurrentMove)
-     && moveTarget == MOVE_TARGET_SELECTED
+     && moveEffect != EFFECT_ME_FIRST
+     && moveEffect != EFFECT_COPYCAT
+     && (moveTarget == MOVE_TARGET_SELECTED || moveTarget == MOVE_TARGET_OPPONENT || moveTarget & MOVE_TARGET_RANDOM)
      && !IsBattlerAlly(gBattlerAttacker, gSideTimers[side].followmeTarget))
     {
         gBattleStruct->moveTarget[gBattlerAttacker] = gBattlerTarget = gSideTimers[side].followmeTarget; // follow me moxie fix

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -376,6 +376,7 @@ bool32 IsAffectedByFollowMe(u32 battlerAtk, u32 defSide, u32 move)
 
     if (gSideTimers[defSide].followmeTimer == 0
         || (!IsBattlerAlive(gSideTimers[defSide].followmeTarget) && !IsDragonDartsSecondHit(effect))
+        || (GetConfig(B_FOLLOW_ME_FUTURE_SIGHT) >= GEN_6 && effect == EFFECT_FUTURE_SIGHT)
         || effect == EFFECT_SNIPE_SHOT
         || effect == EFFECT_SKY_DROP
         || IsAbilityAndRecord(battlerAtk, ability, ABILITY_PROPELLER_TAIL)

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -2699,7 +2699,7 @@ static enum MoveCanceler CancelerMoveFailure(struct BattleContext *ctx)
             battleScript = BattleScript_ButItFailed;
         break;
     case EFFECT_FOLLOW_ME:
-        if (B_UPDATED_MOVE_DATA >= GEN_8 && !(gBattleTypeFlags & BATTLE_TYPE_DOUBLE))
+        if (GetConfig(B_FOLLOW_ME_SINGLES_FAIL) && !(gBattleTypeFlags & BATTLE_TYPE_DOUBLE))
             battleScript = BattleScript_ButItFailed;
         break;
     case EFFECT_FUTURE_SIGHT:

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -2727,7 +2727,7 @@ static enum MoveCanceler CancelerMoveFailure(struct BattleContext *ctx)
             battleScript = BattleScript_ButItFailed;
         break;
     case EFFECT_FOLLOW_ME:
-        if (GetConfig(B_FOLLOW_ME_SINGLES_FAIL) && !(gBattleTypeFlags & BATTLE_TYPE_DOUBLE))
+        if (GetConfig(B_FOLLOW_ME_SINGLES_FAIL) >= GEN_8 && !(gBattleTypeFlags & BATTLE_TYPE_DOUBLE))
             battleScript = BattleScript_ButItFailed;
         break;
     case EFFECT_FUTURE_SIGHT:

--- a/test/battle/move_effect/follow_me.c
+++ b/test/battle/move_effect/follow_me.c
@@ -115,6 +115,7 @@ DOUBLE_BATTLE_TEST("Follow Me no longer redirects if the center of attention fai
         HP_BAR(playerLeft);
     }
 }
+
 TO_DO_BATTLE_TEST("Follow Me can only redirect charging moves on the turn that they would hit")
 TO_DO_BATTLE_TEST("Follow Me can only redirect Future Sight/Doom Desire on the turn they were selected (Gen3-5)")
 TO_DO_BATTLE_TEST("Follow Me does not redirect Future Sight/Doom Desire (Gen 6+)")
@@ -123,8 +124,47 @@ TO_DO_BATTLE_TEST("Follow Me prioritizes the first Pokémon that used it") // Th
 //TO_DO_BATTLE_TEST("Triples: Follow Me can only draw non-adjacent moves if they use a long-range move")
 TO_DO_BATTLE_TEST("Follow Me can be used in Single Battles (Gen3-SwSh)")
 TO_DO_BATTLE_TEST("Follow Me fails in Single Battles (BDSP+)")
-TO_DO_BATTLE_TEST("Follow Me cannot redirect Sky Drop")
-TO_DO_BATTLE_TEST("Follow Me does not draw attack when the user is being Sky-Dropped")
+
+DOUBLE_BATTLE_TEST("Follow Me cannot redirect Sky Drop")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_SKY_DROP) == EFFECT_SKY_DROP);
+        PLAYER(SPECIES_WYNAUT);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN { MOVE(playerRight, MOVE_FOLLOW_ME);
+               MOVE(opponentLeft, MOVE_SKY_DROP, target: playerLeft); }
+        TURN { SKIP_TURN(opponentLeft); SKIP_TURN(playerLeft); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FOLLOW_ME, playerRight);
+        MESSAGE("The opposing Wobbuffet took Wynaut into the sky!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SKY_DROP, opponentLeft);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Follow Me does not draw attack when the user is being Sky-Dropped")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_SKY_DROP) == EFFECT_SKY_DROP);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(60); }
+        PLAYER(SPECIES_WYNAUT) { Speed(100); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(90); }
+        OPPONENT(SPECIES_WYNAUT) { Speed(80); }
+    } WHEN {
+        TURN { MOVE(playerRight, MOVE_FOLLOW_ME);
+               MOVE(opponentLeft, MOVE_SKY_DROP, target: playerRight);
+               MOVE(opponentRight, MOVE_SCRATCH, target: playerLeft);
+               MOVE(playerLeft, MOVE_SPLASH); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FOLLOW_ME, playerRight);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SKY_DROP, opponentLeft);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponentRight);
+        HP_BAR(playerLeft);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SPLASH, playerLeft);
+    }
+}
 
 DOUBLE_BATTLE_TEST("Spotlight redirects single target moves used by the opposing side to Spotlight's target")
 {

--- a/test/battle/move_effect/follow_me.c
+++ b/test/battle/move_effect/follow_me.c
@@ -75,8 +75,46 @@ DOUBLE_BATTLE_TEST("Follow Me does not change Me First's copy target but redirec
     }
 }
 
-TO_DO_BATTLE_TEST("Follow Me doesn't redirect opponent moves that can't affect opponents") //Eg. Helping Hand
-TO_DO_BATTLE_TEST("Follow Me no longer redirects if the center of attention faints mid-turn")
+DOUBLE_BATTLE_TEST("Follow Me doesn't redirect opponent moves that can't affect opponents")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_AROMATIC_MIST) == EFFECT_AROMATIC_MIST);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN { MOVE(playerRight, MOVE_FOLLOW_ME);
+               MOVE(opponentLeft, MOVE_AROMATIC_MIST); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FOLLOW_ME, playerRight);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_AROMATIC_MIST, opponentLeft);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);
+    } THEN {
+        EXPECT_EQ(opponentRight->statStages[STAT_SPDEF], DEFAULT_STAT_STAGE + 1);
+        EXPECT_EQ(playerRight->statStages[STAT_SPDEF], DEFAULT_STAT_STAGE);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Follow Me no longer redirects if the center of attention faints mid-turn")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Speed(30); }
+        PLAYER(SPECIES_WYNAUT) { HP(1); Speed(50); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(60); }
+        OPPONENT(SPECIES_WYNAUT) { Speed(40); }
+    } WHEN {
+        TURN { MOVE(playerRight, MOVE_FOLLOW_ME);
+               MOVE(opponentLeft, MOVE_TACKLE, target: playerLeft);
+               MOVE(opponentRight, MOVE_SCRATCH, target: playerLeft); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FOLLOW_ME, playerRight);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, opponentLeft);
+        HP_BAR(playerRight);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponentRight);
+        HP_BAR(playerLeft);
+    }
+}
 TO_DO_BATTLE_TEST("Follow Me can only redirect charging moves on the turn that they would hit")
 TO_DO_BATTLE_TEST("Follow Me can only redirect Future Sight/Doom Desire on the turn they were selected (Gen3-5)")
 TO_DO_BATTLE_TEST("Follow Me does not redirect Future Sight/Doom Desire (Gen 6+)")

--- a/test/battle/move_effect/follow_me.c
+++ b/test/battle/move_effect/follow_me.c
@@ -116,13 +116,73 @@ DOUBLE_BATTLE_TEST("Follow Me no longer redirects if the center of attention fai
     }
 }
 
-TO_DO_BATTLE_TEST("Follow Me can only redirect charging moves on the turn that they would hit")
-TO_DO_BATTLE_TEST("Follow Me can only redirect Future Sight/Doom Desire on the turn they were selected (Gen3-5)")
-TO_DO_BATTLE_TEST("Follow Me does not redirect Future Sight/Doom Desire (Gen 6+)")
-TO_DO_BATTLE_TEST("Follow Me draws Electric/Water moves even if there's a Pokémon with Lightning Rod/Storm Drain")
-TO_DO_BATTLE_TEST("Follow Me prioritizes the first Pokémon that used it") // There can be 2 centers of attention. If the first is gone, the 2nd is used
-//TO_DO_BATTLE_TEST("Triples: Follow Me can only draw non-adjacent moves if they use a long-range move")
-TO_DO_BATTLE_TEST("Follow Me can be used in Single Battles (Gen3-SwSh)")
+DOUBLE_BATTLE_TEST("Follow Me does not redirect Future Sight (Gen 6+)")
+{
+    GIVEN {
+        WITH_CONFIG(B_FOLLOW_ME_FUTURE_SIGHT, GEN_6);
+        ASSUME(GetMoveEffect(MOVE_FUTURE_SIGHT) == EFFECT_FUTURE_SIGHT);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN { MOVE(opponentRight, MOVE_FOLLOW_ME);
+               MOVE(playerLeft, MOVE_FUTURE_SIGHT, target: opponentLeft); }
+        TURN { }
+        TURN { }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FOLLOW_ME, opponentRight);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FUTURE_SIGHT, playerLeft);
+        MESSAGE("The opposing Wobbuffet took the Future Sight attack!");
+        HP_BAR(opponentLeft);
+        NOT HP_BAR(opponentRight);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Follow Me can only redirect Future Sight on the turn they were selected (Gen3-5)")
+{
+    GIVEN {
+        WITH_CONFIG(B_FOLLOW_ME_FUTURE_SIGHT, GEN_5);
+        ASSUME(GetMoveEffect(MOVE_FUTURE_SIGHT) == EFFECT_FUTURE_SIGHT);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN { MOVE(opponentRight, MOVE_FOLLOW_ME);
+               MOVE(playerLeft, MOVE_FUTURE_SIGHT, target: opponentLeft); }
+        TURN { }
+        TURN { MOVE(opponentLeft, MOVE_FOLLOW_ME); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FOLLOW_ME, opponentRight);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FUTURE_SIGHT, playerLeft);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FOLLOW_ME, opponentLeft);
+        MESSAGE("The opposing Wynaut took the Future Sight attack!");
+        HP_BAR(opponentRight);
+        NOT HP_BAR(opponentLeft);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Follow Me prioritizes the first Pokémon that used it") // There can be 2 centers of attention. If the first is gone, the 2nd is used
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN { MOVE(opponentLeft, MOVE_FOLLOW_ME);
+               MOVE(opponentRight, MOVE_FOLLOW_ME);
+               MOVE(playerLeft, MOVE_SCRATCH, target: opponentRight); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FOLLOW_ME, opponentLeft);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FOLLOW_ME, opponentRight);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, playerLeft);
+        HP_BAR(opponentLeft);
+        NOT HP_BAR(opponentRight);
+    }
+}
+
 
 SINGLE_BATTLE_TEST("Follow Me fails in Single Battles (BDSP+)")
 {
@@ -214,3 +274,8 @@ DOUBLE_BATTLE_TEST("Spotlight redirects single target moves used by the opposing
             HP_BAR(playerLeft);
     }
 }
+
+TO_DO_BATTLE_TEST("Follow Me can only redirect charging moves on the turn that they would hit")
+TO_DO_BATTLE_TEST("Follow Me draws Electric/Water moves even if there's a Pokémon with Lightning Rod/Storm Drain")
+TO_DO_BATTLE_TEST("Follow Me can be used in Single Battles (Gen3-SwSh)")
+//TO_DO_BATTLE_TEST("Triples: Follow Me can only draw non-adjacent moves if they use a long-range move")

--- a/test/battle/move_effect/follow_me.c
+++ b/test/battle/move_effect/follow_me.c
@@ -115,7 +115,7 @@ DOUBLE_BATTLE_TEST("Follow Me does not change Me First's copy target but redirec
 DOUBLE_BATTLE_TEST("Follow Me doesn't redirect moves that can't target opponents")
 {
     GIVEN {
-        ASSUME(GetMoveTarget(MOVE_AROMATIC_MIST) == MOVE_TARGET_OPPONENT);
+        ASSUME(GetMoveTarget(MOVE_AROMATIC_MIST) == MOVE_TARGET_ALLY);
         ASSUME(GetMoveEffect(MOVE_AROMATIC_MIST) == EFFECT_AROMATIC_MIST);
         PLAYER(SPECIES_WOBBUFFET);
         PLAYER(SPECIES_WYNAUT);

--- a/test/battle/move_effect/follow_me.c
+++ b/test/battle/move_effect/follow_me.c
@@ -94,6 +94,7 @@ DOUBLE_BATTLE_TEST("Follow Me does not change Me First's copy target but redirec
 {
     GIVEN {
         ASSUME(GetMoveTarget(MOVE_ME_FIRST) == MOVE_TARGET_OPPONENT);
+        ASSUME(GetMoveEffect(MOVE_ME_FIRST) == EFFECT_ME_FIRST);
         PLAYER(SPECIES_WOBBUFFET) { Speed(100); }
         PLAYER(SPECIES_WYNAUT) { Speed(20); }
         OPPONENT(SPECIES_WOBBUFFET) { Speed(50); }
@@ -111,9 +112,10 @@ DOUBLE_BATTLE_TEST("Follow Me does not change Me First's copy target but redirec
     }
 }
 
-DOUBLE_BATTLE_TEST("Follow Me doesn't redirect opponent moves that can't affect opponents")
+DOUBLE_BATTLE_TEST("Follow Me doesn't redirect moves that can't target opponents")
 {
     GIVEN {
+        ASSUME(GetMoveTarget(MOVE_AROMATIC_MIST) == MOVE_TARGET_OPPONENT);
         ASSUME(GetMoveEffect(MOVE_AROMATIC_MIST) == EFFECT_AROMATIC_MIST);
         PLAYER(SPECIES_WOBBUFFET);
         PLAYER(SPECIES_WYNAUT);

--- a/test/battle/move_effect/follow_me.c
+++ b/test/battle/move_effect/follow_me.c
@@ -123,7 +123,20 @@ TO_DO_BATTLE_TEST("Follow Me draws Electric/Water moves even if there's a Pokém
 TO_DO_BATTLE_TEST("Follow Me prioritizes the first Pokémon that used it") // There can be 2 centers of attention. If the first is gone, the 2nd is used
 //TO_DO_BATTLE_TEST("Triples: Follow Me can only draw non-adjacent moves if they use a long-range move")
 TO_DO_BATTLE_TEST("Follow Me can be used in Single Battles (Gen3-SwSh)")
-TO_DO_BATTLE_TEST("Follow Me fails in Single Battles (BDSP+)")
+
+SINGLE_BATTLE_TEST("Follow Me fails in Single Battles (BDSP+)")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_FOLLOW_ME); }
+    } SCENE {
+        MESSAGE("Wobbuffet used Follow Me!");
+        MESSAGE("But it failed!");
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_FOLLOW_ME, player);
+    }
+}
 
 DOUBLE_BATTLE_TEST("Follow Me cannot redirect Sky Drop")
 {

--- a/test/battle/move_effect/follow_me.c
+++ b/test/battle/move_effect/follow_me.c
@@ -187,14 +187,28 @@ DOUBLE_BATTLE_TEST("Follow Me prioritizes the first Pokémon that used it") // T
 SINGLE_BATTLE_TEST("Follow Me fails in Single Battles (BDSP+)")
 {
     GIVEN {
+        WITH_CONFIG(B_FOLLOW_ME_SINGLES_FAIL, TRUE);
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
         TURN { MOVE(player, MOVE_FOLLOW_ME); }
     } SCENE {
-        MESSAGE("Wobbuffet used Follow Me!");
-        MESSAGE("But it failed!");
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_FOLLOW_ME, player);
+        MESSAGE("But it failed!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Follow Me can be used in Single Battles (Gen3-SwSh)")
+{
+    GIVEN {
+        WITH_CONFIG(B_FOLLOW_ME_SINGLES_FAIL, FALSE);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_FOLLOW_ME); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FOLLOW_ME, player);
+        NOT MESSAGE("But it failed!");
     }
 }
 
@@ -277,5 +291,4 @@ DOUBLE_BATTLE_TEST("Spotlight redirects single target moves used by the opposing
 
 TO_DO_BATTLE_TEST("Follow Me can only redirect charging moves on the turn that they would hit")
 TO_DO_BATTLE_TEST("Follow Me draws Electric/Water moves even if there's a Pokémon with Lightning Rod/Storm Drain")
-TO_DO_BATTLE_TEST("Follow Me can be used in Single Battles (Gen3-SwSh)")
 //TO_DO_BATTLE_TEST("Triples: Follow Me can only draw non-adjacent moves if they use a long-range move")

--- a/test/battle/move_effect/follow_me.c
+++ b/test/battle/move_effect/follow_me.c
@@ -309,10 +309,10 @@ DOUBLE_BATTLE_TEST("Follow Me prioritizes the first Pokémon that used it") // T
 }
 
 
-SINGLE_BATTLE_TEST("Follow Me fails in Single Battles (BDSP+)")
+SINGLE_BATTLE_TEST("Follow Me fails in Single Battles (Gen8+)")
 {
     GIVEN {
-        WITH_CONFIG(B_FOLLOW_ME_SINGLES_FAIL, TRUE);
+        WITH_CONFIG(B_FOLLOW_ME_SINGLES_FAIL, GEN_8);
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
@@ -323,10 +323,10 @@ SINGLE_BATTLE_TEST("Follow Me fails in Single Battles (BDSP+)")
     }
 }
 
-SINGLE_BATTLE_TEST("Follow Me can be used in Single Battles (Gen3-SwSh)")
+SINGLE_BATTLE_TEST("Follow Me can be used in Single Battles (Gen3-7)")
 {
     GIVEN {
-        WITH_CONFIG(B_FOLLOW_ME_SINGLES_FAIL, FALSE);
+        WITH_CONFIG(B_FOLLOW_ME_SINGLES_FAIL, GEN_7);
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {

--- a/test/battle/move_effect/follow_me.c
+++ b/test/battle/move_effect/follow_me.c
@@ -34,6 +34,47 @@ DOUBLE_BATTLE_TEST("Follow Me redirects single target moves used by opponents to
     }
 }
 
+DOUBLE_BATTLE_TEST("Follow Me redirects random target moves used by opponents to user")
+{
+    PASSES_RANDOMLY(2, 2, RNG_RANDOM_TARGET);
+    GIVEN {
+        ASSUME(GetMoveTarget(MOVE_OUTRAGE) == MOVE_TARGET_RANDOM);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN { MOVE(playerRight, MOVE_FOLLOW_ME);
+               MOVE(opponentLeft, MOVE_OUTRAGE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FOLLOW_ME, playerRight);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_OUTRAGE, opponentLeft);
+        HP_BAR(playerRight);
+        NOT HP_BAR(playerLeft);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Follow Me does not change Me First's copy target but redirects the copied move")
+{
+    GIVEN {
+        ASSUME(GetMoveTarget(MOVE_ME_FIRST) == MOVE_TARGET_OPPONENT);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(100); }
+        PLAYER(SPECIES_WYNAUT) { Speed(20); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(50); }
+        OPPONENT(SPECIES_WYNAUT) { Speed(120); }
+    } WHEN {
+        TURN { MOVE(opponentRight, MOVE_FOLLOW_ME);
+               MOVE(playerLeft, MOVE_ME_FIRST, target: opponentLeft);
+               MOVE(opponentLeft, MOVE_TACKLE, target: playerLeft); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FOLLOW_ME, opponentRight);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ME_FIRST, playerLeft);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, playerLeft);
+        HP_BAR(opponentRight);
+        NOT HP_BAR(opponentLeft);
+    }
+}
+
 TO_DO_BATTLE_TEST("Follow Me doesn't redirect opponent moves that can't affect opponents") //Eg. Helping Hand
 TO_DO_BATTLE_TEST("Follow Me no longer redirects if the center of attention faints mid-turn")
 TO_DO_BATTLE_TEST("Follow Me can only redirect charging moves on the turn that they would hit")

--- a/test/battle/move_effect/follow_me.c
+++ b/test/battle/move_effect/follow_me.c
@@ -289,6 +289,40 @@ DOUBLE_BATTLE_TEST("Spotlight redirects single target moves used by the opposing
     }
 }
 
-TO_DO_BATTLE_TEST("Follow Me can only redirect charging moves on the turn that they would hit")
+DOUBLE_BATTLE_TEST("Follow Me can only redirect charging moves on the turn that they would hit")
+{
+    bool32 useFollowMeTurn2;
+    PARAMETRIZE { useFollowMeTurn2 = FALSE; }
+    PARAMETRIZE { useFollowMeTurn2 = TRUE; }
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_FLY) == EFFECT_SEMI_INVULNERABLE);
+        PLAYER(SPECIES_WOBBUFFET) { Moves(MOVE_SPLASH); }
+        PLAYER(SPECIES_WYNAUT) { Moves(MOVE_FOLLOW_ME, MOVE_SPLASH); }
+        OPPONENT(SPECIES_WOBBUFFET) { Moves(MOVE_FLY); }
+        OPPONENT(SPECIES_WYNAUT) { Moves(MOVE_SPLASH); }
+    } WHEN {
+        TURN { MOVE(playerRight, MOVE_FOLLOW_ME);
+               MOVE(opponentLeft, MOVE_FLY, target: playerLeft);
+               MOVE(playerLeft, MOVE_SPLASH);
+               MOVE(opponentRight, MOVE_SPLASH); }
+        TURN { if (useFollowMeTurn2)
+                   MOVE(playerRight, MOVE_FOLLOW_ME);
+               else
+                   MOVE(playerRight, MOVE_SPLASH);
+               SKIP_TURN(opponentLeft);
+               MOVE(playerLeft, MOVE_SPLASH);
+               MOVE(opponentRight, MOVE_SPLASH); }
+    } SCENE {
+        if (useFollowMeTurn2)
+            HP_BAR(playerRight);
+        else
+            HP_BAR(playerLeft);
+        if (useFollowMeTurn2)
+            NOT HP_BAR(playerLeft);
+        else
+            NOT HP_BAR(playerRight);
+    }
+}
+
 TO_DO_BATTLE_TEST("Follow Me draws Electric/Water moves even if there's a Pokémon with Lightning Rod/Storm Drain")
 //TO_DO_BATTLE_TEST("Triples: Follow Me can only draw non-adjacent moves if they use a long-range move")


### PR DESCRIPTION
## Description
1. Follow Me now redirects random-target moves correctly.
> [Jpwiki](https://wiki.xn--rckteqa2e.com/wiki/%E3%81%A1%E3%82%85%E3%81%86%E3%82%82%E3%81%8F%E3%81%AE%E3%81%BE%E3%81%A8):
> あばれる・さわぐ・わるあがきなどの、対象がランダムな技にも効果がある。

2. Fixed Follow Me interactions with Me First and Copycat.
> [Jpwiki](https://wiki.xn--rckteqa2e.com/wiki/%E3%81%A1%E3%82%85%E3%81%86%E3%82%82%E3%81%8F%E3%81%AE%E3%81%BE%E3%81%A8):
> オウムがえし・さきどり (第五世代以降) - 技をコピーする対象を変更することはできないが、オウムがえし・さきどりで選ばれた技はちゅうもくのまとに引き寄せられる。

3. The first Follow Me user now takes priority.
4. Follow Me now interacts correctly with charging moves.

