### PR TITLE
Minor field move fixes (upcoming)

### DIFF
--- a/include/field_move.h
+++ b/include/field_move.h
@@ -7,7 +7,7 @@
 struct FieldMoveUnlock
 {
    bool32 (*isUnlockedFunc)(enum FieldMove);
-   const u8* lockedMessage;
+   const u8 *lockedMessage;
 };
 
 enum FieldMoveUnlockType
@@ -39,12 +39,12 @@ static inline bool32 SetUpFieldMove(enum FieldMove fieldMove)
 
 static inline bool32 IsFieldMoveUnlocked(enum FieldMove fieldMove)
 {
-    return  gFieldMoveUnlocks[gFieldMoveInfo[fieldMove].unlockType].isUnlockedFunc(fieldMove);
+    return gFieldMoveUnlocks[gFieldMoveInfo[fieldMove].unlockType].isUnlockedFunc(fieldMove);
 }
 
 static inline const u8 *FieldMove_GetLockedMessage(enum FieldMove fieldMove)
 {
-    return  gFieldMoveUnlocks[gFieldMoveInfo[fieldMove].unlockType].lockedMessage;
+    return gFieldMoveUnlocks[gFieldMoveInfo[fieldMove].unlockType].lockedMessage;
 }
 
 static inline enum Move FieldMove_GetMoveId(enum FieldMove fieldMove)
@@ -59,7 +59,7 @@ static inline u32 FieldMove_GetPartyMsgID(enum FieldMove fieldMove)
 
 static inline bool32 FieldMove_IsVisible(enum FieldMove fieldMove)
 {
-    return (!gFieldMoveInfo[fieldMove].hideIfLocked || IsFieldMoveUnlocked(fieldMove));
+    return !gFieldMoveInfo[fieldMove].hideIfLocked || IsFieldMoveUnlocked(fieldMove);
 }
 
 #endif //GUARD_FIELD_MOVE_H

--- a/include/field_move.h
+++ b/include/field_move.h
@@ -4,15 +4,33 @@
 #include "global.h"
 #include "constants/field_move.h"
 
+struct FieldMoveUnlock
+{
+   bool32 (*isUnlockedFunc)(enum FieldMove);
+   const u8* lockedMessage;
+};
+
+enum FieldMoveUnlockType
+{
+    CANT_UNLOCK,
+    ALWAYS_UNLOCKED,
+    BADGE_UNLOCK,
+    FIELD_MOVE_UNLOCK_COUNT
+};
+
 struct FieldMoveInfo
 {
     bool32 (*fieldMoveFunc)(void);
-    bool32 (*isUnlockedFunc)(void);
-    u16 moveID;
-    u8 partyMsgID;
+    enum FieldMoveUnlockType unlockType:3;
+    enum Move moveID:11;
+    u32 partyMsgID:7;
+    u32 arg:8;
+    u32 hideIfLocked:1;
+    u32 padding:3;
 };
 
 extern const struct FieldMoveInfo gFieldMoveInfo[];
