### PR TITLE
Remove SaveBlock/PokemonStorage ASLR/Encryption

### DIFF
--- a/include/config/general.h
+++ b/include/config/general.h
@@ -50,6 +50,9 @@
 #endif
 #endif
 
+// Change to TRUE to print memory leaks on InitHeap.
+#define REPORT_MEMORY_LEAKS FALSE
+
 // Compatibility definition for other projects to detect pokeemerald-expansion
 #define RHH_EXPANSION
 

--- a/include/global.h
+++ b/include/global.h
@@ -274,8 +274,6 @@ struct SaveBlock3
 #endif
 }; /* max size 1624 bytes */
 
-extern struct SaveBlock3 *gSaveBlock3Ptr;
-
 struct Pokedex
 {
     /*0x00*/ u8 order;
@@ -625,8 +623,6 @@ struct SaveBlock2
     /*0x64C*/ struct BattleFrontier frontier;
 }; // sizeof=0xF2C
 
-extern struct SaveBlock2 *gSaveBlock2Ptr;
-
 extern u8 UpdateSpritePaletteWithTime(u8);
 
 struct SecretBaseParty
@@ -663,6 +659,7 @@ struct SecretBase
 #include "global.berry.h"
 #include "global.tv.h"
 #include "pokemon.h"
+#include "load_save.h"
 
 struct WarpData
 {
@@ -1212,8 +1209,6 @@ struct SaveBlock1
 #endif
     // sizeof: 0x3???
 };
