### PR TITLE
Test Runner: Replace :L hack

### DIFF
--- a/include/test/battle.h
+++ b/include/test/battle.h
@@ -1356,7 +1356,7 @@ void ValidateFinally(u32 sourceLine);
         s32 _am = Q_4_12_TO_INT(_a * _m); \
         s32 _t = max(Q_4_12_TO_INT(abs(_m) + Q_4_12_ROUND), 1); \
         if (abs(_am-_b) > _t) \
-            Test_ExitWithResult(TEST_RESULT_FAIL, __LINE__, ":L%s:%d: EXPECT_MUL_EQ(%d, %q, %d) failed: %d not in [%d..%d]", gTestRunnerState.test->filename, __LINE__, _a, _m, _b, _am, _b-_t, _b+_t); \
+            Test_ExitWithResult(TEST_RESULT_FAIL, __LINE__, "%s:%d: EXPECT_MUL_EQ(%d, %q, %d) failed: %d not in [%d..%d]", gTestRunnerState.test->filename, __LINE__, _a, _m, _b, _am, _b-_t, _b+_t); \
     } while (0)
 
 #endif

--- a/include/test/test.h
+++ b/include/test/test.h
@@ -142,14 +142,14 @@ s32 Test_MgbaPrintf(const char *fmt, ...);
     do \
     { \
         if (!(c)) \
-            Test_ExitWithResult(TEST_RESULT_ASSUMPTION_FAIL, __LINE__, ":L%s:%d: ASSUME failed", gTestRunnerState.test->filename, __LINE__); \
+            Test_ExitWithResult(TEST_RESULT_ASSUMPTION_FAIL, __LINE__, "%s:%d: ASSUME failed", gTestRunnerState.test->filename, __LINE__); \
     } while (0)
 
 #define EXPECT(c) \
     do \
     { \
         if (!(c)) \
-            Test_ExitWithResult(TEST_RESULT_FAIL, __LINE__, ":L%s:%d: EXPECT failed", gTestRunnerState.test->filename, __LINE__); \
+            Test_ExitWithResult(TEST_RESULT_FAIL, __LINE__, "%s:%d: EXPECT failed", gTestRunnerState.test->filename, __LINE__); \
     } while (0)
 
 #define EXPECT_EQ(a, b) \
@@ -157,7 +157,7 @@ s32 Test_MgbaPrintf(const char *fmt, ...);
     { \
         typeof(a) _a = (a), _b = (b); \
         if (_a != _b) \
-            Test_ExitWithResult(TEST_RESULT_FAIL, __LINE__, ":L%s:%d: EXPECT_EQ(%d, %d) failed", gTestRunnerState.test->filename, __LINE__, a, b); \
+            Test_ExitWithResult(TEST_RESULT_FAIL, __LINE__, "%s:%d: EXPECT_EQ(%d, %d) failed", gTestRunnerState.test->filename, __LINE__, a, b); \
     } while (0)
 
 #define EXPECT_NE(a, b) \
@@ -165,7 +165,7 @@ s32 Test_MgbaPrintf(const char *fmt, ...);
     { \
         typeof(a) _a = (a), _b = (b); \
         if (_a == _b) \
-            Test_ExitWithResult(TEST_RESULT_FAIL, __LINE__, ":L%s:%d: EXPECT_NE(%d, %d) failed", gTestRunnerState.test->filename, __LINE__, a, b); \
+            Test_ExitWithResult(TEST_RESULT_FAIL, __LINE__, "%s:%d: EXPECT_NE(%d, %d) failed", gTestRunnerState.test->filename, __LINE__, a, b); \
     } while (0)
 
 #define EXPECT_LT(a, b) \
@@ -173,7 +173,7 @@ s32 Test_MgbaPrintf(const char *fmt, ...);
     { \
         typeof(a) _a = (a), _b = (b); \
         if (_a >= _b) \
-            Test_ExitWithResult(TEST_RESULT_FAIL, __LINE__, ":L%s:%d: EXPECT_LT(%d, %d) failed", gTestRunnerState.test->filename, __LINE__, a, b); \
+            Test_ExitWithResult(TEST_RESULT_FAIL, __LINE__, "%s:%d: EXPECT_LT(%d, %d) failed", gTestRunnerState.test->filename, __LINE__, a, b); \
     } while (0)
 
 #define EXPECT_LE(a, b) \
@@ -181,7 +181,7 @@ s32 Test_MgbaPrintf(const char *fmt, ...);
     { \
         typeof(a) _a = (a), _b = (b); \
         if (_a > _b) \
-            Test_ExitWithResult(TEST_RESULT_FAIL, __LINE__, ":L%s:%d: EXPECT_LE(%d, %d) failed", gTestRunnerState.test->filename, __LINE__, a, b); \
+            Test_ExitWithResult(TEST_RESULT_FAIL, __LINE__, "%s:%d: EXPECT_LE(%d, %d) failed", gTestRunnerState.test->filename, __LINE__, a, b); \
     } while (0)
 
 #define EXPECT_GT(a, b) \
@@ -189,7 +189,7 @@ s32 Test_MgbaPrintf(const char *fmt, ...);
     { \
         typeof(a) _a = (a), _b = (b); \
         if (_a <= _b) \
-            Test_ExitWithResult(TEST_RESULT_FAIL, __LINE__, ":L%s:%d: EXPECT_GT(%d, %d) failed", gTestRunnerState.test->filename, __LINE__, a, b); \
+            Test_ExitWithResult(TEST_RESULT_FAIL, __LINE__, "%s:%d: EXPECT_GT(%d, %d) failed", gTestRunnerState.test->filename, __LINE__, a, b); \
     } while (0)
 
 #define EXPECT_GE(a, b) \
@@ -197,7 +197,7 @@ s32 Test_MgbaPrintf(const char *fmt, ...);
     { \
         typeof(a) _a = (a), _b = (b); \
         if (_a < _b) \
-            Test_ExitWithResult(TEST_RESULT_FAIL, __LINE__, ":L%s:%d: EXPECT_GE(%d, %d) failed", gTestRunnerState.test->filename, __LINE__, a, b); \
+            Test_ExitWithResult(TEST_RESULT_FAIL, __LINE__, "%s:%d: EXPECT_GE(%d, %d) failed", gTestRunnerState.test->filename, __LINE__, a, b); \
     } while (0)
 
 struct Benchmark { s32 ticks; };
@@ -234,7 +234,7 @@ static inline struct Benchmark BenchmarkStop(void)
         u32 a_ = (a).ticks; u32 b_ = (b).ticks; \
         Test_MgbaPrintf(#a ": %d ticks, " #b ": %d ticks", a_, b_); \
         if (((a_ - BENCHMARK_ABS) * BENCHMARK_REL) >= (b_ * 100)) \
-            Test_ExitWithResult(TEST_RESULT_FAIL, __LINE__, ":L%s:%d: EXPECT_FASTER(" #a ", " #b ") failed", gTestRunnerState.test->filename, __LINE__); \
+            Test_ExitWithResult(TEST_RESULT_FAIL, __LINE__, "%s:%d: EXPECT_FASTER(" #a ", " #b ") failed", gTestRunnerState.test->filename, __LINE__); \
     } while (0)
 
 #define EXPECT_SLOWER(a, b) \
@@ -243,7 +243,7 @@ static inline struct Benchmark BenchmarkStop(void)
         u32 a_ = (a).ticks; u32 b_ = (b).ticks; \
         Test_MgbaPrintf(#a ": %d ticks, " #b ": %d ticks", a_, b_); \
         if ((a_ * 100) <= ((b_ - BENCHMARK_ABS) * BENCHMARK_REL)) \
-            Test_ExitWithResult(TEST_RESULT_FAIL, __LINE__, ":L%s:%d: EXPECT_SLOWER(" #a ", " #b ") failed", gTestRunnerState.test->filename, __LINE__); \
+            Test_ExitWithResult(TEST_RESULT_FAIL, __LINE__, "%s:%d: EXPECT_SLOWER(" #a ", " #b ") failed", gTestRunnerState.test->filename, __LINE__); \
     } while (0)
 
 #define KNOWN_FAILING \
@@ -266,7 +266,7 @@ static inline struct Benchmark BenchmarkStop(void)
 #define TO_DO \
     do { \
         Test_ExpectedResult(TEST_RESULT_TODO); \
-        Test_ExitWithResult(TEST_RESULT_TODO, __LINE__, ":L%s:%d: EXPECT_TO_DO", gTestRunnerState.test->filename, __LINE__); \
+        Test_ExitWithResult(TEST_RESULT_TODO, __LINE__, "%s:%d: EXPECT_TO_DO", gTestRunnerState.test->filename, __LINE__); \
     } while (0)
 
 #endif

--- a/test/test_runner.c
+++ b/test/test_runner.c
@@ -179,7 +179,7 @@ void TestRunner_CheckMemory(void)
         {
             if (gTasks[i].isActive)
             {
-                Test_MgbaPrintf(":L%s:%d: %p: task not freed", gTestRunnerState.test->filename, SourceLine(0), gTasks[i].func);
+                Test_MgbaPrintf("%s:%d: %p: task not freed", gTestRunnerState.test->filename, SourceLine(0), gTasks[i].func);
                 gTestRunnerState.result = TEST_RESULT_FAIL;
 
                 if (gTestRunnerState.expectedFailState == EXPECT_FAIL_OPEN)
@@ -298,7 +298,7 @@ top:
         }
 
         Test_MgbaPrintf(":N%s", gTestRunnerState.test->name);
-        Test_MgbaPrintf(":L%s:%d", gTestRunnerState.test->filename);
+        Test_MgbaPrintf(":L%s:%d", gTestRunnerState.test->filename, SourceLine(0));
         gTestRunnerState.result = TEST_RESULT_PASS;
         gTestRunnerState.expectedResult = TEST_RESULT_PASS;
         gTestRunnerState.expectLeaks = FALSE;
@@ -603,7 +603,7 @@ static u32 FunctionTest_RandomUniform(enum RandomTag tag, u32 lo, u32 hi, bool32
         if (gFunctionTestRunnerState->rngList[i].tag == tag)
         {
             if (reject && reject(gFunctionTestRunnerState->rngList[i].value))
-                Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), ":LWITH_RNG specified a rejected value (%d)", gFunctionTestRunnerState->rngList[i].value);
+                Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), "WITH_RNG specified a rejected value (%d)", gFunctionTestRunnerState->rngList[i].value);
             return gFunctionTestRunnerState->rngList[i].value;
         }
     }
@@ -650,7 +650,7 @@ static const void* FunctionTest_RandomElementArray(enum RandomTag tag, const voi
                 if (element == gFunctionTestRunnerState->rngList[i].value)
                     return (const u8 *)array + size * index;
             }
-            Test_ExitWithResult(TEST_RESULT_ERROR, SourceLine(0), ":L%s: RandomElement illegal value requested: %d", gTestRunnerState.test->filename, gFunctionTestRunnerState->rngList[i].value);
+            Test_ExitWithResult(TEST_RESULT_ERROR, SourceLine(0), "%s: RandomElement illegal value requested: %d", gTestRunnerState.test->filename, gFunctionTestRunnerState->rngList[i].value);
         }
     }
 