+extern const struct FieldMoveUnlock gFieldMoveUnlocks[];
 
 static inline bool32 SetUpFieldMove(enum FieldMove fieldMove)
 {
@@ -21,7 +39,12 @@ static inline bool32 SetUpFieldMove(enum FieldMove fieldMove)
 
 static inline bool32 IsFieldMoveUnlocked(enum FieldMove fieldMove)
 {
-    return gFieldMoveInfo[fieldMove].isUnlockedFunc();
+    return  gFieldMoveUnlocks[gFieldMoveInfo[fieldMove].unlockType].isUnlockedFunc(fieldMove);
+}
+
+static inline const u8 *FieldMove_GetLockedMessage(enum FieldMove fieldMove)
+{
+    return  gFieldMoveUnlocks[gFieldMoveInfo[fieldMove].unlockType].lockedMessage;
 }
 
 static inline enum Move FieldMove_GetMoveId(enum FieldMove fieldMove)
@@ -32,6 +55,11 @@ static inline enum Move FieldMove_GetMoveId(enum FieldMove fieldMove)
 static inline u32 FieldMove_GetPartyMsgID(enum FieldMove fieldMove)
 {
     return gFieldMoveInfo[fieldMove].partyMsgID;
+}
+
+static inline bool32 FieldMove_IsVisible(enum FieldMove fieldMove)
+{
+    return (!gFieldMoveInfo[fieldMove].hideIfLocked || IsFieldMoveUnlocked(fieldMove));
 }
 
 #endif //GUARD_FIELD_MOVE_H

--- a/src/field_move.c
+++ b/src/field_move.c
@@ -4,175 +4,125 @@
 #include "fldeff.h"
 #include "fldeff_misc.h"
 #include "party_menu.h"
+#include "strings.h"
 #include "constants/field_move.h"
 #include "constants/moves.h"
 #include "constants/party_menu.h"
 
-static bool32 IsFieldMoveUnlocked_Cut(void)
+static bool32 IsAlwaysFalse(enum FieldMove fieldMove)
 {
-    if (IS_FRLG)
-        return FlagGet(FLAG_BADGE02_GET);
-
-    return FlagGet(FLAG_BADGE01_GET);
+    return FALSE;
 }
 
-static bool32 IsFieldMoveUnlocked_Flash(void)
-{
-    if (IS_FRLG)
-        return FlagGet(FLAG_BADGE01_GET);
-
-    return FlagGet(FLAG_BADGE02_GET);
-}
-
-static bool32 IsFieldMoveUnlocked_RockSmash(void)
-{
-    if (IS_FRLG)
-        return FlagGet(FLAG_BADGE06_GET);
-
-    return FlagGet(FLAG_BADGE03_GET);
-}
-
-static bool32 IsFieldMoveUnlocked_Strength(void)
-{
-    return FlagGet(FLAG_BADGE04_GET);
-}
-
-static bool32 IsFieldMoveUnlocked_Surf(void)
-{
-    return FlagGet(FLAG_BADGE05_GET);
-}
-
-static bool32 IsFieldMoveUnlocked_Fly(void)
-{
-    if (IS_FRLG)
-        return FlagGet(FLAG_BADGE03_GET);
-
-    return FlagGet(FLAG_BADGE06_GET);
-}
-
-static bool32 IsFieldMoveUnlocked_Dive(void)
-{
-    return FlagGet(FLAG_BADGE07_GET);
-}
-
-static bool32 IsFieldMoveUnlocked_Waterfall(void)
-{
-    if (IS_FRLG)
-        return FlagGet(FLAG_BADGE07_GET);
-
-    return FlagGet(FLAG_BADGE08_GET);
-}
-
-static bool32 IsFieldMoveUnlocked_RockClimb(void)
-{
-    return OW_ROCK_CLIMB_FIELD_MOVE;
-}
-
-static bool32 IsFieldMoveUnlocked_Teleport(void)
+static bool32 IsAlwaysTrue(enum FieldMove fieldMove)
 {
     return TRUE;
 }
 
-static bool32 IsFieldMoveUnlocked_Dig(void)
+static bool32 HasBadgeForFieldMove(enum FieldMove fieldMove)
 {
-    return TRUE;
+    return FlagGet(gFieldMoveInfo[fieldMove].arg + FLAG_BADGE01_GET);
 }
 
-static bool32 IsFieldMoveUnlocked_SecretPower(void)
+const struct FieldMoveUnlock gFieldMoveUnlocks[FIELD_MOVE_UNLOCK_COUNT] =
 {
-    return TRUE;
-}
+    [CANT_UNLOCK] =
+    {
+        .isUnlockedFunc = IsAlwaysFalse,
+        .lockedMessage = gText_EmptyString2,
+    },
+    [ALWAYS_UNLOCKED] =
+    {
+        .isUnlockedFunc = IsAlwaysTrue,
+        .lockedMessage = gText_EmptyString2,
+    },
+    [BADGE_UNLOCK] =
+    {
+        .isUnlockedFunc = HasBadgeForFieldMove,
+        .lockedMessage = gText_CantUseUntilNewBadge,
+    },
+};
 
-static bool32 IsFieldMoveUnlocked_MilkDrink(void)
-{
-    return TRUE;
-}
-
-static bool32 IsFieldMoveUnlocked_SoftBoiled(void)
-{
-    return TRUE;
-}
-
-static bool32 IsFieldMoveUnlocked_SweetScent(void)
-{
-    return TRUE;
-}
-
-static bool32 IsFieldMoveUnlocked_Defog(void)
-{
-    return OW_DEFOG_FIELD_MOVE;
-}
+#define FLAG_TO_BADGE(flag) flag - FLAG_BADGE01_GET
 
 const struct FieldMoveInfo gFieldMoveInfo[FIELD_MOVES_COUNT] =
 {
     [FIELD_MOVE_CUT] =
     {
         .fieldMoveFunc = SetUpFieldMove_Cut,
-        .isUnlockedFunc = IsFieldMoveUnlocked_Cut,
+        .unlockType = BADGE_UNLOCK,
         .moveID = MOVE_CUT,
         .partyMsgID = PARTY_MSG_NOTHING_TO_CUT,
+        .arg = IS_FRLG ? FLAG_TO_BADGE(FLAG_BADGE02_GET) : FLAG_TO_BADGE(FLAG_BADGE01_GET),
     },
 
     [FIELD_MOVE_FLASH] =
     {
         .fieldMoveFunc = SetUpFieldMove_Flash,
-        .isUnlockedFunc = IsFieldMoveUnlocked_Flash,
+        .unlockType = BADGE_UNLOCK,
         .moveID = MOVE_FLASH,
         .partyMsgID = PARTY_MSG_CANT_USE_HERE,
+        .arg = IS_FRLG ? FLAG_TO_BADGE(FLAG_BADGE01_GET) : FLAG_TO_BADGE(FLAG_BADGE02_GET),
     },
 
     [FIELD_MOVE_ROCK_SMASH] =
     {
         .fieldMoveFunc = SetUpFieldMove_RockSmash,
-        .isUnlockedFunc = IsFieldMoveUnlocked_RockSmash,
+        .unlockType = BADGE_UNLOCK,
         .moveID = MOVE_ROCK_SMASH,
         .partyMsgID = PARTY_MSG_CANT_USE_HERE,
+        .arg = IS_FRLG ? FLAG_TO_BADGE(FLAG_BADGE06_GET) : FLAG_TO_BADGE(FLAG_BADGE03_GET),
     },
 
     [FIELD_MOVE_STRENGTH] =
     {
         .fieldMoveFunc = SetUpFieldMove_Strength,
-        .isUnlockedFunc = IsFieldMoveUnlocked_Strength,
+        .unlockType = BADGE_UNLOCK,
         .moveID = MOVE_STRENGTH,
         .partyMsgID = PARTY_MSG_CANT_USE_HERE,
+        .arg = FLAG_TO_BADGE(FLAG_BADGE04_GET),
     },
 
     [FIELD_MOVE_SURF] =
     {
         .fieldMoveFunc = SetUpFieldMove_Surf,
-        .isUnlockedFunc = IsFieldMoveUnlocked_Surf,
+        .unlockType = BADGE_UNLOCK,
         .moveID = MOVE_SURF,
         .partyMsgID = PARTY_MSG_CANT_SURF_HERE,
+        .arg = FLAG_TO_BADGE(FLAG_BADGE05_GET),
     },
 
     [FIELD_MOVE_FLY] =
     {
         .fieldMoveFunc = SetUpFieldMove_Fly,
-        .isUnlockedFunc = IsFieldMoveUnlocked_Fly,
+        .unlockType = BADGE_UNLOCK,
         .moveID = MOVE_FLY,
         .partyMsgID = PARTY_MSG_CANT_USE_HERE,
+        .arg = IS_FRLG ? FLAG_TO_BADGE(FLAG_BADGE03_GET) : FLAG_TO_BADGE(FLAG_BADGE06_GET),
     },
 
     [FIELD_MOVE_DIVE] =
     {
         .fieldMoveFunc = SetUpFieldMove_Dive,
-        .isUnlockedFunc = IsFieldMoveUnlocked_Dive,
+        .unlockType = BADGE_UNLOCK,
         .moveID = MOVE_DIVE,
         .partyMsgID = PARTY_MSG_CANT_USE_HERE,
+        .arg = FLAG_TO_BADGE(FLAG_BADGE07_GET),
     },
 
     [FIELD_MOVE_WATERFALL] =
     {
         .fieldMoveFunc = SetUpFieldMove_Waterfall,
-        .isUnlockedFunc = IsFieldMoveUnlocked_Waterfall,
+        .unlockType = BADGE_UNLOCK,
         .moveID = MOVE_WATERFALL,
         .partyMsgID = PARTY_MSG_CANT_USE_HERE,
+        .arg = IS_FRLG ? FLAG_TO_BADGE(FLAG_BADGE07_GET) : FLAG_TO_BADGE(FLAG_BADGE08_GET),
     },
 
     [FIELD_MOVE_TELEPORT] =
     {
         .fieldMoveFunc = SetUpFieldMove_Teleport,
-        .isUnlockedFunc = IsFieldMoveUnlocked_Teleport,
+        .unlockType = ALWAYS_UNLOCKED,
         .moveID = MOVE_TELEPORT,
         .partyMsgID = PARTY_MSG_CANT_USE_HERE,
     },
@@ -180,7 +130,7 @@ const struct FieldMoveInfo gFieldMoveInfo[FIELD_MOVES_COUNT] =
     [FIELD_MOVE_DIG] =
     {
         .fieldMoveFunc = SetUpFieldMove_Dig,
-        .isUnlockedFunc = IsFieldMoveUnlocked_Dig,
+        .unlockType = ALWAYS_UNLOCKED,
         .moveID = MOVE_DIG,
         .partyMsgID = PARTY_MSG_CANT_USE_HERE,
     },
@@ -188,7 +138,7 @@ const struct FieldMoveInfo gFieldMoveInfo[FIELD_MOVES_COUNT] =
     [FIELD_MOVE_SECRET_POWER] =
     {
         .fieldMoveFunc = SetUpFieldMove_SecretPower,
-        .isUnlockedFunc = IsFieldMoveUnlocked_SecretPower,
+        .unlockType = ALWAYS_UNLOCKED,
         .moveID = MOVE_SECRET_POWER,
         .partyMsgID = PARTY_MSG_CANT_USE_HERE,
     },
@@ -196,7 +146,7 @@ const struct FieldMoveInfo gFieldMoveInfo[FIELD_MOVES_COUNT] =
     [FIELD_MOVE_MILK_DRINK] =
     {
         .fieldMoveFunc = SetUpFieldMove_SoftBoiled,
-        .isUnlockedFunc = IsFieldMoveUnlocked_MilkDrink,
+        .unlockType = ALWAYS_UNLOCKED,
         .moveID = MOVE_MILK_DRINK,
         .partyMsgID = PARTY_MSG_NOT_ENOUGH_HP,
     },
@@ -204,7 +154,7 @@ const struct FieldMoveInfo gFieldMoveInfo[FIELD_MOVES_COUNT] =
     [FIELD_MOVE_SOFT_BOILED] =
     {
         .fieldMoveFunc = SetUpFieldMove_SoftBoiled,
-        .isUnlockedFunc = IsFieldMoveUnlocked_SoftBoiled,
+        .unlockType = ALWAYS_UNLOCKED,
         .moveID = MOVE_SOFT_BOILED,
         .partyMsgID = PARTY_MSG_NOT_ENOUGH_HP,
     },
@@ -212,22 +162,32 @@ const struct FieldMoveInfo gFieldMoveInfo[FIELD_MOVES_COUNT] =
     [FIELD_MOVE_SWEET_SCENT] =
     {
         .fieldMoveFunc = SetUpFieldMove_SweetScent,
-        .isUnlockedFunc = IsFieldMoveUnlocked_SweetScent,
+        .unlockType = ALWAYS_UNLOCKED,
         .moveID = MOVE_SWEET_SCENT,
         .partyMsgID = PARTY_MSG_CANT_USE_HERE,
     },
     [FIELD_MOVE_ROCK_CLIMB] =
     {
         .fieldMoveFunc = SetUpFieldMove_RockClimb,
-        .isUnlockedFunc = IsFieldMoveUnlocked_RockClimb,
+#if OW_ROCK_CLIMB_FIELD_MOVE
+        .unlockType = ALWAYS_UNLOCKED,
+#else
+        .unlockType = CANT_UNLOCK,
+#endif
         .moveID = MOVE_ROCK_CLIMB,
         .partyMsgID = PARTY_MSG_CANT_USE_HERE,
+        .hideIfLocked = TRUE,
     },
     [FIELD_MOVE_DEFOG] =
     {
         .fieldMoveFunc = SetUpFieldMove_Defog,
-        .isUnlockedFunc = IsFieldMoveUnlocked_Defog,
+#if OW_DEFOG_FIELD_MOVE
+        .unlockType = ALWAYS_UNLOCKED,
+#else
+        .unlockType = CANT_UNLOCK,
+#endif
         .moveID = MOVE_DEFOG,
         .partyMsgID = PARTY_MSG_CANT_USE_HERE,
+        .hideIfLocked = TRUE,
     },
 };

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -2962,6 +2962,9 @@ static void SetPartyMonFieldSelectionActions(struct Pokemon *mons, u8 slotId)
     {
         for (j = 0; j != FIELD_MOVES_COUNT; j++)
         {
+            if (!FieldMove_IsVisible(j))
+                continue;
+
             if (GetMonData(&mons[slotId], i + MON_DATA_MOVE1) == FieldMove_GetMoveId(j))
             {
                 AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, j + MENU_FIELD_MOVES);
@@ -4095,70 +4098,64 @@ static void CursorCb_FieldMove(u8 taskId)
     PartyMenuRemoveWindow(&sPartyMenuInternal->windowId[1]);
     if (MenuHelpers_IsLinkActive() == TRUE || InUnionRoom() == TRUE)
     {
-        if (fieldMove == FIELD_MOVE_MILK_DRINK || fieldMove == FIELD_MOVE_SOFT_BOILED)
-            DisplayPartyMenuStdMessage(PARTY_MSG_CANT_USE_HERE);
-        else
-            DisplayPartyMenuStdMessage(FieldMove_GetPartyMsgID(fieldMove));
-
+        DisplayPartyMenuStdMessage(PARTY_MSG_CANT_USE_HERE);
         gTasks[taskId].func = Task_CancelAfterAorBPress;
+        return;
     }
+
+    if (!IsFieldMoveUnlocked(fieldMove))
+    {
+        DisplayPartyMenuMessage(FieldMove_GetLockedMessage(fieldMove), TRUE);
+        gTasks[taskId].func = Task_ReturnToChooseMonAfterText;
+    }
+    else if (SetUpFieldMove(fieldMove) == TRUE)
+    {
+        switch (fieldMove)
+        {
+        case FIELD_MOVE_MILK_DRINK:
+        case FIELD_MOVE_SOFT_BOILED:
+            ChooseMonForSoftboiled(taskId);
+            break;
+        case FIELD_MOVE_TELEPORT:
+            mapHeader = Overworld_GetMapHeaderByGroupAndId(gSaveBlock1Ptr->lastHealLocation.mapGroup, gSaveBlock1Ptr->lastHealLocation.mapNum);
+            GetMapNameGeneric(gStringVar1, mapHeader->regionMapSectionId);
+            StringExpandPlaceholders(gStringVar4, gText_ReturnToHealingSpot);
+            DisplayFieldMoveExitAreaMessage(taskId);
+            sPartyMenuInternal->data[0] = fieldMove;
+            break;
+        case FIELD_MOVE_DIG:
+            mapHeader = Overworld_GetMapHeaderByGroupAndId(gSaveBlock1Ptr->escapeWarp.mapGroup, gSaveBlock1Ptr->escapeWarp.mapNum);
+            GetMapNameGeneric(gStringVar1, mapHeader->regionMapSectionId);
+            StringExpandPlaceholders(gStringVar4, gText_EscapeFromHere);
+            DisplayFieldMoveExitAreaMessage(taskId);
+            sPartyMenuInternal->data[0] = fieldMove;
+            break;
+        case FIELD_MOVE_FLY:
+            gPartyMenu.exitCallback = CB2_OpenFlyMap;
+            Task_ClosePartyMenu(taskId);
+            break;
+        default:
+            gPartyMenu.exitCallback = CB2_ReturnToField;
+            Task_ClosePartyMenu(taskId);
+            break;
+        }
+    }
+    // Cant use Field Move
     else
     {
-        // All field moves before WATERFALL are HMs.
-        if (!IsFieldMoveUnlocked(fieldMove))
+        switch (fieldMove)
         {
-            DisplayPartyMenuMessage(gText_CantUseUntilNewBadge, TRUE);
-            gTasks[taskId].func = Task_ReturnToChooseMonAfterText;
+        case FIELD_MOVE_SURF:
+            DisplayCantUseSurfMessage();
+            break;
+        case FIELD_MOVE_FLASH:
+            DisplayCantUseFlashMessage();
+            break;
+        default:
+            DisplayPartyMenuStdMessage(FieldMove_GetPartyMsgID(fieldMove));
+            break;
         }
-        else if (SetUpFieldMove(fieldMove) == TRUE)
-        {
-            switch (fieldMove)
-            {
-            case FIELD_MOVE_MILK_DRINK:
-            case FIELD_MOVE_SOFT_BOILED:
-                ChooseMonForSoftboiled(taskId);
-                break;
-            case FIELD_MOVE_TELEPORT:
-                mapHeader = Overworld_GetMapHeaderByGroupAndId(gSaveBlock1Ptr->lastHealLocation.mapGroup, gSaveBlock1Ptr->lastHealLocation.mapNum);
-                GetMapNameGeneric(gStringVar1, mapHeader->regionMapSectionId);
-                StringExpandPlaceholders(gStringVar4, gText_ReturnToHealingSpot);
-                DisplayFieldMoveExitAreaMessage(taskId);
-                sPartyMenuInternal->data[0] = fieldMove;
-                break;
-            case FIELD_MOVE_DIG:
-                mapHeader = Overworld_GetMapHeaderByGroupAndId(gSaveBlock1Ptr->escapeWarp.mapGroup, gSaveBlock1Ptr->escapeWarp.mapNum);
-                GetMapNameGeneric(gStringVar1, mapHeader->regionMapSectionId);
-                StringExpandPlaceholders(gStringVar4, gText_EscapeFromHere);
-                DisplayFieldMoveExitAreaMessage(taskId);
-                sPartyMenuInternal->data[0] = fieldMove;
-                break;
-            case FIELD_MOVE_FLY:
-                gPartyMenu.exitCallback = CB2_OpenFlyMap;
-                Task_ClosePartyMenu(taskId);
-                break;
-            default:
-                gPartyMenu.exitCallback = CB2_ReturnToField;
-                Task_ClosePartyMenu(taskId);
-                break;
-            }
-        }
-        // Cant use Field Move
-        else
-        {
-            switch (fieldMove)
-            {
-            case FIELD_MOVE_SURF:
-                DisplayCantUseSurfMessage();
-                break;
-            case FIELD_MOVE_FLASH:
-                DisplayCantUseFlashMessage();
-                break;
-            default:
-                DisplayPartyMenuStdMessage(FieldMove_GetPartyMsgID(fieldMove));
-                break;
-            }
-            gTasks[taskId].func = Task_CancelAfterAorBPress;
-        }
+        gTasks[taskId].func = Task_CancelAfterAorBPress;
     }
 }
 


### PR DESCRIPTION
Upcoming duplicate of #10451

## Media

https://github.com/user-attachments/assets/f152cda5-5cab-4e40-8e5a-bfc76887b468


## Issue(s) that this PR fixes
- Fixes field moves with FALSE config appearing in the summary menu
- Fixes message when trying to use a locked field move. It would always reference badges even if the unlock condition didn't use badges

## Things to note in the release changelog:
- Field move unlock functions were rewritten to use an intermediate unlock type. If you use custom unlock functions, you will likely need to rewrite them

## Discord contact info
Jamie