### PR TITLE
Fix blend-immune sprite not fading properly

### DIFF
--- a/src/palette.c
+++ b/src/palette.c
@@ -220,7 +220,7 @@ void ResetPaletteFadeControl(void)
 static u8 UpdateTimeOfDayPaletteFade(void)
 {
     u32 timePalettes;
-    u16 copyPalettes;
+    u32 copyPalettes;
     u16 *src;
     u16 *dst;
 


### PR DESCRIPTION
The 32 palettes are now faded at the same so we need a 32 bit variable to hold the value 

## Issue(s) that this PR fixes
Fixes  #9543



## Discord contact info
Jamie
