### PR TITLE
docs: added note about BoxPokemon encryption works test

### DIFF
--- a/test/pokemon.c
+++ b/test/pokemon.c
@@ -558,6 +558,9 @@ TEST("CalculateMonStats")
 
 TEST("BoxPokemon encryption works")
 {
+    // This test exists to ensure that expansion has not broken anything with regards to how BoxPokemon encryption works.
+    // If users make changes to the definitions of BoxPokemon, Pokemon, or any of their members, it is expected that this test will fail. To avoid the failing test from blocking CI, users can uncomment the KNOWN_FAILING declaration.
+    // KNOWN_FAILING;
     u32 raw[20] =
     {
         990384375,


### PR DESCRIPTION
Inspired by this comment: https://discord.com/channels/419213663107416084/1077168246555430962/1485563250081792122

I do not believe we should expect the average user to[ maintain vanilla encyrption](https://discord.com/channels/419213663107416084/1077168246555430962/1485563869693743104) as they make changes to their game, but rather, we should be letting them know that's its safe to mark this test as `KNOWN_FAILING` without negatively impacting their game.

