### PR TITLE
Fix player's hp display showing 0 max hp for p2 in link battles after taking damage

### DIFF
--- a/src/battle_controllers.c
+++ b/src/battle_controllers.c
@@ -2166,11 +2166,13 @@ static void Controller_HandleTrainerSlideBack(enum BattlerId battler)
 void Controller_WaitForHealthBar(enum BattlerId battler)
 {
     s16 hpValue = MoveBattleBar(battler, gHealthboxSpriteIds[battler], HEALTH_BAR, 0);
+    struct Pokemon *mon = GetBattlerMon(battler);
+    s32 maxHP = GetMonData(mon, MON_DATA_MAX_HP);   
 
     SetHealthboxSpriteVisible(gHealthboxSpriteIds[battler]);
     if (hpValue != -1)
     {
-        UpdateHpTextInHealthbox(gHealthboxSpriteIds[battler], HP_CURRENT, hpValue, gBattleMons[battler].maxHP);
+        UpdateHpTextInHealthbox(gHealthboxSpriteIds[battler], HP_CURRENT, hpValue, maxHP);
     }
     else
     {


### PR DESCRIPTION
# Description
In a link battle, when player 2's pokemon takes damage, `Controller_WaitForHealthBar` previously set the displayed maxHP to 0 in player 2's game because of directly accessing `gBattleMons[battler].maxHP`. This PR fixes it by using `GetBattlerMon` and `GetMonData` to keep correctly displaying the maxHP. 

# Discord contact info
viperio