### PR TITLE
Fix frlg intro trying to create too many sprites

### DIFF
--- a/src/title_screen_frlg.c
+++ b/src/title_screen_frlg.c
@@ -1024,9 +1024,9 @@ static bool32 CreateFlameSprite(s32 x, s32 y, s32 xspeed, s32 yspeed, bool32 cre
 {
     u8 spriteId;
     if (createFlame)
-        spriteId = CreateSprite(&sSpriteTemplate_FlameOrLeaf, x, y, 0);
+        spriteId = CreateSpriteUnchecked(&sSpriteTemplate_FlameOrLeaf, x, y, 0);
     else
-        spriteId = CreateSprite(&sSpriteTemplate_BlankFlame, x, y, 0);
+        spriteId = CreateSpriteUnchecked(&sSpriteTemplate_BlankFlame, x, y, 0);
 
     if (spriteId != MAX_SPRITES)
     {


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
The intro for FRLG is creating too many sprites for the engine to handle and was causing an `assertf` error if idling on the intro screen.
But it has built-in checking if the return value is `MAX_SPRITES`, therefore the `CreateSpriteUnchecked` function can be used.

### Large Language Models (AI)
<!-- Does your pull request contain code or assets generated by a large language model (AI)? If so, where? -->
<!-- NOTE: There is an expectation that you have fully reviewed your code to ensure it meets all merge criteria (detailed above). -->
<!-- If the maintainers believe that a pull request was generated by AI with no or little to no human oversight, the pull request will be closed without further discussion. -->
No

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara