### PR TITLE
BattleCalcValues usage and rename BattleContext back to DamageContext

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -105,7 +105,8 @@ struct SpecialStatus
     u8 neutralizingGasRemoved:1;
     u8 berryReduced:1;
     u8 mindBlownRecoil:1;
-    u8 padding:2;
+    u8 updateStallMons:1;
+    u8 padding:1;
     // End of byte
     u8 statLowered:1;
     u8 abilityRedirected:1;

--- a/include/battle_ai_util.h
+++ b/include/battle_ai_util.h
@@ -167,7 +167,7 @@ u32 CountNegativeStatStages(enum BattlerId battlerId);
 
 // move checks
 bool32 Ai_IsPriorityBlocked(enum BattlerId battlerAtk, enum BattlerId battlerDef, enum Move move, struct AiLogicData *aiData);
-bool32 AI_CanMoveBeBlockedByTarget(struct BattleContext *ctx);
+bool32 AI_CanMoveBeBlockedByTarget(struct DamageContext *ctx);
 bool32 MovesWithCategoryUnusable(u32 attacker, u32 target, enum DamageCategory category);
 enum MoveComparisonResult CompareMoveEffects(enum Move move1, enum Move move2, enum BattlerId battlerAtk, enum BattlerId battlerDef, s32 noOfHitsToKo);
 struct SimulatedDamage AI_CalcDamageSaveBattlers(enum Move move, enum BattlerId battlerAtk, enum BattlerId battlerDef, uq4_12_t *typeEffectiveness, enum AIConsiderGimmick considerGimmickAtk, enum AIConsiderGimmick considerGimmickDef);

--- a/include/battle_terastal.h
+++ b/include/battle_terastal.h
@@ -7,7 +7,7 @@ bool32 CanTerastallize(enum BattlerId battler);
 enum Type GetBattlerTeraType(enum BattlerId battler);
 void ExpendTypeStellarBoost(enum BattlerId battler, enum Type type);
 bool32 IsTypeStellarBoosted(enum BattlerId battler, enum Type type);
-uq4_12_t GetTeraMultiplier(struct BattleContext *ctx);
+uq4_12_t GetTeraMultiplier(struct DamageContext *ctx);
 
 u16 GetTeraTypeRGB(enum Type type);
 

--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -92,7 +92,7 @@ enum ImmunityHealStatusOutcome
     IMMUNITY_TAUNT_CLEARED,
 };
 
-struct BattleContext
+struct DamageContext
 {
     enum BattlerId battlerAtk:3;
     enum BattlerId battlerDef:3;
@@ -201,10 +201,10 @@ void TryClearRageAndFuryCutter(void);
 bool32 HasNoMonsToSwitch(enum BattlerId battler, u8 partyIdBattlerOn1, u8 partyIdBattlerOn2);
 bool32 TryChangeBattleWeather(enum BattlerId battler, u32 battleWeatherId, enum Ability ability);
 bool32 TryChangeBattleTerrain(enum BattlerId battler, u32 statusFlag);
-bool32 CanTargetBlockPranksterMove(struct BattleContext *ctx, s32 movePriority);
-bool32 CanPsychicTerrainProtectTarget(struct BattleContext *ctx, s32 movePriority);
-bool32 CanMoveBeBlockedByTarget(struct BattleContext *ctx, s32 movePriority);
-bool32 CanAbilityAbsorbMove(struct BattleContext *ctx);
+bool32 CanTargetBlockPranksterMove(struct DamageContext *ctx, s32 movePriority);
+bool32 CanPsychicTerrainProtectTarget(struct DamageContext *ctx, s32 movePriority);
+bool32 CanMoveBeBlockedByTarget(struct DamageContext *ctx, s32 movePriority);
+bool32 CanAbilityAbsorbMove(struct DamageContext *ctx);
 bool32 TryFieldEffects(enum FieldEffectCases caseId);
 u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum Ability ability, enum Move move, bool32 shouldAbilityTrigger);
 bool32 TryPrimalReversion(enum BattlerId battler);
@@ -219,7 +219,7 @@ u32 IsAbilityOnOpposingSide(enum BattlerId battler, enum Ability ability);
 u32 IsAbilityOnField(enum Ability ability);
 u32 IsAbilityOnFieldExcept(enum BattlerId battler, enum Ability ability);
 u32 IsAbilityPreventingEscape(enum BattlerId battler);
-bool32 IsBattlerProtected(struct BattleContext *ctx);
+bool32 IsBattlerProtected(struct BattleCalcValues *cv);
 enum ProtectType GetProtectType(enum ProtectMethod method);
 bool32 CanBattlerEscape(enum BattlerId battler); // no ability check
 void BattleScriptExecute(const u8 *BS_ptr);
