### PR TITLE
Renaming + reworking Can Use All Moves to Values Moves Over Splash.

### DIFF
--- a/test/battle/ai/values_moves_over_splash.c
+++ b/test/battle/ai/values_moves_over_splash.c
@@ -7,55 +7,7 @@
 // Jump to "TODO: AI HANDLING" and "TODO: AI TESTS"
 // In many cases, AI handling exists but is likely insufficient in some way.
 
-AI_DOUBLE_BATTLE_TEST("AI uses Final Gambit")
-{
-    GIVEN {
-        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT);
-        PLAYER(SPECIES_WOBBUFFET);
-        PLAYER(SPECIES_WOBBUFFET);
-        PLAYER(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_WOBBUFFET) { Moves(MOVE_SPLASH, MOVE_FINAL_GAMBIT); }
-        OPPONENT(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_WOBBUFFET);
-    } WHEN {
-        TURN { EXPECT_MOVE(opponentLeft, MOVE_FINAL_GAMBIT); SEND_OUT(playerLeft, 2); }
-    }
-}
-
-AI_DOUBLE_BATTLE_TEST("AI uses Guillotine")
-{
-    GIVEN {
-        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT);
-        PLAYER(SPECIES_WOBBUFFET);
-        PLAYER(SPECIES_WOBBUFFET);
-        PLAYER(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_WOBBUFFET) { Moves(MOVE_SPLASH, MOVE_GUILLOTINE); }
-        OPPONENT(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_WOBBUFFET);
-    } WHEN {
-        TURN { EXPECT_MOVE(opponentLeft, MOVE_GUILLOTINE); SEND_OUT(playerLeft, 2); }
-    }
-}
-
-AI_DOUBLE_BATTLE_TEST("AI uses Sheer Cold")
-{
-    GIVEN {
-        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT);
-        PLAYER(SPECIES_WOBBUFFET);
-        PLAYER(SPECIES_WOBBUFFET);
-        PLAYER(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_WOBBUFFET) { Moves(MOVE_SPLASH, MOVE_SHEER_COLD); }
-        OPPONENT(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_WOBBUFFET);
-    } WHEN {
-        TURN { EXPECT_MOVE(opponentLeft, MOVE_SHEER_COLD); SEND_OUT(playerLeft, 2); }
-    }
-}
-
-AI_DOUBLE_BATTLE_TEST("AI can use all moves, 1-100")
+AI_DOUBLE_BATTLE_TEST("AI values moves above Splash, 1-100")
 {
     enum Move moveStart = MOVE_NONE;
     enum Move moveCap = 100;
@@ -63,61 +15,59 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 1-100")
     if (moveCap > MOVES_COUNT)
         moveCap = MOVES_COUNT - 1;
 
-    s32 j;
     enum Move move = MOVE_NONE;
 
     enum BattleMoveEffects effect;
 
-    for (j = moveStart + 1; j <= moveCap; j++)
+    for (u32 j = moveStart + 1; j <= moveCap; j++)
     {
         effect = GetMoveEffect(j);
-
-        // Stat raising effects are not meant to be used when you have only Splash.
-        if (IsStatRaisingMove(j))
-            continue;
 
         switch (effect)
         {
         //TODO: AI HANDLING
-        case EFFECT_OHKO: // Guillotine is crashing the test entirely.
         case EFFECT_MIST:
         case EFFECT_TELEPORT:
 
         //TODO: AI TESTS
         case EFFECT_RESTORE_HP:
-        case EFFECT_MIMIC:
         case EFFECT_DISABLE:
 
         // tests exist elsewhere
-
-        // Skipped on purpose.
-        case EFFECT_PROTECT:
-        case EFFECT_NON_VOLATILE_STATUS:
-        case EFFECT_DO_NOTHING:
-        case EFFECT_HOLD_HANDS:
-        case EFFECT_CELEBRATE:
-        case EFFECT_HAPPY_HOUR:
+        case EFFECT_STAT_CHANGE:
+        case EFFECT_GROWTH:
             break;
+
         default:
             PARAMETRIZE { move = j; }
         }
     }
 
     GIVEN {
-        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_HP_AWARE | AI_FLAG_OMNISCIENT);
-        PLAYER(SPECIES_WOBBUFFET) { Status1(STATUS1_POISON); }
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT);
         PLAYER(SPECIES_WOBBUFFET);
         PLAYER(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_WOBBUFFET) { Moves(MOVE_SPLASH, move); Status1(STATUS1_BURN); Item(ITEM_STARF_BERRY); }
