### PR TITLE
Parallelize CI jobs and cache build tools

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,6 +199,16 @@ jobs:
           TEST: 1
         run: make -j$(nproc) check
 
+  # Gate job: satisfies the "build" branch protection rule.
+  # Passes only when all parallel build/test jobs succeed.
+  build:
+    if: github.actor != 'allcontributors[bot]'
+    runs-on: ubuntu-latest
+    needs: [build-emerald, build-firered, build-leafgreen, release, test]
+    steps:
+      - name: All builds passed
+        run: echo "All builds and tests passed."
+
   docs_validate:
     if: github.actor != 'allcontributors[bot]'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation

When beginning work on my romhack, I noticed that the CI changes took quite a long time. I noticed that multiple roms were being built in sequence, along with the test suite taking quite a long time to run.

In my own personal romhack repo, I've been a bit more aggressive with the optimization, conditionally building the non-emerald roms, splitting up the test suite, etc., but wanted to keep my upstream contribution more targeted and minimal.

## Description

The CI currently runs all build steps sequentially in a single job: Emerald → FireRed → LeafGreen → Release → Test. Each build writes to its own output directory (`build/emerald`, `build/emerald-release`, `build/emerald-test`, etc.) with no shared artifacts, but they wait on each other. This PR splits them into 5 parallel jobs. Wall-clock time drops from ~28 min to ~18 min, limited by the Test job.

**Before:**
```
Install (46s) → Emerald (4m) → FireRed (1.5m) → LeafGreen (1.5m) → Release (2.5m) → Test (18m) = ~28 min
```

**After:**
```
Emerald   (~5 min)  ──┐
FireRed   (~3 min)  ──┤
LeafGreen (~3 min)  ──┤ all parallel ──→ build (gate) ✓
Release   (~5 min)  ──┤
Test      (~18 min) ──┘  = ~18 min wall-clock
```

Example from my own fork's PR - https://github.com/TrevorEdris/pokeemerald-expansion/pull/1

<img width="877" height="546" alt="Screenshot 2026-03-15 at 7 05 01 PM" src="https://github.com/user-attachments/assets/ac4305c1-a497-4486-98d5-dd8a82b589cf" />

Also:
- Adds `actions/cache@v4` for compiled host tools (gbagfx, scaninc, mid2agb, etc.). Cache key is a hash of all tool source files. Saves ~20-30s per job on cache hit.
- Bumps `actions/checkout` from v2 to v4 (v2 uses deprecated Node 12).
- Release no longer runs `make tidy` first since each job has a clean workspace.
- Uses `apt-get` instead of `apt` for non-interactive CI.
- Hoists shared env vars to workflow level.

No changes to build commands, Makefile, or test behavior. All 5 jobs use the same `make` invocations as before.

## Discord contact info

`@MuchUsername`

<img width="311" height="226" alt="Screenshot 2026-03-15 at 6 37 04 PM" src="https://github.com/user-attachments/assets/d7d9f8ca-51a1-41d4-b2d2-9ecd7648d92b" />

## Things to note in the release changelog:
- CI builds now run in parallel