### PR TITLE
Make doubles AI skip scoring on itself

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -929,7 +929,7 @@ static u32 ChooseMoveOrAction_Doubles(enum BattlerId battler)
 
     for (enum BattlerId battlerIndex = 0; battlerIndex < MAX_BATTLERS_COUNT; battlerIndex++)
     {
-        if (gBattleMons[battlerIndex].hp == 0)
+        if (gBattleMons[battlerIndex].hp == 0 || battler == battlerIndex)
         {
             actionOrMoveIndex[battlerIndex] = 0xFF;
             bestMovePointsForTarget[battlerIndex] = -1;

--- a/test/battle/ai/ai.c
+++ b/test/battle/ai/ai.c
@@ -236,7 +236,7 @@ AI_SINGLE_BATTLE_TEST("AI prefers moves with the best possible score, chosen ran
     }
 }
 
-AI_SINGLE_BATTLE_TEST("AI can choose a status move that boosts the attack by two")
+AI_SINGLE_BATTLE_TEST("AI can choose a status move that boosts the attack by two (singles)")
 {
     GIVEN {
         ASSUME(GetMoveCategory(MOVE_STRENGTH) == DAMAGE_CATEGORY_PHYSICAL);

--- a/test/battle/ai/ai_doubles.c
+++ b/test/battle/ai/ai_doubles.c
@@ -1193,3 +1193,29 @@ AI_DOUBLE_BATTLE_TEST("AI uses Magnetic Flux")
         TURN { EXPECT_MOVE(opponentLeft, MOVE_MAGNETIC_FLUX); }
     }
 }
+
+AI_DOUBLE_BATTLE_TEST("AI can choose a status move that boosts the attack by two (doubles)")
+{
+    GIVEN {
+        ASSUME(GetMoveCategory(MOVE_STRENGTH) == DAMAGE_CATEGORY_PHYSICAL);
+        ASSUME(GetMoveCategory(MOVE_HORN_ATTACK) == DAMAGE_CATEGORY_PHYSICAL);
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT);
+        PLAYER(SPECIES_WOBBUFFET) { HP(277); }
+        PLAYER(SPECIES_WOBBUFFET) { HP(277); }
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_KANGASKHAN) { Moves(MOVE_STRENGTH, MOVE_HORN_ATTACK, MOVE_SWORDS_DANCE); }
+        OPPONENT(SPECIES_KANGASKHAN) { Moves(MOVE_STRENGTH, MOVE_HORN_ATTACK, MOVE_SWORDS_DANCE); }
+    } WHEN {
+        TURN { 
+            EXPECT_MOVES(opponentLeft, MOVE_STRENGTH, MOVE_SWORDS_DANCE);
+            EXPECT_MOVES(opponentRight, MOVE_STRENGTH, MOVE_SWORDS_DANCE);
+        }
+        TURN {
+            EXPECT_MOVE(opponentLeft, MOVE_STRENGTH);
+            EXPECT_MOVE(opponentRight, MOVE_STRENGTH);
+            SEND_OUT(playerLeft, 2);
+            SEND_OUT(playerRight, 3);
+        }
+    }
+}

--- a/test/battle/ai/ai_thinking_time.c
+++ b/test/battle/ai/ai_thinking_time.c
@@ -4,9 +4,9 @@
 #define AI_FRAME_CEILING_SINGLES_NO_FLAGS                       3
 #define AI_FRAME_CEILING_SINGLES_SMART_TRAINER                  8
 #define AI_FRAME_CEILING_DOUBLES_NO_FLAGS                       21
-#define AI_FRAME_CEILING_DOUBLES_SMART_TRAINER                  37
+#define AI_FRAME_CEILING_DOUBLES_SMART_TRAINER                  35
 #define AI_FRAME_CEILING_STEVEN_MULTI                           27
-#define AI_FRAME_CEILING_STEVEN_MULTI_SMART_TRAINER             30
+#define AI_FRAME_CEILING_STEVEN_MULTI_SMART_TRAINER             29
 #define AI_FRAME_CEILING_CHECK                                  FALSE // If TRUE, forces all thinking time tests to fail. Useful for printing all actual frame times to console by running the tests
 
 AI_SINGLE_BATTLE_TEST("AI thinking time doesn't explode (singles, no flags)")

--- a/test/battle/trainer_slides.c
+++ b/test/battle/trainer_slides.c
@@ -692,9 +692,9 @@ AI_MULTI_BATTLE_TEST("Trainer Slide: Multi: Last Switchin")
         OPPONENT_B(SPECIES_WOBBUFFET) { Speed(2); Moves(MOVE_CELEBRATE); }
     } WHEN {
         TURN { 
-            EXPECT_MOVE(opponentLeft, MOVE_MEMENTO, target: playerRight); EXPECT_SEND_OUT(opponentLeft,1); 
+            EXPECT_MOVE(opponentLeft, MOVE_MEMENTO); EXPECT_SEND_OUT(opponentLeft,1); 
             MOVE(playerRight, MOVE_MEMENTO, target: opponentRight); SEND_OUT(playerRight,1); 
-            EXPECT_MOVE(opponentRight, MOVE_MEMENTO, target: playerRight); EXPECT_SEND_OUT(opponentRight,1); 
+            EXPECT_MOVE(opponentRight, MOVE_MEMENTO); EXPECT_SEND_OUT(opponentRight,1); 
         }
     } SCENE {
         MESSAGE("The opposing Wobbuffet fainted!");


### PR DESCRIPTION
Note: I put the refactor label just to make sure this doesn't go in before 1.16, though I suppose it also could be the world's smallest refactor

## Description
- AI cannot target itself from a move scoring perspective, therefore there is no point going through move scoring with itself as the target. 
- Adds a doubles test to ensure Swords Dance can still be clicked as an additional check
- Removes explicit targets from a multibattle trainer slide test which never needed them in the first place, as this somehow changed the chosen target; though that test has no AI anyway.

Cuts the doubles/multi times on upcoming from this:
- test/battle/ai/ai_thinking_time.c:98: EXPECT_LE(36, 0) failed - AI thinking time doesn't explode (doubles, smart).
- test/battle/ai/ai_thinking_time.c:146: EXPECT_LE(29, 0) failed - AI thinking time doesn't explode (Steven multi, smart).
 To this:
  - test/battle/ai/ai_thinking_time.c:98: EXPECT_LE(34, 0) failed - AI thinking time doesn't explode (doubles, smart).
  - test/battle/ai/ai_thinking_time.c:146: EXPECT_LE(28, 0) failed - AI thinking time doesn't explode (Steven multi, smart).

### Large Language Models (AI)
No

## Discord contact info
grintoul