### PR TITLE
Fix Solar Beam, Solar Blade and Electro Shot skipping their charging …

### DIFF
--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -1673,7 +1673,8 @@ static bool32 CanTwoTurnMoveFireThisTurn(struct BattleCalcValues *cv)
     u32 attackerWeather = GetAttackerWeather(cv->holdEffects[cv->battlerAtk], cv->abilities[cv->battlerAtk], weather);
     u32 isMoveWeatherAffected = GetMoveTwoTurnAttackWeather(cv->move);
 
-    return (attackerWeather & isMoveWeatherAffected) || (weather & isMoveWeatherAffected);
+    return (attackerWeather & isMoveWeatherAffected)
+        || IsBattlerWeatherAffected(cv->holdEffects[cv->battlerAtk], weather, isMoveWeatherAffected);
 }
 
 static enum CancelerResult HandleSkyDropResult(struct BattleCalcValues *cv)

--- a/test/battle/move_effect/two_turns_attack.c
+++ b/test/battle/move_effect/two_turns_attack.c
@@ -263,22 +263,13 @@ SINGLE_BATTLE_TEST("Solar Beam and Solar Blade still need a charging turn in Sun
         PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_UTILITY_UMBRELLA); }
         OPPONENT(SPECIES_TORKOAL) { Ability(ABILITY_DROUGHT); }
     } WHEN {
-        TURN { MOVE(player, move); }
-        TURN { SKIP_TURN(player); }
+        TURN { MOVE(player, move); MOVE(opponent, MOVE_CELEBRATE); }
+        TURN { SKIP_TURN(player); MOVE(opponent, MOVE_CELEBRATE); }
     } SCENE {
         // Charging turn
-        if (move == MOVE_SOLAR_BEAM) {
-            MESSAGE("Wobbuffet used Solar Beam!");
-        } else {
-            MESSAGE("Wobbuffet used Solar Blade!");
-        }
         MESSAGE("Wobbuffet absorbed light!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
         // Attack turn
-        if (move == MOVE_SOLAR_BEAM) {
-            MESSAGE("Wobbuffet used Solar Beam!");
-        } else {
-            MESSAGE("Wobbuffet used Solar Blade!");
-        }
         ANIMATION(ANIM_TYPE_MOVE, move, player);
         HP_BAR(opponent);
     }
@@ -479,20 +470,15 @@ SINGLE_BATTLE_TEST("Electro Shot still needs a charging turn in Rain with Utilit
         PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_UTILITY_UMBRELLA); }
         OPPONENT(SPECIES_POLITOED) { Ability(ABILITY_DRIZZLE); }
     } WHEN {
-        TURN { MOVE(player, MOVE_ELECTRO_SHOT); }
-        TURN { SKIP_TURN(player); }
+        TURN { MOVE(player, MOVE_ELECTRO_SHOT); MOVE(opponent, MOVE_CELEBRATE); }
+        TURN { SKIP_TURN(player); MOVE(opponent, MOVE_CELEBRATE); }
     } SCENE {
         // Charging turn
-        MESSAGE("Wobbuffet used Electro Shot!");
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_ELECTRO_SHOT, player);
         MESSAGE("Wobbuffet absorbed electricity!");
-        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-        MESSAGE("Wobbuffet's Sp. Atk rose!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
         // Attack turn
-        MESSAGE("Wobbuffet used Electro Shot!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ELECTRO_SHOT, player);
         HP_BAR(opponent);
-    } THEN {
-        EXPECT_EQ(player->statStages[STAT_SPATK], DEFAULT_STAT_STAGE + 1);
     }
 }
 

--- a/test/battle/move_effect/two_turns_attack.c
+++ b/test/battle/move_effect/two_turns_attack.c
@@ -253,6 +253,37 @@ SINGLE_BATTLE_TEST("Solar Beam and Solar Blade can be used instantly in Sunlight
     }
 }
 
+SINGLE_BATTLE_TEST("Solar Beam and Solar Blade still need a charging turn in Sunlight with Utility Umbrella")
+{
+    enum Move move;
+    PARAMETRIZE { move = MOVE_SOLAR_BEAM; }
+    PARAMETRIZE { move = MOVE_SOLAR_BLADE; }
+    GIVEN {
+        ASSUME(GetItemHoldEffect(ITEM_UTILITY_UMBRELLA) == HOLD_EFFECT_UTILITY_UMBRELLA);
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_UTILITY_UMBRELLA); }
+        OPPONENT(SPECIES_TORKOAL) { Ability(ABILITY_DROUGHT); }
+    } WHEN {
+        TURN { MOVE(player, move); }
+        TURN { SKIP_TURN(player); }
+    } SCENE {
+        // Charging turn
+        if (move == MOVE_SOLAR_BEAM) {
+            MESSAGE("Wobbuffet used Solar Beam!");
+        } else {
+            MESSAGE("Wobbuffet used Solar Blade!");
+        }
+        MESSAGE("Wobbuffet absorbed light!");
+        // Attack turn
+        if (move == MOVE_SOLAR_BEAM) {
+            MESSAGE("Wobbuffet used Solar Beam!");
+        } else {
+            MESSAGE("Wobbuffet used Solar Blade!");
+        }
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        HP_BAR(opponent);
+    }
+}
+
 SINGLE_BATTLE_TEST("Solar Beam's power is halved in Rain", s16 damage)
 {
     enum Move move;
@@ -438,6 +469,30 @@ SINGLE_BATTLE_TEST("Electro Shot doesn't need to charge when it's raining")
             MESSAGE("Wobbuffet used Electro Shot!");
         }
         HP_BAR(opponent);
+    }
+}
+
+SINGLE_BATTLE_TEST("Electro Shot still needs a charging turn in Rain with Utility Umbrella")
+{
+    GIVEN {
+        ASSUME(GetItemHoldEffect(ITEM_UTILITY_UMBRELLA) == HOLD_EFFECT_UTILITY_UMBRELLA);
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_UTILITY_UMBRELLA); }
+        OPPONENT(SPECIES_POLITOED) { Ability(ABILITY_DRIZZLE); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_ELECTRO_SHOT); }
+        TURN { SKIP_TURN(player); }
+    } SCENE {
+        // Charging turn
+        MESSAGE("Wobbuffet used Electro Shot!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ELECTRO_SHOT, player);
+        MESSAGE("Wobbuffet absorbed electricity!");
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        MESSAGE("Wobbuffet's Sp. Atk rose!");
+        // Attack turn
+        MESSAGE("Wobbuffet used Electro Shot!");
+        HP_BAR(opponent);
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_SPATK], DEFAULT_STAT_STAGE + 1);
     }
 }
 


### PR DESCRIPTION
…turn with Utility Umbrella

`GetAttackerWeather` correctly strips `B_WEATHER_SUN` and `B_WEATHER_RAIN` for a `HOLD_EFFECT_UTILITY_UMBRELLA` holder, but the second clause then re-admits exactly what it stripped by testing the raw field weather, so the umbrella could never have an effect here. The damage path was already right, since it uses `GetAttackerWeather` on its own.

The raw-weather clause is what lets `Mega Sol` still benefit from real weather, which `mega_sol.c` has explicit tests for. So I swapped it for `IsBattlerWeatherAffected`, which is the umbrella-aware version of the same check, that keeps the two cases separate. `Utility Umbrella` subtracts the holder's Sun/Rain so the move charges, while `Mega Sol` adds Sun without removing the field's own weather, so it still activates `Electro Shot` in Rain and still fires `Solar Beam` instantly with no weather at all.

I checked and these three are the only moves with a `twoTurnAttack.weather` argument, so nothing else is affected.
I added specific regression tests for all the related cases.

### Large Language Models (AI)

No AI has been used.

## Issue(s) that this PR fixes

Fixes #10533

## Discord contact info

syreldar