### PR TITLE
Fix `FillSpriteRect` wrongly triggering an assert

### DIFF
--- a/src/sprite.c
+++ b/src/sprite.c
@@ -1927,6 +1927,16 @@ static void FillSpriteRect(u32 spriteId, u32 left, u32 top, u32 width, u32 heigh
         u32 srcMask;
         u32 dstMask;
         u32 currSpriteId = spriteId;
+
+        //  Handle switching sprites along X-axis
+        if (currStart > 0 && (currStart % spriteWidth) == 0)
+        {
+            spriteId = gSprites[spriteId].nextX;
+            tiles = (u32 *)((OBJ_VRAM0) + gSprites[spriteId].oam.tileNum * TILE_SIZE_4BPP);
+            if (!isColor)
+                src = GetSrcPtrFromSprite(&gSprites[spriteId]);
+        }
+
         if (currStart % PIXELS_PER_TILE == 0 && remainingWidth >= PIXELS_PER_TILE)
         {
             //  Full tile width, nothing special
@@ -2020,14 +2030,6 @@ static void FillSpriteRect(u32 spriteId, u32 left, u32 top, u32 width, u32 heigh
 
         remainingWidth -= currWidth;
         currStart += currWidth;
-        //  Handle switching sprites along X-axis
-        if (currStart > 0 && (currStart % spriteWidth) == 0)
-        {
-            spriteId = gSprites[spriteId].nextX;
-            tiles = (u32 *)((OBJ_VRAM0) + gSprites[spriteId].oam.tileNum * TILE_SIZE_4BPP);
-            if (!isColor)
-                src = GetSrcPtrFromSprite(&gSprites[spriteId]);
-        }
     }
     return;
 }


### PR DESCRIPTION
## Description

Currently sprite switching in `FillSpriteRect` occurs at the end of the `while` loop, which causes to trigger an assert within `GetSrcPtrFromSprite` , due the lack of a next sprite to use, on the next cycle, when trying to draw on the right edge of the last sprite, at the very end of the operation. This PR fixes it by moving sprite switching at the beginning of the `while` loop.

This was tested by calling `TestSpritePrinting` from a `callnative`:
```C
#include "global.h"
#include "sprite.h"
#include "text.h"
#include "menu.h"
#include "decompress.h"
#include "malloc.h"

#define TAG_TEST 15000

static const struct OamData sOamData =
{
    .shape = SPRITE_SHAPE(64x64),
    .size = SPRITE_SIZE(64x64),
    .priority = 1,
};

static const struct SpriteTemplate sSpriteTemplate =
{
    .tileTag = TAG_TEST,
    .paletteTag = TAG_TEST,
    .oam = &sOamData,
};

void Test_SpritePrinting(void)
{
    u32 size1, size2;
    void *data1 = malloc_and_decompress(gSpeciesInfo[SPECIES_ABRA].frontPic, &size1);
    void *data2 = malloc_and_decompress(gSpeciesInfo[SPECIES_ABSOL].frontPic, &size2);

    struct SpriteSheet sheet = { .data = data1, .size = size1, .tag = TAG_TEST };
    struct SpritePalette pal = { .data = gSpeciesInfo[SPECIES_ABRA].palette, .tag = TAG_TEST };

    LoadSpriteSheet(&sheet);
    LoadSpritePalette(&pal);

    u8 spriteId = CreateSprite(&sSpriteTemplate, 32, 32, 120);
    const u32 *spriteSrc[] = { data2 };
    
    SetupSpritesForTextPrinting(&spriteId, spriteSrc, 1, 1);
    FillSpriteRectSprite(spriteId, 0, 0, 64, 64);

    Free(data1);
    Free(data2);
}
```

### Note when merging with `upcoming`:
Check that the moved snippet uses `(currStart & widthMask)` instead of `(currStart % spriteWidth)`:
```C
//  Handle switching sprites along X-axis
if (currStart > 0 && (currStart & widthMask) == 0)
{
    spriteId = gSprites[spriteId].nextX;
    tiles = (u32 *)((OBJ_VRAM0) + gSprites[spriteId].oam.tileNum * TILE_SIZE_4BPP);
    if (!isColor)
        src = GetSrcPtrFromSprite(&gSprites[spriteId]);
}
```

### Large Language Models (AI)
None.

## Discord contact info
estellar.cheese