-
-extern struct SaveBlock1 *gSaveBlock1Ptr;
 
 struct MapPosition
 {

--- a/include/item.h
+++ b/include/item.h
@@ -104,7 +104,7 @@ struct TmHmIndexKey
 
 extern const u8 gQuestionMarksItemName[];
 extern const struct ItemInfo gItemsInfo[];
-extern struct BagPocket gBagPockets[];
+extern const struct BagPocket gBagPockets[];
 extern const struct TmHmIndexKey gTMHMItemMoveIds[];
 
 #define UNPACK_ITEM_TO_TM_INDEX(_tm) case CAT(ITEM_TM_, _tm): return CAT(ENUM_TM_HM_, _tm) + 1;
@@ -212,10 +212,10 @@ static inline enum Item BerryTypeToItemId(enum BerryId berryId)
 #undef GET_BERRY_ID
 #undef GET_BERRY_ITEM_ID
 
-void BagPocket_SetSlotData(struct BagPocket *pocket, u32 pocketPos, struct ItemSlot newSlot);
-struct ItemSlot BagPocket_GetSlotData(struct BagPocket *pocket, u32 pocketPos);
+void BagPocket_SetSlotData(const struct BagPocket *pocket, u32 pocketPos, struct ItemSlot newSlot);
+struct ItemSlot BagPocket_GetSlotData(const struct BagPocket *pocket, u32 pocketPos);
 
-static inline void BagPocket_SetSlotItemIdAndCount(struct BagPocket *pocket, u32 pocketPos, enum Item itemId, u16 quantity)
+static inline void BagPocket_SetSlotItemIdAndCount(const struct BagPocket *pocket, u32 pocketPos, enum Item itemId, u16 quantity)
 {
     BagPocket_SetSlotData(pocket, pocketPos, (struct ItemSlot) {itemId, quantity});
 }
@@ -236,7 +236,6 @@ static inline struct ItemSlot GetBagItemIdAndQuantity(enum Pocket pocketId, u32 
 }
 
 void ApplyNewEncryptionKeyToBagItems(u32 newKey);
-void SetBagItemsPointers(void);
 u8 *CopyItemName(enum Item itemId, u8 *dst);
 u8 *CopyItemNameHandlePlural(enum Item itemId, u8 *dst, u32 quantity);
 bool32 IsBagPocketNonEmpty(enum Pocket pocketId);
@@ -247,7 +246,7 @@ bool32 CheckBagHasSpace(enum Item itemId, u16 count);
 u32 GetFreeSpaceForItemInBag(enum Item itemId);
 bool32 AddBagItem(enum Item itemId, u16 count);
 bool32 RemoveBagItem(enum Item itemId, u16 count);
-void RemoveBagItemFromSlot(struct BagPocket *pocket, u16 slotId, u16 count);
+void RemoveBagItemFromSlot(const struct BagPocket *pocket, u16 slotId, u16 count);
 u8 CountUsedPCItemSlots(void);
 bool32 CheckPCHasItem(enum Item itemId, u16 count);
 bool32 AddPCItem(enum Item itemId, u16 count);

--- a/include/item_menu.h
+++ b/include/item_menu.h
@@ -122,6 +122,6 @@ void DisplayItemMessage(u8 taskId, u8 fontId, const u8 *str, TaskFunc callback);
 void DisplayItemMessageOnField(u8 taskId, const u8 *string, TaskFunc callback);
 void CloseItemMessage(u8 taskId);
 void CB2_ChooseBall(void);
-void SortItemsInBag(struct BagPocket *pocket, enum BagSortOptions type);
+void SortItemsInBag(const struct BagPocket *pocket, enum BagSortOptions type);
 
 #endif //GUARD_ITEM_MENU_H

--- a/include/load_save.h
+++ b/include/load_save.h
@@ -21,7 +21,6 @@ void ClearSav3(void);
 void ClearSav2(void);
 void ClearSav1(void);
 void SetSaveBlocksPointers();
-void RotateEncryptionKey_ResetHeap(void);
 u32 UseContinueGameWarp(void);
 void ClearContinueGameWarpStatus(void);
 void SetContinueGameWarpStatus(void);
@@ -37,5 +36,7 @@ void LoadPlayerBag(void);
 void SavePlayerBag(void);
 void ApplyNewEncryptionKeyToHword(u16 *hWord, u32 newKey);
 void ApplyNewEncryptionKeyToWord(u32 *word, u32 newKey);
+void EncryptSave(void);
+void DecryptSave(void);
 
 #endif // GUARD_LOAD_SAVE_H

--- a/include/load_save.h
+++ b/include/load_save.h
@@ -4,44 +4,24 @@
 #include "pokemon_storage_system.h"
 #include "save.h"
 
-#define SAVEBLOCK_MOVE_RANGE    128
+extern struct SaveBlock1 gSaveBlock1;
+extern struct SaveBlock2 gSaveBlock2;
+extern struct SaveBlock3 gSaveBlock3;
+extern struct PokemonStorage gPokemonStorage;
 
-/**
- * These structs are to prevent them from being reordered on newer or modern
- * toolchains. If this is not done, the ClearSav functions will end up erasing
- * the wrong memory leading to various glitches.
- */
-struct SaveBlock2ASLR {
-    struct SaveBlock2 block;
-    u8 aslr[SAVEBLOCK_MOVE_RANGE];
-};
-
-struct SaveBlock1ASLR {
-    struct SaveBlock1 block;
-    u8 aslr[SAVEBLOCK_MOVE_RANGE];
-};
-
-struct PokemonStorageASLR {
-    struct PokemonStorage block;
-    u8 aslr[SAVEBLOCK_MOVE_RANGE];
-};
-
-extern struct SaveBlock1ASLR gSaveblock1;
-extern struct SaveBlock2ASLR gSaveblock2;
-extern struct SaveBlock3 gSaveblock3;
-extern struct PokemonStorageASLR gPokemonStorage;
+#define gSaveBlock1Ptr (&gSaveBlock1)
+#define gSaveBlock2Ptr (&gSaveBlock2)
+#define gSaveBlock3Ptr (&gSaveBlock3)
+#define gPokemonStoragePtr (&gPokemonStorage)
 
 extern bool32 gFlashMemoryPresent;
-extern struct SaveBlock1 *gSaveBlock1Ptr;
-extern struct SaveBlock2 *gSaveBlock2Ptr;
-extern struct PokemonStorage *gPokemonStoragePtr;
 
 void CheckForFlashMemory(void);
 void ClearSav3(void);
 void ClearSav2(void);
 void ClearSav1(void);
-void SetSaveBlocksPointers(u16 offset);
-void MoveSaveBlocks_ResetHeap(void);
+void SetSaveBlocksPointers();
+void RotateEncryptionKey_ResetHeap(void);
 u32 UseContinueGameWarp(void);
 void ClearContinueGameWarpStatus(void);
 void SetContinueGameWarpStatus(void);

--- a/include/malloc.h
+++ b/include/malloc.h
@@ -67,6 +67,7 @@ void *AllocZeroed_(u32 size, const char *location);
 void *AllocZeroedUnchecked_(u32 size, const char *location);
 void Free(void *pointer);
 void InitHeap(void *heapStart, u32 heapSize);
+void ResetHeap(void);
 void PrintHeap(void);
 
 const struct MemBlock *HeapHead(void);

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -273,10 +273,18 @@ struct BoxPokemon
     u16 shinyModifier:1;
     u16 unused_1E:1;
 
-    union
+    union BoxPokemonSecure
     {
         u32 raw[(NUM_SUBSTRUCT_BYTES * 4) / 4]; // *4 because there are 4 substructs, /4 because it's u32, not u8
-        union PokemonSubstruct substructs[4];
+
+        union PokemonSubstruct substructs[4] __attribute__((deprecated("Use substruct0 instead of substructs[i].type0, etc")));
+
+        struct {
+            struct PokemonSubstruct0 substruct0;
+            struct PokemonSubstruct1 substruct1;
+            struct PokemonSubstruct2 substruct2;
+            struct PokemonSubstruct3 substruct3;
+        };
     } secure;
 };
 

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -39,7 +39,6 @@ enum MonData {
     MON_DATA_HIDDEN_NATURE,
     MON_DATA_HP_LOST,
     MON_DATA_DAYS_SINCE_FORM_CHANGE,
-    MON_DATA_ENCRYPT_SEPARATOR,
     MON_DATA_NICKNAME,
     MON_DATA_NICKNAME10,
     MON_DATA_SPECIES,
@@ -955,6 +954,10 @@ struct BoxPokemon *GetSelectedBoxMonFromPcOrParty(void);
 u32 GiveScriptedMonToPlayer(struct Pokemon *mon, u8 slot);
 void ChangePokemonNicknameWithCallback(void (*callback)(void));
 bool32 HasShedinjaHPHandling(enum Species species);
+void EncryptMon(struct Pokemon *mon);
+void DecryptMon(struct Pokemon *mon);
+void EncryptBoxMon(struct BoxPokemon *boxMon);
+void DecryptBoxMon(struct BoxPokemon *boxMon);
 
 static inline u32 OWE_GetMovementTypeFromSpecies(enum Species speciesId)
 {

--- a/include/pokemon_storage_system.h
+++ b/include/pokemon_storage_system.h
@@ -26,8 +26,6 @@ struct PokemonStorage
     /*0x8432*/ struct Pokemon fusions[MAX_FUSION_STORAGE];
 };
 
-extern struct PokemonStorage *gPokemonStoragePtr;
-
 void DrawTextWindowAndBufferTiles(const u8 *string, void *dst, u8 zero1, u8 zero2, s32 bytesToBuffer);
 u8 CountMonsInBox(u8 boxId);
 s16 GetFirstFreeBoxSpot(u8 boxId);

--- a/include/save.h
+++ b/include/save.h
@@ -105,7 +105,6 @@ bool8 LinkFullSave_SetLastSectorSignature(void);
 bool8 WriteSaveBlock2(void);
 bool8 WriteSaveBlock1Sector(void);
 u8 LoadGameSave(u8 saveType);
-u16 GetSaveBlocksPointersBaseOffset(void);
 u32 TryReadSpecialSaveSector(u8 sector, u8 *dst);
 u32 TryWriteSpecialSaveSector(u8 sector, u8 *src);
 void Task_LinkFullSave(u8 taskId);

--- a/include/test/test.h
+++ b/include/test/test.h
@@ -228,6 +228,9 @@ static inline struct Benchmark BenchmarkStop(void)
 // us to be confident that it's faster than another.
 #define BENCHMARK_REL 95
 
+// An (under-)approximation of how many ticks are in a frame.
+#define FRAME_TICKS (280896 / 64)
+
 #define EXPECT_FASTER(a, b) \
     do \
     { \

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -475,7 +475,7 @@ const u8 *const gStatusConditionStringsTable[][2] =
 void CB2_InitBattle(void)
 {
     if (!gTestRunnerEnabled)
-        RotateEncryptionKey_ResetHeap();
+        ResetHeap();
     AllocateBattleResources();
     AllocateBattleSpritesData();
     AllocateMonSpritesGfx();

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -475,7 +475,7 @@ const u8 *const gStatusConditionStringsTable[][2] =
 void CB2_InitBattle(void)
 {
     if (!gTestRunnerEnabled)
-        MoveSaveBlocks_ResetHeap();
+        RotateEncryptionKey_ResetHeap();
     AllocateBattleResources();
     AllocateBattleSpritesData();
     AllocateMonSpritesGfx();

--- a/src/crt0.s
+++ b/src/crt0.s
@@ -7,12 +7,14 @@
 	.align 2, 0
 Init::
 @ Set up location for IRQ stack
-	mov r0, #PSR_IRQ_MODE
-	msr cpsr_cf, r0
+	msr cpsr_c, #PSR_IRQ_MODE
 	ldr sp, sp_irq
-@ Set up location for system stack
-	mov r0, #PSR_SYS_MODE
-	msr cpsr_cf, r0
+@ Set up location for FIQ stack, and set its spsr to return to SYS in Thumb
+	msr cpsr_c, #PSR_FIQ_MODE
+	msr spsr_c, #(PSR_SYS_MODE | PSR_T_BIT)
+	ldr sp, sp_irq
+@ Set up location for SYS stack
+	msr cpsr_cf, #PSR_SYS_MODE
 	ldr sp, sp_sys
 @ Dispatch memory reset request to hardware
 	mov r0, #255 @ RESET_ALL

--- a/src/intro.c
+++ b/src/intro.c
@@ -1140,7 +1140,7 @@ void CB2_InitCopyrightScreenAfterBootup(void)
 {
     if (!SetUpCopyrightScreen())
     {
-        SetSaveBlocksPointers(GetSaveBlocksPointersBaseOffset());
+        SetSaveBlocksPointers();
         ResetMenuAndMonGlobals();
         Save_ResetSaveCounters();
         LoadGameSave(SAVE_NORMAL);

--- a/src/item.c
+++ b/src/item.c
@@ -33,11 +33,43 @@ static bool32 CheckPyramidBagHasItem(enum Item itemId, u16 count);
 static bool32 CheckPyramidBagHasSpace(enum Item itemId, u16 count);
 static const u8 *GetItemPluralName(enum Item);
 static bool32 DoesItemHavePluralName(enum Item);
-static void NONNULL BagPocket_CompactItems(struct BagPocket *pocket);
+static void NONNULL BagPocket_CompactItems(const struct BagPocket *pocket);
 static enum Item SanitizeItemId(enum Item itemId);
 static enum Item SanitizeBagItemId(enum Item itemId);
 
-EWRAM_DATA struct BagPocket gBagPockets[POCKETS_COUNT] = {0};
+const struct BagPocket gBagPockets[POCKETS_COUNT] =
+{
+    [POCKET_ITEMS] =
+    {
+        .id = POCKET_ITEMS,
+        .capacity = BAG_ITEMS_COUNT,
+        .itemSlots = gSaveBlock1.bag.items,
+    },
+    [POCKET_KEY_ITEMS] =
+    {
+        .id = POCKET_KEY_ITEMS,
+        .capacity = BAG_KEYITEMS_COUNT,
+        .itemSlots = gSaveBlock1.bag.keyItems,
+    },
+    [POCKET_POKE_BALLS] =
+    {
+        .id = POCKET_POKE_BALLS,
+        .capacity = BAG_POKEBALLS_COUNT,
+        .itemSlots = gSaveBlock1.bag.pokeBalls,
+    },
+    [POCKET_TM_HM] =
+    {
+        .id = POCKET_TM_HM,
+        .capacity = BAG_TMHM_COUNT,
+        .itemSlots = gSaveBlock1.bag.TMsHMs,
+    },
+    [POCKET_BERRIES] =
+    {
+        .id = POCKET_BERRIES,
+        .capacity = BAG_BERRIES_COUNT,
+        .itemSlots = gSaveBlock1.bag.berries,
+    },
+};
 
 #include "data/pokemon/item_effects.h"
 #include "data/items.h"
@@ -63,7 +95,7 @@ const struct TmHmIndexKey gTMHMItemMoveIds[NUM_ALL_MACHINES + 1] =
 #undef UNPACK_TM_ITEM_ID
 #undef UNPACK_HM_ITEM_ID
 
-static inline struct ItemSlot NONNULL BagPocket_GetSlotDataGeneric(struct BagPocket *pocket, u32 pocketPos)
+static inline struct ItemSlot NONNULL BagPocket_GetSlotDataGeneric(const struct BagPocket *pocket, u32 pocketPos)
 {
     return (struct ItemSlot) {
         .itemId = pocket->itemSlots[pocketPos].itemId,
@@ -71,7 +103,7 @@ static inline struct ItemSlot NONNULL BagPocket_GetSlotDataGeneric(struct BagPoc
     };
 }
 
-static inline struct ItemSlot NONNULL BagPocket_GetSlotDataPC(struct BagPocket *pocket, u32 pocketPos)
+static inline struct ItemSlot NONNULL BagPocket_GetSlotDataPC(const struct BagPocket *pocket, u32 pocketPos)
 {
     return (struct ItemSlot) {
         .itemId = pocket->itemSlots[pocketPos].itemId,
@@ -79,19 +111,19 @@ static inline struct ItemSlot NONNULL BagPocket_GetSlotDataPC(struct BagPocket *
     };
 }
 
-static inline void NONNULL BagPocket_SetSlotDataGeneric(struct BagPocket *pocket, u32 pocketPos, struct ItemSlot newSlot)
+static inline void NONNULL BagPocket_SetSlotDataGeneric(const struct BagPocket *pocket, u32 pocketPos, struct ItemSlot newSlot)
 {
     pocket->itemSlots[pocketPos].itemId = newSlot.itemId;
     pocket->itemSlots[pocketPos].quantity = newSlot.quantity ^ gSaveBlock2Ptr->encryptionKey;
 }
 
-static inline void NONNULL BagPocket_SetSlotDataPC(struct BagPocket *pocket, u32 pocketPos, struct ItemSlot newSlot)
+static inline void NONNULL BagPocket_SetSlotDataPC(const struct BagPocket *pocket, u32 pocketPos, struct ItemSlot newSlot)
 {
     pocket->itemSlots[pocketPos].itemId = newSlot.itemId;
     pocket->itemSlots[pocketPos].quantity = newSlot.quantity;
 }
 
-struct ItemSlot NONNULL BagPocket_GetSlotData(struct BagPocket *pocket, u32 pocketPos)
+struct ItemSlot NONNULL BagPocket_GetSlotData(const struct BagPocket *pocket, u32 pocketPos)
 {
     switch (pocket->id)
     {
@@ -108,7 +140,7 @@ struct ItemSlot NONNULL BagPocket_GetSlotData(struct BagPocket *pocket, u32 pock
     return (struct ItemSlot) {0}; // Because compiler complains
 }
 
-void NONNULL BagPocket_SetSlotData(struct BagPocket *pocket, u32 pocketPos, struct ItemSlot newSlot)
+void NONNULL BagPocket_SetSlotData(const struct BagPocket *pocket, u32 pocketPos, struct ItemSlot newSlot)
 {
     if (newSlot.itemId == ITEM_NONE || newSlot.quantity == 0) // Sets to zero if quantity or itemId is zero
     {
@@ -140,29 +172,6 @@ void ApplyNewEncryptionKeyToBagItems(u32 newKey)
         for (item = ITEM_NONE; item < gBagPockets[pocketId].capacity; item++)
             ApplyNewEncryptionKeyToHword(&(gBagPockets[pocketId].itemSlots[item].quantity), newKey);
     }
-}
-
-void SetBagItemsPointers(void)
-{
-    gBagPockets[POCKET_ITEMS].itemSlots = gSaveBlock1Ptr->bag.items;
-    gBagPockets[POCKET_ITEMS].capacity = BAG_ITEMS_COUNT;
-    gBagPockets[POCKET_ITEMS].id = POCKET_ITEMS;
-
-    gBagPockets[POCKET_KEY_ITEMS].itemSlots = gSaveBlock1Ptr->bag.keyItems;
-    gBagPockets[POCKET_KEY_ITEMS].capacity = BAG_KEYITEMS_COUNT;
-    gBagPockets[POCKET_KEY_ITEMS].id = POCKET_KEY_ITEMS;
-
-    gBagPockets[POCKET_POKE_BALLS].itemSlots = gSaveBlock1Ptr->bag.pokeBalls;
-    gBagPockets[POCKET_POKE_BALLS].capacity = BAG_POKEBALLS_COUNT;
-    gBagPockets[POCKET_POKE_BALLS].id = POCKET_POKE_BALLS;
-
-    gBagPockets[POCKET_TM_HM].itemSlots = gSaveBlock1Ptr->bag.TMsHMs;
-    gBagPockets[POCKET_TM_HM].capacity = BAG_TMHM_COUNT;
-    gBagPockets[POCKET_TM_HM].id = POCKET_TM_HM;
-
-    gBagPockets[POCKET_BERRIES].itemSlots = gSaveBlock1Ptr->bag.berries;
-    gBagPockets[POCKET_BERRIES].capacity = BAG_BERRIES_COUNT;
-    gBagPockets[POCKET_BERRIES].id = POCKET_BERRIES;
 }
 
 u8 *CopyItemName(enum Item itemId, u8 *dst)
@@ -201,7 +210,7 @@ bool32 IsBagPocketNonEmpty(enum Pocket pocketId)
     return FALSE;
 }
 
-static bool32 NONNULL BagPocket_CheckHasItem(struct BagPocket *pocket, enum Item itemId, u16 count)
+static bool32 NONNULL BagPocket_CheckHasItem(const struct BagPocket *pocket, enum Item itemId, u16 count)
 {
     struct ItemSlot tempItem;
 
@@ -258,7 +267,7 @@ bool32 CheckBagHasSpace(enum Item itemId, u16 count)
     return GetFreeSpaceForItemInBag(itemId) >= count;
 }
 
-static u32 NONNULL BagPocket_GetFreeSpaceForItem(struct BagPocket *pocket, enum Item itemId)
+static u32 NONNULL BagPocket_GetFreeSpaceForItem(const struct BagPocket *pocket, enum Item itemId)
 {
     u32 spaceForItem = 0;
     struct ItemSlot tempItem;
@@ -282,7 +291,7 @@ u32 GetFreeSpaceForItemInBag(enum Item itemId)
     return BagPocket_GetFreeSpaceForItem(&gBagPockets[GetItemPocket(itemId)], itemId);
 }
 
-static inline bool32 NONNULL CheckSlotAndUpdateCount(struct BagPocket *pocket, enum Item itemId, u32 pocketPos, u32 *nextPocketPos, u16 *count, u16 *tempPocketSlotQuantities)
+static inline bool32 NONNULL CheckSlotAndUpdateCount(const struct BagPocket *pocket, enum Item itemId, u32 pocketPos, u32 *nextPocketPos, u16 *count, u16 *tempPocketSlotQuantities)
 {
     struct ItemSlot tempItem = BagPocket_GetSlotData(pocket, pocketPos);
     if (tempItem.itemId == ITEM_NONE || tempItem.itemId == itemId)
@@ -305,7 +314,7 @@ static inline bool32 NONNULL CheckSlotAndUpdateCount(struct BagPocket *pocket, e
     return FALSE;
 }
 
-static bool32 NONNULL BagPocket_AddItem(struct BagPocket *pocket, enum Item itemId, u16 count)
+static bool32 NONNULL BagPocket_AddItem(const struct BagPocket *pocket, enum Item itemId, u16 count)
 {
     u32 itemLookupIndex, itemAddIndex = 0;
 
@@ -360,7 +369,7 @@ bool32 AddBagItem(enum Item itemId, u16 count)
     return BagPocket_AddItem(&gBagPockets[GetItemPocket(itemId)], itemId, count);
 }
 
-static bool32 NONNULL BagPocket_RemoveItem(struct BagPocket *pocket, enum Item itemId, u16 count)
+static bool32 NONNULL BagPocket_RemoveItem(const struct BagPocket *pocket, enum Item itemId, u16 count)
 {
     u32 itemLookupIndex, itemRemoveIndex = 0, totalQuantity = 0;
     struct ItemSlot tempItem;
@@ -418,13 +427,13 @@ bool32 RemoveBagItem(enum Item itemId, u16 count)
 }
 
 // Unsafe function: Only use with functions that already check the slot and count are valid
-void RemoveBagItemFromSlot(struct BagPocket *pocket, u16 slotId, u16 count)
+void RemoveBagItemFromSlot(const struct BagPocket *pocket, u16 slotId, u16 count)
 {
     struct ItemSlot itemSlot = BagPocket_GetSlotData(pocket, slotId);
     BagPocket_SetSlotItemIdAndCount(pocket, slotId, itemSlot.itemId, itemSlot.quantity - count);
 }
 
-static u8 NONNULL BagPocket_CountUsedItemSlots(struct BagPocket *pocket)
+static u8 NONNULL BagPocket_CountUsedItemSlots(const struct BagPocket *pocket)
 {
     u8 usedSlots = 0;
 
@@ -442,7 +451,7 @@ u8 CountUsedPCItemSlots(void)
     return BagPocket_CountUsedItemSlots(&dummyPocket);
 }
 
-static bool32 NONNULL BagPocket_CheckPocketForItemCount(struct BagPocket *pocket, enum Item itemId, u16 count)
+static bool32 NONNULL BagPocket_CheckPocketForItemCount(const struct BagPocket *pocket, enum Item itemId, u16 count)
 {
     struct ItemSlot tempItem;
 
@@ -467,7 +476,7 @@ bool32 AddPCItem(enum Item itemId, u16 count)
     return BagPocket_AddItem(&dummyPocket, itemId, count);
 }
 
-static void NONNULL BagPocket_CompactItems(struct BagPocket *pocket)
+static void NONNULL BagPocket_CompactItems(const struct BagPocket *pocket)
 {
     struct ItemSlot tempItem;
     u32 slotCursor = 0;
@@ -526,7 +535,7 @@ void CompactItemsInBagPocket(enum Pocket pocketId)
     BagPocket_CompactItems(&gBagPockets[pocketId]);
 }
 
-static inline void NONNULL BagPocket_MoveItemSlot(struct BagPocket *pocket, u32 from, u32 to)
+static inline void NONNULL BagPocket_MoveItemSlot(const struct BagPocket *pocket, u32 from, u32 to)
 {
     if (from != to)
     {
@@ -562,7 +571,7 @@ void ClearBag(void)
     CpuFastFill(0, &gSaveBlock1Ptr->bag, sizeof(struct Bag));
 }
 
-static inline u16 NONNULL BagPocket_CountTotalItemQuantity(struct BagPocket *pocket, enum Item itemId)
+static inline u16 NONNULL BagPocket_CountTotalItemQuantity(const struct BagPocket *pocket, enum Item itemId)
 {
     u32 ownedCount = 0;
     struct ItemSlot tempItem;

--- a/src/item_menu.c
+++ b/src/item_menu.c
@@ -229,7 +229,7 @@ static void ItemMenu_SortByAmount(u8 taskId);
 static void ItemMenu_SortByIndex(u8 taskId);
 static void SortBagItems(u8 taskId);
 static void Task_SortFinish(u8 taskId);
-static void MergeSort(struct BagPocket *pocket, s32 (*comparator)(enum Pocket, struct ItemSlot, struct ItemSlot));
+static void MergeSort(const struct BagPocket *pocket, s32 (*comparator)(enum Pocket, struct ItemSlot, struct ItemSlot));
 static s32 CompareItemsAlphabetically(enum Pocket pocketId, struct ItemSlot item1, struct ItemSlot item2);
 static s32 CompareItemsByMost(enum Pocket pocketId, struct ItemSlot item1, struct ItemSlot item2);
 static s32 CompareItemsByType(enum Pocket pocketId, struct ItemSlot item1, struct ItemSlot item2);
@@ -1159,7 +1159,7 @@ void UpdatePocketItemList(enum Pocket pocketId)
     if (pocketId >= POCKETS_COUNT)
         return; // shouldn't even get here
 
-    struct BagPocket *pocket = &gBagPockets[pocketId];
+    const struct BagPocket *pocket = &gBagPockets[pocketId];
     switch (pocketId)
     {
     case POCKET_TM_HM:
@@ -2886,7 +2886,7 @@ static void Task_SortFinish(u8 taskId)
     }
 }
 
-void SortItemsInBag(struct BagPocket *pocket, enum BagSortOptions type)
+void SortItemsInBag(const struct BagPocket *pocket, enum BagSortOptions type)
 {
     switch (type)
     {
@@ -2905,7 +2905,7 @@ void SortItemsInBag(struct BagPocket *pocket, enum BagSortOptions type)
     }
 }
 
-static inline __attribute__((always_inline)) void Merge(struct BagPocket *pocket, u32 iLeft, u32 iRight, u32 iEnd, struct ItemSlot *dummySlots, s32 (*comparator)(enum Pocket, struct ItemSlot, struct ItemSlot))
+static inline __attribute__((always_inline)) void Merge(const struct BagPocket *pocket, u32 iLeft, u32 iRight, u32 iEnd, struct ItemSlot *dummySlots, s32 (*comparator)(enum Pocket, struct ItemSlot, struct ItemSlot))
 {
     struct ItemSlot item_i, item_j;
     u32 i = iLeft, j = iRight;
@@ -2927,7 +2927,7 @@ static inline __attribute__((always_inline)) void Merge(struct BagPocket *pocket
 }
 
 // Source: https://en.wikipedia.org/wiki/Merge_sort#Bottom-up_implementation
-static void MergeSort(struct BagPocket *pocket, s32 (*comparator)(enum Pocket, struct ItemSlot, struct ItemSlot))
+static void MergeSort(const struct BagPocket *pocket, s32 (*comparator)(enum Pocket, struct ItemSlot, struct ItemSlot))
 {
     struct ItemSlot *dummySlots = AllocZeroed(sizeof(struct ItemSlot) * pocket->capacity);
 

--- a/src/load_save.c
+++ b/src/load_save.c
@@ -20,8 +20,6 @@
 #include "event_data.h"
 #include "constants/event_objects.h"
 
-static void ApplyNewEncryptionKeyToAllEncryptedData(u32 encryptionKey);
-
 #define SAVEBLOCK_MOVE_RANGE    128
 
 struct LoadedSaveData
@@ -37,7 +35,6 @@ EWRAM_DATA struct SaveBlock1 gSaveBlock1 = {0};
 EWRAM_DATA struct PokemonStorage gPokemonStorage = {0};
 
 EWRAM_DATA struct LoadedSaveData gLoadedSaveData = {0};
-EWRAM_DATA u32 gLastEncryptionKey = 0;
 
 // IWRAM common
 COMMON_DATA bool32 gFlashMemoryPresent = 0;
@@ -75,28 +72,6 @@ void ClearSav1(void)
 void SetSaveBlocksPointers(void)
 {
     SetDecorationInventoriesPointers();
-}
-
-void RotateEncryptionKey_ResetHeap(void)
-{
-    // save interrupt functions and turn them off
-    void *vblankCB = gMain.vblankCallback;
-    void *hblankCB = gMain.hblankCallback;
-    gMain.vblankCallback = NULL;
-    gMain.hblankCallback = NULL;
-    gTrainerHillVBlankCounter = NULL;
-
-    // heap was destroyed in the copying process, so reset it
-    InitHeap(gHeap, HEAP_SIZE);
-
-    // restore interrupt functions
-    gMain.hblankCallback = hblankCB;
-    gMain.vblankCallback = vblankCB;
-
-    // create a new encryption key
-    u32 encryptionKey = Random32();
-    ApplyNewEncryptionKeyToAllEncryptedData(encryptionKey);
-    gSaveBlock2Ptr->encryptionKey = encryptionKey;
 }
 
 u32 UseContinueGameWarp(void)
@@ -213,34 +188,14 @@ void CopyPartyAndObjectsFromSave(void)
 
 void LoadPlayerBag(void)
 {
-    int i;
-
-    // load player bag.
     memcpy(&gLoadedSaveData.bag, &gSaveBlock1Ptr->bag, sizeof(struct Bag));
-
-    // load mail.
-    for (i = 0; i < MAIL_COUNT; i++)
-        gLoadedSaveData.mail[i] = gSaveBlock1Ptr->mail[i];
-
-    gLastEncryptionKey = gSaveBlock2Ptr->encryptionKey;
+    memcpy(gLoadedSaveData.mail, gSaveBlock1Ptr->mail, sizeof(gLoadedSaveData.mail));
 }
 
 void SavePlayerBag(void)
 {
-    int i;
-    u32 encryptionKeyBackup;
-
-    // save player bag.
     memcpy(&gSaveBlock1Ptr->bag, &gLoadedSaveData.bag, sizeof(struct Bag));
-
-    // save mail.
-    for (i = 0; i < MAIL_COUNT; i++)
-        gSaveBlock1Ptr->mail[i] = gLoadedSaveData.mail[i];
-
-    encryptionKeyBackup = gSaveBlock2Ptr->encryptionKey;
-    gSaveBlock2Ptr->encryptionKey = gLastEncryptionKey;
-    ApplyNewEncryptionKeyToBagItems(encryptionKeyBackup);
-    gSaveBlock2Ptr->encryptionKey = encryptionKeyBackup; // updated twice?
+    memcpy(gSaveBlock1Ptr->mail, gLoadedSaveData.mail, sizeof(gSaveBlock1Ptr->mail));
 }
 
 void ApplyNewEncryptionKeyToHword(u16 *hWord, u32 newKey)
@@ -255,11 +210,53 @@ void ApplyNewEncryptionKeyToWord(u32 *word, u32 newKey)
     *word ^= newKey;
 }
 
-static void ApplyNewEncryptionKeyToAllEncryptedData(u32 encryptionKey)
+void EncryptSave(void)
 {
-    ApplyNewEncryptionKeyToGameStats(encryptionKey);
-    ApplyNewEncryptionKeyToBagItems(encryptionKey);
-    ApplyNewEncryptionKeyToBerryPowder(encryptionKey);
-    ApplyNewEncryptionKeyToWord(&gSaveBlock1Ptr->money, encryptionKey);
-    ApplyNewEncryptionKeyToHword(&gSaveBlock1Ptr->coins, encryptionKey);
+    for (u32 i = 0; i < ARRAY_COUNT(gSaveBlock1Ptr->playerParty); i++)
+        EncryptMon(&gSaveBlock1Ptr->playerParty[i]);
+    for (u32 i = 0; i < ARRAY_COUNT(gSaveBlock1Ptr->daycare.mons); i++)
+        EncryptBoxMon(&gSaveBlock1Ptr->daycare.mons[i].mon);
+    #if IS_FRLG
+    EncryptBoxMon(&gSaveBlock1Ptr->route5DayCareMon.mon);
+    #endif
+
+    for (u32 i = 0; i < TOTAL_BOXES_COUNT; i++)
+    {
+        for (u32 j = 0; j < IN_BOX_COUNT; j++)
+            EncryptBoxMon(&gPokemonStoragePtr->boxes[i][j]);
+    }
+    for (u32 i = 0; i < ARRAY_COUNT(gPokemonStoragePtr->fusions); i++)
+        EncryptMon(&gPokemonStoragePtr->fusions[i]);
+}
+
+void DecryptSave(void)
+{
+    // HINT: Setting the encyptionKey to 0 means that encrypting would
+    // be a no-op, allowing us to skip decrypting them in the future.
+    if (gSaveBlock2Ptr->encryptionKey != 0)
+    {
+        ApplyNewEncryptionKeyToGameStats(0);
+        ApplyNewEncryptionKeyToBagItems(0);
+        ApplyNewEncryptionKeyToBerryPowder(0);
+        ApplyNewEncryptionKeyToWord(&gSaveBlock1Ptr->money, 0);
+        ApplyNewEncryptionKeyToHword(&gSaveBlock1Ptr->coins, 0);
+
+        gSaveBlock2Ptr->encryptionKey = 0;
+    }
+
+    for (u32 i = 0; i < ARRAY_COUNT(gSaveBlock1Ptr->playerParty); i++)
+        EncryptMon(&gSaveBlock1Ptr->playerParty[i]);
+    for (u32 i = 0; i < ARRAY_COUNT(gSaveBlock1Ptr->daycare.mons); i++)
+        EncryptBoxMon(&gSaveBlock1Ptr->daycare.mons[i].mon);
+    #if IS_FRLG
+    EncryptBoxMon(&gSaveBlock1Ptr->route5DayCareMon.mon);
+    #endif
+
+    for (u32 i = 0; i < TOTAL_BOXES_COUNT; i++)
+    {
+        for (u32 j = 0; j < IN_BOX_COUNT; j++)
+            DecryptBoxMon(&gPokemonStoragePtr->boxes[i][j]);
+    }
+    for (u32 i = 0; i < ARRAY_COUNT(gPokemonStoragePtr->fusions); i++)
+        DecryptMon(&gPokemonStoragePtr->fusions[i]);
 }

--- a/src/load_save.c
+++ b/src/load_save.c
@@ -31,20 +31,16 @@ struct LoadedSaveData
 };
 
 // EWRAM DATA
-EWRAM_DATA struct SaveBlock3 gSaveblock3 = {};
-EWRAM_DATA struct SaveBlock2ASLR gSaveblock2 = {0};
-EWRAM_DATA struct SaveBlock1ASLR gSaveblock1 = {0};
-EWRAM_DATA struct PokemonStorageASLR gPokemonStorage = {0};
+EWRAM_DATA struct SaveBlock3 gSaveBlock3 = {};
+EWRAM_DATA struct SaveBlock2 gSaveBlock2 = {0};
+EWRAM_DATA struct SaveBlock1 gSaveBlock1 = {0};
+EWRAM_DATA struct PokemonStorage gPokemonStorage = {0};
 
 EWRAM_DATA struct LoadedSaveData gLoadedSaveData = {0};
 EWRAM_DATA u32 gLastEncryptionKey = 0;
 
 // IWRAM common
 COMMON_DATA bool32 gFlashMemoryPresent = 0;
-COMMON_DATA struct SaveBlock1 *gSaveBlock1Ptr = NULL;
-COMMON_DATA struct SaveBlock2 *gSaveBlock2Ptr = NULL;
-IWRAM_INIT struct SaveBlock3 *gSaveBlock3Ptr = &gSaveblock3;
-COMMON_DATA struct PokemonStorage *gPokemonStoragePtr = NULL;
 
 // code
 void CheckForFlashMemory(void)
@@ -62,71 +58,33 @@ void CheckForFlashMemory(void)
 
 void ClearSav3(void)
 {
-    CpuFill16(0, &gSaveblock3, sizeof(struct SaveBlock3));
+    CpuFill16(0, &gSaveBlock3, sizeof(gSaveBlock3));
     FakeRtc_Reset();
 }
 
 void ClearSav2(void)
 {
-    CpuFill16(0, &gSaveblock2, sizeof(struct SaveBlock2ASLR));
+    CpuFill16(0, &gSaveBlock2, sizeof(gSaveBlock2));
 }
 
 void ClearSav1(void)
 {
-    CpuFill16(0, &gSaveblock1, sizeof(struct SaveBlock1ASLR));
+    CpuFill16(0, &gSaveBlock1, sizeof(gSaveBlock1));
 }
 
-// Offset is the sum of the trainer id bytes
-void SetSaveBlocksPointers(u16 offset)
+void SetSaveBlocksPointers(void)
 {
-    struct SaveBlock1 **sav1_LocalVar = &gSaveBlock1Ptr;
-
-    offset = (offset + Random()) & (SAVEBLOCK_MOVE_RANGE - 4);
-
-    gSaveBlock2Ptr = (void *)(&gSaveblock2) + offset;
-    *sav1_LocalVar = (void *)(&gSaveblock1) + offset;
-    gPokemonStoragePtr = (void *)(&gPokemonStorage) + offset;
-
-    SetBagItemsPointers();
     SetDecorationInventoriesPointers();
 }
 
-void MoveSaveBlocks_ResetHeap(void)
+void RotateEncryptionKey_ResetHeap(void)
 {
-    void *vblankCB, *hblankCB;
-    u32 encryptionKey;
-    struct SaveBlock2 *saveBlock2Copy;
-    struct SaveBlock1 *saveBlock1Copy;
-    struct PokemonStorage *pokemonStorageCopy;
-
     // save interrupt functions and turn them off
-    vblankCB = gMain.vblankCallback;
-    hblankCB = gMain.hblankCallback;
+    void *vblankCB = gMain.vblankCallback;
+    void *hblankCB = gMain.hblankCallback;
     gMain.vblankCallback = NULL;
     gMain.hblankCallback = NULL;
     gTrainerHillVBlankCounter = NULL;
-
-    saveBlock2Copy = (struct SaveBlock2 *)(gHeap);
-    saveBlock1Copy = (struct SaveBlock1 *)(gHeap + sizeof(struct SaveBlock2));
-    pokemonStorageCopy = (struct PokemonStorage *)(gHeap + sizeof(struct SaveBlock2) + sizeof(struct SaveBlock1));
-
-    // backup the saves.
-    *saveBlock2Copy = *gSaveBlock2Ptr;
-    *saveBlock1Copy = *gSaveBlock1Ptr;
-    *pokemonStorageCopy = *gPokemonStoragePtr;
-
-    // change saveblocks' pointers
-    // argument is a sum of the individual trainerId bytes
-    SetSaveBlocksPointers(
-      saveBlock2Copy->playerTrainerId[0] +
-      saveBlock2Copy->playerTrainerId[1] +
-      saveBlock2Copy->playerTrainerId[2] +
-      saveBlock2Copy->playerTrainerId[3]);
-
-    // restore saveblock data since the pointers changed
-    *gSaveBlock2Ptr = *saveBlock2Copy;
-    *gSaveBlock1Ptr = *saveBlock1Copy;
-    *gPokemonStoragePtr = *pokemonStorageCopy;
 
     // heap was destroyed in the copying process, so reset it
     InitHeap(gHeap, HEAP_SIZE);
@@ -136,7 +94,7 @@ void MoveSaveBlocks_ResetHeap(void)
     gMain.vblankCallback = vblankCB;
 
     // create a new encryption key
-    encryptionKey = Random32();
+    u32 encryptionKey = Random32();
     ApplyNewEncryptionKeyToAllEncryptedData(encryptionKey);
     gSaveBlock2Ptr->encryptionKey = encryptionKey;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -186,8 +186,6 @@ static void InitMainCallbacks(void)
     gMain.vblankCounter2 = 0;
     gMain.callback1 = NULL;
     SetMainCallback2(gInitialMainCB2);
-    gSaveBlock2Ptr = &gSaveblock2.block;
-    gPokemonStoragePtr = &gPokemonStorage.block;
 }
 
 static void CallCallbacks(void)

--- a/src/malloc.c
+++ b/src/malloc.c
@@ -175,6 +175,13 @@ static bool32 CheckMemBlockInternal(void *heapStart, void *pointer)
 
 void InitHeap(void *heapStart, u32 heapSize)
 {
+    // The heap already exists, report any leaks.
+    if (REPORT_MEMORY_LEAKS && sHeapStart != NULL)
+    {
+        DebugPrintf("Memory leaks:");
+        PrintHeap();
+    }
+
     sHeapStart = heapStart;
     sHeapSize = heapSize;
     PutFirstMemBlockHeader(heapStart, heapSize);

--- a/src/malloc.c
+++ b/src/malloc.c
@@ -1,5 +1,6 @@
 #include "global.h"
 #include "malloc.h"
+#include "trainer_hill.h"
 #if TESTING
 #include "test/test.h"
 #endif
@@ -243,6 +244,23 @@ void *AllocZeroedUnchecked_(u32 size, const char *location)
 void Free(void *pointer)
 {
     FreeInternal(sHeapStart, pointer);
+}
+
+void ResetHeap(void)
+{
+    // save interrupt functions and turn them off
+    void *vblankCB = gMain.vblankCallback;
+    void *hblankCB = gMain.hblankCallback;
+    gMain.vblankCallback = NULL;
+    gMain.hblankCallback = NULL;
+    gTrainerHillVBlankCounter = NULL;
+
+    // reset heap
+    InitHeap(gHeap, HEAP_SIZE);
+
+    // restore interrupt functions
+    gMain.hblankCallback = hblankCB;
+    gMain.vblankCallback = vblankCB;
 }
 
 bool32 CheckMemBlock(void *pointer)

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -131,7 +131,7 @@ static void InitObjectEventsLocal(void);
 static void InitOverworldGraphicsRegisters(void);
 static u8 GetSpriteForLinkedPlayer(u8);
 static u16 KeyInterCB_SendNothing(u32);
-static void ResetMirageTowerAndSaveBlockPtrs(void);
+static void ResetMirageTowerAndHeap(void);
 static void ResetScreenForMapLoad(void);
 static void OffsetCameraFocusByLinkPlayerId(void);
 static void SpawnLinkPlayers(void);
@@ -2218,7 +2218,7 @@ static bool32 LoadMapInStepsLink(u8 *state)
         InitOverworldBgs();
         ScriptContext_Init();
         UnlockPlayerFieldControls();
-        ResetMirageTowerAndSaveBlockPtrs();
+        ResetMirageTowerAndHeap();
         ResetScreenForMapLoad();
         (*state)++;
         break;
@@ -2300,7 +2300,7 @@ static bool32 LoadMapInStepsLocal(u8 *state, bool32 a2)
         (*state)++;
         break;
     case 1:
-        ResetMirageTowerAndSaveBlockPtrs();
+        ResetMirageTowerAndHeap();
         ResetScreenForMapLoad();
         (*state)++;
         break;
@@ -2372,7 +2372,7 @@ static bool32 ReturnToFieldLocal(u8 *state)
     switch (*state)
     {
     case 0:
-        ResetMirageTowerAndSaveBlockPtrs();
+        ResetMirageTowerAndHeap();
         ResetScreenForMapLoad();
         ResumeMap(FALSE);
         InitObjectEventsReturnToField();
@@ -2407,7 +2407,7 @@ static bool32 ReturnToFieldLink(u8 *state)
     {
     case 0:
         FieldClearVBlankHBlankCallbacks();
-        ResetMirageTowerAndSaveBlockPtrs();
+        ResetMirageTowerAndHeap();
         ResetScreenForMapLoad();
         (*state)++;
         break;
@@ -2483,10 +2483,10 @@ static void DoMapLoadLoop(u8 *state)
     while (!LoadMapInStepsLocal(state, FALSE));
 }
 
-static void ResetMirageTowerAndSaveBlockPtrs(void)
+static void ResetMirageTowerAndHeap(void)
 {
     ClearMirageTowerPulseBlend();
-    MoveSaveBlocks_ResetHeap();
+    RotateEncryptionKey_ResetHeap();
 }
 
 static void ResetScreenForMapLoad(void)

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -2486,7 +2486,7 @@ static void DoMapLoadLoop(u8 *state)
 static void ResetMirageTowerAndHeap(void)
 {
     ClearMirageTowerPulseBlend();
-    RotateEncryptionKey_ResetHeap();
+    ResetHeap();
 }
 
 static void ResetScreenForMapLoad(void)

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -84,7 +84,6 @@ struct SpeciesItem
     enum Item item;
 };
 
-static union PokemonSubstruct *GetSubstruct(struct BoxPokemon *boxMon, u32 personality, enum SubstructType substructType);
 static void Task_PlayMapChosenOrBattleBGM(u8 taskId);
 void TrySpecialOverworldEvo();
 
@@ -1325,43 +1324,41 @@ void CreateEnemyEventMon(void)
     }
 }
 
-struct SubstructOrder
-{
-    u8 encrypt[4];
-    u8 decrypt[4];
+static const u8 sSubstructOrders[24][4] = {
+    [0]  = { 0, 1, 2, 3 },
+    [1]  = { 0, 1, 3, 2 },
+    [2]  = { 0, 2, 1, 3 },
+    [3]  = { 0, 3, 1, 2 },
+    [4]  = { 0, 2, 3, 1 },
+    [5]  = { 0, 3, 2, 1 },
+    [6]  = { 1, 0, 2, 3 },
+    [7]  = { 1, 0, 3, 2 },
+    [8]  = { 2, 0, 1, 3 },
+    [9]  = { 3, 0, 1, 2 },
+    [10] = { 2, 0, 3, 1 },
+    [11] = { 3, 0, 2, 1 },
+    [12] = { 1, 2, 0, 3 },
+    [13] = { 1, 3, 0, 2 },
+    [14] = { 2, 1, 0, 3 },
+    [15] = { 3, 1, 0, 2 },
+    [16] = { 2, 3, 0, 1 },
+    [17] = { 3, 2, 0, 1 },
+    [18] = { 1, 2, 3, 0 },
+    [19] = { 1, 3, 2, 0 },
+    [20] = { 2, 1, 3, 0 },
+    [21] = { 3, 1, 2, 0 },
+    [22] = { 2, 3, 1, 0 },
+    [23] = { 3, 2, 1, 0 },
 };
 
-static const struct SubstructOrder sSubstructOrders[24] = {
-    [0]  = { .encrypt = { 0, 1, 2, 3 }, .decrypt = { 0, 1, 2, 3 } },
-    [1]  = { .encrypt = { 0, 1, 3, 2 }, .decrypt = { 0, 1, 3, 2 } },
-    [2]  = { .encrypt = { 0, 2, 1, 3 }, .decrypt = { 0, 2, 1, 3 } },
-    [3]  = { .encrypt = { 0, 2, 3, 1 }, .decrypt = { 0, 3, 1, 2 } },
-    [4]  = { .encrypt = { 0, 3, 1, 2 }, .decrypt = { 0, 2, 3, 1 } },
-    [5]  = { .encrypt = { 0, 3, 2, 1 }, .decrypt = { 0, 3, 2, 1 } },
-    [6]  = { .encrypt = { 1, 0, 2, 3 }, .decrypt = { 1, 0, 2, 3 } },
-    [7]  = { .encrypt = { 1, 0, 3, 2 }, .decrypt = { 1, 0, 3, 2 } },
-    [8]  = { .encrypt = { 1, 2, 0, 3 }, .decrypt = { 2, 0, 1, 3 } },
-    [9]  = { .encrypt = { 1, 2, 3, 0 }, .decrypt = { 3, 0, 1, 2 } },
-    [10] = { .encrypt = { 1, 3, 0, 2 }, .decrypt = { 2, 0, 3, 1 } },
-    [11] = { .encrypt = { 1, 3, 2, 0 }, .decrypt = { 3, 0, 2, 1 } },
-    [12] = { .encrypt = { 2, 0, 1, 3 }, .decrypt = { 1, 2, 0, 3 } },
-    [13] = { .encrypt = { 2, 0, 3, 1 }, .decrypt = { 1, 3, 0, 2 } },
-    [14] = { .encrypt = { 2, 1, 0, 3 }, .decrypt = { 2, 1, 0, 3 } },
-    [15] = { .encrypt = { 2, 1, 3, 0 }, .decrypt = { 3, 1, 0, 2 } },
-    [16] = { .encrypt = { 2, 3, 0, 1 }, .decrypt = { 2, 3, 0, 1 } },
-    [17] = { .encrypt = { 2, 3, 1, 0 }, .decrypt = { 3, 2, 0, 1 } },
-    [18] = { .encrypt = { 3, 0, 1, 2 }, .decrypt = { 1, 2, 3, 0 } },
-    [19] = { .encrypt = { 3, 0, 2, 1 }, .decrypt = { 1, 3, 2, 0 } },
-    [20] = { .encrypt = { 3, 1, 0, 2 }, .decrypt = { 2, 1, 3, 0 } },
-    [21] = { .encrypt = { 3, 1, 2, 0 }, .decrypt = { 3, 1, 2, 0 } },
-    [22] = { .encrypt = { 3, 2, 0, 1 }, .decrypt = { 2, 3, 1, 0 } },
-    [23] = { .encrypt = { 3, 2, 1, 0 }, .decrypt = { 3, 2, 1, 0 } },
-};
-
-ARM_FUNC NOINLINE static const struct SubstructOrder *SubstructOrder(u32 personality)
+ARM_FUNC NOINLINE static const u8 *SubstructOrder(u32 personality)
 {
-    return &sSubstructOrders[personality % ARRAY_COUNT(sSubstructOrders)];
+    return sSubstructOrders[personality % ARRAY_COUNT(sSubstructOrders)];
 }
+
+// WARNING: Must be called from Thumb and stomps on FIQ registers.
+enum FastShuffleSubstructsMode { SHUFFLE_ENCRYPT, SHUFFLE_DECRYPT };
+extern void FastShuffleSubstructs(struct BoxPokemon *, enum FastShuffleSubstructsMode);
 
 void EncryptMon(struct Pokemon *mon)
 {
@@ -1370,13 +1367,29 @@ void EncryptMon(struct Pokemon *mon)
 
 void EncryptBoxMon(struct BoxPokemon *boxMon)
 {
-    union PokemonSubstruct decrypted[4];
-    memcpy(decrypted, boxMon->secure.substructs, sizeof(decrypted));
-    const struct SubstructOrder *substructOrder = SubstructOrder(boxMon->personality);
-    boxMon->secure.substructs[0] = decrypted[substructOrder->encrypt[0]];
-    boxMon->secure.substructs[1] = decrypted[substructOrder->encrypt[1]];
-    boxMon->secure.substructs[2] = decrypted[substructOrder->encrypt[2]];
-    boxMon->secure.substructs[3] = decrypted[substructOrder->encrypt[3]];
+    if (!boxMon->hasSpecies)
+        return;
+
+    if (offsetof(struct BoxPokemon, personality) == 0
+     && sizeof(boxMon->personality) == 4
+     && offsetof(struct BoxPokemon, secure) == 32
+     && sizeof(union BoxPokemonSecure) == 3 * 12
+     && sizeof(union PokemonSubstruct) == 12)
+    {
+        FastShuffleSubstructs(boxMon, SHUFFLE_ENCRYPT);
+    }
+    else
+    {
+        union BoxPokemonSecure decrypted = boxMon->secure;
+        const u8 *substructOrder = SubstructOrder(boxMon->personality);
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+        boxMon->secure.substructs[substructOrder[0]].type0 = decrypted.substruct0;
+        boxMon->secure.substructs[substructOrder[1]].type1 = decrypted.substruct1;
+        boxMon->secure.substructs[substructOrder[2]].type2 = decrypted.substruct2;
+        boxMon->secure.substructs[substructOrder[3]].type3 = decrypted.substruct3;
+        #pragma GCC diagnostic pop
+    }
 
     u32 checksum = 0;
 
@@ -1396,13 +1409,8 @@ void DecryptMon(struct Pokemon *mon)
 
 void DecryptBoxMon(struct BoxPokemon *boxMon)
 {
-    union PokemonSubstruct encrypted[4];
-    memcpy(encrypted, boxMon->secure.substructs, sizeof(encrypted));
-    const struct SubstructOrder *substructOrder = SubstructOrder(boxMon->personality);
-    boxMon->secure.substructs[0] = encrypted[substructOrder->decrypt[0]];
-    boxMon->secure.substructs[1] = encrypted[substructOrder->decrypt[1]];
-    boxMon->secure.substructs[2] = encrypted[substructOrder->decrypt[2]];
-    boxMon->secure.substructs[3] = encrypted[substructOrder->decrypt[3]];
+    if (!boxMon->hasSpecies)
+        return;
 
     u32 checksum = 0;
 
@@ -1414,11 +1422,32 @@ void DecryptBoxMon(struct BoxPokemon *boxMon)
 
     checksum = checksum & 0xFFFF;
 
+    if (offsetof(struct BoxPokemon, personality) == 0
+     && sizeof(boxMon->personality) == 4
+     && offsetof(struct BoxPokemon, secure) == 32
+     && sizeof(union BoxPokemonSecure) == 3 * 12
+     && sizeof(union PokemonSubstruct) == 12)
+    {
+        FastShuffleSubstructs(boxMon, SHUFFLE_DECRYPT);
+    }
+    else
+    {
+        union BoxPokemonSecure encrypted = boxMon->secure;
+        const u8 *substructOrder = SubstructOrder(boxMon->personality);
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+        boxMon->secure.substruct0 = encrypted.substructs[substructOrder[0]].type0;
+        boxMon->secure.substruct1 = encrypted.substructs[substructOrder[1]].type1;
+        boxMon->secure.substruct2 = encrypted.substructs[substructOrder[2]].type2;
+        boxMon->secure.substruct3 = encrypted.substructs[substructOrder[3]].type3;
+        #pragma GCC diagnostic pop
+    }
+
     if (checksum != boxMon->checksum)
     {
         boxMon->isBadEgg = TRUE;
         boxMon->isEgg = TRUE;
-        GetSubstruct(boxMon, boxMon->personality, SUBSTRUCT_TYPE_3)->type3.isEgg = TRUE;
+        boxMon->secure.substruct3.isEgg = TRUE;
     }
 }
 
@@ -1984,10 +2013,6 @@ void SetMultiuseSpriteTemplateToTrainerFront(enum TrainerPicID trainerPicId, enu
     gMultiuseSpriteTemplate.anims = gAnims_Trainer;
 }
 
-static union PokemonSubstruct *GetSubstruct(struct BoxPokemon *boxMon, u32 personality, enum SubstructType substructType)
-{
-    return &boxMon->secure.substructs[substructType];
-}
 
 /* GameFreak called GetMonData with either 2 or 3 arguments, for type
  * safety we have a GetMonData macro (in include/pokemon.h) which
@@ -2053,22 +2078,22 @@ union EvolutionTracker
 
 static ALWAYS_INLINE struct PokemonSubstruct0 *GetSubstruct0(struct BoxPokemon *boxMon)
 {
-    return &(GetSubstruct(boxMon, boxMon->personality, SUBSTRUCT_TYPE_0)->type0);
+    return &boxMon->secure.substruct0;
 }
 
 static ALWAYS_INLINE struct PokemonSubstruct1 *GetSubstruct1(struct BoxPokemon *boxMon)
 {
-    return &(GetSubstruct(boxMon, boxMon->personality, SUBSTRUCT_TYPE_1)->type1);
+    return &boxMon->secure.substruct1;
 }
 
 static ALWAYS_INLINE struct PokemonSubstruct2 *GetSubstruct2(struct BoxPokemon *boxMon)
 {
-    return &(GetSubstruct(boxMon, boxMon->personality, SUBSTRUCT_TYPE_2)->type2);
+    return &boxMon->secure.substruct2;
 }
 
 static ALWAYS_INLINE struct PokemonSubstruct3 *GetSubstruct3(struct BoxPokemon *boxMon)
 {
-    return &(GetSubstruct(boxMon, boxMon->personality, SUBSTRUCT_TYPE_3)->type3);
+    return &boxMon->secure.substruct3;
 }
 
 static bool32 IsBadEgg(struct BoxPokemon *boxMon)

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -84,12 +84,7 @@ struct SpeciesItem
     enum Item item;
 };
 
-static u16 CalculateBoxMonChecksum(struct BoxPokemon *boxMon);
-static u16 CalculateBoxMonChecksumDecrypt(struct BoxPokemon *boxMon);
-static u16 CalculateBoxMonChecksumReencrypt(struct BoxPokemon *boxMon);
 static union PokemonSubstruct *GetSubstruct(struct BoxPokemon *boxMon, u32 personality, enum SubstructType substructType);
-static void EncryptBoxMon(struct BoxPokemon *boxMon);
-static void DecryptBoxMon(struct BoxPokemon *boxMon);
 static void Task_PlayMapChosenOrBattleBGM(u8 taskId);
 void TrySpecialOverworldEvo();
 
@@ -967,7 +962,6 @@ void CreateBoxMon(struct BoxPokemon *boxMon, enum Species species, u8 level, u32
 {
     u8 speciesName[POKEMON_NAME_LENGTH + 1];
     u32 value;
-    u16 checksum;
     bool32 isShiny;
 
     ZeroBoxMonData(boxMon);
@@ -991,9 +985,6 @@ void CreateBoxMon(struct BoxPokemon *boxMon, enum Species species, u8 level, u32
     SetBoxMonData(boxMon, MON_DATA_PERSONALITY, &personality);
     SetBoxMonData(boxMon, MON_DATA_OT_ID, &value);
 
-    checksum = CalculateBoxMonChecksum(boxMon);
-    SetBoxMonData(boxMon, MON_DATA_CHECKSUM, &checksum);
-    EncryptBoxMon(boxMon);
     SetBoxMonData(boxMon, MON_DATA_IS_SHINY, &isShiny);
     StringCopy(speciesName, GetSpeciesName(species));
     SetBoxMonData(boxMon, MON_DATA_NICKNAME, speciesName);
@@ -1334,18 +1325,85 @@ void CreateEnemyEventMon(void)
     }
 }
 
-static u16 CalculateBoxMonChecksum(struct BoxPokemon *boxMon)
+struct SubstructOrder
 {
+    u8 encrypt[4];
+    u8 decrypt[4];
+};
+
+static const struct SubstructOrder sSubstructOrders[24] = {
+    [0]  = { .encrypt = { 0, 1, 2, 3 }, .decrypt = { 0, 1, 2, 3 } },
+    [1]  = { .encrypt = { 0, 1, 3, 2 }, .decrypt = { 0, 1, 3, 2 } },
+    [2]  = { .encrypt = { 0, 2, 1, 3 }, .decrypt = { 0, 2, 1, 3 } },
+    [3]  = { .encrypt = { 0, 2, 3, 1 }, .decrypt = { 0, 3, 1, 2 } },
+    [4]  = { .encrypt = { 0, 3, 1, 2 }, .decrypt = { 0, 2, 3, 1 } },
+    [5]  = { .encrypt = { 0, 3, 2, 1 }, .decrypt = { 0, 3, 2, 1 } },
+    [6]  = { .encrypt = { 1, 0, 2, 3 }, .decrypt = { 1, 0, 2, 3 } },
+    [7]  = { .encrypt = { 1, 0, 3, 2 }, .decrypt = { 1, 0, 3, 2 } },
+    [8]  = { .encrypt = { 1, 2, 0, 3 }, .decrypt = { 2, 0, 1, 3 } },
+    [9]  = { .encrypt = { 1, 2, 3, 0 }, .decrypt = { 3, 0, 1, 2 } },
+    [10] = { .encrypt = { 1, 3, 0, 2 }, .decrypt = { 2, 0, 3, 1 } },
+    [11] = { .encrypt = { 1, 3, 2, 0 }, .decrypt = { 3, 0, 2, 1 } },
+    [12] = { .encrypt = { 2, 0, 1, 3 }, .decrypt = { 1, 2, 0, 3 } },
+    [13] = { .encrypt = { 2, 0, 3, 1 }, .decrypt = { 1, 3, 0, 2 } },
+    [14] = { .encrypt = { 2, 1, 0, 3 }, .decrypt = { 2, 1, 0, 3 } },
+    [15] = { .encrypt = { 2, 1, 3, 0 }, .decrypt = { 3, 1, 0, 2 } },
+    [16] = { .encrypt = { 2, 3, 0, 1 }, .decrypt = { 2, 3, 0, 1 } },
+    [17] = { .encrypt = { 2, 3, 1, 0 }, .decrypt = { 3, 2, 0, 1 } },
+    [18] = { .encrypt = { 3, 0, 1, 2 }, .decrypt = { 1, 2, 3, 0 } },
+    [19] = { .encrypt = { 3, 0, 2, 1 }, .decrypt = { 1, 3, 2, 0 } },
+    [20] = { .encrypt = { 3, 1, 0, 2 }, .decrypt = { 2, 1, 3, 0 } },
+    [21] = { .encrypt = { 3, 1, 2, 0 }, .decrypt = { 3, 1, 2, 0 } },
+    [22] = { .encrypt = { 3, 2, 0, 1 }, .decrypt = { 2, 3, 1, 0 } },
+    [23] = { .encrypt = { 3, 2, 1, 0 }, .decrypt = { 3, 2, 1, 0 } },
+};
+
+ARM_FUNC NOINLINE static const struct SubstructOrder *SubstructOrder(u32 personality)
+{
+    return &sSubstructOrders[personality % ARRAY_COUNT(sSubstructOrders)];
+}
+
+void EncryptMon(struct Pokemon *mon)
+{
+    EncryptBoxMon(&mon->box);
+}
+
+void EncryptBoxMon(struct BoxPokemon *boxMon)
+{
+    union PokemonSubstruct decrypted[4];
+    memcpy(decrypted, boxMon->secure.substructs, sizeof(decrypted));
+    const struct SubstructOrder *substructOrder = SubstructOrder(boxMon->personality);
+    boxMon->secure.substructs[0] = decrypted[substructOrder->encrypt[0]];
+    boxMon->secure.substructs[1] = decrypted[substructOrder->encrypt[1]];
+    boxMon->secure.substructs[2] = decrypted[substructOrder->encrypt[2]];
+    boxMon->secure.substructs[3] = decrypted[substructOrder->encrypt[3]];
+
     u32 checksum = 0;
 
     for (u32 i = 0; i < ARRAY_COUNT(boxMon->secure.raw); i++)
+    {
         checksum += boxMon->secure.raw[i] + (boxMon->secure.raw[i] >> 16);
+        boxMon->secure.raw[i] ^= (boxMon->otId ^ boxMon->personality);
+    }
 
-    return checksum;
+    boxMon->checksum = checksum;
 }
 
-static u16 CalculateBoxMonChecksumDecrypt(struct BoxPokemon *boxMon)
+void DecryptMon(struct Pokemon *mon)
 {
+    DecryptBoxMon(&mon->box);
+}
+
+void DecryptBoxMon(struct BoxPokemon *boxMon)
+{
+    union PokemonSubstruct encrypted[4];
+    memcpy(encrypted, boxMon->secure.substructs, sizeof(encrypted));
+    const struct SubstructOrder *substructOrder = SubstructOrder(boxMon->personality);
+    boxMon->secure.substructs[0] = encrypted[substructOrder->decrypt[0]];
+    boxMon->secure.substructs[1] = encrypted[substructOrder->decrypt[1]];
+    boxMon->secure.substructs[2] = encrypted[substructOrder->decrypt[2]];
+    boxMon->secure.substructs[3] = encrypted[substructOrder->decrypt[3]];
+
     u32 checksum = 0;
 
     for (u32 i = 0; i < ARRAY_COUNT(boxMon->secure.raw); i++)
@@ -1354,20 +1412,14 @@ static u16 CalculateBoxMonChecksumDecrypt(struct BoxPokemon *boxMon)
         checksum += boxMon->secure.raw[i] + (boxMon->secure.raw[i] >> 16);
     }
 
-    return checksum;
-}
+    checksum = checksum & 0xFFFF;
 
-static u16 CalculateBoxMonChecksumReencrypt(struct BoxPokemon *boxMon)
-{
-    u32 checksum = 0;
-
-    for (u32 i = 0; i < ARRAY_COUNT(boxMon->secure.raw); i++)
+    if (checksum != boxMon->checksum)
     {
-        checksum += boxMon->secure.raw[i] + (boxMon->secure.raw[i] >> 16);
-        boxMon->secure.raw[i] ^= (boxMon->otId ^ boxMon->personality);
+        boxMon->isBadEgg = TRUE;
+        boxMon->isEgg = TRUE;
+        GetSubstruct(boxMon, boxMon->personality, SUBSTRUCT_TYPE_3)->type3.isEgg = TRUE;
     }
-
-    return checksum;
 }
 
 void CalculateMonStats(struct Pokemon *mon)
@@ -1932,37 +1984,9 @@ void SetMultiuseSpriteTemplateToTrainerFront(enum TrainerPicID trainerPicId, enu
     gMultiuseSpriteTemplate.anims = gAnims_Trainer;
 }
 
-static void EncryptBoxMon(struct BoxPokemon *boxMon)
-{
-    for (u32 i = 0; i < ARRAY_COUNT(boxMon->secure.raw); i++)
-    {
-        boxMon->secure.raw[i] ^= boxMon->personality;
-        boxMon->secure.raw[i] ^= boxMon->otId;
-    }
-}
-
-static void DecryptBoxMon(struct BoxPokemon *boxMon)
-{
-    for (u32 i = 0; i < ARRAY_COUNT(boxMon->secure.raw); i++)
-    {
-        boxMon->secure.raw[i] ^= boxMon->otId;
-        boxMon->secure.raw[i] ^= boxMon->personality;
-    }
-}
-
-static const u8 sSubstructOffsets[4][24] =
-{
-    [SUBSTRUCT_TYPE_0] = {0, 0, 0, 0, 0, 0, 1, 1, 2, 3, 2, 3, 1, 1, 2, 3, 2, 3, 1, 1, 2, 3, 2, 3},
-    [SUBSTRUCT_TYPE_1] = {1, 1, 2, 3, 2, 3, 0, 0, 0, 0, 0, 0, 2, 3, 1, 1, 3, 2, 2, 3, 1, 1, 3, 2},
-    [SUBSTRUCT_TYPE_2] = {2, 3, 1, 1, 3, 2, 2, 3, 1, 1, 3, 2, 0, 0, 0, 0, 0, 0, 3, 2, 3, 2, 1, 1},
-    [SUBSTRUCT_TYPE_3] = {3, 2, 3, 2, 1, 1, 3, 2, 3, 2, 1, 1, 3, 2, 3, 2, 1, 1, 0, 0, 0, 0, 0, 0},
-};
-
-ARM_FUNC NOINLINE static u32 ConstantMod24(u32 a) { return a % 24; }
-
 static union PokemonSubstruct *GetSubstruct(struct BoxPokemon *boxMon, u32 personality, enum SubstructType substructType)
 {
-    return &boxMon->secure.substructs[sSubstructOffsets[substructType][ConstantMod24(personality)]];
+    return &boxMon->secure.substructs[substructType];
 }
 
 /* GameFreak called GetMonData with either 2 or 3 arguments, for type
@@ -2049,19 +2073,7 @@ static ALWAYS_INLINE struct PokemonSubstruct3 *GetSubstruct3(struct BoxPokemon *
 
 static bool32 IsBadEgg(struct BoxPokemon *boxMon)
 {
-    if (boxMon->isBadEgg)
-        return TRUE;
-
-    if (CalculateBoxMonChecksum(boxMon) != boxMon->checksum)
-    {
-        boxMon->isBadEgg = TRUE;
-        boxMon->isEgg = TRUE;
-        GetSubstruct3(boxMon)->isEgg = TRUE;
-
-        return TRUE;
-    }
-
-    return FALSE;
+    return boxMon->isBadEgg;
 }
 
 static ALWAYS_INLINE bool32 IsEggOrBadEgg(struct BoxPokemon *boxMon)
@@ -2078,11 +2090,8 @@ u32 GetBoxMonData3(struct BoxPokemon *boxMon, s32 field, u8 *data)
     s32 i;
     u32 retVal = 0;
 
-    // Any field greater than MON_DATA_ENCRYPT_SEPARATOR is encrypted and must be treated as such
-    if (field > MON_DATA_ENCRYPT_SEPARATOR)
+    if (TRUE)
     {
-        DecryptBoxMon(boxMon);
-
         switch (field)
         {
         case MON_DATA_NICKNAME:
@@ -2470,14 +2479,6 @@ u32 GetBoxMonData3(struct BoxPokemon *boxMon, s32 field, u8 *data)
                 }.combinedValue;
             }
             break;
-        default:
-            break;
-        }
-    }
-    else
-    {
-        switch (field)
-        {
         case MON_DATA_STATUS:
             retVal = UncompressStatus(boxMon->compressedStatus);
             break;
@@ -2540,9 +2541,6 @@ u32 GetBoxMonData3(struct BoxPokemon *boxMon, s32 field, u8 *data)
             break;
         }
     }
-
-    if (field > MON_DATA_ENCRYPT_SEPARATOR)
-        EncryptBoxMon(boxMon);
 
     return retVal;
 }
@@ -2631,17 +2629,8 @@ void SetBoxMonData(struct BoxPokemon *boxMon, s32 field, const void *dataArg)
 {
     const u8 *data = dataArg;
 
-    if (field > MON_DATA_ENCRYPT_SEPARATOR)
+    if (TRUE)
     {
-        if (CalculateBoxMonChecksumDecrypt(boxMon) != boxMon->checksum)
-        {
-            boxMon->isBadEgg = TRUE;
-            boxMon->isEgg = TRUE;
-            GetSubstruct3(boxMon)->isEgg = TRUE;
-            EncryptBoxMon(boxMon);
-            return;
-        }
-
         switch (field)
         {
         case MON_DATA_NICKNAME:
@@ -2902,14 +2891,6 @@ void SetBoxMonData(struct BoxPokemon *boxMon, s32 field, const void *dataArg)
             substruct1->evolutionTracker2 = evoTracker.tracker2;
             break;
         }
-        default:
-            break;
-        }
-    }
-    else
-    {
-        switch (field)
-        {
         case MON_DATA_STATUS:
         {
             u32 status;
@@ -2972,9 +2953,6 @@ void SetBoxMonData(struct BoxPokemon *boxMon, s32 field, const void *dataArg)
             break;
         }
     }
-
-    if (field > MON_DATA_ENCRYPT_SEPARATOR)
-        boxMon->checksum = CalculateBoxMonChecksumReencrypt(boxMon);
 }
 
 void CopyMon(void *dest, void *src, size_t size)
@@ -6539,35 +6517,11 @@ u32 GetMonAffectionHearts(struct Pokemon *pokemon)
 
 void UpdateMonPersonality(struct BoxPokemon *boxMon, u32 personality)
 {
-    struct PokemonSubstruct0 *old0, *new0;
-    struct PokemonSubstruct1 *old1, *new1;
-    struct PokemonSubstruct2 *old2, *new2;
-    struct PokemonSubstruct3 *old3, *new3;
-    struct BoxPokemon old;
-
     bool32 isShiny = GetBoxMonData(boxMon, MON_DATA_IS_SHINY);
     u32 hiddenNature = GetBoxMonData(boxMon, MON_DATA_HIDDEN_NATURE);
     enum Type teraType = GetBoxMonData(boxMon, MON_DATA_TERA_TYPE);
 
-    old = *boxMon;
-    old0 = &(GetSubstruct(&old, old.personality, SUBSTRUCT_TYPE_0)->type0);
-    old1 = &(GetSubstruct(&old, old.personality, SUBSTRUCT_TYPE_1)->type1);
-    old2 = &(GetSubstruct(&old, old.personality, SUBSTRUCT_TYPE_2)->type2);
-    old3 = &(GetSubstruct(&old, old.personality, SUBSTRUCT_TYPE_3)->type3);
-
-    new0 = &(GetSubstruct(boxMon, personality, SUBSTRUCT_TYPE_0)->type0);
-    new1 = &(GetSubstruct(boxMon, personality, SUBSTRUCT_TYPE_1)->type1);
-    new2 = &(GetSubstruct(boxMon, personality, SUBSTRUCT_TYPE_2)->type2);
-    new3 = &(GetSubstruct(boxMon, personality, SUBSTRUCT_TYPE_3)->type3);
-
-    DecryptBoxMon(&old);
     boxMon->personality = personality;
-    *new0 = *old0;
-    *new1 = *old1;
-    *new2 = *old2;
-    *new3 = *old3;
-    boxMon->checksum = CalculateBoxMonChecksumReencrypt(boxMon);
-
     SetBoxMonData(boxMon, MON_DATA_IS_SHINY, &isShiny);
     SetBoxMonData(boxMon, MON_DATA_HIDDEN_NATURE, &hiddenNature);
     SetBoxMonData(boxMon, MON_DATA_TERA_TYPE, &teraType);

--- a/src/pokemon_asm.s
+++ b/src/pokemon_asm.s
@@ -1,0 +1,102 @@
+	.syntax unified
+        .text
+
+	.include "constants/gba_constants.inc"
+	.include "asm/macros/function.inc"
+
+#define OFFSETOF_PERSONALITY 0
+#define OFFSETOF_SECURE 32
+
+@ void FastShuffleSubstructs(struct BoxPokemon *, mode)
+	thumb_func_start FastShuffleSubstructs
+FastShuffleSubstructs:
+	ldr r3, =0xAAAAAAAB
+	ldr r2, [r0, OFFSETOF_PERSONALITY]
+	adds r0, OFFSETOF_SECURE
+	bx pc
+	.arm
+	@ Switch to FIQ so that we have:
+	@ - spsr_fiq (initialized in crt0.s) to return to SYS in Thumb.
+	@ - Banked registers that don't have to be saved/restored.
+	@ and suppress IRQs because FIQ aliases the IRQ stack.
+	msr cpsr_c, (PSR_FIQ_MODE | PSR_I_BIT)
+	@ Save unbanked registers and lr so we can ldmdb into pc.
+	stmdb sp, {r4-r7, lr}^
+
+	@ Save mode in C.
+	lsrs r1, 1
+
+	@ r14 = personality % 24.
+	umull r4, r14, r2, r3
+	lsr r14, 4
+	add r14, r14, r14, lsl 1
+	sub r14, r2, r14, lsl 3
+
+	@ Load the substructs into r1-r3, r4-r6, r7-r9, r10-r12.
+	@ Positioned as early as possible to maximize prefetch buffer
+	@ opportunity.
+	ldmia r0, {r1-r12}
+
+	@ The addresses of specialized implementations are given by:
+	@ Encrypt[i] = Encrypt0 + (personality % 24) * 40.
+	@ Decrypt[i] = Encrypt0 + (personality % 24) * 40 + 20.
+
+	@ r14 = ((personality % 24) * 2 + mode) * 5.
+	adc r14, r14, r14        @ r14 = (personality % 24) * 2 + mode
+	add r14, r14, r14, lsl 2 @ r14 = r14 * 5
+.LAddPC:
+	@ pc = Encrypt0 + ((personality % 24) * 2 + mode) * 20.
+	add pc, pc, r14, lsl 2
+	.pool
+	.org .LAddPC + 8 @ Ensure that pc is Encrypt0 at .LAddPC.
+
+	Encrypt0: stmia r0!, {r1-r3, r4-r6, r7-r9, r10-r12}; ldmdb sp, {r4-r7, pc}^; nop; nop; nop
+	Decrypt0: stmia r0!, {r1-r3, r4-r6, r7-r9, r10-r12}; ldmdb sp, {r4-r7, pc}^; nop; nop; nop
+	Encrypt1: stmia r0!, {r1-r3, r4-r6, r10-r12}; stmia r0!, {r7-r9}; ldmdb sp, {r4-r7, pc}^; nop; nop
+	Decrypt1: stmia r0!, {r1-r3, r4-r6, r10-r12}; stmia r0!, {r7-r9}; ldmdb sp, {r4-r7, pc}^; nop; nop
+	Encrypt2: stmia r0!, {r1-r3, r7-r9}; stmia r0!, {r4-r6, r10-r12}; ldmdb sp, {r4-r7, pc}^; nop; nop
+	Decrypt2: stmia r0!, {r1-r3, r7-r9}; stmia r0!, {r4-r6, r10-r12}; ldmdb sp, {r4-r7, pc}^; nop; nop
+	Encrypt3: stmia r0!, {r1-r3, r7-r9, r10-r12}; stmia r0!, {r4-r6}; ldmdb sp, {r4-r7, pc}^; nop; nop
+	Decrypt3: stmia r0!, {r1-r3, r10-r12}; stmia r0!, {r4-r6, r7-r9}; ldmdb sp, {r4-r7, pc}^; nop; nop
+	Encrypt4: stmia r0!, {r1-r3, r10-r12}; stmia r0!, {r4-r6, r7-r9}; ldmdb sp, {r4-r7, pc}^; nop; nop
+	Decrypt4: stmia r0!, {r1-r3, r7-r9, r10-r12}; stmia r0!, {r4-r6}; ldmdb sp, {r4-r7, pc}^; nop; nop
+	Encrypt5: stmia r0!, {r1-r3, r10-r12}; stmia r0!, {r7-r9}; stmia r0!, {r4-r6}; ldmdb sp, {r4-r7, pc}^; nop
+	Decrypt5: stmia r0!, {r1-r3, r10-r12}; stmia r0!, {r7-r9}; stmia r0!, {r4-r6}; ldmdb sp, {r4-r7, pc}^; nop
+	Encrypt6: stmia r0!, {r4-r6}; stmia r0!, {r1-r3, r7-r9, r10-r12}; ldmdb sp, {r4-r7, pc}^; nop; nop
+	Decrypt6: stmia r0!, {r4-r6}; stmia r0!, {r1-r3, r7-r9, r10-r12}; ldmdb sp, {r4-r7, pc}^; nop; nop
+	Encrypt7: stmia r0!, {r4-r6}; stmia r0!, {r1-r3, r10-r12}; stmia r0!, {r7-r9}; ldmdb sp, {r4-r7, pc}^; nop
+	Decrypt7: stmia r0!, {r4-r6}; stmia r0!, {r1-r3, r10-r12}; stmia r0!, {r7-r9}; ldmdb sp, {r4-r7, pc}^; nop
+	Encrypt8: stmia r0!, {r4-r6, r7-r9}; stmia r0!, {r1-r3, r10-r12}; ldmdb sp, {r4-r7, pc}^; nop; nop
+	Decrypt8: stmia r0!, {r7-r9}; stmia r0!, {r1-r3, r4-r6, r10-r12}; ldmdb sp, {r4-r7, pc}^; nop; nop
+	Encrypt9: stmia r0!, {r4-r6, r7-r9, r10-r12}; stmia r0!, {r1-r3}; ldmdb sp, {r4-r7, pc}^; nop; nop
+	Decrypt9: stmia r0!, {r10-r12}; stmia r0!, {r1-r3, r4-r6, r7-r9}; ldmdb sp, {r4-r7, pc}^; nop; nop
+	Encrypt10: stmia r0!, {r4-r6, r10-r12}; stmia r0!, {r1-r3, r7-r9}; ldmdb sp, {r4-r7, pc}^; nop; nop
+	Decrypt10: stmia r0!, {r7-r9}; stmia r0!, {r1-r3, r10-r12}; stmia r0!, {r4-r6}; ldmdb sp, {r4-r7, pc}^; nop
+	Encrypt11: stmia r0!, {r4-r6, r10-r12}; stmia r0!, {r7-r9}; stmia r0!, {r1-r3}; ldmdb sp, {r4-r7, pc}^; nop
+	Decrypt11: stmia r0!, {r10-r12}; stmia r0!, {r1-r3, r7-r9}; stmia r0!, {r4-r6}; ldmdb sp, {r4-r7, pc}^; nop
+	Encrypt12: stmia r0!, {r7-r9}; stmia r0!, {r1-r3, r4-r6, r10-r12}; ldmdb sp, {r4-r7, pc}^; nop; nop
+	Decrypt12: stmia r0!, {r4-r6, r7-r9}; stmia r0!, {r1-r3, r10-r12}; ldmdb sp, {r4-r7, pc}^; nop; nop
+	Encrypt13: stmia r0!, {r7-r9}; stmia r0!, {r1-r3, r10-r12}; stmia r0!, {r4-r6}; ldmdb sp, {r4-r7, pc}^; nop
+	Decrypt13: stmia r0!, {r4-r6, r10-r12}; stmia r0!, {r1-r3, r7-r9}; ldmdb sp, {r4-r7, pc}^; nop; nop
+	Encrypt14: stmia r0!, {r7-r9}; stmia r0!, {r4-r6}; stmia r0!, {r1-r3, r10-r12}; ldmdb sp, {r4-r7, pc}^; nop
+	Decrypt14: stmia r0!, {r7-r9}; stmia r0!, {r4-r6}; stmia r0!, {r1-r3, r10-r12}; ldmdb sp, {r4-r7, pc}^; nop
+	Encrypt15: stmia r0!, {r7-r9}; stmia r0!, {r4-r6, r10-r12}; stmia r0!, {r1-r3}; ldmdb sp, {r4-r7, pc}^; nop
+	Decrypt15: stmia r0!, {r10-r12}; stmia r0!, {r4-r6}; stmia r0!, {r1-r3, r7-r9}; ldmdb sp, {r4-r7, pc}^; nop
+	Encrypt16: stmia r0!, {r7-r9, r10-r12}; stmia r0!, {r1-r3, r4-r6}; ldmdb sp, {r4-r7, pc}^; nop; nop
+	Decrypt16: stmia r0!, {r7-r9, r10-r12}; stmia r0!, {r1-r3, r4-r6}; ldmdb sp, {r4-r7, pc}^; nop; nop
+	Encrypt17: stmia r0!, {r7-r9, r10-r12}; stmia r0!, {r4-r6}; stmia r0!, {r1-r3}; ldmdb sp, {r4-r7, pc}^; nop
+	Decrypt17: stmia r0!, {r10-r12}; stmia r0!, {r7-r9}; stmia r0!, {r1-r3, r4-r6}; ldmdb sp, {r4-r7, pc}^; nop
+	Encrypt18: stmia r0!, {r10-r12}; stmia r0!, {r1-r3, r4-r6, r7-r9}; ldmdb sp, {r4-r7, pc}^; nop; nop
+	Decrypt18: stmia r0!, {r4-r6, r7-r9, r10-r12}; stmia r0!, {r1-r3}; ldmdb sp, {r4-r7, pc}^; nop; nop
+	Encrypt19: stmia r0!, {r10-r12}; stmia r0!, {r1-r3, r7-r9}; stmia r0!, {r4-r6}; ldmdb sp, {r4-r7, pc}^; nop
+	Decrypt19: stmia r0!, {r4-r6, r10-r12}; stmia r0!, {r7-r9}; stmia r0!, {r1-r3}; ldmdb sp, {r4-r7, pc}^; nop
+	Encrypt20: stmia r0!, {r10-r12}; stmia r0!, {r4-r6}; stmia r0!, {r1-r3, r7-r9}; ldmdb sp, {r4-r7, pc}^; nop
+	Decrypt20: stmia r0!, {r7-r9}; stmia r0!, {r4-r6, r10-r12}; stmia r0!, {r1-r3}; ldmdb sp, {r4-r7, pc}^; nop
+	Encrypt21: stmia r0!, {r10-r12}; stmia r0!, {r4-r6, r7-r9}; stmia r0!, {r1-r3}; ldmdb sp, {r4-r7, pc}^; nop
+	Decrypt21: stmia r0!, {r10-r12}; stmia r0!, {r4-r6, r7-r9}; stmia r0!, {r1-r3}; ldmdb sp, {r4-r7, pc}^; nop
+	Encrypt22: stmia r0!, {r10-r12}; stmia r0!, {r7-r9}; stmia r0!, {r1-r3, r4-r6}; ldmdb sp, {r4-r7, pc}^; nop
+	Decrypt22: stmia r0!, {r7-r9, r10-r12}; stmia r0!, {r4-r6}; stmia r0!, {r1-r3}; ldmdb sp, {r4-r7, pc}^; nop
+	Encrypt23: stmia r0!, {r10-r12}; stmia r0!, {r7-r9}; stmia r0!, {r4-r6}; stmia r0!, {r1-r3}; ldmdb sp, {r4-r7, pc}^
+	Decrypt23: stmia r0!, {r10-r12}; stmia r0!, {r7-r9}; stmia r0!, {r4-r6}; stmia r0!, {r1-r3}; ldmdb sp, {r4-r7, pc}^
+
+	thumb_func_end FastShuffleSubstructs

--- a/src/reload_save.c
+++ b/src/reload_save.c
@@ -20,7 +20,6 @@ void ReloadSave(void)
     ClearGpuRegBits(REG_OFFSET_DISPCNT, DISPCNT_FORCED_BLANK);
     REG_IME = imeBackup;
     gMain.inBattle = FALSE;
-    SetSaveBlocksPointers(GetSaveBlocksPointersBaseOffset());
     ResetMenuAndMonGlobals();
     Save_ResetSaveCounters();
     LoadGameSave(SAVE_NORMAL);

--- a/src/save.c
+++ b/src/save.c
@@ -16,7 +16,7 @@
 static u16 CalculateChecksum(void *, u16);
 static bool8 ReadFlashSector(u8, struct SaveSector *);
 static u8 GetSaveValidStatus(const struct SaveSectorLocation *);
-static u8 CopySaveSlotData(u16, struct SaveSectorLocation *);
+static u8 LoadSaveSlot(struct SaveSectorLocation *);
 static u8 TryWriteSector(u8, u8 *);
 static u8 HandleWriteSector(u16, const struct SaveSectorLocation *);
 static u8 HandleReplaceSector(u16, const struct SaveSectorLocation *);
@@ -136,40 +136,35 @@ static bool32 SetDamagedSectorBits(u8 op, u8 sectorId)
     return retVal;
 }
 
-static u8 WriteSaveSectorOrSlot(u16 sectorId, const struct SaveSectorLocation *locations)
+static u8 WriteSaveSlot(const struct SaveSectorLocation *locations)
 {
     u32 status;
     u16 i;
 
+    EncryptSave();
+
     gReadWriteSector = &gSaveDataBuffer;
 
-    if (sectorId != FULL_SAVE_SLOT)
-    {
-        // A sector was specified, just write that sector.
-        // This is never reached, FULL_SAVE_SLOT is always used instead.
-        status = HandleWriteSector(sectorId, locations);
-    }
-    else
-    {
-        // No sector was specified, write full save slot.
-        gLastKnownGoodSector = gLastWrittenSector; // backup the current written sector before attempting to write.
-        gLastSaveCounter = gSaveCounter;
-        gLastWrittenSector++;
-        gLastWrittenSector = gLastWrittenSector % NUM_SECTORS_PER_SLOT;
-        gSaveCounter++;
-        status = SAVE_STATUS_OK;
+    // No sector was specified, write full save slot.
+    gLastKnownGoodSector = gLastWrittenSector; // backup the current written sector before attempting to write.
+    gLastSaveCounter = gSaveCounter;
+    gLastWrittenSector++;
+    gLastWrittenSector = gLastWrittenSector % NUM_SECTORS_PER_SLOT;
+    gSaveCounter++;
+    status = SAVE_STATUS_OK;
 
-        for (i = 0; i < NUM_SECTORS_PER_SLOT; i++)
-            HandleWriteSector(i, locations);
+    for (i = 0; i < NUM_SECTORS_PER_SLOT; i++)
+        HandleWriteSector(i, locations);
 
-        if (gDamagedSaveSectors)
-        {
-            // At least one sector save failed
-            status = SAVE_STATUS_ERROR;
-            gLastWrittenSector = gLastKnownGoodSector;
-            gSaveCounter = gLastSaveCounter;
-        }
+    if (gDamagedSaveSectors)
+    {
+        // At least one sector save failed
+        status = SAVE_STATUS_ERROR;
+        gLastWrittenSector = gLastKnownGoodSector;
+        gSaveCounter = gLastSaveCounter;
     }
+
+    DecryptSave();
 
     return status;
 }
@@ -480,14 +475,14 @@ static u8 TryLoadSaveSlot(u16 sectorId, struct SaveSectorLocation *locations)
     else
     {
         status = GetSaveValidStatus(locations);
-        CopySaveSlotData(FULL_SAVE_SLOT, locations);
+        LoadSaveSlot(locations);
+        DecryptSave();
     }
 
     return status;
 }
 
-// sectorId arg is ignored, this always reads the full save slot
-static u8 CopySaveSlotData(u16 sectorId, struct SaveSectorLocation *locations)
+static u8 LoadSaveSlot(struct SaveSectorLocation *locations)
 {
     u16 i;
     u16 checksum;
@@ -731,7 +726,7 @@ u8 HandleSavingData(u8 saveType)
 
         // Write the full save slot first
         CopyPartyAndObjectsToSave();
-        WriteSaveSectorOrSlot(FULL_SAVE_SLOT, gRamSaveSectorLocations);
+        WriteSaveSlot(gRamSaveSectorLocations);
 
         // Save the Hall of Fame
         if (gHoFSaveBuffer != NULL)
@@ -744,17 +739,19 @@ u8 HandleSavingData(u8 saveType)
     case SAVE_NORMAL:
     default:
         CopyPartyAndObjectsToSave();
-        WriteSaveSectorOrSlot(FULL_SAVE_SLOT, gRamSaveSectorLocations);
+        WriteSaveSlot(gRamSaveSectorLocations);
         break;
     case SAVE_LINK:
     case SAVE_EREADER: // Dummied, now duplicate of SAVE_LINK
         // Used by link / Battle Frontier
         // Write only SaveBlocks 1 and 2 (skips the PC)
         CopyPartyAndObjectsToSave();
+        EncryptSave(); // TODO: Skip Pokemon storage.
         for (i = SECTOR_ID_SAVEBLOCK2; i <= SECTOR_ID_SAVEBLOCK1_END; i++)
             HandleReplaceSector(i, gRamSaveSectorLocations);
         for (i = SECTOR_ID_SAVEBLOCK2; i <= SECTOR_ID_SAVEBLOCK1_END; i++)
             WriteSectorSignatureByte_NoOffset(i, gRamSaveSectorLocations);
+        DecryptSave(); // TODO: Skip Pokemon storage.
         break;
     case SAVE_OVERWRITE_DIFFERENT_FILE:
         // Erase Hall of Fame
@@ -763,7 +760,7 @@ u8 HandleSavingData(u8 saveType)
 
         // Overwrite save slot
         CopyPartyAndObjectsToSave();
-        WriteSaveSectorOrSlot(FULL_SAVE_SLOT, gRamSaveSectorLocations);
+        WriteSaveSlot(gRamSaveSectorLocations);
         break;
     }
     gTrainerHillVBlankCounter = backupVar;

--- a/src/save.c
+++ b/src/save.c
@@ -914,31 +914,6 @@ u8 LoadGameSave(u8 saveType)
     return status;
 }
 
-u16 GetSaveBlocksPointersBaseOffset(void)
-{
-    u16 i, slotOffset;
-    struct SaveSector *sector;
-
-    sector = gReadWriteSector = &gSaveDataBuffer;
-    if (gFlashMemoryPresent != TRUE)
-        return 0;
-    UpdateSaveAddresses();
-    GetSaveValidStatus(gRamSaveSectorLocations);
-    slotOffset = NUM_SECTORS_PER_SLOT * (gSaveCounter % NUM_SAVE_SLOTS);
-    for (i = 0; i < NUM_SECTORS_PER_SLOT; i++)
-    {
-        ReadFlashSector(i + slotOffset, gReadWriteSector);
-
-        // Base offset for SaveBlock2 is calculated using the trainer id
-        if (gReadWriteSector->id == SECTOR_ID_SAVEBLOCK2)
-            return sector->data[offsetof(struct SaveBlock2, playerTrainerId[0])] +
-                   sector->data[offsetof(struct SaveBlock2, playerTrainerId[1])] +
-                   sector->data[offsetof(struct SaveBlock2, playerTrainerId[2])] +
-                   sector->data[offsetof(struct SaveBlock2, playerTrainerId[3])];
-    }
-    return 0;
-}
-
 u32 TryReadSpecialSaveSector(u8 sector, u8 *dst)
 {
     s32 i;
@@ -1071,17 +1046,17 @@ static u32 SaveBlock3Size(u32 sectorId)
 {
     s32 begin = sectorId * SAVE_BLOCK_3_CHUNK_SIZE;
     s32 end = (sectorId + 1) * SAVE_BLOCK_3_CHUNK_SIZE;
-    return max(0, min(end, (s32)sizeof(gSaveblock3)) - begin);
+    return max(0, min(end, (s32)sizeof(*gSaveBlock3Ptr)) - begin);
 }
 
 static void CopyToSaveBlock3(u32 sectorId, struct SaveSector *sector)
 {
     u32 size = SaveBlock3Size(sectorId);
-    memcpy((u8 *)&gSaveblock3 + (sectorId * SAVE_BLOCK_3_CHUNK_SIZE), sector->saveBlock3Chunk, size);
+    memcpy((u8 *)gSaveBlock3Ptr + (sectorId * SAVE_BLOCK_3_CHUNK_SIZE), sector->saveBlock3Chunk, size);
 }
 
 static void CopyFromSaveBlock3(u32 sectorId, struct SaveSector *sector)
 {
     u32 size = SaveBlock3Size(sectorId);
-    memcpy(sector->saveBlock3Chunk, (u8 *)&gSaveblock3 + (sectorId * SAVE_BLOCK_3_CHUNK_SIZE), size);
+    memcpy(sector->saveBlock3Chunk, (u8 *)gSaveBlock3Ptr + (sectorId * SAVE_BLOCK_3_CHUNK_SIZE), size);
 }

--- a/test/bag.c
+++ b/test/bag.c
@@ -8,7 +8,7 @@
 
 TEST("TMs and HMs are sorted correctly in the bag")
 {
-    struct BagPocket *pocket = &gBagPockets[POCKET_TM_HM];
+    const struct BagPocket *pocket = &gBagPockets[POCKET_TM_HM];
 
     ASSUME(GetItemPocket(ITEM_HM07) == POCKET_TM_HM);
     ASSUME(GetItemPocket(ITEM_TM25) == POCKET_TM_HM);
@@ -50,7 +50,7 @@ TEST("TMs and HMs are sorted correctly in the bag")
 
 TEST("Berries are sorted correctly in the bag")
 {
-    struct BagPocket *pocket = &gBagPockets[POCKET_BERRIES];
+    const struct BagPocket *pocket = &gBagPockets[POCKET_BERRIES];
 
     ASSUME(GetItemPocket(ITEM_POMEG_BERRY) == POCKET_BERRIES);
     ASSUME(GetItemPocket(ITEM_MAGOST_BERRY) == POCKET_BERRIES);
@@ -99,7 +99,7 @@ TEST("Berries are sorted correctly in the bag")
 
 TEST("Items are correctly sorted and compacted in the bag")
 {
-    struct BagPocket *pocket = &gBagPockets[POCKET_ITEMS];
+    const struct BagPocket *pocket = &gBagPockets[POCKET_ITEMS];
     memset(pocket->itemSlots, 0, sizeof(gSaveBlock1Ptr->bag.items));
 
     ASSUME(GetItemPocket(ITEM_NUGGET) == POCKET_ITEMS);

--- a/test/pokemon.c
+++ b/test/pokemon.c
@@ -660,8 +660,9 @@ TEST("BoxPokemon encryption works")
         2870614922
     };
 
+    DecryptBoxMon((struct BoxPokemon *)raw);
     struct Pokemon mon;
-    BoxMonToMon((struct BoxPokemon *)&raw, &mon);
+    BoxMonToMon((struct BoxPokemon *)raw, &mon);
 
     EXPECT_EQ(GetMonData(&mon, MON_DATA_SANITY_IS_BAD_EGG), 0);
     EXPECT_EQ(GetMonData(&mon, MON_DATA_SPECIES), SPECIES_TORCHIC);
@@ -729,4 +730,39 @@ TEST("BoxPokemon encryption works")
     EXPECT_EQ(GetMonData(&mon, MON_DATA_HYPER_TRAINED_SPDEF), 1);
     EXPECT_EQ(GetMonData(&mon, MON_DATA_DYNAMAX_LEVEL), 3);
     EXPECT_EQ(GetMonData(&mon, MON_DATA_OT_GENDER), 0);
+}
+
+TEST("EncryptBoxMon is the inverse of DecryptBoxMon")
+{
+    u32 raw[20] =
+    {
+        990384375,
+        2948624514,
+        3907508686,
+        14410461,
+        35316705,
+        3907508686,
+        64742109,
+        718729,
+        3102307966,
+        2160206402,
+        49956971,
+        2495766612,
+        1424318580,
+        273408756,
+        2371630199,
+        2708871082,
+        3059937332,
+        2529190026,
+        2290634828,
+        2870614922
+    };
+
+    struct BoxPokemon boxMon;
+    memcpy(&boxMon, raw, sizeof(boxMon));
+    DecryptBoxMon(&boxMon);
+    EncryptBoxMon(&boxMon);
+
+    for (u32 i = 0; i < ARRAY_COUNT(raw); i++)
+        EXPECT_EQ(raw[i], ((u32 *)&boxMon)[i]);
 }

--- a/test/save.c
+++ b/test/save.c
@@ -29,6 +29,29 @@ TEST("PokemonStorage is backwards compatible")
     EXPECT_EQ(sizeof(struct PokemonStorage), T_POKEMONSTORAGE_SIZE);
 }
 
+// TODO: It would be nice to target 2 frames for this.
+TEST("Encrypting and decrypting the save costs less than 3 frames")
+{
+    // Performance is affected by 'PID % 24' so assign them.
+    u32 personality = 0;
+    for (u32 i = 0; i < TOTAL_BOXES_COUNT; i++)
+    {
+        for (u32 j = 0; j < IN_BOX_COUNT; j++)
+        {
+            gPokemonStoragePtr->boxes[i][j].personality = personality++;
+            gPokemonStoragePtr->boxes[i][j].hasSpecies = TRUE;
+        }
+    }
+
+    struct Benchmark encDec;
+    BENCHMARK(&encDec)
+    {
+        EncryptSave();
+        DecryptSave();
+    }
+    EXPECT_LE(encDec.ticks, 3 * FRAME_TICKS);
+}
+
 #undef T_SAVEBLOCK1_SIZE
 #undef T_SAVEBLOCK2_SIZE
 #undef T_SAVEBLOCK3_SIZE

--- a/test/test_runner.c
+++ b/test/test_runner.c
@@ -212,7 +212,8 @@ top:
 
         gTestRunnerState.filterMode = DetectFilterMode(gTestRunnerArgv);
 
-        MoveSaveBlocks_ResetHeap();
+        RotateEncryptionKey_ResetHeap();
+        SetSaveBlocksPointers();
 
         gIntrTable[7] = Intr_Timer2;
 

--- a/test/test_runner.c
+++ b/test/test_runner.c
@@ -212,7 +212,7 @@ top:
 
         gTestRunnerState.filterMode = DetectFilterMode(gTestRunnerArgv);
 
-        RotateEncryptionKey_ResetHeap();
+        ResetHeap();
         SetSaveBlocksPointers();
 
         gIntrTable[7] = Intr_Timer2;


### PR DESCRIPTION
Frees up some IWRAM (20b) and EWRAM (384b):
```diff
Memory region         Used Size  Region Size  %age Used
-          EWRAM:      226320 B       256 KB     86.33%
+          EWRAM:      225936 B       256 KB     86.19%
-          IWRAM:       28392 B        32 KB     86.65%
+          IWRAM:       28372 B        32 KB     86.58%
-            ROM:    26345108 B        32 MB     78.51%
+            ROM:    26336240 B        32 MB     78.49%
```

Makes accesses to the save slightly faster:
A fragment of `gSaveBlock1Ptr->foo`'s codegen changes like so:
```diff
-ldr rX, =gSaveBlock1Ptr
-ldr rX, [rX]
+ldr rX, =gSaveBlock1
```
which shaves the few cycles of loading the pointer from IWRAM. Also, the compiler will be able to share `rX` across multiple saveblock accesses in all cases, whereas before it could not share it across functions defined in other TUs.

At Gudf's request, introduced a `REPORT_MEMORY_LEAKS` config which will (as the name suggests) let you know what was on the stack when it's cleared by the overworld/battles. There's also `PrintHeap` which just tells you what's allocated, and sometimes comes in handy.

## Feature(s) this PR does NOT handle:
- Optimize `GetMonData`/`SetMonData` to take advantage of the now-fixed offsets.
- Remove all `^ gSaveBlock2Ptr->encryptionKey`s because that's now always a no-op.

## Things to note in the release changelog:
- If you have added new `struct BoxPokemon` to your save (including transitively, e.g. via a `struct Pokemon`), you need to handle them in `DecryptSave` and `EncryptSave`.