### PR TITLE
Fix FRLG player sprite glitch when fishing after surfing

### DIFF
--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -1827,9 +1827,9 @@ u16 LoadSheetGraphicsInfo(const struct ObjectEventGraphicsInfo *info, u16 uuid, 
         sprite->usingSheet = FALSE;
 
     }
-    else if (sprite && !sprite->sheetTileStart && sprite->oam.size != info->oam->size)
+    else if (sprite && !sprite->usingSheet && sprite->images->size != info->images->size)
     {
-        // Not usingSheet and info size differs; realloc tiles
+        // Not usingSheet and frame size differs; realloc tiles
         ReallocSpriteTiles(sprite, info->images->size);
     }
     return tag;
@@ -3102,8 +3102,8 @@ static void ObjectEventSetGraphics(struct ObjectEvent *objectEvent, const struct
     if (i != 0xFF)
         UpdateSpritePalette(&sObjectEventSpritePalettes[i], sprite);
 
-    // If gfx size changes, we need to reallocate tiles
-    if (OW_LARGE_OW_SUPPORT && !OW_GFX_COMPRESS && graphicsInfo->oam->size != sprite->oam.size)
+    // If frame size changes, we need to reallocate tiles.
+    if (OW_LARGE_OW_SUPPORT && !OW_GFX_COMPRESS && graphicsInfo->images->size != sprite->images->size)
         ReallocSpriteTiles(sprite, graphicsInfo->images->size);
 
     #if OW_GFX_COMPRESS

--- a/test/event_object_movement.c
+++ b/test/event_object_movement.c
@@ -1,0 +1,72 @@
+#include "global.h"
+#include "event_object_movement.h"
+#include "sprite.h"
+#include "test/test.h"
+
+static const u32 sFrame16x32[256 / sizeof(u32)] = {0};
+static const u32 sFrame32x32[512 / sizeof(u32)] = {0};
+
+static const struct OamData sOam16x32 = {
+    .shape = SPRITE_SHAPE(16x32),
+    .size = SPRITE_SIZE(16x32),
+};
+
+static const struct OamData sOam32x32 = {
+    .shape = SPRITE_SHAPE(32x32),
+    .size = SPRITE_SIZE(32x32),
+};
+
+static const struct SpriteFrameImage sImages16x32[] = {
+    {.data = sFrame16x32, .size = sizeof(sFrame16x32)},
+};
+
+static const struct SpriteFrameImage sImages32x32[] = {
+    {.data = sFrame32x32, .size = sizeof(sFrame32x32)},
+};
+
+static const struct SpriteTemplate sSpriteTemplate16x32 = {
+    .tileTag = TAG_NONE,
+    .paletteTag = TAG_NONE,
+    .oam = &sOam16x32,
+    .images = sImages16x32,
+    .callback = SpriteCallbackDummy,
+};
+
+static const struct ObjectEventGraphicsInfo sGraphicsInfo32x32 = {
+    .tileTag = TAG_NONE,
+    .size = sizeof(sFrame32x32),
+    .oam = &sOam32x32,
+    .images = sImages32x32,
+};
+
+extern u16 LoadSheetGraphicsInfo(const struct ObjectEventGraphicsInfo *info, u16 uuid, struct Sprite *sprite);
+
+TEST("LoadSheetGraphicsInfo reallocates non-sheet sprites when frame size changes")
+{
+    u16 i;
+    u16 tileNum;
+    u16 tileCount;
+    u8 spriteId;
+    struct Sprite *sprite;
+
+    ASSUME(sOam16x32.size == sOam32x32.size);
+    ASSUME(sOam16x32.shape != sOam32x32.shape);
+
+    ResetSpriteData();
+    spriteId = CreateSprite(&sSpriteTemplate16x32, 0, 0, 0);
+    ASSUME(spriteId != MAX_SPRITES);
+
+    sprite = &gSprites[spriteId];
+    tileNum = sprite->oam.tileNum;
+    tileCount = sGraphicsInfo32x32.images->size / TILE_SIZE_4BPP;
+
+    EXPECT_EQ(sprite->images->size, sizeof(sFrame16x32));
+    EXPECT_EQ(sGraphicsInfo32x32.images->size, sizeof(sFrame32x32));
+
+    LoadSheetGraphicsInfo(&sGraphicsInfo32x32, 0, sprite);
+
+    for (i = 0; i < tileCount; i++)
+        EXPECT(SpriteTileAllocBitmapOp(tileNum + i, 2) != 0);
+
+    DestroySprite(sprite);
+}


### PR DESCRIPTION
## Description
This fixes a player overworld sprite corruption issue that could happen when fishing while surfing after returning from battle, especially in FireRed builds.

### Root cause

In FireRed builds, the male player character's `Red` object-event graphics switch from the surfing variant (`gObjectEventGraphicsInfo_RedSurf`) to the fishing variant (`gObjectEventGraphicsInfo_RedFish`). The surfing variant uses 16x32 frames with 256 bytes per frame, while the fishing variant uses 32x32 frames with 512 bytes per frame. Both shapes use the same OAM size enum, so the previous reallocation check compared equal values and did not allocate enough OBJ tile memory for the fishing frame. The 32x32 fishing frame could then overwrite adjacent OBJ tile memory, with the issue becoming visible after battle changed the surrounding allocation state. (The issue also seemed present even before entering a battle - the issue seemed to lay more in the transition between surfing -> fishing)

The fix changes object event graphics reallocation checks to compare the actual frame byte size instead of the OAM size enum. It also uses the sprite's `usingSheet` state directly for the compressed-overworld path, and applies the same frame-size check to the non-compressed large-overworld path.

I also added a regression test that creates a non-sheet 16x32 sprite, switches it to 32x32 graphics with the same OAM size enum, and verifies the larger tile range is allocated.

Relevant code snippets:

```c
// Old check missed 16x32 -> 32x32 because both use the same OAM size enum.
else if (sprite && !sprite->sheetTileStart && sprite->oam.size != info->oam->size)
    ReallocSpriteTiles(sprite, info->images->size);
```

```c
// New check compares the actual frame byte size.
else if (sprite && !sprite->usingSheet && sprite->images->size != info->images->size)
    ReallocSpriteTiles(sprite, info->images->size);
```

```c
// The same frame-size check is used for non-compressed large OW graphics.
if (OW_LARGE_OW_SUPPORT && !OW_GFX_COMPRESS && graphicsInfo->images->size != sprite->images->size)
    ReallocSpriteTiles(sprite, graphicsInfo->images->size);
```

```c
ASSUME(sOam16x32.size == sOam32x32.size);
ASSUME(sOam16x32.shape != sOam32x32.shape);

LoadSheetGraphicsInfo(&sGraphicsInfo32x32, 0, sprite);

for (i = 0; i < tileCount; i++)
    EXPECT(SpriteTileAllocBitmapOp(tileNum + i, 2) != 0);
```

Validation performed:
- `make -j32 check TESTS=test/event_object_movement.c`
- `make -j32 check TESTS=test/event_object_movement.c BUILD=firered`

I also temporarily restored the old `oam.size` condition locally and confirmed the new regression test fails without this fix.



## Media

<img width="808" height="430" alt="mGBA_ZEFvXXZJ8O" src="https://github.com/user-attachments/assets/4bc4b239-c706-4f8b-b9c6-212845ab964a" />

## Issue(s) that this PR fixes
Fixes #9886 

## Things to note in the release changelog:
- Fixed player overworld sprite tile corruption when switching between graphics with the same OAM size enum but different frame byte sizes, such as Surfing to Fishing in FireRed.

## Discord contact info

viridian.
