### PR TITLE
Fix test system not being able to access a saved party

### DIFF
--- a/include/test/battle.h
+++ b/include/test/battle.h
@@ -1052,6 +1052,7 @@ struct moveWithPP {
 #define Shadow(isShadow) Shadow_(__LINE__, isShadow)
 #define Shiny(isShiny) Shiny_(__LINE__, isShiny)
 #define Environment(environment) Environment_(__LINE__, environment)
+#define SetSavedPlayerParty(partySize) SetSavedPlayerParty_(partySize)
 
 void SetFlagForTest(u32 sourceLine, u16 flagId);
 void SetVarForTest(u32 sourceLine, u16 varId, u16 value);
@@ -1062,6 +1063,8 @@ void ClearFlagAfterTest(void);
 void ClearVarAfterTest(void);
 void OpenPokemon(u32 sourceLine, enum BattleTrainer trainer, enum Species species);
 void ClosePokemon(u32 sourceLine);
+void SetSavedPlayerParty_(u32 partySize);
+void ClearSavedPlayerParty(void);
 
 void RNGSeed_(u32 sourceLine, rng_value_t seed);
 void AIFlags_(u32 sourceLine, u64 flags);

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -4217,8 +4217,6 @@ static bool32 WillPlayerWhiteOutIfPartnerWinsAlone()
         return TRUE;
     if (AreMultiPartiesFullTeams())
         return TRUE;
-    if (TESTING)
-        return FALSE;
     for (u32 i = 0; i < PARTY_SIZE; i++)
     {
         if (gSelectedOrderFromParty[i] <= MULTI_PARTY_SIZE)

--- a/test/battle/ai/ai_switching.c
+++ b/test/battle/ai/ai_switching.c
@@ -2509,20 +2509,20 @@ AI_MULTI_BATTLE_TEST("AI will not switch out if the opposite battler is absent a
 {
     GIVEN {
         AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT);
-        PLAYER(SPECIES_WOBBUFFET) { HP(41); Speed(1); }
-        PARTNER(SPECIES_DRAKLOAK) { HP(41); MaxHP(100); Speed(4); Item(ITEM_LIFE_ORB); Moves(MOVE_DRAGON_RAGE, MOVE_SHADOW_BALL); }
-        PARTNER(SPECIES_DRAGAPULT) { Speed(4); Moves(MOVE_SHADOW_BALL); }
-        OPPONENT_A(SPECIES_CYCLIZAR) { HP(41); MaxHP(100); Speed(3); Item(ITEM_LIFE_ORB); Moves(MOVE_BODY_SLAM, MOVE_DRAGON_RAGE); }
-        OPPONENT_A(SPECIES_DRAMPA) { Speed(3); Moves(MOVE_BODY_SLAM); }
-        OPPONENT_B(SPECIES_WYNAUT) { Speed(2); HP(41); }
+        PLAYER(SPECIES_DRAKLOAK) { HP(41); MaxHP(100); Speed(4); Item(ITEM_LIFE_ORB); Moves(MOVE_DRAGON_RAGE, MOVE_SHADOW_BALL); }
+        PLAYER(SPECIES_DRAGAPULT) { Speed(4); Moves(MOVE_SHADOW_BALL, MOVE_DRAGON_RAGE); }
+        PARTNER(SPECIES_WOBBUFFET) { HP(41); Speed(1); }
+        OPPONENT_A(SPECIES_WYNAUT) { Speed(2); HP(41); }
+        OPPONENT_B(SPECIES_CYCLIZAR) { HP(41); MaxHP(100); Speed(3); Item(ITEM_LIFE_ORB); Moves(MOVE_BODY_SLAM, MOVE_DRAGON_RAGE); }
+        OPPONENT_B(SPECIES_DRAMPA) { Speed(3); Moves(MOVE_BODY_SLAM); }
     } WHEN {
         TURN {
-            EXPECT_MOVE(opponentLeft, MOVE_BODY_SLAM, target: playerLeft);
-            EXPECT_MOVE(playerRight, MOVE_SHADOW_BALL, target: opponentRight);
+            EXPECT_MOVE(opponentRight, MOVE_BODY_SLAM, target: playerRight);
+            MOVE(playerLeft, MOVE_SHADOW_BALL, target: opponentLeft);
         }
         TURN {
-            EXPECT_MOVE(opponentLeft, MOVE_DRAGON_RAGE, target: playerRight);
-            EXPECT_MOVE(playerRight, MOVE_DRAGON_RAGE, target: opponentLeft);
+            EXPECT_MOVE(opponentRight, MOVE_DRAGON_RAGE, target: playerLeft);
+            MOVE(playerLeft, MOVE_DRAGON_RAGE, target: opponentRight);
         }
     }
 }

--- a/test/battle/move_effect/trick_room.c
+++ b/test/battle/move_effect/trick_room.c
@@ -78,6 +78,7 @@ AI_MULTI_BATTLE_TEST("Trick Room does not fail if the chosen AI target has faint
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_MEMENTO) == EFFECT_MEMENTO);
         PLAYER(SPECIES_WYNAUT) { Speed(4); Moves(MOVE_MEMENTO); }
+        PLAYER(SPECIES_WOBBUFFET) { Speed(4); }
         PARTNER(SPECIES_WOBBUFFET) { Speed(1); Moves(MOVE_TRICK_ROOM); }
         OPPONENT_A(SPECIES_WOBBUFFET) { Speed(2); Moves(MOVE_MEMENTO); }
         OPPONENT_B(SPECIES_WOBBUFFET) { Speed(3); Moves(MOVE_MEMENTO); }
@@ -88,6 +89,7 @@ AI_MULTI_BATTLE_TEST("Trick Room does not fail if the chosen AI target has faint
             EXPECT_MOVE(opponentRight, MOVE_MEMENTO);
             EXPECT_MOVE(opponentLeft, MOVE_MEMENTO);
             EXPECT_MOVE(playerRight, MOVE_TRICK_ROOM); // Sets controller to AI
+            SEND_OUT(playerLeft, 1);
         }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_MEMENTO, playerLeft);

