### PR TITLE
Fix Ring Target interactions with Ground immunity and grounded status

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -5960,7 +5960,20 @@ enum IronBallCheck
     IGNORE_IRON_BALL
 };
 
-static bool32 IsBattlerGroundedWithoutFlyingType(enum BattlerId battler, enum Ability ability, enum HoldEffect holdEffect, bool32 isAnticipation)
+static bool32 IsBattlerUngroundedByAbilityItemOrEffect(enum BattlerId battler, enum Ability ability, enum HoldEffect holdEffect)
+{
+    if (gBattleMons[battler].volatiles.telekinesis)
+        return TRUE;
+    if (gBattleMons[battler].volatiles.magnetRise)
+        return TRUE;
+    if (holdEffect == HOLD_EFFECT_AIR_BALLOON)
+        return TRUE;
+    if (ability == ABILITY_LEVITATE)
+        return TRUE;
+    return FALSE;
+}
+
+static bool32 IsBattlerGroundedInverseCheck(enum BattlerId battler, enum Ability ability, enum HoldEffect holdEffect, enum InverseBattleCheck checkInverse, bool32 isAnticipation)
 {
     if (holdEffect == HOLD_EFFECT_IRON_BALL)
         return TRUE;
@@ -5970,20 +5983,7 @@ static bool32 IsBattlerGroundedWithoutFlyingType(enum BattlerId battler, enum Ab
         return TRUE;
     if (gBattleMons[battler].volatiles.smackDown)
         return TRUE;
-    if (gBattleMons[battler].volatiles.telekinesis)
-        return FALSE;
-    if (gBattleMons[battler].volatiles.magnetRise)
-        return FALSE;
-    if (holdEffect == HOLD_EFFECT_AIR_BALLOON)
-        return FALSE;
-    if (ability == ABILITY_LEVITATE)
-        return FALSE;
-    return TRUE;
-}
-
-static bool32 IsBattlerGroundedInverseCheck(enum BattlerId battler, enum Ability ability, enum HoldEffect holdEffect, enum InverseBattleCheck checkInverse, bool32 isAnticipation)
-{
-    if (!IsBattlerGroundedWithoutFlyingType(battler, ability, holdEffect, isAnticipation))
+    if (IsBattlerUngroundedByAbilityItemOrEffect(battler, ability, holdEffect))
         return FALSE;
     if (IS_BATTLER_OF_TYPE(battler, TYPE_FLYING) && (checkInverse != INVERSE_BATTLE || !FlagGet(B_FLAG_INVERSE_BATTLE)))
         return FALSE;
@@ -8335,7 +8335,7 @@ static inline uq4_12_t CalcTypeEffectivenessMultiplierInternal(struct BattleCont
     else if (ctx->moveType == TYPE_GROUND
         && !IsBattlerGroundedInverseCheck(ctx->battlerDef, ctx->abilityDef, ctx->holdEffectDef, INVERSE_BATTLE, ctx->isAnticipation)
         && !(MoveIgnoresTypeIfFlyingAndUngrounded(ctx->move))
-        && !(ctx->holdEffectDef == HOLD_EFFECT_RING_TARGET && IS_BATTLER_OF_TYPE(ctx->battlerDef, TYPE_FLYING) && IsBattlerGroundedWithoutFlyingType(ctx->battlerDef, ctx->abilityDef, ctx->holdEffectDef, ctx->isAnticipation)))
+        && !(ctx->holdEffectDef == HOLD_EFFECT_RING_TARGET && IS_BATTLER_OF_TYPE(ctx->battlerDef, TYPE_FLYING) && !IsBattlerUngroundedByAbilityItemOrEffect(ctx->battlerDef, ctx->abilityDef, ctx->holdEffectDef)))
     {
         modifier = UQ_4_12(0.0);
         if (ctx->updateFlags && ctx->abilityDef == ABILITY_LEVITATE)

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -5960,8 +5960,7 @@ enum IronBallCheck
     IGNORE_IRON_BALL
 };
 
-// Only called directly when calculating damage type effectiveness, and Iron Ball's type effectiveness mechanics
-static bool32 IsBattlerGroundedInverseCheck(enum BattlerId battler, enum Ability ability, enum HoldEffect holdEffect, enum InverseBattleCheck checkInverse, bool32 isAnticipation)
+static bool32 IsBattlerGroundedWithoutFlyingType(enum BattlerId battler, enum Ability ability, enum HoldEffect holdEffect, bool32 isAnticipation)
 {
     if (holdEffect == HOLD_EFFECT_IRON_BALL)
         return TRUE;
@@ -5978,6 +5977,13 @@ static bool32 IsBattlerGroundedInverseCheck(enum BattlerId battler, enum Ability
     if (holdEffect == HOLD_EFFECT_AIR_BALLOON)
         return FALSE;
     if (ability == ABILITY_LEVITATE)
+        return FALSE;
+    return TRUE;
+}
+
+static bool32 IsBattlerGroundedInverseCheck(enum BattlerId battler, enum Ability ability, enum HoldEffect holdEffect, enum InverseBattleCheck checkInverse, bool32 isAnticipation)
+{
+    if (!IsBattlerGroundedWithoutFlyingType(battler, ability, holdEffect, isAnticipation))
         return FALSE;
     if (IS_BATTLER_OF_TYPE(battler, TYPE_FLYING) && (checkInverse != INVERSE_BATTLE || !FlagGet(B_FLAG_INVERSE_BATTLE)))
         return FALSE;
@@ -8326,7 +8332,10 @@ static inline uq4_12_t CalcTypeEffectivenessMultiplierInternal(struct BattleCont
         if (B_GLARE_GHOST < GEN_4 && ctx->move == MOVE_GLARE && IS_BATTLER_OF_TYPE(ctx->battlerDef, TYPE_GHOST))
             modifier = UQ_4_12(0.0);
     }
-    else if (ctx->moveType == TYPE_GROUND && !IsBattlerGroundedInverseCheck(ctx->battlerDef, ctx->abilityDef, ctx->holdEffectDef, INVERSE_BATTLE, ctx->isAnticipation) && !(MoveIgnoresTypeIfFlyingAndUngrounded(ctx->move)))
+    else if (ctx->moveType == TYPE_GROUND
+        && !IsBattlerGroundedInverseCheck(ctx->battlerDef, ctx->abilityDef, ctx->holdEffectDef, INVERSE_BATTLE, ctx->isAnticipation)
+        && !(MoveIgnoresTypeIfFlyingAndUngrounded(ctx->move))
+        && !(ctx->holdEffectDef == HOLD_EFFECT_RING_TARGET && IS_BATTLER_OF_TYPE(ctx->battlerDef, TYPE_FLYING) && IsBattlerGroundedWithoutFlyingType(ctx->battlerDef, ctx->abilityDef, ctx->holdEffectDef, ctx->isAnticipation)))
     {
         modifier = UQ_4_12(0.0);
         if (ctx->updateFlags && ctx->abilityDef == ABILITY_LEVITATE)

--- a/test/battle/hold_effect/ring_target.c
+++ b/test/battle/hold_effect/ring_target.c
@@ -6,23 +6,7 @@ ASSUMPTIONS
     ASSUME(gItemsInfo[ITEM_RING_TARGET].holdEffect == HOLD_EFFECT_RING_TARGET);
 }
 
-SINGLE_BATTLE_TEST("Ring Target lets Ground-type moves hit ungrounded Flying-type holders")
-{
-    GIVEN {
-        ASSUME(GetMoveType(MOVE_EARTHQUAKE) == TYPE_GROUND);
-        ASSUME(GetSpeciesType(SPECIES_PIDGEY, 0) == TYPE_FLYING || GetSpeciesType(SPECIES_PIDGEY, 1) == TYPE_FLYING);
-        PLAYER(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_PIDGEY) { Item(ITEM_RING_TARGET); }
-    } WHEN {
-        TURN { MOVE(player, MOVE_EARTHQUAKE); }
-    } SCENE {
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, player);
-        HP_BAR(opponent);
-        NOT MESSAGE("It doesn't affect the opposing Pidgey…");
-    }
-}
-
-SINGLE_BATTLE_TEST("Ring Target lets Normal-type moves hit Ghost-type holders")
+SINGLE_BATTLE_TEST("Ring Target removes a holder's type immunity")
 {
     GIVEN {
         ASSUME(GetMoveType(MOVE_TACKLE) == TYPE_NORMAL);
@@ -34,6 +18,37 @@ SINGLE_BATTLE_TEST("Ring Target lets Normal-type moves hit Ghost-type holders")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, player);
         HP_BAR(opponent);
-        NOT MESSAGE("It doesn't affect the opposing Misdreavus…");
+    }
+}
+
+SINGLE_BATTLE_TEST("Ring Target lets Ground-type moves hit Flying-type holders")
+{
+    GIVEN {
+        ASSUME(GetMoveType(MOVE_EARTHQUAKE) == TYPE_GROUND);
+        ASSUME(GetSpeciesType(SPECIES_PIDGEY, 0) == TYPE_FLYING || GetSpeciesType(SPECIES_PIDGEY, 1) == TYPE_FLYING);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_PIDGEY) { Item(ITEM_RING_TARGET); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_EARTHQUAKE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, player);
+        HP_BAR(opponent);
+    }
+}
+
+SINGLE_BATTLE_TEST("Ring Target does not make Flying-type holders grounded")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_GRASSY_TERRAIN) == EFFECT_GRASSY_TERRAIN);
+        ASSUME(gItemsInfo[ITEM_GRASSY_SEED].holdEffect == HOLD_EFFECT_TERRAIN_SEED);
+        ASSUME(gItemsInfo[ITEM_GRASSY_SEED].holdEffectParam == HOLD_EFFECT_PARAM_GRASSY_TERRAIN);
+        ASSUME(GetSpeciesType(SPECIES_PIDGEY, 0) == TYPE_FLYING || GetSpeciesType(SPECIES_PIDGEY, 1) == TYPE_FLYING);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_PIDGEY) { Item(ITEM_RING_TARGET); MaxHP(100); HP(1); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_GRASSY_TERRAIN); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_GRASSY_TERRAIN, player);
+        NOT HP_BAR(opponent);
     }
 }

