### PR TITLE
Fix Substitute breaking when used by opponentRight in double battles

### DIFF
--- a/src/battle_gfx_sfx_util.c
+++ b/src/battle_gfx_sfx_util.c
@@ -1009,7 +1009,7 @@ void HandleSpeciesGfxDataChange(enum BattlerId battlerAtk, enum BattlerId battle
 
 void BattleLoadSubstituteOrMonSpriteGfx(enum BattlerId battler, bool8 loadMonSprite)
 {
-    s32 i, palOffset;
+    s32 palOffset;
     enum BattlerPosition position;
 
     if (!loadMonSprite)
@@ -1026,7 +1026,7 @@ void BattleLoadSubstituteOrMonSpriteGfx(enum BattlerId battler, bool8 loadMonSpr
         else
             DecompressDataWithHeaderVram(gBattleAnimSpriteGfx_SubstituteBack, gMonSpritesGfxPtr->spritesGfx[position]);
 
-        for (i = 1; i < 4; i++)
+        for (u32 i = 1; i < 2; i++)
         {
             Dma3CopyLarge32_(gMonSpritesGfxPtr->spritesGfx[position], &gMonSpritesGfxPtr->spritesGfx[position][MON_PIC_SIZE * i], MON_PIC_SIZE);
         }


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
#9121 broke Substitute usage since it assumed that every battler still had allocated space for 4 frames, this changes that to 2 frames.

Check by running move animation tests for Substitute:
```diff
diff --git a/include/config/test.h b/include/config/test.h
index 53801063a7..e292d6ab0a 100644
--- a/include/config/test.h
+++ b/include/config/test.h
@@ -1143,6 +1143,6 @@
 #define T_COMPRESSION_SHOULD_PRINT FALSE
 
 //  Move animation testing
-#define T_SHOULD_RUN_MOVE_ANIM  FALSE       //  If TRUE, enables the move animation tests, these are very computationally heavy and takes a long time to run.
+#define T_SHOULD_RUN_MOVE_ANIM  TRUE       //  If TRUE, enables the move animation tests, these are very computationally heavy and takes a long time to run.
 
 #endif // GUARD_CONFIG_TEST_H
diff --git a/test/battle/move_animations/all_anims.c b/test/battle/move_animations/all_anims.c
index 9a05cb3ab7..b09dea14fb 100644
--- a/test/battle/move_animations/all_anims.c
+++ b/test/battle/move_animations/all_anims.c
@@ -6,8 +6,8 @@
 
 #if T_SHOULD_RUN_MOVE_ANIM
 
-#define ANIM_TEST_START_MOVE 1              //  First move to test
-#define ANIM_TEST_END_MOVE   MOVES_COUNT-1  //  Last move to test
+#define ANIM_TEST_START_MOVE MOVE_SUBSTITUTE              //  First move to test
+#define ANIM_TEST_END_MOVE   MOVE_SUBSTITUTE  //  Last move to test
 
 
 static void ParametrizeMovesAndSpecies(u32 j, u32 *pMove, u32 *pSpecies, u32 variation)
 ```
 
 This will fail with `CRASH` on upcoming, but work on this PR.
 ```
 make -j check TESTS="Move Animations don't leak"
 ```

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara