### PR TITLE
Fix reverse-cry off-by-one if Porygon disabled

### DIFF
--- a/sound/cry_tables.inc
+++ b/sound/cry_tables.inc
@@ -2979,8 +2979,8 @@ gCryTable_Reverse::
 	cry_reverse Cry_Sylveon
 .endif @ P_GEN_6_CROSS_EVOS
 .endif @ P_FAMILY_EEVEE
-.if P_FAMILY_PORYGON == TRUE
 	cry_reverse Cry_Porygon
+.if P_FAMILY_PORYGON == TRUE
 .if P_GEN_2_CROSS_EVOS == TRUE
 	cry_reverse Cry_Porygon2
 .if P_GEN_4_CROSS_EVOS == TRUE


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
Fixes reverse cries after Porygon being off-by-one if Porygon is disabled by always including the Porygon reverse cry even if Porygon is disabled to match what was done for the regular cry.

### Large Language Models (AI)
<!-- Does your pull request contain code or assets generated by a large language model (AI)? If so, where? -->
<!-- NOTE: There is an expectation that you have fully reviewed your code to ensure it meets all merge criteria (detailed above). -->
<!-- If the maintainers believe that a pull request was generated by AI with no or little to no human oversight, the pull request will be closed without further discussion. -->
No

## Media

Before
https://github.com/user-attachments/assets/0cbf71da-aef4-4730-acee-74e65b0554f3

After
https://github.com/user-attachments/assets/ffa526f3-6e08-4ccc-b785-6573f2a47243


## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, closes #2222." Remove this section if not applicable.-->
Fixes #10001 

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara