### PR TITLE
Fix Blunder Policy activation for OHKO and multi-hit moves

### DIFF
--- a/src/battle_hold_effects.c
+++ b/src/battle_hold_effects.c
@@ -405,12 +405,12 @@ static enum ItemEffect TryBlunderPolicy(enum BattlerId battlerAtk)
      && IsBattlerAlive(battlerAtk)
      && CompareStat(battlerAtk, STAT_SPEED, MAX_STAT_STAGE, CMP_LESS_THAN, GetBattlerAbility(battlerAtk)))
     {
-        gBattleStruct->blunderPolicy = FALSE;
         SET_STATCHANGER(STAT_SPEED, 2, FALSE);
         BattleScriptCall(BattleScript_AttackerItemStatRaise);
         effect = ITEM_STATS_CHANGE;
     }
 
+    gBattleStruct->blunderPolicy = FALSE;
     return effect;
 }
 

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1174,7 +1174,7 @@ static void AccuracyCheck(bool32 recalcDragonDarts, const u8 *nextInstr, const u
             enum BattleMoveEffects moveEffect = GetMoveEffect(gCurrentMove);
             if (holdEffectAtk == HOLD_EFFECT_BLUNDER_POLICY
              && moveEffect != EFFECT_OHKO
-             && !(gSpecialStatuses[gBattlerAttacker].multiHitOn && (moveEffect == EFFECT_TRIPLE_KICK || moveEffect == EFFECT_POPULATION_BOMB)))
+             && !gSpecialStatuses[gBattlerAttacker].multiHitOn)
                 gBattleStruct->blunderPolicy = TRUE;    // Only activates from missing through acc/evasion checks
 
             if (moveTarget == TARGET_SMART

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1171,7 +1171,8 @@ static void AccuracyCheck(bool32 recalcDragonDarts, const u8 *nextInstr, const u
             gBattleCommunication[MISS_TYPE] = B_MSG_MISSED;
             numMisses++;
 
-            if (holdEffectAtk == HOLD_EFFECT_BLUNDER_POLICY)
+            if (holdEffectAtk == HOLD_EFFECT_BLUNDER_POLICY
+             && GetMoveEffect(gCurrentMove) != EFFECT_OHKO)
                 gBattleStruct->blunderPolicy = TRUE;    // Only activates from missing through acc/evasion checks
 
             if (moveTarget == TARGET_SMART

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1171,8 +1171,10 @@ static void AccuracyCheck(bool32 recalcDragonDarts, const u8 *nextInstr, const u
             gBattleCommunication[MISS_TYPE] = B_MSG_MISSED;
             numMisses++;
 
+            enum BattleMoveEffects moveEffect = GetMoveEffect(gCurrentMove);
             if (holdEffectAtk == HOLD_EFFECT_BLUNDER_POLICY
-             && GetMoveEffect(gCurrentMove) != EFFECT_OHKO)
+             && moveEffect != EFFECT_OHKO
+             && !(gSpecialStatuses[gBattlerAttacker].multiHitOn && (moveEffect == EFFECT_TRIPLE_KICK || moveEffect == EFFECT_POPULATION_BOMB)))
                 gBattleStruct->blunderPolicy = TRUE;    // Only activates from missing through acc/evasion checks
 
             if (moveTarget == TARGET_SMART

--- a/test/battle/hold_effect/blunder_policy.c
+++ b/test/battle/hold_effect/blunder_policy.c
@@ -116,3 +116,89 @@ SINGLE_BATTLE_TEST("Blunder Policy state is cleared between actions if it could 
         EXPECT_EQ(player->statStages[STAT_SPEED], DEFAULT_STAT_STAGE + 5);
     }
 }
+
+SINGLE_BATTLE_TEST("Blunder Policy activates if the first strike of Triple Kick misses")
+{
+    PASSES_RANDOMLY(1, 10, RNG_ACCURACY);
+    GIVEN {
+        ASSUME(GetMoveAccuracy(MOVE_TRIPLE_KICK) == 90);
+        ASSUME(GetMoveEffect(MOVE_TRIPLE_KICK) == EFFECT_TRIPLE_KICK);
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_BLUNDER_POLICY); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_TRIPLE_KICK); }
+    } SCENE {
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_TRIPLE_KICK, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+    } THEN {
+        EXPECT(player->item == ITEM_NONE);
+        EXPECT_EQ(player->statStages[STAT_SPEED], DEFAULT_STAT_STAGE + 2);
+    }
+}
+
+SINGLE_BATTLE_TEST("Blunder Policy does not activate if Triple Kick misses after the first strike")
+{
+    GIVEN {
+        ASSUME(GetMoveAccuracy(MOVE_TRIPLE_KICK) == 90);
+        ASSUME(GetMoveEffect(MOVE_TRIPLE_KICK) == EFFECT_TRIPLE_KICK);
+        ASSUME(MoveMakesContact(MOVE_TRIPLE_KICK));
+        PLAYER(SPECIES_MACHAMP) { Ability(ABILITY_NO_GUARD); Item(ITEM_BLUNDER_POLICY); }
+        OPPONENT(SPECIES_OINKOLOGNE) { Ability(ABILITY_LINGERING_AROMA); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_TRIPLE_KICK, WITH_RNG(RNG_ACCURACY, FALSE)); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TRIPLE_KICK, player);
+        ABILITY_POPUP(opponent, ABILITY_LINGERING_AROMA);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_TRIPLE_KICK, player);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+        }
+    } THEN {
+        EXPECT(player->item == ITEM_BLUNDER_POLICY);
+        EXPECT_EQ(player->statStages[STAT_SPEED], DEFAULT_STAT_STAGE);
+        EXPECT_EQ(player->ability, ABILITY_LINGERING_AROMA);
+    }
+}
+
+SINGLE_BATTLE_TEST("Blunder Policy activates if the first strike of Population Bomb misses")
+{
+    PASSES_RANDOMLY(1, 10, RNG_ACCURACY);
+    GIVEN {
+        ASSUME(GetMoveAccuracy(MOVE_POPULATION_BOMB) == 90);
+        ASSUME(GetMoveEffect(MOVE_POPULATION_BOMB) == EFFECT_POPULATION_BOMB);
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_BLUNDER_POLICY); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_POPULATION_BOMB); }
+    } SCENE {
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_POPULATION_BOMB, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+    } THEN {
+        EXPECT(player->item == ITEM_NONE);
+        EXPECT_EQ(player->statStages[STAT_SPEED], DEFAULT_STAT_STAGE + 2);
+    }
+}
+
+SINGLE_BATTLE_TEST("Blunder Policy does not activate if Population Bomb misses after the first strike")
+{
+    GIVEN {
+        ASSUME(GetMoveAccuracy(MOVE_POPULATION_BOMB) == 90);
+        ASSUME(GetMoveEffect(MOVE_POPULATION_BOMB) == EFFECT_POPULATION_BOMB);
+        ASSUME(MoveMakesContact(MOVE_POPULATION_BOMB));
+        PLAYER(SPECIES_MACHAMP) { Ability(ABILITY_NO_GUARD); Item(ITEM_BLUNDER_POLICY); }
+        OPPONENT(SPECIES_OINKOLOGNE) { Ability(ABILITY_LINGERING_AROMA); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_POPULATION_BOMB, WITH_RNG(RNG_ACCURACY, FALSE)); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POPULATION_BOMB, player);
+        ABILITY_POPUP(opponent, ABILITY_LINGERING_AROMA);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_POPULATION_BOMB, player);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+        }
+    } THEN {
+        EXPECT(player->item == ITEM_BLUNDER_POLICY);
+        EXPECT_EQ(player->statStages[STAT_SPEED], DEFAULT_STAT_STAGE);
+        EXPECT_EQ(player->ability, ABILITY_LINGERING_AROMA);
+    }
+}