-        OPPONENT(SPECIES_WOBBUFFET) { Moves(MOVE_POUND, move); Item(ITEM_STARF_BERRY); }
-        OPPONENT(SPECIES_WOBBUFFET) { Status1(STATUS1_BURN); }
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { Moves(MOVE_SPLASH, move); }
+        OPPONENT(SPECIES_WOBBUFFET) { Moves(MOVE_POUND, move); }
+        OPPONENT(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
-        TURN { EXPECT_MOVE(opponentLeft, move); }
+        switch (GetMoveEffect(move))
+        {
+        case EFFECT_DISABLE:
+            TURN { SCORE_LT_VAL(opponentLeft, move, AI_SCORE_DEFAULT, target: playerLeft); }
+            break;
+        case EFFECT_OHKO:
+            TURN { EXPECT_MOVE(opponentLeft, move); SEND_OUT(playerLeft, 2); }
+            break;
+        default:
+            TURN { EXPECT_MOVE(opponentLeft, move); }
+        }
     }
 }
 
-AI_DOUBLE_BATTLE_TEST("AI can use all moves, 101-200")
+AI_DOUBLE_BATTLE_TEST("AI values moves above Splash, 101-200")
 {
     enum Move moveStart = 100;
     enum Move moveCap = 200;
@@ -125,18 +75,13 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 101-200")
     if (moveCap > MOVES_COUNT)
         moveCap = MOVES_COUNT - 1;
 
-    s32 j;
     enum Move move = MOVE_NONE;
 
     enum BattleMoveEffects effect;
 
-    for (j = moveStart + 1; j <= moveCap; j++)
+    for (u32 j = moveStart + 1; j <= moveCap; j++)
     {
         effect = GetMoveEffect(j);
-
-        // Stat raising effects are not meant to be used when you have only Splash.
-        if (IsStatRaisingMove(j))
-            continue;
 
         switch (effect)
         {
@@ -163,17 +108,15 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 101-200")
         case EFFECT_SPITE:
 
         // tests exist elsewhere
+        case EFFECT_DEFENSE_CURL:
+        case EFFECT_STAT_CHANGE:
         case EFFECT_HAZE:
         case EFFECT_REST:
         case EFFECT_SNORE:
+        case EFFECT_MINIMIZE:
 
         // Skipped on purpose.
         case EFFECT_PROTECT:
-        case EFFECT_NON_VOLATILE_STATUS:
-        case EFFECT_DO_NOTHING:
-        case EFFECT_HOLD_HANDS:
-        case EFFECT_CELEBRATE:
-        case EFFECT_HAPPY_HOUR:
             break;
         default:
             PARAMETRIZE { move = j; }
@@ -181,8 +124,8 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 101-200")
     }
 
     GIVEN {
-        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_HP_AWARE | AI_FLAG_OMNISCIENT);
-        PLAYER(SPECIES_WOBBUFFET) { Status1(STATUS1_POISON); }
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT);
+        PLAYER(SPECIES_WOBBUFFET);
         PLAYER(SPECIES_WOBBUFFET);
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET) { Moves(MOVE_SPLASH, move); Status1(STATUS1_BURN); Item(ITEM_STARF_BERRY); }
@@ -190,11 +133,21 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 101-200")
         OPPONENT(SPECIES_WOBBUFFET) { Status1(STATUS1_BURN); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
-        TURN { EXPECT_MOVE(opponentLeft, move); }
+        switch (GetMoveEffect(move))
+        {
+        case EFFECT_DO_NOTHING:
+            TURN { SCORE_LT_VAL(opponentLeft, move, AI_SCORE_DEFAULT, target: playerLeft); }
+            break;
+        case EFFECT_OHKO:
+            TURN { EXPECT_MOVE(opponentLeft, move); SEND_OUT(playerLeft, 2); }
+            break;
+        default:
+            TURN { EXPECT_MOVE(opponentLeft, move); }
+        }
     }
 }
 
