### PR TITLE
Added `FREE_SECRET_BASES` config

### DIFF
--- a/include/config/save.h
+++ b/include/config/save.h
@@ -7,7 +7,7 @@
 // SaveBlock1 configs
 #define FREE_EXTRA_SEEN_FLAGS_SAVEBLOCK1    FALSE   // Free up unused Pokédex seen flags (52 bytes).
 #define FREE_TRAINER_HILL                   FALSE   // Frees up Trainer Hill data (28 bytes).
-#define FREE_TRAINER_TOWER                  FALSE   // Frees up Trainer Tower data (x bytes).
+#define FREE_TRAINER_TOWER                  FALSE   // Frees up Trainer Tower data (52 bytes).
 #define FREE_MYSTERY_EVENT_BUFFERS          FALSE   // Frees up ramScript (1104 bytes).
 #define FREE_MATCH_CALL                     FALSE   // Frees up match call and rematch / VS Seeker data. (104 bytes).
 #define FREE_UNION_ROOM_CHAT                FALSE   // Frees up union room chat (212 bytes).

--- a/include/config/save.h
+++ b/include/config/save.h
@@ -14,7 +14,8 @@
 #define FREE_ENIGMA_BERRY                   FALSE   // Frees up E-Reader Enigma Berry data (52 bytes).
 #define FREE_LINK_BATTLE_RECORDS            FALSE   // Frees up link battle record data (88 bytes).
 #define FREE_MYSTERY_GIFT                   FALSE   // Frees up Mystery Gift data (876 bytes).
-                                            // SaveBlock1 total: 2516 bytes
+#define FREE_SECRET_BASES                   FALSE   // Frees up Secret Base data (3200 bytes).
+                                            // SaveBlock1 total: 5716 bytes
 // SaveBlock2 configs
 #define FREE_BATTLE_TOWER_E_READER          FALSE   // Frees up Battle Tower E-Reader data (188 bytes).
 #define FREE_POKEMON_JUMP                   FALSE   // Frees up Pokémon Jump data (16 bytes).

--- a/include/config/save.h
+++ b/include/config/save.h
@@ -21,8 +21,8 @@
 #define FREE_POKEMON_JUMP                   FALSE   // Frees up Pokémon Jump data (16 bytes).
 #define FREE_RECORD_MIXING_HALL_RECORDS     FALSE   // Frees up hall records for record mixing (1032 bytes).
 #define FREE_EXTRA_SEEN_FLAGS_SAVEBLOCK2    FALSE   // Free up unused Pokédex seen flags (108 bytes).
-                                            // SaveBlock2 total: 1274 bytes
+                                            // SaveBlock2 total: 1344 bytes
 
-                                            // Grand Total: 3790
+                                            // Grand Total: 7060 bytes
 
 #endif // GUARD_CONFIG_SAVE_H

--- a/include/global.h
+++ b/include/global.h
@@ -1130,7 +1130,9 @@ struct SaveBlock1
     /*0x139C*/ u16 vars[VARS_COUNT];
     /*0x159C*/ u32 gameStats[NUM_GAME_STATS];
     /*0x169C*/ struct BerryTree berryTrees[BERRY_TREES_COUNT];
+#if FREE_SECRET_BASES == FALSE
     /*0x1A9C*/ struct SecretBase secretBases[SECRET_BASES_COUNT];
+#endif //FREE_SECRET_BASES
     /*0x271C*/ u8 playerRoomDecorations[DECOR_MAX_PLAYERS_HOUSE];
     /*0x2728*/ u8 playerRoomDecorationPositions[DECOR_MAX_PLAYERS_HOUSE];
     /*0x2734*/ u8 decorationDesks[10];

--- a/src/battle_util2.c
+++ b/src/battle_util2.c
@@ -43,11 +43,13 @@ void AllocateBattleResources(void)
     gBattleAnimBgTileBuffer = AllocZeroed(0x2000);
     gBattleAnimBgTilemapBuffer = AllocZeroed(0x1000);
 
