### PR TITLE
Fixes post-KO animation assertf trigger caused by OOB battler number

### DIFF
--- a/src/pokemon_animation.c
+++ b/src/pokemon_animation.c
@@ -501,12 +501,7 @@ static void Task_HandleMonAnimation(u8 taskId)
 
     if (gTasks[taskId].tState == 0)
     {
-        enum BattlerId spriteBattler = 0;
-        if (sprite->oam.paletteNum > 3)
-            spriteBattler = (sprite->oam.paletteNum - 14) * 2; // Player side (14 + battler / 2) if player side palette hard-coding is ever changed, this line will need changing
-        else
-            spriteBattler = sprite->oam.paletteNum; // Opponent side
-        gTasks[taskId].tBattlerId = spriteBattler;
+        gTasks[taskId].tBattlerId = sprite->oam.paletteNum;
         gTasks[taskId].tSpeciesId = sprite->data[2];
         sprite->sDontFlip = TRUE;
         sprite->data[0] = 0;


### PR DESCRIPTION
In-battle mon animations using `sprite->data[0]` never restore `sprite->data[0]` to its original value which is used to store battler number, resulting in garbage being passed to `SpriteCB_FaintOpponentMon` triggering an assert when player KOs both opponents and player's ally in a double battle. PR fixes.

## Description
`Task_HandleMonAnimation` changed to restore `sprite->data[0]` from `sprite->oam.paletteNum`

## Issue(s) that this PR fixes
Fixes #9214 

## Discord contact info
grintoul