### PR TITLE
Fix incorrect Loaded Dice priority over Skill Link for Population Bomb

### DIFF
--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -1940,7 +1940,7 @@ static enum CancelerResult CancelerMultihitMoves(struct BattleContext *ctx)
     else if (GetMoveStrikeCount(ctx->move) > 1)
     {
         if (GetMoveEffect(ctx->move) == EFFECT_POPULATION_BOMB
-         && GetBattlerHoldEffect(ctx->battlerAtk) == HOLD_EFFECT_LOADED_DICE
+         && ctx->holdEffectAtk == HOLD_EFFECT_LOADED_DICE
          && ctx->abilityAtk != ABILITY_SKILL_LINK)
         {
             gMultiHitCounter = RandomUniform(RNG_LOADED_DICE, 4, 10);

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -1939,7 +1939,9 @@ static enum CancelerResult CancelerMultihitMoves(struct BattleContext *ctx)
     }
     else if (GetMoveStrikeCount(ctx->move) > 1)
     {
-        if (GetMoveEffect(ctx->move) == EFFECT_POPULATION_BOMB && GetBattlerHoldEffect(ctx->battlerAtk) == HOLD_EFFECT_LOADED_DICE)
+        if (GetMoveEffect(ctx->move) == EFFECT_POPULATION_BOMB
+         && GetBattlerHoldEffect(ctx->battlerAtk) == HOLD_EFFECT_LOADED_DICE
+         && ctx->abilityAtk != ABILITY_SKILL_LINK)
         {
             gMultiHitCounter = RandomUniform(RNG_LOADED_DICE, 4, 10);
         }

--- a/test/battle/move_effect/population_bomb.c
+++ b/test/battle/move_effect/population_bomb.c
@@ -24,6 +24,31 @@ SINGLE_BATTLE_TEST("Population Bomb can hit ten times")
     }
 }
 
+SINGLE_BATTLE_TEST("Population Bomb with Skill Link ignores Loaded Dice roll and still hits ten times")
+{
+    GIVEN {
+        ASSUME(GetMoveStrikeCount(MOVE_POPULATION_BOMB) == 10);
+        ASSUME(GetMoveEffect(MOVE_POPULATION_BOMB) == EFFECT_POPULATION_BOMB);
+        ASSUME(GetItemHoldEffect(ITEM_LOADED_DICE) == HOLD_EFFECT_LOADED_DICE);
+        PLAYER(SPECIES_PIKIPEK) { Ability(ABILITY_SKILL_LINK); Item(ITEM_LOADED_DICE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_POPULATION_BOMB, WITH_RNG(RNG_LOADED_DICE, 4)); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POPULATION_BOMB, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POPULATION_BOMB, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POPULATION_BOMB, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POPULATION_BOMB, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POPULATION_BOMB, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POPULATION_BOMB, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POPULATION_BOMB, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POPULATION_BOMB, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POPULATION_BOMB, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POPULATION_BOMB, player);
+        MESSAGE("The Pokémon was hit 10 time(s)!");
+    }
+}
+
 TO_DO_BATTLE_TEST("Accuracy for Population Bomb is checked independently for each hit")
 TO_DO_BATTLE_TEST("Accuracy for Population Bomb is only checked for the first hit with Skill Link")
 TO_DO_BATTLE_TEST("Accuracy for Population Bomb is only checked for the first hit with Loaded Dice")

--- a/test/battle/move_effect/population_bomb.c
+++ b/test/battle/move_effect/population_bomb.c
@@ -1,10 +1,16 @@
 #include "global.h"
 #include "test/battle.h"
 
