### PR TITLE
Fix Incinerate item handling and Core Enforcer targeting

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2624,7 +2624,7 @@ void SetMoveEffect(enum BattlerId battlerAtk, enum BattlerId effectBattler, enum
         break;
     case MOVE_EFFECT_INCINERATE:
         if ((gItemsInfo[gBattleMons[effectBattler].item].pocket == POCKET_BERRIES
-          || (B_INCINERATE_GEMS >= GEN_6 && GetBattlerHoldEffect(effectBattler) == HOLD_EFFECT_GEMS))
+          || (B_INCINERATE_GEMS >= GEN_6 && GetItemHoldEffect(gBattleMons[effectBattler].item) == HOLD_EFFECT_GEMS))
          && abilities[effectBattler] != ABILITY_STICKY_HOLD)
         {
             gLastUsedItem = gBattleMons[effectBattler].item;

--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -17221,7 +17221,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
         .type = TYPE_DRAGON,
         .accuracy = 100,
         .pp = 10,
-        .target = TARGET_SELECTED,
+        .target = TARGET_BOTH,
         .priority = 0,
         .category = DAMAGE_CATEGORY_SPECIAL,
         .zMove = { .powerOverride = 140 },

--- a/test/battle/ability/harvest.c
+++ b/test/battle/ability/harvest.c
@@ -112,7 +112,33 @@ SINGLE_BATTLE_TEST("Harvest restores a Berry consumed by Natural Gift")
     }
 }
 
-TO_DO_BATTLE_TEST("Harvest only works once per turn"); // Check for berries that are consumed immediately, like Pecha Berry
+SINGLE_BATTLE_TEST("Harvest only works once per turn")
+{
+    GIVEN {
+        ASSUME(gItemsInfo[ITEM_PECHA_BERRY].holdEffect == HOLD_EFFECT_CURE_PSN);
+        ASSUME(GetMoveEffect(MOVE_TOXIC_THREAD) == EFFECT_TOXIC_THREAD);
+        PLAYER(SPECIES_NINETALES) { Ability(ABILITY_DROUGHT); }
+        OPPONENT(SPECIES_EXEGGUTOR) { Ability(ABILITY_HARVEST); Item(ITEM_PECHA_BERRY); Status1(STATUS1_POISON); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_TOXIC_THREAD); }
+    } SCENE {
+        ABILITY_POPUP(player, ABILITY_DROUGHT);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_BERRY, opponent);
+        STATUS_ICON(opponent, poison: FALSE);
+
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TOXIC_THREAD, player);
+        ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
+        STATUS_ICON(opponent, poison: TRUE);
+
+        ABILITY_POPUP(opponent, ABILITY_HARVEST);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_BERRY, opponent);
+        STATUS_ICON(opponent, poison: FALSE);
+        NOT ABILITY_POPUP(opponent, ABILITY_HARVEST);
+    } THEN {
+        EXPECT_EQ(opponent->item, ITEM_NONE);
+        EXPECT_EQ(opponent->status1, STATUS1_NONE);
+    }
+}
 
 SINGLE_BATTLE_TEST("Harvest doesn't restore a Berry when destroyed by Incinerate")
 {

--- a/test/battle/ability/poison_touch.c
+++ b/test/battle/ability/poison_touch.c
@@ -20,6 +20,30 @@ SINGLE_BATTLE_TEST("Poison Touch has a 30% chance to poison when attacking with 
     }
 }
 
+SINGLE_BATTLE_TEST("Poison Touch is checked after the move's additional effect")
+{
+    GIVEN {
+        ASSUME(GetMovePower(MOVE_NUZZLE) > 0);
+        ASSUME(MoveMakesContact(MOVE_NUZZLE));
+        ASSUME(MoveHasAdditionalEffectWithChance(MOVE_NUZZLE, MOVE_EFFECT_PARALYSIS, 100) == TRUE);
+        PLAYER(SPECIES_GRIMER) { Ability(ABILITY_POISON_TOUCH); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_NUZZLE, WITH_RNG(RNG_POISON_TOUCH, TRUE)); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_NUZZLE, player);
+        NONE_OF {
+            ABILITY_POPUP(player, ABILITY_POISON_TOUCH);
+            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
+            STATUS_ICON(opponent, poison: TRUE);
+        }
+        ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PRZ, opponent);
+        STATUS_ICON(opponent, paralysis: TRUE);
+    } THEN {
+        EXPECT(opponent->status1 & STATUS1_PARALYSIS);
+    }
+}
+
 SINGLE_BATTLE_TEST("Poison Touch only applies when using contact moves")
 {
     enum Move move;

--- a/test/battle/ability/toxic_chain.c
+++ b/test/battle/ability/toxic_chain.c
@@ -21,6 +21,30 @@ SINGLE_BATTLE_TEST("Toxic Chain inflicts bad poison when attacking")
     }
 }
 
+SINGLE_BATTLE_TEST("Toxic Chain is checked before the move's additional effect")
+{
+    GIVEN {
+        ASSUME(GetMoveCategory(MOVE_NUZZLE) != DAMAGE_CATEGORY_STATUS);
+        ASSUME(GetMovePower(MOVE_NUZZLE) > 0);
+        ASSUME(MoveHasAdditionalEffectWithChance(MOVE_NUZZLE, MOVE_EFFECT_PARALYSIS, 100) == TRUE);
+        PLAYER(SPECIES_OKIDOGI) { Ability(ABILITY_TOXIC_CHAIN); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_NUZZLE, WITH_RNG(RNG_TOXIC_CHAIN, TRUE)); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_NUZZLE, player);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PRZ, opponent);
+            STATUS_ICON(opponent, paralysis: TRUE);
+        }
+        ABILITY_POPUP(player, ABILITY_TOXIC_CHAIN);
+        ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PSN, opponent);
+        STATUS_ICON(opponent, badPoison: TRUE);    
+    } THEN {
+        EXPECT(opponent->status1 & STATUS1_TOXIC_POISON);
+    }
+}
+
 SINGLE_BATTLE_TEST("Toxic Chain inflicts bad poison on any hit of a multi-hit move")
 {
     GIVEN {

--- a/test/battle/move_effect/core_enforcer.c
+++ b/test/battle/move_effect/core_enforcer.c
@@ -92,13 +92,13 @@ SINGLE_BATTLE_TEST("Core Enforcer immediately ends Neutralizing Gas and reactiva
     }
 }
 
-DOUBLE_BATTLE_TEST("Core Enforcer hits and suppresses the abilities of both opposing targets")
+DOUBLE_BATTLE_TEST("Core Enforcer hits both opposing targets")
 {
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);
         PLAYER(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_WEEZING) { Ability(ABILITY_LEVITATE); }
-        OPPONENT(SPECIES_WEEZING) { Ability(ABILITY_LEVITATE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
         TURN { MOVE(playerLeft, MOVE_CORE_ENFORCER); }
     } SCENE {

--- a/test/battle/move_effect/core_enforcer.c
+++ b/test/battle/move_effect/core_enforcer.c
@@ -91,3 +91,19 @@ SINGLE_BATTLE_TEST("Core Enforcer immediately ends Neutralizing Gas and reactiva
         ABILITY_POPUP(player, ABILITY_DROUGHT);
     }
 }
+
+DOUBLE_BATTLE_TEST("Core Enforcer hits and suppresses the abilities of both opposing targets")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WEEZING) { Ability(ABILITY_LEVITATE); }
+        OPPONENT(SPECIES_WEEZING) { Ability(ABILITY_LEVITATE); }
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_CORE_ENFORCER); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CORE_ENFORCER, playerLeft);
+        HP_BAR(opponentLeft);
+        HP_BAR(opponentRight);
+    }
+}

--- a/test/battle/move_effect_secondary/incinerate.c
+++ b/test/battle/move_effect_secondary/incinerate.c
@@ -1,0 +1,88 @@
+#include "global.h"
+#include "test/battle.h"
+
+ASSUMPTIONS
+{
+    ASSUME(MoveHasAdditionalEffect(MOVE_INCINERATE, MOVE_EFFECT_INCINERATE));
+}
+
+SINGLE_BATTLE_TEST("Incinerate destroys Berries and Gems even if the holder has Klutz")
+{
+    enum Item item;
+
+    PARAMETRIZE { item = ITEM_CHERI_BERRY; }
+    PARAMETRIZE { item = ITEM_GHOST_GEM; }
+
+    GIVEN {
+        ASSUME(GetItemPocket(ITEM_CHERI_BERRY) == POCKET_BERRIES);
+        ASSUME(GetItemHoldEffect(ITEM_GHOST_GEM) == HOLD_EFFECT_GEMS);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_CAPSAKID) { Ability(ABILITY_KLUTZ); Item(item); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_INCINERATE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_INCINERATE, player);
+    } THEN {
+        EXPECT_EQ(opponent->item, ITEM_NONE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Incinerate activates Occa Berry before destroying it")
+{
+    GIVEN {
+        ASSUME(GetMoveType(MOVE_INCINERATE) == TYPE_FIRE);
+        ASSUME(IsSpeciesOfType(SPECIES_CAPSAKID, TYPE_GRASS));
+        ASSUME(GetItemHoldEffect(ITEM_OCCA_BERRY) == HOLD_EFFECT_RESIST_BERRY);
+        ASSUME(GetItemHoldEffectParam(ITEM_OCCA_BERRY) == TYPE_FIRE);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_CAPSAKID) { Item(ITEM_OCCA_BERRY); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_INCINERATE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_BERRY, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_INCINERATE, player);
+        HP_BAR(opponent);
+    } THEN {
+        EXPECT_EQ(opponent->item, ITEM_NONE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Incinerate destroys Oran Berry before it can restore HP")
+{
+    s16 damage;
+
+    GIVEN {
+        ASSUME(GetItemHoldEffect(ITEM_ORAN_BERRY) == HOLD_EFFECT_RESTORE_HP);
+        ASSUME(GetItemHoldEffectParam(ITEM_ORAN_BERRY) == 10);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_ORAN_BERRY); HP(201); MaxHP(400); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_INCINERATE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_INCINERATE, player);
+        HP_BAR(opponent, captureDamage: &damage);
+        NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_BERRY, opponent);
+    } THEN {
+        EXPECT_EQ(opponent->hp, 201 - damage);
+        EXPECT_EQ(opponent->item, ITEM_NONE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Incinerate destroys Rowap Berry before it can damage the attacker")
+{
+    GIVEN {
+        ASSUME(GetMoveCategory(MOVE_INCINERATE) == DAMAGE_CATEGORY_SPECIAL);
+        ASSUME(GetItemHoldEffect(ITEM_ROWAP_BERRY) == HOLD_EFFECT_ROWAP_BERRY);
+        PLAYER(SPECIES_WOBBUFFET) { HP(400); MaxHP(400); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_ROWAP_BERRY); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_INCINERATE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_INCINERATE, player);
+        HP_BAR(opponent);
+        NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_BERRY, opponent);
+    } THEN {
+        EXPECT_EQ(player->hp, 400);
+        EXPECT_EQ(opponent->item, ITEM_NONE);
+    }
+}


### PR DESCRIPTION
## Description
1. Fix [Incinerate](https://bulbapedia.bulbagarden.net/wiki/Incinerate_(move)) so it destroys Gems even when their effects are suppressed by Klutz.
> _Incinerate inflicts damage to all adjacent opponents. It destroys any Berries held by the hit Pokémon. The Occa Berry will activate before being burned up. Berries that would activate in response to Incinerate, such as the Oran Berry or Rowap Berry, are destroyed before they have a chance to be consumed._


2. Core Enforcer should target both foes.
<img width="282" height="672" alt="image" src="https://github.com/user-attachments/assets/d62e699e-2a09-4313-a1db-3f01a0426e39" />