### PR TITLE
Add `if_comptime`

### DIFF
--- a/include/metaprogram.h
+++ b/include/metaprogram.h
@@ -207,4 +207,14 @@ Input must be of the form (upper << lower) where upper can be up to 7, lower up 
 /* Useful for counting arguments */
 #define PLUS_ONE(...) + 1
 
+/* Expands to 'if (true)' if 'cond' can be evaluated at compile-time and
+ * evaluates to non-zero; expands to 'if (false)' otherwise.
+ *
+ * GCC will not generate code for an 'if (false) { ... }', so this can
+ * be used to write compile-time optimizations without a run-time cost.
+ *
+ * Because 'cond' must be known at compile-time, this is rarely useful
+ * outside macros. */
+#define if_comptime(cond) if (__builtin_constant_p((cond) ? 0 : *(int *)0))
+
 #endif

--- a/include/random.h
+++ b/include/random.h
@@ -267,7 +267,11 @@ enum RandomTag
 #define RandomPercentage(tag, t) \
     ({ \
         u32 r; \
-        if (t <= 0) \
+        if_comptime (t == 50) \
+        { \
+            r = RandomUniform(tag, FALSE, TRUE); \
+        } \
+        else if (t <= 0) \
         { \
             r = FALSE; \
         } \


### PR DESCRIPTION
`if` variant that executes its block only if its condition is known to be true at compile-time.

Useful for optimizing macros at compile-time. Targeting `master` because I think this can be useful when maintaining things, not just for new things: f necessary I can split the definition and usage into two PRs.