### PR TITLE
Fix Illusion reveal on fainting without attack damage

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -8909,7 +8909,7 @@ bool32 TryClearIllusion(enum BattlerId battler, enum Ability ability)
 {
     if (gBattleStruct->illusion[battler].state != ILLUSION_ON)
         return FALSE;
-    if (ability == ABILITY_ILLUSION && IsBattlerAlive(battler))
+    if (ability == ABILITY_ILLUSION && !IsBattlerTurnDamaged(battler, EXCLUDING_SUBSTITUTES))
         return FALSE;
 
     gBattleScripting.battler = battler;

--- a/test/battle/ability/illusion.c
+++ b/test/battle/ability/illusion.c
@@ -39,7 +39,7 @@ SINGLE_BATTLE_TEST("Illusion breaks if the target faints")
     }
 }
 
-SINGLE_BATTLE_TEST("Illusion breaks if the attacker faints")
+SINGLE_BATTLE_TEST("Illusion does not break if the attacker faints without taking damage")
 {
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_FINAL_GAMBIT) == EFFECT_FINAL_GAMBIT);
@@ -51,8 +51,10 @@ SINGLE_BATTLE_TEST("Illusion breaks if the attacker faints")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_FINAL_GAMBIT, player);
         HP_BAR(player);
-        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ILLUSION_OFF, player);
-        MESSAGE("Zoroark's illusion wore off!");
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ILLUSION_OFF, player);
+            MESSAGE("Zoroark's illusion wore off!");
+        }
     }
 }
 
@@ -114,7 +116,7 @@ SINGLE_BATTLE_TEST("Illusion breaks if user loses Illusion due to Worry Seed")
     }
 }
 
-SINGLE_BATTLE_TEST("Illusion breaks when attacked behind a substitute")
+SINGLE_BATTLE_TEST("Illusion breaks when hit through a substitute")
 {
     GIVEN {
         WITH_CONFIG(B_INFILTRATOR_SUBSTITUTE, GEN_6);
@@ -129,5 +131,22 @@ SINGLE_BATTLE_TEST("Illusion breaks when attacked behind a substitute")
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ILLUSION_OFF, opponent);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_SWAP_TO_SUBSTITUTE, opponent);
         MESSAGE("The opposing Zoroark's illusion wore off!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Illusion does not break if indirect damage causes the user to faint")
+{
+    GIVEN {
+        PLAYER(SPECIES_ZOROARK) { HP(1); Status1(STATUS1_POISON); }
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { SEND_OUT(player, 1); }
+    } SCENE {
+        HP_BAR(player);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ILLUSION_OFF, player);
+            MESSAGE("Zoroark's illusion wore off!");
+        }
     }
 }


### PR DESCRIPTION
## Description
[Illusion](https://wiki.pokemonwiki.com/wiki/%E3%82%A4%E3%83%AA%E3%83%A5%E3%83%BC%E3%82%B8%E3%83%A7%E3%83%B3)

> 相手の攻撃技のダメージを受けることなくひんしになった場合、イリュージョンが解除されないまま倒れることになる。

_If the Pokémon faints without taking damage from an opponent's attacking move, the Illusion will not be broken, and it will faint while still disguised._