+#if FREE_SECRET_BASES == FALSE
     if (gBattleTypeFlags & BATTLE_TYPE_SECRET_BASE)
     {
         u16 currSecretBaseId = VarGet(VAR_CURRENT_SECRET_BASE);
         CreateSecretBaseEnemyParty(&gSaveBlock1Ptr->secretBases[currSecretBaseId]);
     }
+#endif
 }
 
 void FreeBattleResources(void)

--- a/src/decoration.c
+++ b/src/decoration.c
@@ -523,11 +523,13 @@ void InitDecorationContextItems(void)
     if (sCurDecorationCategory < DECORCAT_COUNT)
         gCurDecorationItems = gDecorationInventories[sCurDecorationCategory].items;
 
+#if FREE_SECRET_BASES == FALSE
     if (sDecorationContext.isPlayerRoom == FALSE)
     {
         sDecorationContext.items = gSaveBlock1Ptr->secretBases[0].decorations;
         sDecorationContext.pos = gSaveBlock1Ptr->secretBases[0].decorationPositions;
     }
+#endif // FREE_SECRET_BASES
 
     if (sDecorationContext.isPlayerRoom == TRUE)
     {
@@ -587,8 +589,10 @@ static void InitDecorationActionsWindow(void)
 void DoSecretBaseDecorationMenu(u8 taskId)
 {
     InitDecorationActionsWindow();
+#if FREE_SECRET_BASES == FALSE
     sDecorationContext.items = gSaveBlock1Ptr->secretBases[0].decorations;
     sDecorationContext.pos = gSaveBlock1Ptr->secretBases[0].decorationPositions;
+#endif //FREE_SECRET_BASES
     sDecorationContext.size = DECOR_MAX_SECRET_BASE;
     sDecorationContext.isPlayerRoom = FALSE;
     gTasks[taskId].func = HandleDecorationActionsMenuInput;
@@ -1082,6 +1086,7 @@ static void IdentifyOwnedDecorationsCurrentlyInUseInternal(u8 taskId)
     memset(sSecretBaseItemsIndicesBuffer, 0, sizeof(sSecretBaseItemsIndicesBuffer));
     memset(sPlayerRoomItemsIndicesBuffer, 0, sizeof(sPlayerRoomItemsIndicesBuffer));
 
+#if FREE_SECRET_BASES == FALSE
     for (i = 0; i < ARRAY_COUNT(sSecretBaseItemsIndicesBuffer); i++)
     {
         if (gSaveBlock1Ptr->secretBases[0].decorations[i] != DECOR_NONE)
@@ -1103,6 +1108,7 @@ static void IdentifyOwnedDecorationsCurrentlyInUseInternal(u8 taskId)
             }
         }
     }
+#endif //FREE_SECRET_BASES
 
     count = 0;
     for (i = 0; i < ARRAY_COUNT(sPlayerRoomItemsIndicesBuffer); i++)

--- a/src/record_mixing.c
+++ b/src/record_mixing.c
@@ -85,7 +85,9 @@ union PlayerRecord
 };
 
 static bool8 sReadyToReceive;
+#if FREE_SECRET_BASES == FALSE
 static struct SecretBase *sSecretBasesSave;
+#endif //FREE_SECRET_BASES
 static TVShow *sTvShowsSave;
 static PokeNews *sPokeNewsSave;
 static OldMan *sOldManSave;
