### PR TITLE
Fix test ROM running out of space at 90%+ usage

### DIFF
--- a/sound/direct_sound_data.inc
+++ b/sound/direct_sound_data.inc
@@ -390,340 +390,476 @@ DirectSoundWaveData_unknown_17::
 .if P_FAMILY_BULBASAUR == TRUE
 	.align 2
 Cry_Bulbasaur::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/bulbasaur.bin"
+.endif
 
 	.align 2
 Cry_Ivysaur::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/ivysaur.bin"
+.endif
 
 	.align 2
 Cry_Venusaur::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/venusaur.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_VenusaurMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/venusaur_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_BULBASAUR
 
 .if P_FAMILY_CHARMANDER == TRUE
 	.align 2
 Cry_Charmander::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/charmander.bin"
+.endif
 
 	.align 2
 Cry_Charmeleon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/charmeleon.bin"
+.endif
 
 	.align 2
 Cry_Charizard::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/charizard.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_CharizardMegaX::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/charizard_mega_x.bin"
+.endif
 
 	.align 2
 Cry_CharizardMegaY::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/charizard_mega_y.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_CHARMANDER
 
 .if P_FAMILY_SQUIRTLE == TRUE
 	.align 2
 Cry_Squirtle::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/squirtle.bin"
+.endif
 
 	.align 2
 Cry_Wartortle::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/wartortle.bin"
+.endif
 
 	.align 2
 Cry_Blastoise::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/blastoise.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_BlastoiseMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/blastoise_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_SQUIRTLE
 
 .if P_FAMILY_CATERPIE == TRUE
 	.align 2
 Cry_Caterpie::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/caterpie.bin"
+.endif
 
 	.align 2
 Cry_Metapod::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/metapod.bin"
+.endif
 
 	.align 2
 Cry_Butterfree::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/butterfree.bin"
+.endif
 .endif @ P_FAMILY_CATERPIE
 
 .if P_FAMILY_WEEDLE == TRUE
 	.align 2
 Cry_Weedle::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/weedle.bin"
+.endif
 
 	.align 2
 Cry_Kakuna::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/kakuna.bin"
+.endif
 
 	.align 2
 Cry_Beedrill::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/beedrill.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_BeedrillMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/beedrill_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_WEEDLE
 
 .if P_FAMILY_PIDGEY == TRUE
 	.align 2
 Cry_Pidgey::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pidgey.bin"
+.endif
 
 	.align 2
 Cry_Pidgeotto::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pidgeotto.bin"
+.endif
 
 	.align 2
 Cry_Pidgeot::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pidgeot.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_PidgeotMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pidgeot_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_PIDGEY
 
 .if P_FAMILY_RATTATA == TRUE
 	.align 2
 Cry_Rattata::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/rattata.bin"
+.endif
 
 	.align 2
 Cry_Raticate::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/raticate.bin"
+.endif
 .endif @ P_FAMILY_RATTATA
 
 .if P_FAMILY_SPEAROW == TRUE
 	.align 2
 Cry_Spearow::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/spearow.bin"
+.endif
 
 	.align 2
 Cry_Fearow::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/fearow.bin"
+.endif
 .endif @ P_FAMILY_SPEAROW
 
 .if P_FAMILY_EKANS == TRUE
 	.align 2
 Cry_Ekans::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/ekans.bin"
+.endif
 
 	.align 2
 Cry_Arbok::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/arbok.bin"
+.endif
 .endif @ P_FAMILY_EKANS
 
 .if P_FAMILY_PIKACHU == TRUE
 .if P_GEN_2_CROSS_EVOS == TRUE
 	.align 2
 Cry_Pichu::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pichu.bin"
+.endif
 .endif @ P_GEN_2_CROSS_EVOS
 
 	.align 2
 Cry_Pikachu::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pikachu.bin"
+.endif
 
 	.align 2
 Cry_Raichu::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/raichu.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_RaichuMegaX::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/raichu_mega_x.bin"
+.endif
 	
 	.align 2
 Cry_RaichuMegaY::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/raichu_mega_y.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_PIKACHU
 
 .if P_FAMILY_SANDSHREW == TRUE
 	.align 2
 Cry_Sandshrew::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sandshrew.bin"
+.endif
 
 	.align 2
 Cry_Sandslash::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sandslash.bin"
+.endif
 .endif @ P_FAMILY_SANDSHREW
 
 .if P_FAMILY_NIDORAN == TRUE
 	.align 2
 Cry_NidoranF::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/nidoran_f.bin"
+.endif
 
 	.align 2
 Cry_Nidorina::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/nidorina.bin"
+.endif
 
 	.align 2
 Cry_Nidoqueen::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/nidoqueen.bin"
+.endif
 
 	.align 2
 Cry_NidoranM::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/nidoran_m.bin"
+.endif
 
 	.align 2
 Cry_Nidorino::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/nidorino.bin"
+.endif
 
 	.align 2
 Cry_Nidoking::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/nidoking.bin"
+.endif
 .endif @ P_FAMILY_NIDORAN
 
 .if P_FAMILY_CLEFAIRY == TRUE
 .if P_GEN_2_CROSS_EVOS == TRUE
 	.align 2
 Cry_Cleffa::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/cleffa.bin"
+.endif
 .endif @ P_GEN_2_CROSS_EVOS
 
 	.align 2
 Cry_Clefairy::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/clefairy.bin"
+.endif
 
 	.align 2
 Cry_Clefable::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/clefable.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_ClefableMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/clefable_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_CLEFAIRY
 
 .if P_FAMILY_VULPIX == TRUE
 	.align 2
 Cry_Vulpix::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/vulpix.bin"
+.endif
 
 	.align 2
 Cry_Ninetales::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/ninetales.bin"
+.endif
 .endif @ P_FAMILY_VULPIX
 
 .if P_FAMILY_JIGGLYPUFF == TRUE
 .if P_GEN_2_CROSS_EVOS == TRUE
 	.align 2
 Cry_Igglybuff::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/igglybuff.bin"
+.endif
 .endif @ P_GEN_2_CROSS_EVOS
 
 	.align 2
 Cry_Jigglypuff::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/jigglypuff.bin"
+.endif
 
 	.align 2
 Cry_Wigglytuff::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/wigglytuff.bin"
+.endif
 .endif @ P_FAMILY_JIGGLYPUFF
 
 .if P_FAMILY_ZUBAT == TRUE
 	.align 2
 Cry_Zubat::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/zubat.bin"
+.endif
 
 	.align 2
 Cry_Golbat::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/golbat.bin"
+.endif
 
 .if P_GEN_2_CROSS_EVOS == TRUE
 	.align 2
 Cry_Crobat::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/crobat.bin"
+.endif
 .endif @ P_GEN_2_CROSS_EVOS
 .endif @ P_FAMILY_ZUBAT
 
 .if P_FAMILY_ODDISH == TRUE
 	.align 2
 Cry_Oddish::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/oddish.bin"
+.endif
 
 	.align 2
 Cry_Gloom::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/gloom.bin"
+.endif
 
 	.align 2
 Cry_Vileplume::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/vileplume.bin"
+.endif
 
 .if P_GEN_2_CROSS_EVOS == TRUE
 	.align 2
 Cry_Bellossom::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/bellossom.bin"
+.endif
 .endif @ P_GEN_2_CROSS_EVOS
 .endif @ P_FAMILY_ODDISH
 
 .if P_FAMILY_PARAS == TRUE
 	.align 2
 Cry_Paras::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/paras.bin"
+.endif
 
 	.align 2
 Cry_Parasect::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/parasect.bin"
+.endif
 .endif @ P_FAMILY_PARAS
 
 .if P_FAMILY_VENONAT == TRUE
 	.align 2
 Cry_Venonat::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/venonat.bin"
+.endif
 
 	.align 2
 Cry_Venomoth::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/venomoth.bin"
+.endif
 .endif @ P_FAMILY_VENONAT
 
 .if P_FAMILY_DIGLETT == TRUE
 	.align 2
 Cry_Diglett::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/diglett.bin"
+.endif
 
 	.align 2
 Cry_Dugtrio::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dugtrio.bin"
+.endif
 .endif @ P_FAMILY_DIGLETT
 
 .if P_FAMILY_MEOWTH == TRUE
 	.align 2
 Cry_Meowth::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/meowth.bin"
+.endif
 
 	.align 2
 Cry_Persian::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/persian.bin"
+.endif
 
 .if P_GALARIAN_FORMS == TRUE
 	.align 2
 Cry_Perrserker::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/perrserker.bin"
+.endif
 
 .endif @ P_GALARIAN_FORMS
 .endif @ P_FAMILY_MEOWTH
@@ -731,170 +867,238 @@ Cry_Perrserker::
 .if P_FAMILY_PSYDUCK == TRUE
 	.align 2
 Cry_Psyduck::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/psyduck.bin"
+.endif
 
 	.align 2
 Cry_Golduck::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/golduck.bin"
+.endif
 .endif @ P_FAMILY_PSYDUCK
 
 .if P_FAMILY_MANKEY == TRUE
 	.align 2
 Cry_Mankey::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/mankey.bin"
+.endif
 
 	.align 2
 Cry_Primeape::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/primeape.bin"
+.endif
 
 .if P_GEN_9_CROSS_EVOS == TRUE
 	.align 2
 Cry_Annihilape::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/annihilape.bin"
+.endif
 .endif @ P_GEN_9_CROSS_EVOS
 .endif @ P_FAMILY_MANKEY
 
 .if P_FAMILY_GROWLITHE == TRUE
 	.align 2
 Cry_Growlithe::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/growlithe.bin"
+.endif
 
 	.align 2
 Cry_Arcanine::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/arcanine.bin"
+.endif
 .endif @ P_FAMILY_GROWLITHE
 
 .if P_FAMILY_POLIWAG == TRUE
 	.align 2
 Cry_Poliwag::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/poliwag.bin"
+.endif
 
 	.align 2
 Cry_Poliwhirl::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/poliwhirl.bin"
+.endif
 
 	.align 2
 Cry_Poliwrath::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/poliwrath.bin"
+.endif
 
 .if P_GEN_2_CROSS_EVOS == TRUE
 	.align 2
 Cry_Politoed::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/politoed.bin"
+.endif
 .endif @ P_GEN_2_CROSS_EVOS
 .endif @ P_FAMILY_POLIWAG
 
 .if P_FAMILY_ABRA == TRUE
 	.align 2
 Cry_Abra::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/abra.bin"
+.endif
 
 	.align 2
 Cry_Kadabra::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/kadabra.bin"
+.endif
 
 	.align 2
 Cry_Alakazam::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/alakazam.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_AlakazamMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/alakazam_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_ABRA
 
 .if P_FAMILY_MACHOP == TRUE
 	.align 2
 Cry_Machop::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/machop.bin"
+.endif
 
 	.align 2
 Cry_Machoke::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/machoke.bin"
+.endif
 
 	.align 2
 Cry_Machamp::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/machamp.bin"
+.endif
 .endif @ P_FAMILY_MACHOP
 
 .if P_FAMILY_BELLSPROUT == TRUE
 	.align 2
 Cry_Bellsprout::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/bellsprout.bin"
+.endif
 
 	.align 2
 Cry_Weepinbell::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/weepinbell.bin"
+.endif
 
 	.align 2
 Cry_Victreebel::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/victreebel.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_VictreebelMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/victreebel_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_BELLSPROUT
 
 .if P_FAMILY_TENTACOOL == TRUE
 	.align 2
 Cry_Tentacool::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tentacool.bin"
+.endif
 
 	.align 2
 Cry_Tentacruel::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tentacruel.bin"
+.endif
 .endif @ P_FAMILY_TENTACOOL
 
 .if P_FAMILY_GEODUDE == TRUE
 	.align 2
 Cry_Geodude::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/geodude.bin"
+.endif
 
 	.align 2
 Cry_Graveler::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/graveler.bin"
+.endif
 
 	.align 2
 Cry_Golem::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/golem.bin"
+.endif
 .endif @ P_FAMILY_GEODUDE
 
 .if P_FAMILY_PONYTA == TRUE
 	.align 2
 Cry_Ponyta::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/ponyta.bin"
+.endif
 
 	.align 2
 Cry_Rapidash::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/rapidash.bin"
+.endif
 .endif @ P_FAMILY_PONYTA
 
 .if P_FAMILY_SLOWPOKE == TRUE
 	.align 2
 Cry_Slowpoke::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/slowpoke.bin"
+.endif
 
 	.align 2
 Cry_Slowbro::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/slowbro.bin"
+.endif
 
 .if P_GEN_2_CROSS_EVOS == TRUE
 	.align 2
 Cry_Slowking::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/slowking.bin"
+.endif
 .endif @ P_GEN_2_CROSS_EVOS
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_SlowbroMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/slowbro_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .if P_GALARIAN_FORMS == TRUE
 	.align 2
 Cry_SlowpokeGalar::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/slowpoke_galar.bin"
+.endif
 
 .endif @ P_GALARIAN_FORMS
 .endif @ P_FAMILY_SLOWPOKE
@@ -902,28 +1106,38 @@ Cry_SlowpokeGalar::
 .if P_FAMILY_MAGNEMITE == TRUE
 	.align 2
 Cry_Magnemite::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/magnemite.bin"
+.endif
 
 	.align 2
 Cry_Magneton::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/magneton.bin"
+.endif
 
 .if P_GEN_4_CROSS_EVOS == TRUE
 	.align 2
 Cry_Magnezone::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/magnezone.bin"
+.endif
 .endif @ P_GEN_4_CROSS_EVOS
 .endif @ P_FAMILY_MAGNEMITE
 
 .if P_FAMILY_FARFETCHD == TRUE
 	.align 2
 Cry_Farfetchd::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/farfetchd.bin"
+.endif
 
 .if P_GALARIAN_FORMS == TRUE
 	.align 2
 Cry_Sirfetchd::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sirfetchd.bin"
+.endif
 
 .endif @ P_GALARIAN_FORMS
 .endif @ P_FAMILY_FARFETCHD
@@ -931,77 +1145,107 @@ Cry_Sirfetchd::
 .if P_FAMILY_DODUO == TRUE
 	.align 2
 Cry_Doduo::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/doduo.bin"
+.endif
 
 	.align 2
 Cry_Dodrio::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dodrio.bin"
+.endif
 .endif @ P_FAMILY_DODUO
 
 .if P_FAMILY_SEEL == TRUE
 	.align 2
 Cry_Seel::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/seel.bin"
+.endif
 
 	.align 2
 Cry_Dewgong::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dewgong.bin"
+.endif
 .endif @ P_FAMILY_SEEL
 
 .if P_FAMILY_GRIMER == TRUE
 	.align 2
 Cry_Grimer::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/grimer.bin"
+.endif
 
 	.align 2
 Cry_Muk::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/muk.bin"
+.endif
 .endif @ P_FAMILY_GRIMER
 
 .if P_FAMILY_SHELLDER == TRUE
 	.align 2
 Cry_Shellder::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/shellder.bin"
+.endif
 
 	.align 2
 Cry_Cloyster::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/cloyster.bin"
+.endif
 .endif @ P_FAMILY_SHELLDER
 
 .if P_FAMILY_GASTLY == TRUE
 	.align 2
 Cry_Gastly::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/gastly.bin"
+.endif
 
 	.align 2
 Cry_Haunter::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/haunter.bin"
+.endif
 
 	.align 2
 Cry_Gengar::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/gengar.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_GengarMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/gengar_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_GASTLY
 
 .if P_FAMILY_ONIX == TRUE
 	.align 2
 Cry_Onix::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/onix.bin"
+.endif
 
 .if P_GEN_2_CROSS_EVOS == TRUE
 	.align 2
 Cry_Steelix::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/steelix.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_SteelixMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/steelix_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_GEN_2_CROSS_EVOS
 .endif @ P_FAMILY_ONIX
@@ -1009,110 +1253,152 @@ Cry_SteelixMega::
 .if P_FAMILY_DROWZEE == TRUE
 	.align 2
 Cry_Drowzee::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/drowzee.bin"
+.endif
 
 	.align 2
 Cry_Hypno::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/hypno.bin"
+.endif
 .endif @ P_FAMILY_DROWZEE
 
 .if P_FAMILY_KRABBY == TRUE
 	.align 2
 Cry_Krabby::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/krabby.bin"
+.endif
 
 	.align 2
 Cry_Kingler::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/kingler.bin"
+.endif
 .endif @ P_FAMILY_KRABBY
 
 .if P_FAMILY_VOLTORB == TRUE
 	.align 2
 Cry_Voltorb::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/voltorb.bin"
+.endif
 
 	.align 2
 Cry_Electrode::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/electrode.bin"
+.endif
 .endif @ P_FAMILY_VOLTORB
 
 .if P_FAMILY_EXEGGCUTE == TRUE
 	.align 2
 Cry_Exeggcute::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/exeggcute.bin"
+.endif
 
 	.align 2
 Cry_Exeggutor::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/exeggutor.bin"
+.endif
 .endif @ P_FAMILY_EXEGGCUTE
 
 .if P_FAMILY_CUBONE == TRUE
 	.align 2
 Cry_Cubone::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/cubone.bin"
+.endif
 
 	.align 2
 Cry_Marowak::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/marowak.bin"
+.endif
 .endif @ P_FAMILY_CUBONE
 
 .if P_FAMILY_HITMONS == TRUE
 .if P_GEN_2_CROSS_EVOS == TRUE
 	.align 2
 Cry_Tyrogue::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tyrogue.bin"
+.endif
 .endif @ P_GEN_2_CROSS_EVOS
 
 	.align 2
 Cry_Hitmonlee::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/hitmonlee.bin"
+.endif
 
 	.align 2
 Cry_Hitmonchan::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/hitmonchan.bin"
+.endif
 
 .if P_GEN_2_CROSS_EVOS == TRUE
 	.align 2
 Cry_Hitmontop::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/hitmontop.bin"
+.endif
 .endif @ P_GEN_2_CROSS_EVOS
 .endif @ P_FAMILY_HITMONS
 
 .if P_FAMILY_LICKITUNG == TRUE
 	.align 2
 Cry_Lickitung::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/lickitung.bin"
+.endif
 
 .if P_GEN_4_CROSS_EVOS == TRUE
 	.align 2
 Cry_Lickilicky::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/lickilicky.bin"
+.endif
 .endif @ P_GEN_4_CROSS_EVOS
 .endif @ P_FAMILY_LICKITUNG
 
 .if P_FAMILY_KOFFING == TRUE
 	.align 2
 Cry_Koffing::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/koffing.bin"
+.endif
 
 	.align 2
 Cry_Weezing::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/weezing.bin"
+.endif
 .endif @ P_FAMILY_KOFFING
 
 .if P_FAMILY_RHYHORN == TRUE
 	.align 2
 Cry_Rhyhorn::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/rhyhorn.bin"
+.endif
 
 	.align 2
 Cry_Rhydon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/rhydon.bin"
+.endif
 
 .if P_GEN_4_CROSS_EVOS == TRUE
 	.align 2
 Cry_Rhyperior::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/rhyperior.bin"
+.endif
 .endif @ P_GEN_4_CROSS_EVOS
 .endif @ P_FAMILY_RHYHORN
 
@@ -1120,83 +1406,113 @@ Cry_Rhyperior::
 .if P_GEN_4_CROSS_EVOS == TRUE
 	.align 2
 Cry_Happiny::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/happiny.bin"
+.endif
 .endif @ P_GEN_4_CROSS_EVOS
 
 	.align 2
 Cry_Chansey::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/chansey.bin"
+.endif
 
 .if P_GEN_2_CROSS_EVOS == TRUE
 	.align 2
 Cry_Blissey::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/blissey.bin"
+.endif
 .endif @ P_GEN_2_CROSS_EVOS
 .endif @ P_FAMILY_CHANSEY
 
 .if P_FAMILY_TANGELA == TRUE
 	.align 2
 Cry_Tangela::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tangela.bin"
+.endif
 
 .if P_GEN_4_CROSS_EVOS == TRUE
 	.align 2
 Cry_Tangrowth::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tangrowth.bin"
+.endif
 .endif @ P_GEN_4_CROSS_EVOS
 .endif @ P_FAMILY_TANGELA
 
 .if P_FAMILY_KANGASKHAN == TRUE
 	.align 2
 Cry_Kangaskhan::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/kangaskhan.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_KangaskhanMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/kangaskhan_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_KANGASKHAN
 
 .if P_FAMILY_HORSEA == TRUE
 	.align 2
 Cry_Horsea::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/horsea.bin"
