### PR TITLE
Fixes Assurance inconsistencies

### DIFF
--- a/asm/macros/battle_script.inc
+++ b/asm/macros/battle_script.inc
@@ -37,9 +37,10 @@
 	.byte \battler
 	.endm
 
-	.macro datahpupdate battler:req
+	.macro datahpupdate battler:req assuranceDouble:req
 	.byte B_SCR_OP_DATAHPUPDATE
 	.byte \battler
+    .byte \assuranceDouble
 	.endm
 
 	.macro critmessage

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -86,7 +86,7 @@ BattleScript_EffectStatChangeHalfHp::
 	attackcanceler
 	trymovestatchanges
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_DOUBLE
 	goto BattleScript_MoveEnd
 
 BattleScript_PlayMoveAnim::
@@ -103,7 +103,7 @@ BattleScript_StatChangeFailed::
 BattleScript_PlayMoveAnimAndChangeHP::
 	call BattleScript_PlayMoveAnim
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_IGNORE
     return
 
 BattleScript_PlayTidyUp::
@@ -263,7 +263,7 @@ BattleScript_EffectShedTail::
 	attackanimation
 	waitanimation
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_IGNORE
 	printstring STRINGID_SHEDITSTAIL
 	waitmessage B_WAIT_TIME_LONG
 	moveendto MOVEEND_ATTACKER_VISIBLE
@@ -431,7 +431,7 @@ BattleScript_SaltCureExtraDamage::
 	playanimation BS_ATTACKER, B_ANIM_SALT_CURE_DAMAGE, NULL
 	waitanimation
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_DOUBLE
 	printstring STRINGID_TARGETISHURTBYSALTCURE
 	waitmessage B_WAIT_TIME_LONG
 	tryfaintmon BS_ATTACKER
@@ -708,7 +708,7 @@ JungleHealing_RestoreTargetHealth:
 	copybyte gBattlerAttacker, gBattlerTarget
 	tryhealquarterhealth BS_TARGET, BattleScript_JungleHealing_TryCureStatus
 	healthbarupdate BS_TARGET
-	datahpupdate BS_TARGET
+	datahpupdate BS_TARGET, ASSURANCE_DOUBLE
 	printstring STRINGID_PKMNREGAINEDHEALTH
 	waitmessage B_WAIT_TIME_LONG
 BattleScript_JungleHealing_TryCureStatus:
@@ -751,7 +751,7 @@ BattleScript_EffectLifeDewCheckPartner:
 BattleScript_EffectLifeDewHealing:
 	tryhealquarterhealth BS_TARGET, BattleScript_EffectLifeDewEnd
 	healthbarupdate BS_TARGET
-	datahpupdate BS_TARGET
+	datahpupdate BS_TARGET, ASSURANCE_DOUBLE
 	printstring STRINGID_PKMNREGAINEDHEALTH
 	waitmessage B_WAIT_TIME_LONG
 	return
@@ -907,7 +907,7 @@ BattleScript_MoveEffectFlameBurst::
 	printstring STRINGID_BURSTINGFLAMESHIT
 	waitmessage B_WAIT_TIME_LONG
 	healthbarupdate BS_EFFECT_BATTLER
-	datahpupdate BS_EFFECT_BATTLER
+	datahpupdate BS_EFFECT_BATTLER, ASSURANCE_DOUBLE
 	tryfaintmon BS_EFFECT_BATTLER
 	return
 
@@ -986,7 +986,7 @@ BattleScript_EffectInstruct::
 BattleScript_FinalGambit::
 	setatkhptozero
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_DOUBLE
 	tryfaintmon BS_ATTACKER
 	return
 
@@ -1091,7 +1091,7 @@ BattleScript_EffectHealPulse::
 	attackanimation
 	waitanimation
 	healthbarupdate BS_TARGET
-	datahpupdate BS_TARGET
+	datahpupdate BS_TARGET, ASSURANCE_DOUBLE
 	printstring STRINGID_PKMNREGAINEDHEALTH
 	waitmessage B_WAIT_TIME_LONG
 	goto BattleScript_MoveEnd
@@ -1164,7 +1164,7 @@ BattleScript_EffectHealingWishRestore:
 	playanimation BS_SCRIPTING, B_ANIM_WISH_HEAL
 	waitanimation
 	healthbarupdate BS_SCRIPTING
-	datahpupdate BS_SCRIPTING
+	datahpupdate BS_SCRIPTING, ASSURANCE_DOUBLE
 	clearstatus BS_SCRIPTING,
 	waitstate
 	updatestatusicon BS_SCRIPTING
@@ -1595,7 +1595,7 @@ BattleScript_EffectAbsorbLiquidOoze::
 
 BattleScript_EffectAbsorb::
 	healthbarupdate BS_EFFECT_BATTLER
-	datahpupdate BS_EFFECT_BATTLER
+	datahpupdate BS_EFFECT_BATTLER, ASSURANCE_DOUBLE
 	printfromtable gAbsorbDrainStringIds
 	waitmessage B_WAIT_TIME_LONG
 	tryfaintmon BS_EFFECT_BATTLER
@@ -1613,7 +1613,7 @@ BattleScript_FaintAttackerForExplosion::
 
 BattleScript_MaxHp50Recoil::
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_DOUBLE
 	tryfaintmon BS_ATTACKER
 	return
 
@@ -1691,7 +1691,7 @@ BattleScript_EffectRestoreHp::
 	waitanimation
 BattleScript_RestoreHp:
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_DOUBLE
 	printstring STRINGID_PKMNREGAINEDHEALTH
 	waitmessage B_WAIT_TIME_LONG
 	goto BattleScript_MoveEnd
@@ -1758,7 +1758,7 @@ BattleScript_RecoilIfMiss::
 	waitmessage B_WAIT_TIME_LONG
 	jumpifability BS_ATTACKER, ABILITY_MAGIC_GUARD, BattleScript_RecoilEnd
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_DOUBLE
 	tryfaintmon BS_ATTACKER
 BattleScript_RecoilEnd:
 	return
@@ -1896,7 +1896,7 @@ BattleScript_EffectSubstitute::
 	attackanimation
 	waitanimation
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_IGNORE
 BattleScript_SubstituteString::
 	pause B_WAIT_TIME_SHORT
 	printfromtable gSubstituteUsedStringIds
@@ -1997,9 +1997,9 @@ BattleScript_EffectPainSplit::
 	attackanimation
 	waitanimation
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_IGNORE
 	healthbarupdate BS_TARGET
-	datahpupdate BS_TARGET
+	datahpupdate BS_TARGET, ASSURANCE_IGNORE
 	printstring STRINGID_SHAREDPAIN
 	waitmessage B_WAIT_TIME_LONG
 	goto BattleScript_MoveEnd
@@ -2128,7 +2128,7 @@ BattleScript_EffectCurse::
 	attackanimation
 	waitanimation
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_DOUBLE
 	printstring STRINGID_PKMNLAIDCURSE
 	waitmessage B_WAIT_TIME_LONG
 	tryfaintmon BS_ATTACKER
@@ -2233,7 +2233,7 @@ BattleScript_PresentHeal::
 	goto BattleScript_PresentHealGetTarget
 BattleScript_PresentHealNextTarget:
 	healthbarupdate BS_TARGET
-	datahpupdate BS_TARGET
+	datahpupdate BS_TARGET, ASSURANCE_DOUBLE
 	printstring STRINGID_PKMNREGAINEDHEALTH
 	waitmessage B_WAIT_TIME_LONG
 	goto BattleScript_MoveEnd
@@ -2411,7 +2411,7 @@ BattleScript_HealTarget::
 BattleScript_HealTargetContinue::
 	playanimation BS_ATTACKER, B_ANIM_SIMPLE_HEAL
 	healthbarupdate BS_TARGET
-	datahpupdate BS_TARGET
+	datahpupdate BS_TARGET, ASSURANCE_DOUBLE
 	printstring STRINGID_PKMNREGAINEDHEALTH
 	waitmessage B_WAIT_TIME_LONG
 	goto BattleScript_MoveEnd
@@ -2473,7 +2473,7 @@ BattleScript_EffectSwallow::
 	attackanimation
 	waitanimation
 	healthbarupdate BS_TARGET
-	datahpupdate BS_TARGET
+	datahpupdate BS_TARGET, ASSURANCE_DOUBLE
 	printstring STRINGID_PKMNREGAINEDHEALTH
 	waitmessage B_WAIT_TIME_LONG
 	goto BattleScript_MoveEnd
@@ -3234,7 +3234,7 @@ BattleScript_IceBodyHeal::
 	call BattleScript_AbilityPopUp
 	playanimation BS_ATTACKER, B_ANIM_SIMPLE_HEAL
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_DOUBLE
 	printstring STRINGID_ICEBODYHPGAIN
 	waitmessage B_WAIT_TIME_LONG
 	return
@@ -3367,7 +3367,7 @@ BattleScript_LeechSeedTurnDrainRecovery::
 	call BattleScript_LeechSeedTurnDrain
 BattleScript_LeechSeedTurnDrainGainHp:
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_DOUBLE
 	copybyte gEffectBattler, gBattlerAttacker @gEffectBattler is overwritten so general usage not possible
 	printfromtable gLeechSeedStringIds
 	waitmessage B_WAIT_TIME_LONG
@@ -3377,7 +3377,7 @@ BattleScript_LeechSeedTurnDrainGainHp:
 BattleScript_LeechSeedTurnDrain:
 	playanimation BS_SCRIPTING, B_ANIM_LEECH_SEED_DRAIN, sB_ANIM_ARG1
 	healthbarupdate BS_SCRIPTING
-	datahpupdate BS_SCRIPTING
+	datahpupdate BS_SCRIPTING, ASSURANCE_DOUBLE
 	tryfaintmon BS_SCRIPTING
 	tryactivateitem BS_SCRIPTING, ACTIVATION_ON_HP_THRESHOLD
 	return
@@ -3484,13 +3484,13 @@ BattleScript_DestinyBondTakesLife::
 	printstring STRINGID_PKMNTOOKFOE
 	waitmessage B_WAIT_TIME_LONG
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_DOUBLE
 	tryfaintmon BS_ATTACKER
 	return
 
 BattleScript_DmgHazardsOnBattler::
 	healthbarupdate BS_SCRIPTING
-	datahpupdate BS_SCRIPTING
+	datahpupdate BS_SCRIPTING, ASSURANCE_DOUBLE
 	call BattleScript_PrintHurtByDmgHazards
 	tryfaintmon BS_SCRIPTING
 	return
@@ -3532,7 +3532,7 @@ BattleScript_PerishSongTakesLife::
 	printstring STRINGID_PKMNPERISHCOUNTFELL
 	waitmessage B_WAIT_TIME_LONG
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_DOUBLE
 	tryfaintmon BS_ATTACKER
 	return
 
@@ -3554,7 +3554,7 @@ BattleScript_GulpMissileGorging::
 	waitstate
 	jumpifability BS_ATTACKER, ABILITY_MAGIC_GUARD, BattleScript_GulpMissileNoDmgGorging
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_DOUBLE
 	tryfaintmon BS_ATTACKER
 	jumpiffainted BS_ATTACKER, TRUE, BattleScript_GulpMissileNoSecondEffectGorging
 BattleScript_GulpMissileNoDmgGorging:
@@ -3574,7 +3574,7 @@ BattleScript_GulpMissileGulping::
 	waitstate
 	jumpifability BS_ATTACKER, ABILITY_MAGIC_GUARD, BattleScript_GulpMissileNoDmgGulping
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_DOUBLE
 	tryfaintmon BS_ATTACKER
 	jumpiffainted BS_ATTACKER, TRUE, BattleScript_GulpMissileNoSecondEffectGulping
 BattleScript_GulpMissileNoDmgGulping:
@@ -3615,7 +3615,7 @@ BattleScript_EarthEaterActivates::
 	pause B_WAIT_TIME_LONG
 	tryhealquarterhealth BS_TARGET, BattleScript_EarthEaterRet
 	healthbarupdate BS_TARGET
