### PR TITLE
Fix Embody Aspect incorrectly reactivating after Neutralizing Gas ends

### DIFF
--- a/include/constants/battle.h
+++ b/include/constants/battle.h
@@ -279,6 +279,7 @@ enum VolatileFlags
     F(VOLATILE_TERRAIN_ABILITY_DONE,        terrainAbilityDone,            (u32, 1)) \
     F(VOLATILE_SYRUP_BOMB_IS_SHINY,         syrupBombIsShiny,              (u32, 1)) \
     F(VOLATILE_USED_PROTEAN_LIBERO,         usedProteanLibero,             (u32, 1)) \
+    F(VOLATILE_EMBODY_ASPECT_ACTIVATED,     embodyAspectActivated,         (u32, 1)) \
     F(VOLATILE_FLASH_FIRE_BOOSTED,          flashFireBoosted,              (u32, 1)) \
     F(VOLATILE_BOOSTER_ENERGY_ACTIVATED,    boosterEnergyActivated,        (u32, 1)) \
     F(VOLATILE_OVERWRITTEN_ABILITY,         overwrittenAbility,            (enum Ability, ABILITIES_COUNT)) \

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3594,9 +3594,10 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
         case ABILITY_EMBODY_ASPECT_HEARTHFLAME_MASK:
         case ABILITY_EMBODY_ASPECT_WELLSPRING_MASK:
         case ABILITY_EMBODY_ASPECT_CORNERSTONE_MASK:
-            if (shouldAbilityTrigger)
+            if (shouldAbilityTrigger && !gBattleMons[battler].volatiles.embodyAspectActivated)
             {
                 enum Stat stat;
+                gBattleMons[battler].volatiles.embodyAspectActivated = TRUE;
 
                 if (gLastUsedAbility == ABILITY_EMBODY_ASPECT_HEARTHFLAME_MASK)
                     stat = STAT_ATK;

--- a/test/battle/ability/embody_aspect.c
+++ b/test/battle/ability/embody_aspect.c
@@ -58,3 +58,27 @@ SINGLE_BATTLE_TEST("Embody Aspect activates when it's no longer effected by Neut
         MESSAGE("The opposing Ogerpon's Embody Aspect raised its Speed!");
     }
 }
+
+SINGLE_BATTLE_TEST("Embody Aspect does not reactivate after Neutralizing Gas ends if it already activated this switch-in")
+{
+    GIVEN {
+        PLAYER(SPECIES_OGERPON_TEAL_TERA) { Ability(ABILITY_EMBODY_ASPECT_TEAL_MASK); }
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WEEZING) { Ability(ABILITY_NEUTRALIZING_GAS); }
+    } WHEN {
+        TURN { SWITCH(opponent, 1); }
+        TURN { SWITCH(opponent, 0); }
+    } SCENE {
+        ABILITY_POPUP(player, ABILITY_EMBODY_ASPECT_TEAL_MASK);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        MESSAGE("Ogerpon's Embody Aspect raised its Speed!");
+
+        ABILITY_POPUP(opponent, ABILITY_NEUTRALIZING_GAS);
+        MESSAGE("Neutralizing gas filled the area!");
+
+        MESSAGE("The effects of the neutralizing gas wore off!");
+        NOT ABILITY_POPUP(player, ABILITY_EMBODY_ASPECT_TEAL_MASK);
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_SPEED], DEFAULT_STAT_STAGE + 1);
+    }
+}


### PR DESCRIPTION
## Description
[Embody Aspect](https://wiki.pokemonwiki.com/wiki/%E3%81%8A%E3%82%82%E3%81%8B%E3%81%92%E3%82%84%E3%81%A9%E3%81%97)

> - おもかげやどしは場に出るたびに1回しか発動しない。
> - かがくへんかガスの発動と解除が起きてもおもかげやどしが再発動することはない。

Embody Aspect activates **only once** each time the Pokemon **enters** the field.
Even if Neutralizing Gas activates and then wears off, Embody Aspect **does not** activate again.