### PR TITLE
Replace string buffer macros with functions

### DIFF
--- a/include/battle_message.h
+++ b/include/battle_message.h
@@ -104,136 +104,6 @@
 #define B_BUFF_PLACEHOLDER_BEGIN        0xFD
 #define B_BUFF_EOS                      0xFF
 
-#define PREPARE_FLAVOR_BUFFER(textVar, flavorId)                            \
-{                                                                           \
-    textVar[0] = B_BUFF_PLACEHOLDER_BEGIN;                                  \
-    textVar[1] = B_BUFF_NEGATIVE_FLAVOR;                                    \
-    textVar[2] = flavorId;                                                  \
-    textVar[3] = B_BUFF_EOS;                                                \
-}
-
-#define PREPARE_STAT_BUFFER(textVar, statId)                                \
-{                                                                           \
-    textVar[0] = B_BUFF_PLACEHOLDER_BEGIN;                                  \
-    textVar[1] = B_BUFF_STAT;                                               \
-    textVar[2] = statId;                                                    \
-    textVar[3] = B_BUFF_EOS;                                                \
-}
-
-#define PREPARE_ABILITY_BUFFER(textVar, abilityId)                          \
-{                                                                           \
-    textVar[0] = B_BUFF_PLACEHOLDER_BEGIN;                                  \
-    textVar[1] = B_BUFF_ABILITY;                                            \
-    textVar[2] = abilityId;                                                 \
-    textVar[3] = (abilityId & 0xFF00) >> 8;                                 \
-    textVar[4] = B_BUFF_EOS;                                                \
-}
-
-#define PREPARE_TYPE_BUFFER(textVar, typeId)                                \
-{                                                                           \
-    textVar[0] = B_BUFF_PLACEHOLDER_BEGIN;                                  \
-    textVar[1] = B_BUFF_TYPE;                                               \
-    textVar[2] = typeId;                                                    \
-    textVar[3] = B_BUFF_EOS;                                                \
-}
-
-#define PREPARE_BYTE_NUMBER_BUFFER(textVar, maxDigits, number)  \
-{                                                               \
-    textVar[0] = B_BUFF_PLACEHOLDER_BEGIN;                      \
-    textVar[1] = B_BUFF_NUMBER;                                 \
-    textVar[2] = 1;                                             \
-    textVar[3] = maxDigits;                                     \
-    textVar[4] = (number);                                      \
-    textVar[5] = B_BUFF_EOS;                                    \
-}
-
-#define PREPARE_HWORD_NUMBER_BUFFER(textVar, maxDigits, number)             \
-{                                                                           \
-    textVar[0] = B_BUFF_PLACEHOLDER_BEGIN;                                  \
-    textVar[1] = B_BUFF_NUMBER;                                             \
-    textVar[2] = 2;                                                         \
-    textVar[3] = maxDigits;                                                 \
-    textVar[4] = (number);                                                  \
-    textVar[5] = (number & 0x0000FF00) >> 8;                                \
-    textVar[6] = B_BUFF_EOS;                                                \
-}
-
-#define PREPARE_WORD_NUMBER_BUFFER(textVar, maxDigits, number)  \
-{                                                               \
-    textVar[0] = B_BUFF_PLACEHOLDER_BEGIN;                      \
-    textVar[1] = B_BUFF_NUMBER;                                 \
-    textVar[2] = 4;                                             \
-    textVar[3] = maxDigits;                                     \
-    textVar[4] = (number);                                      \
-    textVar[5] = (number & 0x0000FF00) >> 8;                    \
-    textVar[6] = (number & 0x00FF0000) >> 16;                   \
-    textVar[7] = (number & 0xFF000000) >> 24;                   \
-    textVar[8] = B_BUFF_EOS;                                    \
-}
-
-#define PREPARE_STRING_BUFFER(textVar, stringId)                \
-{                                                               \
-    textVar[0] = B_BUFF_PLACEHOLDER_BEGIN;                      \
-    textVar[1] = B_BUFF_STRING;                                 \
-    textVar[2] = stringId & 0xFF;                               \
-    textVar[3] = (stringId & 0xFF00) >> 8;                      \
-    textVar[4] = B_BUFF_EOS;                                    \
-}
-
-#define PREPARE_MOVE_BUFFER(textVar, move)                      \
-{                                                               \
-    textVar[0] = B_BUFF_PLACEHOLDER_BEGIN;                      \
-    textVar[1] = B_BUFF_MOVE;                                   \
-    textVar[2] = (move & 0xFF);                                 \
-    textVar[3] = (move & 0xFF00) >> 8;                          \
-    textVar[4] = B_BUFF_EOS;                                    \
-}
-
-#define PREPARE_ITEM_BUFFER(textVar, item)                      \
-{                                                               \
-    textVar[0] = B_BUFF_PLACEHOLDER_BEGIN;                      \
-    textVar[1] = B_BUFF_ITEM;                                   \
-    textVar[2] = item;                                          \
-    textVar[3] = (item & 0xFF00) >> 8;                          \
-    textVar[4] = B_BUFF_EOS;                                    \
-}
-
-#define PREPARE_SPECIES_BUFFER(textVar, species)                \
-{                                                               \
-    textVar[0] = B_BUFF_PLACEHOLDER_BEGIN;                      \
-    textVar[1] = B_BUFF_SPECIES;                                \
-    textVar[2] = species;                                       \
-    textVar[3] = (species & 0xFF00) >> 8;                       \
-    textVar[4] = B_BUFF_EOS;                                    \
-}
-
-#define PREPARE_MON_NICK_WITH_PREFIX_BUFFER(textVar, battler, partyId)      \
-{                                                                           \
-    textVar[0] = B_BUFF_PLACEHOLDER_BEGIN;                                  \
-    textVar[1] = B_BUFF_MON_NICK_WITH_PREFIX;                               \
-    textVar[2] = battler;                                                   \
-    textVar[3] = partyId;                                                   \
-    textVar[4] = B_BUFF_EOS;                                                \
-}
-
-#define PREPARE_MON_NICK_WITH_PREFIX_LOWER_BUFFER(textVar, battler, partyId)    \
-{                                                                               \
-    textVar[0] = B_BUFF_PLACEHOLDER_BEGIN;                                      \
-    textVar[1] = B_BUFF_MON_NICK_WITH_PREFIX_LOWER;                             \
-    textVar[2] = battler;                                                       \
-    textVar[3] = partyId;                                                       \
-    textVar[4] = B_BUFF_EOS;                                                    \
-}
-
-#define PREPARE_MON_NICK_BUFFER(textVar, battler, partyId)      \
-{                                                               \
-    textVar[0] = B_BUFF_PLACEHOLDER_BEGIN;                      \
-    textVar[1] = B_BUFF_MON_NICK;                               \
-    textVar[2] = battler;                                       \
-    textVar[3] = partyId;                                       \
-    textVar[4] = B_BUFF_EOS;                                    \
-}
-
 struct BattleMsgData
 {
     u16 currentMove;
@@ -256,6 +126,21 @@ void BattlePutTextOnWindow(const u8 *text, u8 windowId);
 void SetPpNumbersPaletteInMoveSelection(enum BattlerId battler);
 u8 GetCurrentPpToMaxPpState(u8 currentPp, u8 maxPp);
 void ExpandBattleTextBuffPlaceholders(const u8 *src, u8 *dst);
+
+void PrepareFlavorBuffer(u8 *textVar, u32 flavorId);
+void PrepareStatBuffer(u8 *textVar, enum Stat stat);
+void PrepareAbilityBuffer(u8 *textVar, enum Ability ability);
+void PrepareTypeBuffer(u8 *textVar, enum Type type);
+void PrepareByteNumberBuffer(u8 *textVar, u32 maxDigits, u32 number);
+void PrepareHwordNumberBuffer(u8 *textVar, u32 maxDigits, u32 number);
+void PrepareWordNumberBuffer(u8 *textVar, u32 maxDigits, u32 number);
+void PrepareStringBuffer(u8 *textVar, u32 string);
+void PrepareMoveBuffer(u8 *textVar, enum Move move);
+void PrepareItemBuffer(u8 *textVar, enum Item item);
+void PrepareSpeciesBuffer(u8 *textVar, u32 species);
+void PrepareMonNickWithPrefixBuffer(u8 *textVar, enum BattlerId battler, u32 partyId);
+void PrepareMonNickWithPrefixLowerBuffer(u8 *textVar, enum BattlerId battler, u32 partyId);
+void PrepareMonNickBuffer(u8 *textVar, enum BattlerId battler, u32 partyId);
 
 extern struct BattleMsgData *gBattleMsgDataPtr;
 

--- a/migration_scripts/1.17/string_buffer_migration.sh
+++ b/migration_scripts/1.17/string_buffer_migration.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+find . \( -name "*.c" -o -name "*.h" \) -exec sed -i '/PREPARE_FLAVOR_BUFFER/{s/[^;]$/&;/;s/PREPARE_FLAVOR_BUFFER/PrepareFlavorBuffer/}' {} +
+find . \( -name "*.c" -o -name "*.h" \) -exec sed -i '/PREPARE_STAT_BUFFER/{s/[^;]$/&;/;s/PREPARE_STAT_BUFFER/PrepareStatBuffer/}' {} +
+find . \( -name "*.c" -o -name "*.h" \) -exec sed -i '/PREPARE_ABILITY_BUFFER/{s/[^;]$/&;/;s/PREPARE_ABILITY_BUFFER/PrepareAbilityBuffer/}' {} +
+find . \( -name "*.c" -o -name "*.h" \) -exec sed -i '/PREPARE_TYPE_BUFFER/{s/[^;]$/&;/;s/PREPARE_TYPE_BUFFER/PrepareTypeBuffer/}' {} +
+find . \( -name "*.c" -o -name "*.h" \) -exec sed -i '/PREPARE_BYTE_NUMBER_BUFFER/{s/[^;]$/&;/;s/PREPARE_BYTE_NUMBER_BUFFER/PrepareByteNumberBuffer/}' {} +
+find . \( -name "*.c" -o -name "*.h" \) -exec sed -i '/PREPARE_HWORD_NUMBER_BUFFER/{s/[^;]$/&;/;s/PREPARE_HWORD_NUMBER_BUFFER/PrepareHwordNumberBuffer/}' {} +
+find . \( -name "*.c" -o -name "*.h" \) -exec sed -i '/PREPARE_WORD_NUMBER_BUFFER/{s/[^;]$/&;/;s/PREPARE_WORD_NUMBER_BUFFER/PrepareWordNumberBuffer/}' {} +
+find . \( -name "*.c" -o -name "*.h" \) -exec sed -i '/PREPARE_STRING_BUFFER/{s/[^;]$/&;/;s/PREPARE_STRING_BUFFER/PrepareStringBuffer/}' {} +
+find . \( -name "*.c" -o -name "*.h" \) -exec sed -i '/PREPARE_MOVE_BUFFER/{s/[^;]$/&;/;s/PREPARE_MOVE_BUFFER/PrepareMoveBuffer/}' {} +
+find . \( -name "*.c" -o -name "*.h" \) -exec sed -i '/PREPARE_ITEM_BUFFER/{s/[^;]$/&;/;s/PREPARE_ITEM_BUFFER/PrepareItemBuffer/}' {} +
+find . \( -name "*.c" -o -name "*.h" \) -exec sed -i '/PREPARE_SPECIES_BUFFER/{s/[^;]$/&;/;s/PREPARE_SPECIES_BUFFER/PrepareSpeciesBuffer/}' {} +
+find . \( -name "*.c" -o -name "*.h" \) -exec sed -i '/PREPARE_MON_NICK_WITH_PREFIX_BUFFER/{s/[^;]$/&;/;s/PREPARE_MON_NICK_WITH_PREFIX_BUFFER/PrepareMonNickWithPrefixBuffer/}' {} +
+find . \( -name "*.c" -o -name "*.h" \) -exec sed -i '/PREPARE_MON_NICK_WITH_PREFIX_LOWER_BUFFER/{s/[^;]$/&;/;s/PREPARE_MON_NICK_WITH_PREFIX_LOWER_BUFFER/PrepareMonNickWithPrefixLowerBuffer/}' {} +
+find . \( -name "*.c" -o -name "*.h" \) -exec sed -i '/PREPARE_MON_NICK_BUFFER/{s/[^;]$/&;/;s/PREPARE_MON_NICK_BUFFER/PrepareMonNickBuffer/}' {} +

--- a/src/battle_controller_oak_old_man.c
+++ b/src/battle_controller_oak_old_man.c
@@ -781,7 +781,7 @@ static void OakOldManHandleChooseAction(enum BattlerId battler)
     ActionSelectionCreateCursorAt(gActionSelectionCursor[battler], 0);
     if (gBattleTypeFlags & BATTLE_TYPE_FIRST_BATTLE)
     {
-        PREPARE_MON_NICK_BUFFER(gBattleTextBuff1, battler, gBattlerPartyIndexes[battler]);
+        PrepareMonNickBuffer(gBattleTextBuff1, battler, gBattlerPartyIndexes[battler]);
         BattleStringExpandPlaceholdersToDisplayedString(gText_WhatWillPkmnDo);
     }
     else

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -2032,7 +2032,7 @@ static void PlayerHandleChooseAction(enum BattlerId battler)
 
     TryRestoreLastUsedBall();
     ActionSelectionCreateCursorAt(gActionSelectionCursor[battler], 0);
-    PREPARE_MON_NICK_BUFFER(gBattleTextBuff1, battler, gBattlerPartyIndexes[battler]);
+    PrepareMonNickBuffer(gBattleTextBuff1, battler, gBattlerPartyIndexes[battler]);
     BattleStringExpandPlaceholdersToDisplayedString(gText_WhatWillPkmnDo);
 
     enum BattlerId partner = GetBattlerAtPosition(B_POSITION_PLAYER_RIGHT);

--- a/src/battle_end_turn.c
+++ b/src/battle_end_turn.c
@@ -248,7 +248,7 @@ static bool32 HandleEndTurnFutureSight(enum BattlerId battler)
         else
             gBattleCommunication[MULTISTRING_CHOOSER] = B_MSG_DOOM_DESIRE;
 
-        PREPARE_MOVE_BUFFER(gBattleTextBuff1, gBattleStruct->futureSight[battler].move);
+        PrepareMoveBuffer(gBattleTextBuff1, gBattleStruct->futureSight[battler].move);
 
         gBattlerTarget = battler;
         gBattlerAttacker = gBattleStruct->futureSight[battler].battlerIndex;
@@ -277,7 +277,7 @@ static bool32 HandleEndTurnWish(enum BattlerId battler)
     {
         s32 wishHeal = 0;
         gBattlerTarget = battler;
-        PREPARE_MON_NICK_WITH_PREFIX_BUFFER(gBattleTextBuff1, battler, gBattleStruct->wish[battler].partyId)
+        PrepareMonNickWithPrefixBuffer(gBattleTextBuff1, battler, gBattleStruct->wish[battler].partyId);
         if (GetConfig(B_WISH_HP_SOURCE) >= GEN_5)
             wishHeal = GetMonData(&GetBattlerParty(battler)[gBattleStruct->wish[battler].partyId], MON_DATA_MAX_HP) / 2;
         else
@@ -643,7 +643,7 @@ static bool32 HandleEndTurnWrap(enum BattlerId battler)
 
             gBattleScripting.animArg1 = gBattleMons[battler].volatiles.wrappedMove;
             gBattleScripting.animArg2 = gBattleMons[battler].volatiles.wrappedMove >> 8;
-            PREPARE_MOVE_BUFFER(gBattleTextBuff1, gBattleMons[battler].volatiles.wrappedMove);
+            PrepareMoveBuffer(gBattleTextBuff1, gBattleMons[battler].volatiles.wrappedMove);
             BattleScriptCall(BattleScript_WrapTurnDmg);
             s32 bindDamage = 0;
             if (GetBattlerHoldEffect(gBattleMons[battler].volatiles.wrappedBy) == HOLD_EFFECT_BINDING_BAND)
@@ -655,7 +655,7 @@ static bool32 HandleEndTurnWrap(enum BattlerId battler)
         else  // broke free
         {
             gBattleMons[battler].volatiles.wrapped = FALSE;
-            PREPARE_MOVE_BUFFER(gBattleTextBuff1, gBattleMons[battler].volatiles.wrappedMove);
+            PrepareMoveBuffer(gBattleTextBuff1, gBattleMons[battler].volatiles.wrappedMove);
             BattleScriptCall(BattleScript_WrapEnds);
         }
         effect = TRUE;
@@ -680,7 +680,7 @@ static bool32 HandleEndTurnSaltCure(enum BattlerId battler)
         else
             saltCureDamage = GetNonDynamaxMaxHP(battler) / 8;
         SetPassiveDamageAmount(battler, saltCureDamage);
-        PREPARE_MOVE_BUFFER(gBattleTextBuff1, MOVE_SALT_CURE);
+        PrepareMoveBuffer(gBattleTextBuff1, MOVE_SALT_CURE);
         BattleScriptCall(BattleScript_SaltCureExtraDamage);
         effect = TRUE;
     }
@@ -718,7 +718,7 @@ static bool32 HandleEndTurnSyrupBomb(enum BattlerId battler)
     {
         if (gBattleMons[battler].volatiles.syrupBombTimer > 0 && --gBattleMons[battler].volatiles.syrupBombTimer == 0)
             gBattleMons[battler].volatiles.syrupBomb = FALSE;
-        PREPARE_MOVE_BUFFER(gBattleTextBuff1, MOVE_SYRUP_BOMB);
+        PrepareMoveBuffer(gBattleTextBuff1, MOVE_SYRUP_BOMB);
         gBattlerTarget = battler;
         gBattlerAttacker = gBattleMons[battler].volatiles.stickySyrupedBy;
         SetStatChange(battler, STAT_SPEED, -1);
@@ -739,7 +739,7 @@ static bool32 HandleEndTurnTaunt(enum BattlerId battler)
     {
         gBattleScripting.battler = battler;
         BattleScriptCall(BattleScript_BufferEndTurn);
-        PREPARE_MOVE_BUFFER(gBattleTextBuff1, MOVE_TAUNT);
+        PrepareMoveBuffer(gBattleTextBuff1, MOVE_TAUNT);
         effect = TRUE;
     }
 
@@ -831,7 +831,7 @@ static bool32 HandleEndTurnMagnetRise(enum BattlerId battler)
     {
         gBattleMons[battler].volatiles.magnetRise = FALSE;
         BattleScriptCall(BattleScript_BufferEndTurn);
-        PREPARE_STRING_BUFFER(gBattleTextBuff1, STRINGID_ELECTROMAGNETISM);
+        PrepareStringBuffer(gBattleTextBuff1, STRINGID_ELECTROMAGNETISM);
         effect = TRUE;
     }
 
@@ -960,7 +960,7 @@ static bool32 HandleEndTurnPerishSong(enum BattlerId battler)
     if (gBattleMons[battler].volatiles.perishSong
      && IsBattlerPresent(battler))
     {
-        PREPARE_BYTE_NUMBER_BUFFER(gBattleTextBuff1, 1, gBattleMons[battler].volatiles.perishSongTimer);
+        PrepareByteNumberBuffer(gBattleTextBuff1, 1, gBattleMons[battler].volatiles.perishSongTimer);
         if (gBattleMons[battler].volatiles.perishSongTimer == 0)
         {
             gBattleMons[battler].volatiles.perishSong = FALSE;
@@ -1005,7 +1005,7 @@ static bool32 HandleEndTurnSecondEventBlock(enum BattlerId battler)
             gSideStatuses[side] &= ~SIDE_STATUS_REFLECT;
             BattleScriptCall(BattleScript_SideStatusWoreOff);
             gBattleCommunication[MULTISTRING_CHOOSER] = side;
-            PREPARE_MOVE_BUFFER(gBattleTextBuff1, MOVE_REFLECT);
+            PrepareMoveBuffer(gBattleTextBuff1, MOVE_REFLECT);
             effect = TRUE;
         }
         gBattleStruct->eventState.endTurnBlock++;
@@ -1017,7 +1017,7 @@ static bool32 HandleEndTurnSecondEventBlock(enum BattlerId battler)
             gSideStatuses[side] &= ~SIDE_STATUS_LIGHTSCREEN;
             BattleScriptCall(BattleScript_SideStatusWoreOff);
             gBattleCommunication[MULTISTRING_CHOOSER] = side;
-            PREPARE_MOVE_BUFFER(gBattleTextBuff1, MOVE_LIGHT_SCREEN);
+            PrepareMoveBuffer(gBattleTextBuff1, MOVE_LIGHT_SCREEN);
             effect = TRUE;
         }
         gBattleStruct->eventState.endTurnBlock++;
@@ -1039,7 +1039,7 @@ static bool32 HandleEndTurnSecondEventBlock(enum BattlerId battler)
             gSideStatuses[side] &= ~SIDE_STATUS_MIST;
             BattleScriptCall(BattleScript_SideStatusWoreOff);
             gBattleCommunication[MULTISTRING_CHOOSER] = side;
-            PREPARE_MOVE_BUFFER(gBattleTextBuff1, MOVE_MIST);
+            PrepareMoveBuffer(gBattleTextBuff1, MOVE_MIST);
             effect = TRUE;
         }
         gBattleStruct->eventState.endTurnBlock++;
@@ -1100,7 +1100,7 @@ static bool32 HandleEndTurnSecondEventBlock(enum BattlerId battler)
             gSideStatuses[side] &= ~SIDE_STATUS_AURORA_VEIL;
             BattleScriptCall(BattleScript_SideStatusWoreOff);
             gBattleCommunication[MULTISTRING_CHOOSER] = side;
-            PREPARE_MOVE_BUFFER(gBattleTextBuff1, MOVE_AURORA_VEIL);
+            PrepareMoveBuffer(gBattleTextBuff1, MOVE_AURORA_VEIL);
             effect = TRUE;
         }
         gBattleStruct->eventState.battlerSide++;

--- a/src/battle_hold_effects.c
+++ b/src/battle_hold_effects.c
@@ -62,7 +62,7 @@ enum ItemEffect TryBoosterEnergy(enum BattlerId battler, enum Ability ability)
      || ((ability == ABILITY_QUARK_DRIVE) && !(gFieldStatuses & STATUS_FIELD_ELECTRIC_TERRAIN)))
     {
         gBattleMons[battler].volatiles.paradoxBoostedStat = GetParadoxHighestStatId(battler);
-        PREPARE_STAT_BUFFER(gBattleTextBuff1, gBattleMons[battler].volatiles.paradoxBoostedStat);
+        PrepareStatBuffer(gBattleTextBuff1, gBattleMons[battler].volatiles.paradoxBoostedStat);
         gBattlerAbility = gBattleScripting.battler = battler;
         gBattleMons[battler].volatiles.boosterEnergyActivated = TRUE;
         RecordAbilityBattle(battler, ability);
@@ -244,7 +244,7 @@ static enum ItemEffect TryRockyHelmet(enum BattlerId battlerDef, enum BattlerId 
      && !IsAbilityAndRecord(battlerAtk, ability, ABILITY_MAGIC_GUARD))
     {
         SetPassiveDamageAmount(battlerAtk, GetNonDynamaxMaxHP(battlerAtk) / 6);
-        PREPARE_ITEM_BUFFER(gBattleTextBuff1, item);
+        PrepareItemBuffer(gBattleTextBuff1, item);
         gBattleCommunication[MULTISTRING_CHOOSER] = B_MSG_HURT_BY_ITEM;
         BattleScriptCall(BattleScript_RockyHelmetActivates);
         effect = ITEM_HP_CHANGE;
@@ -345,7 +345,7 @@ static enum ItemEffect TryJabocaBerry(enum BattlerId battlerDef, enum BattlerId 
         SetPassiveDamageAmount(battlerAtk, jabocaDamage);
         gBattleCommunication[MULTISTRING_CHOOSER] = B_MSG_HURT_BY_ITEM;
         BattleScriptCall(BattleScript_JabocaRowapBerryActivates);
-        PREPARE_ITEM_BUFFER(gBattleTextBuff1, item);
+        PrepareItemBuffer(gBattleTextBuff1, item);
         effect = ITEM_HP_CHANGE;
     }
 
@@ -368,7 +368,7 @@ static enum ItemEffect TryRowapBerry(enum BattlerId battlerDef, enum BattlerId b
         SetPassiveDamageAmount(battlerAtk, rowapDamage);
         gBattleCommunication[MULTISTRING_CHOOSER] = B_MSG_HURT_BY_ITEM;
         BattleScriptCall(BattleScript_JabocaRowapBerryActivates);
-        PREPARE_ITEM_BUFFER(gBattleTextBuff1, item);
+        PrepareItemBuffer(gBattleTextBuff1, item);
         effect = ITEM_HP_CHANGE;
     }
 
@@ -462,7 +462,7 @@ static enum ItemEffect TryMentalHerb(enum BattlerId battler, ActivationTiming ti
         {
             gBattleMons[battler].volatiles.tauntTimer = 0;
             gBattleCommunication[MULTISTRING_CHOOSER] |= 1 << B_MSG_MENTALHERBCURE_TAUNT;
-            PREPARE_MOVE_BUFFER(gBattleTextBuff1, MOVE_TAUNT);
+            PrepareMoveBuffer(gBattleTextBuff1, MOVE_TAUNT);
             effect = ITEM_EFFECT_OTHER;
         }
     }
@@ -586,7 +586,7 @@ static enum ItemEffect TryStickyBarbOnEndTurn(enum BattlerId battler, enum Item 
     if (!IsAbilityAndRecord(battler, GetBattlerAbility(battler), ABILITY_MAGIC_GUARD))
     {
         SetPassiveDamageAmount(battler, GetNonDynamaxMaxHP(battler) / 8);
-        PREPARE_ITEM_BUFFER(gBattleTextBuff1, item);
+        PrepareItemBuffer(gBattleTextBuff1, item);
         BattleScriptCall(BattleScript_ItemHurtWithAnim);
         effect = ITEM_HP_CHANGE;
     }
@@ -900,7 +900,7 @@ static enum ItemEffect ItemRestorePp(enum BattlerId battler, enum Item itemId)
         if (changedPP > maxPP)
             changedPP = maxPP;
 
-        PREPARE_MOVE_BUFFER(gBattleTextBuff1, move);
+        PrepareMoveBuffer(gBattleTextBuff1, move);
 
         BattleScriptCall(BattleScript_BerryPPHeal);
 

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -5219,7 +5219,7 @@ static void CheckChangingTurnOrderEffects(void)
                 if (gProtectStructs[battler].usedCustapBerry)
                 {
                     gLastUsedItem = gBattleMons[battler].item;
-                    PREPARE_ITEM_BUFFER(gBattleTextBuff1, gLastUsedItem);
+                    PrepareItemBuffer(gBattleTextBuff1, gLastUsedItem);
                     if (GetBattlerHoldEffect(battler) == HOLD_EFFECT_CUSTAP_BERRY)
                     {
                         // don't record berry since its gone now
@@ -5235,7 +5235,7 @@ static void CheckChangingTurnOrderEffects(void)
                 {
                     gBattlerAbility = battler;
                     gLastUsedAbility = gBattleMons[battler].ability;
-                    PREPARE_ABILITY_BUFFER(gBattleTextBuff1, gLastUsedAbility);
+                    PrepareAbilityBuffer(gBattleTextBuff1, gLastUsedAbility);
                     RecordAbilityBattle(battler, gLastUsedAbility);
                     BattleScriptExecute(BattleScript_QuickDrawActivation);
                 }
@@ -5450,7 +5450,7 @@ static void HandleEndTurn_MonFled(void)
 {
     gCurrentActionFuncId = 0;
 
-    PREPARE_MON_NICK_BUFFER(gBattleTextBuff1, gBattlerAttacker, gBattlerPartyIndexes[gBattlerAttacker]);
+    PrepareMonNickBuffer(gBattleTextBuff1, gBattlerAttacker, gBattlerPartyIndexes[gBattlerAttacker]);
     gBattlescriptCurrInstr = BattleScript_WildMonFled;
 
     gBattleMainFunc = HandleEndTurn_FinishBattle;

--- a/src/battle_message.c
+++ b/src/battle_message.c
@@ -3958,3 +3958,134 @@ u8 GetCurrentPpToMaxPpState(u8 currentPp, u8 maxPp)
 
     return 0;
 }
+
+void PrepareFlavorBuffer(u8 *textVar, u32 flavor)
+{
+    textVar[0] = B_BUFF_PLACEHOLDER_BEGIN;
+    textVar[1] = B_BUFF_NEGATIVE_FLAVOR;
+    textVar[2] = flavor;
+    textVar[3] = B_BUFF_EOS;
+}
+
+void PrepareStatBuffer(u8 *textVar, enum Stat stat)
+{
+    textVar[0] = B_BUFF_PLACEHOLDER_BEGIN;
+    textVar[1] = B_BUFF_STAT;
+    textVar[2] = stat;
+    textVar[3] = B_BUFF_EOS;
+}
+
+void PrepareAbilityBuffer(u8 *textVar, enum Ability ability)
+{
+    textVar[0] = B_BUFF_PLACEHOLDER_BEGIN;
+    textVar[1] = B_BUFF_ABILITY;
+    textVar[2] = ability;
+    textVar[3] = (ability & 0xFF00) >> 8;
+    textVar[4] = B_BUFF_EOS;
+}
+
+void PrepareTypeBuffer(u8 *textVar, enum Type type)
+{
+    textVar[0] = B_BUFF_PLACEHOLDER_BEGIN;
+    textVar[1] = B_BUFF_TYPE;
+    textVar[2] = type;
+    textVar[3] = B_BUFF_EOS;
+}
+
+void PrepareByteNumberBuffer(u8 *textVar, u32 maxDigits, u32 number)
+{
+    textVar[0] = B_BUFF_PLACEHOLDER_BEGIN;
+    textVar[1] = B_BUFF_NUMBER;
+    textVar[2] = 1;
+    textVar[3] = maxDigits;
+    textVar[4] = number;
+    textVar[5] = B_BUFF_EOS;
+}
+
+void PrepareHwordNumberBuffer(u8 *textVar, u32 maxDigits, u32 number)
+{
+    textVar[0] = B_BUFF_PLACEHOLDER_BEGIN;
+    textVar[1] = B_BUFF_NUMBER;
+    textVar[2] = 2;
+    textVar[3] = maxDigits;
+    textVar[4] = number;
+    textVar[5] = (number & 0x0000FF00) >> 8;
+    textVar[6] = B_BUFF_EOS;
+}
+
+void PrepareWordNumberBuffer(u8 *textVar, u32 maxDigits, u32 number)
+{
+    textVar[0] = B_BUFF_PLACEHOLDER_BEGIN;
+    textVar[1] = B_BUFF_NUMBER;
+    textVar[2] = 4;
+    textVar[3] = maxDigits;
+    textVar[4] = number;
+    textVar[5] = (number & 0x000000FF) >> 0;
+    textVar[6] = (number & 0x0000FF00) >> 8;
+    textVar[7] = (number & 0x00FF0000) >> 16;
+    textVar[8] = (number & 0xFF000000) >> 24;
+    textVar[9] = B_BUFF_EOS;
+}
+
+void PrepareStringBuffer(u8 *textVar, u32 string)
+{
+    textVar[0] = B_BUFF_PLACEHOLDER_BEGIN;
+    textVar[1] = B_BUFF_STRING;
+    textVar[2] = string & 0xFF;
+    textVar[3] = (string & 0xFF00) >> 8;
+    textVar[4] = B_BUFF_EOS;
+}
+
+void PrepareMoveBuffer(u8 *textVar, enum Move move)
+{
+    textVar[0] = B_BUFF_PLACEHOLDER_BEGIN;
+    textVar[1] = B_BUFF_MOVE;
+    textVar[2] = move & 0xFF;
+    textVar[3] = (move & 0xFF00) >> 8;
+    textVar[4] = B_BUFF_EOS;
+}
+
+void PrepareItemBuffer(u8 *textVar, enum Item item)
+{
+    textVar[0] = B_BUFF_PLACEHOLDER_BEGIN;
+    textVar[1] = B_BUFF_ITEM;
+    textVar[2] = item;
+    textVar[3] = (item & 0xFF00) >> 8;
+    textVar[4] = B_BUFF_EOS;
+}
+
+void PrepareSpeciesBuffer(u8 *textVar, u32 species)
+{
+    textVar[0] = B_BUFF_PLACEHOLDER_BEGIN;
+    textVar[1] = B_BUFF_SPECIES;
+    textVar[2] = species;
+    textVar[3] = (species & 0xFF00) >> 8;
+    textVar[4] = B_BUFF_EOS;
+}
+
+void PrepareMonNickWithPrefixBuffer(u8 *textVar, enum BattlerId battler, u32 partyId)
+{
+    textVar[0] = B_BUFF_PLACEHOLDER_BEGIN;
+    textVar[1] = B_BUFF_MON_NICK_WITH_PREFIX;
+    textVar[2] = battler;
+    textVar[3] = partyId;
+    textVar[4] = B_BUFF_EOS;
+}
+
+void PrepareMonNickWithPrefixLowerBuffer(u8 *textVar, enum BattlerId battler, u32 partyId)
+{
+    textVar[0] = B_BUFF_PLACEHOLDER_BEGIN;
+    textVar[1] = B_BUFF_MON_NICK_WITH_PREFIX_LOWER;
+    textVar[2] = battler;
+    textVar[3] = partyId;
+    textVar[4] = B_BUFF_EOS;
+}
+
+void PrepareMonNickBuffer(u8 *textVar, enum BattlerId battler, u32 partyId)
+{
+    textVar[0] = B_BUFF_PLACEHOLDER_BEGIN;
+    textVar[1] = B_BUFF_MON_NICK;
+    textVar[2] = battler;
+    textVar[3] = partyId;
+    textVar[4] = B_BUFF_EOS;
+}

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -1647,7 +1647,7 @@ static enum CancelerResult CancelerProtean(struct BattleCalcValues *cv)
     {
         if (GetConfig(B_PROTEAN_LIBERO) >= GEN_9)
             gBattleMons[cv->battlerAtk].volatiles.usedProteanLibero = TRUE;
-        PREPARE_TYPE_BUFFER(gBattleTextBuff1, moveType);
+        PrepareTypeBuffer(gBattleTextBuff1, moveType);
         gBattlerAbility = cv->battlerAtk;
         PrepareStringBattle(STRINGID_EMPTYSTRING3, cv->battlerAtk);
         gBattleCommunication[MSG_DISPLAY] = 1;
@@ -2334,7 +2334,7 @@ static enum CancelerResult CancelerMultihitMoves(struct BattleCalcValues *cv)
             SetRandomMultiHitCounter();
         }
 
-        PREPARE_BYTE_NUMBER_BUFFER(gBattleScripting.multihitString, 1, 0)
+        PrepareByteNumberBuffer(gBattleScripting.multihitString, 1, 0);
     }
     else if (GetMoveStrikeCount(cv->move) > 1)
     {
@@ -2349,7 +2349,7 @@ static enum CancelerResult CancelerMultihitMoves(struct BattleCalcValues *cv)
             gMultiHitCounter = GetMoveStrikeCount(cv->move);
         }
 
-        PREPARE_BYTE_NUMBER_BUFFER(gBattleScripting.multihitString, 3, 0)
+        PrepareByteNumberBuffer(gBattleScripting.multihitString, 3, 0);
     }
     else if (cv->moveEffect == EFFECT_BEAT_UP)
     {
@@ -2375,13 +2375,13 @@ static enum CancelerResult CancelerMultihitMoves(struct BattleCalcValues *cv)
             }
         }
 
-        PREPARE_BYTE_NUMBER_BUFFER(gBattleScripting.multihitString, 1, 0)
+        PrepareByteNumberBuffer(gBattleScripting.multihitString, 1, 0);
     }
     else if (IsMoveParentalBondAffected(cv))
     {
         gSpecialStatuses[gBattlerAttacker].parentalBondState = PARENTAL_BOND_1ST_HIT;
         gMultiHitCounter = 2;
-        PREPARE_BYTE_NUMBER_BUFFER(gBattleScripting.multihitString, 1, 0)
+        PrepareByteNumberBuffer(gBattleScripting.multihitString, 1, 0);
     }
     else
     {
@@ -2518,7 +2518,7 @@ static enum MoveEndResult MoveEndProtectLikeEffect(struct BattleCalcValues *cv)
         if (!IsAbilityAndRecord(cv->battlerAtk, cv->abilities[cv->battlerAtk], ABILITY_MAGIC_GUARD))
         {
             SetPassiveDamageAmount(cv->battlerAtk, GetNonDynamaxMaxHP(cv->battlerAtk) / 8);
-            PREPARE_MOVE_BUFFER(gBattleTextBuff1, MOVE_SPIKY_SHIELD);
+            PrepareMoveBuffer(gBattleTextBuff1, MOVE_SPIKY_SHIELD);
             BattleScriptCall(BattleScript_SpikyShieldEffect);
             result = MOVEEND_RESULT_RUN_SCRIPT;
         }
@@ -2950,7 +2950,7 @@ static enum MoveEndResult MoveEndFaintBlock(struct BattleCalcValues *cv)
                 gBattleMons[cv->battlerAtk].pp[moveIndex] = 0;
                 BtlController_EmitSetMonData(cv->battlerAtk, B_COMM_TO_CONTROLLER, moveIndex + REQUEST_PPMOVE1_BATTLE, 0, sizeof(gBattleMons[cv->battlerAtk].pp[moveIndex]), &gBattleMons[cv->battlerAtk].pp[moveIndex]);
                 MarkBattlerForControllerExec(cv->battlerAtk);
-                PREPARE_MOVE_BUFFER(gBattleTextBuff1, gBattleMons[cv->battlerAtk].moves[moveIndex])
+                PrepareMoveBuffer(gBattleTextBuff1, gBattleMons[cv->battlerAtk].moves[moveIndex]);
                 BattleScriptCall(BattleScript_GrudgeTakesPp);
                 result = MOVEEND_RESULT_RUN_SCRIPT;
             }
@@ -4632,7 +4632,7 @@ static enum MoveResult StatChangeBeforeChange(struct BattleCalcValues *cv)
         return MOVE_RESULT_RUN_SCRIPT_INCREMENT;
     case EFFECT_STOCKPILE:
         gBattleMons[cv->battlerAtk].volatiles.stockpileCounter++;
-        PREPARE_BYTE_NUMBER_BUFFER(gBattleTextBuff1, 1, gBattleMons[cv->battlerAtk].volatiles.stockpileCounter);
+        PrepareByteNumberBuffer(gBattleTextBuff1, 1, gBattleMons[cv->battlerAtk].volatiles.stockpileCounter);
         BattleScriptCall(BattleScript_Stockpile);
         return MOVE_RESULT_RUN_SCRIPT_INCREMENT;
     case EFFECT_DEFOG:
@@ -5240,7 +5240,7 @@ static void CalculateMagnitudeDamage(void)
         magnitude = 10;
     }
 
-    PREPARE_BYTE_NUMBER_BUFFER(gBattleTextBuff1, 2, magnitude)
+    PrepareByteNumberBuffer(gBattleTextBuff1, 2, magnitude);
 }
 
 static void UpdateStallMons(void)

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2934,9 +2934,9 @@ void SetMoveEffect(enum BattlerId battlerAtk, enum BattlerId effectBattler, enum
                 if (gBattleMons[effectBattler].pp[i] < ppToDeduct)
                     ppToDeduct = gBattleMons[effectBattler].pp[i];
 
-                PREPARE_MOVE_BUFFER(gBattleTextBuff1, gLastMoves[effectBattler])
+                PrepareMoveBuffer(gBattleTextBuff1, gLastMoves[effectBattler]);
                 ConvertIntToDecimalStringN(gBattleTextBuff2, ppToDeduct, STR_CONV_MODE_LEFT_ALIGN, 1);
-                PREPARE_BYTE_NUMBER_BUFFER(gBattleTextBuff2, 1, ppToDeduct)
+                PrepareByteNumberBuffer(gBattleTextBuff2, 1, ppToDeduct);
                 gBattleMons[effectBattler].pp[i] -= ppToDeduct;
                 if (!(gBattleMons[effectBattler].volatiles.mimickedMoves & (1u << i))
                     && !(gBattleMons[effectBattler].volatiles.transformed))
@@ -3399,7 +3399,7 @@ void SetMoveEffect(enum BattlerId battlerAtk, enum BattlerId effectBattler, enum
         }
         else
         {
-            PREPARE_MON_NICK_WITH_PREFIX_BUFFER(gBattleTextBuff1, battlerAtk, gBattleStruct->beatUpSpecies[gBattleStruct->beatUpSlot])
+            PrepareMonNickWithPrefixBuffer(gBattleTextBuff1, battlerAtk, gBattleStruct->beatUpSpecies[gBattleStruct->beatUpSlot]);
             BattleScriptPush(battleScript);
             gBattlescriptCurrInstr = BattleScript_BeatUpAttackMessage;
         }
@@ -4080,10 +4080,10 @@ static void Cmd_getexp(void)
                         gBattleStruct->expGetterBattlerId = 0;
                     }
 
-                    PREPARE_MON_NICK_WITH_PREFIX_BUFFER(gBattleTextBuff1, gBattleStruct->expGetterBattlerId, *expMonId);
+                    PrepareMonNickWithPrefixBuffer(gBattleTextBuff1, gBattleStruct->expGetterBattlerId, *expMonId);
                     // buffer 'gained' or 'gained a boosted'
-                    PREPARE_STRING_BUFFER(gBattleTextBuff2, i);
-                    PREPARE_WORD_NUMBER_BUFFER(gBattleTextBuff3, 6, gBattleStruct->battlerExpReward);
+                    PrepareStringBuffer(gBattleTextBuff2, i);
+                    PrepareWordNumberBuffer(gBattleTextBuff3, 6, gBattleStruct->battlerExpReward);
 
                     if (wasSentOut || holdEffect == HOLD_EFFECT_EXP_SHARE)
                     {
@@ -4134,8 +4134,8 @@ static void Cmd_getexp(void)
                 if (gBattleTypeFlags & BATTLE_TYPE_TRAINER && gBattlerPartyIndexes[expBattler] == *expMonId)
                     HandleLowHpMusicChange(GetBattlerMon(expBattler), expBattler);
 
-                PREPARE_MON_NICK_WITH_PREFIX_BUFFER(gBattleTextBuff1, expBattler, *expMonId);
-                PREPARE_BYTE_NUMBER_BUFFER(gBattleTextBuff2, 3, GetMonData(&gParties[B_TRAINER_PLAYER][*expMonId], MON_DATA_LEVEL));
+                PrepareMonNickWithPrefixBuffer(gBattleTextBuff1, expBattler, *expMonId);
+                PrepareByteNumberBuffer(gBattleTextBuff2, 3, GetMonData(&gParties[B_TRAINER_PLAYER][*expMonId], MON_DATA_LEVEL));
 
                 gLeveledUpInBattle |= 1 << *expMonId;
                 BattleScriptCall(BattleScript_LevelUp);
@@ -5105,7 +5105,7 @@ static void Cmd_switchindataupdate(void)
 
     gBattleScripting.battler = battler;
 
-    PREPARE_MON_NICK_BUFFER(gBattleTextBuff1, battler, gBattlerPartyIndexes[battler]);
+    PrepareMonNickBuffer(gBattleTextBuff1, battler, gBattlerPartyIndexes[battler]);
 
     gBattlescriptCurrInstr = cmd->nextInstr;
 }
@@ -5464,8 +5464,8 @@ static void Cmd_switchhandleorder(void)
             SwitchPartyOrder(battler);
         }
 
-        PREPARE_SPECIES_BUFFER(gBattleTextBuff1, gBattleMons[gBattlerAttacker].species)
-        PREPARE_MON_NICK_BUFFER(gBattleTextBuff2, battler, gBattleResources->bufferB[battler][1])
+        PrepareSpeciesBuffer(gBattleTextBuff1, gBattleMons[gBattlerAttacker].species);
+        PrepareMonNickBuffer(gBattleTextBuff2, battler, gBattleResources->bufferB[battler][1]);
         break;
     }
 
@@ -5732,7 +5732,7 @@ static void Cmd_yesnoboxlearnmove(void)
                 {
                     gBattlescriptCurrInstr = cmd->forgotMovePtr;
 
-                    PREPARE_MOVE_BUFFER(gBattleTextBuff2, move)
+                    PrepareMoveBuffer(gBattleTextBuff2, move);
 
                     RemoveMonPPBonus(&gParties[B_TRAINER_PLAYER][gBattleStruct->expGetterMonId], movePosition);
                     SetMonMoveSlot(&gParties[B_TRAINER_PLAYER][gBattleStruct->expGetterMonId], gMoveToLearn, movePosition);
@@ -5927,7 +5927,7 @@ static void Cmd_getmoneyreward(void)
         RemoveMoney(&gSaveBlock1Ptr->money, money);
     }
 
-    PREPARE_WORD_NUMBER_BUFFER(gBattleTextBuff1, 5, money);
+    PrepareWordNumberBuffer(gBattleTextBuff1, 5, money);
     gBattlescriptCurrInstr = cmd->nextInstr;
 }
 
@@ -6270,7 +6270,7 @@ static void Cmd_atknameinbuff1(void)
 {
     CMD_ARGS();
 
-    PREPARE_MON_NICK_BUFFER(gBattleTextBuff1, gBattlerAttacker, gBattlerPartyIndexes[gBattlerAttacker]);
+    PrepareMonNickBuffer(gBattleTextBuff1, gBattlerAttacker, gBattlerPartyIndexes[gBattlerAttacker]);
 
     gBattlescriptCurrInstr = cmd->nextInstr;
 }
@@ -6598,7 +6598,7 @@ static void Cmd_recordability(void)
 
 void BufferMoveToLearnIntoBattleTextBuff2(void)
 {
-    PREPARE_MOVE_BUFFER(gBattleTextBuff2, gMoveToLearn);
+    PrepareMoveBuffer(gBattleTextBuff2, gMoveToLearn);
 }
 
 static void Cmd_buffermovetolearn(void)
@@ -6753,7 +6753,7 @@ static void RemoveAllTerrains(void)
         if (clear)                                          \
         {                                                   \
             if (move)                                       \
-                PREPARE_MOVE_BUFFER(gBattleTextBuff1, move);\
+                PrepareMoveBuffer(gBattleTextBuff1, move);  \
             *sideStatuses &= ~status;                       \
             sideTimer->structField = 0;                     \
             BattleScriptCall(battlescript);                 \
@@ -7296,7 +7296,7 @@ static void Cmd_initmultihitstring(void)
 {
     CMD_ARGS();
 
-    PREPARE_BYTE_NUMBER_BUFFER(gBattleScripting.multihitString, 1, 0)
+    PrepareByteNumberBuffer(gBattleScripting.multihitString, 1, 0);
 
     gBattlescriptCurrInstr = cmd->nextInstr;
 }
@@ -7515,7 +7515,7 @@ static void Cmd_tryconversiontypechange(void)
         else
         {
             SET_BATTLER_TYPE(gBattlerAttacker, moveType);
-            PREPARE_TYPE_BUFFER(gBattleTextBuff1, moveType);
+            PrepareTypeBuffer(gBattleTextBuff1, moveType);
             gBattlescriptCurrInstr = cmd->nextInstr;
         }
     }
@@ -7572,7 +7572,7 @@ static void Cmd_tryconversiontypechange(void)
             while (moveType == gBattleMons[gBattlerAttacker].types[0] || moveType == gBattleMons[gBattlerAttacker].types[1] || moveType == gBattleMons[gBattlerAttacker].types[2]);
 
             SET_BATTLER_TYPE(gBattlerAttacker, moveType);
-            PREPARE_TYPE_BUFFER(gBattleTextBuff1, moveType);
+            PrepareTypeBuffer(gBattleTextBuff1, moveType);
 
             gBattlescriptCurrInstr = cmd->nextInstr;
         }
@@ -7588,7 +7588,7 @@ static void Cmd_givepaydaymoney(void)
         u32 bonusMoney = gPaydayMoney * gBattleStruct->moneyMultiplier;
         AddMoney(&gSaveBlock1Ptr->money, bonusMoney);
 
-        PREPARE_HWORD_NUMBER_BUFFER(gBattleTextBuff1, 5, bonusMoney)
+        PrepareHwordNumberBuffer(gBattleTextBuff1, 5, bonusMoney);
 
         BattleScriptPush(cmd->nextInstr);
         gBattlescriptCurrInstr = BattleScript_PrintPayDayMoneyString;
@@ -7813,7 +7813,7 @@ static void Cmd_transformdataexecution(void)
         timesGotHit = GetBattlerPartyState(gBattlerTarget)->timesGotHit;
         GetBattlerPartyState(gBattlerAttacker)->timesGotHit = timesGotHit;
 
-        PREPARE_SPECIES_BUFFER(gBattleTextBuff1, gBattleMons[gBattlerTarget].species)
+        PrepareSpeciesBuffer(gBattleTextBuff1, gBattleMons[gBattlerTarget].species);
 
         battleMonAttacker = (u8 *)(&gBattleMons[gBattlerAttacker]);
         battleMonTarget = (u8 *)(&gBattleMons[gBattlerTarget]);
@@ -7908,7 +7908,7 @@ static void Cmd_mimicattackcopy(void)
             else
                 gBattleMons[gBattlerAttacker].pp[gCurrMovePos] = 5;
 
-            PREPARE_MOVE_BUFFER(gBattleTextBuff1, gLastMoves[gBattlerTarget])
+            PrepareMoveBuffer(gBattleTextBuff1, gLastMoves[gBattlerTarget]);
 
             gBattleMons[gBattlerAttacker].volatiles.mimickedMoves |= 1u << gCurrMovePos;
             gBattlescriptCurrInstr = cmd->nextInstr;
@@ -7941,7 +7941,7 @@ static void Cmd_disablelastusedattack(void)
     if (gBattleMons[gBattlerTarget].volatiles.disabledMove == MOVE_NONE
         && i != MAX_MON_MOVES && gBattleMons[gBattlerTarget].pp[i] != 0)
     {
-        PREPARE_MOVE_BUFFER(gBattleTextBuff1, gBattleMons[gBattlerTarget].moves[i])
+        PrepareMoveBuffer(gBattleTextBuff1, gBattleMons[gBattlerTarget].moves[i]);
 
         gBattleMons[gBattlerTarget].volatiles.disabledMove = gBattleMons[gBattlerTarget].moves[i];
         if (B_DISABLE_TURNS >= GEN_5)
@@ -8106,7 +8106,7 @@ static void Cmd_settypetorandomresistance(void)
                 else
                 {
                     SET_BATTLER_TYPE(gBattlerAttacker, i);
-                    PREPARE_TYPE_BUFFER(gBattleTextBuff1, i);
+                    PrepareTypeBuffer(gBattleTextBuff1, i);
                     gBattlescriptCurrInstr = cmd->nextInstr;
                     return;
                 }
@@ -8176,7 +8176,7 @@ static void Cmd_copymovepermanently(void)
             BtlController_EmitSetMonData(gBattlerAttacker, B_COMM_TO_CONTROLLER, REQUEST_MOVES_PP_BATTLE, 0, sizeof(movePpData), &movePpData);
             MarkBattlerForControllerExec(gBattlerAttacker);
 
-            PREPARE_MOVE_BUFFER(gBattleTextBuff1, gLastPrintedMoves[gBattlerTarget])
+            PrepareMoveBuffer(gBattleTextBuff1, gLastPrintedMoves[gBattlerTarget]);
 
             gBattlescriptCurrInstr = cmd->nextInstr;
         }
@@ -8256,11 +8256,11 @@ static void Cmd_tryspiteppreduce(void)
             if (gBattleMons[gBattlerTarget].pp[i] < ppToDeduct)
                 ppToDeduct = gBattleMons[gBattlerTarget].pp[i];
 
-            PREPARE_MOVE_BUFFER(gBattleTextBuff1, gLastMoves[gBattlerTarget])
+            PrepareMoveBuffer(gBattleTextBuff1, gLastMoves[gBattlerTarget]);
 
             ConvertIntToDecimalStringN(gBattleTextBuff2, ppToDeduct, STR_CONV_MODE_LEFT_ALIGN, 1);
 
-            PREPARE_BYTE_NUMBER_BUFFER(gBattleTextBuff2, 1, ppToDeduct)
+            PrepareByteNumberBuffer(gBattleTextBuff2, 1, ppToDeduct);
 
             gBattleMons[gBattlerTarget].pp[i] -= ppToDeduct;
 
@@ -8621,7 +8621,7 @@ static void Cmd_rapidspinfree(void)
         gBattleScripting.battler = gBattlerTarget;
         gBattleMons[gBattlerAttacker].volatiles.wrapped = FALSE;
         gBattlerTarget = gBattleMons[gBattlerAttacker].volatiles.wrappedBy;
-        PREPARE_MOVE_BUFFER(gBattleTextBuff1, gBattleMons[gBattlerAttacker].volatiles.wrappedMove);
+        PrepareMoveBuffer(gBattleTextBuff1, gBattleMons[gBattlerAttacker].volatiles.wrappedMove);
         BattleScriptCall(BattleScript_WrapFree);
     }
     else if (gBattleMons[gBattlerAttacker].volatiles.leechSeed)
@@ -8980,8 +8980,8 @@ static void Cmd_tryswapitems(void)
 
             gBattlescriptCurrInstr = cmd->nextInstr;
 
-            PREPARE_ITEM_BUFFER(gBattleTextBuff1, oldItemDef)
-            PREPARE_ITEM_BUFFER(gBattleTextBuff2, oldItemAtk)
+            PrepareItemBuffer(gBattleTextBuff1, oldItemDef);
+            PrepareItemBuffer(gBattleTextBuff2, oldItemAtk);
 
             if (!(IsBattlerAlly(gBattlerAttacker, gBattlerTarget) && IsPartnerMonFromSameTrainer(gBattlerAttacker)))
             {
@@ -9666,7 +9666,7 @@ static void Cmd_settypetoenvironment(void)
     if (!IS_BATTLER_OF_TYPE(gBattlerAttacker, environmentType) && GetActiveGimmick(gBattlerAttacker) != GIMMICK_TERA)
     {
         SET_BATTLER_TYPE(gBattlerAttacker, environmentType);
-        PREPARE_TYPE_BUFFER(gBattleTextBuff1, environmentType);
+        PrepareTypeBuffer(gBattleTextBuff1, environmentType);
 
         gBattlescriptCurrInstr = cmd->nextInstr;
     }
@@ -10728,7 +10728,7 @@ static void Cmd_trysynchronize(void)
         gEffectBattler = gBattleScripting.savedBattler;
         gBattleScripting.moveEffect = synchStatus;
         gBattleStruct->synchronizeState = SYNCH_STATE_SET_STATUS;
-        PREPARE_ABILITY_BUFFER(gBattleTextBuff1, ABILITY_SYNCHRONIZE);
+        PrepareAbilityBuffer(gBattleTextBuff1, ABILITY_SYNCHRONIZE);
         BattleScriptCall(BattleScript_SynchronizeActivates);
         break;
     case SYNCH_STATE_SHOW_ABILITY_POPUP: // Synchronize ability pop up still shows up even if status fails
@@ -11284,7 +11284,7 @@ void BS_ItemRestoreHP(void)
             healAmount = maxHP - hp;
 
         gBattleScripting.battler = battler;
-        PREPARE_SPECIES_BUFFER(gBattleTextBuff1, GetMonData(&party[gBattleStruct->itemPartyIndex[gBattlerAttacker]], MON_DATA_SPECIES));
+        PrepareSpeciesBuffer(gBattleTextBuff1, GetMonData(&party[gBattleStruct->itemPartyIndex[gBattlerAttacker]], MON_DATA_SPECIES));
 
         // Heal is applied as move damage if battler is active.
         if (battler != MAX_BATTLERS_COUNT && hp != 0)
@@ -11345,7 +11345,7 @@ void BS_ItemCureStatus(void)
         return;
     }
 
-    PREPARE_SPECIES_BUFFER(gBattleTextBuff1, GetMonData(&party[gBattleStruct->itemPartyIndex[gBattlerAttacker]], MON_DATA_SPECIES));
+    PrepareSpeciesBuffer(gBattleTextBuff1, GetMonData(&party[gBattleStruct->itemPartyIndex[gBattlerAttacker]], MON_DATA_SPECIES));
     if (targetBattler == MAX_BATTLERS_COUNT)
     {
         gBattlescriptCurrInstr = cmd->nextInstr;
@@ -11432,8 +11432,8 @@ void BS_ItemRestorePP(void)
         }
     }
     gBattleScripting.battler = battler;
-    PREPARE_SPECIES_BUFFER(gBattleTextBuff1, GetMonData(mon, MON_DATA_SPECIES));
-    PREPARE_MOVE_BUFFER(gBattleTextBuff2, moveId);
+    PrepareSpeciesBuffer(gBattleTextBuff1, GetMonData(mon, MON_DATA_SPECIES));
+    PrepareMoveBuffer(gBattleTextBuff2, moveId);
     gBattlescriptCurrInstr = cmd->nextInstr;
 }
 
@@ -12331,7 +12331,7 @@ void BS_TryRevivalBlessing(void)
         u16 hp = GetMonData(&party[gSelectedMonPartyId], MON_DATA_MAX_HP) / 2;
         BtlController_EmitSetMonData(gBattlerAttacker, B_COMM_TO_CONTROLLER, REQUEST_HP_BATTLE, 1u << gSelectedMonPartyId, sizeof(hp), &hp);
         MarkBattlerForControllerExec(gBattlerAttacker);
-        PREPARE_SPECIES_BUFFER(gBattleTextBuff1, GetMonData(&party[gSelectedMonPartyId], MON_DATA_SPECIES));
+        PrepareSpeciesBuffer(gBattleTextBuff1, GetMonData(&party[gSelectedMonPartyId], MON_DATA_SPECIES));
 
         // If an on-field battler is revived, it needs to be sent out again.
         if (IsDoubleBattle() &&
@@ -12507,7 +12507,7 @@ void BS_SwapStats(void)
     default:
         break;
     }
-    PREPARE_STAT_BUFFER(gBattleTextBuff1, stat);
+    PrepareStatBuffer(gBattleTextBuff1, stat);
     gBattlescriptCurrInstr = cmd->nextInstr;
 }
 
@@ -13232,7 +13232,7 @@ void BS_PlayTrainerDefeatedMusic(void)
 void BS_StatTextBuffer(void)
 {
     NATIVE_ARGS();
-    PREPARE_STAT_BUFFER(gBattleTextBuff1, gBattleCommunication[0]);
+    PrepareStatBuffer(gBattleTextBuff1, gBattleCommunication[0]);
     gBattlescriptCurrInstr = cmd->nextInstr;
 }
 
@@ -13469,7 +13469,7 @@ void BS_TrySoak(void)
     else
     {
         SET_BATTLER_TYPE(gBattlerTarget, typeToSet);
-        PREPARE_TYPE_BUFFER(gBattleTextBuff1, typeToSet);
+        PrepareTypeBuffer(gBattleTextBuff1, typeToSet);
         gBattlescriptCurrInstr = cmd->nextInstr;
     }
 }
@@ -13482,7 +13482,7 @@ void BS_HandleFormChange(void)
     if (cmd->caseId == 0) // Buffer name and emit species.
     {
         if (cmd->bufferSpeciesName)
-            PREPARE_SPECIES_BUFFER(gBattleTextBuff1, gBattleMons[battler].species);
+            PrepareSpeciesBuffer(gBattleTextBuff1, gBattleMons[battler].species);
         BtlController_EmitSetMonData(battler, B_COMM_TO_CONTROLLER, REQUEST_SPECIES_BATTLE, 1u << gBattlerPartyIndexes[battler], sizeof(gBattleMons[battler].species), &gBattleMons[battler].species);
         MarkBattlerForControllerExec(battler);
     }
@@ -13550,7 +13550,7 @@ void BS_TryInstruct(void)
         {
             gCurrMovePos = moveIndex;
             gEffectBattler = gBattleStruct->battlerState[gBattlerTarget].lastMoveTarget;
-            PREPARE_MON_NICK_WITH_PREFIX_BUFFER(gBattleTextBuff1, gBattlerTarget, gBattlerPartyIndexes[gBattlerTarget]);
+            PrepareMonNickWithPrefixBuffer(gBattleTextBuff1, gBattlerTarget, gBattlerPartyIndexes[gBattlerTarget]);
             gBattlescriptCurrInstr = cmd->nextInstr;
         }
     }
@@ -14019,7 +14019,7 @@ void BS_TryThirdType(void)
     else
     {
         gBattleMons[gBattlerTarget].types[2] = type;
-        PREPARE_TYPE_BUFFER(gBattleTextBuff1, type);
+        PrepareTypeBuffer(gBattleTextBuff1, type);
         gBattlescriptCurrInstr = cmd->nextInstr;
     }
 }

--- a/src/battle_stat_change.c
+++ b/src/battle_stat_change.c
@@ -100,7 +100,7 @@ static bool32 CheckSpecificMoveCondition(struct BattleCalcValues *cv, struct Sta
         {
             if (!st->onlyChecking)
             {
-                PREPARE_STAT_BUFFER(gBattleTextBuff1, STAT_ATK);
+                PrepareStatBuffer(gBattleTextBuff1, STAT_ATK);
                 gBattleCommunication[MULTISTRING_CHOOSER] = B_MSG_STAT_WONT_CHANGE;
                 st->script = BattleScript_DecreaseStatChangeMessage;
                 gBattleScripting.battler = cv->battlerDef;
@@ -328,7 +328,7 @@ static enum StatChangeResult DecreaseStat(struct BattleCalcValues *cv, struct St
 {
     u32 currStage = gBattleMons[cv->battlerDef].statStages[st->stat];
 
-    PREPARE_STAT_BUFFER(gBattleTextBuff1, st->stat);
+    PrepareStatBuffer(gBattleTextBuff1, st->stat);
 
     if (currStage == (MIN_STAT_STAGE + 1))
         st->stage = -1;
@@ -337,15 +337,15 @@ static enum StatChangeResult DecreaseStat(struct BattleCalcValues *cv, struct St
 
     if (st->stage == -2)
     {
-        PREPARE_STRING_BUFFER(gBattleTextBuff2, STRINGID_STATHARSHLY);
+        PrepareStringBuffer(gBattleTextBuff2, STRINGID_STATHARSHLY);
     }
     else if (st->stage <= -3)
     {
-        PREPARE_STRING_BUFFER(gBattleTextBuff2, STRINGID_SEVERELY);
+        PrepareStringBuffer(gBattleTextBuff2, STRINGID_SEVERELY);
     }
     else
     {
-        PREPARE_STRING_BUFFER(gBattleTextBuff2, STRINGID_EMPTYSTRING3);
+        PrepareStringBuffer(gBattleTextBuff2, STRINGID_EMPTYSTRING3);
     }
 
     if (currStage == MIN_STAT_STAGE)
@@ -389,7 +389,7 @@ static enum StatChangeResult IncreaseStat(struct BattleCalcValues *cv, struct St
     u32 currStage = gBattleMons[cv->battlerDef].statStages[st->stat];
     bool32 isMaxStage = st->stage >= 12;
 
-    PREPARE_STAT_BUFFER(gBattleTextBuff1, st->stat);
+    PrepareStatBuffer(gBattleTextBuff1, st->stat);
 
     if (currStage == MAX_STAT_STAGE - 1)
         st->stage = 1;
@@ -398,15 +398,15 @@ static enum StatChangeResult IncreaseStat(struct BattleCalcValues *cv, struct St
 
     if (st->stage == 2)
     {
-        PREPARE_STRING_BUFFER(gBattleTextBuff2, STRINGID_STATSHARPLY);
+        PrepareStringBuffer(gBattleTextBuff2, STRINGID_STATSHARPLY);
     }
     else if (st->stage >= 3)
     {
-        PREPARE_STRING_BUFFER(gBattleTextBuff2, STRINGID_DRASTICALLY);
+        PrepareStringBuffer(gBattleTextBuff2, STRINGID_DRASTICALLY);
     }
     else
     {
-        PREPARE_STRING_BUFFER(gBattleTextBuff2, STRINGID_EMPTYSTRING3);
+        PrepareStringBuffer(gBattleTextBuff2, STRINGID_EMPTYSTRING3);
     }
 
     if (gBattleMons[cv->battlerDef].statStages[st->stat] == MAX_STAT_STAGE)
@@ -671,7 +671,7 @@ static bool32 IsIntimidateBlocked(struct BattleCalcValues *cv, struct StatChange
     case ABILITY_OBLIVIOUS:
         if (GetConfig(B_UPDATED_INTIMIDATE) < GEN_8)
             return FALSE;
-        PREPARE_STAT_BUFFER(gBattleTextBuff1, st->stat);
+        PrepareStatBuffer(gBattleTextBuff1, st->stat);
         st->script = BattleScript_AbilityNoSpecificStatLoss;
         break;
     case ABILITY_GUARD_DOG:
@@ -720,7 +720,7 @@ static bool32 IsAbilityBlocked(struct BattleCalcValues *cv, struct StatChange *s
         if (!st->onlyChecking)
         {
             MarkStatsAsDone(st, st->stat);
-            PREPARE_STAT_BUFFER(gBattleTextBuff1, st->stat);
+            PrepareStatBuffer(gBattleTextBuff1, st->stat);
             st->script = BattleScript_AbilityNoSpecificStatLoss;
         }
     }

--- a/src/battle_terastal.c
+++ b/src/battle_terastal.c
@@ -32,7 +32,7 @@ void ActivateTera(enum BattlerId battler)
     }
 
     // Execute battle script.
-    PREPARE_TYPE_BUFFER(gBattleTextBuff1, GetBattlerTeraType(battler));
+    PrepareTypeBuffer(gBattleTextBuff1, GetBattlerTeraType(battler));
     if (TryBattleFormChange(gBattlerAttacker, FORM_CHANGE_BATTLE_TERASTALLIZATION, GetBattlerAbility(gBattlerAttacker)))
         BattleScriptPushCursorAndCallback(BattleScript_TeraFormChange);
     else if (gBattleStruct->illusion[gBattlerAttacker].state == ILLUSION_ON

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -509,7 +509,7 @@ void HandleAction_Switch(void)
     gActionSelectionCursor[gBattlerAttacker] = 0;
     gMoveSelectionCursor[gBattlerAttacker] = 0;
 
-    PREPARE_MON_NICK_BUFFER(gBattleTextBuff1, gBattlerAttacker, gBattleStruct->battlerPartyIndexes[gBattlerAttacker]);
+    PrepareMonNickBuffer(gBattleTextBuff1, gBattlerAttacker, gBattleStruct->battlerPartyIndexes[gBattlerAttacker]);
 
     gBattleScripting.battler = gBattlerAttacker;
     gBattlescriptCurrInstr = BattleScript_ActionSwitch;
@@ -876,7 +876,7 @@ void HandleAction_WallyBallThrow(void)
     gBattle_BG0_X = 0;
     gBattle_BG0_Y = 0;
 
-    PREPARE_MON_NICK_BUFFER(gBattleTextBuff1, gBattlerAttacker, gBattlerPartyIndexes[gBattlerAttacker])
+    PrepareMonNickBuffer(gBattleTextBuff1, gBattlerAttacker, gBattlerPartyIndexes[gBattlerAttacker]);
 
     gBattlescriptCurrInstr = gBattlescriptsForSafariActions[3];
     gCurrentActionFuncId = B_ACTION_EXEC_SCRIPT;
@@ -1483,7 +1483,7 @@ u32 TrySetCantSelectMoveBattleScript(enum BattlerId battler)
     if (MoveCantBeUsedTwice(move) && move == gLastResultingMoves[battler])
     {
         gCurrentMove = move;
-        PREPARE_MOVE_BUFFER(gBattleTextBuff1, gCurrentMove);
+        PrepareMoveBuffer(gBattleTextBuff1, gCurrentMove);
         if (gBattleTypeFlags & BATTLE_TYPE_PALACE)
         {
             gPalaceSelectionBattleScripts[battler] = BattleScript_SelectingNotAllowedCurrentMoveInPalace;
@@ -2122,7 +2122,7 @@ static void ForewarnChooseMove(enum BattlerId battler)
     }
 
     gEffectBattler = data[bestId].battler;
-    PREPARE_MOVE_BUFFER(gBattleTextBuff1, data[bestId].moveId)
+    PrepareMoveBuffer(gBattleTextBuff1, data[bestId].moveId);
     RecordKnownMove(data[bestId].battler, data[bestId].moveId);
 
     Free(data);
@@ -2144,7 +2144,7 @@ bool32 ChangeTypeBasedOnTerrain(enum BattlerId battler)
         return FALSE;
 
     SET_BATTLER_TYPE(battler, battlerType);
-    PREPARE_TYPE_BUFFER(gBattleTextBuff1, battlerType);
+    PrepareTypeBuffer(gBattleTextBuff1, battlerType);
     return TRUE;
 }
 
@@ -3004,8 +3004,8 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
                     BattleScriptCall(BattleScript_TraceActivates);
                     gBattleStruct->tracedAbility[battler] = gLastUsedAbility = gBattleMons[chosenTarget].ability;
                     RecordAbilityBattle(chosenTarget, gLastUsedAbility); // Record the opposing battler has this ability
-                    PREPARE_MON_NICK_WITH_PREFIX_LOWER_BUFFER(gBattleTextBuff1, chosenTarget, gBattlerPartyIndexes[chosenTarget])
-                    PREPARE_ABILITY_BUFFER(gBattleTextBuff2, gLastUsedAbility)
+                    PrepareMonNickWithPrefixLowerBuffer(gBattleTextBuff1, chosenTarget, gBattlerPartyIndexes[chosenTarget]);
+                    PrepareAbilityBuffer(gBattleTextBuff2, gLastUsedAbility);
                 }
             }
             break;
@@ -3428,7 +3428,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
             if (shouldAbilityTrigger)
             {
                 gBattleMons[battler].volatiles.vesselOfRuin = TRUE;
-                PREPARE_STAT_BUFFER(gBattleTextBuff1, STAT_SPATK);
+                PrepareStatBuffer(gBattleTextBuff1, STAT_SPATK);
                 BattleScriptCall(BattleScript_RuinAbilityActivates);
                 effect++;
             }
@@ -3437,7 +3437,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
             if (shouldAbilityTrigger)
             {
                 gBattleMons[battler].volatiles.swordOfRuin = TRUE;
-                PREPARE_STAT_BUFFER(gBattleTextBuff1, STAT_DEF);
+                PrepareStatBuffer(gBattleTextBuff1, STAT_DEF);
                 BattleScriptCall(BattleScript_RuinAbilityActivates);
                 effect++;
             }
@@ -3446,7 +3446,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
             if (shouldAbilityTrigger)
             {
                 gBattleMons[battler].volatiles.tabletsOfRuin = TRUE;
-                PREPARE_STAT_BUFFER(gBattleTextBuff1, STAT_ATK);
+                PrepareStatBuffer(gBattleTextBuff1, STAT_ATK);
                 BattleScriptCall(BattleScript_RuinAbilityActivates);
                 effect++;
             }
@@ -3455,7 +3455,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
             if (shouldAbilityTrigger)
             {
                 gBattleMons[battler].volatiles.beadsOfRuin = TRUE;
-                PREPARE_STAT_BUFFER(gBattleTextBuff1, STAT_SPDEF);
+                PrepareStatBuffer(gBattleTextBuff1, STAT_SPDEF);
                 BattleScriptCall(BattleScript_RuinAbilityActivates);
                 effect++;
             }
@@ -3733,7 +3733,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
             {
                 gEffectBattler = gBattlerAbility = battler;
                 SET_BATTLER_TYPE(battler, moveType);
-                PREPARE_TYPE_BUFFER(gBattleTextBuff1, moveType);
+                PrepareTypeBuffer(gBattleTextBuff1, moveType);
                 BattleScriptCall(BattleScript_ColorChangeActivates);
                 effect++;
             }
@@ -3859,7 +3859,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
             {
                 gBattleMons[gBattlerAttacker].volatiles.disabledMove = gChosenMove;
                 gBattleMons[gBattlerAttacker].volatiles.disableTimer = B_DISABLE_TIMER;
-                PREPARE_MOVE_BUFFER(gBattleTextBuff1, gChosenMove);
+                PrepareMoveBuffer(gBattleTextBuff1, gChosenMove);
                 BattleScriptCall(BattleScript_CursedBodyActivates);
                 effect++;
             }
@@ -3977,7 +3977,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
             {
                 if (!IsAbilityAndRecord(gBattlerAttacker, GetBattlerAbility(gBattlerAttacker), ABILITY_MAGIC_GUARD))
                 {
-                    PREPARE_ABILITY_BUFFER(gBattleTextBuff1, gLastUsedAbility);
+                    PrepareAbilityBuffer(gBattleTextBuff1, gLastUsedAbility);
                     SetPassiveDamageAmount(gBattlerAttacker, GetNonDynamaxMaxHP(gBattlerAttacker) / (B_ROUGH_SKIN_DMG >= GEN_4 ? 8 : 16));
                     gBattleCommunication[MULTISTRING_CHOOSER] = B_MSG_HURT;
                     BattleScriptCall(BattleScript_RoughSkinActivates);
@@ -4066,7 +4066,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
                     gEffectBattler = gBattlerAttacker;
                     gBattleScripting.battler = gBattlerTarget;
                     gBattleScripting.moveEffect = MOVE_EFFECT_SLEEP;
-                    PREPARE_ABILITY_BUFFER(gBattleTextBuff1, gLastUsedAbility);
+                    PrepareAbilityBuffer(gBattleTextBuff1, gLastUsedAbility);
                     BattleScriptCall(BattleScript_AbilityStatusEffect);
                     effect++;
                 }
@@ -4088,7 +4088,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
                     gEffectBattler = gBattlerAttacker;
                     gBattleScripting.battler = gBattlerTarget;
                     gBattleScripting.moveEffect = MOVE_EFFECT_POISON;
-                    PREPARE_ABILITY_BUFFER(gBattleTextBuff1, gLastUsedAbility);
+                    PrepareAbilityBuffer(gBattleTextBuff1, gLastUsedAbility);
                     BattleScriptCall(BattleScript_AbilityStatusEffect);
                     effect++;
                 }
@@ -4110,7 +4110,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
                     gEffectBattler = gBattlerAttacker;
                     gBattleScripting.battler = gBattlerTarget;
                     gBattleScripting.moveEffect = MOVE_EFFECT_PARALYSIS;
-                    PREPARE_ABILITY_BUFFER(gBattleTextBuff1, gLastUsedAbility);
+                    PrepareAbilityBuffer(gBattleTextBuff1, gLastUsedAbility);
                     BattleScriptCall(BattleScript_AbilityStatusEffect);
                     effect++;
                 }
@@ -4128,7 +4128,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
                 gEffectBattler = gBattlerAttacker;
                 gBattleScripting.battler = gBattlerTarget;
                 gBattleScripting.moveEffect = MOVE_EFFECT_BURN;
-                PREPARE_ABILITY_BUFFER(gBattleTextBuff1, gLastUsedAbility);
+                PrepareAbilityBuffer(gBattleTextBuff1, gLastUsedAbility);
                 BattleScriptCall(BattleScript_AbilityStatusEffect);
                 effect++;
             }
@@ -4281,7 +4281,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
                 gEffectBattler = gBattlerAttacker;
                 gBattleScripting.battler = gBattlerTarget;
                 gBattleScripting.moveEffect = MOVE_EFFECT_BURN;
-                PREPARE_ABILITY_BUFFER(gBattleTextBuff1, gLastUsedAbility);
+                PrepareAbilityBuffer(gBattleTextBuff1, gLastUsedAbility);
                 BattleScriptCall(BattleScript_AbilityStatusEffect);
                 effect++;
             }
@@ -4305,7 +4305,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
                 gEffectBattler = gBattlerTarget;
                 gBattleScripting.battler = gBattlerAttacker;
                 gBattleScripting.moveEffect = MOVE_EFFECT_POISON;
-                PREPARE_ABILITY_BUFFER(gBattleTextBuff1, gLastUsedAbility);
+                PrepareAbilityBuffer(gBattleTextBuff1, gLastUsedAbility);
                 BattleScriptCall(BattleScript_AbilityStatusEffect);
                 effect++;
             }
@@ -4319,7 +4319,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
                     gEffectBattler = gBattlerTarget;
                     gBattleScripting.battler = gBattlerAttacker;
                     gBattleScripting.moveEffect = MOVE_EFFECT_TOXIC;
-                    PREPARE_ABILITY_BUFFER(gBattleTextBuff1, gLastUsedAbility);
+                    PrepareAbilityBuffer(gBattleTextBuff1, gLastUsedAbility);
                     BattleScriptCall(BattleScript_AbilityStatusEffect);
                     effect++;
                 }
@@ -4346,7 +4346,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
                     gBattleScripting.battler = gBattlerAttacker;
                     gEffectBattler = gBattlerTarget;
                     gBattleScripting.moveEffect = MOVE_EFFECT_CONFUSION;
-                    PREPARE_ABILITY_BUFFER(gBattleTextBuff1, gLastUsedAbility);
+                    PrepareAbilityBuffer(gBattleTextBuff1, gLastUsedAbility);
                     BattleScriptCall(BattleScript_AbilityStatusEffect);
                     effect++;
                 }
@@ -4526,7 +4526,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
                     // Can't use TryBattleFormChange as we can't test form change const data changes.
                     gLastUsedAbility = ability;
                     GetBattlerPartyState(battler)->battleBondBoost = TRUE;
-                    PREPARE_SPECIES_BUFFER(gBattleTextBuff1, gBattleMons[battler].species);
+                    PrepareSpeciesBuffer(gBattleTextBuff1, gBattleMons[battler].species);
                     GetBattlerPartyState(battler)->changedSpecies = gBattleMons[battler].species;
                     gBattleMons[battler].species = SPECIES_GRENINJA_ASH;
                     BattleScriptCall(BattleScript_BattleBondActivatesOnMoveEndAttacker);
@@ -4654,7 +4654,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
              && GET_BASE_SPECIES_ID(GetMonData(GetBattlerMon(battler), MON_DATA_SPECIES)) == SPECIES_TATSUGIRI)
             {
                 gEffectBattler = partner;
-                PREPARE_MON_NICK_BUFFER(gBattleTextBuff1, partner, gBattlerPartyIndexes[partner]);
+                PrepareMonNickBuffer(gBattleTextBuff1, partner, gBattlerPartyIndexes[partner]);
                 gBattleStruct->battlerState[battler].commandingDondozo = TRUE;
                 gBattleStruct->battlerState[partner].commanderSpecies = gBattleMons[battler].species;
                 gBattleMons[battler].volatiles.semiInvulnerable = STATE_COMMANDER;
@@ -4739,7 +4739,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
             {
                 gBattleMons[battler].volatiles.weatherAbilityDone = TRUE;
                 gBattleMons[battler].volatiles.paradoxBoostedStat = GetParadoxHighestStatId(battler);
-                PREPARE_STAT_BUFFER(gBattleTextBuff1, gBattleMons[battler].volatiles.paradoxBoostedStat);
+                PrepareStatBuffer(gBattleTextBuff1, gBattleMons[battler].volatiles.paradoxBoostedStat);
                 gBattleScripting.battler = battler;
                 BattleScriptCall(BattleScript_ProtosynthesisActivates);
                 effect++;
@@ -4771,7 +4771,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
             {
                 gBattleMons[battler].volatiles.terrainAbilityDone = TRUE;
                 gBattleMons[battler].volatiles.paradoxBoostedStat = GetParadoxHighestStatId(battler);
-                PREPARE_STAT_BUFFER(gBattleTextBuff1, gBattleMons[battler].volatiles.paradoxBoostedStat);
+                PrepareStatBuffer(gBattleTextBuff1, gBattleMons[battler].volatiles.paradoxBoostedStat);
                 gBattlerAbility = gBattleScripting.battler = battler;
                 BattleScriptCall(BattleScript_QuarkDriveActivates);
                 effect++;

--- a/src/battle_z_move.c
+++ b/src/battle_z_move.c
@@ -321,7 +321,7 @@ bool32 MoveSelectionDisplayZMove(enum Move zmove, enum BattlerId battler)
                 gDisplayedStringBattle[0] = CHAR_PLUS;
                 gDisplayedStringBattle[1] = 0;
                 gDisplayedStringBattle[2] = EOS;
-                PREPARE_STAT_BUFFER(gBattleTextBuff1, zEffect - Z_EFFECT_ATK_UP_1 + 1);
+                PrepareStatBuffer(gBattleTextBuff1, zEffect - Z_EFFECT_ATK_UP_1 + 1);
                 ExpandBattleTextBuffPlaceholders(gBattleTextBuff1, gDisplayedStringBattle + 2);
                 break;
             case Z_EFFECT_ATK_UP_2:
@@ -335,7 +335,7 @@ bool32 MoveSelectionDisplayZMove(enum Move zmove, enum BattlerId battler)
                 gDisplayedStringBattle[1] = CHAR_PLUS;
                 gDisplayedStringBattle[2] = 0;
                 gDisplayedStringBattle[3] = EOS;
-                PREPARE_STAT_BUFFER(gBattleTextBuff1, zEffect - Z_EFFECT_ATK_UP_2 + 1);
+                PrepareStatBuffer(gBattleTextBuff1, zEffect - Z_EFFECT_ATK_UP_2 + 1);
                 ExpandBattleTextBuffPlaceholders(gBattleTextBuff1, gDisplayedStringBattle + 3);
                 break;
             case Z_EFFECT_ATK_UP_3:
@@ -350,7 +350,7 @@ bool32 MoveSelectionDisplayZMove(enum Move zmove, enum BattlerId battler)
                 gDisplayedStringBattle[2] = CHAR_PLUS;
                 gDisplayedStringBattle[3] = 0;
                 gDisplayedStringBattle[4] = EOS;
-                PREPARE_STAT_BUFFER(gBattleTextBuff1, zEffect - Z_EFFECT_ATK_UP_3 + 1);
+                PrepareStatBuffer(gBattleTextBuff1, zEffect - Z_EFFECT_ATK_UP_3 + 1);
                 ExpandBattleTextBuffPlaceholders(gBattleTextBuff1, gDisplayedStringBattle + 4);
                 break;
             default:

--- a/src/evolution_scene.c
+++ b/src/evolution_scene.c
@@ -1010,7 +1010,7 @@ static void Task_EvolutionScene(u8 taskId)
                     else
                     {
                         // Forget move
-                        PREPARE_MOVE_BUFFER(gBattleTextBuff2, move)
+                        PrepareMoveBuffer(gBattleTextBuff2, move);
 
                         RemoveMonPPBonus(mon, var);
                         SetMonMoveSlot(mon, gMoveToLearn, var);
@@ -1413,7 +1413,7 @@ static void Task_TradeEvolutionScene(u8 taskId)
                     else
                     {
                         // Forget move
-                        PREPARE_MOVE_BUFFER(gBattleTextBuff2, move)
+                        PrepareMoveBuffer(gBattleTextBuff2, move);
 
                         RemoveMonPPBonus(mon, var);
                         SetMonMoveSlot(mon, gMoveToLearn, var);

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -3962,7 +3962,7 @@ bool8 HealStatusConditions(struct Pokemon *mon, u32 healMask, enum BattlerId bat
 {
     u32 status = GetMonData(mon, MON_DATA_STATUS, 0);
 
-    PREPARE_MON_NICK_BUFFER(gBattleTextBuff1, battler, gBattlerPartyIndexes[battler]);
+    PrepareMonNickBuffer(gBattleTextBuff1, battler, gBattlerPartyIndexes[battler]);
 
     if (status & healMask)
     {
@@ -5535,7 +5535,7 @@ void SetMonPreventsSwitchingString(void)
     else
         gBattleTextBuff1[3] = gBattlerPartyIndexes[gBattleStruct->battlerPreventingSwitchout];
 
-    PREPARE_MON_NICK_WITH_PREFIX_BUFFER(gBattleTextBuff2, gBattlerInMenuId, GetPartyIdFromBattlePartyId(gBattlerPartyIndexes[gBattlerInMenuId]))
+    PrepareMonNickWithPrefixBuffer(gBattleTextBuff2, gBattlerInMenuId, GetPartyIdFromBattlePartyId(gBattlerPartyIndexes[gBattlerInMenuId]));
 
     BattleStringExpandPlaceholders(gText_PkmnsXPreventsSwitching, gStringVar4, sizeof(gStringVar4));
 }

--- a/test/text.c
+++ b/test/text.c
@@ -621,9 +621,9 @@ TEST("Battle strings fit on the battle message window")
     }
 
     // Clear buffers
-    PREPARE_STRING_BUFFER(gBattleTextBuff1, STRINGID_EMPTYSTRING3);
-    PREPARE_STRING_BUFFER(gBattleTextBuff2, STRINGID_EMPTYSTRING3);
-    PREPARE_STRING_BUFFER(gBattleTextBuff3, STRINGID_EMPTYSTRING3);
+    PrepareStringBuffer(gBattleTextBuff1, STRINGID_EMPTYSTRING3);
+    PrepareStringBuffer(gBattleTextBuff2, STRINGID_EMPTYSTRING3);
+    PrepareStringBuffer(gBattleTextBuff3, STRINGID_EMPTYSTRING3);
     *gStringVar1 = EOS;
     *gStringVar2 = EOS;
     *gStringVar3 = EOS;
@@ -669,14 +669,14 @@ TEST("Battle strings fit on the battle message window")
         break;
     // Buffer Nickname with prefix to B_BUFF1, " a boosted" to B_BUFF2, "999999" to B_BUFF3
     case STRINGID_PKMNGAINEDEXP:
-        PREPARE_MON_NICK_WITH_PREFIX_BUFFER(gBattleTextBuff1, 0, 0);
-        PREPARE_STRING_BUFFER(gBattleTextBuff2, STRINGID_ABOOSTED); // 'gained a boosted'
-        PREPARE_WORD_NUMBER_BUFFER(gBattleTextBuff3, 6, sixDigitNines);
+        PrepareMonNickWithPrefixBuffer(gBattleTextBuff1, 0, 0);
+        PrepareStringBuffer(gBattleTextBuff2, STRINGID_ABOOSTED); // 'gained a boosted';
+        PrepareWordNumberBuffer(gBattleTextBuff3, 6, sixDigitNines);
         break;
     // Buffer Nickname with prefix to B_BUFF1, "100" to B_BUFF2
     case STRINGID_PKMNGREWTOLV:
-        PREPARE_MON_NICK_WITH_PREFIX_BUFFER(gBattleTextBuff1, 0, 0);
-        PREPARE_BYTE_NUMBER_BUFFER(gBattleTextBuff2, 3, 100);
+        PrepareMonNickWithPrefixBuffer(gBattleTextBuff1, 0, 0);
+        PrepareByteNumberBuffer(gBattleTextBuff2, 3, 100);
         break;
     // Buffer Nickname with prefix to B_BUFF1, move name to B_BUFF2
     case STRINGID_PKMNLEARNEDMOVE:
@@ -686,8 +686,8 @@ TEST("Battle strings fit on the battle message window")
     case STRINGID_PKMNFORGOTMOVE:
     case STRINGID_STOPLEARNINGMOVE:
     case STRINGID_DIDNOTLEARNMOVE:
-        PREPARE_MON_NICK_WITH_PREFIX_BUFFER(gBattleTextBuff1, 0, 0);
-        PREPARE_MOVE_BUFFER(gBattleTextBuff2, longMoveID);
+        PrepareMonNickWithPrefixBuffer(gBattleTextBuff1, 0, 0);
+        PrepareMoveBuffer(gBattleTextBuff2, longMoveID);
         break;
     // Buffer Move name to B_BUFF1
     case STRINGID_PKMNLEARNEDMOVE2:
@@ -704,24 +704,24 @@ TEST("Battle strings fit on the battle message window")
     case STRINGID_CURSEDBODYDISABLED:
     case STRINGID_CURRENTMOVECANTSELECT:
     case STRINGID_TARGETISHURTBYSALTCURE:
-        PREPARE_MOVE_BUFFER(gBattleTextBuff1, longMoveID);
+        PrepareMoveBuffer(gBattleTextBuff1, longMoveID);
         break;
     // Buffer "999999" to B_BUFF1
     case STRINGID_PLAYERGOTMONEY:
     case STRINGID_PLAYERWHITEOUT2_TRAINER:
     case STRINGID_PLAYERPICKEDUPMONEY:
     case STRINGID_PLAYERWHITEOUT2_WILD:
-        PREPARE_WORD_NUMBER_BUFFER(gBattleTextBuff1, 6, sixDigitNines);
+        PrepareWordNumberBuffer(gBattleTextBuff1, 6, sixDigitNines);
         break;
     // Buffer "99" to B_BUFF1
     case STRINGID_HITXTIMES:
     case STRINGID_MAGNITUDESTRENGTH:
-        PREPARE_WORD_NUMBER_BUFFER(gBattleTextBuff1, 2, 99);
+        PrepareWordNumberBuffer(gBattleTextBuff1, 2, 99);
         break;
     // Buffer "9" to B_BUFF1
     case STRINGID_PKMNSTOCKPILED:
     case STRINGID_PKMNPERISHCOUNTFELL:
-        PREPARE_WORD_NUMBER_BUFFER(gBattleTextBuff1, 1, 9);
+        PrepareWordNumberBuffer(gBattleTextBuff1, 1, 9);
         break;
     // Buffer Ability name to B_BUFF1
     case STRINGID_PKMNMADESLEEP:
@@ -730,7 +730,7 @@ TEST("Battle strings fit on the battle message window")
     case STRINGID_PKMNFROZENBY:
     case STRINGID_PKMNWASPARALYZEDBY:
     case STRINGID_CANACTFASTERTHANKSTO:
-        PREPARE_ABILITY_BUFFER(gBattleTextBuff1, longAbilityID);
+        PrepareAbilityBuffer(gBattleTextBuff1, longAbilityID);
         break;
     // Buffer Stat name to B_BUFF1
     case STRINGID_STATSWONTINCREASE:
@@ -750,7 +750,7 @@ TEST("Battle strings fit on the battle message window")
     case STRINGID_THIRDTYPEADDED:
     case STRINGID_ATTACKERLOSTITSTYPE:
     case STRINGID_PKMNTERASTALLIZEDINTO:
-        PREPARE_TYPE_BUFFER(gBattleTextBuff1, longTypeName);
+        PrepareTypeBuffer(gBattleTextBuff1, longTypeName);
         break;
     // Buffer Species name to B_BUFF1
     case STRINGID_PKMNTRANSFORMEDINTO:
@@ -760,20 +760,20 @@ TEST("Battle strings fit on the battle message window")
     case STRINGID_ITEMRESTOREDSPECIESHEALTH: // Should probably use nickname instead?
     case STRINGID_ITEMCUREDSPECIESSTATUS: // Should probably use nickname instead?
     case STRINGID_ITEMRESTOREDSPECIESPP: // Should probably use nickname instead?
-        PREPARE_SPECIES_BUFFER(gBattleTextBuff1, longSpeciesName)
+        PrepareSpeciesBuffer(gBattleTextBuff1, longSpeciesName);
         break;
     // Buffer nickname with prefix to B_BUFF1
     case STRINGID_PKMNATTACK:
     case STRINGID_PKMNWISHCAMETRUE:
-        PREPARE_MON_NICK_WITH_PREFIX_BUFFER(gBattleTextBuff1, 1, 0);
+        PrepareMonNickWithPrefixBuffer(gBattleTextBuff1, 1, 0);
         break;
     // Buffer nickname with prefix in lower case to B_BUFF1
     case STRINGID_USEDINSTRUCTEDMOVE:
-        PREPARE_MON_NICK_WITH_PREFIX_LOWER_BUFFER(gBattleTextBuff1, 1, 0);
+        PrepareMonNickWithPrefixLowerBuffer(gBattleTextBuff1, 1, 0);
         break;
     // Buffer nickname to B_BUFF2
     case STRINGID_ENEMYABOUTTOSWITCHPKMN:
-        PREPARE_MON_NICK_BUFFER(gBattleTextBuff2, 1, 0);
+        PrepareMonNickBuffer(gBattleTextBuff2, 1, 0);
         break;
     // Buffer Item name to B_BUFF1
     case STRINGID_PKMNHURTSWITH:
@@ -782,21 +782,21 @@ TEST("Battle strings fit on the battle message window")
     case STRINGID_PKMNIGNOREDX:
     case STRINGID_PKMNOBTAINEDX:
     case STRINGID_ABOUTTOUSEPOLTERGEIST:
-        PREPARE_ITEM_BUFFER(gBattleTextBuff1, longItemName);
+        PrepareItemBuffer(gBattleTextBuff1, longItemName);
         break;
     // Buffer Item name to B_BUFF2
     case STRINGID_PKMNOBTAINEDX2:
-        PREPARE_ITEM_BUFFER(gBattleTextBuff2, longItemName);
+        PrepareItemBuffer(gBattleTextBuff2, longItemName);
         break;
     // Buffer Item name to B_BUFF1 and B_BUFF2
     case STRINGID_PKMNOBTAINEDXYOBTAINEDZ:
-        PREPARE_ITEM_BUFFER(gBattleTextBuff1, longItemName);
-        PREPARE_ITEM_BUFFER(gBattleTextBuff2, longItemName);
+        PrepareItemBuffer(gBattleTextBuff1, longItemName);
+        PrepareItemBuffer(gBattleTextBuff2, longItemName);
         break;
     // Buffer nickname with prefix to B_BUFF1, Ability name to B_BUFF2
     case STRINGID_PKMNTRACED:
-        PREPARE_MON_NICK_WITH_PREFIX_LOWER_BUFFER(gBattleTextBuff1, 1, 0);
-        PREPARE_ABILITY_BUFFER(gBattleTextBuff2, longAbilityID);
+        PrepareMonNickWithPrefixLowerBuffer(gBattleTextBuff1, 1, 0);
+        PrepareAbilityBuffer(gBattleTextBuff2, longAbilityID);
         break;
     // Buffer Stat name to B_BUFF1, "drastically rose" to B_BUFF2
     case STRINGID_STATROSE:


### PR DESCRIPTION
## Description
Reason: function compile errors are better.

## Things to note in the release changelog:
* Run migrations script with `bash migration_scripts/1.17/string_buffer_func_migration.sh`

