### PR TITLE
Use partner party count for full multi navigation

### DIFF
--- a/include/party_menu.h
+++ b/include/party_menu.h
@@ -72,6 +72,9 @@ bool8 IsMultiBattle(void);
 u8 GetCursorSelectionMonId(void);
 u8 GetPartyMenuType(void);
 void Task_HandleChooseMonInput(u8 taskId);
+#if TESTING
+s8 Test_UpdatePartySelectionSingleLayout(s8 slotId, s8 movementDir, bool8 chooseHalf, u8 lastSelectedSlot);
+#endif
 u8 *GetMonNickname(struct Pokemon *mon, u8 *dest);
 u8 DisplayPartyMenuMessage(const u8 *str, bool8 keepOpen);
 bool8 IsPartyMenuTextPrinterActive(void);

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -319,6 +319,7 @@ static void PartyMenuDisplayYesNoMenu(void);
 static void Task_HandleCancelChooseMonYesNoInput(u8);
 static void Task_ReturnToChooseMonAfterText(u8);
 static void UpdateCurrentPartySelection(s8 *, s8);
+static u8 GetPartyMenuSelectionPartyCount(void);
 static void UpdatePartySelectionSingleLayout(s8 *, s8);
 static void UpdatePartySelectionDoubleLayout(s8 *, s8);
 static s8 GetNewSlotDoubleLayout(s8, s8);
@@ -1790,7 +1791,7 @@ static u16 PartyMenuButtonHandler(s8 *slotPtr)
         return R_BUTTON;
     }
 
-    if (movementDir && gPartiesCount[B_TRAINER_0] != 0)
+    if (movementDir && GetPartyMenuSelectionPartyCount() != 0)
     {
         UpdateCurrentPartySelection(slotPtr, movementDir);
         return 0;
@@ -1827,8 +1828,21 @@ static void UpdateCurrentPartySelection(s8 *slotPtr, s8 movementDir)
     }
 }
 
