### PR TITLE
Fix Mega Sol weather interactions and Piercing Drill AI checks

### DIFF
--- a/include/battle_ai_util.h
+++ b/include/battle_ai_util.h
@@ -145,7 +145,7 @@ bool32 CanKnockOffItem(enum BattlerId fromBattler, enum BattlerId battler, enum 
 bool32 IsAbilityOfRating(enum Ability ability, s32 rating);
 bool32 AI_IsAbilityOnSide(enum BattlerId battlerId, enum Ability ability);
 bool32 AI_MoveMakesContact(enum BattlerId battlerAtk, enum BattlerId battlerDef, enum Ability ability, enum HoldEffect holdEffect, enum Move move);
-bool32 IsUnseenFistContactMove(enum BattlerId battlerAtk, enum BattlerId battlerDef, enum Move move);
+bool32 AI_CanContactBypassProtect(enum BattlerId battlerAtk, enum BattlerId battlerDef, enum Move move);
 bool32 IsConsideringZMove(enum BattlerId battlerAtk, enum BattlerId battlerDef, enum Move move);
 bool32 ShouldUseZMove(enum BattlerId battlerAtk, enum BattlerId battlerDef, enum Move chosenMove);
 void SetAIUsingGimmick(enum BattlerId battler, enum AIConsiderGimmick use);

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -2297,7 +2297,7 @@ static s32 AI_CheckBadMove(enum BattlerId battlerAtk, enum BattlerId battlerDef,
                 }
             }
             if (protectMethod != PROTECT_MAX_GUARD
-             && IsUnseenFistContactMove(battlerDef, battlerAtk, incomingMove))
+             && AI_CanContactBypassProtect(battlerDef, battlerAtk, incomingMove))
             {
                 ADJUST_SCORE(-10);
                 break;

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -6238,7 +6238,7 @@ bool32 IsPartyMonPlannedToBeSwitchedInByPartner(u32 partyIndex, enum BattlerId b
 static u32 AI_GetAdjustedStatStage(enum BattlerId battler, enum Move move, s32 stage)
 {
     if (GetMoveEffect(move) == EFFECT_GROWTH
-     && GetAttackerWeather(gAiLogicData->holdEffects[battler], AI_GetWeather(), B_WEATHER_SUN))
+     && GetAttackerWeather(gAiLogicData->holdEffects[battler], gAiLogicData->abilities[battler], AI_GetWeather()) & B_WEATHER_SUN)
         stage = 2;
 
     switch (gAiLogicData->abilities[battler])

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -2239,7 +2239,7 @@ s32 ProtectChecks(enum BattlerId battlerAtk, enum BattlerId battlerDef, enum Mov
     }
 
     if (GetMoveProtectMethod(move) != PROTECT_MAX_GUARD
-     && IsUnseenFistContactMove(battlerDef, battlerAtk, predictedMove))
+     && AI_CanContactBypassProtect(battlerDef, battlerAtk, predictedMove))
     {
         return WORST_EFFECT;
     }
@@ -4982,11 +4982,11 @@ bool32 AI_MoveMakesContact(enum BattlerId battlerAtk, enum BattlerId battlerDef,
     return TRUE;
 }
 
-bool32 IsUnseenFistContactMove(enum BattlerId battlerAtk, enum BattlerId battlerDef, enum Move move)
+bool32 AI_CanContactBypassProtect(enum BattlerId battlerAtk, enum BattlerId battlerDef, enum Move move)
 {
     if (move == MOVE_NONE || move == MOVE_UNAVAILABLE)
         return FALSE;
-    if (gAiLogicData->abilities[battlerAtk] != ABILITY_UNSEEN_FIST || gAiLogicData->abilities[battlerAtk] == ABILITY_PIERCING_DRILL)
+    if (gAiLogicData->abilities[battlerAtk] != ABILITY_UNSEEN_FIST && gAiLogicData->abilities[battlerAtk] != ABILITY_PIERCING_DRILL)
         return FALSE;
     if (GetMoveEffect(move) == EFFECT_SHELL_SIDE_ARM)
     {

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -10238,7 +10238,7 @@ bool32 CanMoveSkipAccuracyCalc(enum BattlerId battlerAtk, enum BattlerId battler
     {
         u32 attackerWeather = GetAttackerWeather(GetBattlerHoldEffect(battlerAtk), abilityAtk, GetWeather());
 
-        if (MoveAlwaysHitsInRain(move) && (attackerWeather & B_WEATHER_RAIN))
+        if ((attackerWeather & B_WEATHER_RAIN) && MoveAlwaysHitsInRain(move))
             effect = TRUE;
         else if ((attackerWeather & B_WEATHER_ICY_ANY) && MoveAlwaysHitsInHailSnow(move))
             effect = TRUE;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -10234,11 +10234,13 @@ bool32 CanMoveSkipAccuracyCalc(enum BattlerId battlerAtk, enum BattlerId battler
         effect = TRUE;
     }
 
-    if (!effect && HasWeatherEffect())
+    if (!effect)
     {
-        if (MoveAlwaysHitsInRain(move) && IsBattlerWeatherAffected(GetBattlerHoldEffect(battlerDef), gBattleWeather, B_WEATHER_RAIN))// Check mega sol interaction then update to GetAttackerWeather.
+        u32 attackerWeather = GetAttackerWeather(GetBattlerHoldEffect(battlerAtk), abilityAtk, GetWeather());
+
+        if (MoveAlwaysHitsInRain(move) && (attackerWeather & B_WEATHER_RAIN))
             effect = TRUE;
-        else if ((gBattleWeather & B_WEATHER_ICY_ANY) && MoveAlwaysHitsInHailSnow(move))
+        else if ((attackerWeather & B_WEATHER_ICY_ANY) && MoveAlwaysHitsInHailSnow(move))
             effect = TRUE;
 
         if (effect)
@@ -10254,6 +10256,7 @@ bool32 CanMoveSkipAccuracyCalc(enum BattlerId battlerAtk, enum BattlerId battler
 u32 GetTotalAccuracy(enum BattlerId battlerAtk, enum BattlerId battlerDef, enum Move move, enum Ability atkAbility, enum Ability defAbility, enum HoldEffect atkHoldEffect, enum HoldEffect defHoldEffect)
 {
     u32 calc, moveAcc;
+    u32 attackerWeather;
     s8 buff, accStage, evasionStage;
     u32 atkParam = GetBattlerHoldEffectParam(battlerAtk);
     u32 defParam = GetBattlerHoldEffectParam(battlerDef);
@@ -10279,9 +10282,10 @@ u32 GetTotalAccuracy(enum BattlerId battlerAtk, enum BattlerId battlerDef, enum 
         buff = MAX_STAT_STAGE;
 
     moveAcc = GetMoveAccuracy(move);
+    attackerWeather = GetAttackerWeather(atkHoldEffect, atkAbility, GetWeather());
 
     // Check Thunder and Hurricane on sunny weather.
-    if (IsBattlerWeatherAffected(defHoldEffect, GetWeather(), B_WEATHER_SUN) && MoveHas50AccuracyInSun(move))
+    if ((attackerWeather & B_WEATHER_SUN) && MoveHas50AccuracyInSun(move))
         moveAcc = 50;
     // Check Wonder Skin.
     if (defAbility == ABILITY_WONDER_SKIN && IsBattleMoveStatus(move) && moveAcc > 50)
@@ -10311,11 +10315,11 @@ u32 GetTotalAccuracy(enum BattlerId battlerAtk, enum BattlerId battlerDef, enum 
     switch (defAbility)
     {
     case ABILITY_SAND_VEIL:
-        if (GetAttackerWeather(atkHoldEffect, atkAbility, GetWeather()) & B_WEATHER_SANDSTORM)
+        if (attackerWeather & B_WEATHER_SANDSTORM)
             calc = (calc * 80) / 100; // 1.2 sand veil loss
         break;
     case ABILITY_SNOW_CLOAK:
-        if (GetAttackerWeather(atkHoldEffect, atkAbility, GetWeather()) & B_WEATHER_ICY_ANY)
+        if (attackerWeather & B_WEATHER_ICY_ANY)
             calc = (calc * 80) / 100; // 1.2 snow cloak loss
         break;
     case ABILITY_TANGLED_FEET:

--- a/test/battle/ability/mega_sol.c
+++ b/test/battle/ability/mega_sol.c
@@ -7,6 +7,7 @@ SINGLE_BATTLE_TEST("Mega Sol multiplies the power of Fire-type moves by 1.5x")
 
     GIVEN {
         ASSUME(GetMoveType(MOVE_EMBER) == TYPE_FIRE);
+        ASSUME(GetMoveEffect(MOVE_SKILL_SWAP) == EFFECT_SKILL_SWAP);
         PLAYER(SPECIES_MEGANIUM) { Item(ITEM_MEGANIUMITE); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
@@ -29,6 +30,7 @@ SINGLE_BATTLE_TEST("Mega Sol halves the power of the user's Water-type moves")
 
     GIVEN {
         ASSUME(GetMoveType(MOVE_WATER_GUN) == TYPE_WATER);
+        ASSUME(GetMoveEffect(MOVE_SKILL_SWAP) == EFFECT_SKILL_SWAP);
         PLAYER(SPECIES_MEGANIUM) { Item(ITEM_MEGANIUMITE); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
@@ -45,12 +47,36 @@ SINGLE_BATTLE_TEST("Mega Sol halves the power of the user's Water-type moves")
     }
 }
 
+SINGLE_BATTLE_TEST("Weather Ball stays Fire-type under real weather if user has Mega Sol")
+{
+    enum Move weatherMove;
+    PARAMETRIZE { weatherMove = MOVE_RAIN_DANCE; }
+    PARAMETRIZE { weatherMove = MOVE_SANDSTORM; }
+    PARAMETRIZE { weatherMove = MOVE_SNOWSCAPE; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_WEATHER_BALL) == EFFECT_WEATHER_BALL);
+        ASSUME(GetSpeciesType(SPECIES_BELDUM, 0) == TYPE_STEEL || GetSpeciesType(SPECIES_BELDUM, 1) == TYPE_STEEL);
+        PLAYER(SPECIES_MEGANIUM) { Item(ITEM_MEGANIUMITE); }
+        OPPONENT(SPECIES_BELDUM);
+    } WHEN {
+        TURN { MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); }
+        TURN { MOVE(opponent, weatherMove); }
+        TURN { MOVE(player, MOVE_WEATHER_BALL); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, weatherMove, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_WEATHER_BALL, player);
+        MESSAGE("It's super effective!");
+    }
+}
+
 SINGLE_BATTLE_TEST("Weather Ball doubles its power and turns to a Fire-type move if user has Mega Sol")
 {
     s16 damage[2];
 
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_WEATHER_BALL) == EFFECT_WEATHER_BALL);
+        ASSUME(GetMoveEffect(MOVE_SKILL_SWAP) == EFFECT_SKILL_SWAP);
         PLAYER(SPECIES_MEGANIUM) { Item(ITEM_MEGANIUMITE); }
         OPPONENT(SPECIES_PINSIR){HP(9999); MaxHP(9999);}
     } WHEN {
@@ -67,17 +93,22 @@ SINGLE_BATTLE_TEST("Weather Ball doubles its power and turns to a Fire-type move
     }
 }
 
-SINGLE_BATTLE_TEST("Synthesis recovers 2/3 of the user's max HP if user has Mega Sol (Gen3+)")
+SINGLE_BATTLE_TEST("Synthesis, Morning Sun and Moonlight recover 2/3 of the user's max HP if user has Mega Sol")
 {
+    enum Move move;
+    enum BattleMoveEffects effect;
+    PARAMETRIZE { move = MOVE_SYNTHESIS;   effect = EFFECT_SYNTHESIS; }
+    PARAMETRIZE { move = MOVE_MORNING_SUN; effect = EFFECT_MORNING_SUN; }
+    PARAMETRIZE { move = MOVE_MOONLIGHT;   effect = EFFECT_MOONLIGHT; }
+
     GIVEN {
-        ASSUME(GetMoveEffect(MOVE_SYNTHESIS) == EFFECT_SYNTHESIS);
-        WITH_CONFIG(B_TIME_OF_DAY_HEALING_MOVES, GEN_3);
+        ASSUME(GetMoveEffect(move) == effect);
         PLAYER(SPECIES_MEGANIUM) { HP(1); MaxHP(300); Item(ITEM_MEGANIUMITE); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
-        TURN { MOVE(player, MOVE_SYNTHESIS, gimmick: GIMMICK_MEGA); }
+        TURN { MOVE(player, move, gimmick: GIMMICK_MEGA); }
     } SCENE {
-        HP_BAR(player, damage: -(300 / 1.5));
+        HP_BAR(player, damage: -(300 * 2 / 3));
     }
 }
 
@@ -88,6 +119,7 @@ SINGLE_BATTLE_TEST("Mega Sol ignores Sandstorm's solarbeam power reduction, and 
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_SOLARBEAM) == EFFECT_SOLAR_BEAM);
         ASSUME(GetMoveType(MOVE_SOLARBEAM) == TYPE_GRASS);
+        ASSUME(GetMoveEffect(MOVE_SKILL_SWAP) == EFFECT_SKILL_SWAP);
         PLAYER(SPECIES_MEGANIUM) { Item(ITEM_MEGANIUMITE); }
         OPPONENT(SPECIES_BASTIODON) { Ability(ABILITY_SAND_STREAM);}
     } WHEN {
@@ -106,6 +138,33 @@ SINGLE_BATTLE_TEST("Mega Sol ignores Sandstorm's solarbeam power reduction, and 
     }
 }
 
+SINGLE_BATTLE_TEST("Mega Sol ignores Snow's Ice-type Defense boost")
+{
+    s16 damage[2];
+
+    GIVEN {
+        ASSUME(IsBattleMovePhysical(MOVE_SCRATCH));
+        ASSUME(GetMoveEffect(MOVE_SKILL_SWAP) == EFFECT_SKILL_SWAP);
+        ASSUME(GetSpeciesType(SPECIES_GLACEON, 0) == TYPE_ICE || GetSpeciesType(SPECIES_GLACEON, 1) == TYPE_ICE);
+        PLAYER(SPECIES_MEGANIUM) { Item(ITEM_MEGANIUMITE); }
+        OPPONENT(SPECIES_GLACEON);
+    } WHEN {
+        TURN { MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); MOVE(opponent, MOVE_SNOWSCAPE); }
+        TURN { MOVE(player, MOVE_SCRATCH); }
+        TURN { MOVE(opponent, MOVE_SKILL_SWAP); }
+        TURN { MOVE(player, MOVE_SCRATCH); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SNOWSCAPE, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        HP_BAR(opponent, captureDamage: &damage[0]);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SKILL_SWAP, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        HP_BAR(opponent, captureDamage: &damage[1]);
+    } THEN {
+        EXPECT_MUL_EQ(damage[1], Q_4_12(1.5), damage[0]);
+    }
+}
+
 SINGLE_BATTLE_TEST("Mega Sol doesn't trigger the foe's Leaf Guard", s16 damage)
 {
     enum Move move;
@@ -113,13 +172,12 @@ SINGLE_BATTLE_TEST("Mega Sol doesn't trigger the foe's Leaf Guard", s16 damage)
     PARAMETRIZE { move = MOVE_SUNNY_DAY;}
 
     GIVEN {
-        WITH_CONFIG(B_SANDSTORM_SOLAR_BEAM, GEN_3);
         ASSUME(GetMoveEffect(MOVE_WILL_O_WISP) == EFFECT_NON_VOLATILE_STATUS);
         ASSUME(GetMoveNonVolatileStatus(MOVE_WILL_O_WISP) == MOVE_EFFECT_BURN);
-        PLAYER(SPECIES_MEGANIUM_MEGA) { Ability(ABILITY_MEGA_SOL);}
+        PLAYER(SPECIES_MEGANIUM) { Item(ITEM_MEGANIUMITE);}
         OPPONENT(SPECIES_LEAFEON) { Ability(ABILITY_LEAF_GUARD);}
     } WHEN {
-        TURN { MOVE(player, move); }
+        TURN { MOVE(player, move, gimmick: GIMMICK_MEGA); }
         TURN { MOVE(player, MOVE_WILL_O_WISP); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, move, player);
@@ -136,24 +194,66 @@ SINGLE_BATTLE_TEST("Mega Sol doesn't trigger the foe's Leaf Guard", s16 damage)
     }
 }
 
-
-SINGLE_BATTLE_TEST("Mega Sol ignores Cloud Nine", s16 damage)
+// TODO: Air Lock
+SINGLE_BATTLE_TEST("Mega Sol ignores Cloud Nine")
 {
-    ASSUME(GetMoveType(MOVE_EMBER) == TYPE_FIRE);
+    s16 damage[2];
 
-    enum Ability ability;
-    PARAMETRIZE { ability = ABILITY_OVERGROW;}
-    PARAMETRIZE { ability = ABILITY_MEGA_SOL;}
     GIVEN {
-        PLAYER(SPECIES_MEGANIUM_MEGA) { Ability(ability);}
-        OPPONENT(SPECIES_WOBBUFFET)  { Ability(ABILITY_CLOUD_NINE); HP(9999); }
+        ASSUME(GetMoveType(MOVE_EMBER) == TYPE_FIRE);
+        ASSUME(GetMoveEffect(MOVE_SKILL_SWAP) == EFFECT_SKILL_SWAP);
+        PLAYER(SPECIES_MEGANIUM) { Item(ITEM_MEGANIUMITE);}
+        OPPONENT(SPECIES_WOBBUFFET)  { Ability(ABILITY_CLOUD_NINE); }
     } WHEN {
+        TURN { MOVE(player, MOVE_EMBER, gimmick: GIMMICK_MEGA); MOVE(opponent, MOVE_SKILL_SWAP); }
         TURN { MOVE(player, MOVE_EMBER); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EMBER, player);
-        HP_BAR(opponent, captureDamage: &results[i].damage);
-    } FINALLY {
-        EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.5), results[1].damage);
+        HP_BAR(opponent, captureDamage: &damage[0]);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SKILL_SWAP, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EMBER, player);
+        HP_BAR(opponent, captureDamage: &damage[1]);
+    } THEN {
+        EXPECT_MUL_EQ(damage[1], Q_4_12(1.5), damage[0]);
+    }
+}
+
+SINGLE_BATTLE_TEST("Mega Sol lowers the user's Thunder and Hurricane accuracy to 50%")
+{
+    enum Move move;
+    PARAMETRIZE { move = MOVE_THUNDER; }
+    PARAMETRIZE { move = MOVE_HURRICANE; }
+    PASSES_RANDOMLY(50, 100, RNG_ACCURACY);
+    GIVEN {
+        ASSUME(GetMoveAccuracy(move) == 70);
+        ASSUME(MoveHas50AccuracyInSun(move) == TRUE);
+        PLAYER(SPECIES_MEGANIUM) { Item(ITEM_MEGANIUMITE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, move, gimmick: GIMMICK_MEGA); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        HP_BAR(opponent);
+    }
+}
+
+SINGLE_BATTLE_TEST("Mega Sol lowers the user's Thunder and Hurricane accuracy to 50% in Rain")
+{
+    enum Move move;
+    PARAMETRIZE { move = MOVE_THUNDER; }
+    PARAMETRIZE { move = MOVE_HURRICANE; }
+    PASSES_RANDOMLY(50, 100, RNG_ACCURACY);
+    GIVEN {
+        ASSUME(GetMoveAccuracy(move) == 70);
+        ASSUME(MoveAlwaysHitsInRain(move) == TRUE);
+        ASSUME(MoveHas50AccuracyInSun(move) == TRUE);
+        PLAYER(SPECIES_PELIPPER) { Ability(ABILITY_DRIZZLE); }
+        OPPONENT(SPECIES_MEGANIUM) { Item(ITEM_MEGANIUMITE); }
+    } WHEN {
+        TURN { MOVE(opponent, move, gimmick: GIMMICK_MEGA); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, opponent);
+        HP_BAR(player);
     }
 }
 
@@ -165,14 +265,14 @@ SINGLE_BATTLE_TEST("Mega Sol: Solar Beam does not need a charging turn if user h
         PLAYER(SPECIES_MEGANIUM) { Item(ITEM_MEGANIUMITE); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
-        TURN { MOVE(player, MOVE_SOLAR_BEAM, gimmick: GIMMICK_MEGA); MOVE(opponent, MOVE_CELEBRATE); }
+        TURN { MOVE(player, MOVE_SOLAR_BEAM, gimmick: GIMMICK_MEGA); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SOLAR_BEAM, player);
         HP_BAR(opponent);
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
     }
 }
 
+// Not clear if this is a bug or not
 SINGLE_BATTLE_TEST("Mega Sol: Growth increases Attack and Sp. Atk by 2 stages under Mega Sol (Gen 5+)")
 {
     GIVEN {
@@ -191,36 +291,36 @@ SINGLE_BATTLE_TEST("Mega Sol: Growth increases Attack and Sp. Atk by 2 stages un
     }
 }
 
-SINGLE_BATTLE_TEST("Mega Sol ignores Sand Veil")
+SINGLE_BATTLE_TEST("Mega Sol ignores Sand Veil's accuracy drop")
 {
     PASSES_RANDOMLY(5, 5, RNG_ACCURACY);
     GIVEN {
-        ASSUME(GetMoveAccuracy(MOVE_POUND) == 100);
+        ASSUME(GetMoveAccuracy(MOVE_SCRATCH) == 100);
         PLAYER(SPECIES_SANDSHREW) { Ability(ABILITY_SAND_VEIL); }
         OPPONENT(SPECIES_MEGANIUM) { Item(ITEM_MEGANIUMITE); }
     } WHEN {
         TURN { MOVE(player, MOVE_SANDSTORM); }
-        TURN { MOVE(opponent, MOVE_POUND, gimmick: GIMMICK_MEGA); }
+        TURN { MOVE(opponent, MOVE_SCRATCH, gimmick: GIMMICK_MEGA); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SANDSTORM, player);
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_POUND, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
         HP_BAR(player);
     }
 }
 
-SINGLE_BATTLE_TEST("Mega Sol ignores Snow Cloak")
+SINGLE_BATTLE_TEST("Mega Sol ignores Snow Cloak's accuracy drop")
 {
     PASSES_RANDOMLY(5, 5, RNG_ACCURACY);
     GIVEN {
-        ASSUME(GetMoveAccuracy(MOVE_POUND) == 100);
+        ASSUME(GetMoveAccuracy(MOVE_SCRATCH) == 100);
         PLAYER(SPECIES_GLACEON) { Ability(ABILITY_SNOW_CLOAK); }
         OPPONENT(SPECIES_MEGANIUM) { Item(ITEM_MEGANIUMITE); }
     } WHEN {
         TURN { MOVE(player, MOVE_HAIL); }
-        TURN { MOVE(opponent, MOVE_POUND, gimmick: GIMMICK_MEGA); }
+        TURN { MOVE(opponent, MOVE_SCRATCH, gimmick: GIMMICK_MEGA); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_HAIL, player);
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_POUND, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
         HP_BAR(player);
     }
 }

--- a/test/battle/ability/mega_sol.c
+++ b/test/battle/ability/mega_sol.c
@@ -147,7 +147,7 @@ SINGLE_BATTLE_TEST("Mega Sol ignores Snow's Ice-type Defense boost")
     GIVEN {
         ASSUME(IsBattleMovePhysical(MOVE_SCRATCH));
         ASSUME(GetMoveEffect(MOVE_SKILL_SWAP) == EFFECT_SKILL_SWAP);
-        ASSUME(GetSpeciesType(SPECIES_GLACEON, 0) == TYPE_ICE || GetSpeciesType(SPECIES_GLACEON, 1) == TYPE_ICE);
+        ASSUME(GetSpeciesType(SPECIES_VANILLUXE, 0) == TYPE_ICE || GetSpeciesType(SPECIES_VANILLUXE, 1) == TYPE_ICE);
         PLAYER(SPECIES_MEGANIUM) { Item(ITEM_MEGANIUMITE); }
         OPPONENT(SPECIES_VANILLUXE) { Ability(ABILITY_SNOW_WARNING); }
     } WHEN {

--- a/test/battle/ability/mega_sol.c
+++ b/test/battle/ability/mega_sol.c
@@ -77,6 +77,7 @@ SINGLE_BATTLE_TEST("Weather Ball doubles its power and turns to a Fire-type move
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_WEATHER_BALL) == EFFECT_WEATHER_BALL);
         ASSUME(GetMoveEffect(MOVE_SKILL_SWAP) == EFFECT_SKILL_SWAP);
+        ASSUME(GetSpeciesType(SPECIES_PINSIR, 0) == TYPE_BUG || GetSpeciesType(SPECIES_PINSIR, 1) == TYPE_BUG);
         PLAYER(SPECIES_MEGANIUM) { Item(ITEM_MEGANIUMITE); }
         OPPONENT(SPECIES_PINSIR){HP(9999); MaxHP(9999);}
     } WHEN {
@@ -120,6 +121,7 @@ SINGLE_BATTLE_TEST("Mega Sol ignores Sandstorm's solarbeam power reduction, and 
         ASSUME(GetMoveEffect(MOVE_SOLARBEAM) == EFFECT_SOLAR_BEAM);
         ASSUME(GetMoveType(MOVE_SOLARBEAM) == TYPE_GRASS);
         ASSUME(GetMoveEffect(MOVE_SKILL_SWAP) == EFFECT_SKILL_SWAP);
+        ASSUME(GetSpeciesType(SPECIES_BASTIODON, 0) == TYPE_ROCK || GetSpeciesType(SPECIES_BASTIODON, 1) == TYPE_ROCK);
         PLAYER(SPECIES_MEGANIUM) { Item(ITEM_MEGANIUMITE); }
         OPPONENT(SPECIES_BASTIODON) { Ability(ABILITY_SAND_STREAM);}
     } WHEN {
@@ -147,14 +149,14 @@ SINGLE_BATTLE_TEST("Mega Sol ignores Snow's Ice-type Defense boost")
         ASSUME(GetMoveEffect(MOVE_SKILL_SWAP) == EFFECT_SKILL_SWAP);
         ASSUME(GetSpeciesType(SPECIES_GLACEON, 0) == TYPE_ICE || GetSpeciesType(SPECIES_GLACEON, 1) == TYPE_ICE);
         PLAYER(SPECIES_MEGANIUM) { Item(ITEM_MEGANIUMITE); }
-        OPPONENT(SPECIES_GLACEON);
+        OPPONENT(SPECIES_VANILLUXE) { Ability(ABILITY_SNOW_WARNING); }
     } WHEN {
-        TURN { MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); MOVE(opponent, MOVE_SNOWSCAPE); }
+        TURN { MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); }
         TURN { MOVE(player, MOVE_SCRATCH); }
         TURN { MOVE(opponent, MOVE_SKILL_SWAP); }
         TURN { MOVE(player, MOVE_SCRATCH); }
     } SCENE {
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_SNOWSCAPE, opponent);
+        ABILITY_POPUP(opponent, ABILITY_SNOW_WARNING);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
         HP_BAR(opponent, captureDamage: &damage[0]);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SKILL_SWAP, opponent);
@@ -181,12 +183,14 @@ SINGLE_BATTLE_TEST("Mega Sol doesn't trigger the foe's Leaf Guard", s16 damage)
         TURN { MOVE(player, MOVE_WILL_O_WISP); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, move, player);
-        if (move == MOVE_CELEBRATE) {
-	    ANIMATION(ANIM_TYPE_MOVE, MOVE_WILL_O_WISP, player);
+        if (move == MOVE_CELEBRATE)
+        {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_WILL_O_WISP, player);
             STATUS_ICON(opponent, STATUS1_BURN);
         }
-        else {
-	    NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_WILL_O_WISP, player);
+        else
+        {
+            NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_WILL_O_WISP, player);
             ABILITY_POPUP(opponent, ABILITY_LEAF_GUARD);
             MESSAGE("It doesn't affect the opposing Leafeon…");
             NOT STATUS_ICON(opponent, STATUS1_BURN);
@@ -194,16 +198,20 @@ SINGLE_BATTLE_TEST("Mega Sol doesn't trigger the foe's Leaf Guard", s16 damage)
     }
 }
 
-// TODO: Air Lock
 SINGLE_BATTLE_TEST("Mega Sol ignores Cloud Nine")
 {
     s16 damage[2];
+    u16 species;
+    enum Ability ability;
+
+    PARAMETRIZE { species = SPECIES_GOLDUCK;  ability = ABILITY_CLOUD_NINE; }
+    PARAMETRIZE { species = SPECIES_RAYQUAZA; ability = ABILITY_AIR_LOCK; }
 
     GIVEN {
         ASSUME(GetMoveType(MOVE_EMBER) == TYPE_FIRE);
         ASSUME(GetMoveEffect(MOVE_SKILL_SWAP) == EFFECT_SKILL_SWAP);
         PLAYER(SPECIES_MEGANIUM) { Item(ITEM_MEGANIUMITE);}
-        OPPONENT(SPECIES_WOBBUFFET)  { Ability(ABILITY_CLOUD_NINE); }
+        OPPONENT(species) { Ability(ability); }
     } WHEN {
         TURN { MOVE(player, MOVE_EMBER, gimmick: GIMMICK_MEGA); MOVE(opponent, MOVE_SKILL_SWAP); }
         TURN { MOVE(player, MOVE_EMBER); }
@@ -223,6 +231,7 @@ SINGLE_BATTLE_TEST("Mega Sol lowers the user's Thunder and Hurricane accuracy to
     enum Move move;
     PARAMETRIZE { move = MOVE_THUNDER; }
     PARAMETRIZE { move = MOVE_HURRICANE; }
+
     PASSES_RANDOMLY(50, 100, RNG_ACCURACY);
     GIVEN {
         ASSUME(GetMoveAccuracy(move) == 70);
@@ -242,6 +251,7 @@ SINGLE_BATTLE_TEST("Mega Sol lowers the user's Thunder and Hurricane accuracy to
     enum Move move;
     PARAMETRIZE { move = MOVE_THUNDER; }
     PARAMETRIZE { move = MOVE_HURRICANE; }
+
     PASSES_RANDOMLY(50, 100, RNG_ACCURACY);
     GIVEN {
         ASSUME(GetMoveAccuracy(move) == 70);
@@ -253,6 +263,40 @@ SINGLE_BATTLE_TEST("Mega Sol lowers the user's Thunder and Hurricane accuracy to
         TURN { MOVE(opponent, move, gimmick: GIMMICK_MEGA); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, move, opponent);
+        HP_BAR(player);
+    }
+}
+
+SINGLE_BATTLE_TEST("Mega Sol ignores Sand Veil's accuracy drop")
+{
+    PASSES_RANDOMLY(5, 5, RNG_ACCURACY);
+    GIVEN {
+        ASSUME(GetMoveAccuracy(MOVE_SCRATCH) == 100);
+        PLAYER(SPECIES_SANDSHREW) { Ability(ABILITY_SAND_VEIL); }
+        OPPONENT(SPECIES_MEGANIUM) { Item(ITEM_MEGANIUMITE); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SANDSTORM); }
+        TURN { MOVE(opponent, MOVE_SCRATCH, gimmick: GIMMICK_MEGA); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SANDSTORM, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
+        HP_BAR(player);
+    }
+}
+
+SINGLE_BATTLE_TEST("Mega Sol ignores Snow Cloak's accuracy drop")
+{
+    PASSES_RANDOMLY(5, 5, RNG_ACCURACY);
+    GIVEN {
+        ASSUME(GetMoveAccuracy(MOVE_SCRATCH) == 100);
+        PLAYER(SPECIES_GLACEON) { Ability(ABILITY_SNOW_CLOAK); }
+        OPPONENT(SPECIES_MEGANIUM) { Item(ITEM_MEGANIUMITE); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_HAIL); }
+        TURN { MOVE(opponent, MOVE_SCRATCH, gimmick: GIMMICK_MEGA); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_HAIL, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
         HP_BAR(player);
     }
 }
@@ -288,40 +332,6 @@ SINGLE_BATTLE_TEST("Mega Sol: Growth increases Attack and Sp. Atk by 2 stages un
     } THEN {
         EXPECT_EQ(player->statStages[STAT_SPATK], DEFAULT_STAT_STAGE + 2);
         EXPECT_EQ(player->statStages[STAT_ATK], DEFAULT_STAT_STAGE + 2);
-    }
-}
-
-SINGLE_BATTLE_TEST("Mega Sol ignores Sand Veil's accuracy drop")
-{
-    PASSES_RANDOMLY(5, 5, RNG_ACCURACY);
-    GIVEN {
-        ASSUME(GetMoveAccuracy(MOVE_SCRATCH) == 100);
-        PLAYER(SPECIES_SANDSHREW) { Ability(ABILITY_SAND_VEIL); }
-        OPPONENT(SPECIES_MEGANIUM) { Item(ITEM_MEGANIUMITE); }
-    } WHEN {
-        TURN { MOVE(player, MOVE_SANDSTORM); }
-        TURN { MOVE(opponent, MOVE_SCRATCH, gimmick: GIMMICK_MEGA); }
-    } SCENE {
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_SANDSTORM, player);
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
-        HP_BAR(player);
-    }
-}
-
-SINGLE_BATTLE_TEST("Mega Sol ignores Snow Cloak's accuracy drop")
-{
-    PASSES_RANDOMLY(5, 5, RNG_ACCURACY);
-    GIVEN {
-        ASSUME(GetMoveAccuracy(MOVE_SCRATCH) == 100);
-        PLAYER(SPECIES_GLACEON) { Ability(ABILITY_SNOW_CLOAK); }
-        OPPONENT(SPECIES_MEGANIUM) { Item(ITEM_MEGANIUMITE); }
-    } WHEN {
-        TURN { MOVE(player, MOVE_HAIL); }
-        TURN { MOVE(opponent, MOVE_SCRATCH, gimmick: GIMMICK_MEGA); }
-    } SCENE {
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_HAIL, player);
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
-        HP_BAR(player);
     }
 }
 


### PR DESCRIPTION
## Description
[Mega Sol](https://bulbapedia.bulbagarden.net/wiki/Mega_Sol_(Ability))

> - Synthesis, Moonlight, and Morning Sun restore ⅔ of the Pokémon's maximum HP.
> - Thunder and Hurricane have their accuracy reduced to 50%.

> If a Pokémon with Mega Sol uses Growth and harsh sunlight isn't already on the field, the move won't have any effect. 

`Mega Sol: Growth increases Attack and Sp. Atk by 2 stages under Mega Sol (Gen 5+)` needs to be validated.