### PR TITLE
Basic daily seed

### DIFF
--- a/include/config/overworld.h
+++ b/include/config/overworld.h
@@ -120,9 +120,6 @@
                                             // Due to changes in project scope, as detailed in docs/team_procedures/scope.md,
                                             // no other overworld popups will be implemented in expansion.
 
-// Daily seed config
-#define OW_USE_DAILY_SEED          FALSE    // Adds a random 32 bit number that changes everyday to the save file (currently unused)
-
 // Gen5 map pop-up config
 // Constants
 #define OW_POPUP_BW_TIME_NONE      0   // Don't show the time

--- a/include/config/overworld.h
+++ b/include/config/overworld.h
@@ -120,6 +120,9 @@
                                             // Due to changes in project scope, as detailed in docs/team_procedures/scope.md,
                                             // no other overworld popups will be implemented in expansion.
 
+// Daily seed config
+#define OW_USE_DAILY_SEED          FALSE    // Adds a random 32 bit number that changes everyday to the save file (currently unused)
+
 // Gen5 map pop-up config
 // Constants
 #define OW_POPUP_BW_TIME_NONE      0   // Don't show the time

--- a/include/global.h
+++ b/include/global.h
@@ -255,6 +255,9 @@ struct NPCFollower
 
 struct SaveBlock3
 {
+#if OW_USE_DAILY_SEED
+    u32 dailySeed;
+#endif
 #if OW_USE_FAKE_RTC
     struct SiiRtcInfo fakeRTC;
 #endif

--- a/include/global.h
+++ b/include/global.h
@@ -255,9 +255,6 @@ struct NPCFollower
 
 struct SaveBlock3
 {
-#if OW_USE_DAILY_SEED
-    u32 dailySeed;
-#endif
 #if OW_USE_FAKE_RTC
     struct SiiRtcInfo fakeRTC;
 #endif
@@ -1175,7 +1172,7 @@ struct SaveBlock1
     /*0x3150*/ struct LinkBattleRecords linkBattleRecords;
 #endif //FREE_LINK_BATTLE_RECORDS
     /*0x31A8*/ u8 giftRibbons[NUM_GIFT_RIBBONS];
-               u8 padding[4];
+               u32 dailySeed;
     /*0x31B3*/ struct ExternalEventData externalEventData;
     /*0x31C7*/ struct ExternalEventFlags externalEventFlags;
     /*0x31DC*/ struct Roamer roamer[ROAMER_COUNT];

--- a/include/global.h
+++ b/include/global.h
@@ -1120,7 +1120,8 @@ struct SaveBlock1
     /*0x988*/ u8 filler1[0x34]; // Previously Dex Flags, feel free to remove.
 #endif //FREE_EXTRA_SEEN_FLAGS_SAVEBLOCK1
     /*0x9BC*/ u16 berryBlenderRecords[3];
-    /*0x9C2*/ u8 unused_9C2[6];
+    /*0x9C2*/ u8 unused_9C2[2];
+              u32 dailySeed;
 #if FREE_MATCH_CALL == FALSE
     /*0x9C8*/ u16 trainerRematchStepCounter;
     /*0x9CA*/ u8 trainerRematches[MAX_REMATCH_ENTRIES];
@@ -1172,7 +1173,7 @@ struct SaveBlock1
     /*0x3150*/ struct LinkBattleRecords linkBattleRecords;
 #endif //FREE_LINK_BATTLE_RECORDS
     /*0x31A8*/ u8 giftRibbons[NUM_GIFT_RIBBONS];
-               u32 dailySeed;
+               u8 padding[4];
     /*0x31B3*/ struct ExternalEventData externalEventData;
     /*0x31C7*/ struct ExternalEventFlags externalEventFlags;
     /*0x31DC*/ struct Roamer roamer[ROAMER_COUNT];

--- a/include/random.h
+++ b/include/random.h
@@ -312,6 +312,5 @@ const void *RandomElementArrayDefaultValue(enum RandomTag tag, const void *array
 #endif
 
 u32 Crc32B (const u8 *data, u32 size);
-u32 GetDailySeed(void);
 
 #endif // GUARD_RANDOM_H

--- a/include/random.h
+++ b/include/random.h
@@ -311,4 +311,7 @@ const void *RandomElementArrayTrials(enum RandomTag tag, const void *array, size
 const void *RandomElementArrayDefaultValue(enum RandomTag tag, const void *array, size_t size, size_t count, void *caller);
 #endif
 
+u32 Crc32B (const u8 *data, u32 size);
+u32 GetDailySeed(void);
+
 #endif // GUARD_RANDOM_H

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -128,7 +128,6 @@ static void HandleEndTurn_BattleLost(void);
 static void HandleEndTurn_RanFromBattle(void);
 static void HandleEndTurn_MonFled(void);
 static void HandleEndTurn_FinishBattle(void);
-static u32 Crc32B (const u8 *data, u32 size);
 static u32 GeneratePartyHash(const struct Trainer *trainer, u32 i);
 
 EWRAM_DATA u16 gBattle_BG0_X = 0;
@@ -1803,26 +1802,6 @@ void CB2_QuitRecordedBattle(void)
         FreeAllWindowBuffers();
         SetMainCallback2(gMain.savedCallback);
     }
-}
-
-static u32 Crc32B (const u8 *data, u32 size)
-{
-   s32 i, j;
-   u32 byte, crc, mask;
-
-   i = 0;
-   crc = 0xFFFFFFFF;
-   for (i = 0; i < size; ++i)
-   {
-        byte = data[i];
-        crc = crc ^ byte;
-        for (j = 7; j >= 0; --j)
-        {
-            mask = -(crc & 1);
-            crc = (crc >> 1) ^ (0xEDB88320 & mask);
-        }
-   }
-   return ~crc;
 }
 
 static u32 GeneratePartyHash(const struct Trainer *trainer, u32 i)

--- a/src/clock.c
+++ b/src/clock.c
@@ -37,6 +37,13 @@ void DoTimeBasedEvents(void)
     }
 }
 
+static void UpdateDailySeed(void)
+{
+    #if OW_USE_DAILY_SEED
+    gSaveBlock3Ptr->dailySeed = Random32();
+    #endif
+}
+
 static void UpdatePerDay(struct Time *localTime)
 {
     u16 *days = GetVarPointer(VAR_DAYS);
@@ -46,6 +53,7 @@ static void UpdatePerDay(struct Time *localTime)
     {
         daysSince = localTime->days - *days;
         ClearDailyFlags();
+        UpdateDailySeed();
         UpdateDewfordTrendPerDay(daysSince);
         UpdateTVShowsPerDay(daysSince);
         UpdateWeatherPerDay(daysSince);

--- a/src/clock.c
+++ b/src/clock.c
@@ -39,9 +39,7 @@ void DoTimeBasedEvents(void)
 
 static void UpdateDailySeed(void)
 {
-    #if OW_USE_DAILY_SEED
-    gSaveBlock3Ptr->dailySeed = Random32();
-    #endif
+    gSaveBlock1Ptr->dailySeed = Random32();
 }
 
 static void UpdatePerDay(struct Time *localTime)

--- a/src/clock.c
+++ b/src/clock.c
@@ -9,6 +9,7 @@
 #include "main.h"
 #include "overworld.h"
 #include "pokerus.h"
+#include "random.h"
 #include "rtc.h"
 #include "time_events.h"
 #include "tv.h"

--- a/src/random.c
+++ b/src/random.c
@@ -264,3 +264,32 @@ u32 RandomBitIndex(enum RandomTag tag, u32 bits)
   else
     return setIndexes[RandomUniform(tag, 0, n-1)];
 }
+
+u32 Crc32B (const u8 *data, u32 size)
+{
+   s32 i, j;
+   u32 byte, crc, mask;
+
+   i = 0;
+   crc = 0xFFFFFFFF;
+   for (i = 0; i < size; ++i)
+   {
+        byte = data[i];
+        crc = crc ^ byte;
+        for (j = 7; j >= 0; --j)
+        {
+            mask = -(crc & 1);
+            crc = (crc >> 1) ^ (0xEDB88320 & mask);
+        }
+   }
+   return ~crc;
+}
+
+u32 GetDailySeed(void)
+{
+    #if OW_USE_DAILY_SEED
+    return gSaveBlock3Ptr->dailySeed;
+    #endif
+    errorf("Tried to access daily seed but OW_USE_DAILY_SEED is set to FALSE");
+    return 0;
+}

--- a/src/random.c
+++ b/src/random.c
@@ -284,12 +284,3 @@ u32 Crc32B (const u8 *data, u32 size)
    }
    return ~crc;
 }
-
-u32 GetDailySeed(void)
-{
-    #if OW_USE_DAILY_SEED
-    return gSaveBlock3Ptr->dailySeed;
-    #endif
-    errorf("Tried to access daily seed but OW_USE_DAILY_SEED is set to FALSE");
-    return 0;
-}


### PR DESCRIPTION
I used wrapper so that the preprocessor can be left in the config.
I put daily seed in random.h because files needing daily seed would likely use other random functions 
I also moved the hash function in battle_main.c to random.c so that people can use the has function to "salt" the daily seed

## Feature(s) this PR does NOT handle:
- config to prevent save scumming (make next daily seed deterministic based on previous one)
- config for mirage island and lottery to use daily seed
- script commands to access daily seed

## Things to note in the release changelog:
- Adds a new config OW_USE_DAILY_SEED that stores a random number in save file updated every day

## Discord contact info
Jamie