+static u8 GetPartyMenuSelectionPartyCount(void)
+{
+    if (gPartyMenu.layout == PARTY_LAYOUT_MULTI_FULL_PARTNER)
+        return CalculatePartyCount(B_TRAINER_2);
+    else
+        return gPartiesCount[B_TRAINER_0];
+}
+
 static void UpdatePartySelectionSingleLayout(s8 *slotPtr, s8 movementDir)
 {
+    u8 partyCount = GetPartyMenuSelectionPartyCount();
+
+    if (partyCount == 0)
+        return;
+
     // PARTY_SIZE + 1 is Cancel, PARTY_SIZE is Confirm
     switch (movementDir)
     {
@@ -1839,14 +1853,14 @@ static void UpdatePartySelectionSingleLayout(s8 *slotPtr, s8 movementDir)
         }
         else if (*slotPtr == PARTY_SIZE)
         {
-            *slotPtr = gPartiesCount[B_TRAINER_0] - 1;
+            *slotPtr = partyCount - 1;
         }
         else if (*slotPtr == PARTY_SIZE + 1)
         {
             if (sPartyMenuInternal->chooseHalf)
                 *slotPtr = PARTY_SIZE;
             else
-                *slotPtr = gPartiesCount[B_TRAINER_0] - 1;
+                *slotPtr = partyCount - 1;
         }
         else
         {
@@ -1860,7 +1874,7 @@ static void UpdatePartySelectionSingleLayout(s8 *slotPtr, s8 movementDir)
         }
         else
         {
-            if (*slotPtr == gPartiesCount[B_TRAINER_0] - 1)
+            if (*slotPtr == partyCount - 1)
             {
                 if (sPartyMenuInternal->chooseHalf)
                     *slotPtr = PARTY_SIZE;
@@ -1874,9 +1888,10 @@ static void UpdatePartySelectionSingleLayout(s8 *slotPtr, s8 movementDir)
         }
         break;
     case MENU_DIR_RIGHT:
-        if (gPartiesCount[B_TRAINER_0] != 1 && *slotPtr == 0)
+        if (partyCount != 1 && *slotPtr == 0)
         {
-            if (sPartyMenuInternal->lastSelectedSlot == 0)
+            if (sPartyMenuInternal->lastSelectedSlot == 0
+             || sPartyMenuInternal->lastSelectedSlot >= partyCount)
                 *slotPtr = 1;
             else
                 *slotPtr = sPartyMenuInternal->lastSelectedSlot;
@@ -1891,6 +1906,23 @@ static void UpdatePartySelectionSingleLayout(s8 *slotPtr, s8 movementDir)
         break;
     }
 }
+
+#if TESTING
+s8 Test_UpdatePartySelectionSingleLayout(s8 slotId, s8 movementDir, bool8 chooseHalf, u8 lastSelectedSlot)
+{
+    struct PartyMenuInternal internal = {0};
+    struct PartyMenuInternal *savedInternal = sPartyMenuInternal;
+
+    internal.chooseHalf = chooseHalf;
+    internal.lastSelectedSlot = lastSelectedSlot;
+    sPartyMenuInternal = &internal;
+
+    UpdatePartySelectionSingleLayout(&slotId, movementDir);
+
+    sPartyMenuInternal = savedInternal;
+    return slotId;
+}
+#endif
 
 static void UpdatePartySelectionDoubleLayout(s8 *slotPtr, s8 movementDir)
 {

--- a/test/party_menu.c
+++ b/test/party_menu.c
@@ -1,0 +1,58 @@
+#include "global.h"
+#include "battle.h"
+#include "party_menu.h"
+#include "pokemon.h"
+#include "test/test.h"
+
+#define TEST_MENU_DIR_DOWN     1
+#define TEST_MENU_DIR_UP      -1
+#define TEST_MENU_DIR_RIGHT    2
+
+static void SetTestPartySize(enum BattleTrainer trainer, u8 partySize)
+{
+    u32 i;
+
+    for (i = 0; i < PARTY_SIZE; i++)
+        ZeroMonData(&gParties[trainer][i]);
+
+    for (i = 0; i < partySize; i++)
+        CreateMon(&gParties[trainer][i], SPECIES_WOBBUFFET, 50, 0, OTID_STRUCT_PRESET(0));
+
+    gPartiesCount[trainer] = partySize;
+}
+
+TEST("Full multi partner party menu stops down navigation at partner party count")
+{
+    SetTestPartySize(B_TRAINER_0, PARTY_SIZE);
+    SetTestPartySize(B_TRAINER_2, 2);
+    gPartyMenu.layout = PARTY_LAYOUT_MULTI_FULL_PARTNER;
+
+    EXPECT_EQ(Test_UpdatePartySelectionSingleLayout(1, TEST_MENU_DIR_DOWN, FALSE, 0), PARTY_SIZE + 1);
+}
+
+TEST("Full multi partner party menu allows down navigation through partner party count")
+{
+    SetTestPartySize(B_TRAINER_0, 2);
+    SetTestPartySize(B_TRAINER_2, PARTY_SIZE);
+    gPartyMenu.layout = PARTY_LAYOUT_MULTI_FULL_PARTNER;
+
+    EXPECT_EQ(Test_UpdatePartySelectionSingleLayout(1, TEST_MENU_DIR_DOWN, FALSE, 0), 2);
+}
+
+TEST("Full multi partner party menu wraps cancel up to partner party count")
+{
+    SetTestPartySize(B_TRAINER_0, PARTY_SIZE);
+    SetTestPartySize(B_TRAINER_2, 2);
+    gPartyMenu.layout = PARTY_LAYOUT_MULTI_FULL_PARTNER;
+
+    EXPECT_EQ(Test_UpdatePartySelectionSingleLayout(PARTY_SIZE + 1, TEST_MENU_DIR_UP, FALSE, 0), 1);
+}
+
+TEST("Full multi partner party menu ignores stale last selected slot outside partner party count")
+{
+    SetTestPartySize(B_TRAINER_0, PARTY_SIZE);
+    SetTestPartySize(B_TRAINER_2, 2);
+    gPartyMenu.layout = PARTY_LAYOUT_MULTI_FULL_PARTNER;
+
+    EXPECT_EQ(Test_UpdatePartySelectionSingleLayout(0, TEST_MENU_DIR_RIGHT, FALSE, PARTY_SIZE - 1), 1);
+}


### PR DESCRIPTION
# Fix full-team multi partner party menu navigation

## Description
This fixes the full-team multi battle partner party menu using the player's party count for cursor navigation.

Root cause:
- `PARTY_LAYOUT_MULTI_FULL_PARTNER` reuses the single-column party menu navigation path.
- That path used `gPartiesCount[B_TRAINER_0]`, which is the player's party count.
- When viewing the partner party in a full-team multi battle, the actual party being navigated is `B_TRAINER_2`.
- As a result, bringing anything other than 3 Pokemon could make the partner party cursor stop too early, move into empty slots, or wrap from Cancel to the wrong slot.

Fix:
- Added a party-count helper for menu selection that returns `CalculatePartyCount(B_TRAINER_2)` while `PARTY_LAYOUT_MULTI_FULL_PARTNER` is active.
- Updated the single-layout navigation path to use that selected party count for movement, wrapping, and Cancel navigation.
- Clamped a stale `lastSelectedSlot` when switching into a smaller partner party so rightward movement cannot jump to a slot outside the partner's actual party.
- Added party menu regression tests for the 2-Pokemon and 6-Pokemon repro shapes described in the issue

Validation:
- `make -j32`
- `make check -j32 TESTS=test/party_menu.c`
- `git diff --check`

I also used a local-only Petalburg City script testbed to manually start a full-team multi battle with Steven as the player's partner to ensure the fix works (see Media)

## Media
<img width="808" height="430" alt="mGBA_To5gCWBb4d" src="https://github.com/user-attachments/assets/2ef4edc4-3358-4c69-8f43-9404468bef15" />


## Issue(s) that this PR fixes
Fixes #9815.

## Feature(s) this PR does NOT handle:
N/A

## Things to note in the release changelog:
- Fixed full-team multi battle partner party menu navigation using the player's party count instead of the partner's party count.

## Discord contact info
viridian.
