### PR TITLE
Fix Flying Press using its secondary type for damage modifiers

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -8282,8 +8282,11 @@ uq4_12_t CalcTypeEffectivenessMultiplier(struct DamageContext *ctx)
         modifier = CalcTypeEffectivenessMultiplierInternal(ctx, modifier);
         if (GetMoveEffect(ctx->move) == EFFECT_TWO_TYPED_MOVE && !ctx->isAnticipation)
         {
+            enum Type primaryType = ctx->moveType;
+
             ctx->moveType = GetMoveArgType(ctx->move);
             modifier = CalcTypeEffectivenessMultiplierInternal(ctx, modifier);
+            ctx->moveType = primaryType;
         }
     }
 

--- a/test/battle/move_effect/two_typed_move.c
+++ b/test/battle/move_effect/two_typed_move.c
@@ -1,9 +1,32 @@
 #include "global.h"
 #include "test/battle.h"
 
+SINGLE_BATTLE_TEST("Sky Plate doesn't boost Flying Press' power", s16 damage)
+{
+    enum Item item;
+
+    PARAMETRIZE { item = ITEM_NONE; }
+    PARAMETRIZE { item = ITEM_SKY_PLATE; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_FLYING_PRESS) == EFFECT_TWO_TYPED_MOVE);
+        ASSUME(GetMoveType(MOVE_FLYING_PRESS) == TYPE_FIGHTING);
+        ASSUME(GetMoveArgType(MOVE_FLYING_PRESS) == TYPE_FLYING);
+        ASSUME(gItemsInfo[ITEM_SKY_PLATE].holdEffect == HOLD_EFFECT_PLATE);
+        ASSUME(gItemsInfo[ITEM_SKY_PLATE].secondaryId == TYPE_FLYING);
+        PLAYER(SPECIES_WOBBUFFET) { Item(item); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_FLYING_PRESS); }
+    } SCENE {
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_EQ(results[0].damage, results[1].damage);
+    }
+}
+
 TO_DO_BATTLE_TEST("Flying Press does both Fighting and Flying-type for type effectiveness")
 TO_DO_BATTLE_TEST("Flying-type Pokémon don't receive STAB on Flying Press")
-TO_DO_BATTLE_TEST("Sky Plate doesn't boost Flying Press' power") // Check Fist Plate for comparison
 TO_DO_BATTLE_TEST("Sharp Beak doesn't boost Flying Press' power") // Check Black Belt for comparison
 TO_DO_BATTLE_TEST("Flying Gem doesn't trigger when using Flying Press") // Check Fighting Gem for comparison
 TO_DO_BATTLE_TEST("Coba Berry doesn't trigger when the user is attacked by Flying Press")


### PR DESCRIPTION
## Description
Flying Press uses its secondary type for effectiveness but fails to restore its primary type afterward.
