### PR TITLE
ci: Do not install recommended packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install binutils
         run: |
           sudo apt-get update
-          sudo apt-get install -y binutils-arm-none-eabi gcc-arm-none-eabi libnewlib-arm-none-eabi libpng-dev python3
+          sudo apt-get install -y --no-install-recommends binutils-arm-none-eabi gcc-arm-none-eabi libnewlib-arm-none-eabi libpng-dev python3
 
       - name: Cache build tools
         uses: actions/cache@v4
@@ -62,7 +62,7 @@ jobs:
       - name: Install binutils
         run: |
           sudo apt-get update
-          sudo apt-get install -y binutils-arm-none-eabi gcc-arm-none-eabi libnewlib-arm-none-eabi libpng-dev python3
+          sudo apt-get install -y --no-install-recommends binutils-arm-none-eabi gcc-arm-none-eabi libnewlib-arm-none-eabi libpng-dev python3
 
       - name: Cache build tools
         uses: actions/cache@v4
@@ -97,7 +97,7 @@ jobs:
       - name: Install binutils
         run: |
           sudo apt-get update
-          sudo apt-get install -y binutils-arm-none-eabi gcc-arm-none-eabi libnewlib-arm-none-eabi libpng-dev python3
+          sudo apt-get install -y --no-install-recommends binutils-arm-none-eabi gcc-arm-none-eabi libnewlib-arm-none-eabi libpng-dev python3
 
       - name: Cache build tools
         uses: actions/cache@v4
@@ -132,7 +132,7 @@ jobs:
       - name: Install binutils
         run: |
           sudo apt-get update
-          sudo apt-get install -y binutils-arm-none-eabi gcc-arm-none-eabi libnewlib-arm-none-eabi libpng-dev python3
+          sudo apt-get install -y --no-install-recommends binutils-arm-none-eabi gcc-arm-none-eabi libnewlib-arm-none-eabi libpng-dev python3
 
       - name: Cache build tools
         uses: actions/cache@v4
@@ -169,7 +169,7 @@ jobs:
       - name: Install binutils
         run: |
           sudo apt-get update
-          sudo apt-get install -y binutils-arm-none-eabi gcc-arm-none-eabi libnewlib-arm-none-eabi libpng-dev python3
+          sudo apt-get install -y --no-install-recommends binutils-arm-none-eabi gcc-arm-none-eabi libnewlib-arm-none-eabi libpng-dev python3
 
       - name: Cache build tools
         uses: actions/cache@v4


### PR DESCRIPTION
This specifically targets removing the `libstdc++` family of packages, which constitutes ~450 MB of every CI run and can create extreme bottlenecks when the Azure repositories is throttled.

## Before

```
The following additional packages will be installed:
  libnewlib-dev libpng-tools libstdc++-arm-none-eabi-dev
  libstdc++-arm-none-eabi-newlib
Suggested packages:
  libnewlib-doc
The following NEW packages will be installed:
  binutils-arm-none-eabi gcc-arm-none-eabi libnewlib-arm-none-eabi
  libnewlib-dev libpng-dev libpng-tools libstdc++-arm-none-eabi-dev
  libstdc++-arm-none-eabi-newlib
0 upgraded, 8 newly installed, 0 to remove and 96 not upgraded.
Need to get 574 MB of archives.
After this operation, 3107 MB of additional disk space will be used.
```

## After

```
Suggested packages:
  libnewlib-doc
Recommended packages:
  libstdc++-arm-none-eabi-newlib libpng-tools
The following NEW packages will be installed:
  binutils-arm-none-eabi gcc-arm-none-eabi libnewlib-arm-none-eabi
  libnewlib-dev libpng-dev
0 upgraded, 5 newly installed, 0 to remove and 81 not upgraded.
Need to get 110 MB of archives.
After this operation, 975 MB of additional disk space will be used.
```

## Discord contact info

`@lhea`