### PR TITLE
Fix in-battle summary preserving battle party order

### DIFF
--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -3122,10 +3122,11 @@ static void CB2_ShowPokemonSummaryScreen(void)
 {
     if (gPartyMenu.menuType == PARTY_MENU_TYPE_IN_BATTLE)
     {
+        LoadBattlePartyCurrentOrderForLayout();
+        UpdatePartyToBattleOrder();
+
         if (gBattleTypeFlags & BATTLE_TYPE_MULTI)
         {
-            LoadBattlePartyCurrentOrderForLayout();
-            UpdatePartyToBattleOrder();
             if (!AreMultiPartiesFullTeams())
                 GetMultiPartyForSummaryScreen();
         }

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -3122,7 +3122,9 @@ static void CB2_ShowPokemonSummaryScreen(void)
 {
     if (gPartyMenu.menuType == PARTY_MENU_TYPE_IN_BATTLE)
     {
-        LoadBattlePartyCurrentOrderForLayout();
+        if (gBattleTypeFlags & BATTLE_TYPE_MULTI)
+            LoadBattlePartyCurrentOrderForLayout();
+
         UpdatePartyToBattleOrder();
 
         if (gBattleTypeFlags & BATTLE_TYPE_MULTI)


### PR DESCRIPTION
## Description

This fixes an in-battle party summary ordering bug where opening the summary screen for a fainted party member could show the active battler instead, then return to battle with the fainted Pokemon moved into the active slot.

The party menu is converted into battle order when opened in battle, then converted back to field order when the menu closes. The summary callback restored battle order only for multi battles, so regular in-battle summaries interpreted `gPartyMenu.slotId` against field-ordered party data. Returning from summary could then apply the field-order conversion again to an already field-ordered party.

This PR restores battle order before opening the Pokemon summary screen for all in-battle party summaries, while keeping the existing multi-battle-specific summary setup intact.

Validation:

- `make -j32`
- `make check -j32`

I also tested the same flow both without and with the fixed code using a party of 3 Pokemon where one was fainted. The fix functions as expected.

## Media

None.

## Issue(s) that this PR fixes

Fixes #9814.

## Feature(s) this PR does NOT handle:

None.

## Things to note in the release changelog:

- Fixed in-battle Pokemon summaries preserving the correct battle party order after viewing fainted party members.

## Discord contact info

viridian.
