### PR TITLE
Fix Hunger Switch Persisting on Ability pop up

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -3978,6 +3978,7 @@ BattleScript_BattlerFormChangeNoPopup::
 	handleformchange BS_SCRIPTING, 0
 	playanimation BS_SCRIPTING, B_ANIM_FORM_CHANGE
 	waitanimation
+	sethword sABILITY_OVERWRITE, 0
 BattleScript_BattlerFormChangeFromAfterAnimation::
 	handleformchange BS_SCRIPTING, 1
 	switchinabilities BS_SCRIPTING


### PR DESCRIPTION
Fixes Hunger Switch Ability Overwriting the next ability pop up name after form change triggers in battle

Added ability word overwrite to the end of morpeko's form change script

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

## Description
When Morpeko changes form at the end of a turn during battle, the next ability pop up that shows in battle display's "Hunger Switch" rather than its actual ability name. This PR fixes that issue.

## Media
Before: https://github.com/user-attachments/assets/c8107faf-e291-4041-9cab-433a6b33c7d0

After: https://github.com/user-attachments/assets/75c7707d-f68d-456f-849f-14206275d377

## Discord contact info
ChrispyChris27

