### PR TITLE
Fix failed contact moves activating contact effects of protect moves

### DIFF
--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -3088,6 +3088,8 @@ static enum MoveEndResult MoveEndSetValues(struct BattleCalcValues *cv)
 
 static bool32 GetProtectBypassMethod(enum BattlerId battlerDef, enum Ability abilityAtk)
 {
+    if (IsBattlerUnaffectedByMove(battlerDef))
+        return PROTECT_BYPASS_NONE;
     if (MoveIgnoresProtect(gCurrentMove))
         return PROTECT_BYPASS_MOVE_IGNORES;
     if (GetProtectType(gProtectStructs[battlerDef].protected) == PROTECT_TYPE_SINGLE
@@ -3149,7 +3151,7 @@ static enum MoveEndResult MoveEndProtectLikeEffect(struct BattleCalcValues *cv)
         return result;
     }
 
-    if (gBattleStruct->moveResultFlags[cv->battlerDef] == MOVE_RESULT_FAILED)
+    if (IsBattlerUnaffectedByMove(cv->battlerDef) && !(gBattleStruct->moveResultFlags[cv->battlerDef] & MOVE_RESULT_PROTECTED))
     {
         gBattleScripting.moveendState++;
         return result;

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -3149,59 +3149,62 @@ static enum MoveEndResult MoveEndProtectLikeEffect(struct BattleCalcValues *cv)
         return result;
     }
 
-    if (gBattleStruct->moveResultFlags[cv->battlerDef] == MOVE_RESULT_PROTECTED)
+    if (gBattleStruct->moveResultFlags[cv->battlerDef] == MOVE_RESULT_FAILED)
     {
-        switch (method)
+        gBattleScripting.moveendState++;
+        return result;
+    }
+
+    switch (method)
+    {
+    case PROTECT_SPIKY_SHIELD:
+        if (!IsAbilityAndRecord(cv->battlerAtk, cv->abilities[cv->battlerAtk], ABILITY_MAGIC_GUARD))
         {
-        case PROTECT_SPIKY_SHIELD:
-            if (!IsAbilityAndRecord(cv->battlerAtk, cv->abilities[cv->battlerAtk], ABILITY_MAGIC_GUARD))
-            {
-                SetPassiveDamageAmount(cv->battlerAtk, GetNonDynamaxMaxHP(cv->battlerAtk) / 8);
-                PREPARE_MOVE_BUFFER(gBattleTextBuff1, MOVE_SPIKY_SHIELD);
-                BattleScriptCall(BattleScript_SpikyShieldEffect);
-                result = MOVEEND_RESULT_RUN_SCRIPT;
-            }
-            break;
-        case PROTECT_KINGS_SHIELD:
+            SetPassiveDamageAmount(cv->battlerAtk, GetNonDynamaxMaxHP(cv->battlerAtk) / 8);
+            PREPARE_MOVE_BUFFER(gBattleTextBuff1, MOVE_SPIKY_SHIELD);
+            BattleScriptCall(BattleScript_SpikyShieldEffect);
+            result = MOVEEND_RESULT_RUN_SCRIPT;
+        }
+        break;
+    case PROTECT_KINGS_SHIELD:
+    {
+        s32 stage = (B_KINGS_SHIELD_LOWER_ATK >= GEN_8) ? -1 : -2;
+        gEffectBattler = gBattlerAttacker;
+        SetStatChange(gEffectBattler, STAT_ATK, stage);
+        BattleScriptCall(BattleScript_KingsShieldEffect);
+        result = MOVEEND_RESULT_RUN_SCRIPT;
+        break;
+    }
+    case PROTECT_BANEFUL_BUNKER:
+        if (CanBePoisoned(cv->battlerDef, cv->battlerAtk, cv->abilities[cv->battlerDef], cv->abilities[cv->battlerAtk]))
         {
-            s32 stage = (B_KINGS_SHIELD_LOWER_ATK >= GEN_8) ? -1 : -2;
-            gEffectBattler = gBattlerAttacker;
-            SetStatChange(gEffectBattler, STAT_ATK, stage);
-            BattleScriptCall(BattleScript_KingsShieldEffect);
+            gBattleScripting.moveEffect = MOVE_EFFECT_POISON;
+            BattleScriptCall(BattleScript_BanefulBunkerEffect);
             result = MOVEEND_RESULT_RUN_SCRIPT;
-            break;
         }
-        case PROTECT_BANEFUL_BUNKER:
-            if (CanBePoisoned(cv->battlerDef, cv->battlerAtk, cv->abilities[cv->battlerDef], cv->abilities[cv->battlerAtk]))
-            {
-                gBattleScripting.moveEffect = MOVE_EFFECT_POISON;
-                BattleScriptCall(BattleScript_BanefulBunkerEffect);
-                result = MOVEEND_RESULT_RUN_SCRIPT;
-            }
-            break;
-        case PROTECT_BURNING_BULWARK:
-            if (CanBeBurned(cv->battlerDef, cv->battlerAtk, cv->abilities[cv->battlerAtk]))
-            {
-                gBattleScripting.moveEffect = MOVE_EFFECT_BURN;
-                BattleScriptCall(BattleScript_BanefulBunkerEffect);
-                result = MOVEEND_RESULT_RUN_SCRIPT;
-            }
-            break;
-        case PROTECT_OBSTRUCT:
-            gEffectBattler = gBattlerAttacker;
-            SetStatChange(gEffectBattler, STAT_DEF, -2);
-            BattleScriptCall(BattleScript_KingsShieldEffect);
+        break;
+    case PROTECT_BURNING_BULWARK:
+        if (CanBeBurned(cv->battlerDef, cv->battlerAtk, cv->abilities[cv->battlerAtk]))
+        {
+            gBattleScripting.moveEffect = MOVE_EFFECT_BURN;
+            BattleScriptCall(BattleScript_BanefulBunkerEffect);
             result = MOVEEND_RESULT_RUN_SCRIPT;
-            break;
-        case PROTECT_SILK_TRAP:
-            gEffectBattler = gBattlerAttacker;
-            SetStatChange(gEffectBattler, STAT_SPEED, -1);
-            BattleScriptCall(BattleScript_KingsShieldEffect);
-            result = MOVEEND_RESULT_RUN_SCRIPT;
-            break;
-        default:
-            break;
         }
+        break;
+    case PROTECT_OBSTRUCT:
+        gEffectBattler = gBattlerAttacker;
+        SetStatChange(gEffectBattler, STAT_DEF, -2);
+        BattleScriptCall(BattleScript_KingsShieldEffect);
+        result = MOVEEND_RESULT_RUN_SCRIPT;
+        break;
+    case PROTECT_SILK_TRAP:
+        gEffectBattler = gBattlerAttacker;
+        SetStatChange(gEffectBattler, STAT_SPEED, -1);
+        BattleScriptCall(BattleScript_KingsShieldEffect);
+        result = MOVEEND_RESULT_RUN_SCRIPT;
+        break;
+    default:
+        break;
     }
 
     // Not strictly a protect effect, but works the same way

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -3151,7 +3151,7 @@ static enum MoveEndResult MoveEndProtectLikeEffect(struct BattleCalcValues *cv)
         return result;
     }
 
-    if (IsBattlerUnaffectedByMove(cv->battlerDef) && !(gBattleStruct->moveResultFlags[cv->battlerDef] & MOVE_RESULT_PROTECTED))
+    if (gBattleStruct->unableToUseMove)
     {
         gBattleScripting.moveendState++;
         return result;

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -3149,56 +3149,59 @@ static enum MoveEndResult MoveEndProtectLikeEffect(struct BattleCalcValues *cv)
         return result;
     }
 
-    switch (method)
+    if (gBattleStruct->moveResultFlags[cv->battlerDef] == MOVE_RESULT_PROTECTED)
     {
-    case PROTECT_SPIKY_SHIELD:
-        if (!IsAbilityAndRecord(cv->battlerAtk, cv->abilities[cv->battlerAtk], ABILITY_MAGIC_GUARD))
+        switch (method)
         {
-            SetPassiveDamageAmount(cv->battlerAtk, GetNonDynamaxMaxHP(cv->battlerAtk) / 8);
-            PREPARE_MOVE_BUFFER(gBattleTextBuff1, MOVE_SPIKY_SHIELD);
-            BattleScriptCall(BattleScript_SpikyShieldEffect);
-            result = MOVEEND_RESULT_RUN_SCRIPT;
-        }
-        break;
-    case PROTECT_KINGS_SHIELD:
-    {
-        s32 stage = (B_KINGS_SHIELD_LOWER_ATK >= GEN_8) ? -1 : -2;
-        gEffectBattler = gBattlerAttacker;
-        SetStatChange(gEffectBattler, STAT_ATK, stage);
-        BattleScriptCall(BattleScript_KingsShieldEffect);
-        result = MOVEEND_RESULT_RUN_SCRIPT;
-        break;
-    }
-    case PROTECT_BANEFUL_BUNKER:
-        if (CanBePoisoned(cv->battlerDef, cv->battlerAtk, cv->abilities[cv->battlerDef], cv->abilities[cv->battlerAtk]))
+        case PROTECT_SPIKY_SHIELD:
+            if (!IsAbilityAndRecord(cv->battlerAtk, cv->abilities[cv->battlerAtk], ABILITY_MAGIC_GUARD))
+            {
+                SetPassiveDamageAmount(cv->battlerAtk, GetNonDynamaxMaxHP(cv->battlerAtk) / 8);
+                PREPARE_MOVE_BUFFER(gBattleTextBuff1, MOVE_SPIKY_SHIELD);
+                BattleScriptCall(BattleScript_SpikyShieldEffect);
+                result = MOVEEND_RESULT_RUN_SCRIPT;
+            }
+            break;
+        case PROTECT_KINGS_SHIELD:
         {
-            gBattleScripting.moveEffect = MOVE_EFFECT_POISON;
-            BattleScriptCall(BattleScript_BanefulBunkerEffect);
+            s32 stage = (B_KINGS_SHIELD_LOWER_ATK >= GEN_8) ? -1 : -2;
+            gEffectBattler = gBattlerAttacker;
+            SetStatChange(gEffectBattler, STAT_ATK, stage);
+            BattleScriptCall(BattleScript_KingsShieldEffect);
             result = MOVEEND_RESULT_RUN_SCRIPT;
+            break;
         }
-        break;
-    case PROTECT_BURNING_BULWARK:
-        if (CanBeBurned(cv->battlerDef, cv->battlerAtk, cv->abilities[cv->battlerAtk]))
-        {
-            gBattleScripting.moveEffect = MOVE_EFFECT_BURN;
-            BattleScriptCall(BattleScript_BanefulBunkerEffect);
+        case PROTECT_BANEFUL_BUNKER:
+            if (CanBePoisoned(cv->battlerDef, cv->battlerAtk, cv->abilities[cv->battlerDef], cv->abilities[cv->battlerAtk]))
+            {
+                gBattleScripting.moveEffect = MOVE_EFFECT_POISON;
+                BattleScriptCall(BattleScript_BanefulBunkerEffect);
+                result = MOVEEND_RESULT_RUN_SCRIPT;
+            }
+            break;
+        case PROTECT_BURNING_BULWARK:
+            if (CanBeBurned(cv->battlerDef, cv->battlerAtk, cv->abilities[cv->battlerAtk]))
+            {
+                gBattleScripting.moveEffect = MOVE_EFFECT_BURN;
+                BattleScriptCall(BattleScript_BanefulBunkerEffect);
+                result = MOVEEND_RESULT_RUN_SCRIPT;
+            }
+            break;
+        case PROTECT_OBSTRUCT:
+            gEffectBattler = gBattlerAttacker;
+            SetStatChange(gEffectBattler, STAT_DEF, -2);
+            BattleScriptCall(BattleScript_KingsShieldEffect);
             result = MOVEEND_RESULT_RUN_SCRIPT;
+            break;
+        case PROTECT_SILK_TRAP:
+            gEffectBattler = gBattlerAttacker;
+            SetStatChange(gEffectBattler, STAT_SPEED, -1);
+            BattleScriptCall(BattleScript_KingsShieldEffect);
+            result = MOVEEND_RESULT_RUN_SCRIPT;
+            break;
+        default:
+            break;
         }
-        break;
-    case PROTECT_OBSTRUCT:
-        gEffectBattler = gBattlerAttacker;
-        SetStatChange(gEffectBattler, STAT_DEF, -2);
-        BattleScriptCall(BattleScript_KingsShieldEffect);
-        result = MOVEEND_RESULT_RUN_SCRIPT;
-        break;
-    case PROTECT_SILK_TRAP:
-        gEffectBattler = gBattlerAttacker;
-        SetStatChange(gEffectBattler, STAT_SPEED, -1);
-        BattleScriptCall(BattleScript_KingsShieldEffect);
-        result = MOVEEND_RESULT_RUN_SCRIPT;
-        break;
-    default:
-        break;
     }
 
     // Not strictly a protect effect, but works the same way

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -5822,7 +5822,7 @@ bool32 IsBattlerProtected(struct BattleCalcValues *cv)
         isProtected = TRUE;
     else if (gProtectStructs[cv->battlerDef].protected == PROTECT_BANEFUL_BUNKER)
         isProtected = TRUE;
-    else if (gProtectStructs[cv->battlerDef].protected == PROTECT_BURNING_BULWARK)
+    else if (gProtectStructs[cv->battlerDef].protected == PROTECT_BURNING_BULWARK && !IsBattleMoveStatus(cv->move))
         isProtected = TRUE;
     else if (gProtectStructs[cv->battlerDef].protected == PROTECT_OBSTRUCT && !IsBattleMoveStatus(cv->move))
         isProtected = TRUE;

--- a/test/battle/move_effect/protect.c
+++ b/test/battle/move_effect/protect.c
@@ -1062,3 +1062,36 @@ SINGLE_BATTLE_TEST("Protect doesn't fail if used consecutively if broken by Fein
         ANIMATION(ANIM_TYPE_MOVE, MOVE_PROTECT, player);
     }
 }
+
+SINGLE_BATTLE_TEST("Contact effects from certain protect moves do not apply if the attacker's contact move fails")
+{
+    enum Move move;
+
+    PARAMETRIZE { move = MOVE_BANEFUL_BUNKER; }
+    PARAMETRIZE { move = MOVE_BURNING_BULWARK; }
+    PARAMETRIZE { move = MOVE_OBSTRUCT; }
+    PARAMETRIZE { move = MOVE_SILK_TRAP; }
+    PARAMETRIZE { move = MOVE_KINGS_SHIELD; }
+    PARAMETRIZE { move = MOVE_SPIKY_SHIELD; }
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, move); MOVE(opponent, MOVE_SUCKER_PUNCH); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        switch (move)
+        {
+            case MOVE_SPIKY_SHIELD:
+                NOT HP_BAR(opponent);
+            default:
+                break;
+        }
+    } THEN {
+        EXPECT_EQ(player->status1, STATUS1_NONE);
+        EXPECT_EQ(opponent->statStages[STAT_ATK], DEFAULT_STAT_STAGE);
+        EXPECT_EQ(opponent->statStages[STAT_DEF], DEFAULT_STAT_STAGE);
+        EXPECT_EQ(opponent->statStages[STAT_SPEED], DEFAULT_STAT_STAGE);
+    }
+}

