### PR TITLE
Fix Toxic Chain activation order to resolve after move additional effects

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -617,7 +617,6 @@ struct BattleStruct
     u8 friskedAbility:1; // If identifies two mons, show the ability pop-up only once.
     u8 fickleBeamBoosted:1;
     u8 poisonPuppeteerConfusion:1;
-    u8 toxicChainPriority:1; // If Toxic Chain will trigger on target, all other non volatiles will be blocked
     u8 battlersSorted:1; // To avoid unnessasery computation
     struct BattleTvMovePoints tvMovePoints;
     struct BattleTv tv;

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -3759,7 +3759,6 @@ static enum MoveEndResult MoveEndClearBits(void)
     gBattleStruct->poisonPuppeteerConfusion = FALSE;
     gBattleStruct->fickleBeamBoosted = FALSE;
     gBattleStruct->battlerState[gBattlerAttacker].usedMicleBerry = FALSE;
-    gBattleStruct->toxicChainPriority = FALSE;
     gBattleStruct->flingItem = ITEM_NONE;
     if (gBattleStruct->unableToUseMove)
         gBattleStruct->pledgeMove = FALSE;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -3731,10 +3731,6 @@ static bool32 CanApplyAdditionalEffect(const struct AdditionalEffect *additional
     if (additionalEffect->preAttackEffect)
         return FALSE;
 
-    // If Toxic Chain will activate it blocks all other non volatile effects
-    if (gBattleStruct->toxicChainPriority && additionalEffect->moveEffect <= MOVE_EFFECT_FROSTBITE)
-        return FALSE;
-
     if (additionalEffect->self
      && NumAffectedSpreadMoveTargets() > 1
      && GetNextTarget(GetBattlerMoveTargetType(gBattlerAttacker, gCurrentMove), TRUE) != MAX_BATTLERS_COUNT)
@@ -3751,20 +3747,6 @@ static bool32 CanApplyAdditionalEffect(const struct AdditionalEffect *additional
     return TRUE;
 }
 
-static void SetToxicChainPriority(void)
-{
-    if (gBattleStruct->toxicChainPriority)
-        return;
-
-    enum Ability abilityAtk = GetBattlerAbility(gBattlerAttacker);
-    if (abilityAtk == ABILITY_TOXIC_CHAIN
-     && IsBattlerAlive(gBattlerTarget)
-     && CanBePoisoned(gBattlerAttacker, gBattlerTarget, abilityAtk, GetBattlerAbility(gBattlerTarget))
-     && IsBattlerTurnDamaged(gBattlerTarget, EXCLUDING_SUBSTITUTES)
-     && RandomWeighted(RNG_TOXIC_CHAIN, 7, 3))
-        gBattleStruct->toxicChainPriority = TRUE;
-}
-
 static void Cmd_setadditionaleffects(void)
 {
     CMD_ARGS();
@@ -3772,7 +3754,6 @@ static void Cmd_setadditionaleffects(void)
     if (!IsBattlerUnaffectedByMove(gBattlerTarget))
     {
         u32 numAdditionalEffects = GetMoveAdditionalEffectCount(gCurrentMove);
-        SetToxicChainPriority();
         if (numAdditionalEffects > gBattleStruct->additionalEffectsCounter)
         {
             u32 percentChance;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4348,18 +4348,19 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
             }
             break;
         case ABILITY_TOXIC_CHAIN:
-            if (gBattleStruct->toxicChainPriority)
+            if (IsBattlerAlive(gBattlerTarget)
+             && !gBattleStruct->unableToUseMove
+             && !IsMoveEffectBlockedByTarget(GetBattlerAbility(gBattlerTarget))
+             && CanBePoisoned(gBattlerAttacker, gBattlerTarget, gLastUsedAbility, GetBattlerAbility(gBattlerTarget))
+             && IsBattlerTurnDamaged(gBattlerTarget, EXCLUDING_SUBSTITUTES)
+             && RandomWeighted(RNG_TOXIC_CHAIN, 7, 3))
             {
-                gBattleStruct->toxicChainPriority = FALSE;
-                if (!IsMoveEffectBlockedByTarget(GetBattlerAbility(gBattlerTarget)))
-                {
-                    gEffectBattler = gBattlerTarget;
-                    gBattleScripting.battler = gBattlerAttacker;
-                    gBattleScripting.moveEffect = MOVE_EFFECT_TOXIC;
-                    PREPARE_ABILITY_BUFFER(gBattleTextBuff1, gLastUsedAbility);
-                    BattleScriptCall(BattleScript_AbilityStatusEffect);
-                    effect++;
-                }
+                gEffectBattler = gBattlerTarget;
+                gBattleScripting.battler = gBattlerAttacker;
+                gBattleScripting.moveEffect = MOVE_EFFECT_TOXIC;
+                PREPARE_ABILITY_BUFFER(gBattleTextBuff1, gLastUsedAbility);
+                BattleScriptCall(BattleScript_AbilityStatusEffect);
+                effect++;
             }
             break;
         case ABILITY_STENCH:

--- a/test/battle/ability/toxic_chain.c
+++ b/test/battle/ability/toxic_chain.c
@@ -177,9 +177,10 @@ SINGLE_BATTLE_TEST("Toxic Chain is blocked by Covert Cloak")
     }
 }
 
-SINGLE_BATTLE_TEST("Toxic Chain does not override the move's guaranteed non-volatile status")
+SINGLE_BATTLE_TEST("Toxic Chain is checked after the move's additional effect")
 {
     GIVEN {
+        ASSUME(MoveHasAdditionalEffectWithChance(MOVE_NUZZLE, MOVE_EFFECT_PARALYSIS, 100) == TRUE);
         ASSUME(GetMoveCategory(MOVE_NUZZLE) != DAMAGE_CATEGORY_STATUS);
         ASSUME(GetMovePower(MOVE_NUZZLE) > 0);
         PLAYER(SPECIES_OKIDOGI) { Ability(ABILITY_TOXIC_CHAIN); }

--- a/test/battle/ability/toxic_chain.c
+++ b/test/battle/ability/toxic_chain.c
@@ -176,3 +176,27 @@ SINGLE_BATTLE_TEST("Toxic Chain is blocked by Covert Cloak")
         EXPECT(opponent->status1 == 0);
     }
 }
+
+SINGLE_BATTLE_TEST("Toxic Chain does not override the move's guaranteed non-volatile status")
+{
+    GIVEN {
+        ASSUME(GetMoveCategory(MOVE_NUZZLE) != DAMAGE_CATEGORY_STATUS);
+        ASSUME(GetMovePower(MOVE_NUZZLE) > 0);
+        PLAYER(SPECIES_OKIDOGI) { Ability(ABILITY_TOXIC_CHAIN); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_NUZZLE, WITH_RNG(RNG_TOXIC_CHAIN, TRUE)); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_NUZZLE, player);
+        ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PRZ, opponent);
+        STATUS_ICON(opponent, paralysis: TRUE);
+        NONE_OF {
+            ABILITY_POPUP(player, ABILITY_TOXIC_CHAIN);
+            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
+            STATUS_ICON(opponent, badPoison: TRUE);
+        }
+    } THEN {
+        EXPECT(opponent->status1 & STATUS1_PARALYSIS);
+        EXPECT(!(opponent->status1 & STATUS1_TOXIC_POISON));
+    }
+}


### PR DESCRIPTION
## Description
[Toxic Chain](https://wiki.pokemonwiki.com/wiki/%e3%81%a9%e3%81%8f%e3%81%ae%e3%81%8f%e3%81%95%e3%82%8a)

> 基本的に追加効果の後に特性の発動判定がある。

Basically, Toxic Chain's activation check takes place after the additional effects.
