### PR TITLE
Fix Sea of Fire damage immunities

### DIFF
--- a/src/battle_end_turn.c
+++ b/src/battle_end_turn.c
@@ -356,7 +356,10 @@ static bool32 HandleEndTurnFirstEventBlock(enum BattlerId battler)
         gBattleStruct->eventState.endTurnBlock++;
         break;
     case FIRST_EVENT_BLOCK_SEA_OF_FIRE_DAMAGE:
-        if (gSideStatuses[GetBattlerSide(battler)] & SIDE_STATUS_SEA_OF_FIRE)
+        side = GetBattlerSide(battler);
+        if ((gSideStatuses[side] & SIDE_STATUS_SEA_OF_FIRE)
+         && !IS_BATTLER_OF_TYPE(battler, TYPE_FIRE)
+         && !IsAbilityAndRecord(battler, GetBattlerAbility(battler), ABILITY_MAGIC_GUARD))
         {
             gBattlerAttacker = battler;
             SetPassiveDamageAmount(battler, GetNonDynamaxMaxHP(battler) / 8);

--- a/test/battle/move_effect/pledge.c
+++ b/test/battle/move_effect/pledge.c
@@ -136,12 +136,18 @@ DOUBLE_BATTLE_TEST("Sea Of Fire deals 1/8th damage per turn")
 
 DOUBLE_BATTLE_TEST("Sea Of Fire does not damage Fire-types or Magic Guard Pokemon")
 {
+    enum Species species;
+    enum Ability ability;
+
+    PARAMETRIZE { species = SPECIES_VICTINI;  ability = ABILITY_VICTORY_STAR; }
+    PARAMETRIZE { species = SPECIES_CLEFABLE; ability = ABILITY_MAGIC_GUARD; }
+
     GIVEN {
         ASSUME(IsSpeciesOfType(SPECIES_VICTINI, TYPE_FIRE));
         PLAYER(SPECIES_WOBBUFFET) { Speed(4); }
         PLAYER(SPECIES_WOBBUFFET) { Speed(3); }
-        OPPONENT(SPECIES_VICTINI) { Speed(2); }
-        OPPONENT(SPECIES_CLEFABLE) { Speed(1); Ability(ABILITY_MAGIC_GUARD); }
+        OPPONENT(species) { Speed(2); Ability(ability); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); }
     } WHEN {
         TURN { MOVE(playerLeft, MOVE_FIRE_PLEDGE, target: opponentRight);
                MOVE(playerRight, MOVE_GRASS_PLEDGE, target: opponentRight);
@@ -153,12 +159,9 @@ DOUBLE_BATTLE_TEST("Sea Of Fire does not damage Fire-types or Magic Guard Pokemo
         NONE_OF {
             ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, opponentLeft);
             HP_BAR(opponentLeft);
-            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, opponentRight);
-            HP_BAR(opponentRight);
         }
     } THEN {
         EXPECT_EQ(opponentLeft->hp, opponentLeft->maxHP);
-        EXPECT_EQ(opponentRight->hp, opponentRight->maxHP);
     }
 }
 

--- a/test/battle/move_effect/pledge.c
+++ b/test/battle/move_effect/pledge.c
@@ -134,6 +134,34 @@ DOUBLE_BATTLE_TEST("Sea Of Fire deals 1/8th damage per turn")
     }
 }
 
+DOUBLE_BATTLE_TEST("Sea Of Fire does not damage Fire-types or Magic Guard Pokemon")
+{
+    GIVEN {
+        ASSUME(IsSpeciesOfType(SPECIES_VICTINI, TYPE_FIRE));
+        PLAYER(SPECIES_WOBBUFFET) { Speed(4); }
+        PLAYER(SPECIES_WOBBUFFET) { Speed(3); }
+        OPPONENT(SPECIES_VICTINI) { Speed(2); }
+        OPPONENT(SPECIES_CLEFABLE) { Speed(1); Ability(ABILITY_MAGIC_GUARD); }
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_FIRE_PLEDGE, target: opponentRight);
+               MOVE(playerRight, MOVE_GRASS_PLEDGE, target: opponentRight);
+        }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FIRE_PLEDGE, playerRight);
+        HP_BAR(opponentRight);
+        MESSAGE("A sea of fire enveloped the opposing team!");
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, opponentLeft);
+            HP_BAR(opponentLeft);
+            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_BRN, opponentRight);
+            HP_BAR(opponentRight);
+        }
+    } THEN {
+        EXPECT_EQ(opponentLeft->hp, opponentLeft->maxHP);
+        EXPECT_EQ(opponentRight->hp, opponentRight->maxHP);
+    }
+}
+
 DOUBLE_BATTLE_TEST("Grass and Water Pledge create a swamp on the user's side of the field for four turns")
 {
     GIVEN {


### PR DESCRIPTION
## Description
[Sea of Fire](https://wiki.pokemonwiki.com/wiki/%e3%81%b2%e3%81%ae%e3%81%86%e3%81%bf_(%e5%a0%b4%e3%81%ae%e7%8a%b6%e6%85%8b))

> 特性がマジックガードのポケモンはHPが減らない。
> 特性がもらいびのポケモンであっても、ほのおタイプでなければダメージを受ける。

_Pokémon with the Magic Guard Ability will not lose HP.
A Pokémon with the Flash Fire Ability will still take damage unless it is a Fire type._