### PR TITLE
Removes DecompressTrainerBackPic fixing multibattles with 5-frame partner back sprites

### DIFF
--- a/include/battle_gfx_sfx_util.h
+++ b/include/battle_gfx_sfx_util.h
@@ -15,7 +15,6 @@ void BattleLoadMonSpriteGfx(struct Pokemon *mon, enum BattlerId battler);
 void DecompressGhostFrontPic(enum BattlerId battler);
 void BattleGfxSfxDummy2(enum Species species);
 void DecompressTrainerFrontPic(u16 frontPicId, enum BattlerId battler);
-void DecompressTrainerBackPic(enum TrainerPicID backPicId, enum BattlerId battler);
 void FreeTrainerFrontPicPalette(u16 frontPicId);
 bool8 BattleLoadAllHealthBoxesGfx(u8 state);
 void LoadBattleBarGfx(u8 unused);

--- a/src/battle_controllers.c
+++ b/src/battle_controllers.c
@@ -2458,7 +2458,7 @@ void BtlController_HandleDrawTrainerPic(enum BattlerId battler, enum TrainerPicI
         }
         else
         {
-            DecompressTrainerBackPic(trainerPicId, battler);
+            LoadSpritePalette(&gTrainerBacksprites[trainerPicId].palette);
             SetMultiuseSpriteTemplateToTrainerBack(trainerPicId, GetBattlerPosition(battler));
             if (subpriority == -1)
                 subpriority = GetBattlerSpriteSubpriority(battler);
@@ -2488,7 +2488,7 @@ void BtlController_HandleTrainerSlide(enum BattlerId battler, enum TrainerPicID 
 {
     if (IsOnPlayerSide(battler))
     {
-        DecompressTrainerBackPic(trainerPicId, battler);
+        LoadSpritePalette(&gTrainerBacksprites[trainerPicId].palette);
         SetMultiuseSpriteTemplateToTrainerBack(trainerPicId, GetBattlerPosition(battler));
         gBattleStruct->trainerSlideSpriteIds[battler] = CreateSprite(&gMultiuseSpriteTemplate,
                                                          80,

--- a/src/battle_gfx_sfx_util.c
+++ b/src/battle_gfx_sfx_util.c
@@ -697,13 +697,6 @@ void DecompressTrainerFrontPic(u16 frontPicId, enum BattlerId battler)
     LoadSpritePalette(&gTrainerSprites[frontPicId].palette);
 }
 
-void DecompressTrainerBackPic(enum TrainerPicID backPicId, enum BattlerId battler)
-{
-    enum BattlerPosition position = GetBattlerPosition(battler);
-    CopyTrainerBackspriteFramesToDest(backPicId, gMonSpritesGfxPtr->spritesGfx[position]);
-    LoadSpritePalette(&gTrainerBacksprites[backPicId].palette);
-}
-
 void FreeTrainerFrontPicPalette(u16 frontPicId)
 {
     FreeSpritePaletteByTag(gTrainerSprites[frontPicId].palette.tag);

--- a/src/reshow_battle_screen.c
+++ b/src/reshow_battle_screen.c
@@ -282,9 +282,9 @@ static bool8 LoadBattlerSpriteGfx(enum BattlerId battler)
                 BattleLoadSubstituteOrMonSpriteGfx(battler, FALSE);
         }
         else if (gBattleTypeFlags & BATTLE_TYPE_SAFARI && position == B_POSITION_PLAYER_LEFT)
-            DecompressTrainerBackPic((gSaveBlock2Ptr->playerGender == FEMALE) ? TRAINER_BACK_PIC_PLAYER_FEMALE : TRAINER_BACK_PIC_PLAYER_MALE, battler);
+            LoadSpritePalette(&gTrainerBacksprites[(gSaveBlock2Ptr->playerGender == FEMALE) ? TRAINER_BACK_PIC_PLAYER_FEMALE : TRAINER_BACK_PIC_PLAYER_MALE].palette);
         else if (gBattleTypeFlags & BATTLE_TYPE_CATCH_TUTORIAL && position == B_POSITION_PLAYER_LEFT)
-            DecompressTrainerBackPic(CATCH_TUTORIAL_TRAINER_PIC_BACK, battler);
+            LoadSpritePalette(&gTrainerBacksprites[CATCH_TUTORIAL_TRAINER_PIC_BACK].palette);
         else if (!gBattleSpritesDataPtr->battlerData[battler].behindSubstitute)
             BattleLoadMonSpriteGfx(GetBattlerMon(battler), battler);
         else


### PR DESCRIPTION
## Description
Change from 4 frame to 2 frame allocation per battler resulted in 5-frame back sprites on partner (battler2) in multibattles loading OOB, resulting in a crash caused by an effort to `Free()` in a garbage location. Appears only the palette load is actually necessary therefore `DecompressTrainerBackPic` has been replaced with the palette load in all places and `DecompressTrainerBackPic` removed.

Going to upcoming as the change to frame allocation is only in upcoming

## Discord contact info
grintoul