### PR TITLE
Set higher HP in Gem Damage calculation test fixing gen5 config result

### DIFF
--- a/test/battle/damage_formula.c
+++ b/test/battle/damage_formula.c
@@ -318,7 +318,6 @@ SINGLE_BATTLE_TEST("Gem boosted Damage calculation")
     PARAMETRIZE { expectedDamage = 205; }
     PARAMETRIZE { expectedDamage = 204; }
 #else
-    KNOWN_FAILING;
     PARAMETRIZE { expectedDamage = 273; }
     PARAMETRIZE { expectedDamage = 270; }
     PARAMETRIZE { expectedDamage = 267; }
@@ -338,7 +337,7 @@ SINGLE_BATTLE_TEST("Gem boosted Damage calculation")
 #endif
     GIVEN {
         PLAYER(SPECIES_MAKUHITA) { Item(ITEM_FIGHTING_GEM); }
-        OPPONENT(SPECIES_MAKUHITA);
+        OPPONENT(SPECIES_MAKUHITA) { MaxHP(999); HP(999); }
     } WHEN {
         TURN {
             MOVE(player, MOVE_DRAIN_PUNCH, WITH_RNG(RNG_DAMAGE_MODIFIER, i));


### PR DESCRIPTION
## Description
Test failed because the move KOs meaning captured damage maxed out at 254

### Large Language Models (AI)
no

## Discord contact info
grintoul