### PR TITLE
assert trainer script that needs an object event

### DIFF
--- a/src/battle_setup.c
+++ b/src/battle_setup.c
@@ -1248,6 +1248,10 @@ bool32 GetRematchFromScriptPointer(const u8 *data)
 //       For trainers who spot the player this is handled by PlayerFaceApproachingTrainer
 void SetTrainerFacingDirection(void)
 {
+    assertf(gSelectedObjectEvent != gPlayerAvatar.objectEventId, "trainer script that needs to be used from an object event was called from player")
+    {
+        return;
+    }
     struct ObjectEvent *objectEvent = &gObjectEvents[gSelectedObjectEvent];
     SetTrainerMovementType(objectEvent, GetTrainerFacingDirectionMovementType(objectEvent->facingDirection));
 }


### PR DESCRIPTION
Make sure SetTrainerDirection is called from an object event and not the player because it causes unintuitive behaviors


## Media
Same setup as the video in the issue but with the fix:

https://github.com/user-attachments/assets/1dd66db2-4770-47a6-9ecf-12ea75770487



## Issue(s) that this PR fixes
Fixes #10376


## Discord contact info
Jamie
