### PR TITLE
Fix Guard Dog activating when Intimidate is blocked or cannot lower Attack

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -13266,9 +13266,30 @@ void BS_JumpIfIntimidateAbilityPrevented(void)
         }
         break;
     case ABILITY_GUARD_DOG:
-        hasAbility = TRUE;
-        gBattlescriptCurrInstr = BattleScript_IntimidateInReverse;
+    {
+        bool32 blockedByFlowerVeil = FALSE;
+        u32 flowerVeilBattler = IsFlowerVeilProtected(gBattlerTarget);
+
+        if (flowerVeilBattler != 0)
+        {
+            flowerVeilBattler--;
+            if (gBattleMons[flowerVeilBattler].speed > gBattleMons[gBattlerTarget].speed)
+                blockedByFlowerVeil = TRUE;
+        }
+
+        if (!(gSideTimers[GetBattlerSide(gBattlerTarget)].mistTimer)
+         && CompareStat(gBattlerTarget, STAT_ATK, MIN_STAT_STAGE, CMP_GREATER_THAN, ability)
+         && !blockedByFlowerVeil)
+        {
+            hasAbility = TRUE;
+            gBattlescriptCurrInstr = BattleScript_IntimidateInReverse;
+        }
+        else
+        {
+            gBattlescriptCurrInstr = cmd->nextInstr;
+        }
         break;
+    }
     default:
         gBattlescriptCurrInstr = cmd->nextInstr;
         break;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -13270,7 +13270,7 @@ void BS_JumpIfIntimidateAbilityPrevented(void)
         bool32 blockedByFlowerVeil = FALSE;
         u32 flowerVeilBattler = IsFlowerVeilProtected(gBattlerTarget);
 
-        if (flowerVeilBattler != 0)
+        if (flowerVeilBattler)
         {
             flowerVeilBattler--;
             if (gBattleMons[flowerVeilBattler].speed > gBattleMons[gBattlerTarget].speed)

--- a/test/battle/ability/guard_dog.c
+++ b/test/battle/ability/guard_dog.c
@@ -26,3 +26,167 @@ SINGLE_BATTLE_TEST("Guard Dog raises Attack when intimidated", s16 damage)
         EXPECT_MUL_EQ(results[1].damage, Q_4_12(1.5), results[0].damage);
     }
 }
+
+SINGLE_BATTLE_TEST("Guard Dog raises Attack before Adrenaline Orb when Intimidated")
+{
+    GIVEN {
+        ASSUME(gItemsInfo[ITEM_ADRENALINE_ORB].holdEffect == HOLD_EFFECT_ADRENALINE_ORB);
+        PLAYER(SPECIES_OKIDOGI) { Ability(ABILITY_GUARD_DOG); Item(ITEM_ADRENALINE_ORB); }
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_ARBOK) { Ability(ABILITY_INTIMIDATE); }
+    } WHEN {
+        TURN { SWITCH(opponent, 1); }
+    } SCENE {
+        ABILITY_POPUP(opponent, ABILITY_INTIMIDATE);
+        ABILITY_POPUP(player, ABILITY_GUARD_DOG);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        MESSAGE("Okidogi's Attack rose!");
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_ATK], DEFAULT_STAT_STAGE + 1);
+        EXPECT_EQ(player->statStages[STAT_SPEED], DEFAULT_STAT_STAGE + 1);
+        EXPECT_EQ(player->item, ITEM_NONE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Guard Dog still raises Attack against Intimidate when holding Clear Amulet")
+{
+    GIVEN {
+        ASSUME(gItemsInfo[ITEM_CLEAR_AMULET].holdEffect == HOLD_EFFECT_CLEAR_AMULET);
+        PLAYER(SPECIES_OKIDOGI) { Ability(ABILITY_GUARD_DOG); Item(ITEM_CLEAR_AMULET); }
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_ARBOK) { Ability(ABILITY_INTIMIDATE); }
+    } WHEN {
+        TURN { SWITCH(opponent, 1); }
+    } SCENE {
+        ABILITY_POPUP(opponent, ABILITY_INTIMIDATE);
+        ABILITY_POPUP(player, ABILITY_GUARD_DOG);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        MESSAGE("Okidogi's Attack rose!");
+        NOT MESSAGE("The effects of the Clear Amulet held by Okidogi prevents its stats from being lowered!");
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_ATK], DEFAULT_STAT_STAGE + 1);
+        EXPECT_EQ(player->item, ITEM_CLEAR_AMULET);
+    }
+}
+
+SINGLE_BATTLE_TEST("Guard Dog does not activate if Intimidate is blocked by Substitute")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_SUBSTITUTE) == EFFECT_SUBSTITUTE);
+        PLAYER(SPECIES_OKIDOGI) { Ability(ABILITY_GUARD_DOG); }
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_ARBOK) { Ability(ABILITY_INTIMIDATE); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SUBSTITUTE); }
+        TURN { SWITCH(opponent, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SUBSTITUTE, player);
+        ABILITY_POPUP(opponent, ABILITY_INTIMIDATE);
+        NONE_OF {
+            ABILITY_POPUP(player, ABILITY_GUARD_DOG);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+            MESSAGE("Okidogi's Attack rose!");
+        }
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_ATK], DEFAULT_STAT_STAGE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Guard Dog does not activate if Intimidate is blocked by Mist")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_MIST) == EFFECT_MIST);
+        PLAYER(SPECIES_OKIDOGI) { Ability(ABILITY_GUARD_DOG); }
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_ARBOK) { Ability(ABILITY_INTIMIDATE); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_MIST); }
+        TURN { SWITCH(opponent, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_MIST, player);
+        MESSAGE("Your team became shrouded in mist!");
+        ABILITY_POPUP(opponent, ABILITY_INTIMIDATE);
+        NONE_OF {
+            ABILITY_POPUP(player, ABILITY_GUARD_DOG);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+            MESSAGE("Okidogi's Attack rose!");
+        }
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_ATK], DEFAULT_STAT_STAGE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Guard Dog does not activate if Intimidate cannot lower Attack at minimum stage")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_CHARM) == EFFECT_ATTACK_DOWN_2);
+        PLAYER(SPECIES_OKIDOGI) { Ability(ABILITY_GUARD_DOG); }
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_ARBOK) { Ability(ABILITY_INTIMIDATE); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_CHARM); }
+        TURN { MOVE(opponent, MOVE_CHARM); }
+        TURN { MOVE(opponent, MOVE_CHARM); }
+        TURN { SWITCH(opponent, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CHARM, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CHARM, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CHARM, opponent);
+        ABILITY_POPUP(opponent, ABILITY_INTIMIDATE);
+        NONE_OF {
+            ABILITY_POPUP(player, ABILITY_GUARD_DOG);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+            MESSAGE("Okidogi's Attack rose!");
+        }
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_ATK], MIN_STAT_STAGE);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Guard Dog does not activate if Intimidate is blocked by Flower Veil")
+{
+    GIVEN {
+        ASSUME(GetSpeciesType(SPECIES_CHIKORITA, 0) == TYPE_GRASS || GetSpeciesType(SPECIES_CHIKORITA, 1) == TYPE_GRASS);
+        PLAYER(SPECIES_COMFEY) { Ability(ABILITY_FLOWER_VEIL); Speed(40); }
+        PLAYER(SPECIES_CHIKORITA) { Ability(ABILITY_GUARD_DOG); Speed(30); }
+        OPPONENT(SPECIES_WOBBUFFET) {Speed(20); }
+        OPPONENT(SPECIES_ARBOK) { Ability(ABILITY_INTIMIDATE); Speed(10); }
+    } WHEN {
+        TURN {}
+    } SCENE {
+        ABILITY_POPUP(opponentRight, ABILITY_INTIMIDATE);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
+        ABILITY_POPUP(playerLeft, ABILITY_FLOWER_VEIL);
+        NONE_OF {
+            ABILITY_POPUP(playerRight, ABILITY_GUARD_DOG);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerRight);
+            MESSAGE("Chikorita's Attack rose!");
+        }
+    } THEN {
+        EXPECT_EQ(playerRight->statStages[STAT_ATK], DEFAULT_STAT_STAGE);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Guard Dog activates before Flower Veil if it has higher unmodified Speed")
+{
+    GIVEN {
+        ASSUME(GetSpeciesType(SPECIES_CHIKORITA, 0) == TYPE_GRASS || GetSpeciesType(SPECIES_CHIKORITA, 1) == TYPE_GRASS);
+        PLAYER(SPECIES_COMFEY) { Ability(ABILITY_FLOWER_VEIL); Speed(30); }
+        PLAYER(SPECIES_CHIKORITA) { Ability(ABILITY_GUARD_DOG); Speed(40); }
+        OPPONENT(SPECIES_WOBBUFFET) {Speed(20); }
+        OPPONENT(SPECIES_ARBOK) { Ability(ABILITY_INTIMIDATE); Speed(10); }
+    } WHEN {
+        TURN {}
+    } SCENE {
+        ABILITY_POPUP(opponentRight, ABILITY_INTIMIDATE);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
+        ABILITY_POPUP(playerRight, ABILITY_GUARD_DOG);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerRight);
+        MESSAGE("Chikorita's Attack rose!");
+        NOT ABILITY_POPUP(playerLeft, ABILITY_FLOWER_VEIL);
+    } THEN {
+        EXPECT_EQ(playerRight->statStages[STAT_ATK], DEFAULT_STAT_STAGE + 1);
+    }
+}

--- a/test/battle/ability/guard_dog.c
+++ b/test/battle/ability/guard_dog.c
@@ -67,7 +67,6 @@ SINGLE_BATTLE_TEST("Guard Dog still raises Attack against Intimidate when holdin
         NOT MESSAGE("The effects of the Clear Amulet held by Okidogi prevents its stats from being lowered!");
     } THEN {
         EXPECT_EQ(player->statStages[STAT_ATK], DEFAULT_STAT_STAGE + 1);
-        EXPECT_EQ(player->item, ITEM_CLEAR_AMULET);
     }
 }
 
@@ -148,23 +147,28 @@ SINGLE_BATTLE_TEST("Guard Dog does not activate if Intimidate cannot lower Attac
 DOUBLE_BATTLE_TEST("Guard Dog does not activate if Intimidate is blocked by Flower Veil")
 {
     GIVEN {
-        ASSUME(GetSpeciesType(SPECIES_CHIKORITA, 0) == TYPE_GRASS || GetSpeciesType(SPECIES_CHIKORITA, 1) == TYPE_GRASS);
+        ASSUME(GetMoveEffect(MOVE_FORESTS_CURSE) == EFFECT_THIRD_TYPE);
+        ASSUME(GetMoveArgType(MOVE_FORESTS_CURSE) == TYPE_GRASS);
         PLAYER(SPECIES_COMFEY) { Ability(ABILITY_FLOWER_VEIL); Speed(40); }
-        PLAYER(SPECIES_CHIKORITA) { Ability(ABILITY_GUARD_DOG); Speed(30); }
-        OPPONENT(SPECIES_WOBBUFFET) {Speed(20); }
-        OPPONENT(SPECIES_ARBOK) { Ability(ABILITY_INTIMIDATE); Speed(10); }
+        PLAYER(SPECIES_OKIDOGI) { Ability(ABILITY_GUARD_DOG); Speed(30); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(20); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(10); }
+        OPPONENT(SPECIES_ARBOK) { Ability(ABILITY_INTIMIDATE); Speed(5); }
     } WHEN {
-        TURN {}
+        TURN { MOVE(playerLeft, MOVE_FORESTS_CURSE, target: playerRight); }
+        TURN { SWITCH(opponentRight, 2); }
     } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FORESTS_CURSE, playerLeft);
         ABILITY_POPUP(opponentRight, ABILITY_INTIMIDATE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
         ABILITY_POPUP(playerLeft, ABILITY_FLOWER_VEIL);
         NONE_OF {
             ABILITY_POPUP(playerRight, ABILITY_GUARD_DOG);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerRight);
-            MESSAGE("Chikorita's Attack rose!");
+            MESSAGE("Okidogi's Attack rose!");
         }
     } THEN {
+        EXPECT_EQ(playerRight->types[2], TYPE_GRASS);
         EXPECT_EQ(playerRight->statStages[STAT_ATK], DEFAULT_STAT_STAGE);
     }
 }
@@ -172,21 +176,26 @@ DOUBLE_BATTLE_TEST("Guard Dog does not activate if Intimidate is blocked by Flow
 DOUBLE_BATTLE_TEST("Guard Dog activates before Flower Veil if it has higher unmodified Speed")
 {
     GIVEN {
-        ASSUME(GetSpeciesType(SPECIES_CHIKORITA, 0) == TYPE_GRASS || GetSpeciesType(SPECIES_CHIKORITA, 1) == TYPE_GRASS);
+        ASSUME(GetMoveEffect(MOVE_FORESTS_CURSE) == EFFECT_THIRD_TYPE);
+        ASSUME(GetMoveArgType(MOVE_FORESTS_CURSE) == TYPE_GRASS);
         PLAYER(SPECIES_COMFEY) { Ability(ABILITY_FLOWER_VEIL); Speed(30); }
-        PLAYER(SPECIES_CHIKORITA) { Ability(ABILITY_GUARD_DOG); Speed(40); }
-        OPPONENT(SPECIES_WOBBUFFET) {Speed(20); }
-        OPPONENT(SPECIES_ARBOK) { Ability(ABILITY_INTIMIDATE); Speed(10); }
+        PLAYER(SPECIES_OKIDOGI) { Ability(ABILITY_GUARD_DOG); Speed(40); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(20); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(10); }
+        OPPONENT(SPECIES_ARBOK) { Ability(ABILITY_INTIMIDATE); Speed(5); }
     } WHEN {
-        TURN {}
+        TURN { MOVE(playerLeft, MOVE_FORESTS_CURSE, target: playerRight); }
+        TURN { SWITCH(opponentRight, 2); }
     } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FORESTS_CURSE, playerLeft);
         ABILITY_POPUP(opponentRight, ABILITY_INTIMIDATE);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerLeft);
         ABILITY_POPUP(playerRight, ABILITY_GUARD_DOG);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerRight);
-        MESSAGE("Chikorita's Attack rose!");
+        MESSAGE("Okidogi's Attack rose!");
         NOT ABILITY_POPUP(playerLeft, ABILITY_FLOWER_VEIL);
     } THEN {
+        EXPECT_EQ(playerRight->types[2], TYPE_GRASS);
         EXPECT_EQ(playerRight->statStages[STAT_ATK], DEFAULT_STAT_STAGE + 1);
     }
 }


### PR DESCRIPTION
## Description
[Guard Dog](https://wiki.pokemonwiki.com/wiki/%e3%81%b0%e3%82%93%e3%81%91%e3%82%93)

> - みがわり／しろいきり状態でいかくを防いだとき、ばんけんは発動しない。
> - すでに攻撃が最低まで下がっていていかくの効果が無かったとき、ばんけんは発動しない。
> - ばんけんのポケモンがくさタイプで味方にフラワーベールのポケモンがいる場合、補正抜きの素早さ実数値が高い方の特性が優先して発動する。フラワーベールでいかくの効果が防がれるとばんけんは発動しない。

- If Intimidate is prevented by the effects of **Substitute** or **Mist**, Guard Dog **does not activate**.
- If the user’s Attack is already at its **lowest stage** and the Intimidate has no effect, Guard Dog **does not activate**.
- If the Guard Dog holder is Grass type and a teammate with **Flower Veil** is present, the ability of the faster Pokémon (based on actual Speed, ignoring modifiers) activates first. If Intimidate is prevented by Flower Veil, Guard Dog **does not activate**.

## Others

> ビビリだまを持っているときは、攻撃が上がった後にビビリだまの効果が発動する。

When holding an **Adrenaline Orb**, the effect of the Adrenaline Orb activates after the user’s Attack is raised.

> クリアチャームを持っているときでも、ばんけんの発動が優先されて攻撃が上がる。

Even when holding a **Clear Amulet**, the Guard Dog ability takes priority, and the user’s Attack is raised.



