### PR TITLE
Fixes Trace not activating when reobtained after activation

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -10553,6 +10553,7 @@ bool32 IsAffectedByPowderMove(enum BattlerId battler, enum Ability ability, enum
 void RemoveAbilityFlags(enum BattlerId battler)
 {
     gBattleMons[battler].volatiles.unburdenActive = FALSE;
+    gBattleMons[battler].volatiles.traceActivated = FALSE;
 
     switch (GetBattlerAbility(battler))
     {

--- a/test/battle/ability/trace.c
+++ b/test/battle/ability/trace.c
@@ -82,7 +82,36 @@ SINGLE_BATTLE_TEST("Trace will copy an opponent's ability whenever it has the ch
     }
 }
 
-SINGLE_BATTLE_TEST("Trace doesn't activate if activation was prevented by Ability Shield")
+SINGLE_BATTLE_TEST("Trace will copy an opponent's ability after obtaining it via Skill Swap even if it Traced a different ability before")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_SKILL_SWAP) == EFFECT_SKILL_SWAP);
+        ASSUME(gAbilitiesInfo[ABILITY_FLOWER_GIFT].cantBeTraced);
+        ASSUME(!gAbilitiesInfo[ABILITY_BLAZE].cantBeTraced);
+        ASSUME(!gAbilitiesInfo[ABILITY_FLOWER_GIFT].cantBeSwapped);
+        ASSUME(!gAbilitiesInfo[ABILITY_TRACE].cantBeSwapped);
+        ASSUME(!gAbilitiesInfo[ABILITY_BLAZE].cantBeSwapped);
+        PLAYER(SPECIES_RALTS) { Ability(ABILITY_TRACE); }
+        OPPONENT(SPECIES_TORCHIC) { Ability(ABILITY_BLAZE); }
+        OPPONENT(SPECIES_CHERRIM) { Ability(ABILITY_FLOWER_GIFT); }
+        OPPONENT(SPECIES_RALTS) { Ability(ABILITY_TRACE); }
+    } WHEN {
+        TURN { SWITCH(opponent, 1); MOVE(player, MOVE_SKILL_SWAP); }
+        TURN { SWITCH(opponent, 2); MOVE(player, MOVE_SKILL_SWAP); }
+        TURN { SWITCH(opponent, 0); }
+    } SCENE {
+        ABILITY_POPUP(player, ABILITY_TRACE);
+        MESSAGE("It traced the opposing Torchic's Blaze!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SKILL_SWAP, player);
+        // Player now has Flower Gift
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SKILL_SWAP, player);
+        // Player now has Trace
+        ABILITY_POPUP(player, ABILITY_TRACE);
+        MESSAGE("It traced the opposing Torchic's Blaze!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Trace doesn't try to reactivate if activation was prevented by Ability Shield")
 {
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_KNOCK_OFF) == EFFECT_KNOCK_OFF);

--- a/test/battle/move_effect/protect.c
+++ b/test/battle/move_effect/protect.c
@@ -992,7 +992,7 @@ DOUBLE_BATTLE_TEST("Protect is not ignored after a new mon switched in because o
     }
 }
 
-SINGLE_BATTLE_TEST("Protect may fail if used consecutively")
+SINGLE_BATTLE_TEST("Protect may fail if used consecutively - 2nd time has 1/2 or 1/3 odds")
 {
     u32 numRolls = (B_PROTECT_FAILURE_RATE < GEN_5 ? 2 : 3);
     PASSES_RANDOMLY(1, numRolls, RNG_PROTECT_FAIL);
@@ -1003,6 +1003,44 @@ SINGLE_BATTLE_TEST("Protect may fail if used consecutively")
         TURN { MOVE(player, MOVE_PROTECT); }
         TURN { MOVE(player, MOVE_PROTECT); }
     } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_PROTECT, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_PROTECT, player);
+    }
+}
+
+SINGLE_BATTLE_TEST("Protect may fail if used consecutively - 3rd time has 1/4 or 1/9 odds")
+{
+    u32 numRolls = (B_PROTECT_FAILURE_RATE < GEN_5 ? 4 : 9);
+    PASSES_RANDOMLY(1, numRolls, RNG_PROTECT_FAIL);
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_PROTECT); }
+        TURN { MOVE(player, MOVE_PROTECT, WITH_RNG(RNG_PROTECT_FAIL, 1)); }
+        TURN { MOVE(player, MOVE_PROTECT); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_PROTECT, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_PROTECT, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_PROTECT, player);
+    }
+}
+
+SINGLE_BATTLE_TEST("Protect may fail if used consecutively - 4th time has 1/8 or 1/27 odds")
+{
+    u32 numRolls = (B_PROTECT_FAILURE_RATE < GEN_5 ? 8 : 27);
+    PASSES_RANDOMLY(1, numRolls, RNG_PROTECT_FAIL);
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_PROTECT); }
+        TURN { MOVE(player, MOVE_PROTECT, WITH_RNG(RNG_PROTECT_FAIL, 1)); }
+        TURN { MOVE(player, MOVE_PROTECT, WITH_RNG(RNG_PROTECT_FAIL, 1)); }
+        TURN { MOVE(player, MOVE_PROTECT); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_PROTECT, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_PROTECT, player);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_PROTECT, player);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_PROTECT, player);
     }


### PR DESCRIPTION
#9988 follow up.
Also adds Protect failing on consecutive use tests for 2nd to 4th consecutive uses.

## Discord contact info
PhallenTree