### PR TITLE
Fixes TARGET_FIELD moves failing when partner is not on the field

### DIFF
--- a/include/battle_ai_util.h
+++ b/include/battle_ai_util.h
@@ -149,7 +149,6 @@ bool32 AI_CanContactBypassProtect(enum BattlerId battlerAtk, enum BattlerId batt
 bool32 IsConsideringZMove(enum BattlerId battlerAtk, enum BattlerId battlerDef, enum Move move);
 bool32 ShouldUseZMove(enum BattlerId battlerAtk, enum BattlerId battlerDef, enum Move chosenMove);
 void SetAIUsingGimmick(enum BattlerId battler, enum AIConsiderGimmick use);
-bool32 IsAIUsingGimmick(enum BattlerId battler);
 void DecideTerastal(enum BattlerId battler);
 bool32 CanEndureHit(enum BattlerId battler, enum BattlerId battlerTarget, enum Move move);
 bool32 ShouldFinalGambit(enum BattlerId battlerAtk, enum BattlerId battlerDef, bool32 aiIsFaster);

--- a/include/battle_controllers.h
+++ b/include/battle_controllers.h
@@ -506,7 +506,7 @@ enum BattleTrainer GetTrainerFromBattlePosition(enum BattlerPosition position);
 bool32 BattleSideHasTwoTrainers(enum BattleSide side);
 bool32 BattlersShareParty(enum BattlerId battler1, enum BattlerId battler2);
 bool32 TrainerHasParty(enum BattleTrainer trainer);
-void SetFinalChosenTarget(enum BattlerId battler);
+void SetFinalChosenTarget(enum BattlerId battler, bool32 partner);
 
 
 // oak and old man controller

--- a/include/battle_controllers.h
+++ b/include/battle_controllers.h
@@ -506,6 +506,7 @@ enum BattleTrainer GetTrainerFromBattlePosition(enum BattlerPosition position);
 bool32 BattleSideHasTwoTrainers(enum BattleSide side);
 bool32 BattlersShareParty(enum BattlerId battler1, enum BattlerId battler2);
 bool32 TrainerHasParty(enum BattleTrainer trainer);
+void SetFinalChosenTarget(enum BattlerId battler);
 
 
 // oak and old man controller

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -5208,11 +5208,6 @@ void SetAIUsingGimmick(enum BattlerId battler, enum AIConsiderGimmick use)
         gAiBattleData->aiUsingGimmick &= ~(1<<battler);
 }
 
-bool32 IsAIUsingGimmick(enum BattlerId battler)
-{
-    return (gAiBattleData->aiUsingGimmick & (1<<battler)) != 0;
-}
-
 struct AltTeraCalcs
 {
     struct SimulatedDamage takenWithTera[MAX_MON_MOVES];

--- a/src/battle_controller_opponent.c
+++ b/src/battle_controller_opponent.c
@@ -451,7 +451,7 @@ static void OpponentHandleChooseMove(enum BattlerId battler)
         }
         else
         {
-            SetFinalChosenTarget(battler);
+            SetFinalChosenTarget(battler, FALSE);
         }
         BtlController_Complete(battler);
     }

--- a/src/battle_controller_opponent.c
+++ b/src/battle_controller_opponent.c
@@ -432,9 +432,6 @@ static void OpponentHandleChooseAction(enum BattlerId battler)
 
 static void OpponentHandleChooseMove(enum BattlerId battler)
 {
-    u32 chosenMoveIndex;
-    struct ChooseMoveStruct *moveInfo = (struct ChooseMoveStruct *)(&gBattleResources->bufferA[battler][4]);
-
     if (gBattleTypeFlags & (BATTLE_TYPE_TRAINER | BATTLE_TYPE_FIRST_BATTLE | BATTLE_TYPE_SAFARI | BATTLE_TYPE_ROAMER)
      || IsWildMonSmart())
     {
@@ -454,42 +451,16 @@ static void OpponentHandleChooseMove(enum BattlerId battler)
         }
         else
         {
-            chosenMoveIndex = gAiBattleData->chosenMoveIndex[battler];
-            gBattlerTarget = gAiBattleData->chosenTarget[battler];
-
-            u32 chosenMove = moveInfo->moves[chosenMoveIndex];
-            enum MoveTarget target = GetBattlerMoveTargetType(battler, chosenMove);
-
-            if (target == TARGET_USER)
-                gBattlerTarget = battler;
-
-            if (target == TARGET_ALLY)
-                gBattlerTarget = BATTLE_PARTNER(battler);
-
-            if (target == TARGET_BOTH)
-            {
-                gBattlerTarget = GetBattlerAtPosition(B_POSITION_PLAYER_LEFT);
-                if (gAbsentBattlerFlags & (1u << gBattlerTarget))
-                    gBattlerTarget = GetBattlerAtPosition(B_POSITION_PLAYER_RIGHT);
-            }
-            // If opponent can and should use a gimmick (considering trainer data), do it
-            enum Gimmick usableGimmick = gBattleStruct->gimmick.usableGimmick[battler];
-            if (usableGimmick != GIMMICK_NONE && IsAIUsingGimmick(battler) && !HasTrainerUsedGimmick(battler, usableGimmick))
-            {
-                gBattleStruct->gimmick.toActivate |= 1u << battler;
-                BtlController_EmitTwoReturnValues(battler, B_COMM_TO_ENGINE, B_ACTION_EXEC_SCRIPT, (chosenMoveIndex) | (RET_GIMMICK) | (gBattlerTarget << 8));
-            }
-            else
-            {
-                SetAIUsingGimmick(battler, NO_GIMMICK);
-                BtlController_EmitTwoReturnValues(battler, B_COMM_TO_ENGINE, B_ACTION_EXEC_SCRIPT, (chosenMoveIndex) | (gBattlerTarget << 8));
-            }
+            SetFinalChosenTarget(battler);
         }
         BtlController_Complete(battler);
     }
     else // Wild Pokémon - use random move
     {
-        enum Move move;
+        enum Move move = MOVE_NONE;
+        u32 chosenMoveIndex = 0;
+        struct ChooseMoveStruct *moveInfo = (struct ChooseMoveStruct *)(&gBattleResources->bufferA[battler][4]);
+
         do
         {
             chosenMoveIndex = Random() & (MAX_MON_MOVES - 1);

--- a/src/battle_controller_player_partner.c
+++ b/src/battle_controller_player_partner.c
@@ -274,7 +274,8 @@ static void PlayerPartnerHandleChooseAction(enum BattlerId battler)
 
 static void PlayerPartnerHandleChooseMove(enum BattlerId battler)
 {
-    SetFinalChosenTarget(battler);
+    SetFinalChosenTarget(battler, TRUE);
+    BtlController_Complete(battler);
 }
 
 static void PlayerPartnerHandleChoosePokemon(enum BattlerId battler)

--- a/src/battle_controller_player_partner.c
+++ b/src/battle_controller_player_partner.c
@@ -274,37 +274,7 @@ static void PlayerPartnerHandleChooseAction(enum BattlerId battler)
 
 static void PlayerPartnerHandleChooseMove(enum BattlerId battler)
 {
-    u32 chosenMoveIndex;
-    struct ChooseMoveStruct *moveInfo = (struct ChooseMoveStruct *)(&gBattleResources->bufferA[battler][4]);
-
-    chosenMoveIndex = gAiBattleData->chosenMoveIndex[battler];
-    gBattlerTarget = gAiBattleData->chosenTarget[battler];
-    enum MoveTarget moveTarget = GetBattlerMoveTargetType(battler, moveInfo->moves[chosenMoveIndex]);
-
-    if (moveTarget == TARGET_USER || moveTarget == TARGET_USER_OR_ALLY)
-    {
-        gBattlerTarget = battler;
-    }
-    else if (moveTarget == TARGET_BOTH)
-    {
-        gBattlerTarget = GetBattlerAtPosition(B_POSITION_OPPONENT_LEFT);
-        if (gAbsentBattlerFlags & (1u << gBattlerTarget))
-            gBattlerTarget = GetBattlerAtPosition(B_POSITION_OPPONENT_RIGHT);
-    }
-    // If partner can and should use a gimmick (considering trainer data), do it
-    enum Gimmick usableGimmick = gBattleStruct->gimmick.usableGimmick[battler];
-    if (usableGimmick != GIMMICK_NONE && IsAIUsingGimmick(battler) && !HasTrainerUsedGimmick(battler, usableGimmick))
-    {
-        gBattleStruct->gimmick.toActivate |= 1u << battler;
-        BtlController_EmitTwoReturnValues(battler, B_COMM_TO_ENGINE, B_ACTION_EXEC_SCRIPT, (chosenMoveIndex) | (RET_GIMMICK) | (gBattlerTarget << 8));
-    }
-    else
-    {
-        SetAIUsingGimmick(battler, NO_GIMMICK);
-        BtlController_EmitTwoReturnValues(battler, B_COMM_TO_ENGINE, B_ACTION_EXEC_SCRIPT, (chosenMoveIndex) | (gBattlerTarget << 8));
-    }
-
-    BtlController_Complete(battler);
+    SetFinalChosenTarget(battler);
 }
 
 static void PlayerPartnerHandleChoosePokemon(enum BattlerId battler)

--- a/src/battle_controllers.c
+++ b/src/battle_controllers.c
@@ -3348,38 +3348,48 @@ bool32 TrainerHasParty(enum BattleTrainer trainer)
 }
 
 // Used for partner and opponent
-void SetFinalChosenTarget(enum BattlerId battler)
+void SetFinalChosenTarget(enum BattlerId battler, bool32 partner)
 {
-    enum BattlerId chosenTarget = gAiBattleData->chosenTarget[battler];
     struct ChooseMoveStruct *moveInfo = (struct ChooseMoveStruct *)(&gBattleResources->bufferA[battler][4]);
 
+    enum BattlerId chosenTarget = gAiBattleData->chosenTarget[battler];
     u32 chosenMoveIndex = gAiBattleData->chosenMoveIndex[battler];
     u32 chosenMove = moveInfo->moves[chosenMoveIndex];
     enum MoveTarget targetType = GetBattlerMoveTargetType(battler, chosenMove);
 
     switch (targetType)
     {
+    case TARGET_ALLY:
+        chosenTarget = BATTLE_PARTNER(battler);
+        break;
     case TARGET_USER_OR_ALLY:
+        if (!IsBattlerAlly(battler, chosenTarget))
+            chosenTarget = battler;
+        break;
     case TARGET_USER:
     case TARGET_ALL_BATTLERS:
     case TARGET_FIELD:
         chosenTarget = battler;
         break;
     case TARGET_BOTH:
-        chosenTarget = GetBattlerAtPosition(B_POSITION_OPPONENT_LEFT);
-        if (!IsBattlerAlive(chosenTarget))
-            chosenTarget = GetBattlerAtPosition(B_POSITION_OPPONENT_RIGHT);
-        break;
-    case TARGET_FOES_AND_ALLY:
-        chosenTarget = BATTLE_PARTNER(battler);
-        if (!IsBattlerAlive(chosenTarget))
+        if (partner)
+        {
             chosenTarget = GetBattlerAtPosition(B_POSITION_OPPONENT_LEFT);
-        if (!IsBattlerAlive(chosenTarget))
-            chosenTarget = GetBattlerAtPosition(B_POSITION_OPPONENT_RIGHT);
+            if (!IsBattlerAlive(chosenTarget))
+                chosenTarget = GetBattlerAtPosition(B_POSITION_OPPONENT_RIGHT);
+        }
+        else
+        {
+            chosenTarget = GetBattlerAtPosition(B_POSITION_PLAYER_LEFT);
+            if (!IsBattlerAlive(chosenTarget))
+                chosenTarget = GetBattlerAtPosition(B_POSITION_PLAYER_RIGHT);
+        }
         break;
     default:
         break;
     }
+
+    gBattlerTarget = chosenTarget;
 
     // If partner can and should use a gimmick (considering trainer data), do it
     enum Gimmick usableGimmick = gBattleStruct->gimmick.usableGimmick[battler];
@@ -3394,8 +3404,4 @@ void SetFinalChosenTarget(enum BattlerId battler)
         SetAIUsingGimmick(battler, NO_GIMMICK);
         BtlController_EmitTwoReturnValues(battler, B_COMM_TO_ENGINE, B_ACTION_EXEC_SCRIPT, (chosenMoveIndex) | (chosenTarget << 8));
     }
-
-    BtlController_Complete(battler);
-
-    gBattlerTarget = chosenTarget;
 }

--- a/src/battle_controllers.c
+++ b/src/battle_controllers.c
@@ -3362,7 +3362,7 @@ void SetFinalChosenTarget(enum BattlerId battler, bool32 partner)
     case TARGET_ALLY:
         chosenTarget = BATTLE_PARTNER(battler);
         break;
-    case TARGET_USER_OR_ALLY:
+    case TARGET_USER_OR_ALLY: // AI could have chosen opponent as the target because of the way the score system works
         if (!IsBattlerAlly(battler, chosenTarget))
             chosenTarget = battler;
         break;
@@ -3391,7 +3391,6 @@ void SetFinalChosenTarget(enum BattlerId battler, bool32 partner)
 
     gBattlerTarget = chosenTarget;
 
-    // If partner can and should use a gimmick (considering trainer data), do it
     enum Gimmick usableGimmick = gBattleStruct->gimmick.usableGimmick[battler];
     bool32 isAIUsingGimmick = gAiBattleData->aiUsingGimmick & (1u << battler);
     if (usableGimmick != GIMMICK_NONE && isAIUsingGimmick && !HasTrainerUsedGimmick(battler, usableGimmick))

--- a/src/battle_controllers.c
+++ b/src/battle_controllers.c
@@ -1,6 +1,7 @@
 #include "global.h"
 #include "battle.h"
 #include "battle_ai_main.h"
+#include "battle_ai_util.h"
 #include "battle_anim.h"
 #include "battle_arena.h"
 #include "battle_controllers.h"
@@ -2167,7 +2168,7 @@ void Controller_WaitForHealthBar(enum BattlerId battler)
 {
     s16 hpValue = MoveBattleBar(battler, gHealthboxSpriteIds[battler], HEALTH_BAR, 0);
     struct Pokemon *mon = GetBattlerMon(battler);
-    s32 maxHP = GetMonData(mon, MON_DATA_MAX_HP);   
+    s32 maxHP = GetMonData(mon, MON_DATA_MAX_HP);
 
     SetHealthboxSpriteVisible(gHealthboxSpriteIds[battler]);
     if (hpValue != -1)
@@ -3344,4 +3345,57 @@ bool32 BattlersShareParty(enum BattlerId battler1, enum BattlerId battler2)
 bool32 TrainerHasParty(enum BattleTrainer trainer)
 {
     return (trainer < B_TRAINER_PARTNER || BattleSideHasTwoTrainers((enum BattleSide)(trainer & BIT_SIDE)));
+}
+
+// Used for partner and opponent
+void SetFinalChosenTarget(enum BattlerId battler)
+{
+    enum BattlerId chosenTarget = gAiBattleData->chosenTarget[battler];
+    struct ChooseMoveStruct *moveInfo = (struct ChooseMoveStruct *)(&gBattleResources->bufferA[battler][4]);
+
+    u32 chosenMoveIndex = gAiBattleData->chosenMoveIndex[battler];
+    u32 chosenMove = moveInfo->moves[chosenMoveIndex];
+    enum MoveTarget targetType = GetBattlerMoveTargetType(battler, chosenMove);
+
+    switch (targetType)
+    {
+    case TARGET_USER_OR_ALLY:
+    case TARGET_USER:
+    case TARGET_ALL_BATTLERS:
+    case TARGET_FIELD:
+        chosenTarget = battler;
+        break;
+    case TARGET_BOTH:
+        chosenTarget = GetBattlerAtPosition(B_POSITION_OPPONENT_LEFT);
+        if (!IsBattlerAlive(chosenTarget))
+            chosenTarget = GetBattlerAtPosition(B_POSITION_OPPONENT_RIGHT);
+        break;
+    case TARGET_FOES_AND_ALLY:
+        chosenTarget = BATTLE_PARTNER(battler);
+        if (!IsBattlerAlive(chosenTarget))
+            chosenTarget = GetBattlerAtPosition(B_POSITION_OPPONENT_LEFT);
+        if (!IsBattlerAlive(chosenTarget))
+            chosenTarget = GetBattlerAtPosition(B_POSITION_OPPONENT_RIGHT);
+        break;
+    default:
+        break;
+    }
+
+    // If partner can and should use a gimmick (considering trainer data), do it
+    enum Gimmick usableGimmick = gBattleStruct->gimmick.usableGimmick[battler];
+    bool32 isAIUsingGimmick = gAiBattleData->aiUsingGimmick & (1u << battler);
+    if (usableGimmick != GIMMICK_NONE && isAIUsingGimmick && !HasTrainerUsedGimmick(battler, usableGimmick))
+    {
+        gBattleStruct->gimmick.toActivate |= 1u << battler;
+        BtlController_EmitTwoReturnValues(battler, B_COMM_TO_ENGINE, B_ACTION_EXEC_SCRIPT, (chosenMoveIndex) | (RET_GIMMICK) | (chosenTarget << 8));
+    }
+    else
+    {
+        SetAIUsingGimmick(battler, NO_GIMMICK);
+        BtlController_EmitTwoReturnValues(battler, B_COMM_TO_ENGINE, B_ACTION_EXEC_SCRIPT, (chosenMoveIndex) | (chosenTarget << 8));
+    }
+
+    BtlController_Complete(battler);
+
+    gBattlerTarget = chosenTarget;
 }

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -931,7 +931,7 @@ static enum CancelerResult CancelerSetTargets(struct BattleCalcValues *cv)
                 }
             }
         }
-        else if (moveTarget == TARGET_USER || moveTarget == TARGET_USER_AND_ALLY)
+        else if (moveTarget == TARGET_USER || moveTarget == TARGET_USER_AND_ALLY || moveTarget == TARGET_FIELD)
         {
             cv->battlerDef = cv->battlerAtk;
         }

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -931,7 +931,7 @@ static enum CancelerResult CancelerSetTargets(struct BattleCalcValues *cv)
                 }
             }
         }
-        else if (moveTarget == TARGET_USER || moveTarget == TARGET_USER_AND_ALLY || moveTarget == TARGET_FIELD)
+        else if (moveTarget == TARGET_USER || moveTarget == TARGET_USER_AND_ALLY)
         {
             cv->battlerDef = cv->battlerAtk;
         }

--- a/test/battle/ai/ai.c
+++ b/test/battle/ai/ai.c
@@ -1267,7 +1267,12 @@ AI_DOUBLE_BATTLE_TEST("AI can use Acupressure on its ally")
         OPPONENT(SPECIES_WOBBUFFET) { Moves(MOVE_ACUPRESSURE); }
         OPPONENT(SPECIES_WYNAUT) { Moves(MOVE_SCRATCH); }
     } WHEN {
-        TURN { MOVE(playerLeft, MOVE_CELEBRATE); MOVE(playerRight, MOVE_CELEBRATE); EXPECT_MOVE(opponentRight, MOVE_SCRATCH, target:playerRight); EXPECT_MOVE(opponentLeft, MOVE_ACUPRESSURE, target:opponentRight); }
+        TURN {
+            MOVE(playerLeft, MOVE_CELEBRATE);
+            MOVE(playerRight, MOVE_CELEBRATE);
+            EXPECT_MOVE(opponentRight, MOVE_SCRATCH, target:playerRight);
+            EXPECT_MOVE(opponentLeft, MOVE_ACUPRESSURE, target:opponentRight);
+        }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ACUPRESSURE, opponentLeft);
     }

--- a/test/battle/move_effect/trick_room.c
+++ b/test/battle/move_effect/trick_room.c
@@ -73,4 +73,22 @@ SINGLE_BATTLE_TEST("Trick Room does not affect move priority")
     }
 }
 
+DOUBLE_BATTLE_TEST("Trick Room does not fail if the chosen engine target has fainted")
+{
+    GIVEN {
+        PLAYER(SPECIES_WYNAUT) { Speed(4); }
+        PLAYER(SPECIES_WOBBUFFET) { Speed(3); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(2); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); }
+    } WHEN {
+        TURN {
+            MOVE(playerLeft, MOVE_MEMENTO, target:opponentRight);
+            MOVE(playerRight, MOVE_TRICK_ROOM, target:playerLeft);
+        }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_MEMENTO, playerLeft);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TRICK_ROOM, playerRight);
+    }
+}
+
 TO_DO_BATTLE_TEST("TODO: Write Trick Room (Move Effect) test titles")

