### PR TITLE
fix(battle-anim): fix gust colour cycling animation

### DIFF
--- a/src/battle_anim_flying.c
+++ b/src/battle_anim_flying.c
@@ -371,16 +371,12 @@ static void AnimTask_AnimateGustTornadoPalette_Step(u8 taskId)
     if (gTasks[taskId].data[10]++ == gTasks[taskId].data[1])
     {
         gTasks[taskId].data[10] = 0;
-
         u32 palOffset = OBJ_PLTT_ID(IndexOfSpritePaletteTag(ANIM_TAG_GUST));
-        u32 temp = gPlttBufferFaded[palOffset + 8];
+        u16 *palPtr = &gPlttBufferFaded[palOffset];
 
-        for (u32 i = 7; i > 0; i--)
-        {
-            gPlttBufferFaded[palOffset + 1 + i] = gPlttBufferFaded[palOffset + i];
-        }
-
-        gPlttBufferFaded[palOffset + 1] = temp;
+        u32 temp = palPtr[8];
+        memmove(&palPtr[2], &palPtr[1], PLTT_SIZEOF(7));
+        palPtr[1] = temp;
     }
 
     if (--gTasks[taskId].data[0] == 0)

--- a/src/battle_anim_flying.c
+++ b/src/battle_anim_flying.c
@@ -1,6 +1,7 @@
 #include "global.h"
 #include "battle_anim.h"
 #include "palette.h"
+#include "sprite.h"
 #include "trig.h"
 #include "constants/battle_anim.h"
 #include "constants/rgb.h"
@@ -362,31 +363,24 @@ void AnimTask_AnimateGustTornadoPalette(u8 taskId)
 {
     gTasks[taskId].data[0] = gBattleAnimArgs[1];
     gTasks[taskId].data[1] = gBattleAnimArgs[0];
-    gTasks[taskId].data[2] = IndexOfSpritePaletteTag(ANIM_TAG_GUST);
     gTasks[taskId].func = AnimTask_AnimateGustTornadoPalette_Step;
 }
 
 static void AnimTask_AnimateGustTornadoPalette_Step(u8 taskId)
 {
-    u8 data2;
-    u16 temp;
-    int i, base;
-
     if (gTasks[taskId].data[10]++ == gTasks[taskId].data[1])
     {
         gTasks[taskId].data[10] = 0;
-        data2 = gTasks[taskId].data[2];
-        temp = gPlttBufferFaded[OBJ_PLTT_ID(data2) + 8];
-        i = 7;
-        base = PLTT_ID(data2);
 
-        do
+        u32 palOffset = OBJ_PLTT_ID(IndexOfSpritePaletteTag(ANIM_TAG_GUST));
+        u32 temp = gPlttBufferFaded[palOffset + 8];
+
+        for (u32 i = 7; i > 0; i--)
         {
-            gPlttBufferFaded[base + OBJ_PLTT_OFFSET + 1 + i] = gPlttBufferFaded[base + OBJ_PLTT_OFFSET + i];
-            i--;
-        } while (i > 0);
+            gPlttBufferFaded[palOffset + 1 + i] = gPlttBufferFaded[palOffset + i];
+        }
 
-        gPlttBufferFaded[base + OBJ_PLTT_OFFSET + 1] = temp;
+        gPlttBufferFaded[palOffset + 1] = temp;
     }
 
     if (--gTasks[taskId].data[0] == 0)


### PR DESCRIPTION
## Description

This is a regression from #8497.
The visual task looks up the pal index once and stores it in the task data. Since the task is created before the sprites are created, it ends up storing garbage in the task data.

This PR refactors the animation task function to look up the pal index when needed.

An alternate fix could potentially be to move every instance of this task to after the sprite has been created.

### Large Language Models (AI)

None

## Media

https://github.com/user-attachments/assets/1590f81a-6831-495f-817c-7c140ef87536



## Issue(s) that this PR fixes

Fixes #10337

## Discord contact info

@miriamlefae
