### PR TITLE
Fix incorrect Adaptability interaction with non Tera type moves after Terastalization

### DIFF
--- a/src/battle_terastal.c
+++ b/src/battle_terastal.c
@@ -163,14 +163,18 @@ uq4_12_t GetTeraMultiplier(struct DamageContext *ctx)
         else
             return UQ_4_12(2.0);
     }
-    // Base or Tera type only.
-    else if ((ctx->moveType == teraType && !IS_BATTLER_OF_BASE_TYPE(ctx->battlerAtk, ctx->moveType))
-             || (ctx->moveType != teraType && IS_BATTLER_OF_BASE_TYPE(ctx->battlerAtk, ctx->moveType)))
+    // Tera type only (Adaptability applies).
+    else if (ctx->moveType == teraType && !IS_BATTLER_OF_BASE_TYPE(ctx->battlerAtk, ctx->moveType))
     {
         if (ctx->abilityAtk == ABILITY_ADAPTABILITY)
             return UQ_4_12(2.0);
         else
             return UQ_4_12(1.5);
+    }
+    // Base type only (Adaptability does not apply while Terastallized).
+    else if (ctx->moveType != teraType && IS_BATTLER_OF_BASE_TYPE(ctx->battlerAtk, ctx->moveType))
+    {
+        return UQ_4_12(1.5);
     }
     // Neither base or Tera type.
     else

--- a/test/battle/ability/adaptability.c
+++ b/test/battle/ability/adaptability.c
@@ -61,4 +61,39 @@ SINGLE_BATTLE_TEST("(TERA) Terastallizing into the same type with Adaptability g
     }
 }
 
-TO_DO_BATTLE_TEST("Adaptability does not affect Stellar-type moves");
+SINGLE_BATTLE_TEST("(TERA) Adaptability does not increase non-Tera base STAB beyond 1.5x", s16 damage)
+{
+    u32 move;
+    PARAMETRIZE { move = MOVE_GUST; }
+    PARAMETRIZE { move = MOVE_WATER_GUN; }
+    GIVEN {
+        PLAYER(SPECIES_CRAWDAUNT) { Ability(ABILITY_ADAPTABILITY); TeraType(TYPE_NORMAL); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, move, gimmick: GIMMICK_TERA); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        // With Adaptability, non-Tera base type should still be 1.5x STAB (not 2.0x).
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.5), results[1].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("(TERA) Adaptability does not affect Stellar-type moves", s16 damage)
+{
+    u32 ability;
+    PARAMETRIZE { ability = ABILITY_HYPER_CUTTER; }
+    PARAMETRIZE { ability = ABILITY_ADAPTABILITY; }
+    GIVEN {
+        PLAYER(SPECIES_CRAWDAUNT) { Ability(ability); TeraType(TYPE_STELLAR); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_TERA_BLAST, gimmick: GIMMICK_TERA); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TERA_BLAST, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_EQ(results[0].damage, results[1].damage);
+    }
+}


### PR DESCRIPTION
## Description
**Without Adaptability**
<img width="859" height="179" alt="image" src="https://github.com/user-attachments/assets/f8fa4378-d4b9-4bb9-b340-e94b31788db9" />

**With Adaptability**
<img width="855" height="172" alt="image" src="https://github.com/user-attachments/assets/dd3bc60c-7551-4199-b586-c4827fea4451" />

## Issue(s) that this PR fixes
Fixes #8727 