### PR TITLE
Fixes stat change queue having erroneous stats stored

### DIFF
--- a/include/battle_stat_change.h
+++ b/include/battle_stat_change.h
@@ -39,6 +39,7 @@ void SetStatChange(enum BattlerId battler, enum Stat stat, s32 stage);
 void SetStatChange2(enum BattlerId battler, enum Stat stat, s32 stage);
 void ClearStatChangeValues(void);
 void ClearOtherStatChangeValues(enum BattlerId battler);
+void ClearBothStatChangeQueues(void);
 enum StatChangeResult TrySingleStatChange(struct BattleCalcValues *cv, struct StatChange *st);
 
 u32 GetStatStage(u32 stat, const struct AdditionalEffect *additionalEffect);

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -13,6 +13,7 @@
 #include "battle_pyramid.h"
 #include "battle_scripts.h"
 #include "battle_setup.h"
+#include "battle_stat_change.h"
 #include "battle_tower.h"
 #include "battle_z_move.h"
 #include "battle_gimmick.h"

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -13,7 +13,6 @@
 #include "battle_pyramid.h"
 #include "battle_scripts.h"
 #include "battle_setup.h"
-#include "battle_stat_change.h"
 #include "battle_tower.h"
 #include "battle_z_move.h"
 #include "battle_gimmick.h"

--- a/src/battle_stat_change.c
+++ b/src/battle_stat_change.c
@@ -926,6 +926,20 @@ void ClearOtherStatChangeValues(enum BattlerId battler)
     gBattleStruct->positiveAnimPlayed = 0;
 }
 
+void ClearBothStatChangeQueues(void)
+{
+    for (enum BattlerId battler = 0; battler < gBattlersCount; battler++)
+    {
+        memset(gSpecialStatuses[battler].statStageQueue2, 0, sizeof(gSpecialStatuses[battler].statStageQueue2));
+        gSpecialStatuses[battler].statStageAmount2 = 0;
+        memset(gSpecialStatuses[battler].statStageQueue, 0, sizeof(gSpecialStatuses[battler].statStageQueue));
+        gSpecialStatuses[battler].statStageAmount = 0;
+    }
+    gBattleStruct->negativeAnimPlayed = 0;
+    gBattleStruct->positiveAnimPlayed = 0;
+    gBattleStruct->statChangeBattler  = 0;
+}
+
 bool32 CompareStat(enum BattlerId battler, enum Stat statId, u32 cmpTo, u32 cmpKind, enum Ability ability)
 {
     bool32 ret = FALSE;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -10996,7 +10996,8 @@ bool32 BattlerJustSwitchedIn(enum BattlerId battler)
 
 bool32 IsBattlersFirstTurn(enum BattlerId battler)
 {
-    return gBattleStruct->battlerState[battler].isFirstTurn > 1;
+    return gBattleStruct->battlerState[battler].isFirstTurn == 1
+        || gBattleStruct->battlerState[battler].isFirstTurn == 2;
 }
 
 struct PartyState *GetBattlerPartyState(enum BattlerId battler)

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -66,7 +66,7 @@ static void ResetParadoxTerrainStat(enum BattlerId battler);
 static bool32 CanBattlerFormChange(enum BattlerId battler, enum FormChanges method);
 static bool32 IsPowderMoveBlocked(struct DamageContext *ctx);
 const u8 *AbsorbedByDrainHpAbility(enum BattlerId battlerDef);
-const u8 *AbsorbedByStatIncreaseAbility(enum BattlerId battlerDef, enum Ability abilityDef, enum Stat statId, u32 statAmount);
+const u8 *AbsorbedByStatIncreaseAbility(struct DamageContext *ctx, enum Stat statId, u32 statAmount);
 const u8 *AbsorbedByFlashFire(enum BattlerId battlerDef);
 static bool32 IsCriticalHit(struct DamageContext *ctx);
 
@@ -448,6 +448,7 @@ void HandleAction_UseMove(void)
 
     gBattleStruct->eventState.atkCanceler = 0;
     ClearDamageCalcResults();
+    ClearBothStatChangeQueues();
     gMultiHitCounter = 0;
     gBattleCommunication[MISS_TYPE] = 0;
     gBattlerTarget = gBattleStruct->moveTarget[gBattlerAttacker];
@@ -2255,27 +2256,27 @@ bool32 CanAbilityAbsorbMove(struct DamageContext *ctx)
         break;
     case ABILITY_MOTOR_DRIVE:
         if (ctx->moveType == TYPE_ELECTRIC)
-            battleScript = AbsorbedByStatIncreaseAbility(ctx->battlerDef, ctx->abilities[ctx->battlerDef], STAT_SPEED, 1);
+            battleScript = AbsorbedByStatIncreaseAbility(ctx, STAT_SPEED, 1);
         break;
     case ABILITY_LIGHTNING_ROD:
         if (GetConfig(B_REDIRECT_ABILITY_IMMUNITY) >= GEN_5 && ctx->moveType == TYPE_ELECTRIC)
-            battleScript = AbsorbedByStatIncreaseAbility(ctx->battlerDef, ctx->abilities[ctx->battlerDef], STAT_SPATK, 1);
+            battleScript = AbsorbedByStatIncreaseAbility(ctx, STAT_SPATK, 1);
         break;
     case ABILITY_STORM_DRAIN:
         if (GetConfig(B_REDIRECT_ABILITY_IMMUNITY) >= GEN_5 && ctx->moveType == TYPE_WATER)
-            battleScript = AbsorbedByStatIncreaseAbility(ctx->battlerDef, ctx->abilities[ctx->battlerDef], STAT_SPATK, 1);
+            battleScript = AbsorbedByStatIncreaseAbility(ctx, STAT_SPATK, 1);
         break;
     case ABILITY_SAP_SIPPER:
         if (ctx->moveType == TYPE_GRASS)
-            battleScript = AbsorbedByStatIncreaseAbility(ctx->battlerDef, ctx->abilities[ctx->battlerDef], STAT_ATK, 1);
+            battleScript = AbsorbedByStatIncreaseAbility(ctx, STAT_ATK, 1);
         break;
     case ABILITY_WELL_BAKED_BODY:
         if (ctx->moveType == TYPE_FIRE)
-            battleScript = AbsorbedByStatIncreaseAbility(ctx->battlerDef, ctx->abilities[ctx->battlerDef], STAT_DEF, 2);
+            battleScript = AbsorbedByStatIncreaseAbility(ctx, STAT_DEF, 2);
         break;
     case ABILITY_WIND_RIDER:
         if (IsWindMove(ctx->move))
-            battleScript = AbsorbedByStatIncreaseAbility(ctx->battlerDef, ctx->abilities[ctx->battlerDef], STAT_ATK, 1);
+            battleScript = AbsorbedByStatIncreaseAbility(ctx, STAT_ATK, 1);
         break;
     case ABILITY_FLASH_FIRE:
         if (ctx->moveType == TYPE_FIRE && (B_FLASH_FIRE_FROZEN >= GEN_5 || !(gBattleMons[ctx->battlerDef].status1 & STATUS1_FREEZE)))
@@ -2327,15 +2328,16 @@ const u8 *AbsorbedByDrainHpAbility(enum BattlerId battlerDef)
     }
 }
 
-const u8 *AbsorbedByStatIncreaseAbility(enum BattlerId battlerDef, enum Ability abilityDef, enum Stat statId, u32 statAmount)
+const u8 *AbsorbedByStatIncreaseAbility(struct DamageContext *ctx, enum Stat statId, u32 statAmount)
 {
-    if (!CompareStat(battlerDef, statId, MAX_STAT_STAGE, CMP_LESS_THAN, abilityDef))
+    if (!CompareStat(ctx->battlerDef, statId, MAX_STAT_STAGE, CMP_LESS_THAN, ctx->abilities[ctx->battlerDef]))
     {
         return BattleScript_AbilityProtectedTarget;
     }
     else
     {
-        SetStatChange(battlerDef, statId, statAmount);
+        if (ctx->runScript)
+            SetStatChange(ctx->battlerDef, statId, statAmount);
         return BattleScript_MoveStatDrain;
     }
 }
@@ -10994,8 +10996,7 @@ bool32 BattlerJustSwitchedIn(enum BattlerId battler)
 
 bool32 IsBattlersFirstTurn(enum BattlerId battler)
 {
-    return gBattleStruct->battlerState[battler].isFirstTurn == 1
-        || gBattleStruct->battlerState[battler].isFirstTurn == 2;
+    return gBattleStruct->battlerState[battler].isFirstTurn > 1;
 }
 
 struct PartyState *GetBattlerPartyState(enum BattlerId battler)

