### PR TITLE
fix(learnset_helpers): Harden regex-patterns for preproc directives

### DIFF
--- a/tools/learnset_helpers/make_teachables.py
+++ b/tools/learnset_helpers/make_teachables.py
@@ -24,7 +24,6 @@ For a given species, a move is considered teachable to that species if:
 from itertools import chain
 from textwrap import dedent
 
-import glob
 import json
 import pathlib
 import re
@@ -32,9 +31,9 @@ import sys
 import typing
 
 
-CONFIG_ENABLED_PAT = re.compile(r"#define P_LEARNSET_HELPER_TEACHABLE\s+(?P<cfg_val>[^ ]*)")
-ALPHABETICAL_ORDER_ENABLED_PAT = re.compile(r"#define HGSS_SORT_TMS_BY_NUM\s+(?P<cfg_val>[^ ]*)")
-TM_LITTERACY_PAT = re.compile(r"#define P_TM_LITERACY\s+GEN_(?P<cfg_val>[^ ]*)")
+CONFIG_ENABLED_PAT = re.compile(r"^#define P_LEARNSET_HELPER_TEACHABLE\s+(?P<cfg_val>[^ ]*)", flags=re.MULTILINE)
+ALPHABETICAL_ORDER_ENABLED_PAT = re.compile(r"^#define HGSS_SORT_TMS_BY_NUM\s+(?P<cfg_val>[^ ]*)", flags=re.MULTILINE)
+TM_LITERACY_PAT = re.compile(r"^#define P_TM_LITERACY\s+GEN_(?P<cfg_val>[^ ]*)", flags=re.MULTILINE)
 TMHM_MACRO_PAT = re.compile(r"F\((\w+)\)")
 SNAKIFY_PAT = re.compile(r"(?!^)([A-Z]+)")
 
@@ -64,7 +63,7 @@ def extract_tm_litteracy_config() -> bool:
     config = False
     with open("./include/config/pokemon.h", "r") as cfg_pokemon_fp:
         cfg_pokemon = cfg_pokemon_fp.read()
-        cfg_defined = TM_LITTERACY_PAT.search(cfg_pokemon)
+        cfg_defined = TM_LITERACY_PAT.search(cfg_pokemon)
         if cfg_defined:
             cfg_val = cfg_defined.group("cfg_val")
             if ((cfg_val == "LATEST") or (int(cfg_val) > 6)):
@@ -193,14 +192,13 @@ def main():
         print(__doc__, file=sys.stderr)
         quit(1)
 
-    if len(sys.argv) == 2:
-        SOURCE_DIR = pathlib.Path(sys.argv[1])
-    elif len(sys.argv) == 3:
+    if len(sys.argv) == 3:
         if sys.argv[1] != "--tutors":
             print("Unknown make_teachables mode", file=sys.stderr)
             quit(1)
         tutor_mode = True
-        SOURCE_DIR = pathlib.Path(sys.argv[2])
+
+    SOURCE_DIR = pathlib.Path(sys.argv[-1])
 
     with open("src/data/pokemon/special_movesets.json", "r") as file:
         special_movesets = json.load(file)
@@ -219,7 +217,6 @@ def main():
     assert SOURCE_TEACHING_TYPES_JSON.is_file(), f"{SOURCE_TEACHING_TYPES_JSON=} is not a file"
 
     repo_tms = list(extract_repo_tms())
-    order_alphabetically = False
 
     with open("./include/config/pokedex_plus_hgss.h", "r") as cfg_pokemon_fp:
         cfg_pokemon = cfg_pokemon_fp.read()

--- a/tools/learnset_helpers/make_teaching_types.py
+++ b/tools/learnset_helpers/make_teaching_types.py
@@ -1,16 +1,24 @@
+#!/usr/bin/env python3
+
+"""
+Usage: python3 make_teaching_types.py OUTPUT_FILE
+
+Build a primary store of "teaching-types" for each enabled species in the repository as an
+input for make_teachables.py.
+"""
+
 import glob
 import json
 import pathlib
 import re
 import sys
-import typing
 
-CONFIG_ENABLED_PAT = re.compile(r"#define P_LEARNSET_HELPER_TEACHABLE\s+(?P<cfg_val>[^ ]*)")
+CONFIG_ENABLED_PAT = re.compile(r"^#define P_LEARNSET_HELPER_TEACHABLE\s+(?P<cfg_val>[^ ]*)", flags=re.MULTILINE)
 
 TEACHING_TYPE_PAT =  re.compile(r"\s*\.teachingType\s*=\s*(?P<teaching_type>[A-Z_]+),")
 LEARNSET_PAT = re.compile(r"\s*\.teachableLearnset\s*=\s*s(?P<name>\w+?)TeachableLearnset")
-PREPROC_START_PAT = re.compile(r"#if(def)?\s+\w+")
-PREPROC_END_PAT = re.compile(r"#endif\s*(//\s*\w+)?")
+PREPROC_START_PAT = re.compile(r"^#if(def)?\s+\w+", flags=re.MULTILINE)
+PREPROC_END_PAT = re.compile(r"^#endif\s*(//\s*\w+)?", flags=re.MULTILINE)
 
 def enabled() -> bool:
     """
@@ -35,7 +43,7 @@ def extract_repo_species_data() -> list:
     pokemon_list = []
     teaching_type = "DEFAULT_LEARNING"
     file_list = sorted(glob.glob("src/data/pokemon/species_info/*_families.h"))
-    file_list.append(pathlib.Path("./src/data/pokemon/species_info.h"))
+    file_list.append("./src/data/pokemon/species_info.h")
     for families_fname in file_list:
         with open(families_fname, "r") as family_fp:
             species_lines = family_fp.readlines()
@@ -66,7 +74,7 @@ def extract_repo_species_data() -> list:
                 teaching_type = match.group("teaching_type")
     return species_data
 
-def add_whitesspaces(parsed_list) ->list:
+def add_whitesspaces(parsed_list) -> list:
     for i, item in enumerate(parsed_list):
         if i == 0:
             continue

--- a/tools/learnset_helpers/make_tutors.py
+++ b/tools/learnset_helpers/make_tutors.py
@@ -1,5 +1,12 @@
+#!/usr/bin/env python3
+
+"""
+Usage: python3 make_tutors.py OUTPUT_FILE
+
+Build a primary store of move-tutors in the repository and what moves they teach.
+"""
+
 from itertools import chain
-from textwrap import dedent
 
 import glob
 import json
@@ -8,7 +15,7 @@ import re
 import sys
 import typing
 
-CONFIG_ENABLED_PAT = re.compile(r"#define P_LEARNSET_HELPER_TEACHABLE\s+(?P<cfg_val>[^ ]*)")
+CONFIG_ENABLED_PAT = re.compile(r"^#define P_LEARNSET_HELPER_TEACHABLE\s+(?P<cfg_val>[^ ]*)", flags=re.MULTILINE)
 INCFILE_HAS_TUTOR_PAT = re.compile(r"special ChooseMonForMoveTutor")
 INCFILE_HAS_TUTOR_PAT2 = re.compile(r"chooseboxmon SELECT_PC_MON_MOVE_TUTOR")
 INCFILE_MOVE_PAT = re.compile(r"setvar VAR_0x8005, (MOVE_[A-Z_]*)")


### PR DESCRIPTION
## Description

The regex-patterns used by these tools for finding `cpp` directives do not mandate start-of-line. This leads to some potential footguns where a user can comment-out the directive in-repo, then add another directive after that which they think should turn it off. e.g.,

```c
// Learnset helper toggles
//#define P_LEARNSET_HELPER_TEACHABLE      TRUE
#define P_LEARNSET_HELPER_TEACHABLE      FALSE
```

There is still one footgun that can be tripped by this regex fix, though it is one that I don't expect a user to trip over without actively trying to do so:

```c
/*
#define P_LEARNSET_HELPER_TEACHABLE      TRUE
*/
#define P_LEARNSET_HELPER_TEACHABLE      FALSE
```

I also took the liberty of cleaning up the files that I touched of some minor style-inconsistencies, unused imports/variables, and irregular Python constructs.

## Discord contact info

`@lhea`