### PR TITLE
Fix floor menu in frlg elevator showing wrong values

### DIFF
--- a/src/field_specials.c
+++ b/src/field_specials.c
@@ -2498,13 +2498,13 @@ void ShowScrollableMultichoice(void)
         task->tTaskId = taskId;
         break;
     case SCROLL_MULTI_SILPHCO_FLOORS:
-        task->tMaxItemsOnScreen = 7;
+        task->tMaxItemsOnScreen = MAX_SCROLL_MULTI_ON_SCREEN;
         task->tNumItems = 12;
         task->tLeft = 1;
         task->tTop = 1;
         task->tWidth = 8;
         task->tHeight = 12;
-        task->tKeepOpenAfterSelect = 0;
+        task->tKeepOpenAfterSelect = FALSE;
         task->tTaskId = taskId;
         task->tScrollOffset = sElevatorScroll;
         task->tSelectedRow = sElevatorCursorPos;


### PR DESCRIPTION
Emerald code was designed around 6 items max in a multi list like floor selection so reducing tMaxItemsOnScreen fixes the bug

## Issue(s) that this PR fixes
Fixes #9342


## Discord contact info
Jamie
