### PR TITLE
Add Ability Pop-Ups to Mega Sol

### DIFF
--- a/data/battle_anim_scripts.s
+++ b/data/battle_anim_scripts.s
@@ -135,8 +135,6 @@ gBattleAnimMove_Roost::
 	createsprite gFallingFeatherSpriteTemplate, ANIM_ATTACKER, 0, 0, -16, 96, 2, 104, 11304, 32, 1
 	waitforvisualfinish
 	clearmonbg ANIM_ATTACKER
-	call HealingEffect
-	waitforvisualfinish
 	end
 
 gBattleAnimMove_Gravity::
@@ -9068,7 +9066,6 @@ gBattleAnimMove_ShoreUp::
 	createvisualtask AnimTask_LoadSandstormBackground, 5, 0
 	delay 16
 	create_flying_sand_crescents anim_battler=ANIM_ATTACKER, unknown=0
-	call HealingEffect
 	waitforvisualfinish
 	end
 
@@ -21887,8 +21884,6 @@ gBattleAnimMove_Moonlight::
 	delay 20
 	createvisualtask AnimTask_MoonlightEndFade, 2
 	waitforvisualfinish
-	call HealingEffect
-	waitforvisualfinish
 	end
 
 gBattleAnimMove_ExtremeSpeed::
@@ -24282,8 +24277,6 @@ gBattleAnimMove_Synthesis::
 	unloadspritegfx ANIM_TAG_SPARKLE_2
 	unloadspritepal ANIM_TAG_SPARKLE_2
 	delay 1
-	call HealingEffect
-	waitforvisualfinish
 	end
 
 gBattleAnimMove_Toxic::
@@ -25962,7 +25955,6 @@ gBattleAnimMove_SoftBoiled::
 	setarg 7, -1
 	waitforvisualfinish
 	clearmonbg ANIM_ATK_PARTNER
-	call HealingEffect2
 	end
 
 gBattleAnimMove_HealBell::
@@ -26555,7 +26547,6 @@ gBattleAnimMove_MorningSun::
 	createvisualtask AnimTask_BlendBattleAnimPal, 10, (F_PAL_BG | F_PAL_BATTLERS_2), 3, 12, 0, RGB_WHITE
 	waitforvisualfinish
 	waitsound
-	call HealingEffect
 	end
 MorningSunStar:
 	createsprite gGreenStarSpriteTemplate, ANIM_ATTACKER, 2, 30, 640

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -2255,8 +2255,20 @@ BattleScript_EffectSynthesis::
 BattleScript_EffectMoonlight::
 BattleScript_EffectShoreUp::
 	attackcanceler
+	jumpifability BS_ATTACKER, ABILITY_MEGA_SOL, BattleScript_MegaSolActivatesHealing
+BattleScript_EffectSunHealContinue::
 	recoverbasedonsunlight BattleScript_AlreadyAtFullHp
 	goto BattleScript_HealTarget
+
+BattleScript_MegaSolActivatesHealing::
+	call BattleScript_AbilityPopUp
+	pause B_WAIT_TIME_SHORT
+	goto BattleScript_EffectSunHealContinue
+
+BattleScript_MegaSolActivatesTwoTurnMove::
+	call BattleScript_AbilityPopUp
+	pause B_WAIT_TIME_SHORT
+	return
 
 BattleScript_EffectWeather::
 	attackcanceler

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -2255,16 +2255,15 @@ BattleScript_EffectSynthesis::
 BattleScript_EffectMoonlight::
 BattleScript_EffectShoreUp::
 	attackcanceler
-	jumpifhalfword CMP_COMMON_BITS, gBattleWeather, B_WEATHER_SUN, BattleScript_EffectSunHealContinue
-	jumpifability BS_ATTACKER, ABILITY_MEGA_SOL, BattleScript_MegaSolActivatesHealing
-BattleScript_EffectSunHealContinue::
 	recoverbasedonsunlight BattleScript_AlreadyAtFullHp
 	goto BattleScript_HealTarget
 
 BattleScript_MegaSolActivatesHealing::
