### PR TITLE
fix(debug_menu): fix flicker when used when map pop-up active

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -869,6 +869,7 @@ static void Debug_ShowMenu(DebugFunc HandleInput, const struct DebugMenuOption *
     LoadMessageBoxAndBorderGfx();
     windowId = AddWindow(&sDebugMenuWindowTemplateMain);
     DrawStdWindowFrame(windowId, FALSE);
+    CopyWindowToVram(windowId, COPYWIN_GFX);
 
     u32 totalItems = 0;
 


### PR DESCRIPTION
## Description
Fixes flickering when the debug menu is opened while the map pop-up is active.
To reproduce, leave a building and activate the debug menu while the pop-up is still active

### Large Language Models (AI)
None

## Media
<img width="240" height="160" alt="pokeemerald-1" src="https://github.com/user-attachments/assets/2f45e0cf-eb1a-42e4-bde4-6b93ca176c30" />

This was taken using a breakpoint but the flickering is noticeable.

## Discord contact info
@kildemal
