### PR TITLE
fix (namebox): back 2 back namebox no longer flickers

### DIFF
--- a/include/field_name_box.h
+++ b/include/field_name_box.h
@@ -9,7 +9,7 @@
 extern EWRAM_DATA const u8 *gSpeakerName;
 extern const u8 *const gSpeakerNamesTable[];
 
-void TrySpawnNamebox(u32 tileNum);
+void PrepareNamebox(u32 tileNum);
 u32 GetNameboxWindowId(void);
 void ResetNameboxData(void);
 void DestroyNamebox(void);
@@ -18,5 +18,14 @@ void DrawNamebox(u32 windowId, u32 tileNum, bool32 copyToVram);
 void ClearNamebox(u32 windowId, bool32 copyToVram);
 u32 GetNameboxWidth(void);
 void TrySpawnAndShowNamebox(const u8 *speaker, u32 tileNum);
+bool32 IsSpeakerBuffered(const u8 *str);
+
+static inline void TrySpawnNamebox(const u8 *dialogue, u32 tileNum)
+{
+    if (IsSpeakerBuffered(dialogue))
+        PrepareNamebox(tileNum);
+    else
+        DestroyNamebox();
+}
 
 #endif // GUARD_FIELD_NAME_BOX_H

--- a/src/field_message_box.c
+++ b/src/field_message_box.c
@@ -129,8 +129,8 @@ bool8 ShowFieldMessageFromBuffer(void)
 
 static void ExpandStringAndStartDrawFieldMessage(const u8 *str, bool32 allowSkippingDelayWithButtonPress)
 {
-    TrySpawnNamebox(NAME_BOX_BASE_TILE_NUM);
     StringExpandPlaceholders(gStringVar4, str);
+    TrySpawnNamebox(gStringVar4, NAME_BOX_BASE_TILE_NUM);
     AddTextPrinterForMessage(allowSkippingDelayWithButtonPress);
     CreateTask_DrawFieldMessage();
 }

--- a/src/field_name_box.c
+++ b/src/field_name_box.c
@@ -30,7 +30,7 @@ static void WindowFunc_ClearNamebox(u8, u8, u8, u8, u8, u8);
 void PrepareNamebox(u32 tileNum)
 {
     u8 *strbuf = AllocZeroed(32 * sizeof(u8));
-    if ((OW_FLAG_SUPPRESS_NAME_BOX != 0 && FlagGet(OW_FLAG_SUPPRESS_NAME_BOX)) || !gSpeakerName || !strbuf)
+    if (FlagGet(OW_FLAG_SUPPRESS_NAME_BOX) || !gSpeakerName || !strbuf)
     {
         // Re-check again in case anything but !strbuf is TRUE.
         if (strbuf)

--- a/src/field_name_box.c
+++ b/src/field_name_box.c
@@ -23,19 +23,21 @@ EWRAM_DATA const u8 *gSpeakerName = NULL;
 static const u32 sNameBoxDefaultGfx[] = INCGFX_U32("graphics/text_window/name_box.png", ".4bpp");
 static const u32 sNameBoxPokenavGfx[] = INCGFX_U32("graphics/pokenav/name_box.png", ".4bpp");
 
+static void DestroyNameboxFrame(void);
 static void WindowFunc_DrawNamebox(u32, u32, u32, u32, u32, u32, u32);
 static void WindowFunc_ClearNamebox(u8, u8, u8, u8, u8, u8);
 
-void TrySpawnNamebox(u32 tileNum)
+void PrepareNamebox(u32 tileNum)
 {
     u8 *strbuf = AllocZeroed(32 * sizeof(u8));
-    if ((OW_FLAG_SUPPRESS_NAME_BOX != 0 && FlagGet(OW_FLAG_SUPPRESS_NAME_BOX)) || gSpeakerName == NULL || !strbuf)
+    if ((OW_FLAG_SUPPRESS_NAME_BOX != 0 && FlagGet(OW_FLAG_SUPPRESS_NAME_BOX)) || !gSpeakerName || !strbuf)
     {
         // Re-check again in case anything but !strbuf is TRUE.
         if (strbuf)
             Free(strbuf);
 
         DestroyNamebox();
+        RedrawDialogueFrame();
         return;
     }
 
@@ -53,7 +55,7 @@ void TrySpawnNamebox(u32 tileNum)
 
     if (sNameboxWindowId != WINDOW_NONE)
     {
-        DestroyNamebox();
+        DestroyNameboxFrame();
         RedrawDialogueFrame();
     }
 
@@ -82,9 +84,8 @@ void TrySpawnNamebox(u32 tileNum)
     }
 
     union TextColor savedTextColors = SaveTextColors();
-    AddTextPrinterParameterized3(sNameboxWindowId, fontId, strX, 0, colors, 0, strbuf);
+    AddTextPrinterParameterized3(sNameboxWindowId, fontId, strX, 0, colors, TEXT_SKIP_DRAW, strbuf);
     RestoreTextColors(savedTextColors);
-    PutWindowTilemap(sNameboxWindowId);
     Free(strbuf);
 }
 
@@ -99,16 +100,20 @@ void ResetNameboxData(void)
     gSpeakerName = NULL;
 }
 
