### PR TITLE
Fix Synchronize status immunity ability check

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4668,7 +4668,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
                     gBattlerAttacker,
                     gBattlerTarget,
                     gLastUsedAbility,
-                    GetBattlerAbility(gBattlerAttacker),
+                    GetBattlerAbility(gBattlerTarget),
                     gBattleStruct->synchronizeMoveEffect,
                     CHECK_TRIGGER))
             {

--- a/test/battle/ability/synchronize.c
+++ b/test/battle/ability/synchronize.c
@@ -94,3 +94,49 @@ SINGLE_BATTLE_TEST("Synchronize does not inflict status on a target with status 
         }
     }
 }
+
+SINGLE_BATTLE_TEST("Synchronize does not trigger from Toxic Spikes")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_TOXIC_SPIKES) == EFFECT_TOXIC_SPIKES);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_ABRA) { Ability(ABILITY_SYNCHRONIZE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_TOXIC_SPIKES); }
+        TURN { SWITCH(player, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TOXIC_SPIKES, opponent);
+        ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, player);
+        STATUS_ICON(player, poison: TRUE);
+        NONE_OF {
+            ABILITY_POPUP(player, ABILITY_SYNCHRONIZE);
+            STATUS_ICON(opponent, poison: TRUE);
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Synchronize does not trigger from Toxic Orb or Flame Orb")
+{
+    enum Item item;
+    u32 status1 = STATUS1_NONE;
+
+    PARAMETRIZE { item = ITEM_TOXIC_ORB; status1 = STATUS1_TOXIC_POISON; }
+    PARAMETRIZE { item = ITEM_FLAME_ORB; status1 = STATUS1_BURN; }
+
+    GIVEN {
+        ASSUME(gItemsInfo[ITEM_TOXIC_ORB].holdEffect == HOLD_EFFECT_TOXIC_ORB);
+        ASSUME(gItemsInfo[ITEM_FLAME_ORB].holdEffect == HOLD_EFFECT_FLAME_ORB);
+        PLAYER(SPECIES_ABRA) { Ability(ABILITY_SYNCHRONIZE); Item(item); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN {}
+    } SCENE {
+        STATUS_ICON(player, status1);
+        NONE_OF {
+            ABILITY_POPUP(player, ABILITY_SYNCHRONIZE);
+            STATUS_ICON(opponent, poison: TRUE);
+            STATUS_ICON(opponent, burn: TRUE);
+        }
+    }
+}

--- a/test/battle/ability/synchronize.c
+++ b/test/battle/ability/synchronize.c
@@ -73,3 +73,24 @@ SINGLE_BATTLE_TEST("Synchronize will mirror back static activation")
         STATUS_ICON(player, paralysis: TRUE);
     }
 }
+
+SINGLE_BATTLE_TEST("Synchronize does not inflict status on a target with status immunity ability")
+{
+    GIVEN {
+        ASSUME(MoveMakesContact(MOVE_SCRATCH));
+        ASSUME(GetMoveEffect(MOVE_BANEFUL_BUNKER) == EFFECT_PROTECT);
+        PLAYER(SPECIES_ABRA) { Ability(ABILITY_SYNCHRONIZE); }
+        OPPONENT(SPECIES_SNORLAX) { Ability(ABILITY_IMMUNITY); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SCRATCH); MOVE(opponent, MOVE_BANEFUL_BUNKER); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BANEFUL_BUNKER, opponent);
+        ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, player);
+        STATUS_ICON(player, poison: TRUE);
+        ABILITY_POPUP(player, ABILITY_SYNCHRONIZE);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
+            STATUS_ICON(opponent, poison: TRUE);
+        }
+    }
+}

--- a/test/battle/ability/synchronize.c
+++ b/test/battle/ability/synchronize.c
@@ -77,8 +77,8 @@ SINGLE_BATTLE_TEST("Synchronize will mirror back static activation")
 SINGLE_BATTLE_TEST("Synchronize does not inflict status on a target with status immunity ability")
 {
     GIVEN {
-        ASSUME(MoveMakesContact(MOVE_SCRATCH));
-        ASSUME(GetMoveEffect(MOVE_BANEFUL_BUNKER) == EFFECT_PROTECT);
+        ASSUME(GetMoveEffect(MOVE_POISON_GAS) == EFFECT_NON_VOLATILE_STATUS);
+        ASSUME(GetMoveNonVolatileStatus(MOVE_POISON_GAS) == MOVE_EFFECT_POISON);
         PLAYER(SPECIES_ABRA) { Ability(ABILITY_SYNCHRONIZE); }
         OPPONENT(SPECIES_SNORLAX) { Ability(ABILITY_IMMUNITY); }
     } WHEN {

--- a/test/battle/ability/synchronize.c
+++ b/test/battle/ability/synchronize.c
@@ -82,9 +82,9 @@ SINGLE_BATTLE_TEST("Synchronize does not inflict status on a target with status 
         PLAYER(SPECIES_ABRA) { Ability(ABILITY_SYNCHRONIZE); }
         OPPONENT(SPECIES_SNORLAX) { Ability(ABILITY_IMMUNITY); }
     } WHEN {
-        TURN { MOVE(player, MOVE_SCRATCH); MOVE(opponent, MOVE_BANEFUL_BUNKER); }
+        TURN { MOVE(opponent, MOVE_POISON_GAS); }
     } SCENE {
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_BANEFUL_BUNKER, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POISON_GAS, opponent);
         ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, player);
         STATUS_ICON(player, poison: TRUE);
         ABILITY_POPUP(player, ABILITY_SYNCHRONIZE);


### PR DESCRIPTION
## Description
It should check the target’s status immunity ability, not the **Synchronize** user’s own ability.
