### PR TITLE
Use `overworld_ascending_frames` in picture tables

### DIFF
--- a/src/data/field_effects/field_effect_objects.h
+++ b/src/data/field_effects/field_effect_objects.h
@@ -110,11 +110,7 @@ const struct SpriteTemplate gFieldEffectObjectTemplate_ShadowExtraLarge = {
 };
 
 static const struct SpriteFrameImage sPicTable_TallGrass[] = {
-    overworld_frame(gFieldEffectObjectPic_TallGrass, 2, 2, 0),
-    overworld_frame(gFieldEffectObjectPic_TallGrass, 2, 2, 1),
-    overworld_frame(gFieldEffectObjectPic_TallGrass, 2, 2, 2),
-    overworld_frame(gFieldEffectObjectPic_TallGrass, 2, 2, 3),
-    overworld_frame(gFieldEffectObjectPic_TallGrass, 2, 2, 4),
+    overworld_ascending_frames(gFieldEffectObjectPic_TallGrass, 2, 2),
 };
 
 static const union AnimCmd sAnim_TallGrass[] =
@@ -142,11 +138,7 @@ const struct SpriteTemplate gFieldEffectObjectTemplate_TallGrass = {
 };
 
 static const struct SpriteFrameImage sPicTable_Ripple[] = {
-    overworld_frame(gFieldEffectObjectPic_Ripple, 2, 2, 0),
-    overworld_frame(gFieldEffectObjectPic_Ripple, 2, 2, 1),
-    overworld_frame(gFieldEffectObjectPic_Ripple, 2, 2, 2),
-    overworld_frame(gFieldEffectObjectPic_Ripple, 2, 2, 3),
-    overworld_frame(gFieldEffectObjectPic_Ripple, 2, 2, 4),
+    overworld_ascending_frames(gFieldEffectObjectPic_Ripple, 2, 2),
 };
 
 static const union AnimCmd sAnim_Ripple[] =
@@ -177,11 +169,7 @@ const struct SpriteTemplate gFieldEffectObjectTemplate_Ripple = {
 };
 
 static const struct SpriteFrameImage sPicTable_Ash[] = {
-    overworld_frame(gFieldEffectObjectPic_Ash, 2, 2, 0),
-    overworld_frame(gFieldEffectObjectPic_Ash, 2, 2, 1),
-    overworld_frame(gFieldEffectObjectPic_Ash, 2, 2, 2),
-    overworld_frame(gFieldEffectObjectPic_Ash, 2, 2, 3),
-    overworld_frame(gFieldEffectObjectPic_Ash, 2, 2, 4),
+    overworld_ascending_frames(gFieldEffectObjectPic_Ash, 2, 2),
 };
 
 static const union AnimCmd sAnim_Ash[] =
@@ -209,9 +197,7 @@ const struct SpriteTemplate gFieldEffectObjectTemplate_Ash = {
 };
 
 static const struct SpriteFrameImage sPicTable_SurfBlob[] = {
-    overworld_frame(gFieldEffectObjectPic_SurfBlob, 4, 4, 0),
-    overworld_frame(gFieldEffectObjectPic_SurfBlob, 4, 4, 1),
-    overworld_frame(gFieldEffectObjectPic_SurfBlob, 4, 4, 2),
+    overworld_ascending_frames(gFieldEffectObjectPic_SurfBlob, 4, 4),
 };
 
 static const union AnimCmd sSurfBlobAnim_FaceSouth[] =
@@ -256,14 +242,7 @@ const struct SpriteTemplate gFieldEffectObjectTemplate_SurfBlob = {
 };
 
 static const struct SpriteFrameImage sPicTable_Arrow[] = {
-    overworld_frame(gFieldEffectObjectPic_Arrow, 2, 2, 0),
-    overworld_frame(gFieldEffectObjectPic_Arrow, 2, 2, 1),
-    overworld_frame(gFieldEffectObjectPic_Arrow, 2, 2, 2),
-    overworld_frame(gFieldEffectObjectPic_Arrow, 2, 2, 3),
-    overworld_frame(gFieldEffectObjectPic_Arrow, 2, 2, 4),
-    overworld_frame(gFieldEffectObjectPic_Arrow, 2, 2, 5),
-    overworld_frame(gFieldEffectObjectPic_Arrow, 2, 2, 6),
-    overworld_frame(gFieldEffectObjectPic_Arrow, 2, 2, 7),
+    overworld_ascending_frames(gFieldEffectObjectPic_Arrow, 2, 2),
 };
 
 static const union AnimCmd sArrowAnim_South[] =
@@ -311,9 +290,7 @@ const struct SpriteTemplate gFieldEffectObjectTemplate_Arrow = {
 };
 
 static const struct SpriteFrameImage sPicTable_GroundImpactDust[] = {
-    overworld_frame(gFieldEffectObjectPic_GroundImpactDust, 2, 1, 0),
-    overworld_frame(gFieldEffectObjectPic_GroundImpactDust, 2, 1, 1),
-    overworld_frame(gFieldEffectObjectPic_GroundImpactDust, 2, 1, 2),
+    overworld_ascending_frames(gFieldEffectObjectPic_GroundImpactDust, 2, 1),
 };
 
 static const union AnimCmd sAnim_GroundImpactDust[] =
@@ -339,10 +316,7 @@ const struct SpriteTemplate gFieldEffectObjectTemplate_GroundImpactDust = {
 };
 
 static const struct SpriteFrameImage sPicTable_JumpTallGrass[] = {
-    overworld_frame(gFieldEffectObjectPic_JumpTallGrass, 2, 1, 0),
-    overworld_frame(gFieldEffectObjectPic_JumpTallGrass, 2, 1, 1),
-    overworld_frame(gFieldEffectObjectPic_JumpTallGrass, 2, 1, 2),
-    overworld_frame(gFieldEffectObjectPic_JumpTallGrass, 2, 1, 3),
+    overworld_ascending_frames(gFieldEffectObjectPic_JumpTallGrass, 2, 1),
 };
 
 static const union AnimCmd sAnim_JumpTallGrass[] =
@@ -369,8 +343,7 @@ const struct SpriteTemplate gFieldEffectObjectTemplate_JumpTallGrass = {
 };
 
 static const struct SpriteFrameImage sPicTable_SandFootprints[] = {
-    overworld_frame(gFieldEffectObjectPic_SandFootprints, 2, 2, 0),
-    overworld_frame(gFieldEffectObjectPic_SandFootprints, 2, 2, 1),
+    overworld_ascending_frames(gFieldEffectObjectPic_SandFootprints, 2, 2),
 };
 
 static const union AnimCmd sSandFootprintsAnim_South[] =
@@ -416,8 +389,7 @@ const struct SpriteTemplate gFieldEffectObjectTemplate_SandFootprints = {
 };
 
 static const struct SpriteFrameImage sPicTable_DeepSandFootprints[] = {
-    overworld_frame(gFieldEffectObjectPic_DeepSandFootprints, 2, 2, 0),
-    overworld_frame(gFieldEffectObjectPic_DeepSandFootprints, 2, 2, 1),
+    overworld_ascending_frames(gFieldEffectObjectPic_DeepSandFootprints, 2, 2),
 };
 
 static const union AnimCmd sDeepSandFootprintsAnim_South[] =