@@ -239,13 +239,13 @@ bool32 IsMoveMakingContact(enum BattlerId battlerAtk, enum BattlerId battlerDef,
 bool32 IsBattlerGrounded(enum BattlerId battler, enum Ability ability, enum HoldEffect holdEffect);
 u32 GetMoveSlot(u16 *moves, enum Move move);
 u32 GetBattlerWeight(enum BattlerId battler);
-s32 CalcCritChanceStage(struct BattleContext *ctx);
-s32 CalcCritChanceStageGen1(struct BattleContext *ctx);
-s32 CalculateMoveDamage(struct BattleContext *ctx);
-s32 CalculateMoveDamageVars(struct BattleContext *ctx);
-s32 DoFixedDamageMoveCalc(struct BattleContext *ctx);
-s32 ApplyModifiersAfterDmgRoll(struct BattleContext *ctx, s32 dmg);
-uq4_12_t CalcTypeEffectivenessMultiplier(struct BattleContext *ctx);
+s32 CalcCritChanceStage(struct DamageContext *ctx);
+s32 CalcCritChanceStageGen1(struct DamageContext *ctx);
+s32 CalculateMoveDamage(struct DamageContext *ctx);
+s32 CalculateMoveDamageVars(struct DamageContext *ctx);
+s32 DoFixedDamageMoveCalc(struct DamageContext *ctx);
+s32 ApplyModifiersAfterDmgRoll(struct DamageContext *ctx, s32 dmg);
+uq4_12_t CalcTypeEffectivenessMultiplier(struct DamageContext *ctx);
 uq4_12_t CalcPartyMonTypeEffectivenessMultiplier(enum Move move, enum Species speciesDef, enum Ability abilityDef);
 uq4_12_t GetTypeModifier(enum Type atkType, enum Type defType);
 uq4_12_t GetOverworldTypeEffectiveness(struct Pokemon *mon, enum Type moveType);
@@ -365,7 +365,6 @@ bool32 HasWeatherEffect(void);
 bool32 IsFutureSightAttackerInParty(enum BattlerId battlerAtk, enum BattlerId battlerDef, enum Move move);
 bool32 HadMoreThanHalfHpNowDoesnt(enum BattlerId battler);
 void ChooseStatBoostAnimation(enum BattlerId battler);
-void UpdateStallMons(void);
 bool32 TrySwitchInEjectPack(enum EjectPackTiming timing);
 bool32 EmergencyExitCanBeTriggered(enum BattlerId battler);
 bool32 TryTriggerSymbiosis(enum BattlerId battler, u32 ally);

--- a/include/constants/battle_move_resolution.h
+++ b/include/constants/battle_move_resolution.h
@@ -14,8 +14,8 @@ enum Obedience
 enum CancelerResult
 {
     CANCELER_RESULT_SUCCESS,
-    CANCELER_RESULT_BREAK, // Runs script. Increments state
-    CANCELER_RESULT_PAUSE, // Runs script. Does not increment state
+    CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT, // Runs script. Increments state
+    CANCELER_RESULT_RUN_SCRIPT, // Runs script. Does not increment state
     CANCELER_RESULT_FAILURE, // Move failed, jump to script that handles the failure
 };
 

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -812,7 +812,7 @@ static u32 PpStallReduction(enum Move move, enum BattlerId battlerAtk)
     u32 totalStallValue = 0;
     u32 returnValue = 0;
     struct BattlePokemon backupBattleMon;
-    struct BattleContext ctx = {0};
+    struct DamageContext ctx = {0};
     ctx.battlerAtk = battlerAtk;
     ctx.abilityAtk = gAiLogicData->abilities[battlerAtk];
     ctx.move = ctx.chosenMove = move;
@@ -1299,7 +1299,7 @@ static s32 AI_CheckBadMove(enum BattlerId battlerAtk, enum BattlerId battlerDef,
         if (Ai_IsPriorityBlocked(battlerAtk, battlerDef, move, aiData))
             RETURN_SCORE_MINUS(20);
 
-        struct BattleContext ctx = {0};
+        struct DamageContext ctx = {0};
         ctx.battlerAtk = battlerAtk;
         ctx.battlerDef = battlerDef;
         ctx.move = ctx.chosenMove = move;

--- a/src/battle_ai_switch.c
+++ b/src/battle_ai_switch.c
@@ -495,7 +495,7 @@ static u32 FindMonWithMoveOfEffectiveness(enum BattlerId battler, enum BattlerId
     return FALSE; // There is not a single Pokémon in the party that has a move with this effectiveness threshold
 }
 
-static bool32 CanMoveAffectTarget(struct BattleContext *ctx, u32 moveIndex)
+static bool32 CanMoveAffectTarget(struct DamageContext *ctx, u32 moveIndex)
 {
     if (ctx->move != MOVE_NONE
         && gAiLogicData->effectiveness[ctx->battlerAtk][ctx->battlerDef][moveIndex] > UQ_4_12(0.0)
@@ -504,7 +504,7 @@ static bool32 CanMoveAffectTarget(struct BattleContext *ctx, u32 moveIndex)
     return FALSE;
 }
 
-static bool32 IsMoveBad(struct BattleContext *ctx, u32 moveIndex)
+static bool32 IsMoveBad(struct DamageContext *ctx, u32 moveIndex)
 {
     if (CanMoveAffectTarget(ctx, moveIndex))
         return FALSE;
@@ -516,7 +516,7 @@ static bool32 IsMoveBad(struct BattleContext *ctx, u32 moveIndex)
 static bool32 ShouldSwitchIfAllMovesBad(enum BattlerId battler, enum BattlerId battlerIn1, enum BattlerId battlerIn2)
 {
     enum BattlerId opposingBattler = GetOppositeBattler(battler);
-    struct BattleContext ctx = {0};
+    struct DamageContext ctx = {0};
     ctx.battlerAtk = battler;
     ctx.battlerDef = opposingBattler;
     ctx.abilityAtk = gAiLogicData->abilities[ctx.battlerAtk];
@@ -914,7 +914,7 @@ static bool32 GetHitEscapeTransformState(enum BattlerId battlerAtk, enum Move mo
      || (moveType == TYPE_FIRE && (AI_GetWeather() & B_WEATHER_RAIN_PRIMAL)))
         return FALSE;
 
-    struct BattleContext ctx = {0};
+    struct DamageContext ctx = {0};
     ctx.aiCalc = TRUE;
     ctx.battlerAtk = battlerAtk;
     ctx.move = ctx.chosenMove = move;
@@ -1304,7 +1304,7 @@ static bool32 ShouldSwitchIfBadChoiceLock(enum BattlerId battler)
     enum Move choicedMove = gBattleStruct->choicedMove[battler];
     enum BattlerId opposingBattler = GetOppositeBattler(battler);
 
-    struct BattleContext ctx = {0};
+    struct DamageContext ctx = {0};
     ctx.battlerAtk = battler;
     ctx.battlerDef = opposingBattler;
     ctx.move = ctx.chosenMove = choicedMove;

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -543,7 +543,7 @@ bool32 Ai_IsPriorityBlocked(enum BattlerId battlerAtk, enum BattlerId battlerDef
     return FALSE;
 }
 
-bool32 AI_CanMoveBeBlockedByTarget(struct BattleContext *ctx)
+bool32 AI_CanMoveBeBlockedByTarget(struct DamageContext *ctx)
 {
     return CanMoveBeBlockedByTarget(ctx, GetBattleMovePriority(ctx->battlerAtk, ctx->abilityAtk, ctx->move));
 }
@@ -556,7 +556,7 @@ bool32 MovesWithCategoryUnusable(u32 attacker, u32 target, enum DamageCategory c
     enum Move *moves = GetMovesArray(attacker);
     u32 moveLimitations = gAiLogicData->moveLimitations[attacker];
 
-    struct BattleContext ctx = {0};
+    struct DamageContext ctx = {0};
     ctx.battlerAtk = attacker;
     ctx.battlerDef = target;
     ctx.updateFlags = FALSE;
@@ -628,7 +628,7 @@ static __attribute__((noinline)) ARM_FUNC s32 RandomRollDmg(s32 dmg)
     return dmg;
 }
 
-bool32 IsDamageMoveUnusable(struct BattleContext *ctx)
+bool32 IsDamageMoveUnusable(struct DamageContext *ctx)
 {
     enum Ability battlerDefAbility;
     enum Ability partnerDefAbility;
@@ -758,7 +758,7 @@ static inline void AI_RestoreBattlerTypes(enum BattlerId battlerAtk, enum Type *
     gBattleMons[battlerAtk].types[2] = types[2];
 }
 
-static inline void CalcDynamicMoveDamage(struct BattleContext *ctx, u16 *medianDamage, u16 *minimumDamage, u16 *maximumDamage, u16 *randomDamage)
+static inline void CalcDynamicMoveDamage(struct DamageContext *ctx, u16 *medianDamage, u16 *minimumDamage, u16 *maximumDamage, u16 *randomDamage)
 {
     enum BattleMoveEffects effect = GetMoveEffect(ctx->move);
     u16 median = *medianDamage;
@@ -845,7 +845,7 @@ static inline void CalcDynamicMoveDamage(struct BattleContext *ctx, u16 *medianD
     *randomDamage = random;
 }
 
-static inline bool32 ShouldCalcCritDamage(struct BattleContext *ctx)
+static inline bool32 ShouldCalcCritDamage(struct DamageContext *ctx)
 {
     s32 critChanceIndex = 0;
 
@@ -869,7 +869,7 @@ static inline bool32 ShouldCalcCritDamage(struct BattleContext *ctx)
     return FALSE;
 }
 
-static s32 HandleKOThroughBerryReduction(struct BattleContext *ctx, s32 dmg)
+static s32 HandleKOThroughBerryReduction(struct DamageContext *ctx, s32 dmg)
 {
     if (ctx->aiCheckBerryModifier) // Only set if AI running calcs
     {
@@ -895,7 +895,7 @@ static s32 HandleKOThroughBerryReduction(struct BattleContext *ctx, s32 dmg)
     return dmg;
 }
 
-static s32 AI_ApplyModifiersAfterDmgRoll(struct BattleContext *ctx, s32 dmg)
+static s32 AI_ApplyModifiersAfterDmgRoll(struct DamageContext *ctx, s32 dmg)
 {
     dmg = ApplyModifiersAfterDmgRoll(ctx, dmg);
     dmg = HandleKOThroughBerryReduction(ctx, dmg);
@@ -940,7 +940,7 @@ struct SimulatedDamage AI_CalcDamage(enum Move move, enum BattlerId battlerAtk, 
     gBattleStruct->magnitudeBasePower = 70;
     gBattleStruct->presentBasePower = 80;
 
-    struct BattleContext ctx = {0};
+    struct DamageContext ctx = {0};
     ctx.aiCalc = TRUE;
     ctx.aiCheckBerryModifier = FALSE;
     ctx.battlerAtk = battlerAtk;
@@ -1445,7 +1445,7 @@ uq4_12_t AI_GetMoveEffectiveness(enum Move move, enum BattlerId battlerAtk, enum
 
     gBattleStruct->dynamicMoveType = 0;
     SetTypeBeforeUsingMove(move, battlerAtk);
-    struct BattleContext ctx = {0};
+    struct DamageContext ctx = {0};
     ctx.battlerAtk = battlerAtk;
     ctx.battlerDef = battlerDef;
     ctx.move = ctx.chosenMove = move;

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -2409,7 +2409,7 @@ static bool32 ShouldShowTypeEffectiveness(u32 targetId)
 static u32 CheckTypeEffectiveness(enum BattlerId battlerAtk, enum BattlerId battlerDef)
 {
     struct ChooseMoveStruct *moveInfo = (struct ChooseMoveStruct *)(&gBattleResources->bufferA[battlerAtk][4]);
-    struct BattleContext ctx = {0};
+    struct DamageContext ctx = {0};
     ctx.battlerAtk = battlerAtk;
     ctx.battlerDef = battlerDef;
     ctx.move = moveInfo->moves[gMoveSelectionCursor[battlerAtk]];

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -18,11 +18,12 @@ static void SetSameMoveTurnValues(enum BattleMoveEffects moveEffect);
 static void TryClearChargeVolatile(enum Type moveType);
 static inline bool32 IsBattlerUsingBeakBlast(enum BattlerId battler);
 static void RequestNonVolatileChange(enum BattlerId battlerAtk);
-static bool32 CanBattlerBounceBackMove(struct BattleContext *ctx);
-static bool32 TryMagicBounce(struct BattleContext *ctx);
-static bool32 TryMagicCoat(struct BattleContext *ctx);
+static bool32 CanBattlerBounceBackMove(struct BattleCalcValues *cv);
+static bool32 TryMagicBounce(struct BattleCalcValues *cv);
+static bool32 TryMagicCoat(struct BattleCalcValues *cv);
 static bool32 TryActivatePowderStatus(enum Move move);
 static void CalculateMagnitudeDamage(void);
+static void UpdateStallMons(void);
 
 // Submoves
 static enum Move GetMirrorMoveMove(void);
@@ -36,10 +37,10 @@ static enum Move GetMeFirstMove(void);
 // Attackcanceler
 // ==============
 
-static enum CancelerResult CancelerClearFlags(struct BattleContext *ctx)
+static enum CancelerResult CancelerClearFlags(struct BattleCalcValues *cv)
 {
-    gBattleMons[ctx->battlerAtk].volatiles.grudge = FALSE;
-    gBattleMons[ctx->battlerAtk].volatiles.glaiveRush = FALSE;
+    gBattleMons[cv->battlerAtk].volatiles.grudge = FALSE;
+    gBattleMons[cv->battlerAtk].volatiles.glaiveRush = FALSE;
     gBattleStruct->eventState.atkCancelerBattler = 0;
     return CANCELER_RESULT_SUCCESS;
 }
@@ -58,17 +59,17 @@ static bool32 TryFormChangeBeforeMove(void)
     return FALSE;
 }
 
-static enum CancelerResult CancelerStanceChangeOne(struct BattleContext *ctx)
+static enum CancelerResult CancelerStanceChangeOne(struct BattleCalcValues *cv)
 {
-    if (B_STANCE_CHANGE_FAIL < GEN_7 && ctx->chosenMove == ctx->move && TryFormChangeBeforeMove())
-        return CANCELER_RESULT_BREAK;
+    if (B_STANCE_CHANGE_FAIL < GEN_7 && gChosenMove == cv->move && TryFormChangeBeforeMove())
+        return CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerSkyDrop(struct BattleContext *ctx)
+static enum CancelerResult CancelerSkyDrop(struct BattleCalcValues *cv)
 {
     // If Pokemon is being held in Sky Drop
-    if (gBattleMons[ctx->battlerAtk].volatiles.semiInvulnerable == STATE_SKY_DROP_TARGET)
+    if (gBattleMons[cv->battlerAtk].volatiles.semiInvulnerable == STATE_SKY_DROP_TARGET)
     {
         gBattlescriptCurrInstr = BattleScript_MoveEnd;
         return CANCELER_RESULT_FAILURE;
@@ -76,23 +77,23 @@ static enum CancelerResult CancelerSkyDrop(struct BattleContext *ctx)
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerRecharge(struct BattleContext *ctx)
+static enum CancelerResult CancelerRecharge(struct BattleCalcValues *cv)
 {
-    if (gBattleMons[ctx->battlerAtk].volatiles.rechargeTimer > 0)
+    if (gBattleMons[cv->battlerAtk].volatiles.rechargeTimer > 0)
     {
-        CancelMultiTurnMoves(ctx->battlerAtk);
+        CancelMultiTurnMoves(cv->battlerAtk);
         gBattlescriptCurrInstr = BattleScript_MoveUsedMustRecharge;
         return CANCELER_RESULT_FAILURE;
     }
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerChillyReception(struct BattleContext *ctx)
+static enum CancelerResult CancelerChillyReception(struct BattleCalcValues *cv)
 {
-    if (GetMoveEffect(ctx->move) == EFFECT_WEATHER_AND_SWITCH)
+    if (GetMoveEffect(cv->move) == EFFECT_WEATHER_AND_SWITCH)
     {
         BattleScriptCall(BattleScript_ChillyReceptionMessage);
-        return CANCELER_RESULT_BREAK;
+        return CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
     }
     return CANCELER_RESULT_SUCCESS;
 }
@@ -104,46 +105,46 @@ static void DefrostBattler(enum BattlerId battler, u32 status)
     RequestNonVolatileChange(battler);
 }
 
-static enum CancelerResult CancelerAsleepOrFrozen(struct BattleContext *ctx)
+static enum CancelerResult CancelerAsleepOrFrozen(struct BattleCalcValues *cv)
 {
-    enum CancelerResult result = CANCELER_RESULT_BREAK;
+    enum CancelerResult result = CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
 
-    if (gBattleMons[ctx->battlerAtk].status1 & STATUS1_SLEEP)
+    if (gBattleMons[cv->battlerAtk].status1 & STATUS1_SLEEP)
     {
-        if (UproarWakeUpCheck(ctx->battlerAtk))
+        if (UproarWakeUpCheck(cv->battlerAtk))
         {
-            TryDeactivateSleepClause(GetBattlerSide(ctx->battlerAtk), gBattlerPartyIndexes[ctx->battlerAtk]);
-            gBattleMons[ctx->battlerAtk].status1 &= ~STATUS1_SLEEP;
-            gBattleMons[ctx->battlerAtk].volatiles.nightmare = FALSE;
-            gEffectBattler = ctx->battlerAtk;
+            TryDeactivateSleepClause(GetBattlerSide(cv->battlerAtk), gBattlerPartyIndexes[cv->battlerAtk]);
+            gBattleMons[cv->battlerAtk].status1 &= ~STATUS1_SLEEP;
+            gBattleMons[cv->battlerAtk].volatiles.nightmare = FALSE;
+            gEffectBattler = cv->battlerAtk;
             gBattleCommunication[MULTISTRING_CHOOSER] = B_MSG_WOKE_UP_UPROAR;
-            result = CANCELER_RESULT_BREAK;
+            result = CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
             BattleScriptCall(BattleScript_MoveUsedWokeUp);
         }
         else
         {
             u32 toSub;
-            if (IsAbilityAndRecord(ctx->battlerAtk, ctx->abilityAtk, ABILITY_EARLY_BIRD))
+            if (IsAbilityAndRecord(cv->battlerAtk, cv->abilities[cv->battlerAtk], ABILITY_EARLY_BIRD))
                 toSub = 2;
             else
                 toSub = 1;
 
-            if ((gBattleMons[ctx->battlerAtk].status1 & STATUS1_SLEEP) < toSub)
-                gBattleMons[ctx->battlerAtk].status1 &= ~STATUS1_SLEEP;
+            if ((gBattleMons[cv->battlerAtk].status1 & STATUS1_SLEEP) < toSub)
+                gBattleMons[cv->battlerAtk].status1 &= ~STATUS1_SLEEP;
             else
-                gBattleMons[ctx->battlerAtk].status1 -= toSub;
+                gBattleMons[cv->battlerAtk].status1 -= toSub;
 
-            if (gBattleMons[ctx->battlerAtk].status1 & STATUS1_SLEEP)
+            if (gBattleMons[cv->battlerAtk].status1 & STATUS1_SLEEP)
             {
-                enum BattleMoveEffects moveEffect = GetMoveEffect(ctx->move);
+                enum BattleMoveEffects moveEffect = GetMoveEffect(cv->move);
                 if (moveEffect == EFFECT_SNORE)
                 {
                     BattleScriptCall(BattleScript_BeforeSnoreMessage);
-                    result = CANCELER_RESULT_BREAK;
+                    result = CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
                 }
                 else if (moveEffect == EFFECT_SLEEP_TALK)
                 {
-                    result = CANCELER_RESULT_BREAK;
+                    result = CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
                 }
                 else
                 {
@@ -153,16 +154,16 @@ static enum CancelerResult CancelerAsleepOrFrozen(struct BattleContext *ctx)
             }
             else
             {
-                TryDeactivateSleepClause(GetBattlerSide(ctx->battlerAtk), gBattlerPartyIndexes[ctx->battlerAtk]);
-                gBattleMons[ctx->battlerAtk].volatiles.nightmare = FALSE;
+                TryDeactivateSleepClause(GetBattlerSide(cv->battlerAtk), gBattlerPartyIndexes[cv->battlerAtk]);
+                gBattleMons[cv->battlerAtk].volatiles.nightmare = FALSE;
                 gBattleCommunication[MULTISTRING_CHOOSER] = B_MSG_WOKE_UP;
-                result = CANCELER_RESULT_BREAK;
+                result = CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
                 BattleScriptCall(BattleScript_MoveUsedWokeUp);
             }
         }
-        RequestNonVolatileChange(ctx->battlerAtk);
+        RequestNonVolatileChange(cv->battlerAtk);
     }
-    else if (gBattleMons[ctx->battlerAtk].status1 & STATUS1_FREEZE && !MoveThawsUser(ctx->move))
+    else if (gBattleMons[cv->battlerAtk].status1 & STATUS1_FREEZE && !MoveThawsUser(cv->move))
     {
         if (!RandomPercentage(RNG_FROZEN, 20))
         {
@@ -171,8 +172,8 @@ static enum CancelerResult CancelerAsleepOrFrozen(struct BattleContext *ctx)
         }
         else // unfreeze
         {
-            DefrostBattler(ctx->battlerAtk, STATUS1_FREEZE);
-            result = CANCELER_RESULT_BREAK;
+            DefrostBattler(cv->battlerAtk, STATUS1_FREEZE);
+            result = CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
             BattleScriptCall(BattleScript_BattlerDefrosted);
             gBattleCommunication[MULTISTRING_CHOOSER] = B_MSG_DEFROSTED;
         }
@@ -181,9 +182,9 @@ static enum CancelerResult CancelerAsleepOrFrozen(struct BattleContext *ctx)
     return result;
 }
 
-static enum CancelerResult CancelerObedience(struct BattleContext *ctx)
+static enum CancelerResult CancelerObedience(struct BattleCalcValues *cv)
 {
-    if (!gBattleMons[ctx->battlerAtk].volatiles.multipleTurns)
+    if (!gBattleMons[cv->battlerAtk].volatiles.multipleTurns)
     {
         enum Obedience obedienceResult = GetAttackerObedienceForAction();
         switch (obedienceResult)
@@ -195,12 +196,12 @@ static enum CancelerResult CancelerObedience(struct BattleContext *ctx)
             // B_MSG_LOAFING, B_MSG_WONT_OBEY, B_MSG_TURNED_AWAY, or B_MSG_PRETEND_NOT_NOTICE
             gBattleCommunication[MULTISTRING_CHOOSER] = MOD(Random(), NUM_LOAF_STRINGS);
             gBattlescriptCurrInstr = BattleScript_MoveUsedLoafingAround;
-            gBattleStruct->moveResultFlags[ctx->battlerDef] |= MOVE_RESULT_MISSED;
+            gBattleStruct->moveResultFlags[cv->battlerDef] |= MOVE_RESULT_MISSED;
             return CANCELER_RESULT_FAILURE;
         case DISOBEYS_HITS_SELF:
-            gBattlerTarget = ctx->battlerAtk;
-            struct BattleContext dmgCtx = {0};
-            dmgCtx.battlerAtk = dmgCtx.battlerDef = ctx->battlerAtk;
+            gBattlerTarget = cv->battlerAtk;
+            struct DamageContext dmgCtx = {0};
+            dmgCtx.battlerAtk = dmgCtx.battlerDef = cv->battlerAtk;
             dmgCtx.move = dmgCtx.chosenMove = MOVE_NONE;
             dmgCtx.moveType = TYPE_MYSTERY;
             dmgCtx.isCrit = FALSE;
@@ -208,177 +209,177 @@ static enum CancelerResult CancelerObedience(struct BattleContext *ctx)
             dmgCtx.updateFlags = TRUE;
             dmgCtx.isSelfInflicted = TRUE;
             dmgCtx.fixedBasePower = 40;
-            gBattleStruct->moveDamage[ctx->battlerAtk] = CalculateMoveDamage(&dmgCtx);
+            gBattleStruct->moveDamage[cv->battlerAtk] = CalculateMoveDamage(&dmgCtx);
             gBattlescriptCurrInstr = BattleScript_IgnoresAndHitsItself;
             return CANCELER_RESULT_FAILURE; // Move doesn't fail but mon hits itself
         case DISOBEYS_FALL_ASLEEP:
             if (IsSleepClauseEnabled())
-                gBattleStruct->battlerState[ctx->battlerAtk].sleepClauseEffectExempt = TRUE;
+                gBattleStruct->battlerState[cv->battlerAtk].sleepClauseEffectExempt = TRUE;
             gBattlescriptCurrInstr = BattleScript_IgnoresAndFallsAsleep;
-            gBattleStruct->moveResultFlags[ctx->battlerDef] |= MOVE_RESULT_MISSED;
+            gBattleStruct->moveResultFlags[cv->battlerDef] |= MOVE_RESULT_MISSED;
             return CANCELER_RESULT_FAILURE;
             break;
         case DISOBEYS_WHILE_ASLEEP:
             gBattlescriptCurrInstr = BattleScript_IgnoresWhileAsleep;
-            gBattleStruct->moveResultFlags[ctx->battlerDef] |= MOVE_RESULT_MISSED;
+            gBattleStruct->moveResultFlags[cv->battlerDef] |= MOVE_RESULT_MISSED;
             return CANCELER_RESULT_FAILURE;
         case DISOBEYS_RANDOM_MOVE:
-            gCurrentMove = gCalledMove = gBattleMons[ctx->battlerAtk].moves[gCurrMovePos];
+            gCurrentMove = gCalledMove = gBattleMons[cv->battlerAtk].moves[gCurrMovePos];
             BattleScriptCall(BattleScript_IgnoresAndUsesRandomMove);
             gBattlerTarget = GetBattleMoveTarget(gCalledMove, TARGET_NONE);
-            return CANCELER_RESULT_BREAK;
+            return CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
         }
     }
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerPowerPoints(struct BattleContext *ctx)
+static enum CancelerResult CancelerPowerPoints(struct BattleCalcValues *cv)
 {
-    if (gBattleMons[ctx->battlerAtk].pp[gCurrMovePos] == 0
-     && ctx->move != MOVE_STRUGGLE
-     && !gSpecialStatuses[ctx->battlerAtk].dancerUsedMove
-     && !gBattleMons[ctx->battlerAtk].volatiles.multipleTurns)
+    if (gBattleMons[cv->battlerAtk].pp[gCurrMovePos] == 0
+     && cv->move != MOVE_STRUGGLE
+     && !gSpecialStatuses[cv->battlerAtk].dancerUsedMove
+     && !gBattleMons[cv->battlerAtk].volatiles.multipleTurns)
     {
         gBattlescriptCurrInstr = BattleScript_NoPPForMove;
-        gBattleStruct->moveResultFlags[ctx->battlerDef] |= MOVE_RESULT_MISSED;
+        gBattleStruct->moveResultFlags[cv->battlerDef] |= MOVE_RESULT_MISSED;
         return CANCELER_RESULT_FAILURE;
     }
 
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerTruant(struct BattleContext *ctx)
+static enum CancelerResult CancelerTruant(struct BattleCalcValues *cv)
 {
-    if (GetBattlerAbility(ctx->battlerAtk) == ABILITY_TRUANT && gBattleMons[ctx->battlerAtk].volatiles.truantCounter)
+    if (GetBattlerAbility(cv->battlerAtk) == ABILITY_TRUANT && gBattleMons[cv->battlerAtk].volatiles.truantCounter)
     {
-        CancelMultiTurnMoves(ctx->battlerAtk);
+        CancelMultiTurnMoves(cv->battlerAtk);
         gBattleCommunication[MULTISTRING_CHOOSER] = B_MSG_LOAFING;
-        gBattlerAbility = ctx->battlerAtk;
+        gBattlerAbility = cv->battlerAtk;
         gBattlescriptCurrInstr = BattleScript_TruantLoafingAround;
-        gBattleStruct->moveResultFlags[ctx->battlerDef] |= MOVE_RESULT_MISSED;
+        gBattleStruct->moveResultFlags[cv->battlerDef] |= MOVE_RESULT_MISSED;
         return CANCELER_RESULT_FAILURE;
     }
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerFocus(struct BattleContext *ctx)
+static enum CancelerResult CancelerFocus(struct BattleCalcValues *cv)
 {
     u32 focusPunchFailureConfig = GetConfig(B_FOCUS_PUNCH_FAILURE);
 
     // In Gens 3-4, only check if is using Focus Punch.
     // In Gens 5-6, only check if the chosen move is Focus Punch.
     // In Gens 7+, check if chose and is using Focus Punch.
-    if ((gProtectStructs[ctx->battlerAtk].physicalDmg || gProtectStructs[ctx->battlerAtk].specialDmg)
-     && (focusPunchFailureConfig < GEN_5 || GetMoveEffect(gChosenMoveByBattler[ctx->battlerAtk]) == EFFECT_FOCUS_PUNCH)
-     && (focusPunchFailureConfig == GEN_5 || focusPunchFailureConfig == GEN_6 || GetMoveEffect(ctx->move) == EFFECT_FOCUS_PUNCH)
-     && !gProtectStructs[ctx->battlerAtk].survivedOHKO)
+    if ((gProtectStructs[cv->battlerAtk].physicalDmg || gProtectStructs[cv->battlerAtk].specialDmg)
+     && (focusPunchFailureConfig < GEN_5 || GetMoveEffect(gChosenMoveByBattler[cv->battlerAtk]) == EFFECT_FOCUS_PUNCH)
+     && (focusPunchFailureConfig == GEN_5 || focusPunchFailureConfig == GEN_6 || GetMoveEffect(cv->move) == EFFECT_FOCUS_PUNCH)
+     && !gProtectStructs[cv->battlerAtk].survivedOHKO)
     {
-        CancelMultiTurnMoves(ctx->battlerAtk);
+        CancelMultiTurnMoves(cv->battlerAtk);
         gBattlescriptCurrInstr = BattleScript_FocusPunchLostFocus;
         return CANCELER_RESULT_FAILURE;
     }
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerFocusGen5(struct BattleContext *ctx)
+static enum CancelerResult CancelerFocusGen5(struct BattleCalcValues *cv)
 {
     if (GetConfig(B_FOCUS_PUNCH_FAILURE) >= GEN_5)
-        return CancelerFocus(ctx);
+        return CancelerFocus(cv);
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerFlinch(struct BattleContext *ctx)
+static enum CancelerResult CancelerFlinch(struct BattleCalcValues *cv)
 {
-    if (gBattleMons[ctx->battlerAtk].volatiles.flinched)
+    if (gBattleMons[cv->battlerAtk].volatiles.flinched)
     {
-        CancelMultiTurnMoves(ctx->battlerAtk);
+        CancelMultiTurnMoves(cv->battlerAtk);
         gBattlescriptCurrInstr = BattleScript_MoveUsedFlinched;
         return CANCELER_RESULT_FAILURE;
     }
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerDisabled(struct BattleContext *ctx)
+static enum CancelerResult CancelerDisabled(struct BattleCalcValues *cv)
 {
-    if (GetActiveGimmick(ctx->battlerAtk) != GIMMICK_Z_MOVE
-     && gBattleMons[ctx->battlerAtk].volatiles.disabledMove == ctx->move
-     && gBattleMons[ctx->battlerAtk].volatiles.disabledMove != MOVE_NONE)
+    if (GetActiveGimmick(cv->battlerAtk) != GIMMICK_Z_MOVE
+     && gBattleMons[cv->battlerAtk].volatiles.disabledMove == cv->move
+     && gBattleMons[cv->battlerAtk].volatiles.disabledMove != MOVE_NONE)
     {
-        gBattleScripting.battler = ctx->battlerAtk;
-        CancelMultiTurnMoves(ctx->battlerAtk);
+        gBattleScripting.battler = cv->battlerAtk;
+        CancelMultiTurnMoves(cv->battlerAtk);
         gBattlescriptCurrInstr = BattleScript_MoveUsedIsDisabled;
         return CANCELER_RESULT_FAILURE;
     }
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerVolatileBlocked(struct BattleContext *ctx)
+static enum CancelerResult CancelerVolatileBlocked(struct BattleCalcValues *cv)
 {
-    if (GetActiveGimmick(ctx->battlerAtk) != GIMMICK_Z_MOVE
-     && gBattleMons[ctx->battlerAtk].volatiles.healBlock
-     && IsHealBlockPreventingMove(ctx->battlerAtk, ctx->move))
+    if (GetActiveGimmick(cv->battlerAtk) != GIMMICK_Z_MOVE
+     && gBattleMons[cv->battlerAtk].volatiles.healBlock
+     && IsHealBlockPreventingMove(cv->battlerAtk, cv->move))
     {
-        gBattleScripting.battler = ctx->battlerAtk;
-        CancelMultiTurnMoves(ctx->battlerAtk);
+        gBattleScripting.battler = cv->battlerAtk;
+        CancelMultiTurnMoves(cv->battlerAtk);
         gBattlescriptCurrInstr = BattleScript_MoveUsedHealBlockPrevents;
         return CANCELER_RESULT_FAILURE;
     }
-    else if (gFieldStatuses & STATUS_FIELD_GRAVITY && IsGravityPreventingMove(ctx->move))
+    else if (gFieldStatuses & STATUS_FIELD_GRAVITY && IsGravityPreventingMove(cv->move))
     {
-        gBattleScripting.battler = ctx->battlerAtk;
-        CancelMultiTurnMoves(ctx->battlerAtk);
+        gBattleScripting.battler = cv->battlerAtk;
+        CancelMultiTurnMoves(cv->battlerAtk);
         gBattlescriptCurrInstr = BattleScript_MoveUsedGravityPrevents;
         return CANCELER_RESULT_FAILURE;
     }
-    else if (GetActiveGimmick(ctx->battlerAtk) != GIMMICK_Z_MOVE && gBattleMons[ctx->battlerAtk].volatiles.throatChopTimer > 0 && IsSoundMove(ctx->move))
+    else if (GetActiveGimmick(cv->battlerAtk) != GIMMICK_Z_MOVE && gBattleMons[cv->battlerAtk].volatiles.throatChopTimer > 0 && IsSoundMove(cv->move))
     {
-        CancelMultiTurnMoves(ctx->battlerAtk);
+        CancelMultiTurnMoves(cv->battlerAtk);
         gBattlescriptCurrInstr = BattleScript_MoveUsedIsThroatChopPrevented;
         return CANCELER_RESULT_FAILURE;
     }
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerTaunted(struct BattleContext *ctx)
+static enum CancelerResult CancelerTaunted(struct BattleCalcValues *cv)
 {
-    if (GetActiveGimmick(ctx->battlerAtk) != GIMMICK_Z_MOVE
-     && gBattleMons[ctx->battlerAtk].volatiles.tauntTimer
-     && IsBattleMoveStatus(ctx->move)
-     && (GetConfig(B_TAUNT_ME_FIRST) < GEN_5 || GetMoveEffect(ctx->move) != EFFECT_ME_FIRST))
+    if (GetActiveGimmick(cv->battlerAtk) != GIMMICK_Z_MOVE
+     && gBattleMons[cv->battlerAtk].volatiles.tauntTimer
+     && IsBattleMoveStatus(cv->move)
+     && (GetConfig(B_TAUNT_ME_FIRST) < GEN_5 || GetMoveEffect(cv->move) != EFFECT_ME_FIRST))
     {
-        CancelMultiTurnMoves(ctx->battlerAtk);
+        CancelMultiTurnMoves(cv->battlerAtk);
         gBattlescriptCurrInstr = BattleScript_MoveUsedIsTaunted;
         return CANCELER_RESULT_FAILURE;
     }
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerImprisoned(struct BattleContext *ctx)
+static enum CancelerResult CancelerImprisoned(struct BattleCalcValues *cv)
 {
-    if (GetActiveGimmick(ctx->battlerAtk) != GIMMICK_Z_MOVE && GetImprisonedMovesCount(ctx->battlerAtk, ctx->move))
+    if (GetActiveGimmick(cv->battlerAtk) != GIMMICK_Z_MOVE && GetImprisonedMovesCount(cv->battlerAtk, cv->move))
     {
-        CancelMultiTurnMoves(ctx->battlerAtk);
+        CancelMultiTurnMoves(cv->battlerAtk);
         gBattlescriptCurrInstr = BattleScript_MoveUsedIsImprisoned;
         return CANCELER_RESULT_FAILURE;
     }
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerConfused(struct BattleContext *ctx)
+static enum CancelerResult CancelerConfused(struct BattleCalcValues *cv)
 {
-    if (gBattleMons[ctx->battlerAtk].volatiles.confusionTurns)
+    if (gBattleMons[cv->battlerAtk].volatiles.confusionTurns)
     {
-        if (!gBattleMons[ctx->battlerAtk].volatiles.infiniteConfusion)
-            gBattleMons[ctx->battlerAtk].volatiles.confusionTurns--;
-        if (gBattleMons[ctx->battlerAtk].volatiles.confusionTurns)
+        if (!gBattleMons[cv->battlerAtk].volatiles.infiniteConfusion)
+            gBattleMons[cv->battlerAtk].volatiles.confusionTurns--;
+        if (gBattleMons[cv->battlerAtk].volatiles.confusionTurns)
         {
              // confusion dmg
             if (RandomPercentage(RNG_CONFUSION, (GetConfig(B_CONFUSION_SELF_DMG_CHANCE) >= GEN_7 ? 33 : 50)))
             {
                 gBattleCommunication[MULTISTRING_CHOOSER] = TRUE;
                 gBattlerTarget = gBattlerAttacker;
-                struct BattleContext dmgCtx = {0};
-                dmgCtx.battlerAtk = dmgCtx.battlerDef = ctx->battlerAtk;
+                struct DamageContext dmgCtx = {0};
+                dmgCtx.battlerAtk = dmgCtx.battlerDef = cv->battlerAtk;
                 dmgCtx.move = dmgCtx.chosenMove = MOVE_NONE;
                 dmgCtx.moveType = TYPE_MYSTERY;
                 dmgCtx.isCrit = FALSE;
@@ -386,7 +387,7 @@ static enum CancelerResult CancelerConfused(struct BattleContext *ctx)
                 dmgCtx.updateFlags = TRUE;
                 dmgCtx.isSelfInflicted = TRUE;
                 dmgCtx.fixedBasePower = 40;
-                gBattleStruct->passiveHpUpdate[ctx->battlerAtk] = CalculateMoveDamage(&dmgCtx);
+                gBattleStruct->passiveHpUpdate[cv->battlerAtk] = CalculateMoveDamage(&dmgCtx);
                 gBattlescriptCurrInstr = BattleScript_MoveUsedIsConfused;
                 return CANCELER_RESULT_FAILURE;
             }
@@ -394,23 +395,23 @@ static enum CancelerResult CancelerConfused(struct BattleContext *ctx)
             {
                 gBattleCommunication[MULTISTRING_CHOOSER] = FALSE;
                 BattleScriptCall(BattleScript_MoveUsedIsConfused);
-                return CANCELER_RESULT_BREAK;
+                return CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
             }
         }
         else // snapped out of confusion
         {
             BattleScriptCall(BattleScript_MoveUsedIsConfusedNoMore);
-            return CANCELER_RESULT_BREAK;
+            return CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
         }
     }
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerGhost(struct BattleContext *ctx) // GHOST in pokemon tower
+static enum CancelerResult CancelerGhost(struct BattleCalcValues *cv) // GHOST in pokemon tower
 {
     if (IsGhostBattleWithoutScope())
     {
-        if (GetBattlerSide(ctx->battlerAtk) == B_SIDE_PLAYER)
+        if (GetBattlerSide(cv->battlerAtk) == B_SIDE_PLAYER)
             gBattlescriptCurrInstr = BattleScript_TooScaredToMove;
         else
             gBattlescriptCurrInstr = BattleScript_GhostGetOutGetOut;
@@ -420,10 +421,10 @@ static enum CancelerResult CancelerGhost(struct BattleContext *ctx) // GHOST in 
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerParalyzed(struct BattleContext *ctx)
+static enum CancelerResult CancelerParalyzed(struct BattleCalcValues *cv)
 {
-    if (gBattleMons[ctx->battlerAtk].status1 & STATUS1_PARALYSIS
-        && !(B_MAGIC_GUARD == GEN_4 && IsAbilityAndRecord(ctx->battlerAtk, ctx->abilityAtk, ABILITY_MAGIC_GUARD))
+    if (gBattleMons[cv->battlerAtk].status1 & STATUS1_PARALYSIS
+        && !(B_MAGIC_GUARD == GEN_4 && IsAbilityAndRecord(cv->battlerAtk, cv->abilities[cv->battlerAtk], ABILITY_MAGIC_GUARD))
         && !RandomPercentage(RNG_PARALYSIS, 75))
     {
         CancelMultiTurnMoves(gBattlerAttacker);
@@ -433,20 +434,20 @@ static enum CancelerResult CancelerParalyzed(struct BattleContext *ctx)
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerInfatuation(struct BattleContext *ctx)
+static enum CancelerResult CancelerInfatuation(struct BattleCalcValues *cv)
 {
-    if (gBattleMons[ctx->battlerAtk].volatiles.infatuation)
+    if (gBattleMons[cv->battlerAtk].volatiles.infatuation)
     {
-        gBattleScripting.battler = gBattleMons[ctx->battlerAtk].volatiles.infatuation - 1;
+        gBattleScripting.battler = gBattleMons[cv->battlerAtk].volatiles.infatuation - 1;
         if (!RandomPercentage(RNG_INFATUATION, 50))
         {
             BattleScriptCall(BattleScript_MoveUsedIsInLove);
-            return CANCELER_RESULT_BREAK;
+            return CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
         }
         else
         {
             BattleScriptPush(BattleScript_MoveUsedIsInLoveCantAttack);
-            CancelMultiTurnMoves(ctx->battlerAtk);
+            CancelMultiTurnMoves(cv->battlerAtk);
             gBattlescriptCurrInstr = BattleScript_MoveUsedIsInLove;
             return CANCELER_RESULT_FAILURE;
         }
@@ -454,39 +455,39 @@ static enum CancelerResult CancelerInfatuation(struct BattleContext *ctx)
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerZMoves(struct BattleContext *ctx)
+static enum CancelerResult CancelerZMoves(struct BattleCalcValues *cv)
 {
-    if (GetActiveGimmick(ctx->battlerAtk) == GIMMICK_Z_MOVE)
+    if (GetActiveGimmick(cv->battlerAtk) == GIMMICK_Z_MOVE)
     {
         // attacker has a queued z move
-        RecordItemEffectBattle(ctx->battlerAtk, HOLD_EFFECT_Z_CRYSTAL);
-        SetGimmickAsActivated(ctx->battlerAtk, GIMMICK_Z_MOVE);
+        RecordItemEffectBattle(cv->battlerAtk, HOLD_EFFECT_Z_CRYSTAL);
+        SetGimmickAsActivated(cv->battlerAtk, GIMMICK_Z_MOVE);
 
-        gBattleScripting.battler = ctx->battlerAtk;
-        if (GetMoveCategory(ctx->move) == DAMAGE_CATEGORY_STATUS)
+        gBattleScripting.battler = cv->battlerAtk;
+        if (GetMoveCategory(cv->move) == DAMAGE_CATEGORY_STATUS)
             BattleScriptCall(BattleScript_ZMoveActivateStatus);
         else
             BattleScriptCall(BattleScript_ZMoveActivateDamaging);
 
-        return CANCELER_RESULT_BREAK;
+        return CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
     }
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerChoiceLock(struct BattleContext *ctx)
+static enum CancelerResult CancelerChoiceLock(struct BattleCalcValues *cv)
 {
-    enum Move *choicedMoveAtk = &gBattleStruct->choicedMove[ctx->battlerAtk];
-    enum HoldEffect holdEffect = GetBattlerHoldEffect(ctx->battlerAtk);
+    enum Move *choicedMoveAtk = &gBattleStruct->choicedMove[cv->battlerAtk];
+    enum HoldEffect holdEffect = GetBattlerHoldEffect(cv->battlerAtk);
 
     if (gChosenMove != MOVE_STRUGGLE
      && (*choicedMoveAtk == MOVE_NONE || *choicedMoveAtk == MOVE_UNAVAILABLE)
-     && (IsHoldEffectChoice(holdEffect) || ctx->abilityAtk == ABILITY_GORILLA_TACTICS))
+     && (IsHoldEffectChoice(holdEffect) || cv->abilities[cv->battlerAtk] == ABILITY_GORILLA_TACTICS))
         *choicedMoveAtk = gChosenMove;
 
     u32 moveIndex;
     for (moveIndex = 0; moveIndex < MAX_MON_MOVES; moveIndex++)
     {
-        if (gBattleMons[ctx->battlerAtk].moves[moveIndex] == *choicedMoveAtk)
+        if (gBattleMons[cv->battlerAtk].moves[moveIndex] == *choicedMoveAtk)
             break;
     }
 
@@ -496,14 +497,14 @@ static enum CancelerResult CancelerChoiceLock(struct BattleContext *ctx)
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerCallSubmove(struct BattleContext *ctx)
+static enum CancelerResult CancelerCallSubmove(struct BattleCalcValues *cv)
 {
     bool32 noEffect = FALSE;
     enum Move calledMove = MOVE_NONE;
     const u8 *battleScript = NULL;
     battleScript = BattleScript_SubmoveAttackstring;
 
-    switch (GetMoveEffect(ctx->move))
+    switch (GetMoveEffect(cv->move))
     {
     case EFFECT_MIRROR_MOVE:
         calledMove = GetMirrorMoveMove();
@@ -542,35 +543,35 @@ static enum CancelerResult CancelerCallSubmove(struct BattleContext *ctx)
 
     if (calledMove != MOVE_NONE)
     {
-        if (GetActiveGimmick(ctx->battlerAtk) == GIMMICK_Z_MOVE && !IsBattleMoveStatus(calledMove))
+        if (GetActiveGimmick(cv->battlerAtk) == GIMMICK_Z_MOVE && !IsBattleMoveStatus(calledMove))
             calledMove = GetTypeBasedZMove(calledMove);
-        if (GetMoveEffect(ctx->move) == EFFECT_COPYCAT && IsMaxMove(calledMove))
+        if (GetMoveEffect(cv->move) == EFFECT_COPYCAT && IsMaxMove(calledMove))
             calledMove = gBattleStruct->dynamax.lastUsedBaseMove;
 
         gBattleStruct->submoveAnnouncement = SUBMOVE_SUCCESS;
         gCalledMove = calledMove;
-        if (GetBattlerMoveTargetType(ctx->battlerAtk, ctx->move) == TARGET_DEPENDS) // originally using a move without a set target
+        if (GetBattlerMoveTargetType(cv->battlerAtk, cv->move) == TARGET_DEPENDS) // originally using a move without a set target
             gBattlerTarget = GetBattleMoveTarget(calledMove, TARGET_NONE);
         BattleScriptCall(battleScript);
-        return CANCELER_RESULT_BREAK;
+        return CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
     }
 
     gBattleStruct->submoveAnnouncement = SUBMOVE_FAILURE;
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerThaw(struct BattleContext *ctx)
+static enum CancelerResult CancelerThaw(struct BattleCalcValues *cv)
 {
-    enum CancelerResult result = CANCELER_RESULT_BREAK;
+    enum CancelerResult result = CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
 
-    if (MoveThawsUser(ctx->move))
+    if (MoveThawsUser(cv->move))
     {
-        if (gBattleMons[ctx->battlerAtk].status1 & STATUS1_FREEZE)
+        if (gBattleMons[cv->battlerAtk].status1 & STATUS1_FREEZE)
         {
-            if (!IsMoveEffectRemoveSpeciesType(ctx->move, MOVE_EFFECT_REMOVE_ARG_TYPE, TYPE_FIRE) || IS_BATTLER_OF_TYPE(ctx->battlerAtk, TYPE_FIRE))
+            if (!IsMoveEffectRemoveSpeciesType(cv->move, MOVE_EFFECT_REMOVE_ARG_TYPE, TYPE_FIRE) || IS_BATTLER_OF_TYPE(cv->battlerAtk, TYPE_FIRE))
             {
-                DefrostBattler(ctx->battlerAtk, STATUS1_FREEZE);
-                result = CANCELER_RESULT_BREAK;
+                DefrostBattler(cv->battlerAtk, STATUS1_FREEZE);
+                result = CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
                 BattleScriptCall(BattleScript_BattlerDefrosted);
                 gBattleCommunication[MULTISTRING_CHOOSER] = B_MSG_DEFROSTED_BY_MOVE;
             }
@@ -579,12 +580,12 @@ static enum CancelerResult CancelerThaw(struct BattleContext *ctx)
                 result = CANCELER_RESULT_FAILURE;
             }
         }
-        else if (gBattleMons[ctx->battlerAtk].status1 & STATUS1_FROSTBITE)
+        else if (gBattleMons[cv->battlerAtk].status1 & STATUS1_FROSTBITE)
         {
-            if (!IsMoveEffectRemoveSpeciesType(ctx->move, MOVE_EFFECT_REMOVE_ARG_TYPE, TYPE_FIRE) || IS_BATTLER_OF_TYPE(ctx->battlerAtk, TYPE_FIRE))
+            if (!IsMoveEffectRemoveSpeciesType(cv->move, MOVE_EFFECT_REMOVE_ARG_TYPE, TYPE_FIRE) || IS_BATTLER_OF_TYPE(cv->battlerAtk, TYPE_FIRE))
             {
-                DefrostBattler(ctx->battlerAtk, STATUS1_FROSTBITE);
-                result = CANCELER_RESULT_BREAK;
+                DefrostBattler(cv->battlerAtk, STATUS1_FROSTBITE);
+                result = CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
                 BattleScriptCall(BattleScript_BattlerFrostbiteHealed);
                 gBattleCommunication[MULTISTRING_CHOOSER] = B_MSG_FROSTBITE_HEALED_BY_MOVE;
             }
@@ -597,16 +598,16 @@ static enum CancelerResult CancelerThaw(struct BattleContext *ctx)
     return result;
 }
 
-static enum CancelerResult CancelerStanceChangeTwo(struct BattleContext *ctx)
+static enum CancelerResult CancelerStanceChangeTwo(struct BattleCalcValues *cv)
 {
-    if (B_STANCE_CHANGE_FAIL >= GEN_7 && gChosenMove == ctx->move && TryFormChangeBeforeMove())
-        return CANCELER_RESULT_BREAK;
+    if (B_STANCE_CHANGE_FAIL >= GEN_7 && gChosenMove == cv->move && TryFormChangeBeforeMove())
+        return CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerAttackstring(struct BattleContext *ctx)
+static enum CancelerResult CancelerAttackstring(struct BattleCalcValues *cv)
 {
-    if (gBattleMons[ctx->battlerAtk].volatiles.bideTurns)
+    if (gBattleMons[cv->battlerAtk].volatiles.bideTurns)
         return CANCELER_RESULT_SUCCESS;
 
     BattleScriptCall(BattleScript_Attackstring);
@@ -617,7 +618,7 @@ static enum CancelerResult CancelerAttackstring(struct BattleContext *ctx)
         gLastPrintedMoves[gBattlerAttacker] = gChosenMove;
         RecordKnownMove(gBattlerAttacker, gChosenMove);
     }
-    return CANCELER_RESULT_BREAK;
+    return CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
 }
 
 #define checkFailure TRUE
@@ -776,32 +777,32 @@ bool32 IsAffectedByFollowMe(enum BattlerId battlerAtk, enum BattleSide defSide, 
     return TRUE;
 }
 
-static bool32 HandleMoveTargetRedirection(enum MoveTarget moveTarget)
+static bool32 HandleMoveTargetRedirection(struct BattleCalcValues *cv, enum MoveTarget moveTarget)
 {
     u32 redirectorOrderNum = MAX_BATTLERS_COUNT;
-    enum BattleMoveEffects moveEffect = GetMoveEffect(gCurrentMove);
-    enum BattleSide side = BATTLE_OPPOSITE(GetBattlerSide(gBattlerAttacker));
+    enum BattleMoveEffects moveEffect = GetMoveEffect(cv->move);
+    enum BattleSide side = BATTLE_OPPOSITE(GetBattlerSide(cv->battlerAtk));
 
     if (moveEffect == EFFECT_REFLECT_DAMAGE)
     {
-        enum DamageCategory reflectCategory = GetReflectDamageMoveDamageCategory(gBattlerAttacker, gCurrentMove);
+        enum DamageCategory reflectCategory = GetReflectDamageMoveDamageCategory(cv->battlerAtk, cv->move);
 
         if (reflectCategory == DAMAGE_CATEGORY_PHYSICAL)
-            gBattlerTarget = gBattleStruct->moveTarget[gBattlerAttacker] = gProtectStructs[gBattlerAttacker].physicalBattlerId;
+            cv->battlerDef = gBattleStruct->moveTarget[cv->battlerAtk] = gProtectStructs[cv->battlerAtk].physicalBattlerId;
         else
-            gBattlerTarget = gBattleStruct->moveTarget[gBattlerAttacker] = gProtectStructs[gBattlerAttacker].specialBattlerId;
+            cv->battlerDef = gBattleStruct->moveTarget[cv->battlerAtk] = gProtectStructs[cv->battlerAtk].specialBattlerId;
     }
 
-    if (IsAffectedByFollowMe(gBattlerAttacker, side, gCurrentMove)
+    if (IsAffectedByFollowMe(cv->battlerAtk, side, cv->move)
      && (moveTarget == TARGET_SELECTED || moveTarget == TARGET_SMART || moveEffect == EFFECT_REFLECT_DAMAGE)
-     && !IsBattlerAlly(gBattlerAttacker, gSideTimers[side].followmeTarget))
+     && !IsBattlerAlly(cv->battlerAtk, gSideTimers[side].followmeTarget))
     {
-        gBattleStruct->moveTarget[gBattlerAttacker] = gBattlerTarget = gSideTimers[side].followmeTarget; // follow me moxie fix
+        gBattleStruct->moveTarget[cv->battlerAtk] = cv->battlerDef = gSideTimers[side].followmeTarget; // follow me moxie fix
         return TRUE;
     }
 
-    enum Type moveType = GetBattleMoveType(gCurrentMove);
-    enum Ability ability = GetBattlerAbility(gBattlerTarget);
+    enum Type moveType = GetBattleMoveType(cv->move);
+    enum Ability ability = cv->abilities[cv->battlerDef];
     bool32 currTargetCantAbsorb = ((ability != ABILITY_LIGHTNING_ROD && moveType == TYPE_ELECTRIC)
                                 || (ability != ABILITY_STORM_DRAIN && moveType == TYPE_WATER));
 
@@ -816,124 +817,128 @@ static bool32 HandleMoveTargetRedirection(enum MoveTarget moveTarget)
      && moveEffect != EFFECT_PLEDGE)
     {
         // Find first battler that redirects the move (in turn order)
-        enum Ability abilityAtk = GetBattlerAbility(gBattlerAttacker);
+        enum Ability abilityAtk = cv->abilities[cv->battlerAtk];
         enum BattlerId battler;
         for (battler = 0; battler < gBattlersCount; battler++)
         {
-            ability = GetBattlerAbility(battler);
-            if ((B_REDIRECT_ABILITY_ALLIES >= GEN_4 || !IsBattlerAlly(gBattlerAttacker, battler))
-                && battler != gBattlerAttacker
-                && gBattlerTarget != battler
+            ability = cv->abilities[battler];
+            if ((B_REDIRECT_ABILITY_ALLIES >= GEN_4 || !IsBattlerAlly(cv->battlerAtk, battler))
+                && battler != cv->battlerAtk
+                && battler != cv->battlerDef
                 && ((ability == ABILITY_LIGHTNING_ROD && moveType == TYPE_ELECTRIC)
                  || (ability == ABILITY_STORM_DRAIN && moveType == TYPE_WATER))
                 && GetBattlerTurnOrderNum(battler) < redirectorOrderNum
-                && !IsAbilityAndRecord(gBattlerAttacker, abilityAtk, ABILITY_PROPELLER_TAIL)
-                && !IsAbilityAndRecord(gBattlerAttacker, abilityAtk, ABILITY_STALWART))
+                && !IsAbilityAndRecord(cv->battlerAtk, abilityAtk, ABILITY_PROPELLER_TAIL)
+                && !IsAbilityAndRecord(cv->battlerAtk, abilityAtk, ABILITY_STALWART))
             {
                 redirectorOrderNum = GetBattlerTurnOrderNum(battler);
             }
         }
         if (redirectorOrderNum != MAX_BATTLERS_COUNT)
         {
-            enum Ability battlerAbility;
-            battler = gBattlerByTurnOrder[redirectorOrderNum];
-            battlerAbility = GetBattlerAbility(battler);
-            RecordAbilityBattle(battler, battlerAbility);
-            gSpecialStatuses[battler].abilityRedirected = TRUE;
-            gBattlerTarget = battler;
+            cv->battlerDef = gBattlerByTurnOrder[redirectorOrderNum];
+            RecordAbilityBattle(cv->battlerDef, cv->abilities[cv->battlerDef]);
+            gSpecialStatuses[cv->battlerDef].abilityRedirected = TRUE;
             return TRUE;
         }
     }
+
     return FALSE;
 }
 
-static bool32 WasOriginalTargetAlly(enum MoveTarget moveTarget)
+static bool32 WasOriginalTargetAlly(enum BattlerId battlerAtk, enum BattlerId battlerDef, enum MoveTarget moveTarget)
 {
-    if (!gProtectStructs[BATTLE_PARTNER(gBattlerAttacker)].usedAllySwitch)
+    if (!gProtectStructs[BATTLE_PARTNER(battlerAtk)].usedAllySwitch)
         return FALSE;
 
-    if ((moveTarget == TARGET_ALLY || moveTarget == TARGET_USER_OR_ALLY) && gBattlerAttacker == gBattlerTarget)
+    if ((moveTarget == TARGET_ALLY || moveTarget == TARGET_USER_OR_ALLY) && battlerAtk == battlerDef)
         return TRUE;
 
     return FALSE;
 }
 
-static enum CancelerResult CancelerSetTargets(struct BattleContext *ctx)
+static enum CancelerResult CancelerSetTargets(struct BattleCalcValues *cv)
 {
-    enum MoveTarget moveTarget = GetBattlerMoveTargetType(ctx->battlerAtk, ctx->move);
+    enum MoveTarget moveTarget = GetBattlerMoveTargetType(cv->battlerAtk, cv->move);
 
-    if (!HandleMoveTargetRedirection(moveTarget))
+    if (!HandleMoveTargetRedirection(cv, moveTarget))
     {
         if (IsDoubleBattle() && moveTarget == TARGET_RANDOM)
         {
-            gBattlerTarget = SetRandomTarget(gBattlerAttacker);
-            if (gAbsentBattlerFlags & (1u << gBattlerTarget)
-                && !IsBattlerAlly(gBattlerAttacker, gBattlerTarget))
+            cv->battlerDef = SetRandomTarget(cv->battlerAtk);
+            if (gAbsentBattlerFlags & (1u << cv->battlerAtk)
+                && !IsBattlerAlly(cv->battlerAtk, cv->battlerDef))
             {
-                gBattlerTarget = GetPartnerBattler(gBattlerTarget);
+                cv->battlerDef = GetPartnerBattler(cv->battlerDef);
             }
         }
-        else if (moveTarget == TARGET_ALLY && !IsBattlerAlly(gBattlerTarget, gBattlerAttacker))
+        else if (moveTarget == TARGET_ALLY && !IsBattlerAlly(cv->battlerDef, cv->battlerAtk))
         {
-            gBattlerTarget = BATTLE_PARTNER(gBattlerAttacker);
+            cv->battlerDef = BATTLE_PARTNER(cv->battlerAtk);
         }
         else if (IsDoubleBattle() && moveTarget == TARGET_FOES_AND_ALLY)
         {
-            for (gBattlerTarget = 0; gBattlerTarget < gBattlersCount; gBattlerTarget++)
+            for (enum BattlerId battlerDef = 0; battlerDef < gBattlersCount; battlerDef++)
             {
-                if (gBattlerTarget == gBattlerAttacker)
+                if (battlerDef == cv->battlerAtk)
                     continue;
-                if (IsBattlerAlive(gBattlerTarget))
+
+                if (IsBattlerAlive(battlerDef))
+                {
+                    cv->battlerDef = battlerDef;
                     break;
+                }
             }
         }
         else if (moveTarget == TARGET_USER || moveTarget == TARGET_USER_AND_ALLY)
         {
-            gBattlerTarget = gBattlerAttacker;
+            cv->battlerDef = cv->battlerAtk;
         }
-        else if (!IsBattlerAlive(gBattlerTarget)
+        else if (!IsBattlerAlive(cv->battlerDef)
               && moveTarget != TARGET_OPPONENTS_FIELD
               && IsDoubleBattle()
-              && (!IsBattlerAlly(gBattlerAttacker, gBattlerTarget)))
+              && (!IsBattlerAlly(cv->battlerAtk, cv->battlerDef)))
         {
-            gBattlerTarget = GetBattlerAtPosition(BATTLE_PARTNER(GetBattlerPosition(gBattlerTarget)));
+            cv->battlerDef = GetBattlerAtPosition(BATTLE_PARTNER(GetBattlerPosition(cv->battlerDef)));
         }
     }
+
+    gBattlerTarget = cv->battlerDef; // ShouldCheckTargetMoveFailure relies on gBattlerTarget
 
     while (gBattleStruct->eventState.atkCancelerBattler < gBattlersCount)
     {
         enum BattlerId battlerDef = gBattleStruct->eventState.atkCancelerBattler++;
 
-        if (!ShouldCheckTargetMoveFailure(ctx->battlerAtk, battlerDef, ctx->move, moveTarget))
-            gBattleStruct->battlerState[ctx->battlerAtk].targetsDone[battlerDef] = TRUE;
+        if (!ShouldCheckTargetMoveFailure(cv->battlerAtk, battlerDef, cv->move, moveTarget))
+            gBattleStruct->battlerState[cv->battlerAtk].targetsDone[battlerDef] = TRUE;
     }
     gBattleStruct->eventState.atkCancelerBattler = 0;
 
-    if (IsBattlerAlly(gBattlerAttacker, gBattlerTarget) && !IsBattlerAlive(gBattlerTarget))
+    if (IsBattlerAlly(cv->battlerAtk, cv->battlerDef) && !IsBattlerAlive(cv->battlerDef))
     {
         gBattlescriptCurrInstr = BattleScript_ButItFailed;
         return CANCELER_RESULT_FAILURE;
     }
-    else if (WasOriginalTargetAlly(moveTarget))
+    else if (WasOriginalTargetAlly(cv->battlerAtk, cv->battlerDef, moveTarget))
     {
         gBattlescriptCurrInstr = BattleScript_ButItFailed;
         return CANCELER_RESULT_FAILURE;
     }
 
-    return CANCELER_RESULT_BREAK; // update ctx->battlerDef
+    return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerPPDeduction(struct BattleContext *ctx)
+static enum CancelerResult CancelerPPDeduction(struct BattleCalcValues *cv)
 {
-    if (gBattleMons[ctx->battlerAtk].volatiles.multipleTurns
-     || gSpecialStatuses[ctx->battlerAtk].dancerUsedMove
+    if (gBattleMons[cv->battlerAtk].volatiles.multipleTurns
+     || gSpecialStatuses[cv->battlerAtk].dancerUsedMove
      || gBattleStruct->bouncedMoveIsUsed
-     || gBattleMons[ctx->battlerAtk].volatiles.bideTurns
-     || ctx->move == MOVE_STRUGGLE)
+     || gBattleMons[cv->battlerAtk].volatiles.bideTurns
+     || cv->move == MOVE_STRUGGLE)
         return CANCELER_RESULT_SUCCESS;
 
     s32 ppToDeduct = 1;
-    enum MoveTarget moveTarget = GetBattlerMoveTargetType(ctx->battlerAtk, ctx->move);
+    enum MoveTarget moveTarget = GetBattlerMoveTargetType(cv->battlerAtk, cv->move);
     u32 movePosition = gCurrMovePos;
 
     if (gBattleStruct->submoveAnnouncement == SUBMOVE_SUCCESS)
@@ -942,39 +947,39 @@ static enum CancelerResult CancelerPPDeduction(struct BattleContext *ctx)
     if (IsSpreadMove(moveTarget)
      || moveTarget == TARGET_ALL_BATTLERS
      || moveTarget == TARGET_FIELD
-     || MoveForcesPressure(ctx->move))
+     || MoveForcesPressure(cv->move))
     {
         for (u32 i = 0; i < gBattlersCount; i++)
         {
-            if (!IsBattlerAlly(i, ctx->battlerAtk))
+            if (!IsBattlerAlly(i, cv->battlerAtk))
                 ppToDeduct += (GetBattlerAbility(i) == ABILITY_PRESSURE);
         }
     }
     else if (moveTarget != TARGET_OPPONENTS_FIELD)
     {
-        if (ctx->battlerAtk != ctx->battlerDef && GetBattlerAbility(ctx->battlerDef) == ABILITY_PRESSURE)
+        if (cv->battlerAtk != cv->battlerDef && GetBattlerAbility(cv->battlerDef) == ABILITY_PRESSURE)
              ppToDeduct++;
     }
 
     // For item Metronome, echoed voice
-    if (ctx->move != gLastResultingMoves[ctx->battlerAtk] || gBattleStruct->unableToUseMove)
-        gBattleMons[ctx->battlerAtk].volatiles.metronomeItemCounter = 0;
+    if (cv->move != gLastResultingMoves[cv->battlerAtk] || gBattleStruct->unableToUseMove)
+        gBattleMons[cv->battlerAtk].volatiles.metronomeItemCounter = 0;
 
-    if (gBattleMons[ctx->battlerAtk].pp[movePosition] > ppToDeduct)
-        gBattleMons[ctx->battlerAtk].pp[movePosition] -= ppToDeduct;
+    if (gBattleMons[cv->battlerAtk].pp[movePosition] > ppToDeduct)
+        gBattleMons[cv->battlerAtk].pp[movePosition] -= ppToDeduct;
     else
-        gBattleMons[ctx->battlerAtk].pp[movePosition] = 0;
+        gBattleMons[cv->battlerAtk].pp[movePosition] = 0;
 
-    if (MOVE_IS_PERMANENT(ctx->battlerAtk, movePosition))
+    if (MOVE_IS_PERMANENT(cv->battlerAtk, movePosition))
     {
         BtlController_EmitSetMonData(
-            ctx->battlerAtk,
+            cv->battlerAtk,
             B_COMM_TO_CONTROLLER,
             REQUEST_PPMOVE1_BATTLE + movePosition,
             0,
-            sizeof(gBattleMons[ctx->battlerAtk].pp[movePosition]),
-            &gBattleMons[ctx->battlerAtk].pp[movePosition]);
-        MarkBattlerForControllerExec(ctx->battlerAtk);
+            sizeof(gBattleMons[cv->battlerAtk].pp[movePosition]),
+            &gBattleMons[cv->battlerAtk].pp[movePosition]);
+        MarkBattlerForControllerExec(cv->battlerAtk);
     }
 
     if (gBattleStruct->submoveAnnouncement != SUBMOVE_NO_EFFECT)
@@ -985,7 +990,7 @@ static enum CancelerResult CancelerPPDeduction(struct BattleContext *ctx)
             gBattlescriptCurrInstr = BattleScript_ButItFailed;
             return CANCELER_RESULT_FAILURE;
         }
-        else if (CancelerVolatileBlocked(ctx) == CANCELER_RESULT_FAILURE) // Check Gravity/Heal Block/Throat Chop for Submove
+        else if (CancelerVolatileBlocked(cv) == CANCELER_RESULT_FAILURE) // Check Gravity/Heal Block/Throat Chop for Submove
         {
             gBattleStruct->submoveAnnouncement = SUBMOVE_NO_EFFECT;
             return CANCELER_RESULT_FAILURE;
@@ -997,10 +1002,10 @@ static enum CancelerResult CancelerPPDeduction(struct BattleContext *ctx)
             gBattleScripting.animTargetsHit = 0;
 
             // Possibly better to just move type setting and redirection to attackcanceler as a new case at this point
-            SetTypeBeforeUsingMove(ctx->move, ctx->battlerAtk);
+            SetTypeBeforeUsingMove(cv->move, cv->battlerAtk);
             ClearDamageCalcResults();
-            gBattlescriptCurrInstr = GetMoveBattleScript(ctx->move);
-            return CANCELER_RESULT_BREAK;
+            gBattlescriptCurrInstr = GetMoveBattleScript(cv->move);
+            return CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
         }
     }
 
@@ -1008,25 +1013,25 @@ static enum CancelerResult CancelerPPDeduction(struct BattleContext *ctx)
 }
 
 // We don't have clear data on where this belongs to but I assume it should at least be checked before Protean
-static enum CancelerResult CancelerSkyBattle(struct BattleContext *ctx)
+static enum CancelerResult CancelerSkyBattle(struct BattleCalcValues *cv)
 {
     if (gBattleStruct->isSkyBattle && IsMoveSkyBattleBanned(gCurrentMove))
     {
-        CancelMultiTurnMoves(ctx->battlerAtk);
+        CancelMultiTurnMoves(cv->battlerAtk);
         gBattlescriptCurrInstr = BattleScript_ButItFailed;
         return CANCELER_RESULT_FAILURE;
     }
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerWeatherPrimal(struct BattleContext *ctx)
+static enum CancelerResult CancelerWeatherPrimal(struct BattleCalcValues *cv)
 {
     enum CancelerResult result = CANCELER_RESULT_SUCCESS;
 
-    if (GetMovePower(ctx->move) > 0 && HasWeatherEffect())
+    if (GetMovePower(cv->move) > 0 && HasWeatherEffect())
     {
-        enum Type moveType = GetBattleMoveType(ctx->move);
-        if (moveType == TYPE_FIRE && gBattleWeather & B_WEATHER_RAIN_PRIMAL && (GetConfig(B_POWDER_STATUS_HEAVY_RAIN) >= GEN_7 || !TryActivatePowderStatus(ctx->move)))
+        enum Type moveType = GetBattleMoveType(cv->move);
+        if (moveType == TYPE_FIRE && gBattleWeather & B_WEATHER_RAIN_PRIMAL && (GetConfig(B_POWDER_STATUS_HEAVY_RAIN) >= GEN_7 || !TryActivatePowderStatus(cv->move)))
         {
             gBattleCommunication[MULTISTRING_CHOOSER] = B_MSG_PRIMAL_WEATHER_FIZZLED_BY_RAIN;
             result = CANCELER_RESULT_FAILURE;
@@ -1038,8 +1043,8 @@ static enum CancelerResult CancelerWeatherPrimal(struct BattleContext *ctx)
         }
         if (result == CANCELER_RESULT_FAILURE)
         {
-            gProtectStructs[ctx->battlerAtk].chargingTurn = FALSE;
-            CancelMultiTurnMoves(ctx->battlerAtk);
+            gProtectStructs[cv->battlerAtk].chargingTurn = FALSE;
+            CancelMultiTurnMoves(cv->battlerAtk);
             gBattlescriptCurrInstr = BattleScript_PrimalWeatherBlocksMove;
         }
     }
@@ -1047,38 +1052,38 @@ static enum CancelerResult CancelerWeatherPrimal(struct BattleContext *ctx)
     return result;
 }
 
-static enum CancelerResult CancelerFocusPreGen5(struct BattleContext *ctx)
+static enum CancelerResult CancelerFocusPreGen5(struct BattleCalcValues *cv)
 {
     if (GetConfig(B_FOCUS_PUNCH_FAILURE) < GEN_5)
-        return CancelerFocus(ctx);
+        return CancelerFocus(cv);
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerBide(struct BattleContext *ctx)
+static enum CancelerResult CancelerBide(struct BattleCalcValues *cv)
 {
-    if (GetMoveEffect(ctx->move) != EFFECT_BIDE)
+    if (GetMoveEffect(cv->move) != EFFECT_BIDE)
         return CANCELER_RESULT_SUCCESS;
 
-    if (gBattleMons[ctx->battlerAtk].volatiles.bideTurns)
+    if (gBattleMons[cv->battlerAtk].volatiles.bideTurns)
     {
-        if (--gBattleMons[ctx->battlerAtk].volatiles.bideTurns)
+        if (--gBattleMons[cv->battlerAtk].volatiles.bideTurns)
         {
             gBattlescriptCurrInstr = BattleScript_BideStoringEnergy;
-            return CANCELER_RESULT_BREAK; // Jump to moveend
+            return CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT; // Jump to moveend
         }
-        else if (gBideDmg[ctx->battlerAtk])
+        else if (gBideDmg[cv->battlerAtk])
         {
-            gBattlerTarget = gBideTarget[ctx->battlerAtk];
-            gBattleMons[ctx->battlerAtk].volatiles.multipleTurns = FALSE;
+            gBattlerTarget = gBideTarget[cv->battlerAtk];
+            gBattleMons[cv->battlerAtk].volatiles.multipleTurns = FALSE;
             if (!IsBattlerAlive(gBattlerTarget))
                 gBattlerTarget = GetBattleMoveTarget(gCurrentMove, TARGET_SELECTED);
-            gBattleStruct->battlerState[ctx->battlerAtk].targetsDone[gBattlerTarget] = FALSE;
+            gBattleStruct->battlerState[cv->battlerAtk].targetsDone[gBattlerTarget] = FALSE;
             BattleScriptCall(BattleScript_BideAttack);
-            return CANCELER_RESULT_BREAK;
+            return CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
         }
         else
         {
-            gBattleMons[ctx->battlerAtk].volatiles.multipleTurns = FALSE;
+            gBattleMons[cv->battlerAtk].volatiles.multipleTurns = FALSE;
             gBattlescriptCurrInstr = BattleScript_BideNoEnergyToAttack;
             return CANCELER_RESULT_FAILURE;
         }
@@ -1090,7 +1095,7 @@ static enum CancelerResult CancelerBide(struct BattleContext *ctx)
         gBideDmg[gBattlerAttacker] = 0;
         gBattleMons[gBattlerAttacker].volatiles.bideTurns = 2;
         gBattlescriptCurrInstr = BattleScript_SetUpBide;
-        return CANCELER_RESULT_BREAK; // Jump to moveend
+        return CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT; // Jump to moveend
     }
 
     return CANCELER_RESULT_SUCCESS;
@@ -1107,23 +1112,23 @@ static bool32 ShouldSkipFailureCheckOnBattler(enum BattlerId battlerAtk, enum Ba
     return FALSE;
 }
 
-static enum CancelerResult CancelerMoveFailure(struct BattleContext *ctx)
+static enum CancelerResult CancelerMoveFailure(struct BattleCalcValues *cv)
 {
     const u8 *battleScript = NULL;
 
-    switch (GetMoveEffect(ctx->move))
+    switch (GetMoveEffect(cv->move))
     {
     case EFFECT_FLING:
-        if (!CanFling(ctx->battlerAtk, ctx->abilityAtk))
+        if (!CanFling(cv->battlerAtk, cv->abilities[cv->battlerAtk]))
             battleScript = BattleScript_ButItFailed;
         break;
     case EFFECT_FAIL_IF_NOT_ARG_TYPE:
-        if (!IS_BATTLER_OF_TYPE(ctx->battlerAtk, GetMoveArgType(ctx->move)))
+        if (!IS_BATTLER_OF_TYPE(cv->battlerAtk, GetMoveArgType(cv->move)))
             battleScript = BattleScript_ButItFailed;
         break;
     case EFFECT_AURA_WHEEL:
-        if (gBattleMons[ctx->battlerAtk].species != SPECIES_MORPEKO_FULL_BELLY
-         && gBattleMons[ctx->battlerAtk].species != SPECIES_MORPEKO_HANGRY)
+        if (gBattleMons[cv->battlerAtk].species != SPECIES_MORPEKO_FULL_BELLY
+         && gBattleMons[cv->battlerAtk].species != SPECIES_MORPEKO_HANGRY)
             battleScript = BattleScript_PokemonCantUseTheMove;
         break;
     case EFFECT_AURORA_VEIL:
@@ -1131,38 +1136,38 @@ static enum CancelerResult CancelerMoveFailure(struct BattleContext *ctx)
             battleScript = BattleScript_ButItFailed;
         break;
     case EFFECT_CLANGOROUS_SOUL:
-        if (gBattleMons[ctx->battlerAtk].hp <= max(1, GetNonDynamaxMaxHP(ctx->battlerAtk) / 3))
+        if (gBattleMons[cv->battlerAtk].hp <= max(1, GetNonDynamaxMaxHP(cv->battlerAtk) / 3))
             battleScript = BattleScript_ButItFailed;
         break;
     case EFFECT_REFLECT_DAMAGE:
     {
-        enum DamageCategory reflectCategory = GetReflectDamageMoveDamageCategory(ctx->battlerAtk, ctx->move);
-        if (IsBattlerAlly(ctx->battlerAtk, ctx->battlerDef))
+        enum DamageCategory reflectCategory = GetReflectDamageMoveDamageCategory(cv->battlerAtk, cv->move);
+        if (IsBattlerAlly(cv->battlerAtk, cv->battlerDef))
             battleScript = BattleScript_ButItFailed;
         // Counter / Metal Burst and took physical damage
         else if (reflectCategory == DAMAGE_CATEGORY_PHYSICAL
-              && gProtectStructs[ctx->battlerAtk].physicalDmg > 0
-              && (GetConfig(B_COUNTER_TRY_HIT_PARTNER) >= GEN_5 || gBattleMons[gProtectStructs[ctx->battlerAtk].physicalBattlerId].hp))
+              && gProtectStructs[cv->battlerAtk].physicalDmg > 0
+              && (GetConfig(B_COUNTER_TRY_HIT_PARTNER) >= GEN_5 || gBattleMons[gProtectStructs[cv->battlerAtk].physicalBattlerId].hp))
             break;
         // Mirror Coat / Metal Burst and took special damage
         else if (reflectCategory == DAMAGE_CATEGORY_SPECIAL
-              && gProtectStructs[ctx->battlerAtk].specialDmg > 0
-              && (GetConfig(B_COUNTER_TRY_HIT_PARTNER) >= GEN_5 || gBattleMons[gProtectStructs[ctx->battlerAtk].specialBattlerId].hp))
+              && gProtectStructs[cv->battlerAtk].specialDmg > 0
+              && (GetConfig(B_COUNTER_TRY_HIT_PARTNER) >= GEN_5 || gBattleMons[gProtectStructs[cv->battlerAtk].specialBattlerId].hp))
             break;
         else
             battleScript = BattleScript_ButItFailed;
         break;
     }
     case EFFECT_DESTINY_BOND:
-        if (DoesDestinyBondFail(ctx->battlerAtk))
+        if (DoesDestinyBondFail(cv->battlerAtk))
             battleScript = BattleScript_ButItFailed;
         break;
     case EFFECT_FIRST_TURN_ONLY:
-        if (!gBattleStruct->battlerState[ctx->battlerAtk].isFirstTurn || gSpecialStatuses[ctx->battlerAtk].backUpTarget)
+        if (!gBattleStruct->battlerState[cv->battlerAtk].isFirstTurn || gSpecialStatuses[cv->battlerAtk].backUpTarget)
             battleScript = BattleScript_ButItFailed;
         break;
     case EFFECT_MAT_BLOCK:
-        if (!gBattleStruct->battlerState[ctx->battlerAtk].isFirstTurn || gSpecialStatuses[ctx->battlerAtk].backUpTarget)
+        if (!gBattleStruct->battlerState[cv->battlerAtk].isFirstTurn || gSpecialStatuses[cv->battlerAtk].backUpTarget)
             battleScript = BattleScript_ButItFailed;
         break;
     case EFFECT_FOLLOW_ME:
@@ -1170,24 +1175,24 @@ static enum CancelerResult CancelerMoveFailure(struct BattleContext *ctx)
             battleScript = BattleScript_ButItFailed;
         break;
     case EFFECT_LAST_RESORT:
-        if (!CanUseLastResort(ctx->battlerAtk))
+        if (!CanUseLastResort(cv->battlerAtk))
             battleScript = BattleScript_ButItFailed;
         break;
     case EFFECT_NO_RETREAT:
-        if (gBattleMons[ctx->battlerAtk].volatiles.noRetreat)
+        if (gBattleMons[cv->battlerAtk].volatiles.noRetreat)
             battleScript = BattleScript_ButItFailed;
         break;
     case EFFECT_PROTECT:
     case EFFECT_ENDURE:
-        TryResetConsecutiveUseCounter(ctx->battlerAtk);
-        if (IsLastMonToMove(ctx->battlerAtk))
+        TryResetConsecutiveUseCounter(cv->battlerAtk);
+        if (IsLastMonToMove(cv->battlerAtk))
         {
             battleScript = BattleScript_ButItFailed;
         }
         else
         {
-            enum ProtectMethod protectMethod = GetMoveProtectMethod(ctx->move);
-            bool32 canUseProtectSecondTime = CanUseMoveConsecutively(ctx->battlerAtk);
+            enum ProtectMethod protectMethod = GetMoveProtectMethod(cv->move);
+            bool32 canUseProtectSecondTime = CanUseMoveConsecutively(cv->battlerAtk);
             bool32 canUseWideGuard = (GetConfig(B_WIDE_GUARD) >= GEN_6 && protectMethod == PROTECT_WIDE_GUARD);
             bool32 canUseQuickGuard = (GetConfig(B_QUICK_GUARD) >= GEN_6 && protectMethod == PROTECT_QUICK_GUARD);
 
@@ -1199,24 +1204,24 @@ static enum CancelerResult CancelerMoveFailure(struct BattleContext *ctx)
         }
         if (battleScript != NULL)
         {
-            gBattleMons[ctx->battlerAtk].volatiles.consecutiveMoveUses = 0;
-            gBattleStruct->battlerState[ctx->battlerAtk].stompingTantrumTimer = 2;
+            gBattleMons[cv->battlerAtk].volatiles.consecutiveMoveUses = 0;
+            gBattleStruct->battlerState[cv->battlerAtk].stompingTantrumTimer = 2;
         }
         break;
     case EFFECT_REST:
-        if (gBattleMons[ctx->battlerAtk].status1 & STATUS1_SLEEP
-         || ctx->abilityAtk == ABILITY_COMATOSE)
+        if (gBattleMons[cv->battlerAtk].status1 & STATUS1_SLEEP
+         || cv->abilities[cv->battlerAtk] == ABILITY_COMATOSE)
             battleScript = BattleScript_RestIsAlreadyAsleep;
-        else if (gBattleMons[ctx->battlerAtk].hp == gBattleMons[ctx->battlerAtk].maxHP)
+        else if (gBattleMons[cv->battlerAtk].hp == gBattleMons[cv->battlerAtk].maxHP)
             battleScript = BattleScript_AlreadyAtFullHp;
-        else if (ctx->abilityAtk == ABILITY_INSOMNIA
-              || ctx->abilityAtk == ABILITY_VITAL_SPIRIT
-              || ctx->abilityAtk == ABILITY_PURIFYING_SALT)
+        else if (cv->abilities[cv->battlerAtk] == ABILITY_INSOMNIA
+              || cv->abilities[cv->battlerAtk] == ABILITY_VITAL_SPIRIT
+              || cv->abilities[cv->battlerAtk] == ABILITY_PURIFYING_SALT)
             battleScript = BattleScript_InsomniaProtects;
         break;
     case EFFECT_SNORE:
-        if (!(gBattleMons[ctx->battlerAtk].status1 & STATUS1_SLEEP)
-         && ctx->abilityAtk != ABILITY_COMATOSE)
+        if (!(gBattleMons[cv->battlerAtk].status1 & STATUS1_SLEEP)
+         && cv->abilities[cv->battlerAtk] != ABILITY_COMATOSE)
             battleScript = BattleScript_ButItFailed;
         break;
     case EFFECT_STEEL_ROLLER:
@@ -1224,26 +1229,26 @@ static enum CancelerResult CancelerMoveFailure(struct BattleContext *ctx)
             battleScript = BattleScript_ButItFailed;
         break;
     case EFFECT_STOCKPILE:
-        if (gBattleMons[ctx->battlerAtk].volatiles.stockpileCounter >= 3)
+        if (gBattleMons[cv->battlerAtk].volatiles.stockpileCounter >= 3)
             battleScript = BattleScript_ButItFailed;
         break;
     case EFFECT_STUFF_CHEEKS:
-        if (GetItemPocket(gBattleMons[ctx->battlerAtk].item) != POCKET_BERRIES)
+        if (GetItemPocket(gBattleMons[cv->battlerAtk].item) != POCKET_BERRIES)
             battleScript = BattleScript_ButItFailed;
         break;
     case EFFECT_SWALLOW:
     case EFFECT_SPIT_UP:
-        if (gBattleMons[ctx->battlerAtk].volatiles.stockpileCounter == 0 && !gBattleStruct->snatchedMoveIsUsed)
+        if (gBattleMons[cv->battlerAtk].volatiles.stockpileCounter == 0 && !gBattleStruct->snatchedMoveIsUsed)
             battleScript = BattleScript_ButItFailed;
         break;
     case EFFECT_TELEPORT:
         // TODO: follow up: Can't make sense of teleport logic
         break;
     case EFFECT_NATURAL_GIFT:
-        if (GetItemPocket(gBattleMons[ctx->battlerAtk].item) != POCKET_BERRIES
+        if (GetItemPocket(gBattleMons[cv->battlerAtk].item) != POCKET_BERRIES
          || gFieldStatuses & STATUS_FIELD_MAGIC_ROOM
-         || ctx->abilityAtk == ABILITY_KLUTZ
-         || gBattleMons[ctx->battlerAtk].volatiles.embargo)
+         || cv->abilities[cv->battlerAtk] == ABILITY_KLUTZ
+         || gBattleMons[cv->battlerAtk].volatiles.embargo)
             battleScript = BattleScript_ButItFailed;
         break;
     case EFFECT_PRESENT:
@@ -1272,7 +1277,7 @@ static enum CancelerResult CancelerMoveFailure(struct BattleContext *ctx)
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerMoveEffectFailureTarget(struct BattleContext *ctx)
+static enum CancelerResult CancelerMoveEffectFailureTarget(struct BattleCalcValues *cv)
 {
     const u8 *battleScript = NULL;
     u32 numAffectedTargets = 0;
@@ -1281,10 +1286,10 @@ static enum CancelerResult CancelerMoveEffectFailureTarget(struct BattleContext 
     {
         enum BattlerId battlerDef = gBattleStruct->eventState.atkCancelerBattler++;
 
-        if (ShouldSkipFailureCheckOnBattler(ctx->battlerAtk, battlerDef, TRUE))
+        if (ShouldSkipFailureCheckOnBattler(cv->battlerAtk, battlerDef, TRUE))
             continue;
 
-        switch (GetMoveEffect(ctx->move))
+        switch (GetMoveEffect(cv->move))
         {
         case EFFECT_FLING:
             if (!IsBattlerAlive(battlerDef)) // Edge case for removing a mon's item when there is no target available after using Fling.
@@ -1382,16 +1387,16 @@ static enum CancelerResult CancelerMoveEffectFailureTarget(struct BattleContext 
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerPowderStatus(struct BattleContext *ctx)
+static enum CancelerResult CancelerPowderStatus(struct BattleCalcValues *cv)
 {
-    if (TryActivatePowderStatus(ctx->move))
+    if (TryActivatePowderStatus(cv->move))
     {
-        if (!IsAbilityAndRecord(ctx->battlerAtk, ctx->abilityAtk, ABILITY_MAGIC_GUARD))
-            SetPassiveDamageAmount(ctx->battlerAtk, GetNonDynamaxMaxHP(ctx->battlerAtk) / 4);
+        if (!IsAbilityAndRecord(cv->battlerAtk, cv->abilities[cv->battlerAtk], ABILITY_MAGIC_GUARD))
+            SetPassiveDamageAmount(cv->battlerAtk, GetNonDynamaxMaxHP(cv->battlerAtk) / 4);
 
         // This might be incorrect
-        if (GetActiveGimmick(ctx->battlerAtk) != GIMMICK_Z_MOVE
-         || HasTrainerUsedGimmick(ctx->battlerAtk, GIMMICK_Z_MOVE))
+        if (GetActiveGimmick(cv->battlerAtk) != GIMMICK_Z_MOVE
+         || HasTrainerUsedGimmick(cv->battlerAtk, GIMMICK_Z_MOVE))
             gBattlescriptCurrInstr = BattleScript_MoveUsedPowder;
         return CANCELER_RESULT_FAILURE;
     }
@@ -1410,11 +1415,11 @@ bool32 IsDazzlingAbility(enum Ability ability)
     return FALSE;
 }
 
-static enum CancelerResult CancelerPriorityBlock(struct BattleContext *ctx)
+static enum CancelerResult CancelerPriorityBlock(struct BattleCalcValues *cv)
 {
     bool32 effect = FALSE;
-    s32 priority = GetChosenMovePriority(ctx->battlerAtk, ctx->abilityAtk);
-    enum MoveTarget moveTarget = GetBattlerMoveTargetType(ctx->battlerAtk, ctx->move);
+    s32 priority = GetChosenMovePriority(cv->battlerAtk, cv->abilities[cv->battlerAtk]);
+    enum MoveTarget moveTarget = GetBattlerMoveTargetType(cv->battlerAtk, cv->move);
 
     if (priority <= 0 || moveTarget == TARGET_FIELD || moveTarget == TARGET_OPPONENTS_FIELD)
         return CANCELER_RESULT_SUCCESS;
@@ -1423,10 +1428,10 @@ static enum CancelerResult CancelerPriorityBlock(struct BattleContext *ctx)
     enum Ability ability = ABILITY_NONE; // ability of battler who is blocking
     for (battler = 0; battler < gBattlersCount; battler++)
     {
-        if (!IsBattlerAlive(battler) || IsBattlerAlly(ctx->battlerAtk, battler))
+        if (!IsBattlerAlive(battler) || IsBattlerAlly(cv->battlerAtk, battler))
             continue;
-        if (ShouldSkipFailureCheckOnBattler(ctx->battlerAtk, battler, TRUE)
-         && (!IsDoubleBattle() || ShouldSkipFailureCheckOnBattler(ctx->battlerAtk, BATTLE_PARTNER(battler), TRUE))) // either battler or partner is affected
+        if (ShouldSkipFailureCheckOnBattler(cv->battlerAtk, battler, TRUE)
+         && (!IsDoubleBattle() || ShouldSkipFailureCheckOnBattler(cv->battlerAtk, BATTLE_PARTNER(battler), TRUE))) // either battler or partner is affected
             continue;
 
         ability = GetBattlerAbility(battler);
@@ -1449,27 +1454,27 @@ static enum CancelerResult CancelerPriorityBlock(struct BattleContext *ctx)
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerProtean(struct BattleContext *ctx)
+static enum CancelerResult CancelerProtean(struct BattleCalcValues *cv)
 {
-    enum Type moveType = GetBattleMoveType(ctx->move);
-    if (ProteanTryChangeType(ctx->battlerAtk, ctx->abilityAtk, ctx->move, moveType))
+    enum Type moveType = GetBattleMoveType(cv->move);
+    if (ProteanTryChangeType(cv->battlerAtk, cv->abilities[cv->battlerAtk], cv->move, moveType))
     {
         if (GetConfig(B_PROTEAN_LIBERO) >= GEN_9)
-            gBattleMons[ctx->battlerAtk].volatiles.usedProteanLibero = TRUE;
+            gBattleMons[cv->battlerAtk].volatiles.usedProteanLibero = TRUE;
         PREPARE_TYPE_BUFFER(gBattleTextBuff1, moveType);
-        gBattlerAbility = ctx->battlerAtk;
-        PrepareStringBattle(STRINGID_EMPTYSTRING3, ctx->battlerAtk);
+        gBattlerAbility = cv->battlerAtk;
+        PrepareStringBattle(STRINGID_EMPTYSTRING3, cv->battlerAtk);
         gBattleCommunication[MSG_DISPLAY] = 1;
         BattleScriptCall(BattleScript_ProteanActivates);
-        return CANCELER_RESULT_BREAK;
+        return CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
     }
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerExplodingDamp(struct BattleContext *ctx)
+static enum CancelerResult CancelerExplodingDamp(struct BattleCalcValues *cv)
 {
     u32 dampBattler = IsAbilityOnField(ABILITY_DAMP);
-    if (dampBattler && IsMoveDampBanned(ctx->move))
+    if (dampBattler && IsMoveDampBanned(cv->move))
     {
         gBattleScripting.battler = dampBattler - 1;
         gBattlescriptCurrInstr = BattleScript_DampStopsExplosion;
@@ -1478,60 +1483,60 @@ static enum CancelerResult CancelerExplodingDamp(struct BattleContext *ctx)
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerExplosion(struct BattleContext *ctx)
+static enum CancelerResult CancelerExplosion(struct BattleCalcValues *cv)
 {
     // KO user of Explosion; for Final Gambit doesn't happen if target is immune or if it missed
-    if (IsExplosionMove(ctx->move)
-     && (GetMoveEffect(ctx->move) != EFFECT_FINAL_GAMBIT || IsAnyTargetAffected()))
+    if (IsExplosionMove(cv->move)
+     && (GetMoveEffect(cv->move) != EFFECT_FINAL_GAMBIT || IsAnyTargetAffected()))
     {
         BattleScriptCall(BattleScript_Explosion);
-        return CANCELER_RESULT_BREAK;
+        return CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
     }
 
     return CANCELER_RESULT_SUCCESS;
 }
 
-static bool32 CanTwoTurnMoveFireThisTurn(struct BattleContext *ctx)
+static bool32 CanTwoTurnMoveFireThisTurn(struct BattleCalcValues *cv)
 {
-    if (gBattleMoveEffects[GetMoveEffect(ctx->move)].semiInvulnerableEffect
-     || GetMoveEffect(ctx->move) == EFFECT_GEOMANCY
-     || !IsBattlerWeatherAffected(ctx->holdEffectAtk, GetWeather(), GetMoveTwoTurnAttackWeather(ctx->move)))
+    if (gBattleMoveEffects[GetMoveEffect(cv->move)].semiInvulnerableEffect
+     || GetMoveEffect(cv->move) == EFFECT_GEOMANCY
+     || !IsBattlerWeatherAffected(cv->holdEffects[cv->battlerAtk], GetWeather(), GetMoveTwoTurnAttackWeather(cv->move)))
         return FALSE;
     return TRUE;
 }
 
-static enum CancelerResult HandleSkyDropResult(struct BattleContext *ctx)
+static enum CancelerResult HandleSkyDropResult(struct BattleCalcValues *cv)
 {
-    if (gBattleMons[ctx->battlerAtk].volatiles.multipleTurns) // Second turn
+    if (gBattleMons[cv->battlerAtk].volatiles.multipleTurns) // Second turn
     {
         gBattleScripting.animTurn = 1;
         gBattleScripting.animTargetsHit = 0;
-        gBattleMons[ctx->battlerAtk].volatiles.multipleTurns = FALSE;
-        gBattleMons[ctx->battlerAtk].volatiles.semiInvulnerable = STATE_NONE;
-        gBattleMons[ctx->battlerAtk].volatiles.skyDropTarget = 0;
+        gBattleMons[cv->battlerAtk].volatiles.multipleTurns = FALSE;
+        gBattleMons[cv->battlerAtk].volatiles.semiInvulnerable = STATE_NONE;
+        gBattleMons[cv->battlerAtk].volatiles.skyDropTarget = 0;
 
         // Sky Drop fails if target already left the field
-        if (gBattleMons[ctx->battlerDef].volatiles.semiInvulnerable == STATE_NONE)
+        if (gBattleMons[cv->battlerDef].volatiles.semiInvulnerable == STATE_NONE)
         {
             gBattlescriptCurrInstr = BattleScript_SkyDropNoTarget;
             return CANCELER_RESULT_FAILURE;
         }
 
-        gBattleMons[ctx->battlerDef].volatiles.semiInvulnerable = STATE_NONE;
+        gBattleMons[cv->battlerDef].volatiles.semiInvulnerable = STATE_NONE;
         return CANCELER_RESULT_SUCCESS;
     }
 
-    if (IsBattlerAlly(ctx->battlerAtk, ctx->battlerDef))
+    if (IsBattlerAlly(cv->battlerAtk, cv->battlerDef))
     {
         gBattlescriptCurrInstr = BattleScript_ButItFailed;
         return CANCELER_RESULT_FAILURE;
     }
-    else if (gBattleMons[ctx->battlerDef].volatiles.semiInvulnerable != STATE_NONE)
+    else if (gBattleMons[cv->battlerDef].volatiles.semiInvulnerable != STATE_NONE)
     {
         gBattlescriptCurrInstr = BattleScript_ButItFailed;
         return CANCELER_RESULT_FAILURE;
     }
-    else if (DoesSubstituteBlockMove(ctx->battlerAtk, ctx->battlerDef, ctx->move))
+    else if (DoesSubstituteBlockMove(cv->battlerAtk, cv->battlerDef, cv->move))
     {
         gBattlescriptCurrInstr = BattleScript_ButItFailed;
         return CANCELER_RESULT_FAILURE;
@@ -1544,76 +1549,76 @@ static enum CancelerResult HandleSkyDropResult(struct BattleContext *ctx)
 
     // First turn
 
-    if (gBattleMons[ctx->battlerDef].volatiles.rampageTurns > 0)
-        gBattleMons[ctx->battlerDef].volatiles.confuseAfterDrop = TRUE;
+    if (gBattleMons[cv->battlerDef].volatiles.rampageTurns > 0)
+        gBattleMons[cv->battlerDef].volatiles.confuseAfterDrop = TRUE;
 
-    CancelMultiTurnMoves(ctx->battlerDef);
-    gLockedMoves[ctx->battlerAtk] = ctx->move;
-    gProtectStructs[ctx->battlerAtk].chargingTurn = TRUE;
-    gBattleMons[ctx->battlerAtk].volatiles.multipleTurns = TRUE;
-    gBattleMons[ctx->battlerAtk].volatiles.skyDropTarget = ctx->battlerDef + 1;
-    gBattleMons[ctx->battlerAtk].volatiles.semiInvulnerable = STATE_SKY_DROP_ATTACKER;
-    gBattleMons[ctx->battlerDef].volatiles.semiInvulnerable = STATE_SKY_DROP_TARGET;
-    if (gSideTimers[GetBattlerSide(ctx->battlerDef)].followmeTimer != 0 && gSideTimers[GetBattlerSide(ctx->battlerDef)].followmeTarget == ctx->battlerDef)
-        gSideTimers[GetBattlerSide(ctx->battlerDef)].followmeTimer = 0;
+    CancelMultiTurnMoves(cv->battlerDef);
+    gLockedMoves[cv->battlerAtk] = cv->move;
+    gProtectStructs[cv->battlerAtk].chargingTurn = TRUE;
+    gBattleMons[cv->battlerAtk].volatiles.multipleTurns = TRUE;
+    gBattleMons[cv->battlerAtk].volatiles.skyDropTarget = cv->battlerDef + 1;
+    gBattleMons[cv->battlerAtk].volatiles.semiInvulnerable = STATE_SKY_DROP_ATTACKER;
+    gBattleMons[cv->battlerDef].volatiles.semiInvulnerable = STATE_SKY_DROP_TARGET;
+    if (gSideTimers[GetBattlerSide(cv->battlerDef)].followmeTimer != 0 && gSideTimers[GetBattlerSide(cv->battlerDef)].followmeTarget == cv->battlerDef)
+        gSideTimers[GetBattlerSide(cv->battlerDef)].followmeTimer = 0;
 
     gBattlescriptCurrInstr = BattleScript_SkyDropCharging;
-    return CANCELER_RESULT_BREAK;
+    return CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
 }
 
-static enum CancelerResult CancelerCharging(struct BattleContext *ctx)
+static enum CancelerResult CancelerCharging(struct BattleCalcValues *cv)
 {
     enum CancelerResult result = CANCELER_RESULT_SUCCESS;
 
-    if (!gBattleMoveEffects[GetMoveEffect(ctx->move)].twoTurnEffect)
+    if (!gBattleMoveEffects[GetMoveEffect(cv->move)].twoTurnEffect)
     {
         result = CANCELER_RESULT_SUCCESS;
     }
-    else if (GetMoveEffect(ctx->move) == EFFECT_SKY_DROP)
+    else if (GetMoveEffect(cv->move) == EFFECT_SKY_DROP)
     {
-        result = HandleSkyDropResult(ctx);
+        result = HandleSkyDropResult(cv);
     }
-    else if (gBattleMons[ctx->battlerAtk].volatiles.multipleTurns) // Second turn
+    else if (gBattleMons[cv->battlerAtk].volatiles.multipleTurns) // Second turn
     {
         gBattleScripting.animTurn = 1;
         gBattleScripting.animTargetsHit = 0;
-        gBattleMons[ctx->battlerAtk].volatiles.multipleTurns = FALSE;
-        if (gBattleMoveEffects[GetMoveEffect(ctx->move)].semiInvulnerableEffect)
-            gBattleMons[ctx->battlerAtk].volatiles.semiInvulnerable = STATE_NONE;
+        gBattleMons[cv->battlerAtk].volatiles.multipleTurns = FALSE;
+        if (gBattleMoveEffects[GetMoveEffect(cv->move)].semiInvulnerableEffect)
+            gBattleMons[cv->battlerAtk].volatiles.semiInvulnerable = STATE_NONE;
         result = CANCELER_RESULT_SUCCESS;
     }
-    else if (!gProtectStructs[ctx->battlerAtk].chargingTurn) // First turn charge
+    else if (!gProtectStructs[cv->battlerAtk].chargingTurn) // First turn charge
     {
-        gLockedMoves[ctx->battlerAtk] = ctx->move;
-        gProtectStructs[ctx->battlerAtk].chargingTurn = TRUE;
-        if (gBattleMoveEffects[GetMoveEffect(ctx->move)].semiInvulnerableEffect)
-            gBattleMons[ctx->battlerAtk].volatiles.semiInvulnerable = GetMoveTwoTurnAttackStatus(ctx->move);
+        gLockedMoves[cv->battlerAtk] = cv->move;
+        gProtectStructs[cv->battlerAtk].chargingTurn = TRUE;
+        if (gBattleMoveEffects[GetMoveEffect(cv->move)].semiInvulnerableEffect)
+            gBattleMons[cv->battlerAtk].volatiles.semiInvulnerable = GetMoveTwoTurnAttackStatus(cv->move);
         BattleScriptCall(BattleScript_TwoTurnMoveCharging);
-        result = CANCELER_RESULT_PAUSE;
+        result = CANCELER_RESULT_RUN_SCRIPT;
     }
     else // Try move this turn. Otherwise use next turn
     {
-        if (CanTwoTurnMoveFireThisTurn(ctx))
+        if (CanTwoTurnMoveFireThisTurn(cv))
         {
             gBattleScripting.animTurn = 1;
             gBattleScripting.animTargetsHit = 0;
-            gProtectStructs[ctx->battlerAtk].chargingTurn = FALSE;
+            gProtectStructs[cv->battlerAtk].chargingTurn = FALSE;
             result = CANCELER_RESULT_SUCCESS;
         }
-        else if (ctx->holdEffectAtk == HOLD_EFFECT_POWER_HERB)
+        else if (cv->holdEffects[cv->battlerAtk] == HOLD_EFFECT_POWER_HERB)
         {
             gBattleScripting.animTurn = 1;
             gBattleScripting.animTargetsHit = 0;
-            gProtectStructs[ctx->battlerAtk].chargingTurn = FALSE;
-            gLastUsedItem = gBattleMons[ctx->battlerAtk].item;
+            gProtectStructs[cv->battlerAtk].chargingTurn = FALSE;
+            gLastUsedItem = gBattleMons[cv->battlerAtk].item;
             BattleScriptCall(BattleScript_PowerHerbActivation);
-            result = CANCELER_RESULT_BREAK;
+            result = CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
         }
         else // Use move next turn
         {
-            gBattleMons[ctx->battlerAtk].volatiles.multipleTurns = TRUE;
+            gBattleMons[cv->battlerAtk].volatiles.multipleTurns = TRUE;
             gBattlescriptCurrInstr = BattleScript_MoveEnd;
-            result = CANCELER_RESULT_BREAK;
+            result = CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
         }
 
     }
@@ -1621,20 +1626,20 @@ static enum CancelerResult CancelerCharging(struct BattleContext *ctx)
     return result;
 }
 
-static enum CancelerResult CancelerMoveSpecificMessage(struct BattleContext *ctx)
+static enum CancelerResult CancelerMoveSpecificMessage(struct BattleCalcValues *cv)
 {
-    switch (GetMoveEffect(ctx->move))
+    switch (GetMoveEffect(cv->move))
     {
     case EFFECT_MAGNITUDE:
         CalculateMagnitudeDamage();
         BattleScriptCall(BattleScript_MagnitudeMessage);
-        return CANCELER_RESULT_BREAK;
+        return CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
     case EFFECT_FICKLE_BEAM:
         gBattleStruct->fickleBeamBoosted = RandomPercentage(RNG_FICKLE_BEAM, 30);
         if (gBattleStruct->fickleBeamBoosted)
         {
             BattleScriptCall(BattleScript_FickleBeamMessage);
-            return CANCELER_RESULT_BREAK;
+            return CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
         }
         break;
     default:
@@ -1676,9 +1681,9 @@ static bool32 NoTargetPresent(enum BattlerId battler, enum Move move, enum MoveT
     return FALSE;
 }
 
-static enum CancelerResult CancelerNoTarget(struct BattleContext *ctx)
+static enum CancelerResult CancelerNoTarget(struct BattleCalcValues *cv)
 {
-    enum MoveTarget moveTarget = GetBattlerMoveTargetType(ctx->battlerAtk, ctx->move);
+    enum MoveTarget moveTarget = GetBattlerMoveTargetType(cv->battlerAtk, cv->move);
 
     if (NoTargetPresent(gBattlerAttacker, gCurrentMove, moveTarget))
     {
@@ -1686,9 +1691,9 @@ static enum CancelerResult CancelerNoTarget(struct BattleContext *ctx)
         return CANCELER_RESULT_FAILURE;
     }
 
-    if (ctx->battlerAtk == ctx->battlerDef
+    if (cv->battlerAtk == cv->battlerDef
      && moveTarget == TARGET_ALLY
-     && gProtectStructs[BATTLE_PARTNER(ctx->battlerAtk)].usedAllySwitch)
+     && gProtectStructs[BATTLE_PARTNER(cv->battlerAtk)].usedAllySwitch)
     {
         gBattlescriptCurrInstr = BattleScript_ButItFailed;
         return CANCELER_RESULT_FAILURE;
@@ -1697,116 +1702,144 @@ static enum CancelerResult CancelerNoTarget(struct BattleContext *ctx)
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerTookAttack(struct BattleContext *ctx)
+static enum CancelerResult CancelerTookAttack(struct BattleCalcValues *cv)
 {
-    if (gSpecialStatuses[gBattlerTarget].abilityRedirected)
+    if (gSpecialStatuses[cv->battlerDef].abilityRedirected)
     {
-        gSpecialStatuses[gBattlerTarget].abilityRedirected = FALSE;
+        gSpecialStatuses[cv->battlerDef].abilityRedirected = FALSE;
         BattleScriptCall(BattleScript_TookAttack);
-        return CANCELER_RESULT_BREAK;
+        return CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
     }
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult CancelerTargetFailure(struct BattleContext *ctx)
+static bool32 CanMoveBeBlockedByTargetHelper(struct BattleCalcValues *cv, s32 movePriority)
+{
+    struct DamageContext ctx = {
+        .battlerAtk = cv->battlerAtk,
+        .battlerDef = cv->battlerDef,
+        .move = cv->move,
+        .moveType = GetBattleMoveType(cv->move),
+        .updateFlags = TRUE,
+        .runScript = TRUE,
+        .abilityAtk = cv->abilities[cv->battlerAtk],
+        .abilityDef = cv->abilities[cv->battlerDef],
+        .holdEffectAtk = cv->holdEffects[cv->battlerAtk],
+        .holdEffectDef = cv->holdEffects[cv->battlerDef],
+    };
+
+    return CanMoveBeBlockedByTarget(&ctx, movePriority);
+}
+
+static enum CancelerResult CancelerTargetFailure(struct BattleCalcValues *cv)
 {
     bool32 targetAvoidedAttack = FALSE;
-    enum MoveTarget moveTarget = GetBattlerMoveTargetType(ctx->battlerAtk, ctx->move);
-    s32 movePriority = GetChosenMovePriority(ctx->battlerAtk, ctx->abilityAtk);
-    ctx->moveType = GetBattleMoveType(ctx->move);
-    ctx->updateFlags = TRUE;
-    ctx->runScript = TRUE;
+    enum MoveTarget moveTarget = GetBattlerMoveTargetType(cv->battlerAtk, cv->move);
+    s32 movePriority = GetChosenMovePriority(cv->battlerAtk, cv->abilities[cv->battlerAtk]);
 
     while (gBattleStruct->eventState.atkCancelerBattler < MAX_BATTLERS_COUNT)
     {
-        ctx->battlerDef = GetTargetBySlot(ctx->battlerAtk, gBattleStruct->eventState.atkCancelerBattler);
+        if (IsDoubleBattle())
+            cv->battlerDef = GetTargetBySlot(cv->battlerAtk, gBattleStruct->eventState.atkCancelerBattler);
+        else
+            cv->battlerDef = gBattleStruct->eventState.atkCancelerBattler;
+
         gBattleStruct->eventState.atkCancelerBattler++;
 
-        if (!IsDoubleBattle() && ctx->battlerDef >= gBattlersCount)
+        if (ShouldSkipFailureCheckOnBattler(cv->battlerAtk, cv->battlerDef, FALSE))
+        {
             continue;
-
-        if (ShouldSkipFailureCheckOnBattler(ctx->battlerAtk, ctx->battlerDef, FALSE))
-            continue;
-
-        ctx->abilityDef = GetBattlerAbility(ctx->battlerDef);
-        ctx->holdEffectDef = GetBattlerHoldEffect(ctx->battlerDef);
+        }
 
         if (moveTarget == TARGET_OPPONENTS_FIELD)
         {
-            if (!IsSemiInvulnerable(ctx->battlerDef, CHECK_ALL) && CanBattlerBounceBackMove(ctx))
-                gBattleStruct->moveResultFlags[ctx->battlerDef] |= MOVE_RESULT_FAILED;
+            if (!IsSemiInvulnerable(cv->battlerDef, CHECK_ALL) && CanBattlerBounceBackMove(cv))
+                gBattleStruct->moveResultFlags[cv->battlerDef] |= MOVE_RESULT_FAILED;
         }
-        else if (IsBattlerUnaffectedByMove(ctx->battlerDef)) // immune but targeted
+        else if (IsBattlerUnaffectedByMove(cv->battlerDef)) // immune but targeted
         {
             BattleScriptCall(BattleScript_DoesntAffectScripting);
             targetAvoidedAttack = TRUE;
         }
-        else if (!IsBattlerAlive(ctx->battlerDef))
+        else if (!IsBattlerAlive(cv->battlerDef))
         {
-            gBattleStruct->moveResultFlags[ctx->battlerDef] |= MOVE_RESULT_FAILED;
+            gBattleStruct->moveResultFlags[cv->battlerDef] |= MOVE_RESULT_FAILED;
             continue;
         }
-        else if (!CanBreakThroughSemiInvulnerablity(ctx->battlerAtk, ctx->battlerDef, ctx->abilityAtk, ctx->abilityDef, ctx->move))
+        else if (!CanBreakThroughSemiInvulnerablity(cv->battlerAtk, cv->battlerDef, cv->abilities[cv->battlerAtk], cv->abilities[cv->battlerDef], cv->move))
         {
-            gBattleStruct->moveResultFlags[ctx->battlerDef] |= MOVE_RESULT_FAILED;
+            gBattleStruct->moveResultFlags[cv->battlerDef] |= MOVE_RESULT_FAILED;
             gBattleCommunication[MULTISTRING_CHOOSER] = B_MSG_AVOIDED_ATK;
-            if (GetMoveEffect(ctx->move) == EFFECT_FLING)
+            if (GetMoveEffect(cv->move) == EFFECT_FLING)
                 BattleScriptCall(BattleScript_TargetAvoidsAttackConsumeFlingItem);
             else
                 BattleScriptCall(BattleScript_TargetAvoidsAttack);
             targetAvoidedAttack = TRUE;
         }
-        else if (IsBattlerProtected(ctx))
+        else if (IsBattlerProtected(cv))
         {
             SetOrClearRageVolatile();
-            gBattleStruct->moveResultFlags[ctx->battlerDef] |= MOVE_RESULT_MISSED;
+            gBattleStruct->moveResultFlags[cv->battlerDef] |= MOVE_RESULT_MISSED;
             gBattleCommunication[MULTISTRING_CHOOSER] = B_MSG_PROTECTED;
-            if (GetMoveEffect(ctx->move) == EFFECT_FLING)
+            if (GetMoveEffect(cv->move) == EFFECT_FLING)
                 BattleScriptCall(BattleScript_TargetAvoidsAttackConsumeFlingItem);
             else
                 BattleScriptCall(BattleScript_TargetAvoidsAttack);
             targetAvoidedAttack = TRUE;
         }
-        else if (CanBattlerBounceBackMove(ctx))
+        else if (CanBattlerBounceBackMove(cv))
         {
-            gBattleStruct->moveResultFlags[ctx->battlerDef] |= MOVE_RESULT_FAILED;
+            gBattleStruct->moveResultFlags[cv->battlerDef] |= MOVE_RESULT_FAILED;
         }
-        else if (CanMoveBeBlockedByTarget(ctx, movePriority))
+        else if (CanMoveBeBlockedByTargetHelper(cv, movePriority))
         {
-            gBattleStruct->moveResultFlags[ctx->battlerDef] |= MOVE_RESULT_MISSED;
+            gBattleStruct->moveResultFlags[cv->battlerDef] |= MOVE_RESULT_MISSED;
+            gSpecialStatuses[cv->battlerDef].updateStallMons = TRUE;
             targetAvoidedAttack = TRUE;
         }
-        else if (GetMoveEffect(ctx->move) == EFFECT_SYNCHRONOISE && !DoBattlersShareType(ctx->battlerAtk, ctx->battlerDef))
+        else if (GetMoveEffect(cv->move) == EFFECT_SYNCHRONOISE && !DoBattlersShareType(cv->battlerAtk, cv->battlerDef))
         {
-            gBattleStruct->moveResultFlags[ctx->battlerDef] = MOVE_RESULT_NO_EFFECT;
+            gBattleStruct->moveResultFlags[cv->battlerDef] = MOVE_RESULT_NO_EFFECT;
             BattleScriptCall(BattleScript_ItDoesntAffectFoe);
             targetAvoidedAttack = TRUE;
         }
-        else if (GetMoveEffect(ctx->move) == EFFECT_SKY_DROP
-              && !gProtectStructs[ctx->battlerAtk].chargingTurn
-              && IS_BATTLER_OF_TYPE(ctx->battlerDef, TYPE_FLYING))
+        else if (GetMoveEffect(cv->move) == EFFECT_SKY_DROP
+              && !gProtectStructs[cv->battlerAtk].chargingTurn
+              && IS_BATTLER_OF_TYPE(cv->battlerDef, TYPE_FLYING))
         {
-            gBattleStruct->moveResultFlags[ctx->battlerDef] = MOVE_RESULT_NO_EFFECT;
+            gBattleStruct->moveResultFlags[cv->battlerDef] = MOVE_RESULT_NO_EFFECT;
             BattleScriptCall(BattleScript_SkyDropFlyingType);
             targetAvoidedAttack = TRUE;
         }
         else
         {
-            CalcTypeEffectivenessMultiplier(ctx);
+            struct DamageContext ctx = {
+                .battlerAtk = cv->battlerAtk,
+                .battlerDef = cv->battlerDef,
+                .move = cv->move,
+                .moveType = GetBattleMoveType(cv->move),
+                .updateFlags = TRUE,
+                .runScript = TRUE,
+                .abilityAtk = cv->abilities[cv->battlerAtk],
+                .abilityDef = cv->abilities[cv->battlerDef],
+                .holdEffectAtk = cv->holdEffects[cv->battlerAtk],
+                .holdEffectDef = cv->holdEffects[cv->battlerDef],
+            };
 
-            if (ctx->abilityBlocked)
+            if (CalcTypeEffectivenessMultiplier(&ctx) == UQ_4_12(0.0))
+                gSpecialStatuses[cv->battlerDef].updateStallMons = TRUE;
+
+            if (ctx.abilityBlocked)
             {
-                ctx->abilityBlocked = FALSE;
-                gBattleStruct->moveResultFlags[ctx->battlerDef] = MOVE_RESULT_FAILED;
-                gBattlerAbility = ctx->battlerDef;
-                RecordAbilityBattle(ctx->battlerDef, ctx->abilityDef);
+                gBattleStruct->moveResultFlags[cv->battlerDef] = MOVE_RESULT_FAILED;
+                gBattlerAbility = cv->battlerDef;
+                RecordAbilityBattle(cv->battlerDef, cv->abilities[cv->battlerDef]);
                 BattleScriptCall(BattleScript_NoEffectivenessAbility);
                 targetAvoidedAttack = TRUE;
             }
-            else if (ctx->airBalloonBlocked)
+            else if (ctx.airBalloonBlocked)
             {
-                ctx->airBalloonBlocked = FALSE;
-                gBattleStruct->moveResultFlags[ctx->battlerDef] = MOVE_RESULT_FAILED;
+                gBattleStruct->moveResultFlags[cv->battlerDef] = MOVE_RESULT_FAILED;
                 BattleScriptCall(BattleScript_DoesntAffectScripting);
                 targetAvoidedAttack = TRUE;
             }
@@ -1814,12 +1847,12 @@ static enum CancelerResult CancelerTargetFailure(struct BattleContext *ctx)
 
         if (targetAvoidedAttack)
         {
-            gLastLandedMoves[gBattlerTarget] = 0; // Might need investigation on what exactly clears is
-            gLastHitByType[gBattlerTarget] = 0;
-            gBattleScripting.battler = ctx->battlerDef;
+            gLastLandedMoves[cv->battlerDef] = 0; // Might need investigation on what exactly clears is
+            gLastHitByType[cv->battlerDef] = 0;
+            gBattleScripting.battler = cv->battlerDef;
             gBattleStruct->pledgeMove = FALSE;
-            CancelMultiTurnMoves(ctx->battlerAtk);
-            return CANCELER_RESULT_PAUSE;
+            CancelMultiTurnMoves(cv->battlerAtk);
+            return CANCELER_RESULT_RUN_SCRIPT;
         }
     }
 
@@ -1831,7 +1864,7 @@ static enum CancelerResult CancelerTargetFailure(struct BattleContext *ctx)
             gBattleStruct->numSpreadTargets = CountAliveMonsInBattle(BATTLE_ALIVE_EXCEPT_BATTLER, gBattlerAttacker);
     }
 
-    ctx->battlerDef = gBattlerTarget;
+    cv->battlerDef = gBattlerTarget;
     gBattleStruct->eventState.atkCancelerBattler = 0;
     return CANCELER_RESULT_SUCCESS;
 }
@@ -1846,20 +1879,20 @@ static bool32 CantFullyProtectFromMove(enum BattlerId battlerDef)
         && gProtectStructs[battlerDef].protected != PROTECT_MAX_GUARD;
 }
 
-static enum CancelerResult CancelerNotFullyProtected(struct BattleContext *ctx)
+static enum CancelerResult CancelerNotFullyProtected(struct BattleCalcValues *cv)
 {
     while (gBattleStruct->eventState.atkCancelerBattler < gBattlersCount)
     {
         enum BattlerId battlerDef = gBattleStruct->eventState.atkCancelerBattler++;
 
-        if (ShouldSkipFailureCheckOnBattler(ctx->battlerAtk, battlerDef, TRUE))
+        if (ShouldSkipFailureCheckOnBattler(cv->battlerAtk, battlerDef, TRUE))
             continue;
 
         if (CantFullyProtectFromMove(battlerDef))
         {
             BattleScriptCall(BattleScript_CouldntFullyProtect);
             gBattleScripting.battler = battlerDef;
-            return CANCELER_RESULT_PAUSE;
+            return CANCELER_RESULT_RUN_SCRIPT;
         }
     }
 
@@ -1867,17 +1900,17 @@ static enum CancelerResult CancelerNotFullyProtected(struct BattleContext *ctx)
     return CANCELER_RESULT_SUCCESS;
 }
 
-static bool32 IsMoveParentalBondAffected(struct BattleContext *ctx)
+static bool32 IsMoveParentalBondAffected(struct BattleCalcValues *cv)
 {
-    if (ctx->abilityAtk != ABILITY_PARENTAL_BOND
+    if (cv->abilities[cv->battlerAtk] != ABILITY_PARENTAL_BOND
      || gBattleStruct->numSpreadTargets > 1
-     || IsMoveParentalBondBanned(ctx->move)
-     || GetMoveCategory(ctx->move) == DAMAGE_CATEGORY_STATUS
-     || GetMoveEffect(ctx->move) == EFFECT_SEMI_INVULNERABLE
-     || GetMoveEffect(ctx->move) == EFFECT_TWO_TURNS_ATTACK
-     || GetActiveGimmick(ctx->battlerAtk) == GIMMICK_Z_MOVE
-     || (GetMoveEffect(ctx->move) == EFFECT_PRESENT && gBattleStruct->presentBasePower == 0)
-     || ctx->move == MOVE_STRUGGLE)
+     || IsMoveParentalBondBanned(cv->move)
+     || GetMoveCategory(cv->move) == DAMAGE_CATEGORY_STATUS
+     || GetMoveEffect(cv->move) == EFFECT_SEMI_INVULNERABLE
+     || GetMoveEffect(cv->move) == EFFECT_TWO_TURNS_ATTACK
+     || GetActiveGimmick(cv->battlerAtk) == GIMMICK_Z_MOVE
+     || (GetMoveEffect(cv->move) == EFFECT_PRESENT && gBattleStruct->presentBasePower == 0)
+     || cv->move == MOVE_STRUGGLE)
         return FALSE;
     return TRUE;
 }
@@ -1905,26 +1938,26 @@ static void SetRandomMultiHitCounter()
         gMultiHitCounter = RandomWeighted(RNG_HITS, 0, 0, 3, 3, 1, 1); // 37.5%: 2 hits, 37.5%: 3 hits, 12.5% 4 hits, 12.5% 5 hits.
 }
 
-static enum CancelerResult CancelerMultihitMoves(struct BattleContext *ctx)
+static enum CancelerResult CancelerMultihitMoves(struct BattleCalcValues *cv)
 {
-    SetPossibleNewSmartTarget(ctx->move);
+    SetPossibleNewSmartTarget(cv->move);
 
     if (IsBattlerUnaffectedByMove(gBattlerTarget)) // Dragon Darts can still hit partner
     {
         gMultiHitCounter = 0;
     }
-    else if (IsMultiHitMove(ctx->move))
+    else if (IsMultiHitMove(cv->move))
     {
-        enum Ability ability = ctx->abilityAtk;
+        enum Ability ability = cv->abilities[cv->battlerAtk];
 
         if (ability == ABILITY_SKILL_LINK)
         {
             gMultiHitCounter = 5;
         }
-        else if (GetMoveEffect(ctx->move) == EFFECT_SPECIES_POWER_OVERRIDE
-              && gBattleMons[ctx->battlerAtk].species == GetMoveSpeciesPowerOverride_Species(ctx->move))
+        else if (GetMoveEffect(cv->move) == EFFECT_SPECIES_POWER_OVERRIDE
+              && gBattleMons[cv->battlerAtk].species == GetMoveSpeciesPowerOverride_Species(cv->move))
         {
-            gMultiHitCounter = GetMoveSpeciesPowerOverride_NumOfHits(ctx->move);
+            gMultiHitCounter = GetMoveSpeciesPowerOverride_NumOfHits(cv->move);
         }
         else
         {
@@ -1933,22 +1966,22 @@ static enum CancelerResult CancelerMultihitMoves(struct BattleContext *ctx)
 
         PREPARE_BYTE_NUMBER_BUFFER(gBattleScripting.multihitString, 1, 0)
     }
-    else if (GetMoveStrikeCount(ctx->move) > 1)
+    else if (GetMoveStrikeCount(cv->move) > 1)
     {
-        if (GetMoveEffect(ctx->move) == EFFECT_POPULATION_BOMB && GetBattlerHoldEffect(ctx->battlerAtk) == HOLD_EFFECT_LOADED_DICE)
+        if (GetMoveEffect(cv->move) == EFFECT_POPULATION_BOMB && GetBattlerHoldEffect(cv->battlerAtk) == HOLD_EFFECT_LOADED_DICE)
         {
             gMultiHitCounter = RandomUniform(RNG_LOADED_DICE, 4, 10);
         }
         else
         {
-            gMultiHitCounter = GetMoveStrikeCount(ctx->move);
+            gMultiHitCounter = GetMoveStrikeCount(cv->move);
         }
 
         PREPARE_BYTE_NUMBER_BUFFER(gBattleScripting.multihitString, 3, 0)
     }
-    else if (GetMoveEffect(ctx->move) == EFFECT_BEAT_UP)
+    else if (GetMoveEffect(cv->move) == EFFECT_BEAT_UP)
     {
-        struct Pokemon* party = GetBattlerParty(ctx->battlerAtk);
+        struct Pokemon* party = GetBattlerParty(cv->battlerAtk);
         int i;
         gBattleStruct->beatUpSlot = 0;
         gMultiHitCounter = 0;
@@ -1972,7 +2005,7 @@ static enum CancelerResult CancelerMultihitMoves(struct BattleContext *ctx)
 
         PREPARE_BYTE_NUMBER_BUFFER(gBattleScripting.multihitString, 1, 0)
     }
-    else if (IsMoveParentalBondAffected(ctx))
+    else if (IsMoveParentalBondAffected(cv))
     {
         gSpecialStatuses[gBattlerAttacker].parentalBondState = PARENTAL_BOND_1ST_HIT;
         gMultiHitCounter = 2;
@@ -1986,7 +2019,7 @@ static enum CancelerResult CancelerMultihitMoves(struct BattleContext *ctx)
     return CANCELER_RESULT_SUCCESS;
 }
 
-static enum CancelerResult (*const sMoveSuccessOrderCancelers[])(struct BattleContext *ctx) =
+static enum CancelerResult (*const sMoveSuccessOrderCancelers[])(struct BattleCalcValues *cv) =
 {
     [CANCELER_CLEAR_FLAGS] = CancelerClearFlags,
     [CANCELER_STANCE_CHANGE_1] = CancelerStanceChangeOne,
@@ -2039,18 +2072,22 @@ enum CancelerResult DoAttackCanceler(void)
 {
     enum CancelerResult result = CANCELER_RESULT_SUCCESS;
 
-    struct BattleContext ctx = {0};
-    ctx.battlerAtk = gBattlerAttacker;
-    ctx.battlerDef = gBattlerTarget;
-    ctx.move = gCurrentMove;
-    ctx.chosenMove = gChosenMove;
-    ctx.abilityAtk = GetBattlerAbility(ctx.battlerAtk);
-    ctx.holdEffectAtk = GetBattlerHoldEffect(ctx.battlerAtk);
+    struct BattleCalcValues cv = {
+        .battlerAtk = gBattlerAttacker,
+        .battlerDef = gBattlerTarget,
+        .move = gCurrentMove,
+    };
+
+    for (enum BattlerId battler = 0; battler < gBattlersCount; battler++)
+    {
+        cv.abilities[battler] = GetBattlerAbility(battler);
+        cv.holdEffects[battler] = GetBattlerHoldEffect(battler);
+    }
 
     while (gBattleStruct->eventState.atkCanceler < CANCELER_END && result == CANCELER_RESULT_SUCCESS)
     {
-        result = sMoveSuccessOrderCancelers[gBattleStruct->eventState.atkCanceler](&ctx);
-        if (result != CANCELER_RESULT_PAUSE)
+        result = sMoveSuccessOrderCancelers[gBattleStruct->eventState.atkCanceler](&cv);
+        if (result != CANCELER_RESULT_RUN_SCRIPT)
             gBattleStruct->eventState.atkCanceler++;
     }
 
@@ -4234,41 +4271,41 @@ static enum Move GetMeFirstMove(void)
     return move;
 }
 
-static bool32 CanBattlerBounceBackMove(struct BattleContext *ctx)
+static bool32 CanBattlerBounceBackMove(struct BattleCalcValues *cv)
 {
-    return TryMagicBounce(ctx) || TryMagicCoat(ctx);
+    return TryMagicBounce(cv) || TryMagicCoat(cv);
 }
 
-static bool32 TryMagicBounce(struct BattleContext *ctx)
+static bool32 TryMagicBounce(struct BattleCalcValues *cv)
 {
-    if (!MoveCanBeBouncedBack(ctx->move))
+    if (!MoveCanBeBouncedBack(cv->move))
         return FALSE;
 
     if (gBattleStruct->magicBounceActive || gBattleStruct->bouncedMoveIsUsed)
         return FALSE;
 
-    if (ctx->abilityDef != ABILITY_MAGIC_BOUNCE)
+    if (cv->abilities[cv->battlerDef] != ABILITY_MAGIC_BOUNCE)
         return FALSE;
 
     gBattleStruct->magicBounceActive = TRUE;
-    gBattleStruct->moveBouncer = ctx->battlerDef;
+    gBattleStruct->moveBouncer = cv->battlerDef;
 
     return TRUE;
 }
 
-static bool32 TryMagicCoat(struct BattleContext *ctx)
+static bool32 TryMagicCoat(struct BattleCalcValues *cv)
 {
-    if (!MoveCanBeBouncedBack(ctx->move) || gBattleStruct->magicBounceActive) // Magic Bounce has precedence over magic coat
+    if (!MoveCanBeBouncedBack(cv->move) || gBattleStruct->magicBounceActive) // Magic Bounce has precedence over magic coat
         return FALSE;
 
     if (gBattleStruct->magicCoatActive || gBattleStruct->bouncedMoveIsUsed)
         return FALSE;
 
-    if (!gProtectStructs[ctx->battlerDef].bounceMove)
+    if (!gProtectStructs[cv->battlerDef].bounceMove)
         return FALSE;
 
     gBattleStruct->magicCoatActive = TRUE;
-    gBattleStruct->moveBouncer = ctx->battlerDef;
+    gBattleStruct->moveBouncer = cv->battlerDef;
 
     return TRUE;
 }
@@ -4328,4 +4365,32 @@ static void CalculateMagnitudeDamage(void)
     }
 
     PREPARE_BYTE_NUMBER_BUFFER(gBattleTextBuff1, 2, magnitude)
+}
+
+static void UpdateStallMons(void)
+{
+    if (IsBattlerTurnDamaged(gBattlerTarget, INCLUDING_SUBSTITUTES) || GetMoveCategory(gCurrentMove) == DAMAGE_CATEGORY_STATUS)
+        return;
+
+    struct BattleCalcValues cv = {
+        .battlerAtk = gBattlerAttacker,
+        .battlerDef = gBattlerTarget,
+        .move = gCurrentMove,
+    };
+
+    cv.abilities[cv.battlerAtk] = GetBattlerAbility(cv.battlerAtk);
+    cv.abilities[cv.battlerDef] = GetBattlerAbility(cv.battlerDef);
+    cv.holdEffects[cv.battlerAtk] = GetBattlerHoldEffect(cv.battlerAtk);
+    cv.holdEffects[cv.battlerDef] = GetBattlerHoldEffect(cv.battlerDef);
+
+    if (IsBattlerProtected(&cv))
+        return;
+
+    enum MoveTarget target = GetBattlerMoveTargetType(cv.battlerAtk, cv.move);
+    if (!IsDoubleBattle() || target == TARGET_SELECTED)
+    {
+        if (gSpecialStatuses[cv.battlerDef].updateStallMons)
+            gAiBattleData->playerStallMons[gBattlerPartyIndexes[gBattlerTarget]]++;
+    }
+    //  Handling for moves that target multiple opponents in doubles not handled currently
 }

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1273,7 +1273,7 @@ static void Cmd_critcalc(void)
     gBattlescriptCurrInstr = cmd->nextInstr;
 }
 
-static inline void CalculateAndSetMoveDamage(struct BattleContext *ctx)
+static inline void CalculateAndSetMoveDamage(struct DamageContext *ctx)
 {
     SetDynamicMoveCategory(gBattlerAttacker, ctx->battlerDef, gCurrentMove);
     ctx->isCrit = gSpecialStatuses[ctx->battlerDef].criticalHit;
@@ -1299,7 +1299,7 @@ static void Cmd_damagecalc(void)
         return;
     }
 
-    struct BattleContext ctx = {0};
+    struct DamageContext ctx = {0};
     ctx.battlerAtk = gBattlerAttacker;
     ctx.move = gCurrentMove;
     ctx.chosenMove = gChosenMove;
@@ -1342,7 +1342,7 @@ static void Cmd_typecalc(void)
 {
     CMD_ARGS();
 
-    struct BattleContext ctx = {0};
+    struct DamageContext ctx = {0};
     ctx.battlerAtk = gBattlerAttacker;
     ctx.battlerDef = gBattlerTarget;
     ctx.move = gCurrentMove;

--- a/src/battle_terastal.c
+++ b/src/battle_terastal.c
@@ -131,7 +131,7 @@ bool32 IsTypeStellarBoosted(enum BattlerId battler, enum Type type)
 
 // Returns the STAB power multiplier to use when Terastallized.
 // Power multipliers from Smogon Research thread.
-uq4_12_t GetTeraMultiplier(struct BattleContext *ctx)
+uq4_12_t GetTeraMultiplier(struct DamageContext *ctx)
 {
     enum Type teraType = GetBattlerTeraType(ctx->battlerAtk);
 

--- a/src/battle_tv.c
+++ b/src/battle_tv.c
@@ -1287,7 +1287,7 @@ static void TrySetBattleSeminarShow(void)
         powerOverride = 0;
         if (ShouldCalculateDamage(gCurrentMove, &dmgByMove[i], &powerOverride))
         {
-            struct BattleContext ctx = {0};
+            struct DamageContext ctx = {0};
             ctx.battlerAtk = gBattlerAttacker;
             ctx.battlerDef = gBattlerTarget;
             ctx.move = ctx.chosenMove = gCurrentMove;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -61,7 +61,7 @@ static bool32 IsOpposingSideEmpty(enum BattlerId battler);
 static void ResetParadoxWeatherStat(enum BattlerId battler);
 static void ResetParadoxTerrainStat(enum BattlerId battler);
 static bool32 CanBattlerFormChange(enum BattlerId battler, enum FormChanges method);
-static bool32 IsPowderMoveBlocked(struct BattleContext *ctx);
+static bool32 IsPowderMoveBlocked(struct DamageContext *ctx);
 const u8 *AbsorbedByDrainHpAbility(enum BattlerId battlerDef);
 const u8 *AbsorbedByStatIncreaseAbility(enum BattlerId battlerDef, enum Ability abilityDef, enum Stat statId, u32 statAmount);
 const u8 *AbsorbedByFlashFire(enum BattlerId battlerDef);
@@ -279,7 +279,7 @@ static u32 CalcBeatUpPower(void)
 }
 
 // Gen 3/4
-static s32 CalcBeatUpDamage(struct BattleContext *ctx)
+static s32 CalcBeatUpDamage(struct DamageContext *ctx)
 {
     u32 partyIndex = gBattleStruct->beatUpSpecies[gBattleStruct->beatUpSlot++];
     struct Pokemon *party = GetBattlerParty(ctx->battlerAtk);
@@ -2324,7 +2324,7 @@ void ChooseStatBoostAnimation(enum BattlerId battler)
 #undef ANIM_STAT_ACC
 #undef ANIM_STAT_EVASION
 
-bool32 CanMoveBeBlockedByTarget(struct BattleContext *ctx, s32 movePriority)
+bool32 CanMoveBeBlockedByTarget(struct DamageContext *ctx, s32 movePriority)
 {
     return CanPsychicTerrainProtectTarget(ctx, movePriority)
         || CanTargetBlockPranksterMove(ctx, movePriority)
@@ -2332,7 +2332,7 @@ bool32 CanMoveBeBlockedByTarget(struct BattleContext *ctx, s32 movePriority)
         || CanAbilityAbsorbMove(ctx);
 }
 
-bool32 CanPsychicTerrainProtectTarget(struct BattleContext *ctx, s32 movePriority)
+bool32 CanPsychicTerrainProtectTarget(struct DamageContext *ctx, s32 movePriority)
 {
     if (movePriority <= 0
      || !IsPsychicTerrainAffected(ctx->battlerDef, ctx->abilityDef, ctx->holdEffectDef, gFieldStatuses)
@@ -2347,7 +2347,7 @@ bool32 CanPsychicTerrainProtectTarget(struct BattleContext *ctx, s32 movePriorit
     return TRUE;
 }
 
-bool32 CanTargetBlockPranksterMove(struct BattleContext *ctx, s32 movePriority)
+bool32 CanTargetBlockPranksterMove(struct DamageContext *ctx, s32 movePriority)
 {
     if (movePriority <= 0
      || !IsBattleMoveStatus(ctx->move)
@@ -2361,7 +2361,7 @@ bool32 CanTargetBlockPranksterMove(struct BattleContext *ctx, s32 movePriority)
     return TRUE;
 }
 
-static bool32 IsPowderMoveBlocked(struct BattleContext *ctx)
+static bool32 IsPowderMoveBlocked(struct DamageContext *ctx)
 {
     if (!IsPowderMove(ctx->move)
      || ctx->battlerAtk == ctx->battlerDef
@@ -2378,7 +2378,7 @@ static bool32 IsPowderMoveBlocked(struct BattleContext *ctx)
     return TRUE;
 }
 
-bool32 CanAbilityAbsorbMove(struct BattleContext *ctx)
+bool32 CanAbilityAbsorbMove(struct DamageContext *ctx)
 {
     const u8 *battleScript = NULL;
 
@@ -3214,7 +3214,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
         case ABILITY_ANTICIPATION:
             if (shouldAbilityTrigger)
             {
-                struct BattleContext ctx = {0};
+                struct DamageContext ctx = {0};
                 uq4_12_t modifier = UQ_4_12(1.0);
                 for (i = 0; i < MAX_BATTLERS_COUNT; i++)
                 {
@@ -5770,54 +5770,54 @@ static bool32 IsCraftyShieldProtected(u32 battlerAtk, u32 battlerDef, u32 move)
     return FALSE;
 }
 
-bool32 IsBattlerProtected(struct BattleContext *ctx)
+bool32 IsBattlerProtected(struct BattleCalcValues *cv)
 {
-    if (gProtectStructs[ctx->battlerDef].protected == PROTECT_NONE
-     && gProtectStructs[BATTLE_PARTNER(ctx->battlerDef)].protected == PROTECT_NONE)
+    if (gProtectStructs[cv->battlerDef].protected == PROTECT_NONE
+     && gProtectStructs[BATTLE_PARTNER(cv->battlerDef)].protected == PROTECT_NONE)
         return FALSE;
 
-    if (GetMoveEffect(ctx->move) == EFFECT_CURSE && !IS_BATTLER_OF_TYPE(ctx->battlerAtk, TYPE_GHOST))
+    if (GetMoveEffect(cv->move) == EFFECT_CURSE && !IS_BATTLER_OF_TYPE(cv->battlerAtk, TYPE_GHOST))
         return FALSE;
 
-    if (gProtectStructs[ctx->battlerDef].protected != PROTECT_MAX_GUARD && !MoveIgnoresProtect(ctx->move))
+    if (gProtectStructs[cv->battlerDef].protected != PROTECT_MAX_GUARD && !MoveIgnoresProtect(cv->move))
     {
-        if (IsZMove(ctx->move) || IsMaxMove(ctx->move))
+        if (IsZMove(cv->move) || IsMaxMove(cv->move))
             return FALSE; // Z-Moves and Max Moves bypass protection (except Max Guard).
-        if (ctx->abilityAtk == ABILITY_UNSEEN_FIST
-         && IsMoveMakingContact(ctx->battlerAtk, ctx->battlerDef, ctx->abilityAtk, ctx->holdEffectAtk, ctx->move))
+        if (cv->abilities[cv->battlerAtk] == ABILITY_UNSEEN_FIST
+         && IsMoveMakingContact(cv->battlerAtk, cv->battlerDef, cv->abilities[cv->battlerAtk], cv->holdEffects[cv->battlerAtk], cv->move))
             return FALSE;
     }
 
-    if (GetBattlerMoveTargetType(ctx->battlerAtk, ctx->move) == TARGET_ALL_BATTLERS)
+    if (GetBattlerMoveTargetType(cv->battlerAtk, cv->move) == TARGET_ALL_BATTLERS)
         return FALSE;
 
     bool32 isProtected = FALSE;
 
-    if (IsCraftyShieldProtected(ctx->battlerAtk, ctx->battlerDef, ctx->move))
+    if (IsCraftyShieldProtected(cv->battlerAtk, cv->battlerDef, cv->move))
         isProtected = TRUE;
-    else if (MoveIgnoresProtect(ctx->move))
+    else if (MoveIgnoresProtect(cv->move))
         isProtected = FALSE;
-    else if (IsSideProtected(ctx->battlerDef, PROTECT_WIDE_GUARD) && IsSpreadMove(GetBattlerMoveTargetType(ctx->battlerAtk, ctx->move)))
+    else if (IsSideProtected(cv->battlerDef, PROTECT_WIDE_GUARD) && IsSpreadMove(GetBattlerMoveTargetType(cv->battlerAtk, cv->move)))
         isProtected = TRUE;
-    else if (gProtectStructs[ctx->battlerDef].protected == PROTECT_NORMAL)
+    else if (gProtectStructs[cv->battlerDef].protected == PROTECT_NORMAL)
         isProtected = TRUE;
-    else if (gProtectStructs[ctx->battlerDef].protected == PROTECT_SPIKY_SHIELD)
+    else if (gProtectStructs[cv->battlerDef].protected == PROTECT_SPIKY_SHIELD)
         isProtected = TRUE;
-    else if (gProtectStructs[ctx->battlerDef].protected == PROTECT_MAX_GUARD)
+    else if (gProtectStructs[cv->battlerDef].protected == PROTECT_MAX_GUARD)
         isProtected = TRUE;
-    else if (gProtectStructs[ctx->battlerDef].protected == PROTECT_BANEFUL_BUNKER)
+    else if (gProtectStructs[cv->battlerDef].protected == PROTECT_BANEFUL_BUNKER)
         isProtected = TRUE;
-    else if (gProtectStructs[ctx->battlerDef].protected == PROTECT_BURNING_BULWARK)
+    else if (gProtectStructs[cv->battlerDef].protected == PROTECT_BURNING_BULWARK)
         isProtected = TRUE;
-    else if (gProtectStructs[ctx->battlerDef].protected == PROTECT_OBSTRUCT && !IsBattleMoveStatus(ctx->move))
+    else if (gProtectStructs[cv->battlerDef].protected == PROTECT_OBSTRUCT && !IsBattleMoveStatus(cv->move))
         isProtected = TRUE;
-    else if (gProtectStructs[ctx->battlerDef].protected == PROTECT_SILK_TRAP && !IsBattleMoveStatus(ctx->move))
+    else if (gProtectStructs[cv->battlerDef].protected == PROTECT_SILK_TRAP && !IsBattleMoveStatus(cv->move))
         isProtected = TRUE;
-    else if (gProtectStructs[ctx->battlerDef].protected == PROTECT_KINGS_SHIELD && !IsBattleMoveStatus(ctx->move))
+    else if (gProtectStructs[cv->battlerDef].protected == PROTECT_KINGS_SHIELD && !IsBattleMoveStatus(cv->move))
         isProtected = TRUE;
-    else if (IsSideProtected(ctx->battlerDef, PROTECT_QUICK_GUARD) && GetChosenMovePriority(ctx->battlerAtk, GetBattlerAbility(ctx->battlerAtk)) > 0)
+    else if (IsSideProtected(cv->battlerDef, PROTECT_QUICK_GUARD) && GetChosenMovePriority(cv->battlerAtk, cv->abilities[cv->battlerAtk]) > 0)
         isProtected = TRUE;
-    else if (IsSideProtected(ctx->battlerDef, PROTECT_MAT_BLOCK) && !IsBattleMoveStatus(ctx->move))
+    else if (IsSideProtected(cv->battlerDef, PROTECT_MAT_BLOCK) && !IsBattleMoveStatus(cv->move))
         isProtected = TRUE;
     else
         isProtected = FALSE;
@@ -5971,7 +5971,7 @@ bool32 BattlerHasCopyableChanges(enum BattlerId battler)
     return FALSE;
 }
 
-u32 GetMoveTargetCount(struct BattleContext *ctx)
+u32 GetMoveTargetCount(struct DamageContext *ctx)
 {
     enum BattlerId battlerAtk = ctx->battlerAtk;
     enum BattlerId battlerDef = ctx->battlerDef;
@@ -6042,7 +6042,7 @@ static inline u32 CalcFuryCutterBasePower(enum BattlerId battlerAtk, u32 basePow
     return min(basePower, 160); // The duration to reach 160 depends on a gen
 }
 
-static inline u32 CalcTerrainBoostedPower(struct BattleContext *ctx, u32 basePower)
+static inline u32 CalcTerrainBoostedPower(struct DamageContext *ctx, u32 basePower)
 {
     bool32 isTerrainAffected = FALSE;
 
@@ -6099,7 +6099,7 @@ static inline u32 IsFieldWaterSportAffected(enum Type moveType)
     return FALSE;
 }
 
-static inline u32 CalcMoveBasePower(struct BattleContext *ctx)
+static inline u32 CalcMoveBasePower(struct DamageContext *ctx)
 {
     enum BattlerId battlerAtk = ctx->battlerAtk;
     enum BattlerId battlerDef = ctx->battlerDef;
@@ -6365,7 +6365,7 @@ static inline u32 CalcMoveBasePower(struct BattleContext *ctx)
     return basePower;
 }
 
-static inline u32 CalcMoveBasePowerAfterModifiers(struct BattleContext *ctx)
+static inline u32 CalcMoveBasePowerAfterModifiers(struct DamageContext *ctx)
 {
     u32 holdEffectParamAtk;
     u32 basePower = CalcMoveBasePower(ctx);
@@ -6714,7 +6714,7 @@ static inline uq4_12_t ApplyDefensiveBadgeBoost(uq4_12_t modifier, enum BattlerI
     return modifier;
 }
 
-static inline u32 CalcAttackStat(struct BattleContext *ctx)
+static inline u32 CalcAttackStat(struct DamageContext *ctx)
 {
     u8 atkStage;
     u32 atkStat;
@@ -7012,7 +7012,7 @@ static bool32 CanEvolve(enum Species species)
     return FALSE;
 }
 
-static inline u32 CalcDefenseStat(struct BattleContext *ctx)
+static inline u32 CalcDefenseStat(struct DamageContext *ctx)
 {
     bool32 usesDefStat;
     u8 defStage;
@@ -7205,7 +7205,7 @@ static inline s32 CalculateBaseDamage(u32 power, u32 userFinalAttack, u32 level,
     return power * userFinalAttack * (2 * level / 5 + 2) / targetFinalDefense / 50 + 2;
 }
 
-static inline uq4_12_t GetTargetDamageModifier(struct BattleContext *ctx)
+static inline uq4_12_t GetTargetDamageModifier(struct DamageContext *ctx)
 {
     if (IsDoubleBattle())
     {
@@ -7224,7 +7224,7 @@ static inline uq4_12_t GetParentalBondModifier(enum BattlerId battlerAtk)
     return B_PARENTAL_BOND_DMG >= GEN_7 ? UQ_4_12(0.25) : UQ_4_12(0.5);
 }
 
-static inline uq4_12_t GetSameTypeAttackBonusModifier(struct BattleContext *ctx)
+static inline uq4_12_t GetSameTypeAttackBonusModifier(struct DamageContext *ctx)
 {
     if (ctx->moveType == TYPE_MYSTERY)
         return UQ_4_12(1.0);
@@ -7236,7 +7236,7 @@ static inline uq4_12_t GetSameTypeAttackBonusModifier(struct BattleContext *ctx)
 }
 
 // Utility Umbrella holders take normal damage from what would be rain- and sun-weakened attacks.
-static uq4_12_t GetWeatherDamageModifier(struct BattleContext *ctx)
+static uq4_12_t GetWeatherDamageModifier(struct DamageContext *ctx)
 {
     if (ctx->weather == B_WEATHER_NONE)
         return UQ_4_12(1.0);
@@ -7260,7 +7260,7 @@ static uq4_12_t GetWeatherDamageModifier(struct BattleContext *ctx)
     return UQ_4_12(1.0);
 }
 
-static inline uq4_12_t GetBurnOrFrostBiteModifier(struct BattleContext *ctx)
+static inline uq4_12_t GetBurnOrFrostBiteModifier(struct DamageContext *ctx)
 {
     enum BattleMoveEffects moveEffect = GetMoveEffect(ctx->move);
 
@@ -7290,7 +7290,7 @@ static inline uq4_12_t GetGlaiveRushModifier(enum BattlerId battlerDef)
     return UQ_4_12(1.0);
 }
 
-static inline uq4_12_t GetZMaxMoveAgainstProtectionModifier(struct BattleContext *ctx)
+static inline uq4_12_t GetZMaxMoveAgainstProtectionModifier(struct DamageContext *ctx)
 {
     if (!IsZMove(ctx->move) && !IsMaxMove(ctx->move))
         return UQ_4_12(1.0);
@@ -7329,7 +7329,7 @@ static inline uq4_12_t GetAirborneModifier(enum Move move, enum BattlerId battle
     return UQ_4_12(1.0);
 }
 
-static inline uq4_12_t GetScreensModifier(struct BattleContext *ctx)
+static inline uq4_12_t GetScreensModifier(struct DamageContext *ctx)
 {
     u32 sideStatus = gSideStatuses[GetBattlerSide(ctx->battlerDef)];
     bool32 lightScreen = (sideStatus & SIDE_STATUS_LIGHTSCREEN) && IsBattleMoveSpecial(ctx->move);
@@ -7382,7 +7382,7 @@ static inline uq4_12_t GetAttackerAbilitiesModifier(enum BattlerId battlerAtk, u
     return UQ_4_12(1.0);
 }
 
-static inline uq4_12_t GetDefenderAbilitiesModifier(struct BattleContext *ctx)
+static inline uq4_12_t GetDefenderAbilitiesModifier(struct DamageContext *ctx)
 {
     bool32 recordAbility = FALSE;
     uq4_12_t modifier = UQ_4_12(1.0);
@@ -7484,7 +7484,7 @@ static inline uq4_12_t GetAttackerItemsModifier(enum BattlerId battlerAtk, uq4_1
     return UQ_4_12(1.0);
 }
 
-static inline uq4_12_t GetDefenderItemsModifier(struct BattleContext *ctx)
+static inline uq4_12_t GetDefenderItemsModifier(struct DamageContext *ctx)
 {
     switch (ctx->holdEffectDef)
     {
@@ -7516,7 +7516,7 @@ static inline uq4_12_t GetDefenderItemsModifier(struct BattleContext *ctx)
 // https://bulbapedia.bulbagarden.net/wiki/Damage#Generation_V_onward
 // Please Note: Fixed Point Multiplication is not associative.
 // The order of operations is relevant.
-static inline uq4_12_t GetOtherModifiers(struct BattleContext *ctx)
+static inline uq4_12_t GetOtherModifiers(struct DamageContext *ctx)
 {
     uq4_12_t finalModifier = UQ_4_12(1.0);
     enum BattlerId battlerDefPartner = BATTLE_PARTNER(ctx->battlerDef);
@@ -7556,7 +7556,7 @@ static inline uq4_12_t GetOtherModifiers(struct BattleContext *ctx)
     dmg = uq4_12_multiply_by_int_half_down(modifier, dmg); \
 } while (0)
 
-static inline s32 DoMoveDamageCalcVars(struct BattleContext *ctx)
+static inline s32 DoMoveDamageCalcVars(struct DamageContext *ctx)
 {
     s32 dmg;
     u32 userFinalAttack;
@@ -7596,7 +7596,7 @@ static inline s32 DoMoveDamageCalcVars(struct BattleContext *ctx)
     return dmg;
 }
 
-s32 ApplyModifiersAfterDmgRoll(struct BattleContext *ctx, s32 dmg)
+s32 ApplyModifiersAfterDmgRoll(struct DamageContext *ctx, s32 dmg)
 {
     if (GetActiveGimmick(ctx->battlerAtk) == GIMMICK_TERA)
         DAMAGE_APPLY_MODIFIER(GetTeraMultiplier(ctx));
@@ -7610,7 +7610,7 @@ s32 ApplyModifiersAfterDmgRoll(struct BattleContext *ctx, s32 dmg)
     return dmg;
 }
 
-s32 DoFixedDamageMoveCalc(struct BattleContext *ctx)
+s32 DoFixedDamageMoveCalc(struct DamageContext *ctx)
 {
     s32 dmg = INT32_MAX;
     s32 randDamage;
@@ -7697,7 +7697,7 @@ s32 DoFixedDamageMoveCalc(struct BattleContext *ctx)
     return dmg;
 }
 
-static inline s32 DoMoveDamageCalc(struct BattleContext *ctx)
+static inline s32 DoMoveDamageCalc(struct DamageContext *ctx)
 {
     if (ctx->typeEffectivenessModifier == UQ_4_12(0.0))
         return 0;
@@ -7709,7 +7709,7 @@ static inline s32 DoMoveDamageCalc(struct BattleContext *ctx)
     return DoMoveDamageCalcVars(ctx);
 }
 
-static inline s32 DoFutureSightAttackDamageCalcVars(struct BattleContext *ctx)
+static inline s32 DoFutureSightAttackDamageCalcVars(struct DamageContext *ctx)
 {
     s32 dmg;
     u32 userFinalAttack;
@@ -7754,7 +7754,7 @@ static inline s32 DoFutureSightAttackDamageCalcVars(struct BattleContext *ctx)
     return dmg;
 }
 
-static inline s32 DoFutureSightAttackDamageCalc(struct BattleContext *ctx)
+static inline s32 DoFutureSightAttackDamageCalc(struct DamageContext *ctx)
 {
     if (ctx->typeEffectivenessModifier == UQ_4_12(0.0))
         return 0;
@@ -7832,7 +7832,7 @@ static inline u32 GetHoldEffectCritChanceIncrease(enum BattlerId battler, enum H
     return critStageIncrease;
 }
 
-s32 CalcCritChanceStage(struct BattleContext *ctx)
+s32 CalcCritChanceStage(struct DamageContext *ctx)
 {
     s32 critChance = 0;
 
@@ -7881,7 +7881,7 @@ s32 CalcCritChanceStage(struct BattleContext *ctx)
 // Threshold = Base Speed / 2
 // High crit move = 8 * (Base Speed / 2)
 // Focus Energy = 4 * (Base Speed / 2)
-s32 CalcCritChanceStageGen1(struct BattleContext *ctx)
+s32 CalcCritChanceStageGen1(struct DamageContext *ctx)
 {
     s32 critChance = 0;
     s32 moveCritStage = GetMoveCriticalHitStage(ctx->move);
@@ -7928,7 +7928,7 @@ s32 CalcCritChanceStageGen1(struct BattleContext *ctx)
     return critChance;
 }
 
-static bool32 IsCriticalHit(struct BattleContext *ctx)
+static bool32 IsCriticalHit(struct DamageContext *ctx)
 {
 
     if ((gBattleTypeFlags & (BATTLE_TYPE_CATCH_TUTORIAL | BATTLE_TYPE_POKEDUDE))
@@ -7967,7 +7967,7 @@ static bool32 IsCriticalHit(struct BattleContext *ctx)
     return isCrit;
 }
 
-s32 GetAdjustedDamage(struct BattleContext *ctx, s32 damage)
+s32 GetAdjustedDamage(struct DamageContext *ctx, s32 damage)
 {
     if (DoesSubstituteBlockMove(ctx->battlerAtk, ctx->battlerDef, ctx->move)
      || DoesDisguiseBlockMove(ctx->battlerDef, ctx->move)
@@ -8031,7 +8031,7 @@ s32 GetAdjustedDamage(struct BattleContext *ctx, s32 damage)
     return damage;
 }
 
-s32 CalculateMoveDamage(struct BattleContext *ctx)
+s32 CalculateMoveDamage(struct DamageContext *ctx)
 {
     s32 damage = 0;
 
@@ -8052,12 +8052,12 @@ s32 CalculateMoveDamage(struct BattleContext *ctx)
 }
 
 // for AI so that typeEffectivenessModifier, weather, abilities and holdEffects are calculated only once
-s32 CalculateMoveDamageVars(struct BattleContext *ctx)
+s32 CalculateMoveDamageVars(struct DamageContext *ctx)
 {
     return DoMoveDamageCalcVars(ctx);
 }
 
-static inline void MulByTypeEffectiveness(struct BattleContext *ctx, uq4_12_t *modifier, enum Type defType)
+static inline void MulByTypeEffectiveness(struct DamageContext *ctx, uq4_12_t *modifier, enum Type defType)
 {
     uq4_12_t mod = GetTypeModifier(ctx->moveType, defType);
 
@@ -8115,7 +8115,7 @@ static inline void TryNoticeIllusionInTypeEffectiveness(enum Move move, enum Typ
     // Check if the type effectiveness would've been different if the pokemon really had the types as the disguise.
     uq4_12_t presumedModifier = UQ_4_12(1.0);
 
-    struct BattleContext ctx = {0};
+    struct DamageContext ctx = {0};
     ctx.battlerAtk = battlerAtk;
     ctx.battlerDef = battlerDef;
     ctx.move = ctx.chosenMove = move;
@@ -8158,7 +8158,7 @@ void UpdateMoveResultFlags(uq4_12_t modifier, u16 *resultFlags)
     }
 }
 
-static inline uq4_12_t CalcTypeEffectivenessMultiplierInternal(struct BattleContext *ctx, uq4_12_t modifier)
+static inline uq4_12_t CalcTypeEffectivenessMultiplierInternal(struct DamageContext *ctx, uq4_12_t modifier)
 {
     enum Species illusionSpecies;
     enum Type types[3];
@@ -8242,7 +8242,7 @@ static inline uq4_12_t CalcTypeEffectivenessMultiplierInternal(struct BattleCont
     return modifier;
 }
 
-uq4_12_t CalcTypeEffectivenessMultiplier(struct BattleContext *ctx)
+uq4_12_t CalcTypeEffectivenessMultiplier(struct DamageContext *ctx)
 {
     uq4_12_t modifier = UQ_4_12(1.0);
 
@@ -8268,7 +8268,7 @@ uq4_12_t CalcPartyMonTypeEffectivenessMultiplier(enum Move move, enum Species sp
 
     if (move != MOVE_STRUGGLE && moveType != TYPE_MYSTERY)
     {
-        struct BattleContext ctx = {0};
+        struct DamageContext ctx = {0};
         ctx.move = ctx.chosenMove = move;
         ctx.moveType = moveType;
         ctx.updateFlags = FALSE;
@@ -8310,7 +8310,7 @@ uq4_12_t GetOverworldTypeEffectiveness(struct Pokemon *mon, enum Type moveType)
         return modifier;
 
 
-    struct BattleContext ctx = {0};
+    struct DamageContext ctx = {0};
     ctx.abilityDef = GetMonAbility(mon);
     ctx.move = ctx.chosenMove = MOVE_POUND;
     ctx.moveType = moveType;
@@ -9871,41 +9871,6 @@ bool32 HasWeatherEffect(void)
     }
 
     return TRUE;
-}
-
-void UpdateStallMons(void)
-{
-    if (IsBattlerTurnDamaged(gBattlerTarget, INCLUDING_SUBSTITUTES) || GetMoveCategory(gCurrentMove) == DAMAGE_CATEGORY_STATUS)
-        return;
-
-    struct BattleContext ctx = {0};
-    ctx.battlerAtk = gBattlerAttacker;
-    ctx.battlerDef = gBattlerTarget;
-    ctx.move = ctx.chosenMove = gCurrentMove;
-    ctx.moveType = GetBattleMoveType(gCurrentMove); //  Probably doesn't handle dynamic move types right now
-    ctx.abilityAtk = GetBattlerAbility(ctx.battlerAtk);
-    ctx.abilityDef = GetBattlerAbility(ctx.battlerDef);
-    ctx.holdEffectAtk = GetBattlerHoldEffect(ctx.battlerAtk);
-    ctx.holdEffectDef = GetBattlerHoldEffect(ctx.battlerDef);
-
-    if (IsBattlerProtected(&ctx))
-        return;
-
-    enum MoveTarget target = GetBattlerMoveTargetType(ctx.battlerAtk, ctx.move);
-    if (!IsDoubleBattle()
-     || target == TARGET_SELECTED
-     || target == TARGET_SMART)
-    {
-        if (CanMoveBeBlockedByTarget(&ctx, GetChosenMovePriority(ctx.battlerAtk, ctx.abilityAtk)))
-        {
-            gAiBattleData->playerStallMons[gBattlerPartyIndexes[gBattlerTarget]]++;
-        }
-        else if (CalcTypeEffectivenessMultiplier(&ctx) == UQ_4_12(0.0))
-        {
-            gAiBattleData->playerStallMons[gBattlerPartyIndexes[gBattlerTarget]]++;
-        }
-    }
-    //  Handling for moves that target multiple opponents in doubles not handled currently
 }
 
 bool32 TrySwitchInEjectPack(enum EjectPackTiming timing)


### PR DESCRIPTION
## Description
<!-- Detail the changes made, why they were made, and any important context. -->

"Reverts" #8426

Very sorry about this but I haven't made a good decision back then. It's more future proof / beneficial (avoids some hacky handling and the next refactor takes advantage of it) to use the `BattleCalcValues` in canceler. I also haven't made a good decision of making the damage struct universal. It was explicitly made for the damage calc to make a bridge between ai and actual damage and I kinda forgot that myself. 

Additional change: 
```
CANCELER_RESULT_BREAK -> CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT
CANCELER_RESULT_PAUSE -> CANCELER_RESULT_RUN_SCRIPT
```
The former is a bit verbose but when working with it I got confused myself since break/pause are basically the same thing. 
## Things to note in the release changelog:
<!-- Add any important details for the release changelog. Must be structed as bullet points. --->
<!--- Remove this section if not applicable. --->

BattleCalcValues struct is now used in `AttackCanceler`
`BattleContext` was renamed back to `DamageContext`