### PR TITLE
Migration script for pret#2200

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -270,12 +270,15 @@
 	@ 'callnative's should set 'requests_effects=1' if the native
 	@ contains a call to 'Script_RequestEffects', which allows them
 	@ to be analyzed by 'RunScriptImmediatelyUntilEffect'.
-	.macro callnative func:req, requests_effects=0
+	.macro callnative func:req, requests_effects=0, waitstate=0
 	.byte SCR_OP_CALLNATIVE
 	.if \requests_effects == 0
 	.4byte \func
 	.else
 	.4byte \func + ROM_SIZE
+	.endif
+	.if \waitstate
+	waitstate implicit=1
 	.endif
 	.endm
 

--- a/data/maps/BirthIsland_Exterior_Frlg/scripts.inc
+++ b/data/maps/BirthIsland_Exterior_Frlg/scripts.inc
@@ -42,7 +42,6 @@ BirthIsland_Exterior_Frlg_EventScript_Triangle::
 	lock
 	faceplayer
 	special DoDeoxysRockInteraction
-	waitstate
 	switch VAR_RESULT
 	case 0, BirthIsland_Exterior_EventScript_NotSolved1
 	case 1, BirthIsland_Exterior_EventScript_NotSolved2
@@ -81,7 +80,6 @@ BirthIsland_Exterior_Frlg_EventScript_Deoxys::
 	seteventmon SPECIES_DEOXYS, 30
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special BattleSetup_StartLegendaryBattle
-	waitstate
 	clearflag FLAG_SYS_CTRL_OBJ_DELETE
 	specialvar VAR_RESULT, GetBattleOutcome
 	goto_if_eq VAR_RESULT, B_OUTCOME_WON, BirthIsland_Exterior_Frlg_EventScript_DefeatedDeoxys

--- a/data/maps/CeladonCity_Condominiums_3F_Frlg/scripts.inc
+++ b/data/maps/CeladonCity_Condominiums_3F_Frlg/scripts.inc
@@ -31,7 +31,6 @@ CeladonCity_Condominiums_3F_EventScript_ShowDiploma::
 	waitmessage
 	delay 60
 	special Special_ShowDiploma
-	waitstate
 	release
 	end
 

--- a/data/maps/CeruleanCave_B1F_Frlg/scripts.inc
+++ b/data/maps/CeruleanCave_B1F_Frlg/scripts.inc
@@ -35,7 +35,6 @@ CeruleanCave_B1F_EventScript_Mewtwo::
 	setwildbattle SPECIES_MEWTWO, 70
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special BattleSetup_StartLegendaryBattle
-	waitstate
 	clearflag FLAG_SYS_CTRL_OBJ_DELETE
 	specialvar VAR_RESULT, GetBattleOutcome
 	goto_if_eq VAR_RESULT, B_OUTCOME_WON, CeruleanCave_B1F_EventScript_DefeatedMewtwo

--- a/data/maps/CeruleanCity_House1_Frlg/scripts.inc
+++ b/data/maps/CeruleanCity_House1_Frlg/scripts.inc
@@ -13,7 +13,6 @@ CeruleanCity_House1_EventScript_DescribeAnotherBadge::
 	waitmessage
 	setvar VAR_0x8004, SCROLL_MULTI_BADGES
 	special ShowScrollableMultichoice
-	waitstate
 	switch VAR_RESULT
 	case 0, CeruleanCity_House1_EventScript_DescribeBoulderBadge
 	case 1, CeruleanCity_House1_EventScript_DescribeCascadeBadge

--- a/data/maps/CeruleanCity_House5_Frlg/scripts.inc
+++ b/data/maps/CeruleanCity_House5_Frlg/scripts.inc
@@ -37,7 +37,6 @@ CeruleanCity_House5_EventScript_ChooseExchangeItem::
 	waitmessage
 	setvar VAR_0x8004, SCROLL_MULTI_BERRY_POWDER_VENDOR
 	special ShowScrollableMultichoice
-	waitstate
 	switch VAR_RESULT
 	case 0, CeruleanCity_House5_EventScript_EnergyPowder
 	case 1, CeruleanCity_House5_EventScript_EnergyRoot
@@ -169,7 +168,6 @@ CeruleanCity_House5_EventScript_NotEnoughBerryPowder::
 CeruleanCity_House5_EventScript_BerryCrushRankings::
 	lockall
 	special ShowBerryCrushRankings
-	waitstate
 	releaseall
 	end
 

--- a/data/maps/CinnabarIsland_PokemonLab_Lounge_Frlg/scripts.inc
+++ b/data/maps/CinnabarIsland_PokemonLab_Lounge_Frlg/scripts.inc
@@ -50,7 +50,6 @@ CinnabarIsland_PokemonLab_Lounge_EventScript_Norma::
 	msgbox Trade_Text_DoYouHaveMonWantToTradeForMon, MSGBOX_YESNO
 	goto_if_eq VAR_RESULT, NO, CinnabarIsland_PokemonLab_Lounge_EventScript_NormaDeclineTrade
 	special ChoosePartyMon
-	waitstate
 	copyvar VAR_0x800A, VAR_0x8004
 	goto_if_ge VAR_0x8004, PARTY_SIZE, CinnabarIsland_PokemonLab_Lounge_EventScript_NormaDeclineTrade
 	copyvar VAR_0x8005, VAR_0x800A
@@ -61,7 +60,6 @@ CinnabarIsland_PokemonLab_Lounge_EventScript_Norma::
 	copyvar VAR_0x8005, VAR_0x800A
 	special CreateInGameTradePokemon
 	special DoInGameTradeScene
-	waitstate
 	msgbox Trade_Text_ThanksYoureAPal
 	setflag FLAG_DID_TANGENY_TRADE
 	release

--- a/data/maps/FourIsland_PokemonDayCare_Frlg/scripts.inc
+++ b/data/maps/FourIsland_PokemonDayCare_Frlg/scripts.inc
@@ -20,7 +20,6 @@ FourIsland_PokemonDayCare_GiveMonToRaise::
 	msgbox DayCare_Text_WhichMonShouldWeRaise
 	fadescreen FADE_TO_BLACK
 	special ChooseSendDaycareMon
-	waitstate
 	goto_if_ge VAR_0x8004, PARTY_SIZE, FourIsland_PokemonDayCare_ComeAgain
 	specialvar VAR_RESULT, CountPartyAliveNonEggMons_IgnoreVar0x8004Slot
 	goto_if_eq VAR_RESULT, 0, FourIsland_PokemonDayCare_OnlyOneAliveMonInParty
@@ -90,7 +89,6 @@ FourIsland_PokemonDayCare_TryRetrieveMon::
 	setvar VAR_0x8004, 0
 	goto_if_eq VAR_RESULT, DAYCARE_ONE_MON, FourIsland_PokemonDayCare_CostPrompt
 	special ShowDaycareLevelMenu
-	waitstate
 	copyvar VAR_0x8004, VAR_RESULT
 	goto_if_eq VAR_RESULT, DAYCARE_EXITED_LEVEL_MENU, FourIsland_PokemonDayCare_ComeAgain
 	goto FourIsland_PokemonDayCare_CostPrompt
@@ -180,7 +178,6 @@ FourIsland_PokemonDayCare_TwoMonsInDaycare::
 @ Unused
 FourIsland_PokemonDayCare_EventScript_UnusedRetrieveMon::
 	special ShowDaycareLevelMenu
-	waitstate
 	goto_if_eq VAR_RESULT, 2, FourIsland_PokemonDayCare_ComeAgain
 	copyvar VAR_0x8004, VAR_RESULT
 	specialvar VAR_RESULT, TakePokemonFromDaycare

--- a/data/maps/FuchsiaCity_House3_Frlg/scripts.inc
+++ b/data/maps/FuchsiaCity_House3_Frlg/scripts.inc
@@ -12,7 +12,6 @@ FuchsiaCity_House3_EventScript_MoveDeleter::
 FuchsiaCity_House3_EventScript_ChooseMonForMoveDeleter::
 	msgbox FuchsiaCity_House3_Text_WhichMonShouldForgetMove
 	special ChoosePartyMon
-	waitstate
 	goto_if_ge VAR_0x8004, PARTY_SIZE, FuchsiaCity_House3_EventScript_CancelForgetMove
 	special IsSelectedMonEgg
 	goto_if_eq VAR_RESULT, TRUE, FuchsiaCity_House3_EventScript_CantForgetMoveEgg

--- a/data/maps/LavenderTown_House2_Frlg/scripts.inc
+++ b/data/maps/LavenderTown_House2_Frlg/scripts.inc
@@ -12,7 +12,6 @@ LavenderTown_House2_EventScript_NameRater::
 LavenderTown_House2_EventScript_ChooseMon::
 	msgbox LavenderTown_House2_Text_CritiqueWhichMonsNickname
 	special ChoosePartyMon
-	waitstate
 	goto_if_lt VAR_0x8004, PARTY_SIZE, LavenderTown_House2_EventScript_CheckCanRateMon
 	goto_if_ge VAR_0x8004, PARTY_SIZE, LavenderTown_House2_EventScript_DontRateNickname
 	end

--- a/data/maps/MtEmber_Summit_Frlg/scripts.inc
+++ b/data/maps/MtEmber_Summit_Frlg/scripts.inc
@@ -35,7 +35,6 @@ MtEmber_Summit_EventScript_Moltres::
 	waitbuttonpress
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special BattleSetup_StartLegendaryBattle
-	waitstate
 	clearflag FLAG_SYS_CTRL_OBJ_DELETE
 	specialvar VAR_RESULT, GetBattleOutcome
 	goto_if_eq VAR_RESULT, B_OUTCOME_WON, MtEmber_Summit_EventScript_DefeatedMoltres

--- a/data/maps/NavelRock_Base_Frlg/scripts.inc
+++ b/data/maps/NavelRock_Base_Frlg/scripts.inc
@@ -54,7 +54,6 @@ NavelRock_Base_Frlg_EventScript_Lugia::
 	seteventmon SPECIES_LUGIA, 70
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special BattleSetup_StartLegendaryBattle
-	waitstate
 	clearflag FLAG_SYS_CTRL_OBJ_DELETE
 	specialvar VAR_RESULT, GetBattleOutcome
 	goto_if_eq VAR_RESULT, B_OUTCOME_WON, NavelRock_Base_Frlg_EventScript_DefeatedLugia

--- a/data/maps/NavelRock_Summit_Frlg/scripts.inc
+++ b/data/maps/NavelRock_Summit_Frlg/scripts.inc
@@ -58,7 +58,6 @@ NavelRock_Summit_EventScript_HoOh::
 	seteventmon SPECIES_HO_OH, 70
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special BattleSetup_StartLegendaryBattle
-	waitstate
 	clearflag FLAG_SYS_CTRL_OBJ_DELETE
 	setvar VAR_LAST_TALKED, LOCALID_NAVEL_ROCK_HO_OH
 	specialvar VAR_RESULT, GetBattleOutcome

--- a/data/maps/PalletTown_RivalsHouse_Frlg/scripts.inc
+++ b/data/maps/PalletTown_RivalsHouse_Frlg/scripts.inc
@@ -45,7 +45,6 @@ PalletTown_RivalsHouse_EventScript_GroomMon::
 	goto_if_eq VAR_RESULT, NO, PalletTown_RivalsHouse_EventScript_DeclineGrooming
 	msgbox PalletTown_RivalsHouse_Text_GroomWhichOne
 	special ChoosePartyMon
-	waitstate
 	lock
 	faceplayer
 	goto_if_ge VAR_0x8004, PARTY_SIZE, PalletTown_RivalsHouse_EventScript_DeclineGrooming

--- a/data/maps/PowerPlant_Frlg/scripts.inc
+++ b/data/maps/PowerPlant_Frlg/scripts.inc
@@ -46,7 +46,6 @@ PowerPlant_EventScript_Zapdos::
 	waitbuttonpress
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special BattleSetup_StartLegendaryBattle
-	waitstate
 	clearflag FLAG_SYS_CTRL_OBJ_DELETE
 	specialvar VAR_RESULT, GetBattleOutcome
 	goto_if_eq VAR_RESULT, B_OUTCOME_WON, PowerPlant_EventScript_DefeatedZapdos

--- a/data/maps/Route12_FishingHouse_Frlg/scripts.inc
+++ b/data/maps/Route12_FishingHouse_Frlg/scripts.inc
@@ -34,7 +34,6 @@ Route12_FishingHouse_EventScript_CheckMagikarpRecord::
 	special GetMagikarpSizeRecordInfo
 	msgbox Route12_FishingHouse_Text_OhMagikarpAllowMeToSee
 	special ChoosePartyMon
-	waitstate
 	copyvar VAR_RESULT, VAR_0x8004
 	goto_if_ge VAR_RESULT, PARTY_SIZE, Route12_FishingHouse_EventScript_CancelShowMon
 	special CompareMagikarpSize

--- a/data/maps/Route4_PokemonCenter_1F_Frlg/scripts.inc
+++ b/data/maps/Route4_PokemonCenter_1F_Frlg/scripts.inc
@@ -60,7 +60,6 @@ Route4_PokemonCenter_1F_EventScript_BuyMagikarpParty::
 	fadescreen FADE_TO_BLACK
 	hidemoneybox
 	special ChangePokemonNickname
-	waitstate
 	goto Route4_PokemonCenter_1F_EventScript_BoughtMagikarp
 	end
 
@@ -71,7 +70,6 @@ Route4_PokemonCenter_1F_EventScript_BuyMagikarpPC::
 	fadescreen FADE_TO_BLACK
 	hidemoneybox
 	special ChangePokemonNickname
-	waitstate
 	lock
 	faceplayer
 	goto Route4_PokemonCenter_1F_EventScript_TransferMagikarp

--- a/data/maps/SeafoamIslands_B4F_Frlg/scripts.inc
+++ b/data/maps/SeafoamIslands_B4F_Frlg/scripts.inc
@@ -165,7 +165,6 @@ SeafoamIslands_B4F_EventScript_Articuno::
 	waitbuttonpress
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special BattleSetup_StartLegendaryBattle
-	waitstate
 	clearflag FLAG_SYS_CTRL_OBJ_DELETE
 	specialvar VAR_RESULT, GetBattleOutcome
 	goto_if_eq VAR_RESULT, B_OUTCOME_WON, SeafoamIslands_B4F_EventScript_DefeatedArticuno