--- a/test/battle/hold_effect/blunder_policy.c
+++ b/test/battle/hold_effect/blunder_policy.c
@@ -222,3 +222,37 @@ SINGLE_BATTLE_TEST("Blunder Policy does not activate if Population Bomb misses a
         EXPECT_EQ(player->ability, ABILITY_LINGERING_AROMA);
     }
 }
+
+DOUBLE_BATTLE_TEST("Blunder Policy activates for Dragon Darts if one target misses for accuracy but the other target is hit twice")
+{
+    struct BattlePokemon *chosenTarget = NULL;
+    struct BattlePokemon *finalTarget = NULL;
+    enum Item itemLeft, itemRight;
+    PARAMETRIZE { chosenTarget = opponentLeft;  finalTarget = opponentRight; itemLeft = ITEM_BRIGHT_POWDER;  itemRight = ITEM_NONE; }
+    PARAMETRIZE { chosenTarget = opponentRight; finalTarget = opponentLeft;  itemLeft = ITEM_NONE;           itemRight = ITEM_BRIGHT_POWDER; }
+
+    GIVEN {
+        ASSUME(GetMoveAccuracy(MOVE_DRAGON_DARTS) == 100);
+        ASSUME(GetMoveTarget(MOVE_DRAGON_DARTS) == TARGET_SMART);
+        ASSUME(GetItemHoldEffect(ITEM_BRIGHT_POWDER) == HOLD_EFFECT_EVASION_UP);
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_BLUNDER_POLICY); }
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { Item(itemLeft); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(itemRight); }
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_DRAGON_DARTS, target: chosenTarget, hit: FALSE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DARTS, playerLeft);
+        HP_BAR(finalTarget);
+
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, playerLeft);
+
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DARTS, playerLeft);
+        HP_BAR(finalTarget);
+    } THEN {
+        EXPECT(playerLeft->item == ITEM_NONE);
+        EXPECT_EQ(playerLeft->statStages[STAT_SPEED], DEFAULT_STAT_STAGE + 2);
+        EXPECT_EQ(chosenTarget->hp, chosenTarget->maxHP);
+        EXPECT_LT(finalTarget->hp, finalTarget->maxHP);
+    }
+}

