### PR TITLE
Fix duplicate CANCEL entry in move relearner list after replacing a move

### DIFF
--- a/src/move_relearner.c
+++ b/src/move_relearner.c
@@ -524,8 +524,14 @@ static void UIEndTask(u8 taskId)
     }
     if (gSpecialVar_Result == TRUE)
     {
+        DestroyListMenuTask(sMoveRelearnerStruct->moveListMenuTask, &sMoveRelearnerScrollState.listOffset, &sMoveRelearnerScrollState.listRow);
         CreateLearnableMovesList();
-        RedrawListMenu(sMoveRelearnerStruct->moveListMenuTask);
+        if (sMoveRelearnerScrollState.listOffset + sMoveRelearnerScrollState.listRow >= sMoveRelearnerStruct->numMenuChoices)
+        {
+            sMoveRelearnerScrollState.listOffset = 0;
+            sMoveRelearnerScrollState.listRow = 0;
+        }
+        sMoveRelearnerStruct->moveListMenuTask = ListMenuInit(&gMultiuseListMenuTemplate, sMoveRelearnerScrollState.listOffset, sMoveRelearnerScrollState.listRow);
     }
     ShowTeachMoveText();
     AddScrollArrows();


### PR DESCRIPTION
UIEndTask rebuilt the relearnable moves list after teaching a move but only called RedrawListMenu, which redraws using the ListMenu's cached totalItems/maxShowed from when it was first initialized (before the move was replaced). If the new list is shorter, the leftover slot still holds stale data from the previous render, showing CANCEL twice when a move becomes relearnable again after being replaced by something outside the relearner list (e.g. a TM).

Now the list menu task is destroyed and reinitialized with the fresh item count instead of just redrawn.

## Discord contact info
thales21
