### PR TITLE
Remove template abstraction for pokedex area map

### DIFF
--- a/include/pokedex_area_region_map.h
+++ b/include/pokedex_area_region_map.h
@@ -1,17 +1,8 @@
 #ifndef GUARD_POKEDEX_AREA_REGION_MAP_H
 #define GUARD_POKEDEX_AREA_REGION_MAP_H
 
-struct PokedexAreaMapTemplate
-{
-    u32 bg:2;
-    u32 offset:8;
-    u32 mode:2;
-    u32 unk:20; // never read
-};
-
-void LoadPokedexAreaMapGfx(const struct PokedexAreaMapTemplate *template);
+void LoadPokedexAreaMapGfx();
 bool32 TryShowPokedexAreaMap(void);
 void PokedexAreaMapChangeBgY(u32 move);
-void FreePokedexAreaMapBgNum(void);
 
 #endif // GUARD_POKEDEX_AREA_REGION_MAP_H

--- a/src/pokedex_area_region_map.c
+++ b/src/pokedex_area_region_map.c
@@ -10,7 +10,7 @@
 
 #define POKEDEX_AREA_MAP_BG 3
 
-void LoadPokedexAreaMapGfx()
+void LoadPokedexAreaMapGfx(void)
 {
     enum RegionMapType regionMapType = GetRegionMapType(gMapHeader.regionMapSectionId);
 

--- a/src/pokedex_area_region_map.c
+++ b/src/pokedex_area_region_map.c
@@ -8,48 +8,27 @@
 #include "regions.h"
 #include "region_map.h"
 
-static EWRAM_DATA u8 *sPokedexAreaMapBgNum = NULL;
+#define POKEDEX_AREA_MAP_BG 3
 
-static const u32 sPokedexAreaMapAffine_Gfx[] = INCBIN_U32("graphics/pokedex/region_map_affine.8bpp.smol");
-static const u32 sPokedexAreaMapAffine_Tilemap[] = INCBIN_U32("graphics/pokedex/region_map_affine.bin.smolTM");
-
-void LoadPokedexAreaMapGfx(const struct PokedexAreaMapTemplate *template)
+void LoadPokedexAreaMapGfx()
 {
     enum RegionMapType regionMapType = GetRegionMapType(gMapHeader.regionMapSectionId);
-    u8 mode;
-    void *tilemap;
-    sPokedexAreaMapBgNum = Alloc(sizeof(sPokedexAreaMapBgNum));
-    mode = template->mode;
 
-    if (mode == 0)
-    {
-        SetBgAttribute(template->bg, BG_ATTR_METRIC, 0);
-        DecompressAndCopyTileDataToVram(template->bg, gRegionMapInfos[regionMapType].dexMapGfx, 0, template->offset, 0);
-        tilemap = DecompressAndCopyTileDataToVram(template->bg, gRegionMapInfos[regionMapType].dexMapTilemap, 0, 0, 1);
-        AddValToTilemapBuffer(tilemap, template->offset, 32, 32, FALSE); // template->offset is always 0, so this does nothing.
-    }
-    else
-    {
-        // This is never reached, only a mode of 0 is given
-        SetBgAttribute(template->bg, BG_ATTR_METRIC, 2);
-        SetBgAttribute(template->bg, BG_ATTR_TYPE, BG_TYPE_AFFINE); // This does nothing. BG_ATTR_TYPE can't be set with this function
-        DecompressAndCopyTileDataToVram(template->bg, sPokedexAreaMapAffine_Gfx, 0, template->offset, 0);
-        tilemap = DecompressAndCopyTileDataToVram(template->bg, sPokedexAreaMapAffine_Tilemap, 0, 0, 1);
-        AddValToTilemapBuffer(tilemap, template->offset, 64, 64, TRUE); // template->offset is always 0, so this does nothing.
-    }
+    SetBgAttribute(POKEDEX_AREA_MAP_BG, BG_ATTR_METRIC, 0);
+    DecompressAndCopyTileDataToVram(POKEDEX_AREA_MAP_BG, gRegionMapInfos[regionMapType].dexMapGfx, 0, 0, 0);
+    DecompressAndCopyTileDataToVram(POKEDEX_AREA_MAP_BG, gRegionMapInfos[regionMapType].dexMapTilemap, 0, 0, 1);
 
-    ChangeBgX(template->bg, 0, BG_COORD_SET);
-    ChangeBgY(template->bg, 0, BG_COORD_SET);
-    SetBgAttribute(template->bg, BG_ATTR_PALETTEMODE, 1);
+    ChangeBgX(POKEDEX_AREA_MAP_BG, 0, BG_COORD_SET);
+    ChangeBgY(POKEDEX_AREA_MAP_BG, 0, BG_COORD_SET);
+    SetBgAttribute(POKEDEX_AREA_MAP_BG, BG_ATTR_PALETTEMODE, 1);
     CpuCopy32(gRegionMapInfos[regionMapType].dexMapPalette, &gPlttBufferUnfaded[BG_PLTT_ID(7)], gRegionMapInfos[regionMapType].dexMapPaletteSize);
-    *sPokedexAreaMapBgNum = template->bg;
 }
 
 bool32 TryShowPokedexAreaMap(void)
 {
     if (!FreeTempTileDataBuffersIfPossible())
     {
-        ShowBg(*sPokedexAreaMapBgNum);
+        ShowBg(POKEDEX_AREA_MAP_BG);
         return FALSE;
     }
     else
@@ -58,12 +37,7 @@ bool32 TryShowPokedexAreaMap(void)
     }
 }
 
