### PR TITLE
Revert "Start of 1.16.0 cycle"

### DIFF
--- a/include/constants/expansion.h
+++ b/include/constants/expansion.h
@@ -3,8 +3,8 @@
 
 // Last version: 1.15.0
 #define EXPANSION_VERSION_MAJOR 1
-#define EXPANSION_VERSION_MINOR 16
-#define EXPANSION_VERSION_PATCH 0
+#define EXPANSION_VERSION_MINOR 15
+#define EXPANSION_VERSION_PATCH 1
 
 // FALSE if this this version of Expansion is not a tagged commit, i.e.
 // it contains unreleased changes.


### PR DESCRIPTION
Reverts rh-hideout/pokeemerald-expansion#9400
This was supposed to target `upcoming`