--- a/test/battle/move_effect/trick_room.c
+++ b/test/battle/move_effect/trick_room.c
@@ -73,25 +73,6 @@ SINGLE_BATTLE_TEST("Trick Room does not affect move priority")
     }
 }
 
-DOUBLE_BATTLE_TEST("Trick Room does not fail if the chosen engine target has fainted")
-{
-    GIVEN {
-        ASSUME(GetMoveEffect(MOVE_MEMENTO) == EFFECT_MEMENTO);
-        PLAYER(SPECIES_WYNAUT) { Speed(4); }
-        PLAYER(SPECIES_WOBBUFFET) { Speed(3); }
-        OPPONENT(SPECIES_WOBBUFFET) { Speed(2); }
-        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); }
-    } WHEN {
-        TURN {
-            MOVE(playerLeft, MOVE_MEMENTO, target:opponentRight);
-            MOVE(playerRight, MOVE_TRICK_ROOM);
-        }
-    } SCENE {
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_MEMENTO, playerLeft);
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_TRICK_ROOM, playerRight);
-    }
-}
-
 AI_MULTI_BATTLE_TEST("Trick Room does not fail if the chosen AI target has fainted")
 {
     GIVEN {

--- a/test/battle/move_effect/trick_room.c
+++ b/test/battle/move_effect/trick_room.c
@@ -84,7 +84,7 @@ DOUBLE_BATTLE_TEST("Trick Room does not fail if the chosen engine target has fai
     } WHEN {
         TURN {
             MOVE(playerLeft, MOVE_MEMENTO, target:opponentRight);
-            MOVE(playerRight, MOVE_TRICK_ROOM, target:playerLeft);
+            MOVE(playerRight, MOVE_TRICK_ROOM);
         }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_MEMENTO, playerLeft);

--- a/test/battle/move_effect/trick_room.c
+++ b/test/battle/move_effect/trick_room.c
@@ -76,6 +76,7 @@ SINGLE_BATTLE_TEST("Trick Room does not affect move priority")
 DOUBLE_BATTLE_TEST("Trick Room does not fail if the chosen engine target has fainted")
 {
     GIVEN {
+        ASSUME(GetMoveEffect(MOVE_MEMENTO) == EFFECT_MEMENTO);
         PLAYER(SPECIES_WYNAUT) { Speed(4); }
         PLAYER(SPECIES_WOBBUFFET) { Speed(3); }
         OPPONENT(SPECIES_WOBBUFFET) { Speed(2); }
@@ -87,6 +88,30 @@ DOUBLE_BATTLE_TEST("Trick Room does not fail if the chosen engine target has fai
         }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_MEMENTO, playerLeft);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TRICK_ROOM, playerRight);
+    }
+}
+
+AI_MULTI_BATTLE_TEST("Trick Room does not fail if the chosen AI target has fainted")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_MEMENTO) == EFFECT_MEMENTO);
+        PLAYER(SPECIES_WYNAUT) { Speed(4); Moves(MOVE_MEMENTO); }
+        PARTNER(SPECIES_WOBBUFFET) { Speed(1); Moves(MOVE_TRICK_ROOM); }
+        OPPONENT_A(SPECIES_WOBBUFFET) { Speed(2); Moves(MOVE_MEMENTO); }
+        OPPONENT_B(SPECIES_WOBBUFFET) { Speed(3); Moves(MOVE_MEMENTO); }
+        OPPONENT_B(SPECIES_WOBBUFFET) { Speed(5); }
+    } WHEN {
+        TURN {
+            MOVE(playerLeft, MOVE_MEMENTO, target:playerRight);
+            EXPECT_MOVE(opponentRight, MOVE_MEMENTO);
+            EXPECT_MOVE(opponentLeft, MOVE_MEMENTO);
+            EXPECT_MOVE(playerRight, MOVE_TRICK_ROOM); // Sets controller to AI
+        }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_MEMENTO, playerLeft);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_MEMENTO, opponentRight);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_MEMENTO, opponentLeft);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TRICK_ROOM, playerRight);
     }
 }


### PR DESCRIPTION
The target was set to partner but if there is no partner on the field the move failed.

test by @grintoul1 