### PR TITLE
Fix battle debug not properly freeing some tilemaps

### DIFF
--- a/src/battle_debug.c
+++ b/src/battle_debug.c
@@ -669,7 +669,7 @@ void CB2_BattleDebugMenu(void)
         ResetBgsAndClearDma3BusyFlags(0);
         InitBgsFromTemplates(0, sBgTemplates, ARRAY_COUNT(sBgTemplates));
         ResetAllBgsCoordinates();
-        FreeAllWindowBuffers();
+        CloseMainBattleScreen();
         DeactivateAllTextPrinters();
         SetGpuReg(REG_OFFSET_DISPCNT, DISPCNT_OBJ_ON | DISPCNT_OBJ_1D_MAP);
         ShowBg(0);


### PR DESCRIPTION
regression #9906

The debug window doesn't properly free some battle tilemaps when getting opened but the tilemaps are still allocated when the debug window is closed

## Issue(s) that this PR fixes
Fixes #10013

## Discord contact info
Jamie
