### PR TITLE
Support ITEM_USE_BATTLER inside pyramid

### DIFF
--- a/src/battle_pyramid_bag.c
+++ b/src/battle_pyramid_bag.c
@@ -1314,9 +1314,9 @@ static void BagAction_UseInBattle(u8 taskId)
         return;
 
     CloseMenuActionWindow();
-    if (type == ITEM_USE_BAG_MENU)
+    if (type == ITEM_USE_BAG_MENU || (type == ITEM_USE_BATTLER && !IsDoubleBattle()))
         ItemUseInBattle_BagMenu(taskId);
-    else if (type == ITEM_USE_PARTY_MENU)
+    else if (type == ITEM_USE_PARTY_MENU || (type == ITEM_USE_BATTLER && IsDoubleBattle()))
         ItemUseInBattle_PartyMenu(taskId);
     else if (type == ITEM_USE_PARTY_MENU_MOVES)
         ItemUseInBattle_PartyMenuChooseMove(taskId);


### PR DESCRIPTION
This is just a copy of `static void ItemMenu_UseInBattle(u8 taskId)` in `item_menu.c` but for the pyramid bag
when I added `ITEM_USE_BATTLER`, I didn't make sure it work in pyramid as well
Ideally we would refactor the pyramid bag toshare more code with the item menu but this is a lot of work so this is better as a bugfix

### Large Language Models (AI)
No

## Issue(s) that this PR fixes
Partially fixes #10546

## Discord contact info
Jamie
