### PR TITLE
Fix Paradox stat selection under Wonder Room

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -5996,6 +5996,7 @@ static u32 GetStatValueWithStages(u32 battler, u32 stat)
 u32 GetParadoxHighestStatId(u32 battler)
 {
     u32 highestId = STAT_ATK;
+    bool32 wonderRoom = (gFieldStatuses & STATUS_FIELD_WONDER_ROOM) != 0;
     u32 highestStat = GetStatValueWithStages(battler, STAT_ATK);
 
     for (u32 stat = STAT_DEF; stat < NUM_STATS; stat++)
@@ -6003,7 +6004,23 @@ u32 GetParadoxHighestStatId(u32 battler)
         if (stat == STAT_SPEED)
             continue;
 
-        u32 statValue = GetStatValueWithStages(battler, stat);
+        u32 statValue;
+        switch (stat)
+        {
+        case STAT_DEF:
+            statValue = wonderRoom ? gBattleMons[battler].spDefense : gBattleMons[battler].defense;
+            statValue *= gStatStageRatios[gBattleMons[battler].statStages[STAT_DEF]][0];
+            statValue /= gStatStageRatios[gBattleMons[battler].statStages[STAT_DEF]][1];
+            break;
+        case STAT_SPDEF:
+            statValue = wonderRoom ? gBattleMons[battler].defense : gBattleMons[battler].spDefense;
+            statValue *= gStatStageRatios[gBattleMons[battler].statStages[STAT_SPDEF]][0];
+            statValue /= gStatStageRatios[gBattleMons[battler].statStages[STAT_SPDEF]][1];
+            break;
+        default:
+            statValue = GetStatValueWithStages(battler, stat);
+            break;
+        }
         if (statValue > highestStat)
         {
             highestStat = statValue;

--- a/test/battle/ability/protosynthesis.c
+++ b/test/battle/ability/protosynthesis.c
@@ -134,6 +134,23 @@ SINGLE_BATTLE_TEST("Protosynthesis prioritizes stats in the case of a tie in the
     }
 }
 
+SINGLE_BATTLE_TEST("Protosynthesis uses Wonder Room swapped defenses when choosing boosted stat")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_WONDER_ROOM) == EFFECT_WONDER_ROOM);
+        PLAYER(SPECIES_ROARING_MOON) { Ability(ABILITY_PROTOSYNTHESIS); Attack(50); Defense(200); SpAttack(40); SpDefense(60); Speed(70); Moves(MOVE_WONDER_ROOM); }
+        OPPONENT(SPECIES_WOBBUFFET) { Moves(MOVE_SUNNY_DAY); Speed(60); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_WONDER_ROOM); MOVE(opponent, MOVE_SUNNY_DAY); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_WONDER_ROOM, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SUNNY_DAY, opponent);
+        ABILITY_POPUP(player, ABILITY_PROTOSYNTHESIS);
+        MESSAGE("The harsh sunlight activated Roaring Moon's Protosynthesis!");
+        MESSAGE("Roaring Moon's Sp. Def was heightened!");
+    }
+}
+
 SINGLE_BATTLE_TEST("Protosynthesis activates in Sun before Booster Energy")
 {
     GIVEN {

--- a/test/battle/ability/quark_drive.c
+++ b/test/battle/ability/quark_drive.c
@@ -201,6 +201,23 @@ SINGLE_BATTLE_TEST("Quark Drive prioritizes stats in the case of a tie in the fo
     }
 }
 
+SINGLE_BATTLE_TEST("Quark Drive uses Wonder Room swapped defenses when choosing boosted stat")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_WONDER_ROOM) == EFFECT_WONDER_ROOM);
+        PLAYER(SPECIES_IRON_LEAVES) { Ability(ABILITY_QUARK_DRIVE); Attack(50); Defense(200); SpAttack(40); SpDefense(60); Speed(70); Moves(MOVE_WONDER_ROOM); }
+        OPPONENT(SPECIES_WOBBUFFET) { Moves(MOVE_ELECTRIC_TERRAIN); Speed(60); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_WONDER_ROOM); MOVE(opponent, MOVE_ELECTRIC_TERRAIN); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_WONDER_ROOM, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ELECTRIC_TERRAIN, opponent);
+        ABILITY_POPUP(player, ABILITY_QUARK_DRIVE);
+        MESSAGE("The Electric Terrain activated Iron Leaves's Quark Drive!");
+        MESSAGE("Iron Leaves's Sp. Def was heightened!");
+    }
+}
+
 SINGLE_BATTLE_TEST("Quark Drive activates in Electric Terrain before Booster Energy")
 {
     GIVEN {


### PR DESCRIPTION
## Description
[**Jpwiki**](https://wiki.xn--rckteqa2e.com/wiki/%E3%81%93%E3%81%A0%E3%81%84%E3%81%8B%E3%81%A3%E3%81%9B%E3%81%84)

> 上がる能力を決める際に参照にする数値は以下のように扱う。
>
> - ランク補正の効果は考慮する (ビーストブーストの仕様とは異なる)。
> - パワーシェア/ガードシェア/パワートリック/スピードスワップ/ワンダールームによる実数値変動も考慮する。

When determining which stat to boost, the following values are referenced.

- Rank modifiers are taken into account (this differs from Beast Boost). 
- Changes to actual stat values caused by Power Share, Guard Share, Power Trick, Speed Swap, or **Wonder Room** are also taken into account.
