### PR TITLE
Make sure prevo moves are not duplicated in move relearner

### DIFF
--- a/src/move_relearner.c
+++ b/src/move_relearner.c
@@ -1185,7 +1185,16 @@ static u32 GetRelearnerLevelUpMoves(struct BoxPokemon *mon, u16 *moves)
             if (learnset[i].level > level)
                 break;
 
-            if (!BoxMonKnowsMove(mon, learnset[i].move))
+            if (BoxMonKnowsMove(mon, learnset[i].move))
+                continue;
+
+            bool32 alreadyInList = FALSE;
+            for (u32 j = 0; j < numMoves; j++)
+            {
+                if (learnset[i].move == moves[j])
+                    alreadyInList = TRUE;
+            }
+            if (!alreadyInList)
                 moves[numMoves++] = learnset[i].move;
         }
 


### PR DESCRIPTION
When adding pre evo moves to the move list, duplicates were not check so move could appear up to 3 times for a poke in its third evo stage

## Media
upcoming:

https://github.com/user-attachments/assets/ac59a785-3604-480b-8110-a293273bc61d

this commit:

https://github.com/user-attachments/assets/8575d22a-d44b-4d7d-a12c-ad53cf89371e




## Discord contact info
Jamie