### PR TITLE
Unify default move targeting between tests and in-game

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -1119,6 +1119,7 @@ enum BattlerPosition GetPartnerPosition(enum BattlerPosition position);
 enum BattlerPosition GetOppositePosition(enum BattlerPosition position);
 enum BattlerId GetBattlerLeftFoe(enum BattlerId battler);
 enum BattlerId GetBattlerRightFoe(enum BattlerId battler);
+enum BattlerId GetDefaultSelectionTarget(enum BattlerId battler, enum MoveTarget moveTarget);
 
 static inline bool32 IsBattlerAlive(enum BattlerId battler)
 {

--- a/include/recorded_battle.h
+++ b/include/recorded_battle.h
@@ -51,6 +51,8 @@ enum
     RECORDED_ITEM_MOVE,
 };
 
+#define RECORDED_TARGET_DEFAULT 0xF
+
 extern rng_value_t gRecordedBattleRngSeed;
 extern rng_value_t gBattlePalaceMoveSelectionRngValue;
 extern u8 gRecordedBattleMultiplayerId;

--- a/src/battle_controller_opponent.c
+++ b/src/battle_controller_opponent.c
@@ -468,13 +468,9 @@ static void OpponentHandleChooseMove(enum BattlerId battler)
         } while (move == MOVE_NONE);
 
         enum MoveTarget moveTarget = GetBattlerMoveTargetType(battler, move);
-        if (moveTarget == TARGET_USER || moveTarget == TARGET_USER_OR_ALLY)
+        if (moveTarget == TARGET_USER || moveTarget == TARGET_USER_OR_ALLY || moveTarget == TARGET_ALLY)
         {
-            BtlController_EmitTwoReturnValues(battler, B_COMM_TO_ENGINE, B_ACTION_EXEC_SCRIPT, (chosenMoveIndex) | (battler << 8));
-        }
-        else if (moveTarget == TARGET_ALLY)
-        {
-            BtlController_EmitTwoReturnValues(battler, B_COMM_TO_ENGINE, B_ACTION_EXEC_SCRIPT, (chosenMoveIndex) | (GetPartnerBattler(battler) << 8));
+            BtlController_EmitTwoReturnValues(battler, B_COMM_TO_ENGINE, B_ACTION_EXEC_SCRIPT, (chosenMoveIndex) | (GetDefaultSelectionTarget(battler, moveTarget) << 8));
         }
         else if (IsDoubleBattle())
         {

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -703,12 +703,7 @@ void HandleInputChooseMove(enum BattlerId battler)
         if (GetActiveGimmick(battler) == GIMMICK_DYNAMAX || IsGimmickSelected(battler, GIMMICK_DYNAMAX))
             moveTarget = GetMoveTarget(GetMaxMove(battler, moveInfo->moves[gMoveSelectionCursor[battler]]));
 
-        if (isUserOrAlly)
-            gMultiUsePlayerCursor = battler;
-        else if (moveTarget == TARGET_ALLY)
-            gMultiUsePlayerCursor = GetPartnerBattler(battler);
-        else
-            gMultiUsePlayerCursor = GetBattlerLeftFoe(battler);
+        gMultiUsePlayerCursor = GetDefaultSelectionTarget(battler, moveTarget);
 
         if (gBattleResources->bufferA[battler][1]) // a double battle
         {

--- a/src/battle_controller_recorded_opponent.c
+++ b/src/battle_controller_recorded_opponent.c
@@ -346,6 +346,11 @@ static void RecordedOpponentHandleChooseMove(enum BattlerId battler)
     {
         u8 moveId = RecordedBattle_GetBattlerAction(RECORDED_MOVE_SLOT, battler);
         u8 target = RecordedBattle_GetBattlerAction(RECORDED_MOVE_TARGET, battler);
+        if (target == RECORDED_TARGET_DEFAULT)
+        {
+            struct ChooseMoveStruct *moveInfo = (struct ChooseMoveStruct *)(&gBattleResources->bufferA[battler][4]);
+            target = GetDefaultSelectionTarget(battler, GetMoveTarget(moveInfo->moves[moveId]));
+        }
         BtlController_EmitTwoReturnValues(battler, B_COMM_TO_ENGINE, B_ACTION_EXEC_SCRIPT, moveId | (target << 8));
     }
 

--- a/src/battle_controller_recorded_partner.c
+++ b/src/battle_controller_recorded_partner.c
@@ -267,6 +267,11 @@ static void RecordedPartnerHandleChooseMove(enum BattlerId battler)
 {
     u8 moveIndex = RecordedBattle_GetBattlerAction(RECORDED_MOVE_SLOT, battler);
     u8 target = RecordedBattle_GetBattlerAction(RECORDED_MOVE_TARGET, battler);
+    if (target == RECORDED_TARGET_DEFAULT)
+    {
+        struct ChooseMoveStruct *moveInfo = (struct ChooseMoveStruct *)(&gBattleResources->bufferA[battler][4]);
+        target = GetDefaultSelectionTarget(battler, GetMoveTarget(moveInfo->moves[moveIndex]));
+    }
     BtlController_EmitTwoReturnValues(battler, B_COMM_TO_ENGINE, B_ACTION_EXEC_SCRIPT, moveIndex | (target << 8));
 
     BtlController_Complete(battler);

--- a/src/battle_controller_recorded_player.c
+++ b/src/battle_controller_recorded_player.c
@@ -367,6 +367,11 @@ static void RecordedPlayerHandleChooseMove(enum BattlerId battler)
     {
         u8 moveIndex = RecordedBattle_GetBattlerAction(RECORDED_MOVE_SLOT, battler);
         u8 target = RecordedBattle_GetBattlerAction(RECORDED_MOVE_TARGET, battler);
+        if (target == RECORDED_TARGET_DEFAULT)
+        {
+            struct ChooseMoveStruct *moveInfo = (struct ChooseMoveStruct *)(&gBattleResources->bufferA[battler][4]);
+            target = GetDefaultSelectionTarget(battler, GetMoveTarget(moveInfo->moves[moveIndex]));
+        }
         BtlController_EmitTwoReturnValues(battler, B_COMM_TO_ENGINE, B_ACTION_EXEC_SCRIPT, moveIndex | (target << 8));
     }
 

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -120,6 +120,21 @@ enum BattlerId GetBattlerRightFoe(enum BattlerId battler)
     return GetPartnerBattler(GetBattlerLeftFoe(battler));
 }
 
+enum BattlerId GetDefaultSelectionTarget(enum BattlerId battler, enum MoveTarget moveTarget)
+{
+    switch (moveTarget)
+    {
+    case TARGET_USER:
+    case TARGET_USER_OR_ALLY:
+    case TARGET_USER_AND_ALLY:
+        return battler;
+    case TARGET_ALLY:
+        return GetPartnerBattler(battler);
+    default:
+        return GetBattlerLeftFoe(battler);
+    }
+}
+
 static const u8 sPkblToEscapeFactor[][3] = {
     {
         [B_MSG_MON_CURIOUS]    = 0,

--- a/test/battle/spread_moves.c
+++ b/test/battle/spread_moves.c
@@ -466,7 +466,7 @@ DOUBLE_BATTLE_TEST("Spread Moves: Unless move hits every target user will not in
         TURN { MOVE(opponentRight, MOVE_ICY_WIND); MOVE(playerLeft, MOVE_ROCK_SLIDE); SEND_OUT(playerRight, 2); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ICY_WIND, opponentRight);
-        EFFECTIVENESS_SE(playerRight, SE_SUPER_EFFECTIVE); // SE against sandslash
+        EFFECTIVENESS_SE(playerLeft, SE_SUPER_EFFECTIVE); // SE against sandslash
         HP_BAR(playerLeft);
         HP_BAR(playerRight);
 
@@ -490,8 +490,8 @@ DOUBLE_BATTLE_TEST("Spread Moves: Focus Sash activates correctly")
         TURN { MOVE(playerRight, MOVE_HYPER_VOICE); MOVE(playerLeft, MOVE_EXPLOSION); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_HYPER_VOICE, playerRight);
-        MESSAGE("The opposing Wynaut hung on using its Focus Sash!");
         MESSAGE("The opposing Wobbuffet hung on using its Focus Sash!");
+        MESSAGE("The opposing Wynaut hung on using its Focus Sash!");
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPLOSION, playerLeft);
         MESSAGE("The opposing Wobbuffet fainted!");
         MESSAGE("Wynaut hung on using its Focus Sash!");

--- a/test/test_runner_battle.c
+++ b/test/test_runner_battle.c
@@ -2946,42 +2946,50 @@ s32 MoveGetTarget(enum BattlerId battlerId, enum Move moveId, struct MoveContext
     else
     {
         enum MoveTarget moveTarget = GetMoveTarget(moveId);
-        if (moveTarget == TARGET_RANDOM
-         || moveTarget == TARGET_BOTH
-         || moveTarget == TARGET_DEPENDS
-         || moveTarget == TARGET_FOES_AND_ALLY
-         || moveTarget == TARGET_OPPONENTS_FIELD)
+        switch (moveTarget)
         {
-            target = ((battlerId ^ BIT_SIDE)); // Note: this could be bugged under Ally Switch, but Getters do not work here
-        }
-        else if (moveTarget == TARGET_SELECTED || moveTarget == TARGET_SMART || moveTarget == TARGET_OPPONENT)
-        {
+        case TARGET_RANDOM:
+        case TARGET_BOTH:
+        case TARGET_DEPENDS:
+        case TARGET_FOES_AND_ALLY:
+        case TARGET_OPPONENTS_FIELD:
+        case TARGET_USER:
+        case TARGET_ALL_BATTLERS:
+        case TARGET_FIELD:
+        case TARGET_USER_AND_ALLY:
+        case TARGET_ALLY:
+            break;
+        case TARGET_SELECTED:
+        case TARGET_SMART:
+        case TARGET_OPPONENT:
             // In AI Doubles not specified target allows any target for EXPECT_MOVE.
             if (!IsAIDoublesTest())
             {
                 INVALID_IF(STATE->battlersCount > 2, "%S requires explicit target", GetMoveName(moveId));
             }
-
-            target = ((battlerId ^ BIT_SIDE)); // Note: this could be bugged under Ally Switch, but Getters do not work here
-        }
-        else if (moveTarget == TARGET_USER
-              || moveTarget == TARGET_ALL_BATTLERS
-              || moveTarget == TARGET_FIELD
-              || moveTarget == TARGET_USER_AND_ALLY)
-        {
-            target = battlerId;
-        }
-        else if (moveTarget == TARGET_ALLY)
-        {
-            target = (battlerId ^ BIT_FLANK);
-        }
-        else
-        {
+            break;
+        default:
             // In AI Doubles not specified target allows any target for EXPECT_MOVE.
             if (!IsAIDoublesTest())
             {
                 INVALID("%S requires explicit target", GetMoveName(moveId));
             }
+            break;
+        }
+
+        switch (moveTarget)
+        {
+        case TARGET_USER:
+        case TARGET_USER_OR_ALLY:
+        case TARGET_USER_AND_ALLY:
+            target = battlerId;
+            break;
+        case TARGET_ALLY:
+            target = battlerId ^ BIT_FLANK;
+            break;
+        default:
+            target = (battlerId & BIT_SIDE) ^ BIT_SIDE;
+            break;
         }
     }
     return target;
@@ -3126,7 +3134,8 @@ void Move(u32 sourceLine, struct BattlePokemon *battler, struct MoveContext ctx)
     if (!ctx.explicitAllowed || ctx.allowed)
     {
         PushBattlerAction(sourceLine, battlerId, RECORDED_MOVE_SLOT, moveSlot);
-        PushBattlerAction(sourceLine, battlerId, RECORDED_MOVE_TARGET, target);
+        PushBattlerAction(sourceLine, battlerId, RECORDED_MOVE_TARGET,
+                          ctx.explicitTarget ? target : RECORDED_TARGET_DEFAULT);
     }
 
     if (ctx.explicitPartyIndex)

--- a/test/test_runner_battle.c
+++ b/test/test_runner_battle.c
@@ -268,11 +268,39 @@ static bool32 Test_BattlersShareParty(enum BattlerId battlerId1, enum BattlerId 
     return Test_GetBattlerTrainer(battlerId1) == Test_GetBattlerTrainer(battlerId2);
 }
 
+static void InitTestBattlers(const struct BattleTest *test)
+{
+    switch (test->type)
+    {
+    case BATTLE_TEST_SINGLES:
+    case BATTLE_TEST_WILD:
+    case BATTLE_TEST_GHOST:
+    case BATTLE_TEST_AI_SINGLES:
+        STATE->battlersCount = 2;
+        break;
+    case BATTLE_TEST_DOUBLES:
+    case BATTLE_TEST_AI_DOUBLES:
+    case BATTLE_TEST_MULTI:
+    case BATTLE_TEST_AI_MULTI:
+    case BATTLE_TEST_TWO_VS_ONE:
+    case BATTLE_TEST_AI_TWO_VS_ONE:
+    case BATTLE_TEST_ONE_VS_TWO:
+    case BATTLE_TEST_AI_ONE_VS_TWO:
+        STATE->battlersCount = MAX_BATTLERS_COUNT;
+        break;
+    }
+
+    gBattlersCount = STATE->battlersCount;
+    for (enum BattlerId battler = 0; battler < MAX_BATTLERS_COUNT; battler++)
+        gBattlerPositions[battler] = battler < gBattlersCount ? battler : B_POSITION_ABSENT;
+}
+
 static u32 BattleTest_EstimateCost(void *data)
 {
     u32 cost;
     const struct BattleTest *test = data;
     memset(STATE, 0, sizeof(*STATE));
+    InitTestBattlers(test);
     STATE->runRandomly = TRUE;
     ResetStartingStatuses();
     InvokeTestFunction(test);
@@ -290,6 +318,7 @@ static void BattleTest_SetUp(void *data)
 {
     const struct BattleTest *test = data;
     memset(STATE, 0, sizeof(*STATE));
+    InitTestBattlers(test);
     InvokeTestFunction(test);
     STATE->parameters = STATE->parametersCount;
     if (STATE->parametersCount == 0 && test->resultsSize > 0)
@@ -298,25 +327,6 @@ static void BattleTest_SetUp(void *data)
         Test_ExitWithResult(TEST_RESULT_ERROR, SourceLine(0), "OOM: STATE (%d) + STATE->results (%d) too big for sBackupMapData (%d)", sizeof(*STATE), test->resultsSize * STATE->parameters, sizeof(sBackupMapData));
     STATE->results = (void *)((char *)sBackupMapData + sizeof(struct BattleTestRunnerState));
     memset(STATE->results, 0, test->resultsSize * STATE->parameters);
-    switch (test->type)
-    {
-    case BATTLE_TEST_SINGLES:
-    case BATTLE_TEST_WILD:
-    case BATTLE_TEST_GHOST:
-    case BATTLE_TEST_AI_SINGLES:
-        STATE->battlersCount = 2;
-        break;
-    case BATTLE_TEST_DOUBLES:
-    case BATTLE_TEST_AI_DOUBLES:
-    case BATTLE_TEST_MULTI:
-    case BATTLE_TEST_AI_MULTI:
-    case BATTLE_TEST_TWO_VS_ONE:
-    case BATTLE_TEST_AI_TWO_VS_ONE:
-    case BATTLE_TEST_ONE_VS_TWO:
-    case BATTLE_TEST_AI_ONE_VS_TWO:
-        STATE->battlersCount = 4;
-        break;
-    }
     STATE->hasTornDownBattle = FALSE;
 }
 
@@ -412,6 +422,7 @@ static void BattleTest_Run(void *data)
     const struct BattleTest *test = data;
 
     memset(&DATA, 0, sizeof(DATA));
+    InitTestBattlers(test);
     TestInitConfigData();
 
     DATA.queuedEventsFailIndex = MAX_QUEUED_EVENTS;
@@ -2977,20 +2988,7 @@ s32 MoveGetTarget(enum BattlerId battlerId, enum Move moveId, struct MoveContext
             break;
         }
 
-        switch (moveTarget)
-        {
-        case TARGET_USER:
-        case TARGET_USER_OR_ALLY:
-        case TARGET_USER_AND_ALLY:
-            target = battlerId;
-            break;
-        case TARGET_ALLY:
-            target = battlerId ^ BIT_FLANK;
-            break;
-        default:
-            target = (battlerId & BIT_SIDE) ^ BIT_SIDE;
-            break;
-        }
+        target = GetDefaultSelectionTarget(battlerId, moveTarget);
     }
     return target;
 }


### PR DESCRIPTION
Tests picked a default target in `MoveGetTarget`, the player controller picked one in `HandleInputChooseMove`, and wild Pokémon picked one in `OpponentHandleChooseMove`.

All three now use `GetDefaultMoveTarget`. It is written with the same getters the controllers already used, so the game behaves exactly as before.

`MoveGetTarget` can't call it, since it runs before the battlers exist. Instead, a MOVE without an explicit target records `RECORDED_TARGET_DEFAULT`, and the recorded controllers resolve it with `GetDefaultMoveTarget` once the battle is running. Tests no longer decide targets themselves.

I also corrected two spread move tests, because they were failing since they were relying on the old target. The effectiveness sound in one belongs to the left target, which its own comment already said, and the `Focus Sash` messages in the other come in the opposite order.

**However, I made an important discovery during the process**: The recorded controllers still look up the target type with `GetMoveTarget` rather than `GetBattlerMoveTargetType` like the controllers do. Using the latter fails the test involving Curse + Trick-or-Treat, because the game picks Curse's target before Trick-or-Treat resolves.
That.. looks like a bug to me, but I'm not sure solving it is within the scope of this PR.

### Large Language Models (AI)

No AI has been used.

## Issue(s) that this PR fixes

Fixes #10646

## Discord contact info

syreldar