### PR TITLE
fix(battle): advance bad poison counter during Poison Heal

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -507,7 +507,8 @@ struct BattlerState
     u16 switchIn:1;
     u16 fainted:1;
     u16 isFirstTurn:2;
-    u16 padding:12;
+    u16 toxicCounterAdvancedByPoisonHeal:1;
+    u16 padding:11;
 };
 
 struct PartyState

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -3331,6 +3331,18 @@ static u32 GetTrapDamage(enum BattlerId battler)
     return damage;
 }
 
+static u32 GetToxicDamageMultiplier(enum BattlerId battlerId, u32 status1)
+{
+    if (!gBattleStruct->battlerState[battlerId].toxicCounterAdvancedByPoisonHeal
+     || (status1 & STATUS1_TOXIC_COUNTER) == 0)
+    {
+        if ((status1 & STATUS1_TOXIC_COUNTER) != STATUS1_TOXIC_TURN(15)) // not 16 turns
+            status1 += STATUS1_TOXIC_TURN(1);
+    }
+
+    return (status1 & STATUS1_TOXIC_COUNTER) >> 8;
+}
+
 static u32 GetPoisonDamage(enum BattlerId battlerId)
 {
     u32 damage = 0;
@@ -3346,13 +3358,10 @@ static u32 GetPoisonDamage(enum BattlerId battlerId)
     }
     else if (gBattleMons[battlerId].status1 & STATUS1_TOXIC_POISON)
     {
-        u32 status1Temp = gBattleMons[battlerId].status1;
         damage = gBattleMons[battlerId].maxHP / 16;
         if (damage == 0)
             damage = 1;
-        if ((status1Temp & STATUS1_TOXIC_COUNTER) != STATUS1_TOXIC_TURN(15)) // not 16 turns
-            status1Temp += STATUS1_TOXIC_TURN(1);
-        damage *= (status1Temp & STATUS1_TOXIC_COUNTER) >> 8;
+        damage *= GetToxicDamageMultiplier(battlerId, gBattleMons[battlerId].status1);
     }
     return damage;
 }

--- a/src/battle_end_turn.c
+++ b/src/battle_end_turn.c
@@ -469,6 +469,25 @@ static bool32 HandleEndTurnLeechSeed(enum BattlerId battler)
     return effect;
 }
 
+static u32 GetToxicCounter(enum BattlerId battler)
+{
+    return (gBattleMons[battler].status1 & STATUS1_TOXIC_COUNTER) >> 8;
+}
+
+static void IncrementToxicCounter(enum BattlerId battler)
+{
+    if ((gBattleMons[battler].status1 & STATUS1_TOXIC_COUNTER) != STATUS1_TOXIC_TURN(15)) // not 16 turns
+        gBattleMons[battler].status1 += STATUS1_TOXIC_TURN(1);
+}
+
+static u32 AdvanceToxicCounterForDamage(enum BattlerId battler)
+{
+    if (!gBattleStruct->battlerState[battler].toxicCounterAdvancedByPoisonHeal || GetToxicCounter(battler) == 0)
+        IncrementToxicCounter(battler);
+    gBattleStruct->battlerState[battler].toxicCounterAdvancedByPoisonHeal = FALSE;
+    return GetToxicCounter(battler);
+}
+
 static bool32 HandleEndTurnPoison(enum BattlerId battler)
 {
     bool32 effect = FALSE;
@@ -477,12 +496,20 @@ static bool32 HandleEndTurnPoison(enum BattlerId battler)
 
     gBattleStruct->eventState.endTurnBattler++;
 
+    if (!(gBattleMons[battler].status1 & STATUS1_TOXIC_POISON))
+        gBattleStruct->battlerState[battler].toxicCounterAdvancedByPoisonHeal = FALSE;
+
     if ((gBattleMons[battler].status1 & STATUS1_POISON || gBattleMons[battler].status1 & STATUS1_TOXIC_POISON)
      && IsBattlerAlive(battler)
      && !IsAbilityAndRecord(battler, ability, ABILITY_MAGIC_GUARD))
     {
         if (ability == ABILITY_POISON_HEAL)
         {
+            if (gBattleMons[battler].status1 & STATUS1_TOXIC_POISON)
+            {
+                IncrementToxicCounter(battler);
+                gBattleStruct->battlerState[battler].toxicCounterAdvancedByPoisonHeal = TRUE;
+            }
             if (!IsBattlerAtMaxHp(battler) && !gBattleMons[battler].volatiles.healBlock)
             {
                 SetHealAmount(battler, GetNonDynamaxMaxHP(battler) / 8);
@@ -493,9 +520,7 @@ static bool32 HandleEndTurnPoison(enum BattlerId battler)
         else if (gBattleMons[battler].status1 & STATUS1_TOXIC_POISON)
         {
             SetPassiveDamageAmount(battler, GetNonDynamaxMaxHP(battler) / 16);
-            if ((gBattleMons[battler].status1 & STATUS1_TOXIC_COUNTER) != STATUS1_TOXIC_TURN(15)) // not 16 turns
-                gBattleMons[battler].status1 += STATUS1_TOXIC_TURN(1);
-            gBattleStruct->passiveHpUpdate[battler] *= (gBattleMons[battler].status1 & STATUS1_TOXIC_COUNTER) >> 8;
+            gBattleStruct->passiveHpUpdate[battler] *= AdvanceToxicCounterForDamage(battler);
             BattleScriptExecute(BattleScript_PoisonTurnDmg);
             effect = TRUE;
         }

--- a/test/battle/ability/poison_heal.c
+++ b/test/battle/ability/poison_heal.c
@@ -43,6 +43,34 @@ SINGLE_BATTLE_TEST("Poison Heal heals from Toxic Poison damage are constant")
     }
 }
 
+SINGLE_BATTLE_TEST("Bad poison counter still increases each turn if the Pokemon has Poison Heal")
+{
+    u32 j;
+    s16 poisonDamage;
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_GASTRO_ACID) == EFFECT_GASTRO_ACID);
+        PLAYER(SPECIES_SHROOMISH) { Ability(ABILITY_POISON_HEAL); Status1(STATUS1_TOXIC_POISON); HP(60); MaxHP(160); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        for (j = 0; j < 5; j++)
+            TURN {}
+        TURN { MOVE(opponent, MOVE_GASTRO_ACID); }
+    } SCENE {
+        for (j = 0; j < 5; j++)
+        {
+            ABILITY_POPUP(player, ABILITY_POISON_HEAL);
+            MESSAGE("The poisoning healed Shroomish a little bit!");
+            HP_BAR(player, damage: -(160 / 8));
+        }
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_GASTRO_ACID, opponent);
+        NOT ABILITY_POPUP(player, ABILITY_POISON_HEAL);
+        HP_BAR(player, captureDamage: &poisonDamage);
+    } THEN {
+        EXPECT_EQ(poisonDamage, 160 * 5 / 16);
+    }
+}
+
 SINGLE_BATTLE_TEST("Poison Heal does not heal or cause damage when under Heal Block")
 {
     GIVEN {


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
Badly poisoned Pokemon with Poison Heal now continue advancing their toxic counter while Poison Heal converts the end-of-turn poison effect into healing. If Poison Heal is later suppressed, the next toxic poison damage uses the elapsed toxic counter instead of restarting at 1/16 HP.

This also updates AI poison damage estimation to account for toxic counters that were already advanced by Poison Heal, so the AI does not double-increment the projected damage after Poison Heal is removed.

A regression test was added for a badly poisoned Poison Heal Pokemon that loses Poison Heal to Gastro Acid after five end-of-turn Poison Heal activations.

Validation performed:

- `make check TESTS="Bad poison counter still increases"`
- `make check TESTS="Bad poison deals 1/16th cumulative damage per turn"`
- `make check TESTS="Poison Heal"`
- `make check TESTS="Bad poison"`
- `make check TESTS="AI uses Skill Swap against Poison Heal"`

## Issue(s) that this PR fixes
Fixes #9722

<!-- CREDITS -->
<!-- Once your PR is submitted, leave a comment asking the bot to add you to the credits. -->
<!-- If anybody helped with this PR, please encourage them to comment on your PR and ask the bot to add them to the credits. -->
<!-- If somebody has contributed at any point and has indicated they wish to be credited, please ask the bot to add them to the credits. If they do not have a known GitHub account, add them to the list at bottom of `CREDITS.md`. -->
<!-- EVERY contribution matters! -->
<!-- https://github.com/rh-hideout/pokeemerald-expansion/wiki/CREDITS.md-Frequently-Asked-Questions -->

## Things to note in the release changelog:
- Fixed Poison Heal failing to advance the toxic poison counter each turn.

## Discord contact info
viridian.