### PR TITLE
Fix `AI_CompareDamagingMoves` reading incorrect move indexes

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -1324,7 +1324,7 @@ static bool32 AI_IsMoveEffectInMinus(enum BattlerId battlerAtk, enum BattlerId b
 // Checks if one of the moves has side effects or perks, assuming equal dmg or equal no of hits to KO
 enum MoveComparisonResult CompareMoveEffects(enum Move move1, enum Move move2, enum BattlerId battlerAtk, enum BattlerId battlerDef, s32 noOfHitsToKo)
 {
-    bool32 effect1, effect2;
+    bool32 effect1minus, effect1plus, effect2minus, effect2plus;
     enum Ability defAbility = gAiLogicData->abilities[battlerDef];
     enum Ability atkAbility = gAiLogicData->abilities[battlerAtk];
 
@@ -1342,18 +1342,24 @@ enum MoveComparisonResult CompareMoveEffects(enum Move move1, enum Move move2, e
     }
 
     // Check additional effects.
-    effect1 = AI_IsMoveEffectInMinus(battlerAtk, battlerDef, move1, noOfHitsToKo);
-    effect2 = AI_IsMoveEffectInMinus(battlerAtk, battlerDef, move2, noOfHitsToKo);
-    if (effect2 && !effect1)
-        return MOVE_WON_COMPARISON;
-    if (effect1 && !effect2)
-        return MOVE_LOST_COMPARISON;
+    gAiThinkingStruct->movesetIndex = GetMoveIndex(battlerAtk, move1);
+    effect1minus = AI_IsMoveEffectInMinus(battlerAtk, battlerDef, move1, noOfHitsToKo);
+    effect1plus = AI_IsMoveEffectInPlus(battlerAtk, battlerDef, move1, noOfHitsToKo);
 
-    effect1 = AI_IsMoveEffectInPlus(battlerAtk, battlerDef, move1, noOfHitsToKo);
-    effect2 = AI_IsMoveEffectInPlus(battlerAtk, battlerDef, move2, noOfHitsToKo);
-    if (effect2 && !effect1)
+    gAiThinkingStruct->movesetIndex = GetMoveIndex(battlerAtk, move2);
+    effect2plus = AI_IsMoveEffectInPlus(battlerAtk, battlerDef, move2, noOfHitsToKo);
+    effect2minus = AI_IsMoveEffectInMinus(battlerAtk, battlerDef, move2, noOfHitsToKo);
+
+    gAiThinkingStruct->movesetIndex = 0;
+
+    if (effect2minus && !effect1minus)
+        return MOVE_WON_COMPARISON;
+    if (effect1minus && !effect2minus)
         return MOVE_LOST_COMPARISON;
-    if (effect1 && !effect2)
+    
+    if (effect2plus && !effect1plus)
+        return MOVE_LOST_COMPARISON;
+    if (effect1plus && !effect2plus)
         return MOVE_WON_COMPARISON;
 
     return MOVE_NEUTRAL_COMPARISON;

--- a/test/battle/ai/ai.c
+++ b/test/battle/ai/ai.c
@@ -1285,3 +1285,25 @@ AI_DOUBLE_BATTLE_TEST("AI can use Acupressure on its ally")
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ACUPRESSURE, opponentLeft);
     }
 }
+
+AI_SINGLE_BATTLE_TEST("AI's comparison of damaging moves correctly reads moveset indexes for effects")
+{
+    u32 move = MOVE_NONE;
+    PARAMETRIZE { move = MOVE_TACKLE; }
+    PARAMETRIZE { move = MOVE_DUAL_CHOP; }
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_SMART_SWITCHING | AI_FLAG_SMART_MON_CHOICES | AI_FLAG_OMNISCIENT);
+        PLAYER(SPECIES_RAPIDASH_GALAR){ Level(64); HP(1); Nature(NATURE_TIMID); Moves(MOVE_TACKLE);}
+        OPPONENT(SPECIES_HAXORUS){ Level(64); Nature(NATURE_JOLLY); Ability(ABILITY_MOLD_BREAKER); Moves(move, MOVE_EARTHQUAKE, MOVE_POISON_JAB); }
+    } WHEN {
+        TURN { 
+            MOVE(player, MOVE_TACKLE);
+            if (move == MOVE_TACKLE)
+                SCORE_EQ_VAL(opponent, MOVE_TACKLE, 104);
+            else if (move == MOVE_DUAL_CHOP)
+                SCORE_EQ_VAL(opponent, MOVE_DUAL_CHOP, 60);
+            SCORE_EQ_VAL(opponent, MOVE_EARTHQUAKE, 104);
+            SCORE_EQ_VAL(opponent, MOVE_POISON_JAB, 105);
+        }
+    }
+}


### PR DESCRIPTION
## Description
Discord conversation for context starts around here https://discord.com/channels/419213663107416084/1077168246555430962/1479712441049940008, shoutout to @MaximeGr00 for finding this and the test

In #7301 , `AI_CompareDamagingMoves` got moved out of the main move scoring loop of `BattleAI_DoAiProcessing` to run after it, so it could better serve the purpose of breaking ties based on various criteria. This has thus far been considered extremely successful, which is great.

`BattleAI_DoAiProcessing` runs using a while loop that counts through `gAiThinkingStruct->movesetIndex` from 0 to `MAX_MON_MOVES`. `AI_CompareDamagingMoves` runs after this while loop has finished, and instead evaluates specific moves individually.

The problem is that the two share some function calls. Some of these function calls reference `gAiThinkingStruct->movesetIndex` as they're allowed to do from `BattleAI_DoAiProcessing`. This insteads leads to those functions reading exclusively from move slot 0 when called from `AI_CompareDamagingMoves`.

All of these functions that I could identify are sourced from `CompareMoveEffects`, so the bandaid (or maybe forever) solution I've done is just manually using `gAiThinkingStruct->movesetIndex = GetMoveIndex(battler, move)` to set the variable appropriately before any of the potential problematic function calls.

I can't think of any other really good ways to solve this right this second and must go to bed. I'm open to other ideas. Putting `AI_CompareDamagingMoves` back inside 
the `BattleAI_DoAiProcessing` while loop is not an option, as it requires all of the standard move scoring to finish before it can be run, and this version of the function is both significantly more effective and more popular than before.

## Discord contact info
@Pawkkie 
