### PR TITLE
upcoming: Item consumability rework

### DIFF
--- a/include/item.h
+++ b/include/item.h
@@ -247,6 +247,7 @@ bool32 CheckBagHasSpace(enum Item itemId, u16 count);
 u32 GetFreeSpaceForItemInBag(enum Item itemId);
 bool32 AddBagItem(enum Item itemId, u16 count);
 bool32 RemoveBagItem(enum Item itemId, u16 count);
+bool32 ConsumeBagItem(enum Item itemId, u16 count);
 void RemoveBagItemFromSlot(struct BagPocket *pocket, u16 slotId, u16 count);
 u8 CountUsedPCItemSlots(void);
 bool32 CheckPCHasItem(enum Item itemId, u16 count);

--- a/src/battle_controller_recorded_player.c
+++ b/src/battle_controller_recorded_player.c
@@ -383,7 +383,7 @@ static void RecordedPlayerHandleChooseItem(enum BattlerId battler)
     {
         assertf(CheckBagHasItem(gBattleStruct->chosenItem[battler], 1), "Tried to used an item not present in bag");
         if (!GetItemImportance(gBattleStruct->chosenItem[battler]))
-            RemoveBagItem(gBattleStruct->chosenItem[battler], 1);
+            ConsumeBagItem(gBattleStruct->chosenItem[battler], 1);
     }
 
     gBattleStruct->itemPartyIndex[battler] = RecordedBattle_GetBattlerAction(RECORDED_ITEM_TARGET, battler);

--- a/src/battle_controller_recorded_player.c
+++ b/src/battle_controller_recorded_player.c
@@ -382,8 +382,7 @@ static void RecordedPlayerHandleChooseItem(enum BattlerId battler)
     if (TESTING)
     {
         assertf(CheckBagHasItem(gBattleStruct->chosenItem[battler], 1), "Tried to used an item not present in bag");
-        if (!GetItemImportance(gBattleStruct->chosenItem[battler]))
-            ConsumeBagItem(gBattleStruct->chosenItem[battler], 1);
+        ConsumeBagItem(gBattleStruct->chosenItem[battler], 1);
     }
 
     gBattleStruct->itemPartyIndex[battler] = RecordedBattle_GetBattlerAction(RECORDED_ITEM_TARGET, battler);

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -844,8 +844,7 @@ void HandleAction_ThrowBall(void)
     gBattle_BG0_X = 0;
     gBattle_BG0_Y = 0;
     gLastUsedItem = gBallToDisplay;
-    if (!GetItemImportance(gLastUsedItem))
-        ConsumeBagItem(gLastUsedItem, 1);
+    ConsumeBagItem(gLastUsedItem, 1);
     gBattlescriptCurrInstr = BattleScript_BallThrow;
     gCurrentActionFuncId = B_ACTION_EXEC_SCRIPT;
 }
@@ -9164,7 +9163,7 @@ bool32 CanFling(enum BattlerId battlerAtk, enum Ability abilityAtk)
       || (GetConfig(B_KLUTZ_FLING_INTERACTION) >= GEN_5 && abilityAtk == ABILITY_KLUTZ)
       || gFieldStatuses & STATUS_FIELD_MAGIC_ROOM
       || gBattleMons[battlerAtk].volatiles.embargoTimer
-      || (GetItemTMHMIndex(item) != 0 && GetItemImportance(item) == 1) // don't fling reusable TMs
+      || GetItemImportance(item) // don't fling key items (shouldn't be able to hold them anyway)
       || GetFlingPowerFromItemId(item) == 0
       || !CanBattlerGetOrLoseItem(battlerAtk, battlerAtk, item)) // defender being a paradox mon doesn't matter
         return FALSE;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -845,7 +845,7 @@ void HandleAction_ThrowBall(void)
     gBattle_BG0_Y = 0;
     gLastUsedItem = gBallToDisplay;
     if (!GetItemImportance(gLastUsedItem))
