### PR TITLE
Fix action order when Stall and Lagging Tail both apply

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4863,24 +4863,22 @@ s32 GetWhichBattlerFasterArgs(struct BattleCalcValues *calcValues, bool32 ignore
     if (priority1 == priority2)
     {
         // Quick Claw / Quick Draw / Custap Berry - always first
-        // Stall / Mycelium Might - last but before Lagging Tail
-        // Lagging Tail - always last
+        // Stall / Mycelium Might / Lagging Tail / Full Incense - always last
+        // If both battlers are affected by one of these effects, order is determined by Speed.
         bool32 battler1HasQuickEffect = gProtectStructs[calcValues->battlerAtk].quickDraw || gProtectStructs[calcValues->battlerAtk].usedCustapBerry;
         bool32 battler2HasQuickEffect = gProtectStructs[calcValues->battlerDef].quickDraw || gProtectStructs[calcValues->battlerDef].usedCustapBerry;
         bool32 battler1HasStallingAbility = calcValues->abilities[calcValues->battlerAtk] == ABILITY_STALL || gProtectStructs[calcValues->battlerAtk].myceliumMight;
         bool32 battler2HasStallingAbility = calcValues->abilities[calcValues->battlerDef] == ABILITY_STALL || gProtectStructs[calcValues->battlerDef].myceliumMight;
+        bool32 battler1HasSlowEffect = battler1HasStallingAbility || gProtectStructs[calcValues->battlerAtk].laggingTail;
+        bool32 battler2HasSlowEffect = battler2HasStallingAbility || gProtectStructs[calcValues->battlerDef].laggingTail;
 
         if (battler1HasQuickEffect && !battler2HasQuickEffect)
             strikesFirst = 1;
         else if (battler2HasQuickEffect && !battler1HasQuickEffect)
             strikesFirst = -1;
-        else if (gProtectStructs[calcValues->battlerAtk].laggingTail && !gProtectStructs[calcValues->battlerDef].laggingTail)
+        else if (battler1HasSlowEffect && !battler2HasSlowEffect)
             strikesFirst = -1;
-        else if (gProtectStructs[calcValues->battlerDef].laggingTail && !gProtectStructs[calcValues->battlerAtk].laggingTail)
-            strikesFirst = 1;
-        else if (battler1HasStallingAbility && !battler2HasStallingAbility)
-            strikesFirst = -1;
-        else if (battler2HasStallingAbility && !battler1HasStallingAbility)
+        else if (battler2HasSlowEffect && !battler1HasSlowEffect)
             strikesFirst = 1;
         else
         {

--- a/test/battle/ability/stall.c
+++ b/test/battle/ability/stall.c
@@ -14,7 +14,7 @@ SINGLE_BATTLE_TEST("Stall causes the user to move last in its priority bracket")
     }
 }
 
-SINGLE_BATTLE_TEST("Stall still moves last in its priority bracket under Trick Room")
+SINGLE_BATTLE_TEST("Stall causes the user to move last in its priority bracket (Trick Room)")
 {
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_TRICK_ROOM) == EFFECT_TRICK_ROOM);
@@ -43,7 +43,7 @@ SINGLE_BATTLE_TEST("Stall respects Speed when both battlers have Stall")
     }
 }
 
-SINGLE_BATTLE_TEST("Stall vs Lagging Tail action order depends on Speed")
+SINGLE_BATTLE_TEST("Stall and Lagging Tail action order depends on Speed")
 {
     u32 speed;
 
@@ -70,7 +70,7 @@ SINGLE_BATTLE_TEST("Stall vs Lagging Tail action order depends on Speed")
     }
 }
 
-SINGLE_BATTLE_TEST("Stall and Lagging Tail action order depends on reversed Speed under Trick Room")
+SINGLE_BATTLE_TEST("Stall and Lagging Tail action order depends on Speed (Trick Room)")
 {
     u32 speed;
 

--- a/test/battle/ability/stall.c
+++ b/test/battle/ability/stall.c
@@ -1,4 +1,117 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Stall (Ability) test titles")
+SINGLE_BATTLE_TEST("Stall causes the user to move last in its priority bracket")
+{
+    GIVEN {
+        PLAYER(SPECIES_SABLEYE) { Speed(100); Ability(ABILITY_STALL); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); }
+    } WHEN {
+        TURN {}
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
+    }
+}
+
+SINGLE_BATTLE_TEST("Stall still moves last in its priority bracket under Trick Room")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_TRICK_ROOM) == EFFECT_TRICK_ROOM);
+        PLAYER(SPECIES_SABLEYE) { Speed(1); Ability(ABILITY_STALL); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(100); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_TRICK_ROOM); }
+        TURN {}
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TRICK_ROOM, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
+    }
+}
+
+SINGLE_BATTLE_TEST("Stall respects Speed when both battlers have Stall")
+{
+    GIVEN {
+        PLAYER(SPECIES_SABLEYE) { Speed(100); Ability(ABILITY_STALL); }
+        OPPONENT(SPECIES_SABLEYE) { Speed(1); Ability(ABILITY_STALL); }
+    } WHEN {
+        TURN {}
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
+    }
+}
+
+SINGLE_BATTLE_TEST("Stall vs Lagging Tail action order depends on Speed")
+{
+    u32 speed;
+
+    PARAMETRIZE { speed = 99; }
+    PARAMETRIZE { speed = 101; }
+
+    GIVEN {
+        ASSUME(gItemsInfo[ITEM_LAGGING_TAIL].holdEffect == HOLD_EFFECT_LAGGING_TAIL);
+        PLAYER(SPECIES_SABLEYE) { Speed(100); Ability(ABILITY_STALL); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(speed); Item(ITEM_LAGGING_TAIL); }
+    } WHEN {
+        TURN {}
+    } SCENE {
+        if (speed < 100)
+        {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
+        }
+        else
+        {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Stall and Lagging Tail action order depends on reversed Speed under Trick Room")
+{
+    u32 speed;
+
+    PARAMETRIZE { speed = 99; }
+    PARAMETRIZE { speed = 101; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_TRICK_ROOM) == EFFECT_TRICK_ROOM);
+        ASSUME(gItemsInfo[ITEM_LAGGING_TAIL].holdEffect == HOLD_EFFECT_LAGGING_TAIL);
+        PLAYER(SPECIES_SABLEYE) { Speed(100); Ability(ABILITY_STALL); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(speed); Item(ITEM_LAGGING_TAIL); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_TRICK_ROOM); }
+        TURN {}
+    } SCENE {
+        if (speed < 100)
+        {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_TRICK_ROOM, player);
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
+        }
+        else
+        {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_TRICK_ROOM, player);
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Stall user can move before faster battlers when Quick Claw activates")
+{
+    PASSES_RANDOMLY(2, 10, RNG_QUICK_CLAW);
+    GIVEN {
+        ASSUME(gItemsInfo[ITEM_QUICK_CLAW].holdEffect == HOLD_EFFECT_QUICK_CLAW);
+        PLAYER(SPECIES_SABLEYE) { Speed(1); Ability(ABILITY_STALL); Item(ITEM_QUICK_CLAW); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(100); }
+    } WHEN {
+        TURN {}
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
+    }
+}

--- a/test/battle/ability/stall.c
+++ b/test/battle/ability/stall.c
@@ -86,15 +86,14 @@ SINGLE_BATTLE_TEST("Stall and Lagging Tail action order depends on reversed Spee
         TURN { MOVE(player, MOVE_TRICK_ROOM); }
         TURN {}
     } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TRICK_ROOM, player);
         if (speed < 100)
         {
-            ANIMATION(ANIM_TYPE_MOVE, MOVE_TRICK_ROOM, player);
             ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
             ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
         }
         else
         {
-            ANIMATION(ANIM_TYPE_MOVE, MOVE_TRICK_ROOM, player);
             ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
             ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
         }


### PR DESCRIPTION
## Description
[Stall](https://wiki.pokemonwiki.com/wiki/%e3%81%82%e3%81%a8%e3%81%a0%e3%81%97)

> - まんぷくおこう/こうこうのしっぽを持っているポケモンとあとだしのポケモンは、すばやさの高い方が先攻になる。
> - まんぷくおこう/こうこうのしっぽを持っているポケモン同士では、片方があとだしだとしても関係なく、すばやさの高い方が先攻になる。

- If a Pokémon holding a Lagging Tail or Full Incense and a Pokémon with the Ability Stall use moves with the same priority, the Pokémon with the **higher** Speed moves first.
- If multiple Pokémon holding a Lagging Tail or Full Incense use moves with the same priority, the Pokémon with the **higher** Speed moves first, regardless of whether one of them also has the Ability Stall.
