### PR TITLE
Fix move effect ai stat change check

### DIFF
--- a/include/battle_ai_util.h
+++ b/include/battle_ai_util.h
@@ -300,6 +300,7 @@ s32 GetAILastPartyIndex(enum BattlerId battler);
 u32 GetActiveBattlerIds(enum BattlerId battler, enum BattlerId *battlerIn1, enum BattlerId *battlerIn2);
 bool32 IsPartyMonOnFieldOrChosenToSwitch(enum BattlerId battler, u32 partyIndex, enum BattlerId battlerIn1, enum BattlerId battlerIn2);
 bool32 IsPartyMonPlannedToBeSwitchedInByPartner(u32 partyIndex, enum BattlerId battler);
+u32 AI_GetAdjustedStatStage(enum BattlerId battler, enum Move move, s32 stage);
 s32 GetStatChangeScore(enum BattlerId battlerAtk, enum BattlerId battlerDef, enum Move move);
 s32 GetSelfStatChangeScore(enum BattlerId battlerAtk, enum BattlerId battlerDef, enum Move move);
 s32 GetFoeStatChangeScore(enum BattlerId battlerAtk, enum BattlerId battlerDef, enum Move move);

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -5600,18 +5600,15 @@ static s32 AI_CalcAdditionalEffectScore(enum BattlerId battlerAtk, enum BattlerI
                     if (stage == 0)
                         continue;
 
-                    if (aiData->abilities[battlerAtk] == ABILITY_CONTRARY)
-                        stage = -1 * stage;
-
                     if (additionalEffect->moveEffect == MOVE_EFFECT_STAT_MINUS)
                         stage = -1 * stage;
 
                     stage = AI_GetAdjustedStatStage(battlerAtk, move, stage);
 
-                    if (stage > 0)
-                        ADJUST_SCORE(IncreaseStatUpScore(battlerAtk, battlerDef, stat, stage));
-                    else
-                        ADJUST_SCORE(IncreaseStatDownScore(battlerAtk, battlerDef, stat));
+                    if (stage < 0)
+                        continue;
+
+                    ADJUST_SCORE(IncreaseStatUpScore(battlerAtk, battlerDef, stat, stage));
                 }
                 break;
             case MOVE_EFFECT_ORDER_UP:

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -5591,6 +5591,7 @@ static s32 AI_CalcAdditionalEffectScore(enum BattlerId battlerAtk, enum BattlerI
             switch (additionalEffect->moveEffect)
             {
             case MOVE_EFFECT_STAT_PLUS:
+            case MOVE_EFFECT_STAT_MINUS:
                 for (enum Stat i = STAT_ATK; i < NUM_BATTLE_STATS; i++)
                 {
                     enum Stat stat = sAccurateStatOrder[i];
@@ -5602,28 +5603,15 @@ static s32 AI_CalcAdditionalEffectScore(enum BattlerId battlerAtk, enum BattlerI
                     if (aiData->abilities[battlerAtk] == ABILITY_CONTRARY)
                         stage = -1 * stage;
 
-                    if (stage < 0)
-                        continue;
-
-                    ADJUST_SCORE(IncreaseStatUpScore(battlerAtk, battlerDef, stat, stage));
-                }
-                break;
-            case MOVE_EFFECT_STAT_MINUS:
-                for (enum Stat i = STAT_ATK; i < NUM_BATTLE_STATS; i++)
-                {
-                    enum Stat stat = sAccurateStatOrder[i];
-                    s32 stage = -1 * GetStatStage(stat, additionalEffect);
-
-                    if (stage == 0)
-                        continue;
-
-                    if (aiData->abilities[battlerAtk] == ABILITY_CONTRARY)
+                    if (additionalEffect->moveEffect == MOVE_EFFECT_STAT_MINUS)
                         stage = -1 * stage;
 
-                    if (stage < 0)
-                        continue;
+                    stage = AI_GetAdjustedStatStage(battlerAtk, move, stage);
 
-                    ADJUST_SCORE(IncreaseStatDownScore(battlerAtk, battlerDef, stat));
+                    if (stage > 0)
+                        ADJUST_SCORE(IncreaseStatUpScore(battlerAtk, battlerDef, stat, stage));
+                    else
+                        ADJUST_SCORE(IncreaseStatDownScore(battlerAtk, battlerDef, stat));
                 }
                 break;
             case MOVE_EFFECT_ORDER_UP:

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -6234,7 +6234,7 @@ bool32 IsPartyMonPlannedToBeSwitchedInByPartner(u32 partyIndex, enum BattlerId b
     return FALSE;
 }
 
-static u32 AI_GetAdjustedStatStage(enum BattlerId battler, enum Move move, s32 stage)
+u32 AI_GetAdjustedStatStage(enum BattlerId battler, enum Move move, s32 stage)
 {
     if (GetMoveEffect(move) == EFFECT_GROWTH
      && GetAttackerWeather(gAiLogicData->holdEffects[battler], gAiLogicData->abilities[battler], AI_GetWeather()) & B_WEATHER_SUN)
@@ -6396,6 +6396,9 @@ s32 GetAllyStatChangeScore(u32 battlerAtk, u32 partner, u32 move)
         for (enum Stat stat = STAT_ATK; stat < NUM_STATS; stat++)
         {
             s32 stage = GetStatStage(stat, effect);
+
+            if (stage == 0)
+                continue;
 
             if (effect->moveEffect == STAT_CHANGE_EFFECT_MINUS)
                 stage = -1 * stage;


### PR DESCRIPTION
Noticed by going through #9979 that I made a wrong implementation and that was carried over. Though in other places I did it correctly. 

This is a bug fix since Contrary stat changes would result in buggy behavior 