### PR TITLE
-Wc11-c2x-compat on RHH CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,10 @@ ifeq ($(DEPRECATED_ERROR),0)
   endif
 endif
 
+ifeq ($(GITHUB_REPOSITORY_OWNER),rh-hideout)
+  override CFLAGS += -Werror=free-labels
+endif
+
 LIBPATH := -L "$(dir $(shell $(PATH_ARMCC) -mthumb -print-file-name=libgcc.a))" -L "$(dir $(shell $(PATH_ARMCC) -mthumb -print-file-name=libnosys.a))" -L "$(dir $(shell $(PATH_ARMCC) -mthumb -print-file-name=libc.a))"
 LIB := $(LIBPATH) -lc -lnosys -lgcc -L../../libagbsyscall -lagbsyscall
 # Enable debug info if set

--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ ifeq ($(DEPRECATED_ERROR),0)
 endif
 
 ifeq ($(GITHUB_REPOSITORY_OWNER),rh-hideout)
-  override CFLAGS += -Werror=free-labels
+  override CFLAGS += -Werror=c11-c2x-compat
 endif
 
 LIBPATH := -L "$(dir $(shell $(PATH_ARMCC) -mthumb -print-file-name=libgcc.a))" -L "$(dir $(shell $(PATH_ARMCC) -mthumb -print-file-name=libnosys.a))" -L "$(dir $(shell $(PATH_ARMCC) -mthumb -print-file-name=libc.a))"


### PR DESCRIPTION
Many users have compilers that will reject a declaration immediately following a label. On GCC 15 there's `-Wfree-labels` to detect this, so I've enabled that on our CI only.
EDIT: Turns out (based on the build errors) that we have GCC 13.2.1 and so `-Wfree-labels` doesn't exist. [`-Wc11-c23-compat`](<https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wc11-c23-compat>) probably exists, but is broader and perhaps in a way that catches things it doesn't need to?

Should hopefully prevent issues like #9830 going forward.