### PR TITLE
Split move target selection and resolution

### DIFF
--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -193,6 +193,7 @@ bool32 CantPickupItem(u32 battler);
 u32 GetWeather(void);
 u32 GetAttackerWeather(enum HoldEffect holdEffect, enum Ability ability, u32 weather);
 bool32 IsBattlerWeatherAffected(enum HoldEffect holdEffect, u32 weather, u32 weatherFlags);
+enum MoveTarget GetBattlerMoveSelectionTargetType(enum BattlerId battler, enum Move move);
 enum MoveTarget GetBattlerMoveTargetType(enum BattlerId battler, enum Move move);
 bool32 CanTargetBattler(enum BattlerId battlerAtk, enum BattlerId battlerDef, enum Move move);
 u32 GetNextTarget(u32 moveTarget, bool32 excludeCurrent);

--- a/src/battle_controller_opponent.c
+++ b/src/battle_controller_opponent.c
@@ -467,7 +467,7 @@ static void OpponentHandleChooseMove(enum BattlerId battler)
             move = moveInfo->moves[chosenMoveIndex];
         } while (move == MOVE_NONE);
 
-        enum MoveTarget moveTarget = GetBattlerMoveTargetType(battler, move);
+        enum MoveTarget moveTarget = GetBattlerMoveSelectionTargetType(battler, move);
         if (moveTarget == TARGET_USER || moveTarget == TARGET_USER_OR_ALLY || moveTarget == TARGET_ALLY)
         {
             BtlController_EmitTwoReturnValues(battler, B_COMM_TO_ENGINE, B_ACTION_EXEC_SCRIPT, (chosenMoveIndex) | (GetDefaultSelectionTarget(battler, moveTarget) << 8));
@@ -481,7 +481,7 @@ static void OpponentHandleChooseMove(enum BattlerId battler)
             } while (!CanTargetBattler(battler, targetBattler, move));
 
             // Don't bother to check if they're enemies if the move can't attack ally
-            if (WE_WILD_NATURAL_ENEMIES && GetBattlerMoveTargetType(battler, move) != TARGET_BOTH)
+            if (WE_WILD_NATURAL_ENEMIES && moveTarget != TARGET_BOTH)
             {
                 enum Species speciesAttacker, speciesTarget;
                 speciesAttacker = gBattleMons[battler].species;

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -421,7 +421,7 @@ void HandleInputChooseTarget(enum BattlerId battler)
         B_POSITION_OPPONENT_LEFT,
     };
     enum Move move = GetMonData(GetBattlerMon(battler), MON_DATA_MOVE1 + gMoveSelectionCursor[battler]);
-    enum MoveTarget moveTarget = GetBattlerMoveTargetType(battler, move);
+    enum MoveTarget moveTarget = GetBattlerMoveSelectionTargetType(battler, move);
 
     DoBounceEffect(gMultiUsePlayerCursor, BOUNCE_HEALTHBOX, 15, 1);
     for (i = 0; i < gBattlersCount; i++)
@@ -689,7 +689,7 @@ void HandleInputChooseMove(enum BattlerId battler)
         TryToHideMoveInfoWindow();
         PlaySE(SE_SELECT);
 
-        enum MoveTarget moveTarget = GetBattlerMoveTargetType(battler, moveInfo->moves[gMoveSelectionCursor[battler]]);
+        enum MoveTarget moveTarget = GetBattlerMoveSelectionTargetType(battler, moveInfo->moves[gMoveSelectionCursor[battler]]);
         bool32 isUserOrAlly = moveTarget == TARGET_USER || moveTarget == TARGET_USER_OR_ALLY || moveTarget == TARGET_USER_AND_ALLY;
 
         if (gBattleStruct->zmove.viewing)
@@ -2021,7 +2021,7 @@ static void PlayerHandleChooseAction(enum BattlerId battler)
         StringCopy(gStringVar1, COMPOUND_STRING("Partner will use:\n"));
         enum Move move = GetBattlerChosenMove(partner);
         StringAppend(gStringVar1, GetMoveName(move));
-        enum MoveTarget moveTarget = GetBattlerMoveTargetType(partner, move);
+        enum MoveTarget moveTarget = GetBattlerMoveSelectionTargetType(partner, move);
         if (moveTarget == TARGET_SELECTED || moveTarget == TARGET_SMART)
         {
             if (gAiBattleData->chosenTarget[partner] == B_POSITION_OPPONENT_LEFT)

--- a/src/battle_controller_recorded_opponent.c
+++ b/src/battle_controller_recorded_opponent.c
@@ -349,7 +349,7 @@ static void RecordedOpponentHandleChooseMove(enum BattlerId battler)
         if (target == RECORDED_TARGET_DEFAULT)
         {
             struct ChooseMoveStruct *moveInfo = (struct ChooseMoveStruct *)(&gBattleResources->bufferA[battler][4]);
-            target = GetDefaultSelectionTarget(battler, GetMoveTarget(moveInfo->moves[moveId]));
+            target = GetDefaultSelectionTarget(battler, GetBattlerMoveSelectionTargetType(battler, moveInfo->moves[moveId]));
         }
         BtlController_EmitTwoReturnValues(battler, B_COMM_TO_ENGINE, B_ACTION_EXEC_SCRIPT, moveId | (target << 8));
     }

--- a/src/battle_controller_recorded_partner.c
+++ b/src/battle_controller_recorded_partner.c
@@ -270,7 +270,7 @@ static void RecordedPartnerHandleChooseMove(enum BattlerId battler)
     if (target == RECORDED_TARGET_DEFAULT)
     {
         struct ChooseMoveStruct *moveInfo = (struct ChooseMoveStruct *)(&gBattleResources->bufferA[battler][4]);
-        target = GetDefaultSelectionTarget(battler, GetMoveTarget(moveInfo->moves[moveIndex]));
+        target = GetDefaultSelectionTarget(battler, GetBattlerMoveSelectionTargetType(battler, moveInfo->moves[moveIndex]));
     }
     BtlController_EmitTwoReturnValues(battler, B_COMM_TO_ENGINE, B_ACTION_EXEC_SCRIPT, moveIndex | (target << 8));
 

--- a/src/battle_controller_recorded_player.c
+++ b/src/battle_controller_recorded_player.c
@@ -370,7 +370,7 @@ static void RecordedPlayerHandleChooseMove(enum BattlerId battler)
         if (target == RECORDED_TARGET_DEFAULT)
         {
             struct ChooseMoveStruct *moveInfo = (struct ChooseMoveStruct *)(&gBattleResources->bufferA[battler][4]);
-            target = GetDefaultSelectionTarget(battler, GetMoveTarget(moveInfo->moves[moveIndex]));
+            target = GetDefaultSelectionTarget(battler, GetBattlerMoveSelectionTargetType(battler, moveInfo->moves[moveIndex]));
         }
         BtlController_EmitTwoReturnValues(battler, B_COMM_TO_ENGINE, B_ACTION_EXEC_SCRIPT, moveIndex | (target << 8));
     }

--- a/src/battle_controllers.c
+++ b/src/battle_controllers.c
@@ -3355,7 +3355,7 @@ void SetFinalChosenTarget(enum BattlerId battler, bool32 partner)
     enum BattlerId chosenTarget = gAiBattleData->chosenTarget[battler];
     u32 chosenMoveIndex = gAiBattleData->chosenMoveIndex[battler];
     u32 chosenMove = moveInfo->moves[chosenMoveIndex];
-    enum MoveTarget targetType = GetBattlerMoveTargetType(battler, chosenMove);
+    enum MoveTarget targetType = GetBattlerMoveSelectionTargetType(battler, chosenMove);
 
     switch (targetType)
     {

--- a/src/battle_gfx_sfx_util.c
+++ b/src/battle_gfx_sfx_util.c
@@ -302,7 +302,7 @@ u16 ChooseMoveAndTargetInBattlePalace(enum BattlerId battler)
         }
     }
 
-    enum MoveTarget moveTarget = GetBattlerMoveTargetType(battler, moveInfo->moves[chosenMoveIndex]);
+    enum MoveTarget moveTarget = GetBattlerMoveSelectionTargetType(battler, moveInfo->moves[chosenMoveIndex]);
 
     if (moveTarget == TARGET_USER || moveTarget == TARGET_USER_OR_ALLY || moveTarget == TARGET_USER_AND_ALLY)
         chosenMoveIndex |= (battler << 8);
@@ -325,7 +325,7 @@ u16 ChooseMoveAndTargetInBattlePalace(enum BattlerId battler)
 
 static u8 GetBattlePalaceMoveGroup(enum BattlerId battler, enum Move move)
 {
-    switch (GetBattlerMoveTargetType(battler, move))
+    switch (GetBattlerMoveSelectionTargetType(battler, move))
     {
     case TARGET_SELECTED:
     case TARGET_USER_AND_ALLY:

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -924,6 +924,10 @@ static enum CancelerResult CancelerSetTargets(struct BattleCalcValues *cv)
                 cv->battlerDef = GetPartnerBattler(cv->battlerDef);
             }
         }
