### PR TITLE
 Fix Strong Winds interactions with Weather Ball and healing moves

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -8658,6 +8658,7 @@ static void Cmd_recoverbasedonsunlight(void)
         s32 recoverAmount = 0;
         u32 weather = GetWeather();
         u32 attackerWeather = GetAttackerWeather(GetBattlerHoldEffect(gBattlerAttacker), GetBattlerAbility(gBattlerAttacker), weather);
+        u32 healingWeather = attackerWeather & ~B_WEATHER_STRONG_WINDS;
         if (GetMoveEffect(gCurrentMove) == EFFECT_SHORE_UP)
         {
             if (attackerWeather & B_WEATHER_SANDSTORM)
@@ -8669,7 +8670,7 @@ static void Cmd_recoverbasedonsunlight(void)
         {
             if (attackerWeather & B_WEATHER_SUN)
                 recoverAmount = 20 * GetNonDynamaxMaxHP(gBattlerAttacker) / 30;
-            else if (!(GetWeather() & B_WEATHER_ANY) || GetBattlerHoldEffect(gBattlerAttacker) == HOLD_EFFECT_UTILITY_UMBRELLA)
+            else if (!(healingWeather & B_WEATHER_ANY) || GetBattlerHoldEffect(gBattlerAttacker) == HOLD_EFFECT_UTILITY_UMBRELLA)
                 recoverAmount = GetNonDynamaxMaxHP(gBattlerAttacker) / 2;
             else // not sunny weather
                 recoverAmount = GetNonDynamaxMaxHP(gBattlerAttacker) / 4;
@@ -8700,7 +8701,7 @@ static void Cmd_recoverbasedonsunlight(void)
             }
             if (attackerWeather & B_WEATHER_SUN)
                 recoverAmount = healingModifier * GetNonDynamaxMaxHP(gBattlerAttacker) / 2;
-            else if (!(attackerWeather & B_WEATHER_ANY) || GetBattlerHoldEffect(gBattlerAttacker) == HOLD_EFFECT_UTILITY_UMBRELLA)
+            else if (!(healingWeather & B_WEATHER_ANY) || GetBattlerHoldEffect(gBattlerAttacker) == HOLD_EFFECT_UTILITY_UMBRELLA)
                 recoverAmount = healingModifier * GetNonDynamaxMaxHP(gBattlerAttacker) / 4;
             else // not sunny weather
                 recoverAmount = healingModifier * GetNonDynamaxMaxHP(gBattlerAttacker) / 8;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -6177,7 +6177,7 @@ static inline u32 CalcMoveBasePower(struct DamageContext *ctx)
             basePower *= 2;
         break;
     case EFFECT_WEATHER_BALL:
-        if (GetAttackerWeather(ctx->holdEffects[ctx->battlerAtk], ctx->abilities[ctx->battlerAtk], ctx->weather) & B_WEATHER_ANY)
+        if (GetAttackerWeather(ctx->holdEffects[ctx->battlerAtk], ctx->abilities[ctx->battlerAtk], ctx->weather) & (B_WEATHER_ANY & ~B_WEATHER_STRONG_WINDS))
             basePower *= 2;
         break;
     case EFFECT_PURSUIT:

--- a/test/battle/ability/delta_stream.c
+++ b/test/battle/ability/delta_stream.c
@@ -30,11 +30,11 @@ DOUBLE_BATTLE_TEST("Delta Stream doesn't activate if there's already strong wind
 DOUBLE_BATTLE_TEST("Strong winds continue as long as there's a Pokémon with Delta Stream on the field")
 {
     GIVEN {
-        PLAYER(SPECIES_RAYQUAZA) { HP(1); Moves(MOVE_DRAGON_ASCENT, MOVE_CELEBRATE); }
-        PLAYER(SPECIES_WOBBUFFET);
-        PLAYER(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_RAYQUAZA) { Moves(MOVE_DRAGON_ASCENT, MOVE_CELEBRATE, MOVE_SCRATCH); }
-        OPPONENT(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_RAYQUAZA) { HP(1); Speed(5); Moves(MOVE_DRAGON_ASCENT, MOVE_CELEBRATE); }
+        PLAYER(SPECIES_WOBBUFFET) { Speed(4); }
+        PLAYER(SPECIES_WOBBUFFET) { Speed(3); }
+        OPPONENT(SPECIES_RAYQUAZA) { Speed(2); Moves(MOVE_DRAGON_ASCENT, MOVE_CELEBRATE, MOVE_SCRATCH); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); }
     } WHEN {
         TURN {
             MOVE(playerLeft, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA);

--- a/test/battle/ability/delta_stream.c
+++ b/test/battle/ability/delta_stream.c
@@ -8,18 +8,18 @@
 DOUBLE_BATTLE_TEST("Delta Stream doesn't activate if there's already strong winds")
 {
     GIVEN {
+        PLAYER(SPECIES_RAYQUAZA) { Moves(MOVE_DRAGON_ASCENT, MOVE_CELEBRATE); }
         PLAYER(SPECIES_WOBBUFFET);
-        PLAYER(SPECIES_WOBBUFFET);
-        PLAYER(SPECIES_RAYQUAZA) { Ability(ABILITY_DELTA_STREAM); }
-        OPPONENT(SPECIES_RAYQUAZA) { Ability(ABILITY_DELTA_STREAM); }
+        OPPONENT(SPECIES_RAYQUAZA) { Moves(MOVE_DRAGON_ASCENT, MOVE_CELEBRATE); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
-        TURN { SWITCH(playerLeft, 2); }
+        TURN {
+            MOVE(opponentLeft, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA);
+            MOVE(playerLeft, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA);
+        }
     } SCENE {
         ABILITY_POPUP(opponentLeft, ABILITY_DELTA_STREAM);
         MESSAGE("Mysterious strong winds are protecting Flying-type Pokémon!");
-        SWITCH_OUT_MESSAGE("Wobbuffet");
-        SEND_IN_MESSAGE("Rayquaza");
         NONE_OF {
             ABILITY_POPUP(playerLeft, ABILITY_DELTA_STREAM);
             MESSAGE("Mysterious strong winds are protecting Flying-type Pokémon!");
@@ -30,18 +30,21 @@ DOUBLE_BATTLE_TEST("Delta Stream doesn't activate if there's already strong wind
 DOUBLE_BATTLE_TEST("Strong winds continue as long as there's a Pokémon with Delta Stream on the field")
 {
     GIVEN {
-        PLAYER(SPECIES_RAYQUAZA) { Ability(ABILITY_DELTA_STREAM); HP(1); }
+        PLAYER(SPECIES_RAYQUAZA) { HP(1); Moves(MOVE_DRAGON_ASCENT, MOVE_CELEBRATE); }
         PLAYER(SPECIES_WOBBUFFET);
         PLAYER(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_RAYQUAZA) { Ability(ABILITY_DELTA_STREAM); }
+        OPPONENT(SPECIES_RAYQUAZA) { Moves(MOVE_DRAGON_ASCENT, MOVE_CELEBRATE, MOVE_SCRATCH); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
+        TURN {
+            MOVE(playerLeft, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA);
+            MOVE(opponentLeft, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA);
+        }
         TURN { MOVE(opponentLeft, MOVE_SCRATCH, target: playerLeft); SEND_OUT(playerLeft, 2); }
     } SCENE {
+        ABILITY_POPUP(playerLeft, ABILITY_DELTA_STREAM);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponentLeft);
-        HP_BAR(playerLeft, hp: 0);
-        MESSAGE("Rayquaza fainted!");
-        SEND_IN_MESSAGE("Wobbuffet");
+        HP_BAR(playerLeft);
         NOT MESSAGE("The mysterious strong winds have dissipated!");
     } THEN {
         EXPECT(gBattleWeather & B_WEATHER_STRONG_WINDS);

--- a/test/battle/ability/desolate_land.c
+++ b/test/battle/ability/desolate_land.c
@@ -128,7 +128,8 @@ SINGLE_BATTLE_TEST("Desolate Land blocks weather-setting moves")
 
 SINGLE_BATTLE_TEST("Desolate Land prevents other weather abilities")
 {
-    enum Ability ability; u16 species;
+    enum Ability ability;
+    enum Species species;
     PARAMETRIZE { ability = ABILITY_DROUGHT;      species = SPECIES_NINETALES; }
     PARAMETRIZE { ability = ABILITY_DRIZZLE;      species = SPECIES_POLITOED; }
     PARAMETRIZE { ability = ABILITY_SAND_STREAM;  species = SPECIES_HIPPOWDON; }

--- a/test/battle/ability/desolate_land.c
+++ b/test/battle/ability/desolate_land.c
@@ -151,10 +151,9 @@ SINGLE_BATTLE_TEST("Desolate Land can be replaced by Delta Stream")
 {
     GIVEN {
         PLAYER(SPECIES_GROUDON) { Item(ITEM_RED_ORB); }
-        OPPONENT(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_RAYQUAZA) { Ability(ABILITY_DELTA_STREAM); }
+        OPPONENT(SPECIES_RAYQUAZA) { Moves(MOVE_DRAGON_ASCENT, MOVE_CELEBRATE); }
     } WHEN {
-        TURN { SWITCH(opponent, 1); }
+        TURN { MOVE(opponent, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); }
     } SCENE {
         ABILITY_POPUP(opponent, ABILITY_DELTA_STREAM);
         MESSAGE("Mysterious strong winds are protecting Flying-type Pokémon!");

--- a/test/battle/ability/primordial_sea.c
+++ b/test/battle/ability/primordial_sea.c
@@ -94,7 +94,8 @@ SINGLE_BATTLE_TEST("Primordial Sea blocks weather-setting moves")
 
 SINGLE_BATTLE_TEST("Primordial Sea prevents other weather abilities")
 {
-    enum Ability ability; u16 species;
+    enum Ability ability;
+    enum Species species;
     PARAMETRIZE { ability = ABILITY_DROUGHT;      species = SPECIES_NINETALES; }
     PARAMETRIZE { ability = ABILITY_DRIZZLE;      species = SPECIES_POLITOED; }
     PARAMETRIZE { ability = ABILITY_SAND_STREAM;  species = SPECIES_HIPPOWDON; }

--- a/test/battle/ability/primordial_sea.c
+++ b/test/battle/ability/primordial_sea.c
@@ -117,10 +117,9 @@ SINGLE_BATTLE_TEST("Primordial Sea can be replaced by Delta Stream")
 {
     GIVEN {
         PLAYER(SPECIES_KYOGRE) { Item(ITEM_BLUE_ORB); }
-        OPPONENT(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_RAYQUAZA) { Ability(ABILITY_DELTA_STREAM); }
+        OPPONENT(SPECIES_RAYQUAZA) { Moves(MOVE_DRAGON_ASCENT, MOVE_CELEBRATE); }
     } WHEN {
-        TURN { SWITCH(opponent, 1); }
+        TURN { MOVE(opponent, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); }
     } SCENE {
         ABILITY_POPUP(opponent, ABILITY_DELTA_STREAM);
         MESSAGE("Mysterious strong winds are protecting Flying-type Pokémon!");

--- a/test/battle/move_effect/roost.c
+++ b/test/battle/move_effect/roost.c
@@ -255,12 +255,14 @@ DOUBLE_BATTLE_TEST("Roost suppresses the user's not-yet-aquired Flying-type this
 SINGLE_BATTLE_TEST("Roost prevents a Flying-type user from being protected by Delta Stream")
 {
     GIVEN {
-        ASSUME(GetSpeciesType(SPECIES_RAYQUAZA, 1) == TYPE_FLYING);
-        PLAYER(SPECIES_RAYQUAZA) { HP(1); Ability(ABILITY_DELTA_STREAM); }
+        ASSUME(GetSpeciesType(SPECIES_RAYQUAZA_MEGA, 1) == TYPE_FLYING);
+        PLAYER(SPECIES_RAYQUAZA) { HP(1); Moves(MOVE_DRAGON_ASCENT, MOVE_CELEBRATE, MOVE_ROOST); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
+        TURN { MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); }
         TURN { MOVE(player, MOVE_ROOST); MOVE(opponent, MOVE_ICE_BEAM); }
     } SCENE {
+        ABILITY_POPUP(player, ABILITY_DELTA_STREAM);
         MESSAGE("Rayquaza used Roost!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, player);
         MESSAGE("Rayquaza's HP was restored.");

--- a/test/battle/move_effect/weather_ball.c
+++ b/test/battle/move_effect/weather_ball.c
@@ -97,6 +97,36 @@ SINGLE_BATTLE_TEST("Weather Ball doubles its power and turns to an Ice-type move
     }
 }
 
+SINGLE_BATTLE_TEST("Weather Ball doesn't double its power and stays a Normal-type move in strong winds", s16 damage)
+{
+    enum Ability ability;
+    u16 species;
+    PARAMETRIZE { ability = ABILITY_AIR_LOCK;     species = SPECIES_WOBBUFFET; }
+    PARAMETRIZE { ability = ABILITY_DELTA_STREAM; species = SPECIES_WOBBUFFET; }
+    PARAMETRIZE { ability = ABILITY_DELTA_STREAM; species = SPECIES_GASTLY; }
+
+    GIVEN {
+        ASSUME(GetMoveType(MOVE_WEATHER_BALL) == TYPE_NORMAL);
+        ASSUME(GetSpeciesType(SPECIES_GASTLY, 0) == TYPE_GHOST);
+        PLAYER(SPECIES_RAYQUAZA) { Ability(ability); }
+        OPPONENT(species);
+    } WHEN {
+        TURN { MOVE(player, MOVE_WEATHER_BALL); }
+    } SCENE {
+        if (species == SPECIES_GASTLY) {
+            NONE_OF {
+                ANIMATION(ANIM_TYPE_MOVE, MOVE_WEATHER_BALL, player);
+                HP_BAR(opponent);
+            }
+        } else {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_WEATHER_BALL, player);
+            HP_BAR(opponent, captureDamage: &results[i].damage);
+        }
+    } FINALLY {
+        EXPECT_EQ(results[0].damage, results[1].damage);
+    }
+}
+
 SINGLE_BATTLE_TEST("Weather Ball doesn't double its power in Sunlight or Rain if Cloud Nine/Air Lock is on the field", s16 damage)
 {
     enum Move setupMove;

--- a/test/battle/move_effect/weather_ball.c
+++ b/test/battle/move_effect/weather_ball.c
@@ -99,20 +99,27 @@ SINGLE_BATTLE_TEST("Weather Ball doubles its power and turns to an Ice-type move
 
 SINGLE_BATTLE_TEST("Weather Ball doesn't double its power and stays a Normal-type move in strong winds", s16 damage)
 {
-    enum Ability ability;
+    bool32 strongWinds;
     u16 species;
-    PARAMETRIZE { ability = ABILITY_AIR_LOCK;     species = SPECIES_WOBBUFFET; }
-    PARAMETRIZE { ability = ABILITY_DELTA_STREAM; species = SPECIES_WOBBUFFET; }
-    PARAMETRIZE { ability = ABILITY_DELTA_STREAM; species = SPECIES_GASTLY; }
+    PARAMETRIZE { strongWinds = FALSE; species = SPECIES_WOBBUFFET; }
+    PARAMETRIZE { strongWinds = TRUE;  species = SPECIES_WOBBUFFET; }
+    PARAMETRIZE { strongWinds = TRUE;  species = SPECIES_GASTLY; }
 
     GIVEN {
         ASSUME(GetMoveType(MOVE_WEATHER_BALL) == TYPE_NORMAL);
         ASSUME(GetSpeciesType(SPECIES_GASTLY, 0) == TYPE_GHOST);
-        PLAYER(SPECIES_RAYQUAZA) { Ability(ability); }
+        if (strongWinds)
+            PLAYER(SPECIES_RAYQUAZA) { Moves(MOVE_DRAGON_ASCENT, MOVE_CELEBRATE, MOVE_WEATHER_BALL); }
+        else
+            PLAYER(SPECIES_RAYQUAZA) { Ability(ABILITY_AIR_LOCK); Moves(MOVE_WEATHER_BALL); }
         OPPONENT(species);
     } WHEN {
+        if (strongWinds)
+            TURN { MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); }
         TURN { MOVE(player, MOVE_WEATHER_BALL); }
     } SCENE {
+        if (strongWinds)
+            ABILITY_POPUP(player, ABILITY_DELTA_STREAM);
         if (species == SPECIES_GASTLY) {
             NONE_OF {
                 ANIMATION(ANIM_TYPE_MOVE, MOVE_WEATHER_BALL, player);

--- a/test/battle/move_effect/weather_ball.c
+++ b/test/battle/move_effect/weather_ball.c
@@ -97,7 +97,7 @@ SINGLE_BATTLE_TEST("Weather Ball doubles its power and turns to an Ice-type move
     }
 }
 
-SINGLE_BATTLE_TEST("Weather Ball doesn't double its power and stays a Normal-type move in strong winds", s16 damage)
+DOUBLE_BATTLE_TEST("Weather Ball doesn't double its power and stays a Normal-type move in strong winds", s16 damage)
 {
     bool32 strongWinds;
     u16 species;
@@ -109,25 +109,27 @@ SINGLE_BATTLE_TEST("Weather Ball doesn't double its power and stays a Normal-typ
         ASSUME(GetMoveType(MOVE_WEATHER_BALL) == TYPE_NORMAL);
         ASSUME(GetSpeciesType(SPECIES_GASTLY, 0) == TYPE_GHOST);
         if (strongWinds)
-            PLAYER(SPECIES_RAYQUAZA) { Moves(MOVE_DRAGON_ASCENT, MOVE_CELEBRATE, MOVE_WEATHER_BALL); }
+            PLAYER(SPECIES_RAYQUAZA) { Moves(MOVE_DRAGON_ASCENT, MOVE_CELEBRATE); }
         else
-            PLAYER(SPECIES_RAYQUAZA) { Ability(ABILITY_AIR_LOCK); Moves(MOVE_WEATHER_BALL); }
+            PLAYER(SPECIES_RAYQUAZA) { Ability(ABILITY_AIR_LOCK); }
+        PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(species);
+        OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
         if (strongWinds)
-            TURN { MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); }
-        TURN { MOVE(player, MOVE_WEATHER_BALL); }
+            TURN { MOVE(playerLeft, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); }
+        TURN { MOVE(playerRight, MOVE_WEATHER_BALL, target: opponentLeft); }
     } SCENE {
         if (strongWinds)
-            ABILITY_POPUP(player, ABILITY_DELTA_STREAM);
+            ABILITY_POPUP(playerLeft, ABILITY_DELTA_STREAM);
         if (species == SPECIES_GASTLY) {
             NONE_OF {
-                ANIMATION(ANIM_TYPE_MOVE, MOVE_WEATHER_BALL, player);
-                HP_BAR(opponent);
+                ANIMATION(ANIM_TYPE_MOVE, MOVE_WEATHER_BALL, playerRight);
+                HP_BAR(opponentLeft);
             }
         } else {
-            ANIMATION(ANIM_TYPE_MOVE, MOVE_WEATHER_BALL, player);
-            HP_BAR(opponent, captureDamage: &results[i].damage);
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_WEATHER_BALL, playerRight);
+            HP_BAR(opponentLeft, captureDamage: &results[i].damage);
         }
     } FINALLY {
         EXPECT_EQ(results[0].damage, results[1].damage);

--- a/test/battle/move_effect/weather_ball.c
+++ b/test/battle/move_effect/weather_ball.c
@@ -100,7 +100,7 @@ SINGLE_BATTLE_TEST("Weather Ball doubles its power and turns to an Ice-type move
 DOUBLE_BATTLE_TEST("Weather Ball doesn't double its power and stays a Normal-type move in strong winds", s16 damage)
 {
     bool32 strongWinds;
-    u16 species;
+    enum Species species;
     PARAMETRIZE { strongWinds = FALSE; species = SPECIES_WOBBUFFET; }
     PARAMETRIZE { strongWinds = TRUE;  species = SPECIES_WOBBUFFET; }
     PARAMETRIZE { strongWinds = TRUE;  species = SPECIES_GASTLY; }
@@ -139,7 +139,7 @@ DOUBLE_BATTLE_TEST("Weather Ball doesn't double its power and stays a Normal-typ
 SINGLE_BATTLE_TEST("Weather Ball doesn't double its power in Sunlight or Rain if Cloud Nine/Air Lock is on the field", s16 damage)
 {
     enum Move setupMove;
-    u16 species;
+    enum Species species;
     enum Ability ability;
 
     PARAMETRIZE { species = SPECIES_GOLDUCK;  ability = ABILITY_CLOUD_NINE; setupMove = MOVE_CELEBRATE; }
@@ -170,7 +170,7 @@ SINGLE_BATTLE_TEST("Weather Ball doesn't double its power in Sunlight or Rain if
 SINGLE_BATTLE_TEST("Weather Ball doesn't change type in Sunlight or Rain if Cloud Nine/Air Lock is on the field")
 {
     enum Move setupMove;
-    u16 species;
+    enum Species species;
     enum Ability ability;
 
     PARAMETRIZE { species = SPECIES_GOLDUCK;  ability = ABILITY_CLOUD_NINE; setupMove = MOVE_SUNNY_DAY; }

--- a/test/battle/weather/strong_winds.c
+++ b/test/battle/weather/strong_winds.c
@@ -178,7 +178,7 @@ SINGLE_BATTLE_TEST("Strong winds block weather-setting moves")
 SINGLE_BATTLE_TEST("Strong winds prevent other weather abilities")
 {
     enum Ability ability;
-    u16 species;
+    enum Species species;
     PARAMETRIZE { ability = ABILITY_DROUGHT;      species = SPECIES_NINETALES; }
     PARAMETRIZE { ability = ABILITY_DRIZZLE;      species = SPECIES_POLITOED; }
     PARAMETRIZE { ability = ABILITY_SAND_STREAM;  species = SPECIES_HIPPOWDON; }

--- a/test/battle/weather/strong_winds.c
+++ b/test/battle/weather/strong_winds.c
@@ -1,97 +1,77 @@
 #include "global.h"
 #include "test/battle.h"
 
-DOUBLE_BATTLE_TEST("Strong winds remove Flying-type weaknesses of all battlers") // Electric, Ice, Rock
+ASSUMPTIONS
+{
+    ASSUME(GetMoveType(MOVE_THUNDER_SHOCK) == TYPE_ELECTRIC);
+    ASSUME(GetMoveType(MOVE_ICE_BEAM) == TYPE_ICE);
+    ASSUME(GetMoveType(MOVE_ROCK_THROW) == TYPE_ROCK);
+    ASSUME(GetSpeciesType(SPECIES_PIDGEY, 0) == TYPE_FLYING || GetSpeciesType(SPECIES_PIDGEY, 1) == TYPE_FLYING);
+}
+
+DOUBLE_BATTLE_TEST("Strong winds remove Flying-type weaknesses of all battlers")
 {
     enum Move move;
-    bool32 targetPlayer;
-
-    PARAMETRIZE { move = MOVE_THUNDER_SHOCK; targetPlayer = TRUE; }
-    PARAMETRIZE { move = MOVE_ICE_BEAM; targetPlayer = TRUE; }
-    PARAMETRIZE { move = MOVE_ROCK_THROW; targetPlayer = TRUE; }
-    PARAMETRIZE { move = MOVE_THUNDER_SHOCK; targetPlayer = FALSE; }
-    PARAMETRIZE { move = MOVE_ICE_BEAM; targetPlayer = FALSE; }
-    PARAMETRIZE { move = MOVE_ROCK_THROW; targetPlayer = FALSE; }
+    PARAMETRIZE { move = MOVE_THUNDER_SHOCK; }
+    PARAMETRIZE { move = MOVE_ICE_BEAM; }
+    PARAMETRIZE { move = MOVE_ROCK_THROW; }
 
     GIVEN {
-        ASSUME(GetMoveType(MOVE_THUNDER_SHOCK) == TYPE_ELECTRIC);
-        ASSUME(GetMoveType(MOVE_ICE_BEAM) == TYPE_ICE);
-        ASSUME(GetMoveType(MOVE_ROCK_THROW) == TYPE_ROCK);
-        ASSUME(GetSpeciesType(SPECIES_PIDGEY, 0) == TYPE_NORMAL);
-        ASSUME(GetSpeciesType(SPECIES_PIDGEY, 1) == TYPE_FLYING);
-        PLAYER(SPECIES_RAYQUAZA) { Ability(ABILITY_DELTA_STREAM); }
+        PLAYER(SPECIES_RAYQUAZA) { Moves(MOVE_DRAGON_ASCENT, MOVE_CELEBRATE, move); }
         PLAYER(SPECIES_PIDGEY);
         OPPONENT(SPECIES_PIDGEY);
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
-        if (targetPlayer)
-            TURN { MOVE(opponentLeft, move, target: playerRight); }
-        else
-            TURN { MOVE(playerRight, move, target: opponentLeft); }
-    } SCENE {
-        if (targetPlayer) {
-            if (move == MOVE_THUNDER_SHOCK)
-                MESSAGE("The opposing Pidgey used Thunder Shock!");
-            else if (move == MOVE_ICE_BEAM)
-                MESSAGE("The opposing Pidgey used Ice Beam!");
-            else
-                MESSAGE("The opposing Pidgey used Rock Throw!");
-            MESSAGE("The mysterious strong winds weakened the attack!");
-            ANIMATION(ANIM_TYPE_MOVE, move, opponentLeft);
-        } else {
-            if (move == MOVE_THUNDER_SHOCK)
-                MESSAGE("Pidgey used Thunder Shock!");
-            else if (move == MOVE_ICE_BEAM)
-                MESSAGE("Pidgey used Ice Beam!");
-            else
-                MESSAGE("Pidgey used Rock Throw!");
-            MESSAGE("The mysterious strong winds weakened the attack!");
-            ANIMATION(ANIM_TYPE_MOVE, move, playerRight);
+        TURN { MOVE(playerLeft, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); }
+        TURN {
+            MOVE(playerLeft, move, target: opponentLeft);
+            MOVE(opponentRight, move, target: playerRight);
         }
+    } SCENE {
+        ABILITY_POPUP(playerLeft, ABILITY_DELTA_STREAM);
+        ANIMATION(ANIM_TYPE_MOVE, move, playerLeft);
+        EFFECTIVENESS_SE(opponentLeft, SE_EFFECTIVE);
+        HP_BAR(opponentLeft);
+        ANIMATION(ANIM_TYPE_MOVE, move, opponentRight);
+        EFFECTIVENESS_SE(playerRight, SE_EFFECTIVE);
+        HP_BAR(playerRight);
     }
 }
 
-DOUBLE_BATTLE_TEST("Strong winds remove Flying-type weaknesses of all battlers - Inverse Battle", s16 damagePlayer, s16 damageOpponent) // Bug, Fighting, Grass
+DOUBLE_BATTLE_TEST("Strong winds remove Flying-type weaknesses of all battlers - Inverse Battle")
 {
     enum Move move;
-    bool32 strongWinds;
-
-    PARAMETRIZE { move = MOVE_BUG_BITE; strongWinds = FALSE; }
-    PARAMETRIZE { move = MOVE_BUG_BITE; strongWinds = TRUE; }
-    PARAMETRIZE { move = MOVE_KARATE_CHOP; strongWinds = FALSE; }
-    PARAMETRIZE { move = MOVE_KARATE_CHOP; strongWinds = TRUE; }
-    PARAMETRIZE { move = MOVE_VINE_WHIP; strongWinds = FALSE; }
-    PARAMETRIZE { move = MOVE_VINE_WHIP; strongWinds = TRUE; }
+    PARAMETRIZE { move = MOVE_BUG_BITE; }
+    PARAMETRIZE { move = MOVE_KARATE_CHOP; }
+    PARAMETRIZE { move = MOVE_VINE_WHIP; }
+    PARAMETRIZE { move = MOVE_MUD_SLAP; }
 
     GIVEN {
         FLAG_SET(B_FLAG_INVERSE_BATTLE);
         ASSUME(GetMoveType(MOVE_BUG_BITE) == TYPE_BUG);
         ASSUME(GetMoveType(MOVE_KARATE_CHOP) == TYPE_FIGHTING);
         ASSUME(GetMoveType(MOVE_VINE_WHIP) == TYPE_GRASS);
+        ASSUME(GetMoveType(MOVE_MUD_SLAP) == TYPE_GROUND);
         ASSUME(GetSpeciesType(SPECIES_TORNADUS, 0) == TYPE_FLYING);
         ASSUME(GetSpeciesType(SPECIES_TORNADUS, 1) == TYPE_FLYING);
-        if (strongWinds)
-            PLAYER(SPECIES_RAYQUAZA) { Ability(ABILITY_DELTA_STREAM); }
-        else
-            PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_RAYQUAZA) { Moves(MOVE_DRAGON_ASCENT, MOVE_CELEBRATE, move); }
         PLAYER(SPECIES_TORNADUS);
         OPPONENT(SPECIES_TORNADUS);
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
+        TURN { MOVE(playerLeft, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); }
         TURN {
-            MOVE(opponentLeft, move, target: playerRight);
-            MOVE(playerRight, move, target: opponentLeft);
+            MOVE(playerLeft, move, target: opponentLeft);
+            MOVE(opponentRight, move, target: playerRight);
         }
     } SCENE {
-        HP_BAR(playerRight, captureDamage: &results[i].damagePlayer);
-        HP_BAR(opponentLeft, captureDamage: &results[i].damageOpponent);
-    } FINALLY {
-        EXPECT_GT(results[0].damagePlayer, results[1].damagePlayer);
-        EXPECT_GT(results[0].damageOpponent, results[1].damageOpponent);
-        EXPECT_GT(results[2].damagePlayer, results[3].damagePlayer);
-        EXPECT_GT(results[2].damageOpponent, results[3].damageOpponent);
-        EXPECT_GT(results[4].damagePlayer, results[5].damagePlayer);
-        EXPECT_GT(results[4].damageOpponent, results[5].damageOpponent);
+        ABILITY_POPUP(playerLeft, ABILITY_DELTA_STREAM);
+        ANIMATION(ANIM_TYPE_MOVE, move, playerLeft);
+        EFFECTIVENESS_SE(opponentLeft, SE_EFFECTIVE);
+        HP_BAR(opponentLeft);
+        ANIMATION(ANIM_TYPE_MOVE, move, opponentRight);
+        EFFECTIVENESS_SE(playerRight, SE_EFFECTIVE);
+        HP_BAR(playerRight);
     }
 }
 
@@ -99,54 +79,52 @@ SINGLE_BATTLE_TEST("Strong winds prevent Weakness Policy from activating on Flyi
 {
     GIVEN {
         ASSUME(GetItemHoldEffect(ITEM_WEAKNESS_POLICY) == HOLD_EFFECT_WEAKNESS_POLICY);
-        ASSUME(GetMoveType(MOVE_THUNDER_SHOCK) == TYPE_ELECTRIC);
-        ASSUME(GetSpeciesType(SPECIES_PIDGEY, 0) == TYPE_NORMAL);
-        ASSUME(GetSpeciesType(SPECIES_PIDGEY, 1) == TYPE_FLYING);
-        PLAYER(SPECIES_RAYQUAZA) { Ability(ABILITY_DELTA_STREAM); Moves(MOVE_THUNDER_SHOCK); }
+        PLAYER(SPECIES_RAYQUAZA) { Moves(MOVE_DRAGON_ASCENT, MOVE_CELEBRATE, MOVE_THUNDER_SHOCK); }
         OPPONENT(SPECIES_PIDGEY) { Item(ITEM_WEAKNESS_POLICY); }
     } WHEN {
+        TURN { MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); }
         TURN { MOVE(player, MOVE_THUNDER_SHOCK); }
     } SCENE {
-        MESSAGE("Rayquaza used Thunder Shock!");
-        MESSAGE("The mysterious strong winds weakened the attack!");
+        ABILITY_POPUP(player, ABILITY_DELTA_STREAM);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_THUNDER_SHOCK, player);
         HP_BAR(opponent);
         NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
     }
 }
 
-SINGLE_BATTLE_TEST("Anticipation still triggers with Strong Winds active")
+SINGLE_BATTLE_TEST("Strong winds Anticipation still triggers with Strong Winds active")
 {
     GIVEN {
-        ASSUME(GetMoveType(MOVE_THUNDER_SHOCK) == TYPE_ELECTRIC);
-        ASSUME(GetSpeciesType(SPECIES_PIDGEY, 0) == TYPE_NORMAL);
-        ASSUME(GetSpeciesType(SPECIES_PIDGEY, 1) == TYPE_FLYING);
-        PLAYER(SPECIES_RAYQUAZA) { Ability(ABILITY_DELTA_STREAM); Moves(MOVE_THUNDER_SHOCK, MOVE_CELEBRATE); }
-        OPPONENT(SPECIES_PIDGEY) { Ability(ABILITY_ANTICIPATION); Moves(MOVE_CELEBRATE); }
+        ASSUME(GetSpeciesType(SPECIES_RAYQUAZA_MEGA, 0) == TYPE_DRAGON);
+        ASSUME(GetSpeciesType(SPECIES_RAYQUAZA_MEGA, 1) == TYPE_FLYING);
+        ASSUME(GetMoveEffect(MOVE_SKILL_SWAP) == EFFECT_SKILL_SWAP);
+        PLAYER(SPECIES_RAYQUAZA) { Moves(MOVE_DRAGON_ASCENT, MOVE_CELEBRATE); }
+        OPPONENT(SPECIES_EEVEE) { Ability(ABILITY_ANTICIPATION); Moves(MOVE_ROCK_THROW, MOVE_SKILL_SWAP); }
     } WHEN {
-        TURN { MOVE(player, MOVE_CELEBRATE); MOVE(opponent, MOVE_CELEBRATE); }
+        TURN { MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); MOVE(opponent, MOVE_SKILL_SWAP); }
     } SCENE {
-        ABILITY_POPUP(opponent, ABILITY_ANTICIPATION);
-        MESSAGE("Rayquaza used Celebrate!");
-        MESSAGE("The opposing Pidgey used Celebrate!");
+        ABILITY_POPUP(player, ABILITY_DELTA_STREAM);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SKILL_SWAP, opponent);
+        ABILITY_POPUP(player, ABILITY_ANTICIPATION);
     }
 }
 
-SINGLE_BATTLE_TEST("Anticipation still triggers with Strong Winds active in Inverse Battle")
+SINGLE_BATTLE_TEST("Strong winds Anticipation still triggers with Strong Winds active - Inverse Battle")
 {
     GIVEN {
         FLAG_SET(B_FLAG_INVERSE_BATTLE);
-        ASSUME(GetMoveType(MOVE_VINE_WHIP) == TYPE_GRASS);
-        ASSUME(GetSpeciesType(SPECIES_TORNADUS, 0) == TYPE_FLYING);
-        ASSUME(GetSpeciesType(SPECIES_TORNADUS, 1) == TYPE_FLYING);
-        PLAYER(SPECIES_RAYQUAZA) { Ability(ABILITY_DELTA_STREAM); Moves(MOVE_VINE_WHIP, MOVE_CELEBRATE); }
-        OPPONENT(SPECIES_TORNADUS) { Ability(ABILITY_ANTICIPATION); Moves(MOVE_CELEBRATE); }
+        ASSUME(GetMoveType(MOVE_BUG_BITE) == TYPE_BUG);
+        ASSUME(GetSpeciesType(SPECIES_RAYQUAZA_MEGA, 0) == TYPE_DRAGON);
+        ASSUME(GetSpeciesType(SPECIES_RAYQUAZA_MEGA, 1) == TYPE_FLYING);
+        ASSUME(GetMoveEffect(MOVE_SKILL_SWAP) == EFFECT_SKILL_SWAP);
+        PLAYER(SPECIES_RAYQUAZA) { Moves(MOVE_DRAGON_ASCENT, MOVE_CELEBRATE); }
+        OPPONENT(SPECIES_EEVEE) { Ability(ABILITY_ANTICIPATION); Moves(MOVE_BUG_BITE, MOVE_SKILL_SWAP); }
     } WHEN {
-        TURN { MOVE(player, MOVE_CELEBRATE); MOVE(opponent, MOVE_CELEBRATE); }
+        TURN { MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); MOVE(opponent, MOVE_SKILL_SWAP); }
     } SCENE {
-        ABILITY_POPUP(opponent, ABILITY_ANTICIPATION);
-        MESSAGE("Rayquaza used Celebrate!");
-        MESSAGE("The opposing Tornadus used Celebrate!");
+        ABILITY_POPUP(player, ABILITY_DELTA_STREAM);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SKILL_SWAP, opponent);
+        ABILITY_POPUP(player, ABILITY_ANTICIPATION);
     }
 }
 
@@ -154,18 +132,17 @@ SINGLE_BATTLE_TEST("Strong winds don't affect Stealth Rock's damage")
 {
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_STEALTH_ROCK) == EFFECT_STEALTH_ROCK);
-        ASSUME(GetSpeciesType(SPECIES_PIDGEY, 0) == TYPE_NORMAL);
-        ASSUME(GetSpeciesType(SPECIES_PIDGEY, 1) == TYPE_FLYING);
         PLAYER(SPECIES_WOBBUFFET);
-        PLAYER(SPECIES_PIDGEY);
-        OPPONENT(SPECIES_RAYQUAZA) { Ability(ABILITY_DELTA_STREAM); }
+        PLAYER(SPECIES_PIDGEY){ HP(200); MaxHP(200); }
+        OPPONENT(SPECIES_RAYQUAZA) { Moves(MOVE_DRAGON_ASCENT, MOVE_CELEBRATE, MOVE_STEALTH_ROCK); }
     } WHEN {
+        TURN { MOVE(opponent, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); }
         TURN { MOVE(opponent, MOVE_STEALTH_ROCK); }
         TURN { SWITCH(player, 1); }
     } SCENE {
-        s32 maxHP = GetMonData(&PLAYER_PARTY[1], MON_DATA_MAX_HP);
+        ABILITY_POPUP(opponent, ABILITY_DELTA_STREAM);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_STEALTH_ROCK, opponent);
-        HP_BAR(player, damage: maxHP / 4);
+        HP_BAR(player, damage: 50);
     }
 }
 
@@ -185,11 +162,13 @@ SINGLE_BATTLE_TEST("Strong winds block weather-setting moves")
         ASSUME(GetMoveWeatherType(MOVE_SANDSTORM) == BATTLE_WEATHER_SANDSTORM);
         ASSUME(GetMoveWeatherType(MOVE_HAIL) == BATTLE_WEATHER_HAIL);
         ASSUME(GetMoveWeatherType(MOVE_SNOWSCAPE) == BATTLE_WEATHER_SNOW);
-        PLAYER(SPECIES_RAYQUAZA) { Ability(ABILITY_DELTA_STREAM); }
+        PLAYER(SPECIES_RAYQUAZA) { Moves(MOVE_DRAGON_ASCENT, MOVE_CELEBRATE); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
+        TURN { MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); }
         TURN { MOVE(opponent, move); }
     } SCENE {
+        ABILITY_POPUP(player, ABILITY_DELTA_STREAM);
         NOT ANIMATION(ANIM_TYPE_MOVE, move, opponent);
     } THEN {
         EXPECT(gBattleWeather & B_WEATHER_STRONG_WINDS);
@@ -206,10 +185,11 @@ SINGLE_BATTLE_TEST("Strong winds prevent other weather abilities")
     PARAMETRIZE { ability = ABILITY_SNOW_WARNING; species = SPECIES_ABOMASNOW; }
 
     GIVEN {
-        PLAYER(SPECIES_RAYQUAZA) { Ability(ABILITY_DELTA_STREAM); }
+        PLAYER(SPECIES_RAYQUAZA) { Moves(MOVE_DRAGON_ASCENT, MOVE_CELEBRATE); }
         OPPONENT(SPECIES_WOBBUFFET);
         OPPONENT(species) { Ability(ability); }
     } WHEN {
+        TURN { MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); }
         TURN { SWITCH(opponent, 1); }
     } SCENE {
         ABILITY_POPUP(opponent, ability);
@@ -221,10 +201,11 @@ SINGLE_BATTLE_TEST("Strong winds prevent other weather abilities")
 SINGLE_BATTLE_TEST("Strong winds can be replaced by Desolate Land")
 {
     GIVEN {
-        PLAYER(SPECIES_RAYQUAZA) { Ability(ABILITY_DELTA_STREAM); }
+        PLAYER(SPECIES_RAYQUAZA) { Moves(MOVE_DRAGON_ASCENT, MOVE_CELEBRATE); }
         OPPONENT(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_GROUDON) { Item(ITEM_RED_ORB); }
     } WHEN {
+        TURN { MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); }
         TURN { SWITCH(opponent, 1); }
     } SCENE {
         ABILITY_POPUP(opponent, ABILITY_DESOLATE_LAND);
@@ -237,15 +218,37 @@ SINGLE_BATTLE_TEST("Strong winds can be replaced by Desolate Land")
 SINGLE_BATTLE_TEST("Strong winds can be replaced by Primordial Sea")
 {
     GIVEN {
-        PLAYER(SPECIES_RAYQUAZA) { Ability(ABILITY_DELTA_STREAM); }
+        PLAYER(SPECIES_RAYQUAZA) { Moves(MOVE_DRAGON_ASCENT, MOVE_CELEBRATE); }
         OPPONENT(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_KYOGRE) { Item(ITEM_BLUE_ORB); }
     } WHEN {
+        TURN { MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); }
         TURN { SWITCH(opponent, 1); }
     } SCENE {
         ABILITY_POPUP(opponent, ABILITY_PRIMORDIAL_SEA);
         MESSAGE("A heavy rain began to fall!");
     } THEN {
         EXPECT(gBattleWeather & B_WEATHER_RAIN_PRIMAL);
+    }
+}
+
+SINGLE_BATTLE_TEST("Strong winds don't reduce Synthesis, Morning Sun or Moonlight recovery")
+{
+    enum Move move;
+    enum BattleMoveEffects effect;
+    PARAMETRIZE { move = MOVE_SYNTHESIS;   effect = EFFECT_SYNTHESIS; }
+    PARAMETRIZE { move = MOVE_MORNING_SUN; effect = EFFECT_MORNING_SUN; }
+    PARAMETRIZE { move = MOVE_MOONLIGHT;   effect = EFFECT_MOONLIGHT; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(move) == effect);
+        PLAYER(SPECIES_RAYQUAZA) { HP(1); MaxHP(200); Moves(MOVE_DRAGON_ASCENT, MOVE_CELEBRATE, move); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); }
+        TURN { MOVE(player, move); }
+    } SCENE {
+        ABILITY_POPUP(player, ABILITY_DELTA_STREAM);
+        HP_BAR(player, damage: -100);
     }
 }

--- a/test/battle/weather/strong_winds.c
+++ b/test/battle/weather/strong_winds.c
@@ -92,7 +92,7 @@ SINGLE_BATTLE_TEST("Strong winds prevent Weakness Policy from activating on Flyi
     }
 }
 
-SINGLE_BATTLE_TEST("Strong winds Anticipation still triggers with Strong Winds active")
+SINGLE_BATTLE_TEST("Anticipation still triggers with Strong Winds active")
 {
     GIVEN {
         ASSUME(GetSpeciesType(SPECIES_RAYQUAZA_MEGA, 0) == TYPE_DRAGON);
@@ -109,7 +109,7 @@ SINGLE_BATTLE_TEST("Strong winds Anticipation still triggers with Strong Winds a
     }
 }
 
-SINGLE_BATTLE_TEST("Strong winds Anticipation still triggers with Strong Winds active - Inverse Battle")
+SINGLE_BATTLE_TEST("Anticipation still triggers with Strong Winds active - Inverse Battle")
 {
     GIVEN {
         FLAG_SET(B_FLAG_INVERSE_BATTLE);


### PR DESCRIPTION
## Description
> 1. _Weather Ball remains a **Normal-type** move during strong winds and **does not have its power doubled**._
> 2. _The moves **Moonlight, Morning Sun, and Synthesis** continue to recover **½ of max HP**, as they do in clear weather._

Also Cleaned up the old tests I wrote before, including illegal `ability = ABILITY_DELTA_STREAM` usage(Clean code makes me happy...)