### PR TITLE
Fixes Binding Band no longer affecting bound battler's hp decrease when nullified

### DIFF
--- a/include/constants/battle.h
+++ b/include/constants/battle.h
@@ -219,6 +219,7 @@ enum VolatileFlags
     F(VOLATILE_WRAPPED,                     wrapped,                       (u32, 1)) \
     F(VOLATILE_WRAPPED_BY,                  wrappedBy,                     (enum BattlerId, MAX_BITS(MAX_BATTLERS_COUNT))) \
     F(VOLATILE_WRAPPED_MOVE,                wrappedMove,                   (u32, MOVES_COUNT_ALL - 1)) \
+    F(VOLATILE_WRAPPED_BINDING_BAND,        wrappedBindingBand,            (u32, 1)) \
     F(VOLATILE_POWDER,                      powder,                        (u32, 1)) \
     F(VOLATILE_UNUSED,                      padding,                       (u32, 1)) \
     F(VOLATILE_INFATUATION,                 infatuation,                   (enum BattlerId, MAX_BITS(MAX_BATTLERS_COUNT))) \

--- a/src/battle_end_turn.c
+++ b/src/battle_end_turn.c
@@ -667,7 +667,7 @@ static bool32 HandleEndTurnWrap(enum BattlerId battler)
             PREPARE_MOVE_BUFFER(gBattleTextBuff1, gBattleMons[battler].volatiles.wrappedMove);
             BattleScriptCall(BattleScript_WrapTurnDmg);
             s32 bindDamage = 0;
-            if (GetBattlerHoldEffect(gBattleMons[battler].volatiles.wrappedBy) == HOLD_EFFECT_BINDING_BAND)
+            if (gBattleMons[battler].volatiles.wrappedBindingBand)
                 bindDamage = GetNonDynamaxMaxHP(battler) / (B_BINDING_DAMAGE >= GEN_6 ? 6 : 8);
             else
                 bindDamage = GetNonDynamaxMaxHP(battler) / (B_BINDING_DAMAGE >= GEN_6 ? 8 : 16);

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -10723,9 +10723,15 @@ void SetWrapTurns(enum BattlerId battler, enum HoldEffect holdEffect)
 {
     u32 normalWrapTurns = B_WRAP_TURNS - 2; // 5 turns
     if (holdEffect == HOLD_EFFECT_GRIP_CLAW)
+    {
         gBattleMons[battler].volatiles.wrapTurns = GetConfig(B_BINDING_TURNS) >= GEN_5 ? B_WRAP_TURNS : normalWrapTurns;
+        gBattleMons[battler].volatiles.wrappedBindingBand = FALSE;
+    }
     else
+    {
         gBattleMons[battler].volatiles.wrapTurns = GetConfig(B_BINDING_TURNS) >= GEN_5 ? RandomUniform(RNG_WRAP, 4, normalWrapTurns) : RandomUniform(RNG_WRAP, 2, normalWrapTurns);
+        gBattleMons[battler].volatiles.wrappedBindingBand = holdEffect == HOLD_EFFECT_BINDING_BAND;
+    }
 }
 
 // Return True if the order was changed, and false if the order was not changed(for example because the target would move after the attacker anyway).

--- a/test/battle/hold_effect/binding_band.c
+++ b/test/battle/hold_effect/binding_band.c
@@ -1,4 +1,56 @@
 #include "global.h"
 #include "test/battle.h"
 
+ASSUMPTIONS
+{
+    ASSUME(MoveHasAdditionalEffect(MOVE_WRAP, MOVE_EFFECT_WRAP));
+    ASSUME(GetItemHoldEffect(ITEM_BINDING_BAND) == HOLD_EFFECT_BINDING_BAND);
+}
+
+SINGLE_BATTLE_TEST("Binding Band increases the damage taken from binding effects", s16 damage)
+{
+    enum Item item;
+
+    PARAMETRIZE { item = ITEM_NONE; }
+    PARAMETRIZE { item = ITEM_BINDING_BAND; }
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WYNAUT) { Item(item); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_WRAP); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_WRAP, opponent);
+        HP_BAR(player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_TURN_TRAP, player);
+        HP_BAR(player, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_GT(results[1].damage, results[0].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Binding Band increases the damage taken from binding effects even if holder's item gets nullified after", s16 damage)
+{
+    enum Item item;
+
+    PARAMETRIZE { item = ITEM_NONE; }
+    PARAMETRIZE { item = ITEM_BINDING_BAND; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_EMBARGO) == EFFECT_EMBARGO);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WYNAUT) { Item(item); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_WRAP); MOVE(player, MOVE_EMBARGO); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_WRAP, opponent);
+        HP_BAR(player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EMBARGO, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_TURN_TRAP, player);
+        HP_BAR(player, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_GT(results[1].damage, results[0].damage);
+    }
+}
+
 TO_DO_BATTLE_TEST("TODO: Write Binding Band (Hold Effect) test titles")


### PR DESCRIPTION
The linked issue also mentions Grip Claw, but I believe the mentioned bug is only present for Binding Band.

Also adds tests for Binding Band.

## Issue(s) that this PR fixes
Fixes #10222

## Discord contact info
PhallenTree