### PR TITLE
Add Gen 9 Overworld Weather Behavior

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -2339,6 +2339,13 @@ BattleScript_BlockedByPrimalWeather::
 	jumpifhalfword CMP_COMMON_BITS, gBattleWeather, B_WEATHER_STRONG_WINDS, BattleScript_MysteriousAirCurrentBlowsOn
 	return
 
+BattleScript_BlockedByOverworldWeather::
+	call BattleScript_AbilityPopUp
+	waitmessage B_WAIT_TIME_SHORT
+    printstring STRINGID_BUTITFAILED
+	waitmessage B_WAIT_TIME_LONG
+	return
+
 BattleScript_EffectPsychUp::
 	attackcanceler
 	accuracycheck

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -5700,6 +5700,11 @@ BattleScript_ActivateTeraformZero::
 	jumpifhalfword CMP_COMMON_BITS, gBattleWeather, B_WEATHER_ANY, BattleScript_ActivateTeraformZero_RemoveWeather
 	jumpifterrain CMP_NOT_EQUAL, B_TERRAIN_NONE, BattleScript_ActivateTeraformZero_RemoveTerrain
 	goto BattleScript_ActivateTeraformZero_Ret
+BattleScript_ActivateTeraformZeroRemovesOnlyTerrain::
+	call BattleScript_AbilityPopUp
+	waitmessage B_WAIT_TIME_LONG
+	jumpifterrain CMP_NOT_EQUAL, B_TERRAIN_NONE, BattleScript_ActivateTeraformZero_RemoveTerrain
+	goto BattleScript_ActivateTeraformZero_Ret
 BattleScript_ActivateTeraformZero_RemoveWeather:
 	removeweather
 	printfromtable gWeatherEndsStringIds

--- a/include/battle.h
+++ b/include/battle.h
@@ -733,6 +733,7 @@ struct BattleStruct
     u8 intimidateActivated:1;
     u8 allowPartingShot:1;
     u8 adrenalineOrbActivated:1; // prevents looping after an adrenaline stat changed
+    u8 overworldWeatherPresent:1;
 };
 
 struct AiBattleData

--- a/include/battle_scripts.h
+++ b/include/battle_scripts.h
@@ -355,6 +355,7 @@ extern const u8 BattleScript_CheekPouchActivates[];
 extern const u8 BattleScript_TotemBoost[];
 extern const u8 BattleScript_AnnounceAirLockCloudNine[];
 extern const u8 BattleScript_ActivateTeraformZero[];
+extern const u8 BattleScript_ActivateTeraformZeroRemovesOnlyTerrain[];
 extern const u8 BattleScript_BallFetch[];
 extern const u8 BattleScript_PerishBodyActivates[];
 extern const u8 BattleScript_ActivateAsOne[];

--- a/include/battle_scripts.h
+++ b/include/battle_scripts.h
@@ -390,6 +390,7 @@ extern const u8 BattleScript_PlayMoveAnimAndMoveSwitch[];
 extern const u8 BattleScript_MysteriousAirCurrentBlowsOn[];
 extern const u8 BattleScript_AttackWeakenedByStrongWinds[];
 extern const u8 BattleScript_BlockedByPrimalWeather[];
+extern const u8 BattleScript_BlockedByOverworldWeather[];
 extern const u8 BattleScript_PrimalReversion[];
 extern const u8 BattleScript_SelectingNotAllowedMoveGorillaTactics[];
 extern const u8 BattleScript_SelectingNotAllowedMoveGorillaTacticsInPalace[];

--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -170,6 +170,14 @@ enum SubCheck
     INCLUDING_SUBSTITUTES
 };
 
+enum WeatherFailure
+{
+    WEATHER_FAILURE_SAME_WEATHER,
+    WEATHER_FAILURE_OVERWORLD,
+    WEATHER_FAILURE_PRIMAL,
+    WEATHER_FAILURE_SUCCESS,
+};
+
 void HandleAction_ThrowBall(void);
 enum BattleWeather GetCurrentBattleWeather(u32 weather);
 bool32 EndOrContinueWeather(void);
@@ -213,7 +221,7 @@ s32 GetDrainedBigRootHp(enum BattlerId battler, s32 hp);
 bool32 IsAbilityAndRecord(enum BattlerId battler, enum Ability battlerAbility, enum Ability abilityToCheck);
 bool32 HandleFaintedMonActions(void);
 bool32 HasNoMonsToSwitch(enum BattlerId battler, u8 partyIdBattlerOn1, u8 partyIdBattlerOn2);
