### PR TITLE
Fix multi-target stat move miss messages

### DIFF
--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -4821,7 +4821,8 @@ static enum MoveResult StatChangeTryChange(struct BattleCalcValues *cv)
 
         if (gBattleStruct->moveResultFlags[cv->battlerDef] & MOVE_RESULT_MISSED)
         {
-            gBattleScripting.battler = gBattleStruct->statChangeBattler++;
+            gBattleScripting.battler = cv->battlerDef;
+            gBattleStruct->statChangeBattler++;
             BattleScriptCall(BattleScript_BattlerAvoidedAttack);
             return MOVE_RESULT_RUN_SCRIPT;
         }

--- a/test/battle/spread_moves.c
+++ b/test/battle/spread_moves.c
@@ -549,3 +549,18 @@ DOUBLE_BATTLE_TEST("Spread Moves: Earthquake fails due to accuracy in order of a
         MESSAGE("The opposing Wynaut avoided the attack!");
     }
 }
+
+DOUBLE_BATTLE_TEST("Spread Moves: A missed multi-target stat move names the missed battler")
+{
+    GIVEN {
+        ASSUME(GetMoveTarget(MOVE_STRING_SHOT) == TARGET_BOTH);
+        PLAYER(SPECIES_CATERPIE);
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_BELDUM) { Ability(ABILITY_CLEAR_BODY); }
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_STRING_SHOT, hit: FALSE); }
+    } SCENE {
+        MESSAGE("The opposing Wobbuffet avoided the attack!");
+    }
+}


### PR DESCRIPTION
Multi-target stat moves track their targets using attacker-relative slots. When one of these moves missed, the target slot was assigned directly to `gBattleScripting.battler`, causing the avoided-attack message to potentially name the wrong battler in double battles.

I also added a double-battle regression test that verifies a missed String Shot names the correct opponent.

### Large Language Models (AI)

No AI has been used.

## Issue(s) that this PR fixes

Fixes #10685.

Discord contact info

syreldar