### PR TITLE
Fix Magic Coat activation if in Semi-Invulnerable state

### DIFF
--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -1723,9 +1723,7 @@ static enum CancelerResult CancelerTargetFailure(struct BattleContext *ctx)
 
         if (moveTarget == TARGET_OPPONENTS_FIELD)
         {
-            if (IsSemiInvulnerable(ctx->battlerDef, CHECK_ALL))
-                ctx->abilityDef = ABILITY_NONE;
-            if (CanBattlerBounceBackMove(ctx))
+            if (!IsSemiInvulnerable(ctx->battlerDef, CHECK_ALL) && CanBattlerBounceBackMove(ctx))
                 gBattleStruct->moveResultFlags[ctx->battlerDef] |= MOVE_RESULT_FAILED;
         }
         else if (IsBattlerUnaffectedByMove(ctx->battlerDef)) // immune but targeted


### PR DESCRIPTION
Same as #9501 (for moves that target the field) but the same logic applies to Magic Coat so just prevent both.