### PR TITLE
Fix Magician target selection priority for spread moves

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4507,7 +4507,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
                 enum BattlerId battlers[MAX_BATTLERS_COUNT] = {0, 1, 2, 3};
 
                 if (numMagicianTargets > 1)
-                    SortBattlersBySpeed(battlers, FALSE);
+                    SortBattlersBySpeed(battlers, (gFieldStatuses & STATUS_FIELD_TRICK_ROOM) != 0);
 
                 for (u32 i = 0; i < gBattlersCount; i++)
                 {

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4463,6 +4463,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
         case ABILITY_MAGICIAN:
             if (GetMoveEffect(move) != EFFECT_FLING
              && GetMoveEffect(move) != EFFECT_NATURAL_GIFT
+             && GetMoveEffect(move) != EFFECT_FUTURE_SIGHT
              && gBattleMons[battler].item == ITEM_NONE
              && IsBattlerAlive(battler)
              && !gSpecialStatuses[battler].gemBoost) // In base game, gems are consumed after magician would activate.

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4468,8 +4468,10 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
              && IsBattlerAlive(battler)
              && !gSpecialStatuses[battler].gemBoost) // In base game, gems are consumed after magician would activate.
             {
-                u32 numMagicianTargets = 0;
-                u32 magicianTargets = 0;
+                u32 numFoeMagicianTargets = 0;
+                u32 numAllyMagicianTargets = 0;
+                u32 foeMagicianTargets = 0;
+                u32 allyMagicianTargets = 0;
 
                 for (enum BattlerId battlerDef = 0; battlerDef < gBattlersCount; battlerDef++)
                 {
@@ -4478,21 +4480,32 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
                      && IsBattlerTurnDamaged(battlerDef, EXCLUDING_SUBSTITUTES)
                      && CanStealItem(battler, battlerDef, gBattleMons[battlerDef].item)
                      && !GetBattlerPartyState(battlerDef)->isKnockedOff
-                     && !DoesSubstituteBlockMove(battler, battlerDef, move)
-                     && (GetBattlerAbility(battlerDef) != ABILITY_STICKY_HOLD || !IsBattlerAlive(battlerDef)))
+                     && !DoesSubstituteBlockMove(battler, battlerDef, move))
                     {
-                        magicianTargets |= 1u << battlerDef;
-                        numMagicianTargets++;
+                        if (IsBattlerAlly(battler, battlerDef))
+                        {
+                            allyMagicianTargets |= 1u << battlerDef;
+                            numAllyMagicianTargets++;
+                        }
+                        else
+                        {
+                            foeMagicianTargets |= 1u << battlerDef;
+                            numFoeMagicianTargets++;
+                        }
                     }
                 }
 
-                if (numMagicianTargets == 0)
+                if (numFoeMagicianTargets == 0 && numAllyMagicianTargets == 0)
                 {
                     effect = FALSE;
                     break;
                 }
 
+                // For spread moves, Magician prioritizes opponents over allies.
+                u32 magicianTargets = (numFoeMagicianTargets != 0) ? foeMagicianTargets : allyMagicianTargets;
+                u32 numMagicianTargets = (numFoeMagicianTargets != 0) ? numFoeMagicianTargets : numAllyMagicianTargets;
                 enum BattlerId battlers[MAX_BATTLERS_COUNT] = {0, 1, 2, 3};
+
                 if (numMagicianTargets > 1)
                     SortBattlersBySpeed(battlers, FALSE);
 
@@ -4502,6 +4515,12 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
 
                     if (!(magicianTargets & 1u << targetBattler))
                         continue;
+
+                    if (GetBattlerAbility(targetBattler) == ABILITY_STICKY_HOLD && IsBattlerAlive(targetBattler))
+                    {
+                        effect = FALSE;
+                        break;
+                    }
 
                     StealTargetItem(battler, targetBattler);
                     gBattlerAbility = battler;

