### PR TITLE
Fixes bounced moves not activating some effects

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -700,6 +700,7 @@ struct BattleStruct
     s16 moveDamage[MAX_BATTLERS_COUNT];
     u16 innardsOutHpLost[MAX_BATTLERS_COUNT];
     u32 moveResultFlags[MAX_BATTLERS_COUNT];
+    u32 savedMoveResultFlags[MAX_BATTLERS_COUNT]; // for Bounced moves
     u8 doneDoublesSpreadHit:1;
     u8 calculatedDamageDone:1;
     u8 calculatedSpreadMoveAccuracy:1;

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -684,9 +684,7 @@ static bool32 IsTargetingBothFoes(enum BattlerId battlerAtk, enum BattlerId batt
 {
     if (battlerDef == BATTLE_PARTNER(battlerAtk) || battlerAtk == battlerDef)
     {
-        // Because of Magic Bounce and Magic Coat we don't want to set MOVE_RESULT_NO_EFFECT
-        if (GetMoveCategory(gCurrentMove) != DAMAGE_CATEGORY_STATUS)
-            gBattleStruct->moveResultFlags[battlerDef] = MOVE_RESULT_DOESNT_AFFECT_FOE;
+        gBattleStruct->moveResultFlags[battlerDef] = MOVE_RESULT_DOESNT_AFFECT_FOE;
         return skipFailure;
     }
     return checkFailure;
@@ -3142,7 +3140,7 @@ static enum MoveEndResult MoveEndNextTarget(struct BattleCalcValues *cv)
 static enum MoveEndResult MoveEndBouncedMove(struct BattleCalcValues *cv)
 {
     if (gBattleStruct->bouncedMoveIsUsed)
-    {        
+    {
         gBattleScripting.moveendState++;
         return MOVEEND_RESULT_CONTINUE;
     }

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -3142,10 +3142,9 @@ static enum MoveEndResult MoveEndNextTarget(struct BattleCalcValues *cv)
 static enum MoveEndResult MoveEndBouncedMove(struct BattleCalcValues *cv)
 {
     if (gBattleStruct->bouncedMoveIsUsed)
-    {
-        RestoreAttacker();
-        RestoreTarget();
-        gBattleStruct->bouncedMoveIsUsed = FALSE;
+    {        
+        gBattleScripting.moveendState++;
+        return MOVEEND_RESULT_CONTINUE;
     }
 
     if (gBattleStruct->magicBouncePending || gBattleStruct->magicCoatPending)
@@ -3188,12 +3187,15 @@ static enum MoveEndResult MoveEndBouncedMove(struct BattleCalcValues *cv)
             gBattlerTarget = cv->battlerAtk;
             gBattlerAttacker = bounceBattler;
             gBattleStruct->bouncedMoveIsUsed = TRUE;
+            for (enum BattlerId i = B_BATTLER_0; i < gBattlersCount; i++)
+            {
+                gBattleStruct->savedMoveResultFlags[i] = gBattleStruct->moveResultFlags[i];
+                gBattleStruct->battlerState[cv->battlerAtk].targetsDone[i] = FALSE;
+            }
 
             ClearDamageCalcResults();
             gBattleStruct->eventState.atkCanceler = CANCELER_SET_TARGETS;
             gBattleStruct->eventState.atkCancelerBattler = 0;
-            for (enum BattlerId i = B_BATTLER_0; i < gBattlersCount; i++)
-                gBattleStruct->battlerState[cv->battlerAtk].targetsDone[i] = FALSE;
             gBattleStruct->moveTarget[cv->battlerAtk] = cv->battlerDef;
             gBattleScripting.moveendState = 0;
             gBattleScripting.animTurn = 0;
@@ -4240,6 +4242,18 @@ static bool32 ShouldSetStompingTantrumTimer(void)
 
 static enum MoveEndResult MoveEndClearBits(struct BattleCalcValues *cv)
 {
+    // go to next Bouncer or original attacker if possible
+    if (gBattleStruct->bouncedMoveIsUsed)
+    {
+        RestoreAttacker();
+        RestoreTarget();
+        gBattleStruct->bouncedMoveIsUsed = FALSE;
+        gBattleStruct->moveendState = MOVEEND_BOUNCED_MOVE;
+        for (enum BattlerId battler = B_BATTLER_0; battler < gBattlersCount; battler++)
+            gBattleStruct->moveResultFlags[battler] = gBattleStruct->savedMoveResultFlags[battler];
+        return MOVEEND_RESULT_RUN_SCRIPT;
+    }
+
     ValidateBattlers();
 
     enum Move originallyUsedMove = GetOriginallyUsedMove(gChosenMove);

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -4248,7 +4248,7 @@ static enum MoveEndResult MoveEndClearBits(struct BattleCalcValues *cv)
         RestoreAttacker();
         RestoreTarget();
         gBattleStruct->bouncedMoveIsUsed = FALSE;
-        gBattleStruct->moveendState = MOVEEND_BOUNCED_MOVE;
+        gBattleScripting.moveendState = MOVEEND_BOUNCED_MOVE;
         for (enum BattlerId battler = B_BATTLER_0; battler < gBattlersCount; battler++)
             gBattleStruct->moveResultFlags[battler] = gBattleStruct->savedMoveResultFlags[battler];
         return MOVEEND_RESULT_RUN_SCRIPT;

--- a/test/battle/hold_effect/throat_spray.c
+++ b/test/battle/hold_effect/throat_spray.c
@@ -209,3 +209,30 @@ SINGLE_BATTLE_TEST("Throat Spray will not activate if the mon just switched in")
         NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player); // throat spray
     }
 }
+
+DOUBLE_BATTLE_TEST("Throat Spray activates on user and bouncer if at least one target if affected by sound move")
+{
+    enum Ability ability;
+
+    PARAMETRIZE { ability = ABILITY_SOUNDPROOF; }
+    PARAMETRIZE { ability = ABILITY_RATTLED; }
+
+    GIVEN {
+        ASSUME(IsSoundMove(MOVE_GROWL));
+        ASSUME(MoveCanBeBouncedBack(MOVE_GROWL));
+        ASSUME(GetMoveTarget(MOVE_GROWL) == TARGET_BOTH);
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_THROAT_SPRAY); }
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_HATTERENE) { Ability(ABILITY_MAGIC_BOUNCE); Item(ITEM_THROAT_SPRAY); }
+        OPPONENT(SPECIES_WHISMUR) { Ability(ability); }
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_GROWL); }
+    } SCENE {
+        ABILITY_POPUP(opponentLeft, ABILITY_MAGIC_BOUNCE);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponentLeft);
+        if (ability == ABILITY_SOUNDPROOF)
+            NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, playerLeft);
+        else
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, playerLeft);
+    }
+}