-AI_DOUBLE_BATTLE_TEST("AI can use all moves, 201-300")
+AI_DOUBLE_BATTLE_TEST("AI values moves above Splash, 201-300")
 {
     enum Move moveStart = 200;
     enum Move moveCap = 300;
@@ -202,18 +155,13 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 201-300")
     if (moveCap > MOVES_COUNT)
         moveCap = MOVES_COUNT - 1;
 
-    s32 j;
     enum Move move = MOVE_NONE;
 
     enum BattleMoveEffects effect;
 
-    for (j = moveStart + 1; j <= moveCap; j++)
+    for (u32 j = moveStart + 1; j <= moveCap; j++)
     {
         effect = GetMoveEffect(j);
-
-        // Stat raising effects are not meant to be used when you have only Splash.
-        if (IsStatRaisingMove(j))
-            continue;
 
         switch (effect)
         {
@@ -240,11 +188,12 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 201-300")
         case EFFECT_SPIT_UP:
         case EFFECT_SWALLOW:
         case EFFECT_WISH:
-        case EFFECT_RECYCLE:
 
         // tests exist elsewhere
+        case EFFECT_STAT_CHANGE:
+        case EFFECT_CHARGE:
+        case EFFECT_STOCKPILE:
         case EFFECT_HEAL_BELL:
-        case EFFECT_SLEEP_TALK:
         case EFFECT_WEATHER:
         case EFFECT_ROLE_PLAY:
         case EFFECT_REFRESH:
@@ -252,10 +201,6 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 201-300")
         // Skipped on purpose.
         case EFFECT_PROTECT:
         case EFFECT_NON_VOLATILE_STATUS:
-        case EFFECT_DO_NOTHING:
-        case EFFECT_HOLD_HANDS:
-        case EFFECT_CELEBRATE:
-        case EFFECT_HAPPY_HOUR:
             break;
         default:
             PARAMETRIZE { move = j; }
@@ -263,7 +208,7 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 201-300")
     }
 
     GIVEN {
-        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_HP_AWARE | AI_FLAG_OMNISCIENT);
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT);
         PLAYER(SPECIES_WOBBUFFET) { Status1(STATUS1_POISON); }
         PLAYER(SPECIES_WOBBUFFET);
         PLAYER(SPECIES_WOBBUFFET);
@@ -272,11 +217,19 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 201-300")
         OPPONENT(SPECIES_WOBBUFFET) { Status1(STATUS1_BURN); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
-        TURN { EXPECT_MOVE(opponentLeft, move); }
+        switch (GetMoveEffect(move))
+        {
+        case EFFECT_RECYCLE:
+        case EFFECT_SLEEP_TALK:
+            TURN { SCORE_LT_VAL(opponentLeft, move, AI_SCORE_DEFAULT, target: playerLeft); }
+            break;
+        default:
+            TURN { EXPECT_MOVE(opponentLeft, move); }
+        }
     }
 }
 