--- a/test/battle/ability/magician.c
+++ b/test/battle/ability/magician.c
@@ -6,51 +6,134 @@ SINGLE_BATTLE_TEST("Magician gets self-damage recoil after stealing Life Orb")
     GIVEN {
         ASSUME(gItemsInfo[ITEM_LIFE_ORB].holdEffect == HOLD_EFFECT_LIFE_ORB);
         ASSUME(GetMoveCategory(MOVE_SCRATCH) != DAMAGE_CATEGORY_STATUS);
-        PLAYER(SPECIES_DELPHOX) { Ability(ABILITY_MAGICIAN); Item(ITEM_NONE); }
+        PLAYER(SPECIES_DELPHOX) { Ability(ABILITY_MAGICIAN); }
         OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_LIFE_ORB); }
     } WHEN {
         TURN { MOVE(player, MOVE_SCRATCH); }
         TURN { MOVE(player, MOVE_SCRATCH); }
     } SCENE {
         // 1st turn
-        MESSAGE("Delphox used Scratch!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
         ABILITY_POPUP(player, ABILITY_MAGICIAN);
         MESSAGE("Delphox stole the opposing Wobbuffet's Life Orb!");
         HP_BAR(player);
         MESSAGE("Delphox was hurt by the Life Orb!");
         // 2nd turn - Life Orb recoil happens now
-        MESSAGE("Delphox used Scratch!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
         HP_BAR(player);
         MESSAGE("Delphox was hurt by the Life Orb!");
+    } THEN {
+        EXPECT_EQ(player->item, ITEM_LIFE_ORB);
+        EXPECT_EQ(opponent->item, ITEM_NONE);
     }
 }
 
-DOUBLE_BATTLE_TEST("Magician steal the item from the fastest possible target")
+DOUBLE_BATTLE_TEST("Magician prioritizes opponents over allies among valid targets by speed")
 {
     u32 playerRightSpeed = 0;
     u32 opponentLeftSpeed = 0;
     u32 opponentRightSpeed = 0;
+    u32 expectedItem = ITEM_NONE;
 
-    PARAMETRIZE { playerRightSpeed = 4; opponentLeftSpeed = 2; opponentRightSpeed = 3; }
-    PARAMETRIZE { playerRightSpeed = 3; opponentLeftSpeed = 4; opponentRightSpeed = 2; }
-    PARAMETRIZE { playerRightSpeed = 2; opponentLeftSpeed = 3; opponentRightSpeed = 4; }
+    PARAMETRIZE { playerRightSpeed = 4; opponentLeftSpeed = 2; opponentRightSpeed = 3; expectedItem = ITEM_ULTRA_BALL; }
+    PARAMETRIZE { playerRightSpeed = 3; opponentLeftSpeed = 4; opponentRightSpeed = 2; expectedItem = ITEM_GREAT_BALL; }
+    PARAMETRIZE { playerRightSpeed = 2; opponentLeftSpeed = 3; opponentRightSpeed = 4; expectedItem = ITEM_ULTRA_BALL; }
 
     GIVEN {
-        PLAYER(SPECIES_DELPHOX) { Speed(1); Ability(ABILITY_MAGICIAN); Item(ITEM_NONE); }
+        ASSUME(GetMoveTarget(MOVE_SURF) == TARGET_FOES_AND_ALLY);
+        PLAYER(SPECIES_DELPHOX) { Speed(1); Ability(ABILITY_MAGICIAN); }
         PLAYER(SPECIES_WOBBUFFET) { Speed(playerRightSpeed); Item(ITEM_POKE_BALL); }
         OPPONENT(SPECIES_WOBBUFFET) { Speed(opponentLeftSpeed); Item(ITEM_GREAT_BALL); }
         OPPONENT(SPECIES_WOBBUFFET) { Speed(opponentRightSpeed); Item(ITEM_ULTRA_BALL); }
     } WHEN {
         TURN { MOVE(playerLeft, MOVE_SURF); }
     } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SURF, playerLeft);
         ABILITY_POPUP(playerLeft, ABILITY_MAGICIAN);
     } THEN {
-        if (playerRightSpeed == 4)
-            EXPECT(playerLeft->item == ITEM_POKE_BALL);
-        else if (opponentLeftSpeed == 4)
-            EXPECT(playerLeft->item == ITEM_GREAT_BALL);
-        else if (playerRightSpeed == 4)
-            EXPECT(playerLeft->item == ITEM_ULTRA_BALL);
+        EXPECT_EQ(playerLeft->item, expectedItem);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Magician can steal from ally if no opponent is a valid target")
+{
+    GIVEN {
+        ASSUME(GetMoveTarget(MOVE_SURF) == TARGET_FOES_AND_ALLY);
+        PLAYER(SPECIES_DELPHOX) { Speed(1); Ability(ABILITY_MAGICIAN); }
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); Item(ITEM_POKE_BALL); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(3); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(4); }
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_SURF); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SURF, playerLeft);
+        ABILITY_POPUP(playerLeft, ABILITY_MAGICIAN);
+    } THEN {
+        EXPECT_EQ(playerLeft->item, ITEM_POKE_BALL);
+        EXPECT_EQ(playerRight->item, ITEM_NONE);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Magician is blocked by Sticky Hold unless the target faints")
+{
+    bool32 stickyHoldTargetFaints = FALSE;
+
+    PARAMETRIZE { stickyHoldTargetFaints = FALSE; }
+    PARAMETRIZE { stickyHoldTargetFaints = TRUE; }
+
+    GIVEN {
+        ASSUME(GetMoveTarget(MOVE_SURF) == TARGET_FOES_AND_ALLY);
+        PLAYER(SPECIES_DELPHOX) { Speed(1); Ability(ABILITY_MAGICIAN); }
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); Item(ITEM_POKE_BALL); }
+        OPPONENT(SPECIES_MUK) { Speed(4); HP(stickyHoldTargetFaints ? 1 : 600); Ability(ABILITY_STICKY_HOLD); Item(ITEM_GREAT_BALL); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(3); Item(ITEM_ULTRA_BALL); }
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_SURF); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SURF, playerLeft);
+        if (stickyHoldTargetFaints)
+            ABILITY_POPUP(playerLeft, ABILITY_MAGICIAN);
+        else
+            NOT ABILITY_POPUP(playerLeft, ABILITY_MAGICIAN);
+    } THEN {
+        EXPECT_EQ(playerLeft->item, stickyHoldTargetFaints ? ITEM_GREAT_BALL : ITEM_NONE);
+        EXPECT_EQ(playerRight->item, ITEM_POKE_BALL);
+        EXPECT_EQ(opponentLeft->item, stickyHoldTargetFaints ? ITEM_NONE : ITEM_GREAT_BALL);
+        EXPECT_EQ(opponentRight->item, ITEM_ULTRA_BALL);
+    }
+}
+
+SINGLE_BATTLE_TEST("Magician does not activate with Fling")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_FLING) == EFFECT_FLING);
+        PLAYER(SPECIES_DELPHOX) { Ability(ABILITY_MAGICIAN); Item(ITEM_PECHA_BERRY); }
+        OPPONENT(SPECIES_BLISSEY) { Item(ITEM_POKE_BALL); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_FLING); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FLING, player);
+        NOT ABILITY_POPUP(player, ABILITY_MAGICIAN);
+    } THEN {
+        EXPECT_EQ(player->item, ITEM_NONE);
+        EXPECT_EQ(opponent->item, ITEM_POKE_BALL);
+    }
+}
+
+SINGLE_BATTLE_TEST("Magician does not activate with Natural Gift")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_NATURAL_GIFT) == EFFECT_NATURAL_GIFT);
+        PLAYER(SPECIES_DELPHOX) { Ability(ABILITY_MAGICIAN); Item(ITEM_PECHA_BERRY); }
+        OPPONENT(SPECIES_BLISSEY) { Item(ITEM_POKE_BALL); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_NATURAL_GIFT); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_NATURAL_GIFT, player);
+        NOT ABILITY_POPUP(player, ABILITY_MAGICIAN);
+    } THEN {
+        EXPECT_EQ(player->item, ITEM_NONE);
+        EXPECT_EQ(opponent->item, ITEM_POKE_BALL);
     }
 }
 
@@ -61,11 +144,11 @@ SINGLE_BATTLE_TEST("Magician does not activate with Future Sight or Doom Desire"
         PLAYER(SPECIES_DELPHOX) { Ability(ABILITY_MAGICIAN); }
         OPPONENT(SPECIES_BLISSEY) { Item(ITEM_POKE_BALL); }
     } WHEN {
-        TURN { MOVE(player, MOVE_DOOM_DESIRE); }
+        TURN { MOVE(player, MOVE_FUTURE_SIGHT); }
         TURN {}
         TURN {}
     } SCENE {
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_DOOM_DESIRE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FUTURE_SIGHT, player);
         NOT ABILITY_POPUP(player, ABILITY_MAGICIAN);
     } THEN {
         EXPECT_EQ(player->item, ITEM_NONE);

--- a/test/battle/ability/magician.c
+++ b/test/battle/ability/magician.c
@@ -55,6 +55,28 @@ DOUBLE_BATTLE_TEST("Magician prioritizes opponents over allies among valid targe
     }
 }
 
+DOUBLE_BATTLE_TEST("Magician follows Trick Room order when choosing between foe targets")
+{
+    GIVEN {
+        ASSUME(GetMoveTarget(MOVE_SURF) == TARGET_FOES_AND_ALLY);
+        ASSUME(GetMoveEffect(MOVE_TRICK_ROOM) == EFFECT_TRICK_ROOM);
+        PLAYER(SPECIES_DELPHOX) { Speed(3); Ability(ABILITY_MAGICIAN); }
+        PLAYER(SPECIES_WOBBUFFET) { Speed(5); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(4); Item(ITEM_GREAT_BALL); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(2); Item(ITEM_ULTRA_BALL); }
+    } WHEN {
+        TURN { MOVE(playerRight, MOVE_TRICK_ROOM); }
+        TURN { MOVE(playerLeft, MOVE_SURF); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TRICK_ROOM, playerRight);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SURF, playerLeft);
+        ABILITY_POPUP(playerLeft, ABILITY_MAGICIAN);
+    } THEN {
+        // Under Trick Room, the slower foe should be chosen first.
+        EXPECT_EQ(playerLeft->item, ITEM_ULTRA_BALL);
+    }
+}
+
 DOUBLE_BATTLE_TEST("Magician can steal from ally if no opponent is a valid target")
 {
     GIVEN {

--- a/test/battle/ability/magician.c
+++ b/test/battle/ability/magician.c
@@ -108,7 +108,7 @@ SINGLE_BATTLE_TEST("Magician does not activate with Fling")
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_FLING) == EFFECT_FLING);
         PLAYER(SPECIES_DELPHOX) { Ability(ABILITY_MAGICIAN); Item(ITEM_PECHA_BERRY); }
-        OPPONENT(SPECIES_BLISSEY) { Item(ITEM_POKE_BALL); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_POKE_BALL); }
     } WHEN {
         TURN { MOVE(player, MOVE_FLING); }
     } SCENE {
@@ -125,7 +125,7 @@ SINGLE_BATTLE_TEST("Magician does not activate with Natural Gift")
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_NATURAL_GIFT) == EFFECT_NATURAL_GIFT);
         PLAYER(SPECIES_DELPHOX) { Ability(ABILITY_MAGICIAN); Item(ITEM_PECHA_BERRY); }
-        OPPONENT(SPECIES_BLISSEY) { Item(ITEM_POKE_BALL); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_POKE_BALL); }
     } WHEN {
         TURN { MOVE(player, MOVE_NATURAL_GIFT); }
     } SCENE {
@@ -142,7 +142,7 @@ SINGLE_BATTLE_TEST("Magician does not activate with Future Sight or Doom Desire"
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_FUTURE_SIGHT) == EFFECT_FUTURE_SIGHT);
         PLAYER(SPECIES_DELPHOX) { Ability(ABILITY_MAGICIAN); }
-        OPPONENT(SPECIES_BLISSEY) { Item(ITEM_POKE_BALL); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_POKE_BALL); }
     } WHEN {
         TURN { MOVE(player, MOVE_FUTURE_SIGHT); }
         TURN {}
@@ -153,5 +153,62 @@ SINGLE_BATTLE_TEST("Magician does not activate with Future Sight or Doom Desire"
     } THEN {
         EXPECT_EQ(player->item, ITEM_NONE);
         EXPECT_EQ(opponent->item, ITEM_POKE_BALL);
+    }
+}
+
+SINGLE_BATTLE_TEST("Magician activates after the last hit of a multi-hit move")
+{
+    GIVEN {
+        ASSUME(GetMoveStrikeCount(MOVE_DOUBLE_KICK) == 2);
+        PLAYER(SPECIES_DELPHOX) { Ability(ABILITY_MAGICIAN); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_POKE_BALL); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_DOUBLE_KICK); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DOUBLE_KICK, player);
+        HP_BAR(opponent);
+        HP_BAR(opponent);
+        ABILITY_POPUP(player, ABILITY_MAGICIAN);
+    } THEN {
+        EXPECT_EQ(player->item, ITEM_POKE_BALL);
+        EXPECT_EQ(opponent->item, ITEM_NONE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Magician steals before switching with U-turn")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_U_TURN) == EFFECT_HIT_ESCAPE);
+        PLAYER(SPECIES_DELPHOX) { Ability(ABILITY_MAGICIAN); }
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_POKE_BALL); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_U_TURN); SEND_OUT(player, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_U_TURN, player);
+        HP_BAR(opponent);
+        ABILITY_POPUP(player, ABILITY_MAGICIAN);
+        SEND_IN_MESSAGE("Wynaut");
+    } THEN {
+        EXPECT_EQ(opponent->item, ITEM_NONE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Magician does not activate if user faints from Rocky Helmet recoil")
+{
+    GIVEN {
+        ASSUME(gItemsInfo[ITEM_ROCKY_HELMET].holdEffect == HOLD_EFFECT_ROCKY_HELMET);
+        PLAYER(SPECIES_DELPHOX) { HP(1); Ability(ABILITY_MAGICIAN); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_ROCKY_HELMET); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SCRATCH); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        HP_BAR(opponent);
+        HP_BAR(player);
+        NOT ABILITY_POPUP(player, ABILITY_MAGICIAN);
+    } THEN {
+        EXPECT_EQ(player->item, ITEM_NONE);
+        EXPECT_EQ(opponent->item, ITEM_ROCKY_HELMET);
     }
 }

--- a/test/battle/ability/magician.c
+++ b/test/battle/ability/magician.c
@@ -53,3 +53,22 @@ DOUBLE_BATTLE_TEST("Magician steal the item from the fastest possible target")
             EXPECT(playerLeft->item == ITEM_ULTRA_BALL);
     }
 }
