### PR TITLE
Set var facing on all interactions

### DIFF
--- a/src/field_control_avatar.c
+++ b/src/field_control_avatar.c
@@ -357,6 +357,7 @@ static const u8 *GetInteractedObjectEventScript(struct MapPosition *position, u8
     s16 currY = gObjectEvents[gPlayerAvatar.objectEventId].currentCoords.y;
     u8 currBehavior = MapGridGetMetatileBehaviorAt(currX, currY);
 
+    gSpecialVar_Facing = direction;
     switch (direction)
     {
     case DIR_EAST:
@@ -399,7 +400,6 @@ static const u8 *GetInteractedObjectEventScript(struct MapPosition *position, u8
 
     gSelectedObjectEvent = objectEventId;
     gSpecialVar_LastTalked = gObjectEvents[objectEventId].localId;
-    gSpecialVar_Facing = direction;
 
     if (InTrainerHill() == TRUE)
         script = GetTrainerHillTrainerScript();


### PR DESCRIPTION
In emerald, var facing is only set when inteeracting witha. sign or a an object event.
This PR makes var facing update on all interactions allowing it to work with the player house tv in frlg


## Media

https://github.com/user-attachments/assets/062188b8-2ed2-4c9e-9f02-203e0e3a6660

## Issue(s) that this PR fixes
Fixes #9308


## Feature(s) this PR does NOT handle:
- the var facing when interacting with sign could probably deleted because it's already set but I will make a cleanup PR for that after 1.15

## Discord contact info
Jamie
