### PR TITLE
Fix Shield Dust/Covert Cloak interactions for Poison Touch, Toxic Chain, and Stench

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4331,6 +4331,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
         case ABILITY_POISON_TOUCH:
             if (IsBattlerAlive(gBattlerTarget)
              && !gBattleStruct->unableToUseMove
+             && !IsMoveEffectBlockedByTarget(GetBattlerAbility(gBattlerTarget))
              && CanBePoisoned(gBattlerAttacker, gBattlerTarget, gLastUsedAbility, GetBattlerAbility(gBattlerTarget))
              && IsMoveMakingContact(gBattlerAttacker, gBattlerTarget, GetBattlerAbility(gBattlerAttacker), GetBattlerHoldEffect(gBattlerAttacker), move)
              && IsBattlerTurnDamaged(gBattlerTarget, EXCLUDING_SUBSTITUTES) // Need to actually hit the target
@@ -4348,12 +4349,15 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
             if (gBattleStruct->toxicChainPriority)
             {
                 gBattleStruct->toxicChainPriority = FALSE;
-                gEffectBattler = gBattlerTarget;
-                gBattleScripting.battler = gBattlerAttacker;
-                gBattleScripting.moveEffect = MOVE_EFFECT_TOXIC;
-                PREPARE_ABILITY_BUFFER(gBattleTextBuff1, gLastUsedAbility);
-                BattleScriptCall(BattleScript_AbilityStatusEffect);
-                effect++;
+                if (!IsMoveEffectBlockedByTarget(GetBattlerAbility(gBattlerTarget)))
+                {
+                    gEffectBattler = gBattlerTarget;
+                    gBattleScripting.battler = gBattlerAttacker;
+                    gBattleScripting.moveEffect = MOVE_EFFECT_TOXIC;
+                    PREPARE_ABILITY_BUFFER(gBattleTextBuff1, gLastUsedAbility);
+                    BattleScriptCall(BattleScript_AbilityStatusEffect);
+                    effect++;
+                }
             }
             break;
         case ABILITY_STENCH:
@@ -4363,7 +4367,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
              && IsBattlerTurnDamaged(gBattlerTarget, EXCLUDING_SUBSTITUTES)
              && !MoveHasAdditionalEffect(gCurrentMove, MOVE_EFFECT_FLINCH))
             {
-                SetMoveEffect(gBattlerAttacker, gBattlerTarget, MOVE_EFFECT_FLINCH, gBattlescriptCurrInstr, EFFECT_PRIMARY);
+                SetMoveEffect(gBattlerAttacker, gBattlerTarget, MOVE_EFFECT_FLINCH, gBattlescriptCurrInstr, NO_FLAGS);
                 effect++;
             }
             break;

--- a/test/battle/ability/poison_touch.c
+++ b/test/battle/ability/poison_touch.c
@@ -44,7 +44,6 @@ SINGLE_BATTLE_TEST("Poison Touch only applies when using contact moves")
             NONE_OF {
                 ABILITY_POPUP(player, ABILITY_POISON_TOUCH);
                 ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
-                MESSAGE("The opposing Wobbuffet was poisoned by Grimer's Poison Touch!");
                 STATUS_ICON(opponent, poison: TRUE);
             }
         }
@@ -104,7 +103,6 @@ SINGLE_BATTLE_TEST("Poison Touch activates when user has Protective Pads, but no
             NONE_OF {
                 ABILITY_POPUP(player, ABILITY_POISON_TOUCH);
                 ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
-                MESSAGE("The opposing Wobbuffet was poisoned by Grimer's Poison Touch!");
                 STATUS_ICON(opponent, poison: TRUE);
             }
         }
