### PR TITLE
Fix weight modifier order

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -6012,14 +6012,7 @@ u32 GetBattlerWeight(enum BattlerId battler)
     enum Ability ability = GetBattlerAbility(battler);
     enum HoldEffect holdEffect = GetBattlerHoldEffect(battler);
 
-    if (ability == ABILITY_HEAVY_METAL)
-        weight *= 2;
-    else if (ability == ABILITY_LIGHT_METAL)
-        weight /= 2;
-
-    if (holdEffect == HOLD_EFFECT_FLOAT_STONE)
-        weight /= 2;
-
+    // Autotomize's weight reduction is applied before other weight modifiers (e.g. Heavy Metal / Light Metal / Float Stone).
     for (i = 0; i < gBattleMons[battler].volatiles.autotomizeCount; i++)
     {
         if (weight > 1000)
@@ -6032,6 +6025,14 @@ u32 GetBattlerWeight(enum BattlerId battler)
             break;
         }
     }
+
+    if (ability == ABILITY_HEAVY_METAL)
+        weight *= 2;
+    else if (ability == ABILITY_LIGHT_METAL)
+        weight /= 2;
+
+    if (holdEffect == HOLD_EFFECT_FLOAT_STONE)
+        weight /= 2;
 
     if (weight == 0)
         weight = 1;

--- a/test/battle/ability/light_metal.c
+++ b/test/battle/ability/light_metal.c
@@ -27,4 +27,69 @@ SINGLE_BATTLE_TEST("Light Metal and Heavy Metal affect the power of Low Kick", s
     }
 }
 
-TO_DO_BATTLE_TEST("Light Metal and Heavy Metal don't affect Heavy Ball's multiplier")
+SINGLE_BATTLE_TEST("Autotomize applies before Light Metal and Heavy Metal when determining Heat Crash power", s16 damage)
+{
+    enum Ability ability;
+    PARAMETRIZE { ability = ABILITY_STALWART;    } // 40.0kg -> 0.1kg after Autotomize, ratio 1/1 => 40 BP
+    PARAMETRIZE { ability = ABILITY_LIGHT_METAL; } // 40.0kg -> 0.1kg after Autotomize, then halved (min 0.1kg), ratio 1/1 => 40 BP
+    PARAMETRIZE { ability = ABILITY_HEAVY_METAL; } // 40.0kg -> 0.1kg after Autotomize, then doubled to 0.2kg, ratio 2/1 => 60 BP
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_AUTOTOMIZE) == EFFECT_AUTOTOMIZE);
+        ASSUME(GetMoveEffect(MOVE_HEAT_CRASH) == EFFECT_HEAT_CRASH);
+        ASSUME(GetSpeciesWeight(SPECIES_DURALUDON) == 400);
+        ASSUME(GetSpeciesWeight(SPECIES_GASTLY) == 1);
+        PLAYER(SPECIES_GASTLY);
+        OPPONENT(SPECIES_DURALUDON) { Ability(ability); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_AUTOTOMIZE); }
+        TURN { MOVE(opponent, MOVE_HEAT_CRASH); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_AUTOTOMIZE, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_HEAT_CRASH, opponent);
+        HP_BAR(player, captureDamage: &results[i].damage);
+    } THEN {
+        if (ability == ABILITY_HEAVY_METAL)
+            EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.5), results[i].damage);
+        else
+            EXPECT_EQ(results[0].damage, results[i].damage);
+    }
+}
+
+WILD_BATTLE_TEST("Light Metal doesn't affect Heavy Ball's multiplier", u32 catchingChance)
+{
+    enum Ability ability;
+    PARAMETRIZE { ability = ABILITY_TECHNICIAN;  }
+    PARAMETRIZE { ability = ABILITY_LIGHT_METAL; }
+
+    GIVEN {
+        ASSUME(GetSpeciesWeight(SPECIES_SCIZOR) == 1180);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_SCIZOR) { Ability(ability); }
+    } WHEN {
+        TURN { USE_ITEM(player, ITEM_HEAVY_BALL); }
+    } SCENE {
+        CATCHING_CHANCE(&results[i].catchingChance);
+    } FINALLY {
+        EXPECT_EQ(results[0].catchingChance, results[1].catchingChance);
+    }
+}
+
+WILD_BATTLE_TEST("Heavy Metal doesn't affect Heavy Ball's multiplier", u32 catchingChance)
+{
+    enum Ability ability;
+    PARAMETRIZE { ability = ABILITY_HEATPROOF;   }
+    PARAMETRIZE { ability = ABILITY_HEAVY_METAL; }
+
+    GIVEN {
+        ASSUME(GetSpeciesWeight(SPECIES_BRONZONG) == 1870);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_BRONZONG) { Ability(ability); }
+    } WHEN {
+        TURN { USE_ITEM(player, ITEM_HEAVY_BALL); }
+    } SCENE {
+        CATCHING_CHANCE(&results[i].catchingChance);
+    } FINALLY {
+        EXPECT_EQ(results[0].catchingChance, results[1].catchingChance);
+    }
+}


### PR DESCRIPTION
## Description
[Bulba](https://bulbapedia.bulbagarden.net/wiki/Heavy_Metal_(Ability))

> Autotomize is applied **before** other weight-modifying effects, including Heavy Metal. Heavy Metal is the only effect that can cause a Pokémon's weight to exceed 999.9 kg.
> This has no effect on the Heavy Ball, which uses the Pokémon's species' weight rather than its current weight.

Before:
`w = max[0.1, ApplyAbilityItem(w_base) - 100 * N_autotomize]`
After:
`w = max[0.1, ApplyAbilityItem(max[0.1, w_base - 100 * N_autotomize])]`

Where:
`ApplyAbilityItem` includes `Heavy Metal x2`, `Light Metal x0.5`, `Float Stone x0.5`.