--- a/test/battle/hold_effect/blunder_policy.c
+++ b/test/battle/hold_effect/blunder_policy.c
@@ -65,3 +65,54 @@ SINGLE_BATTLE_TEST("Blunder Policy will never trigger if the move fails due to P
         EXPECT_EQ(player->statStages[STAT_SPEED], DEFAULT_STAT_STAGE);
     }
 }
+
+SINGLE_BATTLE_TEST("415 Blunder Policy does not activate when an OHKO move fails")
+{
+    PASSES_RANDOMLY(7, 10, RNG_ACCURACY);
+    GIVEN {
+        ASSUME(GetMoveAccuracy(MOVE_FISSURE) == 30);
+        ASSUME(GetMoveEffect(MOVE_FISSURE) == EFFECT_OHKO);
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_BLUNDER_POLICY); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_FISSURE); }
+    } SCENE {
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_FISSURE, player);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+        }
+    } THEN {
+        EXPECT(player->item == ITEM_BLUNDER_POLICY);
+        EXPECT_EQ(player->statStages[STAT_SPEED], DEFAULT_STAT_STAGE);
+    }
+}
+
+SINGLE_BATTLE_TEST("415 Blunder Policy state is cleared between actions if it could not activate")
+{
+    PASSES_RANDOMLY(3, 10, RNG_ACCURACY);
+    GIVEN {
+        ASSUME(GetMoveAccuracy(MOVE_FOCUS_BLAST) == 70);
+        ASSUME(GetMoveEffect(MOVE_AGILITY) == EFFECT_SPEED_UP_2);
+        ASSUME(GetMoveEffect(MOVE_CURSE) == EFFECT_CURSE);
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_BLUNDER_POLICY); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_AGILITY); }
+        TURN { MOVE(player, MOVE_AGILITY); }
+        TURN { MOVE(player, MOVE_AGILITY); }
+        TURN { MOVE(player, MOVE_FOCUS_BLAST); }
+        TURN { MOVE(player, MOVE_CURSE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_AGILITY, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_AGILITY, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_AGILITY, player);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_FOCUS_BLAST, player);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+        }
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CURSE, player);
+    } THEN {
+        EXPECT(player->item == ITEM_BLUNDER_POLICY);
+        EXPECT_EQ(player->statStages[STAT_SPEED], DEFAULT_STAT_STAGE + 5);
+    }
+}

