### PR TITLE
Add tests for Future Sight interaction with Ally Switch

### DIFF
--- a/test/battle/move_effect/ally_switch.c
+++ b/test/battle/move_effect/ally_switch.c
@@ -402,6 +402,28 @@ DOUBLE_BATTLE_TEST("Ally Switch does not update Future Sight target position")
     }
 }
 
+DOUBLE_BATTLE_TEST("Ally Switch does not update Future Sight target position when attacker side switches")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_FUTURE_SIGHT) == EFFECT_FUTURE_SIGHT);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_ABRA);
+        OPPONENT(SPECIES_RALTS);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponentLeft, MOVE_FUTURE_SIGHT, target: playerLeft); }
+        TURN { SWITCH(opponentLeft, 2); MOVE(opponentRight, MOVE_ALLY_SWITCH); }
+        TURN { }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FUTURE_SIGHT, opponentLeft);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ALLY_SWITCH, opponentRight);
+        MESSAGE("Wobbuffet took the Future Sight attack!");
+        HP_BAR(playerLeft);
+        NOT HP_BAR(playerRight);
+    }
+}
+
 DOUBLE_BATTLE_TEST("Ally Switch does not update Wish recovery position")
 {
     GIVEN {


### PR DESCRIPTION
## Description

**[Future Sight](https://wiki.xn--rckteqa2e.com/wiki/%E3%81%BF%E3%82%89%E3%81%84%E3%82%88%E3%81%A1):**

> - 予知ターンに指定した対象となる場にポケモンがいれば攻撃は成功する。使用者がひんしになっていても成功する。
> - ダブルバトル以上で、すでに誰もいない位置を選択しても、選択した位置が「みらいにこうげき状態」になる。

**Translation:**

> - If there is a Pokémon in the designated target position at the time of the attack (the turn it hits), the attack succeeds. It succeeds even if the user is fainted.
> - In Double Battles and above, even if you select a position where no Pokémon is present, that position becomes the "future attack state".

[**Ally Switch**](https://wiki.xn--rckteqa2e.com/wiki/%E3%82%B5%E3%82%A4%E3%83%89%E3%83%81%E3%82%A7%E3%83%B3%E3%82%B8):

> 以下の単体の場の状態の位置はサイドチェンジでも変わらない。
> 
> - やどりぎのタネ状態で回復する位置
> - みらいにこうげき状態の位置
> - ねがいごと、いやしのねがい／みかづきのまいで回復する位置

**Translation:**

> The positions of the following single-target field effects do not change even with **Ally Switch**:
> 
> - The position where Leech Seed recovers HP
> - The position of the future attack state
> - The position where Wish, Healing Wish, or Lunar Dance will recover HP

**Explanation:**
Future Sight locks onto a specific position on the field at the moment of use. Two turns later, it attacks whatever Pokémon occupies that position.

If the user uses Ally Switch, the user moves, but the marked position remains unchanged.
Even if the user is no longer on the field (fainted or switched out), the attack still occurs at that original spot.

## Issue(s) that this PR fixes
Closes #8186
