### PR TITLE
Rework simultaneous palette fade

### DIFF
--- a/include/palette.h
+++ b/include/palette.h
@@ -77,7 +77,8 @@ struct PaletteFadeControl
     bool32 softwareFadeFinishing:1;
     bool32 objPaletteToggle:1;
     u32 deltaY:4; // rate of change of blend coefficient
-    u32 padding:15;
+    u32 simultaneousFade:1; // instead of alternating between fading sptite and bg, fade both simultaneously (to avoid visual inconstitencies in rare scenarios)
+    u32 padding:14;
 };
 
 extern const struct BlendSettings gTimeOfDayBlend[];

--- a/include/palette.h
+++ b/include/palette.h
@@ -77,7 +77,7 @@ struct PaletteFadeControl
     bool32 softwareFadeFinishing:1;
     bool32 objPaletteToggle:1;
     u32 deltaY:4; // rate of change of blend coefficient
-    u32 simultaneousFade:1; // instead of alternating between fading sptite and bg, fade both simultaneously (to avoid visual inconstitencies in rare scenarios)
+    u32 simultaneousFade:1; // instead of alternating between fading sptite and bg, fade both simultaneously (to avoid visual inconsistencies in rare scenarios)
     u32 padding:14;
 };
 

--- a/src/field_weather.c
+++ b/src/field_weather.c
@@ -788,6 +788,7 @@ void FadeSelectedPals(u8 mode, s8 delay, u32 selectedPalettes)
         // For cases like that, use fadescreenswapbuffers
         CpuFastCopy(gPlttBufferFaded, gPlttBufferUnfaded, PLTT_BUFFER_SIZE * 2);
 
+        gPaletteFade.simultaneousFade = TRUE;
         BeginNormalPaletteFade(selectedPalettes, delay, 0, 16, fadeColor);
         gWeatherPtr->palProcessingState = WEATHER_PAL_STATE_SCREEN_FADING_OUT;
     }

--- a/src/palette.c
+++ b/src/palette.c
@@ -304,16 +304,84 @@ static u8 UpdateTimeOfDayPaletteFade(void)
     return PALETTE_FADE_STATUS_ACTIVE;
 }
 
-static u32 UpdateNormalPaletteFade(void)
+static u32 UpdateNormalPaletteFade_Alternate()
 {
     u16 paletteOffset;
     u32 selectedPalettes;
 
-    if (!gPaletteFade.active)
-        return PALETTE_FADE_STATUS_DONE;
+    if (!gPaletteFade.objPaletteToggle)
+    {
+        if (gPaletteFade.delayCounter < gPaletteFadeDelay)
+        {
+            gPaletteFade.delayCounter++;
+            return PALETTE_FADE_STATUS_DELAY;
+        }
+        gPaletteFade.delayCounter = 0;
+    }
 
-    if (IsSoftwarePaletteFadeFinishing())
-        return gPaletteFade.active ? PALETTE_FADE_STATUS_ACTIVE : PALETTE_FADE_STATUS_DONE;
+    paletteOffset = 0;
+
+    if (!gPaletteFade.objPaletteToggle)
+    {
+        selectedPalettes = gPaletteFadeSelectedPalettes;
+    }
+    else
+    {
+        selectedPalettes = gPaletteFadeSelectedPalettes >> 16;
+        paletteOffset = OBJ_PLTT_OFFSET;
+    }
+
+    while (selectedPalettes)
+    {
+        if (selectedPalettes & 1)
+            BlendPalette(
+                paletteOffset,
+                16,
+                gPaletteFade.y,
+                gPaletteFade.blendColor);
+        selectedPalettes >>= 1;
+        paletteOffset += 16;
+    }
+
+    gPaletteFade.objPaletteToggle ^= 1;
+
+    if (!gPaletteFade.objPaletteToggle)
+    {
+        if (gPaletteFade.y == gPaletteFade.targetY)
+        {
+            gPaletteFadeSelectedPalettes = 0;
+            gPaletteFade.softwareFadeFinishing = TRUE;
+        }
+        else
+        {
+            s8 val;
+
+            if (!gPaletteFade.yDec)
+            {
+                val = gPaletteFade.y;
+                val += gPaletteFade.deltaY;
+                if (val > gPaletteFade.targetY)
+                    val = gPaletteFade.targetY;
+                gPaletteFade.y = val;
+            }
+            else
+            {
+                val = gPaletteFade.y;
+                val -= gPaletteFade.deltaY;
+                if (val < gPaletteFade.targetY)
+                    val = gPaletteFade.targetY;
+                gPaletteFade.y = val;
+            }
+        }
+    }
+
+    return PALETTE_FADE_STATUS_ACTIVE;
+}
+
+static u32 UpdateNormalPaletteFade_Simultaneous()
+{
+    u16 paletteOffset;
+    u32 selectedPalettes;
 
     // In vanilla Emerald, sprite and background palette are faded on alternate frames
     // In expansion, they are fade simultaneously every two frames to keep the vanilla timing
@@ -351,6 +419,7 @@ static u32 UpdateNormalPaletteFade(void)
     {
         gPaletteFadeSelectedPalettes = 0;
         gPaletteFade.softwareFadeFinishing = TRUE;
+        gPaletteFade.simultaneousFade = FALSE;
     }
     else
     {
@@ -374,9 +443,25 @@ static u32 UpdateNormalPaletteFade(void)
         }
     }
 
-    // gPaletteFade.active cannot change since the last time it was checked. So this
-    // is equivalent to `return PALETTE_FADE_STATUS_ACTIVE;`
-    return gPaletteFade.active ? PALETTE_FADE_STATUS_ACTIVE : PALETTE_FADE_STATUS_DONE;
+    return PALETTE_FADE_STATUS_ACTIVE;
+}
+
+static u32 UpdateNormalPaletteFade(void)
+{
+    if (!gPaletteFade.active)
+        return PALETTE_FADE_STATUS_DONE;
+
+    if (IsSoftwarePaletteFadeFinishing())
+        return gPaletteFade.active ? PALETTE_FADE_STATUS_ACTIVE : PALETTE_FADE_STATUS_DONE;
+
+    if (gPaletteFade.simultaneousFade)
+    {
+        return UpdateNormalPaletteFade_Simultaneous();
+    }
+    else
+    {
+        return UpdateNormalPaletteFade_Alternate();
+    }
 }
 
 void InvertPlttBuffer(u32 selectedPalettes)

--- a/src/palette.c
+++ b/src/palette.c
@@ -304,7 +304,7 @@ static u8 UpdateTimeOfDayPaletteFade(void)
     return PALETTE_FADE_STATUS_ACTIVE;
 }
 
-static u32 UpdateNormalPaletteFade_Alternate()
+static u32 UpdateNormalPaletteFade_Alternate(void)
 {
     u16 paletteOffset;
     u32 selectedPalettes;
@@ -378,7 +378,7 @@ static u32 UpdateNormalPaletteFade_Alternate()
     return PALETTE_FADE_STATUS_ACTIVE;
 }
 
-static u32 UpdateNormalPaletteFade_Simultaneous()
+static u32 UpdateNormalPaletteFade_Simultaneous(void)
 {
     u16 paletteOffset;
     u32 selectedPalettes;
@@ -455,13 +455,9 @@ static u32 UpdateNormalPaletteFade(void)
         return gPaletteFade.active ? PALETTE_FADE_STATUS_ACTIVE : PALETTE_FADE_STATUS_DONE;
 
     if (gPaletteFade.simultaneousFade)
-    {
         return UpdateNormalPaletteFade_Simultaneous();
-    }
     else
-    {
         return UpdateNormalPaletteFade_Alternate();
-    }
 }
 
 void InvertPlttBuffer(u32 selectedPalettes)


### PR DESCRIPTION
Ok this one is a bit complicated, the bug is a regression from #9407
where I changed the way palette fading worked. 
In this PR, I created a new function that use the old palette fading while still keeping the one introduced in #9407
The most recent fade is used in the overworld when using FadeScreen where the original fading was sometimes causing issues
While the old fading is now default again including the evo scene which now appear at normal speed

### Large Language Models (AI)
No

## Media

https://github.com/user-attachments/assets/8e74550b-d7ad-4fb4-8cfa-d0d832815992



## Issue(s) that this PR fixes
Fixes #10280


## Discord contact info
Jamie 
