### PR TITLE
Correct status move miss messaging

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -2243,6 +2243,13 @@ BattleScript_MoveMissed::
 	waitmessage B_WAIT_TIME_LONG
 	goto BattleScript_MoveEnd
 
+BattleScript_TargetAvoidsAttackEnd::
+	pause B_WAIT_TIME_SHORT
+	setbyte cMULTISTRING_CHOOSER, B_MSG_AVOIDED_ATK
+	printfromtable gMissStringIds
+	waitmessage B_WAIT_TIME_LONG
+	goto BattleScript_MoveEnd
+
 BattleScript_TerrainPreventsEnd2::
 	pause B_WAIT_TIME_SHORT
 	printfromtable gTerrainPreventsStringIds

--- a/include/battle_scripts.h
+++ b/include/battle_scripts.h
@@ -12,6 +12,7 @@ extern const u8 BattleScript_MakeMoveMissed[];
 extern const u8 BattleScript_MoveMissedPause[];
 extern const u8 BattleScript_MoveMissedPause[];
 extern const u8 BattleScript_MoveMissed[];
+extern const u8 BattleScript_TargetAvoidsAttackEnd[];
 extern const u8 BattleScript_FlingFailConsumeItem[];
 extern const u8 BattleScript_FlingBlockedByShieldDust[];
 extern const u8 BattleScript_EffectFlingConsumeBerry[];

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1214,7 +1214,9 @@ static void AccuracyCheck(bool32 recalcDragonDarts, const u8 *nextInstr, const u
         }
         else
         {
-            gBattlescriptCurrInstr = failInstr;
+            gBattlescriptCurrInstr = failInstr == BattleScript_ButItFailed
+                ? BattleScript_TargetAvoidsAttackEnd
+                : failInstr;
         }
 
         if (gBattleStruct->moveResultFlags[gBattlerTarget] & (MOVE_RESULT_ONE_HIT_KO_NO_AFFECT | MOVE_RESULT_ONE_HIT_KO_STURDY))

--- a/test/battle/status1/paralysis.c
+++ b/test/battle/status1/paralysis.c
@@ -105,3 +105,17 @@ SINGLE_BATTLE_TEST("Thunder Wave doesn't print an effectiveness message")
         NOT MESSAGE("It's super effective!");
     }
 }
+
+SINGLE_BATTLE_TEST("Thunder Wave prints an avoided attack message when it misses")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_THUNDER_WAVE, hit: FALSE); }
+    } SCENE {
+        MESSAGE("Wobbuffet used Thunder Wave!");
+        MESSAGE("The opposing Wobbuffet avoided the attack!");
+        NOT MESSAGE("But it failed!");
+    }
+}


### PR DESCRIPTION
## Description

Status moves whose battle scripts pass `BattleScript_ButItFailed` to `accuracycheck` were using the generic failure script even when the move missed a visible target due to accuracy. That caused moves like Thunder Wave to print `But it failed!` instead of the expected avoided-attack message.

This PR makes those actual accuracy misses go through a dedicated target avoids script while preserving `BattleScript_ButItFailed` for actual failures. It also adds a Thunder Wave regression test for a target miss.

Validated with:

- `make -j32 check TESTS=test/battle/status1/paralysis.c`
- `make -j32 check TESTS=test/battle/ability/dancer.c`
- `make -j32 check TESTS=test/battle/move_effect/foresight.c`

## Media

N/A.

## Issue(s) that this PR fixes

Fixes #9654

## Feature(s) this PR does NOT handle:

None.

## Things to note in the release changelog:

- Fixed status moves using `accuracycheck BattleScript_ButItFailed` so visible-target accuracy misses print the avoided-attack message instead of `But it failed!`.

## Discord contact info

viridian.
