### PR TITLE
Fix Sturdy incorrectly taking priority over OHKO level check in Gen 5+

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -10531,6 +10531,13 @@ bool32 DoesOHKOMoveMissTarget(struct BattleCalcValues *cv)
         return TRUE;
     }
 
+    // Level check has priority over Sturdy in Gen5+.
+    if (gBattleMons[cv->battlerDef].level > gBattleMons[cv->battlerAtk].level)
+    {
+        gBattleStruct->moveResultFlags[cv->battlerDef] |= MOVE_RESULT_ONE_HIT_KO_NO_AFFECT;
+        return TRUE;
+    }
+
     if (cv->abilities[cv->battlerDef] == ABILITY_STURDY)
     {
         gBattleStruct->moveResultFlags[cv->battlerDef] |= MOVE_RESULT_ONE_HIT_KO_STURDY;
@@ -10539,11 +10546,7 @@ bool32 DoesOHKOMoveMissTarget(struct BattleCalcValues *cv)
 
     enum OHKOResult lands = NO_HIT;
 
-    if (gBattleMons[cv->battlerDef].level > gBattleMons[cv->battlerAtk].level)
-    {
-        lands = NO_HIT;
-    }
-    else if (gBattleMons[cv->battlerAtk].volatiles.battlerWithSureHit == cv->battlerDef + 1
+    if (gBattleMons[cv->battlerAtk].volatiles.battlerWithSureHit == cv->battlerDef + 1
           || IsAbilityAndRecord(cv->battlerAtk, cv->abilities[cv->battlerAtk], ABILITY_NO_GUARD)
           || IsAbilityAndRecord(cv->battlerDef, cv->abilities[cv->battlerDef], ABILITY_NO_GUARD))
     {
@@ -10568,9 +10571,6 @@ bool32 DoesOHKOMoveMissTarget(struct BattleCalcValues *cv)
         gBattleStruct->moveResultFlags[cv->battlerDef] |= MOVE_RESULT_ONE_HIT_KO_NO_AFFECT;
         return FALSE;
     }
-
-    if (gBattleMons[cv->battlerAtk].level < gBattleMons[cv->battlerDef].level)
-        gBattleStruct->moveResultFlags[cv->battlerDef] |= MOVE_RESULT_ONE_HIT_KO_NO_AFFECT;
 
     return TRUE;
 }

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -10531,7 +10531,6 @@ bool32 DoesOHKOMoveMissTarget(struct BattleCalcValues *cv)
         return TRUE;
     }
 
-    // Level check has priority over Sturdy in Gen5+.
     if (gBattleMons[cv->battlerDef].level > gBattleMons[cv->battlerAtk].level)
     {
         gBattleStruct->moveResultFlags[cv->battlerDef] |= MOVE_RESULT_ONE_HIT_KO_NO_AFFECT;

--- a/test/battle/move_effect/ohko.c
+++ b/test/battle/move_effect/ohko.c
@@ -72,6 +72,21 @@ SINGLE_BATTLE_TEST("OHKO moves always fails if the target has a higher level tha
     }
 }
 
+SINGLE_BATTLE_TEST("OHKO moves fail by level before checking Sturdy")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Level(1); }
+        OPPONENT(SPECIES_GEODUDE) { Level(2); Ability(ABILITY_STURDY); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_FISSURE); }
+    } SCENE {
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_FISSURE, player);
+            ABILITY_POPUP(opponent, ABILITY_STURDY);
+        }
+    }
+}
+
 SINGLE_BATTLE_TEST("OHKO moves fail if target protects")
 {
     GIVEN {


### PR DESCRIPTION
## Description
[Sturdy](https://wiki.pokemonwiki.com/wiki/%e3%81%8c%e3%82%93%e3%81%98%e3%82%87%e3%81%86)

> 第五世代以降はレベル差による無効化が優先され、がんじょうのメッセージは出ない。

From Generation V onward, the level-based nullification takes precedence, and the Sturdy message does not appear.