### PR TITLE
Fix Unseen Fist triggering protection move side effects

### DIFF
--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -2061,15 +2061,25 @@ static enum MoveEndResult MoveEndProtectLikeEffect(void)
 {
     enum MoveEndResult result = MOVEEND_RESULT_CONTINUE;
     u32 temp = 0;
+    enum Ability abilityAtk = GetBattlerAbility(gBattlerAttacker);
+    enum HoldEffect holdEffectAtk = GetBattlerHoldEffect(gBattlerAttacker);
+    enum ProtectMethod method = gProtectStructs[gBattlerTarget].protected;
 
     if (gProtectStructs[gBattlerAttacker].chargingTurn
-     || CanBattlerAvoidContactEffects(gBattlerAttacker, gBattlerTarget, GetBattlerAbility(gBattlerAttacker), GetBattlerHoldEffect(gBattlerAttacker), gCurrentMove))
+     || CanBattlerAvoidContactEffects(gBattlerAttacker, gBattlerTarget, abilityAtk, holdEffectAtk, gCurrentMove))
     {
         gBattleScripting.moveendState++;
         return result;
     }
 
-    enum ProtectMethod method = gProtectStructs[gBattlerTarget].protected;
+    if (method != PROTECT_MAX_GUARD
+     && abilityAtk == ABILITY_UNSEEN_FIST
+     && IsMoveMakingContact(gBattlerAttacker, gBattlerTarget, abilityAtk, holdEffectAtk, gCurrentMove))
+    {
+        gBattleScripting.moveendState++;
+        return result;
+    }
+
     switch (method)
     {
     case PROTECT_SPIKY_SHIELD:

--- a/test/battle/ability/unseen_fist.c
+++ b/test/battle/ability/unseen_fist.c
@@ -5,6 +5,12 @@ ASSUMPTIONS
 {
     ASSUME(MoveMakesContact(MOVE_SCRATCH));
     ASSUME(GetMoveEffect(MOVE_PROTECT) == EFFECT_PROTECT);
+    ASSUME(GetMoveEffect(MOVE_KINGS_SHIELD) == EFFECT_PROTECT);
+    ASSUME(GetMoveEffect(MOVE_SPIKY_SHIELD) == EFFECT_PROTECT);
+    ASSUME(GetMoveEffect(MOVE_BANEFUL_BUNKER) == EFFECT_PROTECT);
+    ASSUME(GetMoveEffect(MOVE_BURNING_BULWARK) == EFFECT_PROTECT);
+    ASSUME(GetMoveEffect(MOVE_OBSTRUCT) == EFFECT_PROTECT);
+    ASSUME(GetMoveEffect(MOVE_SILK_TRAP) == EFFECT_PROTECT);
 }
 
 TO_DO_BATTLE_TEST("TODO: Write Unseen Fist (Ability) test titles")
@@ -31,5 +37,40 @@ SINGLE_BATTLE_TEST("Unseen Fist ignores Protect when user has Protective Pads, b
             ANIMATION(ANIM_TYPE_MOVE, MOVE_MACH_PUNCH, player);
         else
             NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_MACH_PUNCH, player);
+    }
+}
+
+SINGLE_BATTLE_TEST("Unseen Fist bypasses protect effects without triggering their contact effects")
+{
+    enum Move protectMove = MOVE_NONE;
+    u8 loweredStat = 0;
+
+    PARAMETRIZE { protectMove = MOVE_SPIKY_SHIELD;    loweredStat = 0; }
+    PARAMETRIZE { protectMove = MOVE_KINGS_SHIELD;    loweredStat = STAT_ATK; }
+    PARAMETRIZE { protectMove = MOVE_BANEFUL_BUNKER;  loweredStat = 0; }
+    PARAMETRIZE { protectMove = MOVE_BURNING_BULWARK; loweredStat = 0; }
+    PARAMETRIZE { protectMove = MOVE_OBSTRUCT;        loweredStat = STAT_DEF; }
+    PARAMETRIZE { protectMove = MOVE_SILK_TRAP;       loweredStat = STAT_SPEED; }
+
+    GIVEN {
+        PLAYER(SPECIES_URSHIFU) { Ability(ABILITY_UNSEEN_FIST); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, protectMove); MOVE(player, MOVE_SCRATCH); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, protectMove, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        HP_BAR(opponent);
+        NONE_OF {
+            HP_BAR(player);
+            STATUS_ICON(player, STATUS1_POISON);
+            STATUS_ICON(player, STATUS1_BURN);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        }
+    } THEN {
+        EXPECT_EQ(player->hp, player->maxHP);
+        EXPECT_EQ(player->status1, STATUS1_NONE);
+        if (loweredStat != 0)
+            EXPECT_EQ(player->statStages[loweredStat], DEFAULT_STAT_STAGE);
     }
 }


### PR DESCRIPTION
## Description
**[Jpwiki](https://wiki.xn--rckteqa2e.com/wiki/%E3%81%B5%E3%81%8B%E3%81%97%E3%81%AE%E3%81%93%E3%81%B6%E3%81%97)**
> ニードルガード/トーチカ/キングシールド/ブロッキング/スレッドトラップ/かえんのまもりを無視したときは、防御時に発動するこれらの技の効果も受けない。

When ignoring Spiky Shield, Baneful Bunker, King's Shield, Burning Bulwark, Obstruct, or Silk Trap, the user also does not suffer from the additional effects of these moves that activate upon defending.
