### PR TITLE
Add Item Icon to Knock Off, Covet, and Thief animations

### DIFF
--- a/data/battle_anim_scripts.s
+++ b/data/battle_anim_scripts.s
@@ -28950,11 +28950,7 @@ gBattleAnimGeneral_PokeblockThrow::
 	end
 
 gBattleAnimGeneral_ItemKnockoff::
-.if B_SHOW_ITEM_ICON_WHEN_LOST
 	createvisualtask AnimTask_KnockOffItem, ANIM_TARGET, 2
-.else
-	createsprite gKnockOffItemSpriteTemplate, ANIM_TARGET, 2
-.endif
 	end
 
 gBattleAnimGeneral_TurnTrap::
@@ -29195,11 +29191,7 @@ gBattleAnimGeneral_ItemSteal::
 	createvisualtask AnimTask_SetAnimAttackerAndTargetForEffectAtk, 2
 	createvisualtask AnimTask_SetTargetToEffectBattler, 2  @ Redundant with above
 	delay 1
-.if B_SHOW_ITEM_ICON_WHEN_LOST
 	createvisualtask AnimTask_StealItem, ANIM_TARGET, 2
-.else
-	create_item_steal_sprite ANIM_ATTACKER, 2, initial_x=0, initial_y=-5, unk2=10, unk3=2, unk4=-1
-.endif
 	end
 
 gBattleAnimGeneral_SnatchMove::

--- a/data/battle_anim_scripts.s
+++ b/data/battle_anim_scripts.s
@@ -28950,7 +28950,11 @@ gBattleAnimGeneral_PokeblockThrow::
 	end
 
 gBattleAnimGeneral_ItemKnockoff::
+.if B_SHOW_ITEM_ICON_WHEN_LOST
+	createvisualtask AnimTask_KnockOffItem, ANIM_TARGET, 2
+.else
 	createsprite gKnockOffItemSpriteTemplate, ANIM_TARGET, 2
+.endif
 	end
 
 gBattleAnimGeneral_TurnTrap::
@@ -29191,7 +29195,11 @@ gBattleAnimGeneral_ItemSteal::
 	createvisualtask AnimTask_SetAnimAttackerAndTargetForEffectAtk, 2
 	createvisualtask AnimTask_SetTargetToEffectBattler, 2  @ Redundant with above
 	delay 1
+.if B_SHOW_ITEM_ICON_WHEN_LOST
+	createvisualtask AnimTask_StealItem, ANIM_TARGET, 2
+.else
 	create_item_steal_sprite ANIM_ATTACKER, 2, initial_x=0, initial_y=-5, unk2=10, unk3=2, unk4=-1
+.endif
 	end
 
 gBattleAnimGeneral_SnatchMove::

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -384,7 +384,6 @@
 #define B_NEW_MORNING_SUN_STAR_PARTICLE FALSE    // If set to TRUE, it updates Morning Sun's star particles.
 #define B_NEW_IMPACT_PALETTE            FALSE    // If set to TRUE, it updates the basic 'hit' palette.
 #define B_NEW_SURF_PARTICLE_PALETTE     FALSE    // If set to TRUE, it updates Surf's wave palette.
-#define B_SHOW_ITEM_ICON_WHEN_LOST      FALSE    // If set to TRUE, it updates Knock Off, Thief and Covet's animations so it shows the item being lost
 
 // Poké Ball animation and sounds
 #define B_ENEMY_THROW_BALLS          GEN_LATEST  // In GEN_6+, enemy Trainers throw Poké Balls into battle instead of them just appearing on the ground and opening.

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -384,6 +384,7 @@
 #define B_NEW_MORNING_SUN_STAR_PARTICLE FALSE    // If set to TRUE, it updates Morning Sun's star particles.
 #define B_NEW_IMPACT_PALETTE            FALSE    // If set to TRUE, it updates the basic 'hit' palette.
 #define B_NEW_SURF_PARTICLE_PALETTE     FALSE    // If set to TRUE, it updates Surf's wave palette.
+#define B_SHOW_ITEM_ICON_WHEN_LOST      FALSE    // If set to TRUE, it updates Knock Off, Thief and Covet's animations so it shows the item being lost
 
 // Poké Ball animation and sounds
 #define B_ENEMY_THROW_BALLS          GEN_LATEST  // In GEN_6+, enemy Trainers throw Poké Balls into battle instead of them just appearing on the ground and opening.

--- a/src/battle_anim_effects_1.c
+++ b/src/battle_anim_effects_1.c
@@ -6,6 +6,7 @@
 #include "decompress.h"
 #include "gpu_regs.h"
 #include "graphics.h"
