### PR TITLE
Fix Eject Pack switch when the holder is trapped

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -7731,7 +7731,7 @@ BattleScript_EjectPackActivate_End2::
 	end2
 
 BattleScript_EjectPackActivates::
-	jumpifcantswitch BS_SCRIPTING, BattleScript_EjectButtonEnd
+	jumpifcantswitch SWITCH_IGNORE_ESCAPE_PREVENTION | BS_SCRIPTING, BattleScript_EjectButtonEnd
 	goto BattleScript_EjectPackActivate_Ret
 
 BattleScript_DoesntAffectTargetAtkString::

--- a/test/battle/hold_effect/eject_pack.c
+++ b/test/battle/hold_effect/eject_pack.c
@@ -64,6 +64,26 @@ SINGLE_BATTLE_TEST("Eject Pack is triggered by self-inflicting stat decreases")
     }
 }
 
+SINGLE_BATTLE_TEST("Eject Pack switches the user out even if rooted by Ingrain")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_INGRAIN) == EFFECT_INGRAIN);
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_EJECT_PACK); }
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_INGRAIN); }
+        TURN { MOVE(player, MOVE_OVERHEAT); SEND_OUT(player, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_INGRAIN, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_OVERHEAT, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+        MESSAGE("Wobbuffet is switched out with the Eject Pack!");
+        SEND_IN_MESSAGE("Wynaut");
+    }
+}
+
 SINGLE_BATTLE_TEST("Eject Pack will miss timing to switch out user if Emergency Exit was activated on target")
 {
     GIVEN {


### PR DESCRIPTION
## Description
This fixes Eject Pack failing to switch out when the holder is affected by escape-prevention effects such as Ingrain.

Eject Pack already found a valid replacement Pokemon, but `BattleScript_EjectPackActivates` used `jumpifcantswitch BS_SCRIPTING`, which treats root/trapping effects as a reason to abort the switch. Eject Pack should ignore those effects, matching the behavior already used by forced move-switch scripts.

```diff
 BattleScript_EjectPackActivates::
-    jumpifcantswitch BS_SCRIPTING, BattleScript_EjectButtonEnd
+    jumpifcantswitch SWITCH_IGNORE_ESCAPE_PREVENTION | BS_SCRIPTING, BattleScript_EjectButtonEnd
     goto BattleScript_EjectPackActivate_Ret
```

This PR also adds a regression test for the reported Ingrain + Overheat case:

```c
SINGLE_BATTLE_TEST("Eject Pack switches the user out even if rooted by Ingrain")
{
    GIVEN {
        ASSUME(GetMoveEffect(MOVE_INGRAIN) == EFFECT_INGRAIN);
        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_EJECT_PACK); }
        PLAYER(SPECIES_WYNAUT);
        OPPONENT(SPECIES_WOBBUFFET);
    } WHEN {
        TURN { MOVE(player, MOVE_INGRAIN); }
        TURN { MOVE(player, MOVE_OVERHEAT); SEND_OUT(player, 1); }
    } SCENE {
        ANIMATION(ANIM_TYPE_MOVE, MOVE_INGRAIN, player);
        ANIMATION(ANIM_TYPE_MOVE, MOVE_OVERHEAT, player);
        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
        MESSAGE("Wobbuffet is switched out with the Eject Pack!");
        SEND_IN_MESSAGE("Wynaut");
    }
}
```

Validation:
- `make check -j32 TESTS=test/battle/hold_effect/eject_pack.c`
- `make -j32`
- `git diff --check`

## Media
N/A

## Issue(s) that this PR fixes
Fixes #9944 

## Feature(s) this PR does NOT handle:
N/A

## Things to note in the release changelog:
- Fixed Eject Pack so it can switch out its holder even when the holder is rooted or otherwise affected by escape-prevention effects.

## Discord contact info
viridian.