### PR TITLE
fix(save): fix reload_save functionality

### DIFF
--- a/src/crt0.s
+++ b/src/crt0.s
@@ -173,6 +173,7 @@ ReInitializeEWRAM::
 	cmp r1, r2
 	beq EndReinitializeEWRAM
 	subs r2, r1
+	lsrs r2, #2
 	movs r3, #1
 	lsls r3, r3, #26
 	orrs r2, r2, r3

--- a/src/reload_save.c
+++ b/src/reload_save.c
@@ -8,6 +8,7 @@
 #include "new_game.h"
 #include "overworld.h"
 #include "malloc.h"
+#include "text.h"
 
 // Reloads the game, continuing from the point of the last save
 // Used to gracefully exit after a link connection error
@@ -21,6 +22,7 @@ void ReloadSave(void)
     REG_IME = imeBackup;
     gMain.inBattle = FALSE;
     SetSaveBlocksPointers(GetSaveBlocksPointersBaseOffset());
+    SetDefaultFontsPointer();
     ResetMenuAndMonGlobals();
     Save_ResetSaveCounters();
     LoadGameSave(SAVE_NORMAL);


### PR DESCRIPTION
## Description

Adds the following commits:

**fix(crt0): add missing lsr in ReInitializeEWRAM**
  `ReInitializeEWRAM` was using the byte count instead of word count for `CpuSet`. This fixes that by adding a `lsrs r2, #2` to the routine.

**fix(reload_save): fix font pointers not being set on save reload**
  The PR also adds the missing `SetDefaultFontsPointer` to `ReloadSave` without which no text would be rendered on reloading the save.

### Large Language Models (AI)

None

## Issue(s) that this PR fixes

Fixes #10578

## Discord contact info

@miriamlefae
