### PR TITLE
Fix GetRandomDifferentSpeciesSeenByPlayer issues with disabled species

### DIFF
--- a/src/tv.c
+++ b/src/tv.c
@@ -3049,24 +3049,30 @@ static enum Species GetRandomDifferentSpeciesAndNameSeenByPlayer(u8 varIdx, enum
 
 static enum Species GetRandomDifferentSpeciesSeenByPlayer(enum Species excludedSpecies)
 {
-    enum Species species = Random() % (NUM_SPECIES - 1) + 1;
-    enum Species initSpecies = species;
-
-    while (GetSetPokedexFlag(SpeciesToNationalPokedexNum(species), FLAG_GET_SEEN) != TRUE || species == excludedSpecies)
+    enum NationalDexOrder selectedNatDex;
+    enum NationalDexOrder excludexNatDex = SpeciesToNationalPokedexNum(excludedSpecies);
+    enum NationalDexOrder *natDexArray = Alloc(POKEMON_SLOTS_NUMBER * sizeof(enum NationalDexOrder));
+    u32 count = 0;
+    for (u32 i = 0; i < NUM_DEX_FLAG_BYTES; i++)
     {
-        if (species == SPECIES_NONE + 1)
-            species = NUM_SPECIES - 1;
-        else
-            species--;
-
-        if (species == initSpecies)
+        u32 tmp = gSaveBlock1Ptr->dexSeen[i];
+        for (u32 j = 0; j < 8; j++)
         {
-            // Looped back to initial species (only Pokémon seen), must choose excluded species
-            species = excludedSpecies;
-            return species;
+            if (tmp & 1)
+                natDexArray[count++] = i * 8 + j + 1;
+            tmp >>= 1;
         }
-    };
-    return species;
+    }
+    if (count <= 1)
+    {
+        Free(natDexArray);
+        return excludedSpecies;
+    }
+    do {
+        selectedNatDex = natDexArray[RandomUniform(RNG_NONE, 0, count - 1)];
+    } while (selectedNatDex == excludexNatDex);
+    Free(natDexArray);
+    return NationalPokedexNumToSpecies(selectedNatDex);
 }
 
 static void Script_FindFirstEmptyNormalTVShowSlot(void)


### PR DESCRIPTION
The previous `GetRandomDifferentSpeciesSeenByPlayer` would sometimes blue screen by trying to read the nat dex of disabled species.
It also had a lot of bias towards some species based on your pokedex state
I rewrote the function to make a list of all set bits in the dexSeen array were set and pick one at random
Even running the function 100 times in a row to view the random results, I didn't notice slowdowns

## Discord contact info
Jamie