### PR TITLE
Fix erroneous failure message for stat change moves

### DIFF
--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -4458,7 +4458,7 @@ static bool32 ShouldSkipStatChangeResolution(enum BattlerId battlerAtk)
     {
         if (gBattleStruct->battlerState[battlerAtk].targetsDone[battler])
             numUnaffectedTargets++;
-        if (gBattleStruct->moveResultFlags[battler] & MOVE_RESULT_NO_EFFECT)
+        else if (gBattleStruct->moveResultFlags[battler] & MOVE_RESULT_NO_EFFECT)
             numUnaffectedTargets++;
     }
 

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -4446,8 +4446,30 @@ static bool32 ShouldSkipStatChangeOnBattler(enum BattlerId battlerAtk, enum Batt
     return FALSE;
 }
 
+// Avoid erroneous, second failure message
+static bool32 ShouldSkipStatChangeResolution(enum BattlerId battlerAtk)
+{
+    if (battlerAtk == gBattlerTarget)
+        return FALSE;
+
+    u32 numUnaffectedTargets = 0;
+
+    for (enum BattlerId battler = 0; battler < gBattlersCount; battler++)
+    {
+        if (gBattleStruct->battlerState[battlerAtk].targetsDone[battler])
+            numUnaffectedTargets++;
+        if (gBattleStruct->moveResultFlags[battler] & MOVE_RESULT_NO_EFFECT)
+            numUnaffectedTargets++;
+    }
+
+    return numUnaffectedTargets == gBattlersCount;
+}
+
 static enum MoveResult StatChangeSubstitute(struct BattleCalcValues *cv)
 {
+    if (ShouldSkipStatChangeResolution(cv->battlerAtk))
+        return MOVE_RESULT_DONE;
+
     for (enum BattlerId battler = 0; battler < gBattlersCount; battler++)
     {
         if (ShouldSkipStatChangeOnBattler(cv->battlerAtk, battler)

--- a/test/battle/move_effect/electrify.c
+++ b/test/battle/move_effect/electrify.c
@@ -55,6 +55,7 @@ SINGLE_BATTLE_TEST("Electrify can change status moves to Electric-type")
         ABILITY_POPUP(opponent, ABILITY_VOLT_ABSORB);
         HP_BAR(opponent, damage: -25);
         MESSAGE("The opposing Jolteon had its HP restored.");
+        NOT MESSAGE("But it failed!");
     }
 }
 


### PR DESCRIPTION
For stat change moves a second failure message was printed if the move failed in some other way. This fix just skips the stat change resolution without any failure message if the move failed prior