### PR TITLE
Safari fixes

### DIFF
--- a/data/scripts/safari_zone.inc
+++ b/data/scripts/safari_zone.inc
@@ -1,11 +1,11 @@
 SafariZone_EventScript_OutOfBallsMidBattle::
-#ifdef IS_FRLG
+#if IS_FRLG
 	setvar VAR_MAP_SCENE_FUCHSIA_CITY_SAFARI_ZONE_ENTRANCE, 3
 #else
 	setvar VAR_SAFARI_ZONE_STATE, 1
 #endif
 	special ExitSafariMode
-#ifdef IS_FRLG
+#if IS_FRLG
 	setwarp MAP_FUCHSIA_CITY_SAFARI_ZONE_ENTRANCE, 4, 1
 #else
 	setwarp MAP_ROUTE121_SAFARI_ZONE_ENTRANCE, 2, 5
@@ -13,13 +13,13 @@ SafariZone_EventScript_OutOfBallsMidBattle::
 	end
 
 SafariZone_EventScript_Exit::
-#ifdef IS_FRLG
+#if IS_FRLG
 	setvar VAR_MAP_SCENE_FUCHSIA_CITY_SAFARI_ZONE_ENTRANCE, 1
 #else
 	setvar VAR_SAFARI_ZONE_STATE, 1
 #endif
 	special ExitSafariMode
-#ifdef IS_FRLG
+#if IS_FRLG
 	warp MAP_FUCHSIA_CITY_SAFARI_ZONE_ENTRANCE, 4, 1
 #else
 	warp MAP_ROUTE121_SAFARI_ZONE_ENTRANCE, 2, 5

--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -1944,7 +1944,7 @@ static void UpdateLeftNoOfBallsTextOnHealthbox(u8 healthboxSpriteId)
     txtPtr = StringCopy(text, gText_SafariBallLeft);
     ConvertIntToDecimalStringN(txtPtr, gNumSafariBalls, STR_CONV_MODE_LEFT_ALIGN, 2);
 
-    FillSpriteRectColor(healthboxSpriteId, 55, 19, 31, 12, HEALTHBOX_BG_INDEX);
+    FillSpriteRectColor(healthboxSpriteId, 55, 19, 39, 12, HEALTHBOX_BG_INDEX);
     AddSpriteTextPrinterParameterized6(healthboxSpriteId, FONT_SMALL, 55, 19, 0, 0, sHealthBoxTextColor, 0, text);
 
     gSprites[healthboxSpriteId].data[1] = savedValue1;


### PR DESCRIPTION
Two bugfixes in one PR because the issue was two bugs in one as well

- IS_FRLG is defined to 0 when compiling in emerald mode so `#ifdef IS_FRLG` returns true which causes issues. Changing it to `#if IS_FRLG` fixes the issue
- I modified the clearrect function in the safari box in #9341 but I didn't check what happend when the text was rewritten and cut too many pixels, increasing width of the area being erased fixes that

## Issue(s) that this PR fixes
Fixes #9873

## Discord contact info
Jamie