-AI_DOUBLE_BATTLE_TEST("AI can use all moves, 301-400")
+AI_DOUBLE_BATTLE_TEST("AI values moves above Splash, 301-400")
 {
     enum Move moveStart = 300;
     enum Move moveCap = 400;
@@ -284,23 +237,17 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 301-400")
     if (moveCap > MOVES_COUNT)
         moveCap = MOVES_COUNT - 1;
 
-    s32 j;
     enum Move move = MOVE_NONE;
 
     enum BattleMoveEffects effect;
 
-    for (j = moveStart + 1; j <= moveCap; j++)
+    for (u32 j = moveStart + 1; j <= moveCap; j++)
     {
         effect = GetMoveEffect(j);
-
-        // Stat raising effects are not meant to be used when you have only Splash.
-        if (IsStatRaisingMove(j))
-            continue;
 
         switch (effect)
         {
         //TODO: AI HANDLING
-        case EFFECT_OHKO: // Guillotine is crashing the test entirely.
         case EFFECT_WATER_SPORT:
         case EFFECT_LUCKY_CHANT:
         case EFFECT_ME_FIRST:
@@ -314,24 +261,18 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 301-400")
         //TODO: AI TESTS
         case EFFECT_RESTORE_HP:
         case EFFECT_ROOST:
-        case EFFECT_GUARD_SWAP:
-        case EFFECT_POWER_SWAP:
-        case EFFECT_HEART_SWAP:
         case EFFECT_TAILWIND:
         case EFFECT_POWER_TRICK:
         case EFFECT_MAGNET_RISE:
 
         // tests exist elsewhere
+        case EFFECT_STAT_CHANGE:
         case EFFECT_GRAVITY:
         case EFFECT_HEAL_BELL:
 
         // Skipped on purpose.
         case EFFECT_PROTECT:
         case EFFECT_NON_VOLATILE_STATUS:
-        case EFFECT_DO_NOTHING:
-        case EFFECT_HOLD_HANDS:
-        case EFFECT_CELEBRATE:
-        case EFFECT_HAPPY_HOUR:
             break;
         default:
             PARAMETRIZE { move = j; }
@@ -339,7 +280,7 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 301-400")
     }
 
     GIVEN {
-        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_HP_AWARE | AI_FLAG_OMNISCIENT);
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT);
         PLAYER(SPECIES_WOBBUFFET) { Status1(STATUS1_POISON); }
         PLAYER(SPECIES_WOBBUFFET);
         PLAYER(SPECIES_WOBBUFFET);
@@ -348,11 +289,23 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 301-400")
         OPPONENT(SPECIES_WOBBUFFET) { Status1(STATUS1_BURN); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
-        TURN { EXPECT_MOVE(opponentLeft, move); }
+        switch (GetMoveEffect(move))
+        {
+        case EFFECT_GUARD_SWAP:
+        case EFFECT_POWER_SWAP:
+        case EFFECT_HEART_SWAP:
+            TURN { SCORE_LT_VAL(opponentLeft, move, AI_SCORE_DEFAULT, target: playerLeft); }
+            break;
+        case EFFECT_OHKO:
+            TURN { EXPECT_MOVE(opponentLeft, move); SEND_OUT(playerLeft, 2); }
+            break;
+        default:
+            TURN { EXPECT_MOVE(opponentLeft, move); }
+        }
     }
 }
 
-AI_DOUBLE_BATTLE_TEST("AI can use all moves, 401-500")
+AI_DOUBLE_BATTLE_TEST("AI values moves above Splash, 401-500")
 {
     enum Move moveStart = 400;
     enum Move moveCap = 500;
@@ -360,18 +313,13 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 401-500")
     if (moveCap > MOVES_COUNT)
         moveCap = MOVES_COUNT - 1;
 
-    s32 j;
     enum Move move = MOVE_NONE;
 
     enum BattleMoveEffects effect;
 
-    for (j = moveStart + 1; j <= moveCap; j++)
+    for (u32 j = moveStart + 1; j <= moveCap; j++)
     {
         effect = GetMoveEffect(j);
-
-        // Stat raising effects are not meant to be used when you have only Splash.
-        if (IsStatRaisingMove(j))
-            continue;
 
         switch (effect)
         {
@@ -385,10 +333,11 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 401-500")
 
         //TODO: AI TESTS
         case EFFECT_RESTORE_HP:
-        case EFFECT_CAPTIVATE:
         case EFFECT_DARK_VOID: // Gen 4-6's case is not being handled
 
         // tests exist elsewhere
+        case EFFECT_STAT_CHANGE:
+        case EFFECT_AUTOTOMIZE:
         case EFFECT_TRICK_ROOM:
         case EFFECT_GUARD_SPLIT:
         case EFFECT_POWER_SPLIT:
@@ -396,10 +345,6 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 401-500")
         // Skipped on purpose.
         case EFFECT_PROTECT:
         case EFFECT_NON_VOLATILE_STATUS:
-        case EFFECT_DO_NOTHING:
-        case EFFECT_HOLD_HANDS:
-        case EFFECT_CELEBRATE:
-        case EFFECT_HAPPY_HOUR:
             break;
         default:
             PARAMETRIZE { move = j; }
@@ -407,7 +352,7 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 401-500")
     }
 
     GIVEN {
-        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_HP_AWARE | AI_FLAG_OMNISCIENT);
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT);
         PLAYER(SPECIES_WOBBUFFET) { Status1(STATUS1_POISON); }
         PLAYER(SPECIES_WOBBUFFET);
         PLAYER(SPECIES_WOBBUFFET);
@@ -416,11 +361,18 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 401-500")
         OPPONENT(SPECIES_WOBBUFFET) { Status1(STATUS1_BURN); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
-        TURN { EXPECT_MOVE(opponentLeft, move); }
+        switch (GetMoveEffect(move))
+        {
+        case EFFECT_CAPTIVATE:
+            TURN { SCORE_LT_VAL(opponentLeft, move, AI_SCORE_DEFAULT, target: playerLeft); }
+            break;
+        default:
+            TURN { EXPECT_MOVE(opponentLeft, move); }
+        }
     }
 }
 
