### PR TITLE
Fixed `TryScriptEvolution`

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -2225,7 +2225,7 @@
 	setvar VAR_0x8000, \evoMethod
 	setvar VAR_0x8001, \canStopEvo
 	setvar VAR_0x8002, \tryMultiple
-	special TrySpecialScriptEvolution
+	special TryScriptEvolution
 	.endm
 
 	.macro ai_vs_ai_battle trainer1:req, trainer2:req
@@ -2649,7 +2649,7 @@
 	callnative DoFacilityTrainerBattle
 	.byte \facility
 	.endm
-	
+
 	.macro ingame_trade tradeId:req wantTradeMsg:req, declineTradeJump:req, wrongMonJump:req, tradeCompleteMsg:req
 	setvar VAR_0x8005, \tradeId
 	specialvar VAR_0x8009, GetInGameTradeSpeciesInfo

--- a/data/specials.inc
+++ b/data/specials.inc
@@ -541,7 +541,7 @@ gSpecials::
 	def_special RemoveRecordsWindow
 	def_special CloseDeptStoreElevatorWindow
 	def_special TrySetBattleTowerLinkType
-	def_special TrySpecialOverworldEvo
+	def_special TryScriptEvolution
 	def_special GetNumberSprayStrength
 	def_special GetSprayId
 	def_special GetLastUsedSprayType

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -6933,13 +6933,13 @@ void TryScriptEvolution(void)
             if (tryMultiple)
                 gCB2_AfterEvolution = TryScriptEvolution;
             else
-                gCB2_AfterEvolution = CB2_ReturnToField;
+                gCB2_AfterEvolution = CB2_ReturnToFieldContinueScriptPlayMapMusic;
             return;
         }
     }
 
     sTriedEvolving = 0;
-    SetMainCallback2(CB2_ReturnToField);
+    SetMainCallback2(CB2_ReturnToFieldContinueScriptPlayMapMusic);
 }
 
 void TrySpecialOverworldEvo(void)


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
Also fixed it not allowing for the calling script to continue.

Script used for testing:
```
DemoCave1F_GalarianYamask_Trigger::
	lockall
	tryspecialevo 0
	waitstate
	checkspecies SPECIES_YAMASK_GALAR
	goto_if_eq VAR_RESULT, TRUE, DemoCave1F_GalarianYamask_Trigger_StillYamask
	releaseall
	end

DemoCave1F_GalarianYamask_Trigger_StillYamask::
	msgbox DemoCave1F_Text_GalarianYamask_StillYamask
	release
	end

DemoCave1F_Text_GalarianYamask_StillYamask::
	.string "If your Galarian Yamask didn't evolve,\n"
	.string "it may haven't gotten 49 damage,\l"
	.string "or maybe you pressed B to cancel.$"
```

## Media
Before vs after
![mGBA_KWF7PVVdAF](https://github.com/user-attachments/assets/2ffe1fe5-3a84-4220-b0e4-b185db5f6a41) ![mGBA_nkYHfl9rSL](https://github.com/user-attachments/assets/b3ce38be-4184-4dd0-99d9-b9dc3aaecd5c)

## Issue(s) that this PR fixes
Fixes #9646

## Discord contact info
AsparagusEduardo