@@ -463,13 +435,11 @@ const struct SpriteTemplate gFieldEffectObjectTemplate_DeepSandFootprints = {
 };
 
 static const struct SpriteFrameImage sPicTable_BugTracks[] = {
-    overworld_frame(gFieldEffectObjectPic_BugTracks, 2, 2, 0),
-    overworld_frame(gFieldEffectObjectPic_BugTracks, 2, 2, 1),
+    overworld_ascending_frames(gFieldEffectObjectPic_BugTracks, 2, 2),
 };
 
 static const struct SpriteFrameImage sPicTable_SpotTracks[] = {
-    overworld_frame(gFieldEffectObjectPic_SpotTracks, 2, 2, 0),
-    overworld_frame(gFieldEffectObjectPic_SpotTracks, 2, 2, 1),
+    overworld_ascending_frames(gFieldEffectObjectPic_SpotTracks, 2, 2),
 };
 
 const struct SpriteTemplate gFieldEffectObjectTemplate_BugTracks = {
@@ -491,18 +461,11 @@ const struct SpriteTemplate gFieldEffectObjectTemplate_SpotTracks = {
 };
 
 static const struct SpriteFrameImage sPicTable_BikeTireTracks[] = {
-    overworld_frame(gFieldEffectObjectPic_BikeTireTracks, 2, 2, 0),
-    overworld_frame(gFieldEffectObjectPic_BikeTireTracks, 2, 2, 1),
-    overworld_frame(gFieldEffectObjectPic_BikeTireTracks, 2, 2, 2),
-    overworld_frame(gFieldEffectObjectPic_BikeTireTracks, 2, 2, 3),
+    overworld_ascending_frames(gFieldEffectObjectPic_BikeTireTracks, 2, 2),
 };
 
-
 static const struct SpriteFrameImage sPicTable_SlitherTracks[] = {
-    overworld_frame(gFieldEffectObjectPic_SlitherTracks, 2, 2, 0),
-    overworld_frame(gFieldEffectObjectPic_SlitherTracks, 2, 2, 1),
-    overworld_frame(gFieldEffectObjectPic_SlitherTracks, 2, 2, 2),
-    overworld_frame(gFieldEffectObjectPic_SlitherTracks, 2, 2, 3),
+    overworld_ascending_frames(gFieldEffectObjectPic_SlitherTracks, 2, 2),
 };
 
 static const union AnimCmd sBikeTireTracksAnim_South[] =
@@ -586,10 +549,7 @@ const struct SpriteTemplate gFieldEffectObjectTemplate_SlitherTracks = {
 };
 
 static const struct SpriteFrameImage sPicTable_JumpBigSplash[] = {
-    overworld_frame(gFieldEffectObjectPic_JumpBigSplash, 2, 2, 0),
-    overworld_frame(gFieldEffectObjectPic_JumpBigSplash, 2, 2, 1),
-    overworld_frame(gFieldEffectObjectPic_JumpBigSplash, 2, 2, 2),
-    overworld_frame(gFieldEffectObjectPic_JumpBigSplash, 2, 2, 3),
+    overworld_ascending_frames(gFieldEffectObjectPic_JumpBigSplash, 2, 2),
 };
 
 static const union AnimCmd sAnim_JumpBigSplash[] =
@@ -616,8 +576,7 @@ const struct SpriteTemplate gFieldEffectObjectTemplate_JumpBigSplash = {
 };
 
 static const struct SpriteFrameImage sPicTable_Splash[] = {
-    overworld_frame(gFieldEffectObjectPic_Splash, 2, 1, 0),
-    overworld_frame(gFieldEffectObjectPic_Splash, 2, 1, 1),
+    overworld_ascending_frames(gFieldEffectObjectPic_Splash, 2, 1),
 };
 
 static const union AnimCmd sAnim_Splash_0[] =
@@ -656,9 +615,7 @@ const struct SpriteTemplate gFieldEffectObjectTemplate_Splash = {
 };
 
 static const struct SpriteFrameImage sPicTable_JumpSmallSplash[] = {
-    overworld_frame(gFieldEffectObjectPic_JumpSmallSplash, 2, 1, 0),
-    overworld_frame(gFieldEffectObjectPic_JumpSmallSplash, 2, 1, 1),
-    overworld_frame(gFieldEffectObjectPic_JumpSmallSplash, 2, 1, 2),
+    overworld_ascending_frames(gFieldEffectObjectPic_JumpSmallSplash, 2, 1),
 };
 
 static const union AnimCmd sAnim_JumpSmallSplash[] =
@@ -717,12 +674,7 @@ const struct SpriteTemplate gFieldEffectObjectTemplate_LongGrass = {
 };
 
 static const struct SpriteFrameImage sPicTable_JumpLongGrass[] = {
-    overworld_frame(gFieldEffectObjectPic_JumpLongGrass, 2, 2, 0),
-    overworld_frame(gFieldEffectObjectPic_JumpLongGrass, 2, 2, 1),
-    overworld_frame(gFieldEffectObjectPic_JumpLongGrass, 2, 2, 2),
-    overworld_frame(gFieldEffectObjectPic_JumpLongGrass, 2, 2, 3),
-    overworld_frame(gFieldEffectObjectPic_JumpLongGrass, 2, 2, 4),
-    overworld_frame(gFieldEffectObjectPic_JumpLongGrass, 2, 2, 6),
+    overworld_ascending_frames(gFieldEffectObjectPic_JumpLongGrass, 2, 2),
 };
 
 static const union AnimCmd sAnim_JumpLongGrass[] =
@@ -791,10 +743,7 @@ const struct SpriteTemplate gFieldEffectObjectTemplate_UnusedGrass = {
 };
 
 static const struct SpriteFrameImage sPicTable_UnusedGrass2[] = {
-    overworld_frame(gFieldEffectObjectPic_UnusedGrass2, 2, 2, 0),
-    overworld_frame(gFieldEffectObjectPic_UnusedGrass2, 2, 2, 1),
-    overworld_frame(gFieldEffectObjectPic_UnusedGrass2, 2, 2, 2),
-    overworld_frame(gFieldEffectObjectPic_UnusedGrass2, 2, 2, 3),
+    overworld_ascending_frames(gFieldEffectObjectPic_UnusedGrass2, 2, 2),
 };
 
 static const union AnimCmd sAnim_UnusedGrass2[] =
@@ -823,10 +772,7 @@ const struct SpriteTemplate gFieldEffectObjectTemplate_UnusedGrass2 = {
 };
 
 static const struct SpriteFrameImage sPicTable_UnusedSand[] = {
-    overworld_frame(gFieldEffectObjectPic_UnusedSand, 2, 2, 0),
-    overworld_frame(gFieldEffectObjectPic_UnusedSand, 2, 2, 1),
-    overworld_frame(gFieldEffectObjectPic_UnusedSand, 2, 2, 2),
-    overworld_frame(gFieldEffectObjectPic_UnusedSand, 2, 2, 3),
+    overworld_ascending_frames(gFieldEffectObjectPic_UnusedSand, 2, 2),
 };
 
 static const union AnimCmd sAnim_UnusedSand[] =
@@ -853,9 +799,7 @@ const struct SpriteTemplate gFieldEffectObjectTemplate_UnusedSand = {
 };
 
 static const struct SpriteFrameImage sPicTable_SandPile[] = {
-    overworld_frame(gFieldEffectObjectPic_SandPile, 2, 1, 0),
-    overworld_frame(gFieldEffectObjectPic_SandPile, 2, 1, 1),
-    overworld_frame(gFieldEffectObjectPic_SandPile, 2, 1, 2),
+    overworld_ascending_frames(gFieldEffectObjectPic_SandPile, 2, 1),
 };
 
 static const union AnimCmd sAnim_SandPile[] =
@@ -881,10 +825,7 @@ const struct SpriteTemplate gFieldEffectObjectTemplate_SandPile = {
 };
 
 static const struct SpriteFrameImage sPicTable_WaterSurfacing[] = {
-    overworld_frame(gFieldEffectObjectPic_WaterSurfacing, 2, 2, 0),
-    overworld_frame(gFieldEffectObjectPic_WaterSurfacing, 2, 2, 1),
-    overworld_frame(gFieldEffectObjectPic_WaterSurfacing, 2, 2, 2),
-    overworld_frame(gFieldEffectObjectPic_WaterSurfacing, 2, 2, 3),
+    overworld_ascending_frames(gFieldEffectObjectPic_WaterSurfacing, 2, 2),
 };
 
 static const union AnimCmd sAnim_WaterSurfacing[] =
@@ -954,12 +895,7 @@ const struct SpriteTemplate gFieldEffectObjectTemplate_ReflectionDistortion = {
 };
 
 static const struct SpriteFrameImage sPicTable_Sparkle[] = {
-    overworld_frame(gFieldEffectObjectPic_Sparkle, 2, 2, 0),
-    overworld_frame(gFieldEffectObjectPic_Sparkle, 2, 2, 1),
-    overworld_frame(gFieldEffectObjectPic_Sparkle, 2, 2, 2),
-    overworld_frame(gFieldEffectObjectPic_Sparkle, 2, 2, 3),
-    overworld_frame(gFieldEffectObjectPic_Sparkle, 2, 2, 4),
-    overworld_frame(gFieldEffectObjectPic_Sparkle, 2, 2, 5),
+    overworld_ascending_frames(gFieldEffectObjectPic_Sparkle, 2, 2),
 };
 
 static const union AnimCmd sAnim_Sparkle[] =
@@ -1002,13 +938,7 @@ const struct SpriteTemplate gFieldEffectObjectTemplate_Sparkle = {
 };
 
 static const struct SpriteFrameImage sPicTable_TreeDisguise[] = {
-    overworld_frame(gFieldEffectObjectPic_TreeDisguise, 2, 4, 0),
-    overworld_frame(gFieldEffectObjectPic_TreeDisguise, 2, 4, 1),
-    overworld_frame(gFieldEffectObjectPic_TreeDisguise, 2, 4, 2),
-    overworld_frame(gFieldEffectObjectPic_TreeDisguise, 2, 4, 3),
-    overworld_frame(gFieldEffectObjectPic_TreeDisguise, 2, 4, 4),
-    overworld_frame(gFieldEffectObjectPic_TreeDisguise, 2, 4, 5),
-    overworld_frame(gFieldEffectObjectPic_TreeDisguise, 2, 4, 6),
+    overworld_ascending_frames(gFieldEffectObjectPic_TreeDisguise, 2, 4),
 };
 
 static const union AnimCmd sAnim_TreeDisguise[] =
@@ -1045,13 +975,7 @@ const struct SpriteTemplate gFieldEffectObjectTemplate_TreeDisguise = {
 };
 
 static const struct SpriteFrameImage sPicTable_MountainDisguise[] = {
-    overworld_frame(gFieldEffectObjectPic_MountainDisguise, 2, 4, 0),
-    overworld_frame(gFieldEffectObjectPic_MountainDisguise, 2, 4, 1),
-    overworld_frame(gFieldEffectObjectPic_MountainDisguise, 2, 4, 2),
-    overworld_frame(gFieldEffectObjectPic_MountainDisguise, 2, 4, 3),
-    overworld_frame(gFieldEffectObjectPic_MountainDisguise, 2, 4, 4),
-    overworld_frame(gFieldEffectObjectPic_MountainDisguise, 2, 4, 5),
-    overworld_frame(gFieldEffectObjectPic_MountainDisguise, 2, 4, 6),
+    overworld_ascending_frames(gFieldEffectObjectPic_MountainDisguise, 2, 4),
 };
 
 static const union AnimCmd sAnim_MountainDisguise[] =
@@ -1088,13 +1012,7 @@ const struct SpriteTemplate gFieldEffectObjectTemplate_MountainDisguise = {
 };
 
 static const struct SpriteFrameImage sPicTable_SandDisguisePlaceholder[] = {
-    overworld_frame(gFieldEffectObjectPic_SandDisguisePlaceholder, 2, 4, 0),
-    overworld_frame(gFieldEffectObjectPic_SandDisguisePlaceholder, 2, 4, 1),
-    overworld_frame(gFieldEffectObjectPic_SandDisguisePlaceholder, 2, 4, 2),
-    overworld_frame(gFieldEffectObjectPic_SandDisguisePlaceholder, 2, 4, 3),
-    overworld_frame(gFieldEffectObjectPic_SandDisguisePlaceholder, 2, 4, 4),
-    overworld_frame(gFieldEffectObjectPic_SandDisguisePlaceholder, 2, 4, 5),
-    overworld_frame(gFieldEffectObjectPic_SandDisguisePlaceholder, 2, 4, 6),
+    overworld_ascending_frames(gFieldEffectObjectPic_SandDisguisePlaceholder, 2, 4),
 };
 
 const struct SpriteTemplate gFieldEffectObjectTemplate_SandDisguisePlaceholder = {
@@ -1130,8 +1048,7 @@ const struct SpriteTemplate gFieldEffectObjectTemplate_Bird = {
 };
 
 static const struct SpriteFrameImage sPicTable_ShortGrass[] = {
-    overworld_frame(gFieldEffectObjectPic_ShortGrass, 2, 2, 0),
-    overworld_frame(gFieldEffectObjectPic_ShortGrass, 2, 2, 1),
+    overworld_ascending_frames(gFieldEffectObjectPic_ShortGrass, 2, 2),
 };
 
 static const union AnimCmd sAnim_ShortGrass[] =
@@ -1180,11 +1097,7 @@ const struct SpriteTemplate gFieldEffectObjectTemplate_HotSpringsWater = {
 };
 
 static const struct SpriteFrameImage sPicTable_AshPuff[] = {
-    overworld_frame(gFieldEffectObjectPic_AshPuff, 2, 2, 0),
-    overworld_frame(gFieldEffectObjectPic_AshPuff, 2, 2, 1),
-    overworld_frame(gFieldEffectObjectPic_AshPuff, 2, 2, 2),
-    overworld_frame(gFieldEffectObjectPic_AshPuff, 2, 2, 3),
-    overworld_frame(gFieldEffectObjectPic_AshPuff, 2, 2, 4),
+    overworld_ascending_frames(gFieldEffectObjectPic_AshPuff, 2, 2),
 };
 
 static const union AnimCmd sAnim_AshPuff[] =
@@ -1215,11 +1128,7 @@ const struct SpriteTemplate gFieldEffectObjectTemplate_AshPuff =
 const struct SpritePalette gSpritePalette_Ash = {gFieldEffectPal_Ash, FLDEFF_PAL_TAG_ASH};
 
 static const struct SpriteFrameImage sPicTable_AshLaunch[] = {
-    overworld_frame(gFieldEffectObjectPic_AshLaunch, 2, 2, 0),
-    overworld_frame(gFieldEffectObjectPic_AshLaunch, 2, 2, 1),
-    overworld_frame(gFieldEffectObjectPic_AshLaunch, 2, 2, 2),
-    overworld_frame(gFieldEffectObjectPic_AshLaunch, 2, 2, 3),
-    overworld_frame(gFieldEffectObjectPic_AshLaunch, 2, 2, 4),
+    overworld_ascending_frames(gFieldEffectObjectPic_AshLaunch, 2, 2),
 };
 
 static const union AnimCmd sAnim_AshLaunch[] =
@@ -1248,14 +1157,7 @@ const struct SpriteTemplate gFieldEffectObjectTemplate_AshLaunch =
 };
 
 static const struct SpriteFrameImage sPicTable_Bubbles[] = {
-    overworld_frame(gFieldEffectObjectPic_Bubbles, 2, 4, 0),
-    overworld_frame(gFieldEffectObjectPic_Bubbles, 2, 4, 1),
-    overworld_frame(gFieldEffectObjectPic_Bubbles, 2, 4, 2),
-    overworld_frame(gFieldEffectObjectPic_Bubbles, 2, 4, 3),
-    overworld_frame(gFieldEffectObjectPic_Bubbles, 2, 4, 4),
-    overworld_frame(gFieldEffectObjectPic_Bubbles, 2, 4, 5),
-    overworld_frame(gFieldEffectObjectPic_Bubbles, 2, 4, 6),
-    overworld_frame(gFieldEffectObjectPic_Bubbles, 2, 4, 7),
+    overworld_ascending_frames(gFieldEffectObjectPic_Bubbles, 2, 4),
 };
 
 static const union AnimCmd sAnim_Bubbles[] =
@@ -1286,8 +1188,7 @@ const struct SpriteTemplate gFieldEffectObjectTemplate_Bubbles = {
 };
 
 static const struct SpriteFrameImage sPicTable_SmallSparkle[] = {
-    overworld_frame(gFieldEffectObjectPic_SmallSparkle, 2, 2, 0),
-    overworld_frame(gFieldEffectObjectPic_SmallSparkle, 2, 2, 1),
+    overworld_ascending_frames(gFieldEffectObjectPic_SmallSparkle, 2, 2),
 };
 
 static const union AnimCmd sAnim_SmallSparkle[] =
@@ -1341,10 +1242,7 @@ static const struct SpritePalette sSpritePalette_Unused = {gObjectEventPal_Npc3,
 // cave dust
 static const struct SpriteFrameImage sPicTable_CaveDust[] =
 {
-    overworld_frame(gFieldEffectObjectPic_CaveDust, 2, 2, 0),
-    overworld_frame(gFieldEffectObjectPic_CaveDust, 2, 2, 1),
-    overworld_frame(gFieldEffectObjectPic_CaveDust, 2, 2, 2),
-    overworld_frame(gFieldEffectObjectPic_CaveDust, 2, 2, 3),
+    overworld_ascending_frames(gFieldEffectObjectPic_CaveDust, 2, 2),
 };
 const struct SpriteTemplate gFieldEffectObjectTemplate_CaveDust = {
     .tileTag = 0xFFFF,
@@ -1384,9 +1282,7 @@ static const union AnimCmd *const sAnimTable_RockClimbDust[] =
     sAnim_RockClimbDust,
 };
 static const struct SpriteFrameImage sPicTable_RockClimbDust[] = {
-    overworld_frame(gFieldEffectObjectPic_RockClimbDust, 4, 4, 0),
-    overworld_frame(gFieldEffectObjectPic_RockClimbDust, 4, 4, 1),
-    overworld_frame(gFieldEffectObjectPic_RockClimbDust, 4, 4, 2),
+    overworld_ascending_frames(gFieldEffectObjectPic_RockClimbDust, 4, 4),
 };
 const struct SpriteTemplate gFieldEffectObjectTemplate_RockClimbDust = {
     .tileTag = 0xFFFF,
@@ -1400,14 +1296,7 @@ const struct SpriteTemplate gFieldEffectObjectTemplate_RockClimbDust = {
 const struct SpritePalette gSpritePalette_BigDust = {gFieldEffectPal_DustCloud, FLDEFF_PAL_TAG_DUST_CLOUD};
 
 static const struct SpriteFrameImage sPicTable_ShinySparkle[] = {
-    overworld_frame(gFieldEffectObjectPic_ShinySparkle, 2, 4, 0),
-    overworld_frame(gFieldEffectObjectPic_ShinySparkle, 2, 4, 1),
-    overworld_frame(gFieldEffectObjectPic_ShinySparkle, 2, 4, 2),
-    overworld_frame(gFieldEffectObjectPic_ShinySparkle, 2, 4, 3),
-    overworld_frame(gFieldEffectObjectPic_ShinySparkle, 2, 4, 4),
-    overworld_frame(gFieldEffectObjectPic_ShinySparkle, 2, 4, 5),
-    overworld_frame(gFieldEffectObjectPic_ShinySparkle, 2, 4, 6),
-    overworld_frame(gFieldEffectObjectPic_ShinySparkle, 2, 4, 7),
+    overworld_ascending_frames(gFieldEffectObjectPic_ShinySparkle, 2, 4),
 };
 
 static const union AnimCmd sAnim_ShinySparkle[] =

--- a/src/data/object_events/object_event_pic_tables.h
+++ b/src/data/object_events/object_event_pic_tables.h
@@ -1069,11 +1069,7 @@ static const struct SpriteFrameImage sPicTable_SudowoodoTree[] = {
 };
 
 static const struct SpriteFrameImage sPicTable_RayquazaCutscene[] = {
-    overworld_frame(gObjectEventPic_RayquazaCutscene, 8, 8, 0),
-    overworld_frame(gObjectEventPic_RayquazaCutscene, 8, 8, 1),
-    overworld_frame(gObjectEventPic_RayquazaCutscene, 8, 8, 2),
-    overworld_frame(gObjectEventPic_RayquazaCutscene, 8, 8, 3),
-    overworld_frame(gObjectEventPic_RayquazaCutscene, 8, 8, 4),
+    overworld_ascending_frames(gObjectEventPic_RayquazaCutscene, 8, 8),
 };
 
 static const struct SpriteFrameImage sPicTable_BirthIslandStone[] = {
@@ -1387,15 +1383,7 @@ static const struct SpriteFrameImage sPicTable_RedNormal[] = {
 };
 
 static const struct SpriteFrameImage sPicTable_RedBike[] = {
-    overworld_frame(gObjectEventPic_RedBike, 4, 4, 0),
-    overworld_frame(gObjectEventPic_RedBike, 4, 4, 1),
-    overworld_frame(gObjectEventPic_RedBike, 4, 4, 2),
-    overworld_frame(gObjectEventPic_RedBike, 4, 4, 3),
-    overworld_frame(gObjectEventPic_RedBike, 4, 4, 4),
-    overworld_frame(gObjectEventPic_RedBike, 4, 4, 5),
-    overworld_frame(gObjectEventPic_RedBike, 4, 4, 6),
-    overworld_frame(gObjectEventPic_RedBike, 4, 4, 7),
-    overworld_frame(gObjectEventPic_RedBike, 4, 4, 8),
+    overworld_ascending_frames(gObjectEventPic_RedBike, 4, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_GreenNormal[] = {
@@ -1422,15 +1410,7 @@ static const struct SpriteFrameImage sPicTable_GreenNormal[] = {
 };
 
 static const struct SpriteFrameImage sPicTable_GreenBike[] = {
-    overworld_frame(gObjectEventPic_GreenBike, 4, 4, 0),
-    overworld_frame(gObjectEventPic_GreenBike, 4, 4, 1),
-    overworld_frame(gObjectEventPic_GreenBike, 4, 4, 2),
-    overworld_frame(gObjectEventPic_GreenBike, 4, 4, 3),
-    overworld_frame(gObjectEventPic_GreenBike, 4, 4, 4),
-    overworld_frame(gObjectEventPic_GreenBike, 4, 4, 5),
-    overworld_frame(gObjectEventPic_GreenBike, 4, 4, 6),
-    overworld_frame(gObjectEventPic_GreenBike, 4, 4, 7),
-    overworld_frame(gObjectEventPic_GreenBike, 4, 4, 8),
+    overworld_ascending_frames(gObjectEventPic_GreenBike, 4, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_RedSurf[] = {
@@ -1464,112 +1444,39 @@ static const struct SpriteFrameImage sPicTable_GreenSurf[] = {
 };
 
 static const struct SpriteFrameImage sPicTable_RedItem[] = {
-    overworld_frame(gObjectEventPic_RedItem, 2, 4, 0),
-    overworld_frame(gObjectEventPic_RedItem, 2, 4, 1),
-    overworld_frame(gObjectEventPic_RedItem, 2, 4, 2),
-    overworld_frame(gObjectEventPic_RedItem, 2, 4, 3),
-    overworld_frame(gObjectEventPic_RedItem, 2, 4, 4),
-    overworld_frame(gObjectEventPic_RedItem, 2, 4, 5),
-    overworld_frame(gObjectEventPic_RedItem, 2, 4, 6),
-    overworld_frame(gObjectEventPic_RedItem, 2, 4, 7),
-    overworld_frame(gObjectEventPic_RedItem, 2, 4, 8),
+    overworld_ascending_frames(gObjectEventPic_RedItem, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_GreenItem[] = {
-    overworld_frame(gObjectEventPic_GreenItem, 2, 4, 0),
-    overworld_frame(gObjectEventPic_GreenItem, 2, 4, 1),
-    overworld_frame(gObjectEventPic_GreenItem, 2, 4, 2),
-    overworld_frame(gObjectEventPic_GreenItem, 2, 4, 3),
-    overworld_frame(gObjectEventPic_GreenItem, 2, 4, 4),
-    overworld_frame(gObjectEventPic_GreenItem, 2, 4, 5),
-    overworld_frame(gObjectEventPic_GreenItem, 2, 4, 6),
-    overworld_frame(gObjectEventPic_GreenItem, 2, 4, 7),
-    overworld_frame(gObjectEventPic_GreenItem, 2, 4, 8),
+    overworld_ascending_frames(gObjectEventPic_GreenItem, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_RedFish[] = {
-    overworld_frame(gObjectEventPic_RedFish, 4, 4, 0),
-    overworld_frame(gObjectEventPic_RedFish, 4, 4, 1),
-    overworld_frame(gObjectEventPic_RedFish, 4, 4, 2),
-    overworld_frame(gObjectEventPic_RedFish, 4, 4, 3),
-    overworld_frame(gObjectEventPic_RedFish, 4, 4, 4),
-    overworld_frame(gObjectEventPic_RedFish, 4, 4, 5),
-    overworld_frame(gObjectEventPic_RedFish, 4, 4, 6),
-    overworld_frame(gObjectEventPic_RedFish, 4, 4, 7),
-    overworld_frame(gObjectEventPic_RedFish, 4, 4, 8),
-    overworld_frame(gObjectEventPic_RedFish, 4, 4, 9),
-    overworld_frame(gObjectEventPic_RedFish, 4, 4, 10),
-    overworld_frame(gObjectEventPic_RedFish, 4, 4, 11),
+    overworld_ascending_frames(gObjectEventPic_RedFish, 4, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_GreenFish[] = {
-    overworld_frame(gObjectEventPic_GreenFish, 4, 4, 0),
-    overworld_frame(gObjectEventPic_GreenFish, 4, 4, 1),
-    overworld_frame(gObjectEventPic_GreenFish, 4, 4, 2),
-    overworld_frame(gObjectEventPic_GreenFish, 4, 4, 3),
-    overworld_frame(gObjectEventPic_GreenFish, 4, 4, 4),
-    overworld_frame(gObjectEventPic_GreenFish, 4, 4, 5),
-    overworld_frame(gObjectEventPic_GreenFish, 4, 4, 6),
-    overworld_frame(gObjectEventPic_GreenFish, 4, 4, 7),
-    overworld_frame(gObjectEventPic_GreenFish, 4, 4, 8),
-    overworld_frame(gObjectEventPic_GreenFish, 4, 4, 9),
-    overworld_frame(gObjectEventPic_GreenFish, 4, 4, 10),
-    overworld_frame(gObjectEventPic_GreenFish, 4, 4, 11),
+    overworld_ascending_frames(gObjectEventPic_GreenFish, 4, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_RedVSSeekerBike[] = {
-    overworld_frame(gObjectEventPic_RedVSSeekerBike, 4, 4, 0),
-    overworld_frame(gObjectEventPic_RedVSSeekerBike, 4, 4, 1),
-    overworld_frame(gObjectEventPic_RedVSSeekerBike, 4, 4, 2),
-    overworld_frame(gObjectEventPic_RedVSSeekerBike, 4, 4, 3),
-    overworld_frame(gObjectEventPic_RedVSSeekerBike, 4, 4, 4),
-    overworld_frame(gObjectEventPic_RedVSSeekerBike, 4, 4, 5),
+    overworld_ascending_frames(gObjectEventPic_RedVSSeekerBike, 4, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_GreenVSSeekerBike[] = {
-    overworld_frame(gObjectEventPic_GreenVSSeekerBike, 4, 4, 0),
-    overworld_frame(gObjectEventPic_GreenVSSeekerBike, 4, 4, 1),
-    overworld_frame(gObjectEventPic_GreenVSSeekerBike, 4, 4, 2),
-    overworld_frame(gObjectEventPic_GreenVSSeekerBike, 4, 4, 3),
-    overworld_frame(gObjectEventPic_GreenVSSeekerBike, 4, 4, 4),
-    overworld_frame(gObjectEventPic_GreenVSSeekerBike, 4, 4, 5),
+    overworld_ascending_frames(gObjectEventPic_GreenVSSeekerBike, 4, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_Policeman[] = {
-    overworld_frame(gObjectEventPic_Policeman, 2, 4, 0),
-    overworld_frame(gObjectEventPic_Policeman, 2, 4, 1),
-    overworld_frame(gObjectEventPic_Policeman, 2, 4, 2),
-    overworld_frame(gObjectEventPic_Policeman, 2, 4, 3),
-    overworld_frame(gObjectEventPic_Policeman, 2, 4, 4),
-    overworld_frame(gObjectEventPic_Policeman, 2, 4, 5),
-    overworld_frame(gObjectEventPic_Policeman, 2, 4, 6),
-    overworld_frame(gObjectEventPic_Policeman, 2, 4, 7),
-    overworld_frame(gObjectEventPic_Policeman, 2, 4, 8),
+    overworld_ascending_frames(gObjectEventPic_Policeman, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_LittleBoyFrlg[] = {
-    overworld_frame(gObjectEventPic_LittleBoyFrlg, 2, 2, 0),
-    overworld_frame(gObjectEventPic_LittleBoyFrlg, 2, 2, 1),
-    overworld_frame(gObjectEventPic_LittleBoyFrlg, 2, 2, 2),
-    overworld_frame(gObjectEventPic_LittleBoyFrlg, 2, 2, 3),
-    overworld_frame(gObjectEventPic_LittleBoyFrlg, 2, 2, 4),
-    overworld_frame(gObjectEventPic_LittleBoyFrlg, 2, 2, 5),
-    overworld_frame(gObjectEventPic_LittleBoyFrlg, 2, 2, 6),
-    overworld_frame(gObjectEventPic_LittleBoyFrlg, 2, 2, 7),
-    overworld_frame(gObjectEventPic_LittleBoyFrlg, 2, 2, 8),
+    overworld_ascending_frames(gObjectEventPic_LittleBoyFrlg, 2, 2),
 };
 
 static const struct SpriteFrameImage sPicTable_LittleGirlFrlg[] = {
-    overworld_frame(gObjectEventPic_LittleGirlFrlg, 2, 2, 0),
-    overworld_frame(gObjectEventPic_LittleGirlFrlg, 2, 2, 1),
-    overworld_frame(gObjectEventPic_LittleGirlFrlg, 2, 2, 2),
-    overworld_frame(gObjectEventPic_LittleGirlFrlg, 2, 2, 3),
-    overworld_frame(gObjectEventPic_LittleGirlFrlg, 2, 2, 4),
-    overworld_frame(gObjectEventPic_LittleGirlFrlg, 2, 2, 5),
-    overworld_frame(gObjectEventPic_LittleGirlFrlg, 2, 2, 6),
-    overworld_frame(gObjectEventPic_LittleGirlFrlg, 2, 2, 7),
-    overworld_frame(gObjectEventPic_LittleGirlFrlg, 2, 2, 8),
-    overworld_frame(gObjectEventPic_LittleGirlFrlg, 2, 2, 9),
+    overworld_ascending_frames(gObjectEventPic_LittleGirlFrlg, 2, 2),
 };
 
 static const struct SpriteFrameImage sPicTable_SittingBoy[] = {
@@ -1585,180 +1492,59 @@ static const struct SpriteFrameImage sPicTable_SittingBoy[] = {
 };
 
 static const struct SpriteFrameImage sPicTable_LassFrlg[] = {
-    overworld_frame(gObjectEventPic_LassFrlg, 2, 4, 0),
-    overworld_frame(gObjectEventPic_LassFrlg, 2, 4, 1),
-    overworld_frame(gObjectEventPic_LassFrlg, 2, 4, 2),
-    overworld_frame(gObjectEventPic_LassFrlg, 2, 4, 3),
-    overworld_frame(gObjectEventPic_LassFrlg, 2, 4, 4),
-    overworld_frame(gObjectEventPic_LassFrlg, 2, 4, 5),
-    overworld_frame(gObjectEventPic_LassFrlg, 2, 4, 6),
-    overworld_frame(gObjectEventPic_LassFrlg, 2, 4, 7),
-    overworld_frame(gObjectEventPic_LassFrlg, 2, 4, 8),
-    overworld_frame(gObjectEventPic_LassFrlg, 2, 4, 9),
+    overworld_ascending_frames(gObjectEventPic_LassFrlg, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_YoungsterFrlg[] = {
-    overworld_frame(gObjectEventPic_YoungsterFrlg, 2, 4, 0),
-    overworld_frame(gObjectEventPic_YoungsterFrlg, 2, 4, 1),
-    overworld_frame(gObjectEventPic_YoungsterFrlg, 2, 4, 2),
-    overworld_frame(gObjectEventPic_YoungsterFrlg, 2, 4, 3),
-    overworld_frame(gObjectEventPic_YoungsterFrlg, 2, 4, 4),
-    overworld_frame(gObjectEventPic_YoungsterFrlg, 2, 4, 5),
-    overworld_frame(gObjectEventPic_YoungsterFrlg, 2, 4, 6),
-    overworld_frame(gObjectEventPic_YoungsterFrlg, 2, 4, 7),
-    overworld_frame(gObjectEventPic_YoungsterFrlg, 2, 4, 8),
-    overworld_frame(gObjectEventPic_YoungsterFrlg, 2, 4, 9),
+    overworld_ascending_frames(gObjectEventPic_YoungsterFrlg, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_Woman1Frlg[] = {
-    overworld_frame(gObjectEventPic_Woman1Frlg, 2, 4, 0),
-    overworld_frame(gObjectEventPic_Woman1Frlg, 2, 4, 1),
-    overworld_frame(gObjectEventPic_Woman1Frlg, 2, 4, 2),
-    overworld_frame(gObjectEventPic_Woman1Frlg, 2, 4, 3),
-    overworld_frame(gObjectEventPic_Woman1Frlg, 2, 4, 4),
-    overworld_frame(gObjectEventPic_Woman1Frlg, 2, 4, 5),
-    overworld_frame(gObjectEventPic_Woman1Frlg, 2, 4, 6),
-    overworld_frame(gObjectEventPic_Woman1Frlg, 2, 4, 7),
-    overworld_frame(gObjectEventPic_Woman1Frlg, 2, 4, 8),
-    overworld_frame(gObjectEventPic_Woman1Frlg, 2, 4, 9),
+    overworld_ascending_frames(gObjectEventPic_Woman1Frlg, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_Woman3Frlg[] = {
-    overworld_frame(gObjectEventPic_Woman3Frlg, 2, 4, 0),
-    overworld_frame(gObjectEventPic_Woman3Frlg, 2, 4, 1),
-    overworld_frame(gObjectEventPic_Woman3Frlg, 2, 4, 2),
-    overworld_frame(gObjectEventPic_Woman3Frlg, 2, 4, 3),
-    overworld_frame(gObjectEventPic_Woman3Frlg, 2, 4, 4),
-    overworld_frame(gObjectEventPic_Woman3Frlg, 2, 4, 5),
-    overworld_frame(gObjectEventPic_Woman3Frlg, 2, 4, 6),
-    overworld_frame(gObjectEventPic_Woman3Frlg, 2, 4, 7),
-    overworld_frame(gObjectEventPic_Woman3Frlg, 2, 4, 8),
+    overworld_ascending_frames(gObjectEventPic_Woman3Frlg, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_CrushGirl[] = {
-    overworld_frame(gObjectEventPic_CrushGirl, 2, 4, 0),
-    overworld_frame(gObjectEventPic_CrushGirl, 2, 4, 1),
-    overworld_frame(gObjectEventPic_CrushGirl, 2, 4, 2),
-    overworld_frame(gObjectEventPic_CrushGirl, 2, 4, 3),
-    overworld_frame(gObjectEventPic_CrushGirl, 2, 4, 4),
-    overworld_frame(gObjectEventPic_CrushGirl, 2, 4, 5),
-    overworld_frame(gObjectEventPic_CrushGirl, 2, 4, 6),
-    overworld_frame(gObjectEventPic_CrushGirl, 2, 4, 7),
-    overworld_frame(gObjectEventPic_CrushGirl, 2, 4, 8),
-    overworld_frame(gObjectEventPic_CrushGirl, 2, 4, 9),
+    overworld_ascending_frames(gObjectEventPic_CrushGirl, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_BugCatcherFrlg[] = {
-    overworld_frame(gObjectEventPic_BugCatcherFrlg, 2, 4, 0),
-    overworld_frame(gObjectEventPic_BugCatcherFrlg, 2, 4, 1),
-    overworld_frame(gObjectEventPic_BugCatcherFrlg, 2, 4, 2),
-    overworld_frame(gObjectEventPic_BugCatcherFrlg, 2, 4, 3),
-    overworld_frame(gObjectEventPic_BugCatcherFrlg, 2, 4, 4),
-    overworld_frame(gObjectEventPic_BugCatcherFrlg, 2, 4, 5),
-    overworld_frame(gObjectEventPic_BugCatcherFrlg, 2, 4, 6),
-    overworld_frame(gObjectEventPic_BugCatcherFrlg, 2, 4, 7),
-    overworld_frame(gObjectEventPic_BugCatcherFrlg, 2, 4, 8),
-    overworld_frame(gObjectEventPic_BugCatcherFrlg, 2, 4, 9),
+    overworld_ascending_frames(gObjectEventPic_BugCatcherFrlg, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_FatManFrlg[] = {
-    overworld_frame(gObjectEventPic_FatManFrlg, 2, 4, 0),
-    overworld_frame(gObjectEventPic_FatManFrlg, 2, 4, 1),
-    overworld_frame(gObjectEventPic_FatManFrlg, 2, 4, 2),
-    overworld_frame(gObjectEventPic_FatManFrlg, 2, 4, 3),
-    overworld_frame(gObjectEventPic_FatManFrlg, 2, 4, 4),
-    overworld_frame(gObjectEventPic_FatManFrlg, 2, 4, 5),
-    overworld_frame(gObjectEventPic_FatManFrlg, 2, 4, 6),
-    overworld_frame(gObjectEventPic_FatManFrlg, 2, 4, 7),
-    overworld_frame(gObjectEventPic_FatManFrlg, 2, 4, 8),
+    overworld_ascending_frames(gObjectEventPic_FatManFrlg, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_BaldingMan[] = {
-    overworld_frame(gObjectEventPic_BaldingMan, 2, 4, 0),
-    overworld_frame(gObjectEventPic_BaldingMan, 2, 4, 1),
-    overworld_frame(gObjectEventPic_BaldingMan, 2, 4, 2),
-    overworld_frame(gObjectEventPic_BaldingMan, 2, 4, 3),
-    overworld_frame(gObjectEventPic_BaldingMan, 2, 4, 4),
-    overworld_frame(gObjectEventPic_BaldingMan, 2, 4, 5),
-    overworld_frame(gObjectEventPic_BaldingMan, 2, 4, 6),
-    overworld_frame(gObjectEventPic_BaldingMan, 2, 4, 7),
-    overworld_frame(gObjectEventPic_BaldingMan, 2, 4, 8),
-    overworld_frame(gObjectEventPic_BaldingMan, 2, 4, 9),
+    overworld_ascending_frames(gObjectEventPic_BaldingMan, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_Woman2Frlg[] = {
-    overworld_frame(gObjectEventPic_Woman2Frlg, 2, 4, 0),
-    overworld_frame(gObjectEventPic_Woman2Frlg, 2, 4, 1),
-    overworld_frame(gObjectEventPic_Woman2Frlg, 2, 4, 2),
-    overworld_frame(gObjectEventPic_Woman2Frlg, 2, 4, 3),
-    overworld_frame(gObjectEventPic_Woman2Frlg, 2, 4, 4),
-    overworld_frame(gObjectEventPic_Woman2Frlg, 2, 4, 5),
-    overworld_frame(gObjectEventPic_Woman2Frlg, 2, 4, 6),
-    overworld_frame(gObjectEventPic_Woman2Frlg, 2, 4, 7),
-    overworld_frame(gObjectEventPic_Woman2Frlg, 2, 4, 8),
-    overworld_frame(gObjectEventPic_Woman2Frlg, 2, 4, 9),
+    overworld_ascending_frames(gObjectEventPic_Woman2Frlg, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_OldMan1[] = {
-    overworld_frame(gObjectEventPic_OldMan1, 2, 4, 0),
-    overworld_frame(gObjectEventPic_OldMan1, 2, 4, 1),
-    overworld_frame(gObjectEventPic_OldMan1, 2, 4, 2),
-    overworld_frame(gObjectEventPic_OldMan1, 2, 4, 3),
-    overworld_frame(gObjectEventPic_OldMan1, 2, 4, 4),
-    overworld_frame(gObjectEventPic_OldMan1, 2, 4, 5),
-    overworld_frame(gObjectEventPic_OldMan1, 2, 4, 6),
-    overworld_frame(gObjectEventPic_OldMan1, 2, 4, 7),
-    overworld_frame(gObjectEventPic_OldMan1, 2, 4, 8),
-    overworld_frame(gObjectEventPic_OldMan1, 2, 4, 9),
+    overworld_ascending_frames(gObjectEventPic_OldMan1, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_WorkerM[] = {
-    overworld_frame(gObjectEventPic_WorkerM, 2, 4, 0),
-    overworld_frame(gObjectEventPic_WorkerM, 2, 4, 1),
-    overworld_frame(gObjectEventPic_WorkerM, 2, 4, 2),
-    overworld_frame(gObjectEventPic_WorkerM, 2, 4, 3),
-    overworld_frame(gObjectEventPic_WorkerM, 2, 4, 4),
-    overworld_frame(gObjectEventPic_WorkerM, 2, 4, 5),
-    overworld_frame(gObjectEventPic_WorkerM, 2, 4, 6),
-    overworld_frame(gObjectEventPic_WorkerM, 2, 4, 7),
-    overworld_frame(gObjectEventPic_WorkerM, 2, 4, 8),
+    overworld_ascending_frames(gObjectEventPic_WorkerM, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_WorkerF[] = {
-    overworld_frame(gObjectEventPic_WorkerF, 2, 4, 0),
-    overworld_frame(gObjectEventPic_WorkerF, 2, 4, 1),
-    overworld_frame(gObjectEventPic_WorkerF, 2, 4, 2),
-    overworld_frame(gObjectEventPic_WorkerF, 2, 4, 3),
-    overworld_frame(gObjectEventPic_WorkerF, 2, 4, 4),
-    overworld_frame(gObjectEventPic_WorkerF, 2, 4, 5),
-    overworld_frame(gObjectEventPic_WorkerF, 2, 4, 6),
-    overworld_frame(gObjectEventPic_WorkerF, 2, 4, 7),
-    overworld_frame(gObjectEventPic_WorkerF, 2, 4, 8),
+    overworld_ascending_frames(gObjectEventPic_WorkerF, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_BeautyFrlg[] = {
-    overworld_frame(gObjectEventPic_BeautyFrlg, 2, 4, 0),
-    overworld_frame(gObjectEventPic_BeautyFrlg, 2, 4, 1),
-    overworld_frame(gObjectEventPic_BeautyFrlg, 2, 4, 2),
-    overworld_frame(gObjectEventPic_BeautyFrlg, 2, 4, 3),
-    overworld_frame(gObjectEventPic_BeautyFrlg, 2, 4, 4),
-    overworld_frame(gObjectEventPic_BeautyFrlg, 2, 4, 5),
-    overworld_frame(gObjectEventPic_BeautyFrlg, 2, 4, 6),
-    overworld_frame(gObjectEventPic_BeautyFrlg, 2, 4, 7),
-    overworld_frame(gObjectEventPic_BeautyFrlg, 2, 4, 8),
-    overworld_frame(gObjectEventPic_BeautyFrlg, 2, 4, 9),
+    overworld_ascending_frames(gObjectEventPic_BeautyFrlg, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_Chef[] = {
-    overworld_frame(gObjectEventPic_Chef, 2, 4, 0),
-    overworld_frame(gObjectEventPic_Chef, 2, 4, 1),
-    overworld_frame(gObjectEventPic_Chef, 2, 4, 2),
-    overworld_frame(gObjectEventPic_Chef, 2, 4, 3),
-    overworld_frame(gObjectEventPic_Chef, 2, 4, 4),
-    overworld_frame(gObjectEventPic_Chef, 2, 4, 5),
-    overworld_frame(gObjectEventPic_Chef, 2, 4, 6),
-    overworld_frame(gObjectEventPic_Chef, 2, 4, 7),
-    overworld_frame(gObjectEventPic_Chef, 2, 4, 8),
+    overworld_ascending_frames(gObjectEventPic_Chef, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_OldMan2[] = {
@@ -1787,336 +1573,107 @@ static const struct SpriteFrameImage sPicTable_OldManLyingDown[] = {
 };
 
 static const struct SpriteFrameImage sPicTable_OldWomanFrlg[] = {
-    overworld_frame(gObjectEventPic_OldWomanFrlg, 2, 4, 0),
-    overworld_frame(gObjectEventPic_OldWomanFrlg, 2, 4, 1),
-    overworld_frame(gObjectEventPic_OldWomanFrlg, 2, 4, 2),
-    overworld_frame(gObjectEventPic_OldWomanFrlg, 2, 4, 3),
-    overworld_frame(gObjectEventPic_OldWomanFrlg, 2, 4, 4),
-    overworld_frame(gObjectEventPic_OldWomanFrlg, 2, 4, 5),
-    overworld_frame(gObjectEventPic_OldWomanFrlg, 2, 4, 6),
-    overworld_frame(gObjectEventPic_OldWomanFrlg, 2, 4, 7),
-    overworld_frame(gObjectEventPic_OldWomanFrlg, 2, 4, 8),
+    overworld_ascending_frames(gObjectEventPic_OldWomanFrlg, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_CamperFrlg[] = {
-    overworld_frame(gObjectEventPic_CamperFrlg, 2, 4, 0),
-    overworld_frame(gObjectEventPic_CamperFrlg, 2, 4, 1),
-    overworld_frame(gObjectEventPic_CamperFrlg, 2, 4, 2),
-    overworld_frame(gObjectEventPic_CamperFrlg, 2, 4, 3),
-    overworld_frame(gObjectEventPic_CamperFrlg, 2, 4, 4),
-    overworld_frame(gObjectEventPic_CamperFrlg, 2, 4, 5),
-    overworld_frame(gObjectEventPic_CamperFrlg, 2, 4, 6),
-    overworld_frame(gObjectEventPic_CamperFrlg, 2, 4, 7),
-    overworld_frame(gObjectEventPic_CamperFrlg, 2, 4, 8),
-    overworld_frame(gObjectEventPic_CamperFrlg, 2, 4, 9),
+    overworld_ascending_frames(gObjectEventPic_CamperFrlg, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_PicnickerFrlg[] = {
-    overworld_frame(gObjectEventPic_PicnickerFrlg, 2, 4, 0),
-    overworld_frame(gObjectEventPic_PicnickerFrlg, 2, 4, 1),
-    overworld_frame(gObjectEventPic_PicnickerFrlg, 2, 4, 2),
-    overworld_frame(gObjectEventPic_PicnickerFrlg, 2, 4, 3),
-    overworld_frame(gObjectEventPic_PicnickerFrlg, 2, 4, 4),
-    overworld_frame(gObjectEventPic_PicnickerFrlg, 2, 4, 5),
-    overworld_frame(gObjectEventPic_PicnickerFrlg, 2, 4, 6),
-    overworld_frame(gObjectEventPic_PicnickerFrlg, 2, 4, 7),
-    overworld_frame(gObjectEventPic_PicnickerFrlg, 2, 4, 8),
-    overworld_frame(gObjectEventPic_PicnickerFrlg, 2, 4, 9),
+    overworld_ascending_frames(gObjectEventPic_PicnickerFrlg, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_CooltrainerM[] = {
-    overworld_frame(gObjectEventPic_CooltrainerM, 2, 4, 0),
-    overworld_frame(gObjectEventPic_CooltrainerM, 2, 4, 1),
-    overworld_frame(gObjectEventPic_CooltrainerM, 2, 4, 2),
-    overworld_frame(gObjectEventPic_CooltrainerM, 2, 4, 3),
-    overworld_frame(gObjectEventPic_CooltrainerM, 2, 4, 4),
-    overworld_frame(gObjectEventPic_CooltrainerM, 2, 4, 5),
-    overworld_frame(gObjectEventPic_CooltrainerM, 2, 4, 6),
-    overworld_frame(gObjectEventPic_CooltrainerM, 2, 4, 7),
-    overworld_frame(gObjectEventPic_CooltrainerM, 2, 4, 8),
-    overworld_frame(gObjectEventPic_CooltrainerM, 2, 4, 9),
+    overworld_ascending_frames(gObjectEventPic_CooltrainerM, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_CooltrainerF[] = {
-    overworld_frame(gObjectEventPic_CooltrainerF, 2, 4, 0),
-    overworld_frame(gObjectEventPic_CooltrainerF, 2, 4, 1),
-    overworld_frame(gObjectEventPic_CooltrainerF, 2, 4, 2),
-    overworld_frame(gObjectEventPic_CooltrainerF, 2, 4, 3),
-    overworld_frame(gObjectEventPic_CooltrainerF, 2, 4, 4),
-    overworld_frame(gObjectEventPic_CooltrainerF, 2, 4, 5),
-    overworld_frame(gObjectEventPic_CooltrainerF, 2, 4, 6),
-    overworld_frame(gObjectEventPic_CooltrainerF, 2, 4, 7),
-    overworld_frame(gObjectEventPic_CooltrainerF, 2, 4, 8),
-    overworld_frame(gObjectEventPic_CooltrainerF, 2, 4, 9),
+    overworld_ascending_frames(gObjectEventPic_CooltrainerF, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_Boy[] = {
-    overworld_frame(gObjectEventPic_Boy, 2, 4, 0),
-    overworld_frame(gObjectEventPic_Boy, 2, 4, 1),
-    overworld_frame(gObjectEventPic_Boy, 2, 4, 2),
-    overworld_frame(gObjectEventPic_Boy, 2, 4, 3),
-    overworld_frame(gObjectEventPic_Boy, 2, 4, 4),
-    overworld_frame(gObjectEventPic_Boy, 2, 4, 5),
-    overworld_frame(gObjectEventPic_Boy, 2, 4, 6),
-    overworld_frame(gObjectEventPic_Boy, 2, 4, 7),
-    overworld_frame(gObjectEventPic_Boy, 2, 4, 8),
-    overworld_frame(gObjectEventPic_Boy, 2, 4, 9),
+    overworld_ascending_frames(gObjectEventPic_Boy, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_PokeManiacFrlg[] = {
-    overworld_frame(gObjectEventPic_PokeManiacFrlg, 2, 4, 0),
-    overworld_frame(gObjectEventPic_PokeManiacFrlg, 2, 4, 1),
-    overworld_frame(gObjectEventPic_PokeManiacFrlg, 2, 4, 2),
-    overworld_frame(gObjectEventPic_PokeManiacFrlg, 2, 4, 3),
-    overworld_frame(gObjectEventPic_PokeManiacFrlg, 2, 4, 4),
-    overworld_frame(gObjectEventPic_PokeManiacFrlg, 2, 4, 5),
-    overworld_frame(gObjectEventPic_PokeManiacFrlg, 2, 4, 6),
-    overworld_frame(gObjectEventPic_PokeManiacFrlg, 2, 4, 7),
-    overworld_frame(gObjectEventPic_PokeManiacFrlg, 2, 4, 8),
-    overworld_frame(gObjectEventPic_PokeManiacFrlg, 2, 4, 9),
+    overworld_ascending_frames(gObjectEventPic_PokeManiacFrlg, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_Channeler[] = {
-    overworld_frame(gObjectEventPic_Channeler, 2, 4, 0),
-    overworld_frame(gObjectEventPic_Channeler, 2, 4, 1),
-    overworld_frame(gObjectEventPic_Channeler, 2, 4, 2),
-    overworld_frame(gObjectEventPic_Channeler, 2, 4, 3),
-    overworld_frame(gObjectEventPic_Channeler, 2, 4, 4),
-    overworld_frame(gObjectEventPic_Channeler, 2, 4, 5),
-    overworld_frame(gObjectEventPic_Channeler, 2, 4, 6),
-    overworld_frame(gObjectEventPic_Channeler, 2, 4, 7),
-    overworld_frame(gObjectEventPic_Channeler, 2, 4, 8),
-    overworld_frame(gObjectEventPic_Channeler, 2, 4, 9),
+    overworld_ascending_frames(gObjectEventPic_Channeler, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_RocketF[] = {
-    overworld_frame(gObjectEventPic_RocketF, 2, 4, 0),
-    overworld_frame(gObjectEventPic_RocketF, 2, 4, 1),
-    overworld_frame(gObjectEventPic_RocketF, 2, 4, 2),
-    overworld_frame(gObjectEventPic_RocketF, 2, 4, 3),
-    overworld_frame(gObjectEventPic_RocketF, 2, 4, 4),
-    overworld_frame(gObjectEventPic_RocketF, 2, 4, 5),
-    overworld_frame(gObjectEventPic_RocketF, 2, 4, 6),
-    overworld_frame(gObjectEventPic_RocketF, 2, 4, 7),
-    overworld_frame(gObjectEventPic_RocketF, 2, 4, 8),
+    overworld_ascending_frames(gObjectEventPic_RocketF, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_SwimmerMWater[] = {
-    overworld_frame(gObjectEventPic_SwimmerMWater, 2, 4, 0),
-    overworld_frame(gObjectEventPic_SwimmerMWater, 2, 4, 1),
-    overworld_frame(gObjectEventPic_SwimmerMWater, 2, 4, 2),
-    overworld_frame(gObjectEventPic_SwimmerMWater, 2, 4, 3),
-    overworld_frame(gObjectEventPic_SwimmerMWater, 2, 4, 4),
-    overworld_frame(gObjectEventPic_SwimmerMWater, 2, 4, 5),
-    overworld_frame(gObjectEventPic_SwimmerMWater, 2, 4, 6),
-    overworld_frame(gObjectEventPic_SwimmerMWater, 2, 4, 7),
-    overworld_frame(gObjectEventPic_SwimmerMWater, 2, 4, 8),
-    overworld_frame(gObjectEventPic_SwimmerMWater, 2, 4, 9),
+    overworld_ascending_frames(gObjectEventPic_SwimmerMWater, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_SwimmerFWater[] = {
-    overworld_frame(gObjectEventPic_SwimmerFWater, 2, 4, 0),
-    overworld_frame(gObjectEventPic_SwimmerFWater, 2, 4, 1),
-    overworld_frame(gObjectEventPic_SwimmerFWater, 2, 4, 2),
-    overworld_frame(gObjectEventPic_SwimmerFWater, 2, 4, 3),
-    overworld_frame(gObjectEventPic_SwimmerFWater, 2, 4, 4),
-    overworld_frame(gObjectEventPic_SwimmerFWater, 2, 4, 5),
-    overworld_frame(gObjectEventPic_SwimmerFWater, 2, 4, 6),
-    overworld_frame(gObjectEventPic_SwimmerFWater, 2, 4, 7),
-    overworld_frame(gObjectEventPic_SwimmerFWater, 2, 4, 8),
-    overworld_frame(gObjectEventPic_SwimmerFWater, 2, 4, 9),
+    overworld_ascending_frames(gObjectEventPic_SwimmerFWater, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_SwimmerMLand[] = {
-    overworld_frame(gObjectEventPic_SwimmerMLand, 2, 4, 0),
-    overworld_frame(gObjectEventPic_SwimmerMLand, 2, 4, 1),
-    overworld_frame(gObjectEventPic_SwimmerMLand, 2, 4, 2),
-    overworld_frame(gObjectEventPic_SwimmerMLand, 2, 4, 3),
-    overworld_frame(gObjectEventPic_SwimmerMLand, 2, 4, 4),
-    overworld_frame(gObjectEventPic_SwimmerMLand, 2, 4, 5),
-    overworld_frame(gObjectEventPic_SwimmerMLand, 2, 4, 6),
-    overworld_frame(gObjectEventPic_SwimmerMLand, 2, 4, 7),
-    overworld_frame(gObjectEventPic_SwimmerMLand, 2, 4, 8),
-    overworld_frame(gObjectEventPic_SwimmerMLand, 2, 4, 9),
+    overworld_ascending_frames(gObjectEventPic_SwimmerMLand, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_SwimmerFLand[] = {
-    overworld_frame(gObjectEventPic_SwimmerFLand, 2, 4, 0),
-    overworld_frame(gObjectEventPic_SwimmerFLand, 2, 4, 1),
-    overworld_frame(gObjectEventPic_SwimmerFLand, 2, 4, 2),
-    overworld_frame(gObjectEventPic_SwimmerFLand, 2, 4, 3),
-    overworld_frame(gObjectEventPic_SwimmerFLand, 2, 4, 4),
-    overworld_frame(gObjectEventPic_SwimmerFLand, 2, 4, 5),
-    overworld_frame(gObjectEventPic_SwimmerFLand, 2, 4, 6),
-    overworld_frame(gObjectEventPic_SwimmerFLand, 2, 4, 7),
-    overworld_frame(gObjectEventPic_SwimmerFLand, 2, 4, 8),
-    overworld_frame(gObjectEventPic_SwimmerFLand, 2, 4, 9),
+    overworld_ascending_frames(gObjectEventPic_SwimmerFLand, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_BlackBeltFrlg[] = {
-    overworld_frame(gObjectEventPic_BlackBeltFrlg, 2, 4, 0),
-    overworld_frame(gObjectEventPic_BlackBeltFrlg, 2, 4, 1),
-    overworld_frame(gObjectEventPic_BlackBeltFrlg, 2, 4, 2),
-    overworld_frame(gObjectEventPic_BlackBeltFrlg, 2, 4, 3),
-    overworld_frame(gObjectEventPic_BlackBeltFrlg, 2, 4, 4),
-    overworld_frame(gObjectEventPic_BlackBeltFrlg, 2, 4, 5),
-    overworld_frame(gObjectEventPic_BlackBeltFrlg, 2, 4, 6),
-    overworld_frame(gObjectEventPic_BlackBeltFrlg, 2, 4, 7),
-    overworld_frame(gObjectEventPic_BlackBeltFrlg, 2, 4, 8),
-    overworld_frame(gObjectEventPic_BlackBeltFrlg, 2, 4, 9),
+    overworld_ascending_frames(gObjectEventPic_BlackBeltFrlg, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_Scientist[] = {
-    overworld_frame(gObjectEventPic_Scientist, 2, 4, 0),
-    overworld_frame(gObjectEventPic_Scientist, 2, 4, 1),
-    overworld_frame(gObjectEventPic_Scientist, 2, 4, 2),
-    overworld_frame(gObjectEventPic_Scientist, 2, 4, 3),
-    overworld_frame(gObjectEventPic_Scientist, 2, 4, 4),
-    overworld_frame(gObjectEventPic_Scientist, 2, 4, 5),
-    overworld_frame(gObjectEventPic_Scientist, 2, 4, 6),
-    overworld_frame(gObjectEventPic_Scientist, 2, 4, 7),
-    overworld_frame(gObjectEventPic_Scientist, 2, 4, 8),
-    overworld_frame(gObjectEventPic_Scientist, 2, 4, 9),
+    overworld_ascending_frames(gObjectEventPic_Scientist, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_GentlemanFrlg[] = {
-    overworld_frame(gObjectEventPic_GentlemanFrlg, 2, 4, 0),
-    overworld_frame(gObjectEventPic_GentlemanFrlg, 2, 4, 1),
-    overworld_frame(gObjectEventPic_GentlemanFrlg, 2, 4, 2),
-    overworld_frame(gObjectEventPic_GentlemanFrlg, 2, 4, 3),
-    overworld_frame(gObjectEventPic_GentlemanFrlg, 2, 4, 4),
-    overworld_frame(gObjectEventPic_GentlemanFrlg, 2, 4, 5),
-    overworld_frame(gObjectEventPic_GentlemanFrlg, 2, 4, 6),
-    overworld_frame(gObjectEventPic_GentlemanFrlg, 2, 4, 7),
-    overworld_frame(gObjectEventPic_GentlemanFrlg, 2, 4, 8),
-    overworld_frame(gObjectEventPic_GentlemanFrlg, 2, 4, 9),
+    overworld_ascending_frames(gObjectEventPic_GentlemanFrlg, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_SailorFrlg[] = {
-    overworld_frame(gObjectEventPic_SailorFrlg, 2, 4, 0),
-    overworld_frame(gObjectEventPic_SailorFrlg, 2, 4, 1),
-    overworld_frame(gObjectEventPic_SailorFrlg, 2, 4, 2),
-    overworld_frame(gObjectEventPic_SailorFrlg, 2, 4, 3),
-    overworld_frame(gObjectEventPic_SailorFrlg, 2, 4, 4),
-    overworld_frame(gObjectEventPic_SailorFrlg, 2, 4, 5),
-    overworld_frame(gObjectEventPic_SailorFrlg, 2, 4, 6),
-    overworld_frame(gObjectEventPic_SailorFrlg, 2, 4, 7),
-    overworld_frame(gObjectEventPic_SailorFrlg, 2, 4, 8),
-    overworld_frame(gObjectEventPic_SailorFrlg, 2, 4, 9),
+    overworld_ascending_frames(gObjectEventPic_SailorFrlg, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_Captain[] = {
-    overworld_frame(gObjectEventPic_Captain, 2, 4, 0),
-    overworld_frame(gObjectEventPic_Captain, 2, 4, 1),
-    overworld_frame(gObjectEventPic_Captain, 2, 4, 2),
-    overworld_frame(gObjectEventPic_Captain, 2, 4, 3),
-    overworld_frame(gObjectEventPic_Captain, 2, 4, 4),
-    overworld_frame(gObjectEventPic_Captain, 2, 4, 5),
-    overworld_frame(gObjectEventPic_Captain, 2, 4, 6),
-    overworld_frame(gObjectEventPic_Captain, 2, 4, 7),
-    overworld_frame(gObjectEventPic_Captain, 2, 4, 8),
+    overworld_ascending_frames(gObjectEventPic_Captain, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_Fisher[] = {
-    overworld_frame(gObjectEventPic_Fisher, 2, 4, 0),
-    overworld_frame(gObjectEventPic_Fisher, 2, 4, 1),
-    overworld_frame(gObjectEventPic_Fisher, 2, 4, 2),
-    overworld_frame(gObjectEventPic_Fisher, 2, 4, 3),
-    overworld_frame(gObjectEventPic_Fisher, 2, 4, 4),
-    overworld_frame(gObjectEventPic_Fisher, 2, 4, 5),
-    overworld_frame(gObjectEventPic_Fisher, 2, 4, 6),
-    overworld_frame(gObjectEventPic_Fisher, 2, 4, 7),
-    overworld_frame(gObjectEventPic_Fisher, 2, 4, 8),
-    overworld_frame(gObjectEventPic_Fisher, 2, 4, 9),
+    overworld_ascending_frames(gObjectEventPic_Fisher, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_TeachyTVHost[] = {
-    overworld_frame(gObjectEventPic_TeachyTVHost, 2, 4, 0),
-    overworld_frame(gObjectEventPic_TeachyTVHost, 2, 4, 1),
-    overworld_frame(gObjectEventPic_TeachyTVHost, 2, 4, 2),
-    overworld_frame(gObjectEventPic_TeachyTVHost, 2, 4, 3),
-    overworld_frame(gObjectEventPic_TeachyTVHost, 2, 4, 4),
-    overworld_frame(gObjectEventPic_TeachyTVHost, 2, 4, 5),
-    overworld_frame(gObjectEventPic_TeachyTVHost, 2, 4, 6),
-    overworld_frame(gObjectEventPic_TeachyTVHost, 2, 4, 7),
-    overworld_frame(gObjectEventPic_TeachyTVHost, 2, 4, 8),
+    overworld_ascending_frames(gObjectEventPic_TeachyTVHost, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_TuberFFrlg[] = {
-    overworld_frame(gObjectEventPic_TuberFFrlg, 2, 2, 0),
-    overworld_frame(gObjectEventPic_TuberFFrlg, 2, 2, 1),
-    overworld_frame(gObjectEventPic_TuberFFrlg, 2, 2, 2),
-    overworld_frame(gObjectEventPic_TuberFFrlg, 2, 2, 3),
-    overworld_frame(gObjectEventPic_TuberFFrlg, 2, 2, 4),
-    overworld_frame(gObjectEventPic_TuberFFrlg, 2, 2, 5),
-    overworld_frame(gObjectEventPic_TuberFFrlg, 2, 2, 6),
-    overworld_frame(gObjectEventPic_TuberFFrlg, 2, 2, 7),
-    overworld_frame(gObjectEventPic_TuberFFrlg, 2, 2, 8),
-    overworld_frame(gObjectEventPic_TuberFFrlg, 2, 2, 9),
+    overworld_ascending_frames(gObjectEventPic_TuberFFrlg, 2, 2)
 };
 
 static const struct SpriteFrameImage sPicTable_TuberMWater[] = {
-    overworld_frame(gObjectEventPic_TuberMWater, 2, 2, 0),
-    overworld_frame(gObjectEventPic_TuberMWater, 2, 2, 1),
-    overworld_frame(gObjectEventPic_TuberMWater, 2, 2, 2),
-    overworld_frame(gObjectEventPic_TuberMWater, 2, 2, 3),
-    overworld_frame(gObjectEventPic_TuberMWater, 2, 2, 4),
-    overworld_frame(gObjectEventPic_TuberMWater, 2, 2, 5),
-    overworld_frame(gObjectEventPic_TuberMWater, 2, 2, 6),
-    overworld_frame(gObjectEventPic_TuberMWater, 2, 2, 7),
-    overworld_frame(gObjectEventPic_TuberMWater, 2, 2, 8),
-    overworld_frame(gObjectEventPic_TuberMWater, 2, 2, 9),
+    overworld_ascending_frames(gObjectEventPic_TuberMWater, 2, 2)
 };
 
 static const struct SpriteFrameImage sPicTable_TuberMLand[] = {
-    overworld_frame(gObjectEventPic_TuberMLand, 2, 2, 0),
-    overworld_frame(gObjectEventPic_TuberMLand, 2, 2, 1),
-    overworld_frame(gObjectEventPic_TuberMLand, 2, 2, 2),
-    overworld_frame(gObjectEventPic_TuberMLand, 2, 2, 3),
-    overworld_frame(gObjectEventPic_TuberMLand, 2, 2, 4),
-    overworld_frame(gObjectEventPic_TuberMLand, 2, 2, 5),
-    overworld_frame(gObjectEventPic_TuberMLand, 2, 2, 6),
-    overworld_frame(gObjectEventPic_TuberMLand, 2, 2, 7),
-    overworld_frame(gObjectEventPic_TuberMLand, 2, 2, 8),
-    overworld_frame(gObjectEventPic_TuberMLand, 2, 2, 9),
+    overworld_ascending_frames(gObjectEventPic_TuberMLand, 2, 2),
 };
 
 static const struct SpriteFrameImage sPicTable_HikerFrlg[] = {
-    overworld_frame(gObjectEventPic_HikerFrlg, 2, 4, 0),
-    overworld_frame(gObjectEventPic_HikerFrlg, 2, 4, 1),
-    overworld_frame(gObjectEventPic_HikerFrlg, 2, 4, 2),
-    overworld_frame(gObjectEventPic_HikerFrlg, 2, 4, 3),
-    overworld_frame(gObjectEventPic_HikerFrlg, 2, 4, 4),
-    overworld_frame(gObjectEventPic_HikerFrlg, 2, 4, 5),
-    overworld_frame(gObjectEventPic_HikerFrlg, 2, 4, 6),
-    overworld_frame(gObjectEventPic_HikerFrlg, 2, 4, 7),
-    overworld_frame(gObjectEventPic_HikerFrlg, 2, 4, 8),
-    overworld_frame(gObjectEventPic_HikerFrlg, 2, 4, 9),
+    overworld_ascending_frames(gObjectEventPic_HikerFrlg, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_Biker[] = {
-    overworld_frame(gObjectEventPic_Biker, 4, 4, 0),
-    overworld_frame(gObjectEventPic_Biker, 4, 4, 1),
-    overworld_frame(gObjectEventPic_Biker, 4, 4, 2),
-    overworld_frame(gObjectEventPic_Biker, 4, 4, 3),
-    overworld_frame(gObjectEventPic_Biker, 4, 4, 4),
-    overworld_frame(gObjectEventPic_Biker, 4, 4, 5),
-    overworld_frame(gObjectEventPic_Biker, 4, 4, 6),
-    overworld_frame(gObjectEventPic_Biker, 4, 4, 7),
-    overworld_frame(gObjectEventPic_Biker, 4, 4, 8),
-    overworld_frame(gObjectEventPic_Biker, 4, 4, 9),
+    overworld_ascending_frames(gObjectEventPic_Biker, 4, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_GymGuy[] = {
-    overworld_frame(gObjectEventPic_GymGuy, 2, 4, 0),
-    overworld_frame(gObjectEventPic_GymGuy, 2, 4, 1),
-    overworld_frame(gObjectEventPic_GymGuy, 2, 4, 2),
-    overworld_frame(gObjectEventPic_GymGuy, 2, 4, 3),
-    overworld_frame(gObjectEventPic_GymGuy, 2, 4, 4),
-    overworld_frame(gObjectEventPic_GymGuy, 2, 4, 5),
-    overworld_frame(gObjectEventPic_GymGuy, 2, 4, 6),
-    overworld_frame(gObjectEventPic_GymGuy, 2, 4, 7),
-    overworld_frame(gObjectEventPic_GymGuy, 2, 4, 8),
+    overworld_ascending_frames(gObjectEventPic_GymGuy, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_NurseFrlg[] = {
@@ -2133,53 +1690,19 @@ static const struct SpriteFrameImage sPicTable_NurseFrlg[] = {
 };
 
 static const struct SpriteFrameImage sPicTable_ProfOak[] = {
-    overworld_frame(gObjectEventPic_ProfOak, 2, 4, 0),
-    overworld_frame(gObjectEventPic_ProfOak, 2, 4, 1),
-    overworld_frame(gObjectEventPic_ProfOak, 2, 4, 2),
-    overworld_frame(gObjectEventPic_ProfOak, 2, 4, 3),
-    overworld_frame(gObjectEventPic_ProfOak, 2, 4, 4),
-    overworld_frame(gObjectEventPic_ProfOak, 2, 4, 5),
-    overworld_frame(gObjectEventPic_ProfOak, 2, 4, 6),
-    overworld_frame(gObjectEventPic_ProfOak, 2, 4, 7),
-    overworld_frame(gObjectEventPic_ProfOak, 2, 4, 8),
+    overworld_ascending_frames(gObjectEventPic_ProfOak, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_Man[] = {
-    overworld_frame(gObjectEventPic_Man, 2, 4, 0),
-    overworld_frame(gObjectEventPic_Man, 2, 4, 1),
-    overworld_frame(gObjectEventPic_Man, 2, 4, 2),
-    overworld_frame(gObjectEventPic_Man, 2, 4, 3),
-    overworld_frame(gObjectEventPic_Man, 2, 4, 4),
-    overworld_frame(gObjectEventPic_Man, 2, 4, 5),
-    overworld_frame(gObjectEventPic_Man, 2, 4, 6),
-    overworld_frame(gObjectEventPic_Man, 2, 4, 7),
-    overworld_frame(gObjectEventPic_Man, 2, 4, 8),
-    overworld_frame(gObjectEventPic_Man, 2, 4, 9),
+    overworld_ascending_frames(gObjectEventPic_Man, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_Rocker[] = {
-    overworld_frame(gObjectEventPic_Rocker, 2, 4, 0),
-    overworld_frame(gObjectEventPic_Rocker, 2, 4, 1),
-    overworld_frame(gObjectEventPic_Rocker, 2, 4, 2),
-    overworld_frame(gObjectEventPic_Rocker, 2, 4, 3),
-    overworld_frame(gObjectEventPic_Rocker, 2, 4, 4),
-    overworld_frame(gObjectEventPic_Rocker, 2, 4, 5),
-    overworld_frame(gObjectEventPic_Rocker, 2, 4, 6),
-    overworld_frame(gObjectEventPic_Rocker, 2, 4, 7),
-    overworld_frame(gObjectEventPic_Rocker, 2, 4, 8),
-    overworld_frame(gObjectEventPic_Rocker, 2, 4, 9),
+    overworld_ascending_frames(gObjectEventPic_Rocker, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_MrFuji[] = {
-    overworld_frame(gObjectEventPic_MrFuji, 2, 4, 0),
-    overworld_frame(gObjectEventPic_MrFuji, 2, 4, 1),
-    overworld_frame(gObjectEventPic_MrFuji, 2, 4, 2),
-    overworld_frame(gObjectEventPic_MrFuji, 2, 4, 3),
-    overworld_frame(gObjectEventPic_MrFuji, 2, 4, 4),
-    overworld_frame(gObjectEventPic_MrFuji, 2, 4, 5),
-    overworld_frame(gObjectEventPic_MrFuji, 2, 4, 6),
-    overworld_frame(gObjectEventPic_MrFuji, 2, 4, 7),
-    overworld_frame(gObjectEventPic_MrFuji, 2, 4, 8),
+    overworld_ascending_frames(gObjectEventPic_MrFuji, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_Bruno[] = {
@@ -2202,15 +1725,7 @@ static const struct SpriteFrameImage sPicTable_CuttableTreeFrlg[] = {
 };
 
 static const struct SpriteFrameImage sPicTable_Clerk[] = {
-    overworld_frame(gObjectEventPic_Clerk, 2, 4, 0),
-    overworld_frame(gObjectEventPic_Clerk, 2, 4, 1),
-    overworld_frame(gObjectEventPic_Clerk, 2, 4, 2),
-    overworld_frame(gObjectEventPic_Clerk, 2, 4, 3),
-    overworld_frame(gObjectEventPic_Clerk, 2, 4, 4),
-    overworld_frame(gObjectEventPic_Clerk, 2, 4, 5),
-    overworld_frame(gObjectEventPic_Clerk, 2, 4, 6),
-    overworld_frame(gObjectEventPic_Clerk, 2, 4, 7),
-    overworld_frame(gObjectEventPic_Clerk, 2, 4, 8),
+    overworld_ascending_frames(gObjectEventPic_Clerk, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_MGDeliveryman[] = {
@@ -2273,15 +1788,7 @@ static const struct SpriteFrameImage sPicTable_PushableBoulderFrlg[] = {
 };
 
 static const struct SpriteFrameImage sPicTable_RocketM[] = {
-    overworld_frame(gObjectEventPic_RocketM, 2, 4, 0),
-    overworld_frame(gObjectEventPic_RocketM, 2, 4, 1),
-    overworld_frame(gObjectEventPic_RocketM, 2, 4, 2),
-    overworld_frame(gObjectEventPic_RocketM, 2, 4, 3),
-    overworld_frame(gObjectEventPic_RocketM, 2, 4, 4),
-    overworld_frame(gObjectEventPic_RocketM, 2, 4, 5),
-    overworld_frame(gObjectEventPic_RocketM, 2, 4, 6),
-    overworld_frame(gObjectEventPic_RocketM, 2, 4, 7),
-    overworld_frame(gObjectEventPic_RocketM, 2, 4, 8),
+    overworld_ascending_frames(gObjectEventPic_RocketM, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_Celio[] = {
@@ -2369,15 +1876,7 @@ static const struct SpriteFrameImage sPicTable_Koga[] = {
 };
 
 static const struct SpriteFrameImage sPicTable_Giovanni[] = {
-    overworld_frame(gObjectEventPic_Giovanni, 2, 4, 0),
-    overworld_frame(gObjectEventPic_Giovanni, 2, 4, 1),
-    overworld_frame(gObjectEventPic_Giovanni, 2, 4, 2),
-    overworld_frame(gObjectEventPic_Giovanni, 2, 4, 3),
-    overworld_frame(gObjectEventPic_Giovanni, 2, 4, 4),
-    overworld_frame(gObjectEventPic_Giovanni, 2, 4, 5),
-    overworld_frame(gObjectEventPic_Giovanni, 2, 4, 6),
-    overworld_frame(gObjectEventPic_Giovanni, 2, 4, 7),
-    overworld_frame(gObjectEventPic_Giovanni, 2, 4, 8),
+    overworld_ascending_frames(gObjectEventPic_Giovanni, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_Blaine[] = {
@@ -2405,39 +1904,15 @@ static const struct SpriteFrameImage sPicTable_Sabrina[] = {
 };
 
 static const struct SpriteFrameImage sPicTable_Bill[] = {
-    overworld_frame(gObjectEventPic_Bill, 2, 4, 0),
-    overworld_frame(gObjectEventPic_Bill, 2, 4, 1),
-    overworld_frame(gObjectEventPic_Bill, 2, 4, 2),
-    overworld_frame(gObjectEventPic_Bill, 2, 4, 3),
-    overworld_frame(gObjectEventPic_Bill, 2, 4, 4),
-    overworld_frame(gObjectEventPic_Bill, 2, 4, 5),
-    overworld_frame(gObjectEventPic_Bill, 2, 4, 6),
-    overworld_frame(gObjectEventPic_Bill, 2, 4, 7),
-    overworld_frame(gObjectEventPic_Bill, 2, 4, 8),
+    overworld_ascending_frames(gObjectEventPic_Bill, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_Daisy[] = {
-    overworld_frame(gObjectEventPic_Daisy, 2, 4, 0),
-    overworld_frame(gObjectEventPic_Daisy, 2, 4, 1),
-    overworld_frame(gObjectEventPic_Daisy, 2, 4, 2),
-    overworld_frame(gObjectEventPic_Daisy, 2, 4, 3),
-    overworld_frame(gObjectEventPic_Daisy, 2, 4, 4),
-    overworld_frame(gObjectEventPic_Daisy, 2, 4, 5),
-    overworld_frame(gObjectEventPic_Daisy, 2, 4, 6),
-    overworld_frame(gObjectEventPic_Daisy, 2, 4, 7),
-    overworld_frame(gObjectEventPic_Daisy, 2, 4, 8),
+    overworld_ascending_frames(gObjectEventPic_Daisy, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_Lorelei[] = {
-    overworld_frame(gObjectEventPic_Lorelei, 2, 4, 0),
-    overworld_frame(gObjectEventPic_Lorelei, 2, 4, 1),
-    overworld_frame(gObjectEventPic_Lorelei, 2, 4, 2),
-    overworld_frame(gObjectEventPic_Lorelei, 2, 4, 3),
-    overworld_frame(gObjectEventPic_Lorelei, 2, 4, 4),
-    overworld_frame(gObjectEventPic_Lorelei, 2, 4, 5),
-    overworld_frame(gObjectEventPic_Lorelei, 2, 4, 6),
-    overworld_frame(gObjectEventPic_Lorelei, 2, 4, 7),
-    overworld_frame(gObjectEventPic_Lorelei, 2, 4, 8),
+    overworld_ascending_frames(gObjectEventPic_Lorelei, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_Lance[] = {
@@ -2453,15 +1928,7 @@ static const struct SpriteFrameImage sPicTable_Lance[] = {
 };
 
 static const struct SpriteFrameImage sPicTable_Blue[] = {
-    overworld_frame(gObjectEventPic_Blue, 2, 4, 0),
-    overworld_frame(gObjectEventPic_Blue, 2, 4, 1),
-    overworld_frame(gObjectEventPic_Blue, 2, 4, 2),
-    overworld_frame(gObjectEventPic_Blue, 2, 4, 3),
-    overworld_frame(gObjectEventPic_Blue, 2, 4, 4),
-    overworld_frame(gObjectEventPic_Blue, 2, 4, 5),
-    overworld_frame(gObjectEventPic_Blue, 2, 4, 6),
-    overworld_frame(gObjectEventPic_Blue, 2, 4, 7),
-    overworld_frame(gObjectEventPic_Blue, 2, 4, 8),
+    overworld_ascending_frames(gObjectEventPic_Blue, 2, 4),
 };
 
 static const struct SpriteFrameImage sPicTable_TownMap[] = {

--- a/src/fldeff_misc.c
+++ b/src/fldeff_misc.c
@@ -165,30 +165,18 @@ static const union AnimCmd *const sAnimTable_SecretPowerShrub[] =
 
 static const struct SpriteFrameImage sPicTable_SecretPowerCave[] =
 {
-    overworld_frame(sSecretPowerCave_Gfx, 2, 2, 0),
-    overworld_frame(sSecretPowerCave_Gfx, 2, 2, 1),
-    overworld_frame(sSecretPowerCave_Gfx, 2, 2, 2),
-    overworld_frame(sSecretPowerCave_Gfx, 2, 2, 3),
-    overworld_frame(sSecretPowerCave_Gfx, 2, 2, 4),
+    overworld_ascending_frames(sSecretPowerCave_Gfx, 2, 2),
 };
 
 static const struct SpriteFrameImage sPicTable_SecretPowerTree[] =
 {
-    overworld_frame(sSecretPowerTree_Gfx, 2, 2, 0),
-    overworld_frame(sSecretPowerTree_Gfx, 2, 2, 1),
-    overworld_frame(sSecretPowerTree_Gfx, 2, 2, 2),
-    overworld_frame(sSecretPowerTree_Gfx, 2, 2, 3),
-    overworld_frame(sSecretPowerTree_Gfx, 2, 2, 4),
+    overworld_ascending_frames(sSecretPowerTree_Gfx, 2, 2),
     // 6th frame exists but isnt accessed, the tree vine metatile is used instead
 };
 
 static const struct SpriteFrameImage sPicTable_SecretPowerShrub[] =
 {
-    overworld_frame(sSecretPowerShrub_Gfx, 2, 2, 0),
-    overworld_frame(sSecretPowerShrub_Gfx, 2, 2, 1),
-    overworld_frame(sSecretPowerShrub_Gfx, 2, 2, 2),
-    overworld_frame(sSecretPowerShrub_Gfx, 2, 2, 3),
-    overworld_frame(sSecretPowerShrub_Gfx, 2, 2, 4),
+    overworld_ascending_frames(sSecretPowerShrub_Gfx, 2, 2),
 };
 
 static const struct SpriteTemplate sSpriteTemplate_SecretPowerCave =
@@ -273,9 +261,7 @@ static const u16 sRecordMixLights_Pal[] = INCGFX_U16("graphics/field_effects/pal
 
 static const struct SpriteFrameImage sPicTable_RecordMixLights[] =
 {
-    overworld_frame(sRecordMixLights_Gfx, 4, 1, 0),
-    overworld_frame(sRecordMixLights_Gfx, 4, 1, 1),
-    overworld_frame(sRecordMixLights_Gfx, 4, 1, 2),
+    overworld_ascending_frames(sRecordMixLights_Gfx, 4, 1),
 };
 
 static const struct SpritePalette sSpritePalette_RecordMixLights = {sRecordMixLights_Pal, 0x1000};


### PR DESCRIPTION


## Description
Promotes the usage of  `overworld_ascending_frames` across the code base for picture tables, this in order to save a few bytes of ROM.

### Large Language Models (AI)
No.

## Discord contact info
estellar.cheese