### PR TITLE
Fix debug time scripts leaving followers frozen

### DIFF
--- a/data/scripts/debug.inc
+++ b/data/scripts/debug.inc
@@ -202,6 +202,7 @@ Debug_EventScript_Text_DefensiveIVs:
 
 Debug_EventScript_Script_1::
     dynmultichoice 0, 0, FALSE, 2, 0, DYN_MULTICHOICE_CB_NONE, EventScript_ExampleScript_Text_1, EventScript_ExampleScript_Text_2, EventScript_ExampleScript_Text_3
+    releaseall
     end
 
 EventScript_ExampleScript_Text_1::
@@ -810,22 +811,19 @@ Debug_EventScript_FontTest::
 Debug_EventScript_TellTheTime::
 	callnative DebugMenu_CalculateTime
 	msgbox Debug_EventScript_TellTheTime_Text_0, MSGBOX_DEFAULT
-	waitmessage
-	closemessage
+	releaseall
 	end
 
 Debug_EventScript_PrintTimeOfDay::
 	callnative DebugMenu_CalculateTimeOfDay
 	msgbox DebugEventScript_PrintWeekday_Text_0, MSGBOX_DEFAULT
-	waitmessage
-	closemessage
+	releaseall
 	end
 
 Debug_EventScript_FakeRTCNotEnabled::
 	msgbox Debug_EventScript_FakeRTCNotEnabled_Text_0, MSGBOX_DEFAULT
-	waitmessage
-	closemessage
-	return
+	releaseall
+	end
 
 Debug_EventScript_FakeRTCNotEnabled_Text_0:
 	.string "You currently do not have Fake RTC\nenabled. Please enable it in include/\lconfig/overworld.h$"


### PR DESCRIPTION
## Media
<table>
  <tr>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/4e2562d6-e847-4849-8489-ea0c39443346" alt="Before-Time" width="300" />
      <br />
      <b>Before‑Time</b>
    </td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/44f29bda-bc7d-4b8a-89ce-7c7543135f85" alt="Before-Script1" width="300" />
      <br />
      <b>Before‑Script1</b>
    </td>
  </tr>
  <tr>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/c6b63026-1929-4ee4-8746-fb11d2dfded7" alt="After-Time" width="300" />
      <br />
      <b>After‑Time</b>
    </td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/63815d8c-801c-4810-b8b6-bbfd4ba29f30" alt="After-Script1" width="300" />
      <br />
      <b>After‑Script1</b>
    </td>
  </tr>
</table>

## Issue(s) that this PR fixes
Fixes #10380 