### PR TITLE
Fix setting the wall clock crashing with OW_USE_FAKE_RTC set to FALSE and LTO=1

### DIFF
--- a/src/fake_rtc.c
+++ b/src/fake_rtc.c
@@ -50,6 +50,9 @@ void FakeRtc_TickTimeForward(void)
 
 void FakeRtc_AdvanceTimeBy(u32 days, u32 hours, u32 minutes, u32 seconds)
 {
+    if (!OW_USE_FAKE_RTC)
+        return;
+
     struct DateTime dateTime;
     struct SiiRtcInfo *rtc = FakeRtc_GetCurrentTime();
 
@@ -63,6 +66,9 @@ void FakeRtc_AdvanceTimeBy(u32 days, u32 hours, u32 minutes, u32 seconds)
 
 void FakeRtc_ForwardTimeTo(u32 hour, u32 minute, u32 second)
 {
+    if (!OW_USE_FAKE_RTC)
+        return;
+
     Script_PauseFakeRtc();
     struct Time diff, target;
     struct SiiRtcInfo *fakeRtc = FakeRtc_GetCurrentTime();

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -349,7 +349,8 @@ void RtcCalcLocalTimeOffset(s32 days, s32 hours, s32 minutes, s32 seconds)
     gLocalTime.hours = hours;
     gLocalTime.minutes = minutes;
     gLocalTime.seconds = seconds;
-    FakeRtc_ManuallySetTime(gLocalTime.days, gLocalTime.hours, gLocalTime.minutes, seconds);
+    if (!OW_USE_FAKE_RTC)
+        FakeRtc_ManuallySetTime(gLocalTime.days, gLocalTime.hours, gLocalTime.minutes, seconds);
     RtcGetInfo(&sRtc);
     RtcCalcTimeDifference(&sRtc, &gSaveBlock2Ptr->localTimeOffset, &gLocalTime);
 }

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -3239,6 +3239,9 @@ bool8 ScrCmd_fwdtime(struct ScriptContext *ctx)
 
 bool8 ScrCmd_fwdweekday(struct ScriptContext *ctx)
 {
+    if (!OW_USE_FAKE_RTC)
+        return FALSE;
+
     struct SiiRtcInfo *rtc = FakeRtc_GetCurrentTime();
 
     u32 weekdayTarget = ScriptReadWord(ctx);


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
Adds checks to make sure that a `nullptr` isn't used where the fake rtc struct is expected.

## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, closes #2222." Remove this section if not applicable.-->
Fixes #9297 

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara