### PR TITLE
Remove redundant SetBattlerAiData call in GetMostSuitableMonToSwitchInto

### DIFF
--- a/include/config/ai.h
+++ b/include/config/ai.h
@@ -7,7 +7,7 @@
 #define AI_FRAME_CEILING_DOUBLES_NO_FLAGS                       22
 #define AI_FRAME_CEILING_DOUBLES_SMART_TRAINER                  38
 #define AI_FRAME_CEILING_STEVEN_MULTI                           27
-#define AI_FRAME_CEILING_STEVEN_MULTI_SMART_TRAINER             31
+#define AI_FRAME_CEILING_STEVEN_MULTI_SMART_TRAINER             32
 
 // For the details on what specific factors the switching functions are considering, go read the corresponding function inside ShouldSwitch in src/battle_ai_switch_items.c
 // These configuration options control how likely the AI is to switch if it determines that a switch meets all of its criteria

--- a/include/config/ai.h
+++ b/include/config/ai.h
@@ -7,7 +7,7 @@
 #define AI_FRAME_CEILING_DOUBLES_NO_FLAGS                       22
 #define AI_FRAME_CEILING_DOUBLES_SMART_TRAINER                  38
 #define AI_FRAME_CEILING_STEVEN_MULTI                           27
-#define AI_FRAME_CEILING_STEVEN_MULTI_SMART_TRAINER             33
+#define AI_FRAME_CEILING_STEVEN_MULTI_SMART_TRAINER             31
 
 // For the details on what specific factors the switching functions are considering, go read the corresponding function inside ShouldSwitch in src/battle_ai_switch_items.c
 // These configuration options control how likely the AI is to switch if it determines that a switch meets all of its criteria

--- a/src/battle_ai_switch.c
+++ b/src/battle_ai_switch.c
@@ -1692,9 +1692,9 @@ static u32 GetSwitchinSingleUseItemHealing(enum BattlerId battler, enum BattlerI
     enum Item aiItem = gAiLogicData->items[battler];
     u32 maxHP = gBattleMons[battler].maxHP;
     s32 itemHeal = 0;
-    
+
     // Check if we're at a single use healing item threshold
-    if (currentHP <= 0 
+    if (currentHP <= 0
      || gAiLogicData->abilities[battler] == ABILITY_KLUTZ
      || (gAiLogicData->abilities[opposingBattler] == ABILITY_UNNERVE && GetItemPocket(aiItem) == POCKET_BERRIES))
         return itemHeal;
@@ -2535,7 +2535,6 @@ static u32 GetBestMonIntegrated(struct Pokemon *party, int lastId, enum BattlerI
     gBattleStruct->battlerState[battler].notOnField = savedNotOnField;
     FreeRestoreAiLogicData(savedAiLogicData);
     FreeRestoreBattleMons(savedBattleMons);
-    SetBattlerAiData(battler, gAiLogicData);
 
     // GetSwitchinCandidate returns either the *last* party mon that met a threshold (without AI_FLAG_RANDOMIZE_SWITCHIN), or a random one that met a threshold
     // If we aren't using AI_FLAG_RANDOMIZE_SWITCHIN there are cases where we don't want the *last* mon, we want the *best* mon
@@ -2844,7 +2843,7 @@ static void SetBattlerStatusForSwitchin(enum BattlerId battler)
             gBattleMons[battler].status1 = STATUS1_TOXIC_POISON;
             gBattleMons[battler].status1 += STATUS1_TOXIC_TURN(1);
         }
-    } 
+    }
 }
 
 static void SetBattlerStatStagesForSwitchin(enum BattlerId battler, enum BattlerId opposingBattler, u32 fieldStatus)


### PR DESCRIPTION
We already back up `AiLogicData`. This was just a leftover

Saves 2 frames