+        else if (moveTarget == TARGET_SELECTED && cv->battlerDef == cv->battlerAtk)
+        {
+            cv->battlerDef = SetRandomTarget(cv->battlerAtk);
+        }
         else if (moveTarget == TARGET_ALLY && !IsBattlerAlly(cv->battlerDef, cv->battlerAtk))
         {
             cv->battlerDef = GetPartnerBattler(cv->battlerAtk);

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -9430,17 +9430,23 @@ static u32 CanBattlerHitBothFoesInTerrain(enum BattlerId battler, enum Move move
         && IsBattlerTerrainAffected(battler, GetBattlerAbility(battler), GetBattlerHoldEffect(battler), GetMoveTerrainBoost_Terrain(move), gFieldTimers.terrain);
 }
 
-enum MoveTarget GetBattlerMoveTargetType(enum BattlerId battler, enum Move move)
+enum MoveTarget GetBattlerMoveSelectionTargetType(enum BattlerId battler, enum Move move)
 {
     enum BattleMoveEffects effect = GetMoveEffect(move);
     if (effect == EFFECT_CURSE && !IS_BATTLER_OF_TYPE(battler, TYPE_GHOST))
         return TARGET_USER;
-    if (CanBattlerHitBothFoesInTerrain(battler, move, effect))
-        return TARGET_BOTH;
     if (effect == EFFECT_TERA_STARSTORM && gBattleMons[battler].species == SPECIES_TERAPAGOS_STELLAR)
         return TARGET_BOTH;
 
     return GetMoveTarget(move);
+}
+
+enum MoveTarget GetBattlerMoveTargetType(enum BattlerId battler, enum Move move)
+{
+    if (CanBattlerHitBothFoesInTerrain(battler, move, GetMoveEffect(move)))
+        return TARGET_BOTH;
+
+    return GetBattlerMoveSelectionTargetType(battler, move);
 }
 
 bool32 CanTargetBattler(enum BattlerId battlerAtk, enum BattlerId battlerDef, enum Move move)

--- a/test/battle/move_effect/terrain_boost.c
+++ b/test/battle/move_effect/terrain_boost.c
@@ -41,7 +41,7 @@ DOUBLE_BATTLE_TEST("Terrain Boost: Expanding Force hits both foes in Psychic Ter
         OPPONENT(SPECIES_WYNAUT);
     } WHEN {
         TURN { MOVE(playerLeft, MOVE_EXPANDING_FORCE, target: opponentLeft); MOVE(playerRight, MOVE_PSYCHIC_TERRAIN); }
-        TURN { MOVE(playerLeft, MOVE_EXPANDING_FORCE, target: opponentLeft); }
+        TURN { MOVE(playerLeft, MOVE_EXPANDING_FORCE, target: playerRight); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPANDING_FORCE, playerLeft);
         HP_BAR(opponentLeft);
@@ -50,6 +50,10 @@ DOUBLE_BATTLE_TEST("Terrain Boost: Expanding Force hits both foes in Psychic Ter
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPANDING_FORCE, playerLeft);
         HP_BAR(opponentLeft);
         HP_BAR(opponentRight);
+    } THEN {
+        enum BattlerId battler = GetBattlerAtPosition(B_POSITION_PLAYER_LEFT);
+        EXPECT_EQ(GetBattlerMoveSelectionTargetType(battler, MOVE_EXPANDING_FORCE), TARGET_SELECTED);
+        EXPECT_EQ(GetBattlerMoveTargetType(battler, MOVE_EXPANDING_FORCE), TARGET_BOTH);
     }
 }
 

--- a/test/battle/move_effect/terrain_boost.c
+++ b/test/battle/move_effect/terrain_boost.c
@@ -50,10 +50,6 @@ DOUBLE_BATTLE_TEST("Terrain Boost: Expanding Force hits both foes in Psychic Ter
         ANIMATION(ANIM_TYPE_MOVE, MOVE_EXPANDING_FORCE, playerLeft);
         HP_BAR(opponentLeft);
         HP_BAR(opponentRight);
-    } THEN {
-        enum BattlerId battler = GetBattlerAtPosition(B_POSITION_PLAYER_LEFT);
-        EXPECT_EQ(GetBattlerMoveSelectionTargetType(battler, MOVE_EXPANDING_FORCE), TARGET_SELECTED);
-        EXPECT_EQ(GetBattlerMoveTargetType(battler, MOVE_EXPANDING_FORCE), TARGET_BOTH);
     }
 }
 


### PR DESCRIPTION
## Description

`GetBattlerMoveTargetType` currently serves both move selection and move resolution, even though Expanding Force has different targeting behavior at those two stages. It should remain `TARGET_SELECTED` while choosing a target, then become `TARGET_BOTH` if Psychic Terrain affects the user when the move executes.

This adds `GetBattlerMoveSelectionTargetType` for selection-time behavior and keeps `GetBattlerMoveTargetType` for resolved behavior. Player, opponent, recorded-battle, partner, and Battle Palace selection paths now use the new helper. The resolution path also recovers a valid opponent if a selected-target move reaches execution with the user stored as its target.

The Expanding Force terrain test now selects an ally and verifies that selection remains `TARGET_SELECTED` while execution resolves to `TARGET_BOTH` and damages both foes.

### Large Language Models (AI)

No AI was used.

## Issue(s) that this PR fixes

Fixes #10689

## Things to note in the release changelog:

- Fixed Expanding Force target selection in Psychic Terrain while retaining its spread targeting when the move executes.

## Discord contact info

syreldar