### PR TITLE
Add Spot Coord Limits

### DIFF
--- a/src/pokemon_spots.c
+++ b/src/pokemon_spots.c
@@ -179,8 +179,8 @@ static void DrawPokemonSpots(u32 personality, const struct MonSpotTemplate* spot
         u8 pidLowerNibble = pidByteForSpot & NIBBLE_LOWER;
         u8 pidUpperNibble = (pidByteForSpot & NIBBLE_UPPER) >> 4;
 
-        u8 x = spot->x + pidLowerNibble * (spotTemplate->scale / 2);
-        u8 y = spot->y + pidUpperNibble * (spotTemplate->scale / 2);
+        s32 x = spot->x + pidLowerNibble * (spotTemplate->scale / 2);
+        s32 y = spot->y + pidUpperNibble * (spotTemplate->scale / 2);
 
         switch (spotAnimFrame)
         {
@@ -202,7 +202,7 @@ static void DrawPokemonSpots(u32 personality, const struct MonSpotTemplate* spot
         for (u32 i = 0; i < size; i++)
         {
             u32 spotPixelRow = GetSpotRow(spot->image, i, spotTemplate->scale);
-            u32 row = y + i;
+            s32 row = y + i;
 
             //INFO: This loop draws one row
             for (u32 j = 0; j < size; j++)
@@ -210,7 +210,11 @@ static void DrawPokemonSpots(u32 personality, const struct MonSpotTemplate* spot
                 u32 bit = (spotPixelRow >> j) & 1;
                 if (bit)
                 {
-                    u32 col = x + j;
+                    s32 col = x + j;
+                    if (col < 0 || col >= MON_PIC_WIDTH
+                     || row < 0 || row >= MON_PIC_HEIGHT * MAX_MON_PIC_FRAMES)
+                        continue;
+
                     u8* destPixels = dest + CoordToByteOffset(col, row);
 
                     u8 shift = (col & 1) ? ODD_PIXEL_SHIFT : EVEN_PIXEL_SHIFT;


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
The Pokédex list screen crashes when trying to load the Spinda front sprite when `gSaveBlock2Ptr->pokedex.spindaPersonality`is `0`. I believe this was due to too high values in `CoordToByteOffset`.
```diff
    switch (spotAnimFrame)
        {
        …
        }

+       DebugPrintf("%d, %d", x, y);
```
This `DebugPrintf` give a y value of `255`. I believe this was caused by the `u8` it was stored in ‘underflowing’. Changing it and the row to an `s32` will lead it to result in `-1` instead, which will be caught by the limit added to the for loop.

### Large Language Models (AI)
<!-- Does your pull request contain code or assets generated by a large language model (AI)? If so, where? -->
<!-- NOTE: There is an expectation that you have fully reviewed your code to ensure it meets all merge criteria (detailed above). -->
<!-- If the maintainers believe that a pull request was generated by AI with no or little to no human oversight, the pull request will be closed without further discussion. -->
None

## Media
<!--- Add relevant images, GIFs, or videos to help reviewers understand the changes. Remove this section if not applicable. --->
Before:

https://github.com/user-attachments/assets/2cfa11eb-0ec6-4084-8ad4-380db3fbce02

https://github.com/user-attachments/assets/83f7b88d-5f0e-4135-a016-205d67a849b6

After:
<img width="240" height="160" alt="spinda-fixed" src="https://github.com/user-attachments/assets/4ab5e8bd-c7f8-4fb7-9530-7d6323ea85f2" />


## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
HashtagMarky#4240
