### PR TITLE
Add the Ability to Disable Map Name in Map Preview Screen

### DIFF
--- a/docs/tutorials/how_to_map_preview_screen.md
+++ b/docs/tutorials/how_to_map_preview_screen.md
@@ -97,6 +97,7 @@ static const struct MapPreviewScreen sMapPreviewScreenData[MPS_COUNT] = {
 * `flagId` is just the name of the flag you want to set when visiting this map for the first time. The flag state determines how long the map preview will last on screen; it gets a shorter duration if the player has been to that map before. A lot of Emerald maps already have associated flags, but Petalburg Woods does not have one by default, so I repurposed one of the unused flags for use in this example. If you don't want to use a flag, you can enter `MPS_FLAG_NULL` here and the duration will have its own custom value (this can be adjusted in the configs in ***include/map_preview_screen.h***).
 * `tilesptr`, `tilemapptr`, and `palptr` are the image, tiles, and palette that you want to use for this preview. I'm just using the existing image from Viridian Forest here.
 * If the image will load more than 3 16-color palettes, you should add `.usesAllPalettes = TRUE` to the entry. Otherwise the palettes won't be loaded properly. (None of the vanilla FRLG images need this.)
+* If you don't want the map preview to display the map name, you should add `.nameDisabled = TRUE` to the entry.
 
 That's all there is to it!
 

--- a/include/map_preview_screen.h
+++ b/include/map_preview_screen.h
@@ -44,8 +44,10 @@ enum MapPreviewScreenId
 struct MapPreviewScreen
 {
     mapsec_u8_t mapsec;
-    u8 type;
-    u8 usesAllPalettes;
+    u8 type:2;
+    u8 usesAllPalettes:1;
+    u8 nameDisabled:1;
+    u8 padding:4;
     u16 flagId;
     const void *tilesptr;
     const void *tilemapptr;

--- a/src/map_preview_screen.c
+++ b/src/map_preview_screen.c
@@ -493,7 +493,7 @@ void Task_MapPreviewScreen_NonFade(u8 taskId)
         {
             u8 idx = GetMapPreviewScreenIdx(tMapSecId);
 
-            if (sMapPreviewScreenData[idx].nameDisabled == FALSE)
+            if (!sMapPreviewScreenData[idx].nameDisabled)
             {
                 tWindowId = MapPreview_CreateMapNameWindow(tMapSecId);
                 CopyWindowToVram(tWindowId, COPYWIN_FULL);

--- a/src/map_preview_screen.c
+++ b/src/map_preview_screen.c
@@ -769,7 +769,7 @@ static void Task_MapPreviewScreen_Script(u8 taskId)
         {
             u8 idx = GetMapPreviewScreenIdx(gMapHeader.regionMapSectionId);
 
-            if (sMapPreviewScreenData[idx].nameDisabled == FALSE)
+            if (!sMapPreviewScreenData[idx].nameDisabled)
             {
                 tWindowId = MapPreview_CreateMapNameWindow(gMapHeader.regionMapSectionId);
                 CopyWindowToVram(tWindowId, COPYWIN_FULL);

--- a/src/map_preview_screen.c
+++ b/src/map_preview_screen.c
@@ -582,7 +582,7 @@ void RunMapPreviewScreenFadeIn(mapsec_u8_t mapsec)
     SetBgAttribute(0, BG_ATTR_PRIORITY, 0);
     SetGpuRegBits(REG_OFFSET_WININ, WININ_WIN0_CLR | WININ_WIN1_CLR);
     SetGpuRegBits(REG_OFFSET_WINOUT, WINOUT_WIN01_CLR);
-    if (sMapPreviewScreenData[idx].nameDisabled == FALSE)
+    if (!sMapPreviewScreenData[idx].nameDisabled)
         gTasks[taskId].tWindowId = MapPreview_CreateMapNameWindow(mapsec);
 
     LockPlayerFieldControls();

--- a/src/map_preview_screen.c
+++ b/src/map_preview_screen.c
@@ -491,8 +491,13 @@ void Task_MapPreviewScreen_NonFade(u8 taskId)
     case 1:
         if (!MapPreview_IsGfxLoadFinished())
         {
-            tWindowId = MapPreview_CreateMapNameWindow(tMapSecId);
-            CopyWindowToVram(tWindowId, COPYWIN_FULL);
+            u8 idx = GetMapPreviewScreenIdx(tMapSecId);
+
+            if (sMapPreviewScreenData[idx].nameDisabled == FALSE)
+            {
+                tWindowId = MapPreview_CreateMapNameWindow(tMapSecId);
+                CopyWindowToVram(tWindowId, COPYWIN_FULL);
+            }
             tState++;
         }
         break;
@@ -562,6 +567,7 @@ void Task_MapPreviewScreen_NonFade(u8 taskId)
 void RunMapPreviewScreenFadeIn(mapsec_u8_t mapsec)
 {
     u8 taskId;
+    u8 idx = GetMapPreviewScreenIdx(mapsec);
 
     taskId = CreateTask(Task_MapPreviewScreen_FadeIn, 0);
     gTasks[taskId].tBGPriority = GetBgAttribute(0, BG_ATTR_PRIORITY);
@@ -576,7 +582,9 @@ void RunMapPreviewScreenFadeIn(mapsec_u8_t mapsec)
     SetBgAttribute(0, BG_ATTR_PRIORITY, 0);
     SetGpuRegBits(REG_OFFSET_WININ, WININ_WIN0_CLR | WININ_WIN1_CLR);
     SetGpuRegBits(REG_OFFSET_WINOUT, WINOUT_WIN01_CLR);
-    gTasks[taskId].tWindowId = MapPreview_CreateMapNameWindow(mapsec);
+    if (sMapPreviewScreenData[idx].nameDisabled == FALSE)
+        gTasks[taskId].tWindowId = MapPreview_CreateMapNameWindow(mapsec);
+
     LockPlayerFieldControls();
 }
 
@@ -759,8 +767,13 @@ static void Task_MapPreviewScreen_Script(u8 taskId)
     case 1:
         if (!MapPreview_IsGfxLoadFinished() && !IsDma3ManagerBusyWithBgCopy())
         {
-            tWindowId = MapPreview_CreateMapNameWindow(gMapHeader.regionMapSectionId);
-            CopyWindowToVram(tWindowId, COPYWIN_FULL);
+            u8 idx = GetMapPreviewScreenIdx(gMapHeader.regionMapSectionId);
+
+            if (sMapPreviewScreenData[idx].nameDisabled == FALSE)
+            {
+                tWindowId = MapPreview_CreateMapNameWindow(gMapHeader.regionMapSectionId);
+                CopyWindowToVram(tWindowId, COPYWIN_FULL);
+            }
             tTaskStep++;
         }
         break;


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
This adds the ability to prevent creating a text box for the map name on map previews. Only the image itself will be displayed. This is applied to individual previews.

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
bivurnum