### PR TITLE
fix no continue script after early rival battle

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -831,7 +831,7 @@
 
 	@ Starts a trainer battle with victory text if the player loses. If flags is nonzero, the player will be healed after battle (and its assumed to be the tutorial battle)
 	.macro trainerbattle_earlyrival trainer:req, flags:req, lose_text:req, victory_text:req
-	trainerbattle OBJ_ID_NONE, \trainer, NULL, \lose_text, NULL, OBJ_ID_NONE, TRAINER_NONE, NULL, NULL, NULL, \victory_text, NULL, FALSE, TRUE, FALSE, FALSE, FALSE, FALSE, TRUE, \flags
+	trainerbattle OBJ_ID_NONE, \trainer, NULL, \lose_text, NULL, OBJ_ID_NONE, TRAINER_NONE, NULL, NULL, NULL, \victory_text, NULL, FALSE, TRUE, FALSE, FALSE, TRUE, FALSE, TRUE, \flags
 	.endm
 
 	@ Starts a lavaridge gym battle


### PR DESCRIPTION
fixes a regressio from #8678 
## Description
sets `continueScript` to TRUE for the early rival battle in frlg

### Large Language Models (AI)
no

## Media

## Issue(s) that this PR fixes
fixes #10279

## Discord contact info
u8.Salem