-void FreePokedexAreaMapBgNum(void)
-{
-    TRY_FREE_AND_SET_NULL(sPokedexAreaMapBgNum);
-}
-
 void PokedexAreaMapChangeBgY(u32 move)
 {
-    ChangeBgY(*sPokedexAreaMapBgNum, move * 0x100, BG_COORD_SET);
+    ChangeBgY(POKEDEX_AREA_MAP_BG, move * 0x100, BG_COORD_SET);
 }

--- a/src/pokedex_area_screen.c
+++ b/src/pokedex_area_screen.c
@@ -174,14 +174,6 @@ static const mapsec_u16_t sLandmarkData[][2] =
 
 #include "data/pokedex_area_glow.h"
 
-static const struct PokedexAreaMapTemplate sPokedexAreaMapTemplate =
-{
-    .bg = 3,
-    .offset = 0,
-    .mode = 0,
-    .unk = 2,
-};
-
 static const u8 sAreaMarkerTiles[];
 static const struct SpriteSheet sAreaMarkerSpriteSheet =
 {
@@ -751,7 +743,7 @@ static void Task_ShowPokedexAreaScreen(u8 taskId)
         break;
     case 1:
         SetBgAttribute(3, BG_ATTR_CHARBASEINDEX, 3);
-        LoadPokedexAreaMapGfx(&sPokedexAreaMapTemplate);
+        LoadPokedexAreaMapGfx();
         StringFill(sPokedexAreaScreen->charBuffer, CHAR_SPACE, 16);
         break;
     case 2:
@@ -826,7 +818,7 @@ static void Task_UpdatePokedexAreaScreen(u8 taskId)
         break;
     case 1:
         SetBgAttribute(3, BG_ATTR_CHARBASEINDEX, 3);
-        LoadPokedexAreaMapGfx(&sPokedexAreaMapTemplate);
+        LoadPokedexAreaMapGfx();
         PokedexAreaMapChangeBgY(-8);
         StringFill(sPokedexAreaScreen->charBuffer, CHAR_SPACE, 16);
         break;
@@ -935,7 +927,6 @@ static void Task_HandlePokedexAreaScreenInput(u8 taskId)
         sPokedexAreaScreen->screenSwitchState[0] = gTasks[taskId].data[1];
         ResetPokedexAreaMapBg();
         DestroyTask(taskId);
-        FreePokedexAreaMapBgNum();
         FREE_AND_SET_NULL(sPokedexAreaScreen);
         return;
     }


### PR DESCRIPTION
At some point GF probably consider other ways to draw maps, so they created a pokedex area template that is only used once and whose template feature are poorly developed. I have trouble imagining what they even wanted to do with that abstraction so I don't expect it to be useful to other developpers
This PR also saves EWRAM because there were storing the constant bg value into an EWRAM pointer ( GF moment )

## Media
Just a small video to test if things are still working properly:

https://github.com/user-attachments/assets/28369ff5-4c71-4f90-91d5-e6bcd96e122a



## Discord contact info
Jamie