--- a/data/maps/SevenIsland_House_Room1_Frlg/scripts.inc
+++ b/data/maps/SevenIsland_House_Room1_Frlg/scripts.inc
@@ -117,7 +117,6 @@ SevenIsland_House_Room1_EventScript_ChooseParty::
 	msgbox SevenIsland_House_Room1_Text_LimitThreeMonsPerSide
 	fadescreen FADE_TO_BLACK
 	special ChooseHalfPartyForBattle
-	waitstate
 	return
 
 SevenIsland_House_Room1_EventScript_EnterBattleRoomNorth::

--- a/data/maps/SevenIsland_House_Room2_Frlg/scripts.inc
+++ b/data/maps/SevenIsland_House_Room2_Frlg/scripts.inc
@@ -21,7 +21,6 @@ SevenIsland_House_Room2_EventScript_BattleVisitingTrainer::
 	setvar VAR_0x8004, 2
 	setvar VAR_0x8005, 0
 	special DoSpecialTrainerBattle
-	waitstate
 	call_if_eq VAR_RESULT, 3, SevenIsland_House_Room2_EventScript_BattleTie
 	call_if_eq VAR_RESULT, 1, SevenIsland_House_Room2_EventScript_BattleWon
 	call_if_eq VAR_RESULT, 2, SevenIsland_House_Room2_EventScript_BattleLost

--- a/data/maps/SilphCo_Elevator_Frlg/scripts.inc
+++ b/data/maps/SilphCo_Elevator_Frlg/scripts.inc
@@ -12,7 +12,6 @@ SilphCo_Elevator_EventScript_FloorSelect::
 	setvar VAR_0x8004, SCROLL_MULTI_SILPHCO_FLOORS
 	specialvar VAR_RESULT, InitElevatorFloorSelectMenuPos
 	special ShowScrollableMultichoice
-	waitstate
 	switch VAR_RESULT
 	case 0, SilphCo_Elevator_EventScript_To11F
 	case 1, SilphCo_Elevator_EventScript_To10F

--- a/data/maps/SixIsland_WaterPath_House1_Frlg/scripts.inc
+++ b/data/maps/SixIsland_WaterPath_House1_Frlg/scripts.inc
@@ -10,7 +10,6 @@ SixIsland_WaterPath_House1_EventScript_Beauty::
 	special GetHeracrossSizeRecordInfo
 	msgbox SixIsland_WaterPath_House1_Text_MayIMeasureHeracross
 	special ChoosePartyMon
-	waitstate
 	copyvar VAR_RESULT, VAR_0x8004
 	goto_if_ge VAR_RESULT, PARTY_SIZE, SixIsland_WaterPath_House1_EventScript_DontShowMon
 	special CompareHeracrossSize

--- a/data/maps/TrainerTower_Lobby_Frlg/scripts.inc
+++ b/data/maps/TrainerTower_Lobby_Frlg/scripts.inc
@@ -208,7 +208,6 @@ TrainerTower_Lobby_EventScript_ShowRecords::
 	fadescreen FADE_TO_BLACK
 	setvar VAR_0x8004, 1
 	special ShowTrainerHillRecords
-	waitstate
 	releaseall
 	end
 

--- a/data/maps/TwoIsland_House_Frlg/scripts.inc
+++ b/data/maps/TwoIsland_House_Frlg/scripts.inc
@@ -47,7 +47,6 @@ TwoIsland_House_EventScript_AskTutorMon::
 TwoIsland_House_EventScript_ChooseMonToTutor::
 	msgbox TwoIsland_House_Text_TutorWhichMon
 	special ChooseMonForMoveRelearner
-	waitstate
 	goto_if_ge VAR_0x8004, PARTY_SIZE, TwoIsland_House_EventScript_EndTutorMove
 	special IsSelectedMonEgg
 	goto_if_eq VAR_RESULT, TRUE, TwoIsland_House_EventScript_CantTutorEgg
@@ -58,7 +57,6 @@ TwoIsland_House_EventScript_ChooseMonToTutor::
 TwoIsland_House_EventScript_ChooseMoveToTeach::
 	msgbox TwoIsland_House_Text_TeachWhichMove
 	special TeachMoveRelearnerMove
-	waitstate
 	goto_if_eq VAR_0x8004, 0, TwoIsland_House_EventScript_ChooseMonToTutor
 	goto_if_set HAS_BOTH_MUSHROOMS, TwoIsland_House_EventScript_ChooseMushroom
 	goto_if_set HAS_BIG_MUSHROOM, TwoIsland_House_EventScript_GiveBigMushroom

--- a/data/scripts/cable_club_frlg.inc
+++ b/data/scripts/cable_club_frlg.inc
@@ -263,7 +263,6 @@ CableClub_EventScript_TryEnterColosseum_Frlg::
 	waitmessage
 	textcolor NPC_TEXT_COLOR_NEUTRAL
 	special TryBattleLinkup
-	waitstate
 	call EventScript_RestorePrevTextColor
 	goto_if_eq VAR_RESULT, LINKUP_SUCCESS, CableClub_EventScript_EnterColosseum_Frlg
 	goto_if_eq VAR_RESULT, LINKUP_SOMEONE_NOT_READY, CableClub_EventScript_AbortLinkSomeoneNotReady_Frlg
@@ -301,7 +300,6 @@ CableClub_EventScript_EnterColosseum_Frlg::
 	special SetCableClubWarp
 	warp MAP_BATTLE_COLOSSEUM_2P, 6, 8
 	special DoCableClubWarp
-	waitstate
 	end
 
 @ Unused
@@ -314,7 +312,6 @@ CableClub_EventScript_WarpTo4PColosseum_Frlg::
 	special SetCableClubWarp
 	warp MAP_BATTLE_COLOSSEUM_4P, 5, 8
 	special DoCableClubWarp
-	waitstate
 	end
 
 CableClub_EventScript_AbortLinkIncorrectNumberOfBattlers_Frlg::
@@ -359,7 +356,6 @@ CableClub_EventScript_TradeCenter_Frlg::
 	waitmessage
 	textcolor NPC_TEXT_COLOR_NEUTRAL
 	special TryTradeLinkup
-	waitstate
 	call EventScript_RestorePrevTextColor
 	goto_if_eq VAR_RESULT, LINKUP_SUCCESS, CableClub_EventScript_EnterTradeCenter_Frlg
 	goto_if_eq VAR_RESULT, LINKUP_SOMEONE_NOT_READY, CableClub_EventScript_AbortLinkSomeoneNotReady_Frlg
@@ -396,7 +392,6 @@ CableClub_EventScript_EnterTradeCenter_Frlg::
 	special SetCableClubWarp
 	setwarp MAP_TRADE_CENTER_FRLG, 5, 8
 	special DoCableClubWarp
-	waitstate
 	end
 
 CableClub_EventScript_CheckPartyTradeRequirements_Frlg::
@@ -467,7 +462,6 @@ CableClub_EventScript_AbortMinigame_Frlg::
 CableClub_EventScript_CableClubWarp_Frlg::
 	special SetCableClubWarp
 	special DoCableClubWarp
-	waitstate
 	end
 
 CableClub_EventScript_AbortLinkIncorrectNumberOfParticipants_Frlg::
@@ -547,7 +541,6 @@ CableClub_EventScript_ShowBattleRecords_Frlg::
 	fadescreen FADE_TO_BLACK
 	setvar VAR_0x8004, 0
 	special ShowTrainerHillRecords
-	waitstate
 	releaseall
 	end
 
@@ -555,58 +548,48 @@ BattleColosseum_2P_EventScript_PlayerSpot0::
 	setvar VAR_0x8005, 0
 	textcolor NPC_TEXT_COLOR_NEUTRAL
 	special ColosseumPlayerSpotTriggered
-	waitstate
 	end
 
 BattleColosseum_2P_EventScript_PlayerSpot1::
 	setvar VAR_0x8005, 1
 	textcolor NPC_TEXT_COLOR_NEUTRAL
 	special ColosseumPlayerSpotTriggered
-	waitstate
 	end
 
 BattleColosseum_4P_EventScript_PlayerSpot0::
 	fadescreen FADE_TO_BLACK
 	special ChooseHalfPartyForBattle
-	waitstate
 	goto_if_eq VAR_RESULT, 0, BattleColosseum_4P_EventScript_CancelSpotTrigger_Frlg
 	setvar VAR_0x8005, 0
 	textcolor NPC_TEXT_COLOR_NEUTRAL
 	special ColosseumPlayerSpotTriggered
-	waitstate
 	end
 
 BattleColosseum_4P_EventScript_PlayerSpot1::
 	fadescreen FADE_TO_BLACK
 	special ChooseHalfPartyForBattle
-	waitstate
 	goto_if_eq VAR_RESULT, 0, BattleColosseum_4P_EventScript_CancelSpotTrigger_Frlg
 	setvar VAR_0x8005, 1
 	textcolor NPC_TEXT_COLOR_NEUTRAL
 	special ColosseumPlayerSpotTriggered
-	waitstate
 	end
 
 BattleColosseum_4P_EventScript_PlayerSpot2::
 	fadescreen FADE_TO_BLACK
 	special ChooseHalfPartyForBattle
-	waitstate
 	goto_if_eq VAR_RESULT, 0, BattleColosseum_4P_EventScript_CancelSpotTrigger_Frlg
 	setvar VAR_0x8005, 2
 	textcolor NPC_TEXT_COLOR_NEUTRAL
 	special ColosseumPlayerSpotTriggered
-	waitstate
 	end
 
 BattleColosseum_4P_EventScript_PlayerSpot3::
 	fadescreen FADE_TO_BLACK
 	special ChooseHalfPartyForBattle
-	waitstate
 	goto_if_eq VAR_RESULT, 0, BattleColosseum_4P_EventScript_CancelSpotTrigger_Frlg
 	setvar VAR_0x8005, 3
 	textcolor NPC_TEXT_COLOR_NEUTRAL
 	special ColosseumPlayerSpotTriggered
