### PR TITLE
Fix newlines not working with sprite printing

### DIFF
--- a/src/text.c
+++ b/src/text.c
@@ -480,7 +480,10 @@ bool32 AddTextPrinter(struct TextPrinterTemplate *printerTemplate, u8 speed, voi
     sTempTextPrinter.textSpeed = speed;
 
     if (printerTemplate->type == SPRITE_TEXT_PRINTER)
-        printerTemplate->firstSprite = printerTemplate->spriteId;
+    {
+        sTempTextPrinter.printerTemplate.firstSprite = printerTemplate->spriteId;
+        sTempTextPrinter.printerTemplate.firstSpriteInRow = printerTemplate->spriteId;
+    }
 
 
     GenerateFontHalfRowLookupTable(printerTemplate->color);


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
The `.firstSprite` and `.firstSpriteInRow` values were not set in the template of the actual sprite printer.
This sets those values.
Without this fix using a newline in a string that's printed to a sprite would either do nothing or corrupt sprite 0.

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara