### PR TITLE
Fix Poison Puppeteer target tracking

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -116,7 +116,8 @@ struct SpecialStatus
     u8 neutralizingGasRemoved:1;
     u8 berryReduced:1;
     u8 mindBlownRecoil:1;
-    u8 padding2:2;
+    u8 poisonPuppeteer:1;
+    u8 padding2:1;
     // End of byte
     u8 gemParam:7;
     u8 gemBoost:1;
@@ -617,7 +618,7 @@ struct BattleStruct
     u8 battlerKOAnimsRunning:3;
     u8 friskedAbility:1; // If identifies two mons, show the ability pop-up only once.
     u8 fickleBeamBoosted:1;
-    u8 poisonPuppeteerConfusion:1;
+    u8 unused2:1;
     u8 toxicChainPriority:1; // If Toxic Chain will trigger on target, all other non volatiles will be blocked
     u8 battlersSorted:1; // To avoid unnessasery computation
     struct BattleTvMovePoints tvMovePoints;

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -3761,7 +3761,6 @@ static enum MoveEndResult MoveEndClearBits(void)
     gBattleStruct->categoryOverride = FALSE;
     gBattleStruct->additionalEffectsCounter = 0;
     gBattleStruct->triAttackBurn = FALSE;
-    gBattleStruct->poisonPuppeteerConfusion = FALSE;
     gBattleStruct->fickleBeamBoosted = FALSE;
     gBattleStruct->battlerState[gBattlerAttacker].usedMicleBerry = FALSE;
     gBattleStruct->toxicChainPriority = FALSE;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2384,8 +2384,8 @@ static void SetNonVolatileStatus(enum BattlerId effectBattler, enum MoveEffect e
      || effect == MOVE_EFFECT_BURN)
         gBattleStruct->synchronizeMoveEffect = effect;
 
-    if (effect == MOVE_EFFECT_POISON || effect == MOVE_EFFECT_TOXIC)
-        gBattleStruct->poisonPuppeteerConfusion = TRUE;
+    if ((effect == MOVE_EFFECT_POISON || effect == MOVE_EFFECT_TOXIC) && trigger == TRIGGER_ON_MOVE)
+        gSpecialStatuses[effectBattler].poisonPuppeteer = TRUE;
 }
 
 static inline bool32 IgnoreTargetingForMoveEffect(enum MoveEffect moveEffect) // Currently only used to determine move effects which happen even if the move's defined effectbattler is fainted

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4378,14 +4378,18 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
             break;
         case ABILITY_POISON_PUPPETEER:
             if (IsRestrictedAbility(gBattlerAttacker, ABILITY_POISON_PUPPETEER)
-             && gBattleStruct->poisonPuppeteerConfusion == TRUE
-             && CanBeConfused(gBattlerTarget))
+             && gSpecialStatuses[gBattlerTarget].poisonPuppeteer)
             {
-                gBattleStruct->poisonPuppeteerConfusion = FALSE;
-                gBattleScripting.moveEffect = MOVE_EFFECT_CONFUSION;
-                PREPARE_ABILITY_BUFFER(gBattleTextBuff1, gLastUsedAbility);
-                BattleScriptCall(BattleScript_AbilityStatusEffect);
-                effect++;
+                gSpecialStatuses[gBattlerTarget].poisonPuppeteer = FALSE;
+                if (CanBeConfused(gBattlerTarget))
+                {
+                    gBattleScripting.battler = gBattlerAttacker;
+                    gEffectBattler = gBattlerTarget;
+                    gBattleScripting.moveEffect = MOVE_EFFECT_CONFUSION;
+                    PREPARE_ABILITY_BUFFER(gBattleTextBuff1, gLastUsedAbility);
+                    BattleScriptCall(BattleScript_AbilityStatusEffect);
+                    effect++;
+                }
             }
             break;
         default:

--- a/test/battle/ability/poison_puppeteer.c
+++ b/test/battle/ability/poison_puppeteer.c
@@ -67,3 +67,92 @@ SINGLE_BATTLE_TEST("Poison Puppeteer does not trigger if poison is Toxic Spikes 
         }
     }
 }
