### PR TITLE
Change order of enduring damage effects

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -8127,21 +8127,14 @@ s32 GetAdjustedDamage(struct BattleContext *ctx, s32 damage)
     u32 rand = Random() % 100;
     u32 affectionScore = GetBattlerAffectionHearts(ctx->battlerDef);
 
-    if (GetMoveEffect(ctx->move) == EFFECT_FALSE_SWIPE)
-    {
-        enduredHit = TRUE;
-    }
-    else if (gBattleMons[ctx->battlerDef].volatiles.endured)
+    if (gBattleMons[ctx->battlerDef].volatiles.endured)
     {
         enduredHit = TRUE;
         gBattleStruct->moveResultFlags[ctx->battlerDef] |= MOVE_RESULT_FOE_ENDURED;
     }
-    else if (ctx->holdEffectDef == HOLD_EFFECT_FOCUS_BAND && rand < GetBattlerHoldEffectParam(ctx->battlerDef))
+    else if (GetMoveEffect(ctx->move) == EFFECT_FALSE_SWIPE)
     {
         enduredHit = TRUE;
-        RecordItemEffectBattle(ctx->battlerDef, ctx->holdEffectDef);
-        gLastUsedItem = gBattleMons[ctx->battlerDef].item;
-        gBattleStruct->moveResultFlags[ctx->battlerDef] |= MOVE_RESULT_FOE_HUNG_ON;
     }
     else if (GetConfig(B_STURDY) >= GEN_5 && ctx->abilityDef == ABILITY_STURDY && IsBattlerAtMaxHp(ctx->battlerDef))
     {
@@ -8149,6 +8142,13 @@ s32 GetAdjustedDamage(struct BattleContext *ctx, s32 damage)
         RecordAbilityBattle(ctx->battlerDef, ABILITY_STURDY);
         gLastUsedAbility = ABILITY_STURDY;
         gBattleStruct->moveResultFlags[ctx->battlerDef] |= MOVE_RESULT_STURDIED;
+    }
+    else if (ctx->holdEffectDef == HOLD_EFFECT_FOCUS_BAND && rand < GetBattlerHoldEffectParam(ctx->battlerDef))
+    {
+        enduredHit = TRUE;
+        RecordItemEffectBattle(ctx->battlerDef, ctx->holdEffectDef);
+        gLastUsedItem = gBattleMons[ctx->battlerDef].item;
+        gBattleStruct->moveResultFlags[ctx->battlerDef] |= MOVE_RESULT_FOE_HUNG_ON;
     }
     else if (ctx->holdEffectDef == HOLD_EFFECT_FOCUS_SASH && IsBattlerAtMaxHp(ctx->battlerDef))
     {

--- a/test/battle/move_effect/endure.c
+++ b/test/battle/move_effect/endure.c
@@ -75,6 +75,53 @@ SINGLE_BATTLE_TEST("Endure only lasts for one turn")
     }
 }
 
+SINGLE_BATTLE_TEST("Endure takes precedence over False Swipe (Gen 5+)")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { HP(1); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_ENDURE); MOVE(player, MOVE_FALSE_SWIPE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ENDURE, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FALSE_SWIPE, player);
+        MESSAGE("The opposing Wobbuffet endured the hit!");
+        // No message for False Swipe, but Endure message should still happen
+    }
+}
+
+SINGLE_BATTLE_TEST("Endure takes precedence over Sturdy (Gen 5+)")
+{
+    GIVEN {
+        WITH_CONFIG(B_STURDY, GEN_5);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_ARON) { HP(1); MaxHP(1); Ability(ABILITY_STURDY); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_ENDURE); MOVE(player, MOVE_POUND); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ENDURE, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POUND, player);
+        MESSAGE("The opposing Wobbuffet endured the hit!");
+        NOT ABILITY_POPUP(opponent, ABILITY_STURDY);
+    }
+}
+
+SINGLE_BATTLE_TEST("Endure takes precedence over Focus Sash/Focus Band")
+{
+    GIVEN {
+        ASSUME(GetItemHoldEffect(ITEM_FOCUS_SASH) == HOLD_EFFECT_FOCUS_SASH);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { HP(1); MaxHP(1); Item(ITEM_FOCUS_SASH); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_ENDURE); MOVE(player, MOVE_POUND); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ENDURE, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POUND, player);
+        MESSAGE("The opposing Wobbuffet endured the hit!");
+        NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
+    }
+}
+
 TO_DO_BATTLE_TEST("Endure's success rate decreases for every consecutively used turn");
 TO_DO_BATTLE_TEST("Endure uses the same counter as Protect");
 TO_DO_BATTLE_TEST("Endure doesn't trigger effects that require damage to be done to the Pokémon (Gen 2-4)"); // Eg. Rough Skin

--- a/test/battle/move_effect/endure.c
+++ b/test/battle/move_effect/endure.c
@@ -101,7 +101,7 @@ SINGLE_BATTLE_TEST("Endure takes precedence over Sturdy (Gen 5+)")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ENDURE, opponent);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_POUND, player);
-        MESSAGE("The opposing Wobbuffet endured the hit!");
+        MESSAGE("The opposing Aron endured the hit!");
         NOT ABILITY_POPUP(opponent, ABILITY_STURDY);
     }
 }


### PR DESCRIPTION
Changes order of enduring effects:

1. Endure
2. False Swipe / Hold Back
3. Sturdy
4. Focus Sash / Focus Band
5. Affection

According to jpwiki.

In Gen 4-, Endure was below False Swipe, but does anybody want a config just for that? ...

## Discord contact info
PhallenTree