+	attackanimation
+	waitanimation
 	call BattleScript_AbilityPopUp
 	pause B_WAIT_TIME_SHORT
-	goto BattleScript_EffectSunHealContinue
+	goto BattleScript_HealTargetContinue
 
 BattleScript_MegaSolActivatesTwoTurnMove::
 	call BattleScript_AbilityPopUpScripting
@@ -2381,6 +2380,7 @@ BattleScript_EffectSoftboiled::
 BattleScript_HealTarget::
 	attackanimation
 	waitanimation
+BattleScript_HealTargetContinue::
 	healthbarupdate BS_TARGET
 	datahpupdate BS_TARGET
 	printstring STRINGID_PKMNREGAINEDHEALTH

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -2266,7 +2266,7 @@ BattleScript_MegaSolActivatesHealing::
 	goto BattleScript_EffectSunHealContinue
 
 BattleScript_MegaSolActivatesTwoTurnMove::
-	call BattleScript_AbilityPopUp
+	call BattleScript_AbilityPopUpScripting
 	pause B_WAIT_TIME_SHORT
 	return
 

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -2255,6 +2255,7 @@ BattleScript_EffectSynthesis::
 BattleScript_EffectMoonlight::
 BattleScript_EffectShoreUp::
 	attackcanceler
+	jumpifhalfword CMP_COMMON_BITS, gBattleWeather, B_WEATHER_SUN, BattleScript_EffectSunHealContinue
 	jumpifability BS_ATTACKER, ABILITY_MEGA_SOL, BattleScript_MegaSolActivatesHealing
 BattleScript_EffectSunHealContinue::
 	recoverbasedonsunlight BattleScript_AlreadyAtFullHp

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -2381,6 +2381,7 @@ BattleScript_HealTarget::
 	attackanimation
 	waitanimation
 BattleScript_HealTargetContinue::
+	playanimation BS_ATTACKER, B_ANIM_SIMPLE_HEAL
 	healthbarupdate BS_TARGET
 	datahpupdate BS_TARGET
 	printstring STRINGID_PKMNREGAINEDHEALTH

--- a/include/battle_scripts.h
+++ b/include/battle_scripts.h
@@ -509,6 +509,7 @@ extern const u8 BattleScript_DecreaseStatChangeMessageMinStat[];
 extern const u8 BattleScript_StatDidntChangeMessagePause[];
 extern const u8 BattleScript_WildBattleVictory[];
 extern const u8 BattleScript_BelchFails[];
+extern const u8 BattleScript_MegaSolActivatesTwoTurnMove[];
 
 // zmoves
 extern const u8 BattleScript_ZMoveActivateDamaging[];

--- a/include/battle_scripts.h
+++ b/include/battle_scripts.h
@@ -604,6 +604,7 @@ extern const u8 BattleScript_EffectBatonPass[];
 extern const u8 BattleScript_EffectMorningSun[];
 extern const u8 BattleScript_EffectSynthesis[];
 extern const u8 BattleScript_EffectMoonlight[];
+extern const u8 BattleScript_MegaSolActivatesHealing[];
 extern const u8 BattleScript_EffectWeather[];
 extern const u8 BattleScript_EffectStatChange[];
 extern const u8 BattleScript_EffectStatChangeHalfHp[];

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -1683,7 +1683,7 @@ static enum CancelerResult CancelerProtean(struct BattleCalcValues *cv)
     return CANCELER_RESULT_SUCCESS;
 }
 
