### PR TITLE
Fix applymovementat potentially setting direction overwrite for wrong objects

### DIFF
--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -1427,12 +1427,7 @@ u8 GetFirstInactiveObjectEventId(void)
 u8 GetObjectEventIdByLocalIdAndMap(u8 localId, u8 mapNum, u8 mapGroupId)
 {
     if (localId < OBJ_EVENT_ID_DYNAMIC_BASE)
-    {
-        if (PlayerHasFollowerNPC() && localId == OBJ_EVENT_ID_NPC_FOLLOWER)
-            return GetFollowerNPCObjectId();
-        else
-            return GetObjectEventIdByLocalIdAndMapInternal(localId, mapNum, mapGroupId);
-    }
+        return GetObjectEventIdByLocalIdAndMapInternal(localId, mapNum, mapGroupId);
 
     return GetObjectEventIdByLocalId(localId);
 }

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -1293,7 +1293,7 @@ bool8 ScrCmd_applymovement(struct ScriptContext *ctx)
     struct ObjectEvent *objEvent;
     u8 objectEventId;
 
-    if (!TryGetObjectEventIdByLocalIdAndMap(localId, gSaveBlock1Ptr->location.mapNum, gSaveBlock1Ptr->location.mapGroup, &objectEventId))
+    if (TryGetObjectEventIdByLocalIdAndMap(localId, gSaveBlock1Ptr->location.mapNum, gSaveBlock1Ptr->location.mapGroup, &objectEventId))
     {
         errorf("Trying to apply movement for local id %d on current map but no object found", localId);
         return FALSE;
@@ -1328,7 +1328,7 @@ bool8 ScrCmd_applymovementat(struct ScriptContext *ctx)
     u8 mapNum = ScriptReadByte(ctx);
     u8 objectEventId;
 
-    if (!TryGetObjectEventIdByLocalIdAndMap(localId, mapNum, mapGroup, &objectEventId))
+    if (TryGetObjectEventIdByLocalIdAndMap(localId, mapNum, mapGroup, &objectEventId))
     {
         errorf("Trying to apply movement for local id %d on map %d but no object found", localId, (mapNum | mapGroup << 8));
         return FALSE;

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -1291,18 +1291,24 @@ bool8 ScrCmd_applymovement(struct ScriptContext *ctx)
     u16 localId = VarGet(ScriptReadHalfword(ctx));
     const u8 *movementScript = (const u8 *)ScriptReadWord(ctx);
     struct ObjectEvent *objEvent;
+    u8 objectEventId;
 
+    if (!TryGetObjectEventIdByLocalIdAndMap(localId, gSaveBlock1Ptr->location.mapNum, gSaveBlock1Ptr->location.mapGroup, &objectEventId))
+    {
+        errorf("Trying to apply movement for local id %d on current map but no object found", localId);
+        return FALSE;
+    }
     Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
 
     // When applying script movements to follower, it may have frozen animation that must be cleared
     if ((localId == OBJ_EVENT_ID_FOLLOWER && (objEvent = GetFollowerObject()) && objEvent->frozen)
-            || ((objEvent = &gObjectEvents[GetObjectEventIdByLocalId(localId)]) && IS_OW_MON_OBJ(objEvent)))
+            || ((objEvent = &gObjectEvents[objectEventId]) && IS_OW_MON_OBJ(objEvent)))
     {
         ClearObjectEventMovement(objEvent, &gSprites[objEvent->spriteId]);
         gSprites[objEvent->spriteId].animCmdIndex = 0; // Reset start frame of animation
     }
 
-    gObjectEvents[GetObjectEventIdByLocalIdAndMap(localId, gSaveBlock1Ptr->location.mapNum, gSaveBlock1Ptr->location.mapGroup)].directionOverwrite = DIR_NONE;
+    gObjectEvents[objectEventId].directionOverwrite = DIR_NONE;
     ScriptMovement_StartObjectMovementScript(localId, gSaveBlock1Ptr->location.mapNum, gSaveBlock1Ptr->location.mapGroup, movementScript);
     sMovingNpcId = localId;
     if (localId != OBJ_EVENT_ID_FOLLOWER
@@ -1320,10 +1326,17 @@ bool8 ScrCmd_applymovementat(struct ScriptContext *ctx)
     const void *movementScript = (const void *)ScriptReadWord(ctx);
     u8 mapGroup = ScriptReadByte(ctx);
     u8 mapNum = ScriptReadByte(ctx);
+    u8 objectEventId;
+
+    if (!TryGetObjectEventIdByLocalIdAndMap(localId, mapNum, mapGroup, &objectEventId))
+    {
+        errorf("Trying to apply movement for local id %d on map %d but no object found", localId, (mapNum | mapGroup << 8));
+        return FALSE;
+    }
 
     Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
 
-    gObjectEvents[GetObjectEventIdByLocalIdAndMap(localId, mapNum, mapGroup)].directionOverwrite = DIR_NONE;
+    gObjectEvents[objectEventId].directionOverwrite = DIR_NONE;
     ScriptMovement_StartObjectMovementScript(localId, mapNum, mapGroup, movementScript);
     sMovingNpcId = localId;
     return FALSE;

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -1302,7 +1302,7 @@ bool8 ScrCmd_applymovement(struct ScriptContext *ctx)
         gSprites[objEvent->spriteId].animCmdIndex = 0; // Reset start frame of animation
     }
 
-    gObjectEvents[GetObjectEventIdByLocalId(localId)].directionOverwrite = DIR_NONE;
+    gObjectEvents[GetObjectEventIdByLocalIdAndMapInternal(localId, gSaveBlock1Ptr->location.mapNum, gSaveBlock1Ptr->location.mapGroup)].directionOverwrite = DIR_NONE;
     ScriptMovement_StartObjectMovementScript(localId, gSaveBlock1Ptr->location.mapNum, gSaveBlock1Ptr->location.mapGroup, movementScript);
     sMovingNpcId = localId;
     if (localId != OBJ_EVENT_ID_FOLLOWER
@@ -1323,7 +1323,7 @@ bool8 ScrCmd_applymovementat(struct ScriptContext *ctx)
 
     Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
 
-    gObjectEvents[GetObjectEventIdByLocalId(localId)].directionOverwrite = DIR_NONE;
+    gObjectEvents[GetObjectEventIdByLocalIdAndMapInternal(localId, mapNum, mapGroup)].directionOverwrite = DIR_NONE;
     ScriptMovement_StartObjectMovementScript(localId, mapNum, mapGroup, movementScript);
     sMovingNpcId = localId;
     return FALSE;

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -1302,7 +1302,7 @@ bool8 ScrCmd_applymovement(struct ScriptContext *ctx)
         gSprites[objEvent->spriteId].animCmdIndex = 0; // Reset start frame of animation
     }
 
-    gObjectEvents[GetObjectEventIdByLocalIdAndMapInternal(localId, gSaveBlock1Ptr->location.mapNum, gSaveBlock1Ptr->location.mapGroup)].directionOverwrite = DIR_NONE;
+    gObjectEvents[GetObjectEventIdByLocalIdAndMap(localId, gSaveBlock1Ptr->location.mapNum, gSaveBlock1Ptr->location.mapGroup)].directionOverwrite = DIR_NONE;
     ScriptMovement_StartObjectMovementScript(localId, gSaveBlock1Ptr->location.mapNum, gSaveBlock1Ptr->location.mapGroup, movementScript);
     sMovingNpcId = localId;
     if (localId != OBJ_EVENT_ID_FOLLOWER
@@ -1323,7 +1323,7 @@ bool8 ScrCmd_applymovementat(struct ScriptContext *ctx)
 
     Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
 
-    gObjectEvents[GetObjectEventIdByLocalIdAndMapInternal(localId, mapNum, mapGroup)].directionOverwrite = DIR_NONE;
+    gObjectEvents[GetObjectEventIdByLocalIdAndMap(localId, mapNum, mapGroup)].directionOverwrite = DIR_NONE;
     ScriptMovement_StartObjectMovementScript(localId, mapNum, mapGroup, movementScript);
     sMovingNpcId = localId;
     return FALSE;


### PR DESCRIPTION
applymovement is supposed to apply to a unique object but an object event can't be uniquely identified by its localid because an object with the same localid from a different map could wander on the current map (this is also why applymovementat exist to be able to "select" these objects that originates from different maps)

The GF part of the function do make sure to identify the object event by its localid, map num and map group but the code added later by expansion does not. This fixes that

## Discord contact info
Jamie
