### PR TITLE
Fix single-target moves hitting all foes in the shared shadow animation

### DIFF
--- a/src/battle_anim_ghost.c
+++ b/src/battle_anim_ghost.c
@@ -870,7 +870,7 @@ void AnimTask_DestinyBondWhiteShadow(u8 taskId)
             if (battler != gBattleAnimAttacker
              && battler != BATTLE_PARTNER(gBattleAnimAttacker)
              && IsBattlerSpriteVisible(battler)
-             && (gAnimMoveIndex == MOVE_DARK_VOID || gAnimMoveIndex == MOVE_DESTINY_BOND || battler == gBattleAnimTarget))
+             && (GetMoveTarget(gAnimMoveIndex) == TARGET_BOTH || gAnimMoveIndex == MOVE_DESTINY_BOND || battler == gBattleAnimTarget))
             {
                 if (gAnimMoveIndex == MOVE_DARK_VOID
                  || gAnimMoveIndex == MOVE_POLTERGEIST)

--- a/src/battle_anim_ghost.c
+++ b/src/battle_anim_ghost.c
@@ -869,7 +869,8 @@ void AnimTask_DestinyBondWhiteShadow(u8 taskId)
         {
             if (battler != gBattleAnimAttacker
              && battler != BATTLE_PARTNER(gBattleAnimAttacker)
-             && IsBattlerSpriteVisible(battler))
+             && IsBattlerSpriteVisible(battler)
+             && (gAnimMoveIndex == MOVE_DARK_VOID || gAnimMoveIndex == MOVE_DESTINY_BOND || battler == gBattleAnimTarget))
             {
                 if (gAnimMoveIndex == MOVE_DARK_VOID
                  || gAnimMoveIndex == MOVE_POLTERGEIST)

--- a/src/battle_anim_ghost.c
+++ b/src/battle_anim_ghost.c
@@ -870,7 +870,9 @@ void AnimTask_DestinyBondWhiteShadow(u8 taskId)
             if (battler != gBattleAnimAttacker
              && battler != BATTLE_PARTNER(gBattleAnimAttacker)
              && IsBattlerSpriteVisible(battler)
-             && (GetMoveTarget(gAnimMoveIndex) == TARGET_BOTH || gAnimMoveIndex == MOVE_DESTINY_BOND || battler == gBattleAnimTarget))
+             && (GetMoveTarget(gAnimMoveIndex) == TARGET_BOTH // Move hits both foes on purpose, e.g. Dark Void
+              || GetMoveTarget(gAnimMoveIndex) == TARGET_USER // Real target isn't known yet at animation time, e.g. Destiny Bond
+              || battler == gBattleAnimTarget)) // Otherwise only send the shadow to the actual move target
             {
                 if (gAnimMoveIndex == MOVE_DARK_VOID
                  || gAnimMoveIndex == MOVE_POLTERGEIST)


### PR DESCRIPTION
## Summary
- `AnimTask_DestinyBondWhiteShadow` (shared by Destiny Bond, Dark Void, Phantom Force, Hyperspace Hole, Spectral Thief, Skitter Smack, Poltergeist and Shadow Sneak) creates a shadow streak toward every visible battler on the opposing side, without checking whether that battler is actually the move's target.
- In double battles, this made all the single-target moves in that list (everything except Dark Void) send the shadow to both opponents even though only the real target gets hit by the impact animation.

## Fix
The condition is now based on the move's actual target type, so it stays correct if any of these moves' targets ever change:
- `TARGET_BOTH` (Dark Void) keeps hitting every opposing battler on purpose.
- `TARGET_USER` (Destiny Bond) also keeps hitting every opposing battler, since the real target isn't known until a foe lands the finishing blow — `gBattleAnimTarget` just points at the user when this animation plays.
- Everything else now only sends the shadow to the actual `gBattleAnimTarget`.

The attacker's ally was already, and still is, unconditionally excluded regardless of the move's target — that part was untouched.

## Discord contact info
thales21
