### PR TITLE
Fix Bead and Dream Mail

### DIFF
--- a/src/item_use.c
+++ b/src/item_use.c
@@ -234,6 +234,7 @@ static void CB2_CheckMail(void)
 {
     struct Mail mail;
     mail.itemId = gSpecialVar_ItemId;
+    mail.species = SPECIES_NONE;
     ReadMail(&mail, CB2_ReturnToBagMenuPocket, FALSE);
 }
 


### PR DESCRIPTION
Bead and Dream Mail currently show a golisopod. Vanilla behaviour is to show nothing. I believe this bug might well have existed on emerald but was missed because the code for show mail ignores the mail->species field if it's < species_none or > num_species defines. 

Since we've expanded the number of species, we now need to sanitise mail->species before we look at mail from the item menu.
So we just add mail.species = species_none. 1 line fix!

<img width="240" height="160" alt="image" src="https://github.com/user-attachments/assets/dd1e4262-f082-47bc-b373-795c3bf6e8a1" />
