### PR TITLE
Make trainerproc-generated files depend on trainerproc

### DIFF
--- a/trainer_rules.mk
+++ b/trainer_rules.mk
@@ -7,5 +7,5 @@ AUTO_GEN_TARGETS += src/data/battle_partners.h
 AUTO_GEN_TARGETS += test/battle/trainer_control.h
 AUTO_GEN_TARGETS += src/data/debug_trainers.h
 
-%.h: %.party
+%.h: %.party $(TRAINERPROC)
 	$(CPP) $(CPPFLAGS) -traditional-cpp - < $< | $(TRAINERPROC) -o $@ -i $< -


### PR DESCRIPTION
## Description

If you build `expansion/1.14.4`, then switch to and attempt to build `expansion/1.15.0`, the build will produce a slew of errors attributed to `*.party` files. This is because `make` does not realize that each `.party`'s associated `*.h` files are out of date, so `make` does not regenerate these files.

This PR marks `src/data/trainers.h` and friends as depending on `trainerproc`; so that when `trainerproc` changes, `src/data/trainers.h` and friends will be rebuilt without a manual deletion of `src/data/trainers.h` nor a `make clean`

## Discord contact info
yoshord