### PR TITLE
Fix Psycho Shift status transfer interactions

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -899,7 +899,6 @@ BattleScript_EffectPsychoShift::
 	goto BattleScript_ButItFailed
 BattleScript_EffectPsychoShiftCanWork:
 	jumpifstatus BS_TARGET, STATUS1_ANY, BattleScript_ButItFailed
-	jumpifsafeguard BattleScript_SafeguardProtected
 	trypsychoshift BattleScript_ButItFailed, BattleScript_SleepClauseBlocked
 	attackanimation
 	waitanimation

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -898,7 +898,9 @@ BattleScript_EffectPsychoShift::
 	jumpifstatus BS_ATTACKER, STATUS1_ANY, BattleScript_EffectPsychoShiftCanWork
 	goto BattleScript_ButItFailed
 BattleScript_EffectPsychoShiftCanWork:
+	jumpifsubstituteblocks BattleScript_ButItFailed
 	jumpifstatus BS_TARGET, STATUS1_ANY, BattleScript_ButItFailed
+	jumpifsafeguard BattleScript_SafeguardProtected
 	trypsychoshift BattleScript_ButItFailed, BattleScript_SleepClauseBlocked
 	attackanimation
 	waitanimation
@@ -907,6 +909,8 @@ BattleScript_EffectPsychoShiftCanWork:
 	waitmessage B_WAIT_TIME_LONG
 	statusanimation BS_TARGET
 	updatestatusicon BS_TARGET
