### PR TITLE
Fix Defiant/Competitive forcing positive stat changes to use single stat anims

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -7981,7 +7981,7 @@ static u32 ChangeStatBuffs(enum BattlerId battler, s8 statValue, enum Stat statI
     if (gBattleMons[battler].statStages[statId] > MAX_STAT_STAGE)
         gBattleMons[battler].statStages[statId] = MAX_STAT_STAGE;
 
-    if (ShouldDefiantCompetitiveActivate(battler, battlerAbility))
+    if (statValue <= -1 && ShouldDefiantCompetitiveActivate(battler, battlerAbility))
         stats = 0; // use single stat animations when Defiant/Competitive activate
     else
         stats &= ~(1u << statId);


### PR DESCRIPTION
This is actually much less of an issue than I thought, since it requires a multi-stat boost when the Competitive/Defiant mon isn't the attacker, but it should still check whether the change is negative.

## Discord contact info
PhallenTree