### PR TITLE
Fix missing string buffer in the ingame_trade macro

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -2663,6 +2663,7 @@
 	special CreateInGameTradePokemon
 	special DoInGameTradeScene
 	waitstate
+	bufferspeciesname STR_VAR_1, VAR_0x8009
 	msgbox \tradeCompleteMsg, MSGBOX_DEFAULT
 	.endm
 


### PR DESCRIPTION

## Media

https://github.com/user-attachments/assets/5f470365-5eae-4f89-a38e-023700ec2450

## Issue(s) that this PR fixes
Fixes #9801

## Discord contact info
Jamie