-	waitstate
 	end
 
 BattleColosseum_4P_EventScript_CancelSpotTrigger_Frlg::
@@ -616,14 +599,12 @@ TradeCenter_EventScript_Chair0::
 	setvar VAR_0x8005, 0
 	textcolor NPC_TEXT_COLOR_NEUTRAL
 	special PlayerEnteredTradeSeat
-	waitstate
 	end
 
 TradeCenter_EventScript_Chair1::
 	setvar VAR_0x8005, 1
 	textcolor NPC_TEXT_COLOR_NEUTRAL
 	special PlayerEnteredTradeSeat
-	waitstate
 	end
 
 @ Unused
@@ -631,7 +612,6 @@ TradeCenter_EventScript_Chair2_Frlg::
 	setvar VAR_0x8005, 2
 	textcolor NPC_TEXT_COLOR_NEUTRAL
 	special PlayerEnteredTradeSeat
-	waitstate
 	end
 
 @ Unused
@@ -639,7 +619,6 @@ TradeCenter_EventScript_Chair3_Frlg::
 	setvar VAR_0x8005, 3
 	textcolor NPC_TEXT_COLOR_NEUTRAL
 	special PlayerEnteredTradeSeat
-	waitstate
 	end
 
 @ Nop in FRLG
@@ -655,7 +634,6 @@ CableClub_EventScript_ReadTrainerCard_Frlg::
 	msgbox Text_LookedAtPlayersTrainerCard_Frlg
 	fadescreen FADE_TO_BLACK
 	special Script_ShowLinkTrainerCard
-	waitstate
 	end
 
 CableClub_EventScript_ReadTrainerCardColored_Frlg::
@@ -663,7 +641,6 @@ CableClub_EventScript_ReadTrainerCardColored_Frlg::
 	msgbox Text_LookedAtPlayersTrainerCardColored_Frlg
 	fadescreen FADE_TO_BLACK
 	special Script_ShowLinkTrainerCard
-	waitstate
 	end
 
 CableClub_EventScript_TooBusyToNotice_Frlg::
@@ -710,7 +687,6 @@ TradeCenter_TerminateLink_Frlg::
 CableClub_EventScript_DoLinkRoomExit_Frlg::
 	special CleanupLinkRoomState
 	special ReturnFromLinkRoom
-	waitstate
 	end
 
 CableClub_EventScript_UnionRoomAttendant_Frlg::
@@ -1010,12 +986,10 @@ CableClub_EventScript_TryJoinGroupXPlayers_Frlg::
 
 CableClub_EventScript_TryBecomeLinkLeader_Frlg::
 	special TryBecomeLinkLeader
-	waitstate
 	return
 
 CableClub_EventScript_TryJoinLinkGroup_Frlg::
 	special TryJoinLinkGroup
-	waitstate
 	return
 
 CableClub_EventScript_EnterWirelessLinkRoom_Frlg::
@@ -1051,7 +1025,6 @@ CableClub_EventScript_ShowWirelessCommunicationScreen_Frlg::
 	goto_if_eq VAR_RESULT, FALSE, CableClub_EventScript_AdapterNotConnected_Frlg
 	fadescreen FADE_TO_BLACK
 	special ShowWirelessCommunicationScreen
-	waitstate
 	msgbox CableClub_Text_ParticipantsStepUpToCounter_Frlg
 	releaseall
 	end
@@ -1142,7 +1115,6 @@ CableClub_EventScript_PlayPokemonJump_Frlg::
 	msgbox Text_EnterWhichPokemon_Frlg
 	setvar VAR_0x8005, 0
 	special ChooseMonForWirelessMinigame
-	waitstate
 	goto_if_ge VAR_0x8004, PARTY_SIZE, CableClub_EventScript_AbortMinigame_Frlg
 	call Common_EventScript_SaveGame
 	goto_if_eq VAR_RESULT, 0, CableClub_EventScript_AbortMinigame_Frlg
@@ -1157,7 +1129,6 @@ CableClub_EventScript_PlayDodrioBerryPicking_Frlg::
 	msgbox Text_EnterWhichPokemon_Frlg
 	setvar VAR_0x8005, 1
 	special ChooseMonForWirelessMinigame
-	waitstate
 	goto_if_ge VAR_0x8004, PARTY_SIZE, CableClub_EventScript_AbortMinigame_Frlg
 	call Common_EventScript_SaveGame
 	goto_if_eq VAR_RESULT, 0, CableClub_EventScript_AbortMinigame_Frlg
@@ -1238,14 +1209,12 @@ CableClub_EventScript_ExplainDodrioBerryPickingRequirements_Frlg::
 TwoIsland_JoyfulGameCorner_EventScript_ShowPokemonJumpRecords::
 	lockall
 	special ShowPokemonJumpRecords
-	waitstate
 	releaseall
 	end
 
 TwoIsland_JoyfulGameCorner_EventScript_ShowDodrioBerryPickingRecords::
 	lockall
 	special ShowDodrioBerryPickingRecords
