### PR TITLE
Fix assert failure on disabled species in Sprite Visualizer

### DIFF
--- a/src/pokemon_sprite_visualizer.c
+++ b/src/pokemon_sprite_visualizer.c
@@ -575,7 +575,7 @@ static void SetStructPtr(u8 taskId, void *ptr)
 static void PrintDigitChars(struct PokemonSpriteVisualizer *data)
 {
     s32 i;
-    u16 species = IsSpeciesEnabled(data->modifyArrows.currValue) ? data->modifyArrows.currValue : 0;
+    u16 species = IsSpeciesEnabled(data->modifyArrows.currValue) ? data->modifyArrows.currValue : SPECIES_NONE;
 
     u8 text[MODIFY_DIGITS_MAX + POKEMON_NAME_LENGTH + 8];
 


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
Looking at a disabled species in the sprite visualizer would cause an `assertf` error, now it shows a decamark instead.

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara