### PR TITLE
fix: battle message assert no longer calls for gText_Blank

### DIFF
--- a/src/battle_message.c
+++ b/src/battle_message.c
@@ -2995,7 +2995,7 @@ static const u8 *BattleStringGetOpponentNameByTrainerId(u16 trainerId, u8 *text,
 
     assertf(DoesStringProperlyTerminate(toCpy, TRAINER_NAME_LENGTH + 1),"Opponent needs a valid name")
     {
-        return gText_Blank;
+        return sText_EmptyString4;
     }
 
     return toCpy;


### PR DESCRIPTION
## Description
#9195 adds an asserts that returned `gText_Blank` when an invalid trainer was called.
#9051 was removed `gText_Blank`. It was submitted before #9195, and I didn't update the branch before I merged.

This PR removes the call to gText_Blank in favor of sText_EmptyString, which already existed.

`upcoming` will not build until this is merged.

## Discord contact info
pkmnsnfrn

https://discord.com/channels/419213663107416084/1177369851807924234/1481479638139146404