### PR TITLE
Fix Aroma Veil not blocking Destiny Knot infatuation

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -8466,6 +8466,18 @@ static void Cmd_animatewildpokemonafterfailedpokeball(void)
 static void Cmd_tryinfatuating(void)
 {
     CMD_ARGS(const u8 *failInstr);
+    enum BattlerId battler;
+
+    battler = IsAbilityOnSide(gBattlerTarget, ABILITY_AROMA_VEIL);
+    if (battler)
+    {
+        gBattlerAbility = battler - 1;
+        BattleScriptPush(cmd->failInstr);
+        gBattlescriptCurrInstr = BattleScript_AromaVeilProtectsRet;
+        gLastUsedAbility = ABILITY_AROMA_VEIL;
+        RecordAbilityBattle(gBattlerAbility, ABILITY_AROMA_VEIL);
+        return;
+    }
 
     if (GetBattlerAbility(gBattlerTarget) == ABILITY_OBLIVIOUS)
     {

--- a/test/battle/ability/aroma_veil.c
+++ b/test/battle/ability/aroma_veil.c
@@ -171,6 +171,30 @@ DOUBLE_BATTLE_TEST("Aroma Veil protects the Pokémon's side from Infatuation")
     }
 }
 
+DOUBLE_BATTLE_TEST("Aroma Veil protects the Pokémon's side from Destiny Knot infatuation")
+{
+    struct BattlePokemon *moveTarget = NULL;
+    PARAMETRIZE { moveTarget = playerLeft; }
+    PARAMETRIZE { moveTarget = playerRight; }
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_ATTRACT) == EFFECT_ATTRACT);
+        ASSUME(gItemsInfo[ITEM_DESTINY_KNOT].holdEffect == HOLD_EFFECT_DESTINY_KNOT);
+        PLAYER(SPECIES_AROMATISSE) { Ability(ABILITY_AROMA_VEIL); Gender(MON_MALE); }
+        PLAYER(SPECIES_WOBBUFFET) { Gender(MON_MALE); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_DESTINY_KNOT); Gender(MON_FEMALE); }
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN { MOVE(moveTarget, MOVE_ATTRACT, target: opponentLeft); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ATTRACT, moveTarget);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponentLeft);
+        ABILITY_POPUP(playerLeft, ABILITY_AROMA_VEIL);
+        MESSAGE("But it failed!");
+    } THEN {
+        EXPECT(!moveTarget->volatiles.infatuation);
+    }
+}
+
 DOUBLE_BATTLE_TEST("Aroma Veil does not protect the Pokémon's side from Imprison")
 {
     GIVEN {


### PR DESCRIPTION
## Description
[Aroma Veil](https://wiki.pokemonwiki.com/wiki/%e3%82%a2%e3%83%ad%e3%83%9e%e3%83%99%e3%83%bc%e3%83%ab)

> 持ち物あかいいとの効果も防ぐことができる。

It can also prevent the effect of the held item Destiny Knot.