### PR TITLE
Fix ss anne disappearing early

### DIFF
--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -9600,8 +9600,8 @@ static void UpdateObjectEventVisibility(struct ObjectEvent *objectEvent, struct 
 
 static void UpdateObjectEventOffscreen(struct ObjectEvent *objectEvent, struct Sprite *sprite)
 {
-    u16 x, y;
-    u16 x2, y2;
+    s32 x, y;
+    s32 x2, y2;
     const struct ObjectEventGraphicsInfo *graphicsInfo;
 
     objectEvent->offScreen = FALSE;
@@ -9617,15 +9617,17 @@ static void UpdateObjectEventOffscreen(struct ObjectEvent *objectEvent, struct S
         x = sprite->x + sprite->x2 + sprite->centerToCornerVecX;
         y = sprite->y + sprite->y2 + sprite->centerToCornerVecY;
     }
-    x2 = graphicsInfo->width;
-    x2 += x;
-    y2 = y;
-    y2 += graphicsInfo->height;
+    x2 = x + graphicsInfo->width;
+    y2 = y + graphicsInfo->height;
 
-    if ((s16)x >= DISPLAY_WIDTH + 16 || (s16)x2 < -16)
+    s32 minX = -16;
+    if (objectEvent->graphicsId == OBJ_EVENT_GFX_SS_ANNE)
+        minX = -32;
+
+    if (x >= DISPLAY_WIDTH + 16 || x2 < minX)
         objectEvent->offScreen = TRUE;
 
-    if ((s16)y >= DISPLAY_HEIGHT + 16 || (s16)y2 < -16)
+    if (y >= DISPLAY_HEIGHT + 16 || y2 < -16)
         objectEvent->offScreen = TRUE;
 }
 


### PR DESCRIPTION
A proper fix was too complicated so I did the same hardcoded exception that GF did in FireRed (the function is called `CalcWhetherObjectIsOffscreen` in pokefirered)

But here is why it's not working
`UpdateObjectEventOffscreen` seems pretty straightforward at first. You calculate the position of left, right, top and bottom edges of a sprite and compare their position to the edge of the screen to determine if an object event is off screen or not.

But it's not working for SS Anne because the centerToCornerVec values are incorrect.
For object events, centerToCornerVec values are set to half the width and height of the full graphics instead of where it set when the sprite is created

The SS Anne is composed of a 2by2 grid of 64x32 subsprite so the right edge of the graphic  should be position of the first sprite minus centerToCorner plus 128 or position of the first sprite plus 96

But because the centerToCorner is changed, to half the width, the calculated position of the right edge is now position of the first sprite plus 64. So we need to check SS Anne is at least 32 pixels away from the calculated position before making it invisible or it disappears early


A proper fix would have large consequences to all large sprite object events OR would force to recalculate center evc every frame which are both bad solutions so I stuck with the GF fix

## Media

https://github.com/user-attachments/assets/678e28f7-e38e-4aa7-a0f3-5b18003345e0

## Issue(s) that this PR fixes
Fixes #9311

## Feature(s) this PR does NOT handle:
- proper out of screen check for ALL large sprites

## Discord contact info
Jamie
