### PR TITLE
Add Protect animation + bug fixes

### DIFF
--- a/data/battle_anim_scripts.s
+++ b/data/battle_anim_scripts.s
@@ -35047,3 +35047,13 @@ gBattleAnimGeneral_DynamaxGrowth:: @ PORTED FROM CFRU
 	createvisualtask AnimTask_DynamaxGrowth, 5, 1, 0
 	waitforvisualfinish
 	end
+
+gBattleAnimGeneral_ProtectedItself::
+	monbg ANIM_ATTACKER
+	splitbgprio ANIM_TARGET
+	playsewithpan SE_ICE_STAIRS, SOUND_PAN_ATTACKER
+	createsprite gProtectTemplate, ANIM_TARGET, 2, 0x0, 0x0
+	createvisualtask AnimTask_ShakeMon2, 2, ANIM_TARGET, 2, 0, 10, 1
+	waitforvisualfinish
+	clearmonbg ANIM_ATTACKER
+	end

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -6281,6 +6281,8 @@ BattleScript_TargetAvoidsAttack::
 
 BattleScript_TargetProtected::
 	pause B_WAIT_TIME_SHORT
+	playanimation BS_SCRIPTING, B_ANIM_PROTECTED_ITSELF
+	waitanimation
 	printstring STRINGID_PKMNPROTECTEDITSELF
 	waitmessage B_WAIT_TIME_LONG
 	return

--- a/include/battle_anim_scripts.h
+++ b/include/battle_anim_scripts.h
@@ -1023,5 +1023,6 @@ extern const u8 gBattleAnimSpecial_BallThrowWithTrainer[];
 extern const u8 gBattleAnimSpecial_SubstituteToMon[];
 extern const u8 gBattleAnimSpecial_MonToSubstitute[];
 extern const u8 gBattleAnimSpecial_CriticalCaptureBallThrow[];
+extern const u8 gBattleAnimGeneral_ProtectedItself[];
 
 #endif // GUARD_BATTLE_ANIM_SCRIPTS_H

--- a/include/constants/battle_anim.h
+++ b/include/constants/battle_anim.h
@@ -608,7 +608,8 @@ enum AnimBattler
 #define B_ANIM_FORM_CHANGE_INSTANT      61
 #define B_ANIM_FORM_CHANGE_DISGUISE     62
 #define B_ANIM_HELD_ITEM_BERRY          63
-#define NUM_B_ANIMS_GENERAL             64
+#define B_ANIM_PROTECTED_ITSELF         64
+#define NUM_B_ANIMS_GENERAL             65
 
 // special animations table (sBattleAnims_Special)
 #define B_ANIM_LVL_UP                   0

--- a/src/battle_anim.c
+++ b/src/battle_anim.c
@@ -266,6 +266,7 @@ static const u8* const sBattleAnims_General[NUM_B_ANIMS_GENERAL] =
     [B_ANIM_ROCK_THROW]             = gBattleAnimGeneral_SafariRockThrow,
     [B_ANIM_SAFARI_REACTION]        = gBattleAnimGeneral_SafariReaction,
     [B_ANIM_HELD_ITEM_BERRY]        = gBattleAnimGeneral_HeldItemBerry,
+    [B_ANIM_PROTECTED_ITSELF]       = gBattleAnimGeneral_ProtectedItself,
 };
 
 static const u8* const sBattleAnims_Special[NUM_B_ANIMS_SPECIAL] =

--- a/src/battle_anim_new.c
+++ b/src/battle_anim_new.c
@@ -99,6 +99,7 @@ static void SpriteCB_GlacialLance_Step1(struct Sprite* sprite);
 static void SpriteCB_GlacialLance_Step2(struct Sprite* sprite);
 static void SpriteCB_GlacialLance(struct Sprite* sprite);
 static void SpriteCB_TripleArrowKick(struct Sprite* sprite);
+static void SpriteCB_Protect(struct Sprite* sprite);
 
 // const data
 // general
@@ -2716,6 +2717,15 @@ const struct SpriteTemplate gSunsteelStrikeBlackFlyBallTemplate =
     .oam = &gOamData_AffineDouble_ObjNormal_64x64,
     .affineAnims = gAffineAnims_FlyBallUp,
     .callback = AnimFlyBallUp,
