### PR TITLE
Fix stat change berries showing held item anim twice

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -197,7 +197,8 @@ BattleScript_ItemStatChange::
 BattleScript_ConsumableBerryStatRaise::
 	call BattleScript_ItemPopUp_Scripting
  	playanimation BS_SCRIPTING, B_ANIM_HELD_ITEM_BERRY
-	call BattleScript_ConsumableItemStatRaise
+	trybattlerstatchange BS_SCRIPTING, STAT_CHANGE_ITEM | STAT_CHANGE_CERTAIN
+	removeitem BS_SCRIPTING
 	return
 
 BattleScript_ConsumableBerryStatRaiseRipen::

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -205,7 +205,8 @@ BattleScript_ConsumableBerryStatRaiseRipen::
 	call BattleScript_AbilityPopUp
 	call BattleScript_ItemPopUp_Scripting
  	playanimation BS_SCRIPTING, B_ANIM_HELD_ITEM_BERRY
-	call BattleScript_ConsumableItemStatRaise
+	trybattlerstatchange BS_SCRIPTING, STAT_CHANGE_ITEM | STAT_CHANGE_CERTAIN
+	removeitem BS_SCRIPTING
 	return
 
 BattleScript_ConsumableItemStatRaise::


### PR DESCRIPTION
Title. Targets upcoming due to the issue existing only in upcoming.

## Description
Found when looking into an issue related to item popups. Previously, if a Pokémon were to eat a stat berry like Liechi Berry, it would do the following:
* Item Popup
* Berry eating animation (`B_ANIM_HELD_ITEM_BERRY`)
* Item Popup (again)
* Held item animation (`B_ANIM_HELD_ITEM_EFFECT`)

This PR fixes this so it only plays the item popup and the berry eating animation.

### Large Language Models (AI)
None

## Media

https://github.com/user-attachments/assets/d4f32411-c3e0-4323-a0a6-e25336538827

## Discord contact info
linathan