--- a/test/battle/multi_battle_whiteout.c
+++ b/test/battle/multi_battle_whiteout.c
@@ -142,6 +142,7 @@ MULTI_BATTLE_TEST("Player does not whiteout in a multibattle if the Partner stil
         OPPONENT_B(SPECIES_DRAGONAIR);
         OPPONENT_B(SPECIES_DRAGONAIR);
         OPPONENT_B(SPECIES_DRAGONAIR);
+        SetSavedPlayerParty(6);
     } WHEN {
         TURN {
             MOVE(opponentLeft, MOVE_DRAGON_RAGE, target:playerLeft);
@@ -183,6 +184,7 @@ TWO_VS_ONE_BATTLE_TEST("Player does not whiteout in a multibattle if the Partner
         OPPONENT_A(SPECIES_DRAGONITE);
         OPPONENT_A(SPECIES_DRAGONITE);
         OPPONENT_A(SPECIES_DRAGONITE);
+        SetSavedPlayerParty(6);
     } WHEN {
         TURN {
             MOVE(opponentLeft, MOVE_DRAGON_RAGE, target:playerLeft);

--- a/test/test_runner_battle.c
+++ b/test/test_runner_battle.c
@@ -2068,6 +2068,7 @@ static void CB2_BattleTest_NextParameter(void)
         SetMainCallback2(CB2_TestRunner);
         ClearFlagAfterTest();
         ClearVarAfterTest();
+        ClearSavedPlayerParty();
     }
     else
     {
@@ -2136,6 +2137,7 @@ static void BattleTest_TearDown(void *data)
     // aborted unexpectedly.
     ClearFlagAfterTest();
     ClearVarAfterTest();
+    ClearSavedPlayerParty();
     TestFreeConfigData();
     if (!STATE->hasTornDownBattle)
     {
@@ -2377,6 +2379,32 @@ void ClosePokemon(u32 sourceLine)
     data = DATA.isShiny;
     SetMonData(DATA.currentMon, MON_DATA_IS_SHINY, &data);
     DATA.currentMon = NULL;
+}
+
+void SetSavedPlayerParty_(u32 partyCount)
+{
+    u8 battlePartyCount = DATA.partySizes[B_TRAINER_PLAYER];
+    struct Pokemon wobb = {0};
+
+    CreateMon(&wobb, SPECIES_WOBBUFFET, 100, 0, OTID_STRUCT_PRESET(0));
+
+    memset(gSaveBlock1Ptr->playerParty, 0, sizeof(gSaveBlock1Ptr->playerParty));
+    *GetSavedPlayerPartyCount() = partyCount;
+
+
+    for (u32 i = 0; i < partyCount; i++)
+    {
+        if (i < battlePartyCount)
+            memcpy(&gSaveBlock1Ptr->playerParty[i], &DATA.recordedBattle.parties[B_TRAINER_PLAYER][i], sizeof(struct Pokemon));
+        else
+            memcpy(&gSaveBlock1Ptr->playerParty[i], &wobb, sizeof(struct Pokemon));
+    }
+}
+
+void ClearSavedPlayerParty(void)
+{
+    memset(gSaveBlock1Ptr->playerParty, 0, sizeof(gSaveBlock1Ptr->playerParty));
+    *GetSavedPlayerPartyCount() = 0;
 }
 
 static void SetGimmick(u32 sourceLine, enum BattleTrainer trainer, u32 partyIndex, enum Gimmick gimmick)


### PR DESCRIPTION
## Description
Test system can't access a saved party making testing multi whiteout not possible in full. A workaround built into the system sought to fix this but caused bugs. This seeks to resolve.

### Large Language Models (AI)
No.

## Discord contact info
grintoul