### PR TITLE
Fixes Critical Hit message being printed on fixed damage moves

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -7824,6 +7824,7 @@ s32 DoFixedDamageMoveCalc(struct BattleContext *ctx)
         return dmg;
 
     gBattleStruct->moveResultFlags[ctx->battlerDef] &= ~(MOVE_RESULT_NOT_VERY_EFFECTIVE | MOVE_RESULT_SUPER_EFFECTIVE);
+    gSpecialStatuses[ctx->battlerDef].criticalHit = FALSE;
 
     if (dmg == 0)
         dmg = 1;


### PR DESCRIPTION
Just a visual problem.
