### PR TITLE
fix(spots): add arguments to incgfx and check for isEgg

### DIFF
--- a/src/decompress.c
+++ b/src/decompress.c
@@ -1168,7 +1168,7 @@ void LoadSpecialPokePicIsEgg(void *dest, enum Species species, u32 personality, 
             DecompressDataWithHeaderWram(gSpeciesInfo[SPECIES_NONE].backPic, dest);
     }
 
-    if (ShouldDrawSpotsOnSpecies(species) && isFrontPic)
+    if (ShouldDrawSpotsOnSpecies(species) && isFrontPic && !isEgg)
     {
         DrawPokemonSpotsBothFrames(personality, species, dest);
     }

--- a/src/pokemon_spots.c
+++ b/src/pokemon_spots.c
@@ -94,10 +94,10 @@ static inline u32 GetSpotRow(const u32* image, u32 row, enum SpotScale scale);
 
 // SPECIES_SPINDA
 static const SpotImage16 sSpindaSpotImages[4] = {
-    INCGFX_U32("graphics/pokemon/spinda/spots/spot_0.png", ".1bpp"),
-    INCGFX_U32("graphics/pokemon/spinda/spots/spot_1.png", ".1bpp"),
-    INCGFX_U32("graphics/pokemon/spinda/spots/spot_2.png", ".1bpp"),
-    INCGFX_U32("graphics/pokemon/spinda/spots/spot_3.png", ".1bpp"),
+    INCGFX_U32("graphics/pokemon/spinda/spots/spot_0.png", ".1bpp", "-plain -data_width 2"),
+    INCGFX_U32("graphics/pokemon/spinda/spots/spot_1.png", ".1bpp", "-plain -data_width 2"),
+    INCGFX_U32("graphics/pokemon/spinda/spots/spot_2.png", ".1bpp", "-plain -data_width 2"),
+    INCGFX_U32("graphics/pokemon/spinda/spots/spot_3.png", ".1bpp", "-plain -data_width 2"),
 };
 //NOTE: Spinda spots have been ordered in reverse for save compatibility
 static const struct MonSpot sSpindaSpots[] = {
@@ -123,7 +123,7 @@ static const struct MonSpotTemplate* GetSpeciesSpots(enum Species species)
 {
     switch (species)
     {
-    case SPECIES_SPINDA: 
+    case SPECIES_SPINDA:
             return &gSpindaSpotTemplate;
     default:
         return NULL;


### PR DESCRIPTION
## Description

The arguments for the spinda spot graphics rules were not properly
migrated to INCGFX. This fixes that and also adds a missing check for
isEgg so that spots aren't applied to Eggs.

### Large Language Models (AI)

None

## Issue(s) that this PR fixes

Resolves #10246

## Discord contact info

@miriamlefae