-AI_DOUBLE_BATTLE_TEST("AI can use all moves, 501-600")
+AI_DOUBLE_BATTLE_TEST("AI values moves above Splash, 501-600")
 {
     enum Move moveStart = 515;
     enum Move moveCap = 600;
@@ -428,22 +380,16 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 501-600")
     if (moveCap > MOVES_COUNT)
         moveCap = MOVES_COUNT - 1;
 
-    s32 j;
     enum Move move = MOVE_NONE;
 
     enum BattleMoveEffects effect;
 
-    for (j = moveStart + 1; j <= moveCap; j++)
+    for (u32 j = moveStart + 1; j <= moveCap; j++)
     {
         effect = GetMoveEffect(j);
 
-        // Stat raising effects are not meant to be used when you have only Splash.
-        if (IsStatRaisingMove(j))
-            continue;
-
         switch (effect)
         {
-        case EFFECT_FINAL_GAMBIT:
         //TODO: AI HANDLING
         case EFFECT_ALLY_SWITCH:
         case EFFECT_QUASH:
@@ -462,6 +408,7 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 501-600")
         case EFFECT_FAIRY_LOCK:
 
         // tests exist elsewhere
+        case EFFECT_STAT_CHANGE:
         case EFFECT_ROTOTILLER:
         case EFFECT_FLOWER_SHIELD:
         case EFFECT_GRASSY_TERRAIN:
@@ -470,10 +417,6 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 501-600")
         // Skipped on purpose.
         case EFFECT_PROTECT:
         case EFFECT_NON_VOLATILE_STATUS:
-        case EFFECT_DO_NOTHING:
-        case EFFECT_HOLD_HANDS:
-        case EFFECT_CELEBRATE:
-        case EFFECT_HAPPY_HOUR:
             break;
         default:
             PARAMETRIZE { move = j; }
@@ -481,7 +424,7 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 501-600")
     }
 
     GIVEN {
-        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_HP_AWARE | AI_FLAG_OMNISCIENT);
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT);
         PLAYER(SPECIES_WOBBUFFET) { Status1(STATUS1_POISON); }
         PLAYER(SPECIES_WOBBUFFET);
         PLAYER(SPECIES_WOBBUFFET);
@@ -490,11 +433,18 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 501-600")
         OPPONENT(SPECIES_WOBBUFFET) { Status1(STATUS1_BURN); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
-        TURN { EXPECT_MOVE(opponentLeft, move); }
+        switch (GetMoveEffect(move))
+        {
+        case EFFECT_FINAL_GAMBIT:
+            TURN { EXPECT_MOVE(opponentLeft, move); SEND_OUT(playerLeft, 2); }
+            break;
+        default:
+            TURN { EXPECT_MOVE(opponentLeft, move); }
+        }
     }
 }
 
