### PR TITLE
Fix frlg fishing sprite

### DIFF
--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -3103,7 +3103,8 @@ static void ObjectEventSetGraphics(struct ObjectEvent *objectEvent, const struct
         UpdateSpritePalette(&sObjectEventSpritePalettes[i], sprite);
 
     // If gfx size changes, we need to reallocate tiles
-    if (OW_LARGE_OW_SUPPORT && !OW_GFX_COMPRESS && graphicsInfo->oam->size != sprite->oam.size)
+    if ((OW_LARGE_OW_SUPPORT && !OW_GFX_COMPRESS && graphicsInfo->oam->size != sprite->oam.size)
+     || (sprite->images->size != graphicsInfo->images->size))
         ReallocSpriteTiles(sprite, graphicsInfo->images->size);
 
     #if OW_GFX_COMPRESS


### PR DESCRIPTION
## Description
The issue seems to be the size difference between `gObjectEventGraphicsInfo_RedSurf` (`256`) and `gObjectEventGraphicsInfo_RedFish` (`512`), so tile reallocation is required.
I am not 100% sure on these 2 points:
- this might make the first condition obsolete `(OW_LARGE_OW_SUPPORT && !OW_GFX_COMPRESS && graphicsInfo->oam->size != sprite->oam.size)`.
- it's possible that comparing oams (`oam.size` and `oam.shape`) might be better than `image->size`

## Issue(s) that this PR fixes
Fixes #9886

## Discord contact info
.cawt
