### PR TITLE
Fallthrough instead break after ordering by speed

### DIFF
--- a/src/battle_switch_in.c
+++ b/src/battle_switch_in.c
@@ -36,7 +36,7 @@ bool32 DoSwitchInEvents(void)
         gBattleStruct->switchInBattlerCounter = 0;
         gBattleStruct->eventState.battlerSwitchIn = 0;
         gBattleStruct->eventState.switchIn++;
-        break;
+        // fallthrough
     case SWITCH_IN_EVENTS_TERA_SHIFT:
         while (gBattleStruct->switchInBattlerCounter < gBattlersCount)
         {


### PR DESCRIPTION
Breaking here is a waste. Just fallthrough.