### PR TITLE
Multiple xp bugfixes

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -581,6 +581,7 @@ struct BattleStruct
     u8 expGetterMonId;
     u8 expOrderId:3;
     u8 teamGotExpMsgPrinted:1; // The 'Rest of your team got msg' has been printed.
+    u8 padding0:4;
     u8 givenExpMons[2]; // Bits for enemy party's Pokémon that gave exp to player's party.
     u8 expSentInMons; // As bits for player party mons - not including exp share mons.
     u8 wildVictorySong;

--- a/include/battle.h
+++ b/include/battle.h
@@ -580,7 +580,6 @@ struct BattleStruct
     u8 expGettersOrder[PARTY_SIZE]; // First battlers which were sent out, then via exp-share
     u8 expGetterMonId;
     u8 expOrderId:3;
-    u8 expGetterBattlerId:2;
     u8 teamGotExpMsgPrinted:1; // The 'Rest of your team got msg' has been printed.
     u8 givenExpMons; // Bits for enemy party's Pokémon that gave exp to player's party.
     u8 expSentInMons; // As bits for player party mons - not including exp share mons.

--- a/include/battle.h
+++ b/include/battle.h
@@ -581,7 +581,7 @@ struct BattleStruct
     u8 expGetterMonId;
     u8 expOrderId:3;
     u8 teamGotExpMsgPrinted:1; // The 'Rest of your team got msg' has been printed.
-    u8 givenExpMons; // Bits for enemy party's Pokémon that gave exp to player's party.
+    u8 givenExpMons[2]; // Bits for enemy party's Pokémon that gave exp to player's party.
     u8 expSentInMons; // As bits for player party mons - not including exp share mons.
     u8 wildVictorySong;
     enum Type dynamicMoveType;

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3073,7 +3073,8 @@ static void BattleStartClearSetData(void)
     gBattleStruct->wildVictorySong = 0;
     gBattleStruct->moneyMultiplier = 1;
 
-    gBattleStruct->givenExpMons = 0;
+    gBattleStruct->givenExpMons[0] = 0;
+    gBattleStruct->givenExpMons[1] = 0;
     gBattleStruct->palaceFlags = 0;
 
     gBattleResults.shinyWildMon = IsMonShiny(&gParties[B_TRAINER_OPPONENT_A][0]);

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -3894,7 +3894,7 @@ static void Cmd_getexp(void)
         else
         {
             gBattleScripting.getexpState++;
-            gBattleStruct->givenExpMons |= (1u << gBattlerPartyIndexes[gBattlerFainted]);
+            gBattleStruct->givenExpMons[GetBattlerTrainer(gBattlerFainted) & BIT_FLANK] |= (1u << gBattlerPartyIndexes[gBattlerFainted]);
         }
         break;
     case 1: // calculate experience points to redistribute

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -5654,7 +5654,7 @@ static void Cmd_yesnoboxlearnmove(void)
                 gBattleScripting.learnMoveState = 5;
             }
         }
-        else if (JOY_NEW(B_BUTTON))
+        else if (JOY_NEW(B_BUTTON) || TESTING)
         {
             PlaySE(SE_SELECT);
             gBattleScripting.learnMoveState = 5;
@@ -6298,7 +6298,7 @@ static void Cmd_drawlvlupbox(void)
         }
         break;
     case 6:
-        if (gMain.newKeys != 0 || RECORDED_WILD_BATTLE)
+        if (gMain.newKeys != 0 || RECORDED_WILD_BATTLE || TESTING)
         {
             // Draw page 2 of level up box
             PlaySE(SE_SELECT);
@@ -6308,7 +6308,7 @@ static void Cmd_drawlvlupbox(void)
         }
         break;
     case 8:
-        if (gMain.newKeys != 0 || RECORDED_WILD_BATTLE)
+        if (gMain.newKeys != 0 || RECORDED_WILD_BATTLE || TESTING)
         {
             // Close level up box
             PlaySE(SE_SELECT);

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -4040,7 +4040,7 @@ static void Cmd_getexp(void)
                     }
 
                     // get exp getter battler
