### PR TITLE
Fix Fling Berry effects not being blocked by Covert Cloak and Shield Dust

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -13299,15 +13299,15 @@ void BS_TryFlingHoldEffect(void)
     NATIVE_ARGS();
     enum HoldEffect holdEffect = GetItemHoldEffect(gBattleStruct->flingItem);
 
-    if (GetItemPocket(gBattleStruct->flingItem) == POCKET_BERRIES)
-    {
-        gBattlescriptCurrInstr = BattleScript_EffectFlingConsumeBerry;
-        return;
-    }
-
     if (IsMoveEffectBlockedByTarget(GetBattlerAbility(gBattlerTarget)))
     {
         gBattlescriptCurrInstr = BattleScript_FlingBlockedByShieldDust;
+        return;
+    }
+
+    if (GetItemPocket(gBattleStruct->flingItem) == POCKET_BERRIES)
+    {
+        gBattlescriptCurrInstr = BattleScript_EffectFlingConsumeBerry;
         return;
     }
 

--- a/test/battle/move_effect/fling.c
+++ b/test/battle/move_effect/fling.c
@@ -391,6 +391,60 @@ SINGLE_BATTLE_TEST("Fling's secondary effects are blocked by Shield Dust")
     }
 }
 
+SINGLE_BATTLE_TEST("Fling's berry effects are blocked by Shield Dust")
+{
+    enum Item item;
+    u32 status1 = STATUS1_NONE;
+
+    PARAMETRIZE { item = ITEM_CHERI_BERRY;  status1 = STATUS1_PARALYSIS; }
+    PARAMETRIZE { item = ITEM_LIECHI_BERRY; status1 = STATUS1_NONE; }
+
+    GIVEN {
+        ASSUME(GetItemHoldEffect(ITEM_CHERI_BERRY) == HOLD_EFFECT_CURE_PAR);
+        ASSUME(GetItemHoldEffect(ITEM_LIECHI_BERRY) == HOLD_EFFECT_ATTACK_UP);
+        PLAYER(SPECIES_WOBBUFFET) { Item(item); }
+        OPPONENT(SPECIES_VIVILLON) { Ability(ABILITY_SHIELD_DUST); Status1(status1); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_FLING); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FLING, player);
+        HP_BAR(opponent);
+        NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
+    } THEN {
+        if (status1 != STATUS1_NONE)
+            EXPECT_EQ(opponent->status1, status1);
+        else
+            EXPECT_EQ(opponent->statStages[STAT_ATK], DEFAULT_STAT_STAGE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Fling's berry effects are blocked by Covert Cloak")
+{
+    enum Item item;
+    u32 status1 = STATUS1_NONE;
+
+    PARAMETRIZE { item = ITEM_CHERI_BERRY;  status1 = STATUS1_PARALYSIS; }
+    PARAMETRIZE { item = ITEM_LIECHI_BERRY; status1 = STATUS1_NONE; }
+
+    GIVEN {
+        ASSUME(GetItemHoldEffect(ITEM_CHERI_BERRY) == HOLD_EFFECT_CURE_PAR);
+        ASSUME(GetItemHoldEffect(ITEM_LIECHI_BERRY) == HOLD_EFFECT_ATTACK_UP);
+        PLAYER(SPECIES_WOBBUFFET) { Item(item); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_COVERT_CLOAK); Status1(status1); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_FLING); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FLING, player);
+        HP_BAR(opponent);
+        NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
+    } THEN {
+        if (status1 != STATUS1_NONE)
+            EXPECT_EQ(opponent->status1, status1);
+        else
+            EXPECT_EQ(opponent->statStages[STAT_ATK], DEFAULT_STAT_STAGE);
+    }
+}
+
 SINGLE_BATTLE_TEST("Fling - thrown berry's effect activates for the target even if the trigger conditions are not met")
 {
     enum Item item;


### PR DESCRIPTION
## Description
[Covert Cloak](https://wiki.pokemonwiki.com/wiki/%e3%81%8a%e3%82%93%e3%81%bf%e3%81%a4%e3%83%9e%e3%83%b3%e3%83%88)

> なげつけるにより追加効果がある道具を投げられたとき、防御側にとってメリットとなる効果も含めて全てが防がれる。

When an item with an additional effect is thrown via Fling, all effects—including those beneficial to the defender—are blocked.