+
+SINGLE_BATTLE_TEST("Poison Puppeteer does not trigger when poison came from Poison Point")
+{
+    GIVEN {
+        ASSUME(MoveMakesContact(MOVE_SCRATCH));
+        ASSUME(GetMoveEffect(MOVE_SOAK) == EFFECT_SOAK);
+        ASSUME(GetMoveArgType(MOVE_SOAK) == TYPE_WATER);
+        ASSUME(GetSpeciesType(SPECIES_SKRELP, 0) == TYPE_POISON || GetSpeciesType(SPECIES_SKRELP, 1) == TYPE_POISON);
+        PLAYER(SPECIES_PECHARUNT) { Ability(ABILITY_POISON_PUPPETEER); }
+        OPPONENT(SPECIES_SKRELP) { Ability(ABILITY_POISON_POINT); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SOAK); }
+        TURN { MOVE(player, MOVE_SCRATCH, WITH_RNG(RNG_POISON_POINT, TRUE)); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SOAK, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        HP_BAR(opponent);
+        ABILITY_POPUP(opponent, ABILITY_POISON_POINT);
+        ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, player);
+        STATUS_ICON(player, poison: TRUE);
+        NONE_OF {
+            ABILITY_POPUP(player, ABILITY_POISON_PUPPETEER);
+            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_CONFUSION, opponent);
+        }
+    } THEN {
+        EXPECT_EQ(player->types[0], TYPE_WATER);
+        EXPECT_EQ(player->types[1], TYPE_WATER);
+        EXPECT(player->status1 & STATUS1_POISON);
+        EXPECT(opponent->volatiles.confusionTurns == 0);
+    }
+}
+
+SINGLE_BATTLE_TEST("Poison Puppeteer confuses target (not user) after Flame Body also triggers")
+{
+    GIVEN {
+        ASSUME(MoveMakesContact(MOVE_MORTAL_SPIN));
+        ASSUME(MoveHasAdditionalEffect(MOVE_MORTAL_SPIN, MOVE_EFFECT_POISON));
+        PLAYER(SPECIES_PECHARUNT) { Ability(ABILITY_POISON_PUPPETEER); }
+        OPPONENT(SPECIES_MOLTRES) { Ability(ABILITY_FLAME_BODY); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_MORTAL_SPIN, WITH_RNG(RNG_FLAME_BODY, TRUE)); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_MORTAL_SPIN, player);
+        HP_BAR(opponent);
+        ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
+        STATUS_ICON(opponent, poison: TRUE);
+
+        ABILITY_POPUP(opponent, ABILITY_FLAME_BODY);
+        ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, player);
+        STATUS_ICON(player, burn: TRUE);
+
+        ABILITY_POPUP(player, ABILITY_POISON_PUPPETEER);
+        ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_CONFUSION, opponent);
+        NOT ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_CONFUSION, player);
+    } THEN {
+        EXPECT(player->status1 & STATUS1_BURN);
+        EXPECT(opponent->status1 & STATUS1_POISON);
+        EXPECT(player->volatiles.confusionTurns == 0);
+        EXPECT(opponent->volatiles.confusionTurns > 0);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Poison Puppeteer does not leak confusion to second target")
+{
+    GIVEN {
+        ASSUME(MoveMakesContact(MOVE_MORTAL_SPIN));
+        ASSUME(MoveHasAdditionalEffect(MOVE_MORTAL_SPIN, MOVE_EFFECT_POISON));
+        ASSUME(GetSpeciesType(SPECIES_FERROSEED, 0) == TYPE_STEEL || GetSpeciesType(SPECIES_FERROSEED, 1) == TYPE_STEEL);
+        PLAYER(SPECIES_PECHARUNT) { Ability(ABILITY_POISON_PUPPETEER); }
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_SLOWBRO) { Ability(ABILITY_OWN_TEMPO); } // can be poisoned, cannot be confused
+        OPPONENT(SPECIES_FERROSEED); // Steel-type, cannot be poisoned, can be confused
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_MORTAL_SPIN); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_MORTAL_SPIN, playerLeft);
+        HP_BAR(opponentLeft);
+        ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponentLeft);
+        NONE_OF {
+            ABILITY_POPUP(playerLeft, ABILITY_POISON_PUPPETEER);
+            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_CONFUSION, opponentRight);
+        }
+    } THEN {
+        EXPECT(opponentLeft->status1 & STATUS1_POISON);
+        EXPECT_EQ(opponentRight->status1, STATUS1_NONE);
+        EXPECT(opponentLeft->volatiles.confusionTurns == 0);
+        EXPECT(opponentRight->volatiles.confusionTurns == 0);
+    }
+}

--- a/test/battle/ability/poison_puppeteer.c
+++ b/test/battle/ability/poison_puppeteer.c
@@ -129,6 +129,39 @@ SINGLE_BATTLE_TEST("Poison Puppeteer confuses target (not user) after Flame Body
     }
 }
 
+SINGLE_BATTLE_TEST("Poison Puppeteer consumes its pending target after triggering")
+{
+    GIVEN {
+        ASSUME(GetMoveStrikeCount(MOVE_TWINEEDLE) == 2);
+        ASSUME(MoveHasAdditionalEffect(MOVE_TWINEEDLE, MOVE_EFFECT_POISON));
+        ASSUME(gItemsInfo[ITEM_PERSIM_BERRY].holdEffect == HOLD_EFFECT_CURE_CONFUSION);
+        PLAYER(SPECIES_PECHARUNT) { Ability(ABILITY_POISON_PUPPETEER); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_PERSIM_BERRY); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_TWINEEDLE, WITH_RNG(RNG_SECONDARY_EFFECT, TRUE)); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TWINEEDLE, player);
+        HP_BAR(opponent);
+        ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
+        STATUS_ICON(opponent, poison: TRUE);
+
+        ABILITY_POPUP(player, ABILITY_POISON_PUPPETEER);
+        ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_CONFUSION, opponent);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
+
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TWINEEDLE, player);
+        HP_BAR(opponent);
+        NONE_OF {
+            ABILITY_POPUP(player, ABILITY_POISON_PUPPETEER);
+            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_CONFUSION, opponent);
+        }
+    } THEN {
+        EXPECT_EQ(opponent->item, ITEM_NONE);
+        EXPECT(opponent->status1 & STATUS1_POISON);
+        EXPECT(opponent->volatiles.confusionTurns == 0);
+    }
+}
+
 DOUBLE_BATTLE_TEST("Poison Puppeteer does not leak confusion to second target")
 {
     GIVEN {


### PR DESCRIPTION
## Description
Use `u8 poisonPuppeteerTargets` instead of a single flag so Poison Puppeteer confuses the Pokémon actually poisoned by the move.

## Issue(s) that this PR fixes
Fixes #9675 

## Credit
Alex for providing improvement suggestions.