### PR TITLE
Fix some Mirror Armor issues

### DIFF
--- a/include/battle_stat_change.h
+++ b/include/battle_stat_change.h
@@ -43,11 +43,9 @@ void ClearStatChangeValues(void);
 void ClearOtherStatChangeValues(enum BattlerId battler);
 void ClearBothStatChangeQueues(void);
 enum StatChangeResult TrySingleStatChange(struct BattleCalcValues *cv, struct StatChange *st);
-
 u32 GetStatStage(u32 stat, const struct AdditionalEffect *additionalEffect);
-
+bool32 ShouldDefiantCompetitiveActivate(enum BattlerId battler, enum Ability ability);
 enum MoveResult DoStatChangeResolution(struct BattleCalcValues *cv);
-
 bool32 CanStatChange(struct BattleCalcValues *cv, struct StatChange *st);
 bool32 IsStatChangeStatusMove(enum Move move, bool32 (*isStatChange)(const struct AdditionalEffect *effect));
 bool32 IsAtkStatUpMove(const struct AdditionalEffect *effect);

--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -183,7 +183,6 @@ void MarkBattlerForControllerExec(enum BattlerId battler);
 void MarkBattlerReceivedLinkData(enum BattlerId battler);
 void CancelMultiTurnMoves(enum BattlerId battler);
 bool32 IsLastMonToMove(enum BattlerId battler);
-bool32 ShouldDefiantCompetitiveActivate(enum BattlerId battler, enum Ability ability);
 void PrepareStringBattle(enum StringID stringId, enum BattlerId battler);
 void ResetSentPokesToOpponentValue(void);
 void OpponentSwitchInResetSentPokesToOpponentValue(enum BattlerId battler);

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -191,7 +191,7 @@
 #define B_BATTLE_BOND               GEN_LATEST // In Gen9+, Battle Bond increases Atk, SpAtk and Speed by one stage, once per battle
 #define B_ATE_MULTIPLIER            GEN_LATEST // In Gen7+, -ate abilities (Aerilate, Galvanize, Normalize, Pixilate, Refrigerate) multiply damage by 1.2. Otherwise, it's 1.3, except Normalize which has no multiplier.
 #define B_DEFIANT_STICKY_WEB        GEN_LATEST // In Gen9+, Defiant activates on Sticky Web regardless of who set it up. In Gen8, Defiant does not activate on Sticky Web set up by an ally after Court Change swaps its side.
-#define B_MIRROR_ARMOR_DEFIANT      GEN_LATEST // In Gen9+, Mirror Armor does not reflect the Sticky Web stat change even if the orignal Sticky Web user is still on the field
+#define B_MIRROR_ARMOR_STICKY_WEB   GEN_LATEST // In Gen9+, Mirror Armor does not reflect the Sticky Web stat change even if the original Sticky Web user is still on the field
 #define B_POWDER_OVERCOAT           GEN_LATEST // In Gen6+, Overcoat blocks powder and spore moves from affecting the user.
 #define B_INFILTRATOR_SUBSTITUTE    GEN_LATEST // In Gen6+, Infiltrator bypasses Substitute when using a move, excluding Transform and Sky Drop.
 #define B_DANCER_ORDER              GEN_LATEST // In Gen8+, Dancer activations are based on Speed order including modifiers. In Gen7, Dancer activates from the slowest to fastest battler based on the battler's unmodified Speed stat.

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -191,6 +191,7 @@
 #define B_BATTLE_BOND               GEN_LATEST // In Gen9+, Battle Bond increases Atk, SpAtk and Speed by one stage, once per battle
 #define B_ATE_MULTIPLIER            GEN_LATEST // In Gen7+, -ate abilities (Aerilate, Galvanize, Normalize, Pixilate, Refrigerate) multiply damage by 1.2. Otherwise, it's 1.3, except Normalize which has no multiplier.
 #define B_DEFIANT_STICKY_WEB        GEN_LATEST // In Gen9+, Defiant activates on Sticky Web regardless of who set it up. In Gen8, Defiant does not activate on Sticky Web set up by an ally after Court Change swaps its side.
+#define B_MIRROR_ARMOR_DEFIANT      GEN_LATEST // In Gen9+, Mirror Armor does not reflect the Sticky Web stat change even if the orignal Sticky Web user is still on the field
 #define B_POWDER_OVERCOAT           GEN_LATEST // In Gen6+, Overcoat blocks powder and spore moves from affecting the user.
 #define B_INFILTRATOR_SUBSTITUTE    GEN_LATEST // In Gen6+, Infiltrator bypasses Substitute when using a move, excluding Transform and Sky Drop.
 #define B_DANCER_ORDER              GEN_LATEST // In Gen8+, Dancer activations are based on Speed order including modifiers. In Gen7, Dancer activates from the slowest to fastest battler based on the battler's unmodified Speed stat.

--- a/include/constants/config_changes.h
+++ b/include/constants/config_changes.h
@@ -173,6 +173,7 @@
     F(B_BATTLE_BOND,               battleBond,              (u32, GEN_COUNT - 1)) \
     F(B_ATE_MULTIPLIER,            ateMultiplier,           (u32, GEN_COUNT - 1)) \
     F(B_DEFIANT_STICKY_WEB,        defiantStickyWeb,        (u32, GEN_COUNT - 1)) \
+    F(B_MIRROR_ARMOR_DEFIANT,      mirrorArmorStickyWeb,    (u32, GEN_COUNT - 1)) \
     F(B_INFILTRATOR_SUBSTITUTE,    infiltratorSubstitute,   (u32, GEN_COUNT - 1)) \
     F(B_DANCER_ORDER,              dancerOrder,             (u32, GEN_COUNT - 1)) \
     /* Item settings */ \

--- a/include/constants/config_changes.h
+++ b/include/constants/config_changes.h
@@ -173,7 +173,7 @@
     F(B_BATTLE_BOND,               battleBond,              (u32, GEN_COUNT - 1)) \
     F(B_ATE_MULTIPLIER,            ateMultiplier,           (u32, GEN_COUNT - 1)) \
     F(B_DEFIANT_STICKY_WEB,        defiantStickyWeb,        (u32, GEN_COUNT - 1)) \
-    F(B_MIRROR_ARMOR_DEFIANT,      mirrorArmorStickyWeb,    (u32, GEN_COUNT - 1)) \
+    F(B_MIRROR_ARMOR_STICKY_WEB,   mirrorArmorStickyWeb,    (u32, GEN_COUNT - 1)) \
     F(B_INFILTRATOR_SUBSTITUTE,    infiltratorSubstitute,   (u32, GEN_COUNT - 1)) \
     F(B_DANCER_ORDER,              dancerOrder,             (u32, GEN_COUNT - 1)) \
     /* Item settings */ \

--- a/src/battle_stat_change.c
+++ b/src/battle_stat_change.c
@@ -758,7 +758,7 @@ static bool32 IsMirrorArmorReflected(struct BattleCalcValues *cv, struct StatCha
 
         if (st->stickyWeb)
         {
-            if (GetConfig(B_MIRROR_ARMOR_DEFIANT) >= GEN_9)
+            if (GetConfig(B_MIRROR_ARMOR_STICKY_WEB) >= GEN_9)
             {
                 st->script = BattleScript_AbilityPopUp;
                 return TRUE;

--- a/src/battle_stat_change.c
+++ b/src/battle_stat_change.c
@@ -751,6 +751,7 @@ static bool32 IsMirrorArmorReflected(struct BattleCalcValues *cv, struct StatCha
 
     if (gBattleStruct->moveResultFlags[cv->battlerDef] & MOVE_RESULT_MIRROR_ARMOR_PENDING || !st->ignoreCertainFailure)
     {
+        st->silentFailure = FALSE; // Mirror Armor still deflects damaging move stat drops
         st->script = BattleScript_MirrorArmorReflect;
         gBattlerAbility = cv->battlerDef;
         RecordAbilityBattle(cv->battlerDef, cv->abilities[cv->battlerDef]);
@@ -773,6 +774,9 @@ static bool32 IsMirrorArmorReflected(struct BattleCalcValues *cv, struct StatCha
                 gBattleScripting.battler = cv->battlerDef;
             else
                 gBattleScripting.battler = cv->battlerAtk;
+
+            if (IsBattlerAlly(cv->battlerAtk, cv->battlerDef))
+                gBattleStruct->ignoreDefiant = TRUE;
 
             gBattleStruct->allowPartingShot = TRUE;
         }
@@ -850,6 +854,34 @@ static bool32 AbilityPreventsSpecificStatDrop(u32 ability, u32 stat)
     default:
         return FALSE;
     }
+}
+
+bool32 ShouldDefiantCompetitiveActivate(enum BattlerId battler, enum Ability ability)
+{
+    enum BattleSide side = GetBattlerSide(battler);
+
+    if (gBattleStruct->ignoreDefiant)
+        return FALSE;
+
+    switch (ability)
+    {
+    case ABILITY_DEFIANT:
+        if (CompareStat(battler, STAT_ATK, MAX_STAT_STAGE, CMP_EQUAL, ability))
+            return FALSE;
+        break;
+    case ABILITY_COMPETITIVE:
+        if (CompareStat(battler, STAT_SPATK, MAX_STAT_STAGE, CMP_EQUAL, ability))
+            return FALSE;
+        break;
+    default:
+        return FALSE;
+    }
+
+    if (GetConfig(B_DEFIANT_STICKY_WEB) >= GEN_9 || !gBattleScripting.stickyWebStatDrop)
+        return TRUE;
+
+    // only activate Defiant/Competitive if Web was setup by foe
+    return gSideTimers[side].stickyWebBattlerSide != side;
 }
 
 u32 GetStatStage(u32 stat, const struct AdditionalEffect *additionalEffect)

--- a/src/battle_stat_change.c
+++ b/src/battle_stat_change.c
@@ -758,22 +758,19 @@ static bool32 IsMirrorArmorReflected(struct BattleCalcValues *cv, struct StatCha
 
         if (st->stickyWeb)
         {
-            if (gSideTimers[GetBattlerSide(cv->battlerDef)].stickyWebBattlerId != 0xFF)
-            {
-                gBattleScripting.battler = gSideTimers[GetBattlerSide(cv->battlerDef)].stickyWebBattlerId;
-            }
-            else
+            if (GetConfig(B_MIRROR_ARMOR_DEFIANT) >= GEN_9)
             {
                 st->script = BattleScript_AbilityPopUp;
                 return TRUE;
             }
+            else if (gSideTimers[GetBattlerSide(cv->battlerDef)].stickyWebBattlerId != 0xFF)
+            {
+                gBattleScripting.battler = gSideTimers[GetBattlerSide(cv->battlerDef)].stickyWebBattlerId;
+            }
         }
         else
         {
-            if (cv->battlerAtk == cv->battlerDef)
-                gBattleScripting.battler = cv->battlerDef;
-            else
-                gBattleScripting.battler = cv->battlerAtk;
+            gBattleScripting.battler = cv->battlerAtk;
 
             if (IsBattlerAlly(cv->battlerAtk, cv->battlerDef))
                 gBattleStruct->ignoreDefiant = TRUE;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -1146,34 +1146,6 @@ static bool32 Ai_AttackerMovesLast(enum BattlerId battlerAtk)
     return FALSE;
 }
 
-bool32 ShouldDefiantCompetitiveActivate(enum BattlerId battler, enum Ability ability)
-{
-    enum BattleSide side = GetBattlerSide(battler);
-
-    if (gBattleStruct->ignoreDefiant)
-        return FALSE;
-
-    switch (ability)
-    {
-    case ABILITY_DEFIANT:
-        if (CompareStat(battler, STAT_ATK, MAX_STAT_STAGE, CMP_EQUAL, ability))
-            return FALSE;
-        break;
-    case ABILITY_COMPETITIVE:
-        if (CompareStat(battler, STAT_SPATK, MAX_STAT_STAGE, CMP_EQUAL, ability))
-            return FALSE;
-        break;
-    default:
-        return FALSE;
-    }
-
-    if (GetConfig(B_DEFIANT_STICKY_WEB) >= GEN_9 || !gBattleScripting.stickyWebStatDrop)
-        return TRUE;
-
-    // only activate Defiant/Competitive if Web was setup by foe
-    return gSideTimers[side].stickyWebBattlerSide != side;
-}
-
 void PrepareStringBattle(enum StringID stringId, enum BattlerId battler)
 {
     switch (stringId)

--- a/test/battle/ability/mirror_armor.c
+++ b/test/battle/ability/mirror_armor.c
@@ -264,12 +264,13 @@ DOUBLE_BATTLE_TEST("Mirror Armor does not trigger ally's Defiant")
     }
 }
 
-SINGLE_BATTLE_TEST("Mirror Armor does not does not reflect Sticky Web stat drops (Gen9+)")
+SINGLE_BATTLE_TEST("Mirror Armor does not reflect Sticky Web stat drops (Gen9+)")
 {
     GIVEN {
+        ASSUME(gItemsInfo[ITEM_IRON_BALL].holdEffect == HOLD_EFFECT_IRON_BALL); 
         ASSUME(GetMoveEffect(MOVE_STICKY_WEB) == EFFECT_STICKY_WEB);
         PLAYER(SPECIES_WOBBUFFET);
-        PLAYER(SPECIES_CORVIKNIGHT) { Ability(ABILITY_MIRROR_ARMOR); }
+        PLAYER(SPECIES_CORVIKNIGHT) { Ability(ABILITY_MIRROR_ARMOR); Item(ITEM_IRON_BALL); }
         OPPONENT(SPECIES_WYNAUT);
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {

--- a/test/battle/ability/mirror_armor.c
+++ b/test/battle/ability/mirror_armor.c
@@ -226,3 +226,61 @@ SINGLE_BATTLE_TEST("Mirror Armor does not trigger if the user is behind a Substi
         }
     }
 }
+
+SINGLE_BATTLE_TEST("Mirror Armor reflects stat drops triggered by a damaging move")
+{
+    GIVEN {
+        ASSUME_MOVE_EFFECT_STAT_CHANGE(MOVE_ICY_WIND, speed: -1);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_CORVIKNIGHT) { Ability(ABILITY_MIRROR_ARMOR); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_ICY_WIND); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ICY_WIND, player);
+        HP_BAR(opponent);
+        ABILITY_POPUP(opponent, ABILITY_MIRROR_ARMOR);
+        NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+    } THEN {
+        EXPECT_EQ(opponent->statStages[STAT_SPEED], DEFAULT_STAT_STAGE);
+        EXPECT_EQ(player->statStages[STAT_SPEED], DEFAULT_STAT_STAGE - 1);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Mirror Armor does not trigger ally's Defiant")
+{
+    GIVEN {
+        PLAYER(SPECIES_CORVIKNIGHT) { Ability(ABILITY_MIRROR_ARMOR); }
+        PLAYER(SPECIES_PRIMEAPE) { Ability(ABILITY_DEFIANT); }
+        OPPONENT(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN { MOVE(playerRight, MOVE_FAKE_TEARS, target: playerLeft); }
+    } SCENE {
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_FAKE_TEARS, playerRight);
+        ABILITY_POPUP(playerLeft, ABILITY_MIRROR_ARMOR);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, playerRight);
+        NOT ABILITY_POPUP(playerRight, ABILITY_DEFIANT);
+    }
+}
+
+SINGLE_BATTLE_TEST("Mirror Armor does not does not reflect Sticky Web stat drops (Gen9+)")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_STICKY_WEB) == EFFECT_STICKY_WEB);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_CORVIKNIGHT) { Ability(ABILITY_MIRROR_ARMOR); }
+        OPPONENT(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_STICKY_WEB); }
+        TURN { SWITCH(player, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_STICKY_WEB, opponent);
+        NONE_OF {
+            ABILITY_POPUP(player, ABILITY_MIRROR_ARMOR);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        }
+    }
+}

--- a/test/battle/ability/mirror_armor.c
+++ b/test/battle/ability/mirror_armor.c
@@ -266,8 +266,14 @@ DOUBLE_BATTLE_TEST("Mirror Armor does not trigger ally's Defiant")
 
 SINGLE_BATTLE_TEST("Mirror Armor does not reflect Sticky Web stat drops (Gen9+)")
 {
+    u32 config;
+
+    PARAMETRIZE { config = GEN_8; }
+    PARAMETRIZE { config = GEN_9; }
+
     GIVEN {
-        ASSUME(gItemsInfo[ITEM_IRON_BALL].holdEffect == HOLD_EFFECT_IRON_BALL); 
+        WITH_CONFIG(B_MIRROR_ARMOR_DEFIANT, config);
+        ASSUME(gItemsInfo[ITEM_IRON_BALL].holdEffect == HOLD_EFFECT_IRON_BALL);
         ASSUME(GetMoveEffect(MOVE_STICKY_WEB) == EFFECT_STICKY_WEB);
         PLAYER(SPECIES_WOBBUFFET);
         PLAYER(SPECIES_CORVIKNIGHT) { Ability(ABILITY_MIRROR_ARMOR); Item(ITEM_IRON_BALL); }
@@ -278,10 +284,15 @@ SINGLE_BATTLE_TEST("Mirror Armor does not reflect Sticky Web stat drops (Gen9+)"
         TURN { SWITCH(player, 1); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_STICKY_WEB, opponent);
-        NONE_OF {
-            ABILITY_POPUP(player, ABILITY_MIRROR_ARMOR);
+        ABILITY_POPUP(player, ABILITY_MIRROR_ARMOR);
+        if (config == GEN_8) {
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
-            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+            NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        } else {
+            NONE_OF {
+                ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
+                ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+            }
         }
     }
 }

--- a/test/battle/ability/mirror_armor.c
+++ b/test/battle/ability/mirror_armor.c
@@ -264,7 +264,7 @@ DOUBLE_BATTLE_TEST("Mirror Armor does not trigger ally's Defiant")
     }
 }
 
-SINGLE_BATTLE_TEST("Mirror Armor does not reflect Sticky Web stat drops (Gen9+)")
+SINGLE_BATTLE_TEST("Mirror Armor does not reflect Sticky Web stat drops (Gen9+) / reflects onto Sticky Web setter (Gen 8)")
 {
     u32 config;
 
@@ -272,7 +272,7 @@ SINGLE_BATTLE_TEST("Mirror Armor does not reflect Sticky Web stat drops (Gen9+)"
     PARAMETRIZE { config = GEN_9; }
 
     GIVEN {
-        WITH_CONFIG(B_MIRROR_ARMOR_DEFIANT, config);
+        WITH_CONFIG(B_MIRROR_ARMOR_STICKY_WEB, config);
         ASSUME(gItemsInfo[ITEM_IRON_BALL].holdEffect == HOLD_EFFECT_IRON_BALL);
         ASSUME(GetMoveEffect(MOVE_STICKY_WEB) == EFFECT_STICKY_WEB);
         PLAYER(SPECIES_WOBBUFFET);

--- a/test/battle/move_effect/sticky_web.c
+++ b/test/battle/move_effect/sticky_web.c
@@ -98,7 +98,7 @@ SINGLE_BATTLE_TEST("Sticky Web raises Speed by 1 for a Pokemon with Contrary")
 #define BATTLER_OPPONENT (opponentSetUpper == 0 ? opponentLeft : opponentRight)
 #define BATTLER_PLAYER (playerSetUpper == 0 ? playerLeft : playerRight)
 
-DOUBLE_BATTLE_TEST("Sticky Web has correct interactions with Mirror Armor - the battler which set up Sticky Web has its Speed lowered instead")
+DOUBLE_BATTLE_TEST("Sticky Web has correct interactions with Mirror Armor - the battler which set up Sticky Web has its Speed lowered instead (Gen8)")
 {
     u8 playerSetUpper, opponentSetUpper; // 0 left, 1 right
 
@@ -108,6 +108,7 @@ DOUBLE_BATTLE_TEST("Sticky Web has correct interactions with Mirror Armor - the 
     PARAMETRIZE { playerSetUpper = 1; opponentSetUpper = 1; }
 
     GIVEN {
+        WITH_CONFIG(B_MIRROR_ARMOR_DEFIANT, GEN_8);
         PLAYER(SPECIES_SQUIRTLE);
         PLAYER(SPECIES_CHARMANDER);
         PLAYER(SPECIES_CORVIKNIGHT) { Ability(ABILITY_MIRROR_ARMOR); Item(ITEM_IRON_BALL); } // Iron Ball, so that flying type Corviknight is affected by Sticky Web.
@@ -275,9 +276,10 @@ SINGLE_BATTLE_TEST("Sticky Web is placed on the correct side after Memento")
     }
 }
 
-DOUBLE_BATTLE_TEST("Sticky Web setter has their speed lowered with Mirror Armor even after Ally Switch")
+DOUBLE_BATTLE_TEST("Sticky Web setter has their speed lowered with Mirror Armor even after Ally Switch (Gen8)")
 {
     GIVEN {
+        WITH_CONFIG(B_MIRROR_ARMOR_DEFIANT, GEN_8);
         PLAYER(SPECIES_SQUIRTLE);
         PLAYER(SPECIES_CHARMANDER);
         PLAYER(SPECIES_CORVIKNIGHT) { Ability(ABILITY_MIRROR_ARMOR); Item(ITEM_IRON_BALL); } // Iron Ball, so that flying type Corviknight is affected by Sticky Web.

--- a/test/battle/move_effect/sticky_web.c
+++ b/test/battle/move_effect/sticky_web.c
@@ -108,7 +108,7 @@ DOUBLE_BATTLE_TEST("Sticky Web has correct interactions with Mirror Armor - the 
     PARAMETRIZE { playerSetUpper = 1; opponentSetUpper = 1; }
 
     GIVEN {
-        WITH_CONFIG(B_MIRROR_ARMOR_DEFIANT, GEN_8);
+        WITH_CONFIG(B_MIRROR_ARMOR_STICKY_WEB, GEN_8);
         PLAYER(SPECIES_SQUIRTLE);
         PLAYER(SPECIES_CHARMANDER);
         PLAYER(SPECIES_CORVIKNIGHT) { Ability(ABILITY_MIRROR_ARMOR); Item(ITEM_IRON_BALL); } // Iron Ball, so that flying type Corviknight is affected by Sticky Web.
@@ -279,7 +279,7 @@ SINGLE_BATTLE_TEST("Sticky Web is placed on the correct side after Memento")
 DOUBLE_BATTLE_TEST("Sticky Web setter has their speed lowered with Mirror Armor even after Ally Switch (Gen8)")
 {
     GIVEN {
-        WITH_CONFIG(B_MIRROR_ARMOR_DEFIANT, GEN_8);
+        WITH_CONFIG(B_MIRROR_ARMOR_STICKY_WEB, GEN_8);
         PLAYER(SPECIES_SQUIRTLE);
         PLAYER(SPECIES_CHARMANDER);
         PLAYER(SPECIES_CORVIKNIGHT) { Ability(ABILITY_MIRROR_ARMOR); Item(ITEM_IRON_BALL); } // Iron Ball, so that flying type Corviknight is affected by Sticky Web.


### PR DESCRIPTION
Fixes  #10331

Fixes Defiant triggering on ally if stat drop are induced by Mirror Armor
Fixes Mirror Armor not triggering on damaging stat drop moves
Adds config for gen9 sticky web mirror armor interaction