+};
+
+// Protect
+const struct SpriteTemplate gProtectTemplate =
+{
+    .tileTag = ANIM_TAG_PROTECT,
+    .paletteTag = ANIM_TAG_PROTECT,
+    .oam = &gOamData_AffineOff_ObjBlend_64x64,
+    .callback = SpriteCB_Protect
 };
 
 static const struct OamData sSunsteelStrikeBlastOAM =
@@ -7109,6 +7119,13 @@ static void SpriteCB_GrowingSuperpower(struct Sprite *sprite)
     InitAnimLinearTranslation(sprite);
     StoreSpriteCallbackInData6(sprite, DestroyAnimSprite);
     sprite->callback = AnimTranslateLinear_WithFollowup;
+}
+
+static void SpriteCB_Protect(struct Sprite *sprite)
+{
+    InitSpritePosToAnimTarget(sprite, FALSE);
+
+    sprite->callback = AnimSpiderWeb;
 }
 
 static void SpriteCB_CentredSpiderWeb(struct Sprite *sprite)

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -2127,7 +2127,7 @@ static enum CancelerResult CancelerTargetFailure(struct BattleCalcValues *cv)
             if (ShouldSkipFailureCheckOnBattler(cv->battlerAtk, cv->battlerDef))
                 continue;
 
