### PR TITLE
Fix Debug Menu's `Fly to map` not working immediately

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -1005,7 +1005,7 @@ static void Debug_CreateInputDisplayWindow(u8 taskId)
 
 static void Debug_ResetInputDisplayMonIcon(u8 taskId, enum Species species)
 {
-    if (gTasks[taskId].tSpriteId != WINDOW_NONE)
+    if (gTasks[taskId].tSpriteId != SPRITE_NONE)
     {
         FreeAndDestroyMonIconSprite(&gSprites[gTasks[taskId].tSpriteId]);
         FreeMonIconPalettes();

--- a/src/debug.c
+++ b/src/debug.c
@@ -982,8 +982,8 @@ static void Debug_ShowMenu(DebugFunc HandleInput, const struct DebugMenuOption *
     inputTaskId = CreateTask(HandleInput, 3);
     gTasks[inputTaskId].tMenuTaskId = menuTaskId;
     gTasks[inputTaskId].tWindowId = windowId;
-    gTasks[inputTaskId].tSubWindowId = 0xFF;
-    gTasks[inputTaskId].tSpriteId = 0xFF;
+    gTasks[inputTaskId].tSubWindowId = WINDOW_NONE;
+    gTasks[inputTaskId].tSpriteId = SPRITE_NONE;
 
     // draw everything
     CopyWindowToVram(windowId, COPYWIN_FULL);
@@ -1005,7 +1005,7 @@ static void Debug_CreateInputDisplayWindow(u8 taskId)
 
 static void Debug_ResetInputDisplayMonIcon(u8 taskId, enum Species species)
 {
-    if (gTasks[taskId].tSpriteId != 0xFF)
+    if (gTasks[taskId].tSpriteId != WINDOW_NONE)
     {
         FreeAndDestroyMonIconSprite(&gSprites[gTasks[taskId].tSpriteId]);
         FreeMonIconPalettes();
@@ -1017,7 +1017,7 @@ static void Debug_ResetInputDisplayMonIcon(u8 taskId, enum Species species)
 
 static void Debug_DestroyMenu(u8 taskId)
 {
-    if (gTasks[taskId].tSubWindowId != 0xFF)
+    if (gTasks[taskId].tSubWindowId != WINDOW_NONE)
     {
         ClearStdWindowAndFrame(gTasks[taskId].tSubWindowId, TRUE);
         RemoveWindow(gTasks[taskId].tSubWindowId);
@@ -1030,7 +1030,7 @@ static void Debug_DestroyMenu(u8 taskId)
 
 static void Debug_DestroyMenu_Full(u8 taskId)
 {
-    if (gTasks[taskId].tSubWindowId != 0)
+    if (gTasks[taskId].tSubWindowId != WINDOW_NONE)
     {
         ClearStdWindowAndFrame(gTasks[taskId].tSubWindowId, FALSE);
         DebugAction_DestroyExtraWindow(taskId);


### PR DESCRIPTION
## Description
This PR fixes a bug where the Debug menu option, `Utilities...`>`Fly to map`, wouldn't do anything unless a menu was open.

This due `tSubWindowId`'s window only being destroyed if the value was not `0`, instead of `WINDOW_NONE`. Before #9927 `tSubWindowId` was wrongly being initalizated with the value of `0`,  instead of `WINDOW_NONE`.

### Large Language Models (AI)
None.

## Media
<img width="240" height="160" alt="fix" src="https://github.com/user-attachments/assets/99be4cd2-88e2-4c5e-ab26-bd48b66572bd" />


## Issue(s) that this PR fixes
Closes #10140

## Discord contact info
estellar.cheese
