### PR TITLE
Make updatemoneybox actually a one-byte opcode

### DIFF
--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -2371,14 +2371,9 @@ bool8 ScrCmd_hidemoneybox(struct ScriptContext *ctx)
 
 bool8 ScrCmd_updatemoneybox(struct ScriptContext *ctx)
 {
-    u8 ignore = ScriptReadByte(ctx);
+    Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
 
-    if (!ignore)
-    {
-        Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
-
-        ChangeAmountInMoneyBox(GetMoney(&gSaveBlock1Ptr->money));
-    }
+    ChangeAmountInMoneyBox(GetMoney(&gSaveBlock1Ptr->money));
     return FALSE;
 }
 
@@ -2412,7 +2407,7 @@ bool8 ScrCmd_updatecoinsbox(struct ScriptContext *ctx)
 bool8 ScrCmd_trainerbattle(struct ScriptContext *ctx)
 {
     Script_RequestEffects(SCREFF_V1 | SCREFF_TRAINERBATTLE);
-    
+
     ConfigureTrainerBattle(ctx);
     return FALSE;
 }
@@ -2726,7 +2721,7 @@ void NativeFunc_SetMetatileInRange(struct ScriptContext *ctx)
     bool8 hasCollision = ScriptReadByte(ctx);
     u8 elevation = ScriptReadByte(ctx);
     u32 temp;
-    
+
     if (xmin > xmax)
         SWAP(xmin, xmax, temp);
 
@@ -3354,7 +3349,8 @@ bool8 ScrCmd_setstartingstatus(struct ScriptContext *ctx)
 bool8 ScrCmd_textcolor(struct ScriptContext * ctx)
 {
     // gSpecialVar_PrevTextColor = gSpecialVar_TextColor;
-    u16 UNUSED gSpecialVar_TextColor = ScriptReadByte(ctx);
+    // u16 UNUSED gSpecialVar_TextColor = ScriptReadByte(ctx);
+    ctx->scriptPtr++;
 
     Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
 

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -3349,8 +3349,7 @@ bool8 ScrCmd_setstartingstatus(struct ScriptContext *ctx)
 bool8 ScrCmd_textcolor(struct ScriptContext * ctx)
 {
     // gSpecialVar_PrevTextColor = gSpecialVar_TextColor;
-    // u16 UNUSED gSpecialVar_TextColor = ScriptReadByte(ctx);
-    ctx->scriptPtr++;
+    u16 UNUSED gSpecialVar_TextColor = ScriptReadByte(ctx);
 
     Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
 


### PR DESCRIPTION
## Description
#9335 updated the macro for `updatemoneybox` to make it a 1 byte opcode instead of 4 bytes, but `ScrCmd_updatemoneybox` still implemented it as a 2 byte opcode. This fixes `ScrCmd_updatemoneybox` to no longer take the basically useless `ignore` argument.

### Large Language Models (AI)
My pull request contains no AI-generated content.

## Issue(s) that this PR fixes
No separate issue was opened for this PR, but a bug introduced in #9335 was fixed.

## Discord contact info
tertu
