### PR TITLE
Fix terrain not being reset before battle background load

### DIFF
--- a/src/battle_util2.c
+++ b/src/battle_util2.c
@@ -75,7 +75,7 @@ void FreeBattleResources(void)
     else if (gBattleTypeFlags & BATTLE_TYPE_TRAINER_HILL)
         FreeTrainerHillBattleStruct();
 
-    gFieldStatuses = 0;
+    gFieldTimers.terrain = 0;
     if (gBattleResources != NULL)
     {
         FREE_AND_SET_NULL(gBattleStruct);


### PR DESCRIPTION
The bug is a regression from #10326
Loading the battle background happen before the game resets values for battle.
Before #10326, the terrain info waqs stored in gFieldStatuses which was reset at the end of battle to avoid the bug
but the PR started storing the terrain info in gFieldTimers instead so we reset the terrain value at the end of battle
so that the value is correct when the bg is loading (the value was always correct when the battle start, it is just the bg that was causing issues)


### Large Language Models (AI)
No

## Media


https://github.com/user-attachments/assets/e519f88c-4161-48fb-8697-3721b6114e39



## Issue(s) that this PR fixes
Fixes #10585



## Discord contact info
Jamie