@@ -173,7 +175,9 @@ void RecordMixingPlayerSpotTriggered(void)
 // these variables were const in R/S, but had to become changeable because of saveblocks changing RAM position
 static void SetSrcLookupPointers(void)
 {
+#if FREE_SECRET_BASES == FALSE
     sSecretBasesSave = gSaveBlock1Ptr->secretBases;
+#endif //FREE_SECRET_BASES
     sTvShowsSave = gSaveBlock1Ptr->tvShows;
     sPokeNewsSave = gSaveBlock1Ptr->pokeNews;
     sOldManSave = &gSaveBlock1Ptr->oldMan;
@@ -187,7 +191,9 @@ static void SetSrcLookupPointers(void)
 
 static void PrepareUnknownExchangePacket(struct PlayerRecordRS *dest)
 {
+#if FREE_SECRET_BASES == FALSE
     memcpy(dest->secretBases, sSecretBasesSave, sizeof(dest->secretBases));
+#endif //FREE_SECRET_BASES
     memcpy(dest->tvShows, sTvShowsSave, sizeof(dest->tvShows));
     SanitizeTVShowLocationsForRuby(dest->tvShows);
     memcpy(dest->pokeNews, sPokeNewsSave, sizeof(dest->pokeNews));
@@ -202,7 +208,9 @@ static void PrepareUnknownExchangePacket(struct PlayerRecordRS *dest)
 
 static void PrepareExchangePacketForRubySapphire(struct PlayerRecordRS *dest)
 {
+#if FREE_SECRET_BASES == FALSE
     memcpy(dest->secretBases, sSecretBasesSave, sizeof(dest->secretBases));
+#endif //FREE_SECRET_BASES
     ClearJapaneseSecretBases(dest->secretBases);
     memcpy(dest->tvShows, sTvShowsSave, sizeof(dest->tvShows));
     SanitizeTVShowsForRuby(dest->tvShows);
@@ -234,7 +242,9 @@ static void PrepareExchangePacket(void)
     }
     else
     {
+    #if FREE_SECRET_BASES == FALSE
         memcpy(sSentRecord->emerald.secretBases, sSecretBasesSave, sizeof(sSentRecord->emerald.secretBases));
+    #endif //FREE_SECRET_BASES
         memcpy(sSentRecord->emerald.tvShows, sTvShowsSave, sizeof(sSentRecord->emerald.tvShows));
         memcpy(sSentRecord->emerald.pokeNews, sPokeNewsSave, sizeof(sSentRecord->emerald.pokeNews));
         memcpy(&sSentRecord->emerald.oldMan, sOldManSave, sizeof(sSentRecord->emerald.oldMan));

--- a/src/secret_base.c
+++ b/src/secret_base.c
@@ -228,9 +228,11 @@ static void ClearSecretBase(struct SecretBase *secretBase)
 
 void ClearSecretBases(void)
 {
+#if FREE_SECRET_BASES == FALSE
     u16 i;
     for (i = 0; i < SECRET_BASES_COUNT; i++)
         ClearSecretBase(&gSaveBlock1Ptr->secretBases[i]);
+#endif //FREE_SECRET_BASES
 }
 
 static void SetCurSecretBaseId(void)
@@ -240,6 +242,7 @@ static void SetCurSecretBaseId(void)
 
 void TrySetCurSecretBaseIndex(void)
 {
+#if FREE_SECRET_BASES == FALSE
     u16 i;
 
     gSpecialVar_Result = FALSE;
@@ -252,14 +255,17 @@ void TrySetCurSecretBaseIndex(void)
             break;
         }
     }
+#endif //FREE_SECRET_BASES
 }
 
 void CheckPlayerHasSecretBase(void)
 {
+#if FREE_SECRET_BASES == FALSE
     // The player's secret base is always the first in the array.
     if (gSaveBlock1Ptr->secretBases[0].secretBaseId)
         gSpecialVar_Result = TRUE;
     else
+#endif //FREE_SECRET_BASES
         gSpecialVar_Result = FALSE;
 }
 
@@ -349,6 +355,7 @@ void ToggleSecretBaseEntranceMetatile(void)
     }
 }
 
+#if FREE_SECRET_BASES == FALSE
 static u8 GetNameLength(const u8 *secretBaseOwnerName)
 {
     u8 i;
@@ -360,9 +367,11 @@ static u8 GetNameLength(const u8 *secretBaseOwnerName)
 
     return PLAYER_NAME_LENGTH;
 }
+#endif //FREE_SECRET_BASES
 
 void SetPlayerSecretBase(void)
 {
+#if FREE_SECRET_BASES == FALSE
     u16 i;
 
     gSaveBlock1Ptr->secretBases[0].secretBaseId = sCurSecretBaseId;
@@ -374,11 +383,13 @@ void SetPlayerSecretBase(void)
     gSaveBlock1Ptr->secretBases[0].gender = gSaveBlock2Ptr->playerGender;
     gSaveBlock1Ptr->secretBases[0].language = GAME_LANGUAGE;
     VarSet(VAR_SECRET_BASE_MAP, gMapHeader.regionMapSectionId);
+#endif //FREE_SECRET_BASES
 }
 
 // Set the 'open' entrance metatile for any occupied secret base on this map
 void SetOccupiedSecretBaseEntranceMetatiles(struct MapEvents const *events)
 {
+#if FREE_SECRET_BASES == FALSE
     u16 bgId;
     u16 i, j;
 
@@ -406,6 +417,7 @@ void SetOccupiedSecretBaseEntranceMetatiles(struct MapEvents const *events)
             }
         }
     }
+#endif //FREE_SECRET_BASES
 }
 
 static void SetSecretBaseWarpDestination(void)
@@ -418,7 +430,9 @@ static void SetSecretBaseWarpDestination(void)
 
 static void Task_EnterSecretBase(u8 taskId)
 {
+#if FREE_SECRET_BASES == FALSE
     u16 secretBaseIdx;
+#endif //FREE_SECRET_BASES
 
     switch (gTasks[taskId].tState)
     {
@@ -427,9 +441,11 @@ static void Task_EnterSecretBase(u8 taskId)
             gTasks[taskId].tState = 1;
         break;
     case 1:
+    #if FREE_SECRET_BASES == FALSE
         secretBaseIdx = VarGet(VAR_CURRENT_SECRET_BASE);
         if (gSaveBlock1Ptr->secretBases[secretBaseIdx].numTimesEntered < 255)
             gSaveBlock1Ptr->secretBases[secretBaseIdx].numTimesEntered++;
+    #endif //FREE_SECRET_BASES
 
         SetSecretBaseWarpDestination();
         WarpIntoMap();
@@ -517,6 +533,7 @@ bool8 CurMapIsSecretBase(void)
 
 void InitSecretBaseAppearance(bool8 hidePC)
 {
+#if FREE_SECRET_BASES == FALSE
     u16 secretBaseIdx;
     s16 x, y = 0;
     u8 *decorations;
@@ -546,6 +563,7 @@ void InitSecretBaseAppearance(bool8 hidePC)
             MapGridSetMetatileIdAt(x + MAP_OFFSET, y + MAP_OFFSET, METATILE_SecretBase_Ground | MAPGRID_IMPASSABLE);
         }
     }
+#endif //FREE_SECRET_BASES
 }
 
 void InitSecretBaseDecorationSprites(void)
@@ -568,9 +586,14 @@ void InitSecretBaseDecorationSprites(void)
     }
     else
     {
+    #if FREE_SECRET_BASES == FALSE
         u16 secretBaseIdx = VarGet(VAR_CURRENT_SECRET_BASE);
         decorations = gSaveBlock1Ptr->secretBases[secretBaseIdx].decorations;
         decorationPositions = gSaveBlock1Ptr->secretBases[secretBaseIdx].decorationPositions;
+    #else
+        decorations = gSaveBlock1Ptr->playerRoomDecorations;
+        decorationPositions = gSaveBlock1Ptr->playerRoomDecorationPositions;
+    #endif //FREE_SECRET_BASES
         numDecorations = DECOR_MAX_SECRET_BASE;
     }
 
@@ -687,6 +710,7 @@ bool8 TrySetCurSecretBase(void)
     return TRUE;
 }
 
+#if FREE_SECRET_BASES == FALSE
 static void Task_WarpOutOfSecretBase(u8 taskId)
 {
     switch (gTasks[taskId].data[0])
@@ -715,19 +739,24 @@ static void WarpOutOfSecretBase(void)
     CreateTask(Task_WarpOutOfSecretBase, 0);
     FadeScreen(FADE_TO_BLACK, 0);
 }