+.endif
 
 	.align 2
 Cry_Seadra::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/seadra.bin"
+.endif
 
 .if P_GEN_2_CROSS_EVOS == TRUE
 	.align 2
 Cry_Kingdra::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/kingdra.bin"
+.endif
 .endif @ P_GEN_2_CROSS_EVOS
 .endif @ P_FAMILY_HORSEA
 
 .if P_FAMILY_GOLDEEN == TRUE
 	.align 2
 Cry_Goldeen::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/goldeen.bin"
+.endif
 
 	.align 2
 Cry_Seaking::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/seaking.bin"
+.endif
 .endif @ P_FAMILY_GOLDEEN
 
 .if P_FAMILY_STARYU == TRUE
 	.align 2
 Cry_Staryu::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/staryu.bin"
+.endif
 
 	.align 2
 Cry_Starmie::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/starmie.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_StarmieMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/starmie_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_STARYU
 
@@ -1204,17 +1520,23 @@ Cry_StarmieMega::
 .if P_GEN_4_CROSS_EVOS == TRUE
 	.align 2
 Cry_MimeJr::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/mime_jr.bin"
+.endif
 .endif @ P_GEN_4_CROSS_EVOS
 
 	.align 2
 Cry_MrMime::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/mr_mime.bin"
+.endif
 
 .if P_GALARIAN_FORMS == TRUE
 	.align 2
 Cry_MrRime::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/mr_rime.bin"
+.endif
 
 .endif @ P_GALARIAN_FORMS
 .endif @ P_FAMILY_MR_MIME
@@ -1222,23 +1544,31 @@ Cry_MrRime::
 .if P_FAMILY_SCYTHER == TRUE
 	.align 2
 Cry_Scyther::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/scyther.bin"
+.endif
 
 .if P_GEN_2_CROSS_EVOS == TRUE
 	.align 2
 Cry_Scizor::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/scizor.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_ScizorMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/scizor_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_GEN_2_CROSS_EVOS
 .if P_GEN_8_CROSS_EVOS == TRUE
 	.align 2
 Cry_Kleavor::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/kleavor.bin"
+.endif
 .endif @ P_GEN_8_CROSS_EVOS
 .endif @ P_FAMILY_SCYTHER
 
@@ -1246,29 +1576,39 @@ Cry_Kleavor::
 .if P_GEN_2_CROSS_EVOS == TRUE
 	.align 2
 Cry_Smoochum::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/smoochum.bin"
+.endif
 .endif @ P_GEN_2_CROSS_EVOS
 
 	.align 2
 Cry_Jynx::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/jynx.bin"
+.endif
 .endif @ P_FAMILY_JYNX
 
 .if P_FAMILY_ELECTABUZZ == TRUE
 .if P_GEN_2_CROSS_EVOS == TRUE
 	.align 2
 Cry_Elekid::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/elekid.bin"
+.endif
 .endif @ P_GEN_2_CROSS_EVOS
 
 	.align 2
 Cry_Electabuzz::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/electabuzz.bin"
+.endif
 
 .if P_GEN_4_CROSS_EVOS == TRUE
 	.align 2
 Cry_Electivire::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/electivire.bin"
+.endif
 .endif @ P_GEN_4_CROSS_EVOS
 .endif @ P_FAMILY_ELECTABUZZ
 
@@ -1276,122 +1616,168 @@ Cry_Electivire::
 .if P_GEN_2_CROSS_EVOS == TRUE
 	.align 2
 Cry_Magby::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/magby.bin"
+.endif
 .endif @ P_GEN_2_CROSS_EVOS
 
 	.align 2
 Cry_Magmar::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/magmar.bin"
+.endif
 
 .if P_GEN_4_CROSS_EVOS == TRUE
 	.align 2
 Cry_Magmortar::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/magmortar.bin"
+.endif
 .endif @ P_GEN_4_CROSS_EVOS
 .endif @ P_FAMILY_MAGMAR
 
 .if P_FAMILY_PINSIR == TRUE
 	.align 2
 Cry_Pinsir::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pinsir.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_PinsirMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pinsir_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_PINSIR
 
 .if P_FAMILY_TAUROS == TRUE
 	.align 2
 Cry_Tauros::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tauros.bin"
+.endif
 .endif @ P_FAMILY_TAUROS
 
 .if P_FAMILY_MAGIKARP == TRUE
 	.align 2
 Cry_Magikarp::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/magikarp.bin"
+.endif
 
 	.align 2
 Cry_Gyarados::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/gyarados.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_GyaradosMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/gyarados_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_MAGIKARP
 
 .if P_FAMILY_LAPRAS == TRUE
 	.align 2
 Cry_Lapras::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/lapras.bin"
+.endif
 .endif @ P_FAMILY_LAPRAS
 
 .if P_FAMILY_DITTO == TRUE
 	.align 2
 Cry_Ditto::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/ditto.bin"
+.endif
 .endif @ P_FAMILY_DITTO
 
 .if P_FAMILY_EEVEE == TRUE
 	.align 2
 Cry_Eevee::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/eevee.bin"
+.endif
 
 	.align 2
 Cry_Vaporeon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/vaporeon.bin"
+.endif
 
 	.align 2
 Cry_Jolteon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/jolteon.bin"
+.endif
 
 	.align 2
 Cry_Flareon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/flareon.bin"
+.endif
 
 .if P_GEN_2_CROSS_EVOS == TRUE
 	.align 2
 Cry_Espeon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/espeon.bin"
+.endif
 
 	.align 2
 Cry_Umbreon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/umbreon.bin"
+.endif
 .endif @ P_GEN_2_CROSS_EVOS
 .if P_GEN_4_CROSS_EVOS == TRUE
 	.align 2
 Cry_Leafeon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/leafeon.bin"
+.endif
 
 	.align 2
 Cry_Glaceon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/glaceon.bin"
+.endif
 .endif @ P_GEN_4_CROSS_EVOS
 .if P_GEN_6_CROSS_EVOS == TRUE
 	.align 2
 Cry_Sylveon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sylveon.bin"
+.endif
 .endif @ P_GEN_6_CROSS_EVOS
 .endif @ P_FAMILY_EEVEE
 
 	.align 2
 Cry_Porygon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/porygon.bin"
+.endif
 
 .if P_FAMILY_PORYGON == TRUE
 .if P_GEN_2_CROSS_EVOS == TRUE
 	.align 2
 Cry_Porygon2::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/porygon2.bin"
+.endif
 
 .if P_GEN_4_CROSS_EVOS == TRUE
 	.align 2
 Cry_PorygonZ::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/porygon_z.bin"
+.endif
 .endif @ P_GEN_4_CROSS_EVOS
 .endif @ P_GEN_2_CROSS_EVOS
 .endif @ P_FAMILY_PORYGON
@@ -1399,32 +1785,44 @@ Cry_PorygonZ::
 .if P_FAMILY_OMANYTE == TRUE
 	.align 2
 Cry_Omanyte::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/omanyte.bin"
+.endif
 
 	.align 2
 Cry_Omastar::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/omastar.bin"
+.endif
 .endif @ P_FAMILY_OMANYTE
 
 .if P_FAMILY_KABUTO == TRUE
 	.align 2
 Cry_Kabuto::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/kabuto.bin"
+.endif
 
 	.align 2
 Cry_Kabutops::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/kabutops.bin"
+.endif
 .endif @ P_FAMILY_KABUTO
 
 .if P_FAMILY_AERODACTYL == TRUE
 	.align 2
 Cry_Aerodactyl::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/aerodactyl.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_AerodactylMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/aerodactyl_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_AERODACTYL
 
@@ -1432,221 +1830,307 @@ Cry_AerodactylMega::
 .if P_GEN_4_CROSS_EVOS == TRUE
 	.align 2
 Cry_Munchlax::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/munchlax.bin"
+.endif
 .endif @ P_GEN_4_CROSS_EVOS
 
 	.align 2
 Cry_Snorlax::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/snorlax.bin"
+.endif
 .endif @ P_FAMILY_SNORLAX
 
 .if P_FAMILY_ARTICUNO == TRUE
 	.align 2
 Cry_Articuno::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/articuno.bin"
+.endif
 .endif @ P_FAMILY_ARTICUNO
 
 .if P_FAMILY_ZAPDOS == TRUE
 	.align 2
 Cry_Zapdos::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/zapdos.bin"
+.endif
 .endif @ P_FAMILY_ZAPDOS
 
 .if P_FAMILY_MOLTRES == TRUE
 	.align 2
 Cry_Moltres::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/moltres.bin"
+.endif
 .endif @ P_FAMILY_MOLTRES
 
 .if P_FAMILY_DRATINI == TRUE
 	.align 2
 Cry_Dratini::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dratini.bin"
+.endif
 
 	.align 2
 Cry_Dragonair::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dragonair.bin"
+.endif
 
 	.align 2
 Cry_Dragonite::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dragonite.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_DragoniteMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dragonite_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_DRATINI
 
 .if P_FAMILY_MEWTWO == TRUE
 	.align 2
 Cry_Mewtwo::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/mewtwo.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_MewtwoMegaX::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/mewtwo_mega_x.bin"
+.endif
 
 	.align 2
 Cry_MewtwoMegaY::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/mewtwo_mega_y.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_MEWTWO
 
 .if P_FAMILY_MEW == TRUE
 	.align 2
 Cry_Mew::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/mew.bin"
+.endif
 .endif @ P_FAMILY_MEW
 
 .if P_FAMILY_CHIKORITA == TRUE
 	.align 2
 Cry_Chikorita::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/chikorita.bin"
+.endif
 
 	.align 2
 Cry_Bayleef::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/bayleef.bin"
+.endif
 
 	.align 2
 Cry_Meganium::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/meganium.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_MeganiumMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/meganium_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_CHIKORITA
 
 .if P_FAMILY_CYNDAQUIL == TRUE
 	.align 2
 Cry_Cyndaquil::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/cyndaquil.bin"
+.endif
 
 	.align 2
 Cry_Quilava::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/quilava.bin"
+.endif
 
 	.align 2
 Cry_Typhlosion::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/typhlosion.bin"
+.endif
 .endif @ P_FAMILY_CYNDAQUIL
 
 .if P_FAMILY_TOTODILE == TRUE
 	.align 2
 Cry_Totodile::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/totodile.bin"
+.endif
 
 	.align 2
 Cry_Croconaw::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/croconaw.bin"
+.endif
 
 	.align 2
 Cry_Feraligatr::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/feraligatr.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_FeraligatrMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/feraligatr_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_TOTODILE
 
 .if P_FAMILY_SENTRET == TRUE
 	.align 2
 Cry_Sentret::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sentret.bin"
+.endif
 
 	.align 2
 Cry_Furret::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/furret.bin"
+.endif
 .endif @ P_FAMILY_SENTRET
 
 .if P_FAMILY_HOOTHOOT == TRUE
 	.align 2
 Cry_Hoothoot::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/hoothoot.bin"
+.endif
 
 	.align 2
 Cry_Noctowl::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/noctowl.bin"
+.endif
 .endif @ P_FAMILY_HOOTHOOT
 
 .if P_FAMILY_LEDYBA == TRUE
 	.align 2
 Cry_Ledyba::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/ledyba.bin"
+.endif
 
 	.align 2
 Cry_Ledian::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/ledian.bin"
+.endif
 .endif @ P_FAMILY_LEDYBA
 
 .if P_FAMILY_SPINARAK == TRUE
 	.align 2
 Cry_Spinarak::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/spinarak.bin"
+.endif
 
 	.align 2
 Cry_Ariados::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/ariados.bin"
+.endif
 .endif @ P_FAMILY_SPINARAK
 
 .if P_FAMILY_CHINCHOU == TRUE
 	.align 2
 Cry_Chinchou::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/chinchou.bin"
+.endif
 
 	.align 2
 Cry_Lanturn::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/lanturn.bin"
+.endif
 .endif @ P_FAMILY_CHINCHOU
 
 .if P_FAMILY_TOGEPI == TRUE
 	.align 2
 Cry_Togepi::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/togepi.bin"
+.endif
 
 	.align 2
 Cry_Togetic::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/togetic.bin"
+.endif
 
 .if P_GEN_4_CROSS_EVOS == TRUE
 	.align 2
 Cry_Togekiss::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/togekiss.bin"
+.endif
 .endif @ P_GEN_4_CROSS_EVOS
 .endif @ P_FAMILY_TOGEPI
 
 .if P_FAMILY_NATU == TRUE
 	.align 2
 Cry_Natu::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/natu.bin"
+.endif
 
 	.align 2
 Cry_Xatu::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/xatu.bin"
+.endif
 .endif @ P_FAMILY_NATU
 
 .if P_FAMILY_MAREEP == TRUE
 	.align 2
 Cry_Mareep::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/mareep.bin"
+.endif
 
 	.align 2
 Cry_Flaaffy::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/flaaffy.bin"
+.endif
 
 	.align 2
 Cry_Ampharos::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/ampharos.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_AmpharosMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/ampharos_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_MAREEP
 
@@ -1654,87 +2138,121 @@ Cry_AmpharosMega::
 .if P_GEN_3_CROSS_EVOS == TRUE
 	.align 2
 Cry_Azurill::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/azurill.bin"
+.endif
 .endif @ P_GEN_3_CROSS_EVOS
 
 	.align 2
 Cry_Marill::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/marill.bin"
+.endif
 
 	.align 2
 Cry_Azumarill::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/azumarill.bin"
+.endif
 .endif @ P_FAMILY_MARILL
 
 .if P_FAMILY_SUDOWOODO == TRUE
 	.align 2
 Cry_Bonsly::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/bonsly.bin"
+.endif
 
 	.align 2
 Cry_Sudowoodo::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sudowoodo.bin"
+.endif
 .endif @ P_FAMILY_SUDOWOODO
 
 .if P_FAMILY_HOPPIP == TRUE
 	.align 2
 Cry_Hoppip::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/hoppip.bin"
+.endif
 
 	.align 2
 Cry_Skiploom::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/skiploom.bin"
+.endif
 
 	.align 2
 Cry_Jumpluff::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/jumpluff.bin"
+.endif
 .endif @ P_FAMILY_HOPPIP
 
 .if P_FAMILY_AIPOM == TRUE
 	.align 2
 Cry_Aipom::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/aipom.bin"
+.endif
 
 	.align 2
 Cry_Ambipom::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/ambipom.bin"
+.endif
 .endif @ P_FAMILY_AIPOM
 
 .if P_FAMILY_SUNKERN == TRUE
 	.align 2
 Cry_Sunkern::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sunkern.bin"
+.endif
 
 	.align 2
 Cry_Sunflora::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sunflora.bin"
+.endif
 .endif @ P_FAMILY_SUNKERN
 
 .if P_FAMILY_YANMA == TRUE
 	.align 2
 Cry_Yanma::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/yanma.bin"
+.endif
 
 .if P_GEN_4_CROSS_EVOS == TRUE
 	.align 2
 Cry_Yanmega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/yanmega.bin"
+.endif
 .endif @ P_GEN_4_CROSS_EVOS
 .endif @ P_FAMILY_YANMA
 
 .if P_FAMILY_WOOPER == TRUE
 	.align 2
 Cry_Wooper::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/wooper.bin"
+.endif
 
 	.align 2
 Cry_Quagsire::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/quagsire.bin"
+.endif
 
 .if P_PALDEAN_FORMS == TRUE
 	.align 2
 Cry_Clodsire::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/clodsire.bin"
+.endif
 
 .endif @ P_PALDEAN_FORMS
 .endif @ P_FAMILY_WOOPER
@@ -1742,106 +2260,144 @@ Cry_Clodsire::
 .if P_FAMILY_MURKROW == TRUE
 	.align 2
 Cry_Murkrow::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/murkrow.bin"
+.endif
 
 	.align 2
 Cry_Honchkrow::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/honchkrow.bin"
+.endif
 .endif @ P_FAMILY_MURKROW
 
 .if P_FAMILY_MISDREAVUS == TRUE
 	.align 2
 Cry_Misdreavus::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/misdreavus.bin"
+.endif
 
 	.align 2
 Cry_Mismagius::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/mismagius.bin"
+.endif
 .endif @ P_FAMILY_MISDREAVUS
 
 .if P_FAMILY_UNOWN == TRUE
 	.align 2
 Cry_Unown::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/unown.bin"
+.endif
 .endif @ P_FAMILY_UNOWN
 
 .if P_FAMILY_WOBBUFFET == TRUE
 .if P_GEN_3_CROSS_EVOS == TRUE
 	.align 2
 Cry_Wynaut::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/wynaut.bin"
+.endif
 .endif @ P_GEN_3_CROSS_EVOS
 
 	.align 2
 Cry_Wobbuffet::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/wobbuffet.bin"
+.endif
 .endif @ P_FAMILY_WOBBUFFET
 
 .if P_FAMILY_GIRAFARIG == TRUE
 	.align 2
 Cry_Girafarig::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/girafarig.bin"
+.endif
 
 .if P_GEN_9_CROSS_EVOS == TRUE
 	.align 2
 Cry_Farigiraf::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/farigiraf.bin"
+.endif
 .endif @ P_GEN_9_CROSS_EVOS
 .endif @ P_FAMILY_GIRAFARIG
 
 .if P_FAMILY_PINECO == TRUE
 	.align 2
 Cry_Pineco::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pineco.bin"
+.endif
 
 	.align 2
 Cry_Forretress::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/forretress.bin"
+.endif
 .endif @ P_FAMILY_PINECO
 
 .if P_FAMILY_DUNSPARCE == TRUE
 	.align 2
 Cry_Dunsparce::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dunsparce.bin"
+.endif
 
 .if P_GEN_9_CROSS_EVOS == TRUE
 	.align 2
 Cry_Dudunsparce::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dudunsparce.bin"
+.endif
 .endif @ P_GEN_9_CROSS_EVOS
 .endif @ P_FAMILY_DUNSPARCE
 
 .if P_FAMILY_GLIGAR == TRUE
 	.align 2
 Cry_Gligar::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/gligar.bin"
+.endif
 
 .if P_GEN_4_CROSS_EVOS == TRUE
 	.align 2
 Cry_Gliscor::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/gliscor.bin"
+.endif
 .endif @ P_GEN_4_CROSS_EVOS
 .endif @ P_FAMILY_GLIGAR
 
 .if P_FAMILY_SNUBBULL == TRUE
 	.align 2
 Cry_Snubbull::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/snubbull.bin"
+.endif
 
 	.align 2
 Cry_Granbull::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/granbull.bin"
+.endif
 .endif @ P_FAMILY_SNUBBULL
 
 .if P_FAMILY_QWILFISH == TRUE
 	.align 2
 Cry_Qwilfish::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/qwilfish.bin"
+.endif
 
 .if P_HISUIAN_FORMS == TRUE
 	.align 2
 Cry_Overqwil::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/overqwil.bin"
+.endif
 
 .endif @ P_HISUIAN_FORMS
 .endif @ P_FAMILY_QWILFISH
@@ -1849,35 +2405,47 @@ Cry_Overqwil::
 .if P_FAMILY_SHUCKLE == TRUE
 	.align 2
 Cry_Shuckle::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/shuckle.bin"
+.endif
 .endif @ P_FAMILY_SHUCKLE
 
 .if P_FAMILY_HERACROSS == TRUE
 	.align 2
 Cry_Heracross::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/heracross.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_HeracrossMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/heracross_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_HERACROSS
 
 .if P_FAMILY_SNEASEL == TRUE
 	.align 2
 Cry_Sneasel::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sneasel.bin"
+.endif
 
 .if P_GEN_4_CROSS_EVOS == TRUE
 	.align 2
 Cry_Weavile::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/weavile.bin"
+.endif
 .endif @ P_GEN_4_CROSS_EVOS
 .if P_HISUIAN_FORMS == TRUE
 	.align 2
 Cry_Sneasler::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sneasler.bin"
+.endif
 
 .endif @ P_HISUIAN_FORMS
 .endif @ P_FAMILY_SNEASEL
@@ -1885,58 +2453,80 @@ Cry_Sneasler::
 .if P_FAMILY_TEDDIURSA == TRUE
 	.align 2
 Cry_Teddiursa::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/teddiursa.bin"