-	waitstate
 	releaseall
 	end
 

--- a/data/scripts/day_care_frlg.inc
+++ b/data/scripts/day_care_frlg.inc
@@ -17,7 +17,6 @@ Route5_PokemonDayCare_EventScript_TryGiveMon::
 	fadescreen FADE_TO_BLACK
 	hidemoneybox
 	special ChooseSendDaycareMon
-	waitstate
 	showmoneybox 0, 0
 	goto_if_ge VAR_0x8004, PARTY_SIZE, Route5_PokemonDayCare_EventScript_ComeAgain
 	specialvar VAR_RESULT, CountPartyAliveNonEggMons_IgnoreVar0x8004Slot

--- a/data/scripts/move_tutors_frlg.inc
+++ b/data/scripts/move_tutors_frlg.inc
@@ -545,7 +545,6 @@ CapeBrinkTutor_EventScript_NoLeadStarter::
 
 EventScript_ChooseMoveTutorMon::
 	special ChooseMonForMoveTutor
-	waitstate
 	lock
 	faceplayer
 	return

--- a/data/specials.inc
+++ b/data/specials.inc
@@ -1,12 +1,12 @@
-.macro def_special, ptr:req, waitstate=0, requests_effects=0
+.macro def_special, ptr:req, requests_effects=0, waitstate=0
 .if ALLOCATE_SPECIAL_TABLE
-  .global SPECIAL_\ptr
-  .set SPECIAL_\ptr, __special__
-  .if \requests_effects == 0
-    .4byte \ptr
-  .else
-    .4byte \ptr + ROM_SIZE
-  .endif
+	.global SPECIAL_\ptr
+	.set SPECIAL_\ptr, __special__
+	.if \requests_effects == 0
+		.4byte \ptr
+	.else
+		.4byte \ptr + ROM_SIZE
+	.endif
 .endif
 .set SPECIAL_WAITSTATE_\ptr, \waitstate
 .set __special__, __special__ + 1

--- a/migration_scripts/1.15/delete_implicit_waitstates.py
+++ b/migration_scripts/1.15/delete_implicit_waitstates.py
@@ -1,0 +1,52 @@
+import argparse
+import collections
+import re
+import shutil
+import subprocess
+
+ToDelete = collections.namedtuple('ToDelete', 'path line_number')
+
+def await_warning(line):
+    if re.search(r"Warning: explicit waitstate follows implicit waitstate, ignoring", line):
+        return (await_info, None)
+    else:
+        return (await_warning, None)
+
+def await_info(line):
+    if m := re.match(r"([^:]+):(\d+):  Info: macro invoked from here", line):
+        return (await_warning, ToDelete(m.group(1), int(m.group(2))))
+    else:
+        # NOTE: Does not handle multiple stacked infos.
+        return (await_warning, None)
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="delete_implicit_waitstates",
+        description="Deletes redundant explicit waitstates",
+    )
+    parser.add_argument("build")
+    args = parser.parse_args()
+
+    make = shutil.which("make")
+    p = subprocess.Popen([make, "BUILD={}".format(args.build), "build/{}/data/event_scripts.o".format(args.build), "-W", "data/event_scripts.s"], stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True)
+
+    to_deletes = collections.defaultdict(set)
+    state = await_warning
+    for line in p.stderr:
+        (state, to_delete) = state(line)
+        if to_delete:
+            to_deletes[to_delete.path].add(to_delete.line_number)
+
+    for path, line_numbers in to_deletes.items():
+        with open(path, "r") as f:
+            lines = f.readlines()
+        with open(path, "w") as f:
+            for line_number, line in enumerate(lines, 1):
+                # HINT: 'waitstate' not in line implies that this
+                # waitstate came from a macro. The user will have to
+                # sort that out for themselves.
+                if line_number not in line_numbers or 'waitstate' not in line:
+                    f.write(line)
+
+if __name__ == '__main__':
+    main()

--- a/tools/preproc/preproc.cpp
+++ b/tools/preproc/preproc.cpp
@@ -134,6 +134,9 @@ void PreprocAsmFile(std::string filename, bool isStdin, bool doEnum, bool doSize
                 if (label.type == Label::global)
                     std::printf(".global %s\n%s:\n", s, s);
 
+                if (doSize)
+                    stack.top().OutputLocation();
+
                 prevLabel = label;
             }
             else


### PR DESCRIPTION
## Description
Fixes a bug in our error messages that report the wrong line, and with that working pret#2200's migration script could be adapted to Expansion.

