### PR TITLE
Fix OHKO moves ignoring Glaive Rush accuracy bypass

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -10400,9 +10400,10 @@ bool32 DoesOHKOMoveMissTarget(struct BattleCalcValues *cv)
 
     enum OHKOResult lands = NO_HIT;
 
-    if (gBattleMons[cv->battlerAtk].volatiles.battlerWithSureHit == cv->battlerDef + 1
-          || IsAbilityAndRecord(cv->battlerAtk, cv->abilities[cv->battlerAtk], ABILITY_NO_GUARD)
-          || IsAbilityAndRecord(cv->battlerDef, cv->abilities[cv->battlerDef], ABILITY_NO_GUARD))
+    if (gBattleMons[cv->battlerDef].volatiles.glaiveRush
+     || gBattleMons[cv->battlerAtk].volatiles.battlerWithSureHit == cv->battlerDef + 1
+     || IsAbilityAndRecord(cv->battlerAtk, cv->abilities[cv->battlerAtk], ABILITY_NO_GUARD)
+     || IsAbilityAndRecord(cv->battlerDef, cv->abilities[cv->battlerDef], ABILITY_NO_GUARD))
     {
         lands = SURE_HIT;
     }

--- a/test/battle/move_effect/glaive_rush.c
+++ b/test/battle/move_effect/glaive_rush.c
@@ -22,6 +22,23 @@ SINGLE_BATTLE_TEST("If Glaive Rush is successful moves targeted at the user do n
     }
 }
 
+SINGLE_BATTLE_TEST("If Glaive Rush is successful OHKO moves targeted at the user do not check accuracy")
+{
+    PASSES_RANDOMLY(100, 100, RNG_ACCURACY);
+    GIVEN {
+        ASSUME(GetMoveAccuracy(MOVE_FISSURE) == 30);
+        ASSUME(GetMoveEffect(MOVE_FISSURE) == EFFECT_OHKO);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_GLAIVE_RUSH); MOVE(opponent, MOVE_FISSURE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_GLAIVE_RUSH, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FISSURE, opponent);
+        HP_BAR(player, hp: 0);
+    }
+}
+
 SINGLE_BATTLE_TEST("If Glaive Rush is successful, moves targeted at the user deal double damage")
 {
     s16 glaiveRushEffectedDmg;


### PR DESCRIPTION
## Description
[Glaive Rush](https://bulbapedia.bulbagarden.net/wiki/Glaive_Rush_(move))

> _Glaive Rush inflicts damage. If the move hits, until the next time the user acts, any attacks directed at the user (**including OHKO moves**) deal double the damage (not applicable to moves that deal direct damage) and bypass accuracy and evasion checks to always hit._