### PR TITLE
Fix Sheer Force incorrectly suppressing recoil damage

### DIFF
--- a/include/config/ai.h
+++ b/include/config/ai.h
@@ -5,9 +5,9 @@
 #define AI_FRAME_CEILING_SINGLES_NO_FLAGS                       3
 #define AI_FRAME_CEILING_SINGLES_SMART_TRAINER                  8
 #define AI_FRAME_CEILING_DOUBLES_NO_FLAGS                       21
-#define AI_FRAME_CEILING_DOUBLES_SMART_TRAINER                  38
+#define AI_FRAME_CEILING_DOUBLES_SMART_TRAINER                  39
 #define AI_FRAME_CEILING_STEVEN_MULTI                           29
-#define AI_FRAME_CEILING_STEVEN_MULTI_SMART_TRAINER             31
+#define AI_FRAME_CEILING_STEVEN_MULTI_SMART_TRAINER             32
 
 // For the details on what specific factors the switching functions are considering, go read the corresponding function inside ShouldSwitch in src/battle_ai_switch_items.c
 // These configuration options control how likely the AI is to switch if it determines that a switch meets all of its criteria

--- a/include/config/ai.h
+++ b/include/config/ai.h
@@ -5,9 +5,9 @@
 #define AI_FRAME_CEILING_SINGLES_NO_FLAGS                       3
 #define AI_FRAME_CEILING_SINGLES_SMART_TRAINER                  8
 #define AI_FRAME_CEILING_DOUBLES_NO_FLAGS                       21
-#define AI_FRAME_CEILING_DOUBLES_SMART_TRAINER                  39
+#define AI_FRAME_CEILING_DOUBLES_SMART_TRAINER                  38
 #define AI_FRAME_CEILING_STEVEN_MULTI                           29
-#define AI_FRAME_CEILING_STEVEN_MULTI_SMART_TRAINER             32
+#define AI_FRAME_CEILING_STEVEN_MULTI_SMART_TRAINER             31
 
 // For the details on what specific factors the switching functions are considering, go read the corresponding function inside ShouldSwitch in src/battle_ai_switch_items.c
 // These configuration options control how likely the AI is to switch if it determines that a switch meets all of its criteria

--- a/include/constants/battle_move_resolution.h
+++ b/include/constants/battle_move_resolution.h
@@ -105,7 +105,8 @@ enum MoveEndState
     MOVEEND_HP_THRESHOLD_ITEMS_TARGET, // Activation only during a multi hit move / ability (Parental Bond)
     MOVEEND_MULTIHIT_MOVE,
     MOVEEND_DEFROST,
-    MOVEEND_SHEER_FORCE, // If move is Sheer Force affected, skip to Hit Escape + One
+    MOVEEND_MOVE_BLOCK_RECOIL, // Recoil effects should still happen even if Sheer Force applies
+    MOVEEND_SHEER_FORCE, // If move is Sheer Force affected, jump to effects that are not suppressed
     MOVEEND_MOVE_BLOCK,
     MOVEEND_ITEM_EFFECTS_ATTACKER_2,
     MOVEEND_ABILITY_EFFECT_FOES_FAINTED, // Moxie-like abilities / Battle Bond / Magician

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -2912,10 +2912,18 @@ static enum MoveEndResult MoveEndDefrost(void)
 
 static enum MoveEndResult MoveEndSheerForce(void)
 {
+    // Sheer Force should not remove recoil from moves like Flare Blitz.
     if (IsSheerForceAffected(gCurrentMove, GetBattlerAbility(gBattlerAttacker)))
-        gBattleScripting.moveendState = MOVEEND_ITEMS_EFFECTS_ALL;
+    {
+        if (GetMoveEffect(gCurrentMove) == EFFECT_RECOIL)
+            gBattleScripting.moveendState++;
+        else
+            gBattleScripting.moveendState = MOVEEND_ITEMS_EFFECTS_ALL;
+    }
     else
+    {
         gBattleScripting.moveendState++;
+    }
 
     return MOVEEND_RESULT_CONTINUE;
 }

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -2910,20 +2910,89 @@ static enum MoveEndResult MoveEndDefrost(void)
     return MOVEEND_RESULT_CONTINUE;
 }
 