+static void DestroyNameboxFrame(void)
+{
+    ClearNamebox(sNameboxWindowId, FALSE);
+    ClearWindowTilemap(sNameboxWindowId);
+    RemoveWindow(sNameboxWindowId);
+}
+
 void DestroyNamebox(void)
 {
     if (sNameboxWindowId == WINDOW_NONE)
         return;
 
-    ClearNamebox(sNameboxWindowId, TRUE);
-    ClearWindowTilemap(sNameboxWindowId);
-    RemoveWindow(sNameboxWindowId);
-    sNameboxWindowId = WINDOW_NONE;
-    gSpeakerName = NULL;
+    DestroyNameboxFrame();
+    ResetNameboxData();
 }
 
 u32 GetNameboxWidth(void)
@@ -192,9 +197,30 @@ void SetSpeaker(struct ScriptContext *ctx)
 void TrySpawnAndShowNamebox(const u8 *speaker, u32 tileNum)
 {
     gSpeakerName = speaker;
-    TrySpawnNamebox(tileNum);
-    if (sNameboxWindowId != WINDOW_NONE)
-        DrawNamebox(sNameboxWindowId, tileNum - NAME_BOX_BASE_TILES_TOTAL, TRUE);
-    else // either NULL or SP_NAME_NONE
+    if (sNameboxWindowId != WINDOW_NONE && gSpeakerName == NULL)
+    {
+        ClearNamebox(sNameboxWindowId, TRUE);
+        DestroyNamebox();
         RedrawDialogueFrame();
+        return;
+    }
+
+    PrepareNamebox(tileNum);
+    DrawNamebox(sNameboxWindowId, tileNum - NAME_BOX_BASE_TILES_TOTAL, TRUE);
+}
+
+bool32 IsSpeakerBuffered(const u8 *str)
+{
+    if (str[0] == EXT_CTRL_CODE_BEGIN
+     && str[1] == EXT_CTRL_CODE_SPEAKER
+     && str[2] >= SP_NAME_NONE)
+    {
+        gSpeakerName = gSpeakerNamesTable[str[2]];
+    }
+
+    u32 res = FALSE;
+    if (gSpeakerName)
+        res = TRUE;
+
+    return res;
 }

--- a/src/match_call.c
+++ b/src/match_call.c
@@ -1326,7 +1326,9 @@ static bool32 MatchCall_PrintIntro(u8 taskId)
         if (!sMatchCallState.triggeredFromScript)
             SelectMatchCallMessage(sMatchCallState.trainerId, gStringVar4);
 
-        TrySpawnAndShowNamebox(gSpeakerName, NAME_BOX_BASE_TILE_NUM);
+        if (IsSpeakerBuffered(gStringVar4))
+            TrySpawnAndShowNamebox(gSpeakerName, NAME_BOX_BASE_TILE_NUM);
+
         InitMatchCallTextPrinter(tWindowId, gStringVar4);
         return TRUE;
     }
@@ -1368,6 +1370,7 @@ static bool32 MatchCall_EndCall(u8 taskId)
     u8 playerObjectId;
     if (!IsDma3ManagerBusyWithBgCopy() && !IsSEPlaying())
     {
+        DestroyNamebox();
         ChangeBgY(0, 0, BG_COORD_SET);
         if (!sMatchCallState.triggeredFromScript)
         {


### PR DESCRIPTION
## Description
Improve namebox system to be able to smoothly load speaker with back-to-back `message`/`msgbox` usage.

### Large Language Models (AI)
Nah

## Media
<img width="240" height="160" alt="after_fix" src="https://github.com/user-attachments/assets/9a13fea3-c4fd-471c-a7bd-5829abf90fde" />

## Issue(s) that this PR fixes
Fixes #9889.

## Discord contact info
mudskipper13