@@ -727,7 +727,7 @@ static void Intr_Timer2(void)
             if (gTestRunnerState.state == STATE_RUN_TEST)
                 gTestRunnerState.state = STATE_REPORT_RESULT;
             gTestRunnerState.result = TEST_RESULT_TIMEOUT;
-            Test_MgbaPrintf(":L%s:%d: TIMEOUT", gTestRunnerState.test->filename, SourceLine(0));
+            Test_MgbaPrintf("%s:%d: TIMEOUT", gTestRunnerState.test->filename, SourceLine(0));
             ReinitCallbacks();
             IRQ_LR = ((uintptr_t)JumpToAgbMainLoop & ~1) + 4;
         }
@@ -759,7 +759,7 @@ void Test_ExitWithResult_(enum TestResult result, u32 stopLine, const void *retu
      && gTestRunnerState.expectedResult == TEST_RESULT_FAIL
      && result == TEST_RESULT_FAIL)
     {
-        Test_MgbaPrintf(":L%s:%d: Expected failure in block from line %d, but failed on line %d",
+        Test_MgbaPrintf("%s:%d: Expected failure in block from line %d, but failed on line %d",
          gTestRunnerState.test->filename, stopLine,
          gTestRunnerState.expectedFailLine, stopLine);
     }
@@ -776,6 +776,8 @@ void Test_ExitWithResult_(enum TestResult result, u32 stopLine, const void *retu
                 const void *return0 = __builtin_return_address(0);
                 Test_MgbaPrintf("in %p\nin %p", return1, return0);
             }
+            // TODO: If 'fmt' starts with ':', insert a space to prevent
+            // Hydra interpreting it as a command.
             va_list va;
             va_start(va, fmt);
             MgbaVPrintf_(fmt, va);
@@ -1069,7 +1071,7 @@ u32 RandomUniformDefaultValue(enum RandomTag tag, u32 lo, u32 hi, bool32 (*rejec
         while (reject(default_))
         {
             if (default_ == lo)
-                Test_ExitWithResult(TEST_RESULT_ERROR, SourceLine(0), ":LRandomUniformExcept called from %p with tag %d rejected all values", caller, tag);
+                Test_ExitWithResult(TEST_RESULT_ERROR, SourceLine(0), "RandomUniformExcept called from %p with tag %d rejected all values", caller, tag);
             default_--;
         }
     }
@@ -1081,7 +1083,7 @@ u32 RandomWeightedArrayDefaultValue(enum RandomTag tag, u32 n, const u16 *weight
     while (weights[n-1] == 0)
     {
         if (n == 1)
-            Test_ExitWithResult(TEST_RESULT_ERROR, SourceLine(0), ":LRandomWeightedArray called from %p with tag %d and all zero weights", caller, tag);
+            Test_ExitWithResult(TEST_RESULT_ERROR, SourceLine(0), "RandomWeightedArray called from %p with tag %d and all zero weights", caller, tag);
         n--;
     }
     return n-1;
@@ -1121,5 +1123,5 @@ void SetupRiggedRng(u32 sourceLine, enum RandomTag randomTag, u32 value)
         }
     }
     if (i == RIGGED_RNG_COUNT)
-        Test_ExitWithResult(TEST_RESULT_FAIL, __LINE__, ":L%s:%d: Too many rigged RNGs to set up", gTestRunnerState.test->filename, sourceLine);
+        Test_ExitWithResult(TEST_RESULT_FAIL, __LINE__, "%s:%d: Too many rigged RNGs to set up", gTestRunnerState.test->filename, sourceLine);
 }

--- a/test/test_runner_battle.c
+++ b/test/test_runner_battle.c
@@ -33,10 +33,10 @@
 #undef TestRunner_Battle_RecordEffectivenessSound
 #endif
 
-#define INVALID(fmt, ...) Test_ExitWithResult(TEST_RESULT_INVALID, sourceLine, ":L%s:%d: " fmt, gTestRunnerState.test->filename, sourceLine, ##__VA_ARGS__)
-#define INVALID_IF(c, fmt, ...) do { if (c) Test_ExitWithResult(TEST_RESULT_INVALID, sourceLine, ":L%s:%d: " fmt, gTestRunnerState.test->filename, sourceLine, ##__VA_ARGS__); } while (0)
+#define INVALID(fmt, ...) Test_ExitWithResult(TEST_RESULT_INVALID, sourceLine, "%s:%d: " fmt, gTestRunnerState.test->filename, sourceLine, ##__VA_ARGS__)
+#define INVALID_IF(c, fmt, ...) do { if (c) Test_ExitWithResult(TEST_RESULT_INVALID, sourceLine, "%s:%d: " fmt, gTestRunnerState.test->filename, sourceLine, ##__VA_ARGS__); } while (0)
 
-#define ASSUMPTION_FAIL_IF(c, fmt, ...) do { if (c) Test_ExitWithResult(TEST_RESULT_ASSUMPTION_FAIL, sourceLine, ":L%s:%d: " fmt, gTestRunnerState.test->filename, sourceLine, ##__VA_ARGS__); } while (0)
+#define ASSUMPTION_FAIL_IF(c, fmt, ...) do { if (c) Test_ExitWithResult(TEST_RESULT_ASSUMPTION_FAIL, sourceLine, "%s:%d: " fmt, gTestRunnerState.test->filename, sourceLine, ##__VA_ARGS__); } while (0)
 
 #define STATE gBattleTestRunnerState
 #define DATA gBattleTestRunnerState->data
@@ -293,9 +293,9 @@ static void BattleTest_SetUp(void *data)
     InvokeTestFunction(test);
     STATE->parameters = STATE->parametersCount;
     if (STATE->parametersCount == 0 && test->resultsSize > 0)
-        Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), ":Lresults without PARAMETRIZE");
+        Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), "results without PARAMETRIZE");
     if (sizeof(*STATE) + test->resultsSize * STATE->parameters > sizeof(sBackupMapData))
-        Test_ExitWithResult(TEST_RESULT_ERROR, SourceLine(0), ":LOOM: STATE (%d) + STATE->results (%d) too big for sBackupMapData (%d)", sizeof(*STATE), test->resultsSize * STATE->parameters, sizeof(sBackupMapData));
+        Test_ExitWithResult(TEST_RESULT_ERROR, SourceLine(0), "OOM: STATE (%d) + STATE->results (%d) too big for sBackupMapData (%d)", sizeof(*STATE), test->resultsSize * STATE->parameters, sizeof(sBackupMapData));
     STATE->results = (void *)((char *)sBackupMapData + sizeof(struct BattleTestRunnerState));
     memset(STATE->results, 0, test->resultsSize * STATE->parameters);
     switch (test->type)
@@ -369,7 +369,7 @@ static void SetImplicitSpeeds(void)
             }
         }
         if (!madeProgress)
-            Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), ":LTURNs have contradictory speeds");
+            Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), "TURNs have contradictory speeds");
     }
 }
 
@@ -520,22 +520,22 @@ static void BattleTest_Run(void *data)
             switch (trainer)
             {
             case B_TRAINER_PLAYER:
-                Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), ":L%d PLAYER Pokemon required", requiredPartySizes[trainer]);
+                Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), "%d PLAYER Pokemon required", requiredPartySizes[trainer]);
                 break;
             case B_TRAINER_OPPONENT_A:
                 if (gBattleTypeFlags & BATTLE_TYPE_TWO_OPPONENTS)
-                    Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), ":L%d OPPONENT_A Pokemon required", requiredPartySizes[trainer]);
+                    Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), "%d OPPONENT_A Pokemon required", requiredPartySizes[trainer]);
                 else
-                    Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), ":L%d OPPONENT Pokemon required", requiredPartySizes[trainer]);
+                    Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), "%d OPPONENT Pokemon required", requiredPartySizes[trainer]);
                 break;
             case B_TRAINER_PARTNER:
-                Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), ":L%d PARTNER Pokemon required", requiredPartySizes[trainer]);
+                Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), "%d PARTNER Pokemon required", requiredPartySizes[trainer]);
                 break;
             case B_TRAINER_OPPONENT_B:
-                Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), ":L%d OPPONENT_B Pokemon required", requiredPartySizes[trainer]);
+                Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), "%d OPPONENT_B Pokemon required", requiredPartySizes[trainer]);
                 break;
             default:
-                Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), ":L%d TRAINER %d Pokemon required", requiredPartySizes[trainer], trainer);
+                Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), "%d TRAINER %d Pokemon required", requiredPartySizes[trainer], trainer);
                 break;
             }
         }
