### PR TITLE
Fade background and sprites simulatneously

### DIFF
--- a/src/palette.c
+++ b/src/palette.c
@@ -336,11 +336,13 @@ static u32 UpdateNormalPaletteFade(void)
     while (selectedPalettes)
     {
         if (selectedPalettes & 1)
+        {
             BlendPalette(
                 paletteOffset,
                 16,
                 gPaletteFade.y,
                 gPaletteFade.blendColor);
+        }
         selectedPalettes >>= 1;
         paletteOffset += 16;
     }


### PR DESCRIPTION
Rework palette fade to fade background and sprites simulatneously instead of alternating background fade on one frame and sprite frame or another. It fixes some minor graphical error where a sprite supposed to blend with the background doesn't for one frame when fading.
This seems to work fine on emulators but the additional cycles requires may cause issues in some places in the code or on real hardware (this is why it's going to upcoming)

## Media

https://github.com/user-attachments/assets/fc80f244-2fb0-462d-bd35-fb843f2362e9



## Issue(s) that this PR fixes
Fixes #9327 


## Discord contact info
Jamie