+#include "item_icon.h"
 #include "main.h"
 #include "math_util.h"
 #include "palette.h"
@@ -4372,6 +4373,30 @@ static void AnimKnockOffItem(struct Sprite *sprite)
     }
 }
 
+void AnimTask_KnockOffItem(u8 taskId)
+{
+    u8 iconSpriteId = AddItemIconSprite(ANIM_TAG_ITEM_BAG, ANIM_TAG_ITEM_BAG, gLastUsedItem);
+
+    if (iconSpriteId != MAX_SPRITES)
+    {
+        struct Sprite* sprite = &gSprites[iconSpriteId];
+        sprite->x = GetBattlerSpriteCoord(gBattleAnimTarget, BATTLER_COORD_X);
+        sprite->y = GetBattlerSpriteCoord(gBattleAnimTarget, BATTLER_COORD_Y) + (GetBattlerSpriteCoordAttr(gBattleAnimTarget, BATTLER_COORD_ATTR_HEIGHT) / 2);
+        sprite->oam.priority = 2;
+        sprite->oam.affineMode = ST_OAM_AFFINE_NORMAL;
+        sprite->affineAnims = gFallingBagAffineAnimTable;
+        sprite->callback = AnimKnockOffItem;
+
+		CalcCenterToCornerVec(sprite, sprite->oam.shape, sprite->oam.size, sprite->oam.affineMode);
+		InitSpriteAffineAnim(sprite);
+		++gAnimVisualTaskCount;
+    }
+
+    FreeSpriteTilesByTag(ANIM_TAG_ITEM_BAG);
+    FreeSpritePaletteByTag(ANIM_TAG_ITEM_BAG);
+    DestroyAnimVisualTask(taskId);
+}
+
 // Animates a heal particle upward.
 static void AnimPresentHealParticle(struct Sprite *sprite)
 {
@@ -4438,6 +4463,30 @@ static void AnimItemSteal_Step3(struct Sprite *sprite)
         sprite->callback = AnimItemSteal_Step2;
         PlaySE12WithPanning(SE_M_BUBBLE2, BattleAnimAdjustPanning(SOUND_PAN_ATTACKER));
     }
+}
+
+void AnimTask_StealItem(u8 taskId)
+{
+    u8 iconSpriteId = AddItemIconSprite(ANIM_TAG_ITEM_BAG, ANIM_TAG_ITEM_BAG, gLastUsedItem);
+
+    if (iconSpriteId != MAX_SPRITES)
+    {
+        struct Sprite* sprite = &gSprites[iconSpriteId];
+        sprite->x = GetBattlerSpriteCoord(gBattleAnimTarget, BATTLER_COORD_X);
+        sprite->y = GetBattlerSpriteCoord(gBattleAnimTarget, BATTLER_COORD_Y) + (GetBattlerSpriteCoordAttr(gBattleAnimTarget, BATTLER_COORD_ATTR_HEIGHT) / 2);
+        sprite->oam.priority = 2;
+        sprite->oam.affineMode = ST_OAM_AFFINE_NORMAL;
+        sprite->affineAnims = gFallingBagAffineAnimTable;
+        sprite->callback = AnimItemSteal;
+
+		CalcCenterToCornerVec(sprite, sprite->oam.shape, sprite->oam.size, sprite->oam.affineMode);
+		InitSpriteAffineAnim(sprite);
+		++gAnimVisualTaskCount;
+    }
+
+    DestroyAnimVisualTask(taskId);
+    FreeSpriteTilesByTag(ANIM_TAG_ITEM_BAG);
+    FreeSpritePaletteByTag(ANIM_TAG_ITEM_BAG);
 }
 
 // Moves a bag in a circular motion.


### PR DESCRIPTION
Title.

## Description
Adds a new battle config option called `B_SHOW_ITEM_ICON_WHEN_LOST` to `include/config/battle.h`.

When `B_SHOW_ITEM_ICON_WHEN_LOST` is toggled to `TRUE` in `include/config/battle.h`, it changes the animations of the moves Knock Off, Thief, and Covet so it shows the item icon of the item being knocked off or stolen instead of the item bag sprite. This is currently default to `FALSE`.

### Large Language Models (AI)
None

## Media

https://github.com/user-attachments/assets/5d71b25c-de4c-42c9-8b23-8e8c7a8b44b5

## Issue(s) that this PR fixes
Fixes #10026

## Credits
- CFRU for the original source

## Discord contact info
linathan