### PR TITLE
Fix Mind Reader and Lock-On spam in double battles

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -5942,7 +5942,8 @@ static s32 AI_CheckViability(enum BattlerId battlerAtk, enum BattlerId battlerDe
         }
     }
 
-    if (AI_GetBattlerMoveTargetType(battlerAtk, move) == TARGET_SELECTED
+    if (IsDoubleBattle()
+     && AI_GetBattlerMoveTargetType(battlerAtk, move) == TARGET_SELECTED
      && !IsBattleMoveStatus(move)
      && gBattleMons[battlerAtk].volatiles.battlerWithSureHit == battlerDef + 1)
         ADJUST_SCORE(WEAK_EFFECT);

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -5942,6 +5942,11 @@ static s32 AI_CheckViability(enum BattlerId battlerAtk, enum BattlerId battlerDe
         }
     }
 
+    if (AI_GetBattlerMoveTargetType(battlerAtk, move) == TARGET_SELECTED
+     && !IsBattleMoveStatus(move)
+     && gBattleMons[battlerAtk].volatiles.battlerWithSureHit == battlerDef + 1)
+        ADJUST_SCORE(WEAK_EFFECT);
+
     ADJUST_SCORE(AI_CalcMoveEffectScore(battlerAtk, battlerDef, move, aiData));
     ADJUST_SCORE(AI_CalcAdditionalEffectScore(battlerAtk, battlerDef, move, aiData));
     ADJUST_SCORE(AI_CalcHoldEffectMoveScore(battlerAtk, battlerDef, move, aiData));

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -2254,7 +2254,7 @@ static s32 AI_CheckBadMove(enum BattlerId battlerAtk, enum BattlerId battlerDef,
         //TODO
         break;
     case EFFECT_LOCK_ON:
-        if (gBattleMons[battlerAtk].volatiles.battlerWithSureHit == battlerDef + 1
+        if (gBattleMons[battlerAtk].volatiles.battlerWithSureHit != 0
           || aiData->abilities[battlerAtk] == ABILITY_NO_GUARD
           || aiData->abilities[battlerDef] == ABILITY_NO_GUARD
           || DoesPartnerHaveSameMoveEffect(GetPartnerBattler(battlerAtk), battlerDef, move, aiData->partnerMove))

--- a/test/battle/ai/check_bad_move.c
+++ b/test/battle/ai/check_bad_move.c
@@ -75,6 +75,32 @@ AI_DOUBLE_BATTLE_TEST("AI avoids Mind Reader and Lock-On while any target is loc
     }
 }
 
+AI_DOUBLE_BATTLE_TEST("AI attacks the target of its active Mind Reader or Lock-On")
+{
+    enum Move move;
+
+    PARAMETRIZE { move = MOVE_MIND_READER; }
+    PARAMETRIZE { move = MOVE_LOCK_ON; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(move) == EFFECT_LOCK_ON);
+        TIE_BREAK_SCORE(RNG_AI_SCORE_TIE_DOUBLES_MOVE, SCORE_TIE_LO, 0);
+        TIE_BREAK_TARGET(TARGET_TIE_LO, 0);
+        AI_FLAGS(AI_FLAG_SMART_TRAINER | AI_FLAG_PREFER_HIGHEST_DAMAGE_MOVE);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { Moves(move, MOVE_HYDRO_PUMP); }
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN { EXPECT_MOVE(opponentLeft, move, target: playerLeft); }
+        TURN {
+            EXPECT_MOVE(opponentLeft, MOVE_HYDRO_PUMP, target: playerLeft);
+            SCORE_GT_VAL(opponentLeft, MOVE_HYDRO_PUMP, AI_SCORE_DEFAULT + BEST_DAMAGE_MOVE, target: playerLeft);
+            SCORE_EQ_VAL(opponentLeft, MOVE_HYDRO_PUMP, AI_SCORE_DEFAULT + BEST_DAMAGE_MOVE, target: playerRight);
+        }
+    }
+}
+
 AI_SINGLE_BATTLE_TEST("AI sees No Guard affects semi-invulnerable moves")
 {
     GIVEN {

--- a/test/battle/ai/check_bad_move.c
+++ b/test/battle/ai/check_bad_move.c
@@ -49,6 +49,32 @@ AI_DOUBLE_BATTLE_TEST("AI will not try to lower opposing stats if target is prot
     }
 }
 
+AI_DOUBLE_BATTLE_TEST("AI avoids Mind Reader and Lock-On while any target is locked on")
+{
+    enum Move move;
+
+    PARAMETRIZE { move = MOVE_MIND_READER; }
+    PARAMETRIZE { move = MOVE_LOCK_ON; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(move) == EFFECT_LOCK_ON);
+        TIE_BREAK_SCORE(RNG_AI_SCORE_TIE_DOUBLES_MOVE, SCORE_TIE_LO, 0);
+        TIE_BREAK_TARGET(TARGET_TIE_LO, 0);
+        AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET) { Moves(move, MOVE_SCRATCH); }
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN { EXPECT_MOVE(opponentLeft, move, target: playerLeft); }
+        TURN {
+            EXPECT_MOVE(opponentLeft, MOVE_SCRATCH);
+            SCORE_LT_VAL(opponentLeft, move, AI_SCORE_DEFAULT, target: playerLeft);
+            SCORE_LT_VAL(opponentLeft, move, AI_SCORE_DEFAULT, target: playerRight);
+        }
+    }
+}
+
 AI_SINGLE_BATTLE_TEST("AI sees No Guard affects semi-invulnerable moves")
 {
     GIVEN {


### PR DESCRIPTION
Fixes the AI repeatedly selecting `Mind Reader` or `Lock-On` in double battles while it already has an active Lock-On target. The bad-move check previously compared `battlerWithSureHit` with the target currently being evaluated.
Consequently, the move was discouraged against the locked-on opponent but remained eligible against the other opponent, even though the battle engine would reject it. The check now treats `Mind Reader` and `Lock-On` as unusable whenever the attacker already has any active sure-hit target.

I also made a regression test for the case.

### Large Language Models (AI)

No AI has been used.

## Issue(s) that this PR fixes

Fixes #10668.

## Discord contact info

syreldar