### PR TITLE
Prevent reflection tag palette collisions

### DIFF
--- a/src/field_effect_helpers.c
+++ b/src/field_effect_helpers.c
@@ -15,11 +15,13 @@
 #include "constants/field_effects.h"
 #include "constants/rgb.h"
 #include "constants/songs.h"
+#include "constants/species.h"
 
 #define OBJ_EVENT_PAL_TAG_NONE 0x11FF // duplicate of define in event_object_movement.c
-#define PAL_TAG_REFLECTION_OFFSET 0x2000 // reflection tag value is paletteTag + 0x2000
-#define PAL_RAW_REFLECTION_OFFSET 0x4000 // raw reflection tag is paletteNum + 0x4000
-#define HIGH_BRIDGE_PAL_TAG 0x4010
+#define PAL_TAG_REFLECTION_OFFSET 0x0800 // reflection tag value is paletteTag + 0x0800
+#define PAL_RAW_REFLECTION_OFFSET 0x3000 // raw reflection tag is paletteNum + 0x3000
+#define HIGH_BRIDGE_PAL_TAG (PAL_RAW_REFLECTION_OFFSET + 0x10)
+STATIC_ASSERT(NUM_SPECIES <= PAL_TAG_REFLECTION_OFFSET, TooManySpeciesForReflectionPaletteTags);
 // Build a unique tag for reflection's palette based on based tag, or paletteNum
 #define REFLECTION_PAL_TAG(tag, num) ((tag) == TAG_NONE ? (num) + PAL_RAW_REFLECTION_OFFSET : (tag) + PAL_TAG_REFLECTION_OFFSET)
 
@@ -163,7 +165,7 @@ static void LoadObjectRegularReflectionPalette(struct ObjectEvent *objectEvent, 
     u16 baseTag = GetSpritePaletteTagByPaletteNum(mainSprite->oam.paletteNum);
     u16 paletteTag = REFLECTION_PAL_TAG(baseTag, mainSprite->oam.paletteNum);
     u8 paletteNum = IndexOfSpritePaletteTag(paletteTag);
-    if (paletteNum <= 16)
+    if (paletteNum == 0xFF)
     {
         // Load filtered palette
         u16 filteredData[16];
@@ -209,7 +211,7 @@ static void UpdateObjectReflectionSprite(struct Sprite *reflectionSprite)
         u16 baseTag = GetSpritePaletteTagByPaletteNum(mainSprite->oam.paletteNum);
         u16 paletteTag = REFLECTION_PAL_TAG(baseTag, mainSprite->oam.paletteNum);
         u8 paletteNum = IndexOfSpritePaletteTag(paletteTag);
-        if (paletteNum >= 16)
+        if (paletteNum == 0xFF)
         {
             // Build filtered palette
             u16 filteredData[16];


### PR DESCRIPTION
## Description

Fixes generated overworld reflection palette tags so normal and shiny Pokemon object events can appear together near water without their body and reflection palettes colliding.

The old reflection offset used `0x2000`, which is also `OBJ_EVENT_MON_SHINY`. For example, Charizard's normal palette tag is `0x4006`, its shiny palette tag is `0x6006`, and the old normal reflection tag also became `0x6006`. That let a normal reflection reuse the shiny body palette slot.

This PR changes the generated reflection palette range to avoid the object event Pokemon flag bits, moves raw reflection palette tags out of the `OBJ_EVENT_MON` range, and adds a compile-time guard so the reflection offset remains valid for the current species count. It also fixes the missing-palette checks to only regenerate reflection palettes when `IndexOfSpritePaletteTag` returns `0xFF`.

This PR also fixes shiny reflection palettes accidentally colliding with `BLEND_IMMUNE_FLAG`, causing the reflections to ignore weather or time-based blends entirely.

Verified with:

- `make -j32`

as well as testing in-game.

## Media

<img width="450" height="323" alt="pr-9839-reflection-palettes" src="https://github.com/user-attachments/assets/ec57e81c-04f6-490f-b239-0900e7ad7bc8" />

## Issue(s) that this PR fixes

Fixes #9839.

## Feature(s) this PR does NOT handle:

None.

## Things to note in the release changelog:

- Fixed incorrect overworld reflection palettes when shiny and non-shiny Pokemon object events are loaded near water at the same time.

## Discord contact info

viridian.
