### PR TITLE
Fix trailing newline failing tests

### DIFF
--- a/src/line_break.c
+++ b/src/line_break.c
@@ -295,7 +295,7 @@ void BreakSubStringAutomatic(u8 *src, u32 maxWidth, u32 screenLines, u8 fontId, 
             currWordIndex++;
             while (currWordIndex < numWords)
             {
-                if (currLineWidth + spaceWidth + allWords[currWordIndex].width > maxWidth)
+                if (currLineWidth + spaceWidth + allWords[currWordIndex].width + ((toggleScrollPrompt == SHOW_SCROLL_PROMPT) ? SCROLL_PROMPT_WIDTH : 0) > maxWidth)
                 {
                     //  go to next line
                     currLineIndex++;

--- a/test/test_runner_battle.c
+++ b/test/test_runner_battle.c
@@ -1533,8 +1533,8 @@ static s32 TryMessage(s32 i, s32 n, const u8 *string)
             }
             if (event->pattern[k] == EOS)
             {
-                // Consume any trailing '\p' and '\n'.
-                if (string[j] == CHAR_PROMPT_CLEAR || string[j] == CHAR_NEWLINE)
+                // Consume any trailing '\p'.
+                if (string[j] == CHAR_PROMPT_CLEAR)
                     j++;
             }
             if (string[j] != event->pattern[k])


### PR DESCRIPTION
## Description
There is currently potential edge cases, where `BuildNewString` adds `CHAR_NEWLINE` at the end of a string. With this PR, `TryMessage` ignores trailing `CHAR_NEWLINE`s.
The following example leads to a trailing newline. The same can be achieved by replacing `gFontNormalLatinGlyphWidths` with the FRLG ones. (posted on discord)

Example
```diff
index 0a6f04ca6c..21700dc870 100644
--- a/src/battle_message.c
+++ b/src/battle_message.c
@@ -75,7 +75,7 @@ const u8 gText_PkmnsXPreventsSwitching[] = _("{B_BUFF1} is preventing switching
 const u8 gText_StatSharply[] = _("sharply ");
 const u8 gText_StatRose[] = _("rose!");
 const u8 gText_StatFell[] = _("fell!");
-const u8 gText_DefendersStatRose[] = _("{B_DEF_NAME_WITH_PREFIX}'s {B_BUFF1} {B_BUFF2}rose!");
+const u8 gText_DefendersStatRose[] = _("{B_DEF_NAME_WITH_PREFIX}= {B_BUFF1} {B_BUFF2}{LV}{LV}=");
 static const u8 sText_GotAwaySafely[] = _("{PLAY_SE SE_FLEE}You got away safely!\p");
 static const u8 sText_PlayerDefeatedLinkTrainer[] = _("You defeated {B_LINK_OPPONENT1_NAME}!");
 static const u8 sText_TwoLinkTrainersDefeated[] = _("You defeated {B_LINK_OPPONENT1_NAME} and {B_LINK_OPPONENT2_NAME}!");
@@ -146,7 +146,7 @@ static const u8 sText_ExclamationMark4[] = _("!");
 static const u8 sText_ExclamationMark5[] = _("!");
 static const u8 sText_HP[] = _("HP");
 static const u8 sText_Attack[] = _("Attack");
-static const u8 sText_Defense[] = _("Defense");
+static const u8 sText_Defense[] = _("{LV}{LV}{LV}A;");
 static const u8 sText_Speed[] = _("Speed");
 static const u8 sText_SpAttack[] = _("Sp. Atk");
 static const u8 sText_SpDefense[] = _("Sp. Def");
@@ -183,7 +183,7 @@ const u8 gText_EmptyString3[] = _("");
 static const u8 sText_TwoInGameTrainersDefeated[] = _("You defeated {B_TRAINER1_NAME_WITH_CLASS} and {B_TRAINER2_NAME_WITH_CLASS}!\p");
 
 // New battle strings.
-const u8 gText_drastically[] = _("drastically ");
+const u8 gText_drastically[] = _("{LV}{LV}{LV}{LV}{LV}{LV}A;; ");
 const u8 gText_severely[] = _("severely ");
 static const u8 sText_TerrainReturnedToNormal[] = _("The terrain returned to normal!"); // Unused
 
diff --git a/src/data/pokemon/species_info/gen_2_families.h b/src/data/pokemon/species_info/gen_2_families.h
index bfe6e814fb..f02ce50e80 100644
--- a/src/data/pokemon/species_info/gen_2_families.h
+++ b/src/data/pokemon/species_info/gen_2_families.h
@@ -4231,7 +4231,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .eggGroups = MON_EGG_GROUPS(EGG_GROUP_AMORPHOUS),
         .abilities = { ABILITY_SHADOW_TAG, ABILITY_NONE, ABILITY_TELEPATHY },
         .bodyColor = BODY_COLOR_BLUE,
-        .speciesName = _("Wobbuffet"),
+        .speciesName = _("{LV}{LV}{LV}{LV}=;"),
         .cryId = CRY_WOBBUFFET,
         .natDexNum = NATIONAL_DEX_WOBBUFFET,
         .categoryName = _("Patient"),
diff --git a/test/battle/move_effect/defense_up_3.c b/test/battle/move_effect/defense_up_3.c
index 879fefde0b..00771b4912 100644
--- a/test/battle/move_effect/defense_up_3.c
+++ b/test/battle/move_effect/defense_up_3.c
@@ -22,7 +22,7 @@ SINGLE_BATTLE_TEST("Cotton Guard raises Defense by 3 stages", s16 damage)
         if (raiseDefense) {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_COTTON_GUARD, player);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-            MESSAGE("Wobbuffet's Defense drastically rose!");
+            MESSAGE("{LV}{LV}{LV}{LV}=;= {LV}{LV}{LV}A; {LV}{LV}{LV}{LV}{LV}{LV}A;; {LV}{LV}=");
         }
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
         HP_BAR(player, captureDamage: &results[i].damage);
```

## Feature(s) this PR does NOT handle:
- does not fix `BuildNewString` adding newline at the end

## Discord contact info
.cawt