### PR TITLE
Fix Regenerator/Natural Cure applying to the wrong party slot

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -9355,7 +9355,7 @@ static void Cmd_switchoutabilities(void)
 
         gBattleMons[battler].status1 = 0;
         BtlController_EmitSetMonData(battler, B_COMM_TO_CONTROLLER, REQUEST_STATUS_BATTLE,
-                                        1u << gBattleStruct->battlerPartyIndexes[battler],
+                                        1u << gBattlerPartyIndexes[battler],
                                         sizeof(gBattleMons[battler].status1),
                                         &gBattleMons[battler].status1);
         MarkBattlerForControllerExec(battler);
@@ -9367,7 +9367,7 @@ static void Cmd_switchoutabilities(void)
         if (regenerate > gBattleMons[battler].maxHP)
             regenerate = gBattleMons[battler].maxHP;
         BtlController_EmitSetMonData(battler, B_COMM_TO_CONTROLLER, REQUEST_HP_BATTLE,
-                                        1u << gBattleStruct->battlerPartyIndexes[battler],
+                                        1u << gBattlerPartyIndexes[battler],
                                         sizeof(regenerate),
                                         &regenerate);
         MarkBattlerForControllerExec(battler);

--- a/test/battle/ability/natural_cure.c
+++ b/test/battle/ability/natural_cure.c
@@ -2,3 +2,20 @@
 #include "test/battle.h"
 
 TO_DO_BATTLE_TEST("TODO: Write Natural Cure (Ability) test titles")
+
+SINGLE_BATTLE_TEST("Natural Cure cures the user and not another party member when switching out with a hit escape move")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_U_TURN) == EFFECT_HIT_ESCAPE);
+        PLAYER(SPECIES_WOBBUFFET) { Status1(STATUS1_POISON); }
+        PLAYER(SPECIES_CHANSEY) { Ability(ABILITY_NATURAL_CURE); Status1(STATUS1_POISON); }
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { SWITCH(player, 1); MOVE(opponent, MOVE_CELEBRATE); }
+        TURN { MOVE(player, MOVE_U_TURN); MOVE(opponent, MOVE_CELEBRATE); SEND_OUT(player, 2); }
+    } THEN {
+        EXPECT_EQ(GetMonData(&gParties[B_TRAINER_PLAYER][0], MON_DATA_STATUS), STATUS1_POISON);
+        EXPECT_EQ(GetMonData(&gParties[B_TRAINER_PLAYER][1], MON_DATA_STATUS), STATUS1_NONE);
+    }
+}

--- a/test/battle/ability/regenerator.c
+++ b/test/battle/ability/regenerator.c
@@ -48,3 +48,20 @@ SINGLE_BATTLE_TEST("Regenerator heals 1/3 of max HP upon switching out but doesn
         EXPECT_LE(player->hp, player->maxHP);
     }
 }
+
+SINGLE_BATTLE_TEST("Regenerator heals the user and not a fainted party member when switching out with a hit escape move")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_U_TURN) == EFFECT_HIT_ESCAPE);
+        PLAYER(SPECIES_WOBBUFFET) { HP(1); }
+        PLAYER(SPECIES_SLOWBRO) { Ability(ABILITY_REGENERATOR); HP(1); MaxHP(300); }
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_POUND); SEND_OUT(player, 1); }
+        TURN { MOVE(player, MOVE_U_TURN); MOVE(opponent, MOVE_CELEBRATE); SEND_OUT(player, 2); }
+    } THEN {
+        EXPECT_EQ(GetMonData(&gParties[B_TRAINER_PLAYER][0], MON_DATA_HP), 0);
+        EXPECT_EQ(GetMonData(&gParties[B_TRAINER_PLAYER][1], MON_DATA_HP), 1 + 300 / 3);
+    }
+}


### PR DESCRIPTION
When a Pokémon with Regenerator uses a switching move, such as U-turn, it can revive a fainted Pokémon because the recovered HP value may be applied to the Pokémon switching in instead of the Regenerator user.

<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
Cmd_switchoutabilities addressed the target party slot through gBattleStruct->battlerPartyIndexes[battler], a snapshot that is only refreshed by ChooseMonToSendOut, Cmd_openpartyscreen and B_ACTION_SWITCH.

In the scripts used by switch-out moves, switchoutabilities runs before openpartyscreen, so the snapshot still held the slot recorded by the previous party screen - usually that of the last Pokemon to faint. The ability was therefore applied to an unrelated party member instead of the Pokemon switching out, and Regenerator writing a non-zero HP into a fainted member's slot let that member be sent back out.

Use the live gBattlerPartyIndexes[battler], which still points at the outgoing Pokemon in every script that runs the command, since it is only reassigned later in Cmd_getswitchedmondata.

### Large Language Models (AI)
<!-- Does your pull request contain code or assets generated by a large language model (AI)? If so, where? -->
<!-- NOTE: There is an expectation that you have fully reviewed your code to ensure it meets all merge criteria (detailed above). -->
<!-- If the maintainers believe that a pull request was generated by AI with no or little to no human oversight, the pull request will be closed without further discussion. -->

Claude, revised.

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->

thalescd

Edited: Added a brief summary of the main issue.