### PR TITLE
upcoming: Fix flaky trainer party pool custom rules test

### DIFF
--- a/test/battle/trainer_control.c
+++ b/test/battle/trainer_control.c
@@ -260,7 +260,8 @@ TEST("Trainer Party Pool picks according to custom rules")
     u32 currTrainer = 8;
     gBattleTypeFlags = BATTLE_TYPE_DOUBLE;
     CreateNPCTrainerPartyFromTrainer(testParty, GetTrainerStructFromId(currTrainer));
-    EXPECT(GetMonData(&testParty[0], MON_DATA_SPECIES) == SPECIES_TORKOAL);    //  Lead + Weather Setter
+    enum Species leadSpecies = GetMonData(&testParty[0], MON_DATA_SPECIES);
+    EXPECT(leadSpecies == SPECIES_TORKOAL || leadSpecies == SPECIES_VULPIX);  //  Lead + Weather Setter
     EXPECT(GetMonData(&testParty[1], MON_DATA_SPECIES) == SPECIES_BULBASAUR);  //  Lead + Weather Abuser
     EXPECT(GetMonData(&testParty[2], MON_DATA_SPECIES) == SPECIES_EEVEE);      //  Anything else
     gBattleTypeFlags = 0;

--- a/test/battle/trainer_control.c
+++ b/test/battle/trainer_control.c
@@ -256,12 +256,17 @@ TEST("Trainer Party Pool picks a random lead and a random ace if tags exist in t
 
 TEST("Trainer Party Pool picks according to custom rules")
 {
+    u32 seed;
+    enum Species expectedWeatherSetter;
+    PARAMETRIZE { seed = 0; expectedWeatherSetter = SPECIES_TORKOAL; }
+    PARAMETRIZE { seed = 3; expectedWeatherSetter = SPECIES_VULPIX; }
+
     struct Pokemon *testParty = Alloc(6 * sizeof(struct Pokemon));
     u32 currTrainer = 8;
     gBattleTypeFlags = BATTLE_TYPE_DOUBLE;
+    SeedRng(seed);
     CreateNPCTrainerPartyFromTrainer(testParty, GetTrainerStructFromId(currTrainer));
-    enum Species leadSpecies = GetMonData(&testParty[0], MON_DATA_SPECIES);
-    EXPECT(leadSpecies == SPECIES_TORKOAL || leadSpecies == SPECIES_VULPIX);  //  Lead + Weather Setter
+    EXPECT_EQ(GetMonData(&testParty[0], MON_DATA_SPECIES), expectedWeatherSetter);  //  Lead + Weather Setter
     EXPECT(GetMonData(&testParty[1], MON_DATA_SPECIES) == SPECIES_BULBASAUR);  //  Lead + Weather Abuser
     EXPECT(GetMonData(&testParty[2], MON_DATA_SPECIES) == SPECIES_EEVEE);      //  Anything else
     gBattleTypeFlags = 0;


### PR DESCRIPTION
The `Trainer Party Pool picks according to custom rules` test assumed that Torkoal would always be selected as the lead and weather setter, but both Torkoal and Vulpix have the required `Lead` and `Weather Setter` tags, making either species a valid result.
Changes to the test execution order or worker count can alter the random state and cause Vulpix to be selected. This updates the assertion to accept either valid species.

### Large Language Models (AI)

No AI has been used.

## Issue(s) that this PR fixes

Fixes #10694.

## Discord contact info

syreldar