### PR TITLE
Learnset Helper: Remove unnecessary order-only dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -547,7 +547,7 @@ TEACHABLE_DEPS := $(ALL_LEARNABLES_JSON) $(INCLUDE_DIRS)/constants/tms_hms.h $(I
 $(LEARNSET_HELPERS_BUILD_DIR):
 	@mkdir -p $@
 
-$(ALL_LEARNABLES_JSON):  | $(wildcard $(LEARNSET_HELPERS_DATA_DIR)/*.json)
+$(ALL_LEARNABLES_JSON):
 	python3 $(LEARNSET_HELPERS_DIR)/make_learnables.py $(LEARNSET_HELPERS_DATA_DIR) $@
 
 $(ALL_TUTORS_JSON): $(shell find data/ -type f -name '*.inc')  $(LEARNSET_HELPERS_DIR)/make_tutors.py | $(LEARNSET_HELPERS_BUILD_DIR)


### PR DESCRIPTION
The interaction between order-only dependencies and '$(wildcard ...)' is essentially that those dependencies don't do anything.

So this change achieves nothing but a slightly clearer rule :)