### PR TITLE
Adds new debug command to fill party with mons that knows field moves

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -15,6 +15,7 @@
 #include "event_object_movement.h"
 #include "event_scripts.h"
 #include "field_message_box.h"
+#include "field_move.h"
 #include "field_screen_effect.h"
 #include "field_weather.h"
 #include "follower_npc.h"
@@ -297,6 +298,7 @@ static void DebugAction_PCBag_ClearBoxes(u8 taskId);
 static void DebugAction_Party_HealParty(u8 taskId);
 static void DebugAction_Party_ClearPokerus(u8 taskId);
 static void DebugAction_Party_ClearParty(u8 taskId);
+static void DebugAction_Party_SetFieldMovesParty(u8 taskId);
 static void DebugAction_Party_SetParty(u8 taskId);
 static void DebugAction_Party_BattleSingle(u8 taskId);
 
@@ -651,17 +653,18 @@ static const struct DebugMenuOption sDebugMenu_Actions_EditPokemon[] =
 
 static const struct DebugMenuOption sDebugMenu_Actions_Party[] =
 {
-    { COMPOUND_STRING("Move Relearner"),     DebugAction_ExecuteScript, Common_EventScript_MoveRelearner },
-    { COMPOUND_STRING("Hatch an Egg"),       DebugAction_ExecuteScript, Debug_HatchAnEgg },
-    { COMPOUND_STRING("Heal party"),         DebugAction_Party_HealParty },
-    { COMPOUND_STRING("Edit Pokemon"),       DebugAction_OpenSubMenu, sDebugMenu_Actions_EditPokemon },
-    { COMPOUND_STRING("Check EVs"),          DebugAction_ExecuteScript, Debug_EventScript_CheckEVs },
-    { COMPOUND_STRING("Check IVs"),          DebugAction_ExecuteScript, Debug_EventScript_CheckIVs },
-    { COMPOUND_STRING("Give Pokerus"),       DebugAction_ExecuteScript, Debug_EventScript_GivePokerus },
-    { COMPOUND_STRING("Clear Pokerus"),      DebugAction_Party_ClearPokerus},
-    { COMPOUND_STRING("Clear Party"),        DebugAction_Party_ClearParty },
-    { COMPOUND_STRING("Set Party"),          DebugAction_Party_SetParty },
-    { COMPOUND_STRING("Start Debug Battle"), DebugAction_Party_BattleSingle },
+    { COMPOUND_STRING("Move Relearner"),          DebugAction_ExecuteScript, Common_EventScript_MoveRelearner },
+    { COMPOUND_STRING("Hatch an Egg"),            DebugAction_ExecuteScript, Debug_HatchAnEgg },
+    { COMPOUND_STRING("Heal party"),              DebugAction_Party_HealParty },
+    { COMPOUND_STRING("Edit Pokemon"),            DebugAction_OpenSubMenu, sDebugMenu_Actions_EditPokemon },
+    { COMPOUND_STRING("Check EVs"),               DebugAction_ExecuteScript, Debug_EventScript_CheckEVs },
+    { COMPOUND_STRING("Check IVs"),               DebugAction_ExecuteScript, Debug_EventScript_CheckIVs },
+    { COMPOUND_STRING("Give Pokerus"),            DebugAction_ExecuteScript, Debug_EventScript_GivePokerus },
+    { COMPOUND_STRING("Clear Pokerus"),           DebugAction_Party_ClearPokerus},
+    { COMPOUND_STRING("Clear Party"),             DebugAction_Party_ClearParty },
+    { COMPOUND_STRING("Set Field Moves Party"),   DebugAction_Party_SetFieldMovesParty },
+    { COMPOUND_STRING("Set Party"),               DebugAction_Party_SetParty },
+    { COMPOUND_STRING("Start Debug Battle"),      DebugAction_Party_BattleSingle },
     { NULL }
 };
 
@@ -5650,6 +5653,25 @@ const struct Trainer sDebugTrainers[DIFFICULTY_COUNT][DEBUG_TRAINERS_COUNT] =
 {
 #include "data/debug_trainers.h"
 };
+
+static void DebugAction_Party_SetFieldMovesParty(u8 taskId)
+{
+    ZeroPlayerPartyMons();
+    u32 max = FIELD_MOVES_COUNT;
+    assertf(FIELD_MOVES_COUNT <= PARTY_SIZE * MAX_MON_MOVES, "Can't load more than %d field moves in party", PARTY_SIZE * MAX_MON_MOVES)
+    {
+        max = PARTY_SIZE * MAX_MON_MOVES;
+    }
+    for (u32 i = 0; i < max; i++)
+    {
+        if (i % 4 == 0)
+            CreateRandomMon(&gParties[B_TRAINER_PLAYER][i / 4], SPECIES_SMEARGLE, 100);
+        enum Move move = FieldMove_GetMoveId(i);
+        SetMonData(&gParties[B_TRAINER_PLAYER][i / 4], MON_DATA_MOVE1 + (i % 4), &move);
+    }
+    ScriptContext_Enable();
+    Debug_DestroyMenu_Full(taskId);
+}
 
 const struct Trainer* GetDebugAiTrainer(void)
 {


### PR DESCRIPTION
## Media

https://github.com/user-attachments/assets/1389fd3d-511e-4000-9c34-30f9376f6f88



## Feature(s) this PR does NOT handle:
Unrelated to the field moves bug recently mentionned

## Things to note in the release changelog:
- In the debug menu: Party -> Set Field Moves Party

## Discord contact info
Jamie