--- a/test/battle/hold_effect/ring_target.c
+++ b/test/battle/hold_effect/ring_target.c
@@ -1,4 +1,39 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Ring Target (Hold Effect) test titles")
+ASSUMPTIONS
+{
+    ASSUME(gItemsInfo[ITEM_RING_TARGET].holdEffect == HOLD_EFFECT_RING_TARGET);
+}
+
+SINGLE_BATTLE_TEST("Ring Target lets Ground-type moves hit ungrounded Flying-type holders")
+{
+    GIVEN {
+        ASSUME(GetMoveType(MOVE_EARTHQUAKE) == TYPE_GROUND);
+        ASSUME(GetSpeciesType(SPECIES_PIDGEY, 0) == TYPE_FLYING || GetSpeciesType(SPECIES_PIDGEY, 1) == TYPE_FLYING);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_PIDGEY) { Item(ITEM_RING_TARGET); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_EARTHQUAKE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, player);
+        HP_BAR(opponent);
+        NOT MESSAGE("It doesn't affect the opposing Pidgey…");
+    }
+}
+
+SINGLE_BATTLE_TEST("Ring Target lets Normal-type moves hit Ghost-type holders")
+{
+    GIVEN {
+        ASSUME(GetMoveType(MOVE_TACKLE) == TYPE_NORMAL);
+        ASSUME(GetSpeciesType(SPECIES_GASTLY, 0) == TYPE_GHOST || GetSpeciesType(SPECIES_GASTLY, 1) == TYPE_GHOST);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_GASTLY) { Item(ITEM_RING_TARGET); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_TACKLE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE, player);
+        HP_BAR(opponent);
+        NOT MESSAGE("It doesn't affect the opposing Misdreavus…");
+    }
+}


### PR DESCRIPTION
## Description
[Ring Target](https://bulbapedia.bulbagarden.net/wiki/Ring_Target)
>  Flying-type Pokémon become vulnerable to Ground-type moves, but are otherwise considered ungrounded.