+static enum MoveEndResult MoveEndMoveBlockRecoil(void)
+{
+    enum MoveEndResult result = MOVEEND_RESULT_CONTINUE;
+
+    switch (GetMoveEffect(gCurrentMove))
+    {
+    case EFFECT_RECOIL_IF_MISS:
+        if (IsBattlerAlive(gBattlerAttacker)
+         && IsBattlerUnaffectedByMove(gBattlerTarget)
+         && !gBattleStruct->unableToUseMove)
+        {
+            s32 recoil = 0;
+            if (B_CRASH_IF_TARGET_IMMUNE == GEN_4 && gBattleStruct->moveResultFlags[gBattlerTarget] & MOVE_RESULT_DOESNT_AFFECT_FOE)
+            {
+                recoil = GetNonDynamaxMaxHP(gBattlerTarget) / 2;
+            }
+            if (B_RECOIL_IF_MISS_DMG >= GEN_5)
+            {
+                recoil = GetNonDynamaxMaxHP(gBattlerAttacker) / 2;
+            }
+            else if (B_RECOIL_IF_MISS_DMG >= GEN_3)
+            {
+                if ((GetNonDynamaxMaxHP(gBattlerTarget) / 2) < gBattleStruct->moveDamage[gBattlerTarget])
+                    recoil = gBattleStruct->moveDamage[gBattlerTarget];
+                else
+                    recoil = GetNonDynamaxMaxHP(gBattlerTarget) / 2;
+            }
+            else if (B_RECOIL_IF_MISS_DMG == GEN_2)
+            {
+                recoil = gBattleStruct->moveDamage[gBattlerTarget] / 8;
+            }
+            else
+            {
+                recoil = 1;
+            }
+            SetPassiveDamageAmount(gBattlerAttacker, recoil);
+            BattleScriptCall(BattleScript_RecoilIfMiss);
+            result = MOVEEND_RESULT_RUN_SCRIPT;
+        }
+        break;
+    case EFFECT_RECOIL:
+        if (IsBattlerTurnDamaged(gBattlerTarget, INCLUDING_SUBSTITUTES) && IsBattlerAlive(gBattlerAttacker) && gBattleStruct->moveDamage[gBattlerTarget] > 0)
+        {
+            enum Ability ability = GetBattlerAbility(gBattlerAttacker);
+            if (IsAbilityAndRecord(gBattlerAttacker, ability, ABILITY_ROCK_HEAD)
+             || IsAbilityAndRecord(gBattlerAttacker, ability, ABILITY_MAGIC_GUARD))
+                break;
+
+            SetPassiveDamageAmount(gBattlerAttacker, gBattleScripting.savedDmg * max(1, GetMoveRecoil(gCurrentMove)) / 100);
+            TryUpdateEvolutionTracker(IF_RECOIL_DAMAGE_GE, gBattleStruct->passiveHpUpdate[gBattlerAttacker], MOVE_NONE);
+            BattleScriptCall(BattleScript_MoveEffectRecoil);
+            result = MOVEEND_RESULT_RUN_SCRIPT;
+        }
+        break;
+    case EFFECT_CHLOROBLAST:
+        if (IsBattlerTurnDamaged(gBattlerTarget, INCLUDING_SUBSTITUTES) && IsBattlerAlive(gBattlerAttacker))
+        {
+            enum Ability ability = GetBattlerAbility(gBattlerAttacker);
+            if (IsAbilityAndRecord(gBattlerAttacker, ability, ABILITY_ROCK_HEAD)
+             || IsAbilityAndRecord(gBattlerAttacker, ability, ABILITY_MAGIC_GUARD))
+                break;
+
+            s32 recoil = (GetNonDynamaxMaxHP(gBattlerAttacker) + 1) / 2; // Half of Max HP Rounded UP
+            SetPassiveDamageAmount(gBattlerAttacker, recoil);
+            TryUpdateEvolutionTracker(IF_RECOIL_DAMAGE_GE, gBattleStruct->passiveHpUpdate[gBattlerAttacker], MOVE_NONE);
+            BattleScriptCall(BattleScript_MoveEffectRecoil);
+            result = MOVEEND_RESULT_RUN_SCRIPT;
+        }
+        break;
+    default:
+        break;
+    }
+
+    gBattleScripting.moveendState++;
+    return result;
+}
+
 static enum MoveEndResult MoveEndSheerForce(void)
 {
-    // Sheer Force should not remove recoil from moves like Flare Blitz.
     if (IsSheerForceAffected(gCurrentMove, GetBattlerAbility(gBattlerAttacker)))
-    {
-        if (GetMoveEffect(gCurrentMove) == EFFECT_RECOIL)
-            gBattleScripting.moveendState++;
-        else
-            gBattleScripting.moveendState = MOVEEND_ITEMS_EFFECTS_ALL;
-    }
+        gBattleScripting.moveendState = MOVEEND_ITEMS_EFFECTS_ALL;
     else
-    {
         gBattleScripting.moveendState++;
-    }
 
     return MOVEEND_RESULT_CONTINUE;
 }
@@ -3061,69 +3130,6 @@ static enum MoveEndResult MoveEndMoveBlock(void)
             gBattleMons[gBattlerTarget].volatiles.magnetRise = FALSE;
             gBattleMons[gBattlerTarget].volatiles.semiInvulnerable = STATE_NONE;
             BattleScriptCall(BattleScript_MoveEffectSmackDown);
-            result = MOVEEND_RESULT_RUN_SCRIPT;
-        }
-        break;
-    case EFFECT_RECOIL_IF_MISS:
-        if (IsBattlerAlive(gBattlerAttacker)
-         && IsBattlerUnaffectedByMove(gBattlerTarget)
-         && !gBattleStruct->unableToUseMove)
-        {
-            s32 recoil = 0;
-            if (B_CRASH_IF_TARGET_IMMUNE == GEN_4 && gBattleStruct->moveResultFlags[gBattlerTarget] & MOVE_RESULT_DOESNT_AFFECT_FOE)
-            {
-                recoil = GetNonDynamaxMaxHP(gBattlerTarget) / 2;
-            }
-            if (B_RECOIL_IF_MISS_DMG >= GEN_5)
-            {
-                recoil = GetNonDynamaxMaxHP(gBattlerAttacker) / 2;
-            }
-            else if (B_RECOIL_IF_MISS_DMG >= GEN_3)
-            {
-                if ((GetNonDynamaxMaxHP(gBattlerTarget) / 2) < gBattleStruct->moveDamage[gBattlerTarget])
-                    recoil = gBattleStruct->moveDamage[gBattlerTarget];
-                else
-                    recoil = GetNonDynamaxMaxHP(gBattlerTarget) / 2;
-            }
-            else if (B_RECOIL_IF_MISS_DMG == GEN_2)
-            {
-                recoil = gBattleStruct->moveDamage[gBattlerTarget] / 8;
-            }
-            else
-            {
-                recoil = 1;
-            }
-            SetPassiveDamageAmount(gBattlerAttacker, recoil);
-            BattleScriptCall(BattleScript_RecoilIfMiss);
-            result = MOVEEND_RESULT_RUN_SCRIPT;
-        }
-        break;
-    case EFFECT_RECOIL:
-        if (IsBattlerTurnDamaged(gBattlerTarget, INCLUDING_SUBSTITUTES) && IsBattlerAlive(gBattlerAttacker) && gBattleStruct->moveDamage[gBattlerTarget] > 0)
-        {
-            enum Ability ability = GetBattlerAbility(gBattlerAttacker);
-            if (IsAbilityAndRecord(gBattlerAttacker, ability, ABILITY_ROCK_HEAD)
-             || IsAbilityAndRecord(gBattlerAttacker, ability, ABILITY_MAGIC_GUARD))
-                break;
-
-            SetPassiveDamageAmount(gBattlerAttacker, gBattleScripting.savedDmg * max(1, GetMoveRecoil(gCurrentMove)) / 100);
-            TryUpdateEvolutionTracker(IF_RECOIL_DAMAGE_GE, gBattleStruct->passiveHpUpdate[gBattlerAttacker], MOVE_NONE);
-            BattleScriptCall(BattleScript_MoveEffectRecoil);
-            result = MOVEEND_RESULT_RUN_SCRIPT;
-        }
-        break;
-    case EFFECT_CHLOROBLAST:
-        if (IsBattlerTurnDamaged(gBattlerTarget, INCLUDING_SUBSTITUTES) && IsBattlerAlive(gBattlerAttacker))
-        {
-            enum Ability ability = GetBattlerAbility(gBattlerAttacker);
-            if (IsAbilityAndRecord(gBattlerAttacker, ability, ABILITY_ROCK_HEAD)
-             || IsAbilityAndRecord(gBattlerAttacker, ability, ABILITY_MAGIC_GUARD))
-                break;
-
-            s32 recoil = (GetNonDynamaxMaxHP(gBattlerAttacker) + 1) / 2; // Half of Max HP Rounded UP
-            SetPassiveDamageAmount(gBattlerAttacker, recoil);
-            TryUpdateEvolutionTracker(IF_RECOIL_DAMAGE_GE, gBattleStruct->passiveHpUpdate[gBattlerAttacker], MOVE_NONE);
-            BattleScriptCall(BattleScript_MoveEffectRecoil);
             result = MOVEEND_RESULT_RUN_SCRIPT;
         }
         break;
