### PR TITLE
Type checking for functions adjacent to dex numbers

### DIFF
--- a/docs/tutorials/how_to_code_entry.md
+++ b/docs/tutorials/how_to_code_entry.md
@@ -65,8 +65,7 @@ void GetCodeFeedback(void)
         gSpecialVar_Result = 1;
     else if (!StringCompare(gStringVar2, sText_CaughtEmAll))
     {
-+       u32 i;
-+       for (i = 0; i < NATIONAL_DEX_COUNT; i++)
++       for (enum NationalDexOrder i = 0; i < NATIONAL_DEX_COUNT; i++)
 +       {
 +           GetSetPokedexFlag(i + 1, FLAG_SET_CAUGHT);
 +       }

--- a/include/pokedex_common.h
+++ b/include/pokedex_common.h
@@ -105,7 +105,7 @@ enum
 
 struct PokedexListItem
 {
-    u16 dexNum;
+    enum NationalDexOrder dexNum;
     u16 seen:1;
     u16 owned:1;
 };
@@ -204,7 +204,7 @@ struct PokedexView
     struct EvoScreenData sEvoScreenData;
     struct FromScreenData sFormScreenData;
     enum Species formSpecies;
-    u16 originalSearchSelectionNum;
+    enum NationalDexOrder originalSearchSelectionNum;
     u16 moveSelected;
     u16 movesTotal;
     u16 numTeachableMoves;
@@ -242,7 +242,7 @@ void LoadPokedexBgPalette(bool8);
 void CreatePokedexList(u8, u8);
 void CreateMonDexNum(u16, u8, u8, u16);
 void CreateCaughtBall(u16, u8, u8, u16);
-u8 CreateMonName(u16, u8, u8);
+u8 CreateMonName(enum NationalDexOrder, u8, u8);
 void ClearMonListEntry(u8 x, u8 y, u16 unused);
 void CreateMonSpritesAtPos(u16, u16);
 void SpriteCB_MoveMonForInfoScreen(struct Sprite *sprite);
@@ -259,11 +259,11 @@ void Task_LoadSizeScreen(u8);
 void Task_HandleSizeScreenInput(u8);
 void Task_HandleCaughtMonPageInput(u8);
 void ResetOtherVideoRegisters(u16);
-u8 PrintCryScreenSpeciesName(u8, u16, u8, u8);
-u16 GetPokemonScaleFromNationalDexNumber(u16 nationalNum);
-u16 GetPokemonOffsetFromNationalDexNumber(u16 nationalNum);
-u16 GetTrainerScaleFromNationalDexNumber(u16 nationalNum);
-u16 GetTrainerOffsetFromNationalDexNumber(u16 nationalNum);
+u8 PrintCryScreenSpeciesName(u8, enum NationalDexOrder, u8, u8);
+u16 GetPokemonScaleFromNationalDexNumber(enum NationalDexOrder nationalNum);
+u16 GetPokemonOffsetFromNationalDexNumber(enum NationalDexOrder nationalNum);
+u16 GetTrainerScaleFromNationalDexNumber(enum NationalDexOrder nationalNum);
+u16 GetTrainerOffsetFromNationalDexNumber(enum NationalDexOrder nationalNum);
 u16 CreateSizeScreenTrainerPic(u16, s16, s16, s8);
 void Task_SwitchToSearchMenuTopBar(u8);
 void HighlightSelectedSearchTopBarItem(u8);

--- a/include/pokedex_common.h
+++ b/include/pokedex_common.h
@@ -105,7 +105,7 @@ enum
 
 struct PokedexListItem
 {
-    enum NationalDexOrder dexNum;
+    enum NationalDexOrder dexNum:16;
     u16 seen:1;
     u16 owned:1;
 };
@@ -204,7 +204,7 @@ struct PokedexView
     struct EvoScreenData sEvoScreenData;
     struct FromScreenData sFormScreenData;
     enum Species formSpecies;
-    enum NationalDexOrder originalSearchSelectionNum;
+    enum NationalDexOrder originalSearchSelectionNum:16;
     u16 moveSelected;
     u16 movesTotal;
     u16 numTeachableMoves;

--- a/src/birch_pc.c
+++ b/src/birch_pc.c
@@ -50,15 +50,15 @@ static const u8 *const sBirchDexRatingTexts[BIRCH_DEX_STRINGS] =
 // This shows your Hoenn Pokédex rating and not your National Dex.
 const u8 *GetPokedexRatingText(u32 count)
 {
-    u32 i, j;
     u16 maxDex = REGIONAL_DEX_COUNT - 1;
     // doesNotCountForRegionalPokedex
-    for (i = 0; i < REGIONAL_DEX_COUNT; i++)
+    for (u32 i = 0; i < REGIONAL_DEX_COUNT; i++)
     {
-        j = NationalPokedexNumToSpecies(RegionalToNationalOrder(i + 1));
-        if (gSpeciesInfo[j].isMythical && !gSpeciesInfo[j].dexForceRequired)
+        enum NationalDexOrder natDexNum = RegionalToNationalOrder(i + 1);
+        enum Species species = NationalPokedexNumToSpecies(natDexNum);
+        if (gSpeciesInfo[species].isMythical && !gSpeciesInfo[species].dexForceRequired)
         {
-            if (GetSetPokedexFlag(j, FLAG_GET_CAUGHT))
+            if (GetSetPokedexFlag(natDexNum, FLAG_GET_CAUGHT))
                 count--;
             maxDex--;
         }

--- a/src/credits.c
+++ b/src/credits.c
@@ -66,12 +66,12 @@ enum {
 
 struct CreditsData
 {
-    u16 monToShow[NUM_MON_SLIDES]; // List of Pokémon species ids that will show during the credits
+    enum NationalDexOrder monToShow[NUM_MON_SLIDES]; // List of Pokémon species ids that will show during the credits
     u16 imgCounter; //how many mon images have been shown
     u16 nextImgPos; //if the next image spawns left/center/right
     u16 currShownMon; //index into monToShow
     u16 numMonToShow; //number of Pokémon to show, always NUM_MON_SLIDES after determine function
-    u16 caughtMonIds[NATIONAL_DEX_COUNT]; //temporary location to hold a condensed array of all caught Pokémon
+    enum NationalDexOrder caughtMonIds[NATIONAL_DEX_COUNT]; //temporary location to hold a condensed array of all caught Pokémon
     u16 numCaughtMon; //count of filled spaces in caughtMonIds
     u16 unused[7];
 };
@@ -116,7 +116,7 @@ static void LoadTheEndScreen(u16, u16, u16);
 static void DrawTheEnd(u16, u16);
 static void SpriteCB_Player(struct Sprite *);
 static void SpriteCB_Rival(struct Sprite *);
-static u8 CreateCreditsMonSprite(u16, s16, s16, u16);
+static u8 CreateCreditsMonSprite(enum NationalDexOrder, s16, s16, u16);
 static void DeterminePokemonToShow(void);
 
 static const u8 sTheEnd_LetterMap_T[] =
@@ -1502,7 +1502,7 @@ static void SpriteCB_CreditsMon(struct Sprite *sprite)
 
 #define sMonSpriteId data[0]
 
-static u8 CreateCreditsMonSprite(u16 nationalDexNum, s16 x, s16 y, u16 position)
+static u8 CreateCreditsMonSprite(enum NationalDexOrder nationalDexNum, s16 x, s16 y, u16 position)
 {
     u8 monSpriteId;
     u8 bgSpriteId;

--- a/src/credits.c
+++ b/src/credits.c
@@ -1544,7 +1544,7 @@ static void DeterminePokemonToShow(void)
 {
     enum NationalDexOrder starter = SpeciesToNationalPokedexNum(GetStarterPokemon(VarGet(VAR_STARTER_MON)));
     u16 page;
-    u16 dexNum;
+    enum NationalDexOrder dexNum;
     u16 j;
 
     // Go through the Pokédex, and anything that has gotten caught we put into our massive array.

--- a/src/data/pokemon/pokedex_orders.h
+++ b/src/data/pokemon/pokedex_orders.h
@@ -1,5 +1,5 @@
 // Only list base species here.
-const u16 gPokedexOrder_Alphabetical[] =
+const enum NationalDexOrder gPokedexOrder_Alphabetical[] =
 {
     NATIONAL_DEX_ABOMASNOW,
     NATIONAL_DEX_ABRA,
@@ -1053,7 +1053,7 @@ const u16 gPokedexOrder_Alphabetical[] =
     NATIONAL_DEX_ZYGARDE,
 };
 
-const u16 gPokedexOrder_Weight[] =
+const enum NationalDexOrder gPokedexOrder_Weight[] =
 {
     // 0.0 - 21.8 lbs / 0.0 - 9.9 kg
     NATIONAL_DEX_GASTLY,
@@ -2934,7 +2934,7 @@ const u16 gPokedexOrder_Weight[] =
     NATIONAL_DEX_CELESTEELA,
 };
 
-const u16 gPokedexOrder_Height[] =
+const enum NationalDexOrder gPokedexOrder_Height[] =
 {
     // 0'04" / 0.1m
     NATIONAL_DEX_JOLTIK,

--- a/src/debug.c
+++ b/src/debug.c
@@ -2903,8 +2903,7 @@ static const struct DebugSelection sSetVarSelection = {
 
 static void DebugAction_FlagsVars_PokedexFlags_All(u8 taskId)
 {
-    u16 i;
-    for (i = 0; i < NATIONAL_DEX_COUNT; i++)
+    for (enum NationalDexOrder i = 0; i < NATIONAL_DEX_COUNT; i++)
     {
         GetSetPokedexFlag(i + 1, FLAG_SET_CAUGHT);
         GetSetPokedexFlag(i + 1, FLAG_SET_SEEN);

--- a/src/pokedex.c
+++ b/src/pokedex.c
@@ -99,7 +99,7 @@ static void UpdateSelectedMonSpriteId(void);
 static bool8 TryDoInfoScreenScroll(void);
 static u8 ClearMonSprites(void);
 static u16 GetPokemonSpriteToDisplay(u16);
-static u32 CreatePokedexMonSprite(u16, s16, s16);
+static u32 CreatePokedexMonSprite(enum NationalDexOrder, s16, s16);
 static void CreateInterfaceSprites(u8);
 static void SpriteCB_Scrollbar(struct Sprite *sprite);
 static void SpriteCB_ScrollArrow(struct Sprite *sprite);
@@ -2696,7 +2696,7 @@ static u16 GetPokemonSpriteToDisplay(u16 index)
         return 0;
 }
 
-static u32 CreatePokedexMonSprite(u16 num, s16 x, s16 y)
+static u32 CreatePokedexMonSprite(enum NationalDexOrder num, s16 x, s16 y)
 {
     u8 i;
 

--- a/src/pokedex.c
+++ b/src/pokedex.c
@@ -2082,8 +2082,8 @@ void CreatePokedexList(u8 dexMode, u8 order)
     u32 vars[3]; //I have no idea why three regular variables are stored in an array, but whatever.
 #define temp_dexCount   vars[0]
 #define temp_isHoennDex vars[1]
-#define temp_dexNum     vars[2]
     s32 i, r5, r10;
+    enum NationalDexOrder temp_dexNum;
 
     sPokedexView->pokemonListCount = 0;
 
@@ -2372,13 +2372,13 @@ void CreateCaughtBall(bool16 owned, u8 x, u8 y, u16 unused)
         FillWindowPixelRect(0, PIXEL_FILL(0), x * xMultiplier, y * 8, 8, 16);
 }
 
-u8 CreateMonName(u16 num, u8 left, u8 top)
+u8 CreateMonName(enum NationalDexOrder num, u8 left, u8 top)
 {
     const u8 *str;
 
-    num = NationalPokedexNumToSpeciesForm(num);
-    if (num)
-        str = GetSpeciesName(num);
+    enum Species species = NationalPokedexNumToSpeciesForm(num);
+    if (species)
+        str = GetSpeciesName(species);
     else
         str = sText_TenDashes;
     PrintMonName(0, FONT_NARROW, str, left, top);
@@ -4517,9 +4517,8 @@ s8 GetSetPokedexFlag(enum NationalDexOrder nationalDexNo, u8 caseID)
 u16 GetNationalPokedexCount(u8 caseID)
 {
     u16 count = 0;
-    u16 i;
 
-    for (i = 0; i < NATIONAL_DEX_COUNT; i++)
+    for (enum NationalDexOrder i = 0; i < NATIONAL_DEX_COUNT; i++)
     {
         switch (caseID)
         {
@@ -4546,9 +4545,8 @@ u32 GetRegionalPokedexCount(u8 caseID)
 u16 GetHoennPokedexCount(u8 caseID)
 {
     u16 count = 0;
-    u16 i;
 
-    for (i = 0; i < HOENN_DEX_COUNT - 1; i++)
+    for (enum HoennDexOrder i = 0; i < HOENN_DEX_COUNT - 1; i++)
     {
         switch (caseID)
         {
@@ -4568,18 +4566,17 @@ u16 GetHoennPokedexCount(u8 caseID)
 u16 GetKantoPokedexCount(u8 caseID)
 {
     u16 count = 0;
-    u16 i;
 
-    for (i = 0; i < KANTO_DEX_COUNT - 1; i++)
+    for (enum KantoDexOrder i = 0; i < KANTO_DEX_COUNT - 1; i++)
     {
         switch (caseID)
         {
         case FLAG_GET_SEEN:
-            if (GetSetPokedexFlag(i + 1, FLAG_GET_SEEN))
+            if (GetSetPokedexFlag(KantoToNationalOrder(i + 1), FLAG_GET_SEEN))
                 count++;
             break;
         case FLAG_GET_CAUGHT:
-            if (GetSetPokedexFlag(i + 1, FLAG_GET_CAUGHT))
+            if (GetSetPokedexFlag(KantoToNationalOrder(i + 1), FLAG_GET_CAUGHT))
                 count++;
             break;
         }
@@ -4596,11 +4593,9 @@ bool16 HasAllRegionalMons(void)
 
 bool16 HasAllHoennMons(void)
 {
-    u32 i, j;
-
-    for (i = 0; i < HOENN_DEX_COUNT - 1; i++)
+    for (enum HoennDexOrder i = 0; i < HOENN_DEX_COUNT - 1; i++)
     {
-        j = HoennToNationalOrder(i + 1);
+        enum NationalDexOrder j = HoennToNationalOrder(i + 1);
         if (!(gSpeciesInfo[j].isMythical && !gSpeciesInfo[j].dexForceRequired) && !GetSetPokedexFlag(j, FLAG_GET_CAUGHT))
             return FALSE;
     }
@@ -4609,12 +4604,10 @@ bool16 HasAllHoennMons(void)
 
 bool16 HasAllKantoMons(void)
 {
-    u32 i, j;
-
     // -1 excludes Mew
-    for (i = 0; i < KANTO_DEX_COUNT - 1; i++)
+    for (enum KantoDexOrder i = 0; i < KANTO_DEX_COUNT - 1; i++)
     {
-        j = KantoToNationalOrder(i + 1);
+        enum NationalDexOrder j = KantoToNationalOrder(i + 1);
         if (!(gSpeciesInfo[j].isMythical && !gSpeciesInfo[j].dexForceRequired) && !GetSetPokedexFlag(j, FLAG_GET_CAUGHT))
             return FALSE;
     }
@@ -4623,11 +4616,9 @@ bool16 HasAllKantoMons(void)
 
 bool16 HasAllMons(void)
 {
-    u32 i, j;
-
-    for (i = 1; i < NATIONAL_DEX_COUNT + 1; i++)
+    for (enum NationalDexOrder i = 1; i < NATIONAL_DEX_COUNT + 1; i++)
     {
-        j = NationalPokedexNumToSpecies(i);
+        enum Species j = NationalPokedexNumToSpecies(i);
         if (!(gSpeciesInfo[j].isMythical && !gSpeciesInfo[j].dexForceRequired) && !GetSetPokedexFlag(i, FLAG_GET_CAUGHT))
             return FALSE;
     }
@@ -4695,19 +4686,19 @@ static void UNUSED UnusedPrintNum(u8 windowId, u16 num, u8 left, u8 top)
     PrintInfoSubMenuText(windowId, str, left, top);
 }
 
-u8 PrintCryScreenSpeciesName(u8 windowId, u16 num, u8 left, u8 top)
+u8 PrintCryScreenSpeciesName(u8 windowId, enum NationalDexOrder num, u8 left, u8 top)
 {
     u8 str[POKEMON_NAME_BUFFER_SIZE];
     u8 i;
 
     for (i = 0; i < ARRAY_COUNT(str); i++)
         str[i] = EOS;
-    num = NationalPokedexNumToSpeciesForm(num);
-    switch (num)
+    enum Species species = NationalPokedexNumToSpeciesForm(num);
+    switch (species)
     {
     default:
-        for (i = 0; GetSpeciesName(num)[i] != EOS && i < POKEMON_NAME_LENGTH; i++)
-            str[i] = GetSpeciesName(num)[i];
+        for (i = 0; GetSpeciesName(species)[i] != EOS && i < POKEMON_NAME_LENGTH; i++)
+            str[i] = GetSpeciesName(species)[i];
         WrapFontIdToFit(str, str + i, FONT_NORMAL, 60);
         break;
     case 0:
@@ -4883,28 +4874,28 @@ u16 CreateMonSpriteFromNationalDexNumber(enum NationalDexOrder nationalNum, s16 
     return CreateMonPicSprite(species, FALSE, GetPokedexMonPersonality(species), TRUE, x, y, paletteSlot, TAG_NONE);
 }
 
-u16 GetPokemonScaleFromNationalDexNumber(u16 nationalNum)
+u16 GetPokemonScaleFromNationalDexNumber(enum NationalDexOrder nationalNum)
 {
-    nationalNum = NationalPokedexNumToSpeciesForm(nationalNum);
-    return gSpeciesInfo[nationalNum].pokemonScale;
+    enum Species species = NationalPokedexNumToSpeciesForm(nationalNum);
+    return gSpeciesInfo[species].pokemonScale;
 }
 
-u16 GetPokemonOffsetFromNationalDexNumber(u16 nationalNum)
+u16 GetPokemonOffsetFromNationalDexNumber(enum NationalDexOrder nationalNum)
 {
-    nationalNum = NationalPokedexNumToSpeciesForm(nationalNum);
-    return gSpeciesInfo[nationalNum].pokemonOffset;
+    enum Species species = NationalPokedexNumToSpeciesForm(nationalNum);
+    return gSpeciesInfo[species].pokemonOffset;
 }
 
-u16 GetTrainerScaleFromNationalDexNumber(u16 nationalNum)
+u16 GetTrainerScaleFromNationalDexNumber(enum NationalDexOrder nationalNum)
 {
-    nationalNum = NationalPokedexNumToSpeciesForm(nationalNum);
-    return gSpeciesInfo[nationalNum].trainerScale;
+    enum Species species = NationalPokedexNumToSpeciesForm(nationalNum);
+    return gSpeciesInfo[species].trainerScale;
 }
 
-u16 GetTrainerOffsetFromNationalDexNumber(u16 nationalNum)
+u16 GetTrainerOffsetFromNationalDexNumber(enum NationalDexOrder nationalNum)
 {
-    nationalNum = NationalPokedexNumToSpeciesForm(nationalNum);
-    return gSpeciesInfo[nationalNum].trainerOffset;
+    enum Species species = NationalPokedexNumToSpeciesForm(nationalNum);
+    return gSpeciesInfo[species].trainerOffset;
 }
 
 u16 CreateSizeScreenTrainerPic(u16 species, s16 x, s16 y, s8 paletteSlot)

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -3110,7 +3110,7 @@ bool8 ScrCmd_checkobjectat(struct ScriptContext *ctx)
 
 bool8 Scrcmd_getsetpokedexflag(struct ScriptContext *ctx)
 {
-    enum NationalDexOrder speciesId = SpeciesToNationalPokedexNum(VarGet(ScriptReadHalfword(ctx)));
+    enum NationalDexOrder natDexNum = SpeciesToNationalPokedexNum(VarGet(ScriptReadHalfword(ctx)));
     u32 desiredFlag = VarGet(ScriptReadHalfword(ctx));
 
     if (desiredFlag == FLAG_SET_CAUGHT || desiredFlag == FLAG_SET_SEEN)
@@ -3118,10 +3118,10 @@ bool8 Scrcmd_getsetpokedexflag(struct ScriptContext *ctx)
     else
         Script_RequestEffects(SCREFF_V1);
 
-    gSpecialVar_Result = GetSetPokedexFlag(speciesId, desiredFlag);
+    gSpecialVar_Result = GetSetPokedexFlag(natDexNum, desiredFlag);
 
     if (desiredFlag == FLAG_SET_CAUGHT)
-        GetSetPokedexFlag(speciesId, FLAG_SET_SEEN);
+        GetSetPokedexFlag(natDexNum, FLAG_SET_SEEN);
 
     return FALSE;
 }


### PR DESCRIPTION

## Description
Added some missing type checks for functions like `GetSetPokedexFlag` and `HandleSetPokedexFlag`.

Also fixes potential issues in:
- `GetPokedexRatingText`, where it was passing species to `GetSetPokedexFlag` instead of National Dex number.
- `GetKantoPokedexCount`, where post-gen1 (pre-)evolutions could make it so Kanto dex would no longer match National Dex number.

### Large Language Models (AI)
Never.

## Discord contact info
n/a
