### PR TITLE
Fix Struggle recoil damage not using standard rounding

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2534,6 +2534,8 @@ void SetMoveEffect(enum BattlerId battlerAtk, enum BattlerId effectBattler, enum
     case MOVE_EFFECT_RECOIL_HP_25: // Struggle
     {
         s32 recoil = (gBattleMons[effectBattler].maxHP) / 4;
+        if (B_UPDATED_MOVE_DATA >= GEN_5 && (gBattleMons[effectBattler].maxHP % 4) >= 2) // Account for standard rounding (Gen5+)
+            recoil++;
         if (recoil == 0)
             recoil = 1;
         SetPassiveDamageAmount(effectBattler, recoil);

--- a/test/battle/move_effect/struggle.c
+++ b/test/battle/move_effect/struggle.c
@@ -73,3 +73,40 @@ SINGLE_BATTLE_TEST("Struggle does not receive normal-type STAB")
         EXPECT_MUL_EQ(struggleDamage, Q_4_12(1.5), cutDamage);
     }
 }
+
+SINGLE_BATTLE_TEST("Struggle recoil is subject to standard rounding (Gen 5+)")
+{
+    ASSUME(GetMoveEffect(MOVE_STRUGGLE) == EFFECT_STRUGGLE);
+
+    s16 recoil;
+    u32 hpStat = 0;
+
+    PARAMETRIZE { hpStat = 200; }
+    PARAMETRIZE { hpStat = 201; }
+    PARAMETRIZE { hpStat = 202; }
+    PARAMETRIZE { hpStat = 203; }
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { MaxHP(hpStat); HP(hpStat); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_STRUGGLE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_STRUGGLE, player);
+        HP_BAR(player, captureDamage: &recoil);
+    } THEN {
+        switch (hpStat)
+        {
+            case 200:
+                EXPECT_EQ(player->hp, 150);
+                break;
+            case 201:
+            case 202:
+                EXPECT_EQ(player->hp, 151);
+                break;
+            case 203:
+                EXPECT_EQ(player->hp, 152);
+                break;
+        }
+    }
+}


### PR DESCRIPTION
Title.

## Description
As of Gen 5, Struggle recoil damage uses standard rounding. For example, if a Pokemon were to have 200 or 201 max HP, it would take 50 damage from Struggle recoil, but if it were to have 202 or 203 max HP, it would take 51 damage.

### Large Language Models (AI)
None

## Media
### Gen 5
https://github.com/user-attachments/assets/028c87cd-85f2-4a6c-9520-fe11edcbf3f0

### Champions
https://github.com/user-attachments/assets/8ec7df9d-33bb-4e70-a0a9-6bf757ef474d

## Issue(s) that this PR fixes
Fixes #10444

## Discord contact info
linathan