### PR TITLE
Fixed the Multi Battle party-slot collision

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -8857,7 +8857,7 @@ void SetIllusionMon(struct Pokemon *mon, enum BattlerId battler)
     party = GetBattlerParty(battler);
 
     if (IsBattlerAlive(GetPartnerBattler(battler)))
-        partnerMon = &party[gBattlerPartyIndexes[GetPartnerBattler(battler)]];
+        partnerMon = GetBattlerMon(GetPartnerBattler(battler));
     else
         partnerMon = mon;
 

--- a/test/battle/ability/illusion.c
+++ b/test/battle/ability/illusion.c
@@ -88,6 +88,26 @@ ONE_VS_TWO_BATTLE_TEST("Illusion works for the second opponent trainer in a batt
     }
 }
 
+MULTI_BATTLE_TEST("Illusion works when the user's partner and disguise are in the same party slot")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_ZOROARK) { Ability(ABILITY_ILLUSION); }
+        PLAYER(SPECIES_WYNAUT);
+        PARTNER(SPECIES_WOBBUFFET);
+        PARTNER(SPECIES_WOBBUFFET);
+        PARTNER(SPECIES_WOBBUFFET);
+        OPPONENT_A(SPECIES_WOBBUFFET);
+        OPPONENT_B(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { SWITCH(playerRight, 2); }
+        TURN { SWITCH(playerLeft, 1); }
+    } THEN {
+        EXPECT_EQ(gBattleStruct->illusion[B_POSITION_PLAYER_LEFT].state, ILLUSION_ON);
+        EXPECT(&gParties[B_TRAINER_PLAYER][2] == gBattleStruct->illusion[B_POSITION_PLAYER_LEFT].mon);
+    }
+}
+
 SINGLE_BATTLE_TEST("Illusion breaks in Neutralizing Gas")
 {
     GIVEN {


### PR DESCRIPTION
Illusion was using the active partner’s party slot to look up a Pokémon in Zoroark’s party. If the partner occupied the same slot as the intended disguise, Illusion incorrectly treated that Pokémon as the active partner and failed to activate.

The partner is now retrieved from its actual trainer party.
Implemented the issuer's regression test as well.

### Large Language Models (AI)

No AI has been used.

## Issue(s) that this PR fixes

Fixes #10602.

## Discord contact info

syreldar