### PR TITLE
Fix battler invisibility during move selection

### DIFF
--- a/include/battle_main.h
+++ b/include/battle_main.h
@@ -78,7 +78,7 @@ void SpriteCallbackDummy_2(struct Sprite *sprite);
 void SpriteCB_FaintOpponentMon(struct Sprite *sprite);
 void SpriteCB_ShowAsMoveTarget(struct Sprite *sprite);
 void SpriteCB_HideAsMoveTarget(struct Sprite *sprite);
-bool32 IsBattlerSpriteShowingAsMoveTarget(enum BattlerId battler);
+bool32 ShouldHideBattler(enum BattlerId battler);
 void SpriteCB_OpponentMonFromBall(struct Sprite *sprite);
 void SpriteCB_BattleSpriteStartSlideLeft(struct Sprite *sprite);
 void SpriteCB_FaintSlideAnim(struct Sprite *sprite);

--- a/include/battle_main.h
+++ b/include/battle_main.h
@@ -78,6 +78,7 @@ void SpriteCallbackDummy_2(struct Sprite *sprite);
 void SpriteCB_FaintOpponentMon(struct Sprite *sprite);
 void SpriteCB_ShowAsMoveTarget(struct Sprite *sprite);
 void SpriteCB_HideAsMoveTarget(struct Sprite *sprite);
+bool32 IsBattlerSpriteShowingAsMoveTarget(enum BattlerId battler);
 void SpriteCB_OpponentMonFromBall(struct Sprite *sprite);
 void SpriteCB_BattleSpriteStartSlideLeft(struct Sprite *sprite);
 void SpriteCB_FaintSlideAnim(struct Sprite *sprite);

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -579,7 +579,9 @@ static void HideAllTargets(void)
 {
     for (enum BattlerId i = 0; i < MAX_BATTLERS_COUNT; i++)
     {
-        if (IsBattlerAlive(i) && gBattleSpritesDataPtr->healthBoxesData[i].healthboxIsBouncing)
+        if (IsBattlerAlive(i)
+         && gBattleSpritesDataPtr->healthBoxesData[i].healthboxIsBouncing
+         && IsBattlerSpriteShowingAsMoveTarget(i))
         {
             gSprites[gBattlerSpriteIds[i]].callback = SpriteCB_HideAsMoveTarget;
             EndBounceEffect(i, BOUNCE_HEALTHBOX);

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -579,9 +579,7 @@ static void HideAllTargets(void)
 {
     for (enum BattlerId i = 0; i < MAX_BATTLERS_COUNT; i++)
     {
-        if (IsBattlerAlive(i)
-         && gBattleSpritesDataPtr->healthBoxesData[i].healthboxIsBouncing
-         && IsBattlerSpriteShowingAsMoveTarget(i))
+        if (ShouldHideBattler(i))
         {
             gSprites[gBattlerSpriteIds[i]].callback = SpriteCB_HideAsMoveTarget;
             EndBounceEffect(i, BOUNCE_HEALTHBOX);

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -2754,13 +2754,11 @@ void SpriteCB_HideAsMoveTarget(struct Sprite *sprite)
 
 bool32 ShouldHideBattler(enum BattlerId battler)
 {
-    SpriteCallback callback;
-
     if (!IsBattlerAlive(battler)
      || !gBattleSpritesDataPtr->healthBoxesData[battler].healthboxIsBouncing)
         return FALSE;
 
-    callback = gSprites[gBattlerSpriteIds[battler]].callback;
+    SpriteCallback callback = gSprites[gBattlerSpriteIds[battler]].callback;
     return callback == SpriteCB_ShowAsMoveTarget || callback == SpriteCB_BlinkVisible;
 }
 

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -2752,6 +2752,13 @@ void SpriteCB_HideAsMoveTarget(struct Sprite *sprite)
     sprite->callback = SpriteCallbackDummy_2;
 }
 
+bool32 IsBattlerSpriteShowingAsMoveTarget(enum BattlerId battler)
+{
+    SpriteCallback callback = gSprites[gBattlerSpriteIds[battler]].callback;
+
+    return callback == SpriteCB_ShowAsMoveTarget || callback == SpriteCB_BlinkVisible;
+}
+
 void SpriteCB_OpponentMonFromBall(struct Sprite *sprite)
 {
     if (sprite->affineAnimEnded)

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -2752,10 +2752,15 @@ void SpriteCB_HideAsMoveTarget(struct Sprite *sprite)
     sprite->callback = SpriteCallbackDummy_2;
 }
 
-bool32 IsBattlerSpriteShowingAsMoveTarget(enum BattlerId battler)
+bool32 ShouldHideBattler(enum BattlerId battler)
 {
-    SpriteCallback callback = gSprites[gBattlerSpriteIds[battler]].callback;
+    SpriteCallback callback;
 
+    if (!IsBattlerAlive(battler)
+     || !gBattleSpritesDataPtr->healthBoxesData[battler].healthboxIsBouncing)
+        return FALSE;
+
+    callback = gSprites[gBattlerSpriteIds[battler]].callback;
     return callback == SpriteCB_ShowAsMoveTarget || callback == SpriteCB_BlinkVisible;
 }
 


### PR DESCRIPTION
`HideAllTargets` used the healthbox bounce state to determine which battler sprites were highlighted as move targets. However, the acting battler's healthbox also bounces during move selection. This could run `SpriteCB_HideAsMoveTarget` on a battler that was never shown as a move target, restoring its visibility from unrelated sprite data and sometimes making it invisible.

My fix adds a check for the move-target sprite callbacks and only hides battlers that are actually being displayed as targets.

### Large Language Models (AI)

No AI has been used.

## Issue(s) that this PR fixes

Fixes #10691.

## Discord contact info

syreldar