### PR TITLE
Fix icon tags for eggs and female icons not being properly cleared

### DIFF
--- a/include/pokemon_icon.h
+++ b/include/pokemon_icon.h
@@ -3,8 +3,15 @@
 
 extern const struct SpritePalette gMonIconPaletteTable[];
 
+enum SpeciesIconType {
+    NORMAL_ICON,
+    FEMALE_ICON,
+    EGG_ICON
+};
+
 const u8 *GetMonIconTiles(enum Species species, u32 personality);
 const u8 *GetMonIconTilesIsEgg(enum Species species, u32 personality, bool32 isEgg);
+const u8 *GetMonIconTilesByIconType(enum Species species, enum SpeciesIconType iconType);
 void TryLoadAllMonIconPalettesAtOffset(u16 offset);
 u8 GetValidMonIconPalIndex(enum Species species);
 const u8 *GetMonIconPtr(enum Species species, u32 personality);

--- a/src/pokemon_icon.c
+++ b/src/pokemon_icon.c
@@ -345,14 +345,11 @@ const u8 *GetMonIconTilesIsEgg(enum Species species, u32 personality, bool32 isE
 
 const u8 *GetMonIconTilesByIconType(enum Species species, enum SpeciesIconType iconType)
 {
-    const u8 *iconSprite;
     if (iconType == EGG_ICON)
-        iconSprite = gEggDatas[gSpeciesInfo[species].eggId].eggIcon;
-    else if (iconType == FEMALE_ICON)
-        iconSprite = gSpeciesInfo[species].iconSpriteFemale;
-    else
-        iconSprite = gSpeciesInfo[species].iconSprite;
-    return iconSprite;
+        return gEggDatas[gSpeciesInfo[species].eggId].eggIcon;
+    if (iconType == FEMALE_ICON)
+        return gSpeciesInfo[species].iconSpriteFemale;
+    return gSpeciesInfo[species].iconSprite;
 }
 
 void TryLoadAllMonIconPalettesAtOffset(u16 offset)

--- a/src/pokemon_icon.c
+++ b/src/pokemon_icon.c
@@ -343,6 +343,18 @@ const u8 *GetMonIconTilesIsEgg(enum Species species, u32 personality, bool32 isE
     return iconSprite;
 }
 
+const u8 *GetMonIconTilesByIconType(enum Species species, enum SpeciesIconType iconType)
+{
+    const u8 *iconSprite;
+    if (iconType == EGG_ICON)
+        iconSprite = gEggDatas[gSpeciesInfo[species].eggId].eggIcon;
+    else if (iconType == FEMALE_ICON)
+        iconSprite = gSpeciesInfo[species].iconSpriteFemale;
+    else
+        iconSprite = gSpeciesInfo[species].iconSprite;
+    return iconSprite;
+}
+
 void TryLoadAllMonIconPalettesAtOffset(u16 offset)
 {
     s32 i;

--- a/src/pokemon_storage_system.c
+++ b/src/pokemon_storage_system.c
@@ -5103,24 +5103,26 @@ static void SpriteCB_HeldMon(struct Sprite *sprite)
     sprite->y = sStorage->cursorSprite->y + sStorage->cursorSprite->y2 + 4;
 }
 
-static u16 TryLoadMonIconTiles(enum Species species, u32 personality, bool32 isEgg)
+static u32 MakeIconIdFromSpeciesAndIconType(enum Species species, enum SpeciesIconType iconType)
 {
-    u16 i, offset;
+    u32 iconId;
+    if (iconType == FEMALE_ICON)
+        iconId = species | (1 << 15);
+    else if (iconType == EGG_ICON)
+        iconId = species | (1 << 14);
+    else
+        iconId = species;
+    return iconId;
+}
 
-#if P_GENDER_DIFFERENCES
-    // Treat female mons as a seperate species as they may have a different icon than males
-    if (gSpeciesInfo[species].iconSpriteFemale != NULL && IsPersonalityFemale(species, personality))
-        species |= (1 << 15);
-#endif
+static u16 TryLoadMonIconTiles(enum Species species, enum SpeciesIconType iconType)
+{
+    u32 i, offset;
+    u32 iconId = MakeIconIdFromSpeciesAndIconType(species, iconType);
 
-    // Treat eggs as a seperate species as they might have unique sprites
-    if (isEgg)
-        species |= (1 << 14);
-
-    // Search icon list for this species
     for (i = 0; i < MAX_MON_ICONS; i++)
     {
-        if (sStorage->iconSpeciesList[i] == species)
+        if (sStorage->iconSpeciesList[i] == iconId)
             break;
     }
 
@@ -5140,32 +5142,22 @@ static u16 TryLoadMonIconTiles(enum Species species, u32 personality, bool32 isE
     }
 
     // Add species to icon list and load tiles
-    sStorage->iconSpeciesList[i] = species;
+    sStorage->iconSpeciesList[i] = iconId;
     sStorage->numIconsPerSpecies[i]++;
     offset = 16 * i;
     species &= SPECIES_MASK;
-    CpuCopy32(GetMonIconTilesIsEgg(species, personality, isEgg), (void *)(OBJ_VRAM0) + offset * TILE_SIZE_4BPP, 0x200);
+    CpuCopy32(GetMonIconTilesByIconType(species, iconType), (void *)(OBJ_VRAM0) + offset * TILE_SIZE_4BPP, 0x200);
 
     return offset;
 }
 
-static void RemoveSpeciesFromIconList(enum Species species)
+static void RemoveSpeciesFromIconList(enum Species species, enum SpeciesIconType iconType)
 {
-    u16 i;
-    bool8 hasFemale = FALSE;
+    u32 iconId = MakeIconIdFromSpeciesAndIconType(species, iconType);
 
-    for (i = 0; i < MAX_MON_ICONS; i++)
+    for (u32 i = 0; i < MAX_MON_ICONS; i++)
     {
-        if (sStorage->iconSpeciesList[i] == (species | 0x8000))
-        {
-            hasFemale = TRUE;
-            break;
-        }
-    }
-
-    for (i = 0; i < MAX_MON_ICONS; i++)
-    {
-        if (sStorage->iconSpeciesList[i] == species && !hasFemale)
+        if (sStorage->iconSpeciesList[i] == iconId)
         {
             if (--sStorage->numIconsPerSpecies[i] == 0)
                 sStorage->iconSpeciesList[i] = SPECIES_NONE;
@@ -5179,19 +5171,27 @@ static struct Sprite *CreateMonIconSprite(enum Species species, u32 personality,
     u16 tileNum;
     u8 spriteId;
     struct SpriteTemplate template = sSpriteTemplate_MonIcon;
+    u32 iconType = NORMAL_ICON;
 
     species = GetIconSpecies(species, personality);
     if (isEgg)
     {
         if (gSpeciesInfo[species].eggId != EGG_ID_NONE)
+        {
             template.paletteTag = PALTAG_MON_ICON_0 + gEggDatas[gSpeciesInfo[species].eggId].eggIconPalIndex;
+            iconType = EGG_ICON;
+        }
         else
+        {
+            species = SPECIES_EGG;
             template.paletteTag = PALTAG_MON_ICON_0 + gSpeciesInfo[SPECIES_EGG].iconPalIndex;
+        }
     }
 #if P_GENDER_DIFFERENCES
     else if (gSpeciesInfo[species].iconSpriteFemale != NULL && IsPersonalityFemale(species, personality))
     {
         template.paletteTag = PALTAG_MON_ICON_0 + gSpeciesInfo[species].iconPalIndexFemale;
+        iconType = FEMALE_ICON;
     }
 #endif
     else
@@ -5199,26 +5199,28 @@ static struct Sprite *CreateMonIconSprite(enum Species species, u32 personality,
         template.paletteTag = PALTAG_MON_ICON_0 + gSpeciesInfo[species].iconPalIndex;
     }
 
-    tileNum = TryLoadMonIconTiles(species, personality, isEgg);
+    tileNum = TryLoadMonIconTiles(species, iconType);
     if (tileNum == 0xFFFF)
         return NULL;
 
     spriteId = CreateSprite(&template, x, y, subpriority);
     if (spriteId == MAX_SPRITES)
     {
-        RemoveSpeciesFromIconList(species);
+        RemoveSpeciesFromIconList(species, iconType);
         return NULL;
     }
 
     gSprites[spriteId].oam.tileNum = tileNum;
     gSprites[spriteId].oam.priority = oamPriority;
     gSprites[spriteId].data[0] = species;
+    gSprites[spriteId].data[1] = iconType;
+
     return &gSprites[spriteId];
 }
 
 static void DestroyBoxMonIcon(struct Sprite *sprite)
 {
-    RemoveSpeciesFromIconList(sprite->data[0]);
+    RemoveSpeciesFromIconList(sprite->data[0], sprite->data[1]);
     DestroySprite(sprite);
 }
 

--- a/src/pokemon_storage_system.c
+++ b/src/pokemon_storage_system.c
@@ -5105,14 +5105,11 @@ static void SpriteCB_HeldMon(struct Sprite *sprite)
 
 static u32 MakeIconIdFromSpeciesAndIconType(enum Species species, enum SpeciesIconType iconType)
 {
-    u32 iconId;
     if (iconType == FEMALE_ICON)
-        iconId = species | (1 << 15);
-    else if (iconType == EGG_ICON)
-        iconId = species | (1 << 14);
-    else
-        iconId = species;
-    return iconId;
+        return (species | (1 << 15));
+    if (iconType == EGG_ICON)
+        return (species | (1 << 14));
+    return species;
 }
 
 static u16 TryLoadMonIconTiles(enum Species species, enum SpeciesIconType iconType)


### PR DESCRIPTION
The pokemon storage system use some sort of tag system for pokemon icon. The tag was either `speciesId` or `speciesId | (1 << 15)` for female pokemon icons or `speciesId | (1 << 14)` for egg icons
But when it come to remove the tag, the system would not properly account egg and female icons and only clear `speciesId`
This was causing an issues when filling the PC with eggs of different species.
I added a new enum PokemonIconType to clarify when a tag was used and made sure to check both the species and iconType when freeing tags 

## Issue(s) that this PR fixes
Fixes #10165


## Discord contact info
Jamie
