### PR TITLE
Fixes Swagger into Own Tempo target softlock

### DIFF
--- a/src/battle_stat_change.c
+++ b/src/battle_stat_change.c
@@ -148,7 +148,7 @@ static bool32 CheckSpecificMoveCondition(struct BattleCalcValues *cv, struct Sta
         {
             if (!st->onlyChecking)
             {
-                st->moveScript = BattleScript_OwnTempoPreventsRet;
+                st->moveScript = BattleScript_OwnTempoPrevents;
                 gBattlerAbility = cv->battlerDef;
                 gLastUsedAbility = ABILITY_OWN_TEMPO;
                 RecordAbilityBattle(cv->battlerDef, ABILITY_OWN_TEMPO);

--- a/test/battle/move_effect/swagger.c
+++ b/test/battle/move_effect/swagger.c
@@ -24,7 +24,24 @@ SINGLE_BATTLE_TEST("Swagger increases the target's Attack by 2 stages and confus
 
 TO_DO_BATTLE_TEST("Swagger raises the target's Attack even if they're already confused")
 TO_DO_BATTLE_TEST("Swagger raises the target's Attack even when protected by Safeguard")
-TO_DO_BATTLE_TEST("Swagger raises the target's Attack even when protected Own Tempo")
+
+SINGLE_BATTLE_TEST("Swagger raises the target's Attack even when protected Own Tempo")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_SLOWBRO) { Ability(ABILITY_OWN_TEMPO); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SWAGGER); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SWAGGER, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
+        ABILITY_POPUP(opponent, ABILITY_OWN_TEMPO);
+    } THEN {
+        EXPECT_EQ(opponent->statStages[STAT_ATK], DEFAULT_STAT_STAGE + 2);
+        EXPECT(opponent->volatiles.confusionTurns == 0);
+    }
+}
+
 TO_DO_BATTLE_TEST("Swagger doesn't confuse the target when they have their Attack maxed (Gen2)")
 TO_DO_BATTLE_TEST("Swagger confuses the target even when they have their Attack maxed (Gen3+)")
 TO_DO_BATTLE_TEST("Swagger confuses the target even when at -6 Attack and has Contrary")


### PR DESCRIPTION
Title. Would softlock due to `BattleScript_OwnTempoPreventsRet` ending in `return` when there was nothing to return to, causing repeated `assertf` failures.

## Discord contact info
PhallenTree