### PR TITLE
Fix out-of-bounds read of gSelectedOrderFromParty

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -4221,7 +4221,7 @@ static bool32 WillPlayerWhiteOutIfPartnerWinsAlone()
         return TRUE;
     if (TESTING)
         return FALSE;
-    for (u32 i = 0; i < PARTY_SIZE; i++)
+    for (u32 i = 0; i < ARRAY_COUNT(gSelectedOrderFromParty); i++)
     {
         if (gSelectedOrderFromParty[i] <= MULTI_PARTY_SIZE)
             continue;


### PR DESCRIPTION
`gSelectedOrderFromParty` is declared `u8 gSelectedOrderFromParty[MAX_FRONTIER_PARTY_SIZE]`, which expands to `max(3, max(4, 2))`, so **4 elements**. `WillPlayerWhiteOutIfPartnerWinsAlone` in `src/battle_script_commands.c` was iterating it to `PARTY_SIZE` (6), so iterations 4 and 5 read two elements past the end of the array.

This just bounds the loop by the array's own size, which is how every other place in the tree walks this array anyway. `src/party_menu.c` already uses `ARRAY_COUNT(gSelectedOrderFromParty)`, and the remaining users index it with small constants. This was the only site bounding it with `PARTY_SIZE`, which is why I'm fairly sure it was just a mix-up between the two sizes.

Targeting `master` since the bug is present there. The function is identical on `upcoming`. I couldn't pin down what those two out-of-bounds bytes actually contain, since it depends on how the linker lays out that EWRAM section, so I can't pinpoint any specific in-game bugs/errors. If they're zero padding the behaviour was already correct by accident; if a neighbouring `static EWRAM_DATA` pointer lands there, the values read are usually greater than `MULTI_PARTY_SIZE` and the loop would run the HP check on two phantom party slots, which can flip the function's result. Either way it shouldn't be reading there.

Details and the layout evidence are in the issue.

### Large Language Models (AI)

No AI has been used.

## Issue(s) that this PR fixes

Fixes #10673's first pass. Reviewers need to tell me how to tackle the second.

## Context from the Issue

The loop variable is doing double duty and I left it be. `i` indexes `gSelectedOrderFromParty`, whose valid range is 0 to 3 and whose *values* are 1-based party indices, and the same `i` is passed to `GetSavedPlayerPartyMon(i)`, whose valid range is 0 to `PARTY_SIZE - 1`. Two different index spaces sharing one variable, which I suspect is how the wrong bound got in to begin with.

Fixing the bound stops the out-of-bounds read, but I'm not confident that iterating only slots 0 to 3 is what the whiteout logic actually intends, and I don't know the intent well enough to change it. That part needs someone who does. There's not even a test for this, as far as I saw, which I know is not ideal for a battle change.

The function returns early with `if (TESTING) return FALSE;` before the loop, so `make check` cannot reach it at all. Writing a test would first require removing that guard, which is a behaviour change of its own and felt out of scope here. Happy to do it as a follow-up if a maintainer thinks the guard should go.

## Discord contact info

syreldar