### PR TITLE
Add Spicy Spray

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4256,6 +4256,20 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
                 effect++;
             }
             break;
+        case ABILITY_SPICY_SPRAY:
+            if (IsBattlerAlive(gBattlerAttacker)
+             && !gBattleStruct->unableToUseMove
+             && IsBattlerTurnDamaged(gBattlerTarget, EXCLUDING_SUBSTITUTES)
+             && CanBeBurned(gBattlerTarget, gBattlerAttacker, GetBattlerAbility(gBattlerAttacker)))
+            {
+                gEffectBattler = gBattlerAttacker;
+                gBattleScripting.battler = gBattlerTarget;
+                gBattleScripting.moveEffect = MOVE_EFFECT_BURN;
+                PREPARE_ABILITY_BUFFER(gBattleTextBuff1, gLastUsedAbility);
+                BattleScriptCall(BattleScript_AbilityStatusEffect);
+                effect++;
+            }
+            break;
         default:
             break;
         }

--- a/src/data/abilities.h
+++ b/src/data/abilities.h
@@ -2459,6 +2459,6 @@ const struct AbilityInfo gAbilitiesInfo[ABILITIES_COUNT] =
     [ABILITY_SPICY_SPRAY] =
     {
         .name = _("Spicy Spray"),
-        .description = COMPOUND_STRING("Unimplemented."),
+        .description = COMPOUND_STRING("Burns the foe when damaged."),
     },
 };

--- a/test/battle/ability/spicy_spray.c
+++ b/test/battle/ability/spicy_spray.c
@@ -97,7 +97,6 @@ SINGLE_BATTLE_TEST("Spicy Spray burns the attacker even if the attacker has Shee
 
 SINGLE_BATTLE_TEST("Spicy Spray burns the attacker even if the defender faints")
 {
-    enum Move move;
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_SCOVILLAIN) { Item(ITEM_SCOVILLAINITE); HP(1); }
@@ -109,6 +108,24 @@ SINGLE_BATTLE_TEST("Spicy Spray burns the attacker even if the defender faints")
         MESSAGE("The opposing Scovillain has Mega Evolved into Mega Scovillain!");
         ABILITY_POPUP(opponent, ABILITY_SPICY_SPRAY);
         ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, player);
+        MESSAGE("Wobbuffet was burned!");
+        STATUS_ICON(player, burn: TRUE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Spicy Spray burns the attacker even if the defender behind a Substitute takes damage")
+{
+    GIVEN {
+        ASSUME(IsSoundMove(MOVE_HYPER_VOICE));
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_SCOVILLAIN) { Item(ITEM_SCOVILLAINITE); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SUBSTITUTE, gimmick: GIMMICK_MEGA); MOVE(player, MOVE_HYPER_VOICE); }
+    } SCENE {
+        MESSAGE("The opposing Scovillain's Scovillainite is reacting to 2's Mega Ring!");
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MEGA_EVOLUTION, opponent);
+        MESSAGE("The opposing Scovillain has Mega Evolved into Mega Scovillain!");
+        ABILITY_POPUP(opponent, ABILITY_SPICY_SPRAY);
         MESSAGE("Wobbuffet was burned!");
         STATUS_ICON(player, burn: TRUE);
     }

--- a/test/battle/ability/spicy_spray.c
+++ b/test/battle/ability/spicy_spray.c
@@ -12,11 +12,85 @@ SINGLE_BATTLE_TEST("Spicy Spray burns the attacker")
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_SCOVILLAIN) { Item(ITEM_SCOVILLAINITE); }
     } WHEN {
-        TURN { MOVE(player, move); }
+        TURN { MOVE(opponent, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); MOVE(player, move); }
     } SCENE {
-        ABILITY_POPUP(opponent, ABILITY_FLAME_BODY);
+        MESSAGE("The opposing Scovillain's Scovillainite is reacting to 2's Mega Ring!");
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MEGA_EVOLUTION, opponent);
+        MESSAGE("The opposing Scovillain has Mega Evolved into Mega Scovillain!");
+        ABILITY_POPUP(opponent, ABILITY_SPICY_SPRAY);
         ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, player);
         MESSAGE("Wobbuffet was burned!");
