### PR TITLE
Fix AI running Focus Punch checks on Present and Fixed HP dmg moves

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -1725,6 +1725,9 @@ static s32 AI_CheckBadMove(enum BattlerId battlerAtk, enum BattlerId battlerDef,
         break;
     case EFFECT_PRESENT:
     case EFFECT_FIXED_HP_DAMAGE:
+        if (aiData->abilities[battlerDef] == ABILITY_WONDER_GUARD && effectiveness < UQ_4_12(2.0))
+            ADJUST_SCORE(-10);
+        break;
     case EFFECT_FOCUS_PUNCH:
         // AI_CBM_HighRiskForDamage
         if (aiData->abilities[battlerDef] == ABILITY_WONDER_GUARD && effectiveness < UQ_4_12(2.0))

--- a/test/battle/ai/ai.c
+++ b/test/battle/ai/ai.c
@@ -1471,3 +1471,42 @@ AI_DOUBLE_BATTLE_TEST("AI does not switch in into invalid Pokemon")
         TURN { }
     }
 }
+
+AI_SINGLE_BATTLE_TEST("AI scores fixed damage moves correctly")
+{
+    enum Move move = MOVE_NONE;
+    s32 hp = 400;
+
+    ASSUME(GetMoveEffect(MOVE_SONIC_BOOM) == EFFECT_FIXED_HP_DAMAGE);
+    ASSUME(GetMoveFixedHPDamage(MOVE_SONIC_BOOM) == 20);
+    ASSUME(GetMoveEffect(MOVE_DRAGON_RAGE) == EFFECT_FIXED_HP_DAMAGE);
+    ASSUME(GetMoveFixedHPDamage(MOVE_DRAGON_RAGE) == 40);
+
+    PARAMETRIZE { move = MOVE_SONIC_BOOM, hp = 20; }
+    PARAMETRIZE { move = MOVE_SONIC_BOOM, hp = 60; }
+    PARAMETRIZE { move = MOVE_DRAGON_RAGE, hp = 40; }
+    PARAMETRIZE { move = MOVE_DRAGON_RAGE, hp = 60; }
+
+    GIVEN {
+        AI_FLAGS(AI_FLAG_SMART_TRAINER);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(4); Moves(MOVE_SCRATCH); MaxHP(hp); HP(hp); Defense(999); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(5); Moves(MOVE_SCRATCH, move); }
+    } WHEN {
+        if (hp == 60)
+        {
+            TURN { 
+                EXPECT_MOVE(opponent, move);
+                SCORE_EQ_VAL(opponent, MOVE_SCRATCH, AI_SCORE_DEFAULT);
+                SCORE_EQ_VAL(opponent, move, AI_SCORE_DEFAULT + BEST_DAMAGE_MOVE);
+            }
+        }
+        else
+        {
+            TURN { 
+                EXPECT_MOVE(opponent, move);
+                SCORE_EQ_VAL(opponent, MOVE_SCRATCH, AI_SCORE_DEFAULT);
+                SCORE_EQ_VAL(opponent, move, AI_SCORE_DEFAULT + BEST_DAMAGE_MOVE + FAST_KILL);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
AI incorrectly runs all focus punch checks on EFFECT_PRESENT and EFFECT_FIXED_HP_DAMAGE, meaning when the target has a damaging move it penalizes for things such as the target not being incapacitated

### Large Language Models (AI)
no

## Discord contact info
grintoul