### PR TITLE
bugfix (friendship): friendship no longer incorrectly maxes out

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -3912,7 +3912,7 @@ bool8 PokemonUseItemEffects(struct Pokemon *mon, enum Item item, u8 partyIndex, 
 {
     u32 dataUnsigned;
     s32 dataSigned, evCap;
-    s32 friendship;
+    u8 friendship;
     s32 i;
     bool8 retVal = TRUE;
     const u8 *itemEffect;


### PR DESCRIPTION
## Description
When `friendship` in `PokemonUseItemEffects` is a `s32`, `SetMonData` passed a `s32` sized address into a `u8` sized field. This causes the value to overflow regardless of what is done to it.

This PR restores `friendship` to a `u8`. I'm pretty sure I broke this a while ago when I cleaned up the friendship macro.

## Media
### Broken
https://github.com/user-attachments/assets/e106a96a-9c51-463e-8db9-6fab39a6d7a9

### Fixed
https://github.com/user-attachments/assets/8ecd7943-c732-41ad-8c2f-3c0ef46b2469

## Discord contact info
pkmnsnfrn

there is no discussion thread.