@@ -128,7 +126,6 @@ SINGLE_BATTLE_TEST("Poison Touch does not trigger if attack is blocked by Substi
         NONE_OF {
             ABILITY_POPUP(player, ABILITY_POISON_TOUCH);
             ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
-            MESSAGE("The opposing Wobbuffet was poisoned by Grimer's Poison Touch!");
             STATUS_ICON(opponent, poison: TRUE);
         }
     } THEN {
@@ -151,7 +148,6 @@ SINGLE_BATTLE_TEST("Poison Touch is blocked by Shield Dust")
         NONE_OF {
             ABILITY_POPUP(player, ABILITY_POISON_TOUCH);
             ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
-            MESSAGE("The opposing Vivillon was poisoned by Grimer's Poison Touch!");
             STATUS_ICON(opponent, poison: TRUE);
         }
     } THEN {
@@ -175,7 +171,6 @@ SINGLE_BATTLE_TEST("Poison Touch is blocked by Covert Cloak")
         NONE_OF {
             ABILITY_POPUP(player, ABILITY_POISON_TOUCH);
             ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
-            MESSAGE("The opposing Wobbuffet was poisoned by Grimer's Poison Touch!");
             STATUS_ICON(opponent, poison: TRUE);
         }
     } THEN {

--- a/test/battle/ability/poison_touch.c
+++ b/test/battle/ability/poison_touch.c
@@ -110,3 +110,75 @@ SINGLE_BATTLE_TEST("Poison Touch activates when user has Protective Pads, but no
         }
     }
 }
+
+SINGLE_BATTLE_TEST("Poison Touch does not trigger if attack is blocked by Substitute")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_SUBSTITUTE) == EFFECT_SUBSTITUTE);
+        ASSUME(GetMoveCategory(MOVE_SCRATCH) != DAMAGE_CATEGORY_STATUS);
+        ASSUME(MoveMakesContact(MOVE_SCRATCH));
+        PLAYER(SPECIES_GRIMER) { Ability(ABILITY_POISON_TOUCH); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SUBSTITUTE); }
+        TURN { MOVE(player, MOVE_SCRATCH, WITH_RNG(RNG_POISON_TOUCH, TRUE)); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SUBSTITUTE, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        NONE_OF {
+            ABILITY_POPUP(player, ABILITY_POISON_TOUCH);
+            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
+            MESSAGE("The opposing Wobbuffet was poisoned by Grimer's Poison Touch!");
+            STATUS_ICON(opponent, poison: TRUE);
+        }
+    } THEN {
+        EXPECT(opponent->status1 == 0);
+    }
+}
+
+SINGLE_BATTLE_TEST("Poison Touch is blocked by Shield Dust")
+{
+    GIVEN {
+        ASSUME(GetMoveCategory(MOVE_SCRATCH) != DAMAGE_CATEGORY_STATUS);
+        ASSUME(MoveMakesContact(MOVE_SCRATCH));
+        PLAYER(SPECIES_GRIMER) { Ability(ABILITY_POISON_TOUCH); }
+        OPPONENT(SPECIES_VIVILLON) { Ability(ABILITY_SHIELD_DUST); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SCRATCH, WITH_RNG(RNG_POISON_TOUCH, TRUE)); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        HP_BAR(opponent);
+        NONE_OF {
+            ABILITY_POPUP(player, ABILITY_POISON_TOUCH);
+            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
+            MESSAGE("The opposing Vivillon was poisoned by Grimer's Poison Touch!");
+            STATUS_ICON(opponent, poison: TRUE);
+        }
+    } THEN {
+        EXPECT(opponent->status1 == 0);
+    }
+}
+
+SINGLE_BATTLE_TEST("Poison Touch is blocked by Covert Cloak")
+{
+    GIVEN {
+        ASSUME(gItemsInfo[ITEM_COVERT_CLOAK].holdEffect == HOLD_EFFECT_COVERT_CLOAK);
+        ASSUME(GetMoveCategory(MOVE_SCRATCH) != DAMAGE_CATEGORY_STATUS);
+        ASSUME(MoveMakesContact(MOVE_SCRATCH));
+        PLAYER(SPECIES_GRIMER) { Ability(ABILITY_POISON_TOUCH); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_COVERT_CLOAK); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SCRATCH, WITH_RNG(RNG_POISON_TOUCH, TRUE)); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        HP_BAR(opponent);
+        NONE_OF {
+            ABILITY_POPUP(player, ABILITY_POISON_TOUCH);
+            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
+            MESSAGE("The opposing Wobbuffet was poisoned by Grimer's Poison Touch!");
+            STATUS_ICON(opponent, poison: TRUE);
+        }
+    } THEN {
+        EXPECT(opponent->status1 == 0);
+    }
+}

