### PR TITLE
Consolidated duplicate absorbing move descriptions

### DIFF
--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -5492,7 +5492,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
     [MOVE_GIGA_DRAIN] =
     {
         .name = COMPOUND_STRING("Giga Drain"),
-        .description = sStealHalfDescription,,
+        .description = sStealHalfDescription,
         .effect = EFFECT_ABSORB,
         .power = B_UPDATED_MOVE_DATA >= GEN_5 ? 75 : 60,
         .type = TYPE_GRASS,


### PR DESCRIPTION
## Description
* Absorb and Bitter Blade have the same description as `sMegaDrainDescription` so they now use that, which has been renamed to the more generic `sAbsorbHalfDescription`
* Leech Life and Giga Drain use the same description so that has been consolidated into `sStealHalfDescription`

## Discord contact info
Frankfurter0
