### PR TITLE
Detect (some) uninitialized battle buffer expansion

### DIFF
--- a/include/battle_message.h
+++ b/include/battle_message.h
@@ -102,6 +102,7 @@
 #define B_BUFF_MON_NICK_WITH_PREFIX_LOWER   11 // lowercase prefix
 
 #define B_BUFF_PLACEHOLDER_BEGIN        0xFD
+#define B_BUFF_POISON                   0xFE
 #define B_BUFF_EOS                      0xFF
 
 #define PREPARE_FLAVOR_BUFFER(textVar, flavorId)                            \
@@ -256,6 +257,7 @@ void BattlePutTextOnWindow(const u8 *text, u8 windowId);
 void SetPpNumbersPaletteInMoveSelection(enum BattlerId battler);
 u8 GetCurrentPpToMaxPpState(u8 currentPp, u8 maxPp);
 void ExpandBattleTextBuffPlaceholders(const u8 *src, u8 *dst);
+void BattleStringPoisonBuffers(void);
 
 extern struct BattleMsgData *gBattleMsgDataPtr;
 

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3168,6 +3168,8 @@ static void BattleStartClearSetData(void)
         gBattleStruct->monCausingSleepClause[B_SIDE_PLAYER] = PARTY_SIZE;
         gBattleStruct->monCausingSleepClause[B_SIDE_OPPONENT] = PARTY_SIZE;
     }
+
+    BattleStringPoisonBuffers();
 }
 
 #define UNPACK_VOLATILE_BATON_PASSABLES(_enum, _fieldName, _typeMaxValue, ...) __VA_OPT__(if ((FIRST(__VA_ARGS__)) & V_BATON_PASSABLE) gBattleMons[battler].volatiles._fieldName = volatilesCopy->_fieldName;)
@@ -3962,6 +3964,7 @@ static void HandleEndTurn_ContinueBattle(void)
         gBattleStruct->eventState.endTurnBlock = 0;
         gBattleStruct->eventState.endTurnBattler = 0;
         gBattleStruct->eventState.endTurn = 0;
+        BattleStringPoisonBuffers();
     }
 }
 

--- a/src/battle_message.c
+++ b/src/battle_message.c
@@ -2859,6 +2859,22 @@ u32 BattleStringExpandPlaceholdersToDisplayedString(const u8 *src)
 #endif
 }
 
+static void BattleStringPoisonBuffer(u8 *buffer)
+{
+    buffer[0] = B_BUFF_PLACEHOLDER_BEGIN;
+    buffer[1] = B_BUFF_POISON;
+    buffer[2] = EOS;
+}
+
+void BattleStringPoisonBuffers(void)
+{
+    // Insert 'B_BUFF_POISON' at the start of the text buffers so that
+    // using them before buffering new text will trip an 'assertf'.
+    BattleStringPoisonBuffer(gBattleTextBuff1);
+    BattleStringPoisonBuffer(gBattleTextBuff2);
+    BattleStringPoisonBuffer(gBattleTextBuff3);
+}
+
 static const u8 *TryGetStatusString(u8 *src)
 {
     u32 i;
@@ -3136,6 +3152,7 @@ u32 BattleStringExpandPlaceholders(const u8 *src, u8 *dst, u32 dstSize)
             case B_TXT_BUFF1:
                 if (gBattleTextBuff1[0] == B_BUFF_PLACEHOLDER_BEGIN)
                 {
+                    assertf(gBattleTextBuff1[1] != B_BUFF_POISON, "B_BUFF1 is uninitialized in %p (%*S) at %p", src, dstID, dst, gBattlescriptCurrInstr);
                     ExpandBattleTextBuffPlaceholders(gBattleTextBuff1, gStringVar1);
                     toCpy = gStringVar1;
                 }
@@ -3149,6 +3166,7 @@ u32 BattleStringExpandPlaceholders(const u8 *src, u8 *dst, u32 dstSize)
             case B_TXT_BUFF2:
                 if (gBattleTextBuff2[0] == B_BUFF_PLACEHOLDER_BEGIN)
                 {
+                    assertf(gBattleTextBuff2[1] != B_BUFF_POISON, "B_BUFF2 is uninitialized in %p (%*S) at %p", src, dstID, dst, gBattlescriptCurrInstr);
                     ExpandBattleTextBuffPlaceholders(gBattleTextBuff2, gStringVar2);
                     toCpy = gStringVar2;
                 }
@@ -3160,6 +3178,7 @@ u32 BattleStringExpandPlaceholders(const u8 *src, u8 *dst, u32 dstSize)
             case B_TXT_BUFF3:
                 if (gBattleTextBuff3[0] == B_BUFF_PLACEHOLDER_BEGIN)
                 {
+                    assertf(gBattleTextBuff3[1] != B_BUFF_POISON, "B_BUFF3 is uninitialized in %p (%*S) at %p", src, dstID, dst, gBattlescriptCurrInstr);
                     ExpandBattleTextBuffPlaceholders(gBattleTextBuff3, gStringVar3);
                     toCpy = gStringVar3;
                 }
@@ -3859,6 +3878,9 @@ void ExpandBattleTextBuffPlaceholders(const u8 *src, u8 *dst)
                 CopyItemName(hword, dst);
             }
             srcID += 3;
+            break;
+        case B_BUFF_POISON:
+            srcID += 1;
             break;
         }
     }

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -488,6 +488,8 @@ void HandleAction_UseMove(void)
     }
 
     gCurrentActionFuncId = B_ACTION_EXEC_SCRIPT;
+
+    BattleStringPoisonBuffers();
 }
 
 void HandleAction_Switch(void)
@@ -535,6 +537,8 @@ void HandleAction_UseItem(void)
 
     gBattlescriptCurrInstr = gBattlescriptsForUsingItem[GetItemBattleUsage(gLastUsedItem) - 1];
     gCurrentActionFuncId = B_ACTION_EXEC_SCRIPT;
+
+    BattleStringPoisonBuffers();
 }
 
 bool32 TryRunFromBattle(enum BattlerId battler)
@@ -9036,9 +9040,15 @@ enum ImmunityHealStatusOutcome TryImmunityAbilityHealStatus(enum BattlerId battl
         break;
     case ABILITY_OBLIVIOUS:
         if (gBattleMons[battler].volatiles.infatuation)
+        {
+            StringCopy(gBattleTextBuff1, COMPOUND_STRING("infatuation"));
             outcome = IMMUNITY_INFATUATION_CLEARED;
+        }
         else if (GetConfig(B_OBLIVIOUS_TAUNT) >= GEN_6 && gBattleMons[battler].volatiles.tauntTimer != 0)
+        {
+            StringCopy(gBattleTextBuff1, COMPOUND_STRING("taunt"));
             outcome = IMMUNITY_TAUNT_CLEARED;
+        }
         break;
     default:
         break;

--- a/test/test_runner.c
+++ b/test/test_runner.c
@@ -822,10 +822,11 @@ static s32 MgbaPutchar_(s32 i, s32 c)
 
 extern const u8 gWireless_RSEtoASCIITable[];
 
-// Bare-bones, only supports plain %s, %S, and %d.
+// Bare-bones, only supports plain %s, %S, %d, and %p; plus a UQ4.12 %q.
 static s32 MgbaVPrintf_(const char *fmt, va_list va)
 {
     s32 i = 0;
+    u32 n;
     s32 c, d;
     u32 p;
     const char *s;
@@ -835,6 +836,16 @@ static s32 MgbaVPrintf_(const char *fmt, va_list va)
         switch ((c = *fmt++))
         {
         case '%':
+            if (*fmt == '*')
+            {
+                fmt++;
+                n = va_arg(va, unsigned);
+            }
+            else
+            {
+                n = -1;
+            }
+
             switch (*fmt++)
             {
             case '%':
@@ -924,7 +935,7 @@ static s32 MgbaVPrintf_(const char *fmt, va_list va)
                 break;
             case 's':
                 s = va_arg(va, const char *);
-                while ((c = *s++) != '\0')
+                while (n-- > 0 && (c = *s++) != '\0')
                     i = MgbaPutchar_(i, c);
                 break;
             case 'S':
@@ -938,7 +949,7 @@ static s32 MgbaVPrintf_(const char *fmt, va_list va)
                 }
                 else
                 {
-                    while ((c = *pokeS++) != EOS)
+                    while (n-- > 0 && (c = *pokeS++) != EOS)
                     {
                         if ((c = gWireless_RSEtoASCIITable[c]) != '\0')
                             i = MgbaPutchar_(i, c);


### PR DESCRIPTION
At points where we know the buffers should be considered uninitialized we overwrite them with a poison value which trips an `assertf` when expanded.

imo poison is a hacky workaround to a bad API, but overhauling the way battle strings are handled is a ton of work, and this might get a surprising amount of bang for its buck. It caught two strings on master (which don't really matter because they're replaced in #9655), and it would have caught #9747.

We could consider expanding `BattleStringPoisonBuffers` to cover more than just buffers. e.g. "poison" things like the last used item, scripting battler, etc (by setting them to invalid values, and adding an `assertf` in the string expansions).