### PR TITLE
Fix AI partner seeing all moves bad on dead adjacent opponent battler

### DIFF
--- a/src/battle_ai_switch.c
+++ b/src/battle_ai_switch.c
@@ -509,6 +509,8 @@ static bool32 ShouldSwitchIfAllMovesBad(struct SwitchAiContext *switchContext)
                 ctx.holdEffects[ctx.battlerDef] = gAiLogicData->holdEffects[ctx.battlerDef];
                 if (!IsMoveBad(&ctx, moveIndex))
                     return FALSE;
+                // Restore opposing battler for next move check
+                ctx.battlerDef = switchContext->opposingBattler;
             }
         }
     }

--- a/test/battle/ai/ai_multi.c
+++ b/test/battle/ai/ai_multi.c
@@ -312,3 +312,19 @@ AI_TWO_VS_ONE_BATTLE_TEST("Battler 2 has AI flags set correctly (2v1)")
     }
 }
 
+AI_MULTI_BATTLE_TEST("AI will not switch thinking all moves are bad when one opponent has fainted (multi)")
+{
+    GIVEN {
+        AI_FLAGS(AI_FLAG_SMART_TRAINER);
+        PLAYER(SPECIES_WOBBUFFET);
+        PARTNER(SPECIES_AGGRON) { Moves(MOVE_THUNDERBOLT, MOVE_PROTECT, MOVE_BODY_PRESS); }
+        PARTNER(SPECIES_AGGRON) { Moves(MOVE_THUNDERBOLT, MOVE_PROTECT, MOVE_BODY_PRESS); }
+        OPPONENT_A(SPECIES_GASTLY) { HP(1); Moves(MOVE_CELEBRATE); }
+        OPPONENT_B(SPECIES_CAMERUPT) { Moves(MOVE_CELEBRATE); }
+        OPPONENT_B(SPECIES_CAMERUPT) { Moves(MOVE_CELEBRATE); }
+        TIE_BREAK_TARGET(TARGET_TIE_HI, 0);
+    } WHEN {
+        TURN { EXPECT_MOVE(playerRight, MOVE_THUNDERBOLT, target:opponentLeft); }
+        TURN { EXPECT_MOVE(playerRight, MOVE_BODY_PRESS, target:opponentRight); }
+    }
+}


### PR DESCRIPTION
## Description
Fixes a niche bug where if partner trainer (battler 2) has an ineffective move in slot 1 vs battler 1, and battler 3 is no longer present, all moves are seen as bad due to incorrectly only checking the remaining moves on battler 3, leading to incorrect switch behaviour.

Test fails on master but not on PR

### Large Language Models (AI)
No

## Feature(s) this PR does NOT handle:
Have not checked for other switch funcs where this bug may be present

## Discord contact info
grintoul