### PR TITLE
Remove explicit targets from opponent in Trainer Slide tests

### DIFF
--- a/test/battle/trainer_slides.c
+++ b/test/battle/trainer_slides.c
@@ -466,7 +466,7 @@ AI_DOUBLE_BATTLE_TEST("Trainer Slide: Doubles: Attacker Lands First Critical Hit
         OPPONENT(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET) { Moves(MOVE_CELEBRATE); }
     } WHEN {
-        TURN { EXPECT_MOVE(opponentLeft, MOVE_SURGING_STRIKES, target: playerLeft); }
+        TURN { EXPECT_MOVE(opponentLeft, MOVE_SURGING_STRIKES); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SURGING_STRIKES, opponentLeft);
         MESSAGE("A critical hit!");
@@ -510,8 +510,8 @@ AI_DOUBLE_BATTLE_TEST("Trainer Slide: Doubles: Attacker Lands First STAB Hit")
         OPPONENT(SPECIES_BULBASAUR);
         OPPONENT(SPECIES_BULBASAUR);
     } WHEN {
-        TURN { EXPECT_MOVE(opponentLeft, MOVE_VINE_WHIP, target: playerLeft); }
-        TURN { EXPECT_MOVE(opponentRight, MOVE_VINE_WHIP, target: playerLeft); }
+        TURN { EXPECT_MOVE(opponentLeft, MOVE_VINE_WHIP); }
+        TURN { EXPECT_MOVE(opponentRight, MOVE_VINE_WHIP); }
     } SCENE {
         MESSAGE("The opposing Bulbasaur used Vine Whip!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_VINE_WHIP, opponentLeft);
@@ -562,8 +562,8 @@ AI_DOUBLE_BATTLE_TEST("Trainer Slide: Doubles: Attacker Lands First Super Effect
         OPPONENT(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
-        TURN { EXPECT_MOVE(opponentLeft, MOVE_BITE, target: playerLeft); }
-        TURN { EXPECT_MOVE(opponentRight, MOVE_BITE, target: playerLeft); }
+        TURN { EXPECT_MOVE(opponentLeft, MOVE_BITE); }
+        TURN { EXPECT_MOVE(opponentRight, MOVE_BITE); }
     } SCENE {
         MESSAGE("It's super effective!");
         MESSAGE("Trainer A: This message plays after the attacker lands their first super effective hit.{PAUSE_UNTIL_PRESS}");
@@ -739,7 +739,7 @@ AI_DOUBLE_BATTLE_TEST("Trainer Slide: Doubles: Opponent Last Half Hp")
     } WHEN {
         TURN {
             MOVE(playerRight, MOVE_MEMENTO, target: playerLeft); 
-            EXPECT_MOVE(opponentLeft, MOVE_SUPER_FANG, target: playerLeft);}
+            EXPECT_MOVE(opponentLeft, MOVE_SUPER_FANG);}
     } SCENE {
         MESSAGE("Trainer A: Opponent last Mon has < 51% HP.{PAUSE_UNTIL_PRESS}");
         NONE_OF {
@@ -781,7 +781,7 @@ AI_DOUBLE_BATTLE_TEST("Trainer Slide: Doubles: Opponent Last Low Hp")
     } WHEN {
         TURN {
             MOVE(playerRight, MOVE_MEMENTO, target: playerLeft);
-            EXPECT_MOVE(opponentLeft, MOVE_FALSE_SWIPE, target: playerLeft);
+            EXPECT_MOVE(opponentLeft, MOVE_FALSE_SWIPE);
         }
     } SCENE {
         MESSAGE("Trainer A: Opponent last Mon has < 26% HP.{PAUSE_UNTIL_PRESS}");
@@ -1017,8 +1017,8 @@ AI_MULTI_BATTLE_TEST("Trainer Slide: Multi: Attacker Lands First Critical Hit")
         OPPONENT_B(SPECIES_WOBBUFFET) { Speed(3); }
     } WHEN {
         TURN { MOVE(playerLeft, MOVE_ENDURE); 
-            EXPECT_MOVE(opponentLeft, MOVE_SURGING_STRIKES, target: playerLeft); 
-            EXPECT_MOVE(opponentRight, MOVE_SURGING_STRIKES, target: playerLeft); 
+            EXPECT_MOVE(opponentLeft, MOVE_SURGING_STRIKES); 
+            EXPECT_MOVE(opponentRight, MOVE_SURGING_STRIKES); 
             MOVE(playerRight, MOVE_SURGING_STRIKES, target: playerLeft); 
         }
     } SCENE {
@@ -1321,7 +1321,7 @@ AI_MULTI_BATTLE_TEST("Trainer Slide: Multi: Opponent Last Switchin")
     } WHEN {
         TURN {
             MOVE(playerLeft, MOVE_MEMENTO, target: opponentRight); SEND_OUT(playerLeft,1); 
-            EXPECT_MOVE(opponentLeft, MOVE_MEMENTO, target: playerRight); EXPECT_SEND_OUT(opponentLeft,1); 
+            EXPECT_MOVE(opponentLeft, MOVE_MEMENTO); EXPECT_SEND_OUT(opponentLeft,1); 
             MOVE(playerRight, MOVE_MEMENTO, target: opponentRight); SEND_OUT(playerRight,1); 
             EXPECT_MOVE(opponentRight, MOVE_CELEBRATE);
         }
@@ -1482,9 +1482,10 @@ AI_MULTI_BATTLE_TEST("Trainer Slide: Multi: Attacker Z Move")
         OPPONENT_A(SPECIES_WOBBUFFET) { Speed(3); Item(ITEM_NORMALIUM_Z); }
         OPPONENT_B(SPECIES_WOBBUFFET) { Speed(1); Item(ITEM_NORMALIUM_Z); }
     } WHEN {
-        TURN { EXPECT_MOVE(opponentLeft, MOVE_QUICK_ATTACK, gimmick: GIMMICK_Z_MOVE, target: playerLeft); 
+        TURN {
+            EXPECT_MOVE(opponentLeft, MOVE_QUICK_ATTACK, gimmick: GIMMICK_Z_MOVE); 
             MOVE(playerRight, MOVE_QUICK_ATTACK, gimmick: GIMMICK_Z_MOVE, target: opponentLeft); 
-            EXPECT_MOVE(opponentRight, MOVE_QUICK_ATTACK, gimmick: GIMMICK_Z_MOVE, target: playerLeft); }
+            EXPECT_MOVE(opponentRight, MOVE_QUICK_ATTACK, gimmick: GIMMICK_Z_MOVE); }
     } SCENE {
         MESSAGE("Trainer A: This message plays before the attacker activates the Z-Move gimmick.{PAUSE_UNTIL_PRESS}");
         MESSAGE("The opposing Wobbuffet surrounded itself with its Z-Power!");
@@ -1645,9 +1646,9 @@ AI_MULTI_BATTLE_TEST("Trainer Slide: Multi: Opponent Z Move")
     } WHEN {
         TURN {
             MOVE(playerLeft, MOVE_QUICK_ATTACK, gimmick: GIMMICK_Z_MOVE, target: opponentLeft); 
-            EXPECT_MOVE(opponentLeft, MOVE_QUICK_ATTACK, gimmick: GIMMICK_Z_MOVE, target: playerLeft); 
+            EXPECT_MOVE(opponentLeft, MOVE_QUICK_ATTACK, gimmick: GIMMICK_Z_MOVE); 
             MOVE(playerRight, MOVE_QUICK_ATTACK, gimmick: GIMMICK_Z_MOVE, target: opponentLeft); 
-            EXPECT_MOVE(opponentRight, MOVE_QUICK_ATTACK, gimmick: GIMMICK_Z_MOVE, target: playerLeft);
+            EXPECT_MOVE(opponentRight, MOVE_QUICK_ATTACK, gimmick: GIMMICK_Z_MOVE);
         }
     } SCENE {
         NONE_OF {


### PR DESCRIPTION
## Description
#10046 caused a trainer slide test to change which target AI selected (changed to a "correct" target), however #9211 mistakenly reintroduced them. This has led to CI failing on other PRs. This PR removes the explicit targets as they're no longer needed now that the test system doesn't require them for multis, in line with AI doubles.

### Large Language Models (AI)
No

## Discord contact info
grintoul