### PR TITLE
Fix Spicy Spray triggering on party future sight attacker

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -4267,6 +4267,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
             if (IsBattlerAlive(gBattlerAttacker)
              && !gBattleStruct->unableToUseMove
              && IsBattlerTurnDamaged(gBattlerTarget, EXCLUDING_SUBSTITUTES)
+             && !IsFutureSightAttackerInParty(gBattlerAttacker, gBattlerTarget, gCurrentMove)
              && CanBeBurned(gBattlerTarget, gBattlerAttacker, GetBattlerAbility(gBattlerAttacker)))
             {
                 gEffectBattler = gBattlerAttacker;

--- a/test/battle/ability/spicy_spray.c
+++ b/test/battle/ability/spicy_spray.c
@@ -112,3 +112,25 @@ SINGLE_BATTLE_TEST("Spicy Spray burns the attacker even if the defender behind a
         STATUS_ICON(player, burn: TRUE);
     }
 }
+
+SINGLE_BATTLE_TEST("Spicy Spray does not activate if Future Sight attacker is not on the field")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_FUTURE_SIGHT) == EFFECT_FUTURE_SIGHT);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_SCOVILLAIN) { Item(ITEM_SCOVILLAINITE); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); MOVE(player, MOVE_FUTURE_SIGHT); }
+        TURN { SWITCH(player, 1); }
+        TURN {}
+        TURN {}
+    } SCENE {
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MEGA_EVOLUTION, opponent);
+        NONE_OF {
+            ABILITY_POPUP(opponent, ABILITY_SPICY_SPRAY);
+            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, player);
+            STATUS_ICON(player, burn: TRUE);
+        }
+    }
+}


### PR DESCRIPTION
Fixes Spicy Spray activating on Future Sight. 

I think in the future it would be best to add an other argument to `IsBattlerTurnDamaged` that checks if future sight attacker is in party if needed. That way we guarantee that it is not going to break in the future. Though I think in that case we need extensive testing on what would activate and what not. 