### PR TITLE
Fixes Throat Chop timer being reset with every use of the move

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -3514,8 +3514,11 @@ void SetMoveEffect(u32 battler, u32 effectBattler, enum MoveEffect moveEffect, c
         }
         break;
     case MOVE_EFFECT_THROAT_CHOP:
-        gDisableStructs[gEffectBattler].throatChopTimer = 2;
-        gBattlescriptCurrInstr = battleScript;
+        if (gDisableStructs[gEffectBattler].throatChopTimer == 0)
+        {
+            gDisableStructs[gEffectBattler].throatChopTimer = 2;
+            gBattlescriptCurrInstr = battleScript;
+        }
         break;
     case MOVE_EFFECT_INCINERATE:
         if (((gBattleMons[gEffectBattler].item >= FIRST_BERRY_INDEX && gBattleMons[gEffectBattler].item <= LAST_BERRY_INDEX)

--- a/test/battle/move_effect_secondary/throat_chop.c
+++ b/test/battle/move_effect_secondary/throat_chop.c
@@ -27,8 +27,9 @@ SINGLE_BATTLE_TEST("Throat Chop prevents the usage of sound moves")
 SINGLE_BATTLE_TEST("Throat Chop prevents sound base moves for 2 turns")
 {
     GIVEN {
+        ASSUME(IsSoundMove(MOVE_HYPER_VOICE));
         PLAYER(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_WOBBUFFET) { Moves(MOVE_HYPER_VOICE, MOVE_ALLURING_VOICE, MOVE_OVERDRIVE, MOVE_ROUND); }
+        OPPONENT(SPECIES_WOBBUFFET) { Moves(MOVE_HYPER_VOICE); }
     } WHEN {
         TURN { MOVE(opponent, MOVE_HYPER_VOICE); MOVE(player, MOVE_THROAT_CHOP); }
         TURN { FORCED_MOVE(opponent); }
@@ -42,6 +43,25 @@ SINGLE_BATTLE_TEST("Throat Chop prevents sound base moves for 2 turns")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_HYPER_VOICE, opponent);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_THROAT_CHOP, player);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_STRUGGLE, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_HYPER_VOICE, opponent);
+    }
+}
+
+SINGLE_BATTLE_TEST("Throat Chop usage when target is already prevented from using sound moves doesn't reset timer")
+{
+    GIVEN {
+        ASSUME(IsSoundMove(MOVE_HYPER_VOICE));
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { Moves(MOVE_HYPER_VOICE); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_HYPER_VOICE); MOVE(player, MOVE_THROAT_CHOP); }
+        TURN { FORCED_MOVE(opponent); MOVE(player, MOVE_THROAT_CHOP); }
+        TURN { MOVE(opponent, MOVE_HYPER_VOICE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_HYPER_VOICE, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_THROAT_CHOP, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_STRUGGLE, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_THROAT_CHOP, player);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_HYPER_VOICE, opponent);
     }
 }


### PR DESCRIPTION
Fixes Throat Chop timer being re-set to 2 when using Throat Chop on a target with `throatChopTimer > 0`

## Discord contact info
PhallenTree