### PR TITLE
Fix AI debug timers

### DIFF
--- a/include/battle_ai_main.h
+++ b/include/battle_ai_main.h
@@ -136,6 +136,8 @@ void SetAiLogicDataForTurn(struct AiLogicData *aiData);
 void ResetDynamicAiFunctions(void);
 void AI_TrySwitchOrUseItem(enum BattlerId battler);
 void CalcBattlerAiMovesData(struct AiLogicData *aiData, enum BattlerId battlerAtk, enum BattlerId battlerDef, u32 weather, u32 fieldStatus);
+void AIDebugTimerStart(void);
+void AIDebugTimerEnd(void);
 
 extern AiSwitchFunc gDynamicAiSwitchFunc;
 

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -141,6 +141,20 @@ static s32 (*const sBattleAiFuncTable[])(enum BattlerId, enum BattlerId, enum Mo
 };
 
 // Functions
+void AIDebugTimerStart()
+{
+    // Set delay timer to count how long it takes for AI to choose action/move
+    gBattleStruct->aiDelayTimer = gMain.vblankCounter1;
+    CycleCountStart();
+}
+
+void AIDebugTimerEnd()
+{
+    // We add to existing to compound multiple calls
+    gBattleStruct->aiDelayFrames += gMain.vblankCounter1 - gBattleStruct->aiDelayTimer;
+    gBattleStruct->aiDelayCycles += CycleCountEnd();
+}
+
 void BattleAI_SetupItems(void)
 {
     u8 *data = (u8 *)gBattleHistory;
@@ -370,6 +384,9 @@ void ComputeBattlerDecisions(enum BattlerId battler)
 
         gAiLogicData->aiCalcInProgress = TRUE;
 
+        if (DEBUG_AI_DELAY_TIMER)
+            AIDebugTimerStart();
+
         // Setup battler and prediction data
         BattleAI_SetupAIData(0xF, battler);
         SetupAIPredictionData(battler, SWITCH_MID_BATTLE_OPTIONAL);
@@ -388,6 +405,9 @@ void ComputeBattlerDecisions(enum BattlerId battler)
         if (isAiBattler)
             BattlerChooseNonMoveAction();
         ModifySwitchAfterMoveScoring(battler);
+
+        if (DEBUG_AI_DELAY_TIMER)
+            AIDebugTimerEnd();
 
         gAiLogicData->aiCalcInProgress = FALSE;
     }
@@ -707,8 +727,10 @@ void SetAiLogicDataForTurn(struct AiLogicData *aiData)
     if (!(gBattleTypeFlags & BATTLE_TYPE_HAS_AI) && !IsWildMonSmart())
         return;
 
-    // Set delay timer to count how long it takes for AI to choose action/move
-    gBattleStruct->aiDelayTimer = gMain.vblankCounter1;
+       gAiLogicData->aiCalcInProgress = TRUE;
+    
+    if (DEBUG_AI_DELAY_TIMER)
+        AIDebugTimerStart();
 
     aiData->weatherHasEffect = HasWeatherEffect();
     weather = AI_GetWeather();
@@ -716,9 +738,6 @@ void SetAiLogicDataForTurn(struct AiLogicData *aiData)
     // get/assume all battler data and simulate AI damage
     battlersCount = gBattlersCount;
 
-    gAiLogicData->aiCalcInProgress = TRUE;
-    if (DEBUG_AI_DELAY_TIMER)
-        CycleCountStart();
     for (enum BattlerId battlerAtk = 0; battlerAtk < battlersCount; battlerAtk++)
     {
         if (!IsBattlerAlive(battlerAtk))
@@ -749,8 +768,8 @@ void SetAiLogicDataForTurn(struct AiLogicData *aiData)
     }
 
     if (DEBUG_AI_DELAY_TIMER)
-        // We add to existing to compound multiple calls
-        gBattleStruct->aiDelayCycles += CycleCountEnd();
+        AIDebugTimerEnd();
+        
     gAiLogicData->aiCalcInProgress = FALSE;
 }
 

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -2003,8 +2003,6 @@ static void HandleChooseActionAfterDma3(enum BattlerId battler)
         gBattle_BG0_Y = DISPLAY_HEIGHT;
         if (gBattleStruct->aiDelayTimer != 0)
         {
-            gBattleStruct->aiDelayFrames = gMain.vblankCounter1 - gBattleStruct->aiDelayTimer;
-            gBattleStruct->aiDelayTimer = 0;
             if (DEBUG_AI_DELAY_TIMER)
             {
                 static const u8 sFramesText[] = _(" frames thinking\n");
@@ -2017,6 +2015,8 @@ static void HandleChooseActionAfterDma3(enum BattlerId battler)
                 StringAppend(gDisplayedStringBattle, sCyclesText);
                 BattlePutTextOnWindow(gDisplayedStringBattle, B_WIN_ACTION_PROMPT);
             }
+            gBattleStruct->aiDelayTimer = 0;
+            gBattleStruct->aiDelayFrames = 0;
         }
         gBattlerControllerFuncs[battler] = HandleInputChooseAction;
     }

--- a/src/data/debug_trainers.party
+++ b/src/data/debug_trainers.party
@@ -30,7 +30,7 @@ EVs: 252 Atk / 252 Def / 6 SpA
 
 === DEBUG_TRAINER_AI ===
 Name: Debugger
-AI: Basic Trainer
+AI: Smart Trainer
 Class: Rival
 Battle Type: Singles
 Pic: Steven


### PR DESCRIPTION
## Description
Haven't followed the `DEBUG_AI_DELAY_TIMER` config in *forever* and happened to today while investing the damage calc speed. It turns out there are some problems with it.

Cycles were only being counted in `SetAiLogicDataForTurn`, when the bulk of the AI's logic is in `ComputeBattlerDecisions`.

Frames weren't being discretely counted; a start point was set in `SetAiLogicDataForTurn`, and then just compared with the current frame at the time of printing. This means it wasn't tracking any discrete function at all.

This PR fixes both cases; cycles and frames are now both counted in discrete chunks instead of just cycles, and both are counted in `ComputeBattlerDecisions` as well. This has reduced the perceived frame count which is now only looking at the two discrete functions instead of literally everything between the start point and printing, and increased the perceived cycle count which is now seeing both major hubs of AI computation.

Would appreciate someone more familiar with frame counting to give this a once over to sanity check :)

## Media
Before:

<img width="1044" height="685" alt="image" src="https://github.com/user-attachments/assets/585eab8b-fa95-4972-a762-d004bfde4682" />


After:

<img width="1046" height="695" alt="image" src="https://github.com/user-attachments/assets/df971683-8922-418a-85f2-025a3887656c" />

## Discord contact info
@Pawkkie 
