### PR TITLE
assertf for NULL goto/call

### DIFF
--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -88,10 +88,6 @@ extern const u8 *gStdScripts_End[];
 static void CloseBrailleWindow(void);
 static void DynamicMultichoiceSortList(struct ListMenuItem *items, u32 count);
 
-// This is defined in here so the optimizer can't see its value when compiling
-// script.c.
-void *const gNullScriptPtr = NULL;
-
 static const u8 sScriptConditionTable[6][3] =
 {
 //  <  =  >

--- a/src/script.c
+++ b/src/script.c
@@ -40,7 +40,6 @@ EWRAM_DATA u8 gMsgBoxIsCancelable = FALSE;
 
 extern ScrCmdFunc gScriptCmdTable[];
 extern ScrCmdFunc gScriptCmdTableEnd[];
-extern void *const gNullScriptPtr;
 
 void InitScriptContext(struct ScriptContext *ctx, void *cmdTable, void *cmdTableEnd)
 {
@@ -108,16 +107,10 @@ bool8 RunScriptCommand(struct ScriptContext *ctx)
             u8 cmdCode;
             ScrCmdFunc *func;
 
-            if (!ctx->scriptPtr)
+            if (ctx->scriptPtr == NULL)
             {
                 ctx->mode = SCRIPT_MODE_STOPPED;
                 return FALSE;
-            }
-
-            if (ctx->scriptPtr == gNullScriptPtr)
-            {
-                while (1)
-                    asm("svc 2"); // HALT
             }
 
             cmdCode = *(ctx->scriptPtr);

--- a/src/script.c
+++ b/src/script.c
@@ -83,9 +83,6 @@ void StopScript(struct ScriptContext *ctx)
 
 bool8 RunScriptCommand(struct ScriptContext *ctx)
 {
-    if (ctx->mode == SCRIPT_MODE_STOPPED)
-        return FALSE;
-
     switch (ctx->mode)
     {
     case SCRIPT_MODE_STOPPED:

--- a/src/script.c
+++ b/src/script.c
@@ -156,16 +156,26 @@ static const u8 *ScriptPop(struct ScriptContext *ctx)
 
 void ScriptJump(struct ScriptContext *ctx, const u8 *ptr)
 {
+    assertf(ptr != NULL, "goto to NULL");
     ctx->scriptPtr = ptr;
 }
 
 void ScriptCall(struct ScriptContext *ctx, const u8 *ptr)
 {
+    assertf(ptr != NULL, "call to NULL")
+    {
+        // HINT: Returning without having pushed the current location is
+        // equivalent to branching to a script that just contains
+        // 'return'.
+        return;
+    }
+
     bool32 failed = ScriptPush(ctx, ctx->scriptPtr);
     assertf(!failed, "could not push %p", ptr)
     {
         return;
     }
+
     ctx->scriptPtr = ptr;
 }
 


### PR DESCRIPTION
- `ScriptJump(ctx, NULL)` is currently an `end`: keep this, but show a blue screen.
- `ScriptCall(ctx, NULL)` is currently an `end`: change this to a `return` and show a blue screen.
- `gNullScriptPointer` is unreachable, the earlier `!ctx->scriptPtr` matches `NULL` and `gNullScriptPtr == NULL`.