### PR TITLE
Fixes Syrup Bomb end turn effect on the wrong battler

### DIFF
--- a/src/battle_end_turn.c
+++ b/src/battle_end_turn.c
@@ -687,6 +687,7 @@ static bool32 HandleEndTurnSyrupBomb(enum BattlerId battler)
         if (gBattleMons[battler].volatiles.syrupBombTimer > 0 && --gBattleMons[battler].volatiles.syrupBombTimer == 0)
             gBattleMons[battler].volatiles.syrupBomb = FALSE;
         PREPARE_MOVE_BUFFER(gBattleTextBuff1, MOVE_SYRUP_BOMB);
+        gBattlerAttacker = gBattlerTarget = battler;
         gBattlescriptCurrInstr = BattleScript_SyrupBombEndTurn;
         BattleScriptExecute(gBattlescriptCurrInstr);
         effect = TRUE;


### PR DESCRIPTION
Happens because `gBattlerAttacker` isn't set before activation. Also sets `gBattlerTarget` because the animation plays on the target.

## Issue(s) that this PR fixes
Fixes #9481

## Discord contact info
PhallenTree