### PR TITLE
Fix Trapping Persisting after KO in doubles

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -5858,6 +5858,9 @@ u32 IsAbilityPreventingEscape(u32 battler)
     {
         if (battler == battlerDef || IsBattlerAlly(battler, battlerDef))
             continue;
+        
+        if (!IsBattlerAlive(battlerDef))
+            continue;
 
         enum Ability ability = GetBattlerAbility(battlerDef);
 


### PR DESCRIPTION
Fixes trapping abilities continuing to trap the player if the last mon on one side of a two trainer double battle has one.

Adds an isbattleralive check in the isabilitypreventingescape function.

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

## Description
If the last pokemon on one side of a two trainer double battle has a trapping ability (shadow tag/arena trap/magnet pull), the player will remain trapped after the trapping mon is KOd. This PR fixes this issues by applying the same isbattleralive check used in other functions (found in unnerve specifically) to the function that determines if the player can escape.

Before the change:

https://github.com/user-attachments/assets/79181bd6-584b-4c4e-bfe2-d4e6116a8f80

After the fix:

https://github.com/user-attachments/assets/70b153bb-8250-4bb1-b239-c7e87e0b782d

## Discord contact info
Followup with chrispychris27 on discord
