### PR TITLE
Fix frlg coinbox window

### DIFF
--- a/data/maps/CeladonCity_GameCorner_Frlg/scripts.inc
+++ b/data/maps/CeladonCity_GameCorner_Frlg/scripts.inc
@@ -22,7 +22,7 @@ CeladonCity_GameCorner_EventScript_CoinsClerk::
 	lock
 	faceplayer
 	showmoneybox 0, 0
-	showcoinsbox 0, 5
+	showcoinsbox 1, 6
 	message CeladonCity_GameCorner_Text_WelcomeBuySomeCoins
 	waitmessage
 	multichoice 13, 0, MULTI_GAME_CORNER_COIN_PURCHASE_COUNTER, FALSE

--- a/data/maps/CeladonCity_GameCorner_PrizeRoom_Frlg/scripts.inc
+++ b/data/maps/CeladonCity_GameCorner_PrizeRoom_Frlg/scripts.inc
@@ -13,7 +13,7 @@ CeladonCity_GameCorner_PrizeRoom_EventScript_PrizeClerkMons::
 	lock
 	faceplayer
 	goto_if_unset FLAG_GOT_COIN_CASE, CeladonCity_GameCorner_PrizeRoom_EventScript_NeedCoinCase
-	showcoinsbox 0, 0
+	showcoinsbox 1, 1
 	msgbox CeladonCity_GameCorner_PrizeRoom_Text_WeExchangeCoinsForPrizes
 	goto CeladonCity_GameCorner_PrizeRoom_EventScript_ChoosePrizeMon
 	end
@@ -240,7 +240,7 @@ CeladonCity_GameCorner_PrizeRoom_EventScript_PrizeClerkTMs::
 	lock
 	faceplayer
 	goto_if_unset FLAG_GOT_COIN_CASE, CeladonCity_GameCorner_PrizeRoom_EventScript_NeedCoinCase
-	showcoinsbox 0, 0
+	showcoinsbox 1, 1
 	msgbox CeladonCity_GameCorner_PrizeRoom_Text_WeExchangeCoinsForPrizes
 	goto CeladonCity_GameCorner_PrizeRoom_EventScript_ChoosePrizeTM
 	end
@@ -330,7 +330,7 @@ CeladonCity_GameCorner_PrizeRoom_EventScript_PrizeClerkItems::
 	lock
 	faceplayer
 	goto_if_unset FLAG_GOT_COIN_CASE, CeladonCity_GameCorner_PrizeRoom_EventScript_NeedCoinCase
-	showcoinsbox 0, 0
+	showcoinsbox 1, 1
 	msgbox CeladonCity_GameCorner_PrizeRoom_Text_WeExchangeCoinsForPrizes
 	goto CeladonCity_GameCorner_PrizeRoom_EventScript_ChoosePrizeItem
 	end


### PR DESCRIPTION
The coinbox window is offset differently in frlg and emerald, I adapted the frlg script to the emerald code because it requires less changes for regular expansion users. However I plan to do a PR after 1.15 to make the scripts match the frlg version because it's more consistent with the showmoneybox command

## Media

https://github.com/user-attachments/assets/179c0566-fa6d-4e1d-b8ef-18fb02c37670


## Issue(s) that this PR fixes
Fixes #9312


## Discord contact info
Jamie 