-	datahpupdate BS_TARGET
+	datahpupdate BS_TARGET, ASSURANCE_DOUBLE
 	printstring STRINGID_PKMNREGAINEDHEALTH
 	waitmessage B_WAIT_TIME_LONG
 BattleScript_EarthEaterRet:
@@ -3796,7 +3796,7 @@ BattleScript_WishComesTrue::
 	printstring STRINGID_PKMNWISHCAMETRUE
 	waitmessage B_WAIT_TIME_LONG
 	healthbarupdate BS_TARGET
-	datahpupdate BS_TARGET
+	datahpupdate BS_TARGET, ASSURANCE_DOUBLE
 	printstring STRINGID_PKMNREGAINEDHEALTH
 	waitmessage B_WAIT_TIME_LONG
 	return
@@ -3823,7 +3823,7 @@ BattleScript_IngrainTurnHeal::
 BattleScript_TurnHeal:
 	waitmessage B_WAIT_TIME_LONG
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_DOUBLE
 	return
 
 BattleScript_AquaRingHeal::
@@ -4073,7 +4073,7 @@ BattleScript_CudChewActivates::
 BattleScript_ApplyDisguiseFormChangeHPLoss::
 	jumpifgenconfiglowerthan CONFIG_B_DISGUISE_HP_LOSS, GEN_8, BattleScript_ApplyDisguiseFormChangeHPLossReturn
 	healthbarupdate BS_SCRIPTING
-	datahpupdate BS_SCRIPTING
+	datahpupdate BS_SCRIPTING, ASSURANCE_DOUBLE
 BattleScript_ApplyDisguiseFormChangeHPLossReturn:
 	return
 
@@ -4127,7 +4127,7 @@ BattleScript_AftermathDmg::
 	call BattleScript_AbilityPopUpScripting
 	jumpifability BS_ATTACKER, ABILITY_MAGIC_GUARD, BattleScript_AftermathDmgRet
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_DOUBLE
 	tryfaintmon BS_ATTACKER
 BattleScript_AftermathDmgRet:
 	return
@@ -4173,7 +4173,7 @@ BattleScript_DoStatusTurnDmg::
 	statusanimation BS_ATTACKER
 BattleScript_DoTurnDmg:
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_DOUBLE
 	tryfaintmon BS_ATTACKER
 	checkteamslost BattleScript_DoTurnDmgEnd
 	tryactivateitem BS_ATTACKER, ACTIVATION_ON_HP_THRESHOLD
@@ -4187,7 +4187,7 @@ BattleScript_PoisonHealActivates::
 	playanimation BS_ATTACKER, B_ANIM_SIMPLE_HEAL
 	waitanimation
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_DOUBLE
 	return
 
 BattleScript_BurnTurnDmg::
@@ -4283,7 +4283,7 @@ BattleScript_DoSelfConfusionDmg::
 	waitstate
 	tryselfconfusiondmgformchange
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_IGNORE
 	resultmessage
 	waitmessage B_WAIT_TIME_LONG
 	tryfaintmon BS_ATTACKER
@@ -4300,7 +4300,7 @@ BattleScript_MoveUsedPowder::
 	hitanimation BS_ATTACKER
 	waitstate
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_DOUBLE
 	printstring STRINGID_POWDEREXPLODES
 	waitmessage B_WAIT_TIME_LONG
 	tryfaintmon BS_ATTACKER
@@ -4495,7 +4495,7 @@ BattleScript_MoveEffectRecoilHP25::
 
 BattleScript_MoveEffectRecoil::
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_DOUBLE
 	printstring STRINGID_PKMNHITWITHRECOIL
 	waitmessage B_WAIT_TIME_LONG
 	tryfaintmon BS_ATTACKER
@@ -4633,7 +4633,7 @@ BattleScript_AbilityHpHeal::
  	playanimation BS_ATTACKER, B_ANIM_SIMPLE_HEAL
 	waitanimation
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_DOUBLE
 	return
 
 BattleScript_CheekPouchActivates::
@@ -4666,7 +4666,7 @@ BattleScript_HarvestActivatesEnd:
 BattleScript_SolarPowerActivates::
 	call BattleScript_AbilityPopUp
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_DOUBLE
 	tryfaintmon BS_ATTACKER
 	return
 
@@ -4781,7 +4781,7 @@ BattleScript_HospitalityActivates::
 	waitmessage B_WAIT_TIME_LONG
  	playanimation BS_EFFECT_BATTLER, B_ANIM_SIMPLE_HEAL
 	healthbarupdate BS_EFFECT_BATTLER
-	datahpupdate BS_EFFECT_BATTLER
+	datahpupdate BS_EFFECT_BATTLER, ASSURANCE_DOUBLE
 	return
 
 BattleScript_AttackWeakenedByStrongWinds::
@@ -4886,7 +4886,7 @@ BattleScript_BadDreams_DmgAfterPopUp:
 	waitmessage B_WAIT_TIME_LONG
 	dmg_1_8_targethp
 	healthbarupdate BS_TARGET
-	datahpupdate BS_TARGET
+	datahpupdate BS_TARGET, ASSURANCE_DOUBLE
 	jumpifhasnohp BS_TARGET, BattleScript_BadDreams_HidePopUp
 BattleScript_BadDreamsIncrement:
 	addbyte gBattlerTarget, 1
@@ -4922,7 +4922,7 @@ BattleScript_MoveHPDrain::
 	pause B_WAIT_TIME_SHORT
 	call BattleScript_AbilityPopUp
 	healthbarupdate BS_SCRIPTING
-	datahpupdate BS_SCRIPTING
+	datahpupdate BS_SCRIPTING, ASSURANCE_DOUBLE
 	printstring STRINGID_PKMNRESTOREDHPUSING
 	waitmessage B_WAIT_TIME_LONG
 	return
