### PR TITLE
fix(makefile): use correct OBJ_DIR_NAME for tidydebug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -397,7 +397,7 @@ tidycheck:
 	rm -rf $(OBJ_DIR_NAME_TEST)
 
 tidydebug:
-	rm -rf $(DEBUG_OBJ_DIR_NAME)
+	rm -rf $(OBJ_DIR_NAME_DEBUG)
 
 tidyrelease:
 ifeq ($(RELEASE),1)


### PR DESCRIPTION
## Description

Fixes the usage of incorrect `OBJ_DIR_NAME` for `tidydebug`. As a result `make tidy` would not delete debug build artifacts.

## Discord contact info

@kildemal