-        RemoveBagItem(gLastUsedItem, 1);
+        ConsumeBagItem(gLastUsedItem, 1);
     gBattlescriptCurrInstr = BattleScript_BallThrow;
     gCurrentActionFuncId = B_ACTION_EXEC_SCRIPT;
 }

--- a/src/item.c
+++ b/src/item.c
@@ -404,6 +404,14 @@ static bool32 NONNULL BagPocket_RemoveItem(struct BagPocket *pocket, enum Item i
     return totalQuantity >= count;
 }
 
+bool32 ConsumeBagItem(enum Item itemId, u16 count)
+{
+    if (!GetItemConsumability(itemId))
+        return TRUE;
+
+    return RemoveBagItem(itemId, count);
+}
+
 bool32 RemoveBagItem(enum Item itemId, u16 count)
 {
     itemId = SanitizeBagItemId(itemId);

--- a/src/item.c
+++ b/src/item.c
@@ -881,7 +881,7 @@ u8 GetItemImportance(enum Item itemId)
 
 u8 GetItemConsumability(enum Item itemId)
 {
-    return !gItemsInfo[SanitizeItemId(itemId)].notConsumed;
+    return !gItemsInfo[SanitizeItemId(itemId)].notConsumed && !gItemsInfo[SanitizeItemId(itemId)].importance;
 }
 
 enum Pocket GetItemPocket(enum Item itemId)

--- a/src/item_use.c
+++ b/src/item_use.c
@@ -1338,7 +1338,7 @@ void ItemUseInBattle_BagMenu(u8 taskId)
     else
     {
         PlaySE(SE_SELECT);
-        if (GetItemConsumability(gSpecialVar_ItemId) && !(B_TRY_CATCH_TRAINER_BALL >= GEN_4 && (GetItemBattleUsage(gSpecialVar_ItemId) == EFFECT_ITEM_THROW_BALL) && (gBattleTypeFlags & BATTLE_TYPE_TRAINER)))
+        if (!(B_TRY_CATCH_TRAINER_BALL >= GEN_4 && (GetItemBattleUsage(gSpecialVar_ItemId) == EFFECT_ITEM_THROW_BALL) && (gBattleTypeFlags & BATTLE_TYPE_TRAINER)))
             RemoveUsedItem();
         ScheduleBgCopyTilemapToVram(2);
         if (CurrentBattlePyramidLocation() == PYRAMID_LOCATION_NONE)

--- a/src/item_use.c
+++ b/src/item_use.c
@@ -793,7 +793,7 @@ void ItemUseOutOfBattle_Berry(u8 taskId)
 
 static void ItemUseOnFieldCB_Berry(u8 taskId)
 {
-    RemoveBagItem(gSpecialVar_ItemId, 1);
+    ConsumeBagItem(gSpecialVar_ItemId, 1);
     LockPlayerFieldControls();
     ScriptContext_SetupScript(BerryTree_EventScript_ItemUsePlantBerry);
     DestroyTask(taskId);
@@ -948,7 +948,7 @@ static void UseTMHM(u8 taskId)
 
 static void RemoveUsedItem(void)
 {
-    RemoveBagItem(gSpecialVar_ItemId, 1);
+    ConsumeBagItem(gSpecialVar_ItemId, 1);
     CopyItemName(gSpecialVar_ItemId, gStringVar2);
     StringExpandPlaceholders(gStringVar4, gText_PlayerUsedVar2);
     if (CurrentBattlePyramidLocation() == PYRAMID_LOCATION_NONE)
@@ -1081,7 +1081,7 @@ static void ItemUseOnFieldCB_EscapeRope(u8 taskId)
 {
     Overworld_ResetStateAfterDigEscRope();
     if (I_KEY_ESCAPE_ROPE < GEN_8)
-        RemoveBagItem(gSpecialVar_ItemId, 1);
+        ConsumeBagItem(gSpecialVar_ItemId, 1);
 
     CopyItemName(gSpecialVar_ItemId, gStringVar2);
     StringExpandPlaceholders(gStringVar4, gText_PlayerUsedVar2);
@@ -1431,7 +1431,7 @@ void Task_UseHoneyOnField(u8 taskId)
 static void ItemUseOnFieldCB_Honey(u8 taskId)
 {
     Overworld_ResetStateAfterDigEscRope();
-    RemoveBagItem(gSpecialVar_ItemId, 1);
+    ConsumeBagItem(gSpecialVar_ItemId, 1);
     CopyItemName(gSpecialVar_ItemId, gStringVar2);
     StringExpandPlaceholders(gStringVar4, gText_PlayerUsedVar2);
     DisplayItemMessageOnField(taskId, gStringVar4, Task_UseHoneyOnField);

--- a/src/item_use.c
+++ b/src/item_use.c
@@ -1338,7 +1338,7 @@ void ItemUseInBattle_BagMenu(u8 taskId)
     else
     {
         PlaySE(SE_SELECT);
-        if (!GetItemImportance(gSpecialVar_ItemId) && !(B_TRY_CATCH_TRAINER_BALL >= GEN_4 && (GetItemBattleUsage(gSpecialVar_ItemId) == EFFECT_ITEM_THROW_BALL) && (gBattleTypeFlags & BATTLE_TYPE_TRAINER)))
+        if (GetItemConsumability(gSpecialVar_ItemId) && !(B_TRY_CATCH_TRAINER_BALL >= GEN_4 && (GetItemBattleUsage(gSpecialVar_ItemId) == EFFECT_ITEM_THROW_BALL) && (gBattleTypeFlags & BATTLE_TYPE_TRAINER)))
             RemoveUsedItem();
         ScheduleBgCopyTilemapToVram(2);
         if (CurrentBattlePyramidLocation() == PYRAMID_LOCATION_NONE)

--- a/src/move_relearner.c
+++ b/src/move_relearner.c
@@ -532,7 +532,7 @@ static void UIEndTask(u8 taskId)
     {
         enum Item item = GetTMHMItemIdFromMoveId(gTasks[taskId].tMove);
         if (!GetItemImportance(item))
-            RemoveBagItem(item, 1);
+            ConsumeBagItem(item, 1);
     }
     if (gRelearnMode == RELEARN_MODE_SCRIPT && gSpecialVar_Result == TRUE)
     {

--- a/src/move_relearner.c
+++ b/src/move_relearner.c
@@ -531,8 +531,7 @@ static void UIEndTask(u8 taskId)
     if (gSpecialVar_Result == TRUE && ShouldConsumeTmItem(gTasks[taskId].tMove))
     {
         enum Item item = GetTMHMItemIdFromMoveId(gTasks[taskId].tMove);
-        if (!GetItemImportance(item))
-            ConsumeBagItem(item, 1);
+        ConsumeBagItem(item, 1);
     }
     if (gRelearnMode == RELEARN_MODE_SCRIPT && gSpecialVar_Result == TRUE)
     {
@@ -706,7 +705,7 @@ static void Task_MoveRelearner_HandleInput(u8 taskId)
         {
             enum Item item = GetTMHMItemIdFromMoveId(gTasks[taskId].tMove);
             StringCopy(gStringVar3, GetItemName(item));
-            if (!GetItemImportance(item))
+            if (GetItemConsumability(item))
                 message = gText_MoveRelearnerTeachMoveConfirmUseTm;
         }
         UIPrintMessage(message);

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -4830,13 +4830,6 @@ static bool32 NotUsingHPEVItemOnShedinja(struct Pokemon *mon, enum Item item)
     return TRUE;
 }
 
-static bool32 IsItemFlute(enum Item item)
-{
-    if (item == ITEM_BLUE_FLUTE || item == ITEM_RED_FLUTE || item == ITEM_YELLOW_FLUTE)
-        return TRUE;
-    return FALSE;
-}
-
 // Battle scripts called in HandleAction_UseItem
 void ItemUseCB_BattleScript(u8 taskId, TaskFunc task)
 {
@@ -4854,8 +4847,7 @@ void ItemUseCB_BattleScript(u8 taskId, TaskFunc task)
         gBattleStruct->itemPartyIndex[gBattlerInMenuId] = GetPartyIdFromBattleSlot(gPartyMenu.slotId);
         gPartyMenuUseExitCallback = TRUE;
         PlaySE(SE_SELECT);
-        if (!IsItemFlute(gSpecialVar_ItemId))
-            ConsumeBagItem(gSpecialVar_ItemId, 1);
+        ConsumeBagItem(gSpecialVar_ItemId, 1);
         ScheduleBgCopyTilemapToVram(2);
         gTasks[taskId].func = task;
     }
@@ -4911,7 +4903,7 @@ void ItemUseCB_Medicine(u8 taskId, TaskFunc task)
     else
     {
         gPartyMenuUseExitCallback = TRUE;
-        if (!IsItemFlute(item))
+        if (GetItemConsumability(item))
         {
             PlaySE(SE_USE_ITEM);
             ConsumeBagItem(item, 1);
@@ -5604,8 +5596,7 @@ static void Task_LearnedMove(u8 taskId)
     if (gPartyMenu.learnMoveState == 0)
     {
         AdjustFriendship(mon, FRIENDSHIP_EVENT_LEARN_TMHM);
-        if (!GetItemImportance(item))
-            ConsumeBagItem(item, 1);
+        ConsumeBagItem(item, 1);
     }
     GetMonNickname(mon, gStringVar1);
     StringCopy(gStringVar2, GetMoveName(gPartyMenu.data1));

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -4855,7 +4855,7 @@ void ItemUseCB_BattleScript(u8 taskId, TaskFunc task)
         gPartyMenuUseExitCallback = TRUE;
         PlaySE(SE_SELECT);
         if (!IsItemFlute(gSpecialVar_ItemId))
-            RemoveBagItem(gSpecialVar_ItemId, 1);
+            ConsumeBagItem(gSpecialVar_ItemId, 1);
         ScheduleBgCopyTilemapToVram(2);
         gTasks[taskId].func = task;
     }
@@ -4914,7 +4914,7 @@ void ItemUseCB_Medicine(u8 taskId, TaskFunc task)
         if (!IsItemFlute(item))
         {
             PlaySE(SE_USE_ITEM);
-            RemoveBagItem(item, 1);
+            ConsumeBagItem(item, 1);
         }
         else
         {
@@ -5019,7 +5019,7 @@ void Task_AbilityCapsule(u8 taskId)
         break;
     case 5:
         SetMonData(&gParties[B_TRAINER_PLAYER][tMonId], MON_DATA_ABILITY_NUM, &tAbilityNum);
-        RemoveBagItem(gSpecialVar_ItemId, 1);
+        ConsumeBagItem(gSpecialVar_ItemId, 1);
         gTasks[taskId].func = Task_ClosePartyMenu;
         break;
     }
@@ -5104,7 +5104,7 @@ void Task_AbilityPatch(u8 taskId)
         break;
     case 5:
         SetMonData(&gParties[B_TRAINER_PLAYER][tMonId], MON_DATA_ABILITY_NUM, &tAbilityNum);
-        RemoveBagItem(gSpecialVar_ItemId, 1);
+        ConsumeBagItem(gSpecialVar_ItemId, 1);
         gTasks[taskId].func = Task_ClosePartyMenu;
         break;
     }
@@ -5205,7 +5205,7 @@ void Task_Mint(u8 taskId)
     case 5:
         SetMonData(&gParties[B_TRAINER_PLAYER][tMonId], MON_DATA_HIDDEN_NATURE, &tNewNature);
         CalculateMonStats(&gParties[B_TRAINER_PLAYER][tMonId]);
-        RemoveBagItem(gSpecialVar_ItemId, 1);
+        ConsumeBagItem(gSpecialVar_ItemId, 1);
         gTasks[taskId].func = Task_ClosePartyMenu;
         break;
     }
@@ -5274,7 +5274,7 @@ void ItemUseCB_ResetEVs(u8 taskId, TaskFunc task)
     {
         gPartyMenuUseExitCallback = TRUE;
         PlaySE(SE_USE_ITEM);
-        RemoveBagItem(item, 1);
+        ConsumeBagItem(item, 1);
         GetMonNickname(mon, gStringVar1);
         StringExpandPlaceholders(gStringVar4, sText_BasePointsResetToZero);
         DisplayPartyMenuMessage(gStringVar4, TRUE);
@@ -5306,7 +5306,7 @@ void ItemUseCB_ReduceEV(u8 taskId, TaskFunc task)
     {
         gPartyMenuUseExitCallback = TRUE;
         PlaySE(SE_USE_ITEM);
-        RemoveBagItem(item, 1);
+        ConsumeBagItem(item, 1);
         GetMonNickname(mon, gStringVar1);
         ItemEffectToStatString(effectType, gStringVar2);
         if (friendship != newFriendship)
@@ -5471,7 +5471,7 @@ static void TryUseItemOnMove(u8 taskId)
             gBattleStruct->itemPartyIndex[gBattlerInMenuId] = GetPartyIdFromBattleSlot(gPartyMenu.slotId);
             gBattleStruct->itemMoveIndex[gBattlerInMenuId] = ptr->data1;
             gPartyMenuUseExitCallback = TRUE;
-            RemoveBagItem(gSpecialVar_ItemId, 1);
+            ConsumeBagItem(gSpecialVar_ItemId, 1);
             ScheduleBgCopyTilemapToVram(2);
             gTasks[taskId].func = Task_ClosePartyMenuAfterText;
         }
@@ -5495,7 +5495,7 @@ static void TryUseItemOnMove(u8 taskId)
         {
             gPartyMenuUseExitCallback = TRUE;
             PlaySE(SE_USE_ITEM);
-            RemoveBagItem(item, 1);
+            ConsumeBagItem(item, 1);
             move = GetMonData(mon, MON_DATA_MOVE1 + *moveSlot);
             StringCopy(gStringVar1, GetMoveName(move));
             GetMedicineItemEffectMessage(item, 0);
@@ -5605,7 +5605,7 @@ static void Task_LearnedMove(u8 taskId)
     {
         AdjustFriendship(mon, FRIENDSHIP_EVENT_LEARN_TMHM);
         if (!GetItemImportance(item))
-            RemoveBagItem(item, 1);
+            ConsumeBagItem(item, 1);
     }
     GetMonNickname(mon, gStringVar1);
     StringCopy(gStringVar2, GetMoveName(gPartyMenu.data1));
@@ -5851,7 +5851,7 @@ void ItemUseCB_RareCandy(u8 taskId, TaskFunc task)
         if (targetSpecies != SPECIES_NONE)
         {
             GetEvolutionTargetSpecies(mon, EVO_MODE_NORMAL, ITEM_NONE, NULL, &canStopEvo, DO_EVO);
-            RemoveBagItem(gSpecialVar_ItemId, 1);
+            ConsumeBagItem(gSpecialVar_ItemId, 1);
             FreePartyPointers();
             gCB2_AfterEvolution = gPartyMenu.exitCallback;
             BeginEvolutionScene(mon, targetSpecies, canStopEvo, gPartyMenu.slotId);
@@ -5873,7 +5873,7 @@ void ItemUseCB_RareCandy(u8 taskId, TaskFunc task)
         sFinalLevel = GetMonData(mon, MON_DATA_LEVEL);
         gPartyMenuUseExitCallback = TRUE;
         UpdateMonDisplayInfoAfterRareCandy(gPartyMenu.slotId, mon);
-        RemoveBagItem(gSpecialVar_ItemId, 1);
+        ConsumeBagItem(gSpecialVar_ItemId, 1);
         GetMonNickname(mon, gStringVar1);
         if (sFinalLevel > sInitialLevel)
         {
@@ -6136,7 +6136,7 @@ void Task_DynamaxCandy(u8 taskId)
     case 3:
         tDynamaxLevel++;
         SetMonData(&gParties[B_TRAINER_PLAYER][tMonId], MON_DATA_DYNAMAX_LEVEL, &tDynamaxLevel);
-        RemoveBagItem(gSpecialVar_ItemId, 1);
+        ConsumeBagItem(gSpecialVar_ItemId, 1);
         gTasks[taskId].func = Task_ClosePartyMenu;
         break;
     }
@@ -6220,7 +6220,7 @@ static void Task_SacredAshLoop(u8 taskId)
             else
             {
                 gPartyMenuUseExitCallback = TRUE;
-                RemoveBagItem(gSpecialVar_ItemId, 1);
+                ConsumeBagItem(gSpecialVar_ItemId, 1);
             }
             gTasks[taskId].func = Task_ClosePartyMenuAfterText;
             gPartyMenu.slotId = 0;
@@ -6259,7 +6259,7 @@ void ItemUseCB_EvolutionStone(u8 taskId, TaskFunc task)
     else
     {
         if (GetItemPocket(gSpecialVar_ItemId) != POCKET_KEY_ITEMS)
-            RemoveBagItem(gSpecialVar_ItemId, 1);
+            ConsumeBagItem(gSpecialVar_ItemId, 1);
         FreePartyPointers();
     }
 }
@@ -6855,7 +6855,7 @@ void ItemUseCB_FormChange(u8 taskId, TaskFunc task)
 void ItemUseCB_FormChange_ConsumedOnUse(u8 taskId, TaskFunc task)
 {
     if (TryItemUseFormChange(taskId, task))
-        RemoveBagItem(gSpecialVar_ItemId, 1);
+        ConsumeBagItem(gSpecialVar_ItemId, 1);
 }
 
 void ItemUseCB_RotomCatalog(u8 taskId, TaskFunc task)

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -4830,7 +4830,7 @@ static bool32 NotUsingHPEVItemOnShedinja(struct Pokemon *mon, enum Item item)
     return TRUE;
 }
 
-static bool32 IsItemFlute(enum Item item)
+static bool32 IsMedicineFlute(enum Item item)
 {
     if (item == ITEM_BLUE_FLUTE || item == ITEM_RED_FLUTE || item == ITEM_YELLOW_FLUTE)
         return TRUE;
@@ -4910,7 +4910,7 @@ void ItemUseCB_Medicine(u8 taskId, TaskFunc task)
     else
     {
         gPartyMenuUseExitCallback = TRUE;
-        if (IsItemFlute(item))
+        if (IsMedicineFlute(item))
             PlaySE(SE_GLASS_FLUTE);
         else
             PlaySE(SE_USE_ITEM);

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -4830,6 +4830,13 @@ static bool32 NotUsingHPEVItemOnShedinja(struct Pokemon *mon, enum Item item)
     return TRUE;
 }
 
+static bool32 IsItemFlute(enum Item item)
+{
+    if (item == ITEM_BLUE_FLUTE || item == ITEM_RED_FLUTE || item == ITEM_YELLOW_FLUTE)
+        return TRUE;
+    return FALSE;
+}
+
 // Battle scripts called in HandleAction_UseItem
 void ItemUseCB_BattleScript(u8 taskId, TaskFunc task)
 {
@@ -4903,15 +4910,11 @@ void ItemUseCB_Medicine(u8 taskId, TaskFunc task)
     else
     {
         gPartyMenuUseExitCallback = TRUE;
-        if (GetItemConsumability(item))
-        {
-            PlaySE(SE_USE_ITEM);
-            ConsumeBagItem(item, 1);
-        }
-        else
-        {
+        if (IsItemFlute(item))
             PlaySE(SE_GLASS_FLUTE);
-        }
+        else
+            PlaySE(SE_USE_ITEM);
+        ConsumeBagItem(item, 1);
         SetPartyMonAilmentGfx(mon, &sPartyMenuBoxes[gPartyMenu.slotId]);
         if (gSprites[sPartyMenuBoxes[gPartyMenu.slotId].statusSpriteId].invisible)
             DisplayPartyPokemonLevelCheck(mon, &sPartyMenuBoxes[gPartyMenu.slotId], 1);

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -4415,7 +4415,7 @@ bool32 DoesMonMeetAdditionalConditions(struct Pokemon *mon, const struct Evoluti
             }
 
             if (removeBagItem != ITEM_NONE)
-                RemoveBagItem(removeBagItem, removeBagItemCount);
+                ConsumeBagItem(removeBagItem, removeBagItemCount);
         }
 
         if (currentCondition == FALSE)


### PR DESCRIPTION
`notConsumed` only ever did anything in battle, so items setting it were still consumed everywhere else. Details in the issue.

Returns `bool32` to match `RemoveBagItem`, so converted call sites that check the result keep working. A non-consumed item returns TRUE because the operation succeeded, there was just nothing to remove.

I switched over exactly 24 call sites, the ones where an item is being used up. That's `item_use.c` (berry planting, Escape Rope, Honey, the generic `RemoveUsedItem`), the medicine / capsule / patch / mint / EV / PP / TM / rare candy / dynamax candy / sacred ash / evolution stone / form change paths in `party_menu.c`, `move_relearner.c`, `pokemon.c`, `battle_util.c` for ball throws, and `battle_controller_recorded_player.c`.

The other 18 stay on `RemoveBagItem` because they aren't consumption: selling and tossing in `item_menu.c`, the script `removeitem` in `scrcmd.c`, giving and taking held items and mail in `party_menu.c` and `pokemon_storage_system.c`, handing an item over in `berry_blender.c`, `berry_crush.c` and `lilycove_lady.c`, and Shedinja eating a spare Poké Ball in `evolution_scene.c`.

Two things I looked at and deliberately didn't touch at all:

1. `battle_controller_player.c:375` calls `GetItemConsumability` but it's the refund path, deciding whether to `AddBagItem` back when a partner's action is cancelled. It stays in step with the new helper on its own, since an item that's never removed is never refunded.

2. The `if (!GetItemImportance(...))` guards in front of four of the converted calls are still there. I tried removing them on the theory that `notConsumed` supersedes them, and the test suite caught it immediately: `USE_ITEM will add item to bag if GIVE_PLAYER_ITEM was not used` fails, because Poké Flute relies on `importance` to survive. Over 130 items do, every TMs and HMs included. The two fields are complementary, `importance` for key items and `notConsumed` for ordinary reusable ones, so both checks belong.

### Large Language Models (AI)

No AI has been used.

## Issue(s) that this PR fixes

Fixes #10680.

## Things to note in the release changelog:
- Cleaned up the behavior of item properties "importance" and "notConsumed", important items can't be stacked, sold or thrown away. They are also reusable. "notConsumed" items are reusable items that can be stacked, tossed away or sold (to be sold an item price also needs to have its be non zero)
- A lot of functions named similar to removeItem have been renamed to consumeItem to indicate the removal from inventory is dependant on their "consumability". An item is consered consumable if neither it's importance or notConsumed flag is set

## Feature(s) this PR does NOT handle:

Doesn't touch `importance` at all. There's a related spot at `battle_util.c:9167`, `GetItemTMHMIndex(item) != 0 && GetItemImportance(item) == 1` with a comment about not flinging reusable TMs, which is `importance` standing in for reusability again. Felt out of scope here.

No test added. The only items setting `notConsumed` today are the five flutes, whose callbacks never called `RemoveBagItem` in the first place, so there's nothing in the tree that changes behaviour to assert on. A test would need a new test-only item, which seemed like more machinery than the change deserves. Happy to add one if you'd rather.

## Discord contact info

syreldar