### PR TITLE
fix(battle): fix memory leak when opening bag in battle

### DIFF
--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -1602,7 +1602,6 @@ static void OpenBagAndChooseItem(enum BattlerId battler)
         gBattlerControllerFuncs[battler] = CompleteWhenChoseItem;
         ReshowBattleScreenDummy();
         CloseMainBattleScreen();
-        CB2_BagMenuFromBattle();
         if (gBattleStruct->victoryCatchState == VICTORY_CATCH_OPEN_BAG)
             CB2_ChooseBall();
         else


### PR DESCRIPTION
## Description

Fixes memory leak introduced by #9008. 

The extra call to `CB2_BagMenuFromBattle` was allocating memory that never gets freed.

Fixes an oom error that happens when repeatedly returning to the battle screen from the bag menu.

### Large Language Models (AI)

None

## Discord contact info

@miriamlefae