@@ -557,7 +557,7 @@ static void BattleTest_Run(void *data)
             }
 
             if (DATA.explicitSpeeds[trainer] != requiredExplicitSpeeds[trainer])
-                Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), ":LSpeed required for all PLAYERs and OPPONENTs");
+                Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), "Speed required for all PLAYERs and OPPONENTs");
         }
     }
     else
@@ -630,14 +630,14 @@ u32 RandomUniformTrials(enum RandomTag tag, u32 lo, u32 hi, bool32 (*reject)(u32
     if (!reject)
     {
         if ((STATE->trials != (hi - lo + 1)) && !(IsTieBreakTag(tag)))
-            Test_ExitWithResult(TEST_RESULT_ERROR, SourceLine(0), ":LRandomUniform called from %p with tag %d and inconsistent trials %d and %d", caller, tag, STATE->trials, hi - lo + 1);
+            Test_ExitWithResult(TEST_RESULT_ERROR, SourceLine(0), "RandomUniform called from %p with tag %d and inconsistent trials %d and %d", caller, tag, STATE->trials, hi - lo + 1);
         return STATE->runTrial + lo;
     }
 
     while (reject(STATE->runTrial + lo + STATE->rngTrialOffset))
     {
         if (STATE->runTrial + lo + STATE->rngTrialOffset > hi)
-            Test_ExitWithResult(TEST_RESULT_ERROR, SourceLine(0), ":LRandomUniformExcept called from %p with tag %d and inconsistent reject", caller, tag);
+            Test_ExitWithResult(TEST_RESULT_ERROR, SourceLine(0), "RandomUniformExcept called from %p with tag %d and inconsistent reject", caller, tag);
         STATE->rngTrialOffset++;
     }
 
@@ -654,7 +654,7 @@ u32 RandomWeightedArrayTrials(enum RandomTag tag, u32 sum, u32 n, const u16 *wei
         for (u32 i = 0; i < n; i++)
             weightSum += weights[i];
         if (weightSum != sum)
-            Test_ExitWithResult(TEST_RESULT_ERROR, SourceLine(0), ":LRandomWeighted called from %p has weights not matching its sum", caller);
+            Test_ExitWithResult(TEST_RESULT_ERROR, SourceLine(0), "RandomWeighted called from %p has weights not matching its sum", caller);
     }
 
     STATE->didRunRandomly = TRUE;
@@ -665,7 +665,7 @@ u32 RandomWeightedArrayTrials(enum RandomTag tag, u32 sum, u32 n, const u16 *wei
     }
     else if (STATE->trials != n)
     {
-        Test_ExitWithResult(TEST_RESULT_ERROR, SourceLine(0), ":LRandomWeighted called from %p with tag %d and inconsistent trials %d and %d", caller, tag, STATE->trials, n);
+        Test_ExitWithResult(TEST_RESULT_ERROR, SourceLine(0), "RandomWeighted called from %p with tag %d and inconsistent trials %d and %d", caller, tag, STATE->trials, n);
     }
 
     STATE->trialRatio = Q_4_12(weights[STATE->runTrial]) / sum;
@@ -682,7 +682,7 @@ const void *RandomElementArrayTrials(enum RandomTag tag, const void *array, size
     }
     else if (STATE->trials != count)
     {
-        Test_ExitWithResult(TEST_RESULT_ERROR, SourceLine(0), ":LRandomElement called from %p with tag %d and inconsistent trials %d and %d", caller, tag, STATE->trials, count);
+        Test_ExitWithResult(TEST_RESULT_ERROR, SourceLine(0), "RandomElement called from %p with tag %d and inconsistent trials %d and %d", caller, tag, STATE->trials, count);
     }
     STATE->trialRatio = Q_4_12(1) / count;
     return (const u8 *)array + size * STATE->runTrial;
@@ -699,7 +699,7 @@ static u32 BattleTest_RandomUniform(enum RandomTag tag, u32 lo, u32 hi, bool32 (
         if (turn && turn->rng.tag == tag)
         {
             if (reject && reject(turn->rng.value))
-                Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), ":LWITH_RNG specified a rejected value (%d)", turn->rng.value);
+                Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), "WITH_RNG specified a rejected value (%d)", turn->rng.value);
             return turn->rng.value;
         }
     }
@@ -812,7 +812,7 @@ static const void *BattleTest_RandomElementArray(enum RandomTag tag, const void 
                 if (element == turn->rng.value)
                     return (const u8 *)array + size * index;
             }
-            Test_ExitWithResult(TEST_RESULT_ERROR, SourceLine(0), ":L%s: RandomElement illegal value requested: %d", gTestRunnerState.test->filename, turn->rng.value);
+            Test_ExitWithResult(TEST_RESULT_ERROR, SourceLine(0), "%s: RandomElement illegal value requested: %d", gTestRunnerState.test->filename, turn->rng.value);
         }
     }
 
@@ -870,7 +870,7 @@ void TestRunner_Battle_RecordAbilityPopUp(enum BattlerId battlerId, enum Ability
                 u32 line = SourceLine(DATA.queuedEvents[match].sourceLineOffset);
                 if (gTestRunnerState.expectedFailState == EXPECT_FAIL_SCENE_OPEN)
                     gTestRunnerState.expectedFailState = EXPECT_FAIL_SUCCESS;
-                Test_ExitWithResult(TEST_RESULT_FAIL, line, ":L%s:%d: Matched ABILITY_POPUP", filename, line);
+                Test_ExitWithResult(TEST_RESULT_FAIL, line, "%s:%d: Matched ABILITY_POPUP", filename, line);
             }
 
             queuedEvent += event->groupSize;
@@ -935,7 +935,7 @@ void TestRunner_Battle_RecordAnimation(u32 animType, u32 animId)
                 u32 line = SourceLine(DATA.queuedEvents[match].sourceLineOffset);
                 if (gTestRunnerState.expectedFailState == EXPECT_FAIL_SCENE_OPEN)
                     gTestRunnerState.expectedFailState = EXPECT_FAIL_SUCCESS;
-                Test_ExitWithResult(TEST_RESULT_FAIL, line, ":L%s:%d: Matched ANIMATION", filename, line);
+                Test_ExitWithResult(TEST_RESULT_FAIL, line, "%s:%d: Matched ANIMATION", filename, line);
             }
 
             queuedEvent += event->groupSize;
@@ -1027,7 +1027,7 @@ void TestRunner_Battle_RecordHP(enum BattlerId battlerId, u32 oldHP, u32 newHP)
                 u32 line = SourceLine(DATA.queuedEvents[match].sourceLineOffset);
                 if (gTestRunnerState.expectedFailState == EXPECT_FAIL_SCENE_OPEN)
                     gTestRunnerState.expectedFailState = EXPECT_FAIL_SUCCESS;
-                Test_ExitWithResult(TEST_RESULT_FAIL, line, ":L%s:%d: Matched HP_BAR", filename, line);
+                Test_ExitWithResult(TEST_RESULT_FAIL, line, "%s:%d: Matched HP_BAR", filename, line);
             }
 
             queuedEvent += event->groupSize;
@@ -1108,7 +1108,7 @@ void TestRunner_Battle_RecordSubHit(enum BattlerId battlerId, u32 damage, bool32
                 u32 line = SourceLine(DATA.queuedEvents[match].sourceLineOffset);
                 if (gTestRunnerState.expectedFailState == EXPECT_FAIL_SCENE_OPEN)
                     gTestRunnerState.expectedFailState = EXPECT_FAIL_SUCCESS;
-                Test_ExitWithResult(TEST_RESULT_FAIL, line, ":L%s:%d: Matched SUB_HIT", filename, line);
+                Test_ExitWithResult(TEST_RESULT_FAIL, line, "%s:%d: Matched SUB_HIT", filename, line);
             }
 
             queuedEvent += event->groupSize;
@@ -1175,16 +1175,16 @@ void TestRunner_Battle_CheckChosenMove(enum BattlerId battlerId, enum Move moveI
         bool32 movePasses = FALSE;
 
         if (expectedAction->type != B_ACTION_USE_MOVE)
-            Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), ":L%s:%d: Expected %s, got MOVE", filename, expectedAction->sourceLine, sBattleActionNames[expectedAction->type]);
+            Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), "%s:%d: Expected %s, got MOVE", filename, expectedAction->sourceLine, sBattleActionNames[expectedAction->type]);
 
         if (expectedAction->explicitTarget && expectedAction->target != target)
-            Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), ":L%s:%d: Expected target %s, got %s", filename, expectedAction->sourceLine, BattlerIdentifier(expectedAction->target), BattlerIdentifier(target));
+            Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), "%s:%d: Expected target %s, got %s", filename, expectedAction->sourceLine, BattlerIdentifier(expectedAction->target), BattlerIdentifier(target));
 
         if ((DATA.targetTieOverride >= DATA.trial.targetTieCount) && (DATA.targetTieResolution == TARGET_TIE_CHOSEN))
-            Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), ":L%s:%d: TIE_BREAK_TARGET override %d, greater than count %d of targets with tied best score", filename, expectedAction->sourceLine, DATA.targetTieOverride, DATA.trial.targetTieCount);
+            Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), "%s:%d: TIE_BREAK_TARGET override %d, greater than count %d of targets with tied best score", filename, expectedAction->sourceLine, DATA.targetTieOverride, DATA.trial.targetTieCount);
 
         if (expectedAction->gimmick != GIMMICKS_COUNT && expectedAction->gimmick != gimmick)
