### PR TITLE
Remove known failing for Blunder Policy/Darts interaction

### DIFF
--- a/test/battle/hold_effect/blunder_policy.c
+++ b/test/battle/hold_effect/blunder_policy.c
@@ -231,7 +231,6 @@ DOUBLE_BATTLE_TEST("Blunder Policy activates for Dragon Darts if one target miss
     PARAMETRIZE { chosenTarget = opponentLeft;  finalTarget = opponentRight; itemLeft = ITEM_BRIGHT_POWDER;  itemRight = ITEM_NONE; }
     PARAMETRIZE { chosenTarget = opponentRight; finalTarget = opponentLeft;  itemLeft = ITEM_NONE;           itemRight = ITEM_BRIGHT_POWDER; }
 
-    KNOWN_FAILING;
     GIVEN {
         ASSUME(GetMoveAccuracy(MOVE_DRAGON_DARTS) == 100);
         ASSUME(GetMoveTarget(MOVE_DRAGON_DARTS) == TARGET_SMART);
@@ -245,11 +244,9 @@ DOUBLE_BATTLE_TEST("Blunder Policy activates for Dragon Darts if one target miss
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DARTS, playerLeft);
         HP_BAR(finalTarget);
-
-        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, playerLeft);
-
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DARTS, playerLeft);
         HP_BAR(finalTarget);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, playerLeft);
     } THEN {
         EXPECT(playerLeft->item == ITEM_NONE);
         EXPECT_EQ(playerLeft->statStages[STAT_SPEED], DEFAULT_STAT_STAGE + 2);


### PR DESCRIPTION
The implementation is correct but the test was wrong. https://discord.com/channels/419213663107416084/1368163973366681712/1497060987168227419
