### PR TITLE
Fix buffer overrun in ReformatItemDescription

### DIFF
--- a/src/overworld.c
+++ b/src/overworld.c
@@ -32,6 +32,7 @@
 #include "io_reg.h"
 #include "item.h"
 #include "item_icon.h"
+#include "line_break.h"
 #include "link.h"
 #include "link_rfu.h"
 #include "load_save.h"
@@ -3695,49 +3696,10 @@ static void DestroyItemIconSprite(void);
 
 static u8 ReformatItemDescription(enum Item item, u8 *dest)
 {
-    u8 count = 0;
-    u8 numLines = 1;
-    u8 maxChars = 32;
-    u8 *desc = (u8 *)GetItemDescription(item);
-
-    while (*desc != EOS)
-    {
-        if (count >= maxChars)
-        {
-            while (*desc != CHAR_SPACE && *desc != CHAR_NEWLINE)
-            {
-                *dest = *desc;  //finish word
-                if (*desc == EOS)
-                    return numLines;
-                dest++;
-                desc++;
-            }
-
-            *dest = CHAR_NEWLINE;
-            count = 0;
-            numLines++;
-            dest++;
-            desc++;
-            continue;
-        }
-
-        *dest = *desc;
-        if (*desc == CHAR_NEWLINE)
-        {
-            if (count > 0 && *(desc - 1) == CHAR_HYPHEN)
-                dest -= 2;
-            else
-                *dest = CHAR_SPACE;
-        }
-
-        dest++;
-        desc++;
-        count++;
-    }
-
-    // finish string
-    *dest = EOS;
-    return numLines;
+    StringCopy(dest, GetItemDescription(item));
+    StripLineBreaks(dest);
+    BreakStringAutomatic(dest, 196, 2, FONT_SMALL, HIDE_SCROLL_PROMPT);
+    return CountLineBreaks(dest) + 1;
 }
 
 void ScriptShowItemDescription(struct ScriptContext *ctx)

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -3707,6 +3707,8 @@ static u8 ReformatItemDescription(enum Item item, u8 *dest)
             while (*desc != CHAR_SPACE && *desc != CHAR_NEWLINE)
             {
                 *dest = *desc;  //finish word
+                if (*desc == EOS)
+                    return numLines;
                 dest++;
                 desc++;
             }
@@ -3722,7 +3724,10 @@ static u8 ReformatItemDescription(enum Item item, u8 *dest)
         *dest = *desc;
         if (*desc == CHAR_NEWLINE)
         {
-            *dest = CHAR_SPACE;
+            if (count > 0 && *(desc - 1) == CHAR_HYPHEN)
+                dest -= 2;
+            else
+                *dest = CHAR_SPACE;
         }
 
         dest++;


### PR DESCRIPTION
So funny story whenever I pick a red apricorn all of the Pokemon in my party become Bad Eggs, but only in release builds. Turns out there's a possible buffer overrun in `ReformatItemDescription` (used by OW_SHOW_ITEM_DESCRIPTIONS) if the final word of the description causes the text to wrap.

## Description
Fixes the possible buffer overrun in  `ReformatItemDescription`. ~~Also includes a change to collapse hyphens when followed by newlines, so for example `"Poke-\nmon"` becomes `"Pokemon"`.~~

### Large Language Models (AI)
None

<!-- CREDITS -->
<!-- Once your PR is submitted, leave a comment asking the bot to add you to the credits. -->
<!-- If anybody helped with this PR, please encourage them to comment on your PR and ask the bot to add them to the credits. -->
<!-- If somebody has contributed at any point and has indicated they wish to be credited, please ask the bot to add them to the credits. If they do not have a known GitHub account, add them to the list at bottom of `CREDITS.md`. -->
<!-- EVERY contribution matters! -->
<!-- https://github.com/rh-hideout/pokeemerald-expansion/wiki/CREDITS.md-Frequently-Asked-Questions -->

## Discord contact info
plish_plash