### PR TITLE
Fix recorded battle parties being corrupted

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -475,7 +475,7 @@ const u8 *const gStatusConditionStringsTable[][2] =
 
 void CB2_InitBattle(void)
 {
-    if (!gTestRunnerEnabled)
+    if (!(gBattleTypeFlags & BATTLE_TYPE_RECORDED))
         MoveSaveBlocks_ResetHeap();
     AllocateBattleResources();
     AllocateBattleSpritesData();

--- a/src/recorded_battle.c
+++ b/src/recorded_battle.c
@@ -294,7 +294,7 @@ bool32 MoveRecordedBattleToSaveData(void)
     battleSave = AllocZeroed(sizeof(struct RecordedBattleSave));
     savSection = AllocZeroed(SECTOR_SIZE);
 
-    memcpy(battleSave->parties, gParties, sizeof(struct Pokemon[MAX_BATTLE_TRAINERS][PARTY_SIZE]));
+    memcpy(battleSave->parties, sSavedParties, sizeof(struct Pokemon[MAX_BATTLE_TRAINERS][PARTY_SIZE]));
 
     battleSave->playersGender = 0;
 


### PR DESCRIPTION
Something something 12v12 

## Description
Fixes parties being either empty or fainted

## Credits
@mrgriffin for significantly simplifying the recorded flag check element

### Large Language Models (AI)
No

## Discord contact info
grintoul