### PR TITLE
Fix battle tutorial crashing after reshow in frlg

### DIFF
--- a/src/battle_bg.c
+++ b/src/battle_bg.c
@@ -935,7 +935,7 @@ void BattleInitBgsAndWindows(void)
         SetBgTilemapBuffer(1, gBattleAnimBgTilemapBuffer);
         SetBgTilemapBuffer(2, gBattleAnimBgTilemapBuffer);
     }
-    else if (IS_FRLG && (gBattleTypeFlags == (BATTLE_TYPE_TRAINER | BATTLE_TYPE_FIRST_BATTLE) || gBattleTypeFlags == BATTLE_TYPE_CATCH_TUTORIAL))
+    else if (IS_FRLG && (gBattleTypeFlags & (BATTLE_TYPE_FIRST_BATTLE | BATTLE_TYPE_CATCH_TUTORIAL)))
     {
         gBattleScripting.windowsType = B_WIN_TYPE_KANTO_TUTORIAL;
     }


### PR DESCRIPTION
When the battle starts, `InitBattleBgsVideo()` occur before `CB2_HandleStartBattle` where the battle flag IS_MASTER is added.
This means the first time InitBattleBgsVideo() is called gBattleTypeFlags is equal to (BATTLE_TYPE_TRAINER | BATTLE_TYPE_FIRST_BATTLE)
but if InitBattleBgsVideo() is called again after coming from the party screen or the bag screen gBattleTypeFlags is now equal  to (BATTLE_TYPE_TRAINER | BATTLE_TYPE_FIRST_BATTLE | BATTLE_TYPE_IS_MASTER)

so the condition `gBattleTypeFlags == (BATTLE_TYPE_TRAINER | BATTLE_TYPE_FIRST_BATTLE)` becomes false, the wrong windows are loaded and the game crashes when trying to write the next tutorial message

We fix it by only checking the BATTLE_TYPE_FIRST_BATTLE bit is set instead of checking the full value of gBattleTypeFlags

## Media

https://github.com/user-attachments/assets/d7661f53-5911-4503-b5de-df4b8333f924



## Issue(s) that this PR fixes
Fixes #9204

## Discord contact info
Jamie
