### PR TITLE
Fix Sand Spit falling under B_ABILITY_WEATHER

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4244,7 +4244,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
                     BattleScriptCall(BattleScript_BlockedByPrimalWeather);
                     effect++;
                 }
-                else if (TryChangeBattleWeather(battler, BATTLE_WEATHER_SANDSTORM, ABILITY_SAND_STREAM))
+                else if (TryChangeBattleWeather(battler, BATTLE_WEATHER_SANDSTORM, ABILITY_NONE)) // use ability none since it's not a switch in ability weather setter
                 {
                     gBattleScripting.battler = battler;
                     BattleScriptCall(BattleScript_WeatherAbilityActivates);


### PR DESCRIPTION
if `B_ABILITY_WEATHER` is set to `GEN_5-` then the Sand Pit tests start failing. 

Since this is not a switch in ability we just treat it as a move.
