### PR TITLE
Fix Eerie Spell PP reduction for Max Moves

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2895,13 +2895,17 @@ void SetMoveEffect(enum BattlerId battlerAtk, enum BattlerId effectBattler, enum
         }
         break;
     case MOVE_EFFECT_EERIE_SPELL:
-        if (gLastMoves[effectBattler] != MOVE_NONE && gLastMoves[effectBattler] != 0xFFFF)
+        if (gLastMoves[effectBattler] != MOVE_NONE && gLastMoves[effectBattler] != MOVE_UNAVAILABLE)
         {
             u32 i;
+            enum Move moveToReduce = gLastMoves[effectBattler];
+
+            if (IsMaxMove(moveToReduce))
+                moveToReduce = gBattleStruct->dynamax.baseMoves[effectBattler];
 
             for (i = 0; i < MAX_MON_MOVES; i++)
             {
-                if (gLastMoves[effectBattler] == gBattleMons[effectBattler].moves[i])
+                if (moveToReduce == gBattleMons[effectBattler].moves[i])
                     break;
             }
 
@@ -2912,7 +2916,7 @@ void SetMoveEffect(enum BattlerId battlerAtk, enum BattlerId effectBattler, enum
                 if (gBattleMons[effectBattler].pp[i] < ppToDeduct)
                     ppToDeduct = gBattleMons[effectBattler].pp[i];
 
-                PREPARE_MOVE_BUFFER(gBattleTextBuff1, gLastMoves[effectBattler])
+                PREPARE_MOVE_BUFFER(gBattleTextBuff1, moveToReduce)
                 ConvertIntToDecimalStringN(gBattleTextBuff2, ppToDeduct, STR_CONV_MODE_LEFT_ALIGN, 1);
                 PREPARE_BYTE_NUMBER_BUFFER(gBattleTextBuff2, 1, ppToDeduct)
                 gBattleMons[effectBattler].pp[i] -= ppToDeduct;

--- a/test/battle/move_effect_secondary/eerie_spell.c
+++ b/test/battle/move_effect_secondary/eerie_spell.c
@@ -1,0 +1,98 @@
+#include "global.h"
+#include "test/battle.h"
+
+ASSUMPTIONS
+{
+    ASSUME(MoveHasAdditionalEffect(MOVE_EERIE_SPELL, MOVE_EFFECT_EERIE_SPELL));
+}
+
+SINGLE_BATTLE_TEST("Eerie Spell reduces the PP of the target's last move by 3")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SCRATCH); MOVE(player, MOVE_EERIE_SPELL); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
+        HP_BAR(player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EERIE_SPELL, player);
+        HP_BAR(opponent);
+        MESSAGE("The opposing Wobbuffet lost 3 PP from Scratch!");
+    } THEN {
+        EXPECT_EQ(opponent->pp[0], GetMovePP(MOVE_SCRATCH) - 4); // 1 from Scratch use + 3 from Eerie Spell
+    }
+}
+
+SINGLE_BATTLE_TEST("Eerie Spell reduces the PP of a Max Move's base move by 3")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SCRATCH, gimmick: GIMMICK_DYNAMAX); MOVE(player, MOVE_EERIE_SPELL); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_MAX_STRIKE, opponent);
+        HP_BAR(player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EERIE_SPELL, player);
+        HP_BAR(opponent);
+        MESSAGE("The opposing Wobbuffet lost 3 PP from Scratch!");
+    } THEN {
+        EXPECT_EQ(opponent->pp[0], GetMovePP(MOVE_SCRATCH) - 4); // 1 from Max Move use + 3 from Eerie Spell
+    }
+}
+
+SINGLE_BATTLE_TEST("Eerie Spell's PP reduction is blocked by Shield Dust")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_VIVILLON) { Ability(ABILITY_SHIELD_DUST); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SCRATCH); MOVE(player, MOVE_EERIE_SPELL); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
+        HP_BAR(player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EERIE_SPELL, player);
+        HP_BAR(opponent);
+        NOT MESSAGE("The opposing Vivillon lost 3 PP from Scratch!");
+    } THEN {
+        EXPECT_EQ(opponent->pp[0], GetMovePP(MOVE_SCRATCH) - 1);
+    }
+}
+
+SINGLE_BATTLE_TEST("Eerie Spell's PP reduction is blocked by Covert Cloak")
+{
+    GIVEN {
+        ASSUME(gItemsInfo[ITEM_COVERT_CLOAK].holdEffect == HOLD_EFFECT_COVERT_CLOAK);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_COVERT_CLOAK); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SCRATCH); MOVE(player, MOVE_EERIE_SPELL); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
+        HP_BAR(player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EERIE_SPELL, player);
+        HP_BAR(opponent);
+        NOT MESSAGE("The opposing Wobbuffet lost 3 PP from Scratch!");
+    } THEN {
+        EXPECT_EQ(opponent->pp[0], GetMovePP(MOVE_SCRATCH) - 1);
+    }
+}
+
+SINGLE_BATTLE_TEST("Eerie Spell does not reduce PP if the target faints")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { HP(1); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SCRATCH); MOVE(player, MOVE_EERIE_SPELL); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
+        HP_BAR(player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EERIE_SPELL, player);
+        HP_BAR(opponent);
+        NOT MESSAGE("The opposing Wobbuffet lost 3 PP from Scratch!");
+    } THEN {
+        EXPECT_EQ(opponent->pp[0], GetMovePP(MOVE_SCRATCH) - 1); // Eerie Spell's PP reduction happens after fainting checks
+    }
+}


### PR DESCRIPTION
## Description
[Eerie Spell](https://wiki.pokemonwiki.com/wiki/%e3%81%b6%e3%81%8d%e3%81%bf%e3%81%aa%e3%81%98%e3%82%85%e3%82%82%e3%82%93)
> ダイマックスわざとそのベースになった技は同一視される。

_Dynamax moves and their base moves are treated as the same move._

> 追加効果としては例外的に、ひんし判定の後に技の効果が発動する。この技で相手をひんしにさせたときはPPを減らさない。

_As an exception among additional effects, this move's PP‑reducing effect activates after the fainting check. If this move causes the target to faint, it does not reduce PP._