--- a/test/battle/move_effect/protect.c
+++ b/test/battle/move_effect/protect.c
@@ -1079,15 +1079,37 @@ SINGLE_BATTLE_TEST("Protect: Contact effects from certain protect moves do not a
         TURN { MOVE(player, move); MOVE(opponent, MOVE_SUCKER_PUNCH); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, move, player);
-        switch (move)
-        {
-            case MOVE_SPIKY_SHIELD:
-                NOT HP_BAR(opponent);
-            default:
-                break;
-        }
     } THEN {
         EXPECT_EQ(player->status1, STATUS1_NONE);
+        EXPECT_EQ(player->hp, player->maxHP);
+        EXPECT_EQ(opponent->statStages[STAT_ATK], DEFAULT_STAT_STAGE);
+        EXPECT_EQ(opponent->statStages[STAT_DEF], DEFAULT_STAT_STAGE);
+        EXPECT_EQ(opponent->statStages[STAT_SPEED], DEFAULT_STAT_STAGE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Protect: Contact effects from certain protect moves do not apply if the attacker's contact move fails (Unseen Fist)")
+{
+    enum Move move;
+
+    PARAMETRIZE { move = MOVE_BANEFUL_BUNKER; }
+    PARAMETRIZE { move = MOVE_BURNING_BULWARK; }
+    PARAMETRIZE { move = MOVE_OBSTRUCT; }
+    PARAMETRIZE { move = MOVE_SILK_TRAP; }
+    PARAMETRIZE { move = MOVE_KINGS_SHIELD; }
+    PARAMETRIZE { move = MOVE_SPIKY_SHIELD; }
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_URSHIFU);
+    } WHEN {
+        TURN { MOVE(player, move); MOVE(opponent, MOVE_SUCKER_PUNCH); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        NOT MESSAGE("Wobbuffet couldn't fully protect itself and got hurt!");
+    } THEN {
+        EXPECT_EQ(player->status1, STATUS1_NONE);
+        EXPECT_EQ(player->hp, player->maxHP);
         EXPECT_EQ(opponent->statStages[STAT_ATK], DEFAULT_STAT_STAGE);
         EXPECT_EQ(opponent->statStages[STAT_DEF], DEFAULT_STAT_STAGE);
         EXPECT_EQ(opponent->statStages[STAT_SPEED], DEFAULT_STAT_STAGE);

--- a/test/battle/move_effect/protect.c
+++ b/test/battle/move_effect/protect.c
@@ -1088,6 +1088,30 @@ SINGLE_BATTLE_TEST("Protect: Contact effects from certain protect moves do not a
     }
 }
 
+SINGLE_BATTLE_TEST("Protect: Contact effects from certain protect moves do not apply if the attacker fails to attack")
+{
+    enum Move move;
+
+    PARAMETRIZE { move = MOVE_OBSTRUCT; }
+    PARAMETRIZE { move = MOVE_SILK_TRAP; }
+    PARAMETRIZE { move = MOVE_KINGS_SHIELD; }
+    PARAMETRIZE { move = MOVE_SPIKY_SHIELD; }
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { Status1(STATUS1_SLEEP_TURN(3)); }
+    } WHEN {
+        TURN { MOVE(player, move); MOVE(opponent, MOVE_SCRATCH); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+    } THEN {
+        EXPECT_EQ(player->hp, player->maxHP);
+        EXPECT_EQ(opponent->statStages[STAT_ATK], DEFAULT_STAT_STAGE);
+        EXPECT_EQ(opponent->statStages[STAT_DEF], DEFAULT_STAT_STAGE);
+        EXPECT_EQ(opponent->statStages[STAT_SPEED], DEFAULT_STAT_STAGE);
+    }
+}
+
 SINGLE_BATTLE_TEST("Protect: Contact effects from certain protect moves do not apply if the attacker's contact move fails (Unseen Fist)")
 {
     enum Move move;

--- a/test/battle/move_effect/protect.c
+++ b/test/battle/move_effect/protect.c
@@ -28,7 +28,6 @@ SINGLE_BATTLE_TEST("Protect: Protect, Detect, Spiky Shield, Baneful Bunker and B
         MOVE_DETECT,
         MOVE_SPIKY_SHIELD,
         MOVE_BANEFUL_BUNKER,
-        MOVE_BURNING_BULWARK,
     };
     enum Move protectMove = MOVE_NONE;
     enum Move usedMove = MOVE_NONE;
@@ -305,7 +304,6 @@ SINGLE_BATTLE_TEST("Protect: Burning Bulwark burns Pokémon for moves making con
     enum Move usedMove = MOVE_NONE;
 
     PARAMETRIZE { usedMove = MOVE_SCRATCH; }
-    PARAMETRIZE { usedMove = MOVE_LEER; }
     PARAMETRIZE { usedMove = MOVE_WATER_GUN; }
 
     GIVEN {

--- a/test/battle/move_effect/protect.c
+++ b/test/battle/move_effect/protect.c
@@ -1095,3 +1095,24 @@ SINGLE_BATTLE_TEST("Protect: Contact effects from certain protect moves do not a
         EXPECT_EQ(opponent->statStages[STAT_SPEED], DEFAULT_STAT_STAGE);
     }
 }
+
+SINGLE_BATTLE_TEST("Protect: King's Shield, Obstruct, Burning Bulwark and Silk Trap do not protect the user from status moves")
+{
+    enum Move move;
+
+    PARAMETRIZE { move = MOVE_BURNING_BULWARK; }
+    PARAMETRIZE { move = MOVE_OBSTRUCT; }
+    PARAMETRIZE { move = MOVE_KINGS_SHIELD; }
+    PARAMETRIZE { move = MOVE_SILK_TRAP; }
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, move); MOVE(opponent, MOVE_LEER); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_LEER, opponent);
+        NOT MESSAGE("Wobbuffet protected itself!");
+    }
+}

--- a/test/battle/move_effect/protect.c
+++ b/test/battle/move_effect/protect.c
@@ -1096,7 +1096,7 @@ SINGLE_BATTLE_TEST("Protect: Contact effects from certain protect moves do not a
     }
 }
 