+        STATUS_ICON(player, burn: TRUE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Spicy Spray burns the attacker even if the attacker is behind a Substitute")
+{
+    enum Move move;
+    PARAMETRIZE { move = MOVE_SCRATCH; }
+    PARAMETRIZE { move = MOVE_SWIFT; }
+    GIVEN {
+        ASSUME(MoveMakesContact(MOVE_SCRATCH));
+        ASSUME(!MoveMakesContact(MOVE_SWIFT));
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_SCOVILLAIN) { Item(ITEM_SCOVILLAINITE); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); MOVE(player, MOVE_SUBSTITUTE); }
+        TURN { MOVE(opponent, MOVE_CELEBRATE); MOVE(player, move); }
+    } SCENE {
+        MESSAGE("The opposing Scovillain's Scovillainite is reacting to 2's Mega Ring!");
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MEGA_EVOLUTION, opponent);
+        MESSAGE("The opposing Scovillain has Mega Evolved into Mega Scovillain!");
+        ABILITY_POPUP(opponent, ABILITY_SPICY_SPRAY);
+        MESSAGE("Wobbuffet was burned!");
+        STATUS_ICON(player, burn: TRUE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Spicy Spray does not burn the attacker if the defender is behind a Substitute")
+{
+    enum Move move;
+    PARAMETRIZE { move = MOVE_SCRATCH; }
+    PARAMETRIZE { move = MOVE_SWIFT; }
+    GIVEN {
+        ASSUME(MoveMakesContact(MOVE_SCRATCH));
+        ASSUME(!MoveMakesContact(MOVE_SWIFT));
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_SCOVILLAIN) { Item(ITEM_SCOVILLAINITE); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SUBSTITUTE, gimmick: GIMMICK_MEGA); MOVE(player, move); }
+    } SCENE {
+        MESSAGE("The opposing Scovillain's Scovillainite is reacting to 2's Mega Ring!");
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MEGA_EVOLUTION, opponent);
+        MESSAGE("The opposing Scovillain has Mega Evolved into Mega Scovillain!");
+        NONE_OF {
+            ABILITY_POPUP(opponent, ABILITY_SPICY_SPRAY);
+            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, player);
+            MESSAGE("Wobbuffet was burned!");
+            STATUS_ICON(player, burn: TRUE);
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Spicy Spray burns the attacker even if the attacker has Sheer Force")
+{
+    enum Move move;
+    PARAMETRIZE { move = MOVE_CRUNCH; }
+    PARAMETRIZE { move = MOVE_ICE_BEAM; }
+    GIVEN {
+        ASSUME(MoveMakesContact(MOVE_CRUNCH));
+        ASSUME(!MoveMakesContact(MOVE_ICE_BEAM));
+        PLAYER(SPECIES_FERALIGATR) { Ability(ABILITY_SHEER_FORCE); }
+        OPPONENT(SPECIES_SCOVILLAIN) { Item(ITEM_SCOVILLAINITE); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); MOVE(player, move); }
+    } SCENE {
+        MESSAGE("The opposing Scovillain's Scovillainite is reacting to 2's Mega Ring!");
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MEGA_EVOLUTION, opponent);
+        MESSAGE("The opposing Scovillain has Mega Evolved into Mega Scovillain!");
+        ABILITY_POPUP(opponent, ABILITY_SPICY_SPRAY);
+        ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, player);
+        MESSAGE("Feraligatr was burned!");
         STATUS_ICON(player, burn: TRUE);
     }
 }

--- a/test/battle/ability/spicy_spray.c
+++ b/test/battle/ability/spicy_spray.c
@@ -14,12 +14,9 @@ SINGLE_BATTLE_TEST("Spicy Spray burns the attacker")
     } WHEN {
         TURN { MOVE(opponent, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); MOVE(player, move); }
     } SCENE {
-        MESSAGE("The opposing Scovillain's Scovillainite is reacting to 2's Mega Ring!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MEGA_EVOLUTION, opponent);
-        MESSAGE("The opposing Scovillain has Mega Evolved into Mega Scovillain!");
         ABILITY_POPUP(opponent, ABILITY_SPICY_SPRAY);
         ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, player);
-        MESSAGE("Wobbuffet was burned!");
         STATUS_ICON(player, burn: TRUE);
     }
 }
@@ -38,11 +35,8 @@ SINGLE_BATTLE_TEST("Spicy Spray burns the attacker even if the attacker is behin
         TURN { MOVE(opponent, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); MOVE(player, MOVE_SUBSTITUTE); }
         TURN { MOVE(opponent, MOVE_CELEBRATE); MOVE(player, move); }
     } SCENE {
-        MESSAGE("The opposing Scovillain's Scovillainite is reacting to 2's Mega Ring!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MEGA_EVOLUTION, opponent);
-        MESSAGE("The opposing Scovillain has Mega Evolved into Mega Scovillain!");
         ABILITY_POPUP(opponent, ABILITY_SPICY_SPRAY);
-        MESSAGE("Wobbuffet was burned!");
         STATUS_ICON(player, burn: TRUE);
     }
 }
@@ -60,13 +54,10 @@ SINGLE_BATTLE_TEST("Spicy Spray does not burn the attacker if the defender is be
     } WHEN {
         TURN { MOVE(opponent, MOVE_SUBSTITUTE, gimmick: GIMMICK_MEGA); MOVE(player, move); }
     } SCENE {
-        MESSAGE("The opposing Scovillain's Scovillainite is reacting to 2's Mega Ring!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MEGA_EVOLUTION, opponent);
-        MESSAGE("The opposing Scovillain has Mega Evolved into Mega Scovillain!");
         NONE_OF {
             ABILITY_POPUP(opponent, ABILITY_SPICY_SPRAY);
             ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, player);
-            MESSAGE("Wobbuffet was burned!");
             STATUS_ICON(player, burn: TRUE);
         }
     }
@@ -85,12 +76,9 @@ SINGLE_BATTLE_TEST("Spicy Spray burns the attacker even if the attacker has Shee
     } WHEN {
         TURN { MOVE(opponent, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); MOVE(player, move); }
     } SCENE {
-        MESSAGE("The opposing Scovillain's Scovillainite is reacting to 2's Mega Ring!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MEGA_EVOLUTION, opponent);
-        MESSAGE("The opposing Scovillain has Mega Evolved into Mega Scovillain!");
         ABILITY_POPUP(opponent, ABILITY_SPICY_SPRAY);
         ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, player);
-        MESSAGE("Feraligatr was burned!");
         STATUS_ICON(player, burn: TRUE);
     }
 }
@@ -103,12 +91,9 @@ SINGLE_BATTLE_TEST("Spicy Spray burns the attacker even if the defender faints")
     } WHEN {
         TURN { MOVE(opponent, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); MOVE(player, MOVE_SCRATCH); }
     } SCENE {
-        MESSAGE("The opposing Scovillain's Scovillainite is reacting to 2's Mega Ring!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MEGA_EVOLUTION, opponent);
-        MESSAGE("The opposing Scovillain has Mega Evolved into Mega Scovillain!");
         ABILITY_POPUP(opponent, ABILITY_SPICY_SPRAY);
         ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, player);
-        MESSAGE("Wobbuffet was burned!");
         STATUS_ICON(player, burn: TRUE);
     }
 }
@@ -122,11 +107,8 @@ SINGLE_BATTLE_TEST("Spicy Spray burns the attacker even if the defender behind a
     } WHEN {
         TURN { MOVE(opponent, MOVE_SUBSTITUTE, gimmick: GIMMICK_MEGA); MOVE(player, MOVE_HYPER_VOICE); }
     } SCENE {
-        MESSAGE("The opposing Scovillain's Scovillainite is reacting to 2's Mega Ring!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MEGA_EVOLUTION, opponent);
-        MESSAGE("The opposing Scovillain has Mega Evolved into Mega Scovillain!");
         ABILITY_POPUP(opponent, ABILITY_SPICY_SPRAY);
-        MESSAGE("Wobbuffet was burned!");
         STATUS_ICON(player, burn: TRUE);
     }
 }

--- a/test/battle/ability/spicy_spray.c
+++ b/test/battle/ability/spicy_spray.c
@@ -94,3 +94,22 @@ SINGLE_BATTLE_TEST("Spicy Spray burns the attacker even if the attacker has Shee
         STATUS_ICON(player, burn: TRUE);
     }
 }
+
+SINGLE_BATTLE_TEST("Spicy Spray burns the attacker even if the defender faints")
+{
+    enum Move move;
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_SCOVILLAIN) { Item(ITEM_SCOVILLAINITE); HP(1); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); MOVE(player, MOVE_SCRATCH); }
+    } SCENE {
+        MESSAGE("The opposing Scovillain's Scovillainite is reacting to 2's Mega Ring!");
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MEGA_EVOLUTION, opponent);
+        MESSAGE("The opposing Scovillain has Mega Evolved into Mega Scovillain!");
+        ABILITY_POPUP(opponent, ABILITY_SPICY_SPRAY);
+        ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, player);
+        MESSAGE("Wobbuffet was burned!");
+        STATUS_ICON(player, burn: TRUE);
+    }
+}

--- a/test/battle/ability/spicy_spray.c
+++ b/test/battle/ability/spicy_spray.c
@@ -1,0 +1,22 @@
+#include "global.h"
+#include "test/battle.h"
+
+SINGLE_BATTLE_TEST("Spicy Spray burns the attacker")
+{
+    enum Move move;
+    PARAMETRIZE { move = MOVE_SCRATCH; }
+    PARAMETRIZE { move = MOVE_SWIFT; }
+    GIVEN {
+        ASSUME(MoveMakesContact(MOVE_SCRATCH));
+        ASSUME(!MoveMakesContact(MOVE_SWIFT));
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_SCOVILLAIN) { Item(ITEM_SCOVILLAINITE); }
+    } WHEN {
+        TURN { MOVE(player, move); }
+    } SCENE {
+        ABILITY_POPUP(opponent, ABILITY_FLAME_BODY);
+        ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, player);
+        MESSAGE("Wobbuffet was burned!");
+        STATUS_ICON(player, burn: TRUE);
+    }
+}


### PR DESCRIPTION
Title. Implements Mega Scovillain's signature ability Spicy Spray.

## Description
The following test cases accounted for are:
* Spicy Spray activates regardless if the move is a contact move
* Spicy Spray does not activate when the defender is behind a Substitute

### Large Language Models (AI)
None

## Media

https://github.com/user-attachments/assets/0b415ec9-8825-4e93-b196-b95f19adfb14

https://github.com/user-attachments/assets/99aef058-f243-4695-8007-b2ead4b4601d

https://github.com/user-attachments/assets/23c77cfb-71c7-4282-ba13-9c84eb82b201

https://github.com/user-attachments/assets/7ae0c1e0-9072-4882-979a-0945142c6dff

https://github.com/user-attachments/assets/20315a25-9124-429c-8df4-7efe50e645f7

## Issue(s) that this PR fixes
Fixes #9739

## Feature(s) this PR does NOT handle:
* "It doesn't affect <attacker>..." battle messages that print as part of failing to apply a status condition (i.e. Spore into a Grass-type, Flame Body into a Fire-type, etc.)

## Discord contact info
linathan