Verifying: I did `git checkout 3ea7f0d71bf0820d418b7b21bf97cc5652e88921 && git checkout 3ea7f0d71bf0820d418b7b21bf97cc5652e88921^ -- data/map` to get myself in the state after hedara's merge but without any script changes and ran `python migration_scripts/1.15/delete_implicit_waitstates.py` with some extra code to print out the affected files and it said:
```
data/maps/PetalburgCity/scripts.inc [41]
data/maps/SlateportCity/scripts.inc [736, 918]
data/maps/RustboroCity/scripts.inc [79, 90]
data/maps/SootopolisCity/scripts.inc [191, 291, 483, 535, 563]
data/maps/Route101/scripts.inc [229]
data/maps/Route111/scripts.inc [110, 115, 122]
data/maps/LittlerootTown_BrendansHouse_2F/scripts.inc [249]
data/maps/LittlerootTown_MaysHouse_2F/scripts.inc [300]
data/maps/FallarborTown_BattleTentLobby/scripts.inc [132]
data/maps/FallarborTown_MoveRelearnersHouse/scripts.inc [39]
data/maps/VerdanturfTown_BattleTentLobby/scripts.inc [133, 282]
data/maps/PetalburgCity_Gym/scripts.inc [1099]
data/maps/RustboroCity_Flat1_2F/scripts.inc [13]
data/maps/LilycoveCity_CoveLilyMotel_2F/scripts.inc [30]
data/maps/LilycoveCity_ContestLobby/scripts.inc [377, 383, 389, 395, 401, 765, 770, 878, 883]
data/maps/LilycoveCity_PokemonTrainerFanClub/scripts.inc [514]
data/maps/LilycoveCity_Harbor/scripts.inc [40, 288]
data/maps/LilycoveCity_DepartmentStoreElevator/scripts.inc [117]
data/maps/MossdeepCity_SpaceCenter_2F/scripts.inc [243, 254]
data/maps/SootopolisCity_MysteryEventsHouse_1F/scripts.inc [117]
data/maps/SootopolisCity_MysteryEventsHouse_B1F/scripts.inc [24]
data/maps/EverGrandeCity_HallOfFame/scripts.inc [55, 63]
data/maps/Route112_CableCarStation/scripts.inc [50]
data/maps/MtChimney_CableCarStation/scripts.inc [49]
data/maps/DesertRuins/scripts.inc [67]
data/maps/SeafloorCavern_Room9/scripts.inc [34, 37, 58]
data/maps/IslandCave/scripts.inc [100]
data/maps/AncientTomb/scripts.inc [67]
data/maps/SealedChamber_InnerRoom/scripts.inc [13, 16, 20, 24]
data/maps/SkyPillar_Outside/scripts.inc [76]
data/maps/SkyPillar_Top/scripts.inc [52]
data/maps/MagmaHideout_4F/scripts.inc [28]
data/maps/MirageTower_4F/scripts.inc [54]
data/maps/MarineCave_End/scripts.inc [39]
data/maps/TerraCave_End/scripts.inc [39]
data/maps/SSTidalCorridor/scripts.inc [153]
data/maps/BattleFrontier_BattleTowerLobby/scripts.inc [203, 267, 332, 396, 776, 834, 887]
data/maps/BattleFrontier_BattleTowerElevator/scripts.inc [18]
data/maps/SouthernIsland_Interior/scripts.inc [79]
data/maps/BattleFrontier_OutsideEast/scripts.inc [118]
data/maps/BattleFrontier_BattleTowerMultiBattleRoom/scripts.inc [334, 365]
data/maps/BattleFrontier_BattleDomeLobby/scripts.inc [167]
data/maps/BattleFrontier_BattleDomePreBattleRoom/scripts.inc [144]
data/maps/BattleFrontier_BattlePalaceLobby/scripts.inc [157]
data/maps/BattleFrontier_BattlePyramidLobby/scripts.inc [139, 455, 463]
data/maps/BattleFrontier_BattleArenaLobby/scripts.inc [140]
data/maps/BattleFrontier_BattlePikeLobby/scripts.inc [127, 272]
data/maps/BattleFrontier_ExchangeServiceCorner/scripts.inc [86, 162, 213, 270]
data/maps/BattleFrontier_Lounge7/scripts.inc [28, 52, 152, 176]
data/maps/BattleFrontier_ReceptionGate/scripts.inc [142]
data/maps/FarawayIsland_Interior/scripts.inc [133]
data/maps/BirthIsland_Exterior/scripts.inc [45, 87]
data/maps/TrainerHill_Entrance/scripts.inc [220]
data/maps/NavelRock_Top/scripts.inc [61]
data/maps/NavelRock_Bottom/scripts.inc [57]
data/maps/TrainerHill_Elevator/scripts.inc [55]
data/maps/Route113_GlassWorkshop/scripts.inc [61]
```
which is at least roughly what hedara's PR looked like it did, but I didn't verify every line. (I think hedara will do more, this PR doesn't touch `waitstate`s inside macros).

## Things to note in the release changelog:
- After you are done with the merge and have committed your changes you can run `python3 migration_scripts/1.15/delete_implicit_waitstates.py emerald` or `python3 migrationscripts/1.15/delete_implicit_waitstates.py firered` to delete any unnecessary `waitstate`s that are written directly in your scripts (ones from macros will have to be cleaned up manually).