### PR TITLE
Adjust documentation for poke balls in trainer parties

### DIFF
--- a/src/data/trainers.party
+++ b/src/data/trainers.party
@@ -46,7 +46,7 @@ Optional fields for Pokemon:
           (Order does not matter)
     - EVs (252 HP / 128 Spe / 48 Def, defaults to all 0, is not capped at 512 total)
           (Order does not matter)
-    - Ball (Poke Ball or ITEM_POKE_BALL, defaults to Poke Ball)
+    - Ball (Poke, Great, Master, Dive, etc.; defaults to Poke)
     - Happiness (Number between 1 and 255)
     - Nature (Rash or NATURE_RASH, defaults to Hardy)
     - Shiny (Yes/No, defaults to No)


### PR DESCRIPTION
## Description
As discused with @mrgriffin on discord earlier!
The ITEM-route doesn't work at all anymore, and the "Ball" at the end is superfluous.
Instead opted to provide a few examples.

I also tested all the other keywords (Happiness, Nature, Tera Type, etc.) to see if they all worked according to documentation.
Seemed to be working fine, no issues during `make`.

### Large Language Models (AI)
No.

## Discord contact info
blusunrize