### PR TITLE
Fix UB in GetBattleMoveCategory

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -9149,7 +9149,7 @@ static enum DamageCategory SwapMoveDamageCategory(enum Move move)
 */
 enum DamageCategory GetBattleMoveCategory(enum Move move)
 {
-    if (gMain.inBattle)
+    if (gBattleStruct != NULL)
     {
         if (gBattleStruct->swapDamageCategory) // Photon Geyser, Shell Side Arm, Light That Burns the Sky, Tera Blast
             return SwapMoveDamageCategory(move);


### PR DESCRIPTION
## Description
`FreeBattleResources` is called before `GetBattleMoveCategory` when a mon learns a move post-evolution after a battle. At this point `gMain.inBattle` is still `TRUE` .

## Discord contact info
.cawt