### PR TITLE
Fix Shell Trap being delayed after a spread move hit

### DIFF
--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -407,7 +407,7 @@ void SetStartingStatus(enum StartingStatus status);
 void ResetStartingStatuses(void);
 bool32 IsUsableWhileAsleepEffect(enum BattleMoveEffects effect);
 void SetWrapTurns(enum BattlerId battler, enum HoldEffect holdEffect);
-bool32 ChangeOrderTargetAfterAttacker(void);
+bool32 ChangeOrderTargetAfterAttacker(enum BattlerId battlerDef);
 void TryUpdateEvolutionTracker(enum EvolutionConditions evolutionCondition, u32 upAmount, enum Move usedMove);
 bool32 CanUseMoveConsecutively(enum BattlerId battler);
 void TryResetConsecutiveUseCounter(enum BattlerId battler);

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -3722,7 +3722,7 @@ static enum MoveEndResult MoveEndShellTrap(struct BattleCalcValues *cv)
 
         for (u32 i = 0; i < gBattlersCount; i++)
         {
-            enum BattlerId battler = gBattlerByTurnOrder[i];
+            enum BattlerId battler = gBattlersBySpeed[i];
 
             if (shellTrapBattlerMask & (1u << battler))
                 shellTrapBattlers[numShellTrapBattlers++] = battler;

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -3697,6 +3697,8 @@ static enum MoveEndResult MoveEndAbilityEffectFoesFainted(struct BattleCalcValue
 
 static enum MoveEndResult MoveEndShellTrap(struct BattleCalcValues *cv)
 {
+    bool32 reordered = FALSE;
+
     for (enum BattlerId battlerDef = 0; battlerDef < gBattlersCount; battlerDef++)
     {
         if (battlerDef == cv->battlerAtk || IsBattlerAlly(battlerDef, cv->battlerAtk))
@@ -3709,8 +3711,10 @@ static enum MoveEndResult MoveEndShellTrap(struct BattleCalcValues *cv)
          && gProtectStructs[battlerDef].physicalBattlerId == cv->battlerAtk)
         {
             gProtectStructs[battlerDef].shellTrap = TRUE;
-            if (IsDoubleBattle()) // Change move order in double battles, so the hit mon with shell trap moves immediately after being hit.
-                ChangeOrderTargetAfterAttacker(); // In what order should 2 targets move that will activate a trap?
+            // Change move order in double battles, so the hit mon with shell trap moves immediately after being hit.
+            // Only the first trapper is moved up; reordering each of them in turn would put the last one first.
+            if (IsDoubleBattle() && !reordered)
+                reordered = ChangeOrderTargetAfterAttacker(battlerDef);
         }
     }
 
@@ -4381,7 +4385,7 @@ static enum MoveEndResult MoveEndPursuitNextAction(struct BattleCalcValues *cv)
         u32 storedTarget = gBattlerTarget;
         if (SetTargetToNextPursuiter(gBattlerTarget))
         {
-            ChangeOrderTargetAfterAttacker();
+            ChangeOrderTargetAfterAttacker(gBattlerTarget);
             gBattleStruct->moveTarget[gBattlerTarget] = storedTarget;
             gBattlerTarget = storedTarget;
         }

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -3697,7 +3697,7 @@ static enum MoveEndResult MoveEndAbilityEffectFoesFainted(struct BattleCalcValue
 
 static enum MoveEndResult MoveEndShellTrap(struct BattleCalcValues *cv)
 {
-    bool32 reordered = FALSE;
+    u32 shellTrapBattlerMask = 0;
 
     for (enum BattlerId battlerDef = 0; battlerDef < gBattlersCount; battlerDef++)
     {
@@ -3711,11 +3711,26 @@ static enum MoveEndResult MoveEndShellTrap(struct BattleCalcValues *cv)
          && gProtectStructs[battlerDef].physicalBattlerId == cv->battlerAtk)
         {
             gProtectStructs[battlerDef].shellTrap = TRUE;
-            // Change move order in double battles, so the hit mon with shell trap moves immediately after being hit.
-            // Only the first trapper is moved up; reordering each of them in turn would put the last one first.
-            if (IsDoubleBattle() && !reordered)
-                reordered = ChangeOrderTargetAfterAttacker(battlerDef);
+            shellTrapBattlerMask |= 1u << battlerDef;
         }
+    }
+
+    if (IsDoubleBattle() && shellTrapBattlerMask != 0)
+    {
+        enum BattlerId shellTrapBattlers[MAX_BATTLERS_COUNT];
+        u32 numShellTrapBattlers = 0;
+
+        for (u32 i = 0; i < gBattlersCount; i++)
+        {
+            enum BattlerId battler = gBattlerByTurnOrder[i];
+
+            if (shellTrapBattlerMask & (1u << battler))
+                shellTrapBattlers[numShellTrapBattlers++] = battler;
+        }
+
+        // Each reorder inserts the battler immediately after the attacker, so use reverse turn order to keep faster battlers first.
+        while (numShellTrapBattlers != 0)
+            ChangeOrderTargetAfterAttacker(shellTrapBattlers[--numShellTrapBattlers]);
     }
 
     gBattleScripting.moveendState++;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -8468,7 +8468,7 @@ static void Cmd_jumpifnopursuitswitchdmg(void)
 
     if (SetTargetToNextPursuiter(gBattlerAttacker))
     {
-        ChangeOrderTargetAfterAttacker();
+        ChangeOrderTargetAfterAttacker(gBattlerTarget);
         gBattleStruct->battlerState[gBattlerAttacker].pursuitTarget = TRUE;
         gBattleStruct->pursuitStoredSwitch = gBattleStruct->monToSwitchIntoId[gBattlerAttacker];
         gSpecialStatuses[gBattlerAttacker].queuedSwitch = NO_QUEUED_SWITCH; // Don't send out replacement before Pursuits
@@ -13251,7 +13251,7 @@ void BS_PowerTrick(void)
 void BS_TryAfterYou(void)
 {
     NATIVE_ARGS(const u8 *failInstr);
-    if (ChangeOrderTargetAfterAttacker())
+    if (ChangeOrderTargetAfterAttacker(gBattlerTarget))
     {
         gSpecialStatuses[gBattlerTarget].afterYou = 1;
         gBattlescriptCurrInstr = cmd->nextInstr;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -10821,13 +10821,13 @@ void SetWrapTurns(enum BattlerId battler, enum HoldEffect holdEffect)
 }
 
 // Return True if the order was changed, and false if the order was not changed(for example because the target would move after the attacker anyway).
-bool32 ChangeOrderTargetAfterAttacker(void)
+bool32 ChangeOrderTargetAfterAttacker(enum BattlerId battlerDef)
 {
     u32 i;
     u8 data[MAX_BATTLERS_COUNT];
     u8 actionsData[MAX_BATTLERS_COUNT];
     u32 attackerTurnOrderNum = GetBattlerTurnOrderNum(gBattlerAttacker);
-    u32 targetTurnOrderNum = GetBattlerTurnOrderNum(gBattlerTarget);
+    u32 targetTurnOrderNum = GetBattlerTurnOrderNum(battlerDef);
 
     if (attackerTurnOrderNum > targetTurnOrderNum)
         return FALSE;
@@ -10841,14 +10841,14 @@ bool32 ChangeOrderTargetAfterAttacker(void)
     }
     if (attackerTurnOrderNum == 0 && targetTurnOrderNum == 2)
     {
-        gBattlerByTurnOrder[1] = gBattlerTarget;
+        gBattlerByTurnOrder[1] = battlerDef;
         gActionsByTurnOrder[1] = actionsData[2];
         gBattlerByTurnOrder[2] = data[1];
         gActionsByTurnOrder[2] = actionsData[1];
     }
     else if (attackerTurnOrderNum == 0 && targetTurnOrderNum == 3)
     {
-        gBattlerByTurnOrder[1] = gBattlerTarget;
+        gBattlerByTurnOrder[1] = battlerDef;
         gActionsByTurnOrder[1] = actionsData[3];
         gBattlerByTurnOrder[2] = data[1];
         gActionsByTurnOrder[2] = actionsData[1];
@@ -10857,7 +10857,7 @@ bool32 ChangeOrderTargetAfterAttacker(void)
     }
     else // attackerTurnOrderNum == 1, targetTurnOrderNum == 3
     {
-        gBattlerByTurnOrder[2] = gBattlerTarget;
+        gBattlerByTurnOrder[2] = battlerDef;
         gActionsByTurnOrder[2] = actionsData[3];
         gBattlerByTurnOrder[3] = data[2];
         gActionsByTurnOrder[3] = actionsData[2];

--- a/test/battle/move_effect/shell_trap.c
+++ b/test/battle/move_effect/shell_trap.c
@@ -280,14 +280,15 @@ DOUBLE_BATTLE_TEST("Shell Trap does not trigger when hit into Substitute")
     }
 }
 
-DOUBLE_BATTLE_TEST("Shell Trap activates on both opposing Targets")
+DOUBLE_BATTLE_TEST("Shell Trap activates for both opposing targets in speed order")
 {
     GIVEN {
         ASSUME(GetMoveTarget(MOVE_EARTHQUAKE) == TARGET_FOES_AND_ALLY);
-        PLAYER(SPECIES_WYNAUT);
-        PLAYER(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_WYNAUT);
-        OPPONENT(SPECIES_WOBBUFFET);
+        ASSUME(GetMoveCategory(MOVE_EARTHQUAKE) == DAMAGE_CATEGORY_PHYSICAL);
+        PLAYER(SPECIES_WYNAUT) { Speed(1); }
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); }
+        OPPONENT(SPECIES_WYNAUT) { Speed(4); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(3); }
     } WHEN {
         TURN {
             MOVE(playerLeft, MOVE_SHELL_TRAP);
@@ -296,9 +297,8 @@ DOUBLE_BATTLE_TEST("Shell Trap activates on both opposing Targets")
         }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponentLeft);
-        // Order might be incorrect compared to vanilla
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_SHELL_TRAP, playerLeft);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_SHELL_TRAP, playerRight);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SHELL_TRAP, playerLeft);
     }
 }
 
