### PR TITLE
Fix colosseum warps frlg

### DIFF
--- a/data/scripts/cable_club_frlg.inc
+++ b/data/scripts/cable_club_frlg.inc
@@ -298,7 +298,7 @@ CableClub_EventScript_EnterColosseum_Frlg::
 	release
 	goto_if_eq VAR_0x8004, USING_MULTI_BATTLE, CableClub_EventScript_WarpTo4PColosseum_Frlg
 	special SetCableClubWarp
-	warp MAP_BATTLE_COLOSSEUM_2P, 6, 8
+	warp MAP_BATTLE_COLOSSEUM_2P_FRLG, 6, 8
 	special DoCableClubWarp
 	end
 
@@ -310,7 +310,7 @@ CableClub_EventScript_PlayerApproachLinkRoomRight_Frlg::
 
 CableClub_EventScript_WarpTo4PColosseum_Frlg::
 	special SetCableClubWarp
-	warp MAP_BATTLE_COLOSSEUM_4P, 5, 8
+	warp MAP_BATTLE_COLOSSEUM_4P_FRLG, 5, 8
 	special DoCableClubWarp
 	end
 


### PR DESCRIPTION
## Description 
Fixes the warps from the frlg cable club to the frlg battle colosseum.

## Discord contact info
viperio