### PR TITLE
Fix batle dome streak thresholds

### DIFF
--- a/src/frontier_util.c
+++ b/src/frontier_util.c
@@ -138,7 +138,7 @@ const struct FrontierBrain gFrontierBrainInfo[NUM_FRONTIER_FACILITIES] =
             COMPOUND_STRING("My DOME ACE title isn't just for show!") //Gold
         },
         .battledBit = {1 << 2, 1 << 3},
-        .streakAppearances = {1, 2, 5, 0},
+        .streakAppearances = {4, 9, 5, 0},
     },
     [FRONTIER_FACILITY_PALACE] =
     {


### PR DESCRIPTION
I just changed the strikeAppearances array to the same values it has on pret (search for sFrontierBrainStreakAppearances), some typo likely made its way during the refactor.

## Issue(s) that this PR fixes
Fixes #9253

## Discord contact info
Jamie
