### PR TITLE
Fix King’s Rock flinch chance with Serene Grace and rainbow

### DIFF
--- a/src/battle_hold_effects.c
+++ b/src/battle_hold_effects.c
@@ -199,9 +199,8 @@ static enum ItemEffect TryKingsRock(enum BattlerId battlerAtk, enum BattlerId ba
     enum Ability ability = GetBattlerAbility(battlerAtk);
     u32 holdEffectParam = GetItemHoldEffectParam(item);
 
-    if (B_SERENE_GRACE_BOOST >= GEN_5 && ability == ABILITY_SERENE_GRACE)
-        holdEffectParam *= 2;
-    if (gSideStatuses[GetBattlerSide(battlerAtk)] & SIDE_STATUS_RAINBOW && gCurrentMove != MOVE_SECRET_POWER)
+    if ((B_SERENE_GRACE_BOOST >= GEN_5 && ability == ABILITY_SERENE_GRACE)
+     || ((gSideStatuses[GetBattlerSide(battlerAtk)] & SIDE_STATUS_RAINBOW) && gCurrentMove != MOVE_SECRET_POWER))
         holdEffectParam *= 2;
     if (ability != ABILITY_STENCH && RandomPercentage(RNG_HOLD_EFFECT_FLINCH, holdEffectParam))
     {

--- a/test/battle/hold_effect/flinch.c
+++ b/test/battle/hold_effect/flinch.c
@@ -44,7 +44,7 @@ DOUBLE_BATTLE_TEST("Kings Rock flinch chance boosted by Serene Grace does not st
         PLAYER(SPECIES_TOGEPI) { Speed(4); Ability(ABILITY_SERENE_GRACE); Item(ITEM_KINGS_ROCK); }
         PLAYER(SPECIES_WOBBUFFET) { Speed(3); }
         OPPONENT(SPECIES_WOBBUFFET) { Speed(2); }
-        OPPONENT(SPECIES_WYNAUT) { Speed(1); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); }
     } WHEN {
         TURN
         {

--- a/test/battle/hold_effect/flinch.c
+++ b/test/battle/hold_effect/flinch.c
@@ -55,6 +55,6 @@ DOUBLE_BATTLE_TEST("Kings Rock flinch chance boosted by Serene Grace does not st
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_WATER_PLEDGE, playerRight);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, playerLeft);
-        MESSAGE("The opposing Wynaut flinched and couldn't move!");
+        MESSAGE("The opposing Wobbuffet flinched and couldn't move!");
     }
 }

--- a/test/battle/hold_effect/flinch.c
+++ b/test/battle/hold_effect/flinch.c
@@ -34,3 +34,27 @@ SINGLE_BATTLE_TEST("Kings Rock does not increase flinch chance of a move that ha
         MESSAGE("The opposing Wobbuffet flinched and couldn't move!");
     }
 }
+
+DOUBLE_BATTLE_TEST("Kings Rock flinch chance boosted by Serene Grace does not stack with rainbow")
+{
+    PASSES_RANDOMLY(20, 100, RNG_HOLD_EFFECT_FLINCH);
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_WATER_PLEDGE) == EFFECT_PLEDGE);
+        ASSUME(GetMoveEffect(MOVE_FIRE_PLEDGE) == EFFECT_PLEDGE);
+        PLAYER(SPECIES_TOGEPI) { Speed(4); Ability(ABILITY_SERENE_GRACE); Item(ITEM_KINGS_ROCK); }
+        PLAYER(SPECIES_WOBBUFFET) { Speed(3); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(2); }
+        OPPONENT(SPECIES_WYNAUT) { Speed(1); }
+    } WHEN {
+        TURN
+        {
+            MOVE(playerLeft, MOVE_WATER_PLEDGE, target : opponentLeft);
+            MOVE(playerRight, MOVE_FIRE_PLEDGE, target : opponentRight);
+        }
+        TURN { MOVE(playerLeft, MOVE_SCRATCH, target: opponentRight); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_WATER_PLEDGE, playerRight);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, playerLeft);
+        MESSAGE("The opposing Wynaut flinched and couldn't move!");
+    }
+}


### PR DESCRIPTION
## Description
[Fire Pledge](https://bulbapedia.bulbagarden.net/wiki/Fire_Pledge_(move))
The rainbow doubles the probability of additional effects taking place for moves used by that side of the field (including the chance of flinching caused by King's Rock and Razor Fang, but not including Secret Power); **this effect is cumulative with Serene Grace for chances to cause a stat change or inflict a status, but not for chances to cause flinching.**