### PR TITLE
fix: set printer type for AddTextPrinterParameterized6

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -1745,6 +1745,7 @@ void AddTextPrinterParameterized6(u8 windowId, u8 fontId, u8 left, u8 top, u8 le
     struct TextPrinterTemplate printer;
 
     printer.currentChar = str;
+    printer.type = WINDOW_TEXT_PRINTER;
     printer.windowId = windowId;
     printer.fontId = fontId;
     printer.x = left;


### PR DESCRIPTION
When the newly added `AddTextPrinterParameterized6` is ran, a bluescreen below occurs from the `errorf` in the `CopyGlyphToVRAM` function. The sprite printer equivalent of this function (`AddSpriteTextPrinterParameterized6`) does not have this issue. This PR fixes the error.

<img width="240" height="160" alt="pokeemerald-43" src="https://github.com/user-attachments/assets/17d423c0-7144-453f-83f1-c825bcfb5357" />

## Discord contact info
mudskipper13