### PR TITLE
Fix leveling up multiple levels at once sometmes teaching wrong moves

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -5522,8 +5522,9 @@ static void Cmd_handlelearnnewmove(void)
 
     if (B_LEVEL_UP_NOTIFICATION >= GEN_9 && gBattleResources->beforeLvlUp->learnMultipleMoves)
     {
-        while (gBattleResources->beforeLvlUp->level <= currLvl)
+        while (gBattleResources->beforeLvlUp->level < currLvl)
         {
+            gBattleResources->beforeLvlUp->level++;
             learnMove = MonTryLearningNewMoveAtLevel(&gParties[B_TRAINER_PLAYER][monId], cmd->isFirstMove, gBattleResources->beforeLvlUp->level);
 
             while (learnMove == MON_ALREADY_KNOWS_MOVE)
@@ -5531,8 +5532,6 @@ static void Cmd_handlelearnnewmove(void)
 
             if (learnMove != MOVE_NONE)
                 break;
-
-            gBattleResources->beforeLvlUp->level++;
         }
     }
     else


### PR DESCRIPTION
In the issue example the following loop 

`while (gBattleResources->beforeLvlUp->level <= currLvl)`

was going through value 33, 34 and 35 and check level up move for these three levels

By making it a strict inequality and moving the increment at the top of the loop,
it will go throgh value 33 and 34 but the levels checked will be 34 and 35

### Large Language Models (AI)
No

## Media


https://github.com/user-attachments/assets/44c78b76-c793-4607-bc7b-141d96963f7e



## Issue(s) that this PR fixes
Fixes #10613

## Discord contact info
Jamie