--- a/test/battle/hold_effect/blunder_policy.c
+++ b/test/battle/hold_effect/blunder_policy.c
@@ -66,7 +66,7 @@ SINGLE_BATTLE_TEST("Blunder Policy will never trigger if the move fails due to P
     }
 }
 
-SINGLE_BATTLE_TEST("Blunder Policy does not activate when an OHKO move fails")
+SINGLE_BATTLE_TEST("Blunder Policy will never trigger if an OHKO move fails")
 {
     PASSES_RANDOMLY(7, 10, RNG_ACCURACY);
     GIVEN {
@@ -79,6 +79,26 @@ SINGLE_BATTLE_TEST("Blunder Policy does not activate when an OHKO move fails")
     } SCENE {
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_FISSURE, player);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+        }
+    } THEN {
+        EXPECT(player->item == ITEM_BLUNDER_POLICY);
+        EXPECT_EQ(player->statStages[STAT_SPEED], DEFAULT_STAT_STAGE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Blunder Policy will never trigger if the move misses due to semi-invulnerability")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_FLY) == EFFECT_SEMI_INVULNERABLE);
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_BLUNDER_POLICY); Speed(5); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(10); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_FLY); MOVE(player, MOVE_SCRATCH); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FLY, opponent);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
         }
     } THEN {

--- a/test/battle/hold_effect/blunder_policy.c
+++ b/test/battle/hold_effect/blunder_policy.c
@@ -66,7 +66,7 @@ SINGLE_BATTLE_TEST("Blunder Policy will never trigger if the move fails due to P
     }
 }
 
-SINGLE_BATTLE_TEST("415 Blunder Policy does not activate when an OHKO move fails")
+SINGLE_BATTLE_TEST("Blunder Policy does not activate when an OHKO move fails")
 {
     PASSES_RANDOMLY(7, 10, RNG_ACCURACY);
     GIVEN {
@@ -87,7 +87,7 @@ SINGLE_BATTLE_TEST("415 Blunder Policy does not activate when an OHKO move fails
     }
 }
 
-SINGLE_BATTLE_TEST("415 Blunder Policy state is cleared between actions if it could not activate")
+SINGLE_BATTLE_TEST("Blunder Policy state is cleared between actions if it could not activate")
 {
     PASSES_RANDOMLY(3, 10, RNG_ACCURACY);
     GIVEN {


### PR DESCRIPTION
## Description
[Blunder Policy](https://bulbapedia.bulbagarden.net/wiki/Blunder_Policy)

> Blunder Policy does not activate if a **one-hit knockout move misses**, if **Triple Kick**, **Triple Axel**, or **Population Bomb** ends early by **failing one of their subsequent accuracy checks**, or if a move misses due to a target being in the semi-invulnerable turn of a move. 

- Blunder Policy no longer activates when a one-hit knockout move misses.
- For Triple Kick, Triple Axel, and Population Bomb, Blunder Policy now activates only if the first strike misses, not when later strikes miss.
- Blunder Policy state is now cleared between actions when it could not activate.