### PR TITLE
Fix TARGET_USER_AND_ALLY flicker

### DIFF
--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -592,7 +592,7 @@ static void HideShownTargets(enum BattlerId battler)
     s32 i;
     for (i = 0; i < MAX_BATTLERS_COUNT; i++)
     {
-        if (IsBattlerAlive(i) && gBattleSpritesDataPtr->healthBoxesData[i].healthboxIsBouncing && i != battler)
+        if (IsBattlerAlive(i) && gBattleSpritesDataPtr->healthBoxesData[i].healthboxIsBouncing)
         {
             gSprites[gBattlerSpriteIds[i]].callback = SpriteCB_HideAsMoveTarget;
             EndBounceEffect(i, BOUNCE_HEALTHBOX);

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -587,19 +587,6 @@ static void HideAllTargets(void)
     }
 }
 
-static void HideShownTargets(enum BattlerId battler)
-{
-    s32 i;
-    for (i = 0; i < MAX_BATTLERS_COUNT; i++)
-    {
-        if (IsBattlerAlive(i) && gBattleSpritesDataPtr->healthBoxesData[i].healthboxIsBouncing)
-        {
-            gSprites[gBattlerSpriteIds[i]].callback = SpriteCB_HideAsMoveTarget;
-            EndBounceEffect(i, BOUNCE_HEALTHBOX);
-        }
-    }
-}
-
 void HandleInputShowEntireFieldTargets(enum BattlerId battler)
 {
     if (JOY_HELD(DPAD_ANY) && gSaveBlock2Ptr->optionsButtonMode == OPTIONS_BUTTON_MODE_L_EQUALS_A)
@@ -638,7 +625,7 @@ void HandleInputShowTargets(enum BattlerId battler)
     if (JOY_NEW(A_BUTTON))
     {
         PlaySE(SE_SELECT);
-        HideShownTargets(battler);
+        HideAllTargets();
         if (gBattleStruct->gimmick.playerSelect)
             BtlController_EmitTwoReturnValues(battler, B_COMM_TO_ENGINE, B_ACTION_EXEC_SCRIPT, gMoveSelectionCursor[battler] | RET_GIMMICK | (gMultiUsePlayerCursor << 8));
         else
@@ -650,7 +637,7 @@ void HandleInputShowTargets(enum BattlerId battler)
     else if (JOY_NEW(B_BUTTON) || gPlayerDpadHoldFrames > 59)
     {
         PlaySE(SE_SELECT);
-        HideShownTargets(battler);
+        HideAllTargets();
         gBattlerControllerFuncs[battler] = HandleInputChooseMove;
         DoBounceEffect(battler, BOUNCE_HEALTHBOX, 7, 1);
         DoBounceEffect(battler, BOUNCE_MON, 7, 1);


### PR DESCRIPTION
After selecting the targets or canceling target choice, the game would disable the flicker and bounc ethat shows the target.
For some reason, it skipped the disable if the target was the user. I think it may be to preserve the bounce effect of the selected battler but the bounce effect is immediately set again on the next line of code so removing the target is user check doesn't seem to have negative side effects

### Large Language Models (AI)
no

## Media


https://github.com/user-attachments/assets/5c3fba47-d975-4ca1-8152-95cade6c8aec



## Issue(s) that this PR fixes
Fixes #10583


## Discord contact info
Jamie
