### PR TITLE
Fix ANIM_RAPID_H_HOPS freezing the game when opponent is wild shiny

### DIFF
--- a/src/battle_anim_throw.c
+++ b/src/battle_anim_throw.c
@@ -14,6 +14,7 @@
 #include "sound.h"
 #include "sprite.h"
 #include "task.h"
+#include "test/battle.h"
 #include "test_runner.h"
 #include "trig.h"
 #include "util.h"
@@ -2272,7 +2273,7 @@ void TryShinyAnimation(enum BattlerId battler, struct Pokemon *mon)
     if (illusionMon != NULL)
         mon = illusionMon;
 
-    if (IsBattlerSpriteVisible(battler) && IsValidForBattle(mon) && !gTestRunnerHeadless)
+    if (IsBattlerSpriteVisible(battler) && IsValidForBattle(mon) && (!gTestRunnerHeadless || gBattleTestRunnerState->forceMoveAnim))
     {
         if (isShiny)
         {

--- a/src/pokemon_animation.c
+++ b/src/pokemon_animation.c
@@ -5,6 +5,7 @@
 #include "pokemon_animation.h"
 #include "sprite.h"
 #include "task.h"
+#include "test/battle.h"
 #include "test_runner.h"
 #include "trig.h"
 #include "util.h"
@@ -509,7 +510,7 @@ static void Task_HandleMonAnimation(u8 taskId)
         for (i = 2; i < ARRAY_COUNT(sprite->data); i++)
             sprite->data[i] = 0;
 
-        if (gTestRunnerHeadless)
+        if (gTestRunnerHeadless && !gBattleTestRunnerState->forceMoveAnim)
             sprite->callback = WaitAnimEnd;
         else
             sprite->callback = sMonAnimFunctions[gTasks[taskId].tAnimId];
@@ -3164,6 +3165,8 @@ static void Anim_RapidHorizontalHops(struct Sprite *sprite)
     TryFlipX(sprite);
     if (sprite->data[2] > 2048)
     {
+        sprite->x2 = 0;
+        sprite->y2 = 0;
         sprite->callback = WaitAnimEnd;
         sprite->data[6] = 0;
     }

--- a/test/battle/front_anim.c
+++ b/test/battle/front_anim.c
@@ -1,0 +1,28 @@
+#include "global.h"
+#include "test/battle.h"
+#include "pokemon_animation.h"
+
+WILD_BATTLE_TEST("Front anims work")
+{
+    enum Species species = SPECIES_WOBBUFFET;
+    for (enum AnimFunctionIDs animId = 0; animId < ANIM_COUNT; animId++)
+    {
+        for (enum Species tempSpecies = SPECIES_NONE + 1; tempSpecies < NUM_SPECIES; tempSpecies++)
+        {
+            if (gSpeciesInfo[tempSpecies].frontAnimId == animId)
+            {
+                PARAMETRIZE { species = tempSpecies; }
+                break;
+            }
+        }
+    }
+    GIVEN {
+        FORCE_MOVE_ANIM(TRUE);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(species) { Shiny(TRUE); }
+    } WHEN {
+        TURN { }
+    } THEN {
+        FORCE_MOVE_ANIM(FALSE);
+    }
+}


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
The end of the `ANIM_RAPID_H_HOPS` animation wasn't returning the mon to its starting position, which apparently breaks something when combined with the shiny animation.

Also adds a test for all currently used front animations to make sure they work, which requires adding exclusions to the intro skipping when `FORCE_MOVE_ANIM` is set to `TRUE`.

### Large Language Models (AI)
<!-- Does your pull request contain code or assets generated by a large language model (AI)? If so, where? -->
<!-- NOTE: There is an expectation that you have fully reviewed your code to ensure it meets all merge criteria (detailed above). -->
<!-- If the maintainers believe that a pull request was generated by AI with no or little to no human oversight, the pull request will be closed without further discussion. -->
No

## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, closes #2222." Remove this section if not applicable.-->
Fixes #10396 

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara