### PR TITLE
Minor battle_util.c fixes

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -6422,12 +6422,12 @@ static inline u32 CalcMoveBasePowerAfterModifiers(struct DamageContext *ctx)
         break;
     }
     case EFFECT_STOMPING_TANTRUM:
-        if (gBattleStruct->battlerState[battlerAtk].stompingTantrumTimer == 1)
+        if (!gAiLogicData->switchInCalc && gBattleStruct->battlerState[battlerAtk].stompingTantrumTimer == 1)
             modifier = uq4_12_multiply(modifier, UQ_4_12(2.0));
         break;
     case EFFECT_MAGNITUDE:
     case EFFECT_EARTHQUAKE:
-        if (gFieldTimers.terrain == B_TERRAIN_GRASSY && !IsSemiInvulnerable(battlerDef, CHECK_ALL))
+        if (ctx->terrain == B_TERRAIN_GRASSY && !IsSemiInvulnerable(battlerDef, CHECK_ALL))
             modifier = uq4_12_multiply(modifier, UQ_4_12(0.5));
         break;
     case EFFECT_KNOCK_OFF:

--- a/test/battle/ai/ai.c
+++ b/test/battle/ai/ai.c
@@ -1651,3 +1651,5 @@ AI_DOUBLE_BATTLE_TEST("AI sees Dragon Darts damage redirecting if one target is 
         }
     }
 }
+
+TO_DO_BATTLE_TEST("AI doesn't see stomping tantrum as boosted for switch AI if its last move before fainting failed");


### PR DESCRIPTION
## Description
EQ/Magnitude terrain check to use `ctx`
Additional check to make sure switch AI calcs don't use boosted stomping tantrum (TO_DO test added)

### Large Language Models (AI)
No

## Discord contact info
grintoul