### PR TITLE
Battle Test: Failure Suggestions

### DIFF
--- a/include/test/battle.h
+++ b/include/test/battle.h
@@ -805,6 +805,7 @@ struct BattleTestData
     struct BattlerTurn battleRecordTurns[MAX_TURNS][MAX_BATTLERS_COUNT];
 
     u8 queuedEventsCount;
+    u8 queuedEventsFailIndex;
     u8 queueGroupType;
     u8 queueGroupStart;
     struct QueuedEvent queuedEvents[MAX_QUEUED_EVENTS];

--- a/include/test_result.h
+++ b/include/test_result.h
@@ -11,7 +11,8 @@ enum TestResult
     TEST_RESULT_TIMEOUT,
     TEST_RESULT_CRASH,
     TEST_RESULT_TODO,
-    TEST_RESULT_KNOWN_FAIL
+    TEST_RESULT_KNOWN_FAIL,
+    TEST_RESULT_FLAKY,
 };
 
 void Test_ExitWithResult_(enum TestResult, u32 stopLine, const void *return0, const char *fmt, ...);

--- a/test/test_runner.c
+++ b/test/test_runner.c
@@ -457,6 +457,9 @@ top:
             case TEST_RESULT_CRASH:
                 result = "CRASH";
                 break;
+            case TEST_RESULT_FLAKY:
+                result = "FLAKY";
+                break;
             default:
                 result = "UNKNOWN";
                 break;

--- a/test/test_runner_battle.c
+++ b/test/test_runner_battle.c
@@ -373,6 +373,26 @@ static void SetImplicitSpeeds(void)
     }
 }
 
+static void StartBattle(void)
+{
+    memset(&DATA.trial, 0, sizeof(DATA.trial));
+
+    SetVariablesForRecordedBattle(&DATA.recordedBattle);
+    if (STATE->trials)
+        gMain.savedCallback = CB2_BattleTest_NextTrial;
+    else if (STATE->parameters)
+        gMain.savedCallback = CB2_BattleTest_NextParameter;
+    else
+        gMain.savedCallback = CB2_TestRunner;
+    SetMainCallback2(CB2_InitBattle);
+
+    STATE->checkProgressParameter = 0;
+    STATE->checkProgressTrial = 0;
+    STATE->checkProgressTurn = 0;
+
+    PrintTestName();
+}
+
 static void BattleTest_Run(void *data)
 {
     s32 i;
@@ -383,6 +403,7 @@ static void BattleTest_Run(void *data)
     memset(&DATA, 0, sizeof(DATA));
     TestInitConfigData();
 
+    DATA.queuedEventsFailIndex = MAX_QUEUED_EVENTS;
     DATA.recordedBattle.rngSeed = defaultSeed;
     DATA.recordedBattle.textSpeed = OPTIONS_TEXT_SPEED_FAST;
     // Set battle flags and opponent ids.
@@ -565,20 +586,7 @@ static void BattleTest_Run(void *data)
         SetImplicitSpeeds();
     }
 
-    SetVariablesForRecordedBattle(&DATA.recordedBattle);
-    if (STATE->trials)
-        gMain.savedCallback = CB2_BattleTest_NextTrial;
-    else if (STATE->parameters)
-        gMain.savedCallback = CB2_BattleTest_NextParameter;
-    else
-        gMain.savedCallback = CB2_TestRunner;
-    SetMainCallback2(CB2_InitBattle);
-
-    STATE->checkProgressParameter = 0;
-    STATE->checkProgressTrial = 0;
-    STATE->checkProgressTurn = 0;
-
-    PrintTestName();
+    StartBattle();
 }
 
 static bool32 IsTieBreakTag(enum RandomTag tag)
@@ -858,7 +866,19 @@ void TestRunner_Battle_RecordAbilityPopUp(enum BattlerId battlerId, enum Ability
     case QUEUE_GROUP_NONE:
     case QUEUE_GROUP_ONE_OF:
         if (TryAbilityPopUp(DATA.trial.queuedEvent, event->groupSize, battlerId, ability) != -1)
+        {
             DATA.trial.queuedEvent += event->groupSize;
+        }
+        else if (DATA.trial.queuedEvent == DATA.queuedEventsFailIndex
+              && DATA.queuedEvents[DATA.queuedEventsFailIndex].type == QUEUED_ABILITY_POPUP_EVENT)
+        {
+            const char *filename = gTestRunnerState.test->filename;
+            u32 line = SourceLine(DATA.queuedEvents[DATA.queuedEventsFailIndex].sourceLineOffset);
+            if (DATA.queuedEvents[DATA.queuedEventsFailIndex].as.ability.ability == ABILITY_NONE)
+                Test_MgbaPrintf("%s:%d: Did you mean: ABILITY_POPUP(%s)", filename, line, BattlerIdentifier(battlerId));
+            else
+                Test_MgbaPrintf("%s:%d: Did you mean: ABILITY_POPUP(%s, ABILITY_%C)", filename, line, BattlerIdentifier(battlerId), gAbilitiesInfo[ability].name);
+        }
         break;
     case QUEUE_GROUP_NONE_OF:
         queuedEvent = DATA.trial.queuedEvent;
@@ -908,6 +928,14 @@ static s32 TryAnimation(s32 i, s32 n, u32 animType, u32 animId)
     return -1;
 }
 