-bool32 TryChangeBattleWeather(enum BattlerId battler, u32 battleWeatherId, enum Ability ability);
+enum WeatherFailure TryChangeBattleWeather(enum BattlerId battler, u32 battleWeatherId, enum Ability ability);
 bool32 TryChangeBattleTerrain(enum BattlerId battler, enum BattleTerrain terrain);
 bool32 IsPowderMoveBlocked(struct DamageContext *ctx);
 bool32 CanTargetBlockPranksterMove(struct DamageContext *ctx, s32 movePriority);

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -327,6 +327,7 @@
 #define B_OVERWORLD_SNOW                GEN_LATEST // In Gen9+, overworld snow will summon snow instead of hail in battle.
 #define B_SNOW_WARNING                  GEN_LATEST // In Gen9+, Snow Warning will summon snow instead of hail.
 #define B_PREFERRED_ICE_WEATHER         B_ICE_WEATHER_BOTH // Toggles hail move effects to snow and vice versa.
+#define B_OVERWORLD_WEATHER_OVERRIDE    GEN_LATEST // In Gen9+, overworld weather cannot be overridden.
 
 // Terrain settings
 #define B_TERRAIN_BG_CHANGE         TRUE       // If set to TRUE, terrain moves permanently change the default battle background until the effect fades.

--- a/include/constants/config_changes.h
+++ b/include/constants/config_changes.h
@@ -224,6 +224,7 @@
     F(B_OVERWORLD_SNOW,            overworldSnow,           (u32, GEN_COUNT - 1)) /* TODO: use in tests */ \
     F(B_SNOW_WARNING,              snowWarning,             (u32, GEN_COUNT - 1)) \
     F(B_PREFERRED_ICE_WEATHER,     preferredIceWeather,     (u32, B_ICE_WEATHER_SNOW)) /* TODO: use in tests */ \
+    F(B_OVERWORLD_WEATHER_OVERRIDE,overworldWeatherOverride,(u32, GEN_COUNT - 1)) \
     /* Terrain settings */ \
     F(B_TERRAIN_TYPE_BOOST,        terrainTypeBoost,        (u32, GEN_COUNT - 1)) /* TODO: use in tests */ \
     F(B_SECRET_POWER_EFFECT,       secretPowerEffect,       (u32, GEN_COUNT - 1)) /* TODO: use in tests */ \

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2707,7 +2707,7 @@ void SetMoveEffect(struct BattleCalcValues *cv, struct SetEffect *se)
         default:
             break;
         }
-        if (TryChangeBattleWeather(battlerAtk, weather, ABILITY_NONE))
+        if (TryChangeBattleWeather(battlerAtk, weather, ABILITY_NONE) == WEATHER_FAILURE_SUCCESS)
         {
             gBattleCommunication[MULTISTRING_CHOOSER] = msg;
             BattleScriptPush(battleScript);
@@ -6565,7 +6565,7 @@ static void Cmd_setfieldweather(void)
 {
     CMD_ARGS();
 
-    if (TryChangeBattleWeather(gBattlerAttacker, GetMoveWeatherType(gCurrentMove), ABILITY_NONE))
+    if (TryChangeBattleWeather(gBattlerAttacker, GetMoveWeatherType(gCurrentMove), ABILITY_NONE) == WEATHER_FAILURE_SUCCESS)
     {
         gBattlescriptCurrInstr = cmd->nextInstr;
         return;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -1953,18 +1953,47 @@ bool32 HasNoMonsToSwitch(enum BattlerId battler, u8 partyIdBattlerOn1, u8 partyI
     }
 }
 
-bool32 TryChangeBattleWeather(enum BattlerId battler, u32 battleWeatherId, enum Ability ability)
+static bool32 TryChangeWeatherWithAbility(enum BattlerId battler, u32 battleWeather, enum Ability ability)
+{
+    switch (TryChangeBattleWeather(battler, battleWeather, ability))
+    {
+    case WEATHER_FAILURE_SAME_WEATHER:
+        if (ability == ABILITY_ORICHALCUM_PULSE)
+        {
+            BattleScriptCall(BattleScript_OrichalcumPulseActivatesInSun);
+            return TRUE;
+        }
+        return FALSE;
+    case WEATHER_FAILURE_OVERWORLD:
+        BattleScriptCall(BattleScript_BlockedByOverworldWeather);
+        return TRUE;
+    case WEATHER_FAILURE_PRIMAL:
+        BattleScriptCall(BattleScript_BlockedByPrimalWeather);
+        return TRUE;
+    case WEATHER_FAILURE_SUCCESS:
+        if (ability == ABILITY_ORICHALCUM_PULSE)
+            BattleScriptCall(BattleScript_OrichalcumPulseActivates);
+        else
+            BattleScriptCall(BattleScript_WeatherAbilityActivates);
+        return TRUE;
+    }
+    return FALSE;
+}
+
+enum WeatherFailure TryChangeBattleWeather(enum BattlerId battler, u32 battleWeatherId, enum Ability ability)
 {
     if (gBattleWeather & sBattleWeatherInfo[battleWeatherId].flag)
-        return FALSE;
-    else if (gBattleStruct->overworldWeatherPresent)
-        return FALSE;
-    else if (gBattleWeather & B_WEATHER_PRIMAL_ANY
+        return WEATHER_FAILURE_SAME_WEATHER;
+
+    if (gBattleStruct->overworldWeatherPresent)
+        return WEATHER_FAILURE_OVERWORLD;
+
+    if (gBattleWeather & B_WEATHER_PRIMAL_ANY
           && ability != ABILITY_DESOLATE_LAND
           && ability != ABILITY_PRIMORDIAL_SEA
           && ability != ABILITY_DELTA_STREAM)
     {
-        return FALSE;
+        return WEATHER_FAILURE_PRIMAL;
     }
 
     if (GetConfig(B_ABILITY_WEATHER) < GEN_6 && ability != ABILITY_NONE)
@@ -2000,7 +2029,7 @@ bool32 TryChangeBattleWeather(enum BattlerId battler, u32 battleWeatherId, enum 
         ResetParadoxWeatherStat(i);
     }
 
-    return TRUE;
+    return WEATHER_FAILURE_SUCCESS;
 }
 
 bool32 TryChangeBattleTerrain(enum BattlerId battler, enum BattleTerrain terrain)
@@ -3236,107 +3265,21 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
             }
             break;
         case ABILITY_DRIZZLE:
-            if (!shouldAbilityTrigger)
-                break;
-            if (TryChangeBattleWeather(battler, BATTLE_WEATHER_RAIN, gLastUsedAbility))
-            {
-                BattleScriptCall(BattleScript_WeatherAbilityActivates);
+            if (shouldAbilityTrigger && TryChangeWeatherWithAbility(battler, BATTLE_WEATHER_RAIN, gLastUsedAbility))
                 effect++;
-            }
-            else if (gBattleStruct->overworldWeatherPresent)
-            {
-                BattleScriptCall(BattleScript_BlockedByOverworldWeather);
-                effect++;
-            }
-            else if (GetWeather() & B_WEATHER_PRIMAL_ANY)
-            {
-                BattleScriptCall(BattleScript_BlockedByPrimalWeather);
-                effect++;
-            }
             break;
         case ABILITY_SAND_STREAM:
-            if (!shouldAbilityTrigger)
-                break;
-            if (TryChangeBattleWeather(battler, BATTLE_WEATHER_SANDSTORM, gLastUsedAbility))
-            {
-                BattleScriptCall(BattleScript_WeatherAbilityActivates);
+            if (shouldAbilityTrigger && TryChangeWeatherWithAbility(battler, BATTLE_WEATHER_SANDSTORM, gLastUsedAbility))
                 effect++;
-            }
-            else if (gBattleStruct->overworldWeatherPresent)
-            {
-                BattleScriptCall(BattleScript_BlockedByOverworldWeather);
-                effect++;
-            }
-            else if (GetWeather() & B_WEATHER_PRIMAL_ANY)
-            {
-                BattleScriptCall(BattleScript_BlockedByPrimalWeather);
-                effect++;
-            }
             break;
         case ABILITY_DROUGHT:
-            if (!shouldAbilityTrigger)
-                break;
-            if (TryChangeBattleWeather(battler, BATTLE_WEATHER_SUN, gLastUsedAbility))
-            {
-                BattleScriptCall(BattleScript_WeatherAbilityActivates);
-                effect++;
-            }
-            else if (gBattleStruct->overworldWeatherPresent)
-            {
-                BattleScriptCall(BattleScript_BlockedByOverworldWeather);
-                effect++;
-            }
-            else if (GetWeather() & B_WEATHER_PRIMAL_ANY)
-            {
-                BattleScriptCall(BattleScript_BlockedByPrimalWeather);
-                effect++;
-            }
-            break;
         case ABILITY_ORICHALCUM_PULSE:
-            if (!shouldAbilityTrigger)
-                break;
-            if (GetWeather() & B_WEATHER_SUN_NORMAL)
-            {
-                BattleScriptCall(BattleScript_OrichalcumPulseActivatesInSun);
+            if (shouldAbilityTrigger && TryChangeWeatherWithAbility(battler, BATTLE_WEATHER_SUN, gLastUsedAbility))
                 effect++;
-            }
-            else if (TryChangeBattleWeather(battler, BATTLE_WEATHER_SUN, gLastUsedAbility))
-            {
-                BattleScriptCall(BattleScript_OrichalcumPulseActivates);
-                effect++;
-            }
-            else if (gBattleStruct->overworldWeatherPresent)
-            {
-                BattleScriptCall(BattleScript_BlockedByOverworldWeather);
-                effect++;
-            }
-            else if (GetWeather() & B_WEATHER_PRIMAL_ANY)
-            {
-                BattleScriptCall(BattleScript_BlockedByPrimalWeather);
-                effect++;
-            }
             break;
         case ABILITY_SNOW_WARNING:
-            if (!shouldAbilityTrigger)
-                break;
-            {
-                u32 weather = (GetConfig(B_SNOW_WARNING) >= GEN_9 ? BATTLE_WEATHER_SNOW : BATTLE_WEATHER_HAIL);
-                if (TryChangeBattleWeather(battler, weather, gLastUsedAbility))
-                {
-                    BattleScriptCall(BattleScript_WeatherAbilityActivates);
-                    effect++;
-                }
-                else if (gBattleStruct->overworldWeatherPresent)
-                {
-                    BattleScriptCall(BattleScript_BlockedByOverworldWeather);
-                    effect++;
-                }
-                else if (GetWeather() & B_WEATHER_PRIMAL_ANY)
-                {
-                    BattleScriptCall(BattleScript_BlockedByPrimalWeather);
-                    effect++;
-                }
-            }
+            if (shouldAbilityTrigger && TryChangeWeatherWithAbility(battler, GetConfig(B_SNOW_WARNING) >= GEN_9 ? BATTLE_WEATHER_SNOW : BATTLE_WEATHER_HAIL, gLastUsedAbility))
+                effect++;
             break;
         case ABILITY_ELECTRIC_SURGE:
             if (!shouldAbilityTrigger)
@@ -3470,46 +3413,16 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
             }
             break;
         case ABILITY_DESOLATE_LAND:
-            if (!shouldAbilityTrigger)
-                break;
-            if (TryChangeBattleWeather(battler, BATTLE_WEATHER_SUN_PRIMAL, gLastUsedAbility))
-            {
-                BattleScriptCall(BattleScript_WeatherAbilityActivates);
+            if (shouldAbilityTrigger && TryChangeWeatherWithAbility(battler, BATTLE_WEATHER_SUN_PRIMAL, gLastUsedAbility))
                 effect++;
-            }
-            else if (gBattleStruct->overworldWeatherPresent)
-            {
-                BattleScriptCall(BattleScript_BlockedByOverworldWeather);
-                effect++;
-            }
             break;
         case ABILITY_PRIMORDIAL_SEA:
-            if (!shouldAbilityTrigger)
-                break;
-            if (TryChangeBattleWeather(battler, BATTLE_WEATHER_RAIN_PRIMAL, gLastUsedAbility))
-            {
-                BattleScriptCall(BattleScript_WeatherAbilityActivates);
+            if (shouldAbilityTrigger && TryChangeWeatherWithAbility(battler, BATTLE_WEATHER_RAIN_PRIMAL, gLastUsedAbility))
                 effect++;
-            }
-            else if (gBattleStruct->overworldWeatherPresent)
-            {
-                BattleScriptCall(BattleScript_BlockedByOverworldWeather);
-                effect++;
-            }
             break;
         case ABILITY_DELTA_STREAM:
-            if (!shouldAbilityTrigger)
-                break;
-            if (TryChangeBattleWeather(battler, BATTLE_WEATHER_STRONG_WINDS, gLastUsedAbility))
-            {
-                BattleScriptCall(BattleScript_WeatherAbilityActivates);
+            if (shouldAbilityTrigger && TryChangeWeatherWithAbility(battler, BATTLE_WEATHER_STRONG_WINDS, gLastUsedAbility))
                 effect++;
-            }
-            else if (gBattleStruct->overworldWeatherPresent)
-            {
-                BattleScriptCall(BattleScript_BlockedByOverworldWeather);
-                effect++;
-            }
             break;
         case ABILITY_VESSEL_OF_RUIN:
             if (shouldAbilityTrigger)
@@ -4276,25 +4189,8 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
             }
             break;
         case ABILITY_SAND_SPIT:
-            if (IsBattlerTurnDamaged(gBattlerTarget, EXCLUDING_SUBSTITUTES) && !(GetWeather() & B_WEATHER_SANDSTORM))
-            {
-                if (GetWeather() & B_WEATHER_PRIMAL_ANY)
-                {
-                    BattleScriptCall(BattleScript_BlockedByPrimalWeather);
-                    effect++;
-                }
-                else if (TryChangeBattleWeather(battler, BATTLE_WEATHER_SANDSTORM, ABILITY_NONE)) // use ability none since it's not a switch in ability weather setter
-                {
-                    gBattleScripting.battler = battler;
-                    BattleScriptCall(BattleScript_WeatherAbilityActivates);
-                    effect++;
-                }
-                else if (gBattleStruct->overworldWeatherPresent)
-                {
-                    BattleScriptCall(BattleScript_BlockedByOverworldWeather);
-                    effect++;
-                }
-            }
+            if (IsBattlerTurnDamaged(gBattlerTarget, EXCLUDING_SUBSTITUTES) && TryChangeWeatherWithAbility(battler, BATTLE_WEATHER_SANDSTORM, gLastUsedAbility))
+                effect++;
             break;
         case ABILITY_PERISH_BODY:
             if (IsBattlerTurnDamaged(gBattlerTarget, EXCLUDING_SUBSTITUTES)

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -2966,7 +2966,10 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
         case ABILITY_TERAFORM_ZERO:
             if (gBattleStruct->overworldWeatherPresent)
             {
-                BattleScriptCall(BattleScript_BlockedByOverworldWeather);
+                if (gFieldTimers.terrain != B_TERRAIN_NONE)
+                    BattleScriptCall(BattleScript_ActivateTeraformZeroRemovesOnlyTerrain);
+                else
+                    BattleScriptCall(BattleScript_BlockedByOverworldWeather);
                 effect++;
             }
             else if (gBattleWeather != WEATHER_NONE || gFieldTimers.terrain != B_TERRAIN_NONE)

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -2964,7 +2964,12 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
         switch (gLastUsedAbility)
         {
         case ABILITY_TERAFORM_ZERO:
-            if (gBattleWeather != WEATHER_NONE || gFieldTimers.terrain != B_TERRAIN_NONE)
+            if (gBattleStruct->overworldWeatherPresent)
+            {
+                BattleScriptCall(BattleScript_BlockedByOverworldWeather);
+                effect++;
+            }
+            else if (gBattleWeather != WEATHER_NONE || gFieldTimers.terrain != B_TERRAIN_NONE)
             {
                 BattleScriptCall(BattleScript_ActivateTeraformZero);
                 effect++;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -1957,7 +1957,8 @@ bool32 TryChangeBattleWeather(enum BattlerId battler, u32 battleWeatherId, enum 
 {
     if (gBattleWeather & sBattleWeatherInfo[battleWeatherId].flag)
         return FALSE;
-
+    else if (gBattleStruct->overworldWeatherPresent)
+        return FALSE;
     else if (gBattleWeather & B_WEATHER_PRIMAL_ANY
           && ability != ABILITY_DESOLATE_LAND
           && ability != ABILITY_PRIMORDIAL_SEA
@@ -2470,6 +2471,8 @@ static bool32 SetStartingWeatherStatus(enum BattleWeather weather, bool32 isPerm
     gBattleWeather = sBattleWeatherInfo[weather].flag;
     gBattleCommunication[MULTISTRING_CHOOSER] = sBattleWeatherInfo[weather].moveStartMessage;
     gBattleScripting.animArg1 = sBattleWeatherInfo[weather].animation;
+    if (GetConfig(B_OVERWORLD_WEATHER_OVERRIDE) >= GEN_9)
+        gBattleStruct->overworldWeatherPresent = TRUE;
 
     if (isPermanent)
         gBattleStruct->weatherDuration = 0;
@@ -2857,6 +2860,8 @@ bool32 TryFieldEffects(enum FieldEffectCases caseId)
         }
         if (effect)
         {
+            if (GetConfig(B_OVERWORLD_WEATHER_OVERRIDE) >= GEN_9)
+                gBattleStruct->overworldWeatherPresent = TRUE;
             gBattleCommunication[MULTISTRING_CHOOSER] = GetCurrentWeather();
             BattleScriptPushCursorAndCallback(BattleScript_OverworldWeatherStarts);
         }
@@ -3230,6 +3235,11 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
                 BattleScriptCall(BattleScript_WeatherAbilityActivates);
                 effect++;
             }
+            else if (gBattleStruct->overworldWeatherPresent)
+            {
+                BattleScriptCall(BattleScript_BlockedByOverworldWeather);
+                effect++;
+            }
             else if (GetWeather() & B_WEATHER_PRIMAL_ANY)
             {
                 BattleScriptCall(BattleScript_BlockedByPrimalWeather);
@@ -3244,6 +3254,11 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
                 BattleScriptCall(BattleScript_WeatherAbilityActivates);
                 effect++;
             }
+            else if (gBattleStruct->overworldWeatherPresent)
+            {
+                BattleScriptCall(BattleScript_BlockedByOverworldWeather);
+                effect++;
+            }
             else if (GetWeather() & B_WEATHER_PRIMAL_ANY)
             {
                 BattleScriptCall(BattleScript_BlockedByPrimalWeather);
@@ -3256,6 +3271,11 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
             if (TryChangeBattleWeather(battler, BATTLE_WEATHER_SUN, gLastUsedAbility))
             {
                 BattleScriptCall(BattleScript_WeatherAbilityActivates);
+                effect++;
+            }
+            else if (gBattleStruct->overworldWeatherPresent)
+            {
+                BattleScriptCall(BattleScript_BlockedByOverworldWeather);
                 effect++;
             }
             else if (GetWeather() & B_WEATHER_PRIMAL_ANY)
@@ -3277,6 +3297,11 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
                 BattleScriptCall(BattleScript_OrichalcumPulseActivates);
                 effect++;
             }
+            else if (gBattleStruct->overworldWeatherPresent)
+            {
+                BattleScriptCall(BattleScript_BlockedByOverworldWeather);
+                effect++;
+            }
             else if (GetWeather() & B_WEATHER_PRIMAL_ANY)
             {
                 BattleScriptCall(BattleScript_BlockedByPrimalWeather);
@@ -3291,6 +3316,11 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
                 if (TryChangeBattleWeather(battler, weather, gLastUsedAbility))
                 {
                     BattleScriptCall(BattleScript_WeatherAbilityActivates);
+                    effect++;
+                }
+                else if (gBattleStruct->overworldWeatherPresent)
+                {
+                    BattleScriptCall(BattleScript_BlockedByOverworldWeather);
                     effect++;
                 }
                 else if (GetWeather() & B_WEATHER_PRIMAL_ANY)
@@ -3439,6 +3469,11 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
                 BattleScriptCall(BattleScript_WeatherAbilityActivates);
                 effect++;
             }
+            else if (gBattleStruct->overworldWeatherPresent)
+            {
+                BattleScriptCall(BattleScript_BlockedByOverworldWeather);
+                effect++;
+            }
             break;
         case ABILITY_PRIMORDIAL_SEA:
             if (!shouldAbilityTrigger)
@@ -3448,6 +3483,11 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
                 BattleScriptCall(BattleScript_WeatherAbilityActivates);
                 effect++;
             }
+            else if (gBattleStruct->overworldWeatherPresent)
+            {
+                BattleScriptCall(BattleScript_BlockedByOverworldWeather);
+                effect++;
+            }
             break;
         case ABILITY_DELTA_STREAM:
             if (!shouldAbilityTrigger)
@@ -3455,6 +3495,11 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
             if (TryChangeBattleWeather(battler, BATTLE_WEATHER_STRONG_WINDS, gLastUsedAbility))
             {
                 BattleScriptCall(BattleScript_WeatherAbilityActivates);
+                effect++;
+            }
+            else if (gBattleStruct->overworldWeatherPresent)
+            {
+                BattleScriptCall(BattleScript_BlockedByOverworldWeather);
                 effect++;
             }
             break;
@@ -4234,6 +4279,11 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
                 {
                     gBattleScripting.battler = battler;
                     BattleScriptCall(BattleScript_WeatherAbilityActivates);
+                    effect++;
+                }
+                else if (gBattleStruct->overworldWeatherPresent)
+                {
+                    BattleScriptCall(BattleScript_BlockedByOverworldWeather);
                     effect++;
                 }
             }

--- a/test/battle/ability/delta_stream.c
+++ b/test/battle/ability/delta_stream.c
@@ -50,3 +50,21 @@ DOUBLE_BATTLE_TEST("Strong winds continue as long as there's a Pokémon with Del
         EXPECT(gBattleWeather & B_WEATHER_STRONG_WINDS);
     }
 }
+
+SINGLE_BATTLE_TEST("Delta Stream fails if overworld weather is present (Gen9)")
+{
+    SetStartingStatus(STARTING_STATUS_WEATHER_SUN);
+
+    GIVEN {
+        PLAYER(SPECIES_RAYQUAZA) { Moves(MOVE_DRAGON_ASCENT, MOVE_CELEBRATE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_MEGA); }
+    } SCENE {
+        ABILITY_POPUP(player, ABILITY_DELTA_STREAM);
+        MESSAGE("But it failed!");
+    } THEN {
+        EXPECT(gBattleWeather & B_WEATHER_SUN);
+        ResetStartingStatuses();
+    }
+}

--- a/test/battle/ability/desolate_land.c
+++ b/test/battle/ability/desolate_land.c
@@ -178,3 +178,21 @@ SINGLE_BATTLE_TEST("Desolate Land can be replaced by Primordial Sea")
         EXPECT(gBattleWeather & B_WEATHER_RAIN_PRIMAL);
     }
 }
