### PR TITLE
Fix Red Card activating when attacker faints

### DIFF
--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -3296,6 +3296,7 @@ static enum MoveEndResult MoveEndKeeMarangaHpThresholdItemTarget(void)
 static bool32 TryRedCard(enum BattlerId battlerAtk, enum BattlerId redCardBattler, enum Move move)
 {
     if (!IsBattlerAlive(redCardBattler)
+     || !IsBattlerAlive(battlerAtk)
      || !IsBattlerTurnDamaged(redCardBattler, EXCLUDING_SUBSTITUTES)
      || DoesSubstituteBlockMove(battlerAtk, redCardBattler, move)
      || !CanBattlerSwitch(battlerAtk))

--- a/test/battle/hold_effect/red_card.c
+++ b/test/battle/hold_effect/red_card.c
@@ -70,6 +70,26 @@ SINGLE_BATTLE_TEST("Red Card does not activate if holder faints")
     }
 }
 
+SINGLE_BATTLE_TEST("Red Card does not activate if attacker faints from recoil")
+{
+    GIVEN {
+        ASSUME(GetMoveRecoil(MOVE_FLARE_BLITZ) > 0);
+        PLAYER(SPECIES_WOBBUFFET) { HP(1); }
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_RED_CARD); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_FLARE_BLITZ); SEND_OUT(player, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FLARE_BLITZ, player);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
+            MESSAGE("The opposing Wobbuffet held up its Red Card against Wobbuffet!");
+        }
+    } THEN {
+        EXPECT_EQ(opponent->item, ITEM_RED_CARD);
+    }
+}
+
 SINGLE_BATTLE_TEST("Red Card does not activate if target is behind a Substitute")
 {
     GIVEN {


### PR DESCRIPTION
## Description
[Red Card](https://wiki.pokemonwiki.com/wiki/%E3%83%AC%E3%83%83%E3%83%89%E3%82%AB%E3%83%BC%E3%83%89)

> 攻撃者が反動技の反動や自滅技によりひんしになった場合、レッドカードは発動しない。

If the attacker faints due to recoil from a recoil move or from a self-KO move, the Red Card does not activate.