+.endif
 
 	.align 2
 Cry_Ursaring::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/ursaring.bin"
+.endif
 
 .if P_GEN_8_CROSS_EVOS == TRUE
 	.align 2
 Cry_Ursaluna::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/ursaluna.bin"
+.endif
 	
 	.align 2
 Cry_UrsalunaBloodmoon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/ursaluna_bloodmoon.bin"
+.endif
 .endif @ P_GEN_8_CROSS_EVOS
 .endif @ P_FAMILY_TEDDIURSA
 
 .if P_FAMILY_SLUGMA == TRUE
 	.align 2
 Cry_Slugma::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/slugma.bin"
+.endif
 
 	.align 2
 Cry_Magcargo::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/magcargo.bin"
+.endif
 .endif @ P_FAMILY_SLUGMA
 
 .if P_FAMILY_SWINUB == TRUE
 	.align 2
 Cry_Swinub::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/swinub.bin"
+.endif
 
 	.align 2
 Cry_Piloswine::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/piloswine.bin"
+.endif
 
 .if P_GEN_4_CROSS_EVOS == TRUE
 	.align 2
 Cry_Mamoswine::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/mamoswine.bin"
+.endif
 .endif @ P_GEN_4_CROSS_EVOS
 .endif @ P_FAMILY_SWINUB
 
 .if P_FAMILY_CORSOLA == TRUE
 	.align 2
 Cry_Corsola::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/corsola.bin"
+.endif
 
 .if P_GALARIAN_FORMS == TRUE
 	.align 2
 Cry_Cursola::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/cursola.bin"
+.endif
 
 .endif @ P_GALARIAN_FORMS
 .endif @ P_FAMILY_CORSOLA
@@ -1944,232 +2534,318 @@ Cry_Cursola::
 .if P_FAMILY_REMORAID == TRUE
 	.align 2
 Cry_Remoraid::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/remoraid.bin"
+.endif
 
 	.align 2
 Cry_Octillery::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/octillery.bin"
+.endif
 .endif @ P_FAMILY_REMORAID
 
 .if P_FAMILY_DELIBIRD == TRUE
 	.align 2
 Cry_Delibird::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/delibird.bin"
+.endif
 .endif @ P_FAMILY_DELIBIRD
 
 .if P_FAMILY_MANTINE == TRUE
 .if P_GEN_4_CROSS_EVOS == TRUE
 	.align 2
 Cry_Mantyke::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/mantyke.bin"
+.endif
 .endif @ P_GEN_4_CROSS_EVOS
 
 	.align 2
 Cry_Mantine::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/mantine.bin"
+.endif
 .endif @ P_FAMILY_MANTINE
 
 .if P_FAMILY_SKARMORY == TRUE
 	.align 2
 Cry_Skarmory::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/skarmory.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_SkarmoryMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/skarmory_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_SKARMORY
 
 .if P_FAMILY_HOUNDOUR == TRUE
 	.align 2
 Cry_Houndour::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/houndour.bin"
+.endif
 
 	.align 2
 Cry_Houndoom::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/houndoom.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_HoundoomMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/houndoom_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_HOUNDOUR
 
 .if P_FAMILY_PHANPY == TRUE
 	.align 2
 Cry_Phanpy::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/phanpy.bin"
+.endif
 
 	.align 2
 Cry_Donphan::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/donphan.bin"
+.endif
 .endif @ P_FAMILY_PHANPY
 
 .if P_FAMILY_STANTLER == TRUE
 	.align 2
 Cry_Stantler::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/stantler.bin"
+.endif
 
 .if P_GEN_8_CROSS_EVOS == TRUE
 	.align 2
 Cry_Wyrdeer::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/wyrdeer.bin"
+.endif
 .endif @ P_GEN_8_CROSS_EVOS
 .endif @ P_FAMILY_STANTLER
 
 .if P_FAMILY_SMEARGLE == TRUE
 	.align 2
 Cry_Smeargle::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/smeargle.bin"
+.endif
 .endif @ P_FAMILY_SMEARGLE
 
 .if P_FAMILY_MILTANK == TRUE
 	.align 2
 Cry_Miltank::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/miltank.bin"
+.endif
 .endif @ P_FAMILY_MILTANK
 
 .if P_FAMILY_RAIKOU == TRUE
 	.align 2
 Cry_Raikou::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/raikou.bin"
+.endif
 .endif @ P_FAMILY_RAIKOU
 
 .if P_FAMILY_ENTEI == TRUE
 	.align 2
 Cry_Entei::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/entei.bin"
+.endif
 .endif @ P_FAMILY_ENTEI
 
 .if P_FAMILY_SUICUNE == TRUE
 	.align 2
 Cry_Suicune::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/suicune.bin"
+.endif
 .endif @ P_FAMILY_SUICUNE
 
 .if P_FAMILY_LARVITAR == TRUE
 	.align 2
 Cry_Larvitar::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/larvitar.bin"
+.endif
 
 	.align 2
 Cry_Pupitar::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pupitar.bin"
+.endif
 
 	.align 2
 Cry_Tyranitar::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tyranitar.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_TyranitarMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tyranitar_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_LARVITAR
 
 .if P_FAMILY_LUGIA == TRUE
 	.align 2
 Cry_Lugia::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/lugia.bin"
+.endif
 .endif @ P_FAMILY_LUGIA
 
 .if P_FAMILY_HO_OH == TRUE
 	.align 2
 Cry_HoOh::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/ho_oh.bin"
+.endif
 .endif @ P_FAMILY_HO_OH
 
 .if P_FAMILY_CELEBI == TRUE
 	.align 2
 Cry_Celebi::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/celebi.bin"
+.endif
 .endif @ P_FAMILY_CELEBI
 
 .if P_FAMILY_TREECKO == TRUE
 	.align 2
 Cry_Treecko::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/treecko.bin"
+.endif
 
 	.align 2
 Cry_Grovyle::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/grovyle.bin"
+.endif
 
 	.align 2
 Cry_Sceptile::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sceptile.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_SceptileMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sceptile_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_TREECKO
 
 .if P_FAMILY_TORCHIC == TRUE
 	.align 2
 Cry_Torchic::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/torchic.bin"
+.endif
 
 	.align 2
 Cry_Combusken::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/combusken.bin"
+.endif
 
 	.align 2
 Cry_Blaziken::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/blaziken.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_BlazikenMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/blaziken_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_TORCHIC
 
 .if P_FAMILY_MUDKIP == TRUE
 	.align 2
 Cry_Mudkip::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/mudkip.bin"
+.endif
 
 	.align 2
 Cry_Marshtomp::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/marshtomp.bin"
+.endif
 
 	.align 2
 Cry_Swampert::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/swampert.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_SwampertMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/swampert_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_MUDKIP
 
 .if P_FAMILY_POOCHYENA == TRUE
 	.align 2
 Cry_Poochyena::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/poochyena.bin"
+.endif
 
 	.align 2
 Cry_Mightyena::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/mightyena.bin"
+.endif
 .endif @ P_FAMILY_POOCHYENA
 
 .if P_FAMILY_ZIGZAGOON == TRUE
 	.align 2
 Cry_Zigzagoon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/zigzagoon.bin"
+.endif
 
 	.align 2
 Cry_Linoone::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/linoone.bin"
+.endif
 
 .if P_GALARIAN_FORMS == TRUE
 	.align 2
 Cry_Obstagoon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/obstagoon.bin"
+.endif
 
 .endif @ P_GALARIAN_FORMS
 .endif @ P_FAMILY_ZIGZAGOON
@@ -2177,100 +2853,142 @@ Cry_Obstagoon::
 .if P_FAMILY_WURMPLE == TRUE
 	.align 2
 Cry_Wurmple::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/wurmple.bin"
+.endif
 
 	.align 2
 Cry_Silcoon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/silcoon.bin"
+.endif
 
 	.align 2
 Cry_Beautifly::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/beautifly.bin"
+.endif
 
 	.align 2
 Cry_Cascoon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/cascoon.bin"
+.endif
 
 	.align 2
 Cry_Dustox::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dustox.bin"
+.endif
 .endif @ P_FAMILY_WURMPLE
 
 .if P_FAMILY_LOTAD == TRUE
 	.align 2
 Cry_Lotad::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/lotad.bin"
+.endif
 
 	.align 2
 Cry_Lombre::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/lombre.bin"
+.endif
 
 	.align 2
 Cry_Ludicolo::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/ludicolo.bin"
+.endif
 .endif @ P_FAMILY_LOTAD
 
 .if P_FAMILY_SEEDOT == TRUE
 	.align 2
 Cry_Seedot::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/seedot.bin"
+.endif
 
 	.align 2
 Cry_Nuzleaf::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/nuzleaf.bin"
+.endif
 
 	.align 2
 Cry_Shiftry::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/shiftry.bin"
+.endif
 .endif @ P_FAMILY_SEEDOT
 
 .if P_FAMILY_TAILLOW == TRUE
 	.align 2
 Cry_Taillow::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/taillow.bin"
+.endif
 
 	.align 2
 Cry_Swellow::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/swellow.bin"
+.endif
 .endif @ P_FAMILY_TAILLOW
 
 .if P_FAMILY_WINGULL == TRUE
 	.align 2
 Cry_Wingull::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/wingull.bin"
+.endif
 
 	.align 2
 Cry_Pelipper::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pelipper.bin"
+.endif
 .endif @ P_FAMILY_WINGULL
 
 .if P_FAMILY_RALTS == TRUE
 	.align 2
 Cry_Ralts::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/ralts.bin"
+.endif
 
 	.align 2
 Cry_Kirlia::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/kirlia.bin"
+.endif
 
 	.align 2
 Cry_Gardevoir::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/gardevoir.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_GardevoirMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/gardevoir_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .if P_GEN_4_CROSS_EVOS == TRUE
 	.align 2
 Cry_Gallade::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/gallade.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_GalladeMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/gallade_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_GEN_4_CROSS_EVOS
 .endif @ P_FAMILY_RALTS
@@ -2278,518 +2996,714 @@ Cry_GalladeMega::
 .if P_FAMILY_SURSKIT == TRUE
 	.align 2
 Cry_Surskit::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/surskit.bin"
+.endif
 
 	.align 2
 Cry_Masquerain::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/masquerain.bin"
+.endif
 .endif @ P_FAMILY_SURSKIT
 
 .if P_FAMILY_SHROOMISH == TRUE
 	.align 2
 Cry_Shroomish::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/shroomish.bin"
+.endif
 
 	.align 2
 Cry_Breloom::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/breloom.bin"
+.endif
 .endif @ P_FAMILY_SHROOMISH
 
 .if P_FAMILY_SLAKOTH == TRUE
 	.align 2
 Cry_Slakoth::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/slakoth.bin"
+.endif
 
 	.align 2
 Cry_Vigoroth::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/vigoroth.bin"
+.endif
 
 	.align 2
 Cry_Slaking::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/slaking.bin"
+.endif
 .endif @ P_FAMILY_SLAKOTH
 
 .if P_FAMILY_NINCADA == TRUE
 	.align 2
 Cry_Nincada::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/nincada.bin"
+.endif
 
 	.align 2
 Cry_Ninjask::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/ninjask.bin"
+.endif
 
 	.align 2
 Cry_Shedinja::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/shedinja.bin"
+.endif
 .endif @ P_FAMILY_NINCADA
 
 .if P_FAMILY_WHISMUR == TRUE
 	.align 2
 Cry_Whismur::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/whismur.bin"
+.endif
 
 	.align 2
 Cry_Loudred::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/loudred.bin"
+.endif
 
 	.align 2
 Cry_Exploud::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/exploud.bin"
+.endif
 .endif @ P_FAMILY_WHISMUR
 
 .if P_FAMILY_MAKUHITA == TRUE
 	.align 2
 Cry_Makuhita::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/makuhita.bin"
+.endif
 
 	.align 2
 Cry_Hariyama::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/hariyama.bin"
+.endif
 .endif @ P_FAMILY_MAKUHITA
 
 .if P_FAMILY_NOSEPASS == TRUE
 	.align 2
 Cry_Nosepass::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/nosepass.bin"
+.endif
 
 .if P_GEN_4_CROSS_EVOS == TRUE
 	.align 2
 Cry_Probopass::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/probopass.bin"
+.endif
 .endif @ P_GEN_4_CROSS_EVOS
 .endif @ P_FAMILY_NOSEPASS
 
 .if P_FAMILY_SKITTY == TRUE
 	.align 2
 Cry_Skitty::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/skitty.bin"
+.endif
 
 	.align 2
 Cry_Delcatty::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/delcatty.bin"
+.endif
 .endif @ P_FAMILY_SKITTY
 
 .if P_FAMILY_SABLEYE == TRUE
 	.align 2
 Cry_Sableye::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sableye.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_SableyeMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sableye_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_SABLEYE
 
 .if P_FAMILY_MAWILE == TRUE
 	.align 2
 Cry_Mawile::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/mawile.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_MawileMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/mawile_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_MAWILE
 
 .if P_FAMILY_ARON == TRUE
 	.align 2
 Cry_Aron::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/aron.bin"
+.endif
 
 	.align 2
 Cry_Lairon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/lairon.bin"
+.endif
 
 	.align 2
 Cry_Aggron::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/aggron.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_AggronMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/aggron_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_ARON
 
 .if P_FAMILY_MEDITITE == TRUE
 	.align 2
 Cry_Meditite::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/meditite.bin"
+.endif
 
 	.align 2
 Cry_Medicham::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/medicham.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_MedichamMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/medicham_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_MEDITITE
 
 .if P_FAMILY_ELECTRIKE == TRUE
 	.align 2
 Cry_Electrike::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/electrike.bin"
+.endif
 
 	.align 2
 Cry_Manectric::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/manectric.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_ManectricMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/manectric_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_ELECTRIKE
 
 .if P_FAMILY_PLUSLE == TRUE
 	.align 2
 Cry_Plusle::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/plusle.bin"
+.endif
 .endif @ P_FAMILY_PLUSLE
 
 .if P_FAMILY_MINUN == TRUE
 	.align 2
 Cry_Minun::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/minun.bin"
+.endif
 .endif @ P_FAMILY_MINUN
 
 .if P_FAMILY_VOLBEAT_ILLUMISE == TRUE
 	.align 2
 Cry_Volbeat::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/volbeat.bin"
+.endif
 
 	.align 2
 Cry_Illumise::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/illumise.bin"
+.endif
 .endif @ P_FAMILY_VOLBEAT_ILLUMISE
 
 .if P_FAMILY_ROSELIA == TRUE
 .if P_GEN_4_CROSS_EVOS == TRUE
 	.align 2
 Cry_Budew::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/budew.bin"
+.endif
 .endif @ P_GEN_4_CROSS_EVOS
 
 	.align 2
 Cry_Roselia::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/roselia.bin"
+.endif
 
 .if P_GEN_4_CROSS_EVOS == TRUE
 	.align 2
 Cry_Roserade::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/roserade.bin"
+.endif
 .endif @ P_GEN_4_CROSS_EVOS
 .endif @ P_FAMILY_ROSELIA
 
 .if P_FAMILY_GULPIN == TRUE
 	.align 2
 Cry_Gulpin::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/gulpin.bin"
+.endif
 
 	.align 2
 Cry_Swalot::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/swalot.bin"
+.endif
 .endif @ P_FAMILY_GULPIN
 
 .if P_FAMILY_CARVANHA == TRUE
 	.align 2
 Cry_Carvanha::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/carvanha.bin"
+.endif
 
 	.align 2
 Cry_Sharpedo::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sharpedo.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_SharpedoMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sharpedo_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_CARVANHA
 
 .if P_FAMILY_WAILMER == TRUE
 	.align 2
 Cry_Wailmer::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/wailmer.bin"
+.endif
 
 	.align 2
 Cry_Wailord::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/wailord.bin"
+.endif
 .endif @ P_FAMILY_WAILMER
 
 .if P_FAMILY_NUMEL == TRUE
 	.align 2
 Cry_Numel::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/numel.bin"
+.endif
 
 	.align 2
 Cry_Camerupt::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/camerupt.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_CameruptMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/camerupt_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_NUMEL
 
 .if P_FAMILY_TORKOAL == TRUE
 	.align 2
 Cry_Torkoal::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/torkoal.bin"
+.endif
 .endif @ P_FAMILY_TORKOAL
 
 .if P_FAMILY_SPOINK == TRUE
 	.align 2
 Cry_Spoink::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/spoink.bin"
+.endif
 
 	.align 2
 Cry_Grumpig::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/grumpig.bin"
+.endif
 .endif @ P_FAMILY_SPOINK
 
 .if P_FAMILY_SPINDA == TRUE
 	.align 2
 Cry_Spinda::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/spinda.bin"
+.endif
 .endif @ P_FAMILY_SPINDA
 
 .if P_FAMILY_TRAPINCH == TRUE
 	.align 2
 Cry_Trapinch::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/trapinch.bin"
+.endif
 
 	.align 2
 Cry_Vibrava::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/vibrava.bin"
+.endif
 
 	.align 2
 Cry_Flygon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/flygon.bin"
+.endif
 .endif @ P_FAMILY_TRAPINCH
 
 .if P_FAMILY_CACNEA == TRUE
 	.align 2
 Cry_Cacnea::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/cacnea.bin"
+.endif
 
 	.align 2
 Cry_Cacturne::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/cacturne.bin"
+.endif
 .endif @ P_FAMILY_CACNEA
 
 .if P_FAMILY_SWABLU == TRUE
 	.align 2
 Cry_Swablu::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/swablu.bin"
+.endif
 
 	.align 2
 Cry_Altaria::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/altaria.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_AltariaMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/altaria_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_SWABLU
 
 .if P_FAMILY_ZANGOOSE == TRUE
 	.align 2
 Cry_Zangoose::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/zangoose.bin"
+.endif
 .endif @ P_FAMILY_ZANGOOSE
 
 .if P_FAMILY_SEVIPER == TRUE
 	.align 2
 Cry_Seviper::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/seviper.bin"
+.endif
 .endif @ P_FAMILY_SEVIPER
 
 .if P_FAMILY_LUNATONE == TRUE
 	.align 2
 Cry_Lunatone::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/lunatone.bin"
+.endif
 .endif @ P_FAMILY_LUNATONE
 
 .if P_FAMILY_SOLROCK == TRUE
 	.align 2
 Cry_Solrock::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/solrock.bin"
+.endif
 .endif @ P_FAMILY_SOLROCK
 
 .if P_FAMILY_BARBOACH == TRUE
 	.align 2
 Cry_Barboach::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/barboach.bin"
+.endif
 
 	.align 2
 Cry_Whiscash::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/whiscash.bin"
+.endif
 .endif @ P_FAMILY_BARBOACH
 
 .if P_FAMILY_CORPHISH == TRUE
 	.align 2
 Cry_Corphish::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/corphish.bin"
+.endif
 
 	.align 2
 Cry_Crawdaunt::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/crawdaunt.bin"
+.endif
 .endif @ P_FAMILY_CORPHISH
 
 .if P_FAMILY_BALTOY == TRUE
 	.align 2
 Cry_Baltoy::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/baltoy.bin"
+.endif
 
 	.align 2
 Cry_Claydol::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/claydol.bin"
+.endif
 .endif @ P_FAMILY_BALTOY
 
 .if P_FAMILY_LILEEP == TRUE
 	.align 2
 Cry_Lileep::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/lileep.bin"
+.endif
 
 	.align 2
 Cry_Cradily::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/cradily.bin"
+.endif
 .endif @ P_FAMILY_LILEEP
 
 .if P_FAMILY_ANORITH == TRUE
 	.align 2
 Cry_Anorith::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/anorith.bin"
+.endif
 
 	.align 2
 Cry_Armaldo::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/armaldo.bin"
+.endif
 .endif @ P_FAMILY_ANORITH
 
 .if P_FAMILY_FEEBAS == TRUE
 	.align 2
 Cry_Feebas::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/feebas.bin"
+.endif
 
 	.align 2
 Cry_Milotic::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/milotic.bin"
+.endif
 .endif @ P_FAMILY_FEEBAS
 
 .if P_FAMILY_CASTFORM == TRUE
 	.align 2
 Cry_Castform::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/castform.bin"
+.endif
 .endif @ P_FAMILY_CASTFORM
 
 .if P_FAMILY_KECLEON == TRUE
 	.align 2
 Cry_Kecleon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/kecleon.bin"
+.endif
 .endif @ P_FAMILY_KECLEON
 
 .if P_FAMILY_SHUPPET == TRUE
 	.align 2
 Cry_Shuppet::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/shuppet.bin"
+.endif
 
 	.align 2
 Cry_Banette::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/banette.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_BanetteMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/banette_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_SHUPPET
 
 .if P_FAMILY_DUSKULL == TRUE
 	.align 2
 Cry_Duskull::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/duskull.bin"
+.endif
 
 	.align 2
 Cry_Dusclops::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dusclops.bin"
+.endif
 
 .if P_GEN_4_CROSS_EVOS == TRUE
 	.align 2
 Cry_Dusknoir::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dusknoir.bin"
+.endif
 .endif @ P_GEN_4_CROSS_EVOS
 .endif @ P_FAMILY_DUSKULL
 
 .if P_FAMILY_TROPIUS == TRUE
 	.align 2
 Cry_Tropius::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tropius.bin"
+.endif
 .endif @ P_FAMILY_TROPIUS
 
 .if P_FAMILY_CHIMECHO == TRUE
 .if P_GEN_4_CROSS_EVOS == TRUE
 	.align 2
 Cry_Chingling::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/chingling.bin"
+.endif
 .endif @ P_GEN_4_CROSS_EVOS
 
 	.align 2
 Cry_Chimecho::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/chimecho.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_ChimechoMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/chimecho_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_CHIMECHO
 
 .if P_FAMILY_ABSOL == TRUE
 	.align 2
 Cry_Absol::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/absol.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_AbsolMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/absol_mega.bin"
+.endif
 
 	.align 2
 Cry_AbsolMegaZ::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/absol_mega_z.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_ABSOL
 
 .if P_FAMILY_SNORUNT == TRUE
 	.align 2
 Cry_Snorunt::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/snorunt.bin"
+.endif
 
 	.align 2
 Cry_Glalie::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/glalie.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_GlalieMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/glalie_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .if P_GEN_4_CROSS_EVOS == TRUE
 	.align 2
 Cry_Froslass::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/froslass.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_FroslassMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/froslass_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_GEN_4_CROSS_EVOS
 .endif @ P_FAMILY_SNORUNT
@@ -2797,134 +3711,184 @@ Cry_FroslassMega::
 .if P_FAMILY_SPHEAL == TRUE
 	.align 2
 Cry_Spheal::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/spheal.bin"
+.endif
 
 	.align 2
 Cry_Sealeo::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sealeo.bin"
+.endif
 
 	.align 2
 Cry_Walrein::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/walrein.bin"
+.endif
 .endif @ P_FAMILY_SPHEAL
 
 .if P_FAMILY_CLAMPERL == TRUE
 	.align 2
 Cry_Clamperl::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/clamperl.bin"
+.endif
 
 	.align 2
 Cry_Huntail::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/huntail.bin"
+.endif
 
 	.align 2
 Cry_Gorebyss::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/gorebyss.bin"
+.endif
 .endif @ P_FAMILY_CLAMPERL
 
 .if P_FAMILY_RELICANTH == TRUE
 	.align 2
 Cry_Relicanth::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/relicanth.bin"
+.endif
 .endif @ P_FAMILY_RELICANTH
 
 .if P_FAMILY_LUVDISC == TRUE
 	.align 2
 Cry_Luvdisc::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/luvdisc.bin"
+.endif
 .endif @ P_FAMILY_LUVDISC
 
 .if P_FAMILY_BAGON == TRUE
 	.align 2
 Cry_Bagon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/bagon.bin"
+.endif
 
 	.align 2
 Cry_Shelgon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/shelgon.bin"
+.endif
 
 	.align 2
 Cry_Salamence::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/salamence.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_SalamenceMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/salamence_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_BAGON
 
 .if P_FAMILY_BELDUM == TRUE
 	.align 2
 Cry_Beldum::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/beldum.bin"
+.endif
 
 	.align 2
 Cry_Metang::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/metang.bin"
+.endif
 
 	.align 2
 Cry_Metagross::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/metagross.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_MetagrossMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/metagross_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_BELDUM
 
 .if P_FAMILY_REGIROCK == TRUE
 	.align 2
 Cry_Regirock::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/regirock.bin"
+.endif
 .endif @ P_FAMILY_REGIROCK
 
 .if P_FAMILY_REGICE == TRUE
 	.align 2
 Cry_Regice::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/regice.bin"
+.endif
 .endif @ P_FAMILY_REGICE
 
 .if P_FAMILY_REGISTEEL == TRUE
 	.align 2
 Cry_Registeel::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/registeel.bin"
+.endif
 .endif @ P_FAMILY_REGISTEEL
 
 .if P_FAMILY_LATIAS == TRUE
 	.align 2
 Cry_Latias::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/latias.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_LatiasMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/latias_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_LATIAS
 
 .if P_FAMILY_LATIOS == TRUE
 	.align 2
 Cry_Latios::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/latios.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_LatiosMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/latios_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_LATIOS
 
 .if P_FAMILY_KYOGRE == TRUE
 	.align 2
 Cry_Kyogre::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/kyogre.bin"
+.endif
 
 .if P_PRIMAL_REVERSIONS == TRUE
 	.align 2
 Cry_KyogrePrimal::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/kyogre_primal.bin"
+.endif
 
 .endif @ P_PRIMAL_REVERSIONS
 .endif @ P_FAMILY_KYOGRE
@@ -2932,12 +3896,16 @@ Cry_KyogrePrimal::
 .if P_FAMILY_GROUDON == TRUE
 	.align 2
 Cry_Groudon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/groudon.bin"
+.endif
 
 .if P_PRIMAL_REVERSIONS == TRUE
 	.align 2
 Cry_GroudonPrimal::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/groudon_primal.bin"
+.endif
 
 .endif @ P_PRIMAL_REVERSIONS
 .endif @ P_FAMILY_GROUDON
@@ -2945,784 +3913,1090 @@ Cry_GroudonPrimal::
 .if P_FAMILY_RAYQUAZA == TRUE
 	.align 2
 Cry_Rayquaza::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/rayquaza.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_RayquazaMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/rayquaza_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_RAYQUAZA
 
 .if P_FAMILY_JIRACHI == TRUE
 	.align 2
 Cry_Jirachi::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/jirachi.bin"
+.endif
 .endif @ P_FAMILY_JIRACHI
 
 .if P_FAMILY_DEOXYS == TRUE
 	.align 2
 Cry_Deoxys::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/deoxys.bin"
+.endif
 .endif @ P_FAMILY_DEOXYS
 
 .if P_FAMILY_TURTWIG == TRUE
 	.align 2
 Cry_Turtwig::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/turtwig.bin"
+.endif
 
 	.align 2
 Cry_Grotle::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/grotle.bin"
+.endif
 
 	.align 2
 Cry_Torterra::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/torterra.bin"
+.endif
 .endif @ P_FAMILY_TURTWIG
 
 .if P_FAMILY_CHIMCHAR == TRUE
 	.align 2
 Cry_Chimchar::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/chimchar.bin"
+.endif
 
 	.align 2
 Cry_Monferno::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/monferno.bin"
+.endif
 
 	.align 2
 Cry_Infernape::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/infernape.bin"
+.endif
 .endif @ P_FAMILY_CHIMCHAR
 
 .if P_FAMILY_PIPLUP == TRUE
 	.align 2
 Cry_Piplup::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/piplup.bin"
+.endif
 
 	.align 2
 Cry_Prinplup::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/prinplup.bin"
+.endif
 
 	.align 2
 Cry_Empoleon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/empoleon.bin"
+.endif
 .endif @ P_FAMILY_PIPLUP
 
 .if P_FAMILY_STARLY == TRUE
 	.align 2
 Cry_Starly::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/starly.bin"
+.endif
 
 	.align 2
 Cry_Staravia::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/staravia.bin"
+.endif
 
 	.align 2
 Cry_Staraptor::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/staraptor.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_StaraptorMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/staraptor_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_STARLY
 
 .if P_FAMILY_BIDOOF == TRUE
 	.align 2
 Cry_Bidoof::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/bidoof.bin"
+.endif
 
 	.align 2
 Cry_Bibarel::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/bibarel.bin"
+.endif
 .endif @ P_FAMILY_BIDOOF
 
 .if P_FAMILY_KRICKETOT == TRUE
 	.align 2
 Cry_Kricketot::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/kricketot.bin"
+.endif
 
 	.align 2
 Cry_Kricketune::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/kricketune.bin"
+.endif
 .endif @ P_FAMILY_KRICKETOT
 
 .if P_FAMILY_SHINX == TRUE
 	.align 2
 Cry_Shinx::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/shinx.bin"
+.endif
 
 	.align 2
 Cry_Luxio::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/luxio.bin"
+.endif
 
 	.align 2
 Cry_Luxray::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/luxray.bin"
+.endif
 .endif @ P_FAMILY_SHINX
 
 .if P_FAMILY_CRANIDOS == TRUE
 	.align 2
 Cry_Cranidos::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/cranidos.bin"
+.endif
 
 	.align 2
 Cry_Rampardos::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/rampardos.bin"
+.endif
 .endif @ P_FAMILY_CRANIDOS
 
 .if P_FAMILY_SHIELDON == TRUE
 	.align 2
 Cry_Shieldon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/shieldon.bin"
+.endif
 
 	.align 2
 Cry_Bastiodon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/bastiodon.bin"
+.endif
 .endif @ P_FAMILY_SHIELDON
 
 .if P_FAMILY_BURMY == TRUE
 	.align 2
 Cry_Burmy::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/burmy.bin"
+.endif
 
 	.align 2
 Cry_Wormadam::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/wormadam.bin"
+.endif
 
 	.align 2
 Cry_Mothim::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/mothim.bin"
+.endif
 .endif @ P_FAMILY_BURMY
 
 .if P_FAMILY_COMBEE == TRUE
 	.align 2
 Cry_Combee::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/combee.bin"
+.endif
 
 	.align 2
 Cry_Vespiquen::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/vespiquen.bin"
+.endif
 .endif @ P_FAMILY_COMBEE
 
 .if P_FAMILY_PACHIRISU == TRUE
 	.align 2
 Cry_Pachirisu::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pachirisu.bin"
+.endif
 .endif @ P_FAMILY_PACHIRISU
 
 .if P_FAMILY_BUIZEL == TRUE
 	.align 2
 Cry_Buizel::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/buizel.bin"
+.endif
 
 	.align 2
 Cry_Floatzel::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/floatzel.bin"
+.endif
 .endif @ P_FAMILY_BUIZEL
 
 .if P_FAMILY_CHERUBI == TRUE
 	.align 2
 Cry_Cherubi::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/cherubi.bin"
+.endif
 
 	.align 2
 Cry_Cherrim::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/cherrim.bin"
+.endif
 .endif @ P_FAMILY_CHERUBI
 
 .if P_FAMILY_SHELLOS == TRUE
 	.align 2
 Cry_Shellos::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/shellos.bin"
+.endif
 
 	.align 2
 Cry_Gastrodon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/gastrodon.bin"
+.endif
 .endif @ P_FAMILY_SHELLOS
 
 .if P_FAMILY_DRIFLOON == TRUE
 	.align 2
 Cry_Drifloon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/drifloon.bin"
+.endif
 
 	.align 2
 Cry_Drifblim::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/drifblim.bin"
+.endif
 .endif @ P_FAMILY_DRIFLOON
 
 .if P_FAMILY_BUNEARY == TRUE
 	.align 2
 Cry_Buneary::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/buneary.bin"
+.endif
 
 	.align 2
 Cry_Lopunny::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/lopunny.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_LopunnyMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/lopunny_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_BUNEARY
 
 .if P_FAMILY_GLAMEOW == TRUE
 	.align 2
 Cry_Glameow::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/glameow.bin"
+.endif
 
 	.align 2
 Cry_Purugly::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/purugly.bin"
+.endif
 .endif @ P_FAMILY_GLAMEOW
 
 .if P_FAMILY_STUNKY == TRUE
 	.align 2
 Cry_Stunky::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/stunky.bin"
+.endif
 
 	.align 2
 Cry_Skuntank::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/skuntank.bin"
+.endif
 .endif @ P_FAMILY_STUNKY
 
 .if P_FAMILY_BRONZOR == TRUE
 	.align 2
 Cry_Bronzor::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/bronzor.bin"
+.endif
 
 	.align 2
 Cry_Bronzong::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/bronzong.bin"
+.endif
 .endif @ P_FAMILY_BRONZOR
 
 .if P_FAMILY_CHATOT == TRUE
 	.align 2
 Cry_Chatot::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/chatot.bin"
+.endif
 .endif @ P_FAMILY_CHATOT
 
 .if P_FAMILY_SPIRITOMB == TRUE
 	.align 2
 Cry_Spiritomb::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/spiritomb.bin"
+.endif
 .endif @ P_FAMILY_SPIRITOMB
 
 .if P_FAMILY_GIBLE == TRUE
 	.align 2
 Cry_Gible::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/gible.bin"
+.endif
 
 	.align 2
 Cry_Gabite::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/gabite.bin"
+.endif
 
 	.align 2
 Cry_Garchomp::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/garchomp.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_GarchompMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/garchomp_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_GIBLE
 
 .if P_FAMILY_RIOLU == TRUE
 	.align 2
 Cry_Riolu::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/riolu.bin"
+.endif
 
 	.align 2
 Cry_Lucario::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/lucario.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_LucarioMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/lucario_mega.bin"
+.endif
 
 	.align 2
 Cry_LucarioMegaZ::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/lucario_mega_z.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_RIOLU
 
 .if P_FAMILY_HIPPOPOTAS == TRUE
 	.align 2
 Cry_Hippopotas::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/hippopotas.bin"
+.endif
 
 	.align 2
 Cry_Hippowdon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/hippowdon.bin"
+.endif
 .endif @ P_FAMILY_HIPPOPOTAS
 
 .if P_FAMILY_SKORUPI == TRUE
 	.align 2
 Cry_Skorupi::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/skorupi.bin"
+.endif
 
 	.align 2
 Cry_Drapion::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/drapion.bin"
+.endif
 .endif @ P_FAMILY_SKORUPI
 
 .if P_FAMILY_CROAGUNK == TRUE
 	.align 2
 Cry_Croagunk::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/croagunk.bin"
+.endif
 
 	.align 2
 Cry_Toxicroak::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/toxicroak.bin"
+.endif
 .endif @ P_FAMILY_CROAGUNK
 
 .if P_FAMILY_CARNIVINE == TRUE
 	.align 2
 Cry_Carnivine::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/carnivine.bin"
+.endif
 .endif @ P_FAMILY_CARNIVINE
 
 .if P_FAMILY_FINNEON == TRUE
 	.align 2
 Cry_Finneon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/finneon.bin"
+.endif
 
 	.align 2
 Cry_Lumineon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/lumineon.bin"
+.endif
 .endif @ P_FAMILY_FINNEON
 
 .if P_FAMILY_SNOVER == TRUE
 	.align 2
 Cry_Snover::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/snover.bin"
+.endif
 
 	.align 2
 Cry_Abomasnow::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/abomasnow.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_AbomasnowMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/abomasnow_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_SNOVER
 
 .if P_FAMILY_ROTOM == TRUE
 	.align 2
 Cry_Rotom::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/rotom.bin"
+.endif
 .endif @ P_FAMILY_ROTOM
 
 .if P_FAMILY_UXIE == TRUE
 	.align 2
 Cry_Uxie::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/uxie.bin"
+.endif
 .endif @ P_FAMILY_UXIE
 
 .if P_FAMILY_MESPRIT == TRUE
 	.align 2
 Cry_Mesprit::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/mesprit.bin"
+.endif
 .endif @ P_FAMILY_MESPRIT
 
 .if P_FAMILY_AZELF == TRUE
 	.align 2
 Cry_Azelf::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/azelf.bin"
+.endif
 .endif @ P_FAMILY_AZELF
 
 .if P_FAMILY_DIALGA == TRUE
 	.align 2
 Cry_Dialga::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dialga.bin"
+.endif
 .endif @ P_FAMILY_DIALGA
 
 .if P_FAMILY_PALKIA == TRUE
 	.align 2
 Cry_Palkia::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/palkia.bin"
+.endif
 .endif @ P_FAMILY_PALKIA
 
 .if P_FAMILY_HEATRAN == TRUE
 	.align 2
 Cry_Heatran::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/heatran.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_HeatranMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/heatran_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_HEATRAN
 
 .if P_FAMILY_REGIGIGAS == TRUE
 	.align 2
 Cry_Regigigas::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/regigigas.bin"
+.endif
 .endif @ P_FAMILY_REGIGIGAS
 
 .if P_FAMILY_GIRATINA == TRUE
 	.align 2
 Cry_Giratina::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/giratina.bin"
+.endif
 .endif @ P_FAMILY_GIRATINA
 
 .if P_FAMILY_CRESSELIA == TRUE
 	.align 2
 Cry_Cresselia::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/cresselia.bin"
+.endif
 .endif @ P_FAMILY_CRESSELIA
 
 .if P_FAMILY_MANAPHY == TRUE
 	.align 2
 Cry_Phione::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/phione.bin"
+.endif
 
 	.align 2
 Cry_Manaphy::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/manaphy.bin"
+.endif
 .endif @ P_FAMILY_MANAPHY
 
 .if P_FAMILY_DARKRAI == TRUE
 	.align 2
 Cry_Darkrai::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/darkrai.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_DarkraiMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/darkrai_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_DARKRAI
 
 .if P_FAMILY_SHAYMIN == TRUE
 	.align 2
 Cry_ShayminLand::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/shaymin_land.bin"
+.endif
 
 	.align 2
 Cry_ShayminSky::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/shaymin_sky.bin"
+.endif
 .endif @ P_FAMILY_SHAYMIN
 
 .if P_FAMILY_ARCEUS == TRUE
 	.align 2
 Cry_Arceus::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/arceus.bin"
+.endif
 .endif @ P_FAMILY_ARCEUS
 
 .if P_FAMILY_VICTINI == TRUE
 	.align 2
 Cry_Victini::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/victini.bin"
+.endif
 .endif @ P_FAMILY_VICTINI
 
 .if P_FAMILY_SNIVY == TRUE
 	.align 2
 Cry_Snivy::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/snivy.bin"
+.endif
 
 	.align 2
 Cry_Servine::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/servine.bin"
+.endif
 
 	.align 2
 Cry_Serperior::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/serperior.bin"
+.endif
 .endif @ P_FAMILY_SNIVY
 
 .if P_FAMILY_TEPIG == TRUE
 	.align 2
 Cry_Tepig::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tepig.bin"
+.endif
 
 	.align 2
 Cry_Pignite::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pignite.bin"
+.endif
 
 	.align 2
 Cry_Emboar::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/emboar.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_EmboarMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/emboar_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_TEPIG
 
 .if P_FAMILY_OSHAWOTT == TRUE
 	.align 2
 Cry_Oshawott::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/oshawott.bin"
+.endif
 
 	.align 2
 Cry_Dewott::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dewott.bin"
+.endif
 
 	.align 2
 Cry_Samurott::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/samurott.bin"
+.endif
 .endif @ P_FAMILY_OSHAWOTT
 
 .if P_FAMILY_PATRAT == TRUE
 	.align 2
 Cry_Patrat::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/patrat.bin"
+.endif
 
 	.align 2
 Cry_Watchog::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/watchog.bin"
+.endif
 .endif @ P_FAMILY_PATRAT
 
 .if P_FAMILY_LILLIPUP == TRUE
 	.align 2
 Cry_Lillipup::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/lillipup.bin"
+.endif
 
 	.align 2
 Cry_Herdier::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/herdier.bin"
+.endif
 
 	.align 2
 Cry_Stoutland::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/stoutland.bin"
+.endif
 .endif @ P_FAMILY_LILLIPUP
 
 .if P_FAMILY_PURRLOIN == TRUE
 	.align 2
 Cry_Purrloin::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/purrloin.bin"
+.endif
 
 	.align 2
 Cry_Liepard::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/liepard.bin"
+.endif
 .endif @ P_FAMILY_PURRLOIN
 
 .if P_FAMILY_PANSAGE == TRUE
 	.align 2
 Cry_Pansage::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pansage.bin"
+.endif
 
 	.align 2
 Cry_Simisage::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/simisage.bin"
+.endif
 .endif @ P_FAMILY_PANSAGE
 
 .if P_FAMILY_PANSEAR == TRUE
 	.align 2
 Cry_Pansear::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pansear.bin"
+.endif
 
 	.align 2
 Cry_Simisear::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/simisear.bin"
+.endif
 .endif @ P_FAMILY_PANSEAR
 
 .if P_FAMILY_PANPOUR == TRUE
 	.align 2
 Cry_Panpour::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/panpour.bin"
+.endif
 
 	.align 2
 Cry_Simipour::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/simipour.bin"
+.endif
 .endif @ P_FAMILY_PANPOUR
 
 .if P_FAMILY_MUNNA == TRUE
 	.align 2
 Cry_Munna::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/munna.bin"
+.endif
 
 	.align 2
 Cry_Musharna::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/musharna.bin"
+.endif
 .endif @ P_FAMILY_MUNNA
 
 .if P_FAMILY_PIDOVE == TRUE
 	.align 2
 Cry_Pidove::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pidove.bin"
+.endif
 
 	.align 2
 Cry_Tranquill::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tranquill.bin"
+.endif
 
 	.align 2
 Cry_Unfezant::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/unfezant.bin"
+.endif
 .endif @ P_FAMILY_PIDOVE
 
 .if P_FAMILY_BLITZLE == TRUE
 	.align 2
 Cry_Blitzle::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/blitzle.bin"
+.endif
 
 	.align 2
 Cry_Zebstrika::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/zebstrika.bin"
+.endif
 .endif @ P_FAMILY_BLITZLE
 
 .if P_FAMILY_ROGGENROLA == TRUE
 	.align 2
 Cry_Roggenrola::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/roggenrola.bin"
+.endif
 
 	.align 2
 Cry_Boldore::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/boldore.bin"
+.endif
 
 	.align 2
 Cry_Gigalith::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/gigalith.bin"
+.endif
 .endif @ P_FAMILY_ROGGENROLA
 
 .if P_FAMILY_WOOBAT == TRUE
 	.align 2
 Cry_Woobat::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/woobat.bin"
+.endif
 
 	.align 2
 Cry_Swoobat::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/swoobat.bin"
+.endif
 .endif @ P_FAMILY_WOOBAT
 
 .if P_FAMILY_DRILBUR == TRUE
 	.align 2
 Cry_Drilbur::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/drilbur.bin"
+.endif
 
 	.align 2
 Cry_Excadrill::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/excadrill.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_ExcadrillMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/excadrill_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_DRILBUR
 
 .if P_FAMILY_AUDINO == TRUE
 	.align 2
 Cry_Audino::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/audino.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_AudinoMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/audino_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_AUDINO
 
 .if P_FAMILY_TIMBURR == TRUE
 	.align 2
 Cry_Timburr::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/timburr.bin"
+.endif
 
 	.align 2
 Cry_Gurdurr::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/gurdurr.bin"
+.endif
 
 	.align 2
 Cry_Conkeldurr::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/conkeldurr.bin"
+.endif
 .endif @ P_FAMILY_TIMBURR
 
 .if P_FAMILY_TYMPOLE == TRUE
 	.align 2
 Cry_Tympole::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tympole.bin"
+.endif
 
 	.align 2
 Cry_Palpitoad::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/palpitoad.bin"
+.endif
 
 	.align 2
 Cry_Seismitoad::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/seismitoad.bin"
+.endif
 .endif @ P_FAMILY_TYMPOLE
 
 .if P_FAMILY_THROH == TRUE
 	.align 2
 Cry_Throh::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/throh.bin"
+.endif
 .endif @ P_FAMILY_THROH
 
 .if P_FAMILY_SAWK == TRUE
 	.align 2
 Cry_Sawk::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sawk.bin"
+.endif
 .endif @ P_FAMILY_SAWK
 
 .if P_FAMILY_SEWADDLE == TRUE
 	.align 2
 Cry_Sewaddle::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sewaddle.bin"
+.endif
 
 	.align 2
 Cry_Swadloon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/swadloon.bin"
+.endif
 
 	.align 2
 Cry_Leavanny::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/leavanny.bin"
+.endif
 .endif @ P_FAMILY_SEWADDLE
 
 .if P_FAMILY_VENIPEDE == TRUE
 	.align 2
 Cry_Venipede::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/venipede.bin"
+.endif
 
 	.align 2
 Cry_Whirlipede::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/whirlipede.bin"
+.endif
 
 	.align 2
 Cry_Scolipede::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/scolipede.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_ScolipedeMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/scolipede_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_VENIPEDE
 
 .if P_FAMILY_COTTONEE == TRUE
 	.align 2
 Cry_Cottonee::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/cottonee.bin"
+.endif
 
 	.align 2
 Cry_Whimsicott::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/whimsicott.bin"
+.endif
 .endif @ P_FAMILY_COTTONEE
 
 .if P_FAMILY_PETILIL == TRUE
 	.align 2
 Cry_Petilil::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/petilil.bin"
+.endif
 
 	.align 2
 Cry_Lilligant::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/lilligant.bin"
+.endif
 .endif @ P_FAMILY_PETILIL
 
 .if P_FAMILY_BASCULIN == TRUE
 	.align 2
 Cry_Basculin::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/basculin.bin"
+.endif
 
 .if P_HISUIAN_FORMS == TRUE
 	.align 2
 Cry_Basculegion::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/basculegion.bin"
+.endif
 
 .endif @ P_HISUIAN_FORMS
 .endif @ P_FAMILY_BASCULIN
@@ -3730,78 +5004,108 @@ Cry_Basculegion::
 .if P_FAMILY_SANDILE == TRUE
 	.align 2
 Cry_Sandile::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sandile.bin"
+.endif
 
 	.align 2
 Cry_Krokorok::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/krokorok.bin"
+.endif
 
 	.align 2
 Cry_Krookodile::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/krookodile.bin"
+.endif
 .endif @ P_FAMILY_SANDILE
 
 .if P_FAMILY_DARUMAKA == TRUE
 	.align 2
 Cry_Darumaka::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/darumaka.bin"
+.endif
 
 	.align 2
 Cry_Darmanitan::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/darmanitan.bin"
+.endif
 .endif @ P_FAMILY_DARUMAKA
 
 .if P_FAMILY_MARACTUS == TRUE
 	.align 2
 Cry_Maractus::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/maractus.bin"
+.endif
 .endif @ P_FAMILY_MARACTUS
 
 .if P_FAMILY_DWEBBLE == TRUE
 	.align 2
 Cry_Dwebble::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dwebble.bin"
+.endif
 
 	.align 2
 Cry_Crustle::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/crustle.bin"
+.endif
 .endif @ P_FAMILY_DWEBBLE
 
 .if P_FAMILY_SCRAGGY == TRUE
 	.align 2
 Cry_Scraggy::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/scraggy.bin"
+.endif
 
 	.align 2
 Cry_Scrafty::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/scrafty.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_ScraftyMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/scrafty_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_SCRAGGY
 
 .if P_FAMILY_SIGILYPH == TRUE
 	.align 2
 Cry_Sigilyph::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sigilyph.bin"
+.endif
 .endif @ P_FAMILY_SIGILYPH
 
 .if P_FAMILY_YAMASK == TRUE
 	.align 2
 Cry_Yamask::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/yamask.bin"
+.endif
 
 	.align 2
 Cry_Cofagrigus::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/cofagrigus.bin"
+.endif
 
 .if P_GALARIAN_FORMS == TRUE
 	.align 2
 Cry_Runerigus::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/runerigus.bin"
+.endif
 
 .endif @ P_GALARIAN_FORMS
 .endif @ P_FAMILY_YAMASK
@@ -3809,470 +5113,654 @@ Cry_Runerigus::
 .if P_FAMILY_TIRTOUGA == TRUE
 	.align 2
 Cry_Tirtouga::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tirtouga.bin"
+.endif
 
 	.align 2
 Cry_Carracosta::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/carracosta.bin"
+.endif
 .endif @ P_FAMILY_TIRTOUGA
 
 .if P_FAMILY_ARCHEN == TRUE
 	.align 2
 Cry_Archen::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/archen.bin"
+.endif
 
 	.align 2
 Cry_Archeops::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/archeops.bin"
+.endif
 .endif @ P_FAMILY_ARCHEN
 
 .if P_FAMILY_TRUBBISH == TRUE
 	.align 2
 Cry_Trubbish::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/trubbish.bin"
+.endif
 
 	.align 2
 Cry_Garbodor::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/garbodor.bin"
+.endif
 .endif @ P_FAMILY_TRUBBISH
 
 .if P_FAMILY_ZORUA == TRUE
 	.align 2
 Cry_Zorua::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/zorua.bin"
+.endif
 
 	.align 2
 Cry_Zoroark::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/zoroark.bin"
+.endif
 .endif @ P_FAMILY_ZORUA
 
 .if P_FAMILY_MINCCINO == TRUE
 	.align 2
 Cry_Minccino::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/minccino.bin"
+.endif
 
 	.align 2
 Cry_Cinccino::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/cinccino.bin"
+.endif
 .endif @ P_FAMILY_MINCCINO
 
 .if P_FAMILY_GOTHITA == TRUE
 	.align 2
 Cry_Gothita::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/gothita.bin"
+.endif
 
 	.align 2
 Cry_Gothorita::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/gothorita.bin"
+.endif
 
 	.align 2
 Cry_Gothitelle::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/gothitelle.bin"
+.endif
 .endif @ P_FAMILY_GOTHITA
 
 .if P_FAMILY_SOLOSIS == TRUE
 	.align 2
 Cry_Solosis::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/solosis.bin"
+.endif
 
 	.align 2
 Cry_Duosion::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/duosion.bin"
+.endif
 
 	.align 2
 Cry_Reuniclus::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/reuniclus.bin"
+.endif
 .endif @ P_FAMILY_SOLOSIS
 
 .if P_FAMILY_DUCKLETT == TRUE
 	.align 2
 Cry_Ducklett::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/ducklett.bin"
+.endif
 
 	.align 2
 Cry_Swanna::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/swanna.bin"
+.endif
 .endif @ P_FAMILY_DUCKLETT
 
 .if P_FAMILY_VANILLITE == TRUE
 	.align 2
 Cry_Vanillite::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/vanillite.bin"
+.endif
 
 	.align 2
 Cry_Vanillish::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/vanillish.bin"
+.endif
 
 	.align 2
 Cry_Vanilluxe::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/vanilluxe.bin"
+.endif
 .endif @ P_FAMILY_VANILLITE
 
 .if P_FAMILY_DEERLING == TRUE
 	.align 2
 Cry_Deerling::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/deerling.bin"
+.endif
 
 	.align 2
 Cry_Sawsbuck::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sawsbuck.bin"
+.endif
 .endif @ P_FAMILY_DEERLING
 
 .if P_FAMILY_EMOLGA == TRUE
 	.align 2
 Cry_Emolga::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/emolga.bin"
+.endif
 .endif @ P_FAMILY_EMOLGA
 
 .if P_FAMILY_KARRABLAST == TRUE
 	.align 2
 Cry_Karrablast::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/karrablast.bin"
+.endif
 
 	.align 2
 Cry_Escavalier::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/escavalier.bin"
+.endif
 .endif @ P_FAMILY_KARRABLAST
 
 .if P_FAMILY_FOONGUS == TRUE
 	.align 2
 Cry_Foongus::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/foongus.bin"
+.endif
 
 	.align 2
 Cry_Amoonguss::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/amoonguss.bin"
+.endif
 .endif @ P_FAMILY_FOONGUS
 
 .if P_FAMILY_FRILLISH == TRUE
 	.align 2
 Cry_Frillish::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/frillish.bin"
+.endif
 
 	.align 2
 Cry_Jellicent::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/jellicent.bin"
+.endif
 .endif @ P_FAMILY_FRILLISH
 
 .if P_FAMILY_ALOMOMOLA == TRUE
 	.align 2
 Cry_Alomomola::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/alomomola.bin"
+.endif
 .endif @ P_FAMILY_ALOMOMOLA
 
 .if P_FAMILY_JOLTIK == TRUE
 	.align 2
 Cry_Joltik::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/joltik.bin"
+.endif
 
 	.align 2
 Cry_Galvantula::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/galvantula.bin"
+.endif
 .endif @ P_FAMILY_JOLTIK
 
 .if P_FAMILY_FERROSEED == TRUE
 	.align 2
 Cry_Ferroseed::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/ferroseed.bin"
+.endif
 
 	.align 2
 Cry_Ferrothorn::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/ferrothorn.bin"
+.endif
 .endif @ P_FAMILY_FERROSEED
 
 .if P_FAMILY_KLINK == TRUE
 	.align 2
 Cry_Klink::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/klink.bin"
+.endif
 
 	.align 2
 Cry_Klang::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/klang.bin"
+.endif
 
 	.align 2
 Cry_Klinklang::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/klinklang.bin"
+.endif
 .endif @ P_FAMILY_KLINK
 
 .if P_FAMILY_TYNAMO == TRUE
 	.align 2
 Cry_Tynamo::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tynamo.bin"
+.endif
 
 	.align 2
 Cry_Eelektrik::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/eelektrik.bin"
+.endif
 
 	.align 2
 Cry_Eelektross::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/eelektross.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_EelektrossMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/eelektross_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_TYNAMO
 
 .if P_FAMILY_ELGYEM == TRUE
 	.align 2
 Cry_Elgyem::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/elgyem.bin"
+.endif
 
 	.align 2
 Cry_Beheeyem::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/beheeyem.bin"
+.endif
 .endif @ P_FAMILY_ELGYEM
 
 .if P_FAMILY_LITWICK == TRUE
 	.align 2
 Cry_Litwick::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/litwick.bin"
+.endif
 
 	.align 2
 Cry_Lampent::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/lampent.bin"
+.endif
 
 	.align 2
 Cry_Chandelure::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/chandelure.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_ChandelureMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/chandelure_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_LITWICK
 
 .if P_FAMILY_AXEW == TRUE
 	.align 2
 Cry_Axew::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/axew.bin"
+.endif
 
 	.align 2
 Cry_Fraxure::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/fraxure.bin"
+.endif
 
 	.align 2
 Cry_Haxorus::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/haxorus.bin"
+.endif
 .endif @ P_FAMILY_AXEW
 
 .if P_FAMILY_CUBCHOO == TRUE
 	.align 2
 Cry_Cubchoo::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/cubchoo.bin"
+.endif
 
 	.align 2
 Cry_Beartic::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/beartic.bin"
+.endif
 .endif @ P_FAMILY_CUBCHOO
 
 .if P_FAMILY_CRYOGONAL == TRUE
 	.align 2
 Cry_Cryogonal::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/cryogonal.bin"
+.endif
 .endif @ P_FAMILY_CRYOGONAL
 
 .if P_FAMILY_SHELMET == TRUE
 	.align 2
 Cry_Shelmet::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/shelmet.bin"
+.endif
 
 	.align 2
 Cry_Accelgor::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/accelgor.bin"
+.endif
 .endif @ P_FAMILY_SHELMET
 
 .if P_FAMILY_STUNFISK == TRUE
 	.align 2
 Cry_Stunfisk::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/stunfisk.bin"
+.endif
 .endif @ P_FAMILY_STUNFISK
 
 .if P_FAMILY_MIENFOO == TRUE
 	.align 2
 Cry_Mienfoo::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/mienfoo.bin"
+.endif
 
 	.align 2
 Cry_Mienshao::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/mienshao.bin"
+.endif
 .endif @ P_FAMILY_MIENFOO
 
 .if P_FAMILY_DRUDDIGON == TRUE
 	.align 2
 Cry_Druddigon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/druddigon.bin"
+.endif
 .endif @ P_FAMILY_DRUDDIGON
 
 .if P_FAMILY_GOLETT == TRUE
 	.align 2
 Cry_Golett::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/golett.bin"
+.endif
 
 	.align 2
 Cry_Golurk::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/golurk.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_GolurkMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/golurk_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_GOLETT
 
 .if P_FAMILY_PAWNIARD == TRUE
 	.align 2
 Cry_Pawniard::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pawniard.bin"
+.endif
 
 	.align 2
 Cry_Bisharp::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/bisharp.bin"
+.endif
 
 .if P_GEN_9_CROSS_EVOS == TRUE
 	.align 2
 Cry_Kingambit::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/kingambit.bin"
+.endif
 .endif @ P_GEN_9_CROSS_EVOS
 .endif @ P_FAMILY_PAWNIARD
 
 .if P_FAMILY_BOUFFALANT == TRUE
 	.align 2
 Cry_Bouffalant::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/bouffalant.bin"
+.endif
 .endif @ P_FAMILY_BOUFFALANT
 
 .if P_FAMILY_RUFFLET == TRUE
 	.align 2
 Cry_Rufflet::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/rufflet.bin"
+.endif
 
 	.align 2
 Cry_Braviary::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/braviary.bin"
+.endif
 .endif @ P_FAMILY_RUFFLET
 
 .if P_FAMILY_VULLABY == TRUE
 	.align 2
 Cry_Vullaby::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/vullaby.bin"
+.endif
 
 	.align 2
 Cry_Mandibuzz::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/mandibuzz.bin"
+.endif
 .endif @ P_FAMILY_VULLABY
 
 .if P_FAMILY_HEATMOR == TRUE
 	.align 2
 Cry_Heatmor::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/heatmor.bin"
+.endif
 .endif @ P_FAMILY_HEATMOR
 
 .if P_FAMILY_DURANT == TRUE
 	.align 2
 Cry_Durant::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/durant.bin"
+.endif
 .endif @ P_FAMILY_DURANT
 
 .if P_FAMILY_DEINO == TRUE
 	.align 2
 Cry_Deino::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/deino.bin"
+.endif
 
 	.align 2
 Cry_Zweilous::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/zweilous.bin"
+.endif
 
 	.align 2
 Cry_Hydreigon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/hydreigon.bin"
+.endif
 .endif @ P_FAMILY_DEINO
 
 .if P_FAMILY_LARVESTA == TRUE
 	.align 2
 Cry_Larvesta::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/larvesta.bin"
+.endif
 
 	.align 2
 Cry_Volcarona::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/volcarona.bin"
+.endif
 .endif @ P_FAMILY_LARVESTA
 
 .if P_FAMILY_COBALION == TRUE
 	.align 2
 Cry_Cobalion::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/cobalion.bin"
+.endif
 .endif @ P_FAMILY_COBALION
 
 .if P_FAMILY_TERRAKION == TRUE
 	.align 2
 Cry_Terrakion::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/terrakion.bin"
+.endif
 .endif @ P_FAMILY_TERRAKION
 
 .if P_FAMILY_VIRIZION == TRUE
 	.align 2
 Cry_Virizion::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/virizion.bin"
+.endif
 .endif @ P_FAMILY_VIRIZION
 
 .if P_FAMILY_TORNADUS == TRUE
 	.align 2
 Cry_TornadusIncarnate::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tornadus_incarnate.bin"
+.endif
 
 	.align 2
 Cry_TornadusTherian::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tornadus_therian.bin"
+.endif
 .endif @ P_FAMILY_TORNADUS
 
 .if P_FAMILY_THUNDURUS == TRUE
 	.align 2
 Cry_ThundurusIncarnate::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/thundurus_incarnate.bin"
+.endif
 
 	.align 2
 Cry_ThundurusTherian::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/thundurus_therian.bin"
+.endif
 .endif @ P_FAMILY_THUNDURUS
 
 .if P_FAMILY_RESHIRAM == TRUE
 	.align 2
 Cry_Reshiram::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/reshiram.bin"
+.endif
 .endif @ P_FAMILY_RESHIRAM
 
 .if P_FAMILY_ZEKROM == TRUE
 	.align 2
 Cry_Zekrom::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/zekrom.bin"
+.endif
 .endif @ P_FAMILY_ZEKROM
 
 .if P_FAMILY_LANDORUS == TRUE
 	.align 2
 Cry_LandorusIncarnate::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/landorus_incarnate.bin"
+.endif
 
 	.align 2
 Cry_LandorusTherian::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/landorus_therian.bin"
+.endif
 .endif @ P_FAMILY_LANDORUS
 
 .if P_FAMILY_KYUREM == TRUE
 	.align 2
 Cry_Kyurem::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/kyurem.bin"
+.endif
 
 .if P_FUSION_FORMS == TRUE
 	.align 2
 Cry_KyuremWhite::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/kyurem_white.bin"
+.endif
 
 	.align 2
 Cry_KyuremBlack::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/kyurem_black.bin"
+.endif
 
 .endif @ P_FUSION_FORMS
 .endif @ P_FAMILY_KYUREM
@@ -4280,941 +5768,1307 @@ Cry_KyuremBlack::
 .if P_FAMILY_KELDEO == TRUE
 	.align 2
 Cry_Keldeo::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/keldeo.bin"
+.endif
 .endif @ P_FAMILY_KELDEO
 
 .if P_FAMILY_MELOETTA == TRUE
 	.align 2
 Cry_Meloetta::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/meloetta.bin"
+.endif
 .endif @ P_FAMILY_MELOETTA
 
 .if P_FAMILY_GENESECT == TRUE
 	.align 2
 Cry_Genesect::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/genesect.bin"
+.endif
 .endif @ P_FAMILY_GENESECT
 
 .if P_FAMILY_CHESPIN == TRUE
 	.align 2
 Cry_Chespin::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/chespin.bin"
+.endif
 
 	.align 2
 Cry_Quilladin::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/quilladin.bin"
+.endif
 
 	.align 2
 Cry_Chesnaught::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/chesnaught.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_ChesnaughtMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/chesnaught_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_CHESPIN
 
 .if P_FAMILY_FENNEKIN == TRUE
 	.align 2
 Cry_Fennekin::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/fennekin.bin"
+.endif
 
 	.align 2
 Cry_Braixen::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/braixen.bin"
+.endif
 
 	.align 2
 Cry_Delphox::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/delphox.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_DelphoxMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/delphox_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_FENNEKIN
 
 .if P_FAMILY_FROAKIE == TRUE
 	.align 2
 Cry_Froakie::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/froakie.bin"
+.endif
 
 	.align 2
 Cry_Frogadier::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/frogadier.bin"
+.endif
 
 	.align 2
 Cry_Greninja::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/greninja.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_GreninjaMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/greninja_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_FROAKIE
 
 .if P_FAMILY_BUNNELBY == TRUE
 	.align 2
 Cry_Bunnelby::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/bunnelby.bin"
+.endif
 
 	.align 2
 Cry_Diggersby::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/diggersby.bin"
+.endif
 .endif @ P_FAMILY_BUNNELBY
 
 .if P_FAMILY_FLETCHLING == TRUE
 	.align 2
 Cry_Fletchling::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/fletchling.bin"
+.endif
 
 	.align 2
 Cry_Fletchinder::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/fletchinder.bin"
+.endif
 
 	.align 2
 Cry_Talonflame::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/talonflame.bin"
+.endif
 .endif @ P_FAMILY_FLETCHLING
 
 .if P_FAMILY_SCATTERBUG == TRUE
 	.align 2
 Cry_Scatterbug::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/scatterbug.bin"
+.endif
 
 	.align 2
 Cry_Spewpa::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/spewpa.bin"
+.endif
 
 	.align 2
 Cry_Vivillon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/vivillon.bin"
+.endif
 .endif @ P_FAMILY_SCATTERBUG
 
 .if P_FAMILY_LITLEO == TRUE
 	.align 2
 Cry_Litleo::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/litleo.bin"
+.endif
 
 	.align 2
 Cry_Pyroar::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pyroar.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_PyroarMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pyroar_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_LITLEO
 
 .if P_FAMILY_FLABEBE == TRUE
 	.align 2
 Cry_Flabebe::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/flabebe.bin"
+.endif
 
 	.align 2
 Cry_Floette::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/floette.bin"
+.endif
 
 	.align 2
 Cry_FloetteEternal::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/floette_eternal.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_FloetteMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/floette_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 
 	.align 2
 Cry_Florges::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/florges.bin"
+.endif
 .endif @ P_FAMILY_FLABEBE
 
 .if P_FAMILY_SKIDDO == TRUE
 	.align 2
 Cry_Skiddo::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/skiddo.bin"
+.endif
 
 	.align 2
 Cry_Gogoat::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/gogoat.bin"
+.endif
 .endif @ P_FAMILY_SKIDDO
 
 .if P_FAMILY_PANCHAM == TRUE
 	.align 2
 Cry_Pancham::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pancham.bin"
+.endif
 
 	.align 2
 Cry_Pangoro::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pangoro.bin"
+.endif
 .endif @ P_FAMILY_PANCHAM
 
 .if P_FAMILY_FURFROU == TRUE
 	.align 2
 Cry_Furfrou::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/furfrou.bin"
+.endif
 .endif @ P_FAMILY_FURFROU
 
 .if P_FAMILY_ESPURR == TRUE
 	.align 2
 Cry_Espurr::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/espurr.bin"
+.endif
 
 	.align 2
 Cry_Meowstic::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/meowstic.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_MeowsticMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/meowstic_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_ESPURR
 
 .if P_FAMILY_HONEDGE == TRUE
 	.align 2
 Cry_Honedge::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/honedge.bin"
+.endif
 
 	.align 2
 Cry_Doublade::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/doublade.bin"
+.endif
 
 	.align 2
 Cry_Aegislash::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/aegislash.bin"
+.endif
 .endif @ P_FAMILY_HONEDGE
 
 .if P_FAMILY_SPRITZEE == TRUE
 	.align 2
 Cry_Spritzee::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/spritzee.bin"
+.endif
 
 	.align 2
 Cry_Aromatisse::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/aromatisse.bin"
+.endif
 .endif @ P_FAMILY_SPRITZEE
 
 .if P_FAMILY_SWIRLIX == TRUE
 	.align 2
 Cry_Swirlix::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/swirlix.bin"
+.endif
 
 	.align 2
 Cry_Slurpuff::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/slurpuff.bin"
+.endif
 .endif @ P_FAMILY_SWIRLIX
 
 .if P_FAMILY_INKAY == TRUE
 	.align 2
 Cry_Inkay::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/inkay.bin"
+.endif
 
 	.align 2
 Cry_Malamar::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/malamar.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_MalamarMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/malamar_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_INKAY
 
 .if P_FAMILY_BINACLE == TRUE
 	.align 2
 Cry_Binacle::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/binacle.bin"
+.endif
 
 	.align 2
 Cry_Barbaracle::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/barbaracle.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_BarbaracleMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/barbaracle_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_BINACLE
 
 .if P_FAMILY_SKRELP == TRUE
 	.align 2
 Cry_Skrelp::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/skrelp.bin"
+.endif
 
 	.align 2
 Cry_Dragalge::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dragalge.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_DragalgeMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dragalge_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_SKRELP
 
 .if P_FAMILY_CLAUNCHER == TRUE
 	.align 2
 Cry_Clauncher::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/clauncher.bin"
+.endif
 
 	.align 2
 Cry_Clawitzer::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/clawitzer.bin"
+.endif
 .endif @ P_FAMILY_CLAUNCHER
 
 .if P_FAMILY_HELIOPTILE == TRUE
 	.align 2
 Cry_Helioptile::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/helioptile.bin"
+.endif
 
 	.align 2
 Cry_Heliolisk::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/heliolisk.bin"
+.endif
 .endif @ P_FAMILY_HELIOPTILE
 
 .if P_FAMILY_TYRUNT == TRUE
 	.align 2
 Cry_Tyrunt::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tyrunt.bin"
+.endif
 
 	.align 2
 Cry_Tyrantrum::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tyrantrum.bin"
+.endif
 .endif @ P_FAMILY_TYRUNT
 
 .if P_FAMILY_AMAURA == TRUE
 	.align 2
 Cry_Amaura::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/amaura.bin"
+.endif
 
 	.align 2
 Cry_Aurorus::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/aurorus.bin"
+.endif
 .endif @ P_FAMILY_AMAURA
 
 .if P_FAMILY_HAWLUCHA == TRUE
 	.align 2
 Cry_Hawlucha::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/hawlucha.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_HawluchaMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/hawlucha_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_HAWLUCHA
 
 .if P_FAMILY_DEDENNE == TRUE
 	.align 2
 Cry_Dedenne::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dedenne.bin"
+.endif
 .endif @ P_FAMILY_DEDENNE
 
 .if P_FAMILY_CARBINK == TRUE
 	.align 2
 Cry_Carbink::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/carbink.bin"
+.endif
 .endif @ P_FAMILY_CARBINK
 
 .if P_FAMILY_GOOMY == TRUE
 	.align 2
 Cry_Goomy::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/goomy.bin"
+.endif
 
 	.align 2
 Cry_Sliggoo::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sliggoo.bin"
+.endif
 
 	.align 2
 Cry_Goodra::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/goodra.bin"
+.endif
 .endif @ P_FAMILY_GOOMY
 
 .if P_FAMILY_KLEFKI == TRUE
 	.align 2
 Cry_Klefki::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/uncomp_klefki.bin"
+.endif
 .endif @ P_FAMILY_KLEFKI
 
 .if P_FAMILY_PHANTUMP == TRUE
 	.align 2
 Cry_Phantump::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/phantump.bin"
+.endif
 
 	.align 2
 Cry_Trevenant::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/trevenant.bin"
+.endif
 .endif @ P_FAMILY_PHANTUMP
 
 .if P_FAMILY_PUMPKABOO == TRUE
 	.align 2
 Cry_Pumpkaboo::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pumpkaboo.bin"
+.endif
 
 	.align 2
 Cry_PumpkabooSuper::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pumpkaboo_super.bin"
+.endif
 
 	.align 2
 Cry_Gourgeist::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/gourgeist.bin"
+.endif
 
 	.align 2
 Cry_GourgeistSuper::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/gourgeist_super.bin"
+.endif
 .endif @ P_FAMILY_PUMPKABOO
 
 .if P_FAMILY_BERGMITE == TRUE
 	.align 2
 Cry_Bergmite::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/bergmite.bin"
+.endif
 
 	.align 2
 Cry_Avalugg::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/avalugg.bin"
+.endif
 .endif @ P_FAMILY_BERGMITE
 
 .if P_FAMILY_NOIBAT == TRUE
 	.align 2
 Cry_Noibat::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/noibat.bin"
+.endif
 
 	.align 2
 Cry_Noivern::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/noivern.bin"
+.endif
 .endif @ P_FAMILY_NOIBAT
 
 .if P_FAMILY_XERNEAS == TRUE
 	.align 2
 Cry_Xerneas::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/xerneas.bin"
+.endif
 .endif @ P_FAMILY_XERNEAS
 
 .if P_FAMILY_YVELTAL == TRUE
 	.align 2
 Cry_Yveltal::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/yveltal.bin"
+.endif
 .endif @ P_FAMILY_YVELTAL
 
 .if P_FAMILY_ZYGARDE == TRUE
 	.align 2
 Cry_Zygarde50::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/zygarde_50.bin"
+.endif
 
 	.align 2
 Cry_Zygarde10::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/zygarde_10.bin"
+.endif
 
 	.align 2
 Cry_ZygardeComplete::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/zygarde_complete.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_ZygardeMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/zygarde_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_ZYGARDE
 
 .if P_FAMILY_DIANCIE == TRUE
 	.align 2
 Cry_Diancie::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/diancie.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_DiancieMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/diancie_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_DIANCIE
 
 .if P_FAMILY_HOOPA == TRUE
 	.align 2
 Cry_HoopaConfined::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/hoopa_confined.bin"
+.endif
 
 	.align 2
 Cry_HoopaUnbound::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/hoopa_unbound.bin"
+.endif
 .endif @ P_FAMILY_HOOPA
 
 .if P_FAMILY_VOLCANION == TRUE
 	.align 2
 Cry_Volcanion::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/volcanion.bin"
+.endif
 .endif @ P_FAMILY_VOLCANION
 
 .if P_FAMILY_ROWLET == TRUE
 	.align 2
 Cry_Rowlet::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/rowlet.bin"
+.endif
 
 	.align 2
 Cry_Dartrix::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dartrix.bin"
+.endif
 
 	.align 2
 Cry_Decidueye::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/decidueye.bin"
+.endif
 .endif @ P_FAMILY_ROWLET
 
 .if P_FAMILY_LITTEN == TRUE
 	.align 2
 Cry_Litten::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/litten.bin"
+.endif
 
 	.align 2
 Cry_Torracat::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/torracat.bin"
+.endif
 
 	.align 2
 Cry_Incineroar::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/incineroar.bin"
+.endif
 .endif @ P_FAMILY_LITTEN
 
 .if P_FAMILY_POPPLIO == TRUE
 	.align 2
 Cry_Popplio::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/popplio.bin"
+.endif
 
 	.align 2
 Cry_Brionne::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/brionne.bin"
+.endif
 
 	.align 2
 Cry_Primarina::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/primarina.bin"
+.endif
 .endif @ P_FAMILY_POPPLIO
 
 .if P_FAMILY_PIKIPEK == TRUE
 	.align 2
 Cry_Pikipek::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pikipek.bin"
+.endif
 
 	.align 2
 Cry_Trumbeak::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/trumbeak.bin"
+.endif
 
 	.align 2
 Cry_Toucannon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/toucannon.bin"
+.endif
 .endif @ P_FAMILY_PIKIPEK
 
 .if P_FAMILY_YUNGOOS == TRUE
 	.align 2
 Cry_Yungoos::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/yungoos.bin"
+.endif
 
 	.align 2
 Cry_Gumshoos::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/gumshoos.bin"
+.endif
 .endif @ P_FAMILY_YUNGOOS
 
 .if P_FAMILY_GRUBBIN == TRUE
 	.align 2
 Cry_Grubbin::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/grubbin.bin"
+.endif
 
 	.align 2
 Cry_Charjabug::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/charjabug.bin"
+.endif
 
 	.align 2
 Cry_Vikavolt::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/vikavolt.bin"
+.endif
 .endif @ P_FAMILY_GRUBBIN
 
 .if P_FAMILY_CRABRAWLER == TRUE
 	.align 2
 Cry_Crabrawler::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/crabrawler.bin"
+.endif
 
 	.align 2
 Cry_Crabominable::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/crabominable.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_CrabominableMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/crabominable_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_CRABRAWLER
 
 .if P_FAMILY_ORICORIO == TRUE
 	.align 2
 Cry_OricorioBaile::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/oricorio_baile.bin"
+.endif
 
 	.align 2
 Cry_OricorioPomPom::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/uncomp_oricorio_pom_pom.bin"
+.endif
 
 	.align 2
 Cry_OricorioPau::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/oricorio_pau.bin"
+.endif
 
 	.align 2
 Cry_OricorioSensu::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/oricorio_sensu.bin"
+.endif
 .endif @ P_FAMILY_ORICORIO
 
 .if P_FAMILY_CUTIEFLY == TRUE
 	.align 2
 Cry_Cutiefly::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/cutiefly.bin"
+.endif
 
 	.align 2
 Cry_Ribombee::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/ribombee.bin"
+.endif
 .endif @ P_FAMILY_CUTIEFLY
 
 .if P_FAMILY_ROCKRUFF == TRUE
 	.align 2
 Cry_Rockruff::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/rockruff.bin"
+.endif
 
 	.align 2
 Cry_LycanrocMidday::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/lycanroc_midday.bin"
+.endif
 
 	.align 2
 Cry_LycanrocMidnight::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/lycanroc_midnight.bin"
+.endif
 
 	.align 2
 Cry_LycanrocDusk::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/lycanroc_dusk.bin"
+.endif
 .endif @ P_FAMILY_ROCKRUFF
 
 .if P_FAMILY_WISHIWASHI == TRUE
 	.align 2
 Cry_WishiwashiSolo::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/wishiwashi_solo.bin"
+.endif
 
 	.align 2
 Cry_WishiwashiSchool::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/wishiwashi_school.bin"
+.endif
 .endif @ P_FAMILY_WISHIWASHI
 
 .if P_FAMILY_MAREANIE == TRUE
 	.align 2
 Cry_Mareanie::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/mareanie.bin"
+.endif
 
 	.align 2
 Cry_Toxapex::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/toxapex.bin"
+.endif
 .endif @ P_FAMILY_MAREANIE
 
 .if P_FAMILY_MUDBRAY == TRUE
 	.align 2
 Cry_Mudbray::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/mudbray.bin"
+.endif
 
 	.align 2
 Cry_Mudsdale::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/mudsdale.bin"
+.endif
 .endif @ P_FAMILY_MUDBRAY
 
 .if P_FAMILY_DEWPIDER == TRUE
 	.align 2
 Cry_Dewpider::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dewpider.bin"
+.endif
 
 	.align 2
 Cry_Araquanid::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/araquanid.bin"
+.endif
 .endif @ P_FAMILY_DEWPIDER
 
 .if P_FAMILY_FOMANTIS == TRUE
 	.align 2
 Cry_Fomantis::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/fomantis.bin"
+.endif
 
 	.align 2
 Cry_Lurantis::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/lurantis.bin"
+.endif
 .endif @ P_FAMILY_FOMANTIS
 
 .if P_FAMILY_MORELULL == TRUE
 	.align 2
 Cry_Morelull::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/morelull.bin"
+.endif
 
 	.align 2
 Cry_Shiinotic::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/shiinotic.bin"
+.endif
 .endif @ P_FAMILY_MORELULL
 
 .if P_FAMILY_SALANDIT == TRUE
 	.align 2
 Cry_Salandit::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/salandit.bin"
+.endif
 
 	.align 2
 Cry_Salazzle::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/salazzle.bin"
+.endif
 .endif @ P_FAMILY_SALANDIT
 
 .if P_FAMILY_STUFFUL == TRUE
 	.align 2
 Cry_Stufful::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/stufful.bin"
+.endif
 
 	.align 2
 Cry_Bewear::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/bewear.bin"
+.endif
 .endif @ P_FAMILY_STUFFUL
 
 .if P_FAMILY_BOUNSWEET == TRUE
 	.align 2
 Cry_Bounsweet::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/bounsweet.bin"
+.endif
 
 	.align 2
 Cry_Steenee::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/steenee.bin"
+.endif
 
 	.align 2
 Cry_Tsareena::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tsareena.bin"
+.endif
 .endif @ P_FAMILY_BOUNSWEET
 
 .if P_FAMILY_COMFEY == TRUE
 	.align 2
 Cry_Comfey::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/comfey.bin"
+.endif
 .endif @ P_FAMILY_COMFEY
 
 .if P_FAMILY_ORANGURU == TRUE
 	.align 2
 Cry_Oranguru::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/oranguru.bin"
+.endif
 .endif @ P_FAMILY_ORANGURU
 
 .if P_FAMILY_PASSIMIAN == TRUE
 	.align 2
 Cry_Passimian::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/passimian.bin"
+.endif
 .endif @ P_FAMILY_PASSIMIAN
 
 .if P_FAMILY_WIMPOD == TRUE
 	.align 2
 Cry_Wimpod::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/wimpod.bin"
+.endif
 
 	.align 2
 Cry_Golisopod::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/golisopod.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_GolisopodMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/golisopod_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_WIMPOD
 
 .if P_FAMILY_SANDYGAST == TRUE
 	.align 2
 Cry_Sandygast::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sandygast.bin"
+.endif
 
 	.align 2
 Cry_Palossand::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/palossand.bin"
+.endif
 .endif @ P_FAMILY_SANDYGAST
 
 .if P_FAMILY_PYUKUMUKU == TRUE
 	.align 2
 Cry_Pyukumuku::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pyukumuku.bin"
+.endif
 .endif @ P_FAMILY_PYUKUMUKU
 
 .if P_FAMILY_TYPE_NULL == TRUE
 	.align 2
 Cry_TypeNull::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/type_null.bin"
+.endif
 
 	.align 2
 Cry_Silvally::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/silvally.bin"
+.endif
 .endif @ P_FAMILY_TYPE_NULL
 
 .if P_FAMILY_MINIOR == TRUE
 	.align 2
 Cry_Minior::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/minior.bin"
+.endif
 .endif @ P_FAMILY_MINIOR
 
 .if P_FAMILY_KOMALA == TRUE
 	.align 2
 Cry_Komala::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/komala.bin"
+.endif
 .endif @ P_FAMILY_KOMALA
 
 .if P_FAMILY_TURTONATOR == TRUE
 	.align 2
 Cry_Turtonator::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/turtonator.bin"
+.endif
 .endif @ P_FAMILY_TURTONATOR
 
 .if P_FAMILY_TOGEDEMARU == TRUE
 	.align 2
 Cry_Togedemaru::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/togedemaru.bin"
