### PR TITLE
Fix Dexnav `assertf`s

### DIFF
--- a/src/dexnav.c
+++ b/src/dexnav.c
@@ -1488,6 +1488,9 @@ static u8 GetEncounterLevelFromMapData(u16 species, enum EncounterType environme
     u8 max = 0;
     u8 i;
 
+    if (headerId == HEADER_NONE)
+        return MON_LEVEL_NONEXISTENT;
+
     switch (environment)
     {
     case ENCOUNTER_TYPE_LAND:    // grass
@@ -1801,6 +1804,8 @@ static bool8 CapturedAllHiddenMons(u32 headerId)
 static void DexNavLoadCapturedAllSymbols(void)
 {
     u32 headerId = GetCurrentMapWildMonHeaderId();
+    if (headerId == HEADER_NONE)
+        return;
 
     LoadCompressedSpriteSheetUsingHeap(&sCapturedAllPokemonSpriteSheet);
 
@@ -1926,6 +1931,9 @@ static void DexNavLoadEncounterData(void)
     memset(sDexNavUiDataPtr->landSpecies, 0, sizeof(sDexNavUiDataPtr->landSpecies));
     memset(sDexNavUiDataPtr->waterSpecies, 0, sizeof(sDexNavUiDataPtr->waterSpecies));
     memset(sDexNavUiDataPtr->hiddenSpecies, 0, sizeof(sDexNavUiDataPtr->hiddenSpecies));
+
+    if (headerId == HEADER_NONE)
+        return;
 
     // land mons
     if (landMonsInfo != NULL && landMonsInfo->encounterRate != 0)
@@ -2505,7 +2513,7 @@ bool32 TryFindHiddenPokemon(void)
 
         // while you can still technically find hidden pokemon if there are not hidden-only pokemon on a map,
         // this prevents any potential lagging on maps you dont want hidden pokemon to appear on
-        if (hiddenMonsInfo == NULL)
+        if (headerId == HEADER_NONE || hiddenMonsInfo == NULL)
             return FALSE;
 
         // encounter rate signifies surfing (1) or land mons (0)!

--- a/src/dexnav.c
+++ b/src/dexnav.c
@@ -2295,6 +2295,12 @@ static void DexNav_RunSetup(void)
 // Entry point for the dexnav GUI
 static void DexNavGuiInit(MainCallback callback)
 {
+    assertf(DEXNAV_ENABLED, "DexNav was opened when DEXNAV_ENABLED config was disabled.\nCheck include/config/dexnav.h")
+    {
+        SetMainCallback2(callback);
+        return;
+    }
+
     if ((sDexNavUiDataPtr = AllocZeroed(sizeof(struct DexNavGUI))) == NULL)
     {
         SetMainCallback2(callback);
@@ -2308,12 +2314,6 @@ static void DexNavGuiInit(MainCallback callback)
 
 void Task_OpenDexNavFromStartMenu(u8 taskId)
 {
-    assertf(DEXNAV_ENABLED, "DexNav was opened when DEXNAV_ENABLED config was disabled! Check include/config/dexnav.h")
-    {
-        DestroyTask(taskId);
-        return;
-    }
-
     if (!gPaletteFade.active)
     {
         CleanupOverworldWindowsAndTilemaps();

--- a/src/dexnav.c
+++ b/src/dexnav.c
@@ -1920,6 +1920,9 @@ static void DexNavLoadEncounterData(void)
     u32 headerId = GetCurrentMapWildMonHeaderId();
     enum TimeOfDay timeOfDay;
 
+    if (headerId == HEADER_NONE)
+        return;
+
     timeOfDay = GetTimeOfDayForEncounters(headerId, WILD_AREA_LAND);
     const struct WildPokemonInfo *landMonsInfo = gWildMonHeaders[headerId].encounterTypes[timeOfDay].landMonsInfo;
     timeOfDay = GetTimeOfDayForEncounters(headerId, WILD_AREA_WATER);
@@ -1931,9 +1934,6 @@ static void DexNavLoadEncounterData(void)
     memset(sDexNavUiDataPtr->landSpecies, 0, sizeof(sDexNavUiDataPtr->landSpecies));
     memset(sDexNavUiDataPtr->waterSpecies, 0, sizeof(sDexNavUiDataPtr->waterSpecies));
     memset(sDexNavUiDataPtr->hiddenSpecies, 0, sizeof(sDexNavUiDataPtr->hiddenSpecies));
-
-    if (headerId == HEADER_NONE)
-        return;
 
     // land mons
     if (landMonsInfo != NULL && landMonsInfo->encounterRate != 0)
@@ -2506,14 +2506,17 @@ bool32 TryFindHiddenPokemon(void)
         u8 index;
         u16 species;
         enum EncounterType environment;
-        enum TimeOfDay timeOfDay = GetTimeOfDayForEncounters(headerId, WILD_AREA_HIDDEN);
 
+        if (headerId == HEADER_NONE)
+            return FALSE;
+
+        enum TimeOfDay timeOfDay = GetTimeOfDayForEncounters(headerId, WILD_AREA_HIDDEN);
         const struct WildPokemonInfo *hiddenMonsInfo = gWildMonHeaders[headerId].encounterTypes[timeOfDay].hiddenMonsInfo;
         bool8 isHiddenMon = FALSE;
 
         // while you can still technically find hidden pokemon if there are not hidden-only pokemon on a map,
         // this prevents any potential lagging on maps you dont want hidden pokemon to appear on
-        if (headerId == HEADER_NONE || hiddenMonsInfo == NULL)
+        if (hiddenMonsInfo == NULL)
             return FALSE;
 
         // encounter rate signifies surfing (1) or land mons (0)!


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
The `assertf` used to determine whether `DEXNAV_ENABLED` is `TRUE` when the DexNav is opened from the start menu will cause a soft-lock, this PR move it after the fade and then returns to the field.

The second commit also adds checks within `dexnav.c` for the wild Pokémon header. This is to help downstream users that add alternative ways to access the DexNav that may miss the `MapHasNoEncounterData` check in `start_menu.c`, preventing them from accessing garbage data and triggering multiple `assertf`s. This doesn't change current behaviour but act as an added layer of redundancy.

## Media
<!--- Add relevant images, GIFs, or videos to help reviewers understand the changes. Remove this section if not applicable. --->
### `DEXNAV_ENABLED`
Before:
![dexnav-disabled-old](https://github.com/user-attachments/assets/2608296e-097f-49f4-9da7-643929808f82)
After:
![dexnav-disabled-new](https://github.com/user-attachments/assets/25862b64-fefe-4291-a729-4bcbff7385e0)

### `headerId == HEADER_NONE`
When accessing the DexNav when there is no encounter data:
<img width="240" height="160" alt="pokeemerald-9" src="https://github.com/user-attachments/assets/6f8647d5-3a58-4a18-b464-2b876956050a" />

<!-- CREDITS -->
<!-- Once your PR is submitted, leave a comment asking the bot to add you to the credits. -->
<!-- If anybody helped with this PR, please encourage them to comment on your PR and ask the bot to add them to the credits. -->
<!-- If somebody has contributed at any point and has indicated they wish to be credited, please ask the bot to add them to the credits. If they do not have a known GitHub account, add them to the list at bottom of `CREDITS.md`. -->
<!-- EVERY contribution matters! -->
<!-- https://github.com/rh-hideout/pokeemerald-expansion/wiki/CREDITS.md-Frequently-Asked-Questions -->

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
HashtagMarky#4240