+static const char *const sAnimTypeNames[] =
+{
+    [ANIM_TYPE_GENERAL] = "ANIM_TYPE_GENERAL",
+    [ANIM_TYPE_MOVE] = "ANIM_TYPE_MOVE",
+    [ANIM_TYPE_STATUS] = "ANIM_TYPE_STATUS",
+    [ANIM_TYPE_SPECIAL] = "ANIM_TYPE_SPECIAL",
+};
+
 void TestRunner_Battle_RecordAnimation(u32 animType, u32 animId)
 {
     s32 queuedEvent;
@@ -923,7 +951,47 @@ void TestRunner_Battle_RecordAnimation(u32 animType, u32 animId)
     case QUEUE_GROUP_NONE:
     case QUEUE_GROUP_ONE_OF:
         if (TryAnimation(DATA.trial.queuedEvent, event->groupSize, animType, animId) != -1)
+        {
             DATA.trial.queuedEvent += event->groupSize;
+        }
+        else if (DATA.trial.queuedEvent == DATA.queuedEventsFailIndex
+              && DATA.queuedEvents[DATA.queuedEventsFailIndex].type == QUEUED_ANIMATION_EVENT
+              && DATA.queuedEvents[DATA.queuedEventsFailIndex].as.animation.type == animType)
+        {
+            const char *filename = gTestRunnerState.test->filename;
+            u32 line = SourceLine(DATA.queuedEvents[DATA.queuedEventsFailIndex].sourceLineOffset);
+            bool32 checkAttacker = DATA.queuedEvents[DATA.queuedEventsFailIndex].as.animation.attacker != 0xF;
+            bool32 checkTarget = DATA.queuedEvents[DATA.queuedEventsFailIndex].as.animation.target != 0xF;
+            if (animType == ANIM_TYPE_MOVE && animId < MOVES_COUNT_ALL)
+            {
+                if (animId == MOVE_CELEBRATE)
+                    ; // TODO: Only if implicit. Difficult to know if it's an action or, e.g. Mirror Move.
+                else if (checkAttacker && checkTarget)
+                    Test_MgbaPrintf("%s:%d: Did you mean: ANIMATION(%s, MOVE_%C, %s, target: %s)", filename, line, sAnimTypeNames[animType], gMovesInfo[animId].name, BattlerIdentifier(gBattleAnimAttacker), BattlerIdentifier(gBattleAnimTarget));
+                else if (checkAttacker)
+                    Test_MgbaPrintf("%s:%d: Did you mean: ANIMATION(%s, MOVE_%C, %s)", filename, line, sAnimTypeNames[animType], gMovesInfo[animId].name, BattlerIdentifier(gBattleAnimAttacker));
+                else
+                    Test_MgbaPrintf("%s:%d: Did you mean: ANIMATION(%s, MOVE_%C)", filename, line, sAnimTypeNames[animType], gMovesInfo[animId].name);
+            }
+            else if (animType < ARRAY_COUNT(sAnimTypeNames))
+            {
+                if (checkAttacker && checkTarget)
+                    Test_MgbaPrintf("%s:%d: Did you mean: ANIMATION(%s, %d, %s, target: %s)", filename, line, sAnimTypeNames[animType], animId, BattlerIdentifier(gBattleAnimAttacker), BattlerIdentifier(gBattleAnimTarget));
+                else if (checkAttacker)
+                    Test_MgbaPrintf("%s:%d: Did you mean: ANIMATION(%s, %d, %s)", filename, line, sAnimTypeNames[animType], animId, BattlerIdentifier(gBattleAnimAttacker));
+                else
+                    Test_MgbaPrintf("%s:%d: Did you mean: ANIMATION(%s, %d)", filename, line, sAnimTypeNames[animType], animId);
+            }
+            else
+            {
+                if (checkAttacker && checkTarget)
+                    Test_MgbaPrintf("%s:%d: Did you mean: ANIMATION(%d, %d, %s, target: %s)", filename, line, animType, animId, BattlerIdentifier(gBattleAnimAttacker), BattlerIdentifier(gBattleAnimTarget));
+                else if (checkAttacker)
+                    Test_MgbaPrintf("%s:%d: Did you mean: ANIMATION(%d, %d, %s)", filename, line, animType, animId, BattlerIdentifier(gBattleAnimAttacker));
+                else
+                    Test_MgbaPrintf("%s:%d: Did you mean: ANIMATION(%d, %d)", filename, line, animType, animId);
+            }
+        }
         break;
     case QUEUE_GROUP_NONE_OF:
         queuedEvent = DATA.trial.queuedEvent;
@@ -1015,7 +1083,27 @@ void TestRunner_Battle_RecordHP(enum BattlerId battlerId, u32 oldHP, u32 newHP)
     case QUEUE_GROUP_NONE:
     case QUEUE_GROUP_ONE_OF:
         if (TryHP(DATA.trial.queuedEvent, event->groupSize, battlerId, oldHP, newHP) != -1)
+        {
             DATA.trial.queuedEvent += event->groupSize;
+        }
+        else if (DATA.trial.queuedEvent == DATA.queuedEventsFailIndex
+              && DATA.queuedEvents[DATA.queuedEventsFailIndex].type == QUEUED_HP_EVENT)
+        {
+            const char *filename = gTestRunnerState.test->filename;
+            u32 line = SourceLine(DATA.queuedEvents[DATA.queuedEventsFailIndex].sourceLineOffset);
+            switch (DATA.queuedEvents[DATA.queuedEventsFailIndex].as.hp.type)
+            {
+            case HP_EVENT_NEW_HP:
+                Test_MgbaPrintf("%s:%d: Did you mean: HP_BAR(%s, hp: %d)", filename, line, BattlerIdentifier(battlerId), newHP);
+                break;
+            case HP_EVENT_DELTA_HP:
+                if (DATA.queuedEvents[DATA.queuedEventsFailIndex].as.hp.address == 0)
+                    Test_MgbaPrintf("%s:%d: Did you mean: HP_BAR(%s)", filename, line, BattlerIdentifier(battlerId));
+                else
+                    Test_MgbaPrintf("%s:%d: Did you mean: HP_BAR(%s, damage: %d)", filename, line, BattlerIdentifier(battlerId), oldHP - newHP);
+                break;
+            }
+        }
         break;
     case QUEUE_GROUP_NONE_OF:
         queuedEvent = DATA.trial.queuedEvent;
@@ -1081,6 +1169,8 @@ static s32 TrySubHit(s32 i, s32 n, enum BattlerId battlerId, u32 damage, bool32 
     return -1;
 }
 
+static const char *const sBoolNames[] = { [FALSE] = "FALSE", [TRUE] = "TRUE" };
+
 void TestRunner_Battle_RecordSubHit(enum BattlerId battlerId, u32 damage, bool32 broke)
 {
     s32 queuedEvent;
@@ -1096,7 +1186,25 @@ void TestRunner_Battle_RecordSubHit(enum BattlerId battlerId, u32 damage, bool32
     case QUEUE_GROUP_NONE:
     case QUEUE_GROUP_ONE_OF:
         if (TrySubHit(DATA.trial.queuedEvent, event->groupSize, battlerId, damage, broke) != -1)
+        {
             DATA.trial.queuedEvent += event->groupSize;
+        }
+        else if (DATA.trial.queuedEvent == DATA.queuedEventsFailIndex
+              && DATA.queuedEvents[DATA.queuedEventsFailIndex].type == QUEUED_SUB_HIT_EVENT)
+        {
+            const char *filename = gTestRunnerState.test->filename;
+            u32 line = SourceLine(event->sourceLineOffset);
+            bool32 checkBreak = DATA.queuedEvents[DATA.queuedEventsFailIndex].as.subHit.checkBreak;
+            bool32 checkDamage = DATA.queuedEvents[DATA.queuedEventsFailIndex].as.subHit.address == 0;
+            if (checkBreak && checkDamage)
+                Test_MgbaPrintf("%s:%d: Did you mean: SUB_HIT(%s, subBreak: %s, damage: %d)", filename, line, BattlerIdentifier(battlerId), sBoolNames[broke], damage);
+            else if (checkBreak)
+                Test_MgbaPrintf("%s:%d: Did you mean: SUB_HIT(%s, subBreak: %s)", filename, line, BattlerIdentifier(battlerId), sBoolNames[broke]);
+            else if (checkDamage)
+                Test_MgbaPrintf("%s:%d: Did you mean: SUB_HIT(%s, damage: %d)", filename, line, BattlerIdentifier(battlerId), damage);
+            else
+                Test_MgbaPrintf("%s:%d: Did you mean: SUB_HIT(%s)", filename, line, BattlerIdentifier(battlerId));
+        }
         break;
     case QUEUE_GROUP_NONE_OF:
         queuedEvent = DATA.trial.queuedEvent;
@@ -1496,7 +1604,27 @@ void TestRunner_Battle_RecordExp(enum BattlerId battlerId, u32 oldExp, u32 newEx
     case QUEUE_GROUP_NONE:
     case QUEUE_GROUP_ONE_OF:
         if (TryExp(DATA.trial.queuedEvent, event->groupSize, battlerId, oldExp, newExp) != -1)
+        {
             DATA.trial.queuedEvent += event->groupSize;
+        }
+        else if (DATA.trial.queuedEvent == DATA.queuedEventsFailIndex
+              && DATA.queuedEvents[DATA.queuedEventsFailIndex].type == QUEUED_EXP_EVENT)
+        {
+            const char *filename = gTestRunnerState.test->filename;
+            u32 line = SourceLine(event->sourceLineOffset);
+            switch (DATA.queuedEvents[DATA.queuedEventsFailIndex].as.exp.type)
+            {
+            case EXP_EVENT_NEW_EXP:
+                Test_MgbaPrintf("%s:%d: Did you mean: EXPERIENCE_BAR(%s, exp: %d)", filename, line, BattlerIdentifier(battlerId), newExp);
+                break;
+            case EXP_EVENT_DELTA_EXP:
+                if (DATA.queuedEvents[DATA.queuedEventsFailIndex].as.exp.address == 0)
+                    Test_MgbaPrintf("%s:%d: Did you mean: EXPERIENCE_BAR(%s)", filename, line, BattlerIdentifier(battlerId));
+                else
+                    Test_MgbaPrintf("%s:%d: Did you mean: EXPERIENCE_BAR(%s, captureGainedExp: %d)", filename, line, BattlerIdentifier(battlerId), oldExp - newExp);
+                break;
+            }
+        }
         break;
     case QUEUE_GROUP_NONE_OF:
         queuedEvent = DATA.trial.queuedEvent;
@@ -1588,7 +1716,60 @@ void TestRunner_Battle_RecordMessage(const u8 *string)
     case QUEUE_GROUP_NONE:
     case QUEUE_GROUP_ONE_OF:
         if (TryMessage(DATA.trial.queuedEvent, event->groupSize, string) != -1)
+        {
             DATA.trial.queuedEvent += event->groupSize;
+        }
+        else if (DATA.trial.queuedEvent == DATA.queuedEventsFailIndex
+              && DATA.queuedEvents[DATA.queuedEventsFailIndex].type == QUEUED_MESSAGE_EVENT)
+        {
+            // Print "similar" messages as comptued by the Dice-Sorensen
+            // coefficient, letter-wise. Bigrams would likely be more
+            // accurate, but more complex to compute.
+            // TODO: Compute (and cache) the pattern's counts when the test
+            // is re-run, rather than on each message.
+            const u8 *pattern = DATA.queuedEvents[DATA.queuedEventsFailIndex].as.message.pattern;
+            u32 expectedLength = 0;
+            u8 expectedCount[256] = { 0 };
+            for (u32 i = 0; pattern[i] != EOS; i++)
+            {
+                expectedLength++;
+                expectedCount[pattern[i]]++;
+            }
+
+            u32 gotLength = 0;
+            u8 gotCount[256] = { 0 };
+            for (u32 i = 0; string[i] != EOS; i++)
+            {
+                switch (string[i])
+                {
+                case CHAR_SPACE:
+                case CHAR_NBSP:
+                case CHAR_PROMPT_SCROLL:
+                case CHAR_PROMPT_CLEAR:
+                case CHAR_NEWLINE:
+                    break;
+                default:
+                    gotLength++;
+                    gotCount[string[i]]++;
+                    break;
+                }
+            }
+
+            u32 intersection = 0;
+            for (u32 i = 0; i < 256; i++)
+                intersection += min(expectedCount[i], gotCount[i]);
+
+            uq4_12_t dsc = UQ_4_12(2 * intersection) / (expectedLength + gotLength);
+
+            // NOTE: 0.7 is a totally arbitrary threshold.
+            if (dsc > UQ_4_12(0.7))
+            {
+                const char *filename = gTestRunnerState.test->filename;
+                u32 line = SourceLine(DATA.queuedEvents[DATA.queuedEventsFailIndex].sourceLineOffset);
+
+                Test_MgbaPrintf("%s:%d: Did you mean: MESSAGE(\"%S\")", filename, line, string);
+            }
+        }
         break;
     case QUEUE_GROUP_NONE_OF:
         queuedEvent = DATA.trial.queuedEvent;
@@ -1655,7 +1836,33 @@ void TestRunner_Battle_RecordStatus1(enum BattlerId battlerId, u32 status1)
     case QUEUE_GROUP_NONE:
     case QUEUE_GROUP_ONE_OF:
         if (TryStatus(DATA.trial.queuedEvent, event->groupSize, battlerId, status1) != -1)
+        {
             DATA.trial.queuedEvent += event->groupSize;
+        }
+        else if (DATA.trial.queuedEvent == DATA.queuedEventsFailIndex
+              && DATA.queuedEvents[DATA.queuedEventsFailIndex].type == QUEUED_STATUS_EVENT)
+        {
+            const char *filename = gTestRunnerState.test->filename;
+            u32 line = SourceLine(DATA.queuedEvents[DATA.queuedEventsFailIndex].sourceLineOffset);
+            if (status1 == STATUS1_NONE)
+                Test_MgbaPrintf("%s:%d: Did you mean: STATUS_ICON(%s, none: TRUE)", filename, line, BattlerIdentifier(battlerId));
+            else if (status1 & STATUS1_SLEEP)
+                Test_MgbaPrintf("%s:%d: Did you mean: STATUS_ICON(%s, sleep: TRUE)", filename, line, BattlerIdentifier(battlerId));
+            else if (status1 & STATUS1_POISON)
+                Test_MgbaPrintf("%s:%d: Did you mean: STATUS_ICON(%s, poison: TRUE)", filename, line, BattlerIdentifier(battlerId));
+            else if (status1 & STATUS1_BURN)
+                Test_MgbaPrintf("%s:%d: Did you mean: STATUS_ICON(%s, burn: TRUE)", filename, line, BattlerIdentifier(battlerId));
+            else if (status1 & STATUS1_FREEZE)
+                Test_MgbaPrintf("%s:%d: Did you mean: STATUS_ICON(%s, freeze: TRUE)", filename, line, BattlerIdentifier(battlerId));
+            else if (status1 & STATUS1_PARALYSIS)
+                Test_MgbaPrintf("%s:%d: Did you mean: STATUS_ICON(%s, paralysis: TRUE)", filename, line, BattlerIdentifier(battlerId));
+            else if (status1 & STATUS1_TOXIC_POISON)
+                Test_MgbaPrintf("%s:%d: Did you mean: STATUS_ICON(%s, badPoison: TRUE)", filename, line, BattlerIdentifier(battlerId));
+            else if (status1 & STATUS1_FROSTBITE)
+                Test_MgbaPrintf("%s:%d: Did you mean: STATUS_ICON(%s, frostbite: TRUE)", filename, line, BattlerIdentifier(battlerId));
+            else
+                Test_MgbaPrintf("%s:%d: Did you mean: STATUS_ICON(%s, status1: %d)", filename, line, BattlerIdentifier(battlerId), status1);
+        }
         break;
     case QUEUE_GROUP_NONE_OF:
         queuedEvent = DATA.trial.queuedEvent;
@@ -1757,38 +1964,6 @@ static const char *const sEventTypeMacros[] =
     [QUEUED_EFFECTIVENESS_EVENT] = "EFFECTIVENESS_SE",
 };
 
-void TestRunner_Battle_AfterLastTurn(void)
-{
-    const struct BattleTest *test = GetBattleTest();
-
-    if (DATA.turns - 1 != DATA.trial.lastActionTurn)
-    {
-        const char *filename = gTestRunnerState.test->filename;
-        Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), "%s:%d: %d TURNs specified, but %d ran", filename, SourceLine(0), DATA.turns, DATA.trial.lastActionTurn + 1);
-    }
-
-    while (DATA.trial.queuedEvent < DATA.queuedEventsCount
-        && DATA.queuedEvents[DATA.trial.queuedEvent].groupType == QUEUE_GROUP_NONE_OF)
-    {
-        DATA.trial.queuedEvent += DATA.queuedEvents[DATA.trial.queuedEvent].groupSize;
-    }
-    if (DATA.trial.queuedEvent != DATA.queuedEventsCount)
-    {
-        const char *filename = gTestRunnerState.test->filename;
-        u32 line = SourceLine(DATA.queuedEvents[DATA.trial.queuedEvent].sourceLineOffset);
-        const char *macro = sEventTypeMacros[DATA.queuedEvents[DATA.trial.queuedEvent].type];
-        if (gTestRunnerState.expectedFailState == EXPECT_FAIL_SCENE_OPEN)
-            gTestRunnerState.expectedFailState = EXPECT_FAIL_SUCCESS;
-        Test_ExitWithResult(TEST_RESULT_FAIL, line, "%s:%d: Unmatched %s", filename, line, macro);
-    }
-
-    STATE->runThen = TRUE;
-    STATE->runFinally = STATE->runParameter + 1 == STATE->parameters && STATE->runTrial + 1 >= STATE->trials;
-    InvokeTestFunction(test);
-    STATE->runThen = FALSE;
-    STATE->runFinally = FALSE;
-}
-
 static void TearDownBattle(void)
 {
     // Zero out the parties, data in them could potentially carry over
@@ -1807,6 +1982,71 @@ static void TearDownBattle(void)
     FreeBattleResources();
     FreeAllWindowBuffers();
     gMain.inBattle = FALSE; // Necessary else some tests report incorrect results when running in same thread as an EXPECT_FAIL test
+}
+
+void TestRunner_Battle_AfterLastTurn(void)
+{
+    const struct BattleTest *test = GetBattleTest();
+
+    if (DATA.turns - 1 != DATA.trial.lastActionTurn)
+    {
+        const char *filename = gTestRunnerState.test->filename;
+        Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), "%s:%d: %d TURNs specified, but %d ran", filename, SourceLine(0), DATA.turns, DATA.trial.lastActionTurn + 1);
+    }
+
+    while (DATA.trial.queuedEvent < DATA.queuedEventsCount
+        && DATA.queuedEvents[DATA.trial.queuedEvent].groupType == QUEUE_GROUP_NONE_OF)
+    {
+        DATA.trial.queuedEvent += DATA.queuedEvents[DATA.trial.queuedEvent].groupSize;
+    }
+    if (DATA.trial.queuedEvent != DATA.queuedEventsCount)
+    {
+        bool32 mayRerun = gTestRunnerHeadless && !STATE->trials;
+        if (mayRerun && DATA.queuedEventsFailIndex == MAX_QUEUED_EVENTS)
+        {
+            // First failure, re-run with logging enabled.
+            // TODO: Track total battle tests and total re-runs, and
+            // disable re-runs if they're too common (to fail faster).
+            DATA.queuedEventsFailIndex = DATA.trial.queuedEvent;
+            gMain.savedCallback = StartBattle; // Re-run once battle exits.
+            return;
+        }
+        else if (!mayRerun || DATA.queuedEventsFailIndex == DATA.trial.queuedEvent)
+        {
+            const char *filename = gTestRunnerState.test->filename;
+            const struct QueuedEvent *event = &DATA.queuedEvents[DATA.trial.queuedEvent];
+            u32 line = SourceLine(event->sourceLineOffset);
+            if (gTestRunnerState.expectedFailState == EXPECT_FAIL_SCENE_OPEN)
+                gTestRunnerState.expectedFailState = EXPECT_FAIL_SUCCESS;
+            DATA.queuedEventsFailIndex = MAX_QUEUED_EVENTS; // For 'handleExitWithResult'.
+            const char *macro = sEventTypeMacros[event->type];
+            switch (event->type)
+            {
+            case QUEUED_MESSAGE_EVENT:
+                Test_ExitWithResult(TEST_RESULT_FAIL, line, "%s:%d: Unmatched MESSAGE(\"%S\")", filename, line, event->as.message.pattern);
+            // TODO: Handle all queued event types explicitly.
+            default:
+                Test_ExitWithResult(TEST_RESULT_FAIL, line, "%s:%d: Unmatched %s", filename, line, macro);
+            }
+        }
+    }
+    if (DATA.queuedEventsFailIndex != MAX_QUEUED_EVENTS
+     && DATA.queuedEventsFailIndex != DATA.trial.queuedEvent)
+    {
+        const char *filename = gTestRunnerState.test->filename;
+        u32 expectedLine = SourceLine(DATA.queuedEvents[DATA.queuedEventsFailIndex].sourceLineOffset);
+        const char *expectedMacro = sEventTypeMacros[DATA.queuedEvents[DATA.queuedEventsFailIndex].type];
+        u32 gotLine = SourceLine(DATA.queuedEvents[DATA.trial.queuedEvent].sourceLineOffset);
+        const char *gotMacro = sEventTypeMacros[DATA.queuedEvents[DATA.trial.queuedEvent].type];
+        DATA.queuedEventsFailIndex = MAX_QUEUED_EVENTS; // For 'handleExitWithResult'.
+        Test_ExitWithResult(TEST_RESULT_FLAKY, expectedLine, "%s:%d: Expected unmatched %s, but got %s at %s:%d", filename, expectedLine, expectedMacro, gotMacro, filename, gotLine);
+    }
+
+    STATE->runThen = TRUE;
+    STATE->runFinally = STATE->runParameter + 1 == STATE->parameters && STATE->runTrial + 1 >= STATE->trials;
+    InvokeTestFunction(test);
+    STATE->runThen = FALSE;
+    STATE->runFinally = FALSE;
 }
 
 static void CB2_BattleTest_NextParameter(void)
@@ -1921,10 +2161,20 @@ static bool32 BattleTest_HandleExitWithResult(void *data, enum TestResult result
      && result != TEST_RESULT_INVALID
      && result != TEST_RESULT_ERROR
      && result != TEST_RESULT_TIMEOUT
+     && result != TEST_RESULT_FLAKY
      && STATE->runTrial < STATE->trials)
     {
         SetMainCallback2(CB2_BattleTest_NextTrial);
         return TRUE;
+    }
+    else if (DATA.queuedEventsFailIndex != MAX_QUEUED_EVENTS)
+    {
+        const char *filename = gTestRunnerState.test->filename;
+        u32 expectedLine = SourceLine(DATA.queuedEvents[DATA.queuedEventsFailIndex].sourceLineOffset);
+        const char *expectedMacro = sEventTypeMacros[DATA.queuedEvents[DATA.queuedEventsFailIndex].type];
+        Test_MgbaPrintf("%s:%d: Expected unmatched %s, but got...", filename, expectedLine, expectedMacro);
+        gTestRunnerState.result = TEST_RESULT_FLAKY;
+        return FALSE;
     }
     else
     {

--- a/test/test_runner_battle.c
+++ b/test/test_runner_battle.c
@@ -1722,7 +1722,7 @@ void TestRunner_Battle_RecordMessage(const u8 *string)
         else if (DATA.trial.queuedEvent == DATA.queuedEventsFailIndex
               && DATA.queuedEvents[DATA.queuedEventsFailIndex].type == QUEUED_MESSAGE_EVENT)
         {
-            // Print "similar" messages as comptued by the Dice-Sorensen
+            // Print "similar" messages as computed by the Dice-Sorensen
             // coefficient, letter-wise. Bigrams would likely be more
             // accurate, but more complex to compute.
             // TODO: Compute (and cache) the pattern's counts when the test


### PR DESCRIPTION
## Description
Adds "did you mean" outputs for a `SCENE` matcher that didn't match anything. It applies to everything but is most helpful for `MESSAGE`s with typos or similar.
```diff
@@ -12,7 +12,7 @@ SINGLE_BATTLE_TEST("Sandstorm deals 1/16 damage per turn")
-        MESSAGE("The opposing Wobbuffet is buffeted by the sandstorm!");
+        MESSAGE("The opposing Wobbuffet is buffeted by the sandstorm.");
```
```
[0] Sandstorm deals 1/16 damage per turn: FAIL
test/battle/weather/sandstorm.c:15: Did you mean: MESSAGE("The opposing Wobbuffet is buffeted by the sandstorm!")
test/battle/weather/sandstorm.c:15: Unmatched MESSAGE("The opposing Wobbuffet is buffeted by the sandstorm.")
```
The ideal implementation would buffer all the events and then run an algorithm over them at the end of the test if it failed... but that requires too much memory. So instead, a test with a failing matcher is
run a second time and the events are scrutinized more closely.

An alternative is scrutinizing all the events as the test runs, but re-running is a better choice because most tests pass, and so the cost of scrutinizing events is paid only by failing tests.

### Large Language Models (AI)
None.

## Feature(s) this PR does NOT handle:
The suggestions could be better when the matchers are in the wrong order, e.g. for something like:
```c
GIVEN {
} WHEN {
  TURN { MOVE(player, MOVE_TACKLE); }
} SCENE {
  HP_BAR(opponent);
  ANIMATION(ANIM_TYPE_MOVE, MOVE_TACKLE);
}
```
where `HP_BAR` should be after `ANIMATION` and which currently fails without any suggestions because no animations play after the HP bar changes. It's straightforward to detect when a failing matcher can be moved backwards (any event that didn't match is a candidate), but I think we'd need extra heuristics to avoid silly suggestions.