### PR TITLE
Fix Item Heal Animation showing recovery on the wrong target

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -5347,7 +5347,7 @@ BattleScript_ItemHealHP_RemoveItem::
 	return
 
 BattleScript_ItemHealHP_RemoveItemRet_AnimContinue:
-	playanimation BS_ATTACKER, B_ANIM_SIMPLE_HEAL
+	playanimation BS_SCRIPTING, B_ANIM_SIMPLE_HEAL
 	healthbarupdate BS_SCRIPTING, PASSIVE_HP_UPDATE
 	datahpupdate BS_SCRIPTING, PASSIVE_HP_UPDATE
 	removeitem BS_SCRIPTING


### PR DESCRIPTION
Title. Targets upcoming as the issue stems from it. Thanks to PCG for finding this.

## Description
This is a simple bug fix to the held item healing animation (applicable to Oran Berry, Sitrus Berry, Berry Juice, etc.) that showed `B_ANIM_SIMPLE_HEAL` on the wrong target.

This can be further validated in-game or by using the test `Restore HP Item effects do not miss timing (Berries)`.

### Large Language Models (AI)
None

## Media

https://github.com/user-attachments/assets/ff673822-520f-464d-a476-7d90f19abab4

## Discord contact info
linathan
