### PR TITLE
Fix Symbiosis items being consumed as resistance Berries by spread moves

### DIFF
--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -2858,6 +2858,7 @@ static enum MoveEndResult MoveEndSymbiosis(struct BattleCalcValues *cv)
             && TryTriggerSymbiosis(battler, GetPartnerBattler(battler)))
         {
             BestowItem(GetPartnerBattler(battler), battler);
+            gSpecialStatuses[battler].berryReduced = FALSE;
             gLastUsedAbility = gBattleMons[GetPartnerBattler(battler)].ability;
             gEffectBattler = battler;
             gBattleScripting.battler = gBattlerAbility = GetPartnerBattler(battler);

--- a/test/battle/ability/symbiosis.c
+++ b/test/battle/ability/symbiosis.c
@@ -138,6 +138,35 @@ DOUBLE_BATTLE_TEST("Symbiosis transfers its item to an ally after it consumes a 
     }
 }
 
+DOUBLE_BATTLE_TEST("A spread move does not consume items received through Symbiosis as resistance Berries")
+{
+    GIVEN {
+        ASSUME(GetMoveTarget(MOVE_EARTHQUAKE) == TARGET_FOES_AND_ALLY);
+        ASSUME(GetMoveType(MOVE_EARTHQUAKE) == TYPE_GROUND);
+        ASSUME(GetItemHoldEffect(ITEM_SHUCA_BERRY) == HOLD_EFFECT_RESIST_BERRY);
+        ASSUME(GetItemHoldEffectParam(ITEM_SHUCA_BERRY) == TYPE_GROUND);
+        PLAYER(SPECIES_ORANGURU) { Ability(ABILITY_SYMBIOSIS); Item(ITEM_POTION); }
+        PLAYER(SPECIES_PIKACHU) { Item(ITEM_SHUCA_BERRY); }
+        OPPONENT(SPECIES_PIKACHU) { Item(ITEM_SHUCA_BERRY); }
+        OPPONENT(SPECIES_ORANGURU) { Ability(ABILITY_SYMBIOSIS); Item(ITEM_POTION); }
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_EARTHQUAKE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_BERRY, opponentLeft);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_BERRY, playerRight);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, playerLeft);
+        ABILITY_POPUP(opponentRight, ABILITY_SYMBIOSIS);
+        NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_BERRY, opponentLeft);
+        ABILITY_POPUP(playerLeft, ABILITY_SYMBIOSIS);
+        NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_BERRY, playerRight);
+    } THEN {
+        EXPECT_EQ(playerLeft->item, ITEM_NONE);
+        EXPECT_EQ(playerRight->item, ITEM_POTION);
+        EXPECT_EQ(opponentLeft->item, ITEM_POTION);
+        EXPECT_EQ(opponentRight->item, ITEM_NONE);
+    }
+}
+
 DOUBLE_BATTLE_TEST("Symbiosis transfers its item after Gem consumption and move execution (Gen7+)")
 {
     GIVEN {


### PR DESCRIPTION
The issue was that `berryReduced` was never cleared, and spread moves re-run the weakness Berry check per target, so the replacement item looked like the Berry that was already consumed.

So we just clear `berryReduced` once Symbiosis has bestowed the new item. Clearing it earlier, when the Berry is eaten, doesn't work because `MoveEndSymbiosis` reads it to know it should trigger at all.

This also doesn't stop a received item activating on its own terms: a Sitrus Berry passed to an ally already below half HP is still eaten immediately, since that goes through `ItemBattleEffects`.

## Large Language Models (AI)

No AI has been used.

## Issue(s) that this PR fixes

Fixes #10650 

## Discord contact info

syreldar