### PR TITLE
Move follower check before trainer hill check whene selecting script

### DIFF
--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -3683,8 +3683,6 @@ void SetObjectEventDirection(struct ObjectEvent *objectEvent, enum Direction dir
 
 static const u8 *GetObjectEventScriptPointerByLocalIdAndMap(u8 localId, u8 mapNum, u8 mapGroup)
 {
-    if (localId == OBJ_EVENT_ID_FOLLOWER)
-        return EventScript_Follower;
     return GetObjectEventTemplateByLocalIdAndMap(localId, mapNum, mapGroup)->script;
 }
 

--- a/src/field_control_avatar.c
+++ b/src/field_control_avatar.c
@@ -401,10 +401,12 @@ static const u8 *GetInteractedObjectEventScript(struct MapPosition *position, u8
     gSelectedObjectEvent = objectEventId;
     gSpecialVar_LastTalked = gObjectEvents[objectEventId].localId;
 
-    if (InTrainerHill() == TRUE)
-        script = GetTrainerHillTrainerScript();
-    else if (PlayerHasFollowerNPC() && objectEventId == GetFollowerNPCObjectId())
+    if (PlayerHasFollowerNPC() && objectEventId == GetFollowerNPCObjectId())
         script = GetFollowerNPCScriptPointer();
+    else if (gObjectEvents[objectEventId].localId == OBJ_EVENT_ID_FOLLOWER)
+        script = EventScript_Follower;
+    else if (InTrainerHill() == TRUE)
+        script = GetTrainerHillTrainerScript();
     else
         script = GetObjectEventScriptPointerByObjectEventId(objectEventId);
 


### PR DESCRIPTION
I modified the order in which the game check for special script. It now checks if you are talking to your follower before checking if you are in trainer hill

## Media

https://github.com/user-attachments/assets/e154b3ba-c5d1-4114-9182-4722e900116a

## Issue(s) that this PR fixes
Fixes #9868

## Discord contact info
Jamie
