### PR TITLE
Restore singmsg and normalmsg functionality

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -1771,12 +1771,12 @@
 	.byte SCR_OP_UNLOADHELP
 	.endm
 
-	@ Used only in FireRed/LeafGreen, does nothing in Emerald.
+	@ After using this command, all standard message boxes will use the signpost frame.
 	.macro signmsg
 	.byte SCR_OP_SIGNMSG
 	.endm
 
-	@ Used only in FireRed/LeafGreen, does nothing in Emerald.
+	@ Ends the effects of signmsg, returning message box frames to normal.
 	.macro normalmsg
 	.byte SCR_OP_NORMALMSG
 	.endm

--- a/data/script_cmd_table.inc
+++ b/data/script_cmd_table.inc
@@ -224,8 +224,8 @@ gScriptCmdTable::
 	script_cmd_table_entry SCR_OP_TEXTCOLOR                     ScrCmd_textcolor,                   requests_effects=1  @ 0xc7
 	script_cmd_table_entry SCR_OP_LOADHELP                      ScrCmd_nop1,                        requests_effects=1  @ 0xc8
 	script_cmd_table_entry SCR_OP_UNLOADHELP                    ScrCmd_nop1,                        requests_effects=1  @ 0xc9
-	script_cmd_table_entry SCR_OP_SIGNMSG                       ScrCmd_nop1,                        requests_effects=1  @ 0xca
-	script_cmd_table_entry SCR_OP_NORMALMSG                     ScrCmd_nop1,                        requests_effects=1  @ 0xcb
+	script_cmd_table_entry SCR_OP_SIGNMSG                       ScrCmd_signmsg,                     requests_effects=1  @ 0xca
+	script_cmd_table_entry SCR_OP_NORMALMSG                     ScrCmd_normalmsg,                   requests_effects=1  @ 0xcb
 	script_cmd_table_entry SCR_OP_COMPAREHIDDENVAR              ScrCmd_nop1,                        requests_effects=1  @ 0xcc
 	script_cmd_table_entry SCR_OP_SETMODERNFATEFULENCOUNTER     ScrCmd_setmodernfatefulencounter,   requests_effects=1  @ 0xcd
 	script_cmd_table_entry SCR_OP_CHECKMODERNFATEFULENCOUNTER   ScrCmd_checkmodernfatefulencounter, requests_effects=1  @ 0xce

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -3423,3 +3423,19 @@ bool8 ScrCmd_getbraillestringwidth(struct ScriptContext * ctx)
     gSpecialVar_0x8004 = GetStringWidth(FONT_BRAILLE, msg, -1);
     return FALSE;
 }
+
+bool8 ScrCmd_signmsg(struct ScriptContext *ctx)
+{
+    Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
+
+    gMsgIsSignPost = TRUE;
+    return FALSE;
+}
+
+bool8 ScrCmd_normalmsg(struct ScriptContext *ctx)
+{
+    Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
+
+    gMsgIsSignPost = FALSE;
+    return FALSE;
+}

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -3426,7 +3426,7 @@ bool8 ScrCmd_getbraillestringwidth(struct ScriptContext * ctx)
 
 bool8 ScrCmd_signmsg(struct ScriptContext *ctx)
 {
-    Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
+    Script_RequestEffects(SCREFF_V1);
 
     gMsgIsSignPost = TRUE;
     return FALSE;
@@ -3434,7 +3434,7 @@ bool8 ScrCmd_signmsg(struct ScriptContext *ctx)
 
 bool8 ScrCmd_normalmsg(struct ScriptContext *ctx)
 {
-    Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
+    Script_RequestEffects(SCREFF_V1);
 
     gMsgIsSignPost = FALSE;
     return FALSE;


### PR DESCRIPTION
## Description
Even though the underlying code behind making the sign text frames work has already been implemented in expansion, the script commands `signmsg` and its accompanying `normalmsg`still do not work currently, causing instances of those commands in scripts to not cause any change on the text frames at all. This PR fixes that by restoring functionality to those commands by simply adding `ScrCmd_signmsg` and `ScrCmd_normalmsg` to be used for their respective commands.

### Large Language Models (AI)
None

## Media
https://github.com/user-attachments/assets/7183967b-8069-4c47-838d-9a4d4959edf7

## Discord contact info
agsmgmaster64