### PR TITLE
Fix send mon text in frlg first battle

### DIFF
--- a/src/battle_message.c
+++ b/src/battle_message.c
@@ -2492,8 +2492,7 @@ void BufferStringBattle(enum StringID stringID, enum BattlerId battler)
         }
         break;
     case STRINGID_INTROSENDOUT: // poke first send-out
-        if (BattlerIsPlayer(battler) || BattlerIsPlayer(BATTLE_PARTNER(battler))
-         || BattlerIsWally(battler) || BattlerIsWally(BATTLE_PARTNER(battler)))
+        if (GetBattlerSide(battler) == B_SIDE_PLAYER)
         {
             if (IsDoubleBattle() && IsValidForBattle(GetBattlerMon(BATTLE_PARTNER(battler))))
             {

--- a/src/battle_message.c
+++ b/src/battle_message.c
@@ -2492,7 +2492,7 @@ void BufferStringBattle(enum StringID stringID, enum BattlerId battler)
         }
         break;
     case STRINGID_INTROSENDOUT: // poke first send-out
-        if (GetBattlerSide(battler) == B_SIDE_PLAYER)
+        if (IsOnPlayerSide(battler))
         {
             if (IsDoubleBattle() && IsValidForBattle(GetBattlerMon(BATTLE_PARTNER(battler))))
             {


### PR DESCRIPTION
The first battle in FRLG doesn't use BATLLE_CONTROLLER_PLAYER but BATTLE_CONTROLLER_OAK_OLD_MAN because of that, it was using the enemy text when player was sending pokemon.
I could have added the controller to the list of "player" ones but checking for side results in the same thing while being simpler

## Media

https://github.com/user-attachments/assets/ef0b2904-d54b-4d4a-928d-d2c3b992609f



## Issue(s) that this PR fixes
Fixes #10418


## Discord contact info
Jamie
