### PR TITLE
Fix Seed Sower not activating when the user faints from an attack

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4276,7 +4276,6 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
         case ABILITY_SEED_SOWER:
             if (!gBattleStruct->unableToUseMove
              && IsBattlerTurnDamaged(gBattlerTarget, EXCLUDING_SUBSTITUTES)
-             && IsBattlerAlive(gBattlerTarget)
              && TryChangeBattleTerrain(gBattlerTarget, STATUS_FIELD_GRASSY_TERRAIN))
             {
                 BattleScriptCall(BattleScript_SeedSowerActivates);

--- a/test/battle/ability/seed_sower.c
+++ b/test/battle/ability/seed_sower.c
@@ -9,12 +9,28 @@ SINGLE_BATTLE_TEST("Seed Sower sets up Grassy Terrain when hit by an attack")
     } WHEN {
         TURN { MOVE(opponent, MOVE_SCRATCH); }
     } SCENE {
-        MESSAGE("The opposing Wobbuffet used Scratch!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
         HP_BAR(player);
-        ABILITY_POPUP(player);
+        ABILITY_POPUP(player, ABILITY_SEED_SOWER);
         MESSAGE("Grass grew to cover the battlefield!");
     }
 }
+
+SINGLE_BATTLE_TEST("Seed Sower sets up Grassy Terrain even when the user faints from an attack")
+{
+    GIVEN {
+        PLAYER(SPECIES_ARBOLIVA) { Ability(ABILITY_SEED_SOWER); HP(1); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SCRATCH); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
+        HP_BAR(player);
+        ABILITY_POPUP(player, ABILITY_SEED_SOWER);
+        MESSAGE("Grass grew to cover the battlefield!");
+        MESSAGE("Arboliva fainted!");
+    }
+} 
 
 #define ABILITY_PARAM(n)(abilities[n] = (k == n) ? ABILITY_SEED_SOWER : ABILITY_HARVEST)
 #define MOVE_HIT(target, position)                      \


### PR DESCRIPTION
## Description
[Jpwiki](https://wiki.pokemonwiki.com/wiki/%e3%81%93%e3%81%bc%e3%82%8c%e3%83%80%e3%83%8d)

> 攻撃技でHPが0になったときも、特性を発動させてからひんしになる。

Even when HP becomes 0 due to a damaging move, Seed Sower will activate first, and then the Pokémon will faint.
