### PR TITLE
Fix Innards Out multihit damage basis and Core Enforcer suppression on fainted targets

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -683,7 +683,7 @@ struct BattleStruct
     u16 prevTurnSpecies[MAX_BATTLERS_COUNT]; // Stores species the AI has in play at start of turn
     s16 passiveHpUpdate[MAX_BATTLERS_COUNT]; // non-move damage and healing
     s16 moveDamage[MAX_BATTLERS_COUNT];
-    u16 innardsOutStartHp[MAX_BATTLERS_COUNT]; // HP before first multihit strike taken this move
+    u16 innardsOutHpLost[MAX_BATTLERS_COUNT];
     u16 moveResultFlags[MAX_BATTLERS_COUNT];
     enum CalcDamageState noResultString[MAX_BATTLERS_COUNT];
     u8 doneDoublesSpreadHit:1;

--- a/include/battle.h
+++ b/include/battle.h
@@ -683,6 +683,7 @@ struct BattleStruct
     u16 prevTurnSpecies[MAX_BATTLERS_COUNT]; // Stores species the AI has in play at start of turn
     s16 passiveHpUpdate[MAX_BATTLERS_COUNT]; // non-move damage and healing
     s16 moveDamage[MAX_BATTLERS_COUNT];
+    u16 innardsOutStartHp[MAX_BATTLERS_COUNT]; // HP before first multihit strike taken this move
     u16 moveResultFlags[MAX_BATTLERS_COUNT];
     enum CalcDamageState noResultString[MAX_BATTLERS_COUNT];
     u8 doneDoublesSpreadHit:1;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1794,6 +1794,13 @@ static void MoveDamageDataHpUpdate(enum BattlerId battler, u32 scriptBattler, co
     }
     else
     {
+        if (gMultiHitCounter != 0
+         && gBattleStruct->moveDamage[battler] > 0
+         && gBattleStruct->innardsOutStartHp[battler] == 0)
+        {
+            gBattleStruct->innardsOutStartHp[battler] = gBattleMons[battler].hp;
+        }
+
         if (gBattleStruct->moveDamage[battler] < 0)
         {
             // Negative damage is HP gain
@@ -2480,7 +2487,9 @@ void SetMoveEffect(enum BattlerId battlerAtk, enum BattlerId effectBattler, enum
           && IsSheerForceAffected(gCurrentMove, abilities[battlerAtk])
           && !(moveEffect == MOVE_EFFECT_ORDER_UP && gBattleStruct->battlerState[gBattlerAttacker].commanderSpecies != SPECIES_NONE))
         moveEffect = MOVE_EFFECT_NONE;
-    else if (!IsBattlerAlive(gEffectBattler) && !IgnoreTargetingForMoveEffect(moveEffect))
+    else if (!IsBattlerAlive(gEffectBattler)
+          && moveEffect != MOVE_EFFECT_CORE_ENFORCER
+          && !IgnoreTargetingForMoveEffect(moveEffect))
         moveEffect = MOVE_EFFECT_NONE;
     else if (DoesSubstituteBlockMoveEffectOnTarget(gBattlerAttacker, gEffectBattler, moveEffect))
         moveEffect = MOVE_EFFECT_NONE;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2431,6 +2431,7 @@ static inline bool32 IgnoreTargetingForMoveEffect(enum MoveEffect moveEffect) //
     case MOVE_EFFECT_INFATUATE_SIDE:
     case MOVE_EFFECT_CONFUSE_SIDE:
     case MOVE_EFFECT_TORMENT_SIDE:
+    case MOVE_EFFECT_CORE_ENFORCER:
         return TRUE;
     default:
         return FALSE;
@@ -2487,9 +2488,7 @@ void SetMoveEffect(enum BattlerId battlerAtk, enum BattlerId effectBattler, enum
           && IsSheerForceAffected(gCurrentMove, abilities[battlerAtk])
           && !(moveEffect == MOVE_EFFECT_ORDER_UP && gBattleStruct->battlerState[gBattlerAttacker].commanderSpecies != SPECIES_NONE))
         moveEffect = MOVE_EFFECT_NONE;
-    else if (!IsBattlerAlive(gEffectBattler)
-          && !(moveEffect == MOVE_EFFECT_CORE_ENFORCER && gBattleMons[gEffectBattler].ability == ABILITY_INNARDS_OUT)
-          && !IgnoreTargetingForMoveEffect(moveEffect))
+    else if (!IsBattlerAlive(gEffectBattler) && !IgnoreTargetingForMoveEffect(moveEffect))
         moveEffect = MOVE_EFFECT_NONE;
     else if (DoesSubstituteBlockMoveEffectOnTarget(gBattlerAttacker, gEffectBattler, moveEffect))
         moveEffect = MOVE_EFFECT_NONE;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2488,7 +2488,7 @@ void SetMoveEffect(enum BattlerId battlerAtk, enum BattlerId effectBattler, enum
           && !(moveEffect == MOVE_EFFECT_ORDER_UP && gBattleStruct->battlerState[gBattlerAttacker].commanderSpecies != SPECIES_NONE))
         moveEffect = MOVE_EFFECT_NONE;
     else if (!IsBattlerAlive(gEffectBattler)
-          && moveEffect != MOVE_EFFECT_CORE_ENFORCER
+          && !(moveEffect == MOVE_EFFECT_CORE_ENFORCER && gBattleMons[gEffectBattler].ability == ABILITY_INNARDS_OUT)
           && !IgnoreTargetingForMoveEffect(moveEffect))
         moveEffect = MOVE_EFFECT_NONE;
     else if (DoesSubstituteBlockMoveEffectOnTarget(gBattlerAttacker, gEffectBattler, moveEffect))

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1794,13 +1794,6 @@ static void MoveDamageDataHpUpdate(enum BattlerId battler, u32 scriptBattler, co
     }
     else
     {
-        if (gMultiHitCounter != 0
-         && gBattleStruct->moveDamage[battler] > 0
-         && gBattleStruct->innardsOutStartHp[battler] == 0)
-        {
-            gBattleStruct->innardsOutStartHp[battler] = gBattleMons[battler].hp;
-        }
-
         if (gBattleStruct->moveDamage[battler] < 0)
         {
             // Negative damage is HP gain
@@ -1810,10 +1803,14 @@ static void MoveDamageDataHpUpdate(enum BattlerId battler, u32 scriptBattler, co
         }
         else
         {
+            u16 hpBefore;
+            u16 hpLost;
+
             gBideDmg[battler] += gBattleStruct->moveDamage[battler];
             gBideTarget[battler] = gBattlerAttacker;
 
             // Deal damage to the battler
+            hpBefore = gBattleMons[battler].hp;
             if (gBattleMons[battler].hp > gBattleStruct->moveDamage[battler])
             {
                 if (GetMoveEffect(gCurrentMove) == EFFECT_OHKO && gBattleStruct->moveResultFlags[gBattlerTarget] & MOVE_RESULT_FOE_HUNG_ON)
@@ -1827,6 +1824,11 @@ static void MoveDamageDataHpUpdate(enum BattlerId battler, u32 scriptBattler, co
                 gBattleStruct->moveDamage[battler] = gBattleMons[battler].hp;
                 gBattleMons[battler].hp = 0;
             }
+
+            hpLost = hpBefore - gBattleMons[battler].hp;
+            if (hpLost != 0)
+                gBattleStruct->innardsOutHpLost[battler] += hpLost;
+
             gProtectStructs[battler].assuranceDoubled = TRUE;
             gProtectStructs[battler].revengeDoubled |= 1u << gBattlerAttacker;
 

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4073,12 +4073,18 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
              && !IsBattlerAlive(gBattlerTarget)
              && IsBattlerAlive(gBattlerAttacker))
             {
+                s32 damage = gBattleStruct->moveDamage[gBattlerTarget];
+
                 // Prevent Innards Out effect if Future Sight user is currently not on field
                 if (IsFutureSightAttackerInParty(gBattlerAttacker, gBattlerTarget, gCurrentMove))
                     break;
 
+                // On multihit moves, use HP before the first strike taken this move.
+                if (gBattleStruct->innardsOutStartHp[gBattlerTarget] != 0)
+                    damage = gBattleStruct->innardsOutStartHp[gBattlerTarget];
+
                 gBattleScripting.battler = gBattlerTarget;
-                SetPassiveDamageAmount(gBattlerAttacker, gBattleStruct->moveDamage[gBattlerTarget]);
+                SetPassiveDamageAmount(gBattlerAttacker, damage);
                 BattleScriptCall(BattleScript_AftermathDmg);
                 effect++;
             }
@@ -9940,6 +9946,7 @@ void ClearDamageCalcResults(void)
     for (enum BattlerId battler = 0; battler < MAX_BATTLERS_COUNT; battler++)
     {
         gBattleStruct->moveDamage[battler] = 0;
+        gBattleStruct->innardsOutStartHp[battler] = 0;
         gBattleStruct->moveResultFlags[battler] = 0;
         gBattleStruct->passiveHpUpdate[battler] = 0;
         gSpecialStatuses[battler].criticalHit = FALSE;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4079,9 +4079,8 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
                 if (IsFutureSightAttackerInParty(gBattlerAttacker, gBattlerTarget, gCurrentMove))
                     break;
 
-                // On multihit moves, use HP before the first strike taken this move.
-                if (gBattleStruct->innardsOutStartHp[gBattlerTarget] != 0)
-                    damage = gBattleStruct->innardsOutStartHp[gBattlerTarget];
+                if (gBattleStruct->innardsOutHpLost[gBattlerTarget] != 0)
+                    damage = gBattleStruct->innardsOutHpLost[gBattlerTarget];
 
                 gBattleScripting.battler = gBattlerTarget;
                 SetPassiveDamageAmount(gBattlerAttacker, damage);
@@ -9946,7 +9945,7 @@ void ClearDamageCalcResults(void)
     for (enum BattlerId battler = 0; battler < MAX_BATTLERS_COUNT; battler++)
     {
         gBattleStruct->moveDamage[battler] = 0;
-        gBattleStruct->innardsOutStartHp[battler] = 0;
+        gBattleStruct->innardsOutHpLost[battler] = 0;
         gBattleStruct->moveResultFlags[battler] = 0;
         gBattleStruct->passiveHpUpdate[battler] = 0;
         gSpecialStatuses[battler].criticalHit = FALSE;

--- a/test/battle/ability/innards_out.c
+++ b/test/battle/ability/innards_out.c
@@ -50,6 +50,30 @@ SINGLE_BATTLE_TEST("Innards Out counters accumulated multihit damage after all s
     }
 }
 
+SINGLE_BATTLE_TEST("Innards Out counters accumulated multihit damage for Parental Bond strikes even if fainting on first hit")
+{
+    s16 captured;
+
+    GIVEN {
+        ASSUME(GetMoveCategory(MOVE_SCRATCH) != DAMAGE_CATEGORY_STATUS);
+        ASSUME(gItemsInfo[ITEM_FOCUS_SASH].holdEffect == HOLD_EFFECT_FOCUS_SASH);
+        PLAYER(SPECIES_PYUKUMUKU) { HP(2); MaxHP(2); Ability(ABILITY_INNARDS_OUT); Item(ITEM_FOCUS_SASH); }
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_KANGASKHAN) { Item(ITEM_KANGASKHANITE); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SCRATCH, gimmick: GIMMICK_MEGA); SEND_OUT(player, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MEGA_EVOLUTION, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
+        HP_BAR(player);
+        HP_BAR(player);
+        ABILITY_POPUP(player, ABILITY_INNARDS_OUT);
+        HP_BAR(opponent, captureDamage: &captured);
+    } THEN {
+        EXPECT_EQ(captured, 2);
+    }
+}
+
 SINGLE_BATTLE_TEST("Innards Out does not trigger when Core Enforcer suppresses it after target has acted")
 {
     GIVEN {

--- a/test/battle/ability/innards_out.c
+++ b/test/battle/ability/innards_out.c
@@ -10,35 +10,80 @@ SINGLE_BATTLE_TEST("Innards Out deal dmg on fainting equal to the amount of dmg 
     PARAMETRIZE { hp = 100; } // This takes out Wobbuffet.
 
     GIVEN {
+        ASSUME(GetMoveCategory(MOVE_PSYCHIC) != DAMAGE_CATEGORY_STATUS);
         PLAYER(SPECIES_PYUKUMUKU) { HP(hp); Ability(ABILITY_INNARDS_OUT); }
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET) { HP(70); SpAttack(1000); }
         OPPONENT(SPECIES_WOBBUFFET);
-        ASSUME(GetMoveCategory(MOVE_PSYCHIC) == DAMAGE_CATEGORY_SPECIAL);
     } WHEN {
         TURN { MOVE(opponent, MOVE_PSYCHIC); SEND_OUT(player, 1); if (hp == 100) { SEND_OUT(opponent, 1); } }
     } SCENE {
-        MESSAGE("The opposing Wobbuffet used Psychic!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_PSYCHIC, opponent);
         HP_BAR(player, hp);
         ABILITY_POPUP(player, ABILITY_INNARDS_OUT);
         HP_BAR(opponent, hp);
     }
 }
 
+SINGLE_BATTLE_TEST("Innards Out counters accumulated multihit damage after all strikes even if fainting on first hit")
+{
+    s16 captured;
+
+    GIVEN {
+        ASSUME(GetMoveStrikeCount(MOVE_DOUBLE_KICK) == 2);
+        ASSUME(GetMoveCategory(MOVE_DOUBLE_KICK) != DAMAGE_CATEGORY_STATUS);
+        ASSUME(gItemsInfo[ITEM_FOCUS_SASH].holdEffect == HOLD_EFFECT_FOCUS_SASH);
+        PLAYER(SPECIES_PYUKUMUKU) { HP(2); MaxHP(2); Ability(ABILITY_INNARDS_OUT); Item(ITEM_FOCUS_SASH); }
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_DOUBLE_KICK); SEND_OUT(player, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DOUBLE_KICK, opponent);
+        HP_BAR(player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DOUBLE_KICK, opponent);
+        HP_BAR(player);
+        ABILITY_POPUP(player, ABILITY_INNARDS_OUT);
+        HP_BAR(opponent, captureDamage: &captured);
+    } THEN {
+        EXPECT_EQ(captured, 2);
+    }
+}
+
+SINGLE_BATTLE_TEST("Innards Out does not trigger when Core Enforcer suppresses it after target has acted")
+{
+    GIVEN {
+        ASSUME(MoveHasAdditionalEffect(MOVE_CORE_ENFORCER, MOVE_EFFECT_CORE_ENFORCER));
+        PLAYER(SPECIES_PYUKUMUKU) { HP(1); Ability(ABILITY_INNARDS_OUT); Speed(3); }
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_CORE_ENFORCER); SEND_OUT(player, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CORE_ENFORCER, opponent);
+        HP_BAR(player);
+        NONE_OF {
+            ABILITY_POPUP(player, ABILITY_INNARDS_OUT);
+            HP_BAR(opponent);
+        }
+    }
+}
+
 SINGLE_BATTLE_TEST("Innards Out does not trigger after Gastro Acid has been used")
 {
     GIVEN {
+        ASSUME(GetMoveCategory(MOVE_PSYCHIC) != DAMAGE_CATEGORY_STATUS);
+        ASSUME(GetMoveEffect(MOVE_GASTRO_ACID) == EFFECT_GASTRO_ACID);
         PLAYER(SPECIES_PYUKUMUKU) { HP(1); Ability(ABILITY_INNARDS_OUT); }
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET);
-        ASSUME(GetMoveCategory(MOVE_PSYCHIC) != DAMAGE_CATEGORY_STATUS);
-        ASSUME(GetMoveEffect(MOVE_GASTRO_ACID) == EFFECT_GASTRO_ACID);
     } WHEN {
         TURN { MOVE(opponent, MOVE_GASTRO_ACID); }
         TURN { MOVE(opponent, MOVE_PSYCHIC); SEND_OUT(player, 1); }
     } SCENE {
-        MESSAGE("The opposing Wobbuffet used Gastro Acid!");
-        MESSAGE("The opposing Wobbuffet used Psychic!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_GASTRO_ACID, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_PSYCHIC, opponent);
         HP_BAR(player);
         NONE_OF {
             ABILITY_POPUP(player, ABILITY_INNARDS_OUT);
@@ -51,14 +96,14 @@ SINGLE_BATTLE_TEST("Innards Out does not trigger after Gastro Acid has been used
 SINGLE_BATTLE_TEST("Innards Out does not damage Magic Guard Pokemon")
 {
     GIVEN {
+        ASSUME(GetMoveCategory(MOVE_PSYCHIC) != DAMAGE_CATEGORY_STATUS);
         PLAYER(SPECIES_PYUKUMUKU) { HP(1); Ability(ABILITY_INNARDS_OUT); }
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_CLEFABLE) { Ability(ABILITY_MAGIC_GUARD); }
-        ASSUME(GetMoveCategory(MOVE_PSYCHIC) != DAMAGE_CATEGORY_STATUS);
     } WHEN {
         TURN { MOVE(opponent, MOVE_PSYCHIC); SEND_OUT(player, 1); }
     } SCENE {
-        MESSAGE("The opposing Clefable used Psychic!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_PSYCHIC, opponent);
         HP_BAR(player);
         ABILITY_POPUP(player, ABILITY_INNARDS_OUT);
         NOT HP_BAR(opponent);

--- a/test/battle/ability/innards_out.c
+++ b/test/battle/ability/innards_out.c
@@ -74,6 +74,57 @@ SINGLE_BATTLE_TEST("Innards Out counters accumulated multihit damage for Parenta
     }
 }
 
+SINGLE_BATTLE_TEST("Innards Out includes mid-move Sitrus Berry recovery in accumulated multihit total")
+{
+    s16 captured;
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_SEISMIC_TOSS) == EFFECT_LEVEL_DAMAGE);
+        ASSUME(gItemsInfo[ITEM_SITRUS_BERRY].holdEffect == HOLD_EFFECT_RESTORE_PCT_HP);
+        PLAYER(SPECIES_PYUKUMUKU) { HP(30); MaxHP(40); Ability(ABILITY_INNARDS_OUT); Item(ITEM_SITRUS_BERRY); }
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_KANGASKHAN) { Level(20); Item(ITEM_KANGASKHANITE); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SEISMIC_TOSS, gimmick: GIMMICK_MEGA); SEND_OUT(player, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MEGA_EVOLUTION, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SEISMIC_TOSS, opponent);
+        HP_BAR(player);
+        HP_BAR(player);
+        HP_BAR(player);
+        ABILITY_POPUP(player, ABILITY_INNARDS_OUT);
+        HP_BAR(opponent, captureDamage: &captured);
+    } THEN {
+        EXPECT_EQ(captured, 40);
+    }
+}
+
+SINGLE_BATTLE_TEST("Innards Out should not include Substitute damage in accumulated multihit total")
+{
+    s16 captured;
+
+    GIVEN {
+        ASSUME(GetMoveStrikeCount(MOVE_DOUBLE_KICK) == 2);
+        ASSUME(GetMoveCategory(MOVE_DOUBLE_KICK) != DAMAGE_CATEGORY_STATUS);
+        PLAYER(SPECIES_PYUKUMUKU) { HP(4); MaxHP(4); Ability(ABILITY_INNARDS_OUT); }
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_SUBSTITUTE); }
+        TURN { MOVE(opponent, MOVE_DOUBLE_KICK); SEND_OUT(player, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SUBSTITUTE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DOUBLE_KICK, opponent);
+        SUB_HIT(player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DOUBLE_KICK, opponent);
+        HP_BAR(player);
+        ABILITY_POPUP(player, ABILITY_INNARDS_OUT);
+        HP_BAR(opponent, captureDamage: &captured);
+    } THEN {
+        EXPECT_EQ(captured, 3);
+    }
+}
+
 SINGLE_BATTLE_TEST("Innards Out does not trigger when Core Enforcer suppresses it after target has acted")
 {
     GIVEN {


### PR DESCRIPTION
## Description
[Innards Out](https://bulbapedia.bulbagarden.net/wiki/Innards_Out_(Ability))
> - If a Pokémon with this Ability moves first and is then knocked out by **Core Enforcer**, Innards Out **will not activate**.
> - If a Pokémon with this ability is knocked out by a **multistrike move** (including a move that becomes multistrike due to **Parental Bond**), **the total HP** dealt by all strikes will be added together and countered back all at once.