+#endif //FREE_SECRET_BASES
 
 void IsCurSecretBaseOwnedByAnotherPlayer(void)
 {
+#if FREE_SECRET_BASES == FALSE
     if (gSaveBlock1Ptr->secretBases[0].secretBaseId != sCurSecretBaseId)
         gSpecialVar_Result = TRUE;
     else
+#endif //FREE_SECRET_BASES
         gSpecialVar_Result = FALSE;
 }
 
 static u8 *GetSecretBaseName(u8 *dest, u8 secretBaseIdx)
 {
+#if FREE_SECRET_BASES == FALSE
     *StringCopyN(dest, gSaveBlock1Ptr->secretBases[secretBaseIdx].trainerName, GetNameLength(gSaveBlock1Ptr->secretBases[secretBaseIdx].trainerName)) = EOS;
     ConvertInternationalString(dest, gSaveBlock1Ptr->secretBases[secretBaseIdx].language);
+#endif //FREE_SECRET_BASES
     return StringAppend(dest, gText_ApostropheSBase);
 }
 
@@ -738,6 +767,7 @@ u8 *GetSecretBaseMapName(u8 *dest)
 
 void CopyCurSecretBaseOwnerName_StrVar1(void)
 {
+#if FREE_SECRET_BASES == FALSE
     u8 secretBaseIdx;
     const u8 *name;
 
@@ -745,16 +775,20 @@ void CopyCurSecretBaseOwnerName_StrVar1(void)
     name = gSaveBlock1Ptr->secretBases[secretBaseIdx].trainerName;
     *StringCopyN(gStringVar1, name, GetNameLength(name)) = EOS;
     ConvertInternationalString(gStringVar1, gSaveBlock1Ptr->secretBases[secretBaseIdx].language);
+#endif //FREE_SECRET_BASES
 }
 
 static bool8 IsSecretBaseRegistered(u8 secretBaseIdx)
 {
+#if FREE_SECRET_BASES == FALSE
     if (gSaveBlock1Ptr->secretBases[secretBaseIdx].registryStatus)
         return TRUE;
+#endif //FREE_SECRET_BASES
 
     return FALSE;
 }
 
+#if FREE_SECRET_BASES == FALSE
 static u8 GetAverageEVs(struct Pokemon *pokemon)
 {
     u16 evTotal;
@@ -766,9 +800,11 @@ static u8 GetAverageEVs(struct Pokemon *pokemon)
     evTotal += GetMonData(pokemon, MON_DATA_SPDEF_EV);
     return evTotal / 6;
 }
+#endif //FREE_SECRET_BASES
 
 void SetPlayerSecretBaseParty(void)
 {
+#if FREE_SECRET_BASES == FALSE
     u16 i;
     u16 moveIndex;
     u16 partyId;
@@ -804,14 +840,17 @@ void SetPlayerSecretBaseParty(void)
             }
         }
     }
+#endif //FREE_SECRET_BASES
 }
 
 void ClearAndLeaveSecretBase(void)
 {
+#if FREE_SECRET_BASES == FALSE
     u16 temp = gSaveBlock1Ptr->secretBases[0].numSecretBasesReceived;
     ClearSecretBase(&gSaveBlock1Ptr->secretBases[0]);
     gSaveBlock1Ptr->secretBases[0].numSecretBasesReceived = temp;
     WarpOutOfSecretBase();
+#endif //FREE_SECRET_BASES
 }
 
 void MoveOutOfSecretBase(void)
@@ -820,6 +859,7 @@ void MoveOutOfSecretBase(void)
     ClearAndLeaveSecretBase();
 }
 
+#if FREE_SECRET_BASES == FALSE
 static void ClosePlayerSecretBaseEntrance(void)
 {
     u16 i;
@@ -849,11 +889,13 @@ static void ClosePlayerSecretBaseEntrance(void)
         }
     }
 }
