### PR TITLE
Fix Cursed Body triggering on Max Moves

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3896,6 +3896,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
              && !gSpecialStatuses[gBattlerAttacker].attackerInParty
              && !IsAbilityOnSide(gBattlerAttacker, ABILITY_AROMA_VEIL)
              && gChosenMove != MOVE_STRUGGLE
+             && GetActiveGimmick(gBattlerAttacker) != GIMMICK_DYNAMAX
              && RandomPercentage(RNG_CURSED_BODY, 30))
             {
                 gBattleMons[gBattlerAttacker].volatiles.disabledMove = gChosenMove;

--- a/test/battle/ability/cursed_body.c
+++ b/test/battle/ability/cursed_body.c
@@ -131,4 +131,48 @@ SINGLE_BATTLE_TEST("Cursed Body disables the base move of a status Z-Move")
     }
 }
 
-TO_DO_BATTLE_TEST("Cursed Body disables damaging Z-Moves, but not the base move")
+SINGLE_BATTLE_TEST("Cursed Body does not trigger on Max Moves")
+{
+    enum Gimmick dyna;
+    enum Move move;
+    PARAMETRIZE { dyna = GIMMICK_NONE; move = MOVE_WATER_GUN; }
+    PARAMETRIZE { dyna = GIMMICK_DYNAMAX; move = MOVE_MAX_GEYSER; }
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_JELLICENT) { Ability(ABILITY_CURSED_BODY); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_WATER_GUN, gimmick: dyna, WITH_RNG(RNG_CURSED_BODY, 1)); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        HP_BAR(opponent);
+        if (dyna == GIMMICK_NONE) {
+            ABILITY_POPUP(opponent, ABILITY_CURSED_BODY);
+        } else {
+            NOT ABILITY_POPUP(opponent, ABILITY_CURSED_BODY);
+        }
+    } THEN {
+        u32 disabledMove = player->volatiles.disabledMove;
+        if (dyna == GIMMICK_NONE)
+            EXPECT_EQ(disabledMove, MOVE_WATER_GUN);
+        else
+            EXPECT_EQ(disabledMove, MOVE_NONE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Cursed Body disables damaging Z-Moves, but not the base move")
+{
+    GIVEN {
+        ASSUME(GetMoveType(MOVE_WATER_GUN) == gItemsInfo[ITEM_WATERIUM_Z].secondaryId);
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_WATERIUM_Z); }
+        OPPONENT(SPECIES_JELLICENT) { Ability(ABILITY_CURSED_BODY); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_WATER_GUN, gimmick: GIMMICK_Z_MOVE, WITH_RNG(RNG_CURSED_BODY, 1)); }
+        TURN { MOVE(player, MOVE_WATER_GUN); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_HYDRO_VORTEX, player);
+        HP_BAR(opponent);
+        ABILITY_POPUP(opponent, ABILITY_CURSED_BODY);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_WATER_GUN, player);
+        HP_BAR(opponent);
+    }
+}


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
Adds check for Dynamax to the Cursed Body trigger.
Adds test for Dynamax + Cursed Body.
Adds test for Z-Move interaction with Cursed Body.

### Large Language Models (AI)
<!-- Does your pull request contain code or assets generated by a large language model (AI)? If so, where? -->
<!-- NOTE: There is an expectation that you have fully reviewed your code to ensure it meets all merge criteria (detailed above). -->
<!-- If the maintainers believe that a pull request was generated by AI with no or little to no human oversight, the pull request will be closed without further discussion. -->
Not from this author.

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara