### PR TITLE
Fix double actions on standard bike

### DIFF
--- a/src/bike.c
+++ b/src/bike.c
@@ -160,7 +160,7 @@ void MovePlayerOnBike(enum Direction direction, u16 newKeys, u16 heldKeys)
 {
     if ((gPlayerAvatar.flags & PLAYER_AVATAR_FLAG_MACH_BIKE) && (gPlayerAvatar.flags & PLAYER_AVATAR_FLAG_ACRO_BIKE))
         MovePlayerOnStandardBike(direction, newKeys, heldKeys);
-    if (gPlayerAvatar.flags & PLAYER_AVATAR_FLAG_MACH_BIKE)
+    else if (gPlayerAvatar.flags & PLAYER_AVATAR_FLAG_MACH_BIKE)
         MovePlayerOnMachBike(direction, newKeys, heldKeys);
     else
         MovePlayerOnAcroBike(direction, newKeys, heldKeys);


### PR DESCRIPTION
The standard bike would execute the movement check of both the standard bike and the mach bike causing some actions like pushing boulders to occur twice


## Media

https://github.com/user-attachments/assets/57214378-33a6-4fb4-b02d-67fe351ff0c9


## Issue(s) that this PR fixes
Fixes #9324


## Discord contact info
Jamie
