### PR TITLE
Fix Trick Room animation playing on wrong battler

### DIFF
--- a/data/battle_anim_scripts.s
+++ b/data/battle_anim_scripts.s
@@ -2300,7 +2300,7 @@ gBattleAnimGeneral_TrickRoom::
 	end
 InitRoomAnimation:
 	setalpha 8, 8
-	createvisualtask AnimTask_ScaleMonAndRestore, 5, -6, -6, 15, ANIM_TARGET, 1
+	createvisualtask AnimTask_ScaleMonAndRestore, 5, -6, -6, 15, ANIM_ATTACKER, 1
 	return
 
 gBattleAnimMove_DracoMeteor::


### PR DESCRIPTION
## Description
Trick Room anim playing on target instead of user

### Large Language Models (AI)
No

## Media
Before:

https://github.com/user-attachments/assets/2016d43d-31b4-4124-8865-87040b82fe63


After:

https://github.com/user-attachments/assets/64d39098-c208-463a-a307-04d235ba4555


## Discord contact info
grintoul