### PR TITLE
Fix Z-Moves being blocked by move restrictions at selection

### DIFF
--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -342,7 +342,9 @@ static enum CancelerResult CancelerVolatileBlocked(struct BattleCalcValues *cv)
         gBattlescriptCurrInstr = BattleScript_MoveUsedHealBlockPrevents;
         result = CANCELER_RESULT_FAILURE;
     }
-    else if (IsGravityPreventingMove(cv->move))
+    // A damaging Z-Move has already replaced the chosen move, so Gravity has to
+    // be judged on the move it was derived from.
+    else if (IsGravityPreventingMove(GetActiveGimmick(cv->battlerAtk) == GIMMICK_Z_MOVE ? gBattleStruct->baseMove : cv->move))
     {
         gBattleScripting.battler = cv->battlerAtk;
         CancelMultiTurnMoves(cv->battlerAtk);

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -342,8 +342,6 @@ static enum CancelerResult CancelerVolatileBlocked(struct BattleCalcValues *cv)
         gBattlescriptCurrInstr = BattleScript_MoveUsedHealBlockPrevents;
         result = CANCELER_RESULT_FAILURE;
     }
-    // Dynamax executes a Max Move, which is not Gravity-banned even when its base
-    // move is, so only a Z-Move has to be judged on the move it replaced.
     else if (IsGravityPreventingMove(GetActiveGimmick(cv->battlerAtk) == GIMMICK_Z_MOVE ? gBattleStruct->baseMove : cv->move))
     {
         gBattleScripting.battler = cv->battlerAtk;

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -342,8 +342,8 @@ static enum CancelerResult CancelerVolatileBlocked(struct BattleCalcValues *cv)
         gBattlescriptCurrInstr = BattleScript_MoveUsedHealBlockPrevents;
         result = CANCELER_RESULT_FAILURE;
     }
-    // A damaging Z-Move has already replaced the chosen move, so Gravity has to
-    // be judged on the move it was derived from.
+    // Dynamax executes a Max Move, which is not Gravity-banned even when its base
+    // move is, so only a Z-Move has to be judged on the move it replaced.
     else if (IsGravityPreventingMove(GetActiveGimmick(cv->battlerAtk) == GIMMICK_Z_MOVE ? gBattleStruct->baseMove : cv->move))
     {
         gBattleScripting.battler = cv->battlerAtk;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -1323,12 +1323,11 @@ bool32 IsBelchPreventingMove(enum BattlerId battler, enum Move move)
     return !GetBattlerPartyState(battler)->ateBerry;
 }
 
-// gimmick.toActivate is only set after this runs, so the gimmick chosen for this
-// action has to be read back from the controller's return value.
-#define GIMMICK_SELECTED(chosen)    ((gBattleResources->bufferB[battler][2] & RET_GIMMICK) && gBattleStruct->gimmick.usableGimmick[battler] == (chosen))
-// Dynamax bypasses all selection prevention except Taunt and Assault Vest.
-#define DYNAMAX_BYPASS_CHECK    (!GIMMICK_SELECTED(GIMMICK_DYNAMAX) && GetActiveGimmick(battler) != GIMMICK_DYNAMAX)
-#define Z_MOVE_BYPASS_CHECK     (!GIMMICK_SELECTED(GIMMICK_Z_MOVE) && GetActiveGimmick(battler) != GIMMICK_Z_MOVE)
+static bool32 IsGimmickChosenForAction(enum BattlerId battler, enum Gimmick gimmick)
+{
+    return (gBattleResources->bufferB[battler][2] & RET_GIMMICK)
+        && gBattleStruct->gimmick.usableGimmick[battler] == gimmick;
+}
 
 u32 TrySetCantSelectMoveBattleScript(enum BattlerId battler)
 {
@@ -1339,8 +1338,14 @@ u32 TrySetCantSelectMoveBattleScript(enum BattlerId battler)
     u16 *choicedMove = &gBattleStruct->choicedMove[battler];
     enum BattleMoveEffects moveEffect = GetMoveEffect(move);
 
+    // Dynamax bypasses all selection prevention except Taunt and Assault Vest.
+    bool32 dynamaxBypassCheck = (!IsGimmickChosenForAction(battler, GIMMICK_DYNAMAX) && GetActiveGimmick(battler) != GIMMICK_DYNAMAX);
+
+    // Z-Moves bypass the effects of disruption moves like Encore, Taunt, Disable
+    bool32 zMoveBypassCheck = (!IsGimmickChosenForAction(battler, GIMMICK_Z_MOVE) && GetActiveGimmick(battler) != GIMMICK_Z_MOVE);
+
     if (GetConfig(B_ENCORE_TARGET) >= GEN_5
-     && DYNAMAX_BYPASS_CHECK && Z_MOVE_BYPASS_CHECK && gBattleMons[battler].volatiles.encoredMove != move && gBattleMons[battler].volatiles.encoredMove != MOVE_NONE)
+     && dynamaxBypassCheck && zMoveBypassCheck && gBattleMons[battler].volatiles.encoredMove != move && gBattleMons[battler].volatiles.encoredMove != MOVE_NONE)
     {
         gBattleScripting.battler = battler;
         gCurrentMove = gBattleMons[battler].volatiles.encoredMove;
@@ -1357,7 +1362,7 @@ u32 TrySetCantSelectMoveBattleScript(enum BattlerId battler)
         return limitations;
     }
 
-    if (DYNAMAX_BYPASS_CHECK && Z_MOVE_BYPASS_CHECK && gBattleMons[battler].volatiles.disabledMove == move && move != MOVE_NONE)
+    if (dynamaxBypassCheck && zMoveBypassCheck && gBattleMons[battler].volatiles.disabledMove == move && move != MOVE_NONE)
     {
         gBattleScripting.battler = battler;
         gCurrentMove = move;
@@ -1373,7 +1378,7 @@ u32 TrySetCantSelectMoveBattleScript(enum BattlerId battler)
         }
     }
 
-    if (DYNAMAX_BYPASS_CHECK && Z_MOVE_BYPASS_CHECK && move == gLastMoves[battler] && move != MOVE_STRUGGLE && (gBattleMons[battler].volatiles.torment == TRUE))
+    if (dynamaxBypassCheck && zMoveBypassCheck && move == gLastMoves[battler] && move != MOVE_STRUGGLE && (gBattleMons[battler].volatiles.torment == TRUE))
     {
         CancelMultiTurnMoves(battler);
         if (gBattleTypeFlags & BATTLE_TYPE_PALACE)
@@ -1388,7 +1393,7 @@ u32 TrySetCantSelectMoveBattleScript(enum BattlerId battler)
         }
     }
 
-    if (Z_MOVE_BYPASS_CHECK
+    if (zMoveBypassCheck
      && gBattleMons[battler].volatiles.tauntTimer != 0
      && IsBattleMoveStatus(move)
      && (GetConfig(B_TAUNT_ME_FIRST) < GEN_5 || moveEffect != EFFECT_ME_FIRST))
@@ -1409,7 +1414,7 @@ u32 TrySetCantSelectMoveBattleScript(enum BattlerId battler)
         }
     }
 
-    if (DYNAMAX_BYPASS_CHECK && Z_MOVE_BYPASS_CHECK && gBattleMons[battler].volatiles.throatChopTimer > 0 && IsSoundMove(move))
+    if (dynamaxBypassCheck && zMoveBypassCheck && gBattleMons[battler].volatiles.throatChopTimer > 0 && IsSoundMove(move))
     {
         gCurrentMove = move;
         if (gBattleTypeFlags & BATTLE_TYPE_PALACE)
@@ -1424,7 +1429,7 @@ u32 TrySetCantSelectMoveBattleScript(enum BattlerId battler)
         }
     }
 
-    if (DYNAMAX_BYPASS_CHECK && Z_MOVE_BYPASS_CHECK && GetImprisonedMovesCount(battler, move))
+    if (dynamaxBypassCheck && zMoveBypassCheck && GetImprisonedMovesCount(battler, move))
     {
         gCurrentMove = move;
         if (gBattleTypeFlags & BATTLE_TYPE_PALACE)
@@ -1439,7 +1444,7 @@ u32 TrySetCantSelectMoveBattleScript(enum BattlerId battler)
         }
     }
 
-    if (DYNAMAX_BYPASS_CHECK && Z_MOVE_BYPASS_CHECK && IsGravityPreventingMove(move))
+    if (dynamaxBypassCheck && zMoveBypassCheck && IsGravityPreventingMove(move))
     {
         gCurrentMove = move;
         if (gBattleTypeFlags & BATTLE_TYPE_PALACE)
@@ -1454,7 +1459,7 @@ u32 TrySetCantSelectMoveBattleScript(enum BattlerId battler)
         }
     }
 
-    if (DYNAMAX_BYPASS_CHECK && Z_MOVE_BYPASS_CHECK && IsHealBlockPreventingMove(battler, move))
+    if (dynamaxBypassCheck && zMoveBypassCheck && IsHealBlockPreventingMove(battler, move))
     {
         gCurrentMove = move;
         if (gBattleTypeFlags & BATTLE_TYPE_PALACE)
@@ -1469,7 +1474,7 @@ u32 TrySetCantSelectMoveBattleScript(enum BattlerId battler)
         }
     }
 
-    if (DYNAMAX_BYPASS_CHECK && Z_MOVE_BYPASS_CHECK && IsBelchPreventingMove(battler, move))
+    if (dynamaxBypassCheck && zMoveBypassCheck && IsBelchPreventingMove(battler, move))
     {
         gCurrentMove = move;
         if (gBattleTypeFlags & BATTLE_TYPE_PALACE)
@@ -1484,7 +1489,7 @@ u32 TrySetCantSelectMoveBattleScript(enum BattlerId battler)
         }
     }
 
-    if (DYNAMAX_BYPASS_CHECK && moveEffect == EFFECT_STUFF_CHEEKS && GetItemPocket(gBattleMons[battler].item) != POCKET_BERRIES)
+    if (dynamaxBypassCheck && moveEffect == EFFECT_STUFF_CHEEKS && GetItemPocket(gBattleMons[battler].item) != POCKET_BERRIES)
     {
         gCurrentMove = move;
         if (gBattleTypeFlags & BATTLE_TYPE_PALACE)
@@ -1516,7 +1521,7 @@ u32 TrySetCantSelectMoveBattleScript(enum BattlerId battler)
     }
 
     gPotentialItemEffectBattler = battler;
-    if (DYNAMAX_BYPASS_CHECK && IsHoldEffectChoice(holdEffect) && *choicedMove != MOVE_NONE && *choicedMove != MOVE_UNAVAILABLE && *choicedMove != move)
+    if (dynamaxBypassCheck && IsHoldEffectChoice(holdEffect) && *choicedMove != MOVE_NONE && *choicedMove != MOVE_UNAVAILABLE && *choicedMove != move)
     {
         gCurrentMove = *choicedMove;
         gLastUsedItem = gBattleMons[battler].item;
@@ -1549,7 +1554,7 @@ u32 TrySetCantSelectMoveBattleScript(enum BattlerId battler)
             limitations++;
         }
     }
