### PR TITLE
Improve `FillSpriteRect` performance

### DIFF
--- a/src/sprite.c
+++ b/src/sprite.c
@@ -1978,7 +1978,7 @@ static void FillSpriteRect(u32 spriteId, u32 left, u32 top, u32 width, u32 heigh
                     if (!isColor)
                         src = GetSrcPtrFromSprite(&gSprites[currSpriteId]);
                 }
-                else if (((top + row) & heigthMask) == spriteHeight - 1)
+                else if (((top + row) & heigthMask) == heightMask)
                 {
                     //  Switch sprite along Y-axis
                     currSpriteId = gSprites[currSpriteId].nextY;
@@ -2010,7 +2010,7 @@ static void FillSpriteRect(u32 spriteId, u32 left, u32 top, u32 width, u32 heigh
                     if (!isColor)
                         src = GetSrcPtrFromSprite(&gSprites[currSpriteId]);
                 }
-                else if (((top + row) & heigthMask) == spriteHeight - 1)
+                else if (((top + row) & heigthMask) == heightMask)
                 {
                     //  Switch sprite along Y-axis
                     currSpriteId = gSprites[currSpriteId].nextY;

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -1893,7 +1893,7 @@ static void FillSpriteRect(u32 spriteId, u32 left, u32 top, u32 width, u32 heigh
     // since all posible values for the sprite
     // width and height in the GBA are a power of two
     u32 widthMask = spriteWidth - 1;
-    u32 heigthMask = spriteHeight - 1;
+    u32 heightMask = spriteHeight - 1;
 
     u32 *src = NULL;
 
@@ -1965,7 +1965,7 @@ static void FillSpriteRect(u32 spriteId, u32 left, u32 top, u32 width, u32 heigh
             for (u32 row = 0; row < height; row++)
             {
                 u32 spriteX = (currStart - (currStart % PIXELS_PER_TILE)) & widthMask;
-                u32 spriteY = (top + row) & heigthMask;
+                u32 spriteY = (top + row) & heightMask;
                 if (isColor)
                     tiles[CURRENT_SPRITE_POS] = color;
                 else
@@ -1978,7 +1978,7 @@ static void FillSpriteRect(u32 spriteId, u32 left, u32 top, u32 width, u32 heigh
                     if (!isColor)
                         src = GetSrcPtrFromSprite(&gSprites[currSpriteId]);
                 }
-                else if (((top + row) & heigthMask) == heightMask)
+                else if (((top + row) & heightMask) == heightMask)
                 {
                     //  Switch sprite along Y-axis
                     currSpriteId = gSprites[currSpriteId].nextY;
@@ -1994,7 +1994,7 @@ static void FillSpriteRect(u32 spriteId, u32 left, u32 top, u32 width, u32 heigh
             for (u32 row = 0; row < height; row++)
             {
                 u32 spriteX = (currStart - (currStart % PIXELS_PER_TILE)) & widthMask;
-                u32 spriteY = (top + row) & heigthMask;
+                u32 spriteY = (top + row) & heightMask;
                 u32 orig = tiles[CURRENT_SPRITE_POS] & dstMask;
                 u32 new;
                 if (isColor)
@@ -2010,7 +2010,7 @@ static void FillSpriteRect(u32 spriteId, u32 left, u32 top, u32 width, u32 heigh
                     if (!isColor)
                         src = GetSrcPtrFromSprite(&gSprites[currSpriteId]);
                 }
-                else if (((top + row) & heigthMask) == heightMask)
+                else if (((top + row) & heightMask) == heightMask)
                 {
                     //  Switch sprite along Y-axis
                     currSpriteId = gSprites[currSpriteId].nextY;

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -1889,6 +1889,12 @@ static void FillSpriteRect(u32 spriteId, u32 left, u32 top, u32 width, u32 heigh
     u32 color = 0;
     bool32 isColor = FALSE;
 
+    // Bit masks for fast modulus division, this is posible
+    // since all posible values for the sprite
+    // width and height in the GBA are a power of two
+    u32 widthMask = spriteWidth - 1;
+    u32 heigthMask = spriteHeight - 1;
+
     u32 *src = NULL;
 
     switch (mode)
@@ -1958,8 +1964,8 @@ static void FillSpriteRect(u32 spriteId, u32 left, u32 top, u32 width, u32 heigh
             //  Separate out the case that doesn't need to mask the pixels
             for (u32 row = 0; row < height; row++)
             {
-                u32 spriteX = (currStart - (currStart % PIXELS_PER_TILE)) % spriteWidth;
-                u32 spriteY = (top + row) % spriteHeight;
+                u32 spriteX = (currStart - (currStart % PIXELS_PER_TILE)) & widthMask;
+                u32 spriteY = (top + row) & heigthMask;
                 if (isColor)
                     tiles[CURRENT_SPRITE_POS] = color;
                 else
@@ -1972,7 +1978,7 @@ static void FillSpriteRect(u32 spriteId, u32 left, u32 top, u32 width, u32 heigh
                     if (!isColor)
                         src = GetSrcPtrFromSprite(&gSprites[currSpriteId]);
                 }
-                else if ((top + row) % spriteHeight == spriteHeight - 1)
+                else if (((top + row) & heigthMask) == spriteHeight - 1)
                 {
                     //  Switch sprite along Y-axis
                     currSpriteId = gSprites[currSpriteId].nextY;
@@ -1987,8 +1993,8 @@ static void FillSpriteRect(u32 spriteId, u32 left, u32 top, u32 width, u32 heigh
             //  Mask these since it's needed
             for (u32 row = 0; row < height; row++)
             {
-                u32 spriteX = (currStart - (currStart % PIXELS_PER_TILE)) % spriteWidth;
-                u32 spriteY = (top + row) % spriteHeight;
+                u32 spriteX = (currStart - (currStart % PIXELS_PER_TILE)) & widthMask;
+                u32 spriteY = (top + row) & heigthMask;
                 u32 orig = tiles[CURRENT_SPRITE_POS] & dstMask;
                 u32 new;
                 if (isColor)
@@ -2004,7 +2010,7 @@ static void FillSpriteRect(u32 spriteId, u32 left, u32 top, u32 width, u32 heigh
                     if (!isColor)
                         src = GetSrcPtrFromSprite(&gSprites[currSpriteId]);
                 }
-                else if ((top + row) % spriteHeight == spriteHeight - 1)
+                else if (((top + row) & heigthMask) == spriteHeight - 1)
                 {
                     //  Switch sprite along Y-axis
                     currSpriteId = gSprites[currSpriteId].nextY;
@@ -2018,7 +2024,7 @@ static void FillSpriteRect(u32 spriteId, u32 left, u32 top, u32 width, u32 heigh
         remainingWidth -= currWidth;
         currStart += currWidth;
         //  Handle switching sprites along X-axis
-        if (currStart > 0 && (currStart % spriteWidth) == 0)
+        if (currStart > 0 && (currStart & widthMask) == 0)
         {
             spriteId = gSprites[spriteId].nextX;
             tiles = (u32 *)((OBJ_VRAM0) + gSprites[spriteId].oam.tileNum * TILE_SIZE_4BPP);


### PR DESCRIPTION
## Description
Improve performance of `FillSpriteRect` by using fast modulus division, this is feasible since all possible widths and heights for a sprite are a power of two.

### Large Language Models (AI)
None.

### Credits
Thanks to Jamie, hedara and MGriffin for confirming my theory. <3

## Discord contact info
estellar.cheese