+.endif
 .endif @ P_FAMILY_TOGEDEMARU
 
 .if P_FAMILY_MIMIKYU == TRUE
 	.align 2
 Cry_Mimikyu::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/mimikyu.bin"
+.endif
 .endif @ P_FAMILY_MIMIKYU
 
 .if P_FAMILY_BRUXISH == TRUE
 	.align 2
 Cry_Bruxish::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/bruxish.bin"
+.endif
 .endif @ P_FAMILY_BRUXISH
 
 .if P_FAMILY_DRAMPA == TRUE
 	.align 2
 Cry_Drampa::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/drampa.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_DrampaMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/drampa_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_DRAMPA
 
 .if P_FAMILY_DHELMISE == TRUE
 	.align 2
 Cry_Dhelmise::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dhelmise.bin"
+.endif
 .endif @ P_FAMILY_DHELMISE
 
 .if P_FAMILY_JANGMO_O == TRUE
 	.align 2
 Cry_JangmoO::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/jangmo_o.bin"
+.endif
 
 	.align 2
 Cry_HakamoO::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/hakamo_o.bin"
+.endif
 
 	.align 2
 Cry_KommoO::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/kommo_o.bin"
+.endif
 .endif @ P_FAMILY_JANGMO_O
 
 .if P_FAMILY_TAPU_KOKO == TRUE
 	.align 2
 Cry_TapuKoko::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tapu_koko.bin"
+.endif
 .endif @ P_FAMILY_TAPU_KOKO
 
 .if P_FAMILY_TAPU_LELE == TRUE
 	.align 2
 Cry_TapuLele::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tapu_lele.bin"
+.endif
 .endif @ P_FAMILY_TAPU_LELE
 
 .if P_FAMILY_TAPU_BULU == TRUE
 	.align 2
 Cry_TapuBulu::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tapu_bulu.bin"
+.endif
 .endif @ P_FAMILY_TAPU_BULU
 
 .if P_FAMILY_TAPU_FINI == TRUE
 	.align 2
 Cry_TapuFini::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tapu_fini.bin"
+.endif
 .endif @ P_FAMILY_TAPU_FINI
 
 .if P_FAMILY_COSMOG == TRUE
 	.align 2
 Cry_Cosmog::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/cosmog.bin"
+.endif
 
 	.align 2
 Cry_Cosmoem::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/cosmoem.bin"
+.endif
 
 	.align 2
 Cry_Solgaleo::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/solgaleo.bin"
+.endif
 
 	.align 2
 Cry_Lunala::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/lunala.bin"
+.endif
 .endif @ P_FAMILY_COSMOG
 
 .if P_FAMILY_NIHILEGO == TRUE
 	.align 2
 Cry_Nihilego::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/nihilego.bin"
+.endif
 .endif @ P_FAMILY_NIHILEGO
 
 .if P_FAMILY_BUZZWOLE == TRUE
 	.align 2
 Cry_Buzzwole::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/buzzwole.bin"
+.endif
 .endif @ P_FAMILY_BUZZWOLE
 
 .if P_FAMILY_PHEROMOSA == TRUE
 	.align 2
 Cry_Pheromosa::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pheromosa.bin"
+.endif
 .endif @ P_FAMILY_PHEROMOSA
 
 .if P_FAMILY_XURKITREE == TRUE
 	.align 2
 Cry_Xurkitree::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/xurkitree.bin"
+.endif
 .endif @ P_FAMILY_XURKITREE
 
 .if P_FAMILY_CELESTEELA == TRUE
 	.align 2
 Cry_Celesteela::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/celesteela.bin"
+.endif
 .endif @ P_FAMILY_CELESTEELA
 
 .if P_FAMILY_KARTANA == TRUE
 	.align 2
 Cry_Kartana::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/kartana.bin"
+.endif
 .endif @ P_FAMILY_KARTANA
 
 .if P_FAMILY_GUZZLORD == TRUE
 	.align 2
 Cry_Guzzlord::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/guzzlord.bin"
+.endif
 .endif @ P_FAMILY_GUZZLORD
 
 .if P_FAMILY_NECROZMA == TRUE
 	.align 2
 Cry_Necrozma::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/necrozma.bin"
+.endif
 
 .if P_FUSION_FORMS == TRUE
 	.align 2
 Cry_NecrozmaDuskMane::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/necrozma_dusk_mane.bin"
+.endif
 
 	.align 2
 Cry_NecrozmaDawnWings::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/necrozma_dawn_wings.bin"
+.endif
 
 .if P_ULTRA_BURST_FORMS == TRUE
 	.align 2
 Cry_NecrozmaUltra::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/necrozma_ultra.bin"
+.endif
 
 .endif @ P_ULTRA_BURST_FORMS
 .endif @ P_FUSION_FORMS
@@ -5223,554 +7077,772 @@ Cry_NecrozmaUltra::
 .if P_FAMILY_MAGEARNA == TRUE
 	.align 2
 Cry_Magearna::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/magearna.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_MagearnaMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/magearna_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_MAGEARNA
 
 .if P_FAMILY_MARSHADOW == TRUE
 	.align 2
 Cry_Marshadow::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/marshadow.bin"
+.endif
 .endif @ P_FAMILY_MARSHADOW
 
 .if P_FAMILY_POIPOLE == TRUE
 	.align 2
 Cry_Poipole::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/poipole.bin"
+.endif
 
 	.align 2
 Cry_Naganadel::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/naganadel.bin"
+.endif
 .endif @ P_FAMILY_POIPOLE
 
 .if P_FAMILY_STAKATAKA == TRUE
 	.align 2
 Cry_Stakataka::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/stakataka.bin"
+.endif
 .endif @ P_FAMILY_STAKATAKA
 
 .if P_FAMILY_BLACEPHALON == TRUE
 	.align 2
 Cry_Blacephalon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/blacephalon.bin"
+.endif
 .endif @ P_FAMILY_BLACEPHALON
 
 .if P_FAMILY_ZERAORA == TRUE
 	.align 2
 Cry_Zeraora::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/zeraora.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_ZeraoraMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/zeraora_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_ZERAORA
 
 .if P_FAMILY_MELTAN == TRUE
 	.align 2
 Cry_Meltan::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/meltan.bin"
+.endif
 
 	.align 2
 Cry_Melmetal::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/melmetal.bin"
+.endif
 .endif @ P_FAMILY_MELTAN
 
 .if P_FAMILY_GROOKEY == TRUE
 	.align 2
 Cry_Grookey::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/grookey.bin"
+.endif
 
 	.align 2
 Cry_Thwackey::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/thwackey.bin"
+.endif
 
 	.align 2
 Cry_Rillaboom::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/rillaboom.bin"
+.endif
 .endif @ P_FAMILY_GROOKEY
 
 .if P_FAMILY_SCORBUNNY == TRUE
 	.align 2
 Cry_Scorbunny::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/scorbunny.bin"
+.endif
 
 	.align 2
 Cry_Raboot::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/raboot.bin"
+.endif
 
 	.align 2
 Cry_Cinderace::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/cinderace.bin"
+.endif
 .endif @ P_FAMILY_SCORBUNNY
 
 .if P_FAMILY_SOBBLE == TRUE
 	.align 2
 Cry_Sobble::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sobble.bin"
+.endif
 
 	.align 2
 Cry_Drizzile::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/drizzile.bin"
+.endif
 
 	.align 2
 Cry_Inteleon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/inteleon.bin"
+.endif
 .endif @ P_FAMILY_SOBBLE
 
 .if P_FAMILY_SKWOVET == TRUE
 	.align 2
 Cry_Skwovet::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/skwovet.bin"
+.endif
 
 	.align 2
 Cry_Greedent::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/greedent.bin"
+.endif
 .endif @ P_FAMILY_SKWOVET
 
 .if P_FAMILY_ROOKIDEE == TRUE
 	.align 2
 Cry_Rookidee::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/rookidee.bin"
+.endif
 
 	.align 2
 Cry_Corvisquire::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/corvisquire.bin"
+.endif
 
 	.align 2
 Cry_Corviknight::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/corviknight.bin"
+.endif
 .endif @ P_FAMILY_ROOKIDEE
 
 .if P_FAMILY_BLIPBUG == TRUE
 	.align 2
 Cry_Blipbug::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/blipbug.bin"
+.endif
 
 	.align 2
 Cry_Dottler::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dottler.bin"
+.endif
 
 	.align 2
 Cry_Orbeetle::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/orbeetle.bin"
+.endif
 .endif @ P_FAMILY_BLIPBUG
 
 .if P_FAMILY_NICKIT == TRUE
 	.align 2
 Cry_Nickit::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/nickit.bin"
+.endif
 
 	.align 2
 Cry_Thievul::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/thievul.bin"
+.endif
 .endif @ P_FAMILY_NICKIT
 
 .if P_FAMILY_GOSSIFLEUR == TRUE
 	.align 2
 Cry_Gossifleur::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/gossifleur.bin"
+.endif
 
 	.align 2
 Cry_Eldegoss::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/eldegoss.bin"
+.endif
 .endif @ P_FAMILY_GOSSIFLEUR
 
 .if P_FAMILY_WOOLOO == TRUE
 	.align 2
 Cry_Wooloo::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/wooloo.bin"
+.endif
 
 	.align 2
 Cry_Dubwool::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dubwool.bin"
+.endif
 .endif @ P_FAMILY_WOOLOO
 
 .if P_FAMILY_CHEWTLE == TRUE
 	.align 2
 Cry_Chewtle::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/chewtle.bin"
+.endif
 
 	.align 2
 Cry_Drednaw::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/drednaw.bin"
+.endif
 .endif @ P_FAMILY_CHEWTLE
 
 .if P_FAMILY_YAMPER == TRUE
 	.align 2
 Cry_Yamper::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/yamper.bin"
+.endif
 
 	.align 2
 Cry_Boltund::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/boltund.bin"
+.endif
 .endif @ P_FAMILY_YAMPER
 
 .if P_FAMILY_ROLYCOLY == TRUE
 	.align 2
 Cry_Rolycoly::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/rolycoly.bin"
+.endif
 
 	.align 2
 Cry_Carkol::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/carkol.bin"
+.endif
 
 	.align 2
 Cry_Coalossal::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/coalossal.bin"
+.endif
 .endif @ P_FAMILY_ROLYCOLY
 
 .if P_FAMILY_APPLIN == TRUE
 	.align 2
 Cry_Applin::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/applin.bin"
+.endif
 
 	.align 2
 Cry_Flapple::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/flapple.bin"
+.endif
 
 	.align 2
 Cry_Appletun::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/appletun.bin"
+.endif
 
 .if P_GEN_9_CROSS_EVOS == TRUE
 	.align 2
 Cry_Dipplin::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dipplin.bin"
+.endif
 
 	.align 2
 Cry_Hydrapple::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/hydrapple.bin"
+.endif
 .endif @ P_GEN_9_CROSS_EVOS
 .endif @ P_FAMILY_APPLIN
 
 .if P_FAMILY_SILICOBRA == TRUE
 	.align 2
 Cry_Silicobra::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/silicobra.bin"
+.endif
 
 	.align 2
 Cry_Sandaconda::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sandaconda.bin"
+.endif
 .endif @ P_FAMILY_SILICOBRA
 
 .if P_FAMILY_CRAMORANT == TRUE
 	.align 2
 Cry_Cramorant::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/cramorant.bin"
+.endif
 	
 	.align 2
 Cry_CramorantGulping::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/cramorant_gulping.bin"
+.endif
 .endif @ P_FAMILY_CRAMORANT
 
 .if P_FAMILY_ARROKUDA == TRUE
 	.align 2
 Cry_Arrokuda::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/arrokuda.bin"
+.endif
 
 	.align 2
 Cry_Barraskewda::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/barraskewda.bin"
+.endif
 .endif @ P_FAMILY_ARROKUDA
 
 .if P_FAMILY_TOXEL == TRUE
 	.align 2
 Cry_Toxel::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/toxel.bin"
+.endif
 
 	.align 2
 Cry_ToxtricityAmped::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/toxtricity_amped.bin"
+.endif
 
 	.align 2
 Cry_ToxtricityLowKey::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/toxtricity_low_key.bin"
+.endif
 .endif @ P_FAMILY_TOXEL
 
 .if P_FAMILY_SIZZLIPEDE == TRUE
 	.align 2
 Cry_Sizzlipede::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sizzlipede.bin"
+.endif
 
 	.align 2
 Cry_Centiskorch::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/centiskorch.bin"
+.endif
 .endif @ P_FAMILY_SIZZLIPEDE
 
 .if P_FAMILY_CLOBBOPUS == TRUE
 	.align 2
 Cry_Clobbopus::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/clobbopus.bin"
+.endif
 
 	.align 2
 Cry_Grapploct::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/grapploct.bin"
+.endif
 .endif @ P_FAMILY_CLOBBOPUS
 
 .if P_FAMILY_SINISTEA == TRUE
 	.align 2
 Cry_Sinistea::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sinistea.bin"
+.endif
 
 	.align 2
 Cry_Polteageist::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/polteageist.bin"
+.endif
 .endif @ P_FAMILY_SINISTEA
 
 .if P_FAMILY_HATENNA == TRUE
 	.align 2
 Cry_Hatenna::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/hatenna.bin"
+.endif
 
 	.align 2
 Cry_Hattrem::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/hattrem.bin"
+.endif
 
 	.align 2
 Cry_Hatterene::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/hatterene.bin"
+.endif
 .endif @ P_FAMILY_HATENNA
 
 .if P_FAMILY_IMPIDIMP == TRUE
 	.align 2
 Cry_Impidimp::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/impidimp.bin"
+.endif
 
 	.align 2
 Cry_Morgrem::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/morgrem.bin"
+.endif
 
 	.align 2
 Cry_Grimmsnarl::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/grimmsnarl.bin"
+.endif
 .endif @ P_FAMILY_IMPIDIMP
 
 .if P_FAMILY_MILCERY == TRUE
 	.align 2
 Cry_Milcery::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/milcery.bin"
+.endif
 
 	.align 2
 Cry_Alcremie::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/alcremie.bin"
+.endif
 .endif @ P_FAMILY_MILCERY
 
 .if P_FAMILY_FALINKS == TRUE
 	.align 2
 Cry_Falinks::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/falinks.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_FalinksMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/falinks_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_FALINKS
 
 .if P_FAMILY_PINCURCHIN == TRUE
 	.align 2
 Cry_Pincurchin::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pincurchin.bin"
+.endif
 .endif @ P_FAMILY_PINCURCHIN
 
 .if P_FAMILY_SNOM == TRUE
 	.align 2
 Cry_Snom::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/snom.bin"
+.endif
 
 	.align 2
 Cry_Frosmoth::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/frosmoth.bin"
+.endif
 .endif @ P_FAMILY_SNOM
 
 .if P_FAMILY_STONJOURNER == TRUE
 	.align 2
 Cry_Stonjourner::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/stonjourner.bin"
+.endif
 .endif @ P_FAMILY_STONJOURNER
 
 .if P_FAMILY_EISCUE == TRUE
 	.align 2
 Cry_EiscueIce::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/eiscue_ice_face.bin"
+.endif
 
 	.align 2
 Cry_EiscueNoice::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/eiscue_noice_face.bin"
+.endif
 .endif @ P_FAMILY_EISCUE
 
 .if P_FAMILY_INDEEDEE == TRUE
 	.align 2
 Cry_IndeedeeM::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/indeedee_male.bin"
+.endif
 
 	.align 2
 Cry_IndeedeeF::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/indeedee_female.bin"
+.endif
 .endif @ P_FAMILY_INDEEDEE
 
 .if P_FAMILY_MORPEKO == TRUE
 	.align 2
 Cry_MorpekoFullBelly::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/morpeko_full_belly.bin"
+.endif
 
 	.align 2
 Cry_MorpekoHangry::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/morpeko_hangry.bin"
+.endif
 .endif @ P_FAMILY_MORPEKO
 
 .if P_FAMILY_CUFANT == TRUE
 	.align 2
 Cry_Cufant::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/cufant.bin"
+.endif
 
 	.align 2
 Cry_Copperajah::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/copperajah.bin"
+.endif
 .endif @ P_FAMILY_CUFANT
 
 .if P_FAMILY_DRACOZOLT == TRUE
 	.align 2
 Cry_Dracozolt::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dracozolt.bin"
+.endif
 .endif @ P_FAMILY_DRACOZOLT
 
 .if P_FAMILY_ARCTOZOLT == TRUE
 	.align 2
 Cry_Arctozolt::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/arctozolt.bin"
+.endif
 .endif @ P_FAMILY_ARCTOZOLT
 
 .if P_FAMILY_DRACOVISH == TRUE
 	.align 2
 Cry_Dracovish::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dracovish.bin"
+.endif
 .endif @ P_FAMILY_DRACOVISH
 
 .if P_FAMILY_ARCTOVISH == TRUE
 	.align 2
 Cry_Arctovish::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/arctovish.bin"
+.endif
 .endif @ P_FAMILY_ARCTOVISH
 
 .if P_FAMILY_DURALUDON == TRUE
 	.align 2
 Cry_Duraludon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/duraludon.bin"
+.endif
 
 	.align 2
 Cry_Archaludon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/archaludon.bin"
+.endif
 .endif @ P_FAMILY_DURALUDON
 
 .if P_FAMILY_DREEPY == TRUE
 	.align 2
 Cry_Dreepy::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dreepy.bin"
+.endif
 
 	.align 2
 Cry_Drakloak::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/drakloak.bin"
+.endif
 
 	.align 2
 Cry_Dragapult::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dragapult.bin"
+.endif
 .endif @ P_FAMILY_DREEPY
 
 .if P_FAMILY_ZACIAN == TRUE
 	.align 2
 Cry_ZacianHero::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/zacian_hero_of_many_battles.bin"
+.endif
 
 	.align 2
 Cry_ZacianCrowned::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/zacian_crowned_sword.bin"
+.endif
 .endif @ P_FAMILY_ZACIAN
 
 .if P_FAMILY_ZAMAZENTA == TRUE
 	.align 2
 Cry_ZamazentaHero::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/zamazenta_hero_of_many_battles.bin"
+.endif
 
 	.align 2
 Cry_ZamazentaCrowned::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/zamazenta_crowned_shield.bin"
+.endif
 .endif @ P_FAMILY_ZAMAZENTA
 
 .if P_FAMILY_ETERNATUS == TRUE
 	.align 2
 Cry_Eternatus::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/eternatus.bin"
+.endif
 
 	.align 2
 Cry_EternatusEternamax::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/eternatus_eternamax.bin"
+.endif
 .endif @ P_FAMILY_ETERNATUS
 
 .if P_FAMILY_KUBFU == TRUE
 	.align 2
 Cry_Kubfu::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/kubfu.bin"
+.endif
 
 	.align 2
 Cry_UrshifuSingleStrike::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/urshifu_single_strike.bin"
+.endif
 
 	.align 2
 Cry_UrshifuRapidStrike::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/urshifu_rapid_strike.bin"
+.endif
 .endif @ P_FAMILY_KUBFU
 
 .if P_FAMILY_ZARUDE == TRUE
 	.align 2
 Cry_Zarude::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/zarude.bin"
+.endif
 .endif @ P_FAMILY_ZARUDE
 
 .if P_FAMILY_REGIELEKI == TRUE
 	.align 2
 Cry_Regieleki::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/regieleki.bin"
+.endif
 .endif @ P_FAMILY_REGIELEKI
 
 .if P_FAMILY_REGIDRAGO == TRUE
 	.align 2
 Cry_Regidrago::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/regidrago.bin"
+.endif
 .endif @ P_FAMILY_REGIDRAGO
 
 .if P_FAMILY_GLASTRIER == TRUE
 	.align 2
 Cry_Glastrier::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/glastrier.bin"
+.endif
 .endif @ P_FAMILY_GLASTRIER
 
 .if P_FAMILY_SPECTRIER == TRUE
 	.align 2
 Cry_Spectrier::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/spectrier.bin"
+.endif
 .endif @ P_FAMILY_SPECTRIER
 
 .if P_FAMILY_CALYREX == TRUE
 	.align 2
 Cry_Calyrex::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/calyrex.bin"
+.endif
 
 .if P_FUSION_FORMS == TRUE
 	.align 2
 Cry_CalyrexIce::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/calyrex_ice.bin"
+.endif
 
 	.align 2
 Cry_CalyrexShadow::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/calyrex_shadow.bin"