-AI_DOUBLE_BATTLE_TEST("AI can use all moves, 601-700")
+AI_DOUBLE_BATTLE_TEST("AI values moves above Splash, 601-700")
 {
     enum Move moveStart = 600;
     enum Move moveCap = 700;
@@ -502,24 +452,17 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 601-700")
     if (moveCap > MOVES_COUNT)
         moveCap = MOVES_COUNT - 1;
 
-    s32 j;
     enum Move move = MOVE_NONE;
 
     enum BattleMoveEffects effect;
 
-    for (j = moveStart + 1; j <= moveCap; j++)
+    for (u32 j = moveStart + 1; j <= moveCap; j++)
     {
         effect = GetMoveEffect(j);
-
-        // Stat raising effects are not meant to be used when you have only Splash.
-        if (IsStatRaisingMove(j))
-            continue;
 
         switch (effect)
         {
         //TODO: AI HANDLING
-        case EFFECT_FAIL_IF_NOT_ARG_TYPE:
-        case EFFECT_STUFF_CHEEKS:
         case EFFECT_NO_RETREAT:
         case EFFECT_TEATIME:
 
@@ -533,18 +476,16 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 601-700")
         case EFFECT_SOAK:
 
         // tests exist elsewhere
+        case EFFECT_STAT_CHANGE:
+        case EFFECT_STUFF_CHEEKS:
+        case EFFECT_GEOMANCY:
         case EFFECT_ELECTRIC_TERRAIN:
         case EFFECT_PSYCHIC_TERRAIN:
         case EFFECT_AURORA_VEIL:
-        case EFFECT_STAT_CHANGE_MAGNETIC:
 
         // Skipped on purpose.
         case EFFECT_PROTECT:
         case EFFECT_NON_VOLATILE_STATUS:
-        case EFFECT_DO_NOTHING:
-        case EFFECT_HOLD_HANDS:
-        case EFFECT_CELEBRATE:
-        case EFFECT_HAPPY_HOUR:
             break;
         default:
             PARAMETRIZE { move = j; }
@@ -552,7 +493,7 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 601-700")
     }
 
     GIVEN {
-        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_HP_AWARE | AI_FLAG_OMNISCIENT);
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT);
         PLAYER(SPECIES_WOBBUFFET) { Status1(STATUS1_POISON); }
         PLAYER(SPECIES_WOBBUFFET);
         PLAYER(SPECIES_WOBBUFFET);
@@ -561,11 +502,26 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 601-700")
         OPPONENT(SPECIES_WOBBUFFET) { Status1(STATUS1_BURN); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
-        TURN { EXPECT_MOVE(opponentLeft, move); }
+        switch (GetMoveEffect(move))
+        {
+        case EFFECT_DO_NOTHING:
+        case EFFECT_HOLD_HANDS:
+        case EFFECT_CELEBRATE:
+        case EFFECT_HAPPY_HOUR:
+        case EFFECT_STAT_CHANGE_MAGNETIC:
+            TURN { SCORE_LT_VAL(opponentLeft, move, AI_SCORE_DEFAULT, target: playerLeft); }
+            break;
+
+        case EFFECT_FAIL_IF_NOT_ARG_TYPE:
+            TURN { NOT_EXPECT_MOVE(opponentLeft, move); }
+            break;
+        default:
+            TURN { EXPECT_MOVE(opponentLeft, move); }
+        }
     }
 }
 