--- a/test/battle/move_effect/parting_shot.c
+++ b/test/battle/move_effect/parting_shot.c
@@ -69,37 +69,39 @@ SINGLE_BATTLE_TEST("Parting Shot: Hyper Cutter blocks Attack drop but still swit
     }
 }
 
-// SINGLE_BATTLE_TEST("Parting Shot: Magic Coat bounces it and switches the target out")
-// {
-//     GIVEN {
-//         PLAYER(SPECIES_WOBBUFFET) { Moves(MOVE_PARTING_SHOT); }
-//         OPPONENT(SPECIES_WOBBUFFET) { Moves(MOVE_MAGIC_COAT); }
-//         OPPONENT(SPECIES_WYNAUT);
-//     } WHEN {
-//         TURN { MOVE(opponent, MOVE_MAGIC_COAT); MOVE(player, MOVE_PARTING_SHOT); SEND_OUT(opponent, 1); }
-//     } THEN {
-//         EXPECT_EQ(player->statStages[STAT_ATK], DEFAULT_STAT_STAGE - 1);
-//         EXPECT_EQ(player->statStages[STAT_SPATK], DEFAULT_STAT_STAGE - 1);
-//         EXPECT_EQ(opponent->species, SPECIES_WYNAUT);
-//     }
-// }
+SINGLE_BATTLE_TEST("Parting Shot: Magic Coat bounces it and switches the target out and original user doesn't switch out")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Moves(MOVE_PARTING_SHOT); }
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET) { Moves(MOVE_MAGIC_COAT); }
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_MAGIC_COAT); MOVE(player, MOVE_PARTING_SHOT); SEND_OUT(opponent, 1); }
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_ATK], DEFAULT_STAT_STAGE - 1);
+        EXPECT_EQ(player->statStages[STAT_SPATK], DEFAULT_STAT_STAGE - 1);
+        EXPECT_EQ(opponent->species, SPECIES_WYNAUT);
+    }
+}
 
-// SINGLE_BATTLE_TEST("Parting Shot: Magic Bounce bounces it and switches the target out")
-// {
-//     GIVEN {
-//         PLAYER(SPECIES_WOBBUFFET) { Moves(MOVE_PARTING_SHOT); }
-//         OPPONENT(SPECIES_ESPEON) { Ability(ABILITY_MAGIC_BOUNCE); }
-//         OPPONENT(SPECIES_WYNAUT);
-//     } WHEN {
-//         TURN { MOVE(player, MOVE_PARTING_SHOT); SEND_OUT(opponent, 1); }
-//     } SCENE {
-//         ABILITY_POPUP(opponent, ABILITY_MAGIC_BOUNCE);
-//     } THEN {
-//         EXPECT_EQ(player->statStages[STAT_ATK], DEFAULT_STAT_STAGE - 1);
-//         EXPECT_EQ(player->statStages[STAT_SPATK], DEFAULT_STAT_STAGE - 1);
-//         EXPECT_EQ(opponent->species, SPECIES_WYNAUT);
-//     }
-// }
+SINGLE_BATTLE_TEST("Parting Shot: Magic Bounce bounces it and switches the target out and original user doesn't switch out")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Moves(MOVE_PARTING_SHOT); }
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_ESPEON) { Ability(ABILITY_MAGIC_BOUNCE); }
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN { MOVE(player, MOVE_PARTING_SHOT); SEND_OUT(opponent, 1); }
+    } SCENE {
+        ABILITY_POPUP(opponent, ABILITY_MAGIC_BOUNCE);
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_ATK], DEFAULT_STAT_STAGE - 1);
+        EXPECT_EQ(player->statStages[STAT_SPATK], DEFAULT_STAT_STAGE - 1);
+        EXPECT_EQ(opponent->species, SPECIES_WYNAUT);
+    }
+}
 
 SINGLE_BATTLE_TEST("Parting Shot: Mirror Armor switches the user even if reflected drops fail")
 {


### PR DESCRIPTION
Fixes Bounced Parting Shot not switching the bouncer out.

Also changed so other effects can also activate for battlers that bounce the move.

According to jpwiki:

> If a sound move is reflected while Magic Coat is active, the Throat Spray on the Magic Coat user will activate. If there are no other Pokémon that are vulnerable to the move, the Throat Spray on the user whose move was reflected will not activate. If there are Pokémon that are vulnerable, the move will be used on that Pokémon, the Throat Spray will activate, and then the effect of Magic Coat will activate.

Brings back `savedMoveResultFlags` since that makes tracking who was originally affected easier.

## Issue(s) that this PR fixes
Fixes #10355

## Discord contact info
PhallenTree