### PR TITLE
Fix Illusion party search range for two-opponent trainers

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -8763,7 +8763,7 @@ enum Species GetIllusionMonSpecies(enum BattlerId battler)
 
 u32 GetIllusionMonPartyId(struct Pokemon *party, struct Pokemon *mon, struct Pokemon *partnerMon, enum BattlerId battler)
 {
-    s32 partyEnd = gPartiesCount[GetBattlerTrainer(battler)];
+    s32 partyEnd = PARTY_SIZE;
 
     // Find last alive non-egg Pokémon.
     for (s32 id = partyEnd - 1; id >= 0; id--)

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -8763,11 +8763,6 @@ enum Species GetIllusionMonSpecies(enum BattlerId battler)
 
 u32 GetIllusionMonPartyId(struct Pokemon *party, struct Pokemon *mon, struct Pokemon *partnerMon, enum BattlerId battler)
 {
-    // Each trainer (player, partner, and both opponents) already has its own
-    // isolated party array starting at index 0, so no left/right split is
-    // needed here. Just search up to that trainer's actual party count, so
-    // link multi battles (which only populate the first MULTI_PARTY_SIZE
-    // slots) don't pick up stale data from a previous battle.
     s32 partyEnd = gPartiesCount[GetBattlerTrainer(battler)];
 
     // Find last alive non-egg Pokémon.

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -8763,10 +8763,8 @@ enum Species GetIllusionMonSpecies(enum BattlerId battler)
 
 u32 GetIllusionMonPartyId(struct Pokemon *party, struct Pokemon *mon, struct Pokemon *partnerMon, enum BattlerId battler)
 {
-    s32 partyEnd = PARTY_SIZE;
-
     // Find last alive non-egg Pokémon.
-    for (s32 id = partyEnd - 1; id >= 0; id--)
+    for (s32 id = PARTY_SIZE - 1; id >= 0; id--)
     {
         if (GetMonData(&party[id], MON_DATA_SANITY_HAS_SPECIES)
             && GetMonData(&party[id], MON_DATA_HP)

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -8763,27 +8763,15 @@ enum Species GetIllusionMonSpecies(enum BattlerId battler)
 
 u32 GetIllusionMonPartyId(struct Pokemon *party, struct Pokemon *mon, struct Pokemon *partnerMon, enum BattlerId battler)
 {
-    s32 partyEnd=6;
-    s32 partyStart=0;
-
-    // Adjust party search range for Multibattles and Player vs two-trainers
-    if ((GetBattlerSide(battler) == B_SIDE_PLAYER && (gBattleTypeFlags & BATTLE_TYPE_MULTI))
-        || (GetBattlerSide(battler) == B_SIDE_OPPONENT && (gBattleTypeFlags & BATTLE_TYPE_TWO_OPPONENTS)))
-        {
-            if ((GetBattlerPosition(battler) == B_POSITION_PLAYER_LEFT) || (GetBattlerPosition(battler) == B_POSITION_OPPONENT_LEFT))
-            {
-                partyEnd = 3;
-                partyStart = 0;
-            }
-            else
-            {
-                partyEnd = 6;
-                partyStart = 3;
-            }
-        }
+    // Each trainer (player, partner, and both opponents) already has its own
+    // isolated party array starting at index 0, so no left/right split is
+    // needed here. Just search up to that trainer's actual party count, so
+    // link multi battles (which only populate the first MULTI_PARTY_SIZE
+    // slots) don't pick up stale data from a previous battle.
+    s32 partyEnd = gPartiesCount[GetBattlerTrainer(battler)];
 
     // Find last alive non-egg Pokémon.
-    for (s32 id = partyEnd - 1; id >= partyStart; id--)
+    for (s32 id = partyEnd - 1; id >= 0; id--)
     {
         if (GetMonData(&party[id], MON_DATA_SANITY_HAS_SPECIES)
             && GetMonData(&party[id], MON_DATA_HP)

--- a/test/battle/ability/illusion.c
+++ b/test/battle/ability/illusion.c
@@ -78,12 +78,13 @@ ONE_VS_TWO_BATTLE_TEST("Illusion works for the second opponent trainer in a batt
         PLAYER(SPECIES_WOBBUFFET);
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT_A(SPECIES_WYNAUT);
-        OPPONENT_B(SPECIES_ZOROARK);
+        OPPONENT_B(SPECIES_ZOROARK) { Ability(ABILITY_ILLUSION); }
         OPPONENT_B(SPECIES_WYNAUT);
+    } WHEN {
+        TURN {}
     } THEN {
-        // opponentRight (OPPONENT_B's battler) has its own isolated 2-mon party (Zoroark, Wynaut),
-        // so Illusion should find Wynaut as the last party member and activate.
         EXPECT_EQ(gBattleStruct->illusion[B_POSITION_OPPONENT_RIGHT].state, ILLUSION_ON);
+        EXPECT(&gParties[B_TRAINER_OPPONENT_B][1] == gBattleStruct->illusion[B_POSITION_OPPONENT_RIGHT].mon);
     }
 }
 

--- a/test/battle/ability/illusion.c
+++ b/test/battle/ability/illusion.c
@@ -72,6 +72,21 @@ SINGLE_BATTLE_TEST("Illusion cannot imitate if the user is on the last slot")
     }
 }
 
+ONE_VS_TWO_BATTLE_TEST("Illusion works for the second opponent trainer in a battle with two opponent trainers")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT_A(SPECIES_WYNAUT);
+        OPPONENT_B(SPECIES_ZOROARK);
+        OPPONENT_B(SPECIES_WYNAUT);
+    } THEN {
+        // opponentRight (OPPONENT_B's battler) has its own isolated 2-mon party (Zoroark, Wynaut),
+        // so Illusion should find Wynaut as the last party member and activate.
+        EXPECT_EQ(gBattleStruct->illusion[B_POSITION_OPPONENT_RIGHT].state, ILLUSION_ON);
+    }
+}
+
 SINGLE_BATTLE_TEST("Illusion breaks in Neutralizing Gas")
 {
     GIVEN {


### PR DESCRIPTION
## Summary

`GetIllusionMonPartyId` decides which party member Illusion should disguise a Pokémon as, and it splits the search range into left/right halves (indices 0-2 vs 3-5) whenever `BATTLE_TYPE_MULTI` (player side) or `BATTLE_TYPE_TWO_OPPONENTS` (opponent side) is set. That split made sense under the old model where both battlers on a side shared a single party array, but each trainer (player, partner, opponent A, opponent B) now has its own isolated party array that always starts at index 0 (`GetBattlerParty`).

In a battle with two opponent trainers, this made the split wrong for both sides:
- The trainer on the **right** (whose own team occupies indices 0-2/0-5, not 3-5) almost always found nothing in that range, so Illusion silently failed to activate — a Zoroark on that side effectively never disguises itself.
- The trainer on the **left** had its search incorrectly capped to only its first 3 party members, ignoring any beyond that even though its own party can hold up to 6.

The same bug applies to the player's side in multi battles (player vs. partner), for the same reason.

## Fix

The range is now taken from `gPartiesCount[GetBattlerTrainer(battler)]`, which already tracks each trainer's actual party size instead of guessing a fixed half-range:

- Since each trainer's party is already isolated starting at index 0, no left/right split is needed anymore — the search simply covers indices `0` to `gPartiesCount[trainer] - 1`.
- This also correctly handles link multi battles, where only the first `MULTI_PARTY_SIZE` (3) slots are populated per trainer and the rest of the array can hold stale data from a previous battle — searching the full range there could have picked up leftover mons.

Added a regression test (`ONE_VS_TWO_BATTLE_TEST`) confirming Illusion now activates correctly for the second opponent trainer's battler in a two-opponent-trainer battle.

https://github.com/user-attachments/assets/58a5cb28-a4da-4544-97e3-85253daead10

https://github.com/user-attachments/assets/e9e426f1-2af3-4090-abd5-ef18e0a2e8e6

## Discord contact info
thalescd