+
+SINGLE_BATTLE_TEST("Magician does not activate with Future Sight or Doom Desire")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_FUTURE_SIGHT) == EFFECT_FUTURE_SIGHT);
+        PLAYER(SPECIES_DELPHOX) { Ability(ABILITY_MAGICIAN); }
+        OPPONENT(SPECIES_BLISSEY) { Item(ITEM_POKE_BALL); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_DOOM_DESIRE); }
+        TURN {}
+        TURN {}
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DOOM_DESIRE, player);
+        NOT ABILITY_POPUP(player, ABILITY_MAGICIAN);
+    } THEN {
+        EXPECT_EQ(player->item, ITEM_NONE);
+        EXPECT_EQ(opponent->item, ITEM_POKE_BALL);
+    }
+}


### PR DESCRIPTION
## Description
[Magician](https://wiki.pokemonwiki.com/wiki/%e3%83%9e%e3%82%b8%e3%82%b7%e3%83%a3%e3%83%b3)
> 全体攻撃技で複数のポケモンに同時にダメージを与えた場合、1. 敵のすばやさが高いポケモン → 2. 敵のすばやさが低いポケモン → 3. 味方のポケモン、という優先順位で道具を奪う相手が選ばれる。
> - トリックルームなどによるすばやさ補正の効果を考慮する。
> - 道具を持っていない相手、ダメージを与えられなかった相手、みがわりで防がれた相手、上記の奪えない道具を持つ相手は省いて考慮する。
> - 一番優先されたポケモンが特性ねんちゃくであるときはマジシャンの効果は防がれる。

When dealing damage to multiple Pokémon simultaneously with a move that hits all adjacent foes, the target from which to steal an item is selected in the following priority order:
**1. Opponent with high Speed → 2. Opponent with low Speed → 3. Ally Pokémon.**

- Speed modifications caused by effects such as **Trick Room** are taken into account.
- Opponents that are not holding an item, those that did not take damage, those that protected themselves with Substitute, or those holding an item that cannot be stolen (as mentioned above) are excluded from consideration.
- If the highest-priority Pokémon has the Ability **Sticky Hold**, the effect of Magician is prevented(**Unless the Sticky Hold target is knocked down**).

## Basis for other tests

> - 連続攻撃技は最後の攻撃が当たってから道具を奪う。
> - とんぼがえり/ボルトチェンジ/クイックターンを使用したときは相手の道具を奪ってから交代する。
> - 反動ダメージや、…持ち物ゴツゴツメットなどのダメージで自身がひんしになった場合、道具は奪えない。

- For multi-hit moves, the item is stolen after the last hit lands.
- When using U-turn / Volt Switch / Flip Turn, it steals the target’s item before switching out.
- If the user faints due to recoil damage or damage from an item such as Rocky Helmet, it cannot steal the item.

## Issue(s) that this PR fixes
Fix #8170 