@@ -3867,6 +3873,7 @@ static enum MoveEndResult (*const sMoveEndHandlers[])(void) =
     [MOVEEND_HP_THRESHOLD_ITEMS_TARGET] = MoveEndHpThresholdItemsTarget,
     [MOVEEND_MULTIHIT_MOVE] = MoveEndMultihitMove,
     [MOVEEND_DEFROST] = MoveEndDefrost,
+    [MOVEEND_MOVE_BLOCK_RECOIL] = MoveEndMoveBlockRecoil,
     [MOVEEND_SHEER_FORCE] = MoveEndSheerForce,
     [MOVEEND_MOVE_BLOCK] = MoveEndMoveBlock,
     [MOVEEND_ITEM_EFFECTS_ATTACKER_2] = MoveEndItemEffectsAttacker2,

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -2919,8 +2919,9 @@ static enum MoveEndResult MoveEndDefrost(void)
 static enum MoveEndResult MoveEndMoveBlockRecoil(void)
 {
     enum MoveEndResult result = MOVEEND_RESULT_CONTINUE;
+    enum BattleMoveEffects moveEffect = GetMoveEffect(gCurrentMove);
 
-    switch (GetMoveEffect(gCurrentMove))
+    switch (moveEffect)
     {
     case EFFECT_RECOIL_IF_MISS:
         if (IsBattlerAlive(gBattlerAttacker)
@@ -2957,19 +2958,9 @@ static enum MoveEndResult MoveEndMoveBlockRecoil(void)
         }
         break;
     case EFFECT_RECOIL:
-        if (IsBattlerTurnDamaged(gBattlerTarget, INCLUDING_SUBSTITUTES) && IsBattlerAlive(gBattlerAttacker) && gBattleStruct->moveDamage[gBattlerTarget] > 0)
-        {
-            enum Ability ability = GetBattlerAbility(gBattlerAttacker);
-            if (IsAbilityAndRecord(gBattlerAttacker, ability, ABILITY_ROCK_HEAD)
-             || IsAbilityAndRecord(gBattlerAttacker, ability, ABILITY_MAGIC_GUARD))
-                break;
-
-            SetPassiveDamageAmount(gBattlerAttacker, gBattleScripting.savedDmg * max(1, GetMoveRecoil(gCurrentMove)) / 100);
-            TryUpdateEvolutionTracker(IF_RECOIL_DAMAGE_GE, gBattleStruct->passiveHpUpdate[gBattlerAttacker], MOVE_NONE);
-            BattleScriptCall(BattleScript_MoveEffectRecoil);
-            result = MOVEEND_RESULT_RUN_SCRIPT;
-        }
-        break;
+        if (gBattleStruct->moveDamage[gBattlerTarget] == 0)
+            break;
+        // fallthrough
     case EFFECT_CHLOROBLAST:
         if (IsBattlerTurnDamaged(gBattlerTarget, INCLUDING_SUBSTITUTES) && IsBattlerAlive(gBattlerAttacker))
         {
@@ -2978,8 +2969,15 @@ static enum MoveEndResult MoveEndMoveBlockRecoil(void)
              || IsAbilityAndRecord(gBattlerAttacker, ability, ABILITY_MAGIC_GUARD))
                 break;
 
-            s32 recoil = (GetNonDynamaxMaxHP(gBattlerAttacker) + 1) / 2; // Half of Max HP Rounded UP
-            SetPassiveDamageAmount(gBattlerAttacker, recoil);
+            if (moveEffect == EFFECT_CHLOROBLAST)
+            {
+                s32 recoil = (GetNonDynamaxMaxHP(gBattlerAttacker) + 1) / 2; // Half of Max HP Rounded UP
+                SetPassiveDamageAmount(gBattlerAttacker, recoil);
+            }
+            else
+            {
+                SetPassiveDamageAmount(gBattlerAttacker, gBattleScripting.savedDmg * max(1, GetMoveRecoil(gCurrentMove)) / 100);
+            }
             TryUpdateEvolutionTracker(IF_RECOIL_DAMAGE_GE, gBattleStruct->passiveHpUpdate[gBattlerAttacker], MOVE_NONE);
             BattleScriptCall(BattleScript_MoveEffectRecoil);
             result = MOVEEND_RESULT_RUN_SCRIPT;

--- a/test/battle/move_effects_combined/axe_kick.c
+++ b/test/battle/move_effects_combined/axe_kick.c
@@ -53,3 +53,25 @@ SINGLE_BATTLE_TEST("Axe Kick deals damage half the hp to user if it fails")
         HP_BAR(player, hp: maxHP / 2);
     }
 }