-            Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), ":L%s:%d: Expected gimmick %s, got %s", filename, expectedAction->sourceLine, sGimmickIdentifiers[expectedAction->gimmick], sGimmickIdentifiers[gimmick]);
+            Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), "%s:%d: Expected gimmick %s, got %s", filename, expectedAction->sourceLine, sGimmickIdentifiers[expectedAction->gimmick], sGimmickIdentifiers[gimmick]);
 
         for (i = 0; i < MAX_MON_MOVES; i++)
         {
@@ -1218,16 +1218,16 @@ void TestRunner_Battle_CheckChosenMove(enum BattlerId battlerId, enum Move moveI
             u32 moveSlot = GetMoveSlot(gBattleMons[battlerId].moves, moveId);
             PrintAiMoveLog(battlerId, moveSlot, moveId, gAiBattleData->finalScore[battlerId][expectedAction->target][moveSlot]);
             if (countExpected > 1)
-                Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), ":L%s:%d: Unmatched EXPECT_MOVES %S, got %S", filename, expectedAction->sourceLine, GetMoveName(expectedMoveId), GetMoveName(moveId));
+                Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), "%s:%d: Unmatched EXPECT_MOVES %S, got %S", filename, expectedAction->sourceLine, GetMoveName(expectedMoveId), GetMoveName(moveId));
             else
-                Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), ":L%s:%d: Unmatched EXPECT_MOVE %S, got %S", filename, expectedAction->sourceLine, GetMoveName(expectedMoveId), GetMoveName(moveId));
+                Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), "%s:%d: Unmatched EXPECT_MOVE %S, got %S", filename, expectedAction->sourceLine, GetMoveName(expectedMoveId), GetMoveName(moveId));
         }
         if (expectedAction->notMove && !movePasses)
         {
             if (countExpected > 1)
-                Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), ":L%s:%d: Unmatched NOT_EXPECT_MOVES %S", filename, expectedAction->sourceLine, GetMoveName(expectedMoveId));
+                Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), "%s:%d: Unmatched NOT_EXPECT_MOVES %S", filename, expectedAction->sourceLine, GetMoveName(expectedMoveId));
             else
-                Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), ":L%s:%d: Unmatched NOT_EXPECT_MOVE %S", filename, expectedAction->sourceLine, GetMoveName(expectedMoveId));
+                Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), "%s:%d: Unmatched NOT_EXPECT_MOVE %S", filename, expectedAction->sourceLine, GetMoveName(expectedMoveId));
         }
     }
     // Turn passed, clear logs from the turn
@@ -1249,10 +1249,10 @@ void TestRunner_Battle_CheckSwitch(enum BattlerId battlerId, u32 partyIndex)
     if (!expectedAction->pass)
     {
         if (expectedAction->type != B_ACTION_SWITCH)
-            Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), ":L%s:%d: Expected %s, got SWITCH/SEND_OUT", filename, expectedAction->sourceLine, sBattleActionNames[expectedAction->type]);
+            Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), "%s:%d: Expected %s, got SWITCH/SEND_OUT", filename, expectedAction->sourceLine, sBattleActionNames[expectedAction->type]);
 
         if (expectedAction->target != partyIndex)
-            Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), ":L%s:%d: Expected partyIndex %d, got %d", filename, expectedAction->sourceLine, expectedAction->target, partyIndex);
+            Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), "%s:%d: Expected partyIndex %d, got %d", filename, expectedAction->sourceLine, expectedAction->target, partyIndex);
     }
     DATA.trial.aiActionsPlayed[battlerId]++;
 }
@@ -1304,7 +1304,7 @@ static void CheckIfMaxScoreEqualExpectMove(enum BattlerId battlerId, s32 target,
             && !(aiAction->moveSlots & (1u << bestScoreId))
             && (DATA.scoreTieResolution == SCORE_TIE_NONE))
         {
-            Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), ":L%s:%d: EXPECT_MOVE %S has the same best score(%d) as not expected MOVE %S. Consider using TIE_BREAK_SCORE.", filename,
+            Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), "%s:%d: EXPECT_MOVE %S has the same best score(%d) as not expected MOVE %S. Consider using TIE_BREAK_SCORE.", filename,
                                 aiAction->sourceLine, GetMoveName(moves[i]), scores[i], GetMoveName(moves[bestScoreId]));
         }
         // We DO NOT expect move 'i', but it has the same best score as another move.
@@ -1314,7 +1314,7 @@ static void CheckIfMaxScoreEqualExpectMove(enum BattlerId battlerId, s32 target,
             && !(aiAction->moveSlots & (1u << bestScoreId))
             && (DATA.scoreTieResolution == SCORE_TIE_NONE))
         {
-            Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), ":L%s:%d: NOT_EXPECT_MOVE %S has the same best score(%d) as MOVE %S. Consider using TIE_BREAK_SCORE.", filename,
+            Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), "%s:%d: NOT_EXPECT_MOVE %S has the same best score(%d) as MOVE %S. Consider using TIE_BREAK_SCORE.", filename,
                                 aiAction->sourceLine, GetMoveName(moves[i]), scores[i], GetMoveName(moves[bestScoreId]));
         }
     }
@@ -1357,7 +1357,7 @@ static void PrintAiMoveLog(enum BattlerId battlerId, u32 moveSlot, enum Move mov
     }
     if (scoreFromLogs != totalScore)
     {
-        Test_ExitWithResult(TEST_RESULT_ERROR, SourceLine(0), ":LWarning! Score from logs(%d) is different than actual score(%d). Make sure all of the score adjustments use the ADJUST_SCORE macro\n", scoreFromLogs, totalScore);
+        Test_ExitWithResult(TEST_RESULT_ERROR, SourceLine(0), "Warning! Score from logs(%d) is different than actual score(%d). Make sure all of the score adjustments use the ADJUST_SCORE macro\n", scoreFromLogs, totalScore);
     }
     Test_MgbaPrintf("Total: %d\n", totalScore);
 }
@@ -1395,7 +1395,7 @@ void TestRunner_Battle_CheckAiMoveScores(enum BattlerId battlerId)
                 PrintAiMoveLog(battlerId, scoreCtx->moveSlot1, moveId1, scores[scoreCtx->moveSlot1]);
                 if (!CheckComparision(scores[scoreCtx->moveSlot1], scoreCtx->value, scoreCtx->cmp))
                 {
-                    Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), ":L%s:%d: Unmatched SCORE_%s_VAL %S %d, got %d",
+                    Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), "%s:%d: Unmatched SCORE_%s_VAL %S %d, got %d",
                                         filename, scoreCtx->sourceLine, sCmpToStringTable[scoreCtx->cmp], GetMoveName(moveId1), scoreCtx->value, scores[scoreCtx->moveSlot1]);
                 }
             }
@@ -1406,7 +1406,7 @@ void TestRunner_Battle_CheckAiMoveScores(enum BattlerId battlerId)
                 PrintAiMoveLog(battlerId, scoreCtx->moveSlot2, moveId2, scores[scoreCtx->moveSlot2]);
                 if (!CheckComparision(scores[scoreCtx->moveSlot1], scores[scoreCtx->moveSlot2], scoreCtx->cmp))
                 {
-                    Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), ":L%s:%d: Unmatched SCORE_%s, got %S: %d, %S: %d",
+                    Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), "%s:%d: Unmatched SCORE_%s, got %S: %d, %S: %d",
                                         filename, scoreCtx->sourceLine, sCmpToStringTable[scoreCtx->cmp], GetMoveName(moveId1), scores[scoreCtx->moveSlot1], GetMoveName(moveId2), scores[scoreCtx->moveSlot2]);
                 }
             }
@@ -1508,7 +1508,7 @@ void TestRunner_Battle_RecordExp(enum BattlerId battlerId, u32 oldExp, u32 newEx
                 u32 line = SourceLine(DATA.queuedEvents[match].sourceLineOffset);
                 if (gTestRunnerState.expectedFailState == EXPECT_FAIL_SCENE_OPEN)
                     gTestRunnerState.expectedFailState = EXPECT_FAIL_SUCCESS;
-                Test_ExitWithResult(TEST_RESULT_FAIL, line, ":L%s:%d: Matched EXPERIENCE_BAR", filename, line);
+                Test_ExitWithResult(TEST_RESULT_FAIL, line, "%s:%d: Matched EXPERIENCE_BAR", filename, line);
             }
 
             queuedEvent += event->groupSize;
@@ -1600,7 +1600,7 @@ void TestRunner_Battle_RecordMessage(const u8 *string)
                 u32 line = SourceLine(DATA.queuedEvents[match].sourceLineOffset);
                 if (gTestRunnerState.expectedFailState == EXPECT_FAIL_SCENE_OPEN)
                     gTestRunnerState.expectedFailState = EXPECT_FAIL_SUCCESS;
-                Test_ExitWithResult(TEST_RESULT_FAIL, line, ":L%s:%d: Matched MESSAGE", filename, line);
+                Test_ExitWithResult(TEST_RESULT_FAIL, line, "%s:%d: Matched MESSAGE", filename, line);
             }
 
             queuedEvent += event->groupSize;
@@ -1667,7 +1667,7 @@ void TestRunner_Battle_RecordStatus1(enum BattlerId battlerId, u32 status1)
                 u32 line = SourceLine(DATA.queuedEvents[match].sourceLineOffset);
                 if (gTestRunnerState.expectedFailState == EXPECT_FAIL_SCENE_OPEN)
                     gTestRunnerState.expectedFailState = EXPECT_FAIL_SUCCESS;
-                Test_ExitWithResult(TEST_RESULT_FAIL, line, ":L%s:%d: Matched STATUS_ICON", filename, line);
+                Test_ExitWithResult(TEST_RESULT_FAIL, line, "%s:%d: Matched STATUS_ICON", filename, line);
             }
 
             queuedEvent += event->groupSize;
