### PR TITLE
Add options to ignore total EV check

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -1065,7 +1065,7 @@
 
 	@ Gives the player a Pokémon of the specified species and level, and allows to customize extra parameters.
 	@ VAR_RESULT will be set to MON_GIVEN_TO_PARTY, MON_GIVEN_TO_PC, or MON_CANT_GIVE depending on the outcome.
-	.macro givemon species:req, level:req, item, ball, nature, abilityNum, gender, hpEv, atkEv, defEv, speedEv, spAtkEv, spDefEv, hpIv, atkIv, defIv, speedIv, spAtkIv, spDefIv, move1, move2, move3, move4, shinyMode, gmaxFactor, teraType, dmaxLevel, isEgg
+	.macro givemon species:req, level:req, item, ball, nature, abilityNum, gender, hpEv, atkEv, defEv, speedEv, spAtkEv, spDefEv, hpIv, atkIv, defIv, speedIv, spAtkIv, spDefIv, move1, move2, move3, move4, shinyMode, gmaxFactor, teraType, dmaxLevel, isEgg, ignoreTotalEvCheck = FALSE
 	callnative ScrCmd_createmon, requests_effects=1
 	.byte 0
 	.byte PARTY_SIZE @ assign to first empty slot
@@ -1098,6 +1098,7 @@
 	.ifnb \teraType; .set givemon_flags, givemon_flags | (1 << 23); .endif
 	.ifnb \dmaxLevel; .set givemon_flags, givemon_flags | (1 << 24); .endif
 	.ifnb \isEgg; .set givemon_flags, givemon_flags | (1 << 25); .endif
+	.if \ignoreTotalEvCheck; .set givemon_flags, givemon_flags | (1 << 26); .endif
 	.4byte givemon_flags
 	.ifnb \item; .2byte \item; .endif
 	.ifnb \ball; .2byte \ball; .endif
@@ -1129,7 +1130,7 @@
 
 	@ creates a mon for a given party and slot
 	@ otherwise
-	.macro createmon side:req, slot:req, species:req, level:req, item, ball, nature, abilityNum, gender, hpEv, atkEv, defEv, speedEv, spAtkEv, spDefEv, hpIv, atkIv, defIv, speedIv, spAtkIv, spDefIv, move1, move2, move3, move4, shinyMode, gmaxFactor, teraType, dmaxLevel, isEgg
+	.macro createmon side:req, slot:req, species:req, level:req, item, ball, nature, abilityNum, gender, hpEv, atkEv, defEv, speedEv, spAtkEv, spDefEv, hpIv, atkIv, defIv, speedIv, spAtkIv, spDefIv, move1, move2, move3, move4, shinyMode, gmaxFactor, teraType, dmaxLevel, isEgg, ignoreTotalEvCheck = FALSE
 	callnative ScrCmd_createmon, requests_effects=1
 	.byte \side	 @ 0 - player, 1 - opponent
 	.byte \slot	 @ 0-5
@@ -1162,6 +1163,7 @@
 	.ifnb \teraType; .set givemon_flags, givemon_flags | (1 << 23); .endif
 	.ifnb \dmaxLevel; .set givemon_flags, givemon_flags | (1 << 24); .endif
 	.ifnb \isEgg; .set givemon_flags, givemon_flags | (1 << 25); .endif
+	.if \ignoreTotalEvCheck; .set givemon_flags, givemon_flags | (1 << 26); .endif
 	.4byte givemon_flags
 	.ifnb \item; .2byte \item; .endif
 	.ifnb \ball; .2byte \ball; .endif

--- a/include/config/overworld.h
+++ b/include/config/overworld.h
@@ -163,4 +163,7 @@
 #define OW_USE_DAILY_SEED_FOR_VANILLA_VARIABLES     FALSE // If TRUE, use daily seed to compute mirage island chance and lottery corner tickets.
                                                           // This has a side effect of removing the deterministic/anti save scumming aspect of the mirage island randomisation
 
+// Script Config
+#define OW_CHECK_FOR_TOTAL_EVS TRUE        // If FALSE, givemon and createmon will not check for total EVs when generating a new Pokemon
+
 #endif // GUARD_CONFIG_OVERWORLD_H

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -543,11 +543,12 @@ struct PokemonTemplate
     u16 dmaxLevel;
     bool16 isEgg;
     enum GeneratedMonOrigin origin;
+    u8 ignoreTotalEvCheck:1;
     u8 doNotUseDefaultShinyness:1;
     u8 doNotUseDefaultBall:1;
     u8 doNotUseDefaultAbility:1;
     u8 doNotUseDefaultTeraType:1;
-    u8 padding:4;
+    u8 padding:3;
 };
 
 struct EggData

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -6862,7 +6862,7 @@ static void ResolveIVs(enum Species species, const u16 *ivsTemplate, u8 *ivs)
     }
 }
 
-static void ResolveEVs(const u16 *evsTemplate, u8 *evs)
+static void ResolveEVs(const u16 *evsTemplate, u8 *evs, bool32 ignoreTotalEvCheck)
 {
     u32 evTotal = 0;
     for (u32 i = 0; i < NUM_STATS; i++)
@@ -6878,6 +6878,8 @@ static void ResolveEVs(const u16 *evsTemplate, u8 *evs)
         }
         evTotal += evs[i];
     }
+    if (!OW_CHECK_FOR_TOTAL_EVS || ignoreTotalEvCheck)
+        return;
     assertf(evTotal <= MAX_TOTAL_EVS, "invalid total ev value of %d above maximum of %d", evTotal, MAX_TOTAL_EVS)
     {
         for (u32 i = 0; i < NUM_STATS; i++)
@@ -7017,7 +7019,7 @@ void CreateMonFromTemplate(struct Pokemon *mon, const struct PokemonTemplate *mo
     u8 ivs[NUM_STATS];
     u8 evs[NUM_STATS];
     ResolveIVs(species, monTemplate->ivs, ivs);
-    ResolveEVs(monTemplate->evs, evs);
+    ResolveEVs(monTemplate->evs, evs, monTemplate->ignoreTotalEvCheck);
     for (u32 i = 0; i < NUM_STATS; i++)
     {
         SetMonData(mon, MON_DATA_HP_IV + i, &ivs[i]);

--- a/src/script_pokemon_util.c
+++ b/src/script_pokemon_util.c
@@ -462,6 +462,8 @@ void ScrCmd_createmon(struct ScriptContext *ctx)
         monTemplate.origin = STATIC_WILDMON_ORIGIN;
     }
 
+    monTemplate.ignoreTotalEvCheck = flags >> 26;
+
     gSpecialVar_Result = ScriptGiveMonParameterized(side, slot, &monTemplate);
 }
 


### PR DESCRIPTION
Fix regression introduced in #9970 that prevented users from generating mons with EV higher than total
Users can use a global config bypass or a bypass on a command by command basis depending on the situation

## Discord contact info
Jamie
