### PR TITLE
Fixes G-Max Tartness additional effect

### DIFF
--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -23436,7 +23436,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
         .category = DAMAGE_CATEGORY_PHYSICAL,
         .battleAnimScript = gBattleAnimMove_GMaxTartness,
         .additionalEffects = ADDITIONAL_EFFECTS({
-            .moveEffect = STAT_CHANGE_EFFECT_MINUS,
+            .moveEffect = MOVE_EFFECT_STAT_MINUS,
             .evasion = 1,
             .onSide = TRUE,
         }),


### PR DESCRIPTION
Caused the move to not deal damage in upcoming and could behave strangely.

The effect used currently is supposed to only be used by status moves.

## Discord contact info
PhallenTree