+
+SINGLE_BATTLE_TEST("Desolate Land fails if overworld weather is present (Gen9)")
+{
+    SetStartingStatus(STARTING_STATUS_WEATHER_SUN);
+
+    GIVEN {
+        PLAYER(SPECIES_GROUDON) { Item(ITEM_RED_ORB); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN {}
+    } SCENE {
+        ABILITY_POPUP(player, ABILITY_DESOLATE_LAND);
+        MESSAGE("But it failed!");
+    } THEN {
+        EXPECT(gBattleWeather & B_WEATHER_SUN);
+        ResetStartingStatuses();
+    }
+}

--- a/test/battle/ability/orichalcum_pulse.c
+++ b/test/battle/ability/orichalcum_pulse.c
@@ -150,3 +150,22 @@ SINGLE_BATTLE_TEST("Orichalcum Pulse does not boost physical moves if holder has
         EXPECT_MUL_EQ(results[1].damage, Q_4_12(1.3333), results[0].damage);
     }
 }
+
+SINGLE_BATTLE_TEST("Orichalcum Pulse activates when entering battle in sun (Overworld Sun)")
+{
+    SetStartingStatus(STARTING_STATUS_WEATHER_SUN);
+
+    GIVEN {
+        WITH_CONFIG(B_OVERWORLD_WEATHER_OVERRIDE, GEN_9);
+        PLAYER(SPECIES_KORAIDON) { Ability(ABILITY_ORICHALCUM_PULSE); }
+        OPPONENT(SPECIES_WOBBUFFET) {};
+    } WHEN {
+        TURN {}
+    } SCENE {
+        ABILITY_POPUP(player, ABILITY_ORICHALCUM_PULSE);
+        NOT MESSAGE("But it failed!");
+        MESSAGE("Koraidon basked in the sunlight, sending its ancient pulse into a frenzy!");
+    } THEN {
+        ResetStartingStatuses();
+    }
+}

