### PR TITLE
feat(test-runner): add support for item popups

### DIFF
--- a/include/test/battle.h
+++ b/include/test/battle.h
@@ -611,6 +611,7 @@ enum
     QUEUED_STATUS_EVENT,
     QUEUED_CATCH_CHANCE_EVENT,
     QUEUED_EFFECTIVENESS_EVENT,
+    QUEUED_ITEM_POPUP_EVENT,
 };
 
 struct QueuedEffectiveness
@@ -623,6 +624,13 @@ struct QueuedAbilityEvent
 {
     enum BattlerId battlerId;
     enum Ability ability;
+};
+
+
+struct QueuedItemEvent
+{
+    enum BattlerId battlerId;
+    enum Item item;
 };
 
 struct QueuedAnimationEvent
@@ -683,6 +691,7 @@ struct QueuedEvent
     union
     {
         struct QueuedAbilityEvent ability;
+        struct QueuedItemEvent item;
         struct QueuedAnimationEvent animation;
         struct QueuedHPEvent hp;
         struct QueuedSubHitEvent subHit;
@@ -1229,6 +1238,8 @@ void GivePlayerItem(u32 sourceLine, enum Item, u32 quantity);
 #define FREEZE_OR_FROSTBURN_STATUS(battler, isFrostbite) \
     (B_USE_FROSTBITE ? STATUS_ICON(battler, frostbite: isFrostbite) : STATUS_ICON(battler, freeze: isFrostbite))
 
+#define ITEM_POPUP(battler, ...) QueueItem(__LINE__, battler, (struct ItemEventContext) { __VA_ARGS__ })
+
 #define SWITCH_OUT_MESSAGE(name) ONE_OF {                                         \
                                      MESSAGE(name ", that's enough! Come back!"); \
                                      MESSAGE(name ", come back!");                \
@@ -1259,6 +1270,11 @@ struct EffectivenessEventContext
 struct AbilityEventContext
 {
     enum Ability ability;
+};
+
+struct ItemEventContext
+{
+    enum Item item;
 };
 
 struct AnimationEventContext
@@ -1342,6 +1358,7 @@ void QueueMessage(u32 sourceLine, const u8 *pattern);
 void QueueStatus(u32 sourceLine, struct BattlePokemon *battler, struct StatusEventContext);
 void QueueCatchingChance(u32 sourceLine, u32 *captureAdress);
 void QueueEffectivenessSound(u32 sourceLine, struct BattlePokemon *battler, struct EffectivenessEventContext);
+void QueueItem(u32 sourceLine, struct BattlePokemon *battler, struct ItemEventContext);
 
 /* Then */
 

--- a/include/test_runner.h
+++ b/include/test_runner.h
@@ -14,6 +14,7 @@ extern const bool8 gTestRunnerSkipIsFail;
 enum Gimmick;
 
 void TestRunner_Battle_RecordAbilityPopUp(enum BattlerId battlerId, enum Ability ability);
+void TestRunner_Battle_RecordItemPopUp(enum BattlerId battlerId, enum Item item);
 void TestRunner_Battle_RecordAnimation(u32 animType, u32 animId);
 void TestRunner_Battle_RecordHP(enum BattlerId battlerId, u32 oldHP, u32 newHP);
 void TestRunner_Battle_RecordSubHit(enum BattlerId battlerId, u32 damage, bool32 broke);
@@ -39,6 +40,7 @@ void TestRunner_Battle_RecordEffectivenessSound(u32 battlerId, u32 soundId);
 #else
 
 #define TestRunner_Battle_RecordAbilityPopUp(...) (void)0
+#define TestRunner_Battle_RecordItemPopUp(...) (void)0
 #define TestRunner_Battle_RecordAnimation(...) (void)0
 #define TestRunner_Battle_RecordHP(...) (void)0
 #define TestRunner_Battle_RecordSubHit(...) (void)0

--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -2717,6 +2717,13 @@ void CreateItemPopUp(enum BattlerId battler)
     struct SpriteTemplate template;
     const s16 (*coords)[2];
 
+    if (gTestRunnerEnabled)
+    {
+        TestRunner_Battle_RecordItemPopUp(battler, gLastUsedItem);
+        if (gTestRunnerHeadless)
+            return;
+    }
+
     if (!IsAnyAbilityPopUpActive())
         LoadSpritePalette(&sSpritePalette_AbilityPopUp);
 

--- a/test/test_runner_battle.c
+++ b/test/test_runner_battle.c
@@ -3544,7 +3544,6 @@ void QueueAbility(u32 sourceLine, struct BattlePokemon *battler, struct AbilityE
     };
 }
 
-
 void QueueItem(u32 sourceLine, struct BattlePokemon *battler, struct ItemEventContext ctx)
 {
     enum BattlerId battlerId = battler - gBattleMons;

--- a/test/test_runner_battle.c
+++ b/test/test_runner_battle.c
@@ -908,6 +908,81 @@ void TestRunner_Battle_RecordAbilityPopUp(enum BattlerId battlerId, enum Ability
     }
 }
 
+static s32 TryItemPopUp(s32 i, s32 n, enum BattlerId battlerId, enum Item item)
+{
+    struct QueuedItemEvent *event;
+    s32 iMax = i + n;
+    for (; i < iMax; i++)
+    {
+        if (DATA.queuedEvents[i].type != QUEUED_ITEM_POPUP_EVENT)
+            continue;
+
+        event = &DATA.queuedEvents[i].as.item;
+
+        if (event->battlerId == battlerId
+         && (event->item == ITEM_NONE || event->item == item))
+            return i;
+    }
+    return -1;
+}
+
+void TestRunner_Battle_RecordItemPopUp(enum BattlerId battlerId, enum Item item)
+{
+    s32 queuedEvent;
+    s32 match;
+    struct QueuedEvent *event;
+
+    if (DATA.trial.queuedEvent == DATA.queuedEventsCount)
+        return;
+
+    event = &DATA.queuedEvents[DATA.trial.queuedEvent];
+    switch (event->groupType)
+    {
+    case QUEUE_GROUP_NONE:
+    case QUEUE_GROUP_ONE_OF:
+        if (TryItemPopUp(DATA.trial.queuedEvent, event->groupSize, battlerId, item) != -1)
+        {
+            DATA.trial.queuedEvent += event->groupSize;
+        }
+        else if (DATA.trial.queuedEvent == DATA.queuedEventsFailIndex
+              && DATA.queuedEvents[DATA.queuedEventsFailIndex].type == QUEUED_ITEM_POPUP_EVENT)
+        {
+            const char *filename = gTestRunnerState.test->filename;
+            u32 line = SourceLine(DATA.queuedEvents[DATA.queuedEventsFailIndex].sourceLineOffset);
+            if (DATA.queuedEvents[DATA.queuedEventsFailIndex].as.item.item == ITEM_NONE)
+                Test_MgbaPrintf("%s:%d: Did you mean: ITEM_POPUP(%s)", filename, line, BattlerIdentifier(battlerId));
+            else
+                Test_MgbaPrintf("%s:%d: Did you mean: ITEM_POPUP(%s, ITEM_%C)", filename, line, BattlerIdentifier(battlerId), gAbilitiesInfo[item].name);
+        }
+        break;
+    case QUEUE_GROUP_NONE_OF:
+        queuedEvent = DATA.trial.queuedEvent;
+        do
+        {
+            if ((match = TryItemPopUp(queuedEvent, event->groupSize, battlerId, item)) != -1)
+            {
+                const char *filename = gTestRunnerState.test->filename;
+                u32 line = SourceLine(DATA.queuedEvents[match].sourceLineOffset);
+                if (gTestRunnerState.expectedFailState == EXPECT_FAIL_SCENE_OPEN)
+                    gTestRunnerState.expectedFailState = EXPECT_FAIL_SUCCESS;
+                Test_ExitWithResult(TEST_RESULT_FAIL, line, "%s:%d: Matched ITEM_POPUP", filename, line);
+            }
+
+            queuedEvent += event->groupSize;
+            if (queuedEvent == DATA.queuedEventsCount)
+                break;
+
+            event = &DATA.queuedEvents[queuedEvent];
+            if (event->groupType == QUEUE_GROUP_NONE_OF)
+                continue;
+
+            if (TryItemPopUp(queuedEvent, event->groupSize, battlerId, item) != -1)
+                DATA.trial.queuedEvent = queuedEvent + event->groupSize;
+        } while (FALSE);
+        break;
+    }
+}
+
 static s32 TryAnimation(s32 i, s32 n, u32 animType, u32 animId)
 {
     struct QueuedAnimationEvent *event;
@@ -1962,6 +2037,7 @@ static const char *const sEventTypeMacros[] =
     [QUEUED_STATUS_EVENT] = "STATUS_ICON",
     [QUEUED_CATCH_CHANCE_EVENT] = "CATCH_CHANCE",
     [QUEUED_EFFECTIVENESS_EVENT] = "EFFECTIVENESS_SE",
+    [QUEUED_ITEM_POPUP_EVENT] = "ITEM_POPUP",
 };
 
 static void TearDownBattle(void)
@@ -3464,6 +3540,29 @@ void QueueAbility(u32 sourceLine, struct BattlePokemon *battler, struct AbilityE
         .as = { .ability = {
             .battlerId = battlerId,
             .ability = ctx.ability,
+        }},
+    };
+}
+
+
+void QueueItem(u32 sourceLine, struct BattlePokemon *battler, struct ItemEventContext ctx)
+{
+    enum BattlerId battlerId = battler - gBattleMons;
+
+    if (gTestRunnerState.expectedFailState == EXPECT_FAIL_OPEN)
+        gTestRunnerState.expectedFailState = EXPECT_FAIL_SCENE_OPEN;
+
+    INVALID_IF(!STATE->runScene, "ITEMN_POPUP outside of SCENE");
+    if (DATA.queuedEventsCount == MAX_QUEUED_EVENTS)
+        Test_ExitWithResult(TEST_RESULT_ERROR, sourceLine, "%s:%d: ITEM exceeds MAX_QUEUED_EVENTS", gTestRunnerState.test->filename, sourceLine);
+    DATA.queuedEvents[DATA.queuedEventsCount++] = (struct QueuedEvent) {
+        .type = QUEUED_ITEM_POPUP_EVENT,
+        .sourceLineOffset = SourceLineOffset(sourceLine),
+        .groupType = QUEUE_GROUP_NONE,
+        .groupSize = 1,
+        .as = { .item = {
+            .battlerId = battlerId,
+            .item = ctx.item,
         }},
     };
 }

--- a/test/test_test_runner.c
+++ b/test/test_test_runner.c
@@ -235,3 +235,30 @@ MULTI_BATTLE_TEST("Celebrate does not need to be explicitly set in a non-AI test
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponentRight);
     }
 }
+
+SINGLE_BATTLE_TEST("ITEM_POPUP correctly detects popups")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { MaxHP(100); HP(1); Item(ITEM_LEFTOVERS); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN {}
+    } SCENE {
+        ITEM_POPUP(player, ITEM_LEFTOVERS);
+    }
+
+}
+
+SINGLE_BATTLE_TEST("ITEM_POPUP fails when specifying the wrong item")
+{
+        GIVEN {
+            PLAYER(SPECIES_WOBBUFFET) { MaxHP(100); HP(1); Item(ITEM_LEFTOVERS); }
+            OPPONENT(SPECIES_WOBBUFFET);
+        } WHEN {
+            TURN {}
+        } SCENE {
+            EXPECT_FAIL {
+                ITEM_POPUP(player, ITEM_BLACK_SLUDGE);
+            }
+        }
+}

--- a/test/test_test_runner.c
+++ b/test/test_test_runner.c
@@ -246,19 +246,18 @@ SINGLE_BATTLE_TEST("ITEM_POPUP correctly detects popups")
     } SCENE {
         ITEM_POPUP(player, ITEM_LEFTOVERS);
     }
-
 }
 
 SINGLE_BATTLE_TEST("ITEM_POPUP fails when specifying the wrong item")
 {
-        GIVEN {
-            PLAYER(SPECIES_WOBBUFFET) { MaxHP(100); HP(1); Item(ITEM_LEFTOVERS); }
-            OPPONENT(SPECIES_WOBBUFFET);
-        } WHEN {
-            TURN {}
-        } SCENE {
-            EXPECT_FAIL {
-                ITEM_POPUP(player, ITEM_BLACK_SLUDGE);
-            }
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { MaxHP(100); HP(1); Item(ITEM_LEFTOVERS); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN {}
+    } SCENE {
+        EXPECT_FAIL {
+            ITEM_POPUP(player, ITEM_BLACK_SLUDGE);
         }
+    }
 }


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description

Adds support for `ITEM_POPUP` in battle tests similar to `ABILITY_POPUP`. The code is nearly identical to the ability popup implementation.

### Large Language Models (AI)

None

## Issue(s) that this PR fixes

Resolves: #10255

## Feature(s) this PR does NOT handle

Does not yet use `ITEM_POPUP` in tests.

## Discord contact info

@miriamlefae
