### PR TITLE
Adds overworld weather enum

### DIFF
--- a/include/constants/weather.h
+++ b/include/constants/weather.h
@@ -1,27 +1,30 @@
 #ifndef GUARD_CONSTANTS_WEATHER_H
 #define GUARD_CONSTANTS_WEATHER_H
 
-#define WEATHER_NONE                    0
-#define WEATHER_SUNNY_CLOUDS            1
-#define WEATHER_SUNNY                   2
-#define WEATHER_RAIN                    3
-#define WEATHER_SNOW                    4   // Unused
-#define WEATHER_RAIN_THUNDERSTORM       5
-#define WEATHER_FOG_HORIZONTAL          6
-#define WEATHER_VOLCANIC_ASH            7
-#define WEATHER_SANDSTORM               8
-#define WEATHER_FOG_DIAGONAL            9   // Unused
-#define WEATHER_UNDERWATER              10  // Unused
-#define WEATHER_SHADE                   11  // Original name was closer to WEATHER_CLOUDY/OVERCAST
-#define WEATHER_DROUGHT                 12
-#define WEATHER_DOWNPOUR                13
-#define WEATHER_UNDERWATER_BUBBLES      14
-#define WEATHER_ABNORMAL                15  // The alternating weather during Groudon/Kyogre conflict
-#define WEATHER_ROUTE119_CYCLE          20
-#define WEATHER_ROUTE123_CYCLE          21
-#define WEATHER_FOG                     22  // Aggregate of WEATHER_FOG_HORIZONTAL and WEATHER_FOG_DIAGONAL
-#define WEATHER_DYNAMIC                 23
-#define WEATHER_COUNT                   24
+enum OverworldWeather
+{
+    WEATHER_NONE,
+    WEATHER_SUNNY_CLOUDS,
+    WEATHER_SUNNY,
+    WEATHER_RAIN,
+    WEATHER_SNOW, // Unused
+    WEATHER_RAIN_THUNDERSTORM,
+    WEATHER_FOG_HORIZONTAL,
+    WEATHER_VOLCANIC_ASH,
+    WEATHER_SANDSTORM,
+    WEATHER_FOG_DIAGONAL, // Unused
+    WEATHER_UNDERWATER, // Unused
+    WEATHER_SHADE, // Original name was closer to WEATHER_CLOUDY/OVERCAST
+    WEATHER_DROUGHT,
+    WEATHER_DOWNPOUR,
+    WEATHER_UNDERWATER_BUBBLES,
+    WEATHER_ABNORMAL, // The alternating weather during Groudon/Kyogre conflict
+    WEATHER_ROUTE119_CYCLE,
+    WEATHER_ROUTE123_CYCLE,
+    WEATHER_FOG, // Aggregate of WEATHER_FOG_HORIZONTAL and WEATHER_FOG_DIAGONAL
+    WEATHER_DYNAMIC,
+    WEATHER_COUNT,
+};
 
 // These are used in maps' coord_weather_event entries.
 // They are not a one-to-one mapping with the engine's

--- a/include/field_weather.h
+++ b/include/field_weather.h
@@ -3,6 +3,7 @@
 
 #include "sprite.h"
 #include "constants/field_weather.h"
+#include "constants/weather.h"
 
 #define TAG_WEATHER_START 0x1200
 enum {
@@ -227,9 +228,9 @@ void Bubbles_InitAll(void);
 bool8 Bubbles_Finish(void);
 
 u8 GetSavedWeather(void);
-void SetSavedWeather(u32 weather);
+void SetSavedWeather(enum OverworldWeather weather);
 void SetSavedWeatherFromCurrMapHeader(void);
-void SetWeather(u32 weather);
+void SetWeather(enum OverworldWeather weather);
 void DoCurrentWeather(void);
 void UpdateWeatherPerDay(u16 increment);
 void ResumePausedWeather(void);

--- a/src/field_weather_effect.c
+++ b/src/field_weather_effect.c
@@ -2508,11 +2508,11 @@ static void CreateAbnormalWeatherTask(void)
 #undef tWeatherB
 #undef tDelay
 
-static u8 TranslateWeatherNum(u8);
+static enum OverworldWeather TranslateWeatherNum(enum OverworldWeather weather);
 static void UpdateRainCounter(u8, u8);
 static u8 GetDynamicWeather(void);
 
-void SetSavedWeather(u32 weather)
+void SetSavedWeather(enum OverworldWeather weather)
 {
     u8 oldWeather = gSaveBlock1Ptr->weather;
     gSaveBlock1Ptr->weather = TranslateWeatherNum(weather);
@@ -2526,12 +2526,12 @@ u8 GetSavedWeather(void)
 
 void SetSavedWeatherFromCurrMapHeader(void)
 {
-    u8 oldWeather = gSaveBlock1Ptr->weather;
+    enum OverworldWeather oldWeather = gSaveBlock1Ptr->weather;
     gSaveBlock1Ptr->weather = TranslateWeatherNum(gMapHeader.weather);
     UpdateRainCounter(gSaveBlock1Ptr->weather, oldWeather);
 }
 
-void SetWeather(u32 weather)
+void SetWeather(enum OverworldWeather weather)
 {
     SetSavedWeather(weather);
     SetNextWeather(GetSavedWeather());
@@ -2662,16 +2662,18 @@ static u8 GetDynamicWeather(void)
     return weathers[LocalRandom32(&localRngState) % count];
 }
 
-static u8 TranslateWeatherNum(u8 weather)
+static enum OverworldWeather TranslateWeatherNum(enum OverworldWeather weather)
 {
     switch (weather)
     {
     case WEATHER_NONE:               return WEATHER_NONE;
+    case WEATHER_COUNT:              return WEATHER_NONE;
     case WEATHER_SUNNY_CLOUDS:       return WEATHER_SUNNY_CLOUDS;
     case WEATHER_SUNNY:              return WEATHER_SUNNY;
     case WEATHER_RAIN:               return WEATHER_RAIN;
     case WEATHER_SNOW:               return WEATHER_SNOW;
     case WEATHER_RAIN_THUNDERSTORM:  return WEATHER_RAIN_THUNDERSTORM;
+    case WEATHER_FOG:                return WEATHER_FOG;
     case WEATHER_FOG_HORIZONTAL:     return WEATHER_FOG_HORIZONTAL;
     case WEATHER_VOLCANIC_ASH:       return WEATHER_VOLCANIC_ASH;
     case WEATHER_SANDSTORM:          return WEATHER_SANDSTORM;
@@ -2685,8 +2687,9 @@ static u8 TranslateWeatherNum(u8 weather)
     case WEATHER_ROUTE119_CYCLE:     return sWeatherCycleRoute119[gSaveBlock1Ptr->weatherCycleStage];
     case WEATHER_ROUTE123_CYCLE:     return sWeatherCycleRoute123[gSaveBlock1Ptr->weatherCycleStage];
     case WEATHER_DYNAMIC:            return GetDynamicWeather();
-    default:                         return WEATHER_NONE;
     }
+
+    return WEATHER_NONE;
 }
 
 void UpdateWeatherPerDay(u16 increment)


### PR DESCRIPTION
This is specifically helpful for when users add a new overworld weather, they will be notified by the compiler with places the weather needs to be added to (as long as there is no default state). 