### PR TITLE
Remove two unused functions from src/event_object_movement.c

### DIFF
--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -1644,31 +1644,6 @@ static u8 InitObjectEventStateFromTemplate(const struct ObjectEventTemplate *tem
     return objectEventId;
 }
 
-u8 Unref_TryInitLocalObjectEvent(u8 localId)
-{
-    u8 i;
-    u8 objectEventCount;
-    struct ObjectEventTemplate *template;
-
-    if (gMapHeader.events != NULL)
-    {
-        if (CurrentBattlePyramidLocation() != PYRAMID_LOCATION_NONE)
-            objectEventCount = GetNumBattlePyramidObjectEvents();
-        else if (InTrainerHill())
-            objectEventCount = HILL_TRAINERS_PER_FLOOR;
-        else
-            objectEventCount = gMapHeader.events->objectEventCount;
-
-        for (i = 0; i < objectEventCount; i++)
-        {
-            template = &gSaveBlock1Ptr->objectEventTemplates[i];
-            if (template->localId == localId && !FlagGet(template->flagId))
-                return InitObjectEventStateFromTemplate(template, gSaveBlock1Ptr->location.mapNum, gSaveBlock1Ptr->location.mapGroup);
-        }
-    }
-    return OBJECT_EVENTS_COUNT;
-}
-
 static bool8 GetAvailableObjectEventId(u16 localId, u8 mapNum, u8 mapGroup, u8 *objectEventId)
 // Looks for an empty slot.
 // Returns FALSE and the location of the available slot
@@ -3507,19 +3482,6 @@ void TryMoveObjectEventToMapCoords(u8 localId, u8 mapNum, u8 mapGroup, s16 x, s1
 void ShiftStillObjectEventCoords(struct ObjectEvent *objectEvent)
 {
     ShiftObjectEventCoords(objectEvent, objectEvent->currentCoords.x, objectEvent->currentCoords.y);
-}
-
-void UpdateObjectEventCoords(struct ObjectEvent *objectEvent, s16 dx, s16 dy)
-{
-    if (objectEvent->active)
-    {
-        objectEvent->initialCoords.x -= dx;
-        objectEvent->initialCoords.y -= dy;
-        objectEvent->currentCoords.x -= dx;
-        objectEvent->currentCoords.y -= dy;
-        objectEvent->previousCoords.x -= dx;
-        objectEvent->previousCoords.y -= dy;
-    }
 }
 
 void UpdateObjectEventCoordsForCameraUpdate(void)


### PR DESCRIPTION
Unref_TryInitLocalObjectEvent is an unused function present in pret for matching
UpdateObjectEventCoords is a leftover from #8434 the function was made obsolete during the review process


## Discord contact info
Jamie