-    if (DYNAMAX_BYPASS_CHECK && (GetBattlerAbility(battler) == ABILITY_GORILLA_TACTICS) && *choicedMove != MOVE_NONE
+    if (dynamaxBypassCheck && (GetBattlerAbility(battler) == ABILITY_GORILLA_TACTICS) && *choicedMove != MOVE_NONE
               && *choicedMove != MOVE_UNAVAILABLE && *choicedMove != move)
     {
         gCurrentMove = *choicedMove;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -1323,12 +1323,12 @@ bool32 IsBelchPreventingMove(enum BattlerId battler, enum Move move)
     return !GetBattlerPartyState(battler)->ateBerry;
 }
 
+// gimmick.toActivate is only set after this runs, so the gimmick chosen for this
+// action has to be read back from the controller's return value.
+#define GIMMICK_SELECTED(chosen)    ((gBattleResources->bufferB[battler][2] & RET_GIMMICK) && gBattleStruct->gimmick.usableGimmick[battler] == (chosen))
 // Dynamax bypasses all selection prevention except Taunt and Assault Vest.
-#define DYNAMAX_BYPASS_CHECK    (!IsGimmickSelected(battler, GIMMICK_DYNAMAX) && GetActiveGimmick(battler) != GIMMICK_DYNAMAX)
-// gimmick.toActivate is only set after this runs, so the chosen gimmick has to
-// be read back from the controller's return value.
-#define Z_MOVE_SELECTED         ((gBattleResources->bufferB[battler][2] & RET_GIMMICK) && gBattleStruct->gimmick.usableGimmick[battler] == GIMMICK_Z_MOVE)
-#define Z_MOVE_BYPASS_CHECK     (!Z_MOVE_SELECTED && GetActiveGimmick(battler) != GIMMICK_Z_MOVE)
+#define DYNAMAX_BYPASS_CHECK    (!GIMMICK_SELECTED(GIMMICK_DYNAMAX) && GetActiveGimmick(battler) != GIMMICK_DYNAMAX)
+#define Z_MOVE_BYPASS_CHECK     (!GIMMICK_SELECTED(GIMMICK_Z_MOVE) && GetActiveGimmick(battler) != GIMMICK_Z_MOVE)
 
 u32 TrySetCantSelectMoveBattleScript(enum BattlerId battler)
 {

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -1326,7 +1326,7 @@ bool32 IsBelchPreventingMove(enum BattlerId battler, enum Move move)
 static bool32 IsGimmickChosenForAction(enum BattlerId battler, enum Gimmick gimmick)
 {
     return (gBattleResources->bufferB[battler][2] & RET_GIMMICK)
-        && gBattleStruct->gimmick.usableGimmick[battler] == gimmick;
+         && gBattleStruct->gimmick.usableGimmick[battler] == gimmick;
 }
 
 u32 TrySetCantSelectMoveBattleScript(enum BattlerId battler)

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -1325,6 +1325,10 @@ bool32 IsBelchPreventingMove(enum BattlerId battler, enum Move move)
 
 // Dynamax bypasses all selection prevention except Taunt and Assault Vest.
 #define DYNAMAX_BYPASS_CHECK    (!IsGimmickSelected(battler, GIMMICK_DYNAMAX) && GetActiveGimmick(battler) != GIMMICK_DYNAMAX)
+// gimmick.toActivate is only set after this runs, so the chosen gimmick has to
+// be read back from the controller's return value.
+#define Z_MOVE_SELECTED         ((gBattleResources->bufferB[battler][2] & RET_GIMMICK) && gBattleStruct->gimmick.usableGimmick[battler] == GIMMICK_Z_MOVE)
+#define Z_MOVE_BYPASS_CHECK     (!Z_MOVE_SELECTED && GetActiveGimmick(battler) != GIMMICK_Z_MOVE)
 
 u32 TrySetCantSelectMoveBattleScript(enum BattlerId battler)
 {
@@ -1336,7 +1340,7 @@ u32 TrySetCantSelectMoveBattleScript(enum BattlerId battler)
     enum BattleMoveEffects moveEffect = GetMoveEffect(move);
 
     if (GetConfig(B_ENCORE_TARGET) >= GEN_5
-     && DYNAMAX_BYPASS_CHECK && GetActiveGimmick(battler) != GIMMICK_Z_MOVE && gBattleMons[battler].volatiles.encoredMove != move && gBattleMons[battler].volatiles.encoredMove != MOVE_NONE)
+     && DYNAMAX_BYPASS_CHECK && Z_MOVE_BYPASS_CHECK && gBattleMons[battler].volatiles.encoredMove != move && gBattleMons[battler].volatiles.encoredMove != MOVE_NONE)
     {
         gBattleScripting.battler = battler;
         gCurrentMove = gBattleMons[battler].volatiles.encoredMove;
@@ -1353,7 +1357,7 @@ u32 TrySetCantSelectMoveBattleScript(enum BattlerId battler)
         return limitations;
     }
 
-    if (DYNAMAX_BYPASS_CHECK && GetActiveGimmick(battler) != GIMMICK_Z_MOVE && gBattleMons[battler].volatiles.disabledMove == move && move != MOVE_NONE)
+    if (DYNAMAX_BYPASS_CHECK && Z_MOVE_BYPASS_CHECK && gBattleMons[battler].volatiles.disabledMove == move && move != MOVE_NONE)
     {
         gBattleScripting.battler = battler;
         gCurrentMove = move;
@@ -1369,7 +1373,7 @@ u32 TrySetCantSelectMoveBattleScript(enum BattlerId battler)
         }
     }
 
-    if (DYNAMAX_BYPASS_CHECK && GetActiveGimmick(battler) != GIMMICK_Z_MOVE && move == gLastMoves[battler] && move != MOVE_STRUGGLE && (gBattleMons[battler].volatiles.torment == TRUE))
+    if (DYNAMAX_BYPASS_CHECK && Z_MOVE_BYPASS_CHECK && move == gLastMoves[battler] && move != MOVE_STRUGGLE && (gBattleMons[battler].volatiles.torment == TRUE))
     {
         CancelMultiTurnMoves(battler);
         if (gBattleTypeFlags & BATTLE_TYPE_PALACE)
@@ -1384,7 +1388,7 @@ u32 TrySetCantSelectMoveBattleScript(enum BattlerId battler)
         }
     }
 
