### PR TITLE
Fixed debug warping allowing player movement in the middle of warp

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -1578,6 +1578,7 @@ static void DebugAction_Util_Warp_SelectWarp(u8 taskId)
         DoWarp();
         ResetInitialPlayerAvatarState();
         DebugAction_DestroyExtraWindow(taskId);
+        ScriptContext_Stop();
     }
     else if (JOY_NEW(B_BUTTON))
     {


### PR DESCRIPTION
Title.

## Description
Previously, it was possible for the player to move while a warp was occurring via debug warping. The implementation adds in a step mimicking `waitstate` to prevent player movement while the warp is happening.

## Issue(s) that this PR fixes
Fixes #9648

## Discord contact info
linathan