### PR TITLE
Cursed Body: don't disable Max Moves

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3906,6 +3906,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
              && !gSpecialStatuses[gBattlerAttacker].attackerInParty
              && !IsAbilityOnSide(gBattlerAttacker, ABILITY_AROMA_VEIL)
              && gChosenMove != MOVE_STRUGGLE
+             && GetActiveGimmick(gBattlerAttacker) != GIMMICK_DYNAMAX // Dynamaxed Pokemon cannot be Disabled.
              && RandomPercentage(RNG_CURSED_BODY, 30))
             {
                 gBattleMons[gBattlerAttacker].volatiles.disabledMove = gChosenMove;

--- a/test/battle/ability/cursed_body.c
+++ b/test/battle/ability/cursed_body.c
@@ -132,4 +132,41 @@ SINGLE_BATTLE_TEST("Cursed Body disables the base move of a status Z-Move")
     }
 }
 
-TO_DO_BATTLE_TEST("Cursed Body disables damaging Z-Moves, but not the base move")
+SINGLE_BATTLE_TEST("Cursed Body cannot disable Max Moves")
+{
+    GIVEN {
+        ASSUME(GetMoveType(MOVE_AQUA_JET) == TYPE_WATER);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_FRILLISH) { Ability(ABILITY_CURSED_BODY); MaxHP(500); HP(500); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_AQUA_JET, gimmick: GIMMICK_DYNAMAX, WITH_RNG(RNG_CURSED_BODY, 1)); }
+    } SCENE {
+        MESSAGE("Wobbuffet used Max Geyser!");
+        HP_BAR(opponent);
+        NONE_OF {
+            ABILITY_POPUP(opponent, ABILITY_CURSED_BODY);
+            MESSAGE("Wobbuffet's Max Geyser was disabled!");
+        }
+    } THEN {
+        u32 disabledMove = player->volatiles.disabledMove;
+        EXPECT_EQ(disabledMove, MOVE_NONE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Cursed Body disables damaging Z-Moves, but not the base move")
+{
+    GIVEN {
+        ASSUME(GetMoveType(MOVE_AQUA_JET) == TYPE_WATER);
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_WATERIUM_Z); }
+        OPPONENT(SPECIES_FRILLISH) { Ability(ABILITY_CURSED_BODY); MaxHP(500); HP(500); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_AQUA_JET, gimmick: GIMMICK_Z_MOVE, WITH_RNG(RNG_CURSED_BODY, 1)); }
+        TURN { MOVE(player, MOVE_AQUA_JET); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ZMOVE_ACTIVATE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_HYDRO_VORTEX, player);
+        ABILITY_POPUP(opponent, ABILITY_CURSED_BODY);
+        MESSAGE("Wobbuffet's Hydro Vortex was disabled!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_AQUA_JET, player);
+    }
+}

--- a/test/battle/gimmick/dynamax.c
+++ b/test/battle/gimmick/dynamax.c
@@ -335,7 +335,7 @@ SINGLE_BATTLE_TEST("Dynamax: Dynamaxed Pokemon can have their ability changed or
     }
 }
 
-// Max Moves don't make contact, so Cursed Body doesn't need to be tested, but it is coded for.
+// See also "Cursed Body cannot disable Max Moves" in test/battle/ability/cursed_body.c.
 SINGLE_BATTLE_TEST("Dynamax: Dynamaxed Pokemon's Max Moves cannot be disabled")
 {
     GIVEN {


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->

Cursed Body sets `volatiles.disabledMove = gChosenMove`, which for a Dynamaxed attacker is the Max Move rather than the base move. Since `disabledMove` is only ever compared against the attacker's `moves[]` slots, the Max Move never matches: the "<mon>'s <move> was disabled!" message is printed but nothing is actually disabled, and the volatile is silently cleared again at the end of the same turn.

Dynamaxed Pokemon are immune to Disable, so guard the ability on the attacker's active gimmick instead. This matches the existing "Dynamaxed Pokemon's Max Moves cannot be disabled" test, which only passes today because the Disable move itself looks the target's last move up in `moves[]` and fails when it isn't found.

Z-Moves are unaffected: a disabled Z-Move is the documented behavior, so the existing TO_DO covering it is filled in as a regression test.

Also drop the comment claiming Cursed Body doesn't need testing against Max Moves because they don't make contact - Cursed Body has no contact requirement.

### Large Language Models (AI)
<!-- Does your pull request contain code or assets generated by a large language model (AI)? If so, where? -->
<!-- NOTE: There is an expectation that you have fully reviewed your code to ensure it meets all merge criteria (detailed above). -->
<!-- If the maintainers believe that a pull request was generated by AI with no or little to no human oversight, the pull request will be closed without further discussion. -->

Yes Claude Code Opus 5 was used for this change.

<!-- CREDITS -->
<!-- Once your PR is submitted, leave a comment asking the bot to add you to the credits. -->
<!-- If anybody helped with this PR, please encourage them to comment on your PR and ask the bot to add them to the credits. -->
<!-- If somebody has contributed at any point and has indicated they wish to be credited, please ask the bot to add them to the credits. If they do not have a known GitHub account, add them to the list at bottom of `CREDITS.md`. -->
<!-- EVERY contribution matters! -->
<!-- https://github.com/rh-hideout/pokeemerald-expansion/wiki/CREDITS.md-Frequently-Asked-Questions -->

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
Gastly.92
