### PR TITLE
Fix trying to remove non existing speaker box

### DIFF
--- a/src/field_name_box.c
+++ b/src/field_name_box.c
@@ -204,6 +204,10 @@ void TrySpawnAndShowNamebox(const u8 *speaker, u32 tileNum)
         RedrawDialogueFrame();
         return;
     }
+    else if (gSpeakerName == NULL)
+    {
+        return;
+    }
 
     PrepareNamebox(tileNum);
     DrawNamebox(sNameboxWindowId, tileNum - NAME_BOX_BASE_TILES_TOTAL, TRUE);


### PR DESCRIPTION
I just added a check to prevent the game from trying to clear a speaker box that doesn't exist causing issues

## Issue(s) that this PR fixes
Fixes #10269


## Discord contact info
Jamie