@@ -5012,7 +5012,7 @@ BattleScript_GrassyTerrainHeals::
 	printstring STRINGID_GRASSYTERRAINHEALS
 	waitmessage B_WAIT_TIME_LONG
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_DOUBLE
 	return
 
 BattleScript_StickyHoldActivates::
@@ -5133,7 +5133,7 @@ BattleScript_ImposterActivates::
 
 BattleScript_HurtAttacker:
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_DOUBLE
 	printfromtable gHurtByStringIds
 	waitmessage B_WAIT_TIME_LONG
 	tryfaintmon BS_ATTACKER
@@ -5141,7 +5141,7 @@ BattleScript_HurtAttacker:
 
 BattleScript_HurtAttackerNoMsg:
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_DOUBLE
 	tryfaintmon BS_ATTACKER
 	return
 
@@ -5162,7 +5162,7 @@ BattleScript_SpikyShieldEffect::
 	jumpifabsent BS_ATTACKER, BattleScript_SpikyShieldRet
 	clearmoveresultflags MOVE_RESULT_NO_EFFECT
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_DOUBLE
 	printstring STRINGID_PKMNWASHURT
 	waitmessage B_WAIT_TIME_LONG
 	tryfaintmon BS_ATTACKER
@@ -5410,7 +5410,7 @@ BattleScript_ItemHealHP_RemoveItem::
 BattleScript_ItemHealHP_RemoveItemRet_AnimContinue:
 	playanimation BS_SCRIPTING, B_ANIM_SIMPLE_HEAL
 	healthbarupdate BS_SCRIPTING
-	datahpupdate BS_SCRIPTING
+	datahpupdate BS_SCRIPTING, ASSURANCE_DOUBLE
 	removeitem BS_SCRIPTING
 	waitabilitypopup
 	return
@@ -5442,7 +5442,7 @@ BattleScript_AirBalloonMsgPop::
 
 BattleScript_ItemHurtRet::
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_DOUBLE
 	printstring STRINGID_HURTBYITEM
 	waitmessage B_WAIT_TIME_LONG
 	tryfaintmon BS_ATTACKER
@@ -5458,7 +5458,7 @@ BattleScript_ItemHurtWithAnim::
 BattleScript_LifeOrbActivates::
 	call BattleScript_ItemPopUp_AttackerNoFlush
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_DOUBLE
 	printstring STRINGID_LOSTSOMEOFITSHP
 	waitmessage B_WAIT_TIME_LONG
 	tryfaintmon BS_ATTACKER
@@ -5469,7 +5469,7 @@ BattleScript_ItemHealHP_Ret::
 	playanimation BS_ATTACKER, B_ANIM_HELD_ITEM_EFFECT
 	playanimation BS_ATTACKER, B_ANIM_SIMPLE_HEAL
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER
+	datahpupdate BS_ATTACKER, ASSURANCE_DOUBLE
 	return
 
 BattleScript_SelectingNotAllowedMoveChoiceItem::
@@ -5532,7 +5532,7 @@ BattleScript_BerryConfuseHealRet_Anim:
 	playanimation BS_SCRIPTING, B_ANIM_HELD_ITEM_BERRY
 	playanimation BS_SCRIPTING, B_ANIM_SIMPLE_HEAL
 	healthbarupdate BS_SCRIPTING
-	datahpupdate BS_SCRIPTING
+	datahpupdate BS_SCRIPTING, ASSURANCE_DOUBLE
 	seteffectprimary BS_SCRIPTING, BS_SCRIPTING, MOVE_EFFECT_CONFUSION
 	removeitem BS_SCRIPTING
 	waitabilitypopup
@@ -5841,7 +5841,7 @@ BattleScript_ZEffectPrintString::
 
 BattleScript_RecoverHPZMove::
 	healthbarupdate BS_SCRIPTING
-	datahpupdate BS_SCRIPTING
+	datahpupdate BS_SCRIPTING, ASSURANCE_DOUBLE
 	printfromtable gZEffectStringIds
 	waitmessage B_WAIT_TIME_LONG
 	return
@@ -5851,7 +5851,7 @@ BattleScript_HealReplacementZMove::
 	printfromtable gZEffectStringIds
 	waitmessage B_WAIT_TIME_LONG
 	healthbarupdate BS_SCRIPTING
-	datahpupdate BS_SCRIPTING
+	datahpupdate BS_SCRIPTING, ASSURANCE_DOUBLE
 	return
 
 BattleScript_RemoveTerrain::
@@ -6210,7 +6210,7 @@ BattleScript_HealOneSixthAlliesLoop:
 	jumpifabsent BS_TARGET, BattleScript_HealOneSixthAlliesIncrement
 	tryhealsixthhealth BattleScript_HealOneSixthAlliesIncrement
 	healthbarupdate BS_TARGET
-	datahpupdate BS_TARGET
+	datahpupdate BS_TARGET, ASSURANCE_DOUBLE
 	printstring STRINGID_PKMNREGAINEDHEALTH
 	waitmessage B_WAIT_TIME_LONG
 BattleScript_HealOneSixthAlliesIncrement:

--- a/data/battle_scripts_2.s
+++ b/data/battle_scripts_2.s
@@ -54,7 +54,7 @@ BattleScript_UseItemMessage:
 BattleScript_ItemRestoreHPRet:
 	clearmoveresultflags MOVE_RESULT_NO_EFFECT
 	healthbarupdate BS_SCRIPTING
-	datahpupdate BS_SCRIPTING
+	datahpupdate BS_SCRIPTING, ASSURANCE_DOUBLE
 	printstring STRINGID_ITEMRESTOREDSPECIESHEALTH
 	waitmessage B_WAIT_TIME_LONG
 	return

--- a/include/constants/battle_script_commands.h
+++ b/include/constants/battle_script_commands.h
@@ -404,4 +404,10 @@ enum SynchronizeState
     SYNCH_STATE_END,
 };
 
