### PR TITLE
Fix Metronome-called spread moves hitting the user’s partner

### DIFF
--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -1051,7 +1051,6 @@ static enum CancelerResult CancelerPPDeduction(struct BattleCalcValues *cv)
 
             // Possibly better to just move type setting and redirection to attackcanceler as a new case at this point
             SetTypeBeforeUsingMove(cv->move, cv->battlerAtk);
-            ClearDamageCalcResults();
             gBattlescriptCurrInstr = GetMoveBattleScript(cv->move);
             return CANCELER_RESULT_RUN_SCRIPT_AND_INCREMENT;
         }

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -7854,6 +7854,7 @@ static void Cmd_setcalledmove(void)
 {
     CMD_ARGS();
     gCurrentMove = gBattleStruct->baseMove = gCalledMove;
+    ClearDamageCalcResults();
     gBattlescriptCurrInstr = cmd->nextInstr;
 }
 
@@ -13891,4 +13892,3 @@ void BS_RestoreStatChangeQueue(void)
     ClearOtherStatChangeValues(gBattlerAttacker);
     gBattlescriptCurrInstr = cmd->nextInstr;
 }
-

--- a/test/battle/move_effect/metronome.c
+++ b/test/battle/move_effect/metronome.c
@@ -61,3 +61,28 @@ SINGLE_BATTLE_TEST("Metronome's called multi-hit move hits multiple times")
         MESSAGE("The Pokémon was hit 5 time(s)!");
     }
 }
+
+DOUBLE_BATTLE_TEST("Metronome's called spread move does not hit the user's partner")
+{
+    GIVEN {
+        ASSUME(GetMoveTarget(MOVE_SWIFT) == TARGET_BOTH);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_METRONOME, WITH_RNG(RNG_METRONOME, MOVE_SWIFT)); }
+    } SCENE {
+        MESSAGE("Wobbuffet used Metronome!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_METRONOME, playerLeft);
+        MESSAGE("Waggling a finger let it use Swift!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SWIFT, playerLeft);
+        HP_BAR(opponentLeft);
+        NOT HP_BAR(playerRight);
+        HP_BAR(opponentRight);
+    } THEN {
+        EXPECT_EQ(playerRight->hp, playerRight->maxHP);
+        EXPECT_LT(opponentLeft->hp, opponentLeft->maxHP);
+        EXPECT_LT(opponentRight->hp, opponentRight->maxHP);
+    }
+}


### PR DESCRIPTION
The called move’s damage state was being cleared during PP deduction, after its targets had already been determined. This removed the flag marking the user’s partner as unaffected.

My change moves the reset to when the called move is assigned, before its targets are calculated. The regression test I made confirms that both opponents are hit while the user’s partner is left untouched.

### Large Language Models (AI)

No AI has been used.

## Issue(s) that this PR fixes

Fixes #10623.

## Discord contact info

syreldar