### PR TITLE
Fix Mental Herb leaving volatile status timers uncleared

### DIFF
--- a/src/battle_hold_effects.c
+++ b/src/battle_hold_effects.c
@@ -431,14 +431,15 @@ static enum ItemEffect TryMentalHerb(enum BattlerId battler, ActivationTiming ti
         if (gBattleMons[battler].volatiles.torment == TRUE)
         {
             gBattleMons[battler].volatiles.torment = FALSE;
+            gBattleMons[battler].volatiles.tormentTimer = 0;
             gBattleCommunication[MULTISTRING_CHOOSER] |= 1 << B_MSG_MENTALHERBCURE_TORMENT;
             effect = ITEM_EFFECT_OTHER;
         }
         // Check disable
         if (gBattleMons[battler].volatiles.disableTimer != 0)
         {
+            gBattleMons[battler].volatiles.disabledMove = MOVE_NONE;
             gBattleMons[battler].volatiles.disableTimer = 0;
-            gBattleMons[battler].volatiles.disabledMove = 0;
             gBattleCommunication[MULTISTRING_CHOOSER] |= 1 << B_MSG_MENTALHERBCURE_DISABLE;
             effect = ITEM_EFFECT_OTHER;
         }
@@ -446,13 +447,14 @@ static enum ItemEffect TryMentalHerb(enum BattlerId battler, ActivationTiming ti
         if (gBattleMons[battler].volatiles.healBlock)
         {
             gBattleMons[battler].volatiles.healBlock = FALSE;
+            gBattleMons[battler].volatiles.healBlockTimer = 0;
             gBattleCommunication[MULTISTRING_CHOOSER] |= 1 << B_MSG_MENTALHERBCURE_HEALBLOCK;
             effect = ITEM_EFFECT_OTHER;
         }
         // Check encore
         if (gBattleMons[battler].volatiles.encoreTimer != 0)
         {
-            gBattleMons[battler].volatiles.encoredMove = 0;
+            gBattleMons[battler].volatiles.encoredMove = MOVE_NONE;
             gBattleMons[battler].volatiles.encoreTimer = 0;
             gBattleCommunication[MULTISTRING_CHOOSER] |= 1 << B_MSG_MENTALHERBCURE_ENCORE;
             effect = ITEM_EFFECT_OTHER;

--- a/test/battle/hold_effect/mental_herb.c
+++ b/test/battle/hold_effect/mental_herb.c
@@ -1,16 +1,20 @@
 #include "global.h"
 #include "test/battle.h"
 
+ASSUMPTIONS
+{
+    ASSUME(gItemsInfo[ITEM_MENTAL_HERB].holdEffect == HOLD_EFFECT_MENTAL_HERB);
+}
+
 SINGLE_BATTLE_TEST("Mental Herb cures infatuation")
 {
     GIVEN {
-        ASSUME(gItemsInfo[ITEM_MENTAL_HERB].holdEffect == HOLD_EFFECT_MENTAL_HERB);
+        ASSUME(GetMoveEffect(MOVE_ATTRACT) == EFFECT_ATTRACT);
         PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_MENTAL_HERB); Gender(MON_MALE); }
         OPPONENT(SPECIES_WOBBUFFET) { Gender(MON_FEMALE); }
     } WHEN {
         TURN { MOVE(opponent, MOVE_ATTRACT); }
     } SCENE {
-        MESSAGE("The opposing Wobbuffet used Attract!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ATTRACT, opponent);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
         MESSAGE("Wobbuffet cured its infatuation status using its Mental Herb!");
@@ -23,17 +27,35 @@ SINGLE_BATTLE_TEST("Mental Herb cures Torment volatile status (Gen 5+)")
 {
     GIVEN {
         WITH_CONFIG(B_MENTAL_HERB, GEN_5);
-        ASSUME(gItemsInfo[ITEM_MENTAL_HERB].holdEffect == HOLD_EFFECT_MENTAL_HERB);
+        ASSUME(GetMoveEffect(MOVE_TORMENT) == EFFECT_TORMENT);
         PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_MENTAL_HERB); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
         TURN { MOVE(opponent, MOVE_TORMENT); }
     } SCENE {
-        MESSAGE("The opposing Wobbuffet used Torment!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TORMENT, opponent);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
         MESSAGE("Wobbuffet is no longer tormented!");
     } THEN {
+        EXPECT(player->volatiles.torment == FALSE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Mental Herb clears the Torment timer set by G-Max Meltdown (Gen 5+)")
+{
+    GIVEN {
+        WITH_CONFIG(B_MENTAL_HERB, GEN_5);
+        ASSUME(MoveHasAdditionalEffect(MOVE_G_MAX_MELTDOWN, MOVE_EFFECT_TORMENT_SIDE));
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_MENTAL_HERB); }
+        OPPONENT(SPECIES_MELMETAL) { GigantamaxFactor(TRUE); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_IRON_HEAD, gimmick: GIMMICK_DYNAMAX); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_G_MAX_MELTDOWN, opponent);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+        MESSAGE("Wobbuffet is no longer tormented!");
+    } THEN {
+        EXPECT(player->volatiles.torment == FALSE);
         EXPECT(player->volatiles.tormentTimer == 0);
     }
 }
@@ -42,17 +64,18 @@ SINGLE_BATTLE_TEST("Mental Herb cures Disable volatile status (Gen 5+)")
 {
     GIVEN {
         WITH_CONFIG(B_MENTAL_HERB, GEN_5);
-        ASSUME(gItemsInfo[ITEM_MENTAL_HERB].holdEffect == HOLD_EFFECT_MENTAL_HERB);
+        ASSUME(GetMoveEffect(MOVE_DISABLE) == EFFECT_DISABLE);
         PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_MENTAL_HERB); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
         TURN { MOVE(opponent, MOVE_CELEBRATE); }
         TURN { MOVE(opponent, MOVE_DISABLE); }
     } SCENE {
-        MESSAGE("The opposing Wobbuffet used Disable!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DISABLE, opponent);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
         MESSAGE("Wobbuffet's move is no longer disabled!");
     } THEN {
+        EXPECT(player->volatiles.disabledMove == MOVE_NONE);
         EXPECT(player->volatiles.disableTimer == 0);
     }
 }
@@ -66,22 +89,20 @@ SINGLE_BATTLE_TEST("Mental Herb cures Heal Block volatile status (Gen 5+)")
 
     GIVEN {
         WITH_CONFIG(B_MENTAL_HERB, GEN_5);
-        ASSUME(gItemsInfo[ITEM_MENTAL_HERB].holdEffect == HOLD_EFFECT_MENTAL_HERB);
+        ASSUME(GetMoveEffect(MOVE_HEAL_BLOCK) == EFFECT_HEAL_BLOCK);
+        ASSUME(MoveHasAdditionalEffect(MOVE_PSYCHIC_NOISE, MOVE_EFFECT_PSYCHIC_NOISE));
         PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_MENTAL_HERB); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
         TURN { MOVE(opponent, move); }
     } SCENE {
-        if (move == MOVE_HEAL_BLOCK)
-            MESSAGE("The opposing Wobbuffet used Heal Block!");
-        else
-            MESSAGE("The opposing Wobbuffet used Psychic Noise!");
         ANIMATION(ANIM_TYPE_MOVE, move, opponent);
         MESSAGE("Wobbuffet was prevented from healing!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
         MESSAGE("Wobbuffet is no longer prevented from healing!");
     } THEN {
         EXPECT(player->volatiles.healBlock == FALSE);
+        EXPECT(player->volatiles.healBlockTimer == 0);
     }
 }
 
@@ -89,18 +110,18 @@ SINGLE_BATTLE_TEST("Mental Herb cures Encore volatile status (Gen 5+)")
 {
     GIVEN {
         WITH_CONFIG(B_MENTAL_HERB, GEN_5);
-        ASSUME(gItemsInfo[ITEM_MENTAL_HERB].holdEffect == HOLD_EFFECT_MENTAL_HERB);
+        ASSUME(GetMoveEffect(MOVE_ENCORE) == EFFECT_ENCORE);
         PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_MENTAL_HERB); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
         TURN { MOVE(opponent, MOVE_ENCORE); }
     } SCENE {
-        MESSAGE("The opposing Wobbuffet used Encore!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ENCORE, opponent);
         MESSAGE("Wobbuffet must do an encore!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
         MESSAGE("Wobbuffet ended its encore!");
     } THEN {
+        EXPECT(player->volatiles.encoredMove == MOVE_NONE);
         EXPECT(player->volatiles.encoreTimer == 0);
     }
 }
@@ -109,27 +130,25 @@ SINGLE_BATTLE_TEST("Mental Herb cures Taunt volatile status (Gen 5+)")
 {
     GIVEN {
         WITH_CONFIG(B_MENTAL_HERB, GEN_5);
-        ASSUME(gItemsInfo[ITEM_MENTAL_HERB].holdEffect == HOLD_EFFECT_MENTAL_HERB);
+        ASSUME(GetMoveEffect(MOVE_TAUNT) == EFFECT_TAUNT);
         PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_MENTAL_HERB); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
         TURN { MOVE(opponent, MOVE_TAUNT); }
     } SCENE {
-        MESSAGE("The opposing Wobbuffet used Taunt!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TAUNT, opponent);
         MESSAGE("Wobbuffet fell for the taunt!");
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
         MESSAGE("Wobbuffet shook off the taunt!");
     } THEN {
-        EXPECT(player->volatiles.encoreTimer == 0);
+        EXPECT(player->volatiles.tauntTimer == 0);
     }
 }
 
-DOUBLE_BATTLE_TEST("Mental Herb cures volatile statuses in the following order - Infatuation, Torment, Disable, Heal Block, Encore, Taunt")
+DOUBLE_BATTLE_TEST("Mental Herb cures volatile statuses in the following order - Infatuation, Torment, Disable, Heal Block, Encore, Taunt (Gen 5+)")
 {
     GIVEN {
         WITH_CONFIG(B_MENTAL_HERB, GEN_5);
-        ASSUME(gItemsInfo[ITEM_MENTAL_HERB].holdEffect == HOLD_EFFECT_MENTAL_HERB);
         PLAYER(SPECIES_WOBBUFFET) { Gender(MON_MALE); }
         PLAYER(SPECIES_WYNAUT);
         OPPONENT(SPECIES_WOBBUFFET) { Gender(MON_FEMALE); }
@@ -155,5 +174,15 @@ DOUBLE_BATTLE_TEST("Mental Herb cures volatile statuses in the following order -
         MESSAGE("Wobbuffet is no longer prevented from healing!");
         MESSAGE("Wobbuffet ended its encore!");
         MESSAGE("Wobbuffet shook off the taunt!");
+    } THEN {
+        EXPECT(playerLeft->volatiles.infatuation == 0);
+        EXPECT(playerLeft->volatiles.torment == FALSE);
+        EXPECT(playerLeft->volatiles.disabledMove == MOVE_NONE);
+        EXPECT(playerLeft->volatiles.disableTimer == 0);
+        EXPECT(playerLeft->volatiles.healBlock == FALSE);
+        EXPECT(playerLeft->volatiles.healBlockTimer == 0);
+        EXPECT(playerLeft->volatiles.encoredMove == MOVE_NONE);
+        EXPECT(playerLeft->volatiles.encoreTimer == 0);
+        EXPECT(playerLeft->volatiles.tauntTimer == 0);
     }
 }


### PR DESCRIPTION
## Description
Missing Mental Herb cleanup for `tormentTimer` and `healBlockTimer`.