### PR TITLE
Fix follower crashing when interupting spin movement

### DIFF
--- a/src/field_player_avatar.c
+++ b/src/field_player_avatar.c
@@ -71,6 +71,7 @@ static void npc_clear_strange_bits(struct ObjectEvent *);
 static void MovePlayerAvatarUsingKeypadInput(enum Direction, u16, u16);
 static void PlayerAllowForcedMovementIfMovingSameDirection(void);
 static u8 GetForcedMovementByMetatileBehavior(void);
+static void PlayerSetCopyableMovement(enum CopyMovement movement);
 
 static bool8 ForcedMovement_None(void);
 static bool8 ForcedMovement_Slip(void);
@@ -512,6 +513,7 @@ static bool8 ForcedMovement_None(void)
         playerObjEvent->enableAnim = TRUE;
         SetObjectEventDirection(playerObjEvent, playerObjEvent->facingDirection);
         gPlayerAvatar.flags &= ~PLAYER_AVATAR_FLAG_FORCED_MOVE;
+        PlayerSetCopyableMovement(COPY_MOVE_NONE);
     }
     return FALSE;
 }


### PR DESCRIPTION
Follower movement is "restarted" as soon as the FORCED_MOVE flag is unset but it seems copying the last set copy movement is causing issues. So I'm setting the copy movement to NONE when the forced movement is interrupted so that the follower pokemon start reappearing on the first step after that

### Large Language Models (AI)
No

## Media

https://github.com/user-attachments/assets/a4a0472b-3c73-47ea-9357-c5e0a1dc8ef7



## Issue(s) that this PR fixes
Fixes #10545

## Discord contact info
Jamie
