### PR TITLE
Fix failing Dream Eater test when target is behind Substitute (Gen 5+)

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -2379,12 +2379,15 @@ BattleScript_MaxHp50Recoil::
 
 BattleScript_EffectDreamEater::
 	attackcanceler
-.if B_DREAM_EATER_SUBSTITUTE < GEN_5
-	jumpifsubstituteblocks BattleScript_DoesntAffectTargetAtkString
-.endif
+	jumpifgenconfiglowerthan CONFIG_B_DREAM_EATER_SUBSTITUTE, GEN_5, BattleScript_DreamEaterSubstituteCheck
+BattleScript_DreamEaterSleepCheck:
 	jumpifstatus BS_TARGET, STATUS1_SLEEP, BattleScript_HitFromAccCheck
 	jumpifability BS_TARGET, ABILITY_COMATOSE, BattleScript_HitFromAccCheck
 	goto BattleScript_DoesntAffectTargetAtkString
+
+BattleScript_DreamEaterSubstituteCheck:
+	jumpifsubstituteblocks BattleScript_DoesntAffectTargetAtkString
+	goto BattleScript_DreamEaterSleepCheck
 
 BattleScript_EffectAttackUp::
 	setstatchanger STAT_ATK, 1, FALSE

--- a/include/constants/generational_changes.h
+++ b/include/constants/generational_changes.h
@@ -135,6 +135,7 @@
     F(B_ENCORE_TARGET,             encoreTarget,            (u32, GEN_COUNT - 1)) \
     F(B_TIME_OF_DAY_HEALING_MOVES, timeOfDayHealingMoves,   (u32, GEN_COUNT - 1)) \
     F(B_DREAM_EATER_LIQUID_OOZE,   dreamEaterLiquidOoze,    (u32, GEN_COUNT - 1)) \
+    F(B_DREAM_EATER_SUBSTITUTE,    dreamEaterSubstitute,    (u32, GEN_COUNT - 1)) \
     F(B_FOCUS_PUNCH_FAILURE,       focusPunchFailure,       (u32, GEN_COUNT - 1)) \
     F(B_RAGE_BUILDS,               rageBuilds,              (u32, GEN_COUNT - 1)) \
     F(B_CHECK_USER_FAILURE,        checkUserFailure,        (u32, GEN_COUNT - 1)) \

--- a/test/battle/move_effect/dream_eater.c
+++ b/test/battle/move_effect/dream_eater.c
@@ -94,9 +94,8 @@ SINGLE_BATTLE_TEST("Dream Eater fails if the target is behind a Substitute (Gen 
 #else
 SINGLE_BATTLE_TEST("Dream Eater works if the target is behind a Substitute (Gen 5+)")
 {
-    s16 damage;
+    u16 damage;
     s16 healed;
-    KNOWN_FAILING; // Dream Eater can hit and drain from a Substitute, but not bypass it.
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_YAWN) == EFFECT_YAWN);
         ASSUME(GetMoveEffect(MOVE_SUBSTITUTE) == EFFECT_SUBSTITUTE);
@@ -108,7 +107,7 @@ SINGLE_BATTLE_TEST("Dream Eater works if the target is behind a Substitute (Gen 
         TURN { MOVE(opponent, MOVE_DREAM_EATER); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DREAM_EATER, opponent);
-        HP_BAR(player, captureDamage: &damage);
+        SUB_HIT(player, captureDamage: &damage);
         HP_BAR(opponent, captureDamage: &healed);
     } THEN {
         EXPECT_MUL_EQ(damage, Q_4_12(-1.0/2.0), healed);

--- a/test/battle/move_effect/dream_eater.c
+++ b/test/battle/move_effect/dream_eater.c
@@ -73,10 +73,10 @@ SINGLE_BATTLE_TEST("Dream Eater works on targets with Comatose")
     }
 }
 
-#if B_UPDATED_MOVE_FLAGS < GEN_5
 SINGLE_BATTLE_TEST("Dream Eater fails if the target is behind a Substitute (Gen 1-4)")
 {
     GIVEN {
+        WITH_CONFIG(B_DREAM_EATER_SUBSTITUTE, GEN_4);
         ASSUME(GetMoveEffect(MOVE_YAWN) == EFFECT_YAWN);
         ASSUME(GetMoveEffect(MOVE_SUBSTITUTE) == EFFECT_SUBSTITUTE);
         ASSUME(!MoveIgnoresSubstitute(MOVE_DREAM_EATER));
@@ -91,14 +91,16 @@ SINGLE_BATTLE_TEST("Dream Eater fails if the target is behind a Substitute (Gen 
         MESSAGE("It doesn't affect Wobbuffet…");
     }
 }
-#else
+
 SINGLE_BATTLE_TEST("Dream Eater works if the target is behind a Substitute (Gen 5+)")
 {
     u16 damage;
     s16 healed;
     GIVEN {
+        WITH_CONFIG(B_DREAM_EATER_SUBSTITUTE, GEN_5);
         ASSUME(GetMoveEffect(MOVE_YAWN) == EFFECT_YAWN);
         ASSUME(GetMoveEffect(MOVE_SUBSTITUTE) == EFFECT_SUBSTITUTE);
+        ASSUME(!MoveIgnoresSubstitute(MOVE_DREAM_EATER));
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET) { HP(1); }
     } WHEN {
@@ -113,4 +115,3 @@ SINGLE_BATTLE_TEST("Dream Eater works if the target is behind a Substitute (Gen 
         EXPECT_MUL_EQ(damage, Q_4_12(-1.0/2.0), healed);
     }
 }
-#endif


### PR DESCRIPTION
## Description
For damage dealt to a Substitute, use `SUB_HIT` instead of `HP_BAR`.