--- a/test/battle/ability/primordial_sea.c
+++ b/test/battle/ability/primordial_sea.c
@@ -144,3 +144,21 @@ SINGLE_BATTLE_TEST("Primordial Sea can be replaced by Desolate Land")
         EXPECT(gBattleWeather & B_WEATHER_SUN_PRIMAL);
     }
 }
+
+SINGLE_BATTLE_TEST("Primordial Sea fails if overworld weather is present (Gen9)")
+{
+    SetStartingStatus(STARTING_STATUS_WEATHER_SUN);
+
+    GIVEN {
+        PLAYER(SPECIES_KYOGRE) { Item(ITEM_BLUE_ORB); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN {}
+    } SCENE {
+        ABILITY_POPUP(player, ABILITY_PRIMORDIAL_SEA);
+        MESSAGE("But it failed!");
+    } THEN {
+        EXPECT(gBattleWeather & B_WEATHER_SUN);
+        ResetStartingStatuses();
+    }
+}

--- a/test/battle/ability/sand_spit.c
+++ b/test/battle/ability/sand_spit.c
@@ -74,3 +74,27 @@ SINGLE_BATTLE_TEST("Sand Spit triggers even if the user is knocked out by the hi
         MESSAGE("The sandstorm is raging.");
     }
 }
+
+SINGLE_BATTLE_TEST("Sand Spit fails if overworld weather is present (Gen9)")
+{
+    SetStartingStatus(STARTING_STATUS_WEATHER_SUN);
+
+    GIVEN {
+        WITH_CONFIG(B_OVERWORLD_WEATHER_OVERRIDE, GEN_9);
+        PLAYER(SPECIES_SANDACONDA) { Ability(ABILITY_SAND_SPIT); }
+        OPPONENT(SPECIES_LANDORUS);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SCRATCH); }
+        TURN {}
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
+        HP_BAR(player);
+        ABILITY_POPUP(player, ABILITY_SAND_SPIT);
+        NONE_OF {
+            MESSAGE("A sandstorm kicked up!");
+            MESSAGE("The sandstorm is raging.");
+        }
+    } THEN {
+        ResetStartingStatuses();
+    }
+}

--- a/test/battle/ability/teraform_zero.c
+++ b/test/battle/ability/teraform_zero.c
@@ -158,3 +158,22 @@ SINGLE_BATTLE_TEST("Teraform Zero fails if overworld weather is present (Gen9)")
         ResetStartingStatuses();
     }
 }
+
+SINGLE_BATTLE_TEST("Teraform Zero removes terrain but not overworld weather (Gen9)")
+{
+    SetStartingStatus(STARTING_STATUS_WEATHER_SUN);
+
+    GIVEN {
+        WITH_CONFIG(B_OVERWORLD_WEATHER_OVERRIDE, GEN_9);
+        PLAYER(SPECIES_TERAPAGOS_TERASTAL);
+        OPPONENT(SPECIES_RILLABOOM) { Ability(ABILITY_GRASSY_SURGE); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_TERA); }
+        TURN {}
+    } SCENE {
+        ABILITY_POPUP(player, ABILITY_TERAFORM_ZERO);
+        MESSAGE("The grass disappeared from the battlefield.");
+    } THEN {
+        ResetStartingStatuses();
+    }
+}

--- a/test/battle/ability/teraform_zero.c
+++ b/test/battle/ability/teraform_zero.c
@@ -139,3 +139,22 @@ SINGLE_BATTLE_TEST("Teraform Zero doesn't reactivate when Terapagos-Stellar swit
         }
     }
 }
+
+SINGLE_BATTLE_TEST("Teraform Zero fails if overworld weather is present (Gen9)")
+{
+    SetStartingStatus(STARTING_STATUS_WEATHER_SUN);
+
+    GIVEN {
+        WITH_CONFIG(B_OVERWORLD_WEATHER_OVERRIDE, GEN_9);
+        PLAYER(SPECIES_TERAPAGOS_TERASTAL);
+        OPPONENT(SPECIES_LANDORUS);
+    } WHEN {
+        TURN { MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_TERA); }
+        TURN {}
+    } SCENE {
+        ABILITY_POPUP(player, ABILITY_TERAFORM_ZERO);
+        MESSAGE("But it failed!");
+    } THEN {
+        ResetStartingStatuses();
+    }
+}

