### PR TITLE
Fix Toxic Debris checking Toxic Spikes cap on the wrong side

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4309,11 +4309,13 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
             }
             break;
         case ABILITY_TOXIC_DEBRIS:
+        {
+            enum BattlerId toxicSpikesTarget = BATTLE_OPPOSITE(gBattlerTarget);
             if (!gBattleStruct->isSkyBattle
              && !gBattleStruct->unableToUseMove
              && IsBattleMovePhysical(gCurrentMove)
              && IsBattlerTurnDamaged(gBattlerTarget, EXCLUDING_SUBSTITUTES)
-             && (gSideTimers[GetBattlerSide(gBattlerAttacker)].toxicSpikesAmount != 2))
+             && (gSideTimers[GetBattlerSide(toxicSpikesTarget)].toxicSpikesAmount != 2))
             {
                 SaveBattlerTarget(gBattlerTarget);
                 SaveBattlerAttacker(gBattlerAttacker);
@@ -4323,6 +4325,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
                 effect++;
             }
             break;
+        }
         default:
             break;
         }

--- a/test/battle/ability/toxic_debris.c
+++ b/test/battle/ability/toxic_debris.c
@@ -140,3 +140,24 @@ DOUBLE_BATTLE_TEST("Toxic Debris sets Toxic Spikes on the opposing side even whe
         MESSAGE("Poison spikes were scattered on the ground all around the opposing team!");
     }
 }
+
+DOUBLE_BATTLE_TEST("Toxic Debris does not activate if two layers of Toxic Spikes are already up on target side")
+{
+    GIVEN {
+        PLAYER(SPECIES_GLIMMORA) { Ability(ABILITY_TOXIC_DEBRIS); }
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_TOXIC_SPIKES), MOVE(playerRight, MOVE_TOXIC_SPIKES); }
+        TURN { MOVE(playerRight, MOVE_SCRATCH, target: playerLeft); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TOXIC_SPIKES, playerLeft);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TOXIC_SPIKES, playerRight);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, playerRight);
+        NONE_OF {
+            ABILITY_POPUP(playerLeft, ABILITY_TOXIC_DEBRIS);
+            MESSAGE("Poison spikes were scattered on the ground all around the opposing team!");
+        }
+    }
+}

--- a/test/battle/ability/toxic_debris.c
+++ b/test/battle/ability/toxic_debris.c
@@ -141,7 +141,7 @@ DOUBLE_BATTLE_TEST("Toxic Debris sets Toxic Spikes on the opposing side even whe
     }
 }
 
-DOUBLE_BATTLE_TEST("Toxic Debris does not activate if two layers of Toxic Spikes are already up on target side")
+DOUBLE_BATTLE_TEST("Toxic Debris does not activate if two layers of Toxic Spikes are already up on the opposing side of the field")
 {
     GIVEN {
         PLAYER(SPECIES_GLIMMORA) { Ability(ABILITY_TOXIC_DEBRIS); }


### PR DESCRIPTION
## Description
**In double battles**, Toxic Debris incorrectly checked Toxic Spikes layers on the attacker's side during **ally-hit scenarios**.