### PR TITLE
Fix Effect Spore RNG trigger order for non-contact turns

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4087,7 +4087,11 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
         {
             enum Ability abilityAtk = GetBattlerAbility(gBattlerAttacker);
             enum HoldEffect holdEffectAtk = GetBattlerHoldEffect(gBattlerAttacker);
-            if (IsAffectedByPowderMove(gBattlerAttacker, abilityAtk, holdEffectAtk))
+            if (IsBattlerAlive(gBattlerAttacker)
+             && !gBattleStruct->unableToUseMove
+             && IsBattlerTurnDamaged(gBattlerTarget, EXCLUDING_SUBSTITUTES)
+             && !CanBattlerAvoidContactEffects(gBattlerAttacker, gBattlerTarget, abilityAtk, holdEffectAtk, move)
+             && IsAffectedByPowderMove(gBattlerAttacker, abilityAtk, holdEffectAtk))
             {
                 u32 poison, paralysis, sleep;
 
@@ -4109,12 +4113,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
                 if (i < paralysis)
                     goto STATIC;
                 // Sleep
-                if (i < sleep
-                 && IsBattlerAlive(gBattlerAttacker)
-                 && !gBattleStruct->unableToUseMove
-                 && IsBattlerTurnDamaged(gBattlerTarget, EXCLUDING_SUBSTITUTES)
-                 && CanBeSlept(gBattlerTarget, gBattlerAttacker, abilityAtk, NOT_BLOCKED_BY_SLEEP_CLAUSE)
-                 && !CanBattlerAvoidContactEffects(gBattlerAttacker, gBattlerTarget, abilityAtk, holdEffectAtk, move))
+                if (i < sleep && CanBeSlept(gBattlerTarget, gBattlerAttacker, abilityAtk, NOT_BLOCKED_BY_SLEEP_CLAUSE))
                 {
                     if (IsSleepClauseEnabled())
                         gBattleStruct->battlerState[gBattlerAttacker].sleepClauseEffectExempt = TRUE;

--- a/test/battle/hold_effect/safety_goggles.c
+++ b/test/battle/hold_effect/safety_goggles.c
@@ -46,16 +46,14 @@ SINGLE_BATTLE_TEST("Safety Goggles blocks damage from Sandstorm")
 
 SINGLE_BATTLE_TEST("Safety Goggles blocks Effect Spore's effect")
 {
-    KNOWN_FAILING;
     PASSES_RANDOMLY(100, 100, RNG_EFFECT_SPORE);
     GIVEN {
-        WITH_CONFIG(B_POWDER_GRASS, GEN_5); // Setting it to Gen 6 causes it to pass
+        WITH_CONFIG(B_POWDER_GRASS, GEN_5);
         ASSUME(MoveMakesContact(MOVE_SCRATCH));
         PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_SAFETY_GOGGLES); }
         OPPONENT(SPECIES_BRELOOM) { Ability(ABILITY_EFFECT_SPORE); }
     } WHEN {
         TURN { MOVE(player, MOVE_SCRATCH); }
-        TURN {}
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
         NONE_OF {


### PR DESCRIPTION
## Description
`WITH_CONFIG(B_POWDER_GRASS, GEN_5)` failed because the test was unintentionally counting an extra `RNG_EFFECT_SPORE` path from the opponent’s default action.

1. In that test, the opponent action was not specified, so the test runner auto-filled `MOVE_CELEBRATE.`
2. `Celebrate` is self-targeting, so on that turn `gBattlerAttacker == gBattlerTarget == Breloom`.
3. In the old Effect Spore logic, `RandomUniform(RNG_EFFECT_SPORE, ...)` was reached **before** confirming real contact-trigger conditions (damage/contact gate).
4. With `B_POWDER_GRASS = GEN_5`, Grass immunity to powder is **not** active, so Breloom passed `IsAffectedByPowderMove(...)` and consumed the tagged RNG on its own `Celebrate` turn.
5. That extra tagged RNG call polluted `PASSES_RANDOMLY(100, 100, RNG_EFFECT_SPORE)` accounting, causing the false failure.