### PR TITLE
Fix Toxic Spikes falsely applying Corrosion during switch-in poison checks

### DIFF
--- a/src/battle_switch_in.c
+++ b/src/battle_switch_in.c
@@ -344,7 +344,7 @@ static bool32 TryHazardsOnSwitchIn(enum BattlerId battler, enum Ability ability,
             effect = TRUE;
         }
         else if (IsBattlerAffectedByHazards(battler, holdEffect, TRUE)
-              && CanBePoisoned(battler, battler, ability, ability))
+              && CanBePoisoned(battler, battler, ABILITY_NONE, ability))
         {
             gBattleScripting.battler = battler;
             BattleScriptPushCursor();

--- a/test/battle/ability/corrosion.c
+++ b/test/battle/ability/corrosion.c
@@ -334,8 +334,9 @@ SINGLE_BATTLE_TEST("Corrosion does not make Toxic Spikes poison a Corrosion user
         TURN { MOVE(player, MOVE_TOXIC_SPIKES); MOVE(opponent, MOVE_CELEBRATE, gimmick: GIMMICK_TERA); }
         TURN { SWITCH(opponent, 1); }
         TURN { SWITCH(opponent, 0); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TOXIC_SPIKES, player);
     } THEN {
-        EXPECT(IsHazardOnSide(B_SIDE_OPPONENT, HAZARDS_TOXIC_SPIKES));
         EXPECT_EQ(opponent->status1, STATUS1_NONE);
     }
 }

--- a/test/battle/ability/corrosion.c
+++ b/test/battle/ability/corrosion.c
@@ -323,4 +323,21 @@ SINGLE_BATTLE_TEST("Corrosion does not affect Poison Spikes")
     }
 }
 
+SINGLE_BATTLE_TEST("Corrosion does not make Toxic Spikes poison a Corrosion user Terastallized into Steel")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_TOXIC_SPIKES) == EFFECT_TOXIC_SPIKES);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_SALANDIT) { Ability(ABILITY_CORROSION); TeraType(TYPE_STEEL); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_TOXIC_SPIKES); MOVE(opponent, MOVE_CELEBRATE, gimmick: GIMMICK_TERA); }
+        TURN { SWITCH(opponent, 1); }
+        TURN { SWITCH(opponent, 0); }
+    } THEN {
+        EXPECT(IsHazardOnSide(B_SIDE_OPPONENT, HAZARDS_TOXIC_SPIKES));
+        EXPECT_EQ(opponent->status1, STATUS1_NONE);
+    }
+}
+
 TO_DO_BATTLE_TEST("Dynamax: Corrosion can poison Poison/Steel types if the Pokémon uses G-Max Malodor")


### PR DESCRIPTION
## Description
[Corrosion](https://wiki.pokemonwiki.com/wiki/%e3%81%b5%e3%81%97%e3%82%87%e3%81%8f)

> どくびし状態の場に、はがねタイプにテラスタルしたふしょくのポケモンを繰り出してもどく状態にはならない。

Even if a Corrosion Pokemon Terastallized into Steel is sent out into Toxic Spikes, it does not become poisoned.
