### PR TITLE
Align Rock Blast Bulletproof ballistic flag threshold to Gen 7

### DIFF
--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -9411,7 +9411,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
         .priority = 0,
         .category = DAMAGE_CATEGORY_PHYSICAL,
         .multiHit = TRUE,
-        .ballisticMove = B_UPDATED_MOVE_FLAGS >= GEN_6,
+        .ballisticMove = B_UPDATED_MOVE_FLAGS >= GEN_7,
         .contestEffect = C_UPDATED_MOVE_EFFECTS >= GEN_6 ? CONTEST_EFFECT_QUALITY_DEPENDS_ON_TIMING : CONTEST_EFFECT_BETTER_IF_SAME_TYPE,
         .contestCategory = CONTEST_CATEGORY_TOUGH,
         .contestComboStarterId = 0,


### PR DESCRIPTION
## Description
**[Bulba](https://bulbapedia.bulbagarden.net/wiki/Bulletproof_(Ability))**
<img width="463" height="694" alt="image" src="https://github.com/user-attachments/assets/81938e3c-77c3-4ab3-80bf-146d6162d6e7" />