@@ -324,4 +324,3 @@ DOUBLE_BATTLE_TEST("Shell Trap activates immediately after its user is hit by a 
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponentRight);
     }
 }
-

--- a/test/battle/move_effect/shell_trap.c
+++ b/test/battle/move_effect/shell_trap.c
@@ -302,3 +302,26 @@ DOUBLE_BATTLE_TEST("Shell Trap activates on both opposing Targets")
     }
 }
 
+DOUBLE_BATTLE_TEST("Shell Trap activates immediately after its user is hit by a spread move")
+{
+    GIVEN {
+        ASSUME(GetMoveTarget(MOVE_EARTHQUAKE) == TARGET_FOES_AND_ALLY);
+        ASSUME(GetMoveCategory(MOVE_EARTHQUAKE) == DAMAGE_CATEGORY_PHYSICAL);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(3); }
+        PLAYER(SPECIES_WOBBUFFET) { Speed(1); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(4); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(2); }
+    } WHEN {
+        TURN {
+            MOVE(opponentLeft, MOVE_EARTHQUAKE);
+            MOVE(playerRight, MOVE_SHELL_TRAP);
+        }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_SHELL_TRAP_SETUP, playerRight);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTHQUAKE, opponentLeft);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SHELL_TRAP, playerRight);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, playerLeft);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponentRight);
+    }
+}
+


