### PR TITLE
Remove Defiant and Competitive from Partner Ability check in Doubles

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -3541,8 +3541,6 @@ static s32 AI_DoubleBattle(enum BattlerId battlerAtk, enum BattlerId battlerDef,
                 }
                 break;
             case ABILITY_CONTRARY:
-            case ABILITY_DEFIANT:
-            case ABILITY_COMPETITIVE:
                 if (IsStatLoweringMove(move) && isFriendlyFireOK && ShouldTriggerAbility(battlerAtk, battlerAtkPartner, atkPartnerAbility))
                 {
                     if (moveTarget == TARGET_FOES_AND_ALLY)


### PR DESCRIPTION
## Description
`AI_DoubleBattle` contains a check that increases a move's score if the user's partner has defiant/competitive, however these abilities only activate if an opponent's move lowers their stats.

### Large Language Models (AI)
no

## Discord contact info
grintoul