### PR TITLE
Fix Palafin-Hero repeatedly switching to activate Zero to Hero

### DIFF
--- a/src/battle_ai_switch.c
+++ b/src/battle_ai_switch.c
@@ -1490,26 +1490,26 @@ bool32 ShouldSwitchIfAllScoresBad(struct SwitchAiContext *switchContext)
 
 bool32 ShouldStayInToUseMove(struct SwitchAiContext *switchContext)
 {
-    enum Move aiMove;
-    enum BattleMoveEffects aiMoveEffect;
     for (u32 moveIndex = 0; moveIndex < MAX_MON_MOVES; moveIndex++)
     {
-        aiMove = gBattleMons[switchContext->battler].moves[moveIndex];
-        aiMoveEffect = GetMoveEffect(aiMove);
-        if (aiMoveEffect == EFFECT_REVIVAL_BLESSING || IsSwitchOutEffect(aiMoveEffect))
-        {
-            // Palafin should not stay in for a hit escape move if it can't use it effectively (slower or no target)
-            if (gBattleMons[switchContext->battler].species == SPECIES_PALAFIN_ZERO
-             && gAiLogicData->abilities[switchContext->battler] == ABILITY_ZERO_TO_HERO
-             && aiMoveEffect == EFFECT_HIT_ESCAPE
-             && !CanPalafinZeroSafelyUseHitEscape(switchContext->battler, aiMove))
-                continue;
+        enum Move move = gBattleMons[switchContext->battler].moves[moveIndex];
+        enum BattleMoveEffects effect = GetMoveEffect(move);
 
-            if (gAiBattleData->finalScore[switchContext->battler][switchContext->opposingBattler][moveIndex] > AI_GOOD_SCORE_THRESHOLD
-                || (IsDoubleBattle() && gAiBattleData->finalScore[switchContext->battler][GetPartnerBattler(switchContext->opposingBattler)][moveIndex] > AI_GOOD_SCORE_THRESHOLD))
-                return TRUE;
-        }
+        if (effect != EFFECT_REVIVAL_BLESSING && !IsSwitchOutEffect(effect))
+            continue;
+
+        // An unsafe hit escape move must not override Palafin-Zero's hard-switch decision.
+        if (effect == EFFECT_HIT_ESCAPE
+         && gBattleMons[switchContext->battler].species == SPECIES_PALAFIN_ZERO
+         && gAiLogicData->abilities[switchContext->battler] == ABILITY_ZERO_TO_HERO
+         && !CanPalafinZeroSafelyUseHitEscape(switchContext->battler, move))
+            continue;
+
+        if (gAiBattleData->finalScore[switchContext->battler][switchContext->opposingBattler][moveIndex] > AI_GOOD_SCORE_THRESHOLD
+         || (IsDoubleBattle() && gAiBattleData->finalScore[switchContext->battler][GetPartnerBattler(switchContext->opposingBattler)][moveIndex] > AI_GOOD_SCORE_THRESHOLD))
+            return TRUE;
     }
+
     return FALSE;
 }
 

--- a/src/battle_ai_switch.c
+++ b/src/battle_ai_switch.c
@@ -811,7 +811,7 @@ static bool32 ShouldSwitchIfBadlyStatused(struct SwitchAiContext *switchContext)
     return FALSE;
 }
 
-static bool32 GetHitEscapeTransformState(enum BattlerId battlerAtk, enum Move move)
+static bool32 CanPalafinZeroSafelyUseHitEscape(enum BattlerId battlerAtk, enum Move move)
 {
     u32 moveIndex;
     bool32 hasValidTarget = FALSE;
@@ -1028,14 +1028,19 @@ static bool32 ShouldSwitchIfAbilityBenefit(struct SwitchAiContext *switchContext
 
     case ABILITY_ZERO_TO_HERO:
     {
-        enum Move hitEscapeMove = MOVE_NONE;
+        u32 moveIndex;
 
-        if (GetBattlerMoveIndexWithEffect(switchContext->battler, EFFECT_HIT_ESCAPE) < MAX_MON_MOVES)
-            hitEscapeMove = gBattleMons[switchContext->battler].moves[GetBattlerMoveIndexWithEffect(switchContext->battler, EFFECT_HIT_ESCAPE)];
-
-        // Prefer to use a hit escape move if Palafin will move first and can hit
-        if (hitEscapeMove != MOVE_NONE && GetHitEscapeTransformState(switchContext->battler, hitEscapeMove))
+        // Hero Form has already activated Zero to Hero.
+        if (gBattleMons[switchContext->battler].species != SPECIES_PALAFIN_ZERO)
             return FALSE;
+
+        moveIndex = GetBattlerMoveIndexWithEffect(switchContext->battler, EFFECT_HIT_ESCAPE);
+
+        // Prefer a safe hit escape move over switching directly.
+        if (moveIndex < MAX_MON_MOVES && CanPalafinZeroSafelyUseHitEscape(switchContext->battler, gBattleMons[switchContext->battler].moves[moveIndex]))
+            return FALSE;
+
+        // No safe pivot is available, so switch directly to transform.
         break;
     }
 
@@ -1497,7 +1502,7 @@ bool32 ShouldStayInToUseMove(struct SwitchAiContext *switchContext)
             if (gBattleMons[switchContext->battler].species == SPECIES_PALAFIN_ZERO
              && gAiLogicData->abilities[switchContext->battler] == ABILITY_ZERO_TO_HERO
              && aiMoveEffect == EFFECT_HIT_ESCAPE
-             && !GetHitEscapeTransformState(switchContext->battler, aiMove))
+             && !CanPalafinZeroSafelyUseHitEscape(switchContext->battler, aiMove))
                 continue;
 
             if (gAiBattleData->finalScore[switchContext->battler][switchContext->opposingBattler][moveIndex] > AI_GOOD_SCORE_THRESHOLD

--- a/test/battle/ai/ai_switching.c
+++ b/test/battle/ai/ai_switching.c
@@ -1893,6 +1893,37 @@ AI_SINGLE_BATTLE_TEST("Switch AI: AI will switch out if Palafin-Zero isn't trans
     }
 }
 
+AI_SINGLE_BATTLE_TEST("Switch AI: Palafin-Hero does not switch to activate Zero to Hero again (Single)")
+{
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT);
+        PLAYER(SPECIES_GLISCOR) { Moves(MOVE_CELEBRATE); }
+        OPPONENT(SPECIES_PALAFIN_HERO) { Ability(ABILITY_ZERO_TO_HERO); Moves(MOVE_JET_PUNCH); }
+        OPPONENT(SPECIES_GLISCOR) { Moves(MOVE_CELEBRATE); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_CELEBRATE); EXPECT_MOVE(opponent, MOVE_JET_PUNCH); }
+    }
+}
+
+AI_DOUBLE_BATTLE_TEST("Switch AI: Palafin-Hero does not switch to activate Zero to Hero again (Doubles)")
+{
+    GIVEN {
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT);
+        PLAYER(SPECIES_GLISCOR) { Moves(MOVE_CELEBRATE); }
+        PLAYER(SPECIES_GLISCOR) { Moves(MOVE_CELEBRATE); }
+        OPPONENT(SPECIES_PALAFIN_HERO) { Ability(ABILITY_ZERO_TO_HERO); Moves(MOVE_JET_PUNCH); }
+        OPPONENT(SPECIES_GLISCOR) { Moves(MOVE_CELEBRATE); }
+        OPPONENT(SPECIES_GLISCOR) { Moves(MOVE_CELEBRATE); }
+    } WHEN {
+        TURN {
+            MOVE(playerLeft, MOVE_CELEBRATE);
+            MOVE(playerRight, MOVE_CELEBRATE);
+            EXPECT_MOVE(opponentLeft, MOVE_JET_PUNCH);
+            EXPECT_MOVE(opponentRight, MOVE_CELEBRATE);
+        }
+    }
+}
+
 AI_SINGLE_BATTLE_TEST("Switch AI: Palafin uses Flip Turn when faster to transform (Single)")
 {
     GIVEN {
@@ -1958,14 +1989,15 @@ AI_DOUBLE_BATTLE_TEST("Switch AI: Palafin hard switches when slower even with Fl
 
 AI_SINGLE_BATTLE_TEST("Switch AI: Palafin hard switches into absorb abilities instead of Flip Turn (Single)")
 {
+    enum Species palafinAbsorbSpecies;
     enum Ability palafinAbsorbAbility;
-    PARAMETRIZE { palafinAbsorbAbility = ABILITY_STORM_DRAIN; }
-    PARAMETRIZE { palafinAbsorbAbility = ABILITY_WATER_ABSORB; }
-    PARAMETRIZE { palafinAbsorbAbility = ABILITY_DRY_SKIN; }
+    PARAMETRIZE { palafinAbsorbSpecies = SPECIES_GASTRODON; palafinAbsorbAbility = ABILITY_STORM_DRAIN; }
+    PARAMETRIZE { palafinAbsorbSpecies = SPECIES_VAPOREON;  palafinAbsorbAbility = ABILITY_WATER_ABSORB; }
+    PARAMETRIZE { palafinAbsorbSpecies = SPECIES_PARASECT;  palafinAbsorbAbility = ABILITY_DRY_SKIN; }
 
     GIVEN {
         AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_OMNISCIENT);
-        PLAYER(SPECIES_GLISCOR) { Speed(10); Ability(palafinAbsorbAbility); }
+        PLAYER(palafinAbsorbSpecies) { Speed(10); Ability(palafinAbsorbAbility); }
         OPPONENT(SPECIES_PALAFIN_ZERO) { Ability(ABILITY_ZERO_TO_HERO); Speed(20); Moves(MOVE_FLIP_TURN, MOVE_TACKLE); }
         OPPONENT(SPECIES_GLISCOR) { Speed(8); }
     } WHEN {
@@ -1975,14 +2007,15 @@ AI_SINGLE_BATTLE_TEST("Switch AI: Palafin hard switches into absorb abilities in
 
 AI_DOUBLE_BATTLE_TEST("Switch AI: Palafin hard switches into absorb abilities instead of Flip Turn (Doubles)")
 {
+    enum Species palafinAbsorbSpecies;
     enum Ability palafinAbsorbAbility;
-    PARAMETRIZE { palafinAbsorbAbility = ABILITY_STORM_DRAIN; }
-    PARAMETRIZE { palafinAbsorbAbility = ABILITY_WATER_ABSORB; }
-    PARAMETRIZE { palafinAbsorbAbility = ABILITY_DRY_SKIN; }
+    PARAMETRIZE { palafinAbsorbSpecies = SPECIES_GASTRODON; palafinAbsorbAbility = ABILITY_STORM_DRAIN; }
+    PARAMETRIZE { palafinAbsorbSpecies = SPECIES_VAPOREON;  palafinAbsorbAbility = ABILITY_WATER_ABSORB; }
+    PARAMETRIZE { palafinAbsorbSpecies = SPECIES_PARASECT;  palafinAbsorbAbility = ABILITY_DRY_SKIN; }
 
     GIVEN {
         AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT | AI_FLAG_OMNISCIENT);
-        PLAYER(SPECIES_GLISCOR) { Speed(5); Ability(palafinAbsorbAbility); Moves(MOVE_CELEBRATE); }
+        PLAYER(palafinAbsorbSpecies) { Speed(5); Ability(palafinAbsorbAbility); Moves(MOVE_CELEBRATE); }
         PLAYER(SPECIES_GLISCOR) { Speed(4); Moves(MOVE_CELEBRATE); }
         OPPONENT(SPECIES_PALAFIN_ZERO) { Ability(ABILITY_ZERO_TO_HERO); Speed(20); Moves(MOVE_FLIP_TURN, MOVE_TACKLE); }
         OPPONENT(SPECIES_GLISCOR) { Speed(1); Moves(MOVE_CELEBRATE); }


### PR DESCRIPTION
## Description
During gameplay, Palafin-Hero was found to repeatedly switch out despite having already transformed and having high-scoring moves available(#8591)
<p align="center">
  <table align="center" style="border-collapse: collapse; border: none;">
    <tr>
      <td align="center" style="padding: 8px;">
        <img src="https://github.com/user-attachments/assets/cd983b9a-f9d6-4ac4-92d3-b54587a95570" width="300" alt="Screenshot 1" style="border-radius: 10px; box-shadow: 0 2px 8px rgba(0,0,0,0.12);" />
      </td>
      <td align="center" style="padding: 8px;">
        <img src="https://github.com/user-attachments/assets/b58bb394-31bc-4d00-ab10-9dc047d650df" width="300" alt="Screenshot 2" style="border-radius: 10px; box-shadow: 0 2px 8px rgba(0,0,0,0.12);" />
      </td>
    </tr>
  </table>
</p>
