### PR TITLE
Fixes Dragon Darts after hit messages

### DIFF
--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -3238,8 +3238,11 @@ static enum MoveEndResult MoveEndMultihitMove(struct BattleCalcValues *cv)
         gBattleScripting.multihitString[4]++;
         if (gMultiHitCounter == 0)
         {
-            BattleScriptCall(BattleScript_MultiHitPrintStrings);
-            result = MOVEEND_RESULT_RUN_SCRIPT;
+            if (target != TARGET_SMART) // Dragon Darts doesn't print hit x times message
+            {
+                BattleScriptCall(BattleScript_MultiHitPrintStrings);
+                result = MOVEEND_RESULT_RUN_SCRIPT;
+            }
         }
         else
         {
@@ -3270,7 +3273,7 @@ static enum MoveEndResult MoveEndMultihitMove(struct BattleCalcValues *cv)
                 gBattlescriptCurrInstr = BattleScript_FlushMessageBox;
                 return MOVEEND_RESULT_BREAK;
             }
-            else
+            else if (target != TARGET_SMART) // Dragon Darts doesn't print hit x times message
             {
                 BattleScriptCall(BattleScript_MultiHitPrintStrings);
                 result = MOVEEND_RESULT_RUN_SCRIPT;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1835,6 +1835,7 @@ static void Cmd_resultmessage(void)
 
     enum StringID stringId = 0;
     u32 *moveResultFlags = &gBattleStruct->moveResultFlags[gBattlerTarget];
+    enum MoveTarget target = GetBattlerMoveTargetType(gBattlerAttacker, gCurrentMove);
 
     if (gBattleControllerExecFlags)
         return;
@@ -1859,7 +1860,7 @@ static void Cmd_resultmessage(void)
                 else
                     stringId = STRINGID_SUPEREFFECTIVE;
             }
-            else if (!gMultiHitCounter)  // Don't print effectiveness on each hit in a multi hit attack
+            else if (!gMultiHitCounter || target == TARGET_SMART)  // Don't print effectiveness on each hit in a multi hit attack
             {
                 stringId = STRINGID_SUPEREFFECTIVE;
             }
@@ -1878,7 +1879,7 @@ static void Cmd_resultmessage(void)
                 else
                     stringId = STRINGID_NOTVERYEFFECTIVE; // Needs a string
             }
-            else if (!gMultiHitCounter)
+            else if (!gMultiHitCounter || target == TARGET_SMART)
             {
                 stringId = STRINGID_NOTVERYEFFECTIVE;
             }

--- a/test/battle/move_effect/dragon_darts.c
+++ b/test/battle/move_effect/dragon_darts.c
@@ -16,7 +16,7 @@ SINGLE_BATTLE_TEST("Dragon Darts strikes twice")
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DARTS, player);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DARTS, player);
-        MESSAGE("The Pokémon was hit 2 time(s)!");
+        NOT MESSAGE("The Pokémon was hit 2 time(s)!");
     }
 }
 
@@ -39,7 +39,6 @@ DOUBLE_BATTLE_TEST("Dragon Darts strikes each opponent once in a double battle")
         HP_BAR(chosenTarget);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DARTS, playerLeft);
         HP_BAR(secondaryTarget);
-        MESSAGE("The Pokémon was hit 2 time(s)!");
     }
 }
 
@@ -62,7 +61,6 @@ DOUBLE_BATTLE_TEST("Dragon Darts strikes the ally twice if the target protects")
         HP_BAR(secondaryTarget);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DARTS, playerLeft);
         HP_BAR(secondaryTarget);
-        MESSAGE("The Pokémon was hit 2 time(s)!");
     }
 }
 
@@ -89,7 +87,6 @@ DOUBLE_BATTLE_TEST("Dragon Darts strikes an opponent twice if the other one is F
         HP_BAR(finalTarget);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DARTS, playerLeft);
         HP_BAR(finalTarget);
-        MESSAGE("The Pokémon was hit 2 time(s)!");
     }
 }
 
@@ -115,7 +112,6 @@ DOUBLE_BATTLE_TEST("Dragon Darts strikes an opponent twice if electrified and th
         HP_BAR(finalTarget);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DARTS, playerLeft);
         HP_BAR(finalTarget);
-        MESSAGE("The Pokémon was hit 2 time(s)!");
     }
 }
 
@@ -141,7 +137,6 @@ DOUBLE_BATTLE_TEST("Dragon Darts strikes an opponent twice if electrified and th
         HP_BAR(finalTarget);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DARTS, playerLeft);
         HP_BAR(finalTarget);
-        MESSAGE("The Pokémon was hit 2 time(s)!");
     }
 }
 
@@ -165,7 +160,6 @@ DOUBLE_BATTLE_TEST("Dragon Darts strikes an opponent twice if the other one is i
         HP_BAR(finalTarget);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DARTS, playerLeft);
         HP_BAR(finalTarget);
-        MESSAGE("The Pokémon was hit 2 time(s)!");
     }
 }
 
@@ -184,7 +178,6 @@ DOUBLE_BATTLE_TEST("Dragon Darts is not effected by Wide Guard")
         HP_BAR(opponentLeft);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DARTS, playerLeft);
         HP_BAR(opponentRight);
-        MESSAGE("The Pokémon was hit 2 time(s)!");
     }
 }
 
@@ -208,7 +201,6 @@ DOUBLE_BATTLE_TEST("Dragon Darts strikes an opponent twice if the other one is f
         HP_BAR(finalTarget);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DARTS, playerLeft);
         HP_BAR(finalTarget);
-        MESSAGE("The Pokémon was hit 2 time(s)!");
     }
 }
 
@@ -231,7 +223,6 @@ DOUBLE_BATTLE_TEST("Dragon Darts strikes left ally twice if one strike misses")
         HP_BAR(finalTarget);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DARTS, playerLeft);
         HP_BAR(finalTarget);
-        MESSAGE("The Pokémon was hit 2 time(s)!");
     }
 }
 
@@ -249,7 +240,6 @@ DOUBLE_BATTLE_TEST("Dragon Darts strikes right ally twice if one strike misses")
         HP_BAR(opponentRight);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DARTS, playerLeft);
         HP_BAR(opponentRight);
-        MESSAGE("The Pokémon was hit 2 time(s)!");
     }
 }
 
@@ -267,7 +257,6 @@ DOUBLE_BATTLE_TEST("Dragon Darts strikes will be both redirected to Follow Me us
         HP_BAR(opponentRight);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DARTS, playerLeft);
         HP_BAR(opponentRight);
-        MESSAGE("The Pokémon was hit 2 time(s)!");
     }
 }
 
@@ -285,12 +274,11 @@ DOUBLE_BATTLE_TEST("Dragon Darts fails to strike any target if under a Fairy-typ
         NONE_OF {
             ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DARTS, playerLeft);
             ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DARTS, playerLeft);
-            MESSAGE("The Pokémon was hit 2 time(s)!");
         }
     }
 }
 
-DOUBLE_BATTLE_TEST("Dragon Darts fails to strike the second target if first target fainted and follow me was active")
+DOUBLE_BATTLE_TEST("Dragon Darts fails to strike the second target if first target fainted and Follow Me was active")
 {
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);
@@ -302,10 +290,7 @@ DOUBLE_BATTLE_TEST("Dragon Darts fails to strike the second target if first targ
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DARTS, playerLeft);
         HP_BAR(opponentRight);
-        NONE_OF {
-            ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DARTS, playerLeft);
-            MESSAGE("The Pokémon was hit 2 time(s)!");
-        }
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DARTS, playerLeft);
     }
 }
 
@@ -329,3 +314,22 @@ DOUBLE_BATTLE_TEST("Dragon Darts can be absorbed by both opponents and hit neith
     }
 }
 
+DOUBLE_BATTLE_TEST("Dragon Darts always prints effectiveness message after every hit")
+{
+    // The messages are possibly incorrect if they should print the target
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_CUFANT);
+        OPPONENT(SPECIES_DRATINI);
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_DRAGON_DARTS, target: opponentLeft); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DARTS, playerLeft);
+        HP_BAR(opponentLeft);
+        MESSAGE("It's not very effective…");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DARTS, playerLeft);
+        HP_BAR(opponentRight);
+        MESSAGE("It's super effective!");
+    }
+}


### PR DESCRIPTION
According to jpwiki,

> The following are some of the ways in which Dragon Darts differs from other multihit moves:
> If the attack is super effective or not very effective, a compatibility message will appear after each hit, even if it wasn't blocked by a substitute.
> The message "You hit twice!" does not appear when the attack ends.

## Discord contact info
PhallenTree
