### PR TITLE
fix(pokedex_plus_hgss): revert incorrect usage of species enum

### DIFF
--- a/src/pokedex_plus_hgss.c
+++ b/src/pokedex_plus_hgss.c
@@ -6460,10 +6460,10 @@ static void PrintEvolutionTargetSpeciesAndMethod(u8 taskId, enum Species species
 
         bool32 isAlcremie = IsSpeciesAlcremie(targetSpecies);
 
-        enum Species speciesNameWidthInChars = GetSpeciesNameWidthInChars(GetSpeciesName(targetSpecies));
-        enum Species speciesNameCharWidth = GetFontAttribute(GetSpeciesNameFontId(speciesNameWidthInChars), FONTATTR_MAX_LETTER_WIDTH);
+        u32 speciesNameWidthInChars = GetSpeciesNameWidthInChars(GetSpeciesName(targetSpecies));
+        u32 speciesNameCharWidth = GetFontAttribute(GetSpeciesNameFontId(speciesNameWidthInChars), FONTATTR_MAX_LETTER_WIDTH);
 
-        enum Species speciesNameWidth = (speciesNameWidthInChars * speciesNameCharWidth);
+        u32 speciesNameWidth = (speciesNameWidthInChars * speciesNameCharWidth);
         u32 base_x_offset = speciesNameWidth + base_x + depth_offset; // for evo method info
         u32 maxScreenWidth = 230 - base_x_offset;
 


### PR DESCRIPTION
Fixes three instances of the incorrect usage of `species Enum` in place of `u32`

## Description

These variables represent width. All three have been reverted to `u32`

## Discord contact info

@kildemal
