### PR TITLE
Fix incorrect style flagging for Battle Factory

### DIFF
--- a/src/battle_factory.c
+++ b/src/battle_factory.c
@@ -595,7 +595,7 @@ static enum FactoryStyle GetMoveBattleStyle(enum Move move)
         return FACTORY_STYLE_SLOW_STEADY;
 
     if (IsExplosionMove(move))
-        return FACTORY_STYLE_SLOW_STEADY;
+        return FACTORY_STYLE_HIGH_RISK;
 
     return FACTORY_STYLE_NONE;
 }


### PR DESCRIPTION
## Description
explosion moves are erroneously flagged as slow and steady moves in `battle_factory.c` - these should be high risk moves

### Large Language Models (AI)
none

## Discord contact info
constable_jongleur