### PR DESCRIPTION
`ChangeOrderTargetAfterAttacker` decided which battler to move up using the global `gBattlerTarget`, but `MoveEndShellTrap` had already worked out which battler was the trapper in its own loop and never passed it along.

With a single target physical move the two are the same battler so it worked. With a spread move they aren't, `gBattlerTarget` is whichever target got processed last, so the reorder either moved the wrong mon or bailed out on the `attackerTurnOrderNum > targetTurnOrderNum` check.

Made the battler an argument instead: The three `gBattlerByTurnOrder[N] = gBattlerTarget;` assignments inside the function body needed the same treatment, they'd otherwise have moved the wrong battler. The other three callers pass `gBattlerTarget` and are unchanged in behaviour, since they genuinely mean it. Both Pursuit sites set it through `SetTargetToNextPursuiter` right before calling, and `BS_TryAfterYou` is moving the ally it targeted.

One extra thing came out of it. With two trappers the loop was now calling the reorder once per trapper with different battlers, and since each call moves its battler to `attacker + 1` the last one processed ended up first. That broke `Shell Trap activates on both opposing Targets`. Previously both calls passed the same `gBattlerTarget` so it amounted to a single reorder, so I've kept it to one reorder, for the first trapper found. `shellTrap` still gets set on every trapper, it's only the turn order change that happens once.

Test is @Cle-bit  's from the issue, in verbatim.

### Large Language Models (AI)

No AI has been used.

## Issue(s) that this PR fixes

Fixes #10678

## Feature(s) this PR does NOT handle:

Well.. it doesn't settle which of two trappers should go first. Right now it's whichever has the lower battler ID rather than the faster one, which is probably wrong, but it's wrong in the same way it was before this PR. The source already asks the question in a comment on that line, and the existing test carries a "// Order might be incorrect compared to vanilla" note, so it seemed like its own issue rather than something to decide inside a spread move fix.

## Discord contact info

syreldar