-            if (IsBattlerProtected(cv))
+            if (IsBattlerProtected(cv) && IsBattlerPresent(cv->battlerDef))
             {
                 SetOrClearRageVolatile();
                 gBattleStruct->moveResultFlags[cv->battlerDef] |= MOVE_RESULT_PROTECTED;

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -2076,7 +2076,7 @@ static enum CancelerResult CancelerTargetFailure(struct BattleCalcValues *cv)
     switch (gBattleStruct->eventState.moveEndBlock)
     {
     case TARGET_FAILURE_SEMI_INVULNERABILITY:
-        for (enum BattlerId battler = B_BATTLER_0; battler < MAX_BATTLERS_COUNT; battler++)
+        for (enum BattlerId battler = B_BATTLER_0; battler < gBattlersCount; battler++)
         {
             cv->battlerDef = GetTargetBySlot(cv->battlerAtk, battler);
 
@@ -2098,7 +2098,7 @@ static enum CancelerResult CancelerTargetFailure(struct BattleCalcValues *cv)
         }
         gBattleStruct->eventState.moveEndBlock++;
     case TARGET_FAILURE_PSYCHIC_TERRAIN:
-        for (enum BattlerId battler = B_BATTLER_0; battler < MAX_BATTLERS_COUNT; battler++)
+        for (enum BattlerId battler = B_BATTLER_0; battler < gBattlersCount; battler++)
         {
             cv->battlerDef = ctx.battlerDef = GetTargetBySlot(cv->battlerAtk, battler);
 
@@ -2117,7 +2117,7 @@ static enum CancelerResult CancelerTargetFailure(struct BattleCalcValues *cv)
         }
         gBattleStruct->eventState.moveEndBlock++;
     case TARGET_FAILURE_PROTECT:
-        for (enum BattlerId battler = B_BATTLER_0; battler < MAX_BATTLERS_COUNT; battler++)
+        for (enum BattlerId battler = B_BATTLER_0; battler < gBattlersCount; battler++)
         {
             cv->battlerDef = GetTargetBySlot(cv->battlerAtk, battler);
 
@@ -2127,7 +2127,7 @@ static enum CancelerResult CancelerTargetFailure(struct BattleCalcValues *cv)
             if (ShouldSkipFailureCheckOnBattler(cv->battlerAtk, cv->battlerDef))
                 continue;
 
-            if (IsBattlerProtected(cv) && IsBattlerPresent(cv->battlerDef))
+            if (IsBattlerProtected(cv))
             {
                 SetOrClearRageVolatile();
                 gBattleStruct->moveResultFlags[cv->battlerDef] |= MOVE_RESULT_PROTECTED;
@@ -2140,7 +2140,7 @@ static enum CancelerResult CancelerTargetFailure(struct BattleCalcValues *cv)
         }
         gBattleStruct->eventState.moveEndBlock++;
     case TARGET_FAILURE_BOUNCE:
-        for (enum BattlerId battler = B_BATTLER_0; battler < MAX_BATTLERS_COUNT; battler++)
+        for (enum BattlerId battler = B_BATTLER_0; battler < gBattlersCount; battler++)
         {
             cv->battlerDef = GetTargetBySlot(cv->battlerAtk, battler);
 
@@ -2164,7 +2164,7 @@ static enum CancelerResult CancelerTargetFailure(struct BattleCalcValues *cv)
         }
         gBattleStruct->eventState.moveEndBlock++;
     case TARGET_FAILURE_TARGET_BLOCKED:
-        for (enum BattlerId battler = B_BATTLER_0; battler < MAX_BATTLERS_COUNT; battler++)
+        for (enum BattlerId battler = B_BATTLER_0; battler < gBattlersCount; battler++)
         {
             cv->battlerDef = ctx.battlerDef = GetTargetBySlot(cv->battlerAtk, battler);
 
@@ -2183,7 +2183,7 @@ static enum CancelerResult CancelerTargetFailure(struct BattleCalcValues *cv)
         }
         gBattleStruct->eventState.moveEndBlock++;
     case TARGET_FAILURE_EFFECTIVENESS:
-        for (enum BattlerId battler = B_BATTLER_0; battler < MAX_BATTLERS_COUNT; battler++)
+        for (enum BattlerId battler = B_BATTLER_0; battler < gBattlersCount; battler++)
         {
             cv->battlerDef = ctx.battlerDef = GetTargetBySlot(cv->battlerAtk, battler);
 

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -5824,7 +5824,8 @@ bool32 IsBattlerProtected(struct BattleCalcValues *cv)
         }
     }
 
-    if (GetBattlerMoveTargetType(cv->battlerAtk, cv->move) == TARGET_ALL_BATTLERS)
+    enum MoveTarget moveTarget = GetBattlerMoveTargetType(cv->battlerAtk, cv->move);
+    if (moveTarget == TARGET_ALL_BATTLERS)
         return FALSE;
 
     bool32 isProtected = FALSE;
@@ -5833,7 +5834,8 @@ bool32 IsBattlerProtected(struct BattleCalcValues *cv)
         isProtected = TRUE;
     else if (MoveIgnoresProtect(cv->move))
         isProtected = FALSE;
-    else if (IsSideProtected(cv->battlerDef, PROTECT_WIDE_GUARD) && IsSpreadMove(GetBattlerMoveTargetType(cv->battlerAtk, cv->move)))
+    else if (IsSideProtected(cv->battlerDef, PROTECT_WIDE_GUARD)
+         && (moveTarget == TARGET_BOTH || moveTarget == TARGET_FOES_AND_ALLY))
         isProtected = TRUE;
     else if (gProtectStructs[cv->battlerDef].protected == PROTECT_NORMAL)
         isProtected = TRUE;

--- a/test/battle/move_effect/protect.c
+++ b/test/battle/move_effect/protect.c
@@ -1161,3 +1161,23 @@ SINGLE_BATTLE_TEST("Protect: Mat Block, King's Shield, Obstruct, Burning Bulwark
         NOT MESSAGE("Wobbuffet protected itself!");
     }
 }
+
+SINGLE_BATTLE_TEST("Protect: Wide Guard protects user from spread moves even in Single Battles")
+{
+    enum Move move;
+
+    PARAMETRIZE { move = MOVE_LEER; }
+    PARAMETRIZE { move = MOVE_DAZZLING_GLEAM; }
+    PARAMETRIZE { move = MOVE_EARTHQUAKE; }
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_WIDE_GUARD); MOVE(opponent, move); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_WIDE_GUARD, player);
+        NOT ANIMATION(ANIM_TYPE_MOVE, move, opponent);
+        MESSAGE("Wobbuffet protected itself!");
+    }
+}


### PR DESCRIPTION
Protect animation came from my personal project! This PR was created in light of the issues captured with it. Targets upcoming due to changes stemming from changes in upcoming.

## Description
When a user successfully protects itself from an attack, a new animation plays. This occurs for all types of Protect.

This PR also fixes the following bugs:
* Wide Guard not protecting against spread moves in a Single Battle
* Quick Guard and Crafty Shield printing extra messages for each targetable battler not present on the field
   * The protect animation being added serves as a bottleneck way of capturing a failure case. If you exclude the changes made in `src/battle_move_resolution.c`, the tests related to this will result in a `TIMEOUT`.

### Large Language Models (AI)
None

## Media
<img width="240" height="160" alt="protect_anim" src="https://github.com/user-attachments/assets/2d55a1ef-7a6d-40c3-9678-916e83553a50" />

## Issue(s) that this PR fixes
Fixes #10456

## Discord contact info
linathan
