### PR TITLE
Fix link singles and doubles using incorrect parties

### DIFF
--- a/src/battle_controllers.c
+++ b/src/battle_controllers.c
@@ -3297,7 +3297,7 @@ void FreeShinyStars(void)
 
 enum BattleTrainer GetBattlerTrainer(enum BattlerId battler)
 {
-    if (gBattleTypeFlags & BATTLE_TYPE_LINK && gBattleTypeFlags & BATTLE_TYPE_MULTI)
+    if (gBattleTypeFlags & BATTLE_TYPE_LINK)
     {
         switch (gBattlerBattleController[battler])
         {
@@ -3310,7 +3310,9 @@ enum BattleTrainer GetBattlerTrainer(enum BattlerId battler)
         case BATTLE_CONTROLLER_LINK_OPPONENT:
         case BATTLE_CONTROLLER_RECORDED_OPPONENT:
         case BATTLE_CONTROLLER_OPPONENT:
-            return (battler & BIT_FLANK) ? B_TRAINER_OPPONENT_B : B_TRAINER_OPPONENT_A;
+            if (gBattleTypeFlags & BATTLE_TYPE_MULTI)
+                return (battler & BIT_FLANK) ? B_TRAINER_OPPONENT_B : B_TRAINER_OPPONENT_A;
+            return B_TRAINER_OPPONENT_A;
         default:
             break;
         }


### PR DESCRIPTION
## Description
Fix `GetBattlerTrainer` for link singles and doubles, which were incorrectly excluded from the link logic due to not having the multi battle flag

## Discord contact info

viperio