+ASSUMPTIONS
+{
+    ASSUME(GetMoveEffect(MOVE_POPULATION_BOMB) == EFFECT_POPULATION_BOMB);
+    ASSUME(GetMoveStrikeCount(MOVE_POPULATION_BOMB) == 10);
+    ASSUME(GetMoveAccuracy(MOVE_POPULATION_BOMB) == 90);
+}
+
 SINGLE_BATTLE_TEST("Population Bomb can hit ten times")
 {
     GIVEN {
-        ASSUME(GetMoveStrikeCount(MOVE_POPULATION_BOMB) == 10);
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
@@ -27,8 +33,6 @@ SINGLE_BATTLE_TEST("Population Bomb can hit ten times")
 SINGLE_BATTLE_TEST("Accuracy for Population Bomb is checked independently for each hit")
 {
     GIVEN {
-        ASSUME(GetMoveAccuracy(MOVE_POPULATION_BOMB) == 90);
-        ASSUME(GetMoveEffect(MOVE_POPULATION_BOMB) == EFFECT_POPULATION_BOMB);
         ASSUME(MoveMakesContact(MOVE_POPULATION_BOMB));
         PLAYER(SPECIES_MACHAMP) { Ability(ABILITY_NO_GUARD); }
         OPPONENT(SPECIES_OINKOLOGNE) { Ability(ABILITY_LINGERING_AROMA); }
@@ -49,9 +53,6 @@ SINGLE_BATTLE_TEST("Accuracy for Population Bomb is only checked for the first h
 {
     PASSES_RANDOMLY(9, 10, RNG_ACCURACY);
     GIVEN {
-        ASSUME(GetMoveAccuracy(MOVE_POPULATION_BOMB) == 90);
-        ASSUME(GetMoveEffect(MOVE_POPULATION_BOMB) == EFFECT_POPULATION_BOMB);
-        ASSUME(GetMoveStrikeCount(MOVE_POPULATION_BOMB) == 10);
         PLAYER(SPECIES_PIKIPEK) { Ability(ABILITY_SKILL_LINK); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
@@ -75,8 +76,6 @@ SINGLE_BATTLE_TEST("Accuracy for Population Bomb is only checked for the first h
 {
     PASSES_RANDOMLY(9, 10, RNG_ACCURACY);
     GIVEN {
-        ASSUME(GetMoveAccuracy(MOVE_POPULATION_BOMB) == 90);
-        ASSUME(GetMoveEffect(MOVE_POPULATION_BOMB) == EFFECT_POPULATION_BOMB);
         ASSUME(GetItemHoldEffect(ITEM_LOADED_DICE) == HOLD_EFFECT_LOADED_DICE);
         PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_LOADED_DICE); }
         OPPONENT(SPECIES_WOBBUFFET);
@@ -94,8 +93,6 @@ SINGLE_BATTLE_TEST("Accuracy for Population Bomb is only checked for the first h
 SINGLE_BATTLE_TEST("Population Bomb with Skill Link ignores Loaded Dice roll and still hits ten times")
 {
     GIVEN {
-        ASSUME(GetMoveStrikeCount(MOVE_POPULATION_BOMB) == 10);
-        ASSUME(GetMoveEffect(MOVE_POPULATION_BOMB) == EFFECT_POPULATION_BOMB);
         ASSUME(GetItemHoldEffect(ITEM_LOADED_DICE) == HOLD_EFFECT_LOADED_DICE);
         PLAYER(SPECIES_PIKIPEK) { Ability(ABILITY_SKILL_LINK); Item(ITEM_LOADED_DICE); }
         OPPONENT(SPECIES_WOBBUFFET);

--- a/test/battle/move_effect/population_bomb.c
+++ b/test/battle/move_effect/population_bomb.c
@@ -46,6 +46,8 @@ SINGLE_BATTLE_TEST("Accuracy for Population Bomb is checked independently for ea
             ANIMATION(ANIM_TYPE_MOVE, MOVE_POPULATION_BOMB, player);
             MESSAGE("The Pokémon was hit 2 time(s)!");
         }
+    } THEN {
+        EXPECT_EQ(player->ability, ABILITY_LINGERING_AROMA);
     }
 }
 

--- a/test/battle/move_effect/population_bomb.c
+++ b/test/battle/move_effect/population_bomb.c
@@ -24,6 +24,73 @@ SINGLE_BATTLE_TEST("Population Bomb can hit ten times")
     }
 }
 
+SINGLE_BATTLE_TEST("Accuracy for Population Bomb is checked independently for each hit")
+{
+    GIVEN {
+        ASSUME(GetMoveAccuracy(MOVE_POPULATION_BOMB) == 90);
+        ASSUME(GetMoveEffect(MOVE_POPULATION_BOMB) == EFFECT_POPULATION_BOMB);
+        ASSUME(MoveMakesContact(MOVE_POPULATION_BOMB));
+        PLAYER(SPECIES_MACHAMP) { Ability(ABILITY_NO_GUARD); }
+        OPPONENT(SPECIES_OINKOLOGNE) { Ability(ABILITY_LINGERING_AROMA); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_POPULATION_BOMB, WITH_RNG(RNG_ACCURACY, FALSE)); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POPULATION_BOMB, player);
+        ABILITY_POPUP(opponent, ABILITY_LINGERING_AROMA);
+        MESSAGE("The Pokémon was hit 1 time(s)!");
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_POPULATION_BOMB, player);
+            MESSAGE("The Pokémon was hit 2 time(s)!");
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Accuracy for Population Bomb is only checked for the first hit with Skill Link")
+{
+    PASSES_RANDOMLY(9, 10, RNG_ACCURACY);
+    GIVEN {
+        ASSUME(GetMoveAccuracy(MOVE_POPULATION_BOMB) == 90);
+        ASSUME(GetMoveEffect(MOVE_POPULATION_BOMB) == EFFECT_POPULATION_BOMB);
+        ASSUME(GetMoveStrikeCount(MOVE_POPULATION_BOMB) == 10);
+        PLAYER(SPECIES_PIKIPEK) { Ability(ABILITY_SKILL_LINK); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_POPULATION_BOMB); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POPULATION_BOMB, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POPULATION_BOMB, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POPULATION_BOMB, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POPULATION_BOMB, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POPULATION_BOMB, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POPULATION_BOMB, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POPULATION_BOMB, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POPULATION_BOMB, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POPULATION_BOMB, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POPULATION_BOMB, player);
+        MESSAGE("The Pokémon was hit 10 time(s)!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Accuracy for Population Bomb is only checked for the first hit with Loaded Dice")
+{
+    PASSES_RANDOMLY(9, 10, RNG_ACCURACY);
+    GIVEN {
+        ASSUME(GetMoveAccuracy(MOVE_POPULATION_BOMB) == 90);
+        ASSUME(GetMoveEffect(MOVE_POPULATION_BOMB) == EFFECT_POPULATION_BOMB);
+        ASSUME(GetItemHoldEffect(ITEM_LOADED_DICE) == HOLD_EFFECT_LOADED_DICE);
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_LOADED_DICE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_POPULATION_BOMB, WITH_RNG(RNG_LOADED_DICE, 4)); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POPULATION_BOMB, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POPULATION_BOMB, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POPULATION_BOMB, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POPULATION_BOMB, player);
+        MESSAGE("The Pokémon was hit 4 time(s)!");
+    }
+}
+
 SINGLE_BATTLE_TEST("Population Bomb with Skill Link ignores Loaded Dice roll and still hits ten times")
 {
     GIVEN {
@@ -48,7 +115,3 @@ SINGLE_BATTLE_TEST("Population Bomb with Skill Link ignores Loaded Dice roll and
         MESSAGE("The Pokémon was hit 10 time(s)!");
     }
 }
-
-TO_DO_BATTLE_TEST("Accuracy for Population Bomb is checked independently for each hit")
-TO_DO_BATTLE_TEST("Accuracy for Population Bomb is only checked for the first hit with Skill Link")
-TO_DO_BATTLE_TEST("Accuracy for Population Bomb is only checked for the first hit with Loaded Dice")


### PR DESCRIPTION
## Description
[Population Bomb](https://bulbapedia.bulbagarden.net/wiki/Population_Bomb_(move))

> If the user is holding Loaded Dice, only one accuracy check is performed, and it will hit between four and ten times (with an even chance of each number of hits). **If the user has Skill Link, the move will have only one accuracy check and hit the maximum ten times.**