-static bool32 CanTwoTurnMoveFireThisTurn(struct BattleCalcValues *cv)
+static bool32 CanTwoTurnMoveFireThisTurn(struct BattleCalcValues *cv, bool32 *showAbilityPopUp)
 {
     if (cv->moveEffect == EFFECT_GEOMANCY || gBattleMoveEffects[cv->moveEffect].semiInvulnerableEffect)
         return FALSE;
@@ -1692,8 +1692,18 @@ static bool32 CanTwoTurnMoveFireThisTurn(struct BattleCalcValues *cv)
     u32 attackerWeather = GetAttackerWeather(cv->holdEffects[cv->battlerAtk], cv->abilities[cv->battlerAtk], weather);
     enum BattleWeather isMoveWeatherAffected = GetTwoTurnMoveWeather(cv->move);
 
-    return (GetCurrentBattleWeather(attackerWeather) == isMoveWeatherAffected)
-        || (GetCurrentBattleWeather(weather) == isMoveWeatherAffected);
+    if (GetCurrentBattleWeather(weather) == isMoveWeatherAffected)
+    {
+        return TRUE;
+    }
+
+    if (GetCurrentBattleWeather(attackerWeather) == isMoveWeatherAffected)
+    {
+        *showAbilityPopUp = TRUE;
+        return TRUE;
+    }
+
+    return FALSE;
 }
 
 static enum CancelerResult HandleSkyDropResult(struct BattleCalcValues *cv)
@@ -1789,22 +1799,23 @@ static enum CancelerResult CancelerCharging(struct BattleCalcValues *cv)
     }
     else // Try move this turn. Otherwise use next turn
     {
-        if (CanTwoTurnMoveFireThisTurn(cv))
+        bool32 showAbilityPopUp = FALSE;
+        if (CanTwoTurnMoveFireThisTurn(cv, &showAbilityPopUp))
         {
             gBattleScripting.animTurn = 1;
             gBattleScripting.animTargetsHit = 0;
             gProtectStructs[cv->battlerAtk].chargingTurn = FALSE;
             if (gBattleMoveEffects[cv->moveEffect].semiInvulnerableEffect)
                 gBattleMons[cv->battlerAtk].volatiles.semiInvulnerable = STATE_NONE;
-            if (cv->abilities[cv->battlerAtk] == ABILITY_MEGA_SOL
-                && cv->moveEffect == EFFECT_SOLAR_BEAM
-                && !(GetWeather() & B_WEATHER_SUN))
+            if (showAbilityPopUp)
             {
                 BattleScriptCall(BattleScript_MegaSolActivatesTwoTurnMove);
                 result = CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
             }
             else
+            {
                 result = CANCELER_RESULT_SUCCESS;
+            }
         }
         else if (cv->holdEffects[cv->battlerAtk] == HOLD_EFFECT_POWER_HERB)
         {

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -1796,7 +1796,8 @@ static enum CancelerResult CancelerCharging(struct BattleCalcValues *cv)
             gProtectStructs[cv->battlerAtk].chargingTurn = FALSE;
             if (gBattleMoveEffects[cv->moveEffect].semiInvulnerableEffect)
                 gBattleMons[cv->battlerAtk].volatiles.semiInvulnerable = STATE_NONE;
-            if (cv->abilities[cv->battlerAtk] == ABILITY_MEGA_SOL)
+            if (cv->abilities[cv->battlerAtk] == ABILITY_MEGA_SOL
+                && cv->moveEffect == EFFECT_SOLAR_BEAM)
             {
                 BattleScriptCall(BattleScript_MegaSolActivatesTwoTurnMove);
                 result = CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -1796,7 +1796,13 @@ static enum CancelerResult CancelerCharging(struct BattleCalcValues *cv)
             gProtectStructs[cv->battlerAtk].chargingTurn = FALSE;
             if (gBattleMoveEffects[cv->moveEffect].semiInvulnerableEffect)
                 gBattleMons[cv->battlerAtk].volatiles.semiInvulnerable = STATE_NONE;
-            result = CANCELER_RESULT_SUCCESS;
+            if (cv->abilities[cv->battlerAtk] == ABILITY_MEGA_SOL)
+            {
+                BattleScriptCall(BattleScript_MegaSolActivatesTwoTurnMove);
+                result = CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
+            }
+            else
+                result = CANCELER_RESULT_SUCCESS;
         }
         else if (cv->holdEffects[cv->battlerAtk] == HOLD_EFFECT_POWER_HERB)
         {

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -1797,7 +1797,8 @@ static enum CancelerResult CancelerCharging(struct BattleCalcValues *cv)
             if (gBattleMoveEffects[cv->moveEffect].semiInvulnerableEffect)
                 gBattleMons[cv->battlerAtk].volatiles.semiInvulnerable = STATE_NONE;
             if (cv->abilities[cv->battlerAtk] == ABILITY_MEGA_SOL
-                && cv->moveEffect == EFFECT_SOLAR_BEAM)
+                && cv->moveEffect == EFFECT_SOLAR_BEAM
+                && !(GetWeather() & B_WEATHER_SUN))
             {
                 BattleScriptCall(BattleScript_MegaSolActivatesTwoTurnMove);
                 result = CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -8042,8 +8042,10 @@ static void Cmd_recoverbasedonsunlight(void)
     {
         s32 recoverAmount = 0;
         u32 weather = GetWeather();
-        u32 attackerWeather = GetAttackerWeather(GetBattlerHoldEffect(gBattlerAttacker), GetBattlerAbility(gBattlerAttacker), weather);
+        enum Ability ability = GetBattlerAbility(gBattlerAttacker);
+        u32 attackerWeather = GetAttackerWeather(GetBattlerHoldEffect(gBattlerAttacker), ability, weather);
         u32 healingWeather = attackerWeather & ~B_WEATHER_STRONG_WINDS;
+        bool32 isAffectedByMegaSol = FALSE;
         if (GetMoveEffect(gCurrentMove) == EFFECT_SHORE_UP)
         {
             if (attackerWeather & B_WEATHER_SANDSTORM)
@@ -8054,7 +8056,11 @@ static void Cmd_recoverbasedonsunlight(void)
         else if (GetConfig(B_TIME_OF_DAY_HEALING_MOVES) != GEN_2)
         {
             if (attackerWeather & B_WEATHER_SUN)
-                recoverAmount = 20 * GetNonDynamaxMaxHP(gBattlerAttacker) / 30;
+            {
+                recoverAmount = 20 * GetNonDynamaxMaxHP(gBattlerAttacker) / 30;   
+                if (ability == ABILITY_MEGA_SOL && !(weather & B_WEATHER_SUN))
+                    isAffectedByMegaSol = TRUE;
+            }
             else if (!(healingWeather & B_WEATHER_ANY) || GetBattlerHoldEffect(gBattlerAttacker) == HOLD_EFFECT_UTILITY_UMBRELLA)
                 recoverAmount = GetNonDynamaxMaxHP(gBattlerAttacker) / 2;
             else // not sunny weather
@@ -8085,16 +8091,22 @@ static void Cmd_recoverbasedonsunlight(void)
                 break;
             }
             if (attackerWeather & B_WEATHER_SUN)
+            {
                 recoverAmount = healingModifier * GetNonDynamaxMaxHP(gBattlerAttacker) / 2;
+                if (ability == ABILITY_MEGA_SOL && !(weather & B_WEATHER_SUN))
+                    isAffectedByMegaSol = TRUE;
+            }
             else if (!(healingWeather & B_WEATHER_ANY) || GetBattlerHoldEffect(gBattlerAttacker) == HOLD_EFFECT_UTILITY_UMBRELLA)
                 recoverAmount = healingModifier * GetNonDynamaxMaxHP(gBattlerAttacker) / 4;
             else // not sunny weather
                 recoverAmount = healingModifier * GetNonDynamaxMaxHP(gBattlerAttacker) / 8;
-
         }
 
         SetHealAmount(gBattlerAttacker, recoverAmount);
-        gBattlescriptCurrInstr = cmd->nextInstr;
+        if (isAffectedByMegaSol)
+            gBattlescriptCurrInstr = BattleScript_MegaSolActivatesHealing;
+        else
+            gBattlescriptCurrInstr = cmd->nextInstr;
     }
     else
     {

--- a/test/battle/ability/mega_sol.c
+++ b/test/battle/ability/mega_sol.c
@@ -324,6 +324,9 @@ SINGLE_BATTLE_TEST("Mega Sol: Solar Beam does not need a charging turn if user h
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SOLAR_BEAM, player);
         HP_BAR(opponent);
         // No ability pop-up while Sun is active
+        NONE_OF {
+            ABILITY_POPUP(player, ABILITY_MEGA_SOL);
+        }
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SOLAR_BEAM, player);
         HP_BAR(opponent);
     }

--- a/test/battle/ability/mega_sol.c
+++ b/test/battle/ability/mega_sol.c
@@ -110,14 +110,12 @@ SINGLE_BATTLE_TEST("Synthesis, Morning Sun and Moonlight recover 2/3 of the user
         TURN { MOVE(player, move, gimmick: GIMMICK_MEGA); MOVE(opponent, MOVE_SUNNY_DAY); }
         TURN { MOVE(player, move); }
     } SCENE {
-        ABILITY_POPUP(player, ABILITY_MEGA_SOL);
         ANIMATION(ANIM_TYPE_MOVE, move, player);
+        ABILITY_POPUP(player, ABILITY_MEGA_SOL);
         HP_BAR(player, damage: -(300 * 2 / 3));
         // No ability pop-up while Sun is active
-        NONE_OF {
-            ABILITY_POPUP(player, ABILITY_MEGA_SOL);
-        }
         ANIMATION(ANIM_TYPE_MOVE, move, player);
+        NOT ABILITY_POPUP(player, ABILITY_MEGA_SOL);
     }
 }
 
@@ -324,9 +322,7 @@ SINGLE_BATTLE_TEST("Mega Sol: Solar Beam does not need a charging turn if user h
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SOLAR_BEAM, player);
         HP_BAR(opponent);
         // No ability pop-up while Sun is active
-        NONE_OF {
-            ABILITY_POPUP(player, ABILITY_MEGA_SOL);
-        }
+        NOT ABILITY_POPUP(player, ABILITY_MEGA_SOL);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SOLAR_BEAM, player);
         HP_BAR(opponent);
     }

