### PR TITLE
Fix trainer slide activating for player in multi battle

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3805,15 +3805,7 @@ static void TryDoEventsBeforeFirstTurn(void)
         break;
     case FIRST_TURN_EVENTS_TRAINER_SLIDE_B:
         if (ShouldDoTrainerSlide(GetBattlerAtPosition(B_POSITION_OPPONENT_RIGHT), TRAINER_SLIDE_BEFORE_FIRST_TURN))
-        {
-            // Ensures only trainer A slide is played in single-trainer doubles (B == A / B == TRAINER_NONE) and 2v1 multibattles (B == 0xFFFF)
-            if (!((TRAINER_BATTLE_PARAM.opponentB == TRAINER_BATTLE_PARAM.opponentA)
-            || (TRAINER_BATTLE_PARAM.opponentB == TRAINER_NONE)
-            || (TRAINER_BATTLE_PARAM.opponentB == 0xFFFF)))
-            {
-                BattleScriptExecute(BattleScript_TrainerBSlideMsgEnd2);
-            }
-        }
+            BattleScriptExecute(BattleScript_TrainerBSlideMsgEnd2);
         gBattleStruct->eventState.beforeFirstTurn++;
         break;
     case FIRST_TURN_EVENTS_TRAINER_SLIDE_PARTNER:

--- a/src/trainer_slide.c
+++ b/src/trainer_slide.c
@@ -276,6 +276,9 @@ enum TrainerSlideTargets ShouldDoTrainerSlide(enum BattlerId battler, enum Train
     if (!IsDoubleBattle() && (battler > B_BATTLER_1))
         return TRAINER_SLIDE_TARGET_NONE;
 
+    if (GetBattlerTrainer(battler) == B_TRAINER_PLAYER)
+        return TRAINER_SLIDE_TARGET_NONE;
+
     SetTrainerSlideParameters(battler, &lastId, &trainerId, &retValue);
     if (IsSpecialTrainer(trainerId))
         return TRAINER_SLIDE_TARGET_NONE;
@@ -331,10 +334,8 @@ enum TrainerSlideTargets ShouldDoTrainerSlide(enum BattlerId battler, enum Train
     if (shouldRun == FALSE)
         return TRAINER_SLIDE_TARGET_NONE;
 
-    // Prevents slides triggering twice in single-trainer doubles (B == A / B == TRAINER_NONE) and 2v1 multibattles (B == 0xFFFF)
-    if (((TRAINER_BATTLE_PARAM.opponentB == TRAINER_BATTLE_PARAM.opponentA)
-     || (TRAINER_BATTLE_PARAM.opponentB == TRAINER_NONE)
-     || (TRAINER_BATTLE_PARAM.opponentB == 0xFFFF)))
+    // Prevents slides triggering twice in single-trainer doubles
+    if (GetBattlerTrainer(battler) == GetBattlerTrainer(GetPartnerBattler(battler)))
     {
         MarkTrainerSlideAsPlayed(GetPartnerBattler(battler), slideId);
     }

--- a/src/trainer_slide.c
+++ b/src/trainer_slide.c
@@ -336,9 +336,7 @@ enum TrainerSlideTargets ShouldDoTrainerSlide(enum BattlerId battler, enum Train
 
     // Prevents slides triggering twice in single-trainer doubles
     if (GetBattlerTrainer(battler) == GetBattlerTrainer(GetPartnerBattler(battler)))
-    {
         MarkTrainerSlideAsPlayed(GetPartnerBattler(battler), slideId);
-    }
 
     MarkTrainerSlideAsPlayed(battler, slideId);
     SetTrainerSlideMessage(difficulty,trainerId,slideId);


### PR DESCRIPTION
The fix is actually:
```
if (GetBattlerTrainer(battler) == B_TRAINER_PLAYER)
        return TRAINER_SLIDE_TARGET_NONE;
```
the game was trying to activate a slide for the player second battler and then using dummy data from the previous slide
The other changes are cleanup, the check to make sure if two battler belong to the same trainer is more line with modern expansion and the trainer b check could be removed because it is implicitly done in `shouldDoTrainerSlide`


### Large Language Models (AI)
No

## Media


https://github.com/user-attachments/assets/cbcf7dd7-95d9-4201-b456-5f82076bdfcf



## Issue(s) that this PR fixes
Fixes #10486



## Discord contact info
Jamie