+#endif //FREE_SECRET_BASES
 
 // When the player moves to a new secret base by interacting with a new secret base
 // entrance in the overworld.
 void MoveOutOfSecretBaseFromOutside(void)
 {
+#if FREE_SECRET_BASES == FALSE
     u16 temp;
 
     ClosePlayerSecretBaseEntrance();
@@ -861,6 +903,7 @@ void MoveOutOfSecretBaseFromOutside(void)
     temp = gSaveBlock1Ptr->secretBases[0].numSecretBasesReceived;
     ClearSecretBase(&gSaveBlock1Ptr->secretBases[0]);
     gSaveBlock1Ptr->secretBases[0].numSecretBasesReceived = temp;
+#endif //FREE_SECRET_BASES
 }
 
 static u8 GetNumRegisteredSecretBases(void)
@@ -888,8 +931,10 @@ void GetCurSecretBaseRegistrationValidity(void)
 
 void ToggleCurSecretBaseRegistry(void)
 {
+#if FREE_SECRET_BASES == FALSE
     gSaveBlock1Ptr->secretBases[VarGet(VAR_CURRENT_SECRET_BASE)].registryStatus ^= 1;
     FlagSet(FLAG_SECRET_BASE_REGISTRY_ENABLED);
+#endif //FREE_SECRET_BASES
 }
 
 void ShowSecretBaseDecorationMenu(void)
@@ -1076,7 +1121,9 @@ void DeleteRegistry_Yes_Callback(u8 taskId)
     u16 *data = (u16*) gTasks[taskId].data;
     ClearDialogWindowAndFrame(0, FALSE);
     DestroyListMenuTask(tListTaskId, &tScrollOffset, &tSelectedRow);
+#if FREE_SECRET_BASES == FALSE
     gSaveBlock1Ptr->secretBases[tSelectedBaseId].registryStatus = UNREGISTERED;
+#endif //FREE_SECRET_BASES
     BuildRegistryMenuItems(taskId);
     SetCursorWithinListBounds(&tScrollOffset, &tSelectedRow, tMaxShownItems, tNumBases);
     FinalizeRegistryMenu(taskId);
@@ -1130,8 +1177,12 @@ static void GoToSecretBasePCRegisterMenu(u8 taskId)
 
 static u8 GetSecretBaseOwnerType(u8 secretBaseIdx)
 {
+#if FREE_SECRET_BASES == FALSE
     return (gSaveBlock1Ptr->secretBases[secretBaseIdx].trainerId[0] % 5)
          + (gSaveBlock1Ptr->secretBases[secretBaseIdx].gender * 5);
+#else
+    return 0;
+#endif //FREE_SECRET_BASES
 }
 
 const u8 *GetSecretBaseTrainerLoseText(void)
@@ -1168,11 +1219,14 @@ void PrepSecretBaseBattleFlags(void)
 
 void SetBattledOwnerFromResult(void)
 {
+#if FREE_SECRET_BASES == FALSE
     gSaveBlock1Ptr->secretBases[VarGet(VAR_CURRENT_SECRET_BASE)].battledOwnerToday = gSpecialVar_Result;
+#endif //FREE_SECRET_BASES
 }
 
 void GetSecretBaseOwnerAndState(void)
 {
+#if FREE_SECRET_BASES == FALSE
     u16 secretBaseIdx;
     u8 i;
 
@@ -1186,6 +1240,7 @@ void GetSecretBaseOwnerAndState(void)
     }
     gSpecialVar_0x8004 = GetSecretBaseOwnerType(secretBaseIdx);
     gSpecialVar_Result = gSaveBlock1Ptr->secretBases[secretBaseIdx].battledOwnerToday;
+#endif //FREE_SECRET_BASES
 }
 
 #define tStepCb  data[0] // See Task_RunPerStepCallback
@@ -1332,6 +1387,7 @@ void SecretBasePerStepCallback(u8 taskId)
 #undef tPlayerY
 #undef tFldEff
 
+#if FREE_SECRET_BASES == FALSE
 static void SaveSecretBase(u8 secretBaseIdx, struct SecretBase *secretBase, enum GameVersion version, enum Language language)
 {
     int stringLength;
@@ -1355,7 +1411,9 @@ static void SaveSecretBase(u8 secretBaseIdx, struct SecretBase *secretBase, enum
             gSaveBlock1Ptr->secretBases[secretBaseIdx].language = GAME_LANGUAGE;
     }
 }
+#endif //FREE_SECRET_BASES
 
+#if FREE_SECRET_BASES == FALSE
 static bool8 SecretBasesHaveSameTrainerId(struct SecretBase *secretBase1, struct SecretBase *secretBase2)
 {
     u8 i;
@@ -1715,6 +1773,7 @@ static void SaveRecordMixBases(struct SecretBaseRecordMixer *mixers)
     TrySaveFriendsSecretBases(&mixers[1], UNREGISTERED);
     TrySaveFriendsSecretBases(&mixers[2], UNREGISTERED);
 }
+#endif //FREE_SECRET_BASES
 
 #define INIT_SECRET_BASE_RECORD_MIXER(linkId1, linkId2, linkId3)        \
             mixers[0].secretBases = secretBases + linkId1 * recordSize; \
@@ -1729,6 +1788,7 @@ static void SaveRecordMixBases(struct SecretBaseRecordMixer *mixers)
 
 void ReceiveSecretBasesData(void *secretBases, size_t recordSize, u8 linkIdx)
 {
+#if FREE_SECRET_BASES == FALSE
     struct SecretBaseRecordMixer mixers[3];
     u16 i;
 
@@ -1791,6 +1851,7 @@ void ReceiveSecretBasesData(void *secretBases, size_t recordSize, u8 linkIdx)
             gSaveBlock1Ptr->secretBases[0].numSecretBasesReceived++;
         }
     }
+#endif //FREE_SECRET_BASES
 }
 
 void ClearJapaneseSecretBases(struct SecretBase *bases)

--- a/src/tv.c
+++ b/src/tv.c
@@ -1971,6 +1971,7 @@ static void SecretBaseVisit_CalculateDecorationData(TVShow *show)
     for (u32 i = 0; i < DECOR_MAX_SECRET_BASE; i++)
         decorationsBuffer[i] = DECOR_NONE;
 
+#if FREE_SECRET_BASES == FALSE
     // Count (and save) the unique decorations in the base
     for (u32 i = 0; i < DECOR_MAX_SECRET_BASE; i++)
     {
@@ -1994,6 +1995,7 @@ static void SecretBaseVisit_CalculateDecorationData(TVShow *show)
             }
         }
     }
+#endif //FREE_SECRET_BASES
 
     // Cap the number of unique decorations to the number the TV show will talk about
     if (n > ARRAY_COUNT(show->secretBaseVisit.decorations))
@@ -2418,10 +2420,12 @@ void TryPutSecretBaseSecretsOnAir(void)
             show->secretBaseSecrets.flags = VarGet(VAR_SECRET_BASE_LOW_TV_FLAGS) + (VarGet(VAR_SECRET_BASE_HIGH_TV_FLAGS) << 16);
             StorePlayerIdInRecordMixShow(show);
             show->secretBaseSecrets.language = gGameLanguage;
+        #if FREE_SECRET_BASES == FALSE
             if (show->secretBaseSecrets.language == LANGUAGE_JAPANESE || gSaveBlock1Ptr->secretBases[VarGet(VAR_CURRENT_SECRET_BASE)].language == LANGUAGE_JAPANESE)
                 show->secretBaseSecrets.baseOwnersNameLanguage = LANGUAGE_JAPANESE;
             else
                 show->secretBaseSecrets.baseOwnersNameLanguage = gSaveBlock1Ptr->secretBases[VarGet(VAR_CURRENT_SECRET_BASE)].language;
+        #endif //FREE_SECRET_BASES
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
Config allows to free 3200 bytes from SaveBlock1 by removing saved Secret Bases.
Also, fixed `FREE_TRAINER_TOWER`'s comment.

## Discord contact info
AsparagusEduardo
