### PR TITLE
Allow make release and check for FRLG by using the BUILD variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,14 @@ GAME_CODE    ?= BPEE
 BUILD_NAME   ?= emerald
 MAP_VERSION  ?= emerald
 
-ifeq (firered,$(MAKECMDGOALS))
+ifeq (firered, $(or $(BUILD), $(MAKECMDGOALS)))
   	GAME_VERSION 	:= FIRERED
 	TITLE       	:= POKEMON FIRE
 	GAME_CODE   	:= BPRE
 	BUILD_NAME  	:= firered
 	MAP_VERSION 	:= firered
 else
-ifeq (leafgreen,$(MAKECMDGOALS))
+ifeq (leafgreen, $(or $(BUILD), $(MAKECMDGOALS)))
 	GAME_VERSION 	:= LEAFGREEN
 	TITLE       	:= POKEMON LEAF
 	GAME_CODE   	:= BPGE


### PR DESCRIPTION
When writing test for #9461, I realised that I could do a `make check firered` or something similar to run the tests with the firered maps loaded. This commit allows to do make check, make release and possibly others in conjunction with "BUILD=firered" or "BUILD=leafgreen" to build a specific game

## Discord contact info
Jamie