@@ -1726,7 +1726,7 @@ void TestRunner_Battle_RecordCatchChance(u32 catchChance)
             {
                 const char *filename = gTestRunnerState.test->filename;
                 u32 line = SourceLine(DATA.queuedEvents[match].sourceLineOffset);
-                Test_ExitWithResult(TEST_RESULT_FAIL, line, ":L%s:%d: Matched CATCH CHANCE", filename, line);
+                Test_ExitWithResult(TEST_RESULT_FAIL, line, "%s:%d: Matched CATCH CHANCE", filename, line);
             }
 
             queuedEvent += event->groupSize;
@@ -1764,7 +1764,7 @@ void TestRunner_Battle_AfterLastTurn(void)
     if (DATA.turns - 1 != DATA.trial.lastActionTurn)
     {
         const char *filename = gTestRunnerState.test->filename;
-        Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), ":L%s:%d: %d TURNs specified, but %d ran", filename, SourceLine(0), DATA.turns, DATA.trial.lastActionTurn + 1);
+        Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), "%s:%d: %d TURNs specified, but %d ran", filename, SourceLine(0), DATA.turns, DATA.trial.lastActionTurn + 1);
     }
 
     while (DATA.trial.queuedEvent < DATA.queuedEventsCount
@@ -1779,7 +1779,7 @@ void TestRunner_Battle_AfterLastTurn(void)
         const char *macro = sEventTypeMacros[DATA.queuedEvents[DATA.trial.queuedEvent].type];
         if (gTestRunnerState.expectedFailState == EXPECT_FAIL_SCENE_OPEN)
             gTestRunnerState.expectedFailState = EXPECT_FAIL_SUCCESS;
-        Test_ExitWithResult(TEST_RESULT_FAIL, line, ":L%s:%d: Unmatched %s", filename, line, macro);
+        Test_ExitWithResult(TEST_RESULT_FAIL, line, "%s:%d: Unmatched %s", filename, line, macro);
     }
 
     STATE->runThen = TRUE;
@@ -1868,13 +1868,13 @@ static void CB2_BattleTest_NextTrial(void)
     else
     {
         if (STATE->rngTag && !STATE->didRunRandomly && STATE->expectedRatio != Q_4_12(0.0) && STATE->expectedRatio != Q_4_12(1.0))
-            Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), ":L%s:%d: PASSES_RANDOMLY specified but no Random* call with that tag executed", gTestRunnerState.test->filename, SourceLine(0));
+            Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), "%s:%d: PASSES_RANDOMLY specified but no Random* call with that tag executed", gTestRunnerState.test->filename, SourceLine(0));
 
         // This is a tolerance of +/- ~2%.
         if (abs(STATE->observedRatio - STATE->expectedRatio) <= Q_4_12(0.02))
             gTestRunnerState.result = TEST_RESULT_PASS;
         else
-            Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), ":L%s:%d: Expected %q passes/successes, observed %q", gTestRunnerState.test->filename, SourceLine(0), STATE->expectedRatio, STATE->observedRatio);
+            Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), "%s:%d: Expected %q passes/successes, observed %q", gTestRunnerState.test->filename, SourceLine(0), STATE->expectedRatio, STATE->observedRatio);
     }
 }
 
@@ -2449,7 +2449,7 @@ static void PushBattlerAction(u32 sourceLine, enum BattlerId battlerId, u32 acti
 {
     u32 recordIndex = DATA.recordIndexes[battlerId]++;
     if (recordIndex >= BATTLER_RECORD_SIZE)
-        Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), ":LToo many actions");
+        Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), "Too many actions");
     DATA.battleRecordTypes[battlerId][recordIndex] = actionType;
     DATA.battleRecordTurnNumbers[battlerId][recordIndex] = DATA.turns;
     DATA.battleRecordSourceLineOffsets[battlerId][recordIndex] = SourceLineOffset(sourceLine);
@@ -2472,10 +2472,10 @@ void TestRunner_Battle_CheckBattleRecordActionType(enum BattlerId battlerId, u32
              && DATA.recordedBattle.battleRecord[battlerId][i-1] == B_ACTION_USE_MOVE)
             {
                 u32 line = SourceLine(DATA.battleRecordSourceLineOffsets[battlerId][i-1]);
-                Test_ExitWithResult(TEST_RESULT_INVALID, line, ":L%s:%d: Illegal MOVE", filename, line);
+                Test_ExitWithResult(TEST_RESULT_INVALID, line, "%s:%d: Illegal MOVE", filename, line);
             }
         }
-        Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), ":L%s:%d: Illegal MOVE", filename, SourceLine(0));
+        Test_ExitWithResult(TEST_RESULT_INVALID, SourceLine(0), "%s:%d: Illegal MOVE", filename, SourceLine(0));
     }
 
     if (DATA.battleRecordTypes[battlerId][recordIndex] != RECORDED_BYTE)
@@ -2505,22 +2505,22 @@ void TestRunner_Battle_CheckBattleRecordActionType(enum BattlerId battlerId, u32
                     switch (DATA.battleRecordTypes[battlerId][recordIndex])
                     {
                     case RECORDED_PARTY_INDEX:
-                        Test_ExitWithResult(TEST_RESULT_INVALID, line, ":L%s:%d: %s not required (is the send out random?)", filename, line, actualMacro);
+                        Test_ExitWithResult(TEST_RESULT_INVALID, line, "%s:%d: %s not required (is the send out random?)", filename, line, actualMacro);
                     default:
-                        Test_ExitWithResult(TEST_RESULT_INVALID, line, ":L%s:%d: %s not required", filename, line, actualMacro);
+                        Test_ExitWithResult(TEST_RESULT_INVALID, line, "%s:%d: %s not required", filename, line, actualMacro);
                     }
                 }
 
                 switch (actionType)
                 {
                 case RECORDED_ACTION_TYPE:
-                    Test_ExitWithResult(TEST_RESULT_INVALID, line, ":L%s:%d: Expected MOVE/SWITCH, got %s", filename, line, actualMacro);
+                    Test_ExitWithResult(TEST_RESULT_INVALID, line, "%s:%d: Expected MOVE/SWITCH, got %s", filename, line, actualMacro);
                 case RECORDED_PARTY_INDEX:
-                    Test_ExitWithResult(TEST_RESULT_INVALID, line, ":L%s:%d: Expected SEND_OUT, got %s", filename, line, actualMacro);
+                    Test_ExitWithResult(TEST_RESULT_INVALID, line, "%s:%d: Expected SEND_OUT, got %s", filename, line, actualMacro);
                 }
             }
 
-            Test_ExitWithResult(TEST_RESULT_ERROR, line, ":L%s:%d: Illegal battle record", filename, line);
+            Test_ExitWithResult(TEST_RESULT_ERROR, line, "%s:%d: Illegal battle record", filename, line);
         }
     }
     else
@@ -2528,7 +2528,7 @@ void TestRunner_Battle_CheckBattleRecordActionType(enum BattlerId battlerId, u32
         if (DATA.trial.lastActionTurn == gBattleResults.battleTurnCounter)
         {
             const char *filename = gTestRunnerState.test->filename;
-            Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), ":L%s:%d: TURN %d incomplete", filename, SourceLine(0), gBattleResults.battleTurnCounter + 1);
+            Test_ExitWithResult(TEST_RESULT_FAIL, SourceLine(0), "%s:%d: TURN %d incomplete", filename, SourceLine(0), gBattleResults.battleTurnCounter + 1);
         }
     }
 }
@@ -2537,7 +2537,7 @@ void OpenTurn(u32 sourceLine)
 {
     INVALID_IF(DATA.turnState != TURN_CLOSED, "Nested TURN");
     if (DATA.turns == MAX_TURNS)
-        Test_ExitWithResult(TEST_RESULT_ERROR, sourceLine, ":L%s:%d: TURN exceeds MAX_TURNS", gTestRunnerState.test->filename, sourceLine);
+        Test_ExitWithResult(TEST_RESULT_ERROR, sourceLine, "%s:%d: TURN exceeds MAX_TURNS", gTestRunnerState.test->filename, sourceLine);
     DATA.turnState = TURN_OPEN;
     DATA.actionBattlers = 0x00;
     DATA.moveBattlers = 0x00;
@@ -2776,7 +2776,7 @@ void Move(u32 sourceLine, struct BattlePokemon *battler, struct MoveContext ctx)
         {
             shellSideArmCount++;
             if (shellSideArmCount > 1)
-                Test_ExitWithResult(TEST_RESULT_ERROR, SourceLine(0), ":L Tried to use fixed RNG for multiple Shell Side Arm moves in the same turn");
+                Test_ExitWithResult(TEST_RESULT_ERROR, SourceLine(0), " Tried to use fixed RNG for multiple Shell Side Arm moves in the same turn");
         }
     }
 