--- a/test/battle/starting_status/weather.c
+++ b/test/battle/starting_status/weather.c
@@ -131,7 +131,7 @@ SINGLE_BATTLE_TEST("StartingStatus weather activates weather-reliant abilities")
     }
 }
 
-SINGLE_BATTLE_TEST("Overworld weather cannot be overridden using abilities (Gen9)")
+SINGLE_BATTLE_TEST("Overworld weather cannot be overridden (Gen9)")
 {
     bool32 viaMove;
 
@@ -148,9 +148,7 @@ SINGLE_BATTLE_TEST("Overworld weather cannot be overridden using abilities (Gen9
         // More than 5 turns
         TURN { MOVE(player, viaMove == TRUE ? MOVE_RAIN_DANCE : MOVE_CELEBRATE); }
     } SCENE {
-        // Harsh Sunlight at battle's start
         MESSAGE("The sunlight turned harsh!");
-        // Player uses Rain Dance
         if (viaMove) {
             MESSAGE("Politoed used Rain Dance!");
             NONE_OF {

--- a/test/battle/starting_status/weather.c
+++ b/test/battle/starting_status/weather.c
@@ -70,6 +70,7 @@ SINGLE_BATTLE_TEST("Weather started after the one which started the battle lasts
     SetStartingStatus(STARTING_STATUS_WEATHER_SUN);
 
     GIVEN {
+        WITH_CONFIG(B_OVERWORLD_WEATHER_OVERRIDE, GEN_8);
         PLAYER(SPECIES_POLITOED) { Ability(viaMove == TRUE ? ABILITY_DAMP : ABILITY_DRIZZLE); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
@@ -125,6 +126,41 @@ SINGLE_BATTLE_TEST("StartingStatus weather activates weather-reliant abilities")
         ABILITY_POPUP(player, ABILITY_HYDRATION);
         MESSAGE("Swanna's burn was cured!");
         STATUS_ICON(player, none: TRUE);
+    } THEN {
+        ResetStartingStatuses();
+    }
+}
+
+SINGLE_BATTLE_TEST("Overworld weather cannot be overridden using abilities (Gen9)")
+{
+    bool32 viaMove;
+
+    PARAMETRIZE { viaMove = TRUE; }
+    PARAMETRIZE { viaMove = FALSE; }
+
+    SetStartingStatus(STARTING_STATUS_WEATHER_SUN);
+
+    GIVEN {
+        WITH_CONFIG(B_OVERWORLD_WEATHER_OVERRIDE, GEN_9);
+        PLAYER(SPECIES_POLITOED) { Ability(viaMove == TRUE ? ABILITY_DAMP : ABILITY_DRIZZLE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        // More than 5 turns
+        TURN { MOVE(player, viaMove == TRUE ? MOVE_RAIN_DANCE : MOVE_CELEBRATE); }
+    } SCENE {
+        // Harsh Sunlight at battle's start
+        MESSAGE("The sunlight turned harsh!");
+        // Player uses Rain Dance
+        if (viaMove) {
+            MESSAGE("Politoed used Rain Dance!");
+            NONE_OF {
+                ANIMATION(ANIM_TYPE_MOVE, MOVE_RAIN_DANCE, player);
+                MESSAGE("It started to rain!");
+            }
+        } else {
+            ABILITY_POPUP(player, ABILITY_DRIZZLE);
+            NOT MESSAGE("It started to rain!");
+        }
     } THEN {
         ResetStartingStatuses();
     }

--- a/test/battle/starting_status/weather.c
+++ b/test/battle/starting_status/weather.c
@@ -145,7 +145,6 @@ SINGLE_BATTLE_TEST("Overworld weather cannot be overridden (Gen9)")
         PLAYER(SPECIES_POLITOED) { Ability(viaMove == TRUE ? ABILITY_DAMP : ABILITY_DRIZZLE); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
-        // More than 5 turns
         TURN { MOVE(player, viaMove == TRUE ? MOVE_RAIN_DANCE : MOVE_CELEBRATE); }
     } SCENE {
         MESSAGE("The sunlight turned harsh!");


### PR DESCRIPTION
Title.

## Description
This adds Overworld Weather behavior introduced in Gen 9 Scarlet/Violet where overworld weather cannot be overridden by any means.

By toggling `B_OVERWORLD_WEATHER_OVERRIDE` to `GEN_9` or later (`GEN_LATEST`), any instance of Overworld Weather on a map or starting status will prevent moves and abilities from changing or removing the weather. For example, Emerald's Route 111 sandstorm cannot be changed or removed in battle by any means. This also prevents the ability Teraform Zero from removing weather as well.

### Large Language Models (AI)
None

## Media

https://github.com/user-attachments/assets/ac82f261-ede3-4e7f-8eee-9657dab00142

## Feature(s) this PR does NOT handle:
* Overworld Terrain, as there are no instances present in Scarlet/Violet to confirm its behavior

## Discord contact info
linathan
