### PR TITLE
Fix outdated move data

### DIFF
--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -17882,8 +17882,13 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
     {
         .name = COMPOUND_STRING("Zippy Zap"),
         .description = COMPOUND_STRING(
+        #if B_UPDATED_MOVE_DATA >= GEN_8
+            "Electric bursts always go\n"
+            "first and raise evasion."),
+        #else
             "Electric bursts always go\n"
             "first and land a critical hit."),
+        #endif
         .effect = EFFECT_HIT,
         .power = B_UPDATED_MOVE_DATA >= GEN_8 ? 80 : 50,
         .type = TYPE_ELECTRIC,
@@ -17894,7 +17899,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
         .category = DAMAGE_CATEGORY_PHYSICAL,
         .makesContact = TRUE,
         .mirrorMoveBanned = B_UPDATED_MOVE_FLAGS < GEN_8,
-        .alwaysCriticalHit = TRUE,
+        .alwaysCriticalHit = B_UPDATED_MOVE_DATA < GEN_8,
         .metronomeBanned = TRUE,
         #if B_UPDATED_MOVE_DATA >= GEN_8
         .additionalEffects = ADDITIONAL_EFFECTS({
@@ -20014,7 +20019,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
         .effect = EFFECT_HIT,
         .power = B_UPDATED_MOVE_DATA >= GEN_9 ? 120 : 90,
         .type = TYPE_FIRE,
-        .accuracy = 100,
+        .accuracy = B_UPDATED_MOVE_DATA >= GEN_9 ? 100 : 85,
         .pp = 10,
         .target = TARGET_RANDOM,
         .priority = 0,
@@ -20392,7 +20397,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
         .power = 0,
         .type = TYPE_PSYCHIC,
         .accuracy = 0,
-        .pp = 10,
+        .pp = B_UPDATED_MOVE_DATA >= GEN_9 ? 5 : 10,
         .target = TARGET_USER,
         .priority = 0,
         .category = DAMAGE_CATEGORY_STATUS,
@@ -20413,7 +20418,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
         .power = 0,
         .type = TYPE_PSYCHIC,
         .accuracy = 0,
-        .pp = 10,
+        .pp = B_UPDATED_MOVE_DATA >= GEN_9 ? 15 : 10,
         .target = TARGET_USER,
         .priority = 0,
         .category = DAMAGE_CATEGORY_STATUS,
@@ -20422,8 +20427,8 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
         .mirrorMoveBanned = TRUE,
         .additionalEffects = ADDITIONAL_EFFECTS({
             .moveEffect = STAT_CHANGE_EFFECT_PLUS,
-            .attack = 1,
             .spAtk = 1,
+            .spDef = 1,
         }),
         .battleAnimScript = gBattleAnimMove_TakeHeart,
     },


### PR DESCRIPTION
## Description
[Raging Fury](https://bulbapedia.bulbagarden.net/wiki/Raging_Fury_(move))

> Generation IX
> _Raging Fury's base power was increased to 120 and its **accuracy was increased to 100%**._

[Lunar Blessing](https://bulbapedia.bulbagarden.net/wiki/Lunar_Blessing_(move))

> Generation IX
> _Lunar Blessing's **PP was reduced to 5**._

[Take Heart ](https://bulbapedia.bulbagarden.net/wiki/Take_Heart_(move))

> Generation IX
> _Take Heart raises the user's Special Attack and Special Defense stats by one stage each_
> _Take Heart's **PP was increased to 15**._

## Issue(s) that this PR fixes
Fixes #10422 