### PR TITLE
Removes a now-incorrect pokemon_summary_screen.c config

### DIFF
--- a/include/constants/move_relearner.h
+++ b/include/constants/move_relearner.h
@@ -6,6 +6,10 @@
 // If you plan on adding more TMs, increase this number too.
 #define MAX_RELEARNER_MOVES 60
 
+
+// While this is inactive, the party menu relearner prompt will default to saying "(select) RELEARN" and relearning level up moves. While active, the prompt reads, for examle "(select) RELEARN TUTOR" and may be scrolled with L/R.
+#define SPECIAL_RELEARNER_IS_ACTIVE (P_ENABLE_MOVE_RELEARNERS || P_TM_MOVES_RELEARNER || FlagGet(P_FLAG_EGG_MOVES) || FlagGet(P_FLAG_TUTOR_MOVES))
+
 // Move Relearner menu change constants
 enum MoveRelearnerStates
 {

--- a/src/pokemon_summary_screen.c
+++ b/src/pokemon_summary_screen.c
@@ -574,7 +574,7 @@ static const struct WindowTemplate sSummaryTemplate[] =
     },
     [PSS_LABEL_WINDOW_PROMPT_RELEARN] = {
         .bg = 0,
-        .tilemapLeft = (P_ENABLE_MOVE_RELEARNERS) ? 18 : 22,
+        .tilemapLeft = 18,
         .tilemapTop = 2,
         .width = 11,
         .height = 2,
@@ -4388,7 +4388,7 @@ static void SetSpriteInvisibility(u8 spriteArrayId, bool8 invisible)
 
 static void HidePageSpecificSprites(void)
 {
-    // Keeps Pok�mon, caught ball and status sprites visible.
+    // Keeps Pokémon, caught ball and status sprites visible.
     u8 i;
 
     for (i = SPRITE_ARR_ID_TYPE; i < ARRAY_COUNT(sMonSummaryScreen->spriteIds); i++)

--- a/src/pokemon_summary_screen.c
+++ b/src/pokemon_summary_screen.c
@@ -1975,7 +1975,6 @@ static void TryUpdateRelearnType(enum IncrDecrUpdateValues delta)
     enum MoveRelearnerStates state = gMoveRelearnerState;
 
     // just in case everything is off, default to level up moves
-        && !P_TM_MOVES_RELEARNER
     if (!SPECIAL_RELEARNER_IS_ACTIVE)
     {
         sMonSummaryScreen->hasRelearnableMoves = HasAnyRelearnableMoves(MOVE_RELEARNER_LEVEL_UP_MOVES);

--- a/src/pokemon_summary_screen.c
+++ b/src/pokemon_summary_screen.c
@@ -574,7 +574,7 @@ static const struct WindowTemplate sSummaryTemplate[] =
     },
     [PSS_LABEL_WINDOW_PROMPT_RELEARN] = {
         .bg = 0,
-        .tilemapLeft = 18,
+        .tilemapLeft = (SPECIAL_RELEARNER_IS_ACTIVE) ? 18 : 22,
         .tilemapTop = 2,
         .width = 11,
         .height = 2,
@@ -1975,10 +1975,8 @@ static void TryUpdateRelearnType(enum IncrDecrUpdateValues delta)
     enum MoveRelearnerStates state = gMoveRelearnerState;
 
     // just in case everything is off, default to level up moves
-    if ((!P_ENABLE_MOVE_RELEARNERS
         && !P_TM_MOVES_RELEARNER
-        && !FlagGet(P_FLAG_EGG_MOVES)
-        && !FlagGet(P_FLAG_TUTOR_MOVES)))
+    if (!SPECIAL_RELEARNER_IS_ACTIVE)
     {
         sMonSummaryScreen->hasRelearnableMoves = HasAnyRelearnableMoves(MOVE_RELEARNER_LEVEL_UP_MOVES);
         return;
@@ -4943,10 +4941,7 @@ static void ShowRelearnPrompt(void)
     const u8 *relearnText;
     int relearnTextXPos;
 
-    if ((!P_ENABLE_MOVE_RELEARNERS
-    && !P_TM_MOVES_RELEARNER
-    && !FlagGet(P_FLAG_EGG_MOVES)
-    && !FlagGet(P_FLAG_TUTOR_MOVES)))
+    if (!SPECIAL_RELEARNER_IS_ACTIVE)
     {
         relearnText = sText_Relearn;
         relearnTextXPos = 0;


### PR DESCRIPTION
This config was originally present to budge some text saying "[START] RELEARN" over to the right, rather than leave a small space. Since then, I think P_ENABLE_MOVE_RELEARNERS has been changed so it'll turn every tutor option on at once. 

Now, when P_ENABLE_MOVE_RELEARNERS = false and P_SUMMARY_SCREEN_MOVE_RELEARNER = true and P_TM_MOVES_RELEARNER = true, you get graphical errors as the text saying "relearn tm", for example, gets pushed so far rightward that it wraps around. This is presumably also true for the egg move/ tutor move flag. 

Budging the text doesn't really seem worth having a config for. It would look something like: 

(P_ENABLE_MOVE_RELEARNERS || (P_FLAG_EGG_MOVES!=0) || ( P_FLAG_TUTOR_MOVES !=0) || P_TM_MOVES_RELEARNER) ? 18 : 22