### PR TITLE
Fix Copycat failing to copy a move that fainted its target

### DIFF
--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -3025,6 +3025,16 @@ static enum MoveEndResult MoveEndUpdateLastMoves(struct BattleCalcValues *cv)
 
         if (!gBattleStruct->unableToUseMove
          && !IsBattlerUnaffectedByMove(cv->battlerDef)
+         && gChosenMove != MOVE_UNAVAILABLE
+         && !gSpecialStatuses[cv->battlerAtk].dancerUsedMove)
+        {
+            gLastUsedMove = cv->move;
+            if (IsMaxMove(cv->move))
+                gBattleStruct->dynamax.lastUsedBaseMove = gBattleStruct->dynamax.baseMoves[cv->battlerAtk];
+        }
+
+        if (!gBattleStruct->unableToUseMove
+         && !IsBattlerUnaffectedByMove(cv->battlerDef)
          && IsBattlerAlive(cv->battlerDef))
         {
             if (gChosenMove == MOVE_UNAVAILABLE)
@@ -3035,12 +3045,6 @@ static enum MoveEndResult MoveEndUpdateLastMoves(struct BattleCalcValues *cv)
             {
                 gLastLandedMoves[cv->battlerDef] = cv->move;
                 gLastHitByType[cv->battlerDef] = GetBattleMoveType(cv->move);
-                if (!gSpecialStatuses[cv->battlerAtk].dancerUsedMove)
-                {
-                    gLastUsedMove = cv->move;
-                    if (IsMaxMove(cv->move))
-                        gBattleStruct->dynamax.lastUsedBaseMove = gBattleStruct->dynamax.baseMoves[cv->battlerAtk];
-                }
             }
         }
         else

--- a/test/battle/move_effect/copycat.c
+++ b/test/battle/move_effect/copycat.c
@@ -42,6 +42,26 @@ SINGLE_BATTLE_TEST("Copycat deducts power points from itself, not the copied mov
     }
 }
 
+DOUBLE_BATTLE_TEST("Copycat can copy a move that fainted its target")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Speed(4); }
+        PLAYER(SPECIES_WOBBUFFET) { Speed(3); }
+        OPPONENT(SPECIES_WOBBUFFET) { HP(1); Speed(2); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); }
+    } WHEN {
+        TURN {
+            MOVE(playerLeft, MOVE_SCRATCH, target: opponentLeft);
+            MOVE(playerRight, MOVE_COPYCAT, target: opponentRight);
+        }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, playerLeft);
+        HP_BAR(opponentLeft);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, playerRight);
+        HP_BAR(opponentRight);
+    }
+}
+
 DOUBLE_BATTLE_TEST("(DYNAMAX) Dynamaxed Pokemon can have their base moves copied by Copycat")
 {
     GIVEN {


### PR DESCRIPTION
Basically `gLastUsedMove` is the last move used in the battle, but it was only set inside a
block that also required the target to still be alive, together with the per-target
`gLastLandedMoves` and `gLastHitByType`. If the move fainted its target the move was
never recorded, so Copycat had nothing to copy.

I moved the `gLastUsedMove` assignment out of that block. It still requires the move to
have been usable and the target not to be unaffected, it just no longer cares whether
the target survived.

### Large Language Models (AI)

No AI has been used.

## Issue(s) that this PR fixes

Fixes #10649 

## Discord contact info

syreldar