### PR TITLE
Random generation cleanup

### DIFF
--- a/include/random.h
+++ b/include/random.h
@@ -45,7 +45,11 @@ static inline u32 _SFC32_Next(struct Sfc32State *state)
 
 static inline u32 LocalRandom32(rng_value_t *val)
 {
+#if TESTING
+    return 0;
+#else
     return _SFC32_Next(val);
+#endif
 }
 
 static inline u16 LocalRandom(rng_value_t *val)

--- a/include/random_mon_generation.h
+++ b/include/random_mon_generation.h
@@ -1,6 +1,7 @@
 #ifndef GUARD_RANDOM_MON_GENERATION_H
 #define GUARD_RANDOM_MON_GENERATION_H
 
+#include "random.h"
 #include "constants/items.h"
 #include "constants/moves.h"
 #include "constants/pokeball.h"
@@ -15,7 +16,9 @@ struct FilterFuncArgs
     u16 arg2;
 };
 
+enum Species GetRandomSpeciesWithSeed(rng_value_t *rng, u32 optionId, const struct FilterFuncArgs *filterFuncArgs);
 enum Species GetRandomSpecies(u32 optionId, const struct FilterFuncArgs *filterFuncArgs);
+enum Item GetRandomItemWithSeed(rng_value_t *rng, u32 optionId, const struct FilterFuncArgs *filterFuncArgs);
 enum Item GetRandomItem(u32 optionId, const struct FilterFuncArgs *filterFuncArgs);
 enum PokeBall GetRandomBall(void);
 void ResolveMoves(enum Species species, u32 level, const u16 *movesTemplate, enum Move *moves);

--- a/src/random_mon_generation.c
+++ b/src/random_mon_generation.c
@@ -337,8 +337,25 @@ enum Species GetRandomSpecies(u32 optionId, const struct FilterFuncArgs *filterF
     return GetRandomSpeciesWithSeed(&gRngValue, optionId, filterFuncArgs);
 }
 
-static bool32 IsRandomItemAllowed(const struct RandomItemGeneratorOptions *options, enum Item item, const struct FilterFuncArgs *filterFuncArgs)
+static bool32 UNUSED IsHeldItemFilterFunc(enum Item item, const struct FilterFuncArgs *filterFuncArgs)
 {
+    (void)filterFuncArgs;
+
+    return GetItemHoldEffect(item) != HOLD_EFFECT_NONE;
+}
+
+struct RandomItemParams
+{
+    const struct RandomItemGeneratorOptions *options;
+    const struct FilterFuncArgs *filterFuncArgs;
+};
+
+static bool32 IsRandomItemAllowed(s32 item, void *params)
+{
+    struct RandomItemParams *itemParams = (struct RandomItemParams *)params;
+    const struct RandomItemGeneratorOptions *options = itemParams->options;
+    const struct FilterFuncArgs *filterFuncArgs = itemParams->filterFuncArgs;
+
     enum HoldEffect holdEffect = GetItemHoldEffect(item);
 
     if (GetItemPocket(item) == POCKET_KEY_ITEMS)
@@ -354,26 +371,6 @@ static bool32 IsRandomItemAllowed(const struct RandomItemGeneratorOptions *optio
         return FALSE;
 
     return TRUE;
-}
-
-struct RandomItemParams
-{
-    const struct RandomItemGeneratorOptions *options;
-    const struct FilterFuncArgs *filterFuncArgs;
-};
-
-static bool32 IsItemAllowed(s32 index, void *params)
-{
-    const struct RandomItemParams *itemParams = (struct RandomItemParams *)params;
-
-    return IsRandomItemAllowed(itemParams->options, index, itemParams->filterFuncArgs);
-}
-
-static bool32 UNUSED IsHeldItemFilterFunc(enum Item item, const struct FilterFuncArgs *filterFuncArgs)
-{
-    (void)filterFuncArgs;
-
-    return GetItemHoldEffect(item) != HOLD_EFFECT_NONE;
 }
 
 enum Item GetRandomItemWithSeed(rng_value_t *rng, u32 optionId, const struct FilterFuncArgs *filterFuncArgs)
@@ -418,7 +415,7 @@ enum Item GetRandomItemWithSeed(rng_value_t *rng, u32 optionId, const struct Fil
         .options = options,
         .filterFuncArgs = filterFuncArgs,
     };
-    s32 randItemIndex = RandomElementFromFilteredArray(rng, itemIndexes, poolSize, &IsItemAllowed, (void *)&itemParams);
+    s32 randItemIndex = RandomElementFromFilteredArray(rng, itemIndexes, poolSize, &IsRandomItemAllowed, (void *)&itemParams);
     if (randItemIndex == poolSize)
     {
         errorf("Could not find a random held item matching random item options");

--- a/src/random_mon_generation.c
+++ b/src/random_mon_generation.c
@@ -13,7 +13,6 @@
 #include "constants/pokeball.h"
 #include "constants/species.h"
 
-#define EXHAUSTIVE_SEARCH_POOL_MAX_SIZE 20
 #define INVALID_RANDOM_SPECIES SPECIES_NONE
 
 enum RandomSpeciesDexMode
@@ -232,9 +231,9 @@ static bool32 DoesSpeciesHaveValidForm(s32 species, void *params)
     if (!options->randomizeForms || formTable == NULL)
     {
         if (IsSpeciesBannedByRandomSpeciesOptions(species, options, filterFuncArgs))
-            return TRUE;
-        else
             return FALSE;
+        else
+            return TRUE;
     }
 
     u16 validForms[RANDOM_MON_MAX_FORMS];
@@ -304,6 +303,7 @@ enum Species GetRandomSpeciesWithSeed(rng_value_t *rng, u32 optionId, const stru
         .rng = rng,
         .randomForm = 0,
     };
+
     s32 randSpeciesIndex = RandomElementFromFilteredArray(rng, speciesIndexes, poolSize, &DoesSpeciesHaveValidForm, (void *)&speciesParams);
     enum Species result;
     if (randSpeciesIndex == poolSize)
@@ -357,11 +357,11 @@ struct RandomItemParams
     const struct FilterFuncArgs *filterFuncArgs;
 };
 
-static bool32 IsRandomItemExcluded(s32 index, void *params)
+static bool32 IsItemAllowed(s32 index, void *params)
 {
     const struct RandomItemParams *itemParams = (struct RandomItemParams *)params;
 
-    return !IsRandomItemAllowed(itemParams->options, index, itemParams->filterFuncArgs);
+    return IsRandomItemAllowed(itemParams->options, index, itemParams->filterFuncArgs);
 }
 
 static bool32 UNUSED IsHeldItemFilterFunc(enum Item item, const struct FilterFuncArgs *filterFuncArgs)
@@ -413,7 +413,7 @@ enum Item GetRandomItemWithSeed(rng_value_t *rng, u32 optionId, const struct Fil
         .options = options,
         .filterFuncArgs = filterFuncArgs,
     };
-    s32 randItemIndex = RandomElementFromFilteredArray(rng, itemIndexes, poolSize, &IsRandomItemExcluded, (void *)&itemParams);
+    s32 randItemIndex = RandomElementFromFilteredArray(rng, itemIndexes, poolSize, &IsItemAllowed, (void *)&itemParams);
     if (randItemIndex == poolSize)
     {
         errorf("Could not find a random held item matching random item options");

--- a/src/random_mon_generation.c
+++ b/src/random_mon_generation.c
@@ -63,13 +63,12 @@ static bool32 IsMoveInMoveset(enum Move move, enum Move *moves, u32 count);
 static s32 RandomElementFromFilteredArray(rng_value_t *rng, s32 *array, u32 length, bool32 (*filterFunc)(s32 value, void *params), void *params)
 {
     u32 index;
-    s32 tmp;
     for (u32 i = 0; i < length; i++)
     {
-        index = LocalRandom32(rng) % (length - 1);
-        if (!filterFunc(array[index], params))
+        index = LocalRandom32(rng) % (length - 1 - i);
+        if (filterFunc(array[index], params))
             return index;
-        SWAP(array[length - 1 - i], array[index], tmp);
+        array[index] = array[length - 1 - i];
     }
     errorf("Could not find a value matching filter in array");
     return length;

--- a/src/random_mon_generation.c
+++ b/src/random_mon_generation.c
@@ -50,8 +50,6 @@ struct RandomItemGeneratorOptions
 
 static bool32 UNUSED IsInBstRangeFilterFunc(enum Species species, const struct FilterFuncArgs *filterFuncArgs);
 static bool32 UNUSED IsHeldItemFilterFunc(enum Item item, const struct FilterFuncArgs *filterFuncArgs);
-static enum PokeBall GetRandomBall(void);
-static enum PokeBall ResolveRandomBall(enum PokeBall ball);
 static bool32 MoveOrder(enum Move moveA, enum Move moveB);
 static void SortMoves(enum Move *moves);
 static bool32 IsMoveInMoveset(enum Move move, enum Move *moves, u32 count);

--- a/src/random_mon_generation.c
+++ b/src/random_mon_generation.c
@@ -1,6 +1,7 @@
 #include "global.h"
 #include "event_data.h"
 #include "item.h"
+#include "malloc.h"
 #include "pokemon.h"
 #include "random.h"
 #include "random_mon_generation.h"
@@ -47,15 +48,8 @@ struct RandomItemGeneratorOptions
     u16 bannedHoldEffectsCount;
 };
 
-static enum Species GetSpeciesCandidateForm(enum Species species, const struct RandomSpeciesGeneratorOptions *options, const struct FilterFuncArgs *filterFuncArgs);
 static bool32 UNUSED IsInBstRangeFilterFunc(enum Species species, const struct FilterFuncArgs *filterFuncArgs);
-static enum Species GetRandomSpeciesAtIndex(const struct RandomSpeciesGeneratorOptions *options, u32 index);
-static enum Species SlowPickRandomSpecies(const struct RandomSpeciesGeneratorOptions *options, u32 poolSize, const struct FilterFuncArgs *filterFuncArgs);
-static enum Species FastPickRandomSpecies(const struct RandomSpeciesGeneratorOptions *options, u32 poolSize, const struct FilterFuncArgs *filterFuncArgs);
-static enum Item GetRandomItemAtIndex(const struct RandomItemGeneratorOptions *options, u32 index);
 static bool32 UNUSED IsHeldItemFilterFunc(enum Item item, const struct FilterFuncArgs *filterFuncArgs);
-static enum Item SlowPickRandomItem(const struct RandomItemGeneratorOptions *options, u32 poolSize, const struct FilterFuncArgs *filterFuncArgs);
-static enum Item FastPickRandomItem(const struct RandomItemGeneratorOptions *options, u32 poolSize, const struct FilterFuncArgs *filterFuncArgs);
 static enum PokeBall GetRandomBall(void);
 static enum PokeBall ResolveRandomBall(enum PokeBall ball);
 static bool32 MoveOrder(enum Move moveA, enum Move moveB);
@@ -68,6 +62,21 @@ static void ResolveRandomMoves(enum Species species, enum Move *moves);
 #else
 #include "data/random_mon_generator.h"
 #endif
+
+static s32 RandomElementFromFilteredArray(rng_value_t *rng, s32 *array, u32 length, bool32 (*filterFunc)(s32 value, void *params), void *params)
+{
+    u32 index;
+    s32 tmp;
+    for (u32 i = 0; i < length; i++)
+    {
+        index = LocalRandom32(rng) % (length - 1);
+        if (!filterFunc(array[index], params))
+            return index;
+        SWAP(array[length - 1 - i], array[index], tmp);
+    }
+    errorf("Could not find a value matching filter in array");
+    return length;
+}
 
 static bool32 IsSpeciesBannedByRandomSpeciesOptions(enum Species species, const struct RandomSpeciesGeneratorOptions *options, const struct FilterFuncArgs *filterFuncArgs)
 {
@@ -119,17 +128,6 @@ static bool32 UNUSED IsInBstRangeFilterFunc(enum Species species, const struct F
     maxBst = bstStandard + bstLeniency;
 
     return bst >= minBst && bst <= maxBst;
-}
-
-static enum Species GetRandomSpeciesAtIndex(const struct RandomSpeciesGeneratorOptions *options, u32 index)
-{
-    if (options->speciesPoolCount != 0)
-        return options->speciesPool[index];
-
-    if (options->dexMode == RANDOM_MON_DEX_HOENN)
-        return NationalPokedexNumToSpecies(HoennToNationalOrder(index + 1));
-
-    return NationalPokedexNumToSpecies(index + 1);
 }
 
 static bool32 IsRandomSpeciesFormTableException(enum Species species)
@@ -220,33 +218,44 @@ static bool32 IsRandomSpeciesFormAllowed(enum Species species, const u16 *formTa
         && !speciesInfo->isPrimalReversion;
 }
 
-static enum Species GetSpeciesCandidateForm(enum Species species, const struct RandomSpeciesGeneratorOptions *options, const struct FilterFuncArgs *filterFuncArgs)
+struct RandomSpeciesParams
 {
-    const u16 *formTable = GetSpeciesFormTable(species);
-    u16 validFormsCount = 0;
-    u16 validForms[RANDOM_MON_MAX_FORMS];
+    const struct RandomSpeciesGeneratorOptions *options;
+    const struct FilterFuncArgs *filterFuncArgs;
+    rng_value_t *rng;
+    u32 randomForm;
+};
 
+static bool32 DoesSpeciesHaveValidForm(s32 species, void *params)
+{
+    struct RandomSpeciesParams *speciesParams = (struct RandomSpeciesParams *)params;
+    const struct RandomSpeciesGeneratorOptions *options = speciesParams->options;
+    const struct FilterFuncArgs *filterFuncArgs = speciesParams->filterFuncArgs;
+
+    const u16 *formTable = GetSpeciesFormTable(species);
     if (!options->randomizeForms || formTable == NULL)
     {
         if (IsSpeciesBannedByRandomSpeciesOptions(species, options, filterFuncArgs))
-            return SPECIES_NONE;
-        return species;
+            return TRUE;
+        else
+            return FALSE;
     }
 
+    u16 validForms[RANDOM_MON_MAX_FORMS];
+    u32 validFormsCount = 0;
     for (u32 i = 0; formTable[i] != FORM_SPECIES_END; i++)
     {
         if (IsRandomSpeciesFormAllowed(formTable[i], formTable)
          && !IsSpeciesBannedByRandomSpeciesOptions(formTable[i], options, filterFuncArgs))
             validForms[validFormsCount++] = i;
     }
-
     if (validFormsCount == 0)
-        return SPECIES_NONE;
-
-    return formTable[validForms[RandomUniform(RNG_NONE, 0, validFormsCount - 1)]];
+        return FALSE;
+    speciesParams->randomForm = validForms[LocalRandom32(speciesParams->rng) % (validFormsCount - 1)];
+    return TRUE;
 }
 
-enum Species GetRandomSpecies(u32 optionId, const struct FilterFuncArgs *filterFuncArgs)
+enum Species GetRandomSpeciesWithSeed(rng_value_t *rng, u32 optionId, const struct FilterFuncArgs *filterFuncArgs)
 {
     const struct RandomSpeciesGeneratorOptions *options;
     u32 poolSize;
@@ -275,46 +284,56 @@ enum Species GetRandomSpecies(u32 optionId, const struct FilterFuncArgs *filterF
         poolSize = NATIONAL_DEX_COUNT;
     }
 
-    if (poolSize <= EXHAUSTIVE_SEARCH_POOL_MAX_SIZE)
-        return SlowPickRandomSpecies(options, poolSize, filterFuncArgs);
 
-    return FastPickRandomSpecies(options, poolSize, filterFuncArgs);
-}
-
-static enum Species SlowPickRandomSpecies(const struct RandomSpeciesGeneratorOptions *options, u32 poolSize, const struct FilterFuncArgs *filterFuncArgs)
-{
-    u32 eligibleSpeciesCount = 0;
-    enum Species eligibleSpecies[EXHAUSTIVE_SEARCH_POOL_MAX_SIZE];
-
-    for (u32 i = 0; i < poolSize; i++)
+    s32 *speciesIndexes = Alloc(poolSize * sizeof(s32));
+    if (options->speciesPoolCount != 0)
     {
-        enum Species species = GetRandomSpeciesAtIndex(options, i);
-        species = GetSpeciesCandidateForm(species, options, filterFuncArgs);
-        if (species != SPECIES_NONE)
-            eligibleSpecies[eligibleSpeciesCount++] = species;
+        for (u32 i = 0; i < poolSize; i++)
+            speciesIndexes[i] = options->speciesPool[i];
+    }
+    else if (options->dexMode == RANDOM_MON_DEX_HOENN)
+    {
+        for (u32 i = 0; i < poolSize; i++)
+            speciesIndexes[i] = HoennToNationalOrder(i + 1);
+    }
+    else
+    {
+        for (u32 i = 0; i < poolSize; i++)
+            speciesIndexes[i] = i + 1;
     }
 
-    if (eligibleSpeciesCount == 0)
+    struct RandomSpeciesParams speciesParams = {
+        .options = options,
+        .filterFuncArgs = filterFuncArgs,
+        .rng = rng,
+        .randomForm = 0,
+    };
+    s32 randSpeciesIndex = RandomElementFromFilteredArray(rng, speciesIndexes, poolSize, &DoesSpeciesHaveValidForm, (void *)&speciesParams);
+    enum Species result;
+    if (randSpeciesIndex == poolSize)
     {
         errorf("Could not find a random species matching random species options");
-        return INVALID_RANDOM_SPECIES;
+        result = INVALID_RANDOM_SPECIES;
     }
-
-    return eligibleSpecies[RandomUniform(RNG_NONE, 0, eligibleSpeciesCount - 1)];
+    else
+    {
+        if (options->randomizeForms)
+        {
+            const u16 *formTable = GetSpeciesFormTable(speciesIndexes[randSpeciesIndex]);
+            result = formTable[speciesParams.randomForm];
+        }
+        else
+        {
+            result = speciesIndexes[randSpeciesIndex];
+        }
+    }
+    Free(speciesIndexes);
+    return result;
 }
 
-static enum Species FastPickRandomSpecies(const struct RandomSpeciesGeneratorOptions *options, u32 poolSize, const struct FilterFuncArgs *filterFuncArgs)
+enum Species GetRandomSpecies(u32 optionId, const struct FilterFuncArgs *filterFuncArgs)
 {
-    for (u32 i = 0; i < poolSize; i++)
-    {
-        enum Species species = GetRandomSpeciesAtIndex(options, RandomUniform(RNG_NONE, 0, poolSize - 1));
-        species = GetSpeciesCandidateForm(species, options, filterFuncArgs);
-        if (species != SPECIES_NONE)
-            return species;
-    }
-
-    errorf("Could not get random species after %d tries", poolSize);
-    return INVALID_RANDOM_SPECIES;
+    return GetRandomSpeciesWithSeed(&gRngValue, optionId, filterFuncArgs);
 }
 
 static bool32 IsRandomItemAllowed(const struct RandomItemGeneratorOptions *options, enum Item item, const struct FilterFuncArgs *filterFuncArgs)
@@ -336,6 +355,19 @@ static bool32 IsRandomItemAllowed(const struct RandomItemGeneratorOptions *optio
     return TRUE;
 }
 
+struct RandomItemParams
+{
+    const struct RandomItemGeneratorOptions *options;
+    const struct FilterFuncArgs *filterFuncArgs;
+};
+
+static bool32 IsRandomItemExcluded(s32 index, void *params)
+{
+    const struct RandomItemParams *itemParams = (struct RandomItemParams *)params;
+
+    return !IsRandomItemAllowed(itemParams->options, index, itemParams->filterFuncArgs);
+}
+
 static bool32 UNUSED IsHeldItemFilterFunc(enum Item item, const struct FilterFuncArgs *filterFuncArgs)
 {
     (void)filterFuncArgs;
@@ -343,52 +375,11 @@ static bool32 UNUSED IsHeldItemFilterFunc(enum Item item, const struct FilterFun
     return GetItemHoldEffect(item) != HOLD_EFFECT_NONE;
 }
 
-static enum Item GetRandomItemAtIndex(const struct RandomItemGeneratorOptions *options, u32 index)
-{
-    if (options->heldItemPoolCount != 0)
-        return options->heldItemPool[index];
-
-    return index + 1;
-}
-
-static enum Item SlowPickRandomItem(const struct RandomItemGeneratorOptions *options, u32 poolSize, const struct FilterFuncArgs *filterFuncArgs)
-{
-    u32 eligibleItemCount = 0;
-    enum Item eligibleItems[EXHAUSTIVE_SEARCH_POOL_MAX_SIZE];
-
-    for (u32 i = 0; i < poolSize; i++)
-    {
-        enum Item item = GetRandomItemAtIndex(options, i);
-        if (IsRandomItemAllowed(options, item, filterFuncArgs))
-            eligibleItems[eligibleItemCount++] = item;
-    }
-
-    assertf(eligibleItemCount > 0, "Could not find a random held item matching random item options")
-    {
-        return ITEM_NONE;
-    }
-
-    return eligibleItems[RandomUniform(RNG_NONE, 0, eligibleItemCount - 1)];
-}
-
-static enum Item FastPickRandomItem(const struct RandomItemGeneratorOptions *options, u32 poolSize, const struct FilterFuncArgs *filterFuncArgs)
-{
-    for (u32 i = 0; i < poolSize; i++)
-    {
-        enum Item item = GetRandomItemAtIndex(options, RandomUniform(RNG_NONE, 0, poolSize - 1));
-        if (IsRandomItemAllowed(options, item, filterFuncArgs))
-            return item;
-    }
-
-    errorf("Could not get random held item after %d tries", poolSize);
-
-    return ITEM_NONE;
-}
-
-enum Item GetRandomItem(u32 optionId, const struct FilterFuncArgs *filterFuncArgs)
+enum Item GetRandomItemWithSeed(rng_value_t *rng, u32 optionId, const struct FilterFuncArgs *filterFuncArgs)
 {
     const struct RandomItemGeneratorOptions *options;
     u32 poolSize;
+    enum Item result;
 
     assertf(optionId < RANDOM_ITEM_OPTIONS_COUNT, "invalid random item option: %d", optionId)
     {
@@ -410,10 +401,39 @@ enum Item GetRandomItem(u32 optionId, const struct FilterFuncArgs *filterFuncArg
         poolSize = ITEMS_COUNT - 1;
     }
 
-    if (poolSize <= EXHAUSTIVE_SEARCH_POOL_MAX_SIZE)
-        return SlowPickRandomItem(options, poolSize, filterFuncArgs);
+    s32 *itemIndexes = Alloc(poolSize * sizeof(s32));
+    if (options->heldItemPoolCount != 0)
+    {
+        for (u32 i = 0; i < poolSize; i++)
+            itemIndexes[i] = options->heldItemPool[i];
+    }
+    else
+    {
+        for (u32 i = 0; i < poolSize; i++)
+            itemIndexes[i] = i + 1;
+    }
 
-    return FastPickRandomItem(options, poolSize, filterFuncArgs);
+    struct RandomItemParams itemParams = {
+        .options = options,
+        .filterFuncArgs = filterFuncArgs,
+    };
+    s32 randItemIndex = RandomElementFromFilteredArray(rng, itemIndexes, poolSize, &IsRandomItemExcluded, (void *)&itemParams);
+    if (randItemIndex == poolSize)
+    {
+        errorf("Could not find a random held item matching random item options");
+        result = ITEM_NONE;
+    }
+    else
+    {
+        result = itemIndexes[randItemIndex];
+    }
+    Free(itemIndexes);
+    return result;
+}
+
+enum Item GetRandomItem(u32 optionId, const struct FilterFuncArgs *filterFuncArgs)
+{
+    return GetRandomItemWithSeed(&gRngValue, optionId, filterFuncArgs);
 }
 
 static enum PokeBall GetRandomBall(void)

--- a/src/random_mon_generation.c
+++ b/src/random_mon_generation.c
@@ -218,7 +218,7 @@ struct RandomSpeciesParams
     const struct RandomSpeciesGeneratorOptions *options;
     const struct FilterFuncArgs *filterFuncArgs;
     rng_value_t *rng;
-    u32 randomForm;
+    s32 randomForm;
 };
 
 static bool32 DoesSpeciesHaveValidForm(s32 species, void *params)
@@ -236,17 +236,22 @@ static bool32 DoesSpeciesHaveValidForm(s32 species, void *params)
             return TRUE;
     }
 
-    u16 validForms[RANDOM_MON_MAX_FORMS];
-    u32 validFormsCount = 0;
+    u32 selectedFormScore = 0;
+    u32 currentFormScore;
     for (u32 i = 0; formTable[i] != FORM_SPECIES_END; i++)
     {
-        if (IsRandomSpeciesFormAllowed(formTable[i], formTable)
-         && !IsSpeciesBannedByRandomSpeciesOptions(formTable[i], options, filterFuncArgs))
-            validForms[validFormsCount++] = i;
+        if (!IsRandomSpeciesFormAllowed(formTable[i], formTable)
+         || IsSpeciesBannedByRandomSpeciesOptions(formTable[i], options, filterFuncArgs))
+            continue;
+        currentFormScore = LocalRandom32(speciesParams->rng);
+        if (currentFormScore >= selectedFormScore)
+        {
+            speciesParams->randomForm = i;
+            selectedFormScore = currentFormScore;
+        }
     }
-    if (validFormsCount == 0)
+    if (speciesParams->randomForm == -1)
         return FALSE;
-    speciesParams->randomForm = validForms[LocalRandom32(speciesParams->rng) % (validFormsCount - 1)];
     return TRUE;
 }
 
@@ -301,7 +306,7 @@ enum Species GetRandomSpeciesWithSeed(rng_value_t *rng, u32 optionId, const stru
         .options = options,
         .filterFuncArgs = filterFuncArgs,
         .rng = rng,
-        .randomForm = 0,
+        .randomForm = -1,
     };
 
     s32 randSpeciesIndex = RandomElementFromFilteredArray(rng, speciesIndexes, poolSize, &DoesSpeciesHaveValidForm, (void *)&speciesParams);


### PR DESCRIPTION
Create a new function to pick an element from a list with elements that are excluded based on a filter function.

Previously, we would have two functions:
- if the list as small, we would exhaustive search for all the valid values and pick a random one
- if the list was big, we would pick values at random until we find a valid one

The first method was too slow for big list but the second method risks to run forever and no failsafe for a list containing no valid values.

So I replaced both functions with a new one, I perform a Fisher–Yates shuffle on my list that will stop if I find a random element. This increases the space complexity to O(n) because I now need to make a in-memory copy of a previously static list but this guarantees to test every value and finds the value fastest on average

I also added an argument to handle passing a rng_value_t so that the functions can be used with seed based randomisers 

## Discord contact info
Jamie
