### PR TITLE
Battle Main: Reset fishing counter if fishing battle was against a shiny pokemon

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -5581,7 +5581,7 @@ static void FreeResetData_ReturnToOvOrDoEvolutions(void)
 {
     if (!gPaletteFade.active)
     {
-        if (gIsFishingEncounter && IsMonShiny(&gEnemyParty[0]))
+        if (gIsFishingEncounter && IsMonShiny(&gParties[B_TRAINER_1][0]))
             gChainFishingDexNavStreak = 0;
         gIsFishingEncounter = FALSE;
         gIsSurfingEncounter = FALSE;

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -5581,6 +5581,8 @@ static void FreeResetData_ReturnToOvOrDoEvolutions(void)
 {
     if (!gPaletteFade.active)
     {
+        if (gIsFishingEncounter && IsMonShiny(&gEnemyParty[0]))
+            gChainFishingDexNavStreak = 0;
         gIsFishingEncounter = FALSE;
         gIsSurfingEncounter = FALSE;
         if (gDexNavSpecies && (gBattleOutcome == B_OUTCOME_WON || gBattleOutcome == B_OUTCOME_CAUGHT))


### PR DESCRIPTION
This is in line with Gen 6's actual behavior of resetting the chain once the shiny is on the hook.

### Large Language Models (AI)
<!-- Does your pull request contain code or assets generated by a large language model (AI)? If so, where? --> No.
<!-- NOTE: There is an expectation that you have fully reviewed your code to ensure it meets all merge criteria (detailed above). -->
<!-- If the maintainers believe that a pull request was generated by AI with no or little to no human oversight, the pull request will be closed without further discussion. -->

<!-- CREDITS -->
<!-- Once your PR is submitted, leave a comment asking the bot to add you to the credits. -->
<!-- If anybody helped with this PR, please encourage them to comment on your PR and ask the bot to add them to the credits. -->
<!-- If somebody has contributed at any point and has indicated they wish to be credited, please ask the bot to add them to the credits. If they do not have a known GitHub account, add them to the list at bottom of `CREDITS.md`. -->
<!-- EVERY contribution matters! -->
<!-- https://github.com/rh-hideout/pokeemerald-expansion/wiki/CREDITS.md-Frequently-Asked-Questions -->

## Things to note in the release changelog:
<!-- Add any important details for the release changelog. Must be structed as bullet points. --->
<!--- Remove this section if not applicable. --->

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->RoseFromTheAshs
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
