### PR TITLE
Make healthbox invisible for previous mon after opening party screen

### DIFF
--- a/src/reshow_battle_screen.c
+++ b/src/reshow_battle_screen.c
@@ -410,12 +410,12 @@ static void CreateHealthboxSprite(enum BattlerId battler)
 
         if (!IsOnPlayerSide(battler))
         {
-            if (GetMonData(GetBattlerMon(battler), MON_DATA_HP) == 0)
+            if (GetMonData(GetBattlerMon(battler), MON_DATA_HP) == 0 || gBattleStruct->battlerState[battler].notOnField)
                 SetHealthboxSpriteInvisible(healthboxSpriteId);
         }
         else if (!(gBattleTypeFlags & BATTLE_TYPE_SAFARI))
         {
-            if (!IsValidForBattle(GetBattlerMon(battler)))
+            if (!IsValidForBattle(GetBattlerMon(battler)) || gBattleStruct->battlerState[battler].notOnField)
                 SetHealthboxSpriteInvisible(healthboxSpriteId);
         }
     }


### PR DESCRIPTION
Makes healthbox invisible for battler switching out after opening party screen to select replacement.

This changes for every type of switch that uses `openpartyscreen` and I personally think it looks better than before.

Video:

https://github.com/user-attachments/assets/9f04c68e-d5dc-456b-8138-4a1b5f6b0b6f


## Issue(s) that this PR fixes
Fixes #9852

## Discord contact info
PhallenTree