--- a/test/battle/stat_change_leaks.c
+++ b/test/battle/stat_change_leaks.c
@@ -1,0 +1,55 @@
+#include "global.h"
+#include "test/battle.h"
+
+AI_SINGLE_BATTLE_TEST("Type-absorbing ability checks don't queue stat increases")
+{
+    enum Ability ability;
+    enum Move absorbedMove;
+    enum Species species;
+    enum Stat boostedStat;
+
+    PARAMETRIZE { species = SPECIES_TATSUGIRI; ability = ABILITY_STORM_DRAIN;   absorbedMove = MOVE_WATER_GUN;   boostedStat = STAT_SPATK; }
+    PARAMETRIZE { species = SPECIES_RAICHU;    ability = ABILITY_LIGHTNING_ROD; absorbedMove = MOVE_THUNDERBOLT; boostedStat = STAT_SPATK; }
+    PARAMETRIZE { species = SPECIES_MARILL;    ability = ABILITY_SAP_SIPPER;    absorbedMove = MOVE_VINE_WHIP;   boostedStat = STAT_ATK; }
+
+    GIVEN {
+        ASSUME(GetMoveType(MOVE_WATER_GUN) == TYPE_WATER);
+        ASSUME(GetMoveType(MOVE_THUNDERBOLT) == TYPE_ELECTRIC);
+        ASSUME(GetMoveType(MOVE_VINE_WHIP) == TYPE_GRASS);
+        ASSUME_STAT_CHANGE(MOVE_GROWL, attack: -1);
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_OMNISCIENT);
+        PLAYER(species) { Ability(ability); Speed(1); }
+        OPPONENT(SPECIES_WOBBUFFET) { Moves(absorbedMove, MOVE_GROWL); Speed(2); }
+    } WHEN {
+        TURN { EXPECT_MOVE(opponent, MOVE_GROWL); }
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_ATK], DEFAULT_STAT_STAGE - 1);
+        if (boostedStat != STAT_ATK)
+            EXPECT_EQ(player->statStages[boostedStat], DEFAULT_STAT_STAGE);
+    }
+}
+
+AI_SINGLE_BATTLE_TEST("Type-absorbing abilities only increase a stat once after AI checks")
+{
+    enum Ability ability;
+    enum Move absorbedMove;
+    enum Species species;
+    enum Stat boostedStat;
+
+    PARAMETRIZE { species = SPECIES_TATSUGIRI; ability = ABILITY_STORM_DRAIN;   absorbedMove = MOVE_WATER_GUN;   boostedStat = STAT_SPATK; }
+    PARAMETRIZE { species = SPECIES_RAICHU;    ability = ABILITY_LIGHTNING_ROD; absorbedMove = MOVE_THUNDERBOLT; boostedStat = STAT_SPATK; }
+    PARAMETRIZE { species = SPECIES_MARILL;    ability = ABILITY_SAP_SIPPER;    absorbedMove = MOVE_VINE_WHIP;   boostedStat = STAT_ATK; }
+
+    GIVEN {
+        ASSUME(GetMoveType(MOVE_WATER_GUN) == TYPE_WATER);
+        ASSUME(GetMoveType(MOVE_THUNDERBOLT) == TYPE_ELECTRIC);
+        ASSUME(GetMoveType(MOVE_VINE_WHIP) == TYPE_GRASS);
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_OMNISCIENT);
+        PLAYER(species) { Ability(ability); Speed(1); }
+        OPPONENT(SPECIES_WOBBUFFET) { Moves(absorbedMove); Speed(2); }
+    } WHEN {
+        TURN { EXPECT_MOVE(opponent, absorbedMove); }
+    } THEN {
+        EXPECT_EQ(player->statStages[boostedStat], DEFAULT_STAT_STAGE + 1);
+    }
+}


### PR DESCRIPTION
## Description
<!-- Detail the changes made, why they were made, and any important context. -->
When the ai checked if a move was blocked by and absorbing Ability it added the stat change to the queue but it was not cleared before move usage. First fix prevents the stats being added, the second is a fail-safe just in case we forgot something.  

## Issue(s) that this PR fixes
#10082

<!-- CREDITS -->
<!-- Once your PR is submitted, leave a comment asking the bot to add you to the credits. -->
<!-- If anybody helped with this PR, please encourage them to comment on your PR and ask the bot to add them to the credits. -->
<!-- If somebody has contributed at any point and has indicated they wish to be credited, please ask the bot to add them to the credits. If they do not have a known GitHub account, add them to the list at bottom of `CREDITS.md`. -->
<!-- EVERY contribution matters! -->
<!-- https://github.com/rh-hideout/pokeemerald-expansion/wiki/CREDITS.md-Frequently-Asked-Questions -->

The hint for the fix came from @PhallenTree and the tests are written by @Cle-bit 