@@ -3142,7 +3142,7 @@ void QueueAbility(u32 sourceLine, struct BattlePokemon *battler, struct AbilityE
 
     INVALID_IF(!STATE->runScene, "ABILITY_POPUP outside of SCENE");
     if (DATA.queuedEventsCount == MAX_QUEUED_EVENTS)
-        Test_ExitWithResult(TEST_RESULT_ERROR, sourceLine, ":L%s:%d: ABILITY exceeds MAX_QUEUED_EVENTS", gTestRunnerState.test->filename, sourceLine);
+        Test_ExitWithResult(TEST_RESULT_ERROR, sourceLine, "%s:%d: ABILITY exceeds MAX_QUEUED_EVENTS", gTestRunnerState.test->filename, sourceLine);
     DATA.queuedEvents[DATA.queuedEventsCount++] = (struct QueuedEvent) {
         .type = QUEUED_ABILITY_POPUP_EVENT,
         .sourceLineOffset = SourceLineOffset(sourceLine),
@@ -3164,7 +3164,7 @@ void QueueAnimation(u32 sourceLine, u32 type, u32 id, struct AnimationEventConte
 
     INVALID_IF(!STATE->runScene, "ANIMATION outside of SCENE");
     if (DATA.queuedEventsCount == MAX_QUEUED_EVENTS)
-        Test_ExitWithResult(TEST_RESULT_ERROR, sourceLine, ":L%s:%d: ANIMATION exceeds MAX_QUEUED_EVENTS", gTestRunnerState.test->filename, sourceLine);
+        Test_ExitWithResult(TEST_RESULT_ERROR, sourceLine, "%s:%d: ANIMATION exceeds MAX_QUEUED_EVENTS", gTestRunnerState.test->filename, sourceLine);
 
     attackerId = ctx.attacker ? ctx.attacker - gBattleMons : 0xF;
     if (type == ANIM_TYPE_MOVE)
@@ -3202,7 +3202,7 @@ void QueueHP(u32 sourceLine, struct BattlePokemon *battler, struct HPEventContex
 
     INVALID_IF(!STATE->runScene, "HP_BAR outside of SCENE");
     if (DATA.queuedEventsCount == MAX_QUEUED_EVENTS)
-        Test_ExitWithResult(TEST_RESULT_ERROR, sourceLine, ":L%s:%d: HP_BAR exceeds MAX_QUEUED_EVENTS", gTestRunnerState.test->filename, sourceLine);
+        Test_ExitWithResult(TEST_RESULT_ERROR, sourceLine, "%s:%d: HP_BAR exceeds MAX_QUEUED_EVENTS", gTestRunnerState.test->filename, sourceLine);
 
     if (ctx.explicitHP)
     {
@@ -3259,7 +3259,7 @@ void QueueSubHit(u32 sourceLine, struct BattlePokemon *battler, struct SubHitEve
 
     INVALID_IF(!STATE->runScene, "SUB_HIT outside of SCENE");
     if (DATA.queuedEventsCount == MAX_QUEUED_EVENTS)
-        Test_ExitWithResult(TEST_RESULT_ERROR, sourceLine, ":L%s:%d: SUB_HIT exceeds MAX_QUEUED_EVENTS", gTestRunnerState.test->filename, sourceLine);
+        Test_ExitWithResult(TEST_RESULT_ERROR, sourceLine, "%s:%d: SUB_HIT exceeds MAX_QUEUED_EVENTS", gTestRunnerState.test->filename, sourceLine);
 
     address = 0;
     if (ctx.explicitCaptureDamage)
@@ -3301,7 +3301,7 @@ void QueueExp(u32 sourceLine, struct BattlePokemon *battler, struct ExpEventCont
 
     INVALID_IF(!STATE->runScene, "EXPERIENCE_BAR outside of SCENE");
     if (DATA.queuedEventsCount == MAX_QUEUED_EVENTS)
-        Test_ExitWithResult(TEST_RESULT_ERROR, sourceLine, ":L%s:%d: EXPERIENCE_BAR exceeds MAX_QUEUED_EVENTS", gTestRunnerState.test->filename, sourceLine);
+        Test_ExitWithResult(TEST_RESULT_ERROR, sourceLine, "%s:%d: EXPERIENCE_BAR exceeds MAX_QUEUED_EVENTS", gTestRunnerState.test->filename, sourceLine);
 
     if (ctx.explicitExp)
     {
@@ -3341,7 +3341,7 @@ void QueueMessage(u32 sourceLine, const u8 *pattern)
 
     INVALID_IF(!STATE->runScene, "MESSAGE outside of SCENE");
     if (DATA.queuedEventsCount == MAX_QUEUED_EVENTS)
-        Test_ExitWithResult(TEST_RESULT_ERROR, sourceLine, ":L%s:%d: MESSAGE exceeds MAX_QUEUED_EVENTS", gTestRunnerState.test->filename, sourceLine);
+        Test_ExitWithResult(TEST_RESULT_ERROR, sourceLine, "%s:%d: MESSAGE exceeds MAX_QUEUED_EVENTS", gTestRunnerState.test->filename, sourceLine);
     DATA.queuedEvents[DATA.queuedEventsCount++] = (struct QueuedEvent) {
         .type = QUEUED_MESSAGE_EVENT,
         .sourceLineOffset = SourceLineOffset(sourceLine),
@@ -3363,7 +3363,7 @@ void QueueStatus(u32 sourceLine, struct BattlePokemon *battler, struct StatusEve
 
     INVALID_IF(!STATE->runScene, "STATUS_ICON outside of SCENE");
     if (DATA.queuedEventsCount == MAX_QUEUED_EVENTS)
-        Test_ExitWithResult(TEST_RESULT_ERROR, sourceLine, ":L%s:%d: STATUS_ICON exceeds MAX_QUEUED_EVENTS", gTestRunnerState.test->filename, sourceLine);
+        Test_ExitWithResult(TEST_RESULT_ERROR, sourceLine, "%s:%d: STATUS_ICON exceeds MAX_QUEUED_EVENTS", gTestRunnerState.test->filename, sourceLine);
 
     if (ctx.none)
         mask = 0;
@@ -3400,7 +3400,7 @@ void QueueCatchingChance(u32 sourceLine, u32 *captureAddress)
 {
     INVALID_IF(!STATE->runScene, "CAPTURE outside of SCENE");
     if (DATA.queuedEventsCount == MAX_QUEUED_EVENTS)
-        Test_ExitWithResult(TEST_RESULT_ERROR, sourceLine, ":L%s:%d: CAPTURE exceeds MAX_QUEUED_EVENTS", gTestRunnerState.test->filename, sourceLine);
+        Test_ExitWithResult(TEST_RESULT_ERROR, sourceLine, "%s:%d: CAPTURE exceeds MAX_QUEUED_EVENTS", gTestRunnerState.test->filename, sourceLine);
     u32 address = (u32)captureAddress;
     DATA.queuedEvents[DATA.queuedEventsCount++] = (struct QueuedEvent) {
         .type = QUEUED_CATCH_CHANCE_EVENT,
@@ -3449,7 +3449,7 @@ struct AILogLine *GetLogLine(enum BattlerId battlerId, u32 moveIndex)
         }
     }
 
-    Test_ExitWithResult(TEST_RESULT_ERROR, SourceLine(0), ":LToo many AI log lines");
+    Test_ExitWithResult(TEST_RESULT_ERROR, SourceLine(0), "Too many AI log lines");
     return NULL;
 }
 
@@ -3481,7 +3481,7 @@ void QueueEffectivenessSound(u32 sourceLine, struct BattlePokemon *battler, stru
     s32 battlerId = battler - gBattleMons;
     INVALID_IF(!STATE->runScene, "EFFECTIVENESS_SE outside of SCENE");
     if (DATA.queuedEventsCount == MAX_QUEUED_EVENTS)
-        Test_ExitWithResult(TEST_RESULT_ERROR, sourceLine, ":L%s:%d: EFFECTIVENESS_SE exceeds MAX_QUEUED_EVENTS", gTestRunnerState.test->filename, sourceLine);
+        Test_ExitWithResult(TEST_RESULT_ERROR, sourceLine, "%s:%d: EFFECTIVENESS_SE exceeds MAX_QUEUED_EVENTS", gTestRunnerState.test->filename, sourceLine);
     DATA.queuedEvents[DATA.queuedEventsCount++] = (struct QueuedEvent) {
         .type = QUEUED_EFFECTIVENESS_EVENT,
         .sourceLineOffset = SourceLineOffset(sourceLine),
@@ -3537,7 +3537,7 @@ void TestRunner_Battle_RecordEffectivenessSound(u32 battlerId, u32 soundId)
             {
                 const char *filename = gTestRunnerState.test->filename;
                 u32 line = SourceLine(DATA.queuedEvents[match].sourceLineOffset);
-                Test_ExitWithResult(TEST_RESULT_FAIL, line, ":L%s:%d: Matched EFFECTIVENESS_SE", filename, line);
+                Test_ExitWithResult(TEST_RESULT_FAIL, line, "%s:%d: Matched EFFECTIVENESS_SE", filename, line);
             }
 
             queuedEvent += event->groupSize;

--- a/tools/mgba-rom-test-hydra/main.c
+++ b/tools/mgba-rom-test-hydra/main.c
@@ -9,8 +9,6 @@
  * COMMANDS
  * N: Sets the test name to the remainder of the line.
  * L: Sets the filename to the remainder of the line.
- * R: Sets the result to the remainder of the line, and flushes any
- *    output buffered since the previous R.
  * P/E/K/F/A: Sets the result to the remaining of the line, flushes any
  *    output since the previous P/E/K/F/A and increment the number of
  *    passes/expected fails/known fails/assumption fails/fails.
@@ -37,11 +35,61 @@
 
 #define min(a, b) ((a) < (b) ? (a) : (b))
 
-#define MAX_PROCESSES               32 // See also test/test.h
-#define MAX_SUMMARY_TESTS_TO_LIST   50
-#define MAX_TEST_LIST_BUFFER_LENGTH 256
+#ifndef _GNU_SOURCE
+// Very naive implementation of 'memmem' for systems which don't make it
+// available by default.
+void *memmem(const void *haystack, size_t haystacklen, const void *needle, size_t needlelen)
+{
+    if (haystacklen < needlelen)
+        return NULL;
+    const char *haystack_ = haystack;
+    const char *needle_ = needle;
+    for (size_t i = 0; i < haystacklen - needlelen; i++)
+    {
+        size_t j;
+        for (j = 0; j < needlelen; j++)
+        {
+            if (haystack_[i+j] != needle_[j])
+                break;
+        }
+        if (j == needlelen)
+            return (void *)&haystack_[i];
+    }
+    return NULL;
+}
+
+void *memrchr(const void *s_, int c, size_t n)
+{
+    const char *s = s_;
+    while (n > 0)
+    {
+        n--;
+        if (s[n] == c)
+            return (void *)&s[n];
+    }
+    return NULL;
+}
+#endif
+
+#define MAX_PROCESSES             32 // See also test/test.h
+#define MAX_SUMMARY_TESTS_TO_LIST 50
 
 #define ARRAY_COUNT(arr) (sizeof((arr)) / sizeof((arr)[0]))
+
+struct SummaryResult
+{
+    char test_name[256];
+    char filename_line[256];
+    char output_line[256];
+};
+
+struct SummaryResults
+{
+    struct SummaryResult results[MAX_SUMMARY_TESTS_TO_LIST];
+    int count;
+};
+
+struct SummaryResults fails_summaries, known_fails_passing_summaries, expected_failing_summaries, assumption_fails_summaries;
 
 struct Runner
 {
@@ -57,23 +105,54 @@ struct Runner
     size_t output_buffer_capacity;
     char *output_buffer;
     int passes;
-    int knownFails;
-    int knownFailsPassing;
-    int expectedFails;
-    int expectedFailsPassing;
+    int expected_fails;
+    int expected_fails_passing;
+    int known_fails;
+    int known_fails_passing;
     int todos;
-    int assumptionFails;
+    int assumption_fails;
     int fails;
     int results;
-    char failed_TestNames[MAX_SUMMARY_TESTS_TO_LIST][MAX_TEST_LIST_BUFFER_LENGTH];
-    char failed_TestFilenameLine[MAX_SUMMARY_TESTS_TO_LIST][MAX_TEST_LIST_BUFFER_LENGTH];
-    char knownFailingPassed_TestNames[MAX_SUMMARY_TESTS_TO_LIST][MAX_TEST_LIST_BUFFER_LENGTH];
-    char knownFailingPassed_FilenameLine[MAX_SUMMARY_TESTS_TO_LIST][MAX_TEST_LIST_BUFFER_LENGTH];
-    char expectedFailingPassed_TestNames[MAX_SUMMARY_TESTS_TO_LIST][MAX_TEST_LIST_BUFFER_LENGTH];
-    char expectedFailingPassed_FilenameLine[MAX_SUMMARY_TESTS_TO_LIST][MAX_TEST_LIST_BUFFER_LENGTH];
-    char assumeFailed_TestNames[MAX_SUMMARY_TESTS_TO_LIST][MAX_TEST_LIST_BUFFER_LENGTH];
-    char assumeFailed_FilenameLine[MAX_SUMMARY_TESTS_TO_LIST][MAX_TEST_LIST_BUFFER_LENGTH];
 };
+
+void push_summary_result(struct SummaryResults *summaries, const struct Runner *runner)
+{
+    if (summaries->count < ARRAY_COUNT(summaries->results))
+    {
+        struct SummaryResult *result = &summaries->results[summaries->count++];
+
+        memcpy(result->test_name, runner->test_name, sizeof(result->test_name));
+
+        memcpy(result->filename_line, runner->filename_line, sizeof(result->filename_line));
+
+        // Extract the last line of the output buffer.
+        // NOTE: '- 1' because 'output_buffer' ends with a '\n'.
+        const char *nl = memrchr(runner->output_buffer, '\n', runner->output_buffer_size - 1);
+        if (nl == NULL)
+            nl = runner->output_buffer;
+        else
+            nl++;
+        // Strip the 'filename:' prefix, if any.
+        size_t nl_n = runner->output_buffer + runner->output_buffer_size - nl - 1;
+        const char *colon = memchr(nl, ':', nl_n);
+        size_t n;
+        if (colon)
+        {
+            colon++;
+            n = nl + nl_n - colon;
+            memcpy(result->output_line, colon, n);
+        }
+        else
+        {
+            n = nl_n;
+            memcpy(result->output_line, nl, n);
+        }
+        if (n < sizeof(result->output_line))
+            result->output_line[n] = '\0';
+        else
+            result->output_line[sizeof(result->output_line) - 1] = '\0';
+    }
+}
 
 struct Symbol {
     const char *name;
@@ -109,30 +188,6 @@ static const struct Symbol *lookup_address(uint32_t address)
     }
     return NULL;
 }
-
-#ifndef _GNU_SOURCE
-// Very naive implementation of 'memmem' for systems which don't make it
-// available by default.
-void *memmem(const void *haystack, size_t haystacklen, const void *needle, size_t needlelen)
-{
-    if (haystacklen < needlelen)
-        return NULL;
-    const char *haystack_ = haystack;
-    const char *needle_ = needle;
-    for (size_t i = 0; i < haystacklen - needlelen; i++)
-    {
-        size_t j;
-        for (j = 0; j < needlelen; j++)
-        {
-            if (haystack_[i+j] != needle_[j])
-                break;
-        }
-        if (j == needlelen)
-            return (void *)&haystack_[i];
-    }
-    return NULL;
-}
-#endif
 
 // Similar to 'fwrite(buffer, 1, size, f)' except that anything which
 // looks like the output of '%p' (i.e. '<0x\d{7}>') is translated into
@@ -246,44 +301,28 @@ static void handle_read(int i, struct Runner *runner)
                     runner->passes++;
                     goto add_to_results;
                 case 'E':
-                    runner->expectedFails++;
+                    runner->expected_fails++;
                     goto add_to_results;
                 case 'K':
-                    runner->knownFails++;
+                    runner->known_fails++;
                     goto add_to_results;
                 case 'U':
-                    if (runner->knownFailsPassing < MAX_SUMMARY_TESTS_TO_LIST)
-                    {
-                        strcpy(runner->knownFailingPassed_TestNames[runner->knownFailsPassing], runner->test_name);
-                        strcpy(runner->knownFailingPassed_FilenameLine[runner->knownFailsPassing], runner->filename_line);
-                    }
-                    runner->knownFailsPassing++;
+                    push_summary_result(&known_fails_passing_summaries, runner);
+                    runner->known_fails_passing++;
                     goto add_to_results;
                 case 'V':
-                    if (runner->expectedFailsPassing < MAX_SUMMARY_TESTS_TO_LIST)
-                    {
-                        strcpy(runner->expectedFailingPassed_TestNames[runner->expectedFailsPassing], runner->test_name);
-                        strcpy(runner->expectedFailingPassed_FilenameLine[runner->expectedFailsPassing], runner->filename_line);
-                    }
-                    runner->expectedFailsPassing++;
+                    push_summary_result(&expected_failing_summaries, runner);
+                    runner->expected_fails_passing++;
                     goto add_to_results;
                 case 'T':
                     runner->todos++;
                     goto add_to_results;
                 case 'A':
-                    if (runner->assumptionFails < MAX_SUMMARY_TESTS_TO_LIST)
-                    {
-                        strcpy(runner->assumeFailed_TestNames[runner->assumptionFails], runner->test_name);
-                        strcpy(runner->assumeFailed_FilenameLine[runner->assumptionFails], runner->filename_line);
-                    }
-                    runner->assumptionFails++;
+                    push_summary_result(&assumption_fails_summaries, runner);
+                    runner->assumption_fails++;
                     goto add_to_results;
                 case 'F':
-                    if (runner->fails < MAX_SUMMARY_TESTS_TO_LIST)
-                    {
-                        strcpy(runner->failed_TestNames[runner->fails], runner->test_name);
-                        strcpy(runner->failed_TestFilenameLine[runner->fails], runner->filename_line);
-                    }
+                    push_summary_result(&fails_summaries, runner);
                     runner->fails++;
 add_to_results:
                     runner->results++;
@@ -752,26 +791,14 @@ int main(int argc, char *argv[])
     // Reap test runners and collate exit codes.
     int exit_code = 0;
     int passes = 0;
-    int expectedFails = 0;
-    int expectedFailsPassing = 0;
-    int knownFails = 0;
-    int knownFailsPassing = 0;
+    int expected_fails = 0;
+    int expected_fails_passing = 0;
+    int known_fails = 0;
+    int known_fails_passing = 0;
     int todos = 0;
-    int assumptionFails = 0;
+    int assumption_fails = 0;
     int fails = 0;
     int results = 0;
-
-    char failed_TestNames[MAX_SUMMARY_TESTS_TO_LIST * MAX_PROCESSES][MAX_TEST_LIST_BUFFER_LENGTH];
-    char failed_TestFilenameLine[MAX_SUMMARY_TESTS_TO_LIST * MAX_PROCESSES][MAX_TEST_LIST_BUFFER_LENGTH];
-
-    char knownFailingPassed_TestNames[MAX_SUMMARY_TESTS_TO_LIST * MAX_PROCESSES][MAX_TEST_LIST_BUFFER_LENGTH];
-    char knownFailingPassed_FilenameLine[MAX_SUMMARY_TESTS_TO_LIST * MAX_PROCESSES][MAX_TEST_LIST_BUFFER_LENGTH];
-
-    char expectedFailingPassed_TestNames[MAX_SUMMARY_TESTS_TO_LIST * MAX_PROCESSES][MAX_TEST_LIST_BUFFER_LENGTH];
-    char expectedFailingPassed_FilenameLine[MAX_SUMMARY_TESTS_TO_LIST * MAX_PROCESSES][MAX_TEST_LIST_BUFFER_LENGTH];
-
-    char assumeFailed_TestNames[MAX_SUMMARY_TESTS_TO_LIST * MAX_PROCESSES][MAX_TEST_LIST_BUFFER_LENGTH];
-    char assumeFailed_FilenameLine[MAX_SUMMARY_TESTS_TO_LIST * MAX_PROCESSES][MAX_TEST_LIST_BUFFER_LENGTH];
 
     for (int i = 0; i < nrunners; i++)
     {
@@ -786,45 +813,13 @@ int main(int argc, char *argv[])
         if (WIFEXITED(wstatus) && WEXITSTATUS(wstatus) > exit_code)
             exit_code = WEXITSTATUS(wstatus);
         passes += runners[i].passes;
-        expectedFails += runners[i].expectedFails;
-        knownFails += runners[i].knownFails;
-        for (int j = 0; j < runners[i].knownFailsPassing; j++)
-        {
-            if (j < MAX_SUMMARY_TESTS_TO_LIST)
-            {
-                strcpy(knownFailingPassed_TestNames[knownFailsPassing], runners[i].knownFailingPassed_TestNames[j]);
-                strcpy(knownFailingPassed_FilenameLine[knownFailsPassing], runners[i].knownFailingPassed_FilenameLine[j]);
-            }
-            knownFailsPassing++;
-        }
-        for (int j = 0; j < runners[i].expectedFailsPassing; j++)
-        {
-            if (j < MAX_SUMMARY_TESTS_TO_LIST)
-            {
-                strcpy(expectedFailingPassed_TestNames[expectedFailsPassing], runners[i].expectedFailingPassed_TestNames[j]);
-                strcpy(expectedFailingPassed_FilenameLine[expectedFailsPassing], runners[i].expectedFailingPassed_FilenameLine[j]);
-            }
-            expectedFailsPassing++;
-        }
+        expected_fails += runners[i].expected_fails;
+        expected_fails_passing += runners[i].expected_fails_passing;
+        known_fails += runners[i].known_fails;
+        known_fails_passing += runners[i].known_fails_passing;
         todos += runners[i].todos;
-        for (int j = 0; j < runners[i].assumptionFails; j++)
-        {
-            if (j < MAX_SUMMARY_TESTS_TO_LIST)
-            {
-                strcpy(assumeFailed_TestNames[assumptionFails], runners[i].assumeFailed_TestNames[j]);
-                strcpy(assumeFailed_FilenameLine[assumptionFails], runners[i].assumeFailed_FilenameLine[j]);
-            }
-            assumptionFails++;
-        }
-        for (int j = 0; j < runners[i].fails; j++)
-        {
-            if (j < MAX_SUMMARY_TESTS_TO_LIST)
-            {
-                strcpy(failed_TestNames[fails], runners[i].failed_TestNames[j]);
-                strcpy(failed_TestFilenameLine[fails], runners[i].failed_TestFilenameLine[j]);
-            }
-            fails++;
-        }
+        assumption_fails += runners[i].assumption_fails;
+        fails += runners[i].fails;
         results += runners[i].results;
     }
 
@@ -837,66 +832,44 @@ int main(int argc, char *argv[])
         if (fails > 0)
         {
             fprintf(stdout, "\n  \e[31mFAILED\e[0m tests:\n");
-            for (int i = 0; i < fails; i++)
-            {
-                if (i >= MAX_SUMMARY_TESTS_TO_LIST)
-                {
-                    fprintf(stdout, "  - \e[31mand %d more...\e[0m\n", fails - MAX_SUMMARY_TESTS_TO_LIST);
-                    break;
-                }
-                fprintf(stdout, "  - \e[31m");
-                fprint_buffer(stdout, failed_TestFilenameLine[i], strlen(failed_TestFilenameLine[i]));
-                fprintf(stdout, "\e[0m - %s.\n", failed_TestNames[i]);
-            }
+            for (int i = 0; i < fails_summaries.count; i++)
+                fprintf(stdout, "  - \e[31m%s\e[0m: %s: %s\n", fails_summaries.results[i].filename_line, fails_summaries.results[i].test_name, fails_summaries.results[i].output_line);
+            if (fails > fails_summaries.count)
+                fprintf(stdout, "  - \e[31mand %d more...\e[0m\n", fails - fails_summaries.count);
         }
 
-        if (assumptionFails > 0)
+        if (assumption_fails > 0)
         {
             fprintf(stdout, "\n  Tests with \e[33mASSUMPTIONS_FAILED\e[0m:\n");
-            for (int i = 0; i < assumptionFails; i++)
-            {
-                if (i >= MAX_SUMMARY_TESTS_TO_LIST)
-                {
-                    fprintf(stdout, "  - \e[33mand %d more...\e[0m\n", assumptionFails - MAX_SUMMARY_TESTS_TO_LIST);
-                    break;
-                }
-                fprintf(stdout, "  - \e[33m");
-                fprint_buffer(stdout, assumeFailed_FilenameLine[i], strlen(assumeFailed_FilenameLine[i]));
-                fprintf(stdout, "\e[0m - %s.\n", assumeFailed_TestNames[i]);
-            }
+            for (int i = 0; i < assumption_fails_summaries.count; i++)
+                fprintf(stdout, "  - \e[33m%s\e[0m: %s: %s\n", assumption_fails_summaries.results[i].filename_line, assumption_fails_summaries.results[i].test_name, assumption_fails_summaries.results[i].output_line);
+            if (assumption_fails > assumption_fails_summaries.count)
+                fprintf(stdout, "  - \e[33mand %d more...\e[0m\n", assumption_fails - assumption_fails_summaries.count);
         }
 
-        if (knownFailsPassing > 0)
+        if (known_fails_passing > 0)
         {
             fprintf(stdout, "\n  \e[33mKNOWN_FAILING\e[0m tests \e[32mPASSING\e[0m:\n");
-            for (int i = 0; i < knownFailsPassing; i++)
-            {
-                if (i >= MAX_SUMMARY_TESTS_TO_LIST)
-                {
-                    fprintf(stdout, "  - \e[32mand %d more...\e[0m\n", knownFailsPassing - MAX_SUMMARY_TESTS_TO_LIST);
-                    break;
-                }
-                fprintf(stdout, "  - \e[32m");
-                fprint_buffer(stdout, knownFailingPassed_FilenameLine[i], strlen(knownFailingPassed_FilenameLine[i]));
-                fprintf(stdout, "\e[0m - %s.\n", knownFailingPassed_TestNames[i]);
-            }
+            for (int i = 0; i < known_fails_passing_summaries.count; i++)
+                fprintf(stdout, "  - \e[32m%s\e[0m: %s: %s.\n", known_fails_passing_summaries.results[i].filename_line, known_fails_passing_summaries.results[i].test_name, known_fails_passing_summaries.results[i].output_line);
+            fprintf(stdout, "  - \e[32mand %d more...\e[0m\n", known_fails_passing - known_fails_passing_summaries.count);
         }
 
         fprintf(stdout, "\n");
         if (fails > 0)
             fprintf(stdout, "- Tests \e[31mFAILED\e[0m :         %d    Add TESTS='X' to run tests with the defined prefix.\n", fails);
-        if (expectedFailsPassing > 0)
-            fprintf(stdout, "- \e[31mEXPECTED_FAIL_PASSING\e[0m: %d\n", expectedFailsPassing);
-        if (knownFails > 0)
-            fprintf(stdout, "- Tests \e[33mKNOWN_FAILING\e[0m:   %d\n", knownFails);
-        if (assumptionFails > 0)
-            fprintf(stdout, "- \e[33mASSUMPTIONS_FAILED\e[0m:    %d\n", assumptionFails);
+        if (expected_fails_passing > 0)
+            fprintf(stdout, "- \e[31mEXPECTED_FAIL_PASSING\e[0m: %d\n", expected_fails_passing);
+        if (known_fails > 0)
+            fprintf(stdout, "- Tests \e[33mKNOWN_FAILING\e[0m:   %d\n", known_fails);
+        if (assumption_fails > 0)
+            fprintf(stdout, "- \e[33mASSUMPTIONS_FAILED\e[0m:    %d\n", assumption_fails);
         if (todos > 0)
             fprintf(stdout, "- Tests \e[33mTO_DO\e[0m:           %d\n", todos);
-        if (knownFailsPassing > 0)
-            fprintf(stdout, "- \e[32mKNOWN_FAILING_PASSING\e[0m: %d   \e[33mPlease remove KNOWN_FAILING if these tests intentionally PASS\e[0m\n", knownFailsPassing);
-        if (expectedFails > 0)
-            fprintf(stdout, "- Tests \e[32mEXPECT_FAILING\e[0m:  %d\n", expectedFails);
+        if (known_fails_passing > 0)
+            fprintf(stdout, "- \e[32mKNOWN_FAILING_PASSING\e[0m: %d   \e[33mPlease remove KNOWN_FAILING if these tests intentionally PASS\e[0m\n", known_fails_passing);
+        if (expected_fails > 0)
+            fprintf(stdout, "- Tests \e[32mEXPECT_FAILING\e[0m:  %d\n", expected_fails);
         if (passes > 0)
             fprintf(stdout, "- Tests \e[32mPASSED\e[0m:          %d\n", passes);
         fprintf(stdout, "- Tests \e[34mTOTAL\e[0m:           %d\n", results);


### PR DESCRIPTION
:L was used to append the failure message to the summaries at the end of Hydra's output. But this stole the output from the buffer, which means that:
1. If too many tests fail some of the failure messages will be discarded.
2. If a failing test has any other output you have to scroll back and forth to see how it relates to the ultimate failure message.

You can see the difference by purposefully causing a test to fail, e.g.:
```diff
    RUN_OVERWORLD_SCRIPT(
-       hypertrain STAT_ATK, 0;
+       // hypertrain STAT_ATK, 0;
        canhypertrain STAT_ATK, 0;
```
Before:
```
[0] canhypertrain/hypertrain affect MON_DATA_HYPER_TRAINED_* and recalculate stats: FAIL

  FAILED tests:
  - test/pokemon.c:197: EXPECT failed - canhypertrain/hypertrain affect MON_DATA_HYPER_TRAINED_* and recalculate stats.
```
After:
```
[0] canhypertrain/hypertrain affect MON_DATA_HYPER_TRAINED_* and recalculate stats: FAIL
test/pokemon.c:197: EXPECT failed

  FAILED tests:
  - test/pokemon.c:177: canhypertrain/hypertrain affect MON_DATA_HYPER_TRAINED_* and recalculate stats: 197: EXPECT failed
```

This PR blocks #9807 because it's practically unusable when you can't see why the test failed.