### PR TITLE
Fix end-turn form changes for fainted battlers

### DIFF
--- a/src/battle_end_turn.c
+++ b/src/battle_end_turn.c
@@ -1315,12 +1315,12 @@ static bool32 HandleEndTurnFormChange(enum BattlerId battler)
 {
     bool32 effect = FALSE;
 
-    enum Ability ability = GetBattlerAbility(battler);
-
     gBattleStruct->eventState.endTurnBattler++;
 
     if (!IsBattlerAlive(battler))
         return FALSE;
+
+    enum Ability ability = GetBattlerAbility(battler);
 
     if (TryBattleFormChange(battler, FORM_CHANGE_BATTLE_TURN_END, ability)
         || TryBattleFormChange(battler, FORM_CHANGE_BATTLE_HP_PERCENT_TURN_END, ability))

--- a/src/battle_end_turn.c
+++ b/src/battle_end_turn.c
@@ -1319,6 +1319,9 @@ static bool32 HandleEndTurnFormChange(enum BattlerId battler)
 
     gBattleStruct->eventState.endTurnBattler++;
 
+    if (!IsBattlerAlive(battler))
+        return FALSE;
+
     if (TryBattleFormChange(battler, FORM_CHANGE_BATTLE_TURN_END, ability)
         || TryBattleFormChange(battler, FORM_CHANGE_BATTLE_HP_PERCENT_TURN_END, ability))
     {

--- a/test/battle/ability/power_construct.c
+++ b/test/battle/ability/power_construct.c
@@ -55,3 +55,65 @@ WILD_BATTLE_TEST("Power Construct Zygarde reverts to its original form upon catc
         EXPECT_EQ(GetMonData(&gPlayerParty[1], MON_DATA_SPECIES), baseSpecies);
     }
 }
+
+SINGLE_BATTLE_TEST("Power Construct does not switch Zygarde's form if end-turn healing brings it above half HP")
+{
+    u16 baseSpecies;
+    PARAMETRIZE { baseSpecies = SPECIES_ZYGARDE_10_POWER_CONSTRUCT; }
+    PARAMETRIZE { baseSpecies = SPECIES_ZYGARDE_50_POWER_CONSTRUCT; }
+
+    GIVEN {
+        ASSUME(gItemsInfo[ITEM_LEFTOVERS].holdEffect == HOLD_EFFECT_LEFTOVERS);
+        PLAYER(baseSpecies)
+        {
+            Ability(ABILITY_POWER_CONSTRUCT);
+            MaxHP(160);
+            HP(78);
+            Item(ITEM_LEFTOVERS);
+        }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN {}
+    } SCENE {
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+        MESSAGE("Zygarde restored a little HP using its Leftovers!");
+        HP_BAR(player, damage: -10);
+        NONE_OF {
+            MESSAGE("You sense the presence of many!");
+            ABILITY_POPUP(player, ABILITY_POWER_CONSTRUCT);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_POWER_CONSTRUCT, player);
+        }
+    } THEN {
+        EXPECT_EQ(player->species, baseSpecies);
+        EXPECT_EQ(player->hp, 88);
+    }
+}
+
+SINGLE_BATTLE_TEST("Power Construct does not switch Zygarde's form if end-turn damage makes it faint")
+{
+    u16 baseSpecies;
+    PARAMETRIZE { baseSpecies = SPECIES_ZYGARDE_10_POWER_CONSTRUCT; }
+    PARAMETRIZE { baseSpecies = SPECIES_ZYGARDE_50_POWER_CONSTRUCT; }
+
+    GIVEN {
+        PLAYER(baseSpecies)
+        {
+            Ability(ABILITY_POWER_CONSTRUCT);
+            HP(1);
+            Status1(STATUS1_POISON);
+        }
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { SEND_OUT(player, 1); }
+    } SCENE {
+        HP_BAR(player);
+        NONE_OF {
+            MESSAGE("You sense the presence of many!");
+            ABILITY_POPUP(player, ABILITY_POWER_CONSTRUCT);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_POWER_CONSTRUCT, player);
+        }
+    } THEN {
+        EXPECT_EQ(GetMonData(&gPlayerParty[0], MON_DATA_SPECIES), baseSpecies);
+    }
+}

--- a/test/battle/ability/power_construct.c
+++ b/test/battle/ability/power_construct.c
@@ -76,7 +76,6 @@ SINGLE_BATTLE_TEST("Power Construct does not switch Zygarde's form if end-turn h
         TURN {}
     } SCENE {
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-        MESSAGE("Zygarde restored a little HP using its Leftovers!");
         HP_BAR(player, damage: -10);
         NONE_OF {
             MESSAGE("You sense the presence of many!");


### PR DESCRIPTION
## Description
[Power Construct](https://wiki.pokemonwiki.com/wiki/%e3%82%b9%e3%83%af%e3%83%bc%e3%83%a0%e3%83%81%e3%82%a7%e3%83%b3%e3%82%b8)

> HPが半分以下の状態でも、場に繰り出した瞬間にフォルムチェンジは発動しない。発動には、そのターンが終了するまで場に残る必要がある。

_Even if HP is at or below half, the form change does not trigger the moment the Pokémon is sent out. For it to trigger, the Pokémon must **remain on the field until the end of that turn**._
