### PR TITLE
Silence Makefile map_version message

### DIFF
--- a/map_data_rules.mk
+++ b/map_data_rules.mk
@@ -43,7 +43,7 @@ $(INCLUDECONSTS_OUTDIR)/map_event_ids.h: $(MAP_JSONS)
 	@echo "$(MAPJSON) event_constants emerald <MAP_JSONS> $(INCLUDECONSTS_OUTDIR)/map_event_ids.h"
 
 .map_version : FORCE
-	(echo "$(MAP_VERSION)" | cmp $@ -) || echo "$(MAP_VERSION)" > .map_version
+	@(echo "$(MAP_VERSION)" | cmp $@ -) || echo "$(MAP_VERSION)" > .map_version
 
 FORCE:
 .PHONY : FORCE


### PR DESCRIPTION
## Description
map_version check in makefile keeps spamming a message at the start of each build; this silences it

## Discord contact info
grintoul