### PR TITLE
Honor forced illegal bench abilities during AI switch evaluation

### DIFF
--- a/src/battle_ai_switch.c
+++ b/src/battle_ai_switch.c
@@ -36,20 +36,39 @@ static bool32 CanUseSuperEffectiveMoveAgainstOpponents(enum BattlerId battler);
 static bool32 FindMonWithFlagsAndSuperEffective(enum BattlerId battler, u16 flags, u32 moduloPercent);
 static u32 GetSwitchinHazardsDamage(enum BattlerId battler);
 static bool32 AI_CanSwitchinAbilityTrapOpponent(enum Ability ability, enum BattlerId opposingBattler);
+static enum Ability GetPartyMonAbilityForSwitchCalc(enum BattlerId battler, u32 monIndex, struct Pokemon *mon);
 static u32 GetBattlerTypeMatchup(enum BattlerId opposingBattler, enum BattlerId battler);
 static u32 GetSwitchinHitsToKO(s32 damageTaken, enum BattlerId battler, const struct IncomingHealInfo *healInfo, u32 originalHp);
 static void GetIncomingHealInfo(enum BattlerId battler, struct IncomingHealInfo *healInfo);
 static u32 GetWishHealAmountForBattler(enum BattlerId battler);
 
+static enum Ability GetPartyMonAbilityForSwitchCalc(enum BattlerId battler, u32 monIndex, struct Pokemon *mon)
+{
+    enum Ability ability = GetMonAbility(mon);
+
+#if TESTING
+    if (gTestRunnerEnabled)
+    {
+        enum BattleTrainer trainer = !IsPartnerMonFromSameTrainer(battler) ? battler : GetBattlerSide(battler);
+        u32 forcedAbility = TestRunner_Battle_GetForcedAbility(trainer, monIndex);
+        if (forcedAbility != 0)
+            ability = forcedAbility;
+    }
+#endif
+
+    return ability;
+}
+
 static void InitializeSwitchinCandidate(enum BattlerId switchinBattler, u32 monIndex, struct Pokemon *mon)
 {
     u32 storeCurrBattlerPartyIndex = gBattlerPartyIndexes[switchinBattler]; // Rage Fist fix
     PokemonToBattleMon(mon, &gBattleMons[switchinBattler]);
+    gBattlerPartyIndexes[switchinBattler] = monIndex;
+    CopyMonAbilityAndTypesToBattleMon(switchinBattler, mon);
     // Setup switchin battler data
     gAiThinkingStruct->saved[switchinBattler].saved = TRUE;
     SetBattlerAiData(switchinBattler, gAiLogicData);
     SetBattlerFieldStatusForSwitchin(switchinBattler);
-    gBattlerPartyIndexes[switchinBattler] = monIndex;
     gAiLogicData->switchInCalc = TRUE;
 
     for (enum BattlerId battlerIndex = 0; battlerIndex < gBattlersCount; battlerIndex++)
@@ -671,7 +690,7 @@ static bool32 FindMonThatAbsorbsOpponentsMove(enum BattlerId battler)
         if (IsAceMon(battler, monIndex))
             continue;
 
-        monAbility = GetMonAbility(&party[monIndex]);
+        monAbility = GetPartyMonAbilityForSwitchCalc(battler, monIndex, &party[monIndex]);
 
         for (u32 absorbingAbilityIndex = 0; absorbingAbilityIndex < numAbsorbingAbilities; absorbingAbilityIndex++)
         {
@@ -734,7 +753,7 @@ static bool32 ShouldSwitchIfTrapperInParty(enum BattlerId battler)
         if (IsAceMon(battler, monIndex))
             continue;
 
-        monAbility = GetMonAbility(&party[monIndex]);
+        monAbility = GetPartyMonAbilityForSwitchCalc(battler, monIndex, &party[monIndex]);
 
         if (AI_CanSwitchinAbilityTrapOpponent(monAbility, opposingBattler) || (AI_CanSwitchinAbilityTrapOpponent(gAiLogicData->abilities[opposingBattler], opposingBattler) && monAbility == ABILITY_TRACE))
         {
@@ -1060,7 +1079,7 @@ static bool32 FindMonWithFlagsAndSuperEffective(enum BattlerId battler, u16 flag
             continue;
 
         species = GetMonData(&party[monIndex], MON_DATA_SPECIES_OR_EGG);
-        monAbility = GetMonAbility(&party[monIndex]);
+        monAbility = GetPartyMonAbilityForSwitchCalc(battler, monIndex, &party[monIndex]);
         typeMultiplier = CalcPartyMonTypeEffectivenessMultiplier(gLastLandedMoves[battler], species, monAbility);
         UpdateMoveResultFlags(typeMultiplier, &moveFlags);
         if (moveFlags & flags)

--- a/test/battle/ai/ai_switching.c
+++ b/test/battle/ai/ai_switching.c
@@ -2000,6 +2000,42 @@ AI_SINGLE_BATTLE_TEST("AI_FLAG_SMART_MON_CHOICES: AI considers both meeting and 
     }
 }
 
+AI_SINGLE_BATTLE_TEST("AI_FLAG_SMART_SWITCHING: benched forced trapper abilities are honored for hard switches")
+{
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_SMART_SWITCHING | AI_FLAG_SMART_MON_CHOICES | AI_FLAG_OMNISCIENT);
+        PLAYER(SPECIES_HERACROSS) {
+            Level(76);
+            Moves(MOVE_BULLET_SEED);
+            Ability(ABILITY_GUTS);
+            Item(ITEM_HERACRONITE);
+            Nature(NATURE_ADAMANT);
+            Speed(157);
+        }
+        PLAYER(SPECIES_WOBBUFFET) {
+            Level(1);
+            Speed(1);
+        }
+        OPPONENT(SPECIES_SWAMPERT) {
+            Level(74);
+            Moves(MOVE_KNOCK_OFF, MOVE_PROTECT, MOVE_LIQUIDATION);
+            Nature(NATURE_CAREFUL);
+            Item(ITEM_RINDO_BERRY);
+            Speed(116);
+        }
+        OPPONENT(SPECIES_CHANDELURE) {
+            Level(74);
+            Moves(MOVE_FLAMETHROWER, MOVE_ENERGY_BALL);
+            Nature(NATURE_TIMID);
+            Item(ITEM_CHOICE_SPECS);
+            Ability(ABILITY_SHADOW_TAG);
+            Speed(160);
+        }
+    } WHEN {
+        TURN { MOVE(player, MOVE_BULLET_SEED); EXPECT_SWITCH(opponent, 1); }
+    }
+}
+
 AI_DOUBLE_BATTLE_TEST("AI will not choose to switch out Dondozo with Commander Tatsugiri")
 {
     PASSES_RANDOMLY(100, 100);

--- a/test/battle/ai/ai_switching.c
+++ b/test/battle/ai/ai_switching.c
@@ -2000,42 +2000,6 @@ AI_SINGLE_BATTLE_TEST("AI_FLAG_SMART_MON_CHOICES: AI considers both meeting and 
     }
 }
 
-AI_SINGLE_BATTLE_TEST("AI_FLAG_SMART_SWITCHING: benched forced trapper abilities are honored for hard switches")
-{
-    GIVEN {
-        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_SMART_SWITCHING | AI_FLAG_SMART_MON_CHOICES | AI_FLAG_OMNISCIENT);
-        PLAYER(SPECIES_HERACROSS) {
-            Level(76);
-            Moves(MOVE_BULLET_SEED);
-            Ability(ABILITY_GUTS);
-            Item(ITEM_HERACRONITE);
-            Nature(NATURE_ADAMANT);
-            Speed(157);
-        }
-        PLAYER(SPECIES_WOBBUFFET) {
-            Level(1);
-            Speed(1);
-        }
-        OPPONENT(SPECIES_SWAMPERT) {
-            Level(74);
-            Moves(MOVE_KNOCK_OFF, MOVE_PROTECT, MOVE_LIQUIDATION);
-            Nature(NATURE_CAREFUL);
-            Item(ITEM_RINDO_BERRY);
-            Speed(116);
-        }
-        OPPONENT(SPECIES_CHANDELURE) {
-            Level(74);
-            Moves(MOVE_FLAMETHROWER, MOVE_ENERGY_BALL);
-            Nature(NATURE_TIMID);
-            Item(ITEM_CHOICE_SPECS);
-            Ability(ABILITY_SHADOW_TAG);
-            Speed(160);
-        }
-    } WHEN {
-        TURN { MOVE(player, MOVE_BULLET_SEED); EXPECT_SWITCH(opponent, 1); }
-    }
-}
-
 AI_DOUBLE_BATTLE_TEST("AI will not choose to switch out Dondozo with Commander Tatsugiri")
 {
     PASSES_RANDOMLY(100, 100);

--- a/test/battle/ai/ai_test_test_runner.c
+++ b/test/battle/ai/ai_test_test_runner.c
@@ -2,6 +2,44 @@
 #include "test/battle.h"
 #include "battle_ai_util.h"
 
+// Intentionally uses an illegal forced ability so the regression exercises the
+// test-runner override path instead of depending on species ability data.
+AI_SINGLE_BATTLE_TEST("TESTING: forced illegal bench abilities are honored during AI switch evaluation")
+{
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_SMART_SWITCHING | AI_FLAG_SMART_MON_CHOICES | AI_FLAG_OMNISCIENT);
+        PLAYER(SPECIES_HERACROSS) {
+            Level(76);
+            Moves(MOVE_BULLET_SEED);
+            Ability(ABILITY_GUTS);
+            Item(ITEM_HERACRONITE);
+            Nature(NATURE_ADAMANT);
+            Speed(157);
+        }
+        PLAYER(SPECIES_WOBBUFFET) {
+            Level(1);
+            Speed(1);
+        }
+        OPPONENT(SPECIES_SWAMPERT) {
+            Level(74);
+            Moves(MOVE_KNOCK_OFF, MOVE_PROTECT, MOVE_LIQUIDATION);
+            Nature(NATURE_CAREFUL);
+            Item(ITEM_RINDO_BERRY);
+            Speed(116);
+        }
+        OPPONENT(SPECIES_CHANDELURE) {
+            Level(74);
+            Moves(MOVE_FLAMETHROWER, MOVE_ENERGY_BALL);
+            Nature(NATURE_TIMID);
+            Item(ITEM_CHOICE_SPECS);
+            Ability(ABILITY_SHADOW_TAG);
+            Speed(160);
+        }
+    } WHEN {
+        TURN { MOVE(player, MOVE_BULLET_SEED); EXPECT_SWITCH(opponent, 1); }
+    }
+}
+
 AI_SINGLE_BATTLE_TEST("TIE_BREAK_SCORE with SCORE_TIE_CHOSEN can control AI move selection when scores are tied (Singles)")
 {
     u32 tiedMove;


### PR DESCRIPTION
<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
This PR fixes a `TESTING` inconsistency in AI switch evaluation.

The battle test runner already supports forced illegal abilities through `Ability(...)`: if the ability is not legal for the species, the test runner stores it as a forced override and active battlers honor that override when the battle starts. Before this change, AI switch evaluation did not consistently honor that same forced state for benched mons.

As a result, a benched Pokemon could be evaluated with a different ability than the one declared by the test. That made AI switch simulations inconsistent with the active-battler state and could cause tests that rely on benched abilities to fail depending on species ability data.

The change does two things:

- `src/battle_ai_switch.c` now reads bench abilities through an override-aware helper during AI switch evaluation
- Switch-in simulation now copies ability/type data through the same override-aware path used for active battlers
- The regression has been moved out of the normal AI behavior file and into the AI test-runner coverage, because this is specifically testing the forced-illegal-ability path under `TESTING`

Affected AI switch paths include:

- `FindMonThatAbsorbsOpponentsMove`
- `ShouldSwitchIfTrapperInParty`
- `FindMonWithFlagsAndSuperEffective`
- `InitializeSwitchinCandidate`

The regression intentionally uses an illegal ability on a benched mon. That is deliberate: the goal is to exercise the test-runner override path directly so downstream species ability changes do not silently invalidate the test.

Validation:

- `make -j32 check TESTS="TESTING: forced illegal bench abilities are honored during AI switch evaluation"`
- `make -j32 check TESTS="test/battle/ai/ai_test_test_runner.c"`
- `make -j32 check TESTS="test/battle/ai/ai_switching.c"`
  - Result: `117 passed, 1 known failing`

## Media
Not applicable.

## Issue(s) that this PR fixes
Fixes #9753 

## Feature(s) this PR does NOT handle:
- Unrelated AI move-scoring bugs
- Changing normal non-test runtime behavior for how party abilities are stored
- Solving broader issue scenarios that depend on additional AI scoring or switching fixes beyond forced bench-ability handling
- Generalizing test coverage for legal bench abilities as those already resolve through normal party data

## Things to note in the release changelog:
- Fixed AI switch-evaluation test simulation so benched mons with forced illegal abilities are evaluated consistently with active battlers under `TESTING`.

## Discord contact info
viridian.
