### PR TITLE
Move animation fixes

### DIFF
--- a/src/battle_anim.c
+++ b/src/battle_anim.c
@@ -984,6 +984,8 @@ static void Task_InitUpdateMonBg(u8 taskId)
         gTasks[updateTaskId].t2_BgY = gBattle_BG2_Y;
     }
 
+    assertf(sMonAnimTaskIdArray[tIsPartner] == TASK_NONE, "Duplicate monbg without clearmonbg");
+
     gTasks[updateTaskId].t2_InBg2 = tInBg2;
     gTasks[updateTaskId].t2_BattlerId = tBattlerId;
     sMonAnimTaskIdArray[tIsPartner] = updateTaskId;

--- a/src/battle_anim_electric.c
+++ b/src/battle_anim_electric.c
@@ -977,9 +977,9 @@ static void AnimTask_ElectricChargingParticles_Step(u8 taskId)
             u8 spriteId;
             task->data[12] = 0;
             if (gAnimMoveIndex == MOVE_FLASH_CANNON || gAnimMoveIndex == MOVE_STEEL_BEAM)
-                spriteId = CreateSprite(&gLightOfRuinGrayChargeTemplate, task->data[14], task->data[15], 2);
+                spriteId = CreateSpriteUnchecked(&gLightOfRuinGrayChargeTemplate, task->data[14], task->data[15], 2);
             else
-                spriteId = CreateSprite(&gElectricChargingParticlesSpriteTemplate, task->data[14], task->data[15], 2);
+                spriteId = CreateSpriteUnchecked(&gElectricChargingParticlesSpriteTemplate, task->data[14], task->data[15], 2);
 
             if (spriteId != MAX_SPRITES)
             {
@@ -1240,13 +1240,13 @@ static bool8 CreateVoltTackleBolt(struct Task *task, u8 taskId)
     switch (gAnimMoveIndex)
     {
     case MOVE_FAIRY_LOCK:
-        spriteId = CreateSprite(&gFairyLockChainsSpriteTemplate, task->data[3], task->data[5] + 10, 35);
+        spriteId = CreateSpriteUnchecked(&gFairyLockChainsSpriteTemplate, task->data[3], task->data[5] + 10, 35);
         break;
     case MOVE_COLLISION_COURSE:
-        spriteId = CreateSprite(&gCollisionCourseSpriteTemplate, task->data[3], task->data[5], 35);
+        spriteId = CreateSpriteUnchecked(&gCollisionCourseSpriteTemplate, task->data[3], task->data[5], 35);
         break;
     default:
-        spriteId = CreateSprite(&gVoltTackleBoltSpriteTemplate, task->data[3], task->data[5], 35);
+        spriteId = CreateSpriteUnchecked(&gVoltTackleBoltSpriteTemplate, task->data[3], task->data[5], 35);
         break;
     }
     bool32 doDestroyOamMatrix = (gAnimMoveIndex == MOVE_FAIRY_LOCK) || (gAnimMoveIndex == MOVE_COLLISION_COURSE);
@@ -1391,7 +1391,7 @@ void AnimTask_ShockWaveProgressingBolt(u8 taskId)
 
 static bool8 CreateShockWaveBoltSprite(struct Task *task, u8 taskId)
 {
-    u8 spriteId = CreateSprite(&gShockWaveProgressingBoltSpriteTemplate, task->data[6], task->data[7], 35);
+    u8 spriteId = CreateSpriteUnchecked(&gShockWaveProgressingBoltSpriteTemplate, task->data[6], task->data[7], 35);
     if (spriteId != MAX_SPRITES)
     {
         gSprites[spriteId].oam.tileNum += task->data[4];


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
Fixes some move animations that are trying to create too many sprites in double battles, but `MAX_SPRITES` is being checked for, so using the unchecked sprite creation functions is fine.

Adds an `assertf` to the `monbg` command to check for if the target stored task is already ocupied.
If a new `monbg` is called while `sMonAnimTaskIdArray[tIsPartner]` is not set too `TASK_NONE`, a task will leak after the move animation.

### Large Language Models (AI)
<!-- Does your pull request contain code or assets generated by a large language model (AI)? If so, where? -->
<!-- NOTE: There is an expectation that you have fully reviewed your code to ensure it meets all merge criteria (detailed above). -->
<!-- If the maintainers believe that a pull request was generated by AI with no or little to no human oversight, the pull request will be closed without further discussion. -->
No

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara