### PR TITLE
refactor(sprite): add sprite flag to create OBJWIN copies of oams

### DIFF
--- a/include/sprite.h
+++ b/include/sprite.h
@@ -216,7 +216,7 @@ struct Sprite
              u16 coordOffsetEnabled:1;      //2
              u16 invisible:1;               //4
              // If set to TRUE a copy of the sprite's OAM is created with objMode set to ST_OAM_OBJ_WINDOW
-             u16 objWinMask:1;                 //8
+             u16 copyToObjWin:1;                 //8
              // if nonzero, tile offset for usingSheet sprites
              // is (offset + 1) << sheetSpan;
              // (This allows using frame-based anim tables for sheet sprites)

--- a/include/sprite.h
+++ b/include/sprite.h
@@ -326,7 +326,7 @@ u16 GetSpritePaletteTagByPaletteNum(u8 paletteNum);
 void FreeSpritePaletteByTag(u16 tag);
 void SetSubspriteTables(struct Sprite *sprite, const struct SubspriteTable *subspriteTables);
 bool8 AddSpriteToOamBuffer(struct Sprite *sprite, u8 *oamIndex);
-bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, struct OamData *destOam, u8 *oamIndex);
+bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, u8 *oamIndex);
 void CopyToSprites(u8 *src);
 void CopyFromSprites(u8 *dest);
 u8 SpriteTileAllocBitmapOp(u16 bit, u8 op);

--- a/include/sprite.h
+++ b/include/sprite.h
@@ -215,7 +215,8 @@ struct Sprite
     /*0x3E*/ u16 inUse:1;                   //1
              u16 coordOffsetEnabled:1;      //2
              u16 invisible:1;               //4
-             u16 flags_3:1;                 //8
+             // If set to TRUE a copy of the sprite's OAM is created with objMode set to ST_OAM_OBJ_WINDOW
+             u16 objWinMask:1;                 //8
              // if nonzero, tile offset for usingSheet sprites
              // is (offset + 1) << sheetSpan;
              // (This allows using frame-based anim tables for sheet sprites)

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -60,6 +60,7 @@
 #include "script_pokemon_util.h"
 #include "secret_base.h"
 #include "sound.h"
+#include "sprite.h"
 #include "start_menu.h"
 #include "string_util.h"
 #include "task.h"
@@ -3691,7 +3692,6 @@ bool8 GetSetItemObtained(enum Item item, enum ItemObtainFlags caseId)
 
 EWRAM_DATA static u8 sHeaderBoxWindowId = 0;
 EWRAM_DATA u8 sItemIconSpriteId = 0;
-EWRAM_DATA u8 sItemIconSpriteId2 = 0;
 
 static void ShowItemIconSprite(enum Item item, bool8 firstTime, bool8 flash);
 static void DestroyItemIconSprite(void);
@@ -3810,7 +3810,6 @@ static void ShowItemIconSprite(enum Item item, bool8 firstTime, bool8 flash)
 {
     s16 x = 0, y = 0;
     u8 iconSpriteId;
-    u8 spriteId2 = MAX_SPRITES;
 
     if (flash)
     {
@@ -3819,8 +3818,10 @@ static void ShowItemIconSprite(enum Item item, bool8 firstTime, bool8 flash)
     }
 
     iconSpriteId = AddItemIconSprite(ITEM_TAG, ITEM_TAG, item);
+
     if (flash)
-        spriteId2 = AddItemIconSprite(ITEM_TAG, ITEM_TAG, item);
+        gSprites[iconSpriteId].objWinMask = TRUE;
+
     if (iconSpriteId != MAX_SPRITES)
     {
         if (!firstTime)
@@ -3841,15 +3842,6 @@ static void ShowItemIconSprite(enum Item item, bool8 firstTime, bool8 flash)
         gSprites[iconSpriteId].oam.priority = 0;
     }
 
-    if (spriteId2 != MAX_SPRITES)
-    {
-        gSprites[spriteId2].x2 = x;
-        gSprites[spriteId2].y2 = y;
-        gSprites[spriteId2].oam.priority = 0;
-        gSprites[spriteId2].oam.objMode = ST_OAM_OBJ_WINDOW;
-        sItemIconSpriteId2 = spriteId2;
-    }
-
     sItemIconSpriteId = iconSpriteId;
 }
 
@@ -3859,12 +3851,6 @@ static void DestroyItemIconSprite(void)
     FreeSpritePaletteByTag(ITEM_TAG);
     FreeSpriteOamMatrix(&gSprites[sItemIconSpriteId]);
     DestroySprite(&gSprites[sItemIconSpriteId]);
-
-    if ((GetFlashLevel() > 0 || InBattlePyramid()) && sItemIconSpriteId2 != MAX_SPRITES)
-    {
-        FreeSpriteOamMatrix(&gSprites[sItemIconSpriteId2]);
-        DestroySprite(&gSprites[sItemIconSpriteId2]);
-    }
 }
 
 // returns old sHoursOverride

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -3820,7 +3820,7 @@ static void ShowItemIconSprite(enum Item item, bool8 firstTime, bool8 flash)
     iconSpriteId = AddItemIconSprite(ITEM_TAG, ITEM_TAG, item);
 
     if (flash)
-        gSprites[iconSpriteId].objWinMask = TRUE;
+        gSprites[iconSpriteId].copyToObjWin = TRUE;
 
     if (iconSpriteId != MAX_SPRITES)
     {

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -386,10 +386,7 @@ void BuildOamBuffer(void)
     for (i = 0, oamIndex = 0; i < toSort; i++)
     {
         if (AddSpriteToOamBuffer(&gSprites[spritePriorities[i] & 0xFF], &oamIndex))
-        {
-            errorf("Failed to add sprite OAMs to OamBuffer");
             break;
-        }
     }
 
     for (i = oamIndex; i < sOamDummyIndex; i++)
@@ -1815,9 +1812,7 @@ bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, struct OamData *destOam, u
             u16 x;
             u16 y;
 
-            u32 limit = sprite->objWinMask ? gOamLimit - 1 : gOamLimit;
-
-            if (*oamIndex >= limit)
+            if (*oamIndex >= gOamLimit)
                 return 1;
 
             x = subspriteTable->subsprites[i].x;
@@ -1855,9 +1850,6 @@ bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, struct OamData *destOam, u
 
             if (sprite->objWinMask)
             {
-                if (*oamIndex >= gOamLimit)
-                    return 1;
-
                 subspriteOam.objMode = ST_OAM_OBJ_WINDOW;
                 destOam[subspriteCount+i] = subspriteOam;
             }

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -1851,7 +1851,7 @@ bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, struct OamData *destOam, u
 
             destOam[i] = subspriteOam;
 
-            if(sprite->objWinMask)
+            if (sprite->objWinMask)
             {
                 subspriteOam.objMode = ST_OAM_OBJ_WINDOW;
                 destOam[subspriteCount+i] = subspriteOam;

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -387,7 +387,7 @@ void BuildOamBuffer(void)
     {
         if (AddSpriteToOamBuffer(&gSprites[spritePriorities[i] & 0xFF], &oamIndex))
         {
-            errorf("Failed to add sprite to OAM");
+            errorf("Failed to add sprite OAMs to OamBuffer");
             break;
         }
     }
@@ -1746,10 +1746,8 @@ void SetSubspriteTables(struct Sprite *sprite, const struct SubspriteTable *subs
 
 bool8 AddSpriteToOamBuffer(struct Sprite *sprite, u8 *oamIndex)
 {
-    assertf(*oamIndex < gOamLimit, "Out of Oam slots")
-    {
+    if (*oamIndex >= gOamLimit)
         return 1;
-    }
 
     if (!sprite->subspriteTables || sprite->subspriteMode == SUBSPRITES_OFF)
     {
@@ -1767,10 +1765,9 @@ bool8 AddSpriteToOamBuffer(struct Sprite *sprite, u8 *oamIndex)
 
 static bool8 AddObjWinMaskToOamBuffer(struct Sprite *sprite, u8 *oamIndex)
 {
-    assertf(*oamIndex < gOamLimit, "Out of Oam slots")
-    {
+
+    if (*oamIndex >= gOamLimit)
         return 1;
-    }
 
     struct OamData oam = sprite->oam;
     oam.objMode = ST_OAM_OBJ_WINDOW;
@@ -1818,10 +1815,10 @@ bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, struct OamData *destOam, u
             u16 x;
             u16 y;
 
-            assertf (*oamIndex < gOamLimit, "Out of Oam Slots")
-            {
+            u32 limit = sprite->objWinMask ? gOamLimit - 1 : gOamLimit;
+
+            if (*oamIndex >= limit)
                 return 1;
-            }
 
             x = subspriteTable->subsprites[i].x;
             y = subspriteTable->subsprites[i].y;
@@ -1858,6 +1855,9 @@ bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, struct OamData *destOam, u
 
             if (sprite->objWinMask)
             {
+                if (*oamIndex >= gOamLimit)
+                    return 1;
+
                 subspriteOam.objMode = ST_OAM_OBJ_WINDOW;
                 destOam[subspriteCount+i] = subspriteOam;
             }

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -1745,7 +1745,7 @@ bool8 AddSpriteToOamBuffer(struct Sprite *sprite, u8 *oamIndex)
 {
     if (!sprite->subspriteTables || sprite->subspriteMode == SUBSPRITES_OFF)
     {
-        return AddToOamBuffer(oamIndex, &sprite->oam, sprite->objWinMask);
+        return AddToOamBuffer(oamIndex, &sprite->oam, sprite->copyToObjWin);
     }
     else
     {
@@ -1763,7 +1763,7 @@ bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, u8 *oamIndex)
 
     if (!subspriteTable || !subspriteTable->subsprites)
     {
-        return AddToOamBuffer(oamIndex, oam, sprite->objWinMask);
+        return AddToOamBuffer(oamIndex, oam, sprite->copyToObjWin);
     }
     else
     {
@@ -1819,7 +1819,7 @@ bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, u8 *oamIndex)
             if (sprite->subspriteMode < SUBSPRITES_IGNORE_PRIORITY)
                 subspriteOam.priority = subspriteTable->subsprites[i].priority;
 
-            if (AddToOamBuffer(oamIndex, &subspriteOam, sprite->objWinMask))
+            if (AddToOamBuffer(oamIndex, &subspriteOam, sprite->copyToObjWin))
                 return TRUE;
         }
 

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -1762,7 +1762,9 @@ bool8 AddSpriteToOamBuffer(struct Sprite *sprite, u8 *oamIndex)
 
 static bool8 AddObjWinMaskToOamBuffer(struct Sprite *sprite, u8 *oamIndex)
 {
-    if (*oamIndex >= gOamLimit)
+    u32 limit = sprite->objWinMask ? gOamLimit - 1 : gOamLimit;
+
+    if (*oamIndex >= limit)
         return 1;
 
     struct OamData oam = sprite->oam;

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -89,6 +89,7 @@ static void ApplyAffineAnimFrame(u8 matrixNum, struct AffineAnimFrameCmd *frameC
 static void AllocSpriteTileRange(u16 tag, u16 start, u16 count);
 static void DoLoadSpritePalette(const u16 *src, u16 paletteOffset);
 static void UpdateSpriteMatrixAnchorPos(struct Sprite *, s32, s32);
+static bool8 AddObjWinMaskToOamBuffer(struct Sprite *sprite, u8 *oamIndex);
 
 typedef void (*AnimFunc)(struct Sprite *);
 typedef void (*AnimCmdFunc)(struct Sprite *);
@@ -1749,11 +1750,29 @@ bool8 AddSpriteToOamBuffer(struct Sprite *sprite, u8 *oamIndex)
     {
         gMain.oamBuffer[*oamIndex] = sprite->oam;
         (*oamIndex)++;
+        if (sprite->objWinMask)
+            return AddObjWinMaskToOamBuffer(sprite, oamIndex);
         return 0;
     }
     else
     {
         return AddSubspritesToOamBuffer(sprite, &gMain.oamBuffer[*oamIndex], oamIndex);
+    }
+}
+
+static bool8 AddObjWinMaskToOamBuffer(struct Sprite *sprite, u8 *oamIndex)
+{
+    if (*oamIndex >= gOamLimit)
+    {
+        return 1;
+    }
+
+    else
+    {
+        struct OamData oam = sprite->oam;
+        oam.objMode = ST_OAM_OBJ_WINDOW;
+        gMain.oamBuffer[(*oamIndex)++] = oam;
+        return 0;
     }
 }
 
@@ -1796,7 +1815,9 @@ bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, struct OamData *destOam, u
             u16 x;
             u16 y;
 
-            if (*oamIndex >= gOamLimit)
+            u8 limit = sprite->objWinMask ? gOamLimit - 1 : gOamLimit;
+
+            if (*oamIndex >= limit)
                 return 1;
 
             x = subspriteTable->subsprites[i].x;
@@ -1820,16 +1841,28 @@ bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, struct OamData *destOam, u
                 y = ~y + 1;
             }
 
-            destOam[i] = *oam;
-            destOam[i].shape = subspriteTable->subsprites[i].shape;
-            destOam[i].size = subspriteTable->subsprites[i].size;
-            destOam[i].x = (s16)baseX + (s16)x;
-            destOam[i].y = baseY + y;
-            destOam[i].tileNum = tileNum + subspriteTable->subsprites[i].tileOffset;
+            struct OamData subspriteOam = *oam;
+            subspriteOam.shape = subspriteTable->subsprites[i].shape;
+            subspriteOam.size = subspriteTable->subsprites[i].size;
+            subspriteOam.x = (s16)baseX + (s16)x;
+            subspriteOam.y = baseY + y;
+            subspriteOam.tileNum = tileNum + subspriteTable->subsprites[i].tileOffset;
 
             if (sprite->subspriteMode < SUBSPRITES_IGNORE_PRIORITY)
-                destOam[i].priority = subspriteTable->subsprites[i].priority;
+                subspriteOam.priority = subspriteTable->subsprites[i].priority;
+
+            destOam[i] = subspriteOam;
+
+            if(sprite->objWinMask)
+            {
+                subspriteOam.objMode = ST_OAM_OBJ_WINDOW;
+                destOam[subspriteCount+i] = subspriteOam;
+            }
+
         }
+
+        if (sprite->objWinMask)
+            (*oamIndex) += subspriteCount;
     }
 
     return 0;

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -1744,13 +1744,9 @@ void SetSubspriteTables(struct Sprite *sprite, const struct SubspriteTable *subs
 bool8 AddSpriteToOamBuffer(struct Sprite *sprite, u8 *oamIndex)
 {
     if (!sprite->subspriteTables || sprite->subspriteMode == SUBSPRITES_OFF)
-    {
         return AddToOamBuffer(oamIndex, &sprite->oam, sprite->copyToObjWin);
-    }
     else
-    {
         return AddSubspritesToOamBuffer(sprite, oamIndex);
-    }
 }
 
 bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, u8 *oamIndex)

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -1785,9 +1785,6 @@ bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, u8 *oamIndex)
             u16 x;
             u16 y;
 
-            if (*oamIndex >= gOamLimit)
-                return 1;
-
             x = subspriteTable->subsprites[i].x;
             y = subspriteTable->subsprites[i].y;
 

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -386,7 +386,10 @@ void BuildOamBuffer(void)
     for (i = 0, oamIndex = 0; i < toSort; i++)
     {
         if (AddSpriteToOamBuffer(&gSprites[spritePriorities[i] & 0xFF], &oamIndex))
+        {
+            errorf("Failed to add sprite to OAM");
             break;
+        }
     }
 
     for (i = oamIndex; i < sOamDummyIndex; i++)

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -1743,8 +1743,10 @@ void SetSubspriteTables(struct Sprite *sprite, const struct SubspriteTable *subs
 
 bool8 AddSpriteToOamBuffer(struct Sprite *sprite, u8 *oamIndex)
 {
-    if (*oamIndex >= gOamLimit)
+    assertf(*oamIndex < gOamLimit, "Out of Oam slots")
+    {
         return 1;
+    }
 
     if (!sprite->subspriteTables || sprite->subspriteMode == SUBSPRITES_OFF)
     {
@@ -1762,10 +1764,10 @@ bool8 AddSpriteToOamBuffer(struct Sprite *sprite, u8 *oamIndex)
 
 static bool8 AddObjWinMaskToOamBuffer(struct Sprite *sprite, u8 *oamIndex)
 {
-    u32 limit = sprite->objWinMask ? gOamLimit - 1 : gOamLimit;
-
-    if (*oamIndex >= limit)
+    assertf(*oamIndex < gOamLimit, "Out of Oam slots")
+    {
         return 1;
+    }
 
     struct OamData oam = sprite->oam;
     oam.objMode = ST_OAM_OBJ_WINDOW;
@@ -1813,10 +1815,10 @@ bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, struct OamData *destOam, u
             u16 x;
             u16 y;
 
-            u32 limit = sprite->objWinMask ? gOamLimit - 1 : gOamLimit;
-
-            if (*oamIndex >= limit)
+            assertf (*oamIndex < gOamLimit, "Out of Oam Slots")
+            {
                 return 1;
+            }
 
             x = subspriteTable->subsprites[i].x;
             y = subspriteTable->subsprites[i].y;

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -1763,17 +1763,13 @@ bool8 AddSpriteToOamBuffer(struct Sprite *sprite, u8 *oamIndex)
 static bool8 AddObjWinMaskToOamBuffer(struct Sprite *sprite, u8 *oamIndex)
 {
     if (*oamIndex >= gOamLimit)
-    {
         return 1;
-    }
 
-    else
-    {
-        struct OamData oam = sprite->oam;
-        oam.objMode = ST_OAM_OBJ_WINDOW;
-        gMain.oamBuffer[(*oamIndex)++] = oam;
-        return 0;
-    }
+    struct OamData oam = sprite->oam;
+    oam.objMode = ST_OAM_OBJ_WINDOW;
+    gMain.oamBuffer[*oamIndex] = oam;
+    (*oamIndex)++;
+    return 0;
 }
 
 bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, struct OamData *destOam, u8 *oamIndex)
@@ -1815,7 +1811,7 @@ bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, struct OamData *destOam, u
             u16 x;
             u16 y;
 
-            u8 limit = sprite->objWinMask ? gOamLimit - 1 : gOamLimit;
+            u32 limit = sprite->objWinMask ? gOamLimit - 1 : gOamLimit;
 
             if (*oamIndex >= limit)
                 return 1;

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -89,7 +89,7 @@ static void ApplyAffineAnimFrame(u8 matrixNum, struct AffineAnimFrameCmd *frameC
 static void AllocSpriteTileRange(u16 tag, u16 start, u16 count);
 static void DoLoadSpritePalette(const u16 *src, u16 paletteOffset);
 static void UpdateSpriteMatrixAnchorPos(struct Sprite *, s32, s32);
-static bool8 AddObjWinMaskToOamBuffer(struct Sprite *sprite, u8 *oamIndex);
+static bool32 AddToOamBuffer(u8 *oamIndex, const struct OamData *oam, bool32 copyToObjWin);
 
 typedef void (*AnimFunc)(struct Sprite *);
 typedef void (*AnimCmdFunc)(struct Sprite *);
@@ -1743,34 +1743,14 @@ void SetSubspriteTables(struct Sprite *sprite, const struct SubspriteTable *subs
 
 bool8 AddSpriteToOamBuffer(struct Sprite *sprite, u8 *oamIndex)
 {
-    if (*oamIndex >= gOamLimit)
-        return 1;
-
     if (!sprite->subspriteTables || sprite->subspriteMode == SUBSPRITES_OFF)
     {
-        gMain.oamBuffer[*oamIndex] = sprite->oam;
-        (*oamIndex)++;
-        if (sprite->objWinMask)
-            return AddObjWinMaskToOamBuffer(sprite, oamIndex);
-        return 0;
+        return AddToOamBuffer(oamIndex, &sprite->oam, sprite->objWinMask);
     }
     else
     {
         return AddSubspritesToOamBuffer(sprite, &gMain.oamBuffer[*oamIndex], oamIndex);
     }
-}
-
-static bool8 AddObjWinMaskToOamBuffer(struct Sprite *sprite, u8 *oamIndex)
-{
-
-    if (*oamIndex >= gOamLimit)
-        return 1;
-
-    struct OamData oam = sprite->oam;
-    oam.objMode = ST_OAM_OBJ_WINDOW;
-    gMain.oamBuffer[*oamIndex] = oam;
-    (*oamIndex)++;
-    return 0;
 }
 
 bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, struct OamData *destOam, u8 *oamIndex)
@@ -1786,9 +1766,7 @@ bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, struct OamData *destOam, u
 
     if (!subspriteTable || !subspriteTable->subsprites)
     {
-        *destOam = *oam;
-        (*oamIndex)++;
-        return 0;
+        return AddToOamBuffer(oamIndex, oam, sprite->objWinMask);
     }
     else
     {
@@ -1861,6 +1839,26 @@ bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, struct OamData *destOam, u
     }
 
     return 0;
+}
+
+static bool32 AddToOamBuffer(u8 *oamIndex, const struct OamData *oam, bool32 copyToObjWin)
+{
+    if (*oamIndex >= gOamLimit)
+        return TRUE;
+
+    gMain.oamBuffer[*oamIndex] = *oam;
+    (*oamIndex)++;
+
+    if (copyToObjWin)
+    {
+        if (*oamIndex >= gOamLimit)
+            return TRUE;
+        gMain.oamBuffer[*oamIndex] = *oam;
+        gMain.oamBuffer[*oamIndex].objMode = ST_OAM_OBJ_WINDOW;
+        (*oamIndex)++;
+    }
+
+    return FALSE;
 }
 
 static const u8 sSpanPerImage[4][4] =

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -1749,17 +1749,14 @@ bool8 AddSpriteToOamBuffer(struct Sprite *sprite, u8 *oamIndex)
     }
     else
     {
-        return AddSubspritesToOamBuffer(sprite, &gMain.oamBuffer[*oamIndex], oamIndex);
+        return AddSubspritesToOamBuffer(sprite, oamIndex);
     }
 }
 
-bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, struct OamData *destOam, u8 *oamIndex)
+bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, u8 *oamIndex)
 {
     const struct SubspriteTable *subspriteTable;
     struct OamData *oam;
-
-    if (*oamIndex >= gOamLimit)
-        return 1;
 
     subspriteTable = &sprite->subspriteTables[sprite->subspriteTableNum];
     oam = &sprite->oam;
@@ -1776,8 +1773,6 @@ bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, struct OamData *destOam, u
         u8 subspriteCount;
         u8 hFlip;
         u8 vFlip;
-        u32 i;
-
         tileNum = oam->tileNum;
         subspriteCount = subspriteTable->subspriteCount;
         hFlip = ((s32)oam->matrixNum >> 3) & 1;
@@ -1785,7 +1780,7 @@ bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, struct OamData *destOam, u
         baseX = oam->x - sprite->centerToCornerVecX;
         baseY = oam->y - sprite->centerToCornerVecY;
 
-        for (i = 0; i < subspriteCount; i++, (*oamIndex)++)
+        for (u32 i = 0; i < subspriteCount; i++)
         {
             u16 x;
             u16 y;
@@ -1824,21 +1819,13 @@ bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, struct OamData *destOam, u
             if (sprite->subspriteMode < SUBSPRITES_IGNORE_PRIORITY)
                 subspriteOam.priority = subspriteTable->subsprites[i].priority;
 
-            destOam[i] = subspriteOam;
-
-            if (sprite->objWinMask)
-            {
-                subspriteOam.objMode = ST_OAM_OBJ_WINDOW;
-                destOam[subspriteCount+i] = subspriteOam;
-            }
-
+            if (AddToOamBuffer(oamIndex, &subspriteOam, sprite->objWinMask))
+                return TRUE;
         }
 
-        if (sprite->objWinMask)
-            (*oamIndex) += subspriteCount;
     }
 
-    return 0;
+    return FALSE;
 }
 
 static bool32 AddToOamBuffer(u8 *oamIndex, const struct OamData *oam, bool32 copyToObjWin)


### PR DESCRIPTION
## Description

This PR adds a flag to `struct Sprite` to enable the automatic creation of copies of the sprite's Oams with `ST_OAM_OBJ_WINDOW`. The item sprite shown along with the description now uses this flag instead of creating two copies of the sprite. This is also generally useful to display sprites while using flash.

### Large Language Models (AI)

None

## Things to note in the release changelog:
- For subsprites the objWin copies are added to immediately after each subsprite's OAM.
- Note that objWin sprites don't count towards the per-scanline sprite pixel limit .


## Discord contact info

@miriamlefae
