### PR TITLE
Prevent Red Card from allowing Z-Move reuse

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -9,6 +9,7 @@
 #include "battle_scripts.h"
 #include "battle_switch_in.h"
 #include "battle_environment.h"
+#include "battle_gimmick.h"
 #include "battle_z_move.h"
 #include "battle_stat_change.h"
 #include "battle_move_resolution.h"
@@ -9287,6 +9288,9 @@ static void Cmd_switchoutabilities(void)
     CMD_ARGS(u8 battler);
 
     enum BattlerId battler = GetBattlerForBattleScript(cmd->battler);
+
+    if (GetActiveGimmick(battler) == GIMMICK_Z_MOVE)
+        SetActiveGimmick(battler, GIMMICK_NONE);
 
     if (gBattleMons[battler].volatiles.neutralizingGas)
     {

--- a/test/battle/hold_effect/red_card.c
+++ b/test/battle/hold_effect/red_card.c
@@ -27,6 +27,25 @@ SINGLE_BATTLE_TEST("Red Card switches the attacker with a random non-fainted rep
     }
 }
 
+SINGLE_BATTLE_TEST("Red Card does not let a switched-out attacker reuse its Z-Move")
+{
+    GIVEN {
+        ASSUME(GetMoveType(MOVE_SCRATCH) == TYPE_NORMAL);
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_NORMALIUM_Z); }
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_RED_CARD); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SCRATCH, gimmick: GIMMICK_Z_MOVE); }
+        TURN { SWITCH(player, 0); }
+        TURN { MOVE(player, MOVE_SCRATCH); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ZMOVE_ACTIVATE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BREAKNECK_BLITZ, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+    }
+}
+
 DOUBLE_BATTLE_TEST("Red Card switches the target with a random non-battler, non-fainted replacement")
 {
     PASSES_RANDOMLY(1, 2, RNG_FORCE_RANDOM_SWITCH);


### PR DESCRIPTION
When `Red Card` forced out a Pokémon after it used a Z-Move, the Pokémon retained its temporary active Z-Move state. This happened because `Red Card` changed the battler's party index before the normal move-end cleanup ran. When the original Pokémon returned, its next regular move could incorrectly become another Z-Move.

The temporary Z-Move state is now cleared during switch-out, while it still refers to the outgoing Pokémon. I checked and persistent gimmicks such as Mega Evolution and Terastallization are unaffected.

I also added regression test for this.

### Large Language Models (AI)

No AI has been used.

## Issue(s) that this PR fixes

Fixes #10532.

## Discord contact info

syreldar