### PR TITLE
Fix Resist Berries not showing the correct item on item popups

### DIFF
--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -2682,6 +2682,7 @@ static enum CancelerResult CancelerPreAnimActivations(struct BattleCalcValues *c
             }
 
             gBattleScripting.battler = battlerDef;
+            gLastUsedItem = gBattleMons[cv->battlerDef].item;
             BattleScriptCall(BattleScript_BerryReduceAnimation);
             return CANCELER_RESULT_RUN_SCRIPT;
         }

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -2682,7 +2682,7 @@ static enum CancelerResult CancelerPreAnimActivations(struct BattleCalcValues *c
             }
 
             gBattleScripting.battler = battlerDef;
-            gLastUsedItem = gBattleMons[cv->battlerDef].item;
+            gLastUsedItem = gBattleMons[battlerDef].item;
             BattleScriptCall(BattleScript_BerryReduceAnimation);
             return CANCELER_RESULT_RUN_SCRIPT;
         }

--- a/test/battle/hold_effect/resist_berry.c
+++ b/test/battle/hold_effect/resist_berry.c
@@ -53,6 +53,7 @@ SINGLE_BATTLE_TEST("Weakness berries decrease the base power of moves by half", 
         TURN { MOVE(player, move); }
     } SCENE {
         if (item != ITEM_NONE) {
+            ITEM_POPUP(opponent, item);
             ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_BERRY, opponent);
         }
         HP_BAR(opponent, captureDamage: &results[i].damage);

--- a/test/battle/spread_moves.c
+++ b/test/battle/spread_moves.c
@@ -70,10 +70,10 @@ DOUBLE_BATTLE_TEST("Spread Moves: A spread move attack will activate both resist
         TURN { MOVE(playerLeft, MOVE_HYPER_VOICE); }
         TURN { MOVE(playerLeft, MOVE_HYPER_VOICE); }
     } SCENE {
-        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_BERRY, opponentLeft);
-        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_BERRY, opponentRight);
         ITEM_POPUP(opponentLeft, ITEM_CHILAN_BERRY);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_BERRY, opponentLeft);
         ITEM_POPUP(opponentRight, ITEM_CHILAN_BERRY);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_BERRY, opponentRight);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_HYPER_VOICE, playerLeft);
         EFFECTIVENESS_SE(opponentLeft, SE_EFFECTIVE); // effective against both
         HP_BAR(opponentLeft, captureDamage: &opponentLeftDmg[0]);

--- a/test/battle/spread_moves.c
+++ b/test/battle/spread_moves.c
@@ -72,6 +72,8 @@ DOUBLE_BATTLE_TEST("Spread Moves: A spread move attack will activate both resist
     } SCENE {
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_BERRY, opponentLeft);
         ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_BERRY, opponentRight);
+        ITEM_POPUP(opponentLeft, ITEM_CHILAN_BERRY);
+        ITEM_POPUP(opponentRight, ITEM_CHILAN_BERRY);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_HYPER_VOICE, playerLeft);
         EFFECTIVENESS_SE(opponentLeft, SE_EFFECTIVE); // effective against both
         HP_BAR(opponentLeft, captureDamage: &opponentLeftDmg[0]);


### PR DESCRIPTION
Title. Also comes with tests to best capture this. Targets upcoming due to item popups only appearing in upcoming at this time.

## Description
This PR fixes an issue present with resist berries (like Chilan Berry, Yache Berry, etc.) where the item name shown in the item popup does not match the item used.

### Large Language Models (AI)
None

## Media

https://github.com/user-attachments/assets/18e0dbdd-442d-4421-a15d-c01859fd65e5

## Discord contact info
linathan