-SINGLE_BATTLE_TEST("Protect: King's Shield, Obstruct, Burning Bulwark and Silk Trap do not protect the user from status moves")
+SINGLE_BATTLE_TEST("Protect: Mat Block, King's Shield, Obstruct, Burning Bulwark and Silk Trap do not protect the user from status moves")
 {
     enum Move move;
 
@@ -1104,6 +1104,7 @@ SINGLE_BATTLE_TEST("Protect: King's Shield, Obstruct, Burning Bulwark and Silk T
     PARAMETRIZE { move = MOVE_OBSTRUCT; }
     PARAMETRIZE { move = MOVE_KINGS_SHIELD; }
     PARAMETRIZE { move = MOVE_SILK_TRAP; }
+    PARAMETRIZE { move = MOVE_MAT_BLOCK; }
 
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);

--- a/test/battle/move_effect/protect.c
+++ b/test/battle/move_effect/protect.c
@@ -1063,7 +1063,7 @@ SINGLE_BATTLE_TEST("Protect doesn't fail if used consecutively if broken by Fein
     }
 }
 
-SINGLE_BATTLE_TEST("Contact effects from certain protect moves do not apply if the attacker's contact move fails")
+SINGLE_BATTLE_TEST("Protect: Contact effects from certain protect moves do not apply if the attacker's contact move fails")
 {
     enum Move move;
 


### PR DESCRIPTION
Title. Found this while I was playtesting my project. Targets upcoming due to the bug stemming from changes in upcoming.

## Description
This PR fixes a bug that occurs when a contact move fails into a target protecting, it would still activate the protect move's contact effects. For example, if an attacker used Sucker Punch against a defender protecting, it would erroneously activate the contact effects of Spiky Shield, Burning Bulwark, Silk Trap, etc.

In addition, some other niche bugs were fixed:
* Burning Bulwark blocking status moves when it shouldn't

### Large Language Models (AI)
None

## Issue(s) that this PR fixes
Fixes #10435

## Discord contact info
linathan