+.endif
 
 .endif @ P_FUSION_FORMS
 .endif @ P_FAMILY_CALYREX
@@ -5778,649 +7850,901 @@ Cry_CalyrexShadow::
 .if P_FAMILY_ENAMORUS == TRUE
 	.align 2
 Cry_EnamorusIncarnate::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/enamorus_incarnate.bin"
+.endif
 
 	.align 2
 Cry_EnamorusTherian::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/enamorus_therian.bin"
+.endif
 .endif @ P_FAMILY_ENAMORUS
 
 .if P_FAMILY_SPRIGATITO == TRUE
 	.align 2
 Cry_Sprigatito::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sprigatito.bin"
+.endif
 
 	.align 2
 Cry_Floragato::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/floragato.bin"
+.endif
 
 	.align 2
 Cry_Meowscarada::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/meowscarada.bin"
+.endif
 .endif @ P_FAMILY_SPRIGATITO
 
 .if P_FAMILY_FUECOCO == TRUE
 	.align 2
 Cry_Fuecoco::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/fuecoco.bin"
+.endif
 
 	.align 2
 Cry_Crocalor::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/crocalor.bin"
+.endif
 
 	.align 2
 Cry_Skeledirge::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/skeledirge.bin"
+.endif
 .endif @ P_FAMILY_FUECOCO
 
 .if P_FAMILY_QUAXLY == TRUE
 	.align 2
 Cry_Quaxly::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/quaxly.bin"
+.endif
 
 	.align 2
 Cry_Quaxwell::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/quaxwell.bin"
+.endif
 
 	.align 2
 Cry_Quaquaval::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/quaquaval.bin"
+.endif
 .endif @ P_FAMILY_QUAXLY
 
 .if P_FAMILY_LECHONK == TRUE
 	.align 2
 Cry_Lechonk::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/lechonk.bin"
+.endif
 
 	.align 2
 Cry_OinkologneM::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/oinkologne_m.bin"
+.endif
 
 	.align 2
 Cry_OinkologneF::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/oinkologne_f.bin"
+.endif
 .endif @ P_FAMILY_LECHONK
 
 .if P_FAMILY_TAROUNTULA == TRUE
 	.align 2
 Cry_Tarountula::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tarountula.bin"
+.endif
 
 	.align 2
 Cry_Spidops::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/spidops.bin"
+.endif
 .endif @ P_FAMILY_TAROUNTULA
 
 .if P_FAMILY_NYMBLE == TRUE
 	.align 2
 Cry_Nymble::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/nymble.bin"
+.endif
 
 	.align 2
 Cry_Lokix::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/lokix.bin"
+.endif
 .endif @ P_FAMILY_NYMBLE
 
 .if P_FAMILY_PAWMI == TRUE
 	.align 2
 Cry_Pawmi::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pawmi.bin"
+.endif
 
 	.align 2
 Cry_Pawmo::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pawmo.bin"
+.endif
 
 	.align 2
 Cry_Pawmot::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pawmot.bin"
+.endif
 .endif @ P_FAMILY_PAWMI
 
 .if P_FAMILY_TANDEMAUS == TRUE
 	.align 2
 Cry_Tandemaus::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tandemaus.bin"
+.endif
 
 	.align 2
 Cry_MausholdThree::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/maushold_three.bin"
+.endif
 
 	.align 2
 Cry_MausholdFour::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/maushold_four.bin"
+.endif
 .endif @ P_FAMILY_TANDEMAUS
 
 .if P_FAMILY_FIDOUGH == TRUE
 	.align 2
 Cry_Fidough::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/fidough.bin"
+.endif
 
 	.align 2
 Cry_Dachsbun::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dachsbun.bin"
+.endif
 .endif @ P_FAMILY_FIDOUGH
 
 .if P_FAMILY_SMOLIV == TRUE
 	.align 2
 Cry_Smoliv::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/smoliv.bin"
+.endif
 
 	.align 2
 Cry_Dolliv::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dolliv.bin"
+.endif
 
 	.align 2
 Cry_Arboliva::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/arboliva.bin"
+.endif
 .endif @ P_FAMILY_SMOLIV
 
 .if P_FAMILY_SQUAWKABILLY == TRUE
 	.align 2
 Cry_Squawkabilly::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/squawkabilly.bin"
+.endif
 .endif @ P_FAMILY_SQUAWKABILLY
 
 .if P_FAMILY_NACLI == TRUE
 	.align 2
 Cry_Nacli::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/nacli.bin"
+.endif
 
 	.align 2
 Cry_Naclstack::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/naclstack.bin"
+.endif
 
 	.align 2
 Cry_Garganacl::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/garganacl.bin"
+.endif
 .endif @ P_FAMILY_NACLI
 
 .if P_FAMILY_CHARCADET == TRUE
 	.align 2
 Cry_Charcadet::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/charcadet.bin"
+.endif
 
 	.align 2
 Cry_Armarouge::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/armarouge.bin"
+.endif
 
 	.align 2
 Cry_Ceruledge::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/ceruledge.bin"
+.endif
 .endif @ P_FAMILY_CHARCADET
 
 .if P_FAMILY_TADBULB == TRUE
 	.align 2
 Cry_Tadbulb::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tadbulb.bin"
+.endif
 
 	.align 2
 Cry_Bellibolt::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/bellibolt.bin"
+.endif
 .endif @ P_FAMILY_TADBULB
 
 .if P_FAMILY_WATTREL == TRUE
 	.align 2
 Cry_Wattrel::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/wattrel.bin"
+.endif
 
 	.align 2
 Cry_Kilowattrel::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/kilowattrel.bin"
+.endif
 .endif @ P_FAMILY_WATTREL
 
 .if P_FAMILY_MASCHIFF == TRUE
 	.align 2
 Cry_Maschiff::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/maschiff.bin"
+.endif
 
 	.align 2
 Cry_Mabosstiff::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/mabosstiff.bin"
+.endif
 .endif @ P_FAMILY_MASCHIFF
 
 .if P_FAMILY_SHROODLE == TRUE
 	.align 2
 Cry_Shroodle::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/shroodle.bin"
+.endif
 
 	.align 2
 Cry_Grafaiai::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/grafaiai.bin"
+.endif
 .endif @ P_FAMILY_SHROODLE
 
 .if P_FAMILY_BRAMBLIN == TRUE
 	.align 2
 Cry_Bramblin::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/bramblin.bin"
+.endif
 
 	.align 2
 Cry_Brambleghast::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/brambleghast.bin"
+.endif
 .endif @ P_FAMILY_BRAMBLIN
 
 .if P_FAMILY_TOEDSCOOL == TRUE
 	.align 2
 Cry_Toedscool::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/toedscool.bin"
+.endif
 
 	.align 2
 Cry_Toedscruel::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/toedscruel.bin"
+.endif
 .endif @ P_FAMILY_TOEDSCOOL
 
 .if P_FAMILY_KLAWF == TRUE
 	.align 2
 Cry_Klawf::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/klawf.bin"
+.endif
 .endif @ P_FAMILY_KLAWF
 
 .if P_FAMILY_CAPSAKID == TRUE
 	.align 2
 Cry_Capsakid::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/capsakid.bin"
+.endif
 
 	.align 2
 Cry_Scovillain::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/scovillain.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_ScovillainMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/scovillain_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_CAPSAKID
 
 .if P_FAMILY_RELLOR == TRUE
 	.align 2
 Cry_Rellor::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/rellor.bin"
+.endif
 
 	.align 2
 Cry_Rabsca::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/rabsca.bin"
+.endif
 .endif @ P_FAMILY_RELLOR
 
 .if P_FAMILY_FLITTLE == TRUE
 	.align 2
 Cry_Flittle::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/flittle.bin"
+.endif
 
 	.align 2
 Cry_Espathra::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/espathra.bin"
+.endif
 .endif @ P_FAMILY_FLITTLE
 
 .if P_FAMILY_TINKATINK == TRUE
 	.align 2
 Cry_Tinkatink::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tinkatink.bin"
+.endif
 
 	.align 2
 Cry_Tinkatuff::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tinkatuff.bin"
+.endif
 
 	.align 2
 Cry_Tinkaton::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tinkaton.bin"
+.endif
 .endif @ P_FAMILY_TINKATINK
 
 .if P_FAMILY_WIGLETT == TRUE
 	.align 2
 Cry_Wiglett::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/wiglett.bin"
+.endif
 
 	.align 2
 Cry_Wugtrio::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/wugtrio.bin"
+.endif
 .endif @ P_FAMILY_WIGLETT
 
 .if P_FAMILY_BOMBIRDIER == TRUE
 	.align 2
 Cry_Bombirdier::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/bombirdier.bin"
+.endif
 .endif @ P_FAMILY_BOMBIRDIER
 
 .if P_FAMILY_FINIZEN == TRUE
 	.align 2
 Cry_Finizen::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/finizen.bin"
+.endif
 
 	.align 2
 Cry_PalafinZero::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/palafin_zero.bin"
+.endif
 
 	.align 2
 Cry_PalafinHero::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/palafin_hero.bin"
+.endif
 .endif @ P_FAMILY_FINIZEN
 
 .if P_FAMILY_VAROOM == TRUE
 	.align 2
 Cry_Varoom::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/varoom.bin"
+.endif
 
 	.align 2
 Cry_Revavroom::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/revavroom.bin"
+.endif
 .endif @ P_FAMILY_VAROOM
 
 .if P_FAMILY_CYCLIZAR == TRUE
 	.align 2
 Cry_Cyclizar::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/cyclizar.bin"
+.endif
 .endif @ P_FAMILY_CYCLIZAR
 
 .if P_FAMILY_ORTHWORM == TRUE
 	.align 2
 Cry_Orthworm::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/orthworm.bin"
+.endif
 .endif @ P_FAMILY_ORTHWORM
 
 .if P_FAMILY_GLIMMET == TRUE
 	.align 2
 Cry_Glimmet::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/glimmet.bin"
+.endif
 
 	.align 2
 Cry_Glimmora::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/glimmora.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_GlimmoraMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/glimmora_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_GLIMMET
 
 .if P_FAMILY_GREAVARD == TRUE
 	.align 2
 Cry_Greavard::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/greavard.bin"
+.endif
 
 	.align 2
 Cry_Houndstone::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/houndstone.bin"
+.endif
 .endif @ P_FAMILY_GREAVARD
 
 .if P_FAMILY_FLAMIGO == TRUE
 	.align 2
 Cry_Flamigo::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/flamigo.bin"
+.endif
 .endif @ P_FAMILY_FLAMIGO
 
 .if P_FAMILY_CETODDLE == TRUE
 	.align 2
 Cry_Cetoddle::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/cetoddle.bin"
+.endif
 
 	.align 2
 Cry_Cetitan::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/cetitan.bin"
+.endif
 .endif @ P_FAMILY_CETODDLE
 
 .if P_FAMILY_VELUZA == TRUE
 	.align 2
 Cry_Veluza::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/veluza.bin"
+.endif
 .endif @ P_FAMILY_VELUZA
 
 .if P_FAMILY_DONDOZO == TRUE
 	.align 2
 Cry_Dondozo::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/dondozo.bin"
+.endif
 .endif @ P_FAMILY_DONDOZO
 
 .if P_FAMILY_TATSUGIRI == TRUE
 	.align 2
 Cry_TatsugiriCurly::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tatsugiri_curly.bin"
+.endif
 
 	.align 2
 Cry_TatsugiriDroopy::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tatsugiri_droopy.bin"
+.endif
 
 	.align 2
 Cry_TatsugiriStretchy::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tatsugiri_stretchy.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_TatsugiriMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/tatsugiri_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_TATSUGIRI
 
 .if P_FAMILY_GREAT_TUSK == TRUE
 	.align 2
 Cry_GreatTusk::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/great_tusk.bin"
+.endif
 .endif @ P_FAMILY_GREAT_TUSK
 
 .if P_FAMILY_SCREAM_TAIL == TRUE
 	.align 2
 Cry_ScreamTail::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/scream_tail.bin"
+.endif
 .endif @ P_FAMILY_SCREAM_TAIL
 
 .if P_FAMILY_BRUTE_BONNET == TRUE
 	.align 2
 Cry_BruteBonnet::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/brute_bonnet.bin"
+.endif
 .endif @ P_FAMILY_BRUTE_BONNET
 
 .if P_FAMILY_FLUTTER_MANE == TRUE
 	.align 2
 Cry_FlutterMane::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/flutter_mane.bin"
+.endif
 .endif @ P_FAMILY_FLUTTER_MANE
 
 .if P_FAMILY_SLITHER_WING == TRUE
 	.align 2
 Cry_SlitherWing::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/slither_wing.bin"
+.endif
 .endif @ P_FAMILY_SLITHER_WING
 
 .if P_FAMILY_SANDY_SHOCKS == TRUE
 	.align 2
 Cry_SandyShocks::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sandy_shocks.bin"
+.endif
 .endif @ P_FAMILY_SANDY_SHOCKS
 
 .if P_FAMILY_IRON_TREADS == TRUE
 	.align 2
 Cry_IronTreads::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/iron_treads.bin"
+.endif
 .endif @ P_FAMILY_IRON_TREADS
 
 .if P_FAMILY_IRON_BUNDLE == TRUE
 	.align 2
 Cry_IronBundle::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/iron_bundle.bin"
+.endif
 .endif @ P_FAMILY_IRON_BUNDLE
 
 .if P_FAMILY_IRON_HANDS == TRUE
 	.align 2
 Cry_IronHands::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/iron_hands.bin"
+.endif
 .endif @ P_FAMILY_IRON_HANDS
 
 .if P_FAMILY_IRON_JUGULIS == TRUE
 	.align 2
 Cry_IronJugulis::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/iron_jugulis.bin"
+.endif
 .endif @ P_FAMILY_IRON_JUGULIS
 
 .if P_FAMILY_IRON_MOTH == TRUE
 	.align 2
 Cry_IronMoth::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/iron_moth.bin"
+.endif
 .endif @ P_FAMILY_IRON_MOTH
 
 .if P_FAMILY_IRON_THORNS == TRUE
 	.align 2
 Cry_IronThorns::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/iron_thorns.bin"
+.endif
 .endif @ P_FAMILY_IRON_THORNS
 
 .if P_FAMILY_FRIGIBAX == TRUE
 	.align 2
 Cry_Frigibax::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/frigibax.bin"
+.endif
 
 	.align 2
 Cry_Arctibax::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/arctibax.bin"
+.endif
 
 	.align 2
 Cry_Baxcalibur::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/baxcalibur.bin"
+.endif
 
 .if P_MODIFIED_MEGA_CRIES == TRUE
 	.align 2
 Cry_BaxcaliburMega::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/baxcalibur_mega.bin"
+.endif
 .endif @ P_MODIFIED_MEGA_CRIES
 .endif @ P_FAMILY_FRIGIBAX
 
 .if P_FAMILY_GIMMIGHOUL == TRUE
 	.align 2
 Cry_Gimmighoul::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/gimmighoul.bin"
+.endif
 
 	.align 2
 Cry_Gholdengo::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/gholdengo.bin"
+.endif
 .endif @ P_FAMILY_GIMMIGHOUL
 
 .if P_FAMILY_WO_CHIEN == TRUE
 	.align 2
 Cry_WoChien::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/wo_chien.bin"
+.endif
 .endif @ P_FAMILY_WO_CHIEN
 
 .if P_FAMILY_CHIEN_PAO == TRUE
 	.align 2
 Cry_ChienPao::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/chien_pao.bin"
+.endif
 .endif @ P_FAMILY_CHIEN_PAO
 
 .if P_FAMILY_TING_LU == TRUE
 	.align 2
 Cry_TingLu::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/ting_lu.bin"
+.endif
 .endif @ P_FAMILY_TING_LU
 
 .if P_FAMILY_CHI_YU == TRUE
 	.align 2
 Cry_ChiYu::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/chi_yu.bin"
+.endif
 .endif @ P_FAMILY_CHI_YU
 
 .if P_FAMILY_ROARING_MOON == TRUE
 	.align 2
 Cry_RoaringMoon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/roaring_moon.bin"
+.endif
 .endif @ P_FAMILY_ROARING_MOON
 
 .if P_FAMILY_IRON_VALIANT == TRUE
 	.align 2
 Cry_IronValiant::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/iron_valiant.bin"
+.endif
 .endif @ P_FAMILY_IRON_VALIANT
 
 .if P_FAMILY_KORAIDON == TRUE
 	.align 2
 Cry_Koraidon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/koraidon.bin"
+.endif
 .endif @ P_FAMILY_KORAIDON
 
 .if P_FAMILY_MIRAIDON == TRUE
 	.align 2
 Cry_Miraidon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/miraidon.bin"
+.endif
 .endif @ P_FAMILY_MIRAIDON
 
 .if P_FAMILY_WALKING_WAKE == TRUE
 	.align 2
 Cry_WalkingWake::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/walking_wake.bin"
+.endif
 .endif @ P_FAMILY_WALKING_WAKE
 
 .if P_FAMILY_IRON_LEAVES == TRUE
 	.align 2
 Cry_IronLeaves::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/iron_leaves.bin"
+.endif
 .endif @ P_FAMILY_IRON_LEAVES
 
 .if P_FAMILY_POLTCHAGEIST == TRUE
 	.align 2
 Cry_Poltchageist::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/poltchageist.bin"
+.endif
 
 	.align 2
 Cry_Sinistcha::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/sinistcha.bin"
+.endif
 .endif @ P_FAMILY_POLTCHAGEIST
 
 .if P_FAMILY_OKIDOGI == TRUE
 	.align 2
 Cry_Okidogi::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/okidogi.bin"
+.endif
 .endif @ P_FAMILY_OKIDOGI
 
 .if P_FAMILY_MUNKIDORI == TRUE
 	.align 2
 Cry_Munkidori::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/munkidori.bin"
+.endif
 .endif @ P_FAMILY_MUNKIDORI
 
 .if P_FAMILY_FEZANDIPITI == TRUE
 	.align 2
 Cry_Fezandipiti::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/fezandipiti.bin"
+.endif
 .endif @ P_FAMILY_FEZANDIPITI
 
 .if P_FAMILY_OGERPON == TRUE
 	.align 2
 Cry_Ogerpon::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/ogerpon.bin"
+.endif
 .endif @ P_FAMILY_OGERPON
 
 .if P_FAMILY_GOUGING_FIRE == TRUE
 	.align 2
 Cry_GougingFire::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/gouging_fire.bin"
+.endif
 .endif @ P_FAMILY_GOUGING_FIRE
 
 .if P_FAMILY_RAGING_BOLT == TRUE
 	.align 2
 Cry_RagingBolt::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/raging_bolt.bin"
+.endif
 .endif @ P_FAMILY_RAGING_BOLT
 
 .if P_FAMILY_IRON_BOULDER == TRUE
 	.align 2
 Cry_IronBoulder::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/iron_boulder.bin"
+.endif
 .endif @ P_FAMILY_IRON_BOULDER
 
 .if P_FAMILY_IRON_CROWN == TRUE
 	.align 2
 Cry_IronCrown::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/iron_crown.bin"
+.endif
 .endif @ P_FAMILY_IRON_CROWN
 
 .if P_FAMILY_TERAPAGOS == TRUE
 	.align 2
 Cry_Terapagos::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/terapagos.bin"
+.endif
 .endif @ P_FAMILY_TERAPAGOS
 
 .if P_FAMILY_PECHARUNT == TRUE
 	.align 2
 Cry_Pecharunt::
+.if TESTING == FALSE
 	.incbin "sound/direct_sound_samples/cries/pecharunt.bin"
+.endif
 .endif @ P_FAMILY_PECHARUNT
 .endif @ P_CRIES_ENABLED
+
+.if TESTING == TRUE
+@ Tests use a single shared cry for all mons, and Fletchling is the standard measurement
+	.align 2
+	.incbin "sound/direct_sound_samples/cries/fletchling.bin"
+.endif
 
 	.align 2
 DirectSoundWaveData_register_noise::


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
Replaces all cries in tests with the Standard Unit Cry (Fletchling).
When not building tests, the `sha1sum` is unchanged.

## Things to note in the release changelog:
<!-- Add any important details for the release changelog. Must be structed as bullet points. --->
<!--- Remove this section if not applicable. --->
- All mon cries in tests now use a single shared cry

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara