### PR TITLE
Fix incorrect Mummy and Doodle ability tests

### DIFF
--- a/test/battle/ability/mummy.c
+++ b/test/battle/ability/mummy.c
@@ -86,17 +86,16 @@ SINGLE_BATTLE_TEST("Mummy doesn't replace abilities that can't be suppressed")
     PARAMETRIZE { species = SPECIES_CALYREX_ICE; ability = ABILITY_AS_ONE_ICE_RIDER; }
     PARAMETRIZE { species = SPECIES_CALYREX_SHADOW; ability = ABILITY_AS_ONE_SHADOW_RIDER; }
     PARAMETRIZE { species = SPECIES_PALAFIN_ZERO; ability = ABILITY_ZERO_TO_HERO; }
-    PARAMETRIZE { species = SPECIES_TATSUGIRI; ability = ABILITY_COMMANDER; }
 
     GIVEN {
-        PLAYER(SPECIES_YAMASK);
+        PLAYER(SPECIES_YAMASK) { Ability(ABILITY_MUMMY); }
         OPPONENT(species) { Ability(ability); }
     } WHEN {
         TURN { MOVE(opponent, MOVE_AQUA_JET); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_AQUA_JET, opponent);
-        NONE_OF {
-            ABILITY_POPUP(opponent, ABILITY_MUMMY);
-        }
+        NOT ABILITY_POPUP(player, ABILITY_MUMMY);
+    } THEN {
+        EXPECT(opponent->ability == ability);
     }
 }

--- a/test/battle/move_effect/doodle.c
+++ b/test/battle/move_effect/doodle.c
@@ -102,17 +102,19 @@ DOUBLE_BATTLE_TEST("Doodle fails if ally's ability can't be suppressed")
     PARAMETRIZE { species = SPECIES_CALYREX_ICE; ability = ABILITY_AS_ONE_ICE_RIDER; }
     PARAMETRIZE { species = SPECIES_CALYREX_SHADOW; ability = ABILITY_AS_ONE_SHADOW_RIDER; }
     PARAMETRIZE { species = SPECIES_PALAFIN_ZERO; ability = ABILITY_ZERO_TO_HERO; }
-    PARAMETRIZE { species = SPECIES_TATSUGIRI; ability = ABILITY_COMMANDER; }
 
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET) { Ability(ABILITY_TELEPATHY); }
         PLAYER(SPECIES_WOBBUFFET) { Ability(ABILITY_TELEPATHY); }
-        OPPONENT(SPECIES_WOBBUFFET) { Ability(ABILITY_TELEPATHY); }
+        OPPONENT(SPECIES_WOBBUFFET) { Ability(ABILITY_SHADOW_TAG); }
         OPPONENT(species) { Ability(ability); }
     } WHEN {
         TURN { MOVE(opponentLeft, MOVE_DOODLE, target: playerLeft); }
     } SCENE {
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_DOODLE, opponentLeft);
         MESSAGE("But it failed!");
+    } THEN {
+        EXPECT(opponentLeft->ability == ABILITY_SHADOW_TAG);
+        EXPECT(opponentRight->ability == ability);
     }
 }


### PR DESCRIPTION
## Description
Found in #10357 , even after removing Commander's
```
.cantBeSuppressed = TRUE
.cantBeOverwritten = TRUE
```

`Mummy doesn't replace abilities that can't be suppressed` and `Doodle fails if ally's ability can't be suppressed` still pass. After checking, the tests appear to be incorrect:

- Test 1 checks `ABILITY_POPUP` on the wrong battler.
- Test 2 passes accidentally because it first hits the failure condition where the user’s Ability is already the same as the target Ability. According to [Jpwiki](https://wiki.pokemonwiki.com/wiki/%e3%81%86%e3%81%a4%e3%81%97%e3%81%88):

> _Doodle should ignore the battler whose Ability already matches the target Ability and still change the other ally’s Ability. It should only fail if both the user and ally are skipped._ 

Will open an issue for this.
