### PR TITLE
Fixes starter never being shiny when P_NO_SHINIES_WITHOUT_POKEBALLS

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -874,7 +874,7 @@ bool32 ComputePlayerShinyOdds(u32 personality, u32 value)
     if (P_ONLY_OBTAINABLE_SHINIES && (CurrentBattlePyramidLocation() != PYRAMID_LOCATION_NONE || (FlagGet(WE_FLAG_NO_CATCHING))))
         return FALSE;
 
-    if (P_NO_SHINIES_WITHOUT_POKEBALLS && !HasAtLeastOnePokeBall())
+    if (P_NO_SHINIES_WITHOUT_POKEBALLS && !HasAtLeastOnePokeBall() && FlagGet(FLAG_SYS_POKEDEX_GET))
         return FALSE;
 
     u32 totalRerolls = 0;


### PR DESCRIPTION

## Description
Checks for sys pokedex flag (pokemon system flag is set before starter choose)

### Large Language Models (AI)
no. 


## Feature(s) this PR does NOT handle:
There is still a major issue left unfixed: gift mons are not shiny while this bool is set.

## Discord contact info
luuma