### PR TITLE
Wrapping and Saturating Arithmetic

### DIFF
--- a/include/global.h
+++ b/include/global.h
@@ -126,10 +126,18 @@
 
 // Macros for checking the joypad
 #define TEST_BUTTON(field, button) ((field) & (button))
-#define JOY_NEW(button) TEST_BUTTON(gMain.newKeys,  button)
-#define JOY_HELD(button)  TEST_BUTTON(gMain.heldKeys, button)
+#define JOY_NEW(button) TEST_BUTTON(gMain.newKeys, button)
+#define JOY_HELD(button) TEST_BUTTON(gMain.heldKeys, button)
 #define JOY_HELD_RAW(button) TEST_BUTTON(gMain.heldKeysRaw, button)
 #define JOY_REPEAT(button) TEST_BUTTON(gMain.newAndRepeatedKeys, button)
+
+// Returns 0 if 'plusButton' and 'minusButton' are in the same state,
+// otherwise returns 1 if 'plusButton' is active or -1 if 'minusButton'
+// is active.
+s32 TestButtonAxis(u32 field, u32 plusButton, u32 minusButton);
+#define JOY_AXIS_NEW(minusButton, plusButton) TestButtonAxis(gMain.newKeys, minusButton, plusButton)
+#define JOY_AXIS_HELD(minusButton, plusButton) TestButtonAxis(gMain.heldKeys, minusButton, plusButton)
+#define JOY_AXIS_REPEAT(minusButton, plusButton) TestButtonAxis(gMain.newAndRepeatedKeys, minusButton, plusButton)
 
 #define S16TOPOSFLOAT(val)   \
 ({                           \

--- a/include/metaprogram.h
+++ b/include/metaprogram.h
@@ -207,4 +207,8 @@ Input must be of the form (upper << lower) where upper can be up to 7, lower up 
 /* Useful for counting arguments */
 #define PLUS_ONE(...) + 1
 
+/* Expands to _default if no arguments, otherwise expands to arguments. */
+#define IF_EMPTY(_default, ...) __VA_OPT__(__VA_ARGS__ IGNORE) (_default)
+#define IGNORE(...)
+
 #endif

--- a/include/util.h
+++ b/include/util.h
@@ -19,5 +19,137 @@ void DoBgAffineSet(struct BgAffineDstData *dest, u32 texX, u32 texY, s16 scrX, s
 void CopySpriteTiles(u8 shape, u8 size, u8 *tiles, u16 *tilemap, u8 *output);
 s32 SubtractClamped(s32 lowestVal, s32 highestVal, s32 currentVal, s32 delta);
 
+/* Clamp(s32 value, s32 min, s32 max)
+ * Clamp(s32 value, s32 min, s32 max, bool32 *clamped)
+ * Clamp(u32 value, u32 min, u32 max)
+ * Clamp(u32 value, u32 min, u32 max, bool32 *clamped)
+ *
+ * If 'value' is between 'min' and 'max' (inclusive), returns 'value'
+ * and sets 'clamped' to 'FALSE'. Otherwise, returns 'min' if
+ * 'value < min' or 'max' if 'value > max' and sets 'clamped' to 'TRUE'. */
+#define Clamp(value, min, max, ...) _Generic(value + min + max, int: ClampS32, s32: ClampS32, u32: ClampU32)(value, min, max, IF_EMPTY(&(bool32){0} __VA_OPT__(, __VA_ARGS__)))
+
+s32 ClampS32(s32 value, s32 min, s32 max, bool32 *clamped);
+u32 ClampU32(u32 value, u32 min, u32 max, bool32 *clamped);
+
+/* If the mathematical result of 'addend1 + addend2' is between 'min'
+ * and 'max' inclusive: 'sum = addend1 + addend2', 'saturated = FALSE'.
+ * Otherwise, if 'addend2 > 0': 'sum = max', 'saturated = TRUE'.
+ * Otherwise, 'addend2 < 0': 'sum = min', 'saturated = TRUE'.
+ *
+ * s32 SatAdd(s32 addend1, s32 addend2, s32 min, s32 max)
+ * s32 SatAdd(s32 addend1, s32 addend2, s32 min, s32 max, bool32 *saturated)
+ * u32 SatAdd(u32 addend1, u32 addend2, u32 min, u32 max)
+ * u32 SatAdd(u32 addend1, u32 addend2, u32 min, u32 max, bool32 *saturated)
+ * Returns 'sum' and stores 'saturated' (if passed).
+ *
+ * bool32 SatAddPtr(s8 *addend1, s32 addend2, s32 min, s32 max)
+ * bool32 SatAddPtr(s16 *addend1, s32 addend2, s32 min, s32 max)
+ * bool32 SatAddPtr(s32 *addend1, s32 addend2, s32 min, s32 max)
+ * bool32 SatAddPtr(u8 *addend1, u32 addend2, u32 min, u32 max)
+ * bool32 SatAddPtr(u16 *addend1, u32 addend2, u32 min, u32 max)
+ * bool32 SatAddPtr(u32 *addend1, u32 addend2, u32 min, u32 max)
+ * Returns 'saturated' and stores 'sum' in 'addend1'.
+ *
+ * Assumes 'min <= addend1 <= max'.
+ *
+ * e.g.
+ *   SatAdd(99, 1, 1, 99) == 99
+ *   SatAdd(95, 10, 1, 99) == 99 */
+#define SatAdd(addend1, addend2, min, max, ...) _Generic(addend1 + addend2 + min + max, int: SatAddS32, s32: SatAddS32, u32: SatAddU32)(addend1, addend2, min, max, IF_EMPTY(&(bool32){0} __VA_OPT__(, __VA_ARGS__)))
+#define SatAddPtr(addend1, addend2, min, max) ({ bool32 saturated; *addend1 = SatAdd(*addend1, addend2, min, max, &saturated); saturated; })
+
+/* If the mathematical result of 'minuend - subtrahend' is between 'min'
+ * and 'max' inclusive: 'difference = minuend - subtrahend', 
+ * 'saturated = FALSE'.
+ * Otherwise, if 'subtrahend > 0', 'difference = min', 'saturated = TRUE'.
+ * Otherwise, 'subtrahend < 0', 'difference = max', 'saturated = TRUE'.
+ *
+ * s32 SatSub(s32 minuend, s32 subtrahend, s32 min, s32 max)
+ * s32 SatSub(s32 minuend, s32 subtrahend, s32 min, s32 max, bool32 *saturated)
+ * u32 SatSub(u32 minuend, u32 subtrahend, u32 min, u32 max)
+ * u32 SatSub(u32 minuend, u32 subtrahend, u32 min, u32 max, bool32 *saturated)
+ * Returns 'difference' and stores 'saturated' (if passed).
+ *
+ * bool32 SatSubPtr(s8 *minuend, s32 subtrahend, s32 min, s32 max)
+ * bool32 SatSubPtr(s16 *minuend, s32 subtrahend, s32 min, s32 max)
+ * bool32 SatSubPtr(s32 *minuend, s32 subtrahend, s32 min, s32 max)
+ * bool32 SatSubPtr(u8 *minuend, u32 subtrahend, u32 min, u32 max)
+ * bool32 SatSubPtr(u16 *minuend, u32 subtrahend, u32 min, u32 max)
+ * bool32 SatSubPtr(u32 *minuend, u32 subtrahend, u32 min, u32 max)
+ * Returns 'saturated' and stores 'difference' in 'minuend'.
+ *
+ * Assumes 'min <= minuend <= max'.
+ *
+ * e.g.
+ *   SatSub(1, 1, 1, 99) == 1
+ *   SatSub(5, 10, 1, 99) == 1 */
+#define SatSub(minuend, subtrahend, min, max, ...) _Generic(minuend + subtrahend + min + max, int: SatSubS32, s32: SatSubS32, u32: SatSubU32)(minuend, subtrahend, min, max, IF_EMPTY(&(bool32){0} __VA_OPT__(, __VA_ARGS__)))
+#define SatSubPtr(minuend, subtrahend, min, max) ({ bool32 saturated; *minuend = SatSub(*minuend, subtrahend, min, max, &saturated); saturated; })
+
+/* If the mathematical result of 'addend1 + addend2' is between 'min'
+ * and 'max' inclusive: 'sum = addend1 + addend2', 'wrapped = FALSE'.
+ * Otherwise, adds or subtracts 'max - min + 1' until 'sum' is in range
+ * and 'wrapped = TRUE'.
+ *
+ * s32 WrapAdd(s32 addend1, s32 addend2, s32 min, s32 max)
+ * s32 WrapAdd(s32 addend1, s32 addend2, s32 min, s32 max, bool32 *wrapped)
+ * u32 WrapAdd(u32 addend1, u32 addend2, u32 min, u32 max)
+ * u32 WrapAdd(u32 addend1, u32 addend2, u32 min, u32 max, bool32 *wrapped)
+ * Returns 'sum' and stores 'wrapped' (if passed).
+ *
+ * bool32 WrapAddPtr(s8 *addend1, s32 addend2, s32 min, s32 max)
+ * bool32 WrapAddPtr(s16 *addend1, s32 addend2, s32 min, s32 max)
+ * bool32 WrapAddPtr(s32 *addend1, s32 addend2, s32 min, s32 max)
+ * bool32 WrapAddPtr(u8 *addend1, u32 addend2, u32 min, u32 max)
+ * bool32 WrapAddPtr(u16 *addend1, u32 addend2, u32 min, u32 max)
+ * bool32 WrapAddPtr(u32 *addend1, u32 addend2, u32 min, u32 max)
+ * Returns 'wrapped' and stores 'sum' in 'addend1'.
+ *
+ * Assumes 'min <= addend1 <= max'.
+ *
+ * e.g.
+ *   WrapAdd(99, 1, 1, 99) == 1
+ *   WrapAdd(95, 10, 1, 99) == 6 */
+#define WrapAdd(addend1, addend2, min, max, ...) _Generic(addend1 + addend2 + min + max, int: WrapAddS32, s32: WrapAddS32, u32: WrapAddU32)(addend1, addend2, min, max, IF_EMPTY(&(bool32){0} __VA_OPT__(, __VA_ARGS__)))
+#define WrapAddPtr(addend1, addend2, min, max) ({ bool32 wrapped; *addend1 = WrapAdd(*addend1, addend2, min, max, &wrapped); wrapped; })
+
+/* If the mathematical result of 'minuend - subtrahend' is between 'min'
+ * and 'max' inclusive: 'difference = minuend - subtrahend',
+ * 'wrapped = FALSE'.
+ * Otherwise, adds or subtracts 'max - min + 1' until 'difference' is in
+ * range and 'wrapped = TRUE'.
+ *
+ * s32 WrapSub(s32 minuend, s32 subtrahend, s32 min, s32 max)
+ * s32 WrapSub(s32 minuend, s32 subtrahend, s32 min, s32 max, bool32 *wrapped)
+ * u32 WrapSub(u32 minuend, u32 subtrahend, u32 min, u32 max)
+ * u32 WrapSub(u32 minuend, u32 subtrahend, u32 min, u32 max, bool32 *wrapped)
+ * Returns 'difference' and stores 'wrapped' (if passed).
+ *
+ * bool32 WrapSubPtr(s8 *minuend, s32 subtrahend, s32 min, s32 max)
+ * bool32 WrapSubPtr(s16 *minuend, s32 subtrahend, s32 min, s32 max)
+ * bool32 WrapSubPtr(s32 *minuend, s32 subtrahend, s32 min, s32 max)
+ * bool32 WrapSubPtr(u8 *minuend, u32 subtrahend, u32 min, u32 max)
+ * bool32 WrapSubPtr(u16 *minuend, u32 subtrahend, u32 min, u32 max)
+ * bool32 WrapSubPtr(u32 *minuend, u32 subtrahend, u32 min, u32 max)
+ * Returns 'wrapped' and stores 'difference' in 'minuend'.
+ *
+ * Assumes 'min <= minuend <= max'.
+ *
+ * e.g.
+ *   WrapSub(1, 1, 1, 99) == 99
+ *   WrapSub(5, 10, 1, 99) == 94 */
+#define WrapSub(minuend, subtrahend, min, max, ...) _Generic(minuend + subtrahend + min + max, int: WrapSubS32, s32: WrapSubS32, u32: WrapSubU32)(minuend, subtrahend, min, max, IF_EMPTY(&(bool32){0} __VA_OPT__(, __VA_ARGS__)))
+#define WrapSubPtr(minuend, subtrahend, min, max) ({ bool32 wrapped; *minuend = WrapSub(*minuend, subtrahend, min, max, &wrapped); wrapped; })
+
+s32 SatAddS32(s32 addend1, s32 addend2, s32 min, s32 max, bool32 *saturated);
+s32 SatSubS32(s32 minuend, s32 subtrahend, s32 min, s32 max, bool32 *saturated);
+s32 WrapAddS32(s32 addend1, s32 addend2, s32 min, s32 max, bool32 *wrapped);
+s32 WrapSubS32(s32 minuend, s32 subtrahend, s32 min, s32 max, bool32 *wrapped);
+
+u32 SatAddU32(u32 addend1, u32 addend2, u32 min, u32 max, bool32 *saturated);
+u32 SatSubU32(u32 minuend, u32 subtrahend, u32 min, u32 max, bool32 *saturated);
+u32 WrapAddU32(u32 addend1, u32 addend2, u32 min, u32 max, bool32 *wrapped);
+u32 WrapSubU32(u32 minuend, u32 subtrahend, u32 min, u32 max, bool32 *wrapped);
 
 #endif // GUARD_UTIL_H

--- a/include/util.h
+++ b/include/util.h
@@ -17,7 +17,6 @@ u32 CalcByteArraySum(const u8 *data, u32 length);
 void BlendPalette(u16 palOffset, u16 numEntries, u8 coeff, u32 blendColor);
 void DoBgAffineSet(struct BgAffineDstData *dest, u32 texX, u32 texY, s16 scrX, s16 scrY, s16 sx, s16 sy, u16 alpha);
 void CopySpriteTiles(u8 shape, u8 size, u8 *tiles, u16 *tilemap, u8 *output);
-s32 SubtractClamped(s32 lowestVal, s32 highestVal, s32 currentVal, s32 delta);
 
 /* Clamp(s32 value, s32 min, s32 max)
  * Clamp(s32 value, s32 min, s32 max, bool32 *clamped)

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -195,37 +195,19 @@ static void CompleteOnBattlerSpritePosX_0(enum BattlerId battler)
         BtlController_Complete(battler);
 }
 
-static u16 GetPrevBall(u16 ballId)
+static enum Item GetNextBall(enum Item ballId, s32 direction)
 {
-    s32 i;
     s32 index = ItemIdToBallId(ballId);
-    u32 newBall = 0;
-     for (i = 0; i < POKEBALL_COUNT; i++)
-    {
-        index--;
-        if (index == -1)
-            index = POKEBALL_COUNT - 1;
-        newBall = gPokeBalls[index].itemId;
-        if (CheckBagHasItem(newBall, 1))
-            return newBall;
-    }
-    return ballId;
-}
+    enum Item newBall = ITEM_NONE;
 
-static u32 GetNextBall(u32 ballId)
-{
-    s32 i;
-    s32 index = ItemIdToBallId(ballId);
-    u32 newBall = 0;
-    for (i = 0; i < POKEBALL_COUNT; i++)
+    for (s32 i = 0; i < POKEBALL_COUNT; i++)
     {
-        index++;
-        if (index == POKEBALL_COUNT)
-            index = 0;
+        WrapAddPtr(&index, direction, 0, POKEBALL_COUNT - 1);
         newBall = gPokeBalls[index].itemId;
         if (CheckBagHasItem(newBall, 1))
             return newBall;
     }
+
     return ballId;
 }
 
@@ -257,27 +239,16 @@ static void HandleInputChooseAction(enum BattlerId battler)
 
         if (gBattleStruct->ackBallUseBtn)
         {
-            if (JOY_HELD(B_LAST_USED_BALL_BUTTON) && (JOY_NEW(DPAD_DOWN) || JOY_NEW(DPAD_RIGHT)))
+            s32 delta = JOY_AXIS_NEW(DPAD_UP | DPAD_LEFT, DPAD_DOWN | DPAD_RIGHT);
+            if (JOY_HELD(B_LAST_USED_BALL_BUTTON) && delta != 0)
             {
                 bool32 sameBall = FALSE;
-                u32 nextBall = GetNextBall(gBallToDisplay);
+                enum Item nextBall = GetNextBall(gBallToDisplay, delta);
                 gBattleStruct->ballSwapped = TRUE;
                 if (gBallToDisplay == nextBall)
                     sameBall = TRUE;
                 else
                     gBallToDisplay = nextBall;
-                SwapBallToDisplay(sameBall);
-                PlaySE(SE_SELECT);
-            }
-            else if (JOY_HELD(B_LAST_USED_BALL_BUTTON) && (JOY_NEW(DPAD_UP) || JOY_NEW(DPAD_LEFT)))
-            {
-                bool32 sameBall = FALSE;
-                u32 prevBall = GetPrevBall(gBallToDisplay);
-                gBattleStruct->ballSwapped = TRUE;
-                if (gBallToDisplay == prevBall)
-                    sameBall = TRUE;
-                else
-                    gBallToDisplay = prevBall;
                 SwapBallToDisplay(sameBall);
                 PlaySE(SE_SELECT);
             }

--- a/src/battle_debug.c
+++ b/src/battle_debug.c
@@ -44,8 +44,8 @@ struct BattleDebugModifyArrows
     u16 minValue;
     u16 maxValue;
     int currValue;
-    u8 currentDigit:4;
-    u8 maxDigits:4;
+    u8 currentDigit;
+    u8 maxDigits;
     u8 charDigits[MAX_MODIFY_DIGITS];
     void *modifiedValPtr;
     u8 typeOfVal;
@@ -613,7 +613,7 @@ static void UpdateMonData(struct BattleDebugMenu *data);
 static void ChangeHazardsValue(struct BattleDebugMenu *data);
 static u32 GetHazardsValue(struct BattleDebugMenu *data);
 static u16 *GetSideStatusValue(struct BattleDebugMenu *data, bool32 changeStatus, bool32 statusTrue);
-static bool32 TryMoveDigit(struct BattleDebugModifyArrows *modArrows, bool32 moveUp);
+static bool32 TryMoveDigit(struct BattleDebugModifyArrows *modArrows, s32 delta);
 static void SwitchToDebugView(u8 taskId);
 static void SwitchToDebugViewFromAiParty(u8 taskId);
 
@@ -1246,6 +1246,7 @@ static void Task_DebugMenuProcessInput(u8 taskId)
     // Handle value modifying.
     else if (data->activeWindow == ACTIVE_WIN_MODIFY)
     {
+        s32 delta;
         if (JOY_NEW(B_BUTTON | A_BUTTON))
         {
             ClearStdWindowAndFrameToTransparent(data->modifyWindowId, TRUE);
@@ -1253,36 +1254,15 @@ static void Task_DebugMenuProcessInput(u8 taskId)
             DestroyModifyArrows(data);
             data->activeWindow = ACTIVE_WIN_SECONDARY;
         }
-        else if (JOY_NEW(DPAD_RIGHT))
+        else if ((delta = JOY_AXIS_NEW(DPAD_LEFT, DPAD_RIGHT)) != 0)
         {
-            if (data->modifyArrows.currentDigit != (data->modifyArrows.maxDigits - 1))
-            {
-                data->modifyArrows.currentDigit++;
-                gSprites[data->modifyArrows.arrowSpriteId[0]].x2 += 6;
-                gSprites[data->modifyArrows.arrowSpriteId[1]].x2 += 6;
-            }
+            SatAddPtr(&data->modifyArrows.currentDigit, delta, 0, data->modifyArrows.maxDigits - 1);
+            gSprites[data->modifyArrows.arrowSpriteId[0]].x2 = data->modifyArrows.currentDigit * 6;
+            gSprites[data->modifyArrows.arrowSpriteId[1]].x2 = data->modifyArrows.currentDigit * 6;
         }
-        else if (JOY_NEW(DPAD_LEFT))
+        else if ((delta = JOY_AXIS_NEW(DPAD_UP, DPAD_DOWN)) != 0)
         {
-            if (data->modifyArrows.currentDigit != 0)
-            {
-                data->modifyArrows.currentDigit--;
-                gSprites[data->modifyArrows.arrowSpriteId[0]].x2 -= 6;
-                gSprites[data->modifyArrows.arrowSpriteId[1]].x2 -= 6;
-            }
-        }
-        else if (JOY_NEW(DPAD_UP))
-        {
-            if (TryMoveDigit(&data->modifyArrows, TRUE))
-            {
-                PrintDigitChars(data);
-                UpdateBattlerValue(data);
-                PrintSecondaryEntries(data);
-            }
-        }
-        else if (JOY_NEW(DPAD_DOWN))
-        {
-            if (TryMoveDigit(&data->modifyArrows, FALSE))
+            if (TryMoveDigit(&data->modifyArrows, delta))
             {
                 PrintDigitChars(data);
                 UpdateBattlerValue(data);
@@ -2071,7 +2051,7 @@ static void SetUpModifyArrows(struct BattleDebugMenu *data)
     ValueToCharDigits(data->modifyArrows.charDigits, data->modifyArrows.currValue, data->modifyArrows.maxDigits);
 }
 
-static bool32 TryMoveDigit(struct BattleDebugModifyArrows *modArrows, bool32 moveUp)
+static bool32 TryMoveDigit(struct BattleDebugModifyArrows *modArrows, s32 delta)
 {
     s32 i;
     u8 charDigits[MAX_MODIFY_DIGITS];
@@ -2080,7 +2060,7 @@ static bool32 TryMoveDigit(struct BattleDebugModifyArrows *modArrows, bool32 mov
     for (i = 0; i < MAX_MODIFY_DIGITS; i++)
         charDigits[i] = modArrows->charDigits[i];
 
-    if (moveUp)
+    if (delta < 0)
     {
         if (charDigits[modArrows->currentDigit] == CHAR_9)
         {

--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -2189,7 +2189,7 @@ static s32 CalcNewBarValue(s32 maxValue, s32 oldValue, s32 receivedValue, s32 *c
             *currValue = oldValue;
     }
 
-    newValue = SubtractClamped(HP_EMPTY, maxValue, oldValue, receivedValue);
+    newValue = SatSub(oldValue, receivedValue, HP_EMPTY, maxValue);
     if (maxValue < scale)
     {
         if (newValue == Q_24_8_TO_INT(*currValue) && (*currValue & 0xFF) == 0)
@@ -2255,7 +2255,7 @@ static u8 CalcBarFilledPixels(s32 maxValue, s32 oldValue, s32 receivedValue, s32
     u8 pixels, filledPixels, totalPixels;
     u8 i;
 
-    s32 newValue = SubtractClamped(HP_EMPTY, maxValue, oldValue, receivedValue);
+    s32 newValue = SatSub(oldValue, receivedValue, HP_EMPTY, maxValue);
     totalPixels = scale * 8;
 
     for (i = 0; i < scale; i++)
@@ -2300,7 +2300,7 @@ static u8 GetScaledExpFraction(s32 oldValue, s32 receivedValue, s32 maxValue, u8
     s8 oldToMax, newToMax;
 
     scale *= (B_FAST_EXP_GROW) ? 2 : 8;
-    newVal = SubtractClamped(HP_EMPTY, maxValue, oldValue, receivedValue);
+    newVal = SatSub(oldValue, receivedValue, HP_EMPTY, maxValue);
 
     oldToMax = oldValue * scale / maxValue;
     newToMax = newVal * scale / maxValue;

--- a/src/debug.c
+++ b/src/debug.c
@@ -51,6 +51,7 @@
 #include "string_util.h"
 #include "task.h"
 #include "tv.h"
+#include "util.h"
 #include "pokemon_summary_screen.h"
 #include "wild_encounter.h"
 #include "constants/abilities.h"
@@ -1051,28 +1052,11 @@ static void Debug_DestroyMenu_Full_Script(u8 taskId, const u8 *script)
 
 static void Debug_HandleInput_Numeric(u8 taskId, s32 min, s32 max, u32 digits)
 {
-    if (JOY_NEW(DPAD_UP))
-    {
-        gTasks[taskId].tInput += sPowersOfTen[gTasks[taskId].tDigit];
-        if (gTasks[taskId].tInput > max)
-            gTasks[taskId].tInput = max;
-    }
-    if (JOY_NEW(DPAD_DOWN))
-    {
-        gTasks[taskId].tInput -= sPowersOfTen[gTasks[taskId].tDigit];
-        if (gTasks[taskId].tInput < min)
-            gTasks[taskId].tInput = min;
-    }
-    if (JOY_NEW(DPAD_LEFT))
-    {
-        if (gTasks[taskId].tDigit > 0)
-            gTasks[taskId].tDigit -= 1;
-    }
-    if (JOY_NEW(DPAD_RIGHT))
-    {
-        if (gTasks[taskId].tDigit < digits - 1)
-            gTasks[taskId].tDigit += 1;
-    }
+    s32 delta;
+    if ((delta = JOY_AXIS_NEW(DPAD_DOWN, DPAD_UP)) != 0)
+        SatAddPtr(&gTasks[taskId].tInput, delta * sPowersOfTen[gTasks[taskId].tDigit], min, max);
+    if ((delta = JOY_AXIS_NEW(DPAD_LEFT, DPAD_RIGHT)) != 0)
+        SatAddPtr(&gTasks[taskId].tDigit, delta, 0, digits - 1);
 }
 
 enum SongType { SONG_SE, SONG_MUS };

--- a/src/main.c
+++ b/src/main.c
@@ -467,3 +467,11 @@ void ClearPokemonCrySongs(void)
 {
     CpuFill16(0, gPokemonCrySongs, MAX_POKEMON_CRIES * sizeof(struct PokemonCrySong));
 }
+
+s32 TestButtonAxis(u32 field, u32 minusButton, u32 plusButton)
+{
+    s32 result = 0;
+    if (field & minusButton) result -= 1;
+    if (field & plusButton) result += 1;
+    return result;
+}

--- a/src/menu.c
+++ b/src/menu.c
@@ -24,6 +24,7 @@
 #include "script.h"
 #include "task.h"
 #include "text_window.h"
+#include "util.h"
 #include "window.h"
 #include "constants/songs.h"
 
@@ -704,15 +705,7 @@ void RedrawMenuCursor(u8 oldPos, u8 newPos)
 u8 Menu_MoveCursor(s8 cursorDelta)
 {
     u8 oldPos = sMenu.cursorPos;
-    int newPos = sMenu.cursorPos + cursorDelta;
-
-    if (newPos < sMenu.minCursorPos)
-        sMenu.cursorPos = sMenu.maxCursorPos;
-    else if (newPos > sMenu.maxCursorPos)
-        sMenu.cursorPos = sMenu.minCursorPos;
-    else
-        sMenu.cursorPos += cursorDelta;
-
+    sMenu.cursorPos = WrapAdd(sMenu.cursorPos, cursorDelta, sMenu.minCursorPos, sMenu.maxCursorPos);
     RedrawMenuCursor(oldPos, sMenu.cursorPos);
     return sMenu.cursorPos;
 }
@@ -720,15 +713,7 @@ u8 Menu_MoveCursor(s8 cursorDelta)
 u8 Menu_MoveCursorNoWrapAround(s8 cursorDelta)
 {
     u8 oldPos = sMenu.cursorPos;
-    int newPos = sMenu.cursorPos + cursorDelta;
-
-    if (newPos < sMenu.minCursorPos)
-        sMenu.cursorPos = sMenu.minCursorPos;
-    else if (newPos > sMenu.maxCursorPos)
-        sMenu.cursorPos = sMenu.maxCursorPos;
-    else
-        sMenu.cursorPos += cursorDelta;
-
+    sMenu.cursorPos = SatAdd(sMenu.cursorPos, cursorDelta, sMenu.minCursorPos, sMenu.maxCursorPos);
     RedrawMenuCursor(oldPos, sMenu.cursorPos);
     return sMenu.cursorPos;
 }
@@ -740,6 +725,7 @@ u8 Menu_GetCursorPos(void)
 
 s8 Menu_ProcessInput(void)
 {
+    s32 delta;
     if (JOY_NEW(A_BUTTON))
     {
         if (!sMenu.APressMuted)
@@ -750,16 +736,10 @@ s8 Menu_ProcessInput(void)
     {
         return MENU_B_PRESSED;
     }
-    else if (JOY_NEW(DPAD_UP))
+    else if ((delta = JOY_AXIS_NEW(DPAD_UP, DPAD_DOWN)) != 0)
     {
         PlaySE(SE_SELECT);
-        Menu_MoveCursor(-1);
-        return MENU_NOTHING_CHOSEN;
-    }
-    else if (JOY_NEW(DPAD_DOWN))
-    {
-        PlaySE(SE_SELECT);
-        Menu_MoveCursor(1);
+        Menu_MoveCursor(delta);
         return MENU_NOTHING_CHOSEN;
     }
 
@@ -768,6 +748,7 @@ s8 Menu_ProcessInput(void)
 
 s8 Menu_ProcessInputNoWrap(void)
 {
+    s32 delta;
     u8 oldPos = sMenu.cursorPos;
 
     if (JOY_NEW(A_BUTTON))
@@ -780,15 +761,9 @@ s8 Menu_ProcessInputNoWrap(void)
     {
         return MENU_B_PRESSED;
     }
-    else if (JOY_NEW(DPAD_UP))
+    else if ((delta = JOY_AXIS_NEW(DPAD_UP, DPAD_DOWN)) != 0)
     {
-        if (oldPos != Menu_MoveCursorNoWrapAround(-1))
-            PlaySE(SE_SELECT);
-        return MENU_NOTHING_CHOSEN;
-    }
-    else if (JOY_NEW(DPAD_DOWN))
-    {
-        if (oldPos != Menu_MoveCursorNoWrapAround(1))
+        if (oldPos != Menu_MoveCursorNoWrapAround(delta))
             PlaySE(SE_SELECT);
         return MENU_NOTHING_CHOSEN;
     }
@@ -1194,6 +1169,7 @@ static s8 UNUSED Menu_ProcessGridInput_NoSoundLimit(void)
 
 s8 Menu_ProcessGridInput(void)
 {
+    s32 delta;
     u8 oldPos = sMenu.cursorPos;
 
     if (JOY_NEW(A_BUTTON))
@@ -1205,15 +1181,9 @@ s8 Menu_ProcessGridInput(void)
     {
         return MENU_B_PRESSED;
     }
-    else if (JOY_NEW(DPAD_UP))
+    else if ((delta = JOY_AXIS_NEW(DPAD_UP, DPAD_DOWN)) != 0)
     {
-        if (oldPos != ChangeGridMenuCursorPosition(0, -1))
-            PlaySE(SE_SELECT);
-        return MENU_NOTHING_CHOSEN;
-    }
-    else if (JOY_NEW(DPAD_DOWN))
-    {
-        if (oldPos != ChangeGridMenuCursorPosition(0, 1))
+        if (oldPos != ChangeGridMenuCursorPosition(0, delta))
             PlaySE(SE_SELECT);
         return MENU_NOTHING_CHOSEN;
     }

--- a/src/option_menu.c
+++ b/src/option_menu.c
@@ -12,6 +12,7 @@
 #include "task.h"
 #include "text.h"
 #include "text_window.h"
+#include "util.h"
 #include "window.h"
 #include "gba/m4a_internal.h"
 #include "constants/rgb.h"
@@ -279,6 +280,7 @@ static void Task_OptionMenuFadeIn(u8 taskId)
 
 static void Task_OptionMenuProcessInput(u8 taskId)
 {
+    s32 delta;
     if (JOY_NEW(A_BUTTON))
     {
         if (gTasks[taskId].tMenuSelection == MENUITEM_CANCEL)
@@ -288,20 +290,9 @@ static void Task_OptionMenuProcessInput(u8 taskId)
     {
         gTasks[taskId].func = Task_OptionMenuSave;
     }
-    else if (JOY_NEW(DPAD_UP))
+    else if ((delta = JOY_AXIS_NEW(DPAD_UP, DPAD_DOWN)) != 0)
     {
-        if (gTasks[taskId].tMenuSelection > 0)
-            gTasks[taskId].tMenuSelection--;
-        else
-            gTasks[taskId].tMenuSelection = MENUITEM_CANCEL;
-        HighlightOptionMenuItem(gTasks[taskId].tMenuSelection);
-    }
-    else if (JOY_NEW(DPAD_DOWN))
-    {
-        if (gTasks[taskId].tMenuSelection < MENUITEM_CANCEL)
-            gTasks[taskId].tMenuSelection++;
-        else
-            gTasks[taskId].tMenuSelection = 0;
+        WrapAddPtr(&gTasks[taskId].tMenuSelection, delta, 0, MENUITEM_CANCEL);
         HighlightOptionMenuItem(gTasks[taskId].tMenuSelection);
     }
     else
@@ -413,22 +404,10 @@ static void DrawOptionMenuChoice(const u8 *text, u8 x, u8 y, u8 style)
 
 static u8 TextSpeed_ProcessInput(u8 selection)
 {
-    if (JOY_NEW(DPAD_RIGHT))
+    s32 delta;
+    if ((delta = JOY_AXIS_NEW(DPAD_LEFT, DPAD_RIGHT)) != 0)
     {
-        if (selection <= 1)
-            selection++;
-        else
-            selection = 0;
-
-        sArrowPressed = TRUE;
-    }
-    if (JOY_NEW(DPAD_LEFT))
-    {
-        if (selection != 0)
-            selection--;
-        else
-            selection = 2;
-
+        WrapAddPtr(&selection, delta, OPTIONS_TEXT_SPEED_SLOW, OPTIONS_TEXT_SPEED_FAST);
         sArrowPressed = TRUE;
     }
     return selection;
@@ -529,24 +508,10 @@ static void Sound_DrawChoices(u8 selection)
 
 static u8 FrameType_ProcessInput(u8 selection)
 {
-    if (JOY_NEW(DPAD_RIGHT))
+    s32 delta;
+    if ((delta = JOY_AXIS_NEW(DPAD_LEFT, DPAD_RIGHT)) != 0)
     {
-        if (selection < WINDOW_FRAMES_COUNT - 1)
-            selection++;
-        else
-            selection = 0;
-
-        LoadBgTiles(1, GetWindowFrameTilesPal(selection)->tiles, 0x120, 0x1A2);
-        LoadPalette(GetWindowFrameTilesPal(selection)->pal, BG_PLTT_ID(7), PLTT_SIZE_4BPP);
-        sArrowPressed = TRUE;
-    }
-    if (JOY_NEW(DPAD_LEFT))
-    {
-        if (selection != 0)
-            selection--;
-        else
-            selection = WINDOW_FRAMES_COUNT - 1;
-
+        WrapAddPtr(&selection, delta, 0, WINDOW_FRAMES_COUNT - 1);
         LoadBgTiles(1, GetWindowFrameTilesPal(selection)->tiles, 0x120, 0x1A2);
         LoadPalette(GetWindowFrameTilesPal(selection)->pal, BG_PLTT_ID(7), PLTT_SIZE_4BPP);
         sArrowPressed = TRUE;
@@ -587,22 +552,10 @@ static void FrameType_DrawChoices(u8 selection)
 
 static u8 ButtonMode_ProcessInput(u8 selection)
 {
-    if (JOY_NEW(DPAD_RIGHT))
+    s32 delta;
+    if ((delta = JOY_AXIS_NEW(DPAD_LEFT, DPAD_RIGHT)) != 0)
     {
-        if (selection <= 1)
-            selection++;
-        else
-            selection = 0;
-
-        sArrowPressed = TRUE;
-    }
-    if (JOY_NEW(DPAD_LEFT))
-    {
-        if (selection != 0)
-            selection--;
-        else
-            selection = 2;
-
+        WrapAddPtr(&selection, delta, 0, 2);
         sArrowPressed = TRUE;
     }
     return selection;

--- a/src/util.c
+++ b/src/util.c
@@ -239,17 +239,6 @@ void BlendPalette(u16 palOffset, u16 numEntries, u8 coeff, u32 blendColor)
     }
 }
 
-s32 SubtractClamped(s32 lowestVal, s32 highestVal, s32 currentVal, s32 delta)
-{
-    s32 newValue = currentVal - delta;
-    if (newValue > highestVal)
-        newValue = highestVal;
-    else if (newValue < lowestVal)
-        newValue = lowestVal;
-
-    return newValue;
-}
-
 s32 ClampS32(s32 value, s32 min, s32 max, bool32 *clamped)
 {
     if (min <= value && value <= max)

--- a/src/util.c
+++ b/src/util.c
@@ -249,3 +249,173 @@ s32 SubtractClamped(s32 lowestVal, s32 highestVal, s32 currentVal, s32 delta)
 
     return newValue;
 }
+
+s32 ClampS32(s32 value, s32 min, s32 max, bool32 *clamped)
+{
+    if (min <= value && value <= max)
+    {
+        *clamped = FALSE;
+        return value;
+    }
+    else
+    {
+        *clamped = TRUE;
+        return min > value ? min : max;
+    }
+}
+
+u32 ClampU32(u32 value, u32 min, u32 max, bool32 *clamped)
+{
+    if (min <= value && value <= max)
+    {
+        *clamped = FALSE;
+        return value;
+    }
+    else
+    {
+        *clamped = TRUE;
+        return min > value ? min : max;
+    }
+}
+
+s32 SatAddS32(s32 addend1, s32 addend2, s32 min, s32 max, bool32 *saturated)
+{
+    s32 sum;
+    if (!__builtin_add_overflow(addend1, addend2, &sum) && min <= sum && sum <= max)
+    {
+        *saturated = FALSE;
+        return sum;
+    }
+    else
+    {
+        *saturated = TRUE;
+        return addend2 >= 0 ? max : min;
+    }
+}
+
+s32 SatSubS32(s32 minuend, s32 subtrahend, s32 min, s32 max, bool32 *saturated)
+{
+    s32 difference;
+    if (!__builtin_sub_overflow(minuend, subtrahend, &difference) && min <= difference && difference <= max)
+    {
+        *saturated = FALSE;
+        return difference;
+    }
+    else
+    {
+        *saturated = TRUE;
+        return subtrahend >= 0 ? min : max;
+    }
+}
+
+s32 WrapAddS32(s32 addend1, s32 addend2, s32 min, s32 max, bool32 *wrapped)
+{
+    s32 sum;
+    if (!__builtin_add_overflow(addend1, addend2, &sum) && min <= sum && sum <= max)
+    {
+        *wrapped = FALSE;
+        return sum;
+    }
+    else
+    {
+        // TODO: Compute directly rather than via biased unsigned.
+        static const u32 BIAS = 0x80000000;
+        u32 baddend1 = (u32)addend1 + BIAS;
+        u32 bmin = (u32)min + BIAS;
+        u32 bmax = (u32)max + BIAS;
+        u32 bresult;
+        if (addend2 >= 0)
+            bresult = WrapAddU32(baddend1, addend2, bmin, bmax, wrapped);
+        else
+            bresult = WrapSubU32(baddend1, -(u32)addend2, bmin, bmax, wrapped);
+        return (s32)(bresult - BIAS);
+    }
+}
+
+s32 WrapSubS32(s32 minuend, s32 subtrahend, s32 min, s32 max, bool32 *wrapped)
+{
+    s32 difference;
+    if (!__builtin_sub_overflow(minuend, subtrahend, &difference) && min <= difference && difference <= max)
+    {
+        *wrapped = FALSE;
+        return difference;
+    }
+    else
+    {
+        // TODO: Compute directly rather than via biased unsigned.
+        static const u32 BIAS = 0x80000000;
+        u32 bminuend = (u32)minuend + BIAS;
+        u32 bmin = (u32)min + BIAS;
+        u32 bmax = (u32)max + BIAS;
+        u32 bresult;
+        if (subtrahend >= 0)
+            bresult = WrapSubU32(bminuend, subtrahend, bmin, bmax, wrapped);
+        else
+            bresult = WrapAddU32(bminuend, -(u32)subtrahend, bmin, bmax, wrapped);
+        return (s32)(bresult - BIAS);
+    }
+}
+
+u32 SatAddU32(u32 addend1, u32 addend2, u32 min, u32 max, bool32 *saturated)
+{
+    u32 sum;
+    if (!__builtin_add_overflow(addend1, addend2, &sum) && sum <= max)
+    {
+        *saturated = FALSE;
+        return sum;
+    }
+    else
+    {
+        *saturated = TRUE;
+        return max;
+    }
+}
+
+u32 SatSubU32(u32 minuend, u32 subtrahend, u32 min, u32 max, bool32 *saturated)
+{
+    u32 difference;
+    if (!__builtin_sub_overflow(minuend, subtrahend, &difference) && min <= difference)
+    {
+        *saturated = FALSE;
+        return difference;
+    }
+    else
+    {
+        *saturated = TRUE;
+        return min;
+    }
+}
+
+u32 WrapAddU32(u32 addend1, u32 addend2, u32 min, u32 max, bool32 *wrapped)
+{
+    u32 sum;
+    if (!__builtin_add_overflow(addend1, addend2, &sum) && sum <= max)
+    {
+        *wrapped = FALSE;
+        return sum;
+    }
+    else
+    {
+        *wrapped = TRUE;
+        if (max - min != UINT32_MAX)
+            addend2 %= max - min + 1;
+        return min + (addend2 - (max - addend1 + 1));
+    }
+}
+
+u32 WrapSubU32(u32 minuend, u32 subtrahend, u32 min, u32 max, bool32 *wrapped)
+{
+    u32 difference;
+    if (!__builtin_sub_overflow(minuend, subtrahend, &difference) && min <= difference)
+    {
+        *wrapped = FALSE;
+        return difference;
+    }
+    else
+    {
+        *wrapped = TRUE;
+        if (max - min != UINT32_MAX)
+            subtrahend %= max - min + 1;
+        return max - (subtrahend - (minuend - min + 1));
+    }
+}

--- a/test/util.c
+++ b/test/util.c
@@ -1,0 +1,275 @@
+#include "global.h"
+#include "test/test.h"
+#include "util.h"
+
+TEST("SatAddS32")
+{
+    s32 addend1, addend2, min, max;
+    s32 expectedResult, actualResult;
+    bool32 expectedSaturated, actualSaturated;
+
+    // No saturation.
+    PARAMETRIZE { addend1 = 9; addend2 = 0; min = 1; max = 9; expectedResult = 9; expectedSaturated = FALSE; }
+    PARAMETRIZE { addend1 = 8; addend2 = 1; min = 1; max = 9; expectedResult = 9; expectedSaturated = FALSE; }
+    PARAMETRIZE { addend1 = 9; addend2 = -1; min = 1; max = 9; expectedResult = 8; expectedSaturated = FALSE; }
+
+    // Saturate.
+    PARAMETRIZE { addend1 = 9; addend2 = 1; min = 1; max = 9; expectedResult = 9; expectedSaturated = TRUE; }
+    PARAMETRIZE { addend1 = 9; addend2 = 2; min = 1; max = 9; expectedResult = 9; expectedSaturated = TRUE; }
+    PARAMETRIZE { addend1 = 9; addend2 = 10; min = 1; max = 9; expectedResult = 9; expectedSaturated = TRUE; }
+    PARAMETRIZE { addend1 = 9; addend2 = INT32_MAX; min = 1; max = 9; expectedResult = 9; expectedSaturated = TRUE; }
+    PARAMETRIZE { addend1 = 9; addend2 = -10; min = 1; max = 9; expectedResult = 1; expectedSaturated = TRUE; }
+    PARAMETRIZE { addend1 = 9; addend2 = -20; min = 1; max = 9; expectedResult = 1; expectedSaturated = TRUE; }
+    PARAMETRIZE { addend1 = 9; addend2 = INT32_MIN; min = 1; max = 9; expectedResult = 1; expectedSaturated = TRUE; }
+
+    actualResult = SatAdd(addend1, addend2, min, max, &actualSaturated);
+    EXPECT_EQ(expectedResult, actualResult);
+    EXPECT_EQ(expectedSaturated, actualSaturated);
+
+    actualSaturated = SatAddPtr(&addend1, addend2, min, max);
+    EXPECT_EQ(expectedResult, addend1);
+    EXPECT_EQ(expectedSaturated, actualSaturated);
+}
+
+TEST("SatSubS32")
+{
+    s32 minuend, subtrahend, min, max;
+    s32 expectedResult, actualResult;
+    bool32 expectedSaturated, actualSaturated;
+
+    // No saturation.
+    PARAMETRIZE { minuend = 9; subtrahend = 0; min = 1; max = 9; expectedResult = 9; expectedSaturated = FALSE; }
+    PARAMETRIZE { minuend = 8; subtrahend = -1; min = 1; max = 9; expectedResult = 9; expectedSaturated = FALSE; }
+    PARAMETRIZE { minuend = 9; subtrahend = 1; min = 1; max = 9; expectedResult = 8; expectedSaturated = FALSE; }
+
+    // Saturate.
+    PARAMETRIZE { minuend = 1; subtrahend = 1; min = 1; max = 9; expectedResult = 1; expectedSaturated = TRUE; }
+    PARAMETRIZE { minuend = 1; subtrahend = 2; min = 1; max = 9; expectedResult = 1; expectedSaturated = TRUE; }
+    PARAMETRIZE { minuend = 1; subtrahend = 10; min = 1; max = 9; expectedResult = 1; expectedSaturated = TRUE; }
+    PARAMETRIZE { minuend = 1; subtrahend = INT32_MAX; min = 1; max = 9; expectedResult = 1; expectedSaturated = TRUE; }
+    PARAMETRIZE { minuend = 1; subtrahend = -10; min = 1; max = 9; expectedResult = 9; expectedSaturated = TRUE; }
+    PARAMETRIZE { minuend = 1; subtrahend = -20; min = 1; max = 9; expectedResult = 9; expectedSaturated = TRUE; }
+    PARAMETRIZE { minuend = 1; subtrahend = INT32_MIN; min = 1; max = 9; expectedResult = 9; expectedSaturated = TRUE; }
+
+    actualResult = SatSub(minuend, subtrahend, min, max, &actualSaturated);
+    EXPECT_EQ(expectedResult, actualResult);
+    EXPECT_EQ(expectedSaturated, actualSaturated);
+
+    actualSaturated = SatSubPtr(&minuend, subtrahend, min, max);
+    EXPECT_EQ(expectedResult, minuend);
+    EXPECT_EQ(expectedSaturated, actualSaturated);
+}
+
+TEST("WrapAddS32")
+{
+    s32 addend1, addend2, min, max;
+    s32 expectedResult, actualResult;
+    bool32 expectedWrapped, actualWrapped;
+
+    // No wrap.
+    PARAMETRIZE { addend1 = 9; addend2 = 0; min = 1; max = 9; expectedResult = 9; expectedWrapped = FALSE; }
+    PARAMETRIZE { addend1 = 8; addend2 = 1; min = 1; max = 9; expectedResult = 9; expectedWrapped = FALSE; }
+    PARAMETRIZE { addend1 = 9; addend2 = -1; min = 1; max = 9; expectedResult = 8; expectedWrapped = FALSE; }
+
+    // Wrap by 1.
+    PARAMETRIZE { addend1 = 9; addend2 = 1; min = 1; max = 9; expectedResult = 1; expectedWrapped = TRUE; }
+    PARAMETRIZE { addend1 = 8; addend2 = 2; min = 1; max = 9; expectedResult = 1; expectedWrapped = TRUE; }
+    PARAMETRIZE { addend1 = 9; addend2 = 10; min = 1; max = 9; expectedResult = 1; expectedWrapped = TRUE; }
+    PARAMETRIZE { addend1 = 1; addend2 = -1; min = 1; max = 9; expectedResult = 9; expectedWrapped = TRUE; }
+    PARAMETRIZE { addend1 = 2; addend2 = -2; min = 1; max = 9; expectedResult = 9; expectedWrapped = TRUE; }
+    PARAMETRIZE { addend1 = 1; addend2 = -10; min = 1; max = 9; expectedResult = 9; expectedWrapped = TRUE; }
+
+    // Wrap by 2.
+    PARAMETRIZE { addend1 = 9; addend2 = 2; min = 1; max = 9; expectedResult = 2; expectedWrapped = TRUE; }
+    PARAMETRIZE { addend1 = 9; addend2 = 11; min = 1; max = 9; expectedResult = 2; expectedWrapped = TRUE; }
+    PARAMETRIZE { addend1 = 1; addend2 = -2; min = 1; max = 9; expectedResult = 8; expectedWrapped = TRUE; }
+    PARAMETRIZE { addend1 = 1; addend2 = -11; min = 1; max = 9; expectedResult = 8; expectedWrapped = TRUE; }
+
+    // Near INT32_MIN/INT32_MAX.
+    PARAMETRIZE { addend1 = INT32_MIN; addend2 = INT32_MIN; min = INT32_MIN; max = INT32_MAX; expectedResult = 0; expectedWrapped = TRUE; }
+    PARAMETRIZE { addend1 = INT32_MIN; addend2 = 0; min = INT32_MIN; max = INT32_MAX; expectedResult = INT32_MIN; expectedWrapped = FALSE; }
+    PARAMETRIZE { addend1 = INT32_MIN; addend2 = INT32_MAX; min = INT32_MIN; max = INT32_MAX; expectedResult = -1; expectedWrapped = FALSE; }
+    PARAMETRIZE { addend1 = 0; addend2 = INT32_MIN; min = INT32_MIN; max = INT32_MAX; expectedResult = INT32_MIN; expectedWrapped = FALSE; }
+    PARAMETRIZE { addend1 = 0; addend2 = INT32_MAX; min = INT32_MIN; max = INT32_MAX; expectedResult = INT32_MAX; expectedWrapped = FALSE; }
+    PARAMETRIZE { addend1 = INT32_MAX; addend2 = INT32_MIN; min = INT32_MIN; max = INT32_MAX; expectedResult = -1; expectedWrapped = FALSE; }
+    PARAMETRIZE { addend1 = INT32_MAX; addend2 = 0; min = INT32_MIN; max = INT32_MAX; expectedResult = INT32_MAX; expectedWrapped = FALSE; }
+    PARAMETRIZE { addend1 = INT32_MAX; addend2 = INT32_MAX; min = INT32_MIN; max = INT32_MAX; expectedResult = -2; expectedWrapped = TRUE; }
+
+    actualResult = WrapAdd(addend1, addend2, min, max, &actualWrapped);
+    EXPECT_EQ(expectedResult, actualResult);
+    EXPECT_EQ(expectedWrapped, actualWrapped);
+
+    actualWrapped = WrapAddPtr(&addend1, addend2, min, max);
+    EXPECT_EQ(expectedResult, addend1);
+    EXPECT_EQ(expectedWrapped, actualWrapped);
+}
+
+TEST("WrapSubS32")
+{
+    s32 minuend, subtrahend, min, max;
+    s32 expectedResult, actualResult;
+    bool32 expectedWrapped, actualWrapped;
+
+    // No wrap.
+    PARAMETRIZE { minuend = 1; subtrahend = 0; min = 1; max = 9; expectedResult = 1; expectedWrapped = FALSE; }
+    PARAMETRIZE { minuend = 2; subtrahend = 1; min = 1; max = 9; expectedResult = 1; expectedWrapped = FALSE; }
+    PARAMETRIZE { minuend = 1; subtrahend = -1; min = 1; max = 9; expectedResult = 2; expectedWrapped = FALSE; }
+
+    // Wrap by 1.
+    PARAMETRIZE { minuend = 1; subtrahend = 1; min = 1; max = 9; expectedResult = 9; expectedWrapped = TRUE; }
+    PARAMETRIZE { minuend = 2; subtrahend = 2; min = 1; max = 9; expectedResult = 9; expectedWrapped = TRUE; }
+    PARAMETRIZE { minuend = 1; subtrahend = 10; min = 1; max = 9; expectedResult = 9; expectedWrapped = TRUE; }
+    PARAMETRIZE { minuend = 9; subtrahend = -1; min = 1; max = 9; expectedResult = 1; expectedWrapped = TRUE; }
+    PARAMETRIZE { minuend = 8; subtrahend = -2; min = 1; max = 9; expectedResult = 1; expectedWrapped = TRUE; }
+    PARAMETRIZE { minuend = 9; subtrahend = -10; min = 1; max = 9; expectedResult = 1; expectedWrapped = TRUE; }
+
+    // Wrap by 2.
+    PARAMETRIZE { minuend = 1; subtrahend = 2; min = 1; max = 9; expectedResult = 8; expectedWrapped = TRUE; }
+    PARAMETRIZE { minuend = 1; subtrahend = 11; min = 1; max = 9; expectedResult = 8; expectedWrapped = TRUE; }
+    PARAMETRIZE { minuend = 9; subtrahend = -2; min = 1; max = 9; expectedResult = 2; expectedWrapped = TRUE; }
+    PARAMETRIZE { minuend = 9; subtrahend = -11; min = 1; max = 9; expectedResult = 2; expectedWrapped = TRUE; }
+
+    // Near INT32_MIN/INT32_MAX.
+    PARAMETRIZE { minuend = INT32_MIN; subtrahend = INT32_MIN; min = INT32_MIN; max = INT32_MAX; expectedResult = 0; expectedWrapped = FALSE; }
+    PARAMETRIZE { minuend = INT32_MIN; subtrahend = 0; min = INT32_MIN; max = INT32_MAX; expectedResult = INT32_MIN; expectedWrapped = FALSE; }
+    PARAMETRIZE { minuend = INT32_MIN; subtrahend = INT32_MAX; min = INT32_MIN; max = INT32_MAX; expectedResult = 1; expectedWrapped = TRUE; }
+    PARAMETRIZE { minuend = 0; subtrahend = INT32_MIN; min = INT32_MIN; max = INT32_MAX; expectedResult = INT32_MIN; expectedWrapped = TRUE; }
+    PARAMETRIZE { minuend = 0; subtrahend = INT32_MAX; min = INT32_MIN; max = INT32_MAX; expectedResult = -INT32_MAX; expectedWrapped = FALSE; }
+    PARAMETRIZE { minuend = INT32_MAX; subtrahend = INT32_MIN; min = INT32_MIN; max = INT32_MAX; expectedResult = -1; expectedWrapped = TRUE; }
+    PARAMETRIZE { minuend = INT32_MAX; subtrahend = 0; min = INT32_MIN; max = INT32_MAX; expectedResult = INT32_MAX; expectedWrapped = FALSE; }
+    PARAMETRIZE { minuend = INT32_MAX; subtrahend = INT32_MAX; min = INT32_MIN; max = INT32_MAX; expectedResult = 0; expectedWrapped = FALSE; }
+
+    actualResult = WrapSub(minuend, subtrahend, min, max, &actualWrapped);
+    EXPECT_EQ(expectedResult, actualResult);
+    EXPECT_EQ(expectedWrapped, actualWrapped);
+
+    actualWrapped = WrapSubPtr(&minuend, subtrahend, min, max);
+    EXPECT_EQ(expectedResult, minuend);
+    EXPECT_EQ(expectedWrapped, actualWrapped);
+}
+
+TEST("SatAddU32")
+{
+    u32 addend1, addend2, min, max;
+    u32 expectedResult, actualResult;
+    bool32 expectedSaturated, actualSaturated;
+
+    // No saturation.
+    PARAMETRIZE { addend1 = 9; addend2 = 0; min = 1; max = 9; expectedResult = 9; expectedSaturated = FALSE; }
+    PARAMETRIZE { addend1 = 8; addend2 = 1; min = 1; max = 9; expectedResult = 9; expectedSaturated = FALSE; }
+
+    // Saturate.
+    PARAMETRIZE { addend1 = 9; addend2 = 1; min = 1; max = 9; expectedResult = 9; expectedSaturated = TRUE; }
+    PARAMETRIZE { addend1 = 9; addend2 = 2; min = 1; max = 9; expectedResult = 9; expectedSaturated = TRUE; }
+    PARAMETRIZE { addend1 = 9; addend2 = 10; min = 1; max = 9; expectedResult = 9; expectedSaturated = TRUE; }
+
+    // Near UINT32_MAX.
+    PARAMETRIZE { addend1 = UINT32_MAX; addend2 = 0; min = 0; max = UINT32_MAX; expectedResult = UINT32_MAX; expectedSaturated = FALSE; }
+    PARAMETRIZE { addend1 = 0; addend2 = UINT32_MAX; min = 0; max = UINT32_MAX; expectedResult = UINT32_MAX; expectedSaturated = FALSE; }
+    PARAMETRIZE { addend1 = UINT32_MAX; addend2 = 1; min = 0; max = UINT32_MAX; expectedResult = UINT32_MAX; expectedSaturated = TRUE; }
+    PARAMETRIZE { addend1 = UINT32_MAX; addend2 = UINT32_MAX; min = 0; max = UINT32_MAX; expectedResult = UINT32_MAX; expectedSaturated = TRUE; }
+
+    actualResult = SatAdd(addend1, addend2, min, max, &actualSaturated);
+    EXPECT_EQ(expectedResult, actualResult);
+    EXPECT_EQ(expectedSaturated, actualSaturated);
+
+    actualSaturated = SatAddPtr(&addend1, addend2, min, max);
+    EXPECT_EQ(expectedResult, addend1);
+    EXPECT_EQ(expectedSaturated, actualSaturated);
+}
+
+TEST("SatSubU32")
+{
+    u32 minuend, subtrahend, min, max;
+    u32 expectedResult, actualResult;
+    bool32 expectedSaturated, actualSaturated;
+
+    // No saturation.
+    PARAMETRIZE { minuend = 1; subtrahend = 0; min = 1; max = 9; expectedResult = 1; expectedSaturated = FALSE; }
+    PARAMETRIZE { minuend = 2; subtrahend = 1; min = 1; max = 9; expectedResult = 1; expectedSaturated = FALSE; }
+
+    // Saturate.
+    PARAMETRIZE { minuend = 1; subtrahend = 1; min = 1; max = 9; expectedResult = 1; expectedSaturated = TRUE; }
+    PARAMETRIZE { minuend = 1; subtrahend = 2; min = 1; max = 9; expectedResult = 1; expectedSaturated = TRUE; }
+    PARAMETRIZE { minuend = 1; subtrahend = 10; min = 1; max = 9; expectedResult = 1; expectedSaturated = TRUE; }
+
+    // Near UINT32_MAX.
+    PARAMETRIZE { minuend = UINT32_MAX; subtrahend = 0; min = 0; max = UINT32_MAX; expectedResult = UINT32_MAX; expectedSaturated = FALSE; }
+    PARAMETRIZE { minuend = UINT32_MAX; subtrahend = UINT32_MAX; min = 0; max = UINT32_MAX; expectedResult = 0; expectedSaturated = FALSE; }
+    PARAMETRIZE { minuend = UINT32_MAX - 1; subtrahend = UINT32_MAX; min = 0; max = UINT32_MAX; expectedResult = 0; expectedSaturated = TRUE; }
+    PARAMETRIZE { minuend = 0; subtrahend = UINT32_MAX; min = 0; max = UINT32_MAX; expectedResult = 0; expectedSaturated = TRUE; }
+
+    actualResult = SatSub(minuend, subtrahend, min, max, &actualSaturated);
+    EXPECT_EQ(expectedResult, actualResult);
+    EXPECT_EQ(expectedSaturated, actualSaturated);
+
+    actualSaturated = SatSubPtr(&minuend, subtrahend, min, max);
+    EXPECT_EQ(expectedResult, minuend);
+    EXPECT_EQ(expectedSaturated, actualSaturated);
+}
+
+TEST("WrapAddU32")
+{
+    u32 addend1, addend2, min, max;
+    u32 expectedResult, actualResult;
+    bool32 expectedWrapped, actualWrapped;
+
+    // No wrap.
+    PARAMETRIZE { addend1 = 9; addend2 = 0; min = 1; max = 9; expectedResult = 9; expectedWrapped = FALSE; }
+    PARAMETRIZE { addend1 = 8; addend2 = 1; min = 1; max = 9; expectedResult = 9; expectedWrapped = FALSE; }
+
+    // Wrap by 1.
+    PARAMETRIZE { addend1 = 9; addend2 = 1; min = 1; max = 9; expectedResult = 1; expectedWrapped = TRUE; }
+    PARAMETRIZE { addend1 = 8; addend2 = 2; min = 1; max = 9; expectedResult = 1; expectedWrapped = TRUE; }
+    PARAMETRIZE { addend1 = 9; addend2 = 10; min = 1; max = 9; expectedResult = 1; expectedWrapped = TRUE; }
+
+    // Wrap by 2.
+    PARAMETRIZE { addend1 = 9; addend2 = 2; min = 1; max = 9; expectedResult = 2; expectedWrapped = TRUE; }
+    PARAMETRIZE { addend1 = 9; addend2 = 11; min = 1; max = 9; expectedResult = 2; expectedWrapped = TRUE; }
+
+    // Near UINT32_MAX.
+    PARAMETRIZE { addend1 = UINT32_MAX; addend2 = 0; min = 0; max = UINT32_MAX; expectedResult = UINT32_MAX; expectedWrapped = FALSE; }
+    PARAMETRIZE { addend1 = UINT32_MAX; addend2 = 1; min = 0; max = UINT32_MAX; expectedResult = 0; expectedWrapped = TRUE; }
+    PARAMETRIZE { addend1 = UINT32_MAX; addend2 = UINT32_MAX; min = 0; max = UINT32_MAX; expectedResult = UINT32_MAX - 1; expectedWrapped = TRUE; }
+
+    actualResult = WrapAdd(addend1, addend2, min, max, &actualWrapped);
+    EXPECT_EQ(expectedResult, actualResult);
+    EXPECT_EQ(expectedWrapped, actualWrapped);
+
+    actualWrapped = WrapAddPtr(&addend1, addend2, min, max);
+    EXPECT_EQ(expectedResult, addend1);
+    EXPECT_EQ(expectedWrapped, actualWrapped);
+}
+
+TEST("WrapSubU32")
+{
+    u32 minuend, subtrahend, min, max;
+    u32 expectedResult, actualResult;
+    bool32 expectedWrapped, actualWrapped;
+
+    // No wrap.
+    PARAMETRIZE { minuend = 1; subtrahend = 0; min = 1; max = 9; expectedResult = 1; expectedWrapped = FALSE; }
+    PARAMETRIZE { minuend = 2; subtrahend = 1; min = 1; max = 9; expectedResult = 1; expectedWrapped = FALSE; }
+
+    // Wrap by 1.
+    PARAMETRIZE { minuend = 1; subtrahend = 1; min = 1; max = 9; expectedResult = 9; expectedWrapped = TRUE; }
+    PARAMETRIZE { minuend = 2; subtrahend = 2; min = 1; max = 9; expectedResult = 9; expectedWrapped = TRUE; }
+    PARAMETRIZE { minuend = 1; subtrahend = 10; min = 1; max = 9; expectedResult = 9; expectedWrapped = TRUE; }
+
+    // Wrap by 2.
+    PARAMETRIZE { minuend = 1; subtrahend = 2; min = 1; max = 9; expectedResult = 8; expectedWrapped = TRUE; }
+    PARAMETRIZE { minuend = 1; subtrahend = 11; min = 1; max = 9; expectedResult = 8; expectedWrapped = TRUE; }
+
+    // Near UINT32_MAX.
+    PARAMETRIZE { minuend = 0; subtrahend = 0; min = 0; max = UINT32_MAX; expectedResult = 0; expectedWrapped = FALSE; }
+    PARAMETRIZE { minuend = 0; subtrahend = 1; min = 0; max = UINT32_MAX; expectedResult = UINT32_MAX; expectedWrapped = TRUE; }
+    PARAMETRIZE { minuend = UINT32_MAX - 1; subtrahend = UINT32_MAX; min = 0; max = UINT32_MAX; expectedResult = UINT32_MAX; expectedWrapped = TRUE; }
+
+    actualResult = WrapSub(minuend, subtrahend, min, max, &actualWrapped);
+    EXPECT_EQ(expectedResult, actualResult);
+    EXPECT_EQ(expectedWrapped, actualWrapped);
+
+    actualWrapped = WrapSubPtr(&minuend, subtrahend, min, max);
+    EXPECT_EQ(expectedResult, minuend);
+    EXPECT_EQ(expectedWrapped, actualWrapped);
+}


### PR DESCRIPTION
## Description
- `Clamp`: If the number is above-max/below-min, clamp it in range.
- `SatAdd`, `SatAddPtr`, `SatSub`, `SatSubPtr`: Saturating arithmetic, if the result is above-max/below-min, clamp it in range.
- `WrapAdd`, `WrapAddPtr`, `WrapSub`, `WrapSubPtr`: Wrapping arithmetic, if the result is above-max/below-min, wraparound to the other extreme.
- `JOY_AXIS_NEW`, `JOY_AXIS_HELD`, `JOY_AXIS_REPEAT`: -1/0/1 depending on which keys are held.

Primarily used in UIs for now, but potentially has uses elsewhere too.

## Large Language Models (AI)
None.

## Feature(s) this PR does NOT handle:
Not all (or even most) code that could use these functions has been migrated (yet?).