-                    if (IsDoubleBattle())
+                    if (IsDoubleBattle() && !(gBattleTypeFlags & BATTLE_TYPE_INGAME_PARTNER))
                     {
                         if (gBattlerPartyIndexes[2] == *expMonId && !(gAbsentBattlerFlags & 4))
                             gBattleStruct->expGetterBattlerId = 2;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -3852,13 +3852,13 @@ static u32 GetMonHoldEffect(struct Pokemon *mon)
 
 static enum BattlerId GetBattlerFromPlayerPartyId(u32 partyId)
 {
-    if (gBattlerPartyIndexes[B_BATTLER_0] == partyId)
+    if (gBattlerPartyIndexes[B_BATTLER_0] == partyId && !(gAbsentBattlerFlags & 1))
         return B_BATTLER_0;
     if (!IsDoubleBattle())
         return MAX_BATTLERS_COUNT;
     if (gBattleTypeFlags & BATTLE_TYPE_INGAME_PARTNER)
         return MAX_BATTLERS_COUNT;
-    if (gBattlerPartyIndexes[B_BATTLER_2] == partyId)
+    if (gBattlerPartyIndexes[B_BATTLER_2] == partyId && !(gAbsentBattlerFlags & 4))
         return B_BATTLER_2;
     return MAX_BATTLERS_COUNT;
 }
@@ -4072,7 +4072,7 @@ static void Cmd_getexp(void)
     case 3: // Set stats and give exp
         if (gBattleControllerExecFlags == 0)
         {
-            gBattleResources->bufferB[gBattleStruct->expGetterBattlerId][0] = 0;
+            gBattleResources->bufferB[0][0] = 0;
             currLvl = GetMonData(&gParties[B_TRAINER_PLAYER][*expMonId], MON_DATA_LEVEL);
             if (GetMonData(&gParties[B_TRAINER_PLAYER][*expMonId], MON_DATA_HP) && currLvl != MAX_LEVEL)
             {

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -3856,7 +3856,7 @@ static enum BattlerId GetBattlerFromPlayerPartyId(u32 partyId)
         return B_BATTLER_0;
     if (!IsDoubleBattle())
         return MAX_BATTLERS_COUNT;
-    if (gBattleTypeFlags & BATTLE_TYPE_INGAME_PARTNER)
+    if (!BattlerIsPlayer(B_BATTLER_2))
         return MAX_BATTLERS_COUNT;
     if (gBattlerPartyIndexes[B_BATTLER_2] == partyId && !(gAbsentBattlerFlags & 4))
         return B_BATTLER_2;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -3850,6 +3850,19 @@ static u32 GetMonHoldEffect(struct Pokemon *mon)
     return holdEffect;
 }
 
+static enum BattlerId GetBattlerFromPlayerPartyId(u32 partyId)
+{
+    if (gBattlerPartyIndexes[B_BATTLER_0] == partyId)
+        return B_BATTLER_0;
+    if (!IsDoubleBattle())
+        return MAX_BATTLERS_COUNT;
+    if (gBattleTypeFlags & BATTLE_TYPE_INGAME_PARTNER)
+        return MAX_BATTLERS_COUNT;
+    if (gBattlerPartyIndexes[B_BATTLER_2] == partyId)
+        return B_BATTLER_2;
+    return MAX_BATTLERS_COUNT;
+}
+
 static void Cmd_getexp(void)
 {
     CMD_ARGS(u8 battler);
@@ -3977,8 +3990,7 @@ static void Cmd_getexp(void)
                 gBattleScripting.getexpState = 5;
                 gBattleStruct->battlerExpReward = 0;
             }
-            else if ((gBattleTypeFlags & BATTLE_TYPE_INGAME_PARTNER && *expMonId >= 3)
-                  || GetMonData(&gParties[B_TRAINER_PLAYER][*expMonId], MON_DATA_LEVEL) == MAX_LEVEL)
+            else if (GetMonData(&gParties[B_TRAINER_PLAYER][*expMonId], MON_DATA_LEVEL) == MAX_LEVEL)
             {
                 gBattleScripting.getexpState = 5;
                 gBattleStruct->battlerExpReward = 0;
@@ -4028,45 +4040,26 @@ static void Cmd_getexp(void)
 
                     if (IsTradedMon(&gParties[B_TRAINER_PLAYER][*expMonId]))
                     {
-                        // check if the Pokémon doesn't belong to the player
-                        if (gBattleTypeFlags & BATTLE_TYPE_INGAME_PARTNER && *expMonId >= 3)
-                            i = STRINGID_EMPTYSTRING4;
-                        else
-                            i = STRINGID_ABOOSTED;
+                        i = STRINGID_ABOOSTED;
                     }
                     else
                     {
                         i = STRINGID_EMPTYSTRING4;
                     }
 
-                    // get exp getter battler
-                    if (IsDoubleBattle() && !(gBattleTypeFlags & BATTLE_TYPE_INGAME_PARTNER))
-                    {
-                        if (gBattlerPartyIndexes[2] == *expMonId && !(gAbsentBattlerFlags & 4))
-                            gBattleStruct->expGetterBattlerId = 2;
-                        else if (!(gAbsentBattlerFlags & 1))
-                            gBattleStruct->expGetterBattlerId = 0;
-                        else
-                            gBattleStruct->expGetterBattlerId = 2;
-                    }
-                    else
-                    {
-                        gBattleStruct->expGetterBattlerId = 0;
-                    }
-
-                    PREPARE_MON_NICK_WITH_PREFIX_BUFFER(gBattleTextBuff1, gBattleStruct->expGetterBattlerId, *expMonId);
+                    PREPARE_MON_NICK_WITH_PREFIX_BUFFER(gBattleTextBuff1, 0, *expMonId);
                     // buffer 'gained' or 'gained a boosted'
                     PREPARE_STRING_BUFFER(gBattleTextBuff2, i);
                     PREPARE_WORD_NUMBER_BUFFER(gBattleTextBuff3, 6, gBattleStruct->battlerExpReward);
 
                     if (wasSentOut || holdEffect == HOLD_EFFECT_EXP_SHARE)
                     {
-                        PrepareStringBattle(STRINGID_PKMNGAINEDEXP, gBattleStruct->expGetterBattlerId);
+                        PrepareStringBattle(STRINGID_PKMNGAINEDEXP, 0);
                     }
                     else if (IsGen6ExpShareEnabled() && !gBattleStruct->teamGotExpMsgPrinted) // Print 'the rest of your team got exp' message once, when all of the sent-in mons were given experience
                     {
                         gLastUsedItem = ITEM_EXP_SHARE;
-                        PrepareStringBattle(STRINGID_TEAMGAINEDEXP, gBattleStruct->expGetterBattlerId);
+                        PrepareStringBattle(STRINGID_TEAMGAINEDEXP, 0);
                         gBattleStruct->teamGotExpMsgPrinted = TRUE;
                     }
 
@@ -4092,8 +4085,8 @@ static void Cmd_getexp(void)
                 gBattleResources->beforeLvlUp->level             = currLvl;
                 gBattleResources->beforeLvlUp->learnMultipleMoves = FALSE;
 
-                BtlController_EmitExpUpdate(gBattleStruct->expGetterBattlerId, B_COMM_TO_CONTROLLER, *expMonId, gBattleStruct->battlerExpReward);
-                MarkBattlerForControllerExec(gBattleStruct->expGetterBattlerId);
+                BtlController_EmitExpUpdate(0, B_COMM_TO_CONTROLLER, *expMonId, gBattleStruct->battlerExpReward);
+                MarkBattlerForControllerExec(0);
             }
             gBattleScripting.getexpState++;
         }
@@ -4101,28 +4094,23 @@ static void Cmd_getexp(void)
     case 4: // lvl up if necessary
         if (gBattleControllerExecFlags == 0)
         {
-            u32 expBattler = gBattleStruct->expGetterBattlerId;
-            if (gBattleResources->bufferB[expBattler][0] == CONTROLLER_TWORETURNVALUES && gBattleResources->bufferB[expBattler][1] == RET_VALUE_LEVELED_UP)
+            if (gBattleResources->bufferB[0][0] == CONTROLLER_TWORETURNVALUES && gBattleResources->bufferB[0][1] == RET_VALUE_LEVELED_UP)
             {
-                u16 temp, battler = 0xFF;
-                if (gBattleTypeFlags & BATTLE_TYPE_TRAINER && gBattlerPartyIndexes[expBattler] == *expMonId)
-                    HandleLowHpMusicChange(GetBattlerMon(expBattler), expBattler);
+                u16 temp = 0xFF;
+                enum BattlerId battler = GetBattlerFromPlayerPartyId(*expMonId);
+                if (gBattleTypeFlags & BATTLE_TYPE_TRAINER && battler != MAX_BATTLERS_COUNT)
+                    HandleLowHpMusicChange(GetBattlerMon(battler), battler);
 
-                PREPARE_MON_NICK_WITH_PREFIX_BUFFER(gBattleTextBuff1, expBattler, *expMonId);
+                PREPARE_MON_NICK_WITH_PREFIX_BUFFER(gBattleTextBuff1, 0, *expMonId);
                 PREPARE_BYTE_NUMBER_BUFFER(gBattleTextBuff2, 3, GetMonData(&gParties[B_TRAINER_PLAYER][*expMonId], MON_DATA_LEVEL));
 
                 gLeveledUpInBattle |= 1 << *expMonId;
                 BattleScriptCall(BattleScript_LevelUp);
-                gBattleStruct->battlerExpReward = T1_READ_32(&gBattleResources->bufferB[expBattler][2]);
+                gBattleStruct->battlerExpReward = T1_READ_32(&gBattleResources->bufferB[0][2]);
                 AdjustFriendship(&gParties[B_TRAINER_PLAYER][*expMonId], FRIENDSHIP_EVENT_GROW_LEVEL);
 
                 // update battle mon structure after level up
-                if (gBattlerPartyIndexes[0] == *expMonId && gBattleMons[0].hp)
-                    battler = 0;
-                else if (gBattlerPartyIndexes[2] == *expMonId && gBattleMons[2].hp && (IsDoubleBattle()))
-                    battler = 2;
-
-                if (battler != 0xFF)
+                if (battler != MAX_BATTLERS_COUNT)
                 {
                     if (gBattleMons[battler].volatiles.transformed)
                     {

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -1747,9 +1747,9 @@ bool32 HandleFaintedMonActions(void)
             do
             {
                 gBattlerFainted = gBattlerTarget = gBattleStruct->eventState.faintedActionBattler;
-                if (gBattleMons[gBattleStruct->eventState.faintedActionBattler].hp == 0
-                 && !(gBattleStruct->givenExpMons & (1u << gBattlerPartyIndexes[gBattleStruct->eventState.faintedActionBattler]))
-                 && !(gAbsentBattlerFlags & (1u << gBattleStruct->eventState.faintedActionBattler)))
+                if (gBattleMons[gBattlerFainted].hp == 0
+                 && !(gBattleStruct->givenExpMons[GetBattlerTrainer(gBattlerFainted) & BIT_FLANK] & (1u << gBattlerPartyIndexes[gBattlerFainted]))
+                 && !(gAbsentBattlerFlags & (1u << gBattlerFainted)))
                 {
                     BattleScriptExecute(BattleScript_GiveExp);
                     gBattleStruct->eventState.faintedAction = FAINTED_ACTIONS_SET_ABSENT_FLAGS;

--- a/test/battle/exp.c
+++ b/test/battle/exp.c
@@ -188,11 +188,11 @@ AI_DOUBLE_BATTLE_TEST("Both player Pokemon gain experience in double battles")
 {
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET) { Level(99); }
-        PLAYER(SPECIES_DITTO) { Level(1); };
+        PLAYER(SPECIES_DITTO) { Level(1); }
         OPPONENT(SPECIES_BRELOOM) { Moves(MOVE_MEMENTO); }
         OPPONENT(SPECIES_BRELOOM) { Moves(MOVE_CELEBRATE); }
     } WHEN {
-        TURN {  }
+        TURN { }
     } THEN {
         EXPECT(GetMonData(&gParties[B_TRAINER_PLAYER][0], MON_DATA_EXP) > gExperienceTables[gSpeciesInfo[SPECIES_WOBBUFFET].growthRate][99]);
         EXPECT(GetMonData(&gParties[B_TRAINER_PLAYER][1], MON_DATA_LEVEL) > 1);
@@ -203,11 +203,11 @@ AI_TWO_VS_ONE_BATTLE_TEST("Partner Pokemon do not gain experience")
 {
     GIVEN {
         PLAYER(SPECIES_METAPOD) { Level(1); }
-        PARTNER(SPECIES_DITTO) { Level(1); };
+        PARTNER(SPECIES_DITTO) { Level(1); }
         OPPONENT(SPECIES_BRELOOM) { Moves(MOVE_MEMENTO); }
         OPPONENT(SPECIES_BRELOOM) { Moves(MOVE_CELEBRATE); }
     } WHEN {
-        TURN {  }
+        TURN { }
     } THEN {
         EXPECT_GT(GetMonData(&gParties[B_TRAINER_PLAYER][0], MON_DATA_LEVEL), 1);
         EXPECT_EQ(GetMonData(&gParties[B_TRAINER_PARTNER][0], MON_DATA_LEVEL), 1);
@@ -220,17 +220,17 @@ AI_ONE_VS_TWO_BATTLE_TEST("Both opponent Pokemon give experience in multi battle
     GIVEN {
         WITH_CONFIG(B_SCALED_EXP, GEN_3);
         WITH_CONFIG(B_UNEVOLVED_EXP_MULTIPLIER, GEN_3);
-        PLAYER(SPECIES_METAPOD) { Level(1); Speed(3);}
-        PLAYER(SPECIES_WOBBUFFET) { Level(100); Speed(3);};
-        OPPONENT_B(SPECIES_WYNAUT)      { Moves(MOVE_MEMENTO); Speed(2);}
-        OPPONENT_B(SPECIES_WYNAUT)   { Moves(MOVE_CELEBRATE); Speed(1); }
-        OPPONENT_A(SPECIES_WOBBUFFET)   { Moves(MOVE_MEMENTO);  Speed(1);}
-        OPPONENT_A(SPECIES_WOBBUFFET)   { Moves(MOVE_CELEBRATE); Speed(1);}
+        PLAYER(SPECIES_METAPOD) { Level(1); Speed(3); }
+        PLAYER(SPECIES_WOBBUFFET) { Level(100); Speed(3); }
+        OPPONENT_B(SPECIES_WYNAUT) { Moves(MOVE_MEMENTO); Speed(2); }
+        OPPONENT_B(SPECIES_WYNAUT) { Moves(MOVE_CELEBRATE); Speed(1); }
+        OPPONENT_A(SPECIES_WOBBUFFET) { Moves(MOVE_MEMENTO); Speed(1); }
+        OPPONENT_A(SPECIES_WOBBUFFET) { Moves(MOVE_CELEBRATE); Speed(1); }
         expectedXp = GetMonData(&gParties[B_TRAINER_PLAYER][0], MON_DATA_EXP);
         expectedXp += gSpeciesInfo[SPECIES_WYNAUT].expYield * 100 / 7 * 150 / 100; // level (100) * scaling multipler (1 / 7) * trainer multiplier (150 /100)
         expectedXp += gSpeciesInfo[SPECIES_WOBBUFFET].expYield * 100 / 7 * 150 / 100;
     } WHEN {
-        TURN {  }
+        TURN { }
     } THEN {
         EXPECT_EQ(GetMonData(&gParties[B_TRAINER_PARTNER][0], MON_DATA_EXP), expectedXp);
     }

--- a/test/battle/exp.c
+++ b/test/battle/exp.c
@@ -216,7 +216,9 @@ AI_TWO_VS_ONE_BATTLE_TEST("Partner Pokemon do not gain experience")
 
 AI_ONE_VS_TWO_BATTLE_TEST("Both opponent's Pokemon give experience in battle against two opponents")
 {
-    u32 expectedXp = 0;
+    u32 expectedXp = 1; // level 1 xp
+    expectedXp += gSpeciesInfo[SPECIES_WYNAUT].expYield * 100 / 7; // level (100) * scaling multipler (1 / 7)
+    expectedXp += gSpeciesInfo[SPECIES_WOBBUFFET].expYield * 100 / 7;
     GIVEN {
         WITH_CONFIG(B_SCALED_EXP, GEN_3);
         WITH_CONFIG(B_UNEVOLVED_EXP_MULTIPLIER, GEN_3);
@@ -226,12 +228,9 @@ AI_ONE_VS_TWO_BATTLE_TEST("Both opponent's Pokemon give experience in battle aga
         OPPONENT_B(SPECIES_WYNAUT) { Moves(MOVE_CELEBRATE); Speed(1); }
         OPPONENT_A(SPECIES_WOBBUFFET) { Moves(MOVE_MEMENTO); Speed(1); }
         OPPONENT_A(SPECIES_WOBBUFFET) { Moves(MOVE_CELEBRATE); Speed(1); }
-        expectedXp = GetMonData(&gParties[B_TRAINER_PLAYER][0], MON_DATA_EXP);
-        expectedXp += gSpeciesInfo[SPECIES_WYNAUT].expYield * 100 / 7 * 150 / 100; // level (100) * scaling multipler (1 / 7) * trainer multiplier (150 /100)
-        expectedXp += gSpeciesInfo[SPECIES_WOBBUFFET].expYield * 100 / 7 * 150 / 100;
     } WHEN {
         TURN { }
     } THEN {
-        EXPECT_EQ(GetMonData(&gParties[B_TRAINER_PARTNER][0], MON_DATA_EXP), expectedXp);
+        EXPECT_EQ(GetMonData(&gParties[B_TRAINER_PLAYER][0], MON_DATA_EXP), expectedXp);
     }
 }

--- a/test/battle/exp.c
+++ b/test/battle/exp.c
@@ -184,7 +184,7 @@ WILD_BATTLE_TEST("Exp Share(held) gives Experience to mons which did not partici
 
 #endif // I_EXP_SHARE_ITEM
 
-AI_DOUBLE_BATTLE_TEST("Both Pokemon gain experience in double battles")
+AI_DOUBLE_BATTLE_TEST("Both player Pokemon gain experience in double battles")
 {
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET) { Level(99); }
@@ -211,5 +211,27 @@ AI_TWO_VS_ONE_BATTLE_TEST("Partner Pokemon do not gain experience")
     } THEN {
         EXPECT_GT(GetMonData(&gParties[B_TRAINER_PLAYER][0], MON_DATA_LEVEL), 1);
         EXPECT_EQ(GetMonData(&gParties[B_TRAINER_PARTNER][0], MON_DATA_LEVEL), 1);
+    }
+}
+
+AI_ONE_VS_TWO_BATTLE_TEST("Both opponent Pokemon give experience in multi battle")
+{
+    u32 expectedXp = 0;
+    GIVEN {
+        WITH_CONFIG(B_SCALED_EXP, GEN_3);
+        WITH_CONFIG(B_UNEVOLVED_EXP_MULTIPLIER, GEN_3);
+        PLAYER(SPECIES_METAPOD) { Level(1); Speed(3);}
+        PLAYER(SPECIES_WOBBUFFET) { Level(100); Speed(3);};
+        OPPONENT_B(SPECIES_WYNAUT)      { Moves(MOVE_MEMENTO); Speed(2);}
+        OPPONENT_B(SPECIES_WYNAUT)   { Moves(MOVE_CELEBRATE); Speed(1); }
+        OPPONENT_A(SPECIES_WOBBUFFET)   { Moves(MOVE_MEMENTO);  Speed(1);}
+        OPPONENT_A(SPECIES_WOBBUFFET)   { Moves(MOVE_CELEBRATE); Speed(1);}
+        expectedXp = GetMonData(&gParties[B_TRAINER_PLAYER][0], MON_DATA_EXP);
+        expectedXp += gSpeciesInfo[SPECIES_WYNAUT].expYield * 100 / 7 * 150 / 100; // level (100) * scaling multipler (1 / 7) * trainer multiplier (150 /100)
+        expectedXp += gSpeciesInfo[SPECIES_WOBBUFFET].expYield * 100 / 7 * 150 / 100;
+    } WHEN {
+        TURN {  }
+    } THEN {
+        EXPECT_EQ(GetMonData(&gParties[B_TRAINER_PARTNER][0], MON_DATA_EXP), expectedXp);
     }
 }

--- a/test/battle/exp.c
+++ b/test/battle/exp.c
@@ -183,3 +183,33 @@ WILD_BATTLE_TEST("Exp Share(held) gives Experience to mons which did not partici
 }
 
 #endif // I_EXP_SHARE_ITEM
+
+AI_DOUBLE_BATTLE_TEST("Both Pokemon gain experience in double battles")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Level(99); }
+        PLAYER(SPECIES_DITTO) { Level(1); };
+        OPPONENT(SPECIES_BRELOOM) { Moves(MOVE_MEMENTO); }
+        OPPONENT(SPECIES_BRELOOM) { Moves(MOVE_CELEBRATE); }
+    } WHEN {
+        TURN {  }
+    } THEN {
+        EXPECT(GetMonData(&gParties[B_TRAINER_PLAYER][0], MON_DATA_EXP) > gExperienceTables[gSpeciesInfo[SPECIES_WOBBUFFET].growthRate][99]);
+        EXPECT(GetMonData(&gParties[B_TRAINER_PLAYER][1], MON_DATA_LEVEL) > 1);
+    }
+}
+
+AI_TWO_VS_ONE_BATTLE_TEST("Partner Pokemon do not gain experience")
+{
+    GIVEN {
+        PLAYER(SPECIES_METAPOD) { Level(1); }
+        PARTNER(SPECIES_DITTO) { Level(1); };
+        OPPONENT(SPECIES_BRELOOM) { Moves(MOVE_MEMENTO); }
+        OPPONENT(SPECIES_BRELOOM) { Moves(MOVE_CELEBRATE); }
+    } WHEN {
+        TURN {  }
+    } THEN {
+        EXPECT_GT(GetMonData(&gParties[B_TRAINER_PLAYER][0], MON_DATA_LEVEL), 1);
+        EXPECT_EQ(GetMonData(&gParties[B_TRAINER_PARTNER][0], MON_DATA_LEVEL), 1);
+    }
+}

--- a/test/battle/exp.c
+++ b/test/battle/exp.c
@@ -214,7 +214,7 @@ AI_TWO_VS_ONE_BATTLE_TEST("Partner Pokemon do not gain experience")
     }
 }
 
-AI_ONE_VS_TWO_BATTLE_TEST("Both opponent Pokemon give experience in multi battle")
+AI_ONE_VS_TWO_BATTLE_TEST("Both opponent's Pokemon give experience in battle against two opponents")
 {
     u32 expectedXp = 0;
     GIVEN {


### PR DESCRIPTION
Fixes multiple xp related bug linked to 12v12

The game was checking the partyId to check if the mon receiving xp was in the left mon or right mon
But if both the player mon and partner mon share the same party id (which is now possible because of 12v12) the game would confuse the partner and player mon thus printing the wrong string

The game was also checking for party id >= 3 to consider those as partner pokemon, these are also fixed

Calculating gBattleStruct->expGetterBattlerId was found unnecessary, this is because the value was used for two things:
- get the trainer associated with the party id of the mon receiving xp (but only the trainer party can receive xp)
- mark a battler/controller to wait for the string to pring and xp bar to fill (which can only happen for the player controller)
so we can just replace gBattleStruct->expGetterBattlerId with 0 and the exp fistribution work fine

The issue was also affecting `gBattleStruct->givenExpMons` which makes sure an opponent pokemon can only give xp once but two pokemon with the same id from different enemies parties would get mixed up and the second one would not give xp

### Large Language Models (AI)
No

### Media

https://github.com/user-attachments/assets/8a32cc4e-6084-4ab2-8ffe-fdaaabae7f0f


## Issue(s) that this PR fixes
Fixes #10487
Fixes #10267
Fixes #10356

## Discord contact info
Jamie