### PR TITLE
Fix Ruin abilities respecting each other even if deactivated

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -7140,10 +7140,10 @@ static inline u32 CalcAttackStat(struct BattleContext *ctx)
     }
 
     // Ruin field effects
-    if (IsBattleMoveSpecial(move) && !gBattleMons[ctx->battlerAtk].volatiles.vesselOfRuin && IsRuinStatusActive(VOLATILE_VESSEL_OF_RUIN))
+    if (IsBattleMoveSpecial(move) && ctx->abilityAtk != ABILITY_VESSEL_OF_RUIN && IsRuinStatusActive(VOLATILE_VESSEL_OF_RUIN))
         modifier = uq4_12_multiply_half_down(modifier, UQ_4_12(0.75));
 
-    if (IsBattleMovePhysical(move) && !gBattleMons[ctx->battlerAtk].volatiles.tabletsOfRuin && IsRuinStatusActive(VOLATILE_TABLETS_OF_RUIN))
+    if (IsBattleMovePhysical(move) && ctx->abilityAtk != ABILITY_TABLETS_OF_RUIN && IsRuinStatusActive(VOLATILE_TABLETS_OF_RUIN))
         modifier = uq4_12_multiply_half_down(modifier, UQ_4_12(0.75));
 
     // attacker's hold effect
@@ -7328,10 +7328,10 @@ static inline u32 CalcDefenseStat(struct BattleContext *ctx)
     }
 
     // Ruin field effects
-    if (usesDefStat && !gBattleMons[ctx->battlerDef].volatiles.swordOfRuin && IsRuinStatusActive(VOLATILE_SWORD_OF_RUIN))
+    if (usesDefStat && ctx->abilityDef != ABILITY_SWORD_OF_RUIN && IsRuinStatusActive(VOLATILE_SWORD_OF_RUIN))
         modifier = uq4_12_multiply_half_down(modifier, UQ_4_12(0.75));
 
-    if (!usesDefStat && !gBattleMons[ctx->battlerDef].volatiles.beadsOfRuin && IsRuinStatusActive(VOLATILE_BEADS_OF_RUIN))
+    if (!usesDefStat && ctx->abilityDef != ABILITY_BEADS_OF_RUIN && IsRuinStatusActive(VOLATILE_BEADS_OF_RUIN))
         modifier = uq4_12_multiply_half_down(modifier, UQ_4_12(0.75));
 
     // target's hold effects

--- a/test/battle/ability/beads_of_ruin.c
+++ b/test/battle/ability/beads_of_ruin.c
@@ -286,3 +286,40 @@ DOUBLE_BATTLE_TEST("Beads of Ruin will not be deactivated with Ability Shield")
         EXPECT_EQ(damage[1], damage[0]);
     }
 }
+
+SINGLE_BATTLE_TEST("Beads of Ruin does not apply any damage reduction on an opposing Beads of Ruin user even if it is deactivated")
+{
+    s16 damage[2];
+
+    GIVEN {
+        ASSUME(GetMoveCategory(MOVE_WATER_GUN) == DAMAGE_CATEGORY_SPECIAL);
+        ASSUME(GetMoveEffect(MOVE_DRAGON_TAIL) == EFFECT_HIT_SWITCH_TARGET);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_CHI_YU) { Ability(ABILITY_BEADS_OF_RUIN); Moves(MOVE_CELEBRATE); }
+        OPPONENT(SPECIES_EXCADRILL) { Ability(ABILITY_MOLD_BREAKER); }
+        OPPONENT(SPECIES_CHI_YU) { Ability(ABILITY_BEADS_OF_RUIN); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_DRAGON_TAIL); }
+        TURN { SWITCH(opponent, 1); MOVE(player, MOVE_CELEBRATE); }
+        TURN { MOVE(opponent, MOVE_WATER_GUN); }
+        TURN { SWITCH(player, 0); MOVE(opponent, MOVE_CELEBRATE); }
+        TURN { SWITCH(player, 1); MOVE(opponent, MOVE_WATER_GUN); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_TAIL, opponent);
+        NOT ABILITY_POPUP(player, ABILITY_BEADS_OF_RUIN); // Move use on deactivated Beads of Ruin
+
+        ABILITY_POPUP(opponent, ABILITY_BEADS_OF_RUIN);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
+
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_WATER_GUN, opponent);
+        HP_BAR(player, captureDamage: &damage[0]);
+
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
+
+        ABILITY_POPUP(player, ABILITY_BEADS_OF_RUIN); // Move use on activated Beads of Ruin
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_WATER_GUN, opponent);
+        HP_BAR(player, captureDamage: &damage[1]);
+    } THEN {
+        EXPECT_EQ(damage[1], damage[0]);
+    }
+}

--- a/test/battle/ability/beads_of_ruin.c
+++ b/test/battle/ability/beads_of_ruin.c
@@ -287,7 +287,7 @@ DOUBLE_BATTLE_TEST("Beads of Ruin will not be deactivated with Ability Shield")
     }
 }
 
-DOUBLE_BATTLE_TEST("Beads of Ruin will still be active after Ability Shield is removed")
+DOUBLE_BATTLE_TEST("Beads of Ruin will still be active while suppressed after Ability Shield is removed")
 {
     s16 damage[2];
 

--- a/test/battle/ability/beads_of_ruin.c
+++ b/test/battle/ability/beads_of_ruin.c
@@ -287,6 +287,42 @@ DOUBLE_BATTLE_TEST("Beads of Ruin will not be deactivated with Ability Shield")
     }
 }
 
+DOUBLE_BATTLE_TEST("Beads of Ruin will still be active after Ability Shield is removed")
+{
+    s16 damage[2];
+
+    GIVEN {
+        ASSUME(GetMoveCategory(MOVE_WATER_GUN) == DAMAGE_CATEGORY_SPECIAL);
+        ASSUME(gItemsInfo[ITEM_ABILITY_SHIELD].holdEffect == HOLD_EFFECT_ABILITY_SHIELD);
+        ASSUME(GetMoveEffect(MOVE_KNOCK_OFF) == EFFECT_KNOCK_OFF);
+        PLAYER(SPECIES_CHI_YU) { Ability(ABILITY_BEADS_OF_RUIN); Item(ITEM_ABILITY_SHIELD); }
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WEEZING) { Ability(ABILITY_NEUTRALIZING_GAS); }
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_WATER_GUN, target: opponentRight); }
+        TURN {
+            SWITCH(opponentLeft, 2);
+            MOVE(opponentRight, MOVE_KNOCK_OFF, target: playerLeft);
+            MOVE(playerLeft, MOVE_WATER_GUN, target: opponentRight);
+        }
+    } SCENE {
+        ABILITY_POPUP(playerLeft, ABILITY_BEADS_OF_RUIN);
+
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_WATER_GUN, playerLeft);
+        HP_BAR(opponentRight, captureDamage: &damage[0]);
+
+        ABILITY_POPUP(opponentLeft, ABILITY_NEUTRALIZING_GAS);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_KNOCK_OFF, opponentRight);
+
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_WATER_GUN, playerLeft);
+        HP_BAR(opponentRight, captureDamage: &damage[1]);
+    } THEN {
+        EXPECT_EQ(damage[1], damage[0]);
+    }
+}
+
 SINGLE_BATTLE_TEST("Beads of Ruin does not apply any damage reduction on an opposing Beads of Ruin user even if it is deactivated")
 {
     s16 damage[2];


### PR DESCRIPTION
It looks like when checking if the modifier should be applied, the actual Ability is checked not the ruin status flag is set