+
+SINGLE_BATTLE_TEST("Axe Kick still deals crash damage when boosted by Sheer Force")
+{
+    enum Ability ability;
+
+    PARAMETRIZE { ability = ABILITY_SHEER_FORCE; }
+    PARAMETRIZE { ability = ABILITY_INTIMIDATE; }
+
+    GIVEN {
+        ASSUME(MoveIsAffectedBySheerForce(MOVE_AXE_KICK));
+        PLAYER(SPECIES_TAUROS) { Ability(ability); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_AXE_KICK, hit: FALSE); }
+    } SCENE {
+        s32 maxHP = GetMonData(&PLAYER_PARTY[0], MON_DATA_MAX_HP);
+        MESSAGE("Tauros used Axe Kick!");
+        MESSAGE("Tauros's attack missed!");
+        MESSAGE("Tauros kept going and crashed!");
+        HP_BAR(player, hp: maxHP / 2);
+    }
+}

--- a/test/battle/move_flags/recoil.c
+++ b/test/battle/move_flags/recoil.c
@@ -84,6 +84,66 @@ SINGLE_BATTLE_TEST("Recoil: Flare Blitz deals 33% of recoil damage to the user a
     }
 }
 
+SINGLE_BATTLE_TEST("Recoil: Flare Blitz still deals recoil damage when boosted by Sheer Force")
+{
+    s16 directDamage;
+    s16 recoilDamage;
+    enum Ability ability;
+
+    PARAMETRIZE { ability = ABILITY_SHEER_FORCE; }
+    PARAMETRIZE { ability = ABILITY_INTIMIDATE; }
+
+    GIVEN {
+        ASSUME(GetMoveRecoil(MOVE_FLARE_BLITZ) == 33);
+        ASSUME(MoveIsAffectedBySheerForce(MOVE_FLARE_BLITZ));
+        PLAYER(SPECIES_TAUROS) { Ability(ability); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_FLARE_BLITZ); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FLARE_BLITZ, player);
+        HP_BAR(opponent, captureDamage: &directDamage);
+        HP_BAR(player, captureDamage: &recoilDamage);
+    } THEN {
+        EXPECT_MUL_EQ(directDamage, UQ_4_12(0.33), recoilDamage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Recoil: Flare Blitz cannot burn the target when boosted by Sheer Force")
+{
+    enum Ability ability;
+    bool32 shouldBurn;
+
+    PARAMETRIZE { ability = ABILITY_SHEER_FORCE; shouldBurn = FALSE; }
+    PARAMETRIZE { ability = ABILITY_INTIMIDATE;  shouldBurn = TRUE; }
+
+    GIVEN {
+        ASSUME(MoveHasAdditionalEffect(MOVE_FLARE_BLITZ, MOVE_EFFECT_BURN));
+        ASSUME(MoveIsAffectedBySheerForce(MOVE_FLARE_BLITZ));
+        PLAYER(SPECIES_TAUROS) { Ability(ability); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_FLARE_BLITZ, WITH_RNG(RNG_SECONDARY_EFFECT, TRUE)); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FLARE_BLITZ, player);
+        HP_BAR(opponent);
+        if (shouldBurn) {
+            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, opponent);
+            STATUS_ICON(opponent, burn: TRUE);
+        } else {
+            NONE_OF {
+                ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, opponent);
+                STATUS_ICON(opponent, burn: TRUE);
+            }
+        }
+    } THEN {
+        if (shouldBurn)
+            EXPECT(opponent->status1 & STATUS1_BURN);
+        else
+            EXPECT(!(opponent->status1 & STATUS1_BURN));
+    }
+}
+
 SINGLE_BATTLE_TEST("Recoil: Flare Blitz is absorbed by Flash Fire and no recoil damage is dealt")
 {
     GIVEN {

--- a/test/battle/move_flags/recoil.c
+++ b/test/battle/move_flags/recoil.c
@@ -109,41 +109,6 @@ SINGLE_BATTLE_TEST("Recoil: Flare Blitz still deals recoil damage when boosted b
     }
 }
 
-SINGLE_BATTLE_TEST("Recoil: Flare Blitz cannot burn the target when boosted by Sheer Force")
-{
-    enum Ability ability;
-    bool32 shouldBurn;
-
-    PARAMETRIZE { ability = ABILITY_SHEER_FORCE; shouldBurn = FALSE; }
-    PARAMETRIZE { ability = ABILITY_INTIMIDATE;  shouldBurn = TRUE; }
-
-    GIVEN {
-        ASSUME(MoveHasAdditionalEffect(MOVE_FLARE_BLITZ, MOVE_EFFECT_BURN));
-        ASSUME(MoveIsAffectedBySheerForce(MOVE_FLARE_BLITZ));
-        PLAYER(SPECIES_TAUROS) { Ability(ability); }
-        OPPONENT(SPECIES_WOBBUFFET);
-    } WHEN {
-        TURN { MOVE(player, MOVE_FLARE_BLITZ, WITH_RNG(RNG_SECONDARY_EFFECT, TRUE)); }
-    } SCENE {
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_FLARE_BLITZ, player);
-        HP_BAR(opponent);
-        if (shouldBurn) {
-            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, opponent);
-            STATUS_ICON(opponent, burn: TRUE);
-        } else {
-            NONE_OF {
-                ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, opponent);
-                STATUS_ICON(opponent, burn: TRUE);
-            }
-        }
-    } THEN {
-        if (shouldBurn)
-            EXPECT(opponent->status1 & STATUS1_BURN);
-        else
-            EXPECT(!(opponent->status1 & STATUS1_BURN));
-    }
-}
-
 SINGLE_BATTLE_TEST("Recoil: Flare Blitz is absorbed by Flash Fire and no recoil damage is dealt")
 {
     GIVEN {


### PR DESCRIPTION
## Description
[Sheer Force](https://bulbapedia.bulbagarden.net/wiki/Sheer_Force_(Ability))
> For example, Flare Blitz inflicts recoil damage to the user, but also has an additional effect to burn; if the user has Sheer Force, Flare Blitz's damage will be boosted by 30% and the user will take recoil damage, but it cannot burn the target. 
