### PR TITLE
Minor AI score calculation clean up

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -40,9 +40,15 @@
 #define AI_ACTION_WATCH         (1 << 2)
 #define AI_ACTION_DO_NOT_ATTACK (1 << 3)
 
-static u32 ChooseMoveOrAction(enum BattlerId battler);
-static u32 ChooseMoveOrAction_Singles(enum BattlerId battler);
-static u32 ChooseMoveOrAction_Doubles(enum BattlerId battler);
+struct ChosenAction
+{
+    u8 moveIndex;
+    enum BattlerId target;
+};
+
+static struct ChosenAction ChooseMoveOrAction(enum BattlerId battler);
+static struct ChosenAction ChooseMoveOrAction_Singles(enum BattlerId battler);
+static struct ChosenAction ChooseMoveOrAction_Doubles(enum BattlerId battlerAtk);
 static inline void BattleAI_DoAIProcessing(struct AiThinkingStruct *aiThink, enum BattlerId battlerAtk, enum BattlerId battlerDef);
 static inline void BattleAI_DoAIProcessing_PredictedSwitchin(struct AiThinkingStruct *aiThink, struct AiLogicData *aiData, enum BattlerId battlerAtk, enum BattlerId battlerDef);
 static bool32 IsPinchBerryItemEffect(enum HoldEffect holdEffect);
@@ -187,8 +193,7 @@ void BattleAI_SetupAIData(u8 defaultScoreMoves, enum BattlerId battler)
         defaultScoreMoves >>= 1;
     }
 
-    gBattlerTarget = SetRandomTarget(battler);
-    gAiBattleData->chosenTarget[battler] = gBattlerTarget;
+    gAiBattleData->chosenTarget[battler] = SetRandomTarget(battler);
 }
 
 void BattleAI_SetupItems(void)
@@ -467,9 +472,9 @@ static void SetAllyMove(u32 battler)
     {
         // DebugPrintf("partnerBattler %d", partnerBattler );
         gAiLogicData->partnerMoveSimulation = TRUE;
-        u32 simulatedMoveIndex = ChooseMoveOrAction_Doubles(partnerBattler);
+        struct ChosenAction chosen = ChooseMoveOrAction_Doubles(partnerBattler);
         gAiLogicData->partnerMoveSimulation = FALSE;
-        gAiLogicData->partnerMove = gBattleMons[partnerBattler].moves[simulatedMoveIndex];
+        gAiLogicData->partnerMove = gBattleMons[partnerBattler].moves[chosen.moveIndex];
     }
     else
     {
@@ -479,7 +484,7 @@ static void SetAllyMove(u32 battler)
     }
 }
 
-static u32 ChooseMoveOrAction(enum BattlerId battler)
+static struct ChosenAction ChooseMoveOrAction(enum BattlerId battler)
 {
     if (IsDoubleBattle())
     {
@@ -572,18 +577,17 @@ void AI_TrySwitchOrUseItem(enum BattlerId battler)
 
 u32 BattleAI_ChooseMoveIndex(enum BattlerId battler)
 {
-    u32 chosenMoveIndex;
-
     SetAIUsingGimmick(battler, USE_GIMMICK);
     SetupRandomRollsForAIMoveSelection(battler);
 
     if (gBattleStruct->gimmick.usableGimmick[battler] == GIMMICK_TERA && (gAiThinkingStruct->aiFlags[battler] & AI_FLAG_SMART_TERA))
         DecideTerastal(battler);
 
-    chosenMoveIndex = ChooseMoveOrAction(battler);
+    struct ChosenAction chosen = ChooseMoveOrAction(battler);
+    gAiBattleData->chosenTarget[battler] = chosen.target;
 
     if (gBattleStruct->gimmick.usableGimmick[battler] != GIMMICK_NONE)
-        ReconsiderGimmick(battler, gBattlerTarget, gBattleMons[battler].moves[chosenMoveIndex]);
+        ReconsiderGimmick(battler, chosen.target, gBattleMons[battler].moves[chosen.moveIndex]);
 
     // Clear protect structures, some flags may be set during AI calcs
     // e.g. pranksterElevated from GetBattleMovePriority
@@ -592,7 +596,7 @@ u32 BattleAI_ChooseMoveIndex(enum BattlerId battler)
     TestRunner_Battle_CheckAiMoveScores(battler);
     #endif // TESTING
 
-    return chosenMoveIndex;
+    return chosen.moveIndex;
 }
 
 static void CopyBattlerDataToAIParty(u32 bPosition, enum BattleTrainer trainer)
@@ -934,32 +938,43 @@ static u32 PpStallReduction(enum Move move, enum BattlerId battlerAtk, enum Batt
     return returnValue;
 }
 
-static u32 ChooseMoveOrAction_Singles(enum BattlerId battler)
+static void DoAIScoreProcessing(enum BattlerId battlerAtk, enum BattlerId battlerDef)
 {
-    u8 currentMoveArray[MAX_MON_MOVES];
-    u8 consideredMoveArray[MAX_MON_MOVES];
-    u32 numOfBestMoves;
-    u64 flags = gAiThinkingStruct->aiFlags[battler];
-    enum BattlerId opposingBattler = GetOppositeBattler(battler);
-
+    u64 flags = gAiThinkingStruct->aiFlags[battlerAtk];
     gAiThinkingStruct->aiLogicId = 0;
     gAiThinkingStruct->movesetIndex = 0;
-    gAiLogicData->partnerMove = MOVE_NONE;   // no ally
+
+    if (gBattleTypeFlags & BATTLE_TYPE_PALACE)
+        BattleAI_SetupAIData(gBattleStruct->palaceFlags >> 4, battlerAtk);
+    else
+        BattleAI_SetupAIData(0xF, battlerAtk);
 
     while (flags != 0)
     {
         if (flags & 1)
         {
-            if (IsBattlerPredictedToSwitch(opposingBattler) && (gAiThinkingStruct->aiFlags[battler] & AI_FLAG_PREDICT_INCOMING_MON))
-                BattleAI_DoAIProcessing_PredictedSwitchin(gAiThinkingStruct, gAiLogicData, battler, opposingBattler);
+            if (IsBattlerPredictedToSwitch(battlerDef) && (gAiThinkingStruct->aiFlags[battlerAtk] & AI_FLAG_PREDICT_INCOMING_MON))
+                BattleAI_DoAIProcessing_PredictedSwitchin(gAiThinkingStruct, gAiLogicData, battlerAtk, battlerDef);
             else
-                BattleAI_DoAIProcessing(gAiThinkingStruct, battler, opposingBattler);
+                BattleAI_DoAIProcessing(gAiThinkingStruct, battlerAtk, battlerDef);
         }
         flags >>= (u64)1;
         gAiThinkingStruct->aiLogicId++;
     }
-    if (gAiThinkingStruct->aiFlags[battler] & AI_FLAG_CHECK_VIABILITY)
-        AI_CompareDamagingMoves(battler, opposingBattler);
+
+    if (gAiThinkingStruct->aiFlags[battlerAtk] & AI_FLAG_CHECK_VIABILITY)
+        AI_CompareDamagingMoves(battlerAtk, battlerDef);
+}
+
+static struct ChosenAction ChooseMoveOrAction_Singles(enum BattlerId battler)
+{
+    u8 currentMoveArray[MAX_MON_MOVES];
+    u8 consideredMoveArray[MAX_MON_MOVES];
+    u32 numOfBestMoves;
+    enum BattlerId opposingBattler = GetOppositeBattler(battler);
+    gAiLogicData->partnerMove = MOVE_NONE;   // no ally
+
+    DoAIScoreProcessing(battler, opposingBattler);
 
     for (u32 moveIndex = 0; moveIndex < MAX_MON_MOVES; moveIndex++)
     {
@@ -989,16 +1004,20 @@ static u32 ChooseMoveOrAction_Singles(enum BattlerId battler)
         }
     }
 
-#if TESTING
+    #if TESTING
     gBattleTestRunnerState->data.trial.scoreTieCount = numOfBestMoves;
-#endif
+    #endif
 
-    return consideredMoveArray[RandomUniform(RNG_AI_SCORE_TIE_SINGLES, 0, numOfBestMoves - 1)];
+    struct ChosenAction chosen = {
+        .moveIndex = consideredMoveArray[RandomUniform(RNG_AI_SCORE_TIE_SINGLES, 0, numOfBestMoves - 1)],
+        .target = opposingBattler,
+    };
+
+    return chosen;
 }
 
-static u32 ChooseMoveOrAction_Doubles(enum BattlerId battler)
+static struct ChosenAction ChooseMoveOrAction_Doubles(enum BattlerId battlerAtk)
 {
-    u64 flags;
     s32 bestMovePointsForTarget[MAX_BATTLERS_COUNT];
     u8 mostViableTargetsArray[MAX_BATTLERS_COUNT];
     u8 actionOrMoveIndex[MAX_BATTLERS_COUNT];
@@ -1008,49 +1027,25 @@ static u32 ChooseMoveOrAction_Doubles(enum BattlerId battler)
     u32 mostViableMovesNo;
     s32 mostMovePoints;
 
-    for (enum BattlerId battlerIndex = 0; battlerIndex < MAX_BATTLERS_COUNT; battlerIndex++)
+    for (enum BattlerId battlerDef = 0; battlerDef < MAX_BATTLERS_COUNT; battlerDef++)
     {
-        if (gBattleMons[battlerIndex].hp == 0 || battler == battlerIndex)
+        if (gBattleMons[battlerDef].hp == 0 || battlerAtk == battlerDef)
         {
-            actionOrMoveIndex[battlerIndex] = 0xFF;
-            bestMovePointsForTarget[battlerIndex] = -1;
+            actionOrMoveIndex[battlerDef] = 0xFF;
+            bestMovePointsForTarget[battlerDef] = -1;
         }
         else
         {
-            if (gBattleTypeFlags & BATTLE_TYPE_PALACE)
-                BattleAI_SetupAIData(gBattleStruct->palaceFlags >> 4, battler);
-            else
-                BattleAI_SetupAIData(0xF, battler);
-
-            gBattlerTarget = battlerIndex;
-
-            gAiThinkingStruct->aiLogicId = 0;
-            gAiThinkingStruct->movesetIndex = 0;
-            flags = gAiThinkingStruct->aiFlags[battler];
-
-            while (flags != 0)
-            {
-                if (flags & 1)
-                {
-                    if (IsBattlerPredictedToSwitch(gBattlerTarget) && (gAiThinkingStruct->aiFlags[battler] & AI_FLAG_PREDICT_INCOMING_MON))
-                        BattleAI_DoAIProcessing_PredictedSwitchin(gAiThinkingStruct, gAiLogicData, battler, gBattlerTarget);
-                    else
-                        BattleAI_DoAIProcessing(gAiThinkingStruct, battler, gBattlerTarget);
-                }
-                flags >>= (u64)1;
-                gAiThinkingStruct->aiLogicId++;
-            }
-            if (gAiThinkingStruct->aiFlags[battler] & AI_FLAG_CHECK_VIABILITY)
-                AI_CompareDamagingMoves(battler, gBattlerTarget);
+            DoAIScoreProcessing(battlerAtk, battlerDef);
 
             mostViableMovesScores[0] = gAiThinkingStruct->score[0];
             mostViableMovesIndices[0] = 0;
             mostViableMovesNo = 1;
             for (u32 moveIndex = 1; moveIndex < MAX_MON_MOVES; moveIndex++)
             {
-                if (gBattleMons[battler].moves[moveIndex] != 0)
+                if (gBattleMons[battlerAtk].moves[moveIndex] != 0)
                 {
-                    if (!CanTargetBattler(battler, battlerIndex, gBattleMons[battler].moves[moveIndex]))
+                    if (!CanTargetBattler(battlerAtk, battlerDef, gBattleMons[battlerAtk].moves[moveIndex]))
                         continue;
 
                     if (mostViableMovesScores[0] == gAiThinkingStruct->score[moveIndex])
@@ -1068,22 +1063,22 @@ static u32 ChooseMoveOrAction_Doubles(enum BattlerId battler)
                 }
             }
 
-#if TESTING
+            #if TESTING
             gBattleTestRunnerState->data.trial.scoreTieCount = mostViableMovesNo;
-#endif
+            #endif
 
-            actionOrMoveIndex[battlerIndex] = mostViableMovesIndices[RandomUniform(RNG_AI_SCORE_TIE_DOUBLES_MOVE, 0, mostViableMovesNo - 1)];
-            bestMovePointsForTarget[battlerIndex] = mostViableMovesScores[0];
+            actionOrMoveIndex[battlerDef] = mostViableMovesIndices[RandomUniform(RNG_AI_SCORE_TIE_DOUBLES_MOVE, 0, mostViableMovesNo - 1)];
+            bestMovePointsForTarget[battlerDef] = mostViableMovesScores[0];
 
             // Don't use a move against ally if it has less than 100 points.
-            if (battlerIndex == BATTLE_PARTNER(battler) && bestMovePointsForTarget[battlerIndex] < AI_SCORE_DEFAULT)
+            if (battlerDef == BATTLE_PARTNER(battlerAtk) && bestMovePointsForTarget[battlerDef] < AI_SCORE_DEFAULT)
             {
-                bestMovePointsForTarget[battlerIndex] = -1;
+                bestMovePointsForTarget[battlerDef] = -1;
             }
 
             for (u32 moveIndex = 0; moveIndex < MAX_MON_MOVES; moveIndex++)
             {
-                gAiBattleData->finalScore[battler][gBattlerTarget][moveIndex] = gAiThinkingStruct->score[moveIndex];
+                gAiBattleData->finalScore[battlerAtk][battlerDef][moveIndex] = gAiThinkingStruct->score[moveIndex];
             }
         }
     }
@@ -1092,29 +1087,30 @@ static u32 ChooseMoveOrAction_Doubles(enum BattlerId battler)
     mostViableTargetsArray[0] = 0;
     mostViableTargetsNo = 1;
 
-    for (enum BattlerId battlerIndex = 1; battlerIndex < MAX_BATTLERS_COUNT; battlerIndex++)
+    for (enum BattlerId battler = 1; battler < MAX_BATTLERS_COUNT; battler++)
     {
-        if (mostMovePoints == bestMovePointsForTarget[battlerIndex])
+        if (mostMovePoints == bestMovePointsForTarget[battler])
         {
-            mostViableTargetsArray[mostViableTargetsNo] = battlerIndex;
+            mostViableTargetsArray[mostViableTargetsNo] = battler;
             mostViableTargetsNo++;
         }
-        if (mostMovePoints < bestMovePointsForTarget[battlerIndex])
+        if (mostMovePoints < bestMovePointsForTarget[battler])
         {
-            mostMovePoints = bestMovePointsForTarget[battlerIndex];
-            mostViableTargetsArray[0] = battlerIndex;
+            mostMovePoints = bestMovePointsForTarget[battler];
+            mostViableTargetsArray[0] = battler;
             mostViableTargetsNo = 1;
         }
     }
 
-#if TESTING
+    #if TESTING
     gBattleTestRunnerState->data.trial.targetTieCount = mostViableTargetsNo;
-#endif
+    #endif
 
-    gBattlerTarget = mostViableTargetsArray[RandomUniform(RNG_AI_SCORE_TIE_DOUBLES_TARGET, 0, mostViableTargetsNo - 1)];
-    gAiBattleData->chosenTarget[battler] = gBattlerTarget;
+    struct ChosenAction chosen = {0};
+    chosen.target = mostViableTargetsArray[RandomUniform(RNG_AI_SCORE_TIE_DOUBLES_TARGET, 0, mostViableTargetsNo - 1)];
+    chosen.moveIndex = actionOrMoveIndex[chosen.target];
 
-    return actionOrMoveIndex[gBattlerTarget];
+    return chosen;
 }
 
 static inline bool32 ShouldConsiderMoveForBattler(enum BattlerId battlerAi, enum BattlerId battlerDef, enum Move move)


### PR DESCRIPTION
A small clean up PR to assist #10041.

Created `DoAIScoreProcessing` to remove duplicate code from `ChooseMoveOrAction_Doubles` and `ChooseMoveOrAction_Singles. Also in the doubles functions the battler args were renamed. `battler` is now `battlerAtk` and `battlerIndex` is now `battlerDef`. I think this makes more sense since this is what is technically done, attacker chooses move against target.