### PR TITLE
Fix Dragon Darts checking the same target multiple times

### DIFF
--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -2192,10 +2192,7 @@ static enum CancelerResult CancelerAccuracyCheck(struct BattleCalcValues *cv)
 
     while (gBattleStruct->eventState.atkCancelerBattler < gBattlersCount)
     {
-        if (isSmartTarget)
-            cv->battlerDef = gBattlerTarget;
-        else
-            cv->battlerDef = GetTargetBySlot(cv->battlerAtk, gBattleStruct->eventState.atkCancelerBattler);
+        cv->battlerDef = GetTargetBySlot(cv->battlerAtk, gBattleStruct->eventState.atkCancelerBattler);
 
         gBattleStruct->eventState.atkCancelerBattler++;
 

--- a/test/battle/move_effect/dragon_darts.c
+++ b/test/battle/move_effect/dragon_darts.c
@@ -42,12 +42,13 @@ DOUBLE_BATTLE_TEST("Dragon Darts strikes each opponent once in a double battle")
     }
 }
 
-DOUBLE_BATTLE_TEST("Dragon Darts strikes the ally twice if the target protects")
+DOUBLE_BATTLE_TEST("Dragon Darts strikes the other opponent twice if one target protects")
 {
     struct BattlePokemon *chosenTarget = NULL;
     struct BattlePokemon *secondaryTarget = NULL;
     PARAMETRIZE { chosenTarget = opponentLeft; secondaryTarget = opponentRight; }
     PARAMETRIZE { chosenTarget = opponentRight; secondaryTarget = opponentLeft; }
+
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);
         PLAYER(SPECIES_WOBBUFFET);
@@ -75,7 +76,8 @@ DOUBLE_BATTLE_TEST("Dragon Darts strikes an opponent twice if the other one is F
     PARAMETRIZE { chosenTarget = opponentRight; finalTarget = opponentLeft;  speciesLeft = SPECIES_WOBBUFFET; speciesRight = SPECIES_FIDOUGH; }
 
     GIVEN {
-        ASSUME(GetSpeciesType(SPECIES_FIDOUGH, 0) == TYPE_FAIRY || GetSpeciesType(SPECIES_FIDOUGH, 1) == TYPE_FAIRY);
+        ASSUME(IsSpeciesOfType(SPECIES_FIDOUGH, TYPE_FAIRY ));
+        ASSUME(GetMoveType(MOVE_DRAGON_DARTS) == TYPE_DRAGON);
         PLAYER(SPECIES_WOBBUFFET);
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(speciesLeft);
@@ -99,6 +101,7 @@ DOUBLE_BATTLE_TEST("Dragon Darts strikes an opponent twice if electrified and th
     PARAMETRIZE { chosenTarget = opponentRight; finalTarget = opponentLeft;  abilityLeft = ABILITY_WATER_ABSORB; abilityRight = ABILITY_VOLT_ABSORB; }
     PARAMETRIZE { chosenTarget = opponentLeft;  finalTarget = opponentRight; abilityLeft = ABILITY_VOLT_ABSORB;  abilityRight = ABILITY_WATER_ABSORB; }
     PARAMETRIZE { chosenTarget = opponentRight; finalTarget = opponentRight; abilityLeft = ABILITY_VOLT_ABSORB;  abilityRight = ABILITY_WATER_ABSORB; }
+
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_ELECTRIFY) == EFFECT_ELECTRIFY);
         PLAYER(SPECIES_WOBBUFFET);
@@ -124,6 +127,7 @@ DOUBLE_BATTLE_TEST("Dragon Darts strikes an opponent twice if electrified and th
     PARAMETRIZE { chosenTarget = opponentRight; finalTarget = opponentLeft;  abilityLeft = ABILITY_VITAL_SPIRIT; abilityRight = ABILITY_MOTOR_DRIVE; }
     PARAMETRIZE { chosenTarget = opponentLeft;  finalTarget = opponentRight; abilityLeft = ABILITY_MOTOR_DRIVE;  abilityRight = ABILITY_VITAL_SPIRIT; }
     PARAMETRIZE { chosenTarget = opponentRight; finalTarget = opponentRight; abilityLeft = ABILITY_MOTOR_DRIVE;  abilityRight = ABILITY_VITAL_SPIRIT; }
+
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_ELECTRIFY) == EFFECT_ELECTRIFY);
         PLAYER(SPECIES_WOBBUFFET);
@@ -146,6 +150,7 @@ DOUBLE_BATTLE_TEST("Dragon Darts strikes an opponent twice if the other one is i
     struct BattlePokemon *finalTarget = NULL;
     PARAMETRIZE { chosenTarget = opponentLeft;  finalTarget = opponentRight; }
     PARAMETRIZE { chosenTarget = opponentRight; finalTarget = opponentLeft; }
+
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_FLY) == EFFECT_SEMI_INVULNERABLE);
         PLAYER(SPECIES_WOBBUFFET);
@@ -188,6 +193,7 @@ DOUBLE_BATTLE_TEST("Dragon Darts strikes an opponent twice if the other one is f
     u32 hpLeft, hpRight;
     PARAMETRIZE { chosenTarget = opponentLeft;  finalTarget = opponentRight; hpLeft = 1; hpRight = 101; }
     PARAMETRIZE { chosenTarget = opponentRight; finalTarget = opponentLeft;  hpLeft = 101; hpRight = 1; }
+
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);
         PLAYER(SPECIES_WOBBUFFET);
@@ -227,14 +233,17 @@ DOUBLE_BATTLE_TEST("Dragon Darts checks the unchosen target for accuracy")
     }
 }
 
-DOUBLE_BATTLE_TEST("Dragon Darts strikes left ally twice if one strike misses")
+DOUBLE_BATTLE_TEST("Dragon Darts strikes the other opponent twice if the chosen target misses")
 {
     struct BattlePokemon *chosenTarget = NULL;
     struct BattlePokemon *finalTarget = NULL;
     enum Item itemLeft, itemRight;
     PARAMETRIZE { chosenTarget = opponentLeft;  finalTarget = opponentRight; itemLeft = ITEM_BRIGHT_POWDER;  itemRight = ITEM_NONE; }
     PARAMETRIZE { chosenTarget = opponentRight; finalTarget = opponentLeft;  itemLeft = ITEM_NONE;           itemRight = ITEM_BRIGHT_POWDER; }
+
     GIVEN {
+        ASSUME(GetMoveAccuracy(MOVE_DRAGON_DARTS) == 100);
+        ASSUME(GetItemHoldEffect(ITEM_BRIGHT_POWDER) == HOLD_EFFECT_EVASION_UP);
         PLAYER(SPECIES_WOBBUFFET);
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET) { Item(itemLeft); }
@@ -249,26 +258,10 @@ DOUBLE_BATTLE_TEST("Dragon Darts strikes left ally twice if one strike misses")
     }
 }
 
-DOUBLE_BATTLE_TEST("Dragon Darts strikes right ally twice if one strike misses")
-{
-    GIVEN {
-        PLAYER(SPECIES_WOBBUFFET);
-        PLAYER(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_BRIGHT_POWDER); }
-        OPPONENT(SPECIES_WOBBUFFET);
-    } WHEN {
-        TURN { MOVE(playerLeft, MOVE_DRAGON_DARTS, target: opponentLeft, hit: FALSE); }
-    } SCENE {
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DARTS, playerLeft);
-        HP_BAR(opponentRight);
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DARTS, playerLeft);
-        HP_BAR(opponentRight);
-    }
-}
-
 DOUBLE_BATTLE_TEST("Dragon Darts strikes will be both redirected to Follow Me user")
 {
     GIVEN {
+        ASSUME(GetMoveEffect(MOVE_FOLLOW_ME) == EFFECT_FOLLOW_ME);
         PLAYER(SPECIES_WOBBUFFET);
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET);
@@ -286,7 +279,9 @@ DOUBLE_BATTLE_TEST("Dragon Darts strikes will be both redirected to Follow Me us
 DOUBLE_BATTLE_TEST("Dragon Darts fails to strike any target if under a Fairy-type follow me user")
 {
     GIVEN {
-        ASSUME(GetSpeciesType(SPECIES_FIDOUGH, 0) == TYPE_FAIRY || GetSpeciesType(SPECIES_FIDOUGH, 1) == TYPE_FAIRY);
+        ASSUME(IsSpeciesOfType(SPECIES_FIDOUGH, TYPE_FAIRY ));
+        ASSUME(GetMoveType(MOVE_DRAGON_DARTS) == TYPE_DRAGON);
+        ASSUME(GetMoveEffect(MOVE_FOLLOW_ME) == EFFECT_FOLLOW_ME);
         PLAYER(SPECIES_WOBBUFFET);
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET);
@@ -304,6 +299,7 @@ DOUBLE_BATTLE_TEST("Dragon Darts fails to strike any target if under a Fairy-typ
 DOUBLE_BATTLE_TEST("Dragon Darts fails to strike the second target if first target fainted and Follow Me was active")
 {
     GIVEN {
+        ASSUME(GetMoveEffect(MOVE_FOLLOW_ME) == EFFECT_FOLLOW_ME);
         PLAYER(SPECIES_WOBBUFFET);
         PLAYER(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET);

--- a/test/battle/move_effect/dragon_darts.c
+++ b/test/battle/move_effect/dragon_darts.c
@@ -204,6 +204,29 @@ DOUBLE_BATTLE_TEST("Dragon Darts strikes an opponent twice if the other one is f
     }
 }
 
+DOUBLE_BATTLE_TEST("Dragon Darts checks the unchosen target for accuracy")
+{
+    GIVEN {
+        ASSUME(GetMoveAccuracy(MOVE_DRAGON_DARTS) == 100);
+        ASSUME(GetItemHoldEffect(ITEM_BRIGHT_POWDER) == HOLD_EFFECT_EVASION_UP);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_MACHAMP) { Ability(ABILITY_NO_GUARD); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_BRIGHT_POWDER); }
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_DRAGON_DARTS, target: opponentLeft, hit: FALSE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DARTS, playerLeft);
+        HP_BAR(opponentLeft);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DARTS, playerLeft);
+        HP_BAR(opponentLeft);
+        NOT HP_BAR(opponentRight);
+    } THEN {
+        EXPECT_LT(opponentLeft->hp, opponentLeft->maxHP);
+        EXPECT_EQ(opponentRight->hp, opponentRight->maxHP);
+    }
+}
+
 DOUBLE_BATTLE_TEST("Dragon Darts strikes left ally twice if one strike misses")
 {
     struct BattlePokemon *chosenTarget = NULL;


### PR DESCRIPTION
## Description

- Fix Dragon Darts repeatedly checked the chosen target instead of both opponents.
- Removed the `Dragon Darts strikes right ally twice if one strike misses` test (It’s already covered by the parameterized test)