### PR TITLE
Fix multi hit result message

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -1657,6 +1657,15 @@ BattleScript_MultiHitPrintStrings::
 	waitmessage B_WAIT_TIME_LONG
 	return
 
+BattleScript_BattlerAvoidedMultiHit::
+	pause B_WAIT_TIME_SHORT
+	printstring STRINGID_BATTLERAVOIDEDATTACK
+	waitmessage B_WAIT_TIME_LONG
+	copyarray gBattleTextBuff1, sMULTIHIT_STRING, 6
+	printstring STRINGID_HITXTIMES
+	waitmessage B_WAIT_TIME_LONG
+	return
+
 BattleScript_EffectConversion::
 	attackcanceler
 	tryconversiontypechange BattleScript_ButItFailed

--- a/include/battle_scripts.h
+++ b/include/battle_scripts.h
@@ -396,6 +396,7 @@ extern const u8 BattleScript_AffectionBasedStatusHeal[];
 extern const u8 BattleScript_AffectionBasedEndurance[];
 extern const u8 BattleScript_SymbiosisActivates[];
 extern const u8 BattleScript_MultiHitPrintStrings[];
+extern const u8 BattleScript_BattlerAvoidedMultiHit[];
 extern const u8 BattleScript_RemoveFireType[];
 extern const u8 BattleScript_AbilityStatChange[];
 extern const u8 BattleScript_DefiantActivates[];

--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -158,6 +158,7 @@ void HandleAction_ThrowBall(void);
 u32 GetCurrentBattleWeather(void);
 bool32 EndOrContinueWeather(void);
 enum DamageCategory GetReflectDamageMoveDamageCategory(enum BattlerId battler, enum Move move);
+bool32 ShouldTeraShellDistortTypeMatchups(struct DamageContext *ctx);
 bool32 IsUnnerveBlocked(enum BattlerId battler, enum Item itemId);
 bool32 IsAffectedByFollowMe(enum BattlerId battlerAtk, enum BattleSide defSide, enum Move move);
 void HandleAction_UseMove(void);

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -2041,9 +2041,16 @@ static enum CancelerResult CancelerTargetFailure(struct BattleCalcValues *cv)
             ctx.abilities[ctx.battlerDef] = cv->abilities[cv->battlerDef];
             ctx.holdEffects[ctx.battlerAtk] = cv->holdEffects[cv->battlerAtk];
             ctx.holdEffects[ctx.battlerDef] = cv->holdEffects[cv->battlerDef];
+            ctx.typeEffectivenessModifier = CalcTypeEffectivenessMultiplier(&ctx);
 
-            if (CalcTypeEffectivenessMultiplier(&ctx) == UQ_4_12(0.0))
+            if (ctx.typeEffectivenessModifier == UQ_4_12(0.0))
                 gSpecialStatuses[cv->battlerDef].updateStallMons = TRUE;
+
+            if (ctx.typeEffectivenessModifier > UQ_4_12(0.0) && ShouldTeraShellDistortTypeMatchups(&ctx))
+            {
+                gSpecialStatuses[ctx.battlerDef].distortedTypeMatchups = TRUE;
+                gSpecialStatuses[ctx.battlerDef].teraShellAbilityDone = TRUE;
+            }
 
             if (ctx.abilityBlocked)
             {
@@ -2177,6 +2184,7 @@ static enum CancelerResult CancelerAccuracyCheck(struct BattleCalcValues *cv)
 
     enum SmartTargetState smartTargetState = INITIAL_STATE;
     bool32 isSmartTarget = GetBattlerMoveTargetType(cv->battlerAtk, cv->move) == TARGET_SMART;
+    bool32 isMultiHitOn = gSpecialStatuses[cv->battlerAtk].multiHitOn;
 
     while (gBattleStruct->eventState.atkCancelerBattler < gBattlersCount)
     {
@@ -2192,7 +2200,6 @@ static enum CancelerResult CancelerAccuracyCheck(struct BattleCalcValues *cv)
 
         if (DoesMoveMissTarget(cv))
         {
-            bool32 isMultiHitOn = gSpecialStatuses[cv->battlerAtk].multiHitOn;
             gBattleStruct->moveResultFlags[cv->battlerDef] |= MOVE_RESULT_MISSED;
 
             if (cv->holdEffects[cv->battlerAtk] == HOLD_EFFECT_BLUNDER_POLICY

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -2192,11 +2192,12 @@ static enum CancelerResult CancelerAccuracyCheck(struct BattleCalcValues *cv)
 
         if (DoesMoveMissTarget(cv))
         {
+            bool32 isMultiHitOn = gSpecialStatuses[cv->battlerAtk].multiHitOn;
             gBattleStruct->moveResultFlags[cv->battlerDef] |= MOVE_RESULT_MISSED;
 
             if (cv->holdEffects[cv->battlerAtk] == HOLD_EFFECT_BLUNDER_POLICY
              && cv->moveEffect != EFFECT_OHKO
-             && !gSpecialStatuses[cv->battlerAtk].multiHitOn)
+             && !isMultiHitOn)
                 gBattleStruct->blunderPolicy = TRUE;
 
             if (isSmartTarget
@@ -2209,7 +2210,7 @@ static enum CancelerResult CancelerAccuracyCheck(struct BattleCalcValues *cv)
                 gBattlerTarget = BATTLE_PARTNER(cv->battlerDef); // Smart target to partner if miss
             }
 
-            if (!gSpecialStatuses[cv->battlerAtk].multiHitOn)
+            if (!isMultiHitOn)
             {
                 gLastLandedMoves[cv->battlerDef] = 0;
                 gLastHitByType[cv->battlerDef] = 0;
@@ -2221,7 +2222,14 @@ static enum CancelerResult CancelerAccuracyCheck(struct BattleCalcValues *cv)
                 continue;
             }
 
-            if (gBattleStruct->moveResultFlags[cv->battlerDef] & MOVE_RESULT_ONE_HIT_KO_STURDY)
+            if (isMultiHitOn)
+            {
+                gMultiHitCounter = 0;
+                gBattleStruct->moveDamage[gBattlerTarget] = 0;
+                gSpecialStatuses[gBattlerTarget].damagedByAttack = FALSE;
+                BattleScriptCall(BattleScript_BattlerAvoidedMultiHit);
+            }
+            else if (gBattleStruct->moveResultFlags[cv->battlerDef] & MOVE_RESULT_ONE_HIT_KO_STURDY)
             {
                 gLastUsedAbility = ABILITY_STURDY;
                 gBattlerAbility = cv->battlerDef;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1851,20 +1851,8 @@ static void Cmd_resultmessage(void)
 
     if (*moveResultFlags & MOVE_RESULT_MISSED && !(*moveResultFlags & MOVE_RESULT_DOESNT_AFFECT_FOE))
     {
-        if (gMultiHitCounter && gMultiHitCounter < GetMoveStrikeCount(gCurrentMove))
-        {
-            gMultiHitCounter = 0;
-            gBattleStruct->moveDamage[gBattlerTarget] = 0;
-            gSpecialStatuses[gBattlerTarget].damagedByAttack = FALSE;
-            *moveResultFlags &= ~MOVE_RESULT_MISSED;
-            BattleScriptCall(BattleScript_MultiHitPrintStrings);
-            return;
-        }
-        else
-        {
-            gBattleCommunication[MSG_DISPLAY] = 1;
-            stringId = STRINGID_PKMNAVOIDEDATTACK;
-        }
+        gBattleCommunication[MSG_DISPLAY] = 1;
+        stringId = STRINGID_PKMNAVOIDEDATTACK;
     }
     else
     {

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1128,19 +1128,10 @@ static void Cmd_printselectionstringfromtable(void)
     }
 }
 
-static inline void CalculateAndSetMoveDamage(struct DamageContext *ctx)
+static inline void SetDynamicMoveCategoryAndDamage(struct DamageContext *ctx)
 {
     SetDynamicMoveCategory(gBattlerAttacker, ctx->battlerDef, gCurrentMove);
-    ctx->isCrit = gSpecialStatuses[ctx->battlerDef].criticalHit;
-    ctx->fixedBasePower = 0;
     gBattleStruct->moveDamage[ctx->battlerDef] = CalculateMoveDamage(ctx);
-
-    // Slighly hacky but we need to check move result flags for distortion match-up as well but it can only be done after damage calcs
-    if (gSpecialStatuses[ctx->battlerDef].distortedTypeMatchups && IsBattlerUnaffectedByMove(ctx->battlerDef))
-    {
-        gSpecialStatuses[ctx->battlerDef].distortedTypeMatchups = FALSE;
-        gSpecialStatuses[ctx->battlerDef].teraShellAbilityDone = FALSE;
-    }
 }
 
 static void Cmd_damagecalc(void)
@@ -1178,14 +1169,14 @@ static void Cmd_damagecalc(void)
                 continue;
 
             ctx.battlerDef = battlerDef;
-            CalculateAndSetMoveDamage(&ctx);
+            SetDynamicMoveCategoryAndDamage(&ctx);
         }
         gBattleStruct->calculatedDamageDone = TRUE;
     }
     else
     {
         ctx.battlerDef = gBattlerTarget;
-        CalculateAndSetMoveDamage(&ctx);
+        SetDynamicMoveCategoryAndDamage(&ctx);
     }
 
     gBattlescriptCurrInstr = cmd->nextInstr;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -320,13 +320,12 @@ enum DamageCategory GetReflectDamageMoveDamageCategory(enum BattlerId battler, e
         return DAMAGE_CATEGORY_PHYSICAL;
 }
 
-static bool32 ShouldTeraShellDistortTypeMatchups(enum Move move, enum BattlerId battlerDef, enum Ability abilityDef)
+bool32 ShouldTeraShellDistortTypeMatchups(struct DamageContext *ctx)
 {
-    if (!gSpecialStatuses[battlerDef].distortedTypeMatchups
-     && gBattleMons[battlerDef].species == SPECIES_TERAPAGOS_TERASTAL
-     && gBattleMons[battlerDef].hp == gBattleMons[battlerDef].maxHP
-     && !IsBattleMoveStatus(move)
-     && abilityDef == ABILITY_TERA_SHELL)
+    if (ctx->abilities[ctx->battlerDef] == ABILITY_TERA_SHELL
+     && gBattleMons[ctx->battlerDef].species == SPECIES_TERAPAGOS_TERASTAL
+     && gBattleMons[ctx->battlerDef].hp == gBattleMons[ctx->battlerDef].maxHP
+     && !IsBattleMoveStatus(ctx->move))
         return TRUE;
 
     return FALSE;
@@ -8074,15 +8073,11 @@ static inline void MulByTypeEffectiveness(struct DamageContext *ctx, uq4_12_t *m
             mod = UQ_4_12(1.0);
     }
 
-    if (gSpecialStatuses[ctx->battlerDef].distortedTypeMatchups || (mod > UQ_4_12(0.0) && ShouldTeraShellDistortTypeMatchups(ctx->move, ctx->battlerDef, ctx->abilities[ctx->battlerDef])))
+    if (gSpecialStatuses[ctx->battlerDef].distortedTypeMatchups || (ctx->aiCalc && mod > UQ_4_12(0.0) && ShouldTeraShellDistortTypeMatchups(ctx)))
     {
         mod = UQ_4_12(0.5);
         if (ctx->updateFlags)
-        {
             RecordAbilityBattle(ctx->battlerDef, ctx->abilities[ctx->battlerDef]);
-            gSpecialStatuses[ctx->battlerDef].distortedTypeMatchups = TRUE;
-            gSpecialStatuses[ctx->battlerDef].teraShellAbilityDone = TRUE;
-        }
     }
 
     *modifier = uq4_12_multiply(*modifier, mod);

--- a/test/battle/ability/tera_shell.c
+++ b/test/battle/ability/tera_shell.c
@@ -42,9 +42,9 @@ SINGLE_BATTLE_TEST("Tera Shell makes all hits of multi-hit moves against Terapag
     } SCENE {
         MESSAGE("The opposing Wobbuffet used Double Hit!");
         ABILITY_POPUP(player, ABILITY_TERA_SHELL);
-        MESSAGE("Terapagos made its shell gleam! It's distorting type matchups!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DOUBLE_HIT, opponent);
         HP_BAR(player, captureDamage: &firstHit);
+        NOT ABILITY_POPUP(player, ABILITY_TERA_SHELL);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DOUBLE_HIT, opponent);
         HP_BAR(player, captureDamage: &secondHit);
         MESSAGE("It's not very effective…");

--- a/test/battle/hold_effect/rocky_helmet.c
+++ b/test/battle/hold_effect/rocky_helmet.c
@@ -25,7 +25,6 @@ SINGLE_BATTLE_TEST("Rocky Helmet does not trigger contact damage again after a l
 {
     const u32 maxHP = 600;
 
-    KNOWN_FAILING;
     GIVEN {
         ASSUME(MoveMakesContact(MOVE_POPULATION_BOMB));
         ASSUME(GetMoveEffect(MOVE_POPULATION_BOMB) == EFFECT_POPULATION_BOMB);


### PR DESCRIPTION
Since accuracy check has been moved to move resolution the failure for multi hit moves was not printed correctly. 

Also fixed Tera Shell activating multiply times on multi hits. It is supposed to active once but the damage reduced for all hits