### PR TITLE
Fix timing and structure of Apricorn Tree messages

### DIFF
--- a/data/scripts/apricorn_tree.inc
+++ b/data/scripts/apricorn_tree.inc
@@ -3,6 +3,7 @@ ApricornTreeScript::
 	faceplayer
 	message ApricornTree_Text_Intro
 	waitmessage
+	waitbuttonpress
 	special ObjectEventInteractionGetApricornTreeData
 	goto_if_gt VAR_0x8005, 0, ApricornTree_EventScript_WantToPick
 	message ApricornTree_Text_Empty
@@ -66,8 +67,8 @@ ApricornTree_Text_Empty:
 	.string "There are no Apricorns…$"
 
 ApricornTree_Text_WantToPick:
-	.string "…It's {STR_VAR_2} {STR_VAR_1}!\p"
-	.string "Do you want to pick the\n"
+	.string "…It's {STR_VAR_2} {STR_VAR_1}!\n"
+	.string "Do you want to pick the\l"
 	.string "{STR_VAR_1}?$"
 
 ApricornTree_Text_PickedTheApricorn:
@@ -81,9 +82,9 @@ ApricornTree_Text_PutAwayApricorn:
 
 ApricornTree_Text_PocketFull:
 	.string "The BAG's {STR_VAR_3} POCKET is full.\p"
-	.string "{PLAYER} gave up on the\p"
+	.string "{PLAYER} gave up on the\n"
 	.string "{STR_VAR_1}…$"
 
 ApricornTree_Text_ApricornLeftUnpicked:
-	.string "{PLAYER} gave up on the\p"
+	.string "{PLAYER} gave up on the\n"
 	.string "{STR_VAR_1}…$"


### PR DESCRIPTION
## Description
Adjusts the textboxes for the default apricorn tree implementation.
The first text box was not awaiting a button press, so
> It's an Apricorn Tree!
was immediately replaced with the description of what's on it.

Also the text boxes were using paragraph breaks in weird places, resulting in full paragraph breaks before the item name.

## Media
![apricorn-tree](https://github.com/user-attachments/assets/fc701572-dad9-49eb-aa24-efbcbbe75e4a)

Ignore the changed tree sprite, this is a clip from my personal project. The text is as in this PR though.
That's why it says "Berries" in non-upper-case too. Getting a clean start and placing apricorn trees somehwere to test a bit too much hassle, when I already had them in my hack to test with.

## Discord contact info
blusunrize