### PR TITLE
upcoming: Clear callbacks between tests

### DIFF
--- a/test/battle/trainer_control.c
+++ b/test/battle/trainer_control.c
@@ -247,7 +247,6 @@ TEST("Trainer Party Pool picks a random lead and a random ace if tags exist in t
 {
     struct Pokemon *testParty = Alloc(6 * sizeof(struct Pokemon));
     u32 currTrainer = 7;
-    gBattleTypeFlags = 0;
     CreateNPCTrainerPartyFromTrainer(testParty, GetTrainerStructFromId(currTrainer));
     EXPECT(GetMonData(&testParty[0], MON_DATA_SPECIES) == SPECIES_ARON);    //  Lead
     EXPECT(GetMonData(&testParty[1], MON_DATA_SPECIES) == SPECIES_WYNAUT);  //  Not Lead or Ace

--- a/test/battle/trainer_control.c
+++ b/test/battle/trainer_control.c
@@ -247,6 +247,7 @@ TEST("Trainer Party Pool picks a random lead and a random ace if tags exist in t
 {
     struct Pokemon *testParty = Alloc(6 * sizeof(struct Pokemon));
     u32 currTrainer = 7;
+    gBattleTypeFlags = 0;
     CreateNPCTrainerPartyFromTrainer(testParty, GetTrainerStructFromId(currTrainer));
     EXPECT(GetMonData(&testParty[0], MON_DATA_SPECIES) == SPECIES_ARON);    //  Lead
     EXPECT(GetMonData(&testParty[1], MON_DATA_SPECIES) == SPECIES_WYNAUT);  //  Not Lead or Ace

--- a/test/test_runner.c
+++ b/test/test_runner.c
@@ -565,6 +565,7 @@ void Test_ExpectFail(u32 failLine)
 static void FunctionTest_SetUp(void *data)
 {
     (void)data;
+    gBattleTypeFlags = 0;
     TestInitConfigData();
     ClearRiggedRng();
     gFunctionTestRunnerState = AllocZeroed(sizeof(*gFunctionTestRunnerState));

--- a/test/test_runner.c
+++ b/test/test_runner.c
@@ -16,6 +16,7 @@
 #define TIMEOUT_SECONDS 60
 
 void CB2_TestRunner(void);
+void ReinitCallbacks(void);
 
 EWRAM_DATA struct TestRunnerState gTestRunnerState;
 EWRAM_DATA struct FunctionTestRunnerState *gFunctionTestRunnerState;
@@ -562,9 +563,16 @@ void Test_ExpectFail(u32 failLine)
     }
 }
 
+static void FunctionTest_ResetGlobalVariables(void)
+{
+    ReinitCallbacks();
+    gBattleTypeFlags = 0;
+}
+
 static void FunctionTest_SetUp(void *data)
 {
     (void)data;
+    FunctionTest_ResetGlobalVariables();
     TestInitConfigData();
     ClearRiggedRng();
     gFunctionTestRunnerState = AllocZeroed(sizeof(*gFunctionTestRunnerState));
@@ -581,11 +589,6 @@ static void FunctionTest_Run(void *data)
         gFunctionTestRunnerState->parameters = 0;
         function();
     } while (++gFunctionTestRunnerState->runParameter < gFunctionTestRunnerState->parameters);
-}
-
-static void FunctionTest_ResetGlobalVariables(void)
-{
-    gBattleTypeFlags = 0;
 }
 
 static void FunctionTest_TearDown(void *data)

--- a/test/test_runner.c
+++ b/test/test_runner.c
@@ -16,7 +16,8 @@
 #define TIMEOUT_SECONDS 60
 
 void CB2_TestRunner(void);
-void ReinitCallbacks(void);
+static void ReinitCallbacks(void);
+static void ResetGlobalVariables(void);
 
 EWRAM_DATA struct TestRunnerState gTestRunnerState;
 EWRAM_DATA struct FunctionTestRunnerState *gFunctionTestRunnerState;
@@ -332,6 +333,7 @@ top:
         gTestRunnerState.state = STATE_REPORT_RESULT;
         gPersistentTestRunnerState.state = CURRENT_TEST_STATE_RUN;
         gPersistentTestRunnerState.expectCrash = FALSE;
+        ResetGlobalVariables();
         SeedRng(0);
         SeedRng2(0);
         if (gTestRunnerState.test->runner->setUp)
@@ -563,7 +565,7 @@ void Test_ExpectFail(u32 failLine)
     }
 }
 
-static void FunctionTest_ResetGlobalVariables(void)
+static void ResetGlobalVariables(void)
 {
     ReinitCallbacks();
     gBattleTypeFlags = 0;
@@ -572,7 +574,6 @@ static void FunctionTest_ResetGlobalVariables(void)
 static void FunctionTest_SetUp(void *data)
 {
     (void)data;
-    FunctionTest_ResetGlobalVariables();
     TestInitConfigData();
     ClearRiggedRng();
     gFunctionTestRunnerState = AllocZeroed(sizeof(*gFunctionTestRunnerState));
@@ -594,7 +595,6 @@ static void FunctionTest_Run(void *data)
 static void FunctionTest_TearDown(void *data)
 {
     (void)data;
-    FunctionTest_ResetGlobalVariables();
     TestFreeConfigData();
     FREE_AND_SET_NULL(gFunctionTestRunnerState);
 }
@@ -718,7 +718,7 @@ static NAKED void JumpToAgbMainLoop(void)
          .pool");
 }
 
-void ReinitCallbacks(void)
+static void ReinitCallbacks(void)
 {
     gMain.callback1 = NULL;
     SetMainCallback2(CB2_TestRunner);

--- a/test/test_runner.c
+++ b/test/test_runner.c
@@ -565,7 +565,6 @@ void Test_ExpectFail(u32 failLine)
 static void FunctionTest_SetUp(void *data)
 {
     (void)data;
-    gBattleTypeFlags = 0;
     TestInitConfigData();
     ClearRiggedRng();
     gFunctionTestRunnerState = AllocZeroed(sizeof(*gFunctionTestRunnerState));
@@ -584,9 +583,15 @@ static void FunctionTest_Run(void *data)
     } while (++gFunctionTestRunnerState->runParameter < gFunctionTestRunnerState->parameters);
 }
 
+static void FunctionTest_ResetGlobalVariables(void)
+{
+    gBattleTypeFlags = 0;
+}
+
 static void FunctionTest_TearDown(void *data)
 {
     (void)data;
+    FunctionTest_ResetGlobalVariables();
     TestFreeConfigData();
     FREE_AND_SET_NULL(gFunctionTestRunnerState);
 }


### PR DESCRIPTION
The Trainer Party Pool random lead and ace test assumed `gBattleTypeFlags` was zero. Function tests can inherit global state from another test running in the same worker, and leaked double-battle state makes slot 1 select a second lead.

The test now deliberately starts with double-battle state and explicitly resets it before generating the party. This makes the regression deterministic: without the reset the test fails, and with it the expected singles party is generated.

### Large Language Models (AI)

No AI has been used.

## Issue(s) that this PR fixes

Fixes #10664.

## Discord contact info

syreldar

