### PR TITLE
Fix bag list truncation when tossing a whole stack in berry pocket

### DIFF
--- a/src/item_menu.c
+++ b/src/item_menu.c
@@ -2918,11 +2918,11 @@ static void MergeSort(struct BagPocket *pocket, s32 (*comparator)(enum Pocket, s
 {
     struct ItemSlot *dummySlots = AllocZeroed(sizeof(struct ItemSlot) * pocket->capacity);
 
-    u32 usedCapacity;
-    for (usedCapacity = 0; usedCapacity < pocket->capacity; usedCapacity++)
+    u32 usedCapacity = 0;
+    for (u32 i = 0; i < pocket->capacity; i++)
     {
-        if (BagPocket_GetSlotData(pocket, usedCapacity).itemId == ITEM_NONE)
-            break;
+        if (BagPocket_GetSlotData(pocket, i).itemId != ITEM_NONE)
+            usedCapacity = i + 1;
     }
 
     for (u32 width = 1; width < usedCapacity; width *= 2)


### PR DESCRIPTION
## Description

This PR fixes a regression introduced in 1fb895ad48. In berry pocket, tossing an entire stack clears entire pocket below the tossed berry. This is due to the current algo only updating to the first empty slot (`ITEM_NONE`). The data for those below are actually still there, but they only show again when picking up another berry. Consequently, when picking up another berry, it fills the empty slot even if the same berry was in another slot below.

The fix properly counts `usedCapacity` to the last occupied slot, not just first `ITEM_NONE`, prior to update sorting.

## Media

master:

https://github.com/user-attachments/assets/6b9ba803-01ac-47f6-842a-c93fd9a64236

this commit:

https://github.com/user-attachments/assets/aebc581a-22d4-4682-8b40-3627d903210e

## Contact

Montblanc