### PR TITLE
fix bard text speed

### DIFF
--- a/src/mauville_old_man.c
+++ b/src/mauville_old_man.c
@@ -664,6 +664,7 @@ static void Task_BardSong(u8 taskId)
             // End song
             FadeInBGM(6);
             m4aMPlayFadeOutTemporarily(&gMPlayInfo_SE2, 2);
+            DeactivateSingleTextPrinter(0, WINDOW_TEXT_PRINTER);
             ScriptContext_Enable();
             DestroyTask(taskId);
         }

--- a/src/text.c
+++ b/src/text.c
@@ -562,6 +562,8 @@ void RunTextPrinters(void)
                         case SPRITE_TEXT_PRINTER:
                             break;
                         }
+                        if (currentPrinter->callback != NULL)
+                            currentPrinter->callback(&currentPrinter->printerTemplate, renderState);
                         break;
                     case RENDER_UPDATE:
                         if (currentPrinter->callback != NULL)


### PR DESCRIPTION
Like edu correctly identifier, the main issue was the lack of printer callback call when the printer is in RENDER_PRINT state.
However once fixed, another issue appeared, the printer would more or less continue when gStringVar4 would get filled again (by trying to print a message).
I'm not exactly sure how it caused but manually closing the printer fixes the issue

### Large Language Models (AI)
No

## Media


https://github.com/user-attachments/assets/3bf7073a-572b-47b6-b852-14d25a295ef8


## Issue(s) that this PR fixes
Fixes #9664

## Discord contact info
Jamie