### PR TITLE
Type-checked GetMonData, GetBoxMonData, SetMonData, SetBoxMonData

### DIFF
--- a/include/constants/global.h
+++ b/include/constants/global.h
@@ -173,7 +173,7 @@ enum ContestCategories
 
 #define MAX_STAMP_CARD_STAMPS 7
 
-enum Gender
+enum __attribute__((packed)) Gender
 {
     MALE,
     FEMALE,

--- a/include/global.h
+++ b/include/global.h
@@ -587,7 +587,7 @@ struct RankingHall2P
 struct SaveBlock2
 {
     /*0x00*/ u8 playerName[PLAYER_NAME_LENGTH + 1];
-    /*0x08*/ u8 playerGender; // MALE, FEMALE
+    /*0x08*/ enum Gender playerGender;
     /*0x09*/ u8 specialSaveWarpFlags;
     /*0x0A*/ u8 playerTrainerId[TRAINER_ID_LENGTH];
     /*0x0E*/ u16 playTimeHours;

--- a/include/global.tv.h
+++ b/include/global.tv.h
@@ -61,7 +61,7 @@ typedef union // size = 0x24
         /*0x0D*/ u8 language;
         /*0x0E*/ u8 pokemonNameLanguage;
         /*0x0F*/ u8 filler_0F[1];
-        /*0x10*/ u8 nickname[PLAYER_NAME_LENGTH + 1];
+        /*0x10*/ u8 nickname[8]; // WARNING: Should be 10.
         /*0x18*/ u16 words18[2];
         /*0x1C*/ u16 words[2];
     } fanclubOpinions;

--- a/include/metaprogram.h
+++ b/include/metaprogram.h
@@ -22,6 +22,10 @@
 #define CAT(a, b) CAT_(a, b)
 #define CAT_(a, b) a ## b
 
+/* Expands 'a', 'b', and 'c' and then concatenates them (left-to-right). */
+#define CAT3(a, b, c) CAT3_(a, b, c)
+#define CAT3_(a, b, c) a ## b ## c
+
 /* Expands '__VA_ARGS__' and then stringizes them. */
 #define STR(...) STR_(__VA_ARGS__)
 #define STR_(...) #__VA_ARGS__
@@ -216,5 +220,11 @@ Input must be of the form (upper << lower) where upper can be up to 7, lower up 
  * Because 'cond' must be known at compile-time, this is rarely useful
  * outside macros. */
 #define if_comptime(cond) if (__builtin_constant_p((cond) ? 0 : *(int *)0))
+
+/* Expands to a no-op but has the side-effect of causing 'cpp' to add a
+ * line-break in its output, which is helpful for limiting the length of
+ * lines seen by 'cc1' as a result of hairy macros, and can avoid the
+ * problem where an error produces a very long line full of whitespace. */
+#define _NEWLINE (void)NULL
 
 #endif

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -1071,17 +1071,16 @@ void SetMonDataPtr(struct Pokemon *mon, enum MonData field, const void *data);
 void SetBoxMonDataPtr(struct BoxPokemon *boxMon, enum MonData field, const void *data);
 
 // HINT: '__builtin_classify_type(exp)' returns:
-// * 5 for pointer types.
-// * 14 for array types.
+// * 5 for pointer and array types.
 // See: https://github.com/gcc-mirror/gcc/blob/master/gcc/typeclass.h
-#define _MONDATA_GET2_RETURN_TYPE(type) typeof(__builtin_choose_expr(__builtin_classify_type(type) == 14, (void)0, (type){0}))
-#define _MONDATA_GET3_PARAMETER_TYPE(type) typeof(__builtin_choose_expr(__builtin_classify_type(type) == 14, (type){0}, (void *)0))
+#define _MONDATA_GET2_RETURN_TYPE(type) typeof(__builtin_choose_expr(__builtin_classify_type((type){0}) == 5, (void)0, (type){0}))
+#define _MONDATA_GET3_PARAMETER_TYPE(type) typeof(__builtin_choose_expr(__builtin_classify_type((type){0}) == 5, (type){0}, (void *)0))
 #define _MONDATA_DEFINE_GET(name, type, structs, readWrite, generic, monType, structFlag) \
     __attribute__((always_inline)) \
     static inline _MONDATA_GET2_RETURN_TYPE(type) CAT3(generic, 2_, name)(monType *mon, enum MonData field) \
     { \
         if_comptime (mon == NULL) { __attribute__((error(STR(generic) "(NULL, field) unsupported"))) void CAT3(generic, 2_mon_, name)(void); _NEWLINE; CAT3(generic, 2_mon_, name)(); } \
-        if_comptime (__builtin_classify_type(type) == 14) { __attribute__((error(STR(generic) "(mon, " STR(name) ") disabled: " STR(type) " is returned via 'data'"))) void CAT3(generic, 2_type_, name)(void); _NEWLINE; CAT3(generic, 2_type_, name)(); } \
+        if_comptime (__builtin_classify_type((type){0}) == 5) { __attribute__((error(STR(generic) "(mon, " STR(name) ") disabled: " STR(type) " is returned via 'data'"))) void CAT3(generic, 2_type_, name)(void); _NEWLINE; CAT3(generic, 2_type_, name)(); } \
         if_comptime (!(structs & structFlag)) { __attribute__((error(STR(generic) "(mon, " STR(name) ") disabled: not " STR(structFlag)))) void CAT3(generic, 2_struct_, name)(void); _NEWLINE; CAT3(generic, 2_struct_, name)(); } \
         if_comptime (!(readWrite & MD_RD)) { __attribute__((error(STR(generic) "(mon, " STR(name) ") disabled: not MD_RD or MD_RDWR"))) void CAT3(generic, 2_RD_, name)(void); _NEWLINE; CAT3(generic, 2_RD_, name)(); } \
         _NEWLINE; \
@@ -1091,8 +1090,8 @@ void SetBoxMonDataPtr(struct BoxPokemon *boxMon, enum MonData field, const void 
     static inline u32 CAT3(generic, 3_, name)(monType *mon, enum MonData field, _MONDATA_GET3_PARAMETER_TYPE(type) data) \
     { \
         if_comptime (mon == NULL) { __attribute__((error(STR(generic) "(NULL, field, data) unsupported"))) void CAT3(generic, 3_mon_, name)(void); _NEWLINE; CAT3(generic, 3_mon_, name)(); } \
-        if_comptime (__builtin_classify_type(type) == 14 && data == NULL) { __attribute__((error(STR(generic) "(mon, field, NULL) unsupported"))) void CAT3(generic, 3_data_, name)(void); _NEWLINE; CAT3(generic, 3_data_, name)(); } \
-        if_comptime (__builtin_classify_type(type) != 14 && data != NULL) { __attribute__((error(STR(generic) "(mon, " STR(name) ", data) disabled: " STR(type) " is returned directly"))) void CAT3(generic, 3_type_, name)(void); _NEWLINE; CAT3(generic, 3_type_, name)(); } \
+        if_comptime (__builtin_classify_type((type){0}) == 5 && data == NULL) { __attribute__((error(STR(generic) "(mon, field, NULL) unsupported"))) void CAT3(generic, 3_data_, name)(void); _NEWLINE; CAT3(generic, 3_data_, name)(); } \
+        if_comptime (__builtin_classify_type((type){0}) != 5 && data != NULL) { __attribute__((error(STR(generic) "(mon, " STR(name) ", data) disabled: " STR(type) " is returned directly"))) void CAT3(generic, 3_type_, name)(void); _NEWLINE; CAT3(generic, 3_type_, name)(); } \
         if_comptime (!(structs & structFlag)) { __attribute__((error(STR(generic) "(mon, " STR(name) ", data) disabled: not " STR(structFlag)))) void CAT3(generic, 3_struct_, name)(void); _NEWLINE; CAT3(generic, 3_struct_, name)(); } \
         if_comptime (!(readWrite & MD_RD)) { __attribute__((error(STR(generic) "(mon, " STR(name) ", data) disabled: not MD_RD or MD_RDWR"))) void CAT3(generic, 3_RD_, name)(void); _NEWLINE; CAT3(generic, 3_RD_, name)(); } \
         _NEWLINE; \
@@ -1108,8 +1107,8 @@ union __attribute__((transparent_union)) PtrU16Ish { const u16 *as_u16; const u3
 // NOTE: '(const type){0} + 0' causes the array to decay into a pointer.
 // This is the correct behavior for strings but unlikely to be correct
 // for other types, including other uses of 'u8[]'.
-#define _MONDATA_SETPTR_PARAMETER_TYPE(type) const typeof(__builtin_choose_expr(__builtin_classify_type(type) == 14, (const type){0} + 0, _Generic((type){0}, u8: (union PtrU8Ish) { .as_u8 = 0 }, u16: (union PtrU16Ish) { .as_u16 = 0 }, default: (type[1]){0})))
-#define _MONDATA_SETIMM_PARAMETER_TYPE(type) const typeof(__builtin_choose_expr(__builtin_classify_type(type) == 14, (const type){0} + 0, (const type){0}))
+#define _MONDATA_SETPTR_PARAMETER_TYPE(type) const typeof(__builtin_choose_expr(__builtin_classify_type((type){0}) == 5, (const type){0} + 0, _Generic((type){0}, u8: (union PtrU8Ish) { .as_u8 = 0 }, u16: (union PtrU16Ish) { .as_u16 = 0 }, default: (type[1]){0})))
+#define _MONDATA_SETIMM_PARAMETER_TYPE(type) const typeof(__builtin_choose_expr(__builtin_classify_type((type){0}) == 5, (const type){0} + 0, (const type){0}))
 
 #define _MONDATA_DEFINE_SET(name, type, structs, readWrite, generic, monType, structFlag) \
     __attribute__((always_inline)) \
@@ -1128,7 +1127,7 @@ union __attribute__((transparent_union)) PtrU16Ish { const u16 *as_u16; const u3
     static inline void CAT3(generic, Imm_, name)(monType *mon, enum MonData field, _MONDATA_SETIMM_PARAMETER_TYPE(type) data) \
     { \
         if_comptime (mon == NULL) { __attribute__((error(STR(generic) "(NULL, field, data) unsupported"))) void CAT3(generic, Imm_mon_, name)(void); _NEWLINE; CAT3(generic, Imm_mon_, name)(); } \
-        if_comptime (__builtin_classify_type(type) == 14) { __attribute__((error(STR(generic) "(mon, " STR(name) ", data) disabled: " STR(type) " must be passed via a pointer"))) void CAT3(generic, Imm_type_, name)(void); _NEWLINE; CAT3(generic, Imm_type_, name)(); } \
+        if_comptime (__builtin_classify_type((type){0}) == 5) { __attribute__((error(STR(generic) "(mon, " STR(name) ", data) disabled: " STR(type) " must be passed via a pointer"))) void CAT3(generic, Imm_type_, name)(void); _NEWLINE; CAT3(generic, Imm_type_, name)(); } \
         if_comptime (!(structs & structFlag)) { __attribute__((error(STR(generic) "(mon, " STR(name) ", data) disabled: not " STR(structFlag)))) void CAT3(generic, Imm_struct_, name)(void); _NEWLINE; CAT3(generic, Imm_struct_, name)(); } \
         if_comptime (!(readWrite & MD_WR)) { __attribute__((error(STR(generic) "(mon, " STR(name) ", data) disabled: not MD_WR or MD_RDWR"))) void CAT3(generic, Imm_WR_, name)(void); _NEWLINE; CAT3(generic, Imm_WR_, name)(); } \
         _NEWLINE; \
@@ -1152,7 +1151,7 @@ FOREACH_MON_DATA(_MONDATA_DEFINE_GETSET)
 #define _GETBOXMONDATA(boxMon, field) _GETMONDATA_SWITCH(boxMon, GetBoxMonData2, field)(boxMon, field)
 #define _GETBOXMONDATA3(boxMon, field, data) _GETMONDATA_SWITCH(boxMon, GetBoxMonData3, field)(boxMon, field, data)
 
-#define _SETMONDATA_CASE(name, type, structs, readWrite, generic, field, data) __builtin_choose_expr(__builtin_constant_p(name == (field) ? 0 : *(int *)0), __builtin_choose_expr(__builtin_classify_type(type) == 14 || __builtin_classify_type(data) == 5, CAT3(generic, Ptr_, name), CAT3(generic, Imm_, name)),
+#define _SETMONDATA_CASE(name, type, structs, readWrite, generic, field, data) __builtin_choose_expr(__builtin_constant_p(name == (field) ? 0 : *(int *)0), __builtin_choose_expr(__builtin_classify_type((type){0}) == 5 || __builtin_classify_type(data) == 5, CAT3(generic, Ptr_, name), CAT3(generic, Imm_, name)),
 #define _SETMONDATA_SWITCH(mon, generic, field, data) (FOREACH_MON_DATA(_SETMONDATA_CASE, generic, field, data) CAT(generic, Ptr) FOREACH_MON_DATA(_MONDATA_RPAREN))
 
 #define _SETMONDATA(mon, field, data) _SETMONDATA_SWITCH(mon, SetMonData, field, data)(mon, field, data)

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -11,6 +11,7 @@
 #include "constants/hold_effects.h"
 #include "constants/items.h"
 #include "constants/map_groups.h"
+#include "constants/pokeball.h"
 #include "constants/regions.h"
 #include "constants/region_map_sections.h"
 #include "constants/map_groups.h"
@@ -21,111 +22,6 @@
 
 #define GET_BASE_SPECIES_ID(speciesId) (GetFormSpeciesId(speciesId, 0))
 #define FORM_SPECIES_END (0xffff)
-
-// Property labels for Get(Box)MonData / Set(Box)MonData
-enum MonData {
-    MON_DATA_PERSONALITY,
-    MON_DATA_STATUS,
-    MON_DATA_OT_ID,
-    MON_DATA_LANGUAGE,
-    MON_DATA_SANITY_IS_BAD_EGG,
-    MON_DATA_SANITY_HAS_SPECIES,
-    MON_DATA_SANITY_IS_EGG,
-    MON_DATA_OT_NAME,
-    MON_DATA_MARKINGS,
-    MON_DATA_CHECKSUM,
-    MON_DATA_HP,
-    MON_DATA_IS_SHINY,
-    MON_DATA_HIDDEN_NATURE,
-    MON_DATA_HP_LOST,
-    MON_DATA_DAYS_SINCE_FORM_CHANGE,
-    MON_DATA_ENCRYPT_SEPARATOR,
-    MON_DATA_NICKNAME,
-    MON_DATA_NICKNAME10,
-    MON_DATA_SPECIES,
-    MON_DATA_HELD_ITEM,
-    MON_DATA_MOVE1,
-    MON_DATA_MOVE2,
-    MON_DATA_MOVE3,
-    MON_DATA_MOVE4,
-    MON_DATA_PP1,
-    MON_DATA_PP2,
-    MON_DATA_PP3,
-    MON_DATA_PP4,
-    MON_DATA_PP_BONUSES,
-    MON_DATA_COOL,
-    MON_DATA_BEAUTY,
-    MON_DATA_CUTE,
-    MON_DATA_EXP,
-    MON_DATA_HP_EV,
-    MON_DATA_ATK_EV,
-    MON_DATA_DEF_EV,
-    MON_DATA_SPEED_EV,
-    MON_DATA_SPATK_EV,
-    MON_DATA_SPDEF_EV,
-    MON_DATA_FRIENDSHIP,
-    MON_DATA_SMART,
-    MON_DATA_POKERUS,
-    MON_DATA_POKERUS_STRAIN,
-    MON_DATA_POKERUS_DAYS_LEFT,
-    MON_DATA_MET_LOCATION,
-    MON_DATA_MET_LEVEL,
-    MON_DATA_MET_GAME,
-    MON_DATA_POKEBALL,
-    MON_DATA_HP_IV,
-    MON_DATA_ATK_IV,
-    MON_DATA_DEF_IV,
-    MON_DATA_SPEED_IV,
-    MON_DATA_SPATK_IV,
-    MON_DATA_SPDEF_IV,
-    MON_DATA_IS_EGG,
-    MON_DATA_ABILITY_NUM,
-    MON_DATA_TOUGH,
-    MON_DATA_SHEEN,
-    MON_DATA_OT_GENDER,
-    MON_DATA_COOL_RIBBON,
-    MON_DATA_BEAUTY_RIBBON,
-    MON_DATA_CUTE_RIBBON,
-    MON_DATA_SMART_RIBBON,
-    MON_DATA_TOUGH_RIBBON,
-    MON_DATA_LEVEL,
-    MON_DATA_MAX_HP,
-    MON_DATA_ATK,
-    MON_DATA_DEF,
-    MON_DATA_SPEED,
-    MON_DATA_SPATK,
-    MON_DATA_SPDEF,
-    MON_DATA_MAIL,
-    MON_DATA_SPECIES_OR_EGG,
-    MON_DATA_IVS,
-    MON_DATA_CHAMPION_RIBBON,
-    MON_DATA_WINNING_RIBBON,
-    MON_DATA_VICTORY_RIBBON,
-    MON_DATA_ARTIST_RIBBON,
-    MON_DATA_EFFORT_RIBBON,
-    MON_DATA_MARINE_RIBBON,
-    MON_DATA_LAND_RIBBON,
-    MON_DATA_SKY_RIBBON,
-    MON_DATA_COUNTRY_RIBBON,
-    MON_DATA_NATIONAL_RIBBON,
-    MON_DATA_EARTH_RIBBON,
-    MON_DATA_WORLD_RIBBON,
-    MON_DATA_MODERN_FATEFUL_ENCOUNTER,
-    MON_DATA_KNOWN_MOVES,
-    MON_DATA_RIBBON_COUNT,
-    MON_DATA_RIBBONS,
-    MON_DATA_HYPER_TRAINED_HP,
-    MON_DATA_HYPER_TRAINED_ATK,
-    MON_DATA_HYPER_TRAINED_DEF,
-    MON_DATA_HYPER_TRAINED_SPEED,
-    MON_DATA_HYPER_TRAINED_SPATK,
-    MON_DATA_HYPER_TRAINED_SPDEF,
-    MON_DATA_IS_SHADOW,
-    MON_DATA_DYNAMAX_LEVEL,
-    MON_DATA_GIGANTAMAX_FACTOR,
-    MON_DATA_TERA_TYPE,
-    MON_DATA_EVOLUTION_TRACKER,
-};
 
 struct PokemonSubstruct0
 {
@@ -184,7 +80,7 @@ struct PokemonSubstruct2
 struct PokemonSubstruct3
 {
     u8 pokerus;
-    u8 metLocation;
+    metloc_u8_t metLocation;
     u16 metLevel:7;
     u16 metGame:4;
     u16 dynamaxLevel:4;
@@ -787,20 +683,6 @@ void SetMultiuseSpriteTemplateToPokemon(enum Species speciesTag, enum BattlerPos
 void SetMultiuseSpriteTemplateToTrainerBack(enum TrainerPicID trainerPicId, enum BattlerPosition battlerPosition);
 void SetMultiuseSpriteTemplateToTrainerFront(enum TrainerPicID trainerPicId, enum BattlerPosition battlerPosition);
 
-/* GameFreak called Get(Box)MonData with either 2 or 3 arguments, for
- * type safety we have a Get(Box)MonData macro which dispatches to
- * either Get(Box)MonData2 or Get(Box)MonData3 based on the number of
- * arguments. The two functions are aliases of each other, but they
- * differ for matching purposes in the caller's codegen. */
-#define GetMonData(...) CAT(GetMonData, NARG_8(__VA_ARGS__))(__VA_ARGS__)
-#define GetBoxMonData(...) CAT(GetBoxMonData, NARG_8(__VA_ARGS__))(__VA_ARGS__)
-u32 GetMonData3(struct Pokemon *mon, s32 field, u8 *data);
-u32 GetMonData2(struct Pokemon *mon, s32 field);
-u32 GetBoxMonData3(struct BoxPokemon *boxMon, s32 field, u8 *data);
-u32 GetBoxMonData2(struct BoxPokemon *boxMon, s32 field);
-
-void SetMonData(struct Pokemon *mon, s32 field, const void *dataArg);
-void SetBoxMonData(struct BoxPokemon *boxMon, s32 field, const void *dataArg);
 void CopyMon(void *dest, void *src, size_t size);
 u8 GiveCapturedMonToPlayer(struct Pokemon *mon);
 u8 CopyMonToPC(struct Pokemon *mon);
@@ -1005,5 +887,275 @@ static inline enum ReturnToIdleOWE OWE_GetReturnToIdleFromSpecies(enum Species s
     enum OverworldWildEncounterBehaviors behavior = gSpeciesInfo[speciesId].overworldEncounterBehavior;
     return gOWESpeciesBehavior[behavior].returnToIdle;
 }
+
+/* T GetMonData(struct Pokemon *, enum MonData field)
+ * T GetMonData(struct Pokemon *, enum MonData field, U data)
+ *
+ * T GetBoxMonData(struct BoxPokemon *, enum MonData field)
+ * T GetBoxMonData(struct BoxPokemon *, enum MonData field, U data)
+ *
+ * If 'field' is not known at compile-time 'T' is 'u32' and 'U' is
+ * 'void *'.
+ *
+ * If 'field' is known at compile-time then 'T' and 'U' are derived from
+ * the corresponding type defined in 'FOREACH_MON_DATA':
+ * - If that type is an array: 'T' is 'u32', 'U' is that type; and the
+ *   two-argument forms are disabled.
+ * - Otherwise: 'T' is that type, 'U' is undefined; and the
+ *   three-argument forms are disabled. */
+#define GetMonData(mon, field, ...) CAT(_GETMONDATA, __VA_OPT__(3))(mon, field, ##__VA_ARGS__)
+#define GetBoxMonData(boxMon, field, ...) CAT(_GETBOXMONDATA, __VA_OPT__(3))(boxMon, field, ##__VA_ARGS__)
+
+/* void SetMonData(struct Pokemon *, enum MonData field, T data)
+/* void SetMonData(struct Pokemon *, enum MonData field, T *data)
+ * void SetBoxMonData(struct BoxPokemon *, enum MonData field, T data)
+ * void SetBoxMonData(struct BoxPokemon *, enum MonData field, T *data)
+ *
+ * If 'field' is not known at compile-time 'T *' is 'const void *' and
+ * the 'T data' functions are disabled.
+ *
+ * If 'field' is known at compile-time then 'T' is derived from the
+ * corresponding type defined in 'FOREACH_MON_DATA':
+ * - If that type is an array: 'T' is the element type; and the 'T data'
+ *   forms are disabled.
+ * - Otherwise: 'T' is that type. */
+#define SetMonData(mon, field, data) _SETMONDATA(mon, field, data)
+#define SetBoxMonData(boxMon, field, data) _SETBOXMONDATA(boxMon, field, data)
+
+enum MonData_Structs { MD_MON = 0b01, MD_BOX = 0b10, MD_MONBOX = 0b11 };
+enum MonData_ReadWrite { MD_RD = 0b01, MD_WR = 0b10, MD_RDWR = 0b11 };
+
+/* F(name, type, structs, readWrite, ##__VA_ARGS__)
+ *
+ * - 'name' is the name of the enumerator in 'enum MonData'.
+ *
+ * - 'type' is used to derive the types of '*MonData'/'*BoxMonData'.
+ *
+ * - 'structs' is used to enable/disable '*MonData'/'*BoxMonData':
+ *   - If 'MD_MON': Only 'struct Pokemon'.
+ *   - If 'MD_BOX': Only 'struct BoxPokemon'.
+ *   - If 'MD_MONBOX': Both 'struct Pokemon' and 'struct BoxPokemon'.
+ *
+ * - 'readWrite' is used to enable/disable 'Get*'/'Set*':
+ *   - If 'MD_RD': Only 'Get*'.
+ *   - If 'MD_WR': Only 'Set*'.
+ *   - If 'MD_RDWR': Both 'Get*' and 'Set*'.
+ *
+ * The ', ##__VA_ARGS__' is used to forward the '...' from
+ * 'FOREACH_MON_DATA' to all the 'F's. */
+#define FOREACH_MON_DATA(F, ...) \
+    F(MON_DATA_PERSONALITY, u32, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_STATUS, u32, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_OT_ID, u32, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_LANGUAGE, enum Language, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_SANITY_IS_BAD_EGG, bool8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_SANITY_HAS_SPECIES, bool8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_SANITY_IS_EGG, bool8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_OT_NAME, u8[PLAYER_NAME_LENGTH], MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_MARKINGS, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_CHECKSUM, u16, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_HP, u16, MD_MON, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_IS_SHINY, bool8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_HIDDEN_NATURE, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_HP_LOST, u16, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_DAYS_SINCE_FORM_CHANGE, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_ENCRYPT_SEPARATOR, void *, 0, 0, ##__VA_ARGS__) \
+    F(MON_DATA_NICKNAME, u8[POKEMON_NAME_LENGTH + 1], MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_NICKNAME10, u8[10 + 1], MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_SPECIES, enum Species, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_HELD_ITEM, enum Item, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_MOVE1, enum Move, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_MOVE2, enum Move, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_MOVE3, enum Move, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_MOVE4, enum Move, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_PP1, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_PP2, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_PP3, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_PP4, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_PP_BONUSES, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_COOL, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_BEAUTY, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_CUTE, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_EXP, u32, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_HP_EV, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_ATK_EV, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_DEF_EV, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_SPEED_EV, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_SPATK_EV, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_SPDEF_EV, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_FRIENDSHIP, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_SMART, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_POKERUS, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_POKERUS_STRAIN, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_POKERUS_DAYS_LEFT, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_MET_LOCATION, metloc_u8_t, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_MET_LEVEL, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_MET_GAME, enum GameVersion, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_POKEBALL, enum PokeBall, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_HP_IV, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_ATK_IV, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_DEF_IV, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_SPEED_IV, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_SPATK_IV, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_SPDEF_IV, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_IS_EGG, bool8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_ABILITY_NUM, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_TOUGH, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_SHEEN, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_OT_GENDER, enum Gender, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_COOL_RIBBON, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_BEAUTY_RIBBON, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_CUTE_RIBBON, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_SMART_RIBBON, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_TOUGH_RIBBON, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_LEVEL, u8, MD_MON, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_MAX_HP, u16, MD_MON, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_ATK, u16, MD_MON, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_DEF, u16, MD_MON, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_SPEED, u16, MD_MON, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_SPATK, u16, MD_MON, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_SPDEF, u16, MD_MON, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_MAIL, u8, MD_MON, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_SPECIES_OR_EGG, enum Species, MD_MONBOX, MD_RD, ##__VA_ARGS__) \
+    F(MON_DATA_IVS, u32, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_CHAMPION_RIBBON, bool8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_WINNING_RIBBON, bool8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_VICTORY_RIBBON, bool8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_ARTIST_RIBBON, bool8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_EFFORT_RIBBON, bool8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_MARINE_RIBBON, bool8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_LAND_RIBBON, bool8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_SKY_RIBBON, bool8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_COUNTRY_RIBBON, bool8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_NATIONAL_RIBBON, bool8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_EARTH_RIBBON, bool8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_WORLD_RIBBON, bool8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_MODERN_FATEFUL_ENCOUNTER, bool8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_RIBBON_COUNT, u8, MD_MONBOX, MD_RD, ##__VA_ARGS__) \
+    F(MON_DATA_RIBBONS, u32, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_HYPER_TRAINED_HP, bool8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_HYPER_TRAINED_ATK, bool8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_HYPER_TRAINED_DEF, bool8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_HYPER_TRAINED_SPEED, bool8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_HYPER_TRAINED_SPATK, bool8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_HYPER_TRAINED_SPDEF, bool8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_IS_SHADOW, bool8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_DYNAMAX_LEVEL, u8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_GIGANTAMAX_FACTOR, bool8, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_TERA_TYPE, enum Type, MD_MONBOX, MD_RDWR, ##__VA_ARGS__) \
+    F(MON_DATA_EVOLUTION_TRACKER, u16, MD_MONBOX, MD_RDWR, ##__VA_ARGS__)
+
+/* enum MonData
+ *
+ * Constants to use with 'GetMonData', 'GetBoxMonData', 'SetMonData',
+ * and 'SetBoxMonData'. Mostly derived from 'FOREACH_MON_DATA' but
+ * 'MON_DATA_KNOWN_MOVES' is an outlier: its 'Get*' argument is input
+ * not output. */
+enum MonData
+{
+#define MON_DATA_IDENTIFIER(name, type, structs, readWrite) name,
+    FOREACH_MON_DATA(MON_DATA_IDENTIFIER)
+#undef MON_DATA_IDENTIFIER
+    MON_DATA_KNOWN_MOVES,
+};
+
+// 'GetMonData', 'GetBoxMonData', 'SetMonData', and 'SetBoxMonData'
+// implementation details.
+
+u32 GetMonData3(struct Pokemon *mon, enum MonData field, void *data);
+u32 GetMonData2(struct Pokemon *mon, enum MonData field);
+u32 GetBoxMonData3(struct BoxPokemon *boxMon, enum MonData field, void *data);
+u32 GetBoxMonData2(struct BoxPokemon *boxMon, enum MonData field);
+
+void SetMonDataPtr(struct Pokemon *mon, enum MonData field, const void *data);
+void SetBoxMonDataPtr(struct BoxPokemon *boxMon, enum MonData field, const void *data);
+
+// HINT: '__builtin_classify_type(exp)' returns:
+// * 5 for pointer types.
+// * 14 for array types.
+// See: https://github.com/gcc-mirror/gcc/blob/master/gcc/typeclass.h
+#define _MONDATA_GET2_RETURN_TYPE(type) typeof(__builtin_choose_expr(__builtin_classify_type(type) == 14, (void)0, (type){0}))
+#define _MONDATA_GET3_PARAMETER_TYPE(type) typeof(__builtin_choose_expr(__builtin_classify_type(type) == 14, (type){0}, (void *)0))
+#define _MONDATA_DEFINE_GET(name, type, structs, readWrite, generic, monType, structFlag) \
+    __attribute__((always_inline)) \
+    static inline _MONDATA_GET2_RETURN_TYPE(type) CAT3(generic, 2_, name)(monType *mon, enum MonData field) \
+    { \
+        if_comptime (mon == NULL) { __attribute__((error(STR(generic) "(NULL, field) unsupported"))) void CAT3(generic, 2_mon_, name)(void); _NEWLINE; CAT3(generic, 2_mon_, name)(); } \
+        if_comptime (__builtin_classify_type(type) == 14) { __attribute__((error(STR(generic) "(mon, " STR(name) ") disabled: " STR(type) " is returned via 'data'"))) void CAT3(generic, 2_type_, name)(void); _NEWLINE; CAT3(generic, 2_type_, name)(); } \
+        if_comptime (!(structs & structFlag)) { __attribute__((error(STR(generic) "(mon, " STR(name) ") disabled: not " STR(structFlag)))) void CAT3(generic, 2_struct_, name)(void); _NEWLINE; CAT3(generic, 2_struct_, name)(); } \
+        if_comptime (!(readWrite & MD_RD)) { __attribute__((error(STR(generic) "(mon, " STR(name) ") disabled: not MD_RD or MD_RDWR"))) void CAT3(generic, 2_RD_, name)(void); _NEWLINE; CAT3(generic, 2_RD_, name)(); } \
+        _NEWLINE; \
+        return (_MONDATA_GET2_RETURN_TYPE(type))CAT(generic, 2)(mon, field); \
+    } \
+    __attribute__((always_inline)) \
+    static inline u32 CAT3(generic, 3_, name)(monType *mon, enum MonData field, _MONDATA_GET3_PARAMETER_TYPE(type) data) \
+    { \
+        if_comptime (mon == NULL) { __attribute__((error(STR(generic) "(NULL, field, data) unsupported"))) void CAT3(generic, 3_mon_, name)(void); _NEWLINE; CAT3(generic, 3_mon_, name)(); } \
+        if_comptime (__builtin_classify_type(type) == 14 && data == NULL) { __attribute__((error(STR(generic) "(mon, field, NULL) unsupported"))) void CAT3(generic, 3_data_, name)(void); _NEWLINE; CAT3(generic, 3_data_, name)(); } \
+        if_comptime (__builtin_classify_type(type) != 14 && data != NULL) { __attribute__((error(STR(generic) "(mon, " STR(name) ", data) disabled: " STR(type) " is returned directly"))) void CAT3(generic, 3_type_, name)(void); _NEWLINE; CAT3(generic, 3_type_, name)(); } \
+        if_comptime (!(structs & structFlag)) { __attribute__((error(STR(generic) "(mon, " STR(name) ", data) disabled: not " STR(structFlag)))) void CAT3(generic, 3_struct_, name)(void); _NEWLINE; CAT3(generic, 3_struct_, name)(); } \
+        if_comptime (!(readWrite & MD_RD)) { __attribute__((error(STR(generic) "(mon, " STR(name) ", data) disabled: not MD_RD or MD_RDWR"))) void CAT3(generic, 3_RD_, name)(void); _NEWLINE; CAT3(generic, 3_RD_, name)(); } \
+        _NEWLINE; \
+        return CAT(generic, 3)(mon, field, data); \
+    }
+
+// NOTE: On little-endian systems you can read from, e.g. a 'u16 *' as
+// if it was a 'u8 *' and get the correct answer if the pointed-to value
+// fits in a 'u8'. This is bad style, but GF did it a lot.
+union __attribute__((transparent_union)) PtrU8Ish { const u8 *as_u8; const u16 *as_u16; const u32 *as_u32; };
+union __attribute__((transparent_union)) PtrU16Ish { const u16 *as_u16; const u32 *as_u32; };
+
+// NOTE: '(const type){0} + 0' causes the array to decay into a pointer.
+// This is the correct behavior for strings but unlikely to be correct
+// for other types, including other uses of 'u8[]'.
+#define _MONDATA_SETPTR_PARAMETER_TYPE(type) const typeof(__builtin_choose_expr(__builtin_classify_type(type) == 14, (const type){0} + 0, _Generic((type){0}, u8: (union PtrU8Ish) { .as_u8 = 0 }, u16: (union PtrU16Ish) { .as_u16 = 0 }, default: (type[1]){0})))
+#define _MONDATA_SETIMM_PARAMETER_TYPE(type) const typeof(__builtin_choose_expr(__builtin_classify_type(type) == 14, (const type){0} + 0, (const type){0}))
+
+#define _MONDATA_DEFINE_SET(name, type, structs, readWrite, generic, monType, structFlag) \
+    __attribute__((always_inline)) \
+    static inline void CAT3(generic, Ptr_, name)(monType *mon, enum MonData field, _MONDATA_SETPTR_PARAMETER_TYPE(type) data) \
+    { \
+        if_comptime (mon == NULL) { __attribute__((error(STR(generic) "(NULL, field, data) unsupported"))) void CAT3(generic, Ptr_mon_, name)(void); _NEWLINE; CAT3(generic, Ptr_mon_, name)(); } \
+        if_comptime (!(structs & structFlag)) { __attribute__((error(STR(generic) "(mon, " STR(name) ", data) disabled: not" STR(structFlag)))) void CAT3(generic, Ptr_struct_, name)(void); _NEWLINE; CAT3(generic, Ptr_struct_, name)(); } \
+        if_comptime (!(readWrite & MD_WR)) { __attribute__((error(STR(generic) "(mon, " STR(name) ", data) disabled: not MD_WR or MD_RDWR"))) void CAT3(generic, Ptr_WR_, name)(void); _NEWLINE; CAT3(generic, Ptr_WR_, name)(); } \
+        const void *data_; \
+        memcpy(&data_, &data, sizeof(data_)); \
+        if_comptime (data_ == NULL) { __attribute__((error(STR(generic) "(mon, field, NULL) unsupported"))) void CAT3(generic, Ptr_data_, name)(void); _NEWLINE; CAT3(generic, Ptr_data_, name)(); } \
+        _NEWLINE; \
+        CAT(generic, Ptr)(mon, field, data_); \
+    } \
+    __attribute__((always_inline)) \
+    static inline void CAT3(generic, Imm_, name)(monType *mon, enum MonData field, _MONDATA_SETIMM_PARAMETER_TYPE(type) data) \
+    { \
+        if_comptime (mon == NULL) { __attribute__((error(STR(generic) "(NULL, field, data) unsupported"))) void CAT3(generic, Imm_mon_, name)(void); _NEWLINE; CAT3(generic, Imm_mon_, name)(); } \
+        if_comptime (__builtin_classify_type(type) == 14) { __attribute__((error(STR(generic) "(mon, " STR(name) ", data) disabled: " STR(type) " must be passed via a pointer"))) void CAT3(generic, Imm_type_, name)(void); _NEWLINE; CAT3(generic, Imm_type_, name)(); } \
+        if_comptime (!(structs & structFlag)) { __attribute__((error(STR(generic) "(mon, " STR(name) ", data) disabled: not " STR(structFlag)))) void CAT3(generic, Imm_struct_, name)(void); _NEWLINE; CAT3(generic, Imm_struct_, name)(); } \
+        if_comptime (!(readWrite & MD_WR)) { __attribute__((error(STR(generic) "(mon, " STR(name) ", data) disabled: not MD_WR or MD_RDWR"))) void CAT3(generic, Imm_WR_, name)(void); _NEWLINE; CAT3(generic, Imm_WR_, name)(); } \
+        _NEWLINE; \
+        CAT(generic, Ptr)(mon, field, &data); \
+    }
+
+#define _MONDATA_DEFINE_GETSET(name, type, structs, readWrite) \
+    _MONDATA_DEFINE_GET(name, type, structs, readWrite, GetMonData, struct Pokemon, MD_MON) \
+    _MONDATA_DEFINE_GET(name, type, structs, readWrite, GetBoxMonData, struct BoxPokemon, MD_BOX) \
+    _MONDATA_DEFINE_SET(name, type, structs, readWrite, SetMonData, struct Pokemon, MD_MON) \
+    _MONDATA_DEFINE_SET(name, type, structs, readWrite, SetBoxMonData, struct BoxPokemon, MD_BOX)
+
+FOREACH_MON_DATA(_MONDATA_DEFINE_GETSET)
+
+#define _MONDATA_RPAREN(name, type, structs, readWrite) )
+#define _GETMONDATA_CASE(name, type, structs, readWrite, generic, field) __builtin_choose_expr(__builtin_constant_p(name == (field) ? 0 : *(int *)0), CAT3(generic, _, name),
+#define _GETMONDATA_SWITCH(mon, generic, field) (FOREACH_MON_DATA(_GETMONDATA_CASE, generic, field) generic FOREACH_MON_DATA(_MONDATA_RPAREN))
+
+#define _GETMONDATA(mon, field) _GETMONDATA_SWITCH(mon, GetMonData2, field)(mon, field)
+#define _GETMONDATA3(mon, field, data) _GETMONDATA_SWITCH(mon, GetMonData3, field)(mon, field, data)
+#define _GETBOXMONDATA(boxMon, field) _GETMONDATA_SWITCH(boxMon, GetBoxMonData2, field)(boxMon, field)
+#define _GETBOXMONDATA3(boxMon, field, data) _GETMONDATA_SWITCH(boxMon, GetBoxMonData3, field)(boxMon, field, data)
+
+#define _SETMONDATA_CASE(name, type, structs, readWrite, generic, field, data) __builtin_choose_expr(__builtin_constant_p(name == (field) ? 0 : *(int *)0), __builtin_choose_expr(__builtin_classify_type(type) == 14 || __builtin_classify_type(data) == 5, CAT3(generic, Ptr_, name), CAT3(generic, Imm_, name)),
+#define _SETMONDATA_SWITCH(mon, generic, field, data) (FOREACH_MON_DATA(_SETMONDATA_CASE, generic, field, data) CAT(generic, Ptr) FOREACH_MON_DATA(_MONDATA_RPAREN))
+
+#define _SETMONDATA(mon, field, data) _SETMONDATA_SWITCH(mon, SetMonData, field, data)(mon, field, data)
+#define _SETBOXMONDATA(boxMon, field, data) _SETMONDATA_SWITCH(boxMon, SetBoxMonData, field, data)(boxMon, field, data)
 
 #endif // GUARD_POKEMON_H

--- a/include/test/battle.h
+++ b/include/test/battle.h
@@ -1090,7 +1090,7 @@ void MovesWithPP_(u32 sourceLine, struct moveWithPP moveWithPP[MAX_MON_MOVES]);
 void Friendship_(u32 sourceLine, u32 friendship);
 void Status1_(u32 sourceLine, u32 status1);
 void OTName_(u32 sourceLine, const u8 *otName);
-void DynamaxLevel_(u32 sourceLine, s16 dynamaxLevel);
+void DynamaxLevel_(u32 sourceLine, u32 dynamaxLevel);
 void GigantamaxFactor_(u32 sourceLine, bool32 gigantamaxFactor);
 void TeraType_(u32 sourceLine, enum Type teraType);
 void Shadow_(u32 sourceLine, bool32 isShadow);

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -1491,7 +1491,8 @@ static void Task_GiveExpWithExpBar(u8 taskId)
     u32 level, expAfterGain;
     enum Species species;
     u32 oldMaxHP;
-    s32 currExp, expOnNextLvl, newExpPoints;
+    u32 currExp, expOnNextLvl;
+    s32 newExpPoints;
 
     if (gTasks[taskId].tExpTask_frames < 13)
     {

--- a/src/battle_controllers.c
+++ b/src/battle_controllers.c
@@ -1805,10 +1805,10 @@ static void SetBattlerMonData(enum BattlerId battler, struct Pokemon *party, u32
         }
         break;
     case REQUEST_SPECIES_BATTLE:
-        SetMonData(&party[monId], MON_DATA_SPECIES, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_SPECIES, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_HELDITEM_BATTLE:
-        SetMonData(&party[monId], MON_DATA_HELD_ITEM, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_HELD_ITEM, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_MOVES_PP_BATTLE:
         for (i = 0; i < MAX_MON_MOVES; i++)
@@ -1822,154 +1822,154 @@ static void SetBattlerMonData(enum BattlerId battler, struct Pokemon *party, u32
     case REQUEST_MOVE2_BATTLE:
     case REQUEST_MOVE3_BATTLE:
     case REQUEST_MOVE4_BATTLE:
-        SetMonData(&party[monId], MON_DATA_MOVE1 + gBattleResources->bufferA[battler][1] - REQUEST_MOVE1_BATTLE, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_MOVE1 + gBattleResources->bufferA[battler][1] - REQUEST_MOVE1_BATTLE, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_PP_DATA_BATTLE:
-        SetMonData(&party[monId], MON_DATA_PP1, &gBattleResources->bufferA[battler][3]);
-        SetMonData(&party[monId], MON_DATA_PP2, &gBattleResources->bufferA[battler][4]);
-        SetMonData(&party[monId], MON_DATA_PP3, &gBattleResources->bufferA[battler][5]);
-        SetMonData(&party[monId], MON_DATA_PP4, &gBattleResources->bufferA[battler][6]);
-        SetMonData(&party[monId], MON_DATA_PP_BONUSES, &gBattleResources->bufferA[battler][7]);
+        SetMonData(&party[monId], MON_DATA_PP1, (void *)&gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_PP2, (void *)&gBattleResources->bufferA[battler][4]);
+        SetMonData(&party[monId], MON_DATA_PP3, (void *)&gBattleResources->bufferA[battler][5]);
+        SetMonData(&party[monId], MON_DATA_PP4, (void *)&gBattleResources->bufferA[battler][6]);
+        SetMonData(&party[monId], MON_DATA_PP_BONUSES, (void *)&gBattleResources->bufferA[battler][7]);
         break;
     case REQUEST_PPMOVE1_BATTLE:
     case REQUEST_PPMOVE2_BATTLE:
     case REQUEST_PPMOVE3_BATTLE:
     case REQUEST_PPMOVE4_BATTLE:
-        SetMonData(&party[monId], MON_DATA_PP1 + gBattleResources->bufferA[battler][1] - REQUEST_PPMOVE1_BATTLE, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_PP1 + gBattleResources->bufferA[battler][1] - REQUEST_PPMOVE1_BATTLE, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_OTID_BATTLE:
-        SetMonData(&party[monId], MON_DATA_OT_ID, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_OT_ID, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_EXP_BATTLE:
-        SetMonData(&party[monId], MON_DATA_EXP, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_EXP, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_HP_EV_BATTLE:
-        SetMonData(&party[monId], MON_DATA_HP_EV, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_HP_EV, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_ATK_EV_BATTLE:
-        SetMonData(&party[monId], MON_DATA_ATK_EV, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_ATK_EV, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_DEF_EV_BATTLE:
-        SetMonData(&party[monId], MON_DATA_DEF_EV, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_DEF_EV, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_SPEED_EV_BATTLE:
-        SetMonData(&party[monId], MON_DATA_SPEED_EV, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_SPEED_EV, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_SPATK_EV_BATTLE:
-        SetMonData(&party[monId], MON_DATA_SPATK_EV, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_SPATK_EV, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_SPDEF_EV_BATTLE:
-        SetMonData(&party[monId], MON_DATA_SPDEF_EV, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_SPDEF_EV, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_FRIENDSHIP_BATTLE:
-        SetMonData(&party[monId], MON_DATA_FRIENDSHIP, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_FRIENDSHIP, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_POKERUS_BATTLE:
-        SetMonData(&party[monId], MON_DATA_POKERUS, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_POKERUS, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_MET_LOCATION_BATTLE:
-        SetMonData(&party[monId], MON_DATA_MET_LOCATION, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_MET_LOCATION, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_MET_LEVEL_BATTLE:
-        SetMonData(&party[monId], MON_DATA_MET_LEVEL, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_MET_LEVEL, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_MET_GAME_BATTLE:
-        SetMonData(&party[monId], MON_DATA_MET_GAME, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_MET_GAME, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_POKEBALL_BATTLE:
-        SetMonData(&party[monId], MON_DATA_POKEBALL, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_POKEBALL, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_ALL_IVS_BATTLE:
-        SetMonData(&party[monId], MON_DATA_HP_IV, &gBattleResources->bufferA[battler][3]);
-        SetMonData(&party[monId], MON_DATA_ATK_IV, &gBattleResources->bufferA[battler][4]);
-        SetMonData(&party[monId], MON_DATA_DEF_IV, &gBattleResources->bufferA[battler][5]);
-        SetMonData(&party[monId], MON_DATA_SPEED_IV, &gBattleResources->bufferA[battler][6]);
-        SetMonData(&party[monId], MON_DATA_SPATK_IV, &gBattleResources->bufferA[battler][7]);
-        SetMonData(&party[monId], MON_DATA_SPDEF_IV, &gBattleResources->bufferA[battler][8]);
+        SetMonData(&party[monId], MON_DATA_HP_IV, (void *)&gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_ATK_IV, (void *)&gBattleResources->bufferA[battler][4]);
+        SetMonData(&party[monId], MON_DATA_DEF_IV, (void *)&gBattleResources->bufferA[battler][5]);
+        SetMonData(&party[monId], MON_DATA_SPEED_IV, (void *)&gBattleResources->bufferA[battler][6]);
+        SetMonData(&party[monId], MON_DATA_SPATK_IV, (void *)&gBattleResources->bufferA[battler][7]);
+        SetMonData(&party[monId], MON_DATA_SPDEF_IV, (void *)&gBattleResources->bufferA[battler][8]);
         break;
     case REQUEST_HP_IV_BATTLE:
-        SetMonData(&party[monId], MON_DATA_HP_IV, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_HP_IV, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_ATK_IV_BATTLE:
-        SetMonData(&party[monId], MON_DATA_ATK_IV, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_ATK_IV, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_DEF_IV_BATTLE:
-        SetMonData(&party[monId], MON_DATA_DEF_IV, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_DEF_IV, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_SPEED_IV_BATTLE:
-        SetMonData(&party[monId], MON_DATA_SPEED_IV, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_SPEED_IV, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_SPATK_IV_BATTLE:
-        SetMonData(&party[monId], MON_DATA_SPATK_IV, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_SPATK_IV, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_SPDEF_IV_BATTLE:
-        SetMonData(&party[monId], MON_DATA_SPDEF_IV, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_SPDEF_IV, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_PERSONALITY_BATTLE:
-        SetMonData(&party[monId], MON_DATA_PERSONALITY, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_PERSONALITY, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_CHECKSUM_BATTLE:
-        SetMonData(&party[monId], MON_DATA_CHECKSUM, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_CHECKSUM, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_STATUS_BATTLE:
-        SetMonData(&party[monId], MON_DATA_STATUS, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_STATUS, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_LEVEL_BATTLE:
-        SetMonData(&party[monId], MON_DATA_LEVEL, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_LEVEL, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_HP_BATTLE:
-        SetMonData(&party[monId], MON_DATA_HP, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_HP, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_MAX_HP_BATTLE:
-        SetMonData(&party[monId], MON_DATA_MAX_HP, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_MAX_HP, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_ATK_BATTLE:
-        SetMonData(&party[monId], MON_DATA_ATK, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_ATK, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_DEF_BATTLE:
-        SetMonData(&party[monId], MON_DATA_DEF, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_DEF, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_SPEED_BATTLE:
-        SetMonData(&party[monId], MON_DATA_SPEED, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_SPEED, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_SPATK_BATTLE:
-        SetMonData(&party[monId], MON_DATA_SPATK, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_SPATK, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_SPDEF_BATTLE:
-        SetMonData(&party[monId], MON_DATA_SPDEF, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_SPDEF, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_COOL_BATTLE:
-        SetMonData(&party[monId], MON_DATA_COOL, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_COOL, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_BEAUTY_BATTLE:
-        SetMonData(&party[monId], MON_DATA_BEAUTY, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_BEAUTY, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_CUTE_BATTLE:
-        SetMonData(&party[monId], MON_DATA_CUTE, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_CUTE, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_SMART_BATTLE:
-        SetMonData(&party[monId], MON_DATA_SMART, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_SMART, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_TOUGH_BATTLE:
-        SetMonData(&party[monId], MON_DATA_TOUGH, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_TOUGH, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_SHEEN_BATTLE:
-        SetMonData(&party[monId], MON_DATA_SHEEN, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_SHEEN, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_COOL_RIBBON_BATTLE:
-        SetMonData(&party[monId], MON_DATA_COOL_RIBBON, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_COOL_RIBBON, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_BEAUTY_RIBBON_BATTLE:
-        SetMonData(&party[monId], MON_DATA_BEAUTY_RIBBON, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_BEAUTY_RIBBON, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_CUTE_RIBBON_BATTLE:
-        SetMonData(&party[monId], MON_DATA_CUTE_RIBBON, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_CUTE_RIBBON, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_SMART_RIBBON_BATTLE:
-        SetMonData(&party[monId], MON_DATA_SMART_RIBBON, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_SMART_RIBBON, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     case REQUEST_TOUGH_RIBBON_BATTLE:
-        SetMonData(&party[monId], MON_DATA_TOUGH_RIBBON, &gBattleResources->bufferA[battler][3]);
+        SetMonData(&party[monId], MON_DATA_TOUGH_RIBBON, (void *)&gBattleResources->bufferA[battler][3]);
         break;
     }
 

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -1889,7 +1889,7 @@ u8 CreateNPCTrainerPartyFromTrainer(struct Pokemon *party, const struct Trainer 
         for (s32 i = 0; i < monsCount; i++)
         {
             u32 monIndex = monIndices[i];
-            s32 ball = -1;
+            enum PokeBall ball = POKEBALL_COUNT;
             u32 personalityHash = GeneratePartyHash(trainer, i);
             const struct TrainerMon *partyData = trainer->party;
             struct OriginalTrainerId otId = OTID_STRUCT_RANDOM_NO_SHINY;
@@ -1985,7 +1985,7 @@ u8 CreateNPCTrainerPartyFromTrainer(struct Pokemon *party, const struct Trainer 
             }
             CalculateMonStats(&party[i]);
 
-            if (B_TRAINER_CLASS_POKE_BALLS >= GEN_7 && ball == -1)
+            if (B_TRAINER_CLASS_POKE_BALLS >= GEN_7 && ball == POKEBALL_COUNT)
             {
                 ball = gTrainerClasses[trainer->trainerClass].ball ?: BALL_POKE;
                 SetMonData(&party[i], MON_DATA_POKEBALL, &ball);
@@ -5800,7 +5800,7 @@ enum Type GetDynamicMoveType(struct Pokemon *mon, enum Move move, enum BattlerId
     else
     {
         species = GetMonData(mon, MON_DATA_SPECIES);
-        heldItem = GetMonData(mon, MON_DATA_HELD_ITEM, 0);
+        heldItem = GetMonData(mon, MON_DATA_HELD_ITEM);
         holdEffect = GetItemHoldEffect(heldItem);
         ability = GetMonAbility(mon);
         types[0] = GetSpeciesType(species, 0);

--- a/src/battle_partner.c
+++ b/src/battle_partner.c
@@ -23,19 +23,21 @@ const struct Trainer gBattlePartners[DIFFICULTY_COUNT][PARTNER_COUNT] =
 
 void FillPartnerParty(u16 trainerId)
 {
-    s32 i, j, k;
+    u32 i, j, k;
     u32 firstIdPart = 0, secondIdPart = 0, thirdIdPart = 0;
     u32 ivs, level, personality;
     u16 monId;
     u32 otID;
     u8 trainerName[(PLAYER_NAME_LENGTH * 3) + 1];
     enum DifficultyLevel difficulty = GetBattlePartnerDifficultyLevel(trainerId);
+    enum Gender gender;
+
     SetFacilityPtrsGetLevel();
     ZeroPartyMons(gParties[B_TRAINER_PARTNER]);
 
     if (trainerId > TRAINER_PARTNER(PARTNER_NONE))
     {
-        s32 lastIndex = AreMultiPartiesFullTeams() ? PARTY_SIZE : MULTI_PARTY_SIZE;
+        u32 lastIndex = AreMultiPartiesFullTeams() ? PARTY_SIZE : MULTI_PARTY_SIZE;
 
         for (i = 0; i < lastIndex && i < gBattlePartners[difficulty][trainerId - TRAINER_PARTNER(PARTNER_NONE)].partySize; i++)
         {
@@ -114,8 +116,8 @@ void FillPartnerParty(u16 trainerId)
             u16 partnerId = GetPartnerIdFromTrainerId(trainerId);
             StringCopy(trainerName, gBattlePartners[difficulty][partnerId].trainerName);
             SetMonData(&gParties[B_TRAINER_PARTNER][i], MON_DATA_OT_NAME, trainerName);
-            j = gBattlePartners[difficulty][partnerId].gender;
-            SetMonData(&gParties[B_TRAINER_PARTNER][i], MON_DATA_OT_GENDER, &j);
+            gender = gBattlePartners[difficulty][partnerId].gender;
+            SetMonData(&gParties[B_TRAINER_PARTNER][i], MON_DATA_OT_GENDER, &gender);
         }
     }
     else if (trainerId == TRAINER_EREADER)
@@ -134,9 +136,9 @@ void FillPartnerParty(u16 trainerId)
             CreateFacilityMon(&gFacilityTrainerMons[monId], level, ivs, otID, 0, &gParties[B_TRAINER_PARTNER][i]);
             for (j = 0; j < PLAYER_NAME_LENGTH + 1; j++)
                 trainerName[j] = gFacilityTrainers[trainerId].trainerName[j];
-            SetMonData(&gParties[B_TRAINER_PARTNER][i], MON_DATA_OT_NAME, &trainerName);
-            j = IsFrontierTrainerFemale(trainerId);
-            SetMonData(&gParties[B_TRAINER_PARTNER][i], MON_DATA_OT_GENDER, &j);
+            SetMonData(&gParties[B_TRAINER_PARTNER][i], MON_DATA_OT_NAME, trainerName);
+            gender = IsFrontierTrainerFemale(trainerId) ? FEMALE : MALE;
+            SetMonData(&gParties[B_TRAINER_PARTNER][i], MON_DATA_OT_GENDER, &gender);
         }
     }
     else if (trainerId < TRAINER_RECORD_MIXING_APPRENTICE)
@@ -162,8 +164,8 @@ void FillPartnerParty(u16 trainerId)
             }
             CreateBattleTowerMon_HandleLevel(&gParties[B_TRAINER_PARTNER][i], &monData, TRUE);
             SetMonData(&gParties[B_TRAINER_PARTNER][i], MON_DATA_OT_NAME, trainerName);
-            j = IsFrontierTrainerFemale(trainerId + TRAINER_RECORD_MIXING_FRIEND);
-            SetMonData(&gParties[B_TRAINER_PARTNER][i], MON_DATA_OT_GENDER, &j);
+            gender = IsFrontierTrainerFemale(trainerId + TRAINER_RECORD_MIXING_FRIEND) ? FEMALE : MALE;
+            SetMonData(&gParties[B_TRAINER_PARTNER][i], MON_DATA_OT_GENDER, &gender);
         }
     }
     else
@@ -172,8 +174,8 @@ void FillPartnerParty(u16 trainerId)
         for (i = 0; i < FRONTIER_MULTI_PARTY_SIZE; i++)
         {
             CreateApprenticeMon(&gParties[B_TRAINER_PARTNER][i], &gSaveBlock2Ptr->apprentices[trainerId], gSaveBlock2Ptr->frontier.trainerIds[18 + i]);
-            j = IsFrontierTrainerFemale(trainerId + TRAINER_RECORD_MIXING_APPRENTICE);
-            SetMonData(&gParties[B_TRAINER_PARTNER][i], MON_DATA_OT_GENDER, &j);
+            gender = IsFrontierTrainerFemale(trainerId + TRAINER_RECORD_MIXING_APPRENTICE) ? FEMALE : MALE;
+            SetMonData(&gParties[B_TRAINER_PARTNER][i], MON_DATA_OT_GENDER, &gender);
         }
     }
 }

--- a/src/battle_pike.c
+++ b/src/battle_pike.c
@@ -782,31 +782,22 @@ static void StatusInflictionScreenFlash(void)
 static void HealMon(struct Pokemon *mon)
 {
     u8 i;
-    u16 hp;
     u8 ppBonuses;
-    u8 data[4];
+    u32 data;
 
-    for (i = 0; i < 4; i++)
-        data[i] = 0;
-
-    hp = GetMonData(mon, MON_DATA_MAX_HP);
-    data[0] = hp;
-    data[1] = hp >> 8;
-    SetMonData(mon, MON_DATA_HP, data);
+    data = GetMonData(mon, MON_DATA_MAX_HP);
+    SetMonData(mon, MON_DATA_HP, &data);
 
     ppBonuses = GetMonData(mon, MON_DATA_PP_BONUSES);
     for (i = 0; i < MAX_MON_MOVES; i++)
     {
         enum Move move = GetMonData(mon, MON_DATA_MOVE1 + i);
-        data[0] = CalculatePPWithBonus(move, ppBonuses, i);
-        SetMonData(mon, MON_DATA_PP1 + i, data);
+        data = CalculatePPWithBonus(move, ppBonuses, i);
+        SetMonData(mon, MON_DATA_PP1 + i, &data);
     }
 
-    data[0] = 0;
-    data[1] = 0;
-    data[2] = 0;
-    data[3] = 0;
-    SetMonData(mon, MON_DATA_STATUS, data);
+    data = 0;
+    SetMonData(mon, MON_DATA_STATUS, &data);
 }
 
 static bool8 DoesAbilityPreventStatus(struct Pokemon *mon, u32 status)

--- a/src/battle_pyramid.c
+++ b/src/battle_pyramid.c
@@ -1571,7 +1571,7 @@ void GenerateBattlePyramidWildMon(enum Species forceSpecies)
 void GenerateBattlePyramidWildMon(enum Species forceSpecies)
 {
     u8 name[POKEMON_NAME_LENGTH + 1];
-    int i;
+    u32 i;
     const struct PyramidWildMon *wildMons;
     u32 id;
     enum FrontierLevelMode lvl = gSaveBlock2Ptr->frontier.lvlMode;
@@ -1588,7 +1588,7 @@ void GenerateBattlePyramidWildMon(enum Species forceSpecies)
     id = GetMonData(&gParties[B_TRAINER_OPPONENT_A][0], MON_DATA_SPECIES) - 1;
     SetMonData(&gParties[B_TRAINER_OPPONENT_A][0], MON_DATA_SPECIES, &wildMons[id].species);
     StringCopy(name, GetSpeciesName(wildMons[id].species));
-    SetMonData(&gParties[B_TRAINER_OPPONENT_A][0], MON_DATA_NICKNAME, &name);
+    SetMonData(&gParties[B_TRAINER_OPPONENT_A][0], MON_DATA_NICKNAME, name);
     if (lvl != FRONTIER_LVL_50)
     {
         lvl = SetFacilityPtrsGetLevel();

--- a/src/braille_puzzles.c
+++ b/src/braille_puzzles.c
@@ -93,11 +93,11 @@ bool8 CheckRelicanthWailord(void)
 {
     // Emerald change: why did they flip it?
     // First comes Wailord
-    if (GetMonData(&gParties[B_TRAINER_PLAYER][0], MON_DATA_SPECIES_OR_EGG, 0) == SPECIES_WAILORD)
+    if (GetMonData(&gParties[B_TRAINER_PLAYER][0], MON_DATA_SPECIES_OR_EGG) == SPECIES_WAILORD)
     {
         CalculatePlayerPartyCount();
         // Last comes Relicanth
-        if (GetMonData(&gParties[B_TRAINER_PLAYER][gPartiesCount[B_TRAINER_PLAYER] - 1], MON_DATA_SPECIES_OR_EGG, 0) == SPECIES_RELICANTH)
+        if (GetMonData(&gParties[B_TRAINER_PLAYER][gPartiesCount[B_TRAINER_PLAYER] - 1], MON_DATA_SPECIES_OR_EGG) == SPECIES_RELICANTH)
             return TRUE;
     }
     return FALSE;

--- a/src/daycare.c
+++ b/src/daycare.c
@@ -1135,7 +1135,7 @@ static void SetInitialEggData(struct Pokemon *mon, enum Species species, struct 
     u32 personality;
     enum PokeBall ball;
     u8 metLevel;
-    u8 language;
+    enum Language language;
 
     personality = daycare->offspringPersonality;
     CreateMonWithIVs(mon, species, EGG_HATCH_LEVEL, personality, OTID_STRUCT_PLAYER_ID, USE_RANDOM_IVS);

--- a/src/debug.c
+++ b/src/debug.c
@@ -3750,7 +3750,7 @@ static void DebugAction_PCBag_Fill_PCBoxes_Fast(u8 taskId) //Credit: Sierraffini
             if (!GetBoxMonData(&gPokemonStoragePtr->boxes[boxId][boxPosition], MON_DATA_SANITY_HAS_SPECIES))
             {
                 StringCopy(speciesName, GetSpeciesName(species));
-                SetBoxMonData(&boxMon, MON_DATA_NICKNAME, &speciesName);
+                SetBoxMonData(&boxMon, MON_DATA_NICKNAME, speciesName);
                 SetBoxMonData(&boxMon, MON_DATA_SPECIES, &species);
                 GiveBoxMonInitialMoveset(&boxMon);
                 gPokemonStoragePtr->boxes[boxId][boxPosition] = boxMon;
@@ -4753,7 +4753,7 @@ static void DebugNativeStep_Party_SetFriendshipSelect(u8 taskId)
     {
         PlaySE(SE_SELECT);
         gTasks[taskId].tFriendship = gTasks[taskId].tInput;
-        SetMonData(&gParties[B_TRAINER_PLAYER][gTasks[taskId].tPartyId], MON_DATA_FRIENDSHIP, &gTasks[taskId].tInput);
+        SetMonData(&gParties[B_TRAINER_PLAYER][gTasks[taskId].tPartyId], MON_DATA_FRIENDSHIP, (void *)&gTasks[taskId].tInput);
     }
     else if (JOY_NEW(B_BUTTON))
     {
@@ -4817,7 +4817,7 @@ static void DebugNativeStep_Party_SetPokerusDaysLeftSelect(u8 taskId)
     if (JOY_NEW(A_BUTTON))
     {
         PlaySE(SE_SELECT);
-        SetMonData(&gParties[B_TRAINER_PLAYER][gTasks[taskId].tPartyId], MON_DATA_POKERUS_DAYS_LEFT, &gTasks[taskId].tInput);
+        SetMonData(&gParties[B_TRAINER_PLAYER][gTasks[taskId].tPartyId], MON_DATA_POKERUS_DAYS_LEFT, (void *)&gTasks[taskId].tInput);
         DebugNativeStep_CloseDebugWindow(taskId);
         return;
     }
@@ -4848,7 +4848,7 @@ static void DebugNativeStep_Party_SetPokerusStrainSelect(u8 taskId)
     {
         PlaySE(SE_SELECT);
         gTasks[taskId].tStrain = gTasks[taskId].tInput;
-        SetMonData(&gParties[B_TRAINER_PLAYER][gTasks[taskId].tPartyId], MON_DATA_POKERUS_STRAIN, &gTasks[taskId].tInput);
+        SetMonData(&gParties[B_TRAINER_PLAYER][gTasks[taskId].tPartyId], MON_DATA_POKERUS_STRAIN, (void *)&gTasks[taskId].tInput);
         gTasks[taskId].tInput = GetMonData(&gParties[B_TRAINER_PLAYER][gTasks[taskId].tPartyId], MON_DATA_POKERUS_DAYS_LEFT);
         Debug_Display_PokerusDaysLeftInfo(gTasks[taskId].tInput, gTasks[taskId].tStrain, gTasks[taskId].tDigit, gTasks[taskId].tSubWindowId);
         gTasks[taskId].func = DebugNativeStep_Party_SetPokerusDaysLeftSelect;

--- a/src/egg_hatch.c
+++ b/src/egg_hatch.c
@@ -310,7 +310,10 @@ static void CreateHatchedMon(struct Pokemon *egg, struct Pokemon *temp)
     enum Species species;
     u32 personality, pokerus;
     enum PokeBall ball;
-    u8 i, friendship, language, gameMet, markings, isModernFatefulEncounter;
+    u8 i, friendship, markings;
+    bool32 isModernFatefulEncounter;
+    enum GameVersion gameMet;
+    enum Language language;
     bool32 isShiny;
     enum Move moves[MAX_MON_MOVES];
     u32 ivs[NUM_STATS];
@@ -723,7 +726,7 @@ static void CB2_EggHatch(void)
             GetMonNickname(&gParties[B_TRAINER_PLAYER][sEggHatchData->eggPartyId], gStringVar3);
             species = GetMonData(&gParties[B_TRAINER_PLAYER][sEggHatchData->eggPartyId], MON_DATA_SPECIES);
             gender = GetMonGender(&gParties[B_TRAINER_PLAYER][sEggHatchData->eggPartyId]);
-            personality = GetMonData(&gParties[B_TRAINER_PLAYER][sEggHatchData->eggPartyId], MON_DATA_PERSONALITY, 0);
+            personality = GetMonData(&gParties[B_TRAINER_PLAYER][sEggHatchData->eggPartyId], MON_DATA_PERSONALITY);
             DoNamingScreen(NAMING_SCREEN_NICKNAME, gStringVar3, species, gender, personality, EggHatchSetMonNickname);
             break;
         case 1: // No

--- a/src/evolution_scene.c
+++ b/src/evolution_scene.c
@@ -1211,7 +1211,7 @@ static void Task_TradeEvolutionScene(u8 taskId)
             DrawTextOnTradeWindow(0, gStringVar4, 1);
             PlayFanfare(MUS_EVOLVED);
             gTasks[taskId].tState++;
-            SetMonData(mon, MON_DATA_SPECIES, (&gTasks[taskId].tPostEvoSpecies));
+            SetMonData(mon, MON_DATA_SPECIES, (void *)&gTasks[taskId].tPostEvoSpecies);
             SetMonData(mon, MON_DATA_EVOLUTION_TRACKER, &zero);
             CalculateMonStats(mon);
             EvolutionRenameMon(mon, gTasks[taskId].tPreEvoSpecies, gTasks[taskId].tPostEvoSpecies);

--- a/src/field_specials.c
+++ b/src/field_specials.c
@@ -1640,7 +1640,7 @@ u8 GetLeadMonIndex(void)
 
 enum Species ScriptGetPartyMonSpecies(void)
 {
-    return GetMonData(&gParties[B_TRAINER_PLAYER][gSpecialVar_0x8004], MON_DATA_SPECIES_OR_EGG, NULL);
+    return GetMonData(&gParties[B_TRAINER_PLAYER][gSpecialVar_0x8004], MON_DATA_SPECIES_OR_EGG);
 }
 
 enum Species ScriptGetSelectedMonSpecies(void)
@@ -3496,7 +3496,7 @@ bool8 IsDestinationBoxFull(void)
     {
         for (i = 0; i < IN_BOX_COUNT; i++)
         {
-            if (GetBoxMonData(GetBoxedMonPtr(box, i), MON_DATA_SPECIES, 0) == SPECIES_NONE)
+            if (GetBoxMonData(GetBoxedMonPtr(box, i), MON_DATA_SPECIES) == SPECIES_NONE)
             {
                 if (GetPCBoxToSendMon() != box)
                     FlagClear(FLAG_SHOWN_BOX_WAS_FULL_MESSAGE);
@@ -4944,7 +4944,7 @@ bool8 DoesPlayerPartyContainSpecies(void)
     u8 i;
     for (i = 0; i < partyCount; i++)
     {
-        if (GetMonData(&gParties[B_TRAINER_PLAYER][i], MON_DATA_SPECIES_OR_EGG, NULL) == gSpecialVar_0x8004)
+        if (GetMonData(&gParties[B_TRAINER_PLAYER][i], MON_DATA_SPECIES_OR_EGG) == gSpecialVar_0x8004)
             return TRUE;
     }
     return FALSE;
@@ -5639,8 +5639,8 @@ bool8 PlayerPartyContainsSpeciesWithPlayerID(void)
     u8 i;
     for (i = 0; i < playerCount; i++)
     {
-        if (GetMonData(&gParties[B_TRAINER_PLAYER][i], MON_DATA_SPECIES_OR_EGG, NULL) == gSpecialVar_0x8004
-            && GetPlayerIDAsU32() == GetMonData(&gParties[B_TRAINER_PLAYER][i], MON_DATA_OT_ID, NULL))
+        if (GetMonData(&gParties[B_TRAINER_PLAYER][i], MON_DATA_SPECIES_OR_EGG) == gSpecialVar_0x8004
+            && GetPlayerIDAsU32() == GetMonData(&gParties[B_TRAINER_PLAYER][i], MON_DATA_OT_ID))
             return TRUE;
     }
     return FALSE;
@@ -5740,8 +5740,8 @@ void UpdateTrainerCardPhotoIcons(void)
     partyCount = CalculatePlayerPartyCount();
     for (i = 0; i < partyCount; i++)
     {
-        species[i] = GetMonData(&gParties[B_TRAINER_PLAYER][i], MON_DATA_SPECIES_OR_EGG, NULL);
-        personality[i] = GetMonData(&gParties[B_TRAINER_PLAYER][i], MON_DATA_PERSONALITY, NULL);
+        species[i] = GetMonData(&gParties[B_TRAINER_PLAYER][i], MON_DATA_SPECIES_OR_EGG);
+        personality[i] = GetMonData(&gParties[B_TRAINER_PLAYER][i], MON_DATA_PERSONALITY);
     }
     VarSet(VAR_TRAINER_CARD_MON_ICON_1, SpeciesToMailSpecies(species[0], personality[0]));
     VarSet(VAR_TRAINER_CARD_MON_ICON_2, SpeciesToMailSpecies(species[1], personality[1]));

--- a/src/mail_data.c
+++ b/src/mail_data.c
@@ -44,13 +44,9 @@ bool8 MonHasMail(struct Pokemon *mon)
 
 u8 GiveMailToMonByItemId(struct Pokemon *mon, enum Item itemId)
 {
-    u8 heldItem[2];
     u8 id, i;
     enum Species species;
     u32 personality;
-
-    heldItem[0] = itemId;
-    heldItem[1] = itemId >> 8;
 
     for (id = 0; id < PARTY_SIZE; id++)
     {
@@ -72,7 +68,7 @@ u8 GiveMailToMonByItemId(struct Pokemon *mon, enum Item itemId)
             gSaveBlock1Ptr->mail[id].species = SpeciesToMailSpecies(species, personality);
             gSaveBlock1Ptr->mail[id].itemId = itemId;
             SetMonData(mon, MON_DATA_MAIL, &id);
-            SetMonData(mon, MON_DATA_HELD_ITEM, heldItem);
+            SetMonData(mon, MON_DATA_HELD_ITEM, &itemId);
             return id;
         }
     }
@@ -127,18 +123,16 @@ static bool32 UNUSED DummyMailFunc(void)
 
 void TakeMailFromMon(struct Pokemon *mon)
 {
-    u8 heldItem[2];
     u8 mailId;
+    enum Item heldItem = ITEM_NONE;
 
     if (MonHasMail(mon))
     {
         mailId = GetMonData(mon, MON_DATA_MAIL);
         gSaveBlock1Ptr->mail[mailId].itemId = ITEM_NONE;
         mailId = MAIL_NONE;
-        heldItem[0] = ITEM_NONE;
-        heldItem[1] = ITEM_NONE << 8;
         SetMonData(mon, MON_DATA_MAIL, &mailId);
-        SetMonData(mon, MON_DATA_HELD_ITEM, heldItem);
+        SetMonData(mon, MON_DATA_HELD_ITEM, &heldItem);
     }
 }
 
@@ -163,7 +157,7 @@ u8 SaveMailToPC(struct Mail *mail)
 
 u8 TakeMailFromMonAndSave(struct Pokemon *mon)
 {
-    u32 heldItem;
+    enum Item heldItem;
     u32 mailId, newMailId;
 
     mailId = GetMonData(mon, MON_DATA_MAIL);

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -2106,16 +2106,12 @@ static void DisplaySwitchedHeldItemMessage(enum Item item, enum Item item2, bool
 
 static void GiveItemToMon(struct Pokemon *mon, enum Item item)
 {
-    u8 itemBytes[2];
-
     if (ItemIsMail(item) == TRUE)
     {
         if (GiveMailToMonByItemId(mon, item) == MAIL_NONE)
             return;
     }
-    itemBytes[0] = item;
-    itemBytes[1] = item >> 8;
-    SetMonData(mon, MON_DATA_HELD_ITEM, itemBytes);
+    SetMonData(mon, MON_DATA_HELD_ITEM, &item);
     TryItemHoldFormChange(&gParties[B_TRAINER_PLAYER][gPartyMenu.slotId], gPartyMenu.slotId, B_TRAINER_PLAYER);
 }
 
@@ -2164,7 +2160,7 @@ static void Task_PartyMenuModifyHP(u8 taskId)
     s8 partySlot = 0;
     GetPartyAndSlotFromPartyMenuId(tPartyId, &party, &partySlot);
 
-    SetMonData(&party[partySlot], MON_DATA_HP, &tHP);
+    SetMonData(&party[partySlot], MON_DATA_HP, (u16 *)&tHP);
     DisplayPartyPokemonHPCheck(&party[partySlot], &sPartyMenuBoxes[partySlot], 1);
     DisplayPartyPokemonHPBarCheck(&party[partySlot], &sPartyMenuBoxes[partySlot]);
     if (tHPToAdd == 0 || tHP == 0 || tHP == tMaxHP)
@@ -5024,7 +5020,7 @@ void Task_AbilityCapsule(u8 taskId)
             tState++;
         break;
     case 5:
-        SetMonData(&gParties[B_TRAINER_PLAYER][tMonId], MON_DATA_ABILITY_NUM, &tAbilityNum);
+        SetMonData(&gParties[B_TRAINER_PLAYER][tMonId], MON_DATA_ABILITY_NUM, (u16 *)&tAbilityNum);
         RemoveBagItem(gSpecialVar_ItemId, 1);
         gTasks[taskId].func = Task_ClosePartyMenu;
         break;
@@ -5109,7 +5105,7 @@ void Task_AbilityPatch(u8 taskId)
             tState++;
         break;
     case 5:
-        SetMonData(&gParties[B_TRAINER_PLAYER][tMonId], MON_DATA_ABILITY_NUM, &tAbilityNum);
+        SetMonData(&gParties[B_TRAINER_PLAYER][tMonId], MON_DATA_ABILITY_NUM, (u16 *)&tAbilityNum);
         RemoveBagItem(gSpecialVar_ItemId, 1);
         gTasks[taskId].func = Task_ClosePartyMenu;
         break;
@@ -5209,7 +5205,7 @@ void Task_Mint(u8 taskId)
             tState++;
         break;
     case 5:
-        SetMonData(&gParties[B_TRAINER_PLAYER][tMonId], MON_DATA_HIDDEN_NATURE, &tNewNature);
+        SetMonData(&gParties[B_TRAINER_PLAYER][tMonId], MON_DATA_HIDDEN_NATURE, (u16 *)&tNewNature);
         CalculateMonStats(&gParties[B_TRAINER_PLAYER][tMonId]);
         RemoveBagItem(gSpecialVar_ItemId, 1);
         gTasks[taskId].func = Task_ClosePartyMenu;
@@ -6133,7 +6129,7 @@ void Task_DynamaxCandy(u8 taskId)
         break;
     case 3:
         tDynamaxLevel++;
-        SetMonData(&gParties[B_TRAINER_PLAYER][tMonId], MON_DATA_DYNAMAX_LEVEL, &tDynamaxLevel);
+        SetMonData(&gParties[B_TRAINER_PLAYER][tMonId], MON_DATA_DYNAMAX_LEVEL, (u16 *)&tDynamaxLevel);
         RemoveBagItem(gSpecialVar_ItemId, 1);
         gTasks[taskId].func = Task_ClosePartyMenu;
         break;

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -1006,8 +1006,8 @@ void CreateBoxMon(struct BoxPokemon *boxMon, enum Species species, u8 level, u32
     SetBoxMonData(boxMon, MON_DATA_MET_LOCATION, &value);
     SetBoxMonData(boxMon, MON_DATA_MET_LEVEL, &level);
     SetBoxMonData(boxMon, MON_DATA_MET_GAME, &gGameVersion);
-    value = BALL_POKE;
-    SetBoxMonData(boxMon, MON_DATA_POKEBALL, &value);
+    enum PokeBall ball = BALL_POKE;
+    SetBoxMonData(boxMon, MON_DATA_POKEBALL, &ball);
     SetBoxMonData(boxMon, MON_DATA_OT_GENDER, &gSaveBlock2Ptr->playerGender);
 
     value = boxMon->personality & 0x1;
@@ -1213,7 +1213,7 @@ void CreateApprenticeMon(struct Pokemon *mon, const struct Apprentice *src, u8 m
 {
     s32 i;
     u16 evAmount;
-    u8 language;
+    enum Language language;
     u32 otId = gApprentices[src->id].otId;
     u32 personality = ((gApprentices[src->id].otId >> 8) | ((gApprentices[src->id].otId & 0xFF) << 8))
                     + src->party[monId].species + src->number;
@@ -1241,7 +1241,7 @@ void CreateApprenticeMon(struct Pokemon *mon, const struct Apprentice *src, u8 m
 void ConvertPokemonToBattleTowerPokemon(struct Pokemon *mon, struct BattleTowerPokemon *dest)
 {
     s32 i;
-    u16 heldItem;
+    enum Item heldItem;
 
     dest->species = GetMonData(mon, MON_DATA_SPECIES);
     heldItem = GetMonData(mon, MON_DATA_HELD_ITEM);
@@ -1317,20 +1317,14 @@ enum TrainerClassID GetUnionRoomTrainerClass(void)
 
 void CreateEnemyEventMon(void)
 {
-    s32 species = gSpecialVar_0x8004;
+    enum Species species = gSpecialVar_0x8004;
     s32 level = gSpecialVar_0x8005;
-    s32 itemId = gSpecialVar_0x8006;
+    enum Item itemId = gSpecialVar_0x8006;
 
     ZeroEnemyPartyMons();
 
     CreateEventMon(&gParties[B_TRAINER_OPPONENT_A][0], species, level, Random32(), OTID_STRUCT_PLAYER_ID);
-    if (itemId)
-    {
-        u8 heldItem[2];
-        heldItem[0] = itemId;
-        heldItem[1] = itemId >> 8;
-        SetMonData(&gParties[B_TRAINER_OPPONENT_A][0], MON_DATA_HELD_ITEM, heldItem);
-    }
+    SetMonData(&gParties[B_TRAINER_OPPONENT_A][0], MON_DATA_HELD_ITEM, &itemId);
 }
 
 static u16 CalculateBoxMonChecksum(struct BoxPokemon *boxMon)
@@ -1372,11 +1366,11 @@ static u16 CalculateBoxMonChecksumReencrypt(struct BoxPokemon *boxMon)
 void CalculateMonStats(struct Pokemon *mon)
 {
     s32 oldMaxHP = GetMonData(mon, MON_DATA_MAX_HP);
-    s32 currentHP = GetMonData(mon, MON_DATA_HP);
+    u32 currentHP = GetMonData(mon, MON_DATA_HP);
     enum Species species = GetMonData(mon, MON_DATA_SPECIES);
     u8 friendship = GetMonData(mon, MON_DATA_FRIENDSHIP);
-    s32 level = GetLevelFromMonExp(mon);
-    s32 newMaxHP;
+    u32 level = GetLevelFromMonExp(mon);
+    u32 newMaxHP;
 
     u8 nature = GetMonData(mon, MON_DATA_HIDDEN_NATURE);
 
@@ -1968,8 +1962,9 @@ static union PokemonSubstruct *GetSubstruct(struct BoxPokemon *boxMon, u32 perso
  * safety we have a GetMonData macro (in include/pokemon.h) which
  * dispatches to either GetMonData2 or GetMonData3 based on the number
  * of arguments. */
-u32 GetMonData3(struct Pokemon *mon, s32 field, u8 *data)
+u32 GetMonData3(struct Pokemon *mon, enum MonData field, void *dataArg)
 {
+    u8 *data = dataArg;
     u32 ret;
 
     switch (field)
@@ -2005,13 +2000,13 @@ u32 GetMonData3(struct Pokemon *mon, s32 field, u8 *data)
         ret = mon->mail;
         break;
     default:
-        ret = GetBoxMonData(&mon->box, field, data);
+        ret = GetBoxMonData3(&mon->box, field, data);
         break;
     }
     return ret;
 }
 
-u32 GetMonData2(struct Pokemon *mon, s32 field)
+u32 GetMonData2(struct Pokemon *mon, enum MonData field)
 {
     return GetMonData3(mon, field, NULL);
 }
@@ -2072,8 +2067,9 @@ static ALWAYS_INLINE bool32 IsEggOrBadEgg(struct BoxPokemon *boxMon)
  * safety we have a GetBoxMonData macro (in include/pokemon.h) which
  * dispatches to either GetBoxMonData2 or GetBoxMonData3 based on the
  * number of arguments. */
-u32 GetBoxMonData3(struct BoxPokemon *boxMon, s32 field, u8 *data)
+u32 GetBoxMonData3(struct BoxPokemon *boxMon, enum MonData field, void *dataArg)
 {
+    u8 *data = dataArg;
     s32 i;
     u32 retVal = 0;
 
@@ -2546,7 +2542,7 @@ u32 GetBoxMonData3(struct BoxPokemon *boxMon, s32 field, u8 *data)
     return retVal;
 }
 
-u32 GetBoxMonData2(struct BoxPokemon *boxMon, s32 field)
+u32 GetBoxMonData2(struct BoxPokemon *boxMon, enum MonData field)
 {
     return GetBoxMonData3(boxMon, field, NULL);
 }
@@ -2568,7 +2564,7 @@ u32 GetBoxMonData2(struct BoxPokemon *boxMon, s32 field)
           SET32(lhs); \
    } while (0)
 
-void SetMonData(struct Pokemon *mon, s32 field, const void *dataArg)
+void SetMonDataPtr(struct Pokemon *mon, enum MonData field, const void *dataArg)
 {
     const u8 *data = dataArg;
 
@@ -2621,12 +2617,12 @@ void SetMonData(struct Pokemon *mon, s32 field, const void *dataArg)
     case MON_DATA_SPECIES_OR_EGG:
         break;
     default:
-        SetBoxMonData(&mon->box, field, data);
+        SetBoxMonDataPtr(&mon->box, field, data);
         break;
     }
 }
 
-void SetBoxMonData(struct BoxPokemon *boxMon, s32 field, const void *dataArg)
+void SetBoxMonDataPtr(struct BoxPokemon *boxMon, enum MonData field, const void *dataArg)
 {
     const u8 *data = dataArg;
 
@@ -2969,6 +2965,8 @@ void SetBoxMonData(struct BoxPokemon *boxMon, s32 field, const void *dataArg)
         case MON_DATA_DAYS_SINCE_FORM_CHANGE:
             SET8(boxMon->daysSinceFormChange);
             break;
+        default:
+            break;
         }
     }
 
@@ -2984,10 +2982,12 @@ void CopyMon(void *dest, void *src, size_t size)
 u8 GiveCapturedMonToPlayer(struct Pokemon *mon)
 {
     s32 i;
+    u32 trainerId;
 
     SetMonData(mon, MON_DATA_OT_NAME, gSaveBlock2Ptr->playerName);
     SetMonData(mon, MON_DATA_OT_GENDER, &gSaveBlock2Ptr->playerGender);
-    SetMonData(mon, MON_DATA_OT_ID, gSaveBlock2Ptr->playerTrainerId);
+    memcpy(&trainerId, gSaveBlock2Ptr->playerTrainerId, sizeof(trainerId));
+    SetMonData(mon, MON_DATA_OT_ID, &trainerId);
 
     for (i = 0; i < PARTY_SIZE; i++)
     {
@@ -3469,7 +3469,8 @@ bool8 ExecuteTableBasedItemEffect(struct Pokemon *mon, enum Item item, u8 partyI
             friendship = 0;                                                                             \
         if (friendship > MAX_FRIENDSHIP)                                                                \
             friendship = MAX_FRIENDSHIP;                                                                \
-        SetMonData(mon, MON_DATA_FRIENDSHIP, &friendship);                                              \
+        dataUnsigned = friendship;                                                                      \
+        SetMonData(mon, MON_DATA_FRIENDSHIP, &dataUnsigned);                                            \
         retVal = FALSE;                                                                                 \
     }                                                                                                   \
 }
@@ -3527,7 +3528,7 @@ bool8 PokemonUseItemEffects(struct Pokemon *mon, enum Item item, u8 partyIndex, 
     // Get item effect
     itemEffect = GetItemEffect(item);
     isLevelUpItem = (itemEffect[3] & ITEM3_LEVEL_UP) != 0;
-    levelBefore = GetMonData(mon, MON_DATA_LEVEL, NULL);
+    levelBefore = GetMonData(mon, MON_DATA_LEVEL);
 
     // Do item effect
     for (i = 0; i < ITEM_EFFECT_ARG_START; i++)
@@ -3582,7 +3583,7 @@ bool8 PokemonUseItemEffects(struct Pokemon *mon, enum Item item, u8 partyIndex, 
                 {
                     SetMonData(mon, MON_DATA_EXP, &dataUnsigned);
                     CalculateMonStats(mon);
-                    if (GetMonData(mon, MON_DATA_LEVEL, NULL) > levelBefore)
+                    if (GetMonData(mon, MON_DATA_LEVEL) > levelBefore)
                         didLevelUp = TRUE;
                     retVal = FALSE;
                 }
@@ -3947,7 +3948,7 @@ bool8 PokemonUseItemEffects(struct Pokemon *mon, enum Item item, u8 partyIndex, 
 
 bool8 HealStatusConditions(struct Pokemon *mon, u32 healMask, enum BattlerId battler)
 {
-    u32 status = GetMonData(mon, MON_DATA_STATUS, 0);
+    u32 status = GetMonData(mon, MON_DATA_STATUS);
 
     PREPARE_MON_NICK_BUFFER(gBattleTextBuff1, battler, gBattlerPartyIndexes[battler]);
 
@@ -4184,7 +4185,7 @@ u8 *UseStatIncreaseItem(enum Item itemId)
 
 u8 GetNature(struct Pokemon *mon)
 {
-    return GetMonData(mon, MON_DATA_PERSONALITY, 0) % NUM_NATURES;
+    return GetMonData(mon, MON_DATA_PERSONALITY) % NUM_NATURES;
 }
 
 u8 GetNatureFromPersonality(u32 personality)
@@ -4209,25 +4210,25 @@ bool32 DoesMonMeetAdditionalConditions(struct Pokemon *mon, const struct Evoluti
     u32 i, j;
     enum Item heldItem = GetMonData(mon, MON_DATA_HELD_ITEM);
     u32 gender = GetMonGender(mon);
-    u32 friendship = GetMonData(mon, MON_DATA_FRIENDSHIP, 0);
-    u32 attack = GetMonData(mon, MON_DATA_ATK, 0);
-    u32 defense = GetMonData(mon, MON_DATA_DEF, 0);
-    u32 personality = GetMonData(mon, MON_DATA_PERSONALITY, 0);
+    u32 friendship = GetMonData(mon, MON_DATA_FRIENDSHIP);
+    u32 attack = GetMonData(mon, MON_DATA_ATK);
+    u32 defense = GetMonData(mon, MON_DATA_DEF);
+    u32 personality = GetMonData(mon, MON_DATA_PERSONALITY);
     u16 upperPersonality = personality >> 16;
     u32 weather = GetCurrentWeather();
     u32 nature = GetNature(mon);
     bool32 removeHoldItem = FALSE;
     enum Item removeBagItem = ITEM_NONE;
     u32 removeBagItemCount = 0;
-    u32 evolutionTracker = GetMonData(mon, MON_DATA_EVOLUTION_TRACKER, 0);
+    u32 evolutionTracker = GetMonData(mon, MON_DATA_EVOLUTION_TRACKER);
     enum Species partnerSpecies;
     enum Item partnerHeldItem;
     enum HoldEffect partnerHoldEffect;
 
     if (tradePartner != NULL)
     {
-        partnerSpecies = GetMonData(tradePartner, MON_DATA_SPECIES, 0);
-        partnerHeldItem = GetMonData(tradePartner, MON_DATA_HELD_ITEM, 0);
+        partnerSpecies = GetMonData(tradePartner, MON_DATA_SPECIES);
+        partnerHeldItem = GetMonData(tradePartner, MON_DATA_HELD_ITEM);
 
         if (partnerHeldItem == ITEM_ENIGMA_BERRY_E_READER)
         #if FREE_ENIGMA_BERRY == FALSE
@@ -4305,14 +4306,14 @@ bool32 DoesMonMeetAdditionalConditions(struct Pokemon *mon, const struct Evoluti
             break;
         case IF_MIN_BEAUTY:
         {
-            u32 beauty = GetMonData(mon, MON_DATA_BEAUTY, 0);
+            u32 beauty = GetMonData(mon, MON_DATA_BEAUTY);
             if (beauty >= params[i].arg1)
                 currentCondition = TRUE;
             break;
         }
         case IF_MIN_COOLNESS:
         {
-            u32 coolness = GetMonData(mon, MON_DATA_COOL, 0);
+            u32 coolness = GetMonData(mon, MON_DATA_COOL);
             if (coolness >= params[i].arg1)
                 currentCondition = TRUE;
             break;
@@ -4321,21 +4322,21 @@ bool32 DoesMonMeetAdditionalConditions(struct Pokemon *mon, const struct Evoluti
         // remember that even though it's called "Smart/Smartness" here,
         // from gen 6 and up it's known as "Clever/Cleverness."
         {
-            u32 smartness = GetMonData(mon, MON_DATA_SMART, 0);
+            u32 smartness = GetMonData(mon, MON_DATA_SMART);
             if (smartness >= params[i].arg1)
                 currentCondition = TRUE;
             break;
         }
         case IF_MIN_TOUGHNESS:
         {
-            u32 toughness = GetMonData(mon, MON_DATA_TOUGH, 0);
+            u32 toughness = GetMonData(mon, MON_DATA_TOUGH);
             if (toughness >= params[i].arg1)
                 currentCondition = TRUE;
             break;
         }
         case IF_MIN_CUTENESS:
         {
-            u32 cuteness = GetMonData(mon, MON_DATA_CUTE, 0);
+            u32 cuteness = GetMonData(mon, MON_DATA_CUTE);
             if (cuteness >= params[i].arg1)
                 currentCondition = TRUE;
             break;
@@ -4537,9 +4538,9 @@ enum Species GetEvolutionTargetSpecies(struct Pokemon *mon, enum EvolutionMode m
 {
     int i;
     enum Species targetSpecies = SPECIES_NONE;
-    enum Species species = GetMonData(mon, MON_DATA_SPECIES, 0);
-    enum Item heldItem = GetMonData(mon, MON_DATA_HELD_ITEM, 0);
-    u32 level = GetMonData(mon, MON_DATA_LEVEL, 0);
+    enum Species species = GetMonData(mon, MON_DATA_SPECIES);
+    enum Item heldItem = GetMonData(mon, MON_DATA_HELD_ITEM);
+    u32 level = GetMonData(mon, MON_DATA_LEVEL);
     enum HoldEffect holdEffect;
     const struct Evolution *evolutions = GetSpeciesEvolutions(species);
 
@@ -4734,8 +4735,8 @@ enum Species GetEvolutionTargetSpecies(struct Pokemon *mon, enum EvolutionMode m
 bool8 IsMonPastEvolutionLevel(struct Pokemon *mon)
 {
     int i;
-    enum Species species = GetMonData(mon, MON_DATA_SPECIES, 0);
-    u8 level = GetMonData(mon, MON_DATA_LEVEL, 0);
+    enum Species species = GetMonData(mon, MON_DATA_SPECIES);
+    u8 level = GetMonData(mon, MON_DATA_LEVEL);
     const struct Evolution *evolutions = GetSpeciesEvolutions(species);
 
     if (evolutions == NULL)
@@ -4876,7 +4877,7 @@ void EvolutionRenameMon(struct Pokemon *mon, enum Species oldSpecies, enum Speci
 {
     u8 language;
     GetMonData(mon, MON_DATA_NICKNAME, gStringVar1);
-    language = GetMonData(mon, MON_DATA_LANGUAGE, &language);
+    language = GetMonData(mon, MON_DATA_LANGUAGE);
     if (language == GAME_LANGUAGE && !StringCompare(GetSpeciesName(oldSpecies), gStringVar1))
         SetMonData(mon, MON_DATA_NICKNAME, GetSpeciesName(newSpecies));
 }
@@ -4962,8 +4963,8 @@ void AdjustFriendship(struct Pokemon *mon, u8 event)
     if (ShouldSkipFriendshipChange())
         return;
 
-    species = GetMonData(mon, MON_DATA_SPECIES_OR_EGG, 0);
-    heldItem = GetMonData(mon, MON_DATA_HELD_ITEM, 0);
+    species = GetMonData(mon, MON_DATA_SPECIES_OR_EGG);
+    heldItem = GetMonData(mon, MON_DATA_HELD_ITEM);
 
     if (heldItem == ITEM_ENIGMA_BERRY_E_READER)
     {
@@ -4984,7 +4985,7 @@ void AdjustFriendship(struct Pokemon *mon, u8 event)
     if (species && species != SPECIES_EGG)
     {
         u8 friendshipLevel = 0;
-        s32 friendship = GetMonData(mon, MON_DATA_FRIENDSHIP, 0);
+        s32 friendship = GetMonData(mon, MON_DATA_FRIENDSHIP);
 
         if (friendship > 99)
             friendshipLevel++;
@@ -5021,7 +5022,8 @@ void AdjustFriendship(struct Pokemon *mon, u8 event)
         if (friendship > MAX_FRIENDSHIP)
             friendship = MAX_FRIENDSHIP;
 
-        SetMonData(mon, MON_DATA_FRIENDSHIP, &friendship);
+        u32 friendship_ = friendship;
+        SetMonData(mon, MON_DATA_FRIENDSHIP, &friendship_);
     }
 }
 
@@ -5059,7 +5061,7 @@ void MonGainEVs(struct Pokemon *mon, enum Species defeatedSpecies)
     u8 bonus;
     u32 currentEVCap = GetCurrentEVCap();
 
-    heldItem = GetMonData(mon, MON_DATA_HELD_ITEM, 0);
+    heldItem = GetMonData(mon, MON_DATA_HELD_ITEM);
     if (heldItem == ITEM_ENIGMA_BERRY_E_READER)
     {
         if (gMain.inBattle)
@@ -5081,7 +5083,7 @@ void MonGainEVs(struct Pokemon *mon, enum Species defeatedSpecies)
 
     for (i = 0; i < NUM_STATS; i++)
     {
-        evs[i] = GetMonData(mon, MON_DATA_HP_EV + i, 0);
+        evs[i] = GetMonData(mon, MON_DATA_HP_EV + i);
         totalEVs += evs[i];
     }
 
@@ -5162,16 +5164,16 @@ u16 GetMonEVCount(struct Pokemon *mon)
     u16 count = 0;
 
     for (i = 0; i < NUM_STATS; i++)
-        count += GetMonData(mon, MON_DATA_HP_EV + i, 0);
+        count += GetMonData(mon, MON_DATA_HP_EV + i);
 
     return count;
 }
 
 bool8 TryIncrementMonLevel(struct Pokemon *mon)
 {
-    enum Species species = GetMonData(mon, MON_DATA_SPECIES, 0);
-    u8 nextLevel = GetMonData(mon, MON_DATA_LEVEL, 0) + 1;
-    u32 expPoints = GetMonData(mon, MON_DATA_EXP, 0);
+    enum Species species = GetMonData(mon, MON_DATA_SPECIES);
+    u8 nextLevel = GetMonData(mon, MON_DATA_LEVEL) + 1;
+    u32 expPoints = GetMonData(mon, MON_DATA_EXP);
     if (expPoints > gExperienceTables[gSpeciesInfo[species].growthRate][MAX_LEVEL])
     {
         expPoints = gExperienceTables[gSpeciesInfo[species].growthRate][MAX_LEVEL];
@@ -5481,7 +5483,7 @@ bool8 IsTradedMon(struct Pokemon *mon)
     u8 otName[PLAYER_NAME_LENGTH + 1];
     u32 otId;
     GetMonData(mon, MON_DATA_OT_NAME, otName);
-    otId = GetMonData(mon, MON_DATA_OT_ID, 0);
+    otId = GetMonData(mon, MON_DATA_OT_ID);
     return IsOtherTrainer(otId, otName);
 }
 
@@ -5510,10 +5512,10 @@ void BoxMonRestorePP(struct BoxPokemon *boxMon)
 
     for (i = 0; i < MAX_MON_MOVES; i++)
     {
-        if (GetBoxMonData(boxMon, MON_DATA_MOVE1 + i, 0))
+        if (GetBoxMonData(boxMon, MON_DATA_MOVE1 + i))
         {
-            enum Move move = GetBoxMonData(boxMon, MON_DATA_MOVE1 + i, 0);
-            u16 bonus = GetBoxMonData(boxMon, MON_DATA_PP_BONUSES, 0);
+            enum Move move = GetBoxMonData(boxMon, MON_DATA_MOVE1 + i);
+            u16 bonus = GetBoxMonData(boxMon, MON_DATA_PP_BONUSES);
             u8 pp = CalculatePPWithBonus(move, bonus, i);
             SetBoxMonData(boxMon, MON_DATA_PP1 + i, &pp);
         }
@@ -5580,7 +5582,7 @@ void SetWildMonHeldItem(void)
                 continue; // prevent overwriting previously set item
 
             rnd = Random() % 100;
-            species = GetMonData(&gParties[B_TRAINER_OPPONENT_A][i], MON_DATA_SPECIES, 0);
+            species = GetMonData(&gParties[B_TRAINER_OPPONENT_A][i], MON_DATA_SPECIES);
             if (gMapHeader.mapLayoutId == LAYOUT_ALTERING_CAVE)
             {
                 s32 alteringCaveId = GetWildMonTableIdInAlteringCave(species);
@@ -6079,7 +6081,7 @@ u8 GetFormIdFromFormSpeciesId(u16 formSpeciesId)
 // Returns the current species if no form change is possible
 enum Species GetFormChangeTargetSpeciesBoxMon(struct BoxPokemon *boxMon, enum FormChanges method)
 {
-    enum Species species = GetBoxMonData(boxMon, MON_DATA_SPECIES, NULL);
+    enum Species species = GetBoxMonData(boxMon, MON_DATA_SPECIES);
     const struct FormChange *formChanges = GetSpeciesFormChanges(species);
 
     if (formChanges == NULL)
@@ -6463,8 +6465,8 @@ static struct PartyState *GetBattlerPartyStateByPokemon(struct Pokemon *partyMon
 
 bool32 TryFormChange(struct Pokemon *mon, enum FormChanges method, enum BattleTrainer trainer)
 {
-    if (GetMonData(mon, MON_DATA_SPECIES_OR_EGG, 0) == SPECIES_NONE
-     || GetMonData(mon, MON_DATA_SPECIES_OR_EGG, 0) == SPECIES_EGG)
+    if (GetMonData(mon, MON_DATA_SPECIES_OR_EGG) == SPECIES_NONE
+     || GetMonData(mon, MON_DATA_SPECIES_OR_EGG) == SPECIES_EGG)
         return FALSE;
 
     enum Species currentSpecies = GetMonData(mon, MON_DATA_SPECIES);
@@ -6501,11 +6503,11 @@ bool32 TryFormChange(struct Pokemon *mon, enum FormChanges method, enum BattleTr
 
 bool32 TryBoxMonFormChange(struct BoxPokemon *boxMon, enum FormChanges method)
 {
-    if (GetBoxMonData(boxMon, MON_DATA_SPECIES_OR_EGG, 0) == SPECIES_NONE
-     || GetBoxMonData(boxMon, MON_DATA_SPECIES_OR_EGG, 0) == SPECIES_EGG)
+    if (GetBoxMonData(boxMon, MON_DATA_SPECIES_OR_EGG) == SPECIES_NONE
+     || GetBoxMonData(boxMon, MON_DATA_SPECIES_OR_EGG) == SPECIES_EGG)
         return FALSE;
 
-    enum Species currentSpecies = GetBoxMonData(boxMon, MON_DATA_SPECIES, NULL);
+    enum Species currentSpecies = GetBoxMonData(boxMon, MON_DATA_SPECIES);
     enum Species targetSpecies = GetFormChangeTargetSpeciesBoxMon(boxMon, method);
 
     assertf(targetSpecies != SPECIES_NONE, "form change target returned NONE. cur:%d, method:%d", currentSpecies, method)
@@ -6716,7 +6718,7 @@ void UpdateDaysPassedSinceFormChange(u16 days)
         if (currentSpecies == SPECIES_NONE)
             continue;
 
-        daysSinceFormChange = GetMonData(mon, MON_DATA_DAYS_SINCE_FORM_CHANGE, 0);
+        daysSinceFormChange = GetMonData(mon, MON_DATA_DAYS_SINCE_FORM_CHANGE);
         if (daysSinceFormChange == 0)
             continue;
 

--- a/src/roulette.c
+++ b/src/roulette.c
@@ -1165,6 +1165,8 @@ static void InitRouletteTableData(void)
         case SPECIES_TAILLOW:
             sRoulette->partySpeciesFlags |= HAS_TAILLOW;
             break;
+        default:
+            break;
         }
     }
     RtcCalcLocalTime();

--- a/src/script_pokemon_util.c
+++ b/src/script_pokemon_util.c
@@ -116,8 +116,6 @@ bool8 DoesPartyHaveEnigmaBerry(void)
 
 void CreateScriptedWildMon(enum Species species, u8 level, enum Item item)
 {
-    u8 heldItem[2];
-
     ZeroEnemyPartyMons();
     u32 personality = GetMonPersonality(species,
         GetSynchronizedGender(STATIC_WILDMON_ORIGIN, species),
@@ -125,18 +123,10 @@ void CreateScriptedWildMon(enum Species species, u8 level, enum Item item)
         RANDOM_UNOWN_LETTER);
     CreateMonWithIVs(&gParties[B_TRAINER_OPPONENT_A][0], species, level, personality, OTID_STRUCT_PLAYER_ID, USE_RANDOM_IVS);
     GiveMonInitialMoveset(&gParties[B_TRAINER_OPPONENT_A][0]);
-    if (item)
-    {
-        heldItem[0] = item;
-        heldItem[1] = item >> 8;
-        SetMonData(&gParties[B_TRAINER_OPPONENT_A][0], MON_DATA_HELD_ITEM, heldItem);
-    }
+    SetMonData(&gParties[B_TRAINER_OPPONENT_A][0], MON_DATA_HELD_ITEM, &item);
 }
 void CreateScriptedDoubleWildMon(enum Species species1, u8 level1, enum Item item1, enum Species species2, u8 level2, enum Item item2)
 {
-    u8 heldItem1[2];
-    u8 heldItem2[2];
-
     ZeroEnemyPartyMons();
     u32 personality = GetMonPersonality(species1,
         GetSynchronizedGender(STATIC_WILDMON_ORIGIN, species1),
@@ -144,12 +134,7 @@ void CreateScriptedDoubleWildMon(enum Species species1, u8 level1, enum Item ite
         RANDOM_UNOWN_LETTER);
     CreateMonWithIVs(&gParties[B_TRAINER_OPPONENT_A][0], species1, level1, personality, OTID_STRUCT_PLAYER_ID, USE_RANDOM_IVS);
     GiveMonInitialMoveset(&gParties[B_TRAINER_OPPONENT_A][0]);
-    if (item1)
-    {
-        heldItem1[0] = item1;
-        heldItem1[1] = item1 >> 8;
-        SetMonData(&gParties[B_TRAINER_OPPONENT_A][0], MON_DATA_HELD_ITEM, heldItem1);
-    }
+    SetMonData(&gParties[B_TRAINER_OPPONENT_A][0], MON_DATA_HELD_ITEM, &item1);
 
     personality = GetMonPersonality(species2,
         GetSynchronizedGender(STATIC_WILDMON_ORIGIN, species2),
@@ -157,12 +142,7 @@ void CreateScriptedDoubleWildMon(enum Species species1, u8 level1, enum Item ite
         RANDOM_UNOWN_LETTER);
     CreateMonWithIVs(&gParties[B_TRAINER_OPPONENT_A][1], species2, level2, personality, OTID_STRUCT_PLAYER_ID, USE_RANDOM_IVS);
     GiveMonInitialMoveset(&gParties[B_TRAINER_OPPONENT_A][1]);
-    if (item2)
-    {
-        heldItem2[0] = item2;
-        heldItem2[1] = item2 >> 8;
-        SetMonData(&gParties[B_TRAINER_OPPONENT_A][1], MON_DATA_HELD_ITEM, heldItem2);
-    }
+    SetMonData(&gParties[B_TRAINER_OPPONENT_A][1], MON_DATA_HELD_ITEM, &item2);
 }
 
 void ScriptSetMonMoveSlot(u8 monIndex, enum Move move, u8 slot)
@@ -479,15 +459,9 @@ static u32 ScriptGiveMonParameterized(u8 side, u8 slot, enum Species species, u8
 u32 ScriptGiveMon(enum Species species, u8 level, enum Item item)
 {
     struct Pokemon mon;
-    u8 heldItem[2];
 
     CreateRandomMon(&mon, species, level);
-    if (item)
-    {
-        heldItem[0] = item;
-        heldItem[1] = item >> 8;
-        SetMonData(&mon, MON_DATA_HELD_ITEM, heldItem);
-    }
+    SetMonData(&mon, MON_DATA_HELD_ITEM, &item);
 
     return GiveScriptedMonToPlayer(&mon, PARTY_SIZE);
 }

--- a/src/trade.c
+++ b/src/trade.c
@@ -159,7 +159,7 @@ struct InGameTrade {
     u16 heldItem;
     u8 mailNum;
     u8 otName[TRAINER_NAME_LENGTH + 1];
-    u8 otGender;
+    enum Gender otGender;
     u8 sheen;
     enum Species requestedSpecies;
 };

--- a/src/trainer_tower.c
+++ b/src/trainer_tower.c
@@ -995,9 +995,9 @@ static s32 GetPartyMaxLevel(void)
 
     for (i = 0; i < PARTY_SIZE; i++)
     {
-        if (GetMonData(&gParties[B_TRAINER_PLAYER][i], MON_DATA_SPECIES, NULL) != 0 && GetMonData(&gParties[B_TRAINER_PLAYER][i], MON_DATA_SPECIES_OR_EGG, NULL) != SPECIES_EGG)
+        if (GetMonData(&gParties[B_TRAINER_PLAYER][i], MON_DATA_SPECIES) != 0 && GetMonData(&gParties[B_TRAINER_PLAYER][i], MON_DATA_SPECIES_OR_EGG) != SPECIES_EGG)
         {
-            s32 currLevel = GetMonData(&gParties[B_TRAINER_PLAYER][i], MON_DATA_LEVEL, NULL);
+            s32 currLevel = GetMonData(&gParties[B_TRAINER_PLAYER][i], MON_DATA_LEVEL);
             if (currLevel > topLevel)
                 topLevel = currLevel;
         }

--- a/src/tv.c
+++ b/src/tv.c
@@ -1616,8 +1616,10 @@ static void InterviewAfter_PkmnFanClubOpinions(void)
     show->fanclubOpinions.friendshipHighNybble = GetMonData(&gParties[B_TRAINER_PLAYER][GetLeadMonIndex()], MON_DATA_FRIENDSHIP) >> 4;
     show->fanclubOpinions.questionAsked = gSpecialVar_0x8007;
     StringCopy(show->fanclubOpinions.playerName, gSaveBlock2Ptr->playerName);
-    GetMonData(&gParties[B_TRAINER_PLAYER][GetLeadMonIndex()], MON_DATA_NICKNAME10, show->fanclubOpinions.nickname);
-    StripExtCtrlCodes(show->fanclubOpinions.nickname);
+    u8 nickname[POKEMON_NAME_LENGTH + 1];
+    GetMonData(&gParties[B_TRAINER_PLAYER][GetLeadMonIndex()], MON_DATA_NICKNAME, nickname);
+    StripExtCtrlCodes(nickname);
+    memcpy(show->fanclubOpinions.nickname, nickname, sizeof(show->fanclubOpinions.nickname));
     show->fanclubOpinions.species = GetMonData(&gParties[B_TRAINER_PLAYER][GetLeadMonIndex()], MON_DATA_SPECIES);
     StorePlayerIdInNormalShow(show);
     show->fanclubOpinions.language = gGameLanguage;
@@ -2978,7 +2980,7 @@ static bool8 IsPartyMonNicknamedOrNotEnglish(u8 monIdx)
 
     pokemon = &gParties[B_TRAINER_PLAYER][monIdx];
     GetMonData(pokemon, MON_DATA_NICKNAME, gStringVar1);
-    language = GetMonData(pokemon, MON_DATA_LANGUAGE, &language);
+    language = GetMonData(pokemon, MON_DATA_LANGUAGE);
     if (language == GAME_LANGUAGE && !StringCompare(GetSpeciesName(GetMonData(pokemon, MON_DATA_SPECIES)), gStringVar1))
         return FALSE;
 

--- a/test/battle/trainer_slides.c
+++ b/test/battle/trainer_slides.c
@@ -813,8 +813,8 @@ AI_MULTI_BATTLE_TEST("Trainer Slide: Multi: Dynamax")
 {
     s32 dynamaxLevelA = 0, dynamaxLevelB = 0;
 
-    PARAMETRIZE { dynamaxLevelA = 10;  dynamaxLevelB = -1;  }
-    PARAMETRIZE { dynamaxLevelA = -1;   dynamaxLevelB = 10; }
+    PARAMETRIZE { dynamaxLevelA = 10; dynamaxLevelB = UINT_MAX; }
+    PARAMETRIZE { dynamaxLevelA = UINT_MAX; dynamaxLevelB = 10; }
 
     GIVEN {
         FLAG_SET(TESTING_FLAG_TRAINER_SLIDES);

--- a/test/pokemon.c
+++ b/test/pokemon.c
@@ -77,14 +77,13 @@ TEST("Terastallization type is reset to the default types when setting Tera Type
 
 TEST("Shininess independent from PID and OTID")
 {
-    u32 pid, otId, data;
+    u32 pid, otId;
     bool32 isShiny;
     struct Pokemon mon;
     PARAMETRIZE { pid = 0; otId = 0; }
     CreateMon(&mon, SPECIES_WOBBUFFET, 100, pid, OTID_STRUCT_PRESET(otId));
     isShiny = IsMonShiny(&mon);
-    data = !isShiny;
-    SetMonData(&mon, MON_DATA_IS_SHINY, &data);
+    SetMonData(&mon, MON_DATA_IS_SHINY, !isShiny);
     EXPECT_EQ(pid, GetMonData(&mon, MON_DATA_PERSONALITY));
     EXPECT_EQ(otId, GetMonData(&mon, MON_DATA_OT_ID));
     EXPECT_EQ(!isShiny, GetMonData(&mon, MON_DATA_IS_SHINY));
@@ -94,13 +93,11 @@ TEST("Shininess set on an Egg persists after hatching")
 {
     u32 personality = SHINY_ODDS;
     u32 trainerId = 0;
-    bool32 isShiny = TRUE;
-    bool8 isEgg = TRUE;
 
     SetTrainerId(trainerId, gSaveBlock2Ptr->playerTrainerId);
     CreateMon(&gParties[B_TRAINER_PLAYER][0], SPECIES_TOGEPI, EGG_HATCH_LEVEL, personality, OTID_STRUCT_PLAYER_ID);
-    SetMonData(&gParties[B_TRAINER_PLAYER][0], MON_DATA_IS_EGG, &isEgg);
-    SetMonData(&gParties[B_TRAINER_PLAYER][0], MON_DATA_IS_SHINY, &isShiny);
+    SetMonData(&gParties[B_TRAINER_PLAYER][0], MON_DATA_IS_EGG, TRUE);
+    SetMonData(&gParties[B_TRAINER_PLAYER][0], MON_DATA_IS_SHINY, TRUE);
 
     EXPECT_EQ(GetMonData(&gParties[B_TRAINER_PLAYER][0], MON_DATA_IS_SHINY), TRUE);
 
@@ -113,11 +110,11 @@ TEST("Shininess set on an Egg persists after hatching")
 
 TEST("Hyper Training increases stats without affecting IVs")
 {
-    u32 data, hp, atk, def, speed, spatk, spdef, friendship = 0;
+    u32 hp, atk, def, speed, spatk, spdef;
     struct Pokemon mon;
     CreateMonWithIVs(&mon, SPECIES_WOBBUFFET, 100, 0, OTID_STRUCT_PRESET(0), 3);
     // Consider B_FRIENDSHIP_BOOST.
-    SetMonData(&mon, MON_DATA_FRIENDSHIP, &friendship);
+    SetMonData(&mon, MON_DATA_FRIENDSHIP, 0);
     CalculateMonStats(&mon);
 
     hp = GetMonData(&mon, MON_DATA_HP);
@@ -127,13 +124,12 @@ TEST("Hyper Training increases stats without affecting IVs")
     spatk = GetMonData(&mon, MON_DATA_SPATK);
     spdef = GetMonData(&mon, MON_DATA_SPDEF);
 
-    data = TRUE;
-    SetMonData(&mon, MON_DATA_HYPER_TRAINED_HP, &data);
-    SetMonData(&mon, MON_DATA_HYPER_TRAINED_ATK, &data);
-    SetMonData(&mon, MON_DATA_HYPER_TRAINED_DEF, &data);
-    SetMonData(&mon, MON_DATA_HYPER_TRAINED_SPEED, &data);
-    SetMonData(&mon, MON_DATA_HYPER_TRAINED_SPATK, &data);
-    SetMonData(&mon, MON_DATA_HYPER_TRAINED_SPDEF, &data);
+    SetMonData(&mon, MON_DATA_HYPER_TRAINED_HP, TRUE);
+    SetMonData(&mon, MON_DATA_HYPER_TRAINED_ATK, TRUE);
+    SetMonData(&mon, MON_DATA_HYPER_TRAINED_DEF, TRUE);
+    SetMonData(&mon, MON_DATA_HYPER_TRAINED_SPEED, TRUE);
+    SetMonData(&mon, MON_DATA_HYPER_TRAINED_SPATK, TRUE);
+    SetMonData(&mon, MON_DATA_HYPER_TRAINED_SPDEF, TRUE);
     CalculateMonStats(&mon);
 
     EXPECT_EQ(GetMonData(&mon, MON_DATA_HP_IV), 3);
@@ -176,11 +172,11 @@ TEST("Status1 round-trips through BoxPokemon")
 
 TEST("canhypertrain/hypertrain affect MON_DATA_HYPER_TRAINED_* and recalculate stats")
 {
-    u32 atk, friendship = 0;
+    u32 atk;
     CreateRandomMonWithIVs(&gParties[B_TRAINER_PLAYER][0], SPECIES_WOBBUFFET, 100, 0);
 
     // Consider B_FRIENDSHIP_BOOST.
-    SetMonData(&gParties[B_TRAINER_PLAYER][0], MON_DATA_FRIENDSHIP, &friendship);
+    SetMonData(&gParties[B_TRAINER_PLAYER][0], MON_DATA_FRIENDSHIP, 0);
     CalculateMonStats(&gParties[B_TRAINER_PLAYER][0]);
 
     atk = GetMonData(&gParties[B_TRAINER_PLAYER][0], MON_DATA_ATK);
@@ -616,7 +612,7 @@ TEST("BoxPokemon encryption works")
     EXPECT_EQ(GetMonData(&mon, MON_DATA_SPECIES), SPECIES_TORCHIC);
     EXPECT_EQ(GetMonData(&mon, MON_DATA_MARKINGS), 3);
     const u8 *actualNickname = COMPOUND_STRING("Testing mon");
-    u8 nickname[12];
+    u8 nickname[POKEMON_NAME_LENGTH + 1];
     GetMonData(&mon, MON_DATA_NICKNAME, nickname);
     u32 charIndex = 0;
     while (actualNickname[charIndex] != EOS)

--- a/test/pokerus.c
+++ b/test/pokerus.c
@@ -290,8 +290,8 @@ TEST("(Pokerus) Test UpdatePartyPokerusTime general behavior")
 {
     u32 enabled = 0;
     u32 strain = 0; 
-    s32 daysLeft = 0;
-    s32 daysPassed = 0;
+    u16 daysLeft = 0;
+    u16 daysPassed = 0;
     for (u32 i = 0; i < 16; i++)
     {
         for (u32 j = 0; j < 16; j++)

--- a/test/test_runner_battle.c
+++ b/test/test_runner_battle.c
@@ -2332,9 +2332,8 @@ void OpenPokemon(u32 sourceLine, enum BattleTrainer trainer, enum Species specie
         data = 0x7F; // Max PP possible
         SetMonData(DATA.currentMon, MON_DATA_PP1 + i, &data);
     }
-    data = 0;
     if (B_FRIENDSHIP_BOOST) // This way, we avoid the boost affecting tests unless explicitly stated.
-        SetMonData(DATA.currentMon, MON_DATA_FRIENDSHIP, &data);
+        SetMonData(DATA.currentMon, MON_DATA_FRIENDSHIP, 0);
     CalculateMonStats(DATA.currentMon);
 }
 
@@ -2362,7 +2361,6 @@ static u32 GenerateNature(u32 nature, u32 offset)
 void ClosePokemon(u32 sourceLine)
 {
     s32 i;
-    u32 data;
     INVALID_IF(DATA.hasExplicitSpeeds && !(DATA.explicitSpeeds[DATA.battlerParty] & (1 << DATA.currentPartyIndex)), "Speed required");
     for (i = 0; i < STATE->battlersCount; i++)
     {
@@ -2373,8 +2371,7 @@ void ClosePokemon(u32 sourceLine)
         }
     }
     UpdateMonPersonality(&DATA.currentMon->box, GenerateNature(DATA.nature, DATA.gender % NUM_NATURES) | DATA.gender);
-    data = DATA.isShiny;
-    SetMonData(DATA.currentMon, MON_DATA_IS_SHINY, &data);
+    SetMonData(DATA.currentMon, MON_DATA_IS_SHINY, &DATA.isShiny);
     DATA.currentMon = NULL;
 }
 
@@ -2419,7 +2416,7 @@ void Nature_(u32 sourceLine, u32 nature)
 
 void Ability_(u32 sourceLine, enum Ability ability)
 {
-    s32 i;
+    u32 i;
     u32 species;
     const struct SpeciesInfo *info;
     INVALID_IF(!DATA.currentMon, "Ability outside of PLAYER/OPPONENT");
@@ -2459,8 +2456,7 @@ void MaxHP_(u32 sourceLine, u32 maxHP)
     INVALID_IF(!DATA.currentMon, "MaxHP outside of PLAYER/OPPONENT");
     INVALID_IF(maxHP == 0, "Illegal max HP: %d", maxHP);
     SetMonData(DATA.currentMon, MON_DATA_MAX_HP, &maxHP);
-    bool32 hyperTrainingFlag = TRUE;
-    SetMonData(DATA.currentMon, MON_DATA_HYPER_TRAINED_HP, &hyperTrainingFlag);
+    SetMonData(DATA.currentMon, MON_DATA_HYPER_TRAINED_HP, TRUE);
 }
 
 void HP_(u32 sourceLine, u32 hp)
@@ -2476,8 +2472,7 @@ void Attack_(u32 sourceLine, u32 attack)
     INVALID_IF(!DATA.currentMon, "Attack outside of PLAYER/OPPONENT");
     INVALID_IF(attack == 0, "Illegal attack: %d", attack);
     SetMonData(DATA.currentMon, MON_DATA_ATK, &attack);
-    bool32 hyperTrainingFlag = TRUE;
-    SetMonData(DATA.currentMon, MON_DATA_HYPER_TRAINED_ATK, &hyperTrainingFlag);
+    SetMonData(DATA.currentMon, MON_DATA_HYPER_TRAINED_ATK, TRUE);
 }
 
 void Defense_(u32 sourceLine, u32 defense)
@@ -2485,8 +2480,7 @@ void Defense_(u32 sourceLine, u32 defense)
     INVALID_IF(!DATA.currentMon, "Defense outside of PLAYER/OPPONENT");
     INVALID_IF(defense == 0, "Illegal defense: %d", defense);
     SetMonData(DATA.currentMon, MON_DATA_DEF, &defense);
-    bool32 hyperTrainingFlag = TRUE;
-    SetMonData(DATA.currentMon, MON_DATA_HYPER_TRAINED_DEF, &hyperTrainingFlag);
+    SetMonData(DATA.currentMon, MON_DATA_HYPER_TRAINED_DEF, TRUE);
 }
 
 void SpAttack_(u32 sourceLine, u32 spAttack)
@@ -2494,8 +2488,7 @@ void SpAttack_(u32 sourceLine, u32 spAttack)
     INVALID_IF(!DATA.currentMon, "SpAttack outside of PLAYER/OPPONENT");
     INVALID_IF(spAttack == 0, "Illegal special attack: %d", spAttack);
     SetMonData(DATA.currentMon, MON_DATA_SPATK, &spAttack);
-    bool32 hyperTrainingFlag = TRUE;
-    SetMonData(DATA.currentMon, MON_DATA_HYPER_TRAINED_SPATK, &hyperTrainingFlag);
+    SetMonData(DATA.currentMon, MON_DATA_HYPER_TRAINED_SPATK, TRUE);
 }
 
 void SpDefense_(u32 sourceLine, u32 spDefense)
@@ -2503,8 +2496,7 @@ void SpDefense_(u32 sourceLine, u32 spDefense)
     INVALID_IF(!DATA.currentMon, "SpDefense outside of PLAYER/OPPONENT");
     INVALID_IF(spDefense == 0, "Illegal special defense: %d", spDefense);
     SetMonData(DATA.currentMon, MON_DATA_SPDEF, &spDefense);
-    bool32 hyperTrainingFlag = TRUE;
-    SetMonData(DATA.currentMon, MON_DATA_HYPER_TRAINED_SPDEF, &hyperTrainingFlag);
+    SetMonData(DATA.currentMon, MON_DATA_HYPER_TRAINED_SPDEF, TRUE);
 }
 
 void Speed_(u32 sourceLine, u32 speed)
@@ -2512,8 +2504,7 @@ void Speed_(u32 sourceLine, u32 speed)
     INVALID_IF(!DATA.currentMon, "Speed outside of PLAYER/OPPONENT");
     INVALID_IF(speed == 0, "Illegal speed: %d", speed);
     SetMonData(DATA.currentMon, MON_DATA_SPEED, &speed);
-    bool32 hyperTrainingFlag = TRUE;
-    SetMonData(DATA.currentMon, MON_DATA_HYPER_TRAINED_SPEED, &hyperTrainingFlag);
+    SetMonData(DATA.currentMon, MON_DATA_HYPER_TRAINED_SPEED, TRUE);
     DATA.hasExplicitSpeeds = TRUE;
     DATA.explicitSpeeds[DATA.battlerParty] |= 1 << DATA.currentPartyIndex;
 }
@@ -2625,14 +2616,15 @@ void Status1_(u32 sourceLine, u32 status1)
 void OTName_(u32 sourceLine, const u8 *otName)
 {
     INVALID_IF(!DATA.currentMon, "OTName outside of PLAYER/OPPONENT");
-    SetMonData(DATA.currentMon, MON_DATA_OT_NAME, &otName);
+    SetMonData(DATA.currentMon, MON_DATA_OT_NAME, otName);
 }
 
-void DynamaxLevel_(u32 sourceLine, s16 dynamaxLevel)
+void DynamaxLevel_(u32 sourceLine, u32 dynamaxLevel)
 {
     INVALID_IF(!DATA.currentMon, "DynamaxLevel outside of PLAYER/OPPONENT");
+    INVALID_IF(MAX_DYNAMAX_LEVEL < dynamaxLevel && dynamaxLevel < UINT_MAX, "Illegal dynamaxLevel");
     SetMonData(DATA.currentMon, MON_DATA_DYNAMAX_LEVEL, &dynamaxLevel);
-    if (dynamaxLevel >= 0)
+    if (dynamaxLevel != UINT_MAX)
         SetGimmick(sourceLine, DATA.battlerParty, DATA.currentPartyIndex, GIMMICK_DYNAMAX);
 }
 


### PR DESCRIPTION
Extends `GetMonData`, `GetBoxMonData`, `SetMonData`, and `SetBoxMonData` with type-checking if the `field` argument is known at compile-time.

Additionally, extends `SetMonData` to accept a value for the `data` argument, not a pointer when `field` is known at compile-time. This allows e.g.:
```diff
-u32 data = MOVE_NONE;
-SetMonData(DATA.currentMon, MON_DATA_MOVE1 + i, &data);
+SetMonData(DATA.currentMon, MON_DATA_MOVE1 + i, MOVE_NONE);
```

Currently marked as a draft while I:
- [ ] Ask @miriamlefae to investigate how much `clangd` hates this.
- [ ] Ask other people to try running it on their downstreams to see how bad the error messages are in practice.
- [ ] Look into type-safe indexing, e.g. `GetMonData(mon, MON_DATA_MOVE + i)` or `GetMonData(mon, MON_DATA_HP + stat)` come up in `for` loops and GCC doesn't think they have compile-time known values so the first isn't `enum Move` and any `Set*MonData`s won't accept values, only pointers.
- [ ] Roll out `Set*MonData` using values where it makes sense. Evaluate if there are enough cases to justify the implementation complexity.

### Large Language Models (AI)
None

## Things to note in the release changelog:
- TODO: Describe the common errors that can be reported by the type-checked `*MonData` functions, and how to fix them.