### PR TITLE
refactor(string): consolidate stringvar arrays with getter function

### DIFF
--- a/include/string_util.h
+++ b/include/string_util.h
@@ -54,5 +54,6 @@ void ConvertInternationalString(u8 *s, enum Language language);
 void StripExtCtrlCodes(u8 *str);
 u8 *StringCopyUppercase(u8 *dest, const u8 *src);
 bool32 DoesStringProperlyTerminate(const u8 *str, u32 last);
+u8* const GetStringVar(u8 index);
 
 #endif // GUARD_STRING_UTIL_H

--- a/include/tv.h
+++ b/include/tv.h
@@ -3,8 +3,6 @@
 
 #include "constants/species.h"
 
-extern u8 *const gTVStringVarPtrs[3];
-
 void ClearTVShowData(void);
 void TryPutBreakingNewsOnAir(void);
 void TryPutBattleSeminarOnAir(enum Species foeSpecies, enum Species species, u8 moveIndex, const u16 *movePtr, enum Move betterMove);

--- a/src/field_specials.c
+++ b/src/field_specials.c
@@ -536,7 +536,7 @@ u8 GetLinkPartnerNames(void)
     {
         if (myLinkPlayerNumber != i)
         {
-            StringCopy(gTVStringVarPtrs[j], gLinkPlayers[i].name);
+            StringCopy(GetStringVar(j), gLinkPlayers[i].name);
             j++;
         }
     }

--- a/src/match_call.c
+++ b/src/match_call.c
@@ -1676,15 +1676,13 @@ static void BuildMatchCallString(int matchCallId, const struct MatchCallText *ma
     StringExpandPlaceholders(str, matchCallText->text);
 }
 
-static u8 *const sMatchCallTextStringVars[] = { gStringVar1, gStringVar2, gStringVar3 };
-
 static void PopulateMatchCallStringVars(int matchCallId, const s8 *stringVarFuncIds)
 {
     int i;
     for (i = 0; i < NUM_STRVARS_IN_MSG; i++)
     {
         if (stringVarFuncIds[i] >= 0)
-            PopulateMatchCallStringVar(matchCallId, stringVarFuncIds[i], sMatchCallTextStringVars[i]);
+            PopulateMatchCallStringVar(matchCallId, stringVarFuncIds[i], GetStringVar(i));
     }
 }
 

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -99,12 +99,6 @@ static const u8 sScriptConditionTable[6][3] =
     {1, 0, 1}, // !=
 };
 
-static u8 *const sScriptStringVars[] =
-{
-    gStringVar1,
-    gStringVar2,
-    gStringVar3,
-};
 
 bool8 ScrCmd_nop(struct ScriptContext *ctx)
 {
@@ -2111,7 +2105,7 @@ bool8 ScrCmd_bufferspeciesname(struct ScriptContext *ctx)
 
     Script_RequestEffects(SCREFF_V1);
 
-    StringCopy(sScriptStringVars[stringVarIndex], GetSpeciesName(species));
+    StringCopy(GetStringVar(stringVarIndex), GetSpeciesName(species));
     return FALSE;
 }
 
@@ -2121,7 +2115,7 @@ bool8 ScrCmd_bufferleadmonspeciesname(struct ScriptContext *ctx)
 
     Script_RequestEffects(SCREFF_V1);
 
-    u8 *dest = sScriptStringVars[stringVarIndex];
+    u8 *dest = GetStringVar(stringVarIndex);
     u8 partyIndex = GetLeadMonIndex();
     enum Species species = GetMonData(&gParties[B_TRAINER_PLAYER][partyIndex], MON_DATA_SPECIES);
     StringCopy(dest, GetSpeciesName(species));
@@ -2134,8 +2128,8 @@ void BufferFirstLiveMonNickname(struct ScriptContext *ctx)
 
     Script_RequestEffects(SCREFF_V1);
 
-    GetMonData(GetFirstLiveMon(), MON_DATA_NICKNAME, sScriptStringVars[stringVarIndex]);
-    StringGet_Nickname(sScriptStringVars[stringVarIndex]);
+    GetMonData(GetFirstLiveMon(), MON_DATA_NICKNAME, GetStringVar(stringVarIndex));
+    StringGet_Nickname(GetStringVar(stringVarIndex));
 }
 
 bool8 ScrCmd_bufferpartymonnick(struct ScriptContext *ctx)
@@ -2145,8 +2139,8 @@ bool8 ScrCmd_bufferpartymonnick(struct ScriptContext *ctx)
 
     Script_RequestEffects(SCREFF_V1);
 
-    GetMonData(&gParties[B_TRAINER_PLAYER][partyIndex], MON_DATA_NICKNAME, sScriptStringVars[stringVarIndex]);
-    StringGet_Nickname(sScriptStringVars[stringVarIndex]);
+    GetMonData(&gParties[B_TRAINER_PLAYER][partyIndex], MON_DATA_NICKNAME, GetStringVar(stringVarIndex));
+    StringGet_Nickname(GetStringVar(stringVarIndex));
     return FALSE;
 }
 
@@ -2157,7 +2151,7 @@ bool8 ScrCmd_bufferitemname(struct ScriptContext *ctx)
 
     Script_RequestEffects(SCREFF_V1);
 
-    CopyItemName(itemId, sScriptStringVars[stringVarIndex]);
+    CopyItemName(itemId, GetStringVar(stringVarIndex));
     return FALSE;
 }
 
@@ -2169,7 +2163,7 @@ bool8 ScrCmd_bufferitemnameplural(struct ScriptContext *ctx)
 
     Script_RequestEffects(SCREFF_V1);
 
-    CopyItemNameHandlePlural(itemId, sScriptStringVars[stringVarIndex], quantity);
+    CopyItemNameHandlePlural(itemId, GetStringVar(stringVarIndex), quantity);
     return FALSE;
 }
 
@@ -2180,7 +2174,7 @@ bool8 ScrCmd_bufferdecorationname(struct ScriptContext *ctx)
 
     Script_RequestEffects(SCREFF_V1);
 
-    StringCopy(sScriptStringVars[stringVarIndex], gDecorations[decorId].name);
+    StringCopy(GetStringVar(stringVarIndex), gDecorations[decorId].name);
     return FALSE;
 }
 
@@ -2191,7 +2185,7 @@ bool8 ScrCmd_buffermovename(struct ScriptContext *ctx)
 
     Script_RequestEffects(SCREFF_V1);
 
-    StringCopy(sScriptStringVars[stringVarIndex], GetMoveName(move));
+    StringCopy(GetStringVar(stringVarIndex), GetMoveName(move));
     return FALSE;
 }
 
@@ -2203,7 +2197,7 @@ bool8 ScrCmd_buffernumberstring(struct ScriptContext *ctx)
 
     Script_RequestEffects(SCREFF_V1);
 
-    ConvertIntToDecimalStringN(sScriptStringVars[stringVarIndex], num, STR_CONV_MODE_LEFT_ALIGN, numDigits);
+    ConvertIntToDecimalStringN(GetStringVar(stringVarIndex), num, STR_CONV_MODE_LEFT_ALIGN, numDigits);
     return FALSE;
 }
 
@@ -2214,7 +2208,7 @@ bool8 ScrCmd_bufferstdstring(struct ScriptContext *ctx)
 
     Script_RequestEffects(SCREFF_V1);
 
-    StringCopy(sScriptStringVars[stringVarIndex], gStdStrings[index]);
+    StringCopy(GetStringVar(stringVarIndex), gStdStrings[index]);
     return FALSE;
 }
 
@@ -2225,7 +2219,7 @@ bool8 ScrCmd_buffercontestname(struct ScriptContext *ctx)
 
     Script_RequestEffects(SCREFF_V1);
 
-    BufferContestName(sScriptStringVars[stringVarIndex], category);
+    BufferContestName(GetStringVar(stringVarIndex), category);
     return FALSE;
 }
 
@@ -2236,7 +2230,7 @@ bool8 ScrCmd_bufferstring(struct ScriptContext *ctx)
 
     Script_RequestEffects(SCREFF_V1);
 
-    StringCopy(sScriptStringVars[stringVarIndex], text);
+    StringCopy(GetStringVar(stringVarIndex), text);
     return FALSE;
 }
 
@@ -2258,7 +2252,7 @@ bool8 ScrCmd_vbufferstring(struct ScriptContext *ctx)
     Script_RequestEffects(SCREFF_V1);
 
     const u8 *src = (u8 *)(addr - sAddressOffset);
-    u8 *dest = sScriptStringVars[stringVarIndex];
+    u8 *dest = GetStringVar(stringVarIndex);
     StringCopy(dest, src);
     return FALSE;
 }
@@ -2270,7 +2264,7 @@ bool8 ScrCmd_bufferboxname(struct ScriptContext *ctx)
 
     Script_RequestEffects(SCREFF_V1);
 
-    StringCopy(sScriptStringVars[stringVarIndex], GetBoxNamePtr(boxId));
+    StringCopy(GetStringVar(stringVarIndex), GetBoxNamePtr(boxId));
     return FALSE;
 }
 
@@ -3054,7 +3048,7 @@ bool8 ScrCmd_buffertrainerclassname(struct ScriptContext *ctx)
 
     Script_RequestEffects(SCREFF_V1);
 
-    StringCopy(sScriptStringVars[stringVarIndex], GetTrainerClassNameFromId(trainerClassId));
+    StringCopy(GetStringVar(stringVarIndex), GetTrainerClassNameFromId(trainerClassId));
     return FALSE;
 }
 
@@ -3065,7 +3059,7 @@ bool8 ScrCmd_buffertrainername(struct ScriptContext *ctx)
 
     Script_RequestEffects(SCREFF_V1);
 
-    StringCopy(sScriptStringVars[stringVarIndex], GetTrainerNameFromId(trainerClassId));
+    StringCopy(GetStringVar(stringVarIndex), GetTrainerNameFromId(trainerClassId));
     return FALSE;
 }
 

--- a/src/string_util.c
+++ b/src/string_util.c
@@ -830,3 +830,19 @@ bool32 DoesStringProperlyTerminate(const u8 *str, u32 last)
 
     return FALSE;
 }
+
+u8* const GetStringVar(u8 index)
+{
+    switch (index)
+    {
+    case 0:
+        return gStringVar1;
+    case 1:
+        return gStringVar2;
+    case 2:
+        return gStringVar3;
+    default:
+        errorf("Incorrect stringvar index");
+        return gStringVar1;
+    }
+}

--- a/src/string_util.c
+++ b/src/string_util.c
@@ -842,7 +842,7 @@ u8* const GetStringVar(u8 index)
     case 2:
         return gStringVar3;
     default:
-        errorf("Incorrect stringvar index");
+        errorf("Incorrect StringVar index: %d", index);
         return gStringVar1;
     }
 }

--- a/src/tv.c
+++ b/src/tv.c
@@ -238,12 +238,6 @@ static const u8 *const sPokeNewsTextGroup_Ending[NUM_POKENEWS_TYPES + 1] = {
     [POKENEWS_BLENDMASTER] = gPokeNewsTextBlendMaster_Ending
 };
 
-u8 *const gTVStringVarPtrs[] = {
-    gStringVar1,
-    gStringVar2,
-    gStringVar3
-};
-
 static const u8 *const sTVFanClubTextGroup[] = {
     gTVFanClubText00,
     gTVFanClubText01,
@@ -2585,16 +2579,16 @@ void CopyContestRankToStringVar(u8 varIdx, u8 rank)
     switch (rank)
     {
     case CONTEST_RANK_NORMAL:
-        StringCopy(gTVStringVarPtrs[varIdx], gStdStrings[STDSTRING_NORMAL]);
+        StringCopy(GetStringVar(varIdx), gStdStrings[STDSTRING_NORMAL]);
         break;
     case CONTEST_RANK_SUPER:
-        StringCopy(gTVStringVarPtrs[varIdx], gStdStrings[STDSTRING_SUPER]);
+        StringCopy(GetStringVar(varIdx), gStdStrings[STDSTRING_SUPER]);
         break;
     case CONTEST_RANK_HYPER:
-        StringCopy(gTVStringVarPtrs[varIdx], gStdStrings[STDSTRING_HYPER]);
+        StringCopy(GetStringVar(varIdx), gStdStrings[STDSTRING_HYPER]);
         break;
     case CONTEST_RANK_MASTER:
-        StringCopy(gTVStringVarPtrs[varIdx], gStdStrings[STDSTRING_MASTER]);
+        StringCopy(GetStringVar(varIdx), gStdStrings[STDSTRING_MASTER]);
         break;
     }
 }
@@ -2604,19 +2598,19 @@ void CopyContestCategoryToStringVar(u8 varIdx, enum ContestCategories category)
     switch (category)
     {
     case CONTEST_CATEGORY_COOL:
-        StringCopy(gTVStringVarPtrs[varIdx], gStdStrings[STDSTRING_COOL]);
+        StringCopy(GetStringVar(varIdx), gStdStrings[STDSTRING_COOL]);
         break;
     case CONTEST_CATEGORY_BEAUTY:
-        StringCopy(gTVStringVarPtrs[varIdx], gStdStrings[STDSTRING_BEAUTY]);
+        StringCopy(GetStringVar(varIdx), gStdStrings[STDSTRING_BEAUTY]);
         break;
     case CONTEST_CATEGORY_CUTE:
-        StringCopy(gTVStringVarPtrs[varIdx], gStdStrings[STDSTRING_CUTE]);
+        StringCopy(GetStringVar(varIdx), gStdStrings[STDSTRING_CUTE]);
         break;
     case CONTEST_CATEGORY_SMART:
-        StringCopy(gTVStringVarPtrs[varIdx], gStdStrings[STDSTRING_SMART]);
+        StringCopy(GetStringVar(varIdx), gStdStrings[STDSTRING_SMART]);
         break;
     case CONTEST_CATEGORY_TOUGH:
-        StringCopy(gTVStringVarPtrs[varIdx], gStdStrings[STDSTRING_TOUGH]);
+        StringCopy(GetStringVar(varIdx), gStdStrings[STDSTRING_TOUGH]);
         break;
     default:
         break;
@@ -2632,7 +2626,7 @@ void SetContestCategoryStringVarForInterview(void)
 void ConvertIntToDecimalString(u8 varIdx, int value)
 {
     int nDigits = CountDigits(value);
-    ConvertIntToDecimalStringN(gTVStringVarPtrs[varIdx], value, STR_CONV_MODE_LEFT_ALIGN, nDigits);
+    ConvertIntToDecimalStringN(GetStringVar(varIdx), value, STR_CONV_MODE_LEFT_ALIGN, nDigits);
 }
 
 size_t CountDigits(int value)
@@ -2924,7 +2918,7 @@ static void CompactTVShowArray(TVShow *shows)
 static enum Species GetRandomDifferentSpeciesAndNameSeenByPlayer(u8 varIdx, enum Species excludedSpecies)
 {
     enum Species species = GetRandomDifferentSpeciesSeenByPlayer(excludedSpecies);
-    StringCopy(gTVStringVarPtrs[varIdx], GetSpeciesName(species));
+    StringCopy(GetStringVar(varIdx), GetSpeciesName(species));
     return species;
 }
 
@@ -3098,7 +3092,7 @@ static void GetNicknameSubstring(u8 varIdx, u8 whichPosition, u8 charParam, u16 
             buff[1] = GetSpeciesName(species)[strlen - (whichPosition + 1)];
         }
     }
-    StringCopy(gTVStringVarPtrs[varIdx], buff);
+    StringCopy(GetStringVar(varIdx), buff);
 }
 
 // Unused script special


### PR DESCRIPTION
## Description

This PR adds the function `GetStringVar` which returns a pointer to one of the three stringvars used in scripts. This replaces the multiple arrays used to access the stringvars.
This was initially added as part of #9535 but I think it's cleaner to handle it in a separate PR. ([discussion](https://github.com/rh-hideout/pokeemerald-expansion/pull/9535#discussion_r3323359845))

### Large Language Models (AI)

None

## Discord contact info

@miriamlefae
