### PR TITLE
Fix Air Balloon not popping when damaging moves hit a Substitute

### DIFF
--- a/src/battle_hold_effects.c
+++ b/src/battle_hold_effects.c
@@ -218,7 +218,8 @@ static enum ItemEffect TryAirBalloon(enum BattlerId battler, ActivationTiming ti
 
     if (timing == IsOnTargetHitActivation)
     {
-        if (IsBattlerTurnDamaged(battler, EXCLUDING_SUBSTITUTES))
+        // If the holder or its substitute is hit by a damaging move (even if it has Disguise), the Air Balloon is destroyed.
+        if (IsBattlerTurnDamaged(battler, INCLUDING_SUBSTITUTES))
         {
             BattleScriptCall(BattleScript_AirBalloonMsgPop);
             effect = ITEM_EFFECT_OTHER;

--- a/test/battle/ability/disguise.c
+++ b/test/battle/ability/disguise.c
@@ -74,28 +74,6 @@ SINGLE_BATTLE_TEST("Disguised Mimikyu takes no damage from a confusion hit and c
     }
 }
 
-SINGLE_BATTLE_TEST("Disguised Mimikyu's Air Balloon will pop upon changing to its busted form")
-{
-    u32 species, newSpecies;
-    PARAMETRIZE { species = SPECIES_MIMIKYU_DISGUISED;       newSpecies = SPECIES_MIMIKYU_BUSTED; }
-    PARAMETRIZE { species = SPECIES_MIMIKYU_TOTEM_DISGUISED; newSpecies = SPECIES_MIMIKYU_BUSTED_TOTEM; }
-    GIVEN {
-        ASSUME(gItemsInfo[ITEM_AIR_BALLOON].holdEffect == HOLD_EFFECT_AIR_BALLOON);
-        PLAYER(species) { Ability(ABILITY_DISGUISE); Item(ITEM_AIR_BALLOON); }
-        OPPONENT(SPECIES_WOBBUFFET);
-    } WHEN {
-        TURN { MOVE(opponent, MOVE_AERIAL_ACE); }
-    } SCENE {
-        MESSAGE("Mimikyu floats in the air with its Air Balloon!");
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_AERIAL_ACE, opponent);
-        NOT HP_BAR(player);
-        ABILITY_POPUP(player, ABILITY_DISGUISE);
-        MESSAGE("Mimikyu's Air Balloon popped!");
-    } THEN {
-        EXPECT_EQ(player->species, newSpecies);
-    }
-}
-
 SINGLE_BATTLE_TEST("Disguised Mimikyu takes damage from secondary damage without breaking the disguise - Stealth Rock")
 {
     u32 species;

--- a/test/battle/hold_effect/air_balloon.c
+++ b/test/battle/hold_effect/air_balloon.c
@@ -6,7 +6,6 @@ ASSUMPTIONS
     ASSUME(gItemsInfo[ITEM_AIR_BALLOON].holdEffect == HOLD_EFFECT_AIR_BALLOON);
     ASSUME(GetMoveType(MOVE_EARTHQUAKE) == TYPE_GROUND);
     ASSUME(GetMoveType(MOVE_SCRATCH) != TYPE_GROUND);
-    ASSUME(GetMoveEffect(MOVE_RECYCLE) == EFFECT_RECYCLE);
 }
 
 SINGLE_BATTLE_TEST("Air Balloon prevents the holder from taking damage from ground type moves")
@@ -47,7 +46,7 @@ SINGLE_BATTLE_TEST("Air Balloon pops when the holder is hit by a move that is no
         TURN { MOVE(opponent, MOVE_SCRATCH); }
     } SCENE {
         MESSAGE("Wobbuffet floats in the air with its Air Balloon!");
-        MESSAGE("The opposing Wobbuffet used Scratch!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
         MESSAGE("Wobbuffet's Air Balloon popped!");
     }
 }
@@ -62,9 +61,8 @@ SINGLE_BATTLE_TEST("Air Balloon no longer prevents the holder from taking damage
         TURN { MOVE(opponent, MOVE_EARTHQUAKE); }
     } SCENE {
         MESSAGE("Wobbuffet floats in the air with its Air Balloon!");
-        MESSAGE("The opposing Wobbuffet used Scratch!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
         MESSAGE("Wobbuffet's Air Balloon popped!");
-        MESSAGE("The opposing Wobbuffet used Earthquake!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponent);
         NOT MESSAGE("It doesn't affect Wobbuffet…");
     }
@@ -73,6 +71,7 @@ SINGLE_BATTLE_TEST("Air Balloon no longer prevents the holder from taking damage
 SINGLE_BATTLE_TEST("Air Balloon can not be restored with Recycle after it has been popped")
 {
     GIVEN {
+        ASSUME(GetMoveEffect(MOVE_RECYCLE) == EFFECT_RECYCLE);
         PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_AIR_BALLOON); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
@@ -82,7 +81,7 @@ SINGLE_BATTLE_TEST("Air Balloon can not be restored with Recycle after it has be
         }
     } SCENE {
         MESSAGE("Wobbuffet floats in the air with its Air Balloon!");
-        MESSAGE("The opposing Wobbuffet used Scratch!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
         MESSAGE("Wobbuffet's Air Balloon popped!");
         MESSAGE("Wobbuffet used Recycle!");
         MESSAGE("But it failed!");
@@ -92,12 +91,14 @@ SINGLE_BATTLE_TEST("Air Balloon can not be restored with Recycle after it has be
 SINGLE_BATTLE_TEST("Air Balloon prevents the user from being healed by Grassy Terrain")
 {
     GIVEN {
+        ASSUME(GetMoveEffect(MOVE_GRASSY_TERRAIN) == EFFECT_GRASSY_TERRAIN);
         PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_AIR_BALLOON); MaxHP(100); HP(1); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
         TURN { MOVE(player, MOVE_GRASSY_TERRAIN); }
     } SCENE {
         MESSAGE("Wobbuffet floats in the air with its Air Balloon!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_GRASSY_TERRAIN, player);
         NOT MESSAGE("Wobbuffet is healed by the Grassy Terrain!");
     }
 }
@@ -111,6 +112,7 @@ SINGLE_BATTLE_TEST("Air Balloon pops before it can be stolen with Magician")
         TURN { MOVE(opponent, MOVE_SCRATCH); }
     } SCENE {
         MESSAGE("Wobbuffet floats in the air with its Air Balloon!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
         MESSAGE("Wobbuffet's Air Balloon popped!");
         NOT ABILITY_POPUP(opponent, ABILITY_MAGICIAN);
     }
@@ -126,7 +128,48 @@ SINGLE_BATTLE_TEST("Air Balloon pops before it can be stolen by Thief")
         TURN { MOVE(opponent, MOVE_THIEF); }
     } SCENE {
         MESSAGE("Wobbuffet floats in the air with its Air Balloon!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_THIEF, opponent);
         MESSAGE("Wobbuffet's Air Balloon popped!");
         NOT MESSAGE("The opposing Wobbuffet stole Wobbuffet's Air Balloon!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Air Balloon pops if a damaging move hits the holder's Substitute")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_SUBSTITUTE) == EFFECT_SUBSTITUTE);
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_AIR_BALLOON); Speed(2); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); }
+    } WHEN {
+        TURN {MOVE(player, MOVE_SUBSTITUTE); MOVE(opponent, MOVE_EMBER);}
+    } SCENE {
+        MESSAGE("Wobbuffet floats in the air with its Air Balloon!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SUBSTITUTE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EMBER, opponent);
+        MESSAGE("Wobbuffet's Air Balloon popped!");
+    } THEN {
+        EXPECT_EQ(player->item, ITEM_NONE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Air Balloon pops when Disguise is broken")
+{
+    u32 species, newSpecies;
+    PARAMETRIZE { species = SPECIES_MIMIKYU_DISGUISED;       newSpecies = SPECIES_MIMIKYU_BUSTED; }
+    PARAMETRIZE { species = SPECIES_MIMIKYU_TOTEM_DISGUISED; newSpecies = SPECIES_MIMIKYU_BUSTED_TOTEM; }
+    
+    GIVEN {
+        PLAYER(species) { Ability(ABILITY_DISGUISE); Item(ITEM_AIR_BALLOON); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_AERIAL_ACE); }
+    } SCENE {
+        MESSAGE("Mimikyu floats in the air with its Air Balloon!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_AERIAL_ACE, opponent);
+        ABILITY_POPUP(player, ABILITY_DISGUISE);
+        HP_BAR(player);
+        MESSAGE("Mimikyu's Air Balloon popped!");
+    } THEN {
+        EXPECT_EQ(player->species, newSpecies);
     }
 }


### PR DESCRIPTION
## Description
[Air Balloon](https://bulbapedia.bulbagarden.net/wiki/Air_Balloon)

> The Air Balloon makes the holder ungrounded, which means that the holder is immune to damaging Ground-type moves and several related effects. **If the holder or its substitute is hit by a damaging move (even if it has Disguise), the Air Balloon is destroyed.** 


By the way, the original `SINGLE_BATTLE_TEST("Disguised Mimikyu's Air Balloon will pop upon changing to its busted form")`was incorrect under Gen8+

Original
```
        ANIMATION(ANIM_TYPE_MOVE, MOVE_AERIAL_ACE, opponent);
        NOT HP_BAR(player);
        ABILITY_POPUP(player, ABILITY_DISGUISE);
```
Should be
```
        ANIMATION(ANIM_TYPE_MOVE, MOVE_AERIAL_ACE, opponent);
        ABILITY_POPUP(player, ABILITY_DISGUISE);
        HP_BAR(player);
```
