### PR TITLE
fix(preproc): Remove unused private field m_scriptData

### DIFF
--- a/tools/preproc/asm_file.h
+++ b/tools/preproc/asm_file.h
@@ -72,7 +72,6 @@ private:
     long m_lineNum;
     long m_lineStart;
     std::string m_filename;
-    bool m_scriptData;
 
     bool ConsumeComma();
     int ReadPadLength();


### PR DESCRIPTION
## Description

This flags as a warning with `-Wunused-private-field`, which is enabled as part of `-Wall` on `clang`.

The following error is emitted from a clean checkout of `master`:

```console
> make
c++ -std=c++11 -O2 -Wall -Wno-switch -Werror asm_file.cpp c_file.cpp charmap.cpp preproc.cpp string_parser.cpp utf8.cpp io.cpp -o preproc
In file included from asm_file.cpp:25:
./asm_file.h:75:10: error: private field 'm_scriptData' is not used [-Werror,-Wunused-private-field]
   75 |     bool m_scriptData;
      |          ^
1 error generated.

> c++ --version
Apple clang version 17.0.0 (clang-1700.6.4.2)
Target: arm64-apple-darwin25.3.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```

## Discord contact info

`@lhea`