### PR TITLE
upcoming: Clamp Battle Frontier entry count to MAX_FRONTIER_PARTY_SIZE

### DIFF
--- a/include/party_menu.h
+++ b/include/party_menu.h
@@ -58,7 +58,7 @@ extern struct PartyMenu gPartyMenu;
 extern bool8 gPartyMenuUseExitCallback;
 extern u8 gSelectedMonPartyId;
 extern MainCallback gPostMenuFieldCallback;
-extern u8 gSelectedOrderFromParty[MAX_FRONTIER_PARTY_SIZE];
+extern u8 gSelectedOrderFromParty[PARTY_SIZE];
 extern u8 gBattlePartyCurrentOrder[PARTY_SIZE / 2];
 
 extern const struct SpriteSheet gSpriteSheet_HeldItem;

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -217,7 +217,7 @@ EWRAM_DATA u8 gSelectedMonPartyId = 0;
 EWRAM_DATA MainCallback gPostMenuFieldCallback = NULL;
 static EWRAM_DATA u16 *sSlot1TilemapBuffer = 0; // for switching party slots
 static EWRAM_DATA u16 *sSlot2TilemapBuffer = 0; //
-EWRAM_DATA u8 gSelectedOrderFromParty[MAX_FRONTIER_PARTY_SIZE] = {0};
+EWRAM_DATA u8 gSelectedOrderFromParty[PARTY_SIZE] = {0};
 static EWRAM_DATA enum Item sPartyMenuItemId = 0;
 EWRAM_DATA u8 gBattlePartyCurrentOrder[PARTY_SIZE / 2] = {0}; // bits 0-3 are the current pos of Slot 1, 4-7 are Slot 2, and so on
 static EWRAM_DATA u8 sInitialLevel = 0;
@@ -7414,7 +7414,7 @@ static u8 GetMaxBattleEntries(void)
     case FACILITY_UNION_ROOM:
         return UNION_ROOM_PARTY_SIZE;
     default: // Battle Frontier
-        return gSpecialVar_0x8005;
+        return min(gSpecialVar_0x8005, MAX_FRONTIER_PARTY_SIZE);
     }
 }
 
@@ -7427,7 +7427,7 @@ static u8 GetMinBattleEntries(void)
     case FACILITY_UNION_ROOM:
         return UNION_ROOM_PARTY_SIZE;
     default: // Battle Frontier
-        return gSpecialVar_0x8005;
+        return min(gSpecialVar_0x8005, MAX_FRONTIER_PARTY_SIZE);
     }
 }
 


### PR DESCRIPTION
## Description

`gSelectedOrderFromParty` is `u8[MAX_FRONTIER_PARTY_SIZE]`, so 4 entries, and the party selection loop fills it up to `GetMaxBattleEntries()`. For the Battle Frontier case that function returned `gSpecialVar_0x8005`.
That's a script variable, so nothing in C bounds it. Every vanilla frontier script sets it to 3 or 4 so it's fine today, but a script setting it higher writes past the end of the array. This is the same array as #10673, except that was a read and this is a write.

They read the same variable, and clamping only the maximum would leave the minimum above the maximum if a script asked for 5, which makes the "choose N Pokémon" validation unsatisfiable: meaning a softlock traded for an overflow.

`MAX_FRONTIER_PARTY_SIZE` rather than `ARRAY_COUNT(gSelectedOrderFromParty)`, because the frontier selection is persisted into `gSaveBlock2Ptr->frontier.selectedPartyMons`, which is `u16[MAX_FRONTIER_PARTY_SIZE]`. The save block is the real limit for a frontier selection, and that stays true if `gSelectedOrderFromParty` is later resized past 4 as discussed on #10673: clamping by the array size would let a 5 or 6 selection be accepted and then silently truncated on save.

This is defensive rather than a fix for anything a player can currently reach. It makes the invariant hold in C instead of by script convention. It is also speculative. Nothing currently selects more than 4, so the extra two entries have no consumer yet. The justification is @grintoul1 's stated plan.

EWRAM grows by 2 bytes.

### Large Language Models (AI)

No AI has been used.

## Issue(s) that this PR fixes

Fixes #10676.

## Discord contact info

syreldar