+	waitstate
+	trysynchronize
 	curestatus BS_ATTACKER
 	printfromtable gCureStatusStringIds
 	waitmessage B_WAIT_TIME_LONG

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -2086,7 +2086,7 @@ static s32 AI_CheckBadMove(enum BattlerId battlerAtk, enum BattlerId battlerDef,
             ADJUST_SCORE(-10);
         else if (gBattleMons[battlerAtk].status1 & STATUS1_SLEEP && !AI_CanPutToSleep(battlerAtk, battlerDef, aiData->abilities[battlerDef], move, aiData->partnerMove))
             ADJUST_SCORE(-10);
-        else
+        else if (!(gBattleMons[battlerAtk].status1 & STATUS1_ANY))
             ADJUST_SCORE(-10);    // attacker has no status to transmit
         break;
     case EFFECT_MUD_SPORT:
@@ -2850,10 +2850,8 @@ static s32 AI_CheckBadMove(enum BattlerId battlerAtk, enum BattlerId battlerDef,
         break;
     case EFFECT_SYNCHRONOISE:
         //Check holding ring target or is of same type
-        if (aiData->holdEffects[battlerDef] == HOLD_EFFECT_RING_TARGET
-          || DoBattlersShareType(battlerAtk, battlerDef))
-            break;
-        else
+        if (aiData->holdEffects[battlerDef] != HOLD_EFFECT_RING_TARGET
+        && !DoBattlersShareType(battlerAtk, battlerDef))
             ADJUST_SCORE(-10);
         break;
     case EFFECT_FLAIL:

--- a/src/battle_ai_switch.c
+++ b/src/battle_ai_switch.c
@@ -1838,7 +1838,7 @@ static u32 GetSwitchinStatusDamage(enum BattlerId battler)
             statusDamage = maxHP / 16;
             if (statusDamage == 0)
                 statusDamage = 1;
-            statusDamage *= gBattleMons[battler].status1 & STATUS1_TOXIC_COUNTER >> 8;
+            statusDamage *= (gBattleMons[battler].status1 & STATUS1_TOXIC_COUNTER) >> 8;
         }
     }
 

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -13206,29 +13206,50 @@ void BS_JumpIfTargetAlly(void)
 void BS_TryPsychoShift(void)
 {
     NATIVE_ARGS(const u8 *failInstr, const u8 *sleepClauseFailInstr);
+    enum Ability attackerAbility = GetBattlerAbility(gBattlerAttacker);
     enum Ability targetAbility = GetBattlerAbility(gBattlerTarget);
+
+    if (IsSubstituteProtected(gBattlerAttacker, gBattlerTarget, attackerAbility, MOVE_PSYCHO_SHIFT))
+    {
+        gBattlescriptCurrInstr = cmd->failInstr;
+        return;
+    }
+
+    if (IsSafeguardProtected(gBattlerAttacker, gBattlerTarget, attackerAbility))
+    {
+        gBattlescriptCurrInstr = BattleScript_SafeguardProtected;
+        return;
+    }
+
     // Psycho shift works
-    if ((gBattleMons[gBattlerAttacker].status1 & STATUS1_POISON) && CanBePoisoned(gBattlerAttacker, gBattlerTarget, GetBattlerAbility(gBattlerAttacker), targetAbility))
+    if ((gBattleMons[gBattlerAttacker].status1 & STATUS1_POISON)
+     && CanSetNonVolatileStatus(gBattlerAttacker, gBattlerTarget, attackerAbility, targetAbility, MOVE_EFFECT_TOXIC, CHECK_TRIGGER))
     {
         gBattleCommunication[MULTISTRING_CHOOSER] = 0;
     }
-    else if ((gBattleMons[gBattlerAttacker].status1 & STATUS1_TOXIC_POISON) && CanBePoisoned(gBattlerAttacker, gBattlerTarget, GetBattlerAbility(gBattlerAttacker), targetAbility))
+    else if ((gBattleMons[gBattlerAttacker].status1 & STATUS1_TOXIC_POISON)
+          && CanSetNonVolatileStatus(gBattlerAttacker, gBattlerTarget, attackerAbility, targetAbility, MOVE_EFFECT_TOXIC, CHECK_TRIGGER))
     {
         gBattleCommunication[MULTISTRING_CHOOSER] = 1;
     }
-    else if ((gBattleMons[gBattlerAttacker].status1 & STATUS1_BURN) && CanBeBurned(gBattlerAttacker, gBattlerTarget, targetAbility))
+    else if ((gBattleMons[gBattlerAttacker].status1 & STATUS1_BURN)
+          && CanSetNonVolatileStatus(gBattlerAttacker, gBattlerTarget, attackerAbility, targetAbility, MOVE_EFFECT_BURN, CHECK_TRIGGER))
     {
         gBattleCommunication[MULTISTRING_CHOOSER] = 2;
     }
-    else if ((gBattleMons[gBattlerAttacker].status1 & STATUS1_PARALYSIS) && CanBeParalyzed(gBattlerAttacker, gBattlerTarget, targetAbility))
+    else if ((gBattleMons[gBattlerAttacker].status1 & STATUS1_PARALYSIS)
+          && CanSetNonVolatileStatus(gBattlerAttacker, gBattlerTarget, attackerAbility, targetAbility, MOVE_EFFECT_PARALYSIS, CHECK_TRIGGER))
     {
         gBattleCommunication[MULTISTRING_CHOOSER] = 3;
     }
-    else if ((gBattleMons[gBattlerAttacker].status1 & STATUS1_SLEEP) && CanBeSlept(gBattlerAttacker, gBattlerTarget, targetAbility, BLOCKED_BY_SLEEP_CLAUSE))
+    else if ((gBattleMons[gBattlerAttacker].status1 & STATUS1_SLEEP)
+          && !IsSleepClauseActiveForSide(GetBattlerSide(gBattlerTarget))
+          && CanSetNonVolatileStatus(gBattlerAttacker, gBattlerTarget, attackerAbility, targetAbility, MOVE_EFFECT_SLEEP, CHECK_TRIGGER))
     {
         gBattleCommunication[MULTISTRING_CHOOSER] = 4;
     }
-    else if ((gBattleMons[gBattlerAttacker].status1 & STATUS1_FROSTBITE) && CanBeFrozen(gBattlerAttacker, gBattlerTarget, targetAbility))
+    else if ((gBattleMons[gBattlerAttacker].status1 & STATUS1_FROSTBITE)
+          && CanSetNonVolatileStatus(gBattlerAttacker, gBattlerTarget, attackerAbility, targetAbility, MOVE_EFFECT_FREEZE_OR_FROSTBITE, CHECK_TRIGGER))
     {
         gBattleCommunication[MULTISTRING_CHOOSER] = 5;
     }

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -13208,39 +13208,32 @@ void BS_TryPsychoShift(void)
     NATIVE_ARGS(const u8 *failInstr, const u8 *sleepClauseFailInstr);
     enum Ability attackerAbility = GetBattlerAbility(gBattlerAttacker);
     enum Ability targetAbility = GetBattlerAbility(gBattlerTarget);
-
-    if (IsSubstituteProtected(gBattlerAttacker, gBattlerTarget, attackerAbility, MOVE_PSYCHO_SHIFT))
-    {
-        gBattlescriptCurrInstr = cmd->failInstr;
-        return;
-    }
-
-    if (IsSafeguardProtected(gBattlerAttacker, gBattlerTarget, attackerAbility))
-    {
-        gBattlescriptCurrInstr = BattleScript_SafeguardProtected;
-        return;
-    }
+    enum MoveEffect synchronizeEffect = MOVE_EFFECT_NONE;
 
     // Psycho shift works
     if ((gBattleMons[gBattlerAttacker].status1 & STATUS1_POISON)
      && CanSetNonVolatileStatus(gBattlerAttacker, gBattlerTarget, attackerAbility, targetAbility, MOVE_EFFECT_TOXIC, CHECK_TRIGGER))
     {
         gBattleCommunication[MULTISTRING_CHOOSER] = 0;
+        synchronizeEffect = MOVE_EFFECT_POISON;
     }
     else if ((gBattleMons[gBattlerAttacker].status1 & STATUS1_TOXIC_POISON)
           && CanSetNonVolatileStatus(gBattlerAttacker, gBattlerTarget, attackerAbility, targetAbility, MOVE_EFFECT_TOXIC, CHECK_TRIGGER))
     {
         gBattleCommunication[MULTISTRING_CHOOSER] = 1;
+        synchronizeEffect = MOVE_EFFECT_TOXIC;
     }
     else if ((gBattleMons[gBattlerAttacker].status1 & STATUS1_BURN)
           && CanSetNonVolatileStatus(gBattlerAttacker, gBattlerTarget, attackerAbility, targetAbility, MOVE_EFFECT_BURN, CHECK_TRIGGER))
     {
         gBattleCommunication[MULTISTRING_CHOOSER] = 2;
+        synchronizeEffect = MOVE_EFFECT_BURN;
     }
     else if ((gBattleMons[gBattlerAttacker].status1 & STATUS1_PARALYSIS)
           && CanSetNonVolatileStatus(gBattlerAttacker, gBattlerTarget, attackerAbility, targetAbility, MOVE_EFFECT_PARALYSIS, CHECK_TRIGGER))
     {
         gBattleCommunication[MULTISTRING_CHOOSER] = 3;
+        synchronizeEffect = MOVE_EFFECT_PARALYSIS;
     }
     else if ((gBattleMons[gBattlerAttacker].status1 & STATUS1_SLEEP)
           && !IsSleepClauseActiveForSide(GetBattlerSide(gBattlerTarget))
@@ -13273,6 +13266,7 @@ void BS_TryPsychoShift(void)
         &gBattleMons[gBattlerTarget].status1);
     MarkBattlerForControllerExec(gBattlerTarget);
     TryActivateSleepClause(gBattlerTarget, gBattlerPartyIndexes[gBattlerTarget]);
+    TrySynchronizeActivation(gBattlerAttacker, gBattlerTarget, synchronizeEffect);
     gBattlescriptCurrInstr = cmd->nextInstr;
 }
 

--- a/test/battle/move_effect/psycho_shift.c
+++ b/test/battle/move_effect/psycho_shift.c
@@ -87,4 +87,23 @@ SINGLE_BATTLE_TEST("Psycho Shift burn is blocked by Safeguard unless the user ha
     }
 }
 
+SINGLE_BATTLE_TEST("Psycho Shift triggers Synchronize before curing the user (Gen5+)")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_PSYCHO_SHIFT) == EFFECT_PSYCHO_SHIFT);
+        PLAYER(SPECIES_WOBBUFFET) { Status1(STATUS1_BURN); }
+        OPPONENT(SPECIES_ABRA) { Ability(ABILITY_SYNCHRONIZE); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_PSYCHO_SHIFT); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_PSYCHO_SHIFT, player);
+        STATUS_ICON(opponent, burn: TRUE);
+        ABILITY_POPUP(opponent, ABILITY_SYNCHRONIZE);
+        STATUS_ICON(player, none: TRUE);
+    } THEN {
+        EXPECT_EQ(player->status1, STATUS1_NONE);
+        EXPECT_EQ(opponent->status1, STATUS1_BURN);
+    }
+}
+
 TO_DO_BATTLE_TEST("TODO: Write Psycho Shift (Move Effect) test titles")

--- a/test/battle/move_effect/psycho_shift.c
+++ b/test/battle/move_effect/psycho_shift.c
@@ -1,4 +1,90 @@
 #include "global.h"
 #include "test/battle.h"
 
