### PR TITLE
Fix freeze when a stat-change move follows Own Tempo-blocked Swagger or No Retreat

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -144,9 +144,15 @@ BattleScript_SwaggerConfusion::
 	trymovestatchanges
 	goto BattleScript_MoveEnd
 
+BattleScript_SwaggerOwnTempoPrevents::
+	call BattleScript_OwnTempoPreventsRet
+	trymovestatchanges
+	goto BattleScript_MoveEnd
+
 BattleScript_NoRetreatMessage::
 	printstring STRINGID_CANTESCAPEDUETOUSEDMOVE
 	waitmessage B_WAIT_TIME_LONG
+	trymovestatchanges
 	goto BattleScript_MoveEnd
 
 BattleScript_AutotomizeMessage::

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -140,7 +140,7 @@ BattleScript_ToxicThread::
 	goto BattleScript_MoveEnd
 
 BattleScript_SwaggerConfusion::
-	seteffectprimary BS_ATTACKER, BS_TARGET, MOVE_EFFECT_CONFUSION
+	seteffectprimary BS_ATTACKER, BS_SCRIPTING, MOVE_EFFECT_CONFUSION
 	trymovestatchanges
 	goto BattleScript_MoveEnd
 

--- a/include/battle_scripts.h
+++ b/include/battle_scripts.h
@@ -180,6 +180,7 @@ extern const u8 BattleScript_AbilityNoSpecificStatLoss[];
 extern const u8 BattleScript_ItemNoStatLoss[];
 extern const u8 BattleScript_OwnTempoPrevents[];
 extern const u8 BattleScript_OwnTempoPreventsRet[];
+extern const u8 BattleScript_SwaggerOwnTempoPrevents[];
 extern const u8 BattleScript_StickyHoldActivates[];
 extern const u8 BattleScript_StickyHoldActivatesRet[];
 extern const u8 BattleScript_ColorChangeActivates[];

--- a/src/battle_stat_change.c
+++ b/src/battle_stat_change.c
@@ -149,7 +149,7 @@ static bool32 CheckSpecificMoveCondition(struct BattleCalcValues *cv, struct Sta
         {
             if (!st->onlyChecking)
             {
-                st->moveScript = BattleScript_OwnTempoPrevents;
+                st->moveScript = BattleScript_SwaggerOwnTempoPrevents;
                 gBattlerAbility = cv->battlerDef;
                 gLastUsedAbility = ABILITY_OWN_TEMPO;
                 RecordAbilityBattle(cv->battlerDef, ABILITY_OWN_TEMPO);

--- a/test/battle/move_effect/flatter.c
+++ b/test/battle/move_effect/flatter.c
@@ -22,6 +22,20 @@ SINGLE_BATTLE_TEST("Flatter increases the target's Sp. Attack by 1 stage and con
     }
 }
 
+SINGLE_BATTLE_TEST("Flatter on a foe with Own Tempo prevents confusion, changes stats, and does not cause a crash if the opponent uses a stat changing move immediately after")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_SLOWPOKE) { Ability(ABILITY_OWN_TEMPO); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_FLATTER); MOVE(opponent, MOVE_CURSE); }
+    } SCENE {
+        ABILITY_POPUP(opponent, ABILITY_OWN_TEMPO);
+        MESSAGE("The opposing Slowpoke cannot be confused!");
+        MESSAGE("The opposing Slowpoke's Defense rose!");
+    }
+}
+
 TO_DO_BATTLE_TEST("Flatter raises the target's Sp. Atk even if they're already confused")
 TO_DO_BATTLE_TEST("Flatter raises the target's Sp. Atk even when protected by Safeguard")
 TO_DO_BATTLE_TEST("Flatter raises the target's Sp. Atk even when protected Own Tempo")

--- a/test/battle/move_effect/no_retreat.c
+++ b/test/battle/move_effect/no_retreat.c
@@ -26,6 +26,26 @@ SINGLE_BATTLE_TEST("No Retreat raises user's Atk/Def/Sp.Atk/Sp.Def/Speed unless 
     }
 }
 
+SINGLE_BATTLE_TEST("No Retreat does not cause a freeze if a stat changing move is used afterwards")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_CURSE) == EFFECT_CURSE);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_NO_RETREAT); }
+        TURN { MOVE(player, MOVE_CURSE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_NO_RETREAT, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CURSE, player);
+        MESSAGE("Wobbuffet's Speed fell!");
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_ATK], DEFAULT_STAT_STAGE + 2);
+        EXPECT_EQ(player->statStages[STAT_DEF], DEFAULT_STAT_STAGE + 2);
+        EXPECT_EQ(player->statStages[STAT_SPEED], DEFAULT_STAT_STAGE);
+    }
+}
+
 // Question: If No Retreat is used is the mon blocking the switch out changed?
 SINGLE_BATTLE_TEST("No Retreat won't fail if user is prevented from escaping")
 {


### PR DESCRIPTION
## Description

### Problem

The game freezes in two cases:

- A battler uses Swagger or Flatter on a target with Own Tempo. Any battler then uses a stat-change move.
- A battler uses No Retreat with success. Any battler then uses a stat-change move.

Both freezes are infinite loops in `StatChangeTryChange` (`src/battle_move_resolution.c`).

### Cause

`DoStatChange` is a state machine. It stores its progress in `gBattleStruct->eventState.resolution`. The machine resets this value only when it completes. When the machine starts a battle script, that script must call `trymovestatchanges`. This call lets the machine continue and complete.

Two scripts did not call `trymovestatchanges`:

- `BattleScript_OwnTempoPrevents`, when Own Tempo blocks the confusion from Swagger or Flatter.
- `BattleScript_NoRetreatMessage`, after a successful No Retreat.

These scripts go to `BattleScript_MoveEnd` directly. The machine never completes, and `eventState.resolution` keeps the value `STAT_CHANGE_TRY_CHANGE`.

The next stat-change move clears the stat queues and starts the machine again. The machine resumes at `STAT_CHANGE_TRY_CHANGE` and skips the step that fills the stat queues. `StatChangeTryChange` then loops forever on a battler with an empty queue. The game freezes.

### Solution

- Add `BattleScript_SwaggerOwnTempoPrevents`. This script shows the Own Tempo message and then calls `trymovestatchanges`. The Swagger and Flatter path now uses this script. The Confuse Ray path keeps `BattleScript_OwnTempoPrevents` unchanged.
- Add `trymovestatchanges` to `BattleScript_NoRetreatMessage`.

### Tests

- Add the regression test from the issue: Flatter into Own Tempo, then Curse. The test timed out before the fix. It passes now.
- Add a No Retreat test: No Retreat, then Curse. The test timed out before the fix. It passes now.

## Issue(s) that this PR fixes

Fixes #10558.

## Things to note in the release changelog:

- Fixed a freeze that occurred when a stat-change move was used after Own Tempo blocked the confusion from Swagger or Flatter.
- Fixed a freeze that occurred when a stat-change move was used after a successful No Retreat.

## Discord contact info

viridian.