--- a/test/battle/ability/mega_sol.c
+++ b/test/battle/ability/mega_sol.c
@@ -318,7 +318,6 @@ SINGLE_BATTLE_TEST("Mega Sol: Solar Beam does not need a charging turn if user h
     }
 }
 
-// Not clear if this is a bug or not
 SINGLE_BATTLE_TEST("Mega Sol: Growth increases Attack and Sp. Atk by 2 stages under Mega Sol (Gen 5+)")
 {
     GIVEN {

--- a/test/battle/ability/mega_sol.c
+++ b/test/battle/ability/mega_sol.c
@@ -109,6 +109,7 @@ SINGLE_BATTLE_TEST("Synthesis, Morning Sun and Moonlight recover 2/3 of the user
     } WHEN {
         TURN { MOVE(player, move, gimmick: GIMMICK_MEGA); }
     } SCENE {
+        ABILITY_POPUP(player, ABILITY_MEGA_SOL);
         HP_BAR(player, damage: -(300 * 2 / 3));
     }
 }
@@ -311,6 +312,7 @@ SINGLE_BATTLE_TEST("Mega Sol: Solar Beam does not need a charging turn if user h
     } WHEN {
         TURN { MOVE(player, MOVE_SOLAR_BEAM, gimmick: GIMMICK_MEGA); }
     } SCENE {
+        ABILITY_POPUP(player, ABILITY_MEGA_SOL);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SOLAR_BEAM, player);
         HP_BAR(opponent);
     }

