### PR TITLE
Fixed Meteor Beam and Electro Shot being callable via Sleep Talk and Instruct

### DIFF
--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -18696,6 +18696,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
         .target = TARGET_SELECTED,
         .priority = 0,
         .category = DAMAGE_CATEGORY_SPECIAL,
+        .sleepTalkBanned = TRUE,
         .instructBanned = TRUE,
         .argument.twoTurnAttack = { .stringId = STRINGID_METEORBEAMCHARGING },
         .additionalEffects = ADDITIONAL_EFFECTS({
@@ -21109,6 +21110,8 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
         .target = TARGET_SELECTED,
         .priority = 0,
         .category = DAMAGE_CATEGORY_SPECIAL,
+        .sleepTalkBanned = TRUE,
+        .instructBanned = TRUE,
         .argument.twoTurnAttack = { .stringId = STRINGID_ELECTROSHOTCHARGING, .weather = B_WEATHER_RAIN },
         .additionalEffects = ADDITIONAL_EFFECTS({
             .moveEffect = MOVE_EFFECT_SP_ATK_PLUS_1,


### PR DESCRIPTION
Title. Found by Frankfurter.

## Description
See [Battle Mechanics Discussion message link](https://discordapp.com/channels/419213663107416084/1368163973366681712/1486511074927841423) for more info. Electro Shot and Meteor Beam are two-turn moves that are typically banned from being called by Sleep Talk and Instruct.

> Interesting, all moves with EFFECT_TWO_TURNS_ATTACK have sleepTalkBanned = TRUE and .instructBanned = TRUE except Meteor Beam (which is missing sleepTalkBanned but has instruct Banned) and Electro Shot (which has neither). Is this how they work in the real games, or do they need to be updated in our code?

## Issue(s) that this PR fixes

## Feature(s) this PR does NOT handle:

## Things to note in the release changelog:

## Discord contact info
linathan