### PR TITLE
Fix move anim pal blending being discarded

### DIFF
--- a/src/battle_anim.c
+++ b/src/battle_anim.c
@@ -1000,15 +1000,6 @@ static void Cmd_waitforvisualfinish(void)
     {
         sBattleAnimScriptPtr++;
         sAnimFramesToWait = 0;
-
-        // Assets can be safely unloaded at the end of waitforvisualfinish
-        // since it's guaranteed that nothing is currently using the assets
-        // by definition here.
-        // Only palettes are unloaded since that's what's usually hitting limits
-        // and is very quick to load again if needed.
-        // Unloading tile allocation was tested, but that did measurably increase
-        // the time it took to run animation tests
-        UnloadAllSpritePalettes();
     }
     else
     {


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
The issue was that move anim palettes were unloaded during `waitforvisualfinish`, which was causing issues when the palettes were blended, since the blend wasn't applied when the palette was loaded again the next time it was used.
The best solution is to simply not unload palettes during `waitforvisualfinish`, it wasn't necessary and was only a "this might be nice to have" feature.

## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, closes #2222." Remove this section if not applicable.-->
Fixes #9591 

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara