### PR TITLE
Fix Mirror Move failing when the target is immune to the copied move

### DIFF
--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -2711,8 +2711,7 @@ static enum MoveEndResult MoveEndMirrorMove(void)
      && gBattlerAttacker != gBattlerTarget
      && IsBattlerAlive(gBattlerAttacker)
      && IsBattlerAlive(gBattlerTarget)
-     && !IsMoveMirrorMoveBanned(GetOriginallyUsedMove(gChosenMove))
-     && !IsBattlerUnaffectedByMove(gBattlerTarget))
+     && !IsMoveMirrorMoveBanned(GetOriginallyUsedMove(gChosenMove)))
     {
         gBattleStruct->lastTakenMove[gBattlerTarget] = gChosenMove;
         gBattleStruct->lastTakenMoveFrom[gBattlerTarget][gBattlerAttacker] = gChosenMove;

--- a/test/battle/move_effect/mirror_move.c
+++ b/test/battle/move_effect/mirror_move.c
@@ -38,6 +38,25 @@ SINGLE_BATTLE_TEST("Mirror Move fails if no move was used before")
     }
 }
 
+SINGLE_BATTLE_TEST("Mirror Move works even if the target was immune to it")
+{
+    GIVEN {
+        ASSUME(GetSpeciesType(SPECIES_ROOKIDEE, 0) == TYPE_FLYING || GetSpeciesType(SPECIES_ROOKIDEE, 1) == TYPE_FLYING);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_ROOKIDEE);
+    } WHEN {
+        TURN { MOVE(player, MOVE_EARTHQUAKE); MOVE(opponent, MOVE_MIRROR_MOVE); }
+    } SCENE {
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, player);
+            HP_BAR(opponent);
+        }
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_MIRROR_MOVE, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
+        HP_BAR(player);
+    }
+}
+
 SINGLE_BATTLE_TEST("Mirror Move's called powder move fails against Grass Types")
 {
     GIVEN {


### PR DESCRIPTION
## Description
[Jpwiki](https://wiki.xn--rckteqa2e.com/wiki/%E3%82%AA%E3%82%A6%E3%83%A0%E3%81%8C%E3%81%88%E3%81%97)

> 第五世代以降
> PPを消費しながらも失敗した技、命中しなかった技、相性・特性・まもる状態などにより無効化された技もコピーできる。

Moves that failed while consuming PP, moves that missed, and moves that were nullified due to type matchup, Ability, Protect state, etc., can also be copied (Gen 5+)

## Issue(s) that this PR fixes
Fixes #9484 

## Note
@hedara90 provides the test.
