### PR TITLE
Throat Chop Fix: Does not reapply its timer to the target while Throat Chopped

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2843,7 +2843,8 @@ void SetMoveEffect(enum BattlerId battlerAtk, enum BattlerId effectBattler, enum
         }
         break;
     case MOVE_EFFECT_THROAT_CHOP:
-        gBattleMons[gEffectBattler].volatiles.throatChopTimer = B_THROAT_CHOP_TIMER;
+        if (gBattleMons[gEffectBattler].volatiles.throatChopTimer == 0)
+            gBattleMons[gEffectBattler].volatiles.throatChopTimer = B_THROAT_CHOP_TIMER;
         gBattlescriptCurrInstr = battleScript;
         break;
     case MOVE_EFFECT_INCINERATE:

--- a/test/battle/move_effect_secondary/throat_chop.c
+++ b/test/battle/move_effect_secondary/throat_chop.c
@@ -45,3 +45,28 @@ SINGLE_BATTLE_TEST("Throat Chop prevents sound base moves for 2 turns")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_HYPER_VOICE, opponent);
     }
 }
+
+SINGLE_BATTLE_TEST("Throat Chop does not reapply while the target is Throat Chopped")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Attack(1); }
+        OPPONENT(SPECIES_WOBBUFFET) { Moves(MOVE_HYPER_VOICE, MOVE_ALLURING_VOICE, MOVE_OVERDRIVE, MOVE_ROUND); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_HYPER_VOICE); MOVE(player, MOVE_THROAT_CHOP); }
+        TURN { FORCED_MOVE(opponent); MOVE(player, MOVE_THROAT_CHOP); }
+        TURN { MOVE(opponent, MOVE_HYPER_VOICE); MOVE(player, MOVE_THROAT_CHOP); }
+        TURN { FORCED_MOVE(opponent); MOVE(player, MOVE_THROAT_CHOP); }
+        TURN { MOVE(opponent, MOVE_HYPER_VOICE); MOVE(player, MOVE_THROAT_CHOP); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_HYPER_VOICE, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_THROAT_CHOP, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_STRUGGLE, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_THROAT_CHOP, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_HYPER_VOICE, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_THROAT_CHOP, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_STRUGGLE, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_THROAT_CHOP, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_HYPER_VOICE, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_THROAT_CHOP, player);
+    }
+}


### PR DESCRIPTION
Title

## Description
This PR fixes the interaction with Throat Chop where its timer gets refreshed after each use, even if the target is already Throat Chopped.

## Media

https://github.com/user-attachments/assets/2e4dd018-1175-4a50-b981-8881dbfa505f

## Issue(s) that this PR fixes
Fixes #9266

## Discord contact info
linathan