### PR TITLE
Fix forced shiny eggs losing shininess on hatch

### DIFF
--- a/src/egg_hatch.c
+++ b/src/egg_hatch.c
@@ -311,6 +311,7 @@ static void CreateHatchedMon(struct Pokemon *egg, struct Pokemon *temp)
     u32 personality, pokerus;
     enum PokeBall ball;
     u8 i, friendship, language, gameMet, markings, isModernFatefulEncounter;
+    bool32 isShiny;
     enum Move moves[MAX_MON_MOVES];
     u32 ivs[NUM_STATS];
 
@@ -330,9 +331,12 @@ static void CreateHatchedMon(struct Pokemon *egg, struct Pokemon *temp)
     markings = GetMonData(egg, MON_DATA_MARKINGS);
     pokerus = GetMonData(egg, MON_DATA_POKERUS);
     isModernFatefulEncounter = GetMonData(egg, MON_DATA_MODERN_FATEFUL_ENCOUNTER);
+    isShiny = GetMonData(egg, MON_DATA_IS_SHINY);
     ball = GetMonData(egg, MON_DATA_POKEBALL);
 
     CreateMonWithIVs(temp, species, EGG_HATCH_LEVEL, personality, OTID_STRUCT_PLAYER_ID, USE_RANDOM_IVS);
+    SetMonData(temp, MON_DATA_IS_SHINY, &isShiny);
+
     for (i = 0; i < MAX_MON_MOVES; i++)
         SetMonData(temp, MON_DATA_MOVE1 + i,  &moves[i]);
 

--- a/test/pokemon.c
+++ b/test/pokemon.c
@@ -1,10 +1,13 @@
 #include "global.h"
 #include "battle.h"
+#include "egg_hatch.h"
 #include "event_data.h"
+#include "new_game.h"
 #include "pokemon.h"
 #include "test/overworld_script.h"
 #include "test/test.h"
 #include "constants/characters.h"
+#include "constants/daycare.h"
 #include "constants/move_relearner.h"
 
 TEST("Nature independent from Hidden Nature")
@@ -85,6 +88,27 @@ TEST("Shininess independent from PID and OTID")
     EXPECT_EQ(pid, GetMonData(&mon, MON_DATA_PERSONALITY));
     EXPECT_EQ(otId, GetMonData(&mon, MON_DATA_OT_ID));
     EXPECT_EQ(!isShiny, GetMonData(&mon, MON_DATA_IS_SHINY));
+}
+
+TEST("Shininess set on an Egg persists after hatching")
+{
+    u32 personality = SHINY_ODDS;
+    u32 trainerId = 0;
+    bool32 isShiny = TRUE;
+    bool8 isEgg = TRUE;
+
+    SetTrainerId(trainerId, gSaveBlock2Ptr->playerTrainerId);
+    CreateMon(&gPlayerParty[0], SPECIES_TOGEPI, EGG_HATCH_LEVEL, personality, OTID_STRUCT_PLAYER_ID);
+    SetMonData(&gPlayerParty[0], MON_DATA_IS_EGG, &isEgg);
+    SetMonData(&gPlayerParty[0], MON_DATA_IS_SHINY, &isShiny);
+
+    EXPECT_EQ(GetMonData(&gPlayerParty[0], MON_DATA_IS_SHINY), TRUE);
+
+    gSpecialVar_0x8004 = 0;
+    ScriptHatchMon();
+
+    EXPECT_EQ(GetMonData(&gPlayerParty[0], MON_DATA_IS_EGG), FALSE);
+    EXPECT_EQ(GetMonData(&gPlayerParty[0], MON_DATA_IS_SHINY), TRUE);
 }
 
 TEST("Hyper Training increases stats without affecting IVs")


### PR DESCRIPTION
## Description

This fixes forced-shiny Eggs losing their shiny state after hatching.

`CreateHatchedMon` recreates the Egg as a new Pokemon and copies selected Egg data back onto the hatched Pokemon. It already preserves data like moves, IVs, Pokerus, markings, and the Poke Ball, but it did not preserve `MON_DATA_IS_SHINY`. If an Egg was made shiny through `SetMonData(MON_DATA_IS_SHINY)` without a naturally shiny PID/OTID pair, the hatch path recreated it as non-shiny.

This PR copies the Egg's `MON_DATA_IS_SHINY` value onto the hatched Pokemon after creation and adds a regression test covering a forced-shiny Egg whose PID/OTID are not naturally shiny.

## Issue(s) that this PR fixes

Fixes #9825

## Things to note in the release changelog:

- Fixed forced-shiny Eggs losing their shiny state after hatching.

## Discord contact info

viridian.

## Testing

- `make check -j32 TESTS=test/pokemon.c`
  - 26 passed
  - 1 known failing