-    if (GetActiveGimmick(battler) != GIMMICK_Z_MOVE
+    if (Z_MOVE_BYPASS_CHECK
      && gBattleMons[battler].volatiles.tauntTimer != 0
      && IsBattleMoveStatus(move)
      && (GetConfig(B_TAUNT_ME_FIRST) < GEN_5 || moveEffect != EFFECT_ME_FIRST))
@@ -1405,7 +1409,7 @@ u32 TrySetCantSelectMoveBattleScript(enum BattlerId battler)
         }
     }
 
-    if (DYNAMAX_BYPASS_CHECK && GetActiveGimmick(battler) != GIMMICK_Z_MOVE && gBattleMons[battler].volatiles.throatChopTimer > 0 && IsSoundMove(move))
+    if (DYNAMAX_BYPASS_CHECK && Z_MOVE_BYPASS_CHECK && gBattleMons[battler].volatiles.throatChopTimer > 0 && IsSoundMove(move))
     {
         gCurrentMove = move;
         if (gBattleTypeFlags & BATTLE_TYPE_PALACE)
@@ -1420,7 +1424,7 @@ u32 TrySetCantSelectMoveBattleScript(enum BattlerId battler)
         }
     }
 
-    if (DYNAMAX_BYPASS_CHECK && GetActiveGimmick(battler) != GIMMICK_Z_MOVE && GetImprisonedMovesCount(battler, move))
+    if (DYNAMAX_BYPASS_CHECK && Z_MOVE_BYPASS_CHECK && GetImprisonedMovesCount(battler, move))
     {
         gCurrentMove = move;
         if (gBattleTypeFlags & BATTLE_TYPE_PALACE)
@@ -1435,7 +1439,7 @@ u32 TrySetCantSelectMoveBattleScript(enum BattlerId battler)
         }
     }
 
-    if (DYNAMAX_BYPASS_CHECK && GetActiveGimmick(battler) != GIMMICK_Z_MOVE && IsGravityPreventingMove(move))
+    if (DYNAMAX_BYPASS_CHECK && Z_MOVE_BYPASS_CHECK && IsGravityPreventingMove(move))
     {
         gCurrentMove = move;
         if (gBattleTypeFlags & BATTLE_TYPE_PALACE)
@@ -1450,7 +1454,7 @@ u32 TrySetCantSelectMoveBattleScript(enum BattlerId battler)
         }
     }
 
-    if (DYNAMAX_BYPASS_CHECK && GetActiveGimmick(battler) != GIMMICK_Z_MOVE && IsHealBlockPreventingMove(battler, move))
+    if (DYNAMAX_BYPASS_CHECK && Z_MOVE_BYPASS_CHECK && IsHealBlockPreventingMove(battler, move))
     {
         gCurrentMove = move;
         if (gBattleTypeFlags & BATTLE_TYPE_PALACE)
@@ -1465,7 +1469,7 @@ u32 TrySetCantSelectMoveBattleScript(enum BattlerId battler)
         }
     }
 
-    if (DYNAMAX_BYPASS_CHECK && GetActiveGimmick(battler) != GIMMICK_Z_MOVE && IsBelchPreventingMove(battler, move))
+    if (DYNAMAX_BYPASS_CHECK && Z_MOVE_BYPASS_CHECK && IsBelchPreventingMove(battler, move))
     {
         gCurrentMove = move;
         if (gBattleTypeFlags & BATTLE_TYPE_PALACE)

--- a/test/battle/gimmick/dynamax.c
+++ b/test/battle/gimmick/dynamax.c
@@ -1826,5 +1826,51 @@ SINGLE_BATTLE_TEST("Dynamax: Max Move power is based on the base move", s16 dama
     }
 }
 
+SINGLE_BATTLE_TEST("Dynamax: Gravity does not prevent Max Guard derived from a Gravity-banned status move")
+{
+    enum Move move;
+
+    PARAMETRIZE { move = MOVE_SPLASH; }
+    PARAMETRIZE { move = MOVE_MAGNET_RISE; }
+    PARAMETRIZE { move = MOVE_TELEKINESIS; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_GRAVITY) == EFFECT_GRAVITY);
+        ASSUME(IsMoveGravityBanned(move));
+        PLAYER(SPECIES_WOBBUFFET) { Speed(1); Moves(move, MOVE_SCRATCH); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(2); Moves(MOVE_GRAVITY, MOVE_CELEBRATE); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_GRAVITY); MOVE(player, MOVE_SCRATCH); }
+        TURN { MOVE(player, move, gimmick: GIMMICK_DYNAMAX); MOVE(opponent, MOVE_CELEBRATE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_GRAVITY, opponent);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_DYNAMAX_GROWTH, player);
+        MESSAGE("Wobbuffet used Max Guard!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Dynamax: Gravity does not prevent a Max Move derived from a Gravity-banned damaging move")
+{
+    enum Move move;
+
+    PARAMETRIZE { move = MOVE_FLY; }
+    PARAMETRIZE { move = MOVE_BOUNCE; }
+    PARAMETRIZE { move = MOVE_HIGH_JUMP_KICK; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_GRAVITY) == EFFECT_GRAVITY);
+        ASSUME(IsMoveGravityBanned(move));
+        PLAYER(SPECIES_WOBBUFFET) { Speed(1); Moves(move, MOVE_SCRATCH); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(2); Moves(MOVE_GRAVITY, MOVE_CELEBRATE); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_GRAVITY); MOVE(player, MOVE_SCRATCH); }
+        TURN { MOVE(player, move, gimmick: GIMMICK_DYNAMAX); MOVE(opponent, MOVE_CELEBRATE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_GRAVITY, opponent);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_DYNAMAX_GROWTH, player);
+        HP_BAR(opponent);
+    }
+}
+
 TO_DO_BATTLE_TEST("Dynamax: Contrary inverts stat-lowering Max Moves, without showing a message")
 TO_DO_BATTLE_TEST("Dynamax: Contrary inverts stat-increasing Max Moves, without showing a message")

--- a/test/battle/gimmick/zmove.c
+++ b/test/battle/gimmick/zmove.c
@@ -841,6 +841,156 @@ SINGLE_BATTLE_TEST("(Z-MOVE) Z-Move power is based on the base move", s16 damage
     }
 }
 
+SINGLE_BATTLE_TEST("(Z-MOVE) Z-Moves can be selected under Taunt")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_TAUNT) == EFFECT_TAUNT);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(1); Item(ITEM_NORMALIUM_Z); Moves(MOVE_CELEBRATE, MOVE_SCRATCH); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(2); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_TAUNT); MOVE(player, MOVE_SCRATCH); }
+        TURN { MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_Z_MOVE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TAUNT, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ZMOVE_ACTIVATE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
+    }
+}
+
+SINGLE_BATTLE_TEST("(Z-MOVE) Z-Moves can be selected while Tormented")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_TORMENT) == EFFECT_TORMENT);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(1); Item(ITEM_NORMALIUM_Z); Moves(MOVE_CELEBRATE, MOVE_SCRATCH); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(2); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_TORMENT); MOVE(player, MOVE_CELEBRATE); }
+        TURN { MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_Z_MOVE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TORMENT, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ZMOVE_ACTIVATE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
+    }
+}
+
+SINGLE_BATTLE_TEST("(Z-MOVE) Z-Moves can be selected while Disabled")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_DISABLE) == EFFECT_DISABLE);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); Item(ITEM_NORMALIUM_Z); Moves(MOVE_CELEBRATE, MOVE_SCRATCH); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_CELEBRATE); MOVE(opponent, MOVE_DISABLE); }
+        TURN { MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_Z_MOVE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DISABLE, opponent);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ZMOVE_ACTIVATE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
+    }
+}
+
+SINGLE_BATTLE_TEST("(Z-MOVE) Z-Moves can be selected while Encored")
+{
+    GIVEN {
+        WITH_CONFIG(B_ENCORE_TARGET, GEN_5);
+        ASSUME(GetMoveEffect(MOVE_ENCORE) == EFFECT_ENCORE);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); Item(ITEM_NORMALIUM_Z); Moves(MOVE_CELEBRATE, MOVE_SCRATCH); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_CELEBRATE); MOVE(opponent, MOVE_ENCORE); }
+        TURN { MOVE(player, MOVE_SCRATCH, gimmick: GIMMICK_Z_MOVE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ENCORE, opponent);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ZMOVE_ACTIVATE, player);
+        HP_BAR(opponent);
+    }
+}
+
+SINGLE_BATTLE_TEST("(Z-MOVE) Z-Moves can be selected while Imprisoned")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_IMPRISON) == EFFECT_IMPRISON);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(1); Item(ITEM_NORMALIUM_Z); Moves(MOVE_CELEBRATE, MOVE_SCRATCH); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(2); Moves(MOVE_IMPRISON, MOVE_CELEBRATE); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_IMPRISON); MOVE(player, MOVE_SCRATCH); }
+        TURN { MOVE(player, MOVE_CELEBRATE, gimmick: GIMMICK_Z_MOVE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_IMPRISON, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ZMOVE_ACTIVATE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
+    }
+}
+
+SINGLE_BATTLE_TEST("(Z-MOVE) Z-Moves can be selected under Heal Block")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_HEAL_BLOCK) == EFFECT_HEAL_BLOCK);
+        ASSUME(GetMoveEffect(MOVE_RECOVER) == EFFECT_RESTORE_HP);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(1); HP(1); Item(ITEM_NORMALIUM_Z); Moves(MOVE_RECOVER, MOVE_SCRATCH); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(2); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_HEAL_BLOCK); MOVE(player, MOVE_SCRATCH); }
+        TURN { MOVE(player, MOVE_RECOVER, gimmick: GIMMICK_Z_MOVE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_HEAL_BLOCK, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ZMOVE_ACTIVATE, player);
+    }
+}
+
+SINGLE_BATTLE_TEST("(Z-MOVE) Z-Moves can be selected and executed under Throat Chop")
+{
+    GIVEN {
+        ASSUME(IsSoundMove(MOVE_GROWL));
+        PLAYER(SPECIES_WOBBUFFET) { Speed(1); Item(ITEM_NORMALIUM_Z); Moves(MOVE_GROWL, MOVE_CELEBRATE); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(2); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_THROAT_CHOP); MOVE(player, MOVE_CELEBRATE); }
+        TURN { MOVE(player, MOVE_GROWL, gimmick: GIMMICK_Z_MOVE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_THROAT_CHOP, opponent);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ZMOVE_ACTIVATE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_GROWL, player);
+    }
+}
+
+SINGLE_BATTLE_TEST("(Z-MOVE) Z-Moves can be selected under Gravity but Gravity still prevents execution")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_GRAVITY) == EFFECT_GRAVITY);
+        ASSUME(IsMoveGravityBanned(MOVE_FLY));
+        PLAYER(SPECIES_WOBBUFFET) { Speed(1); Item(ITEM_FLYINIUM_Z); Moves(MOVE_FLY, MOVE_CELEBRATE); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(2); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_GRAVITY); MOVE(player, MOVE_CELEBRATE); }
+        TURN { MOVE(player, MOVE_FLY, gimmick: GIMMICK_Z_MOVE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_GRAVITY, opponent);
+        MESSAGE("Wobbuffet can't use Supersonic Skystrike because of gravity!");
+        NOT HP_BAR(opponent);
+    }
+}
+
+SINGLE_BATTLE_TEST("(Z-MOVE) Z-Belch can be selected without eating a Berry")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_BELCH) == EFFECT_BELCH);
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_POISONIUM_Z); Moves(MOVE_BELCH, MOVE_CELEBRATE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_BELCH, gimmick: GIMMICK_Z_MOVE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ZMOVE_ACTIVATE, player);
+        HP_BAR(opponent);
+    }
+}
+
 TO_DO_BATTLE_TEST("(Z-MOVE) Stat changes from status Z-Moves are not inverted by Contrary")
 TO_DO_BATTLE_TEST("(Z-MOVE) Stat changes from Extreme Evoboost are inverted by Contrary")
 TO_DO_BATTLE_TEST("(Z-MOVE) Stat changes from Clangorous Soulblaze are inverted by Contrary")

--- a/test/battle/gimmick/zmove.c
+++ b/test/battle/gimmick/zmove.c
@@ -841,7 +841,7 @@ SINGLE_BATTLE_TEST("(Z-MOVE) Z-Move power is based on the base move", s16 damage
     }
 }
 
-SINGLE_BATTLE_TEST("(Z-MOVE) Z-Moves can be selected under Taunt")
+SINGLE_BATTLE_TEST("Z-Move: Z-Moves can be selected under Taunt")
 {
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_TAUNT) == EFFECT_TAUNT);
@@ -858,7 +858,7 @@ SINGLE_BATTLE_TEST("(Z-MOVE) Z-Moves can be selected under Taunt")
     }
 }
 
-SINGLE_BATTLE_TEST("(Z-MOVE) Z-Moves can be selected while Tormented")
+SINGLE_BATTLE_TEST("Z-Move: Z-Moves can be selected while Tormented")
 {
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_TORMENT) == EFFECT_TORMENT);
@@ -875,7 +875,7 @@ SINGLE_BATTLE_TEST("(Z-MOVE) Z-Moves can be selected while Tormented")
     }
 }
 
-SINGLE_BATTLE_TEST("(Z-MOVE) Z-Moves can be selected while Disabled")
+SINGLE_BATTLE_TEST("Z-Move: Z-Moves can be selected while Disabled")
 {
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_DISABLE) == EFFECT_DISABLE);
@@ -892,7 +892,7 @@ SINGLE_BATTLE_TEST("(Z-MOVE) Z-Moves can be selected while Disabled")
     }
 }
 
-SINGLE_BATTLE_TEST("(Z-MOVE) Z-Moves can be selected while Encored")
+SINGLE_BATTLE_TEST("Z-Move: Z-Moves can be selected while Encored")
 {
     GIVEN {
         WITH_CONFIG(B_ENCORE_TARGET, GEN_5);
@@ -910,7 +910,7 @@ SINGLE_BATTLE_TEST("(Z-MOVE) Z-Moves can be selected while Encored")
     }
 }
 
-SINGLE_BATTLE_TEST("(Z-MOVE) Z-Moves can be selected while Imprisoned")
+SINGLE_BATTLE_TEST("Z-Move: Z-Moves can be selected while Imprisoned")
 {
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_IMPRISON) == EFFECT_IMPRISON);
@@ -927,7 +927,7 @@ SINGLE_BATTLE_TEST("(Z-MOVE) Z-Moves can be selected while Imprisoned")
     }
 }
 
-SINGLE_BATTLE_TEST("(Z-MOVE) Z-Moves can be selected under Heal Block")
+SINGLE_BATTLE_TEST("Z-Move: Z-Moves can be selected under Heal Block")
 {
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_HEAL_BLOCK) == EFFECT_HEAL_BLOCK);
@@ -944,7 +944,7 @@ SINGLE_BATTLE_TEST("(Z-MOVE) Z-Moves can be selected under Heal Block")
     }
 }
 
-SINGLE_BATTLE_TEST("(Z-MOVE) Z-Moves can be selected and executed under Throat Chop")
+SINGLE_BATTLE_TEST("Z-Move: Z-Moves can be selected and executed under Throat Chop")
 {
     GIVEN {
         ASSUME(IsSoundMove(MOVE_GROWL));
@@ -960,7 +960,7 @@ SINGLE_BATTLE_TEST("(Z-MOVE) Z-Moves can be selected and executed under Throat C
     }
 }
 
-SINGLE_BATTLE_TEST("(Z-MOVE) Z-Moves can be selected under Gravity but Gravity still prevents execution")
+SINGLE_BATTLE_TEST("Z-Move: Z-Moves can be selected under Gravity but Gravity still prevents execution")
 {
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_GRAVITY) == EFFECT_GRAVITY);
@@ -977,7 +977,7 @@ SINGLE_BATTLE_TEST("(Z-MOVE) Z-Moves can be selected under Gravity but Gravity s
     }
 }
 
-SINGLE_BATTLE_TEST("(Z-MOVE) Z-Belch can be selected without eating a Berry")
+SINGLE_BATTLE_TEST("Z-Move: Z-Belch can be selected without eating a Berry")
 {
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_BELCH) == EFFECT_BELCH);


### PR DESCRIPTION
The checks in `TrySetCantSelectMoveBattleScript` already had a Z-Move exception, but it used `GetActiveGimmick`, and the gimmick isn't active yet while the move is being selected. `IsGimmickSelected` doesn't work either, since `gimmick.toActivate` is only set after this function runs, so the chosen gimmick is read from the controller's return value instead.

Gravity also wasn't stopping execution, because a damaging Z-Move has already replaced the chosen move by then and the Z-Move itself isn't Gravity-banned. It now checks `gBattleStruct->baseMove` in that case. Status Z-Moves aren't replaced, so they were already handled.

Added tests for each restriction, including Gravity being selectable but failing. I got all the related info from Smogon and/or Bulbapedia.

### Large Language Models (AI)

No AI has been used.

## Issue(s) that this PR fixes

Fixes #10643

## Discord contact info

syreldar