### PR TITLE
Fix Air Balloon not popping when holder faints from a damaging hit

### DIFF
--- a/src/battle_hold_effects.c
+++ b/src/battle_hold_effects.c
@@ -1038,7 +1038,8 @@ enum ItemEffect ItemBattleEffects(enum BattlerId itemBattler, enum BattlerId bat
     if (!IsBattlerAlive(itemBattler)
      && holdEffect != HOLD_EFFECT_ROWAP_BERRY // Hacky workaround for them right now
      && holdEffect != HOLD_EFFECT_JABOCA_BERRY
-     && holdEffect != HOLD_EFFECT_ROCKY_HELMET)
+     && holdEffect != HOLD_EFFECT_ROCKY_HELMET
+     && holdEffect != HOLD_EFFECT_AIR_BALLOON)
         return effect;
 
     switch (holdEffect)

--- a/test/battle/hold_effect/air_balloon.c
+++ b/test/battle/hold_effect/air_balloon.c
@@ -173,3 +173,20 @@ SINGLE_BATTLE_TEST("Air Balloon pops when Disguise is broken")
         EXPECT_EQ(player->species, newSpecies);
     }
 }
+
+SINGLE_BATTLE_TEST("Air Balloon pops when the holder faints from a damaging move")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_AIR_BALLOON); HP(1); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SCRATCH); }
+    } SCENE {
+        MESSAGE("Wobbuffet floats in the air with its Air Balloon!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
+        MESSAGE("Wobbuffet's Air Balloon popped!");
+        MESSAGE("Wobbuffet fainted!");
+    } THEN {
+        EXPECT_EQ(player->item, ITEM_NONE);
+    }
+}


### PR DESCRIPTION
## Description

> If the holder or its substitute is hit by a damaging move (even if it has Disguise), the Air Balloon is destroyed.

Even if the holder is knocked out immediately, the Air Balloon should still pop.