### PR TITLE
Preserve Encore target last move after flinch

### DIFF
--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -2680,7 +2680,6 @@ static enum MoveEndResult MoveEndUpdateLastMoves(void)
         }
         else
         {
-            gLastMoves[gBattlerAttacker] = MOVE_UNAVAILABLE;
             gLastResultingMoves[gBattlerAttacker] = MOVE_UNAVAILABLE;
             gLastUsedMoveType[gBattlerAttacker] = 0;
         }

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -8801,10 +8801,10 @@ static void Cmd_trysetencore(void)
         }
     }
 
-    if ((IsMoveEncoreBanned(gLastMoves[gBattlerTarget]))
-     || i == MAX_MON_MOVES
-     || gLastMoves[gBattlerTarget] == MOVE_NONE
+    if (gLastMoves[gBattlerTarget] == MOVE_NONE
      || gLastMoves[gBattlerTarget] == MOVE_UNAVAILABLE
+     || IsMoveEncoreBanned(gLastMoves[gBattlerTarget])
+     || i == MAX_MON_MOVES
      || gBattleMons[gBattlerTarget].pp[i] == 0
      || gBattleMons[gBattlerTarget].volatiles.encoredMove != MOVE_NONE
      || GetMoveEffect(gChosenMoveByBattler[gBattlerTarget]) == EFFECT_SHELL_TRAP)

--- a/test/battle/move_effect/encore.c
+++ b/test/battle/move_effect/encore.c
@@ -95,10 +95,10 @@ SINGLE_BATTLE_TEST("Encore forces the last move used before the target flinched"
         WITH_CONFIG(B_ENCORE_TARGET, GEN_3);
         ASSUME(MoveHasAdditionalEffect(MOVE_HEADBUTT, MOVE_EFFECT_FLINCH) == TRUE);
         PLAYER(SPECIES_WOBBUFFET) { Speed(100); Moves(MOVE_CELEBRATE, MOVE_HEADBUTT, MOVE_ENCORE); }
-        OPPONENT(SPECIES_WOBBUFFET) { Speed(50); Moves(MOVE_GRASS_KNOT, MOVE_CELEBRATE); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(50); Moves(MOVE_GRASS_KNOT, MOVE_SCRATCH, MOVE_CELEBRATE); }
     } WHEN {
         TURN { MOVE(player, MOVE_CELEBRATE); MOVE(opponent, MOVE_GRASS_KNOT); }
-        TURN { MOVE(player, MOVE_HEADBUTT); MOVE(opponent, MOVE_GRASS_KNOT); }
+        TURN { MOVE(player, MOVE_HEADBUTT); MOVE(opponent, MOVE_SCRATCH); }
         TURN { MOVE(player, MOVE_ENCORE); MOVE(opponent, MOVE_CELEBRATE); }
         TURN { FORCED_MOVE(opponent); }
     } SCENE {

--- a/test/battle/move_effect/encore.c
+++ b/test/battle/move_effect/encore.c
@@ -89,6 +89,32 @@ SINGLE_BATTLE_TEST("Encore overrides the chosen move if it occurs first")
     }
 }
 
+SINGLE_BATTLE_TEST("Encore forces the last move used before the target flinched")
+{
+    GIVEN {
+        WITH_CONFIG(B_ENCORE_TARGET, GEN_3);
+        ASSUME(MoveHasAdditionalEffect(MOVE_HEADBUTT, MOVE_EFFECT_FLINCH) == TRUE);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(100); Moves(MOVE_CELEBRATE, MOVE_HEADBUTT, MOVE_ENCORE); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(50); Moves(MOVE_GRASS_KNOT, MOVE_CELEBRATE); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_CELEBRATE); MOVE(opponent, MOVE_GRASS_KNOT); }
+        TURN { MOVE(player, MOVE_HEADBUTT); MOVE(opponent, MOVE_GRASS_KNOT); }
+        TURN { MOVE(player, MOVE_ENCORE); MOVE(opponent, MOVE_CELEBRATE); }
+        TURN { FORCED_MOVE(opponent); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_GRASS_KNOT, opponent);
+
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_HEADBUTT, player);
+        MESSAGE("The opposing Wobbuffet flinched and couldn't move!");
+
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ENCORE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_GRASS_KNOT, opponent);
+
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_GRASS_KNOT, opponent);
+    }
+}
+
 SINGLE_BATTLE_TEST("(DYNAMAX) Dynamaxed Pokemon are immune to Encore")
 {
     GIVEN {


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->
<!--- Suggested title: Fix Encore after the target flinches --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
Fixes Encore failing when the target flinched on the previous turn after successfully using a move before that.

Previously, when a battler was unable to act, `MoveEndUpdateLastMoves` replaced `gLastMoves` with `MOVE_UNAVAILABLE`. That made Encore forget the target's last successfully used move and could send `MOVE_UNAVAILABLE` through Encore's banned move validation path.

This PR keeps `gLastMoves` as the last successfully chosen move when a battler fails to act, while still using `gLastResultingMoves` to track the failed action. It also guards Encore's `MOVE_NONE` and `MOVE_UNAVAILABLE` cases before calling `IsMoveEncoreBanned`.

A regression test was added to verify that Encore locks the target into the move it used before flinching.

Tested with:
- `make check -j32 TESTS="test/battle/move_effect/encore.c"`
- `make check -j32 TESTS="test/battle/move_effect/mimic.c"`
- `make check -j32 TESTS="test/battle/move_effect/stomping_tantrum.c"`

## Media
N/A.

## Issue(s) that this PR fixes
Fixes #9935 

<!-- CREDITS -->
<!-- Once your PR is submitted, leave a comment asking the bot to add you to the credits. -->
<!-- If anybody helped with this PR, please encourage them to comment on your PR and ask the bot to add them to the credits. -->
<!-- If somebody has contributed at any point and has indicated they wish to be credited, please ask the bot to add them to the credits. If they do not have a known GitHub account, add them to the list at bottom of `CREDITS.md`. -->
<!-- EVERY contribution matters! -->
<!-- https://github.com/rh-hideout/pokeemerald-expansion/wiki/CREDITS.md-Frequently-Asked-Questions -->

## Feature(s) this PR does NOT handle:
N/A.

## Discord contact info
viridian.