+enum AssuranceDoubleDamage
+{
+    ASSURANCE_DOUBLE,
+    ASSURANCE_IGNORE,
+};
+
 #endif // GUARD_CONSTANTS_BATTLE_SCRIPT_COMMANDS_H

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -102,7 +102,7 @@ static void SpriteCB_AnimFaintOpponent(struct Sprite *sprite);
 static void SpriteCB_BlinkVisible(struct Sprite *sprite);
 static void SpriteCB_Idle(struct Sprite *sprite);
 static void SpriteCB_BattleSpriteSlideLeft(struct Sprite *sprite);
-static void TurnValuesCleanUp(bool8 var0);
+static void TurnValuesCleanUp(bool32 endTurn);
 static void SpriteCB_BounceEffect(struct Sprite *sprite);
 static void BattleStartClearSetData(void);
 static void DoBattleIntro(void);
@@ -4746,11 +4746,11 @@ static void SetActionsAndBattlersTurnOrder(void)
     gBattleScripting.battler = 0;
 }
 
-static void TurnValuesCleanUp(bool8 var0)
+static void TurnValuesCleanUp(bool32 endTurn)
 {
     for (enum BattlerId i = 0; i < gBattlersCount; i++)
     {
-        if (var0)
+        if (endTurn)
         {
             gProtectStructs[i].protected = PROTECT_NONE;
             gProtectStructs[i].quash = FALSE;

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -2919,6 +2919,8 @@ static bool32 TryMoveDamageUpdate(struct BattleCalcValues *cv)
         gBattleStruct->moveDamage[cv->battlerDef] = 0;
         if (cv->moveEffect == EFFECT_OHKO)
             gProtectStructs[cv->battlerDef].survivedOHKO = TRUE;
+        if (DoesIceFaceBlockMove(cv->battlerDef, cv->move))
+            gProtectStructs[cv->battlerDef].assuranceDoubled = TRUE;
     }
     else
     {

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1274,7 +1274,7 @@ static void Cmd_healthbarupdate(void)
 
 static void Cmd_datahpupdate(void)
 {
-    CMD_ARGS(u8 battler);
+    CMD_ARGS(u8 battler, u8 assuranceDouble);
     enum BattlerId battler = GetBattlerForBattleScript(cmd->battler);
 
     if (gBattleControllerExecFlags)
@@ -1293,8 +1293,9 @@ static void Cmd_datahpupdate(void)
             gBattleMons[battler].hp -= gBattleStruct->passiveHpUpdate[battler];
         else
             gBattleMons[battler].hp = 0;
-        // Since this is reset for the next turn, it should be fine to set it here.
-        gProtectStructs[battler].assuranceDoubled = TRUE;
+
+        if (cmd->assuranceDouble == ASSURANCE_DOUBLE)
+            gProtectStructs[battler].assuranceDoubled = TRUE; // Will reset for the next turn
     }
 
     gBattleStruct->passiveHpUpdate[battler] = 0;
@@ -8139,7 +8140,7 @@ static void Cmd_recoverbasedonsunlight(void)
         {
             if (attackerWeather & B_WEATHER_SUN)
             {
-                recoverAmount = 20 * GetNonDynamaxMaxHP(gBattlerAttacker) / 30;   
+                recoverAmount = 20 * GetNonDynamaxMaxHP(gBattlerAttacker) / 30;
                 if (ability == ABILITY_MEGA_SOL && !(weather & B_WEATHER_SUN))
                     isAffectedByMegaSol = TRUE;
             }

--- a/test/battle/move_effect/assurance.c
+++ b/test/battle/move_effect/assurance.c
@@ -11,6 +11,8 @@ DOUBLE_BATTLE_TEST("Assurance doubles in power if False Swipe connected but didn
     s16 hits[2];
 
     GIVEN {
+        ASSUME(GetMoveEffect(MOVE_FALSE_SWIPE) == EFFECT_FALSE_SWIPE);
+        ASSUME(GetMoveEffect(MOVE_RECOVER) == EFFECT_RESTORE_HP);
         PLAYER(SPECIES_WOBBUFFET) { HP(1); }
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET);
@@ -33,7 +35,63 @@ DOUBLE_BATTLE_TEST("Assurance doubles in power if False Swipe connected but didn
     }
 }
 
-SINGLE_BATTLE_TEST("Assurance doubles in power if the target has been damaged in the same turn - Life Orb")
+DOUBLE_BATTLE_TEST("Assurance does not double in power if the target's damage is blocked by Substitute")
+{
+    s16 hits[2];
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_SUBSTITUTE) == EFFECT_SUBSTITUTE);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_HOPPIP) { Ability(ABILITY_INFILTRATOR); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponentLeft, MOVE_ASSURANCE, target: playerLeft); }
+        TURN {
+            MOVE(playerLeft, MOVE_SUBSTITUTE);
+            MOVE(opponentRight, MOVE_POUND, target: playerLeft);
+            MOVE(opponentLeft, MOVE_ASSURANCE, target: playerLeft);
+        }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponentLeft);
+        HP_BAR(playerLeft, captureDamage: &hits[0]);
+
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SUBSTITUTE, playerLeft);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POUND, opponentRight);
+        SUB_HIT(playerLeft);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponentLeft);
+        HP_BAR(playerLeft, captureDamage: &hits[1]);
+    } THEN {
+        EXPECT_EQ(hits[0], hits[1]);
+    }
+}
+
+SINGLE_BATTLE_TEST("Assurance does not double in power if the target took damage from confusion")
+{
+    s16 hits[2];
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_CONFUSE_RAY) == EFFECT_CONFUSE);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_ASSURANCE); }
+        TURN { MOVE(opponent, MOVE_CONFUSE_RAY); }
+        TURN { MOVE(opponent, MOVE_ASSURANCE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponent);
+        HP_BAR(player, captureDamage: &hits[0]);
+
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CONFUSE_RAY, opponent);
+
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponent);
+        HP_BAR(player, captureDamage: &hits[1]);
+    } THEN {
+        EXPECT_EQ(hits[0], hits[1]);
+    }
+}
+
+SINGLE_BATTLE_TEST("Assurance doubles in power if the target has been damaged by Life Orb")
 {
     s16 hits[2];
 
@@ -42,21 +100,467 @@ SINGLE_BATTLE_TEST("Assurance doubles in power if the target has been damaged in
         PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_LIFE_ORB); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
-        TURN { MOVE(player, MOVE_CELEBRATE); MOVE(opponent, MOVE_ASSURANCE); }
+        TURN { MOVE(opponent, MOVE_ASSURANCE); }
         TURN { MOVE(player, MOVE_POUND); MOVE(opponent, MOVE_ASSURANCE); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponent);
         HP_BAR(player, captureDamage: &hits[0]);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_POUND, player);
-        MESSAGE("Wobbuffet lost some of its HP!");
+        HP_BAR(player); // life orb
         HP_BAR(player, captureDamage: &hits[1]);
     } THEN {
         EXPECT_MUL_EQ(hits[0], Q_4_12(2.0), hits[1]);
     }
 }
 
-TO_DO_BATTLE_TEST("Assurance doubles in power if the target has been damaged in the same turn - Recoil");
-TO_DO_BATTLE_TEST("Assurance doubles in power if the target has been damaged in the same turn - Crash");
-TO_DO_BATTLE_TEST("Assurance doubles in power if the target has been damaged in the same turn - Confusion");
-TO_DO_BATTLE_TEST("Assurance doubles in power if the target has been damaged in the same turn - Rocky Helmet");
+SINGLE_BATTLE_TEST("Assurance doubles in power if the target has been damaged by Recoil")
+{
+    s16 hits[2];
 
+    GIVEN {
+        ASSUME(GetMoveRecoil(MOVE_TAKE_DOWN) > 0);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_ASSURANCE); }
+        TURN { MOVE(player, MOVE_TAKE_DOWN); MOVE(opponent, MOVE_ASSURANCE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponent);
+        HP_BAR(player, captureDamage: &hits[0]);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TAKE_DOWN, player);
+        HP_BAR(player); // recoil
+        HP_BAR(player, captureDamage: &hits[1]);
+    } THEN {
+        EXPECT_MUL_EQ(hits[0], Q_4_12(2.0), hits[1]);
+    }
+}
+
+SINGLE_BATTLE_TEST("Assurance doubles in power if the target has been damaged by Crash")
+{
+    s16 hits[2];
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_JUMP_KICK) == EFFECT_RECOIL_IF_MISS);
+        PLAYER(SPECIES_WOBBUFFET) { MaxHP(999); HP(999); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_ASSURANCE); }
+        TURN {
+            MOVE(player, MOVE_JUMP_KICK, hit: FALSE);
+            MOVE(opponent, MOVE_ASSURANCE);
+        }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponent);
+        HP_BAR(player, captureDamage: &hits[0]);
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_JUMP_KICK, player);
+        HP_BAR(player); // self recoil
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponent);
+        HP_BAR(player, captureDamage: &hits[1]);
+    } THEN {
+        EXPECT_MUL_EQ(hits[0], Q_4_12(2.0), hits[1]);
+    }
+}
+
+SINGLE_BATTLE_TEST("Assurance doubles in power if the target has been damaged by Rocky Helmet")
+{
+    s16 hits[2];
+
+    GIVEN {
+        ASSUME(gItemsInfo[ITEM_ROCKY_HELMET].holdEffect == HOLD_EFFECT_ROCKY_HELMET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_ROCKY_HELMET); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_ASSURANCE); }
+        TURN { MOVE(player, MOVE_POUND); MOVE(opponent, MOVE_ASSURANCE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponent);
+        HP_BAR(player, captureDamage: &hits[0]);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POUND, player);
+        HP_BAR(opponent);
+        HP_BAR(player); // rocky helmet
+        HP_BAR(player, captureDamage: &hits[1]);
+    } THEN {
+        EXPECT_MUL_EQ(hits[0], Q_4_12(2.0), hits[1]);
+    }
+}
+
+SINGLE_BATTLE_TEST("Assurance doubles in power if the target has been damaged by Rough Skin")
+{
+    s16 hits[2];
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_GIBLE) { Ability(ABILITY_ROUGH_SKIN); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_ASSURANCE); }
+        TURN { MOVE(player, MOVE_POUND); MOVE(opponent, MOVE_ASSURANCE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponent);
+        HP_BAR(player, captureDamage: &hits[0]);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POUND, player);
+        HP_BAR(opponent);
+        ABILITY_POPUP(opponent, ABILITY_ROUGH_SKIN);
+        HP_BAR(player); // rough skin
+        HP_BAR(player, captureDamage: &hits[1]);
+    } THEN {
+        EXPECT_MUL_EQ(hits[0], Q_4_12(2.0), hits[1]);
+    }
+}
+
+SINGLE_BATTLE_TEST("Assurance doubles in power if the target has been damaged by Iron Barbs")
+{
+    s16 hits[2];
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { MaxHP(999); HP(999); };
+        OPPONENT(SPECIES_TOGEDEMARU) { Ability(ABILITY_IRON_BARBS); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_ASSURANCE); }
+        TURN { MOVE(player, MOVE_POUND); MOVE(opponent, MOVE_ASSURANCE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponent);
+        HP_BAR(player, captureDamage: &hits[0]);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POUND, player);
+        HP_BAR(opponent);
+        ABILITY_POPUP(opponent, ABILITY_IRON_BARBS);
+        HP_BAR(player); // iron barbs
+        HP_BAR(player, captureDamage: &hits[1]);
+    } THEN {
+        EXPECT_MUL_EQ(hits[0], Q_4_12(2.0), hits[1]);
+    }
+}
+
+SINGLE_BATTLE_TEST("Assurance doubles in power if the target has been damaged by Liquid Ooze")
+{
+    s16 hits[2];
+
+    GIVEN {
+        ASSUME(MoveHasAdditionalEffect(MOVE_ABSORB, MOVE_EFFECT_ABSORB));
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_TENTACOOL) { Ability(ABILITY_LIQUID_OOZE); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_ASSURANCE); }
+        TURN { MOVE(player, MOVE_ABSORB); MOVE(opponent, MOVE_ASSURANCE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponent);
+        HP_BAR(player, captureDamage: &hits[0]);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ABSORB, player);
+        HP_BAR(opponent);
+        HP_BAR(player); // Liquid Ooze
+        HP_BAR(player, captureDamage: &hits[1]);
+    } THEN {
+        EXPECT_MUL_EQ(hits[0], Q_4_12(2.0), hits[1]);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Assurance doubles in power if the target has been damaged by Aftermath")
+{
+    s16 hits[2];
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_VOLTORB) { HP(1); Ability(ABILITY_AFTERMATH); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponentRight, MOVE_ASSURANCE, target: playerLeft); }
+        TURN {
+            MOVE(playerLeft, MOVE_POUND, target: opponentLeft);
+            MOVE(opponentRight, MOVE_ASSURANCE, target: playerLeft);
+        }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponentRight);
+        HP_BAR(playerLeft, captureDamage: &hits[0]);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POUND, playerLeft);
+        ABILITY_POPUP(opponentLeft, ABILITY_AFTERMATH);
+        HP_BAR(playerLeft); // aftermath
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponentRight);
+        HP_BAR(playerLeft, captureDamage: &hits[1]);
+    } THEN {
+        EXPECT_MUL_EQ(hits[0], Q_4_12(2.0), hits[1]);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Assurance doubles in power if the target has been damaged by Innards Out")
+{
+    s16 hits[2];
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_PYUKUMUKU) { HP(1); Ability(ABILITY_INNARDS_OUT); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponentRight, MOVE_ASSURANCE, target: playerLeft); }
+        TURN {
+            MOVE(playerLeft, MOVE_POUND, target: opponentLeft);
+            MOVE(opponentRight, MOVE_ASSURANCE, target: playerLeft);
+        }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponentRight);
+        HP_BAR(playerLeft, captureDamage: &hits[0]);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POUND, playerLeft);
+        ABILITY_POPUP(opponentLeft, ABILITY_INNARDS_OUT);
+        HP_BAR(playerLeft); // innards out
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponentRight);
+        HP_BAR(playerLeft, captureDamage: &hits[1]);
+    } THEN {
+        EXPECT_MUL_EQ(hits[0], Q_4_12(2.0), hits[1]);
+    }
+}
+
+SINGLE_BATTLE_TEST("Assurance doubles in power if the target has been damaged by Jaboca Berry")
+{
+    s16 hits[2];
+
+    GIVEN {
+        ASSUME(gItemsInfo[ITEM_JABOCA_BERRY].holdEffect == HOLD_EFFECT_JABOCA_BERRY);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_JABOCA_BERRY); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_ASSURANCE); }
+        TURN { MOVE(player, MOVE_POUND); MOVE(opponent, MOVE_ASSURANCE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponent);
+        HP_BAR(player, captureDamage: &hits[0]);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POUND, player);
+        HP_BAR(opponent);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_BERRY, opponent);
+        HP_BAR(player); // jaboca berry
+        HP_BAR(player, captureDamage: &hits[1]);
+    } THEN {
+        EXPECT_MUL_EQ(hits[0], Q_4_12(2.0), hits[1]);
+    }
+}
+
+SINGLE_BATTLE_TEST("Assurance doubles in power if the target has been damaged by Rowap Berry")
+{
+    s16 hits[2];
+
+    GIVEN {
+        ASSUME(GetMoveCategory(MOVE_SWIFT) == DAMAGE_CATEGORY_SPECIAL);
+        ASSUME(gItemsInfo[ITEM_ROWAP_BERRY].holdEffect == HOLD_EFFECT_ROWAP_BERRY);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_ROWAP_BERRY); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_ASSURANCE); }
+        TURN { MOVE(player, MOVE_SWIFT); MOVE(opponent, MOVE_ASSURANCE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponent);
+        HP_BAR(player, captureDamage: &hits[0]);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SWIFT, player);
+        HP_BAR(opponent);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_BERRY, opponent);
+        HP_BAR(player); // rowap berry
+        HP_BAR(player, captureDamage: &hits[1]);
+    } THEN {
+        EXPECT_MUL_EQ(hits[0], Q_4_12(2.0), hits[1]);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Assurance doubles in power if the target has been damaged by Spiky Shield")
+{
+    s16 hits[2];
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_SPIKY_SHIELD) == EFFECT_PROTECT);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponentLeft, MOVE_ASSURANCE, target: playerLeft); }
+        TURN {
+            MOVE(opponentLeft, MOVE_SPIKY_SHIELD);
+            MOVE(playerLeft, MOVE_POUND, target: opponentLeft);
+            MOVE(opponentRight, MOVE_ASSURANCE, target: playerLeft);
+        }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponentLeft);
+        HP_BAR(playerLeft, captureDamage: &hits[0]);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SPIKY_SHIELD, opponentLeft);
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_POUND, playerLeft);
+        HP_BAR(playerLeft); // spiky shield
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponentRight);
+        HP_BAR(playerLeft, captureDamage: &hits[1]);
+    } THEN {
+        EXPECT_MUL_EQ(hits[0], Q_4_12(2.0), hits[1]);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Assurance doubles in power if Ice Face has been broken by attacker")
+{
+    s16 hits[2];
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_HAIL) == EFFECT_WEATHER);
+        ASSUME(GetMoveWeatherType(MOVE_HAIL) == BATTLE_WEATHER_HAIL);
+        PLAYER(SPECIES_EISCUE) { Speed(1); Ability(ABILITY_ICE_FACE); }
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(9); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(10); }
+    } WHEN {
+        TURN { MOVE(opponentRight, MOVE_POUND, target: playerLeft); }
+        TURN {
+            MOVE(opponentLeft, MOVE_ASSURANCE, target: playerLeft);
+            MOVE(playerLeft, MOVE_HAIL);
+        }
+        TURN {
+            MOVE(opponentRight, MOVE_POUND, target: playerLeft);
+            MOVE(opponentLeft, MOVE_ASSURANCE, target: playerLeft);
+        }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POUND, opponentRight);
+        ABILITY_POPUP(playerLeft, ABILITY_ICE_FACE);
+
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponentLeft);
+        HP_BAR(playerLeft, captureDamage: &hits[0]);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_HAIL, playerLeft);
+        ABILITY_POPUP(playerLeft, ABILITY_ICE_FACE);
+
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POUND, opponentRight);
+        ABILITY_POPUP(playerLeft, ABILITY_ICE_FACE);
+
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponentLeft);
+        HP_BAR(playerLeft, captureDamage: &hits[1]);
+    } THEN {
+        EXPECT_MUL_EQ(hits[0], Q_4_12(2.0), hits[1]);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Assurance doubles in power if Disguise has been broken")
+{
+    s16 hits[2];
+
+    GIVEN {
+        PLAYER(SPECIES_MIMIKYU_DISGUISED) { Speed(1); Ability(ABILITY_DISGUISE); }
+        PLAYER(SPECIES_MIMIKYU_DISGUISED) { Speed(2); Ability(ABILITY_DISGUISE); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(3); };
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(4); };
+    } WHEN {
+        TURN { MOVE(opponentRight, MOVE_WATER_GUN, target: playerLeft); }
+        TURN { MOVE(opponentLeft, MOVE_ASSURANCE, target: playerLeft); }
+
+        TURN {
+            MOVE(opponentRight, MOVE_WATER_GUN, target: playerRight);
+            MOVE(opponentLeft, MOVE_ASSURANCE, target: playerRight);
+        }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_WATER_GUN, opponentRight);
+        ABILITY_POPUP(playerLeft, ABILITY_DISGUISE);
+
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponentLeft);
+        HP_BAR(playerLeft, captureDamage: &hits[0]);
+
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_WATER_GUN, opponentRight);
+        ABILITY_POPUP(playerRight, ABILITY_DISGUISE);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponentLeft);
+        HP_BAR(playerRight, captureDamage: &hits[1]);
+    } THEN {
+        EXPECT_MUL_EQ(hits[0], Q_4_12(2.0), hits[1]);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Assurance doubles in power if the target has been damaged by Powder")
+{
+    s16 hits[2];
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_POWDER) == EFFECT_POWDER);
+        ASSUME(GetMoveType(MOVE_EMBER) == TYPE_FIRE);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_VIVILLON);
+    } WHEN {
+        TURN { MOVE(opponentLeft, MOVE_ASSURANCE, target: playerLeft); }
+        TURN {
+            MOVE(opponentRight, MOVE_POWDER, target: playerLeft);
+            MOVE(playerLeft, MOVE_EMBER, target: opponentLeft);
+            MOVE(opponentLeft, MOVE_ASSURANCE, target: playerLeft);
+        }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponentLeft);
+        HP_BAR(playerLeft, captureDamage: &hits[0]);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_POWDER, opponentRight);
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_EMBER, playerLeft);
+        HP_BAR(playerLeft);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponentLeft);
+        HP_BAR(playerLeft, captureDamage: &hits[1]);
+    } THEN {
+        EXPECT_MUL_EQ(hits[0], Q_4_12(2.0), hits[1]);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Assurance doubles in power if the target has been damaged by Flame Burst residual damage")
+{
+    s16 hits[2];
+
+    GIVEN {
+        ASSUME(MoveHasAdditionalEffect(MOVE_EMBER, MOVE_EFFECT_BURN));
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(playerRight, MOVE_ASSURANCE, target: opponentRight); }
+        TURN {
+            MOVE(playerLeft, MOVE_FLAME_BURST, target: opponentLeft);
+            MOVE(playerRight, MOVE_ASSURANCE, target: opponentRight);
+        }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, playerRight);
+        HP_BAR(opponentRight, captureDamage: &hits[0]);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FLAME_BURST, playerLeft);
+        HP_BAR(opponentLeft);
+        HP_BAR(opponentRight);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, playerRight);
+        HP_BAR(opponentRight, captureDamage: &hits[1]);
+    } THEN {
+        EXPECT_MUL_EQ(hits[0], Q_4_12(2.0), hits[1]);
+    }
+}
+
+SINGLE_BATTLE_TEST("Assurance does not double in power if HP was reduced by Belly Drum")
+{
+    s16 hits[2];
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_BELLY_DRUM) == EFFECT_BELLY_DRUM);
+        PLAYER(SPECIES_WOBBUFFET) { MaxHP(999); HP(999); };
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_BELLY_DRUM); MOVE(opponent, MOVE_ASSURANCE); }
+        TURN { MOVE(opponent, MOVE_ASSURANCE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BELLY_DRUM, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponent);
+        HP_BAR(player, captureDamage: &hits[0]);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponent);
+        HP_BAR(player, captureDamage: &hits[1]);
+    } THEN {
+        EXPECT_EQ(hits[0], hits[1]);
+    }
+}
+
+SINGLE_BATTLE_TEST("Assurance does not double in power if the target was damaged Pain Split")
+{
+    s16 hits[2];
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_PAIN_SPLIT) == EFFECT_PAIN_SPLIT);
+        PLAYER(SPECIES_WOBBUFFET) { HP(500); MaxHP(1000); }
+        OPPONENT(SPECIES_WOBBUFFET) { HP(500); MaxHP(1000); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_ASSURANCE); }
+        TURN { MOVE(player, MOVE_PAIN_SPLIT); MOVE(opponent, MOVE_ASSURANCE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponent);
+        HP_BAR(player, captureDamage: &hits[0]);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_PAIN_SPLIT, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponent);
+        HP_BAR(player, captureDamage: &hits[1]);
+    } THEN {
+        EXPECT_EQ(hits[0], hits[1]);
+    }
+}


### PR DESCRIPTION
Fixes #8210

I haven't written tests for the hazards case but I think those should be correct. The flag is reset before the next turn and it's always set if not specifically told not to so that would be it takes affect during mid-turn but resets for the next turn after hazards have been applied. 

I didn't want to solve that one on master, so upcoming