### PR TITLE
Fix Berry Mutation Chance

### DIFF
--- a/src/berry.c
+++ b/src/berry.c
@@ -2405,7 +2405,12 @@ static u8 TryForMutation(u8 berryTreeId, u8 berry)
         {
             x2 = gObjectEvents[j].currentCoords.x;
             y2 = gObjectEvents[j].currentCoords.y;
-            if (Random() % 100 < (OW_BERRY_MUTATION_CHANCE * (mulch == ITEM_TO_MULCH(ITEM_SURPRISE_MULCH) || mulch == ITEM_TO_MULCH(ITEM_AMAZE_MULCH))) && (
+            u32 rate = OW_BERRY_MUTATION_CHANCE;
+
+            if (mulch == ITEM_TO_MULCH(ITEM_SURPRISE_MULCH) || mulch == ITEM_TO_MULCH(ITEM_AMAZE_MULCH))
+                rate *= 2;
+
+            if (Random() % 100 < rate && (
                 (x1 == x2 && y1 == y2 - 1) ||
                 (x1 == x2 && y1 == y2 + 1) ||
                 (x1 == x2 - 1 && y1 == y2) ||


### PR DESCRIPTION
The berry mutation chance checker is 0 if mulch is not used and 25% otherwise. This fixes it to be a baseline of 25% with doubled rate for mulch