--- a/test/battle/ability/mega_sol.c
+++ b/test/battle/ability/mega_sol.c
@@ -104,13 +104,20 @@ SINGLE_BATTLE_TEST("Synthesis, Morning Sun and Moonlight recover 2/3 of the user
 
     GIVEN {
         ASSUME(GetMoveEffect(move) == effect);
-        PLAYER(SPECIES_MEGANIUM) { HP(1); MaxHP(300); Item(ITEM_MEGANIUMITE); }
-        OPPONENT(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_MEGANIUM) { HP(1); MaxHP(300); Item(ITEM_MEGANIUMITE); Speed(999); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); }
     } WHEN {
-        TURN { MOVE(player, move, gimmick: GIMMICK_MEGA); }
+        TURN { MOVE(player, move, gimmick: GIMMICK_MEGA); MOVE(opponent, MOVE_SUNNY_DAY); }
+        TURN { MOVE(player, move); }
     } SCENE {
         ABILITY_POPUP(player, ABILITY_MEGA_SOL);
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
         HP_BAR(player, damage: -(300 * 2 / 3));
+        // No ability pop-up while Sun is active
+        NONE_OF {
+            ABILITY_POPUP(player, ABILITY_MEGA_SOL);
+        }
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
     }
 }
 
@@ -307,12 +314,16 @@ SINGLE_BATTLE_TEST("Mega Sol: Solar Beam does not need a charging turn if user h
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_SOLARBEAM) == EFFECT_SOLAR_BEAM);
         ASSUME(GetMoveType(MOVE_SOLARBEAM) == TYPE_GRASS);
-        PLAYER(SPECIES_MEGANIUM) { Item(ITEM_MEGANIUMITE); }
-        OPPONENT(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_MEGANIUM) { Item(ITEM_MEGANIUMITE); Speed(999); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); }
     } WHEN {
-        TURN { MOVE(player, MOVE_SOLAR_BEAM, gimmick: GIMMICK_MEGA); }
+        TURN { MOVE(opponent, MOVE_SUNNY_DAY); MOVE(player, MOVE_SOLAR_BEAM, gimmick: GIMMICK_MEGA); }
+        TURN { MOVE(player, MOVE_SOLAR_BEAM); }
     } SCENE {
         ABILITY_POPUP(player, ABILITY_MEGA_SOL);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SOLAR_BEAM, player);
+        HP_BAR(opponent);
+        // No ability pop-up while Sun is active
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SOLAR_BEAM, player);
         HP_BAR(opponent);
     }

--- a/test/battle/ability/mega_sol.c
+++ b/test/battle/ability/mega_sol.c
@@ -346,7 +346,6 @@ SINGLE_BATTLE_TEST("Mega Sol: Growth increases Attack and Sp. Atk by 2 stages un
     }
 }
 
-// Not clear if this is a bug or not
 SINGLE_BATTLE_TEST("Mega Sol doesn't prevent other weather based activations (Electro Shot)")
 {
     GIVEN {
@@ -362,7 +361,6 @@ SINGLE_BATTLE_TEST("Mega Sol doesn't prevent other weather based activations (El
     }
 }
 
-// Not clear if this is a bug or not
 SINGLE_BATTLE_TEST("Mega Sol doesn't prevent other weather based activations (Aurora Veil)")
 {
     GIVEN {


### PR DESCRIPTION
Title. Adds ability pop-ups to Mega Sol similar to how Champions handles it.

## Description
Adds Ability Pop-Ups to the following instances:
* Using Solar Beam and Solar Blade (`EFFECT_SOLAR_BEAM`)
* Using Synthesis, Morning Sun and Moonlight (moves which healing is boosted under Sun)

Separates `HealingEffect` from the move animation scripts of Soft-Boiled, Roost, Shore Up, Synthesis, Morning Sun, and Moonlight to remain consistent with what's displayed on cart.

These are currently the only confirmed instances of ability pop-ups occurring.

### Large Language Models (AI)
None

## Credits
* [Parasitoid Pod](https://www.youtube.com/@ParasitoidPod) for [Weird Mega-Sol Interactions, Explained](https://youtu.be/sOORr7cpmmc)

## Discord contact info
linathan
