### PR TITLE
Fix Rest failing behavior under Sweet Veil

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -14800,6 +14800,8 @@ void BS_JumpIfAbilityPreventsRest(void)
         gBattlescriptCurrInstr = cmd->jumpInstr;
     else if (IsShieldsDownProtected(battler, ability))
         gBattlescriptCurrInstr = cmd->jumpInstr;
+    else if (IsAbilityOnSide(battler, ABILITY_SWEET_VEIL))
+        gBattlescriptCurrInstr = cmd->jumpInstr;
     else
         gBattlescriptCurrInstr = cmd->nextInstr;
 }

--- a/test/battle/move_effect/rest.c
+++ b/test/battle/move_effect/rest.c
@@ -86,6 +86,36 @@ SINGLE_BATTLE_TEST("Rest fails if the user is protected by Electric/Misty Terrai
     }
 }
 
+SINGLE_BATTLE_TEST("Rest fails if the user is protected by Sweet Veil")
+{
+    GIVEN {
+        PLAYER(SPECIES_BOUNSWEET) { Ability(ABILITY_SWEET_VEIL); HP(1); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_REST); }
+    } SCENE {
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_REST, player);
+    } THEN {
+        EXPECT(!(player->status1 & STATUS1_SLEEP));
+    }
+}
+
+DOUBLE_BATTLE_TEST("Rest fails if the user is protected by ally's Sweet Veil")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { HP(1); }
+        PLAYER(SPECIES_BOUNSWEET) { Ability(ABILITY_SWEET_VEIL); }
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_REST); }
+    } SCENE {
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_REST, playerLeft);
+    } THEN {
+        EXPECT(!(playerLeft->status1 & STATUS1_SLEEP));
+    }
+}
+
 SINGLE_BATTLE_TEST("Rest doesn't fail if the user is protected by Safeguard")
 {
     GIVEN {


### PR DESCRIPTION
## Description
**[Bulba](https://bulbapedia.bulbagarden.net/wiki/Sweet_Veil_(Ability))**
> Sweet Veil prevents the Pokémon with this Ability and its allies (including non-adjacent allies) from falling asleep. **Rest will fail** when used by the **Pokémon with this Ability or an ally** (unless the user has an Ability that ignores other Abilities).