+SINGLE_BATTLE_TEST("Psycho Shift burn is blocked by Substitute unless the user has Infiltrator")
+{
+    enum Ability ability;
+
+    PARAMETRIZE { ability = ABILITY_CLEAR_BODY;  }
+    PARAMETRIZE { ability = ABILITY_INFILTRATOR; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_PSYCHO_SHIFT) == EFFECT_PSYCHO_SHIFT);
+        ASSUME(GetMoveEffect(MOVE_SUBSTITUTE) == EFFECT_SUBSTITUTE);
+        PLAYER(SPECIES_DRAGAPULT) { Ability(ability); Status1(STATUS1_BURN); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SUBSTITUTE); MOVE(player, MOVE_PSYCHO_SHIFT); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SUBSTITUTE, opponent);
+        if (ability == ABILITY_INFILTRATOR)
+        {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_PSYCHO_SHIFT, player);
+            STATUS_ICON(opponent, burn: TRUE);
+            STATUS_ICON(player, none: TRUE);
+        }
+        else
+        {
+            NONE_OF {
+                ANIMATION(ANIM_TYPE_MOVE, MOVE_PSYCHO_SHIFT, player);
+                STATUS_ICON(opponent, burn: TRUE);
+            }
+        }
+    } THEN {
+        if (ability == ABILITY_INFILTRATOR)
+        {
+            EXPECT_EQ(player->status1, STATUS1_NONE);
+            EXPECT_EQ(opponent->status1, STATUS1_BURN);
+        }
+        else
+        {
+            EXPECT_EQ(player->status1, STATUS1_BURN);
+            EXPECT_EQ(opponent->status1, STATUS1_NONE);
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Psycho Shift burn is blocked by Safeguard unless the user has Infiltrator")
+{
+    enum Ability ability;
+
+    PARAMETRIZE { ability = ABILITY_CLEAR_BODY;  }
+    PARAMETRIZE { ability = ABILITY_INFILTRATOR; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_PSYCHO_SHIFT) == EFFECT_PSYCHO_SHIFT);
+        ASSUME(GetMoveEffect(MOVE_SAFEGUARD) == EFFECT_SAFEGUARD);
+        PLAYER(SPECIES_DRAGAPULT) { Ability(ability); Status1(STATUS1_BURN); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SAFEGUARD); MOVE(player, MOVE_PSYCHO_SHIFT); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SAFEGUARD, opponent);
+        if (ability == ABILITY_INFILTRATOR)
+        {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_PSYCHO_SHIFT, player);
+            STATUS_ICON(opponent, burn: TRUE);
+            STATUS_ICON(player, none: TRUE);
+        }
+        else
+        {
+            NONE_OF {
+                ANIMATION(ANIM_TYPE_MOVE, MOVE_PSYCHO_SHIFT, player);
+                STATUS_ICON(opponent, burn: TRUE);
+            }
+        }
+    } THEN {
+        if (ability == ABILITY_INFILTRATOR)
+        {
+            EXPECT_EQ(player->status1, STATUS1_NONE);
+            EXPECT_EQ(opponent->status1, STATUS1_BURN);
+        }
+        else
+        {
+            EXPECT_EQ(player->status1, STATUS1_BURN);
+            EXPECT_EQ(opponent->status1, STATUS1_NONE);
+        }
+    }
+}
+
 TO_DO_BATTLE_TEST("TODO: Write Psycho Shift (Move Effect) test titles")


### PR DESCRIPTION
## Description

- Fixed Psycho Shift interactions with Safeguard and Substitute.
- Adjusted Psycho Shift interactions with Synchronize in Gen 5+.
- Also fixed Toxic counter handling.

[Psycho Shift](https://bulbapedia.bulbagarden.net/wiki/Psycho_Shift_(move))
> **Generation IV**
> _Psycho Shift will cure the user, then inflict the status condition on the opponent. Therefore, if Psycho Shift is used on a Pokémon with Synchronize, Synchronize will activate and afflict the user of Psycho Shift with that status condition again (if the user of Psycho Shift is susceptible to the status condition)._
> **Generation V**
> _**Psycho Shift will now inflict the status condition on the target, then cure the user.** Therefore, if Psycho Shift is used on a Pokémon with Synchronize, the user of Psycho Shift will already be afflicted with a status condition when Synchronize activates._