-AI_DOUBLE_BATTLE_TEST("AI can use all moves, 701-800")
+AI_DOUBLE_BATTLE_TEST("AI values moves above Splash, 701-800")
 {
     enum Move moveStart = 700;
     enum Move moveCap = 800;
@@ -573,18 +529,13 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 701-800")
     if (moveCap > MOVES_COUNT)
         moveCap = MOVES_COUNT - 1;
 
-    s32 j;
     enum Move move = MOVE_NONE;
 
     enum BattleMoveEffects effect;
 
-    for (j = moveStart + 1; j <= moveCap; j++)
+    for (u32 j = moveStart + 1; j <= moveCap; j++)
     {
         effect = GetMoveEffect(j);
-
-        // Stat raising effects are not meant to be used when you have only Splash.
-        if (IsStatRaisingMove(j))
-            continue;
 
         switch (effect)
         {
@@ -595,12 +546,13 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 701-800")
 
         //TODO: AI TESTS
         case EFFECT_RESTORE_HP:
-        case EFFECT_STEEL_ROLLER:
         case EFFECT_JUNGLE_HEALING:
         case EFFECT_POWER_TRICK:
         case EFFECT_TAKE_HEART:
 
         // tests exist elsewhere
+        case EFFECT_STAT_CHANGE:
+        case EFFECT_STAT_CHANGE_HALF_HP:
         case EFFECT_COURT_CHANGE:
         case EFFECT_DOODLE:
         case EFFECT_LIFE_DEW:
@@ -608,10 +560,6 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 701-800")
         // Skipped on purpose.
         case EFFECT_PROTECT:
         case EFFECT_NON_VOLATILE_STATUS:
-        case EFFECT_DO_NOTHING:
-        case EFFECT_HOLD_HANDS:
-        case EFFECT_CELEBRATE:
-        case EFFECT_HAPPY_HOUR:
             break;
         default:
             PARAMETRIZE { move = j; }
@@ -619,7 +567,7 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 701-800")
     }
 
     GIVEN {
-        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_HP_AWARE | AI_FLAG_OMNISCIENT);
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT);
         PLAYER(SPECIES_WOBBUFFET) { Status1(STATUS1_POISON); }
         PLAYER(SPECIES_WOBBUFFET);
         PLAYER(SPECIES_WOBBUFFET);
@@ -628,11 +576,18 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 701-800")
         OPPONENT(SPECIES_WOBBUFFET) { Status1(STATUS1_BURN); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
-        TURN { EXPECT_MOVE(opponentLeft, move); }
+        switch (GetMoveEffect(move))
+        {
+        case EFFECT_STEEL_ROLLER:
+            TURN { SCORE_LT_VAL(opponentLeft, move, AI_SCORE_DEFAULT, target: playerLeft); }
+            break;
+        default:
+            TURN { EXPECT_MOVE(opponentLeft, move); }
+        }
     }
 }
 
-AI_DOUBLE_BATTLE_TEST("AI can use all moves, 801-900")
+AI_DOUBLE_BATTLE_TEST("AI values moves above Splash, 801-900")
 {
     enum Move moveStart = 800;
     enum Move moveCap = 900;
@@ -640,18 +595,13 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 801-900")
     if (moveCap > MOVES_COUNT)
         moveCap = MOVES_COUNT - 1;
 
-    s32 j;
     enum Move move = MOVE_NONE;
 
     enum BattleMoveEffects effect;
 
-    for (j = moveStart + 1; j <= moveCap; j++)
+    for (u32 j = moveStart + 1; j <= moveCap; j++)
     {
         effect = GetMoveEffect(j);
-
-        // Stat raising effects are not meant to be used when you have only Splash.
-        if (IsStatRaisingMove(j))
-            continue;
 
         switch (effect)
         {
@@ -664,6 +614,7 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 801-900")
         case EFFECT_TIDY_UP:
 
         // tests exist elsewhere
+        case EFFECT_STAT_CHANGE:
         case EFFECT_DRAGON_CHEER:
             break;
         case EFFECT_WEATHER:
@@ -675,10 +626,6 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 801-900")
         // Skipped on purpose.
         case EFFECT_PROTECT:
         case EFFECT_NON_VOLATILE_STATUS:
-        case EFFECT_DO_NOTHING:
-        case EFFECT_HOLD_HANDS:
-        case EFFECT_CELEBRATE:
-        case EFFECT_HAPPY_HOUR:
             break;
         default:
             PARAMETRIZE { move = j; }
@@ -686,7 +633,7 @@ AI_DOUBLE_BATTLE_TEST("AI can use all moves, 801-900")
     }
 
     GIVEN {
-        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_HP_AWARE | AI_FLAG_OMNISCIENT);
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT);
         PLAYER(SPECIES_WOBBUFFET) { Status1(STATUS1_POISON); }
         PLAYER(SPECIES_WOBBUFFET);
         PLAYER(SPECIES_WOBBUFFET);


### PR DESCRIPTION
## Description
Renamed the tests comparing move AI scores to Splash to be clearer and cleaned them up a bit. Hopefully this makes more sense to people than it had before?

### Large Language Models (AI)
No.

## Discord contact info
wildvenonat