### PR TITLE
upcoming: Fix Fusion Move AI turn-order checks

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -6606,16 +6606,20 @@ void AI_SetBattlerTurnOrder(u8 *aiTurnOrder)
 
 static bool32 WillPartnerActBeforeOrAfter(enum BattlerId battler, enum BattlerId partner)
 {
-    u8 aiTurnOrder[4] = {0};
+    u8 aiTurnOrder[MAX_BATTLERS_COUNT] = {0};
+    u32 battlerTurnOrder = MAX_BATTLERS_COUNT;
+    u32 partnerTurnOrder = MAX_BATTLERS_COUNT;
     AI_SetBattlerTurnOrder(aiTurnOrder);
 
-    battler = aiTurnOrder[battler];
-    partner = aiTurnOrder[partner];
+    for (u32 i = 0; i < gBattlersCount; i++)
+    {
+        if (aiTurnOrder[i] == battler)
+            battlerTurnOrder = i;
+        else if (aiTurnOrder[i] == partner)
+            partnerTurnOrder = i;
+    }
 
-    if (battler + 1 == partner || battler - 1 == partner)
-        return TRUE;
-
-    return FALSE;
+    return battlerTurnOrder + 1 == partnerTurnOrder || partnerTurnOrder + 1 == battlerTurnOrder;
 }
 
 bool32 ShouldUseFusionMove(enum BattlerId battler)

--- a/test/battle/ai/ai_combo_attack.c
+++ b/test/battle/ai/ai_combo_attack.c
@@ -70,27 +70,30 @@ AI_DOUBLE_BATTLE_TEST("Combo Attack: Round is not disincentivised due to partner
 }
 
 
-AI_DOUBLE_BATTLE_TEST("Combo Attack: Fusion Flare will be chosen if partner acts directly before")
+AI_DOUBLE_BATTLE_TEST("Combo Attack: Fusion moves are only incentivised when partners are adjacent in turn order")
 {
-    u32 speed = 0;
-    PARAMETRIZE { speed = 30; }
-    PARAMETRIZE { speed = 11; }
+    u32 playerLeftSpeed, opponentLeftSpeed, playerRightSpeed, opponentRightSpeed;
+    bool32 partnersAreAdjacent;
+    // Turn order: opponentLeft, opponentRight, playerRight, playerLeft.
+    PARAMETRIZE { playerLeftSpeed = 10; opponentLeftSpeed = 40; playerRightSpeed = 20; opponentRightSpeed = 30; partnersAreAdjacent = TRUE; }
+    // Turn order: opponentLeft, playerRight, playerLeft, opponentRight.
+    PARAMETRIZE { playerLeftSpeed = 20; opponentLeftSpeed = 40; playerRightSpeed = 30; opponentRightSpeed = 10; partnersAreAdjacent = FALSE; }
 
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_FUSION_FLARE) == EFFECT_FUSION_COMBO);
         ASSUME(GetMoveEffect(MOVE_FUSION_BOLT) == EFFECT_FUSION_COMBO);
         AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT);
         TIE_BREAK_TARGET(TARGET_TIE_LO,0);
-        PLAYER(SPECIES_WOBBUFFET) { Speed(10); }
-        PLAYER(SPECIES_WOBBUFFET) { Speed(20); }
-        OPPONENT(SPECIES_RESHIRAM) { Speed(speed); Moves(MOVE_FUSION_FLARE, MOVE_FLAMETHROWER); }
-        OPPONENT(SPECIES_ZEKROM) { Speed(40); Moves(MOVE_FUSION_BOLT); }
+        PLAYER(SPECIES_WOBBUFFET) { Speed(playerLeftSpeed); }
+        PLAYER(SPECIES_WOBBUFFET) { Speed(playerRightSpeed); }
+        OPPONENT(SPECIES_RESHIRAM) { Speed(opponentLeftSpeed); Moves(MOVE_FUSION_FLARE, MOVE_FLAMETHROWER); }
+        OPPONENT(SPECIES_ZEKROM) { Speed(opponentRightSpeed); Moves(MOVE_FUSION_BOLT); }
     } WHEN {
         TURN {
-            if (speed == 30) {
+            if (partnersAreAdjacent) {
                 EXPECT_MOVE(opponentLeft, MOVE_FUSION_FLARE, target:playerLeft);
                 EXPECT_MOVE(opponentRight, MOVE_FUSION_BOLT, target:playerLeft);
-            } else { // Flamethrower gets the best damage move
+            } else {
                 EXPECT_MOVE(opponentLeft, MOVE_FLAMETHROWER, target:playerLeft);
                 EXPECT_MOVE(opponentRight, MOVE_FUSION_BOLT, target:playerLeft);
             }


### PR DESCRIPTION
`AI_SetBattlerTurnOrder` stores battler IDs by turn-order position, but the Fusion Move AI treated battler IDs as indexes into that array. WillPartnerActBeforeOrAfter` now locates each battler's position in the predicted turn order before checking whether the partners are adjacent.

I changed a now-redundant regression test that now includes both failure modes, namely:
- Adjacent partners that were incorrectly treated as non-adjacent.
- Non-adjacent partners that were incorrectly treated as adjacent.

### Large Language Models (AI)

No AI has been used.

## Issue(s) that this PR fixes

Fixes #10686.

## Discord contact info

syreldar