### PR TITLE
Fix contact damage message printing

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -6774,7 +6774,6 @@ BattleScript_HurtAttacker:
 	healthbarupdate BS_ATTACKER, PASSIVE_HP_UPDATE
 	datahpupdate BS_ATTACKER, PASSIVE_HP_UPDATE
 	printfromtable gHurtByStringIds
-	printstring STRINGID_AFTERMATHDMG
 	waitmessage B_WAIT_TIME_LONG
 	tryfaintmon BS_ATTACKER
 	return


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
Fixes an issue where contact damage (rough skin, rocky helmet etc.) related strings were printing too many times (and in case of Rocky Helmet, the correct message was getting instantly cleared and replaced with the incorrect one).

## Media
Before:
https://github.com/user-attachments/assets/e5bc95aa-5165-4626-a822-4a298b03c554


After:
https://github.com/user-attachments/assets/35076f72-8d1c-4ade-8a26-8d697d90e946


## Discord contact info
kaseni