--- a/test/battle/ability/stench.c
+++ b/test/battle/ability/stench.c
@@ -79,4 +79,37 @@ DOUBLE_BATTLE_TEST("Stench doesn't trigger if partner uses a move")
     }
 }
 
+SINGLE_BATTLE_TEST("Stench is blocked by Shield Dust")
+{
+    GIVEN {
+        PLAYER(SPECIES_GRIMER) { Ability(ABILITY_STENCH); }
+        OPPONENT(SPECIES_VIVILLON) { Ability(ABILITY_SHIELD_DUST); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SCRATCH, WITH_RNG(RNG_STENCH, TRUE)); MOVE(opponent, MOVE_CELEBRATE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
+        NONE_OF {
+            MESSAGE("The opposing Vivillon flinched and couldn't move!");
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Stench is blocked by Covert Cloak")
+{
+    GIVEN {
+        ASSUME(gItemsInfo[ITEM_COVERT_CLOAK].holdEffect == HOLD_EFFECT_COVERT_CLOAK);
+        PLAYER(SPECIES_GRIMER) { Ability(ABILITY_STENCH); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_COVERT_CLOAK); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SCRATCH, WITH_RNG(RNG_STENCH, TRUE)); MOVE(opponent, MOVE_CELEBRATE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
+        NONE_OF {
+            MESSAGE("The opposing Wobbuffet flinched and couldn't move!");
+        }
+    }
+}
+
 // TODO: Test against interaction with multi hits

--- a/test/battle/ability/toxic_chain.c
+++ b/test/battle/ability/toxic_chain.c
@@ -110,3 +110,72 @@ SINGLE_BATTLE_TEST("Toxic Chain makes Lum/Pecha Berry trigger before being knock
         EXPECT(opponent->status1 == 0);
     }
 }
+
+SINGLE_BATTLE_TEST("Toxic Chain does not trigger if attack is blocked by Substitute")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_SUBSTITUTE) == EFFECT_SUBSTITUTE);
+        ASSUME(GetMoveCategory(MOVE_SCRATCH) != DAMAGE_CATEGORY_STATUS);
+        PLAYER(SPECIES_OKIDOGI) { Ability(ABILITY_TOXIC_CHAIN); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SUBSTITUTE); }
+        TURN { MOVE(player, MOVE_SCRATCH, WITH_RNG(RNG_TOXIC_CHAIN, TRUE)); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SUBSTITUTE, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        NONE_OF {
+            ABILITY_POPUP(player, ABILITY_TOXIC_CHAIN);
+            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
+            MESSAGE("The opposing Wobbuffet was badly poisoned!");
+            STATUS_ICON(opponent, badPoison: TRUE);
+        }
+    } THEN {
+        EXPECT(opponent->status1 == 0);
+    }
+}
+
+SINGLE_BATTLE_TEST("Toxic Chain is blocked by Shield Dust")
+{
+    GIVEN {
+        ASSUME(GetMoveCategory(MOVE_SCRATCH) != DAMAGE_CATEGORY_STATUS);
+        PLAYER(SPECIES_OKIDOGI) { Ability(ABILITY_TOXIC_CHAIN); }
+        OPPONENT(SPECIES_VIVILLON) { Ability(ABILITY_SHIELD_DUST); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SCRATCH, WITH_RNG(RNG_TOXIC_CHAIN, TRUE)); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        HP_BAR(opponent);
+        NONE_OF {
+            ABILITY_POPUP(player, ABILITY_TOXIC_CHAIN);
+            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
+            MESSAGE("The opposing Vivillon was badly poisoned!");
+            STATUS_ICON(opponent, badPoison: TRUE);
+        }
+    } THEN {
+        EXPECT(opponent->status1 == 0);
+    }
+}
+
+SINGLE_BATTLE_TEST("Toxic Chain is blocked by Covert Cloak")
+{
+    GIVEN {
+        ASSUME(gItemsInfo[ITEM_COVERT_CLOAK].holdEffect == HOLD_EFFECT_COVERT_CLOAK);
+        ASSUME(GetMoveCategory(MOVE_SCRATCH) != DAMAGE_CATEGORY_STATUS);
+        PLAYER(SPECIES_OKIDOGI) { Ability(ABILITY_TOXIC_CHAIN); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_COVERT_CLOAK); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SCRATCH, WITH_RNG(RNG_TOXIC_CHAIN, TRUE)); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        HP_BAR(opponent);
+        NONE_OF {
+            ABILITY_POPUP(player, ABILITY_TOXIC_CHAIN);
+            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
+            MESSAGE("The opposing Wobbuffet was badly poisoned!");
+            STATUS_ICON(opponent, badPoison: TRUE);
+        }
+    } THEN {
+        EXPECT(opponent->status1 == 0);
+    }
+}

--- a/test/battle/ability/toxic_chain.c
+++ b/test/battle/ability/toxic_chain.c
@@ -127,7 +127,6 @@ SINGLE_BATTLE_TEST("Toxic Chain does not trigger if attack is blocked by Substit
         NONE_OF {
             ABILITY_POPUP(player, ABILITY_TOXIC_CHAIN);
             ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
-            MESSAGE("The opposing Wobbuffet was badly poisoned!");
             STATUS_ICON(opponent, badPoison: TRUE);
         }
     } THEN {
@@ -149,7 +148,6 @@ SINGLE_BATTLE_TEST("Toxic Chain is blocked by Shield Dust")
         NONE_OF {
             ABILITY_POPUP(player, ABILITY_TOXIC_CHAIN);
             ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
-            MESSAGE("The opposing Vivillon was badly poisoned!");
             STATUS_ICON(opponent, badPoison: TRUE);
         }
     } THEN {
@@ -172,7 +170,6 @@ SINGLE_BATTLE_TEST("Toxic Chain is blocked by Covert Cloak")
         NONE_OF {
             ABILITY_POPUP(player, ABILITY_TOXIC_CHAIN);
             ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
-            MESSAGE("The opposing Wobbuffet was badly poisoned!");
             STATUS_ICON(opponent, badPoison: TRUE);
         }
     } THEN {


### PR DESCRIPTION
## Description
[Poison Touch](https://wiki.pokemonwiki.com/wiki/%e3%81%a9%e3%81%8f%e3%81%97%e3%82%85)

> - 特性りんぷん、持ち物おんみつマントを持つ相手に対しては特性の効果が発動しない。
> - みがわり状態に攻撃を防がれたときは発動しない。

- The effect of **Poison Touch** does not activate against opponents with the **Shield Dust** or the **Covert Cloak** .
- Does not activate when the attack is blocked by a **Substitute**.

[Toxic Chain](https://wiki.pokemonwiki.com/wiki/%e3%81%a9%e3%81%8f%e3%81%ae%e3%81%8f%e3%81%95%e3%82%8a)

> - 特性りんぷん、持ち物おんみつマントを持つ相手に対しては特性の効果が発動しない。
> - みがわり状態に攻撃を防がれたときは発動しない。

- The effect of **Toxic Chain** does not activate against opponents with the **Shield Dust** or the **Covert Cloak** .
- Does not activate when the attack is blocked by a **Substitute**.

[Stench](https://wiki.pokemonwiki.com/wiki/%e3%81%82%e3%81%8f%e3%81%97%e3%82%85%e3%81%86)

> 特性せいしんりょく/りんぷん、持ち物おんみつマントによりあくしゅうの効果は防がれる。

- The effect of **Stench** is prevented by Inner Focus, **Shield Dust**, or the **Covert Cloak**. 
- (No interaction between Stench and Substitute was found, so no test was added)


## Unconsidered
[Poison Puppeteer](https://wiki.pokemonwiki.com/wiki/%e3%81%a9%e3%81%8f%e3%81%8f%e3%81%90%e3%81%a4)
> 変化技でどく/もうどくにした相手がりんぷん/おんみつマントを持つ場合でも混乱状態は発動する。

Even if the opponent poisoned or badly poisoned by **a status move** has **Shield Dust** or **Covert Cloak**, confusion is **still** triggered.

(Poison Puppeteer differs from the other three Abilities in its interaction with Shield Dust or Covert Cloak, but the wiki only mentions status moves, so it has not been addressed here)