### PR TITLE
Properly cancel move relearner NPC after refusing to learn a move

### DIFF
--- a/data/maps/FallarborTown_MoveRelearnersHouse/scripts.inc
+++ b/data/maps/FallarborTown_MoveRelearnersHouse/scripts.inc
@@ -37,7 +37,7 @@ FallarborTown_MoveRelearnersHouse_EventScript_ChooseMove::
 	msgbox FallarborTown_MoveRelearnersHouse_Text_TeachWhichMove, MSGBOX_DEFAULT
 	special TeachMoveRelearnerMove
 	waitstate
-	goto_if_eq VAR_0x8004, 0, FallarborTown_MoveRelearnersHouse_EventScript_ChooseMon
+	goto_if_eq VAR_RESULT, FALSE, FallarborTown_MoveRelearnersHouse_EventScript_ChooseMon
 	msgbox FallarborTown_MoveRelearnersHouse_Text_HandedOverHeartScale, MSGBOX_DEFAULT
 	removeitem ITEM_HEART_SCALE
 	goto FallarborTown_MoveRelearnersHouse_EventScript_ComeBackWithHeartScale


### PR DESCRIPTION
Bug introduced with the last move relearner refactor. I had already made the move relearner set VAR_RESULT to FALSE when exiting without learning but I didn't verify the default script was using VAR_RESULT to check if the teaching went through (it didn't) so this commit fixes that

## Media
upcoming:

https://github.com/user-attachments/assets/40e0f0ad-998c-4552-83b8-e8a8ce6f565a

this commit:

https://github.com/user-attachments/assets/a9a3a12b-0817-44df-a097-b157e8496e80



## Issue(s) that this PR fixes
Fixes #9771

## Discord contact info
Jamie
