### PR TITLE
Fix Electrify status move test expectations

### DIFF
--- a/test/battle/move_effect/electrify.c
+++ b/test/battle/move_effect/electrify.c
@@ -42,18 +42,19 @@ DOUBLE_BATTLE_TEST("Electrify makes the target's move Electric-type for the rema
 
 SINGLE_BATTLE_TEST("Electrify can change status moves to Electric-type")
 {
-    KNOWN_FAILING;
     GIVEN {
-        ASSUME(GetSpeciesType(SPECIES_SANDSLASH, 0) == TYPE_GROUND || GetSpeciesType(SPECIES_SANDSLASH, 1) == TYPE_GROUND);
         ASSUME(GetMoveCategory(MOVE_LEER) == DAMAGE_CATEGORY_STATUS);
         ASSUME(GetMoveType(MOVE_LEER) != TYPE_ELECTRIC);
         PLAYER(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_SANDSLASH);
+        OPPONENT(SPECIES_JOLTEON) { Ability(ABILITY_VOLT_ABSORB); HP(25); MaxHP(100); }
     } WHEN {
         TURN { MOVE(opponent, MOVE_ELECTRIFY); MOVE(player, MOVE_LEER); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ELECTRIFY, opponent);
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_LEER, player);
+        ABILITY_POPUP(opponent, ABILITY_VOLT_ABSORB);
+        HP_BAR(opponent, damage: -25);
+        MESSAGE("The opposing Jolteon restored HP using its Volt Absorb!");
     }
 }
 


### PR DESCRIPTION
## Description
[Bulba](https://bulbapedia.bulbagarden.net/wiki/Status_move)
> Status moves typically do not employ type effectiveness, so may affect Pokémon regardless of their types...