### PR TITLE
Fix fateful encounter starting battle with 0 hp

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -1708,6 +1708,7 @@ static void CreateEventMon(struct Pokemon *mon, u16 species, u8 level, u32 perso
 
     CreateMon(mon, species, level, personality, otId);
     SetMonData(mon, MON_DATA_MODERN_FATEFUL_ENCOUNTER, &isModernFatefulEncounter);
+    CalculateMonStats(mon);
 }
 
 enum TrainerPicID GetUnionRoomTrainerPic(void)


### PR DESCRIPTION
Regression introduced in #8204 when I modified how event mon are generated

## Media


https://github.com/user-attachments/assets/c0a14092-0eb2-417b-825d-752009189980



## Issue(s) that this PR fixes
Fixes #9620


## Discord contact info
Jamie
