### PR TITLE
Make: Avoid unnecessary incremental relinks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,6 @@ endif
 LIBPATH := -L "$(dir $(shell $(PATH_ARMCC) -mthumb -print-file-name=libgcc.a))" -L "$(dir $(shell $(PATH_ARMCC) -mthumb -print-file-name=libnosys.a))" -L "$(dir $(shell $(PATH_ARMCC) -mthumb -print-file-name=libc.a))"
 LIB := $(LIBPATH) -lc -lnosys -lgcc -L../../libagbsyscall -lagbsyscall
 LIBAGBSYSCALL := libagbsyscall/libagbsyscall.a
-LIBAGBSYSCALL_SRCS := libagbsyscall/Makefile libagbsyscall/libagbsyscall.s
 # Enable debug info if set
 ifeq ($(DINFO),1)
   override CFLAGS += -g
@@ -273,6 +272,7 @@ MAKEFLAGS += --no-print-directory
 
 RULES_NO_SCAN += libagbsyscall clean clean-assets tidy tidymodern tidycheck tidyrelease generated clean-generated clean-teachables clean-teachables_intermediates
 .PHONY: all rom agbcc modern compare check debug release $(TESTELF)
+.PHONY: FORCE_LIBAGBSYSCALL
 .PHONY: $(RULES_NO_SCAN)
 
 infoshell = $(foreach line, $(shell $1 | sed "s/ /__SPACE__/g"), $(info $(subst __SPACE__, ,$(line))))
@@ -573,8 +573,10 @@ LD_SCRIPT := ld_script_modern.ld
 libagbsyscall: $(LIBAGBSYSCALL)
 	@:
 
-$(LIBAGBSYSCALL): $(LIBAGBSYSCALL_SRCS)
+$(LIBAGBSYSCALL): FORCE_LIBAGBSYSCALL
 	@$(MAKE) -C libagbsyscall TOOLCHAIN=$(TOOLCHAIN) MODERN=1
+
+FORCE_LIBAGBSYSCALL:
 
 # Enable LTO LDFLAGS if set
 ifneq ($(LTO),0)

--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,8 @@ endif
 
 LIBPATH := -L "$(dir $(shell $(PATH_ARMCC) -mthumb -print-file-name=libgcc.a))" -L "$(dir $(shell $(PATH_ARMCC) -mthumb -print-file-name=libnosys.a))" -L "$(dir $(shell $(PATH_ARMCC) -mthumb -print-file-name=libc.a))"
 LIB := $(LIBPATH) -lc -lnosys -lgcc -L../../libagbsyscall -lagbsyscall
+LIBAGBSYSCALL := libagbsyscall/libagbsyscall.a
+LIBAGBSYSCALL_SRCS := libagbsyscall/Makefile libagbsyscall/libagbsyscall.s
 # Enable debug info if set
 ifeq ($(DINFO),1)
   override CFLAGS += -g
@@ -347,11 +349,10 @@ LD_SCRIPT_TEST := ld_script_test.ld
 $(OBJ_DIR)/ld_script_test.ld: $(LD_SCRIPT_TEST)
 	cd $(OBJ_DIR) && sed "s#tools/#../../tools/#g" ../../$(LD_SCRIPT_TEST) > ld_script_test.ld
 
-$(TESTELF): $(OBJ_DIR)/ld_script_test.ld $(OBJS) $(TEST_OBJS) libagbsyscall tools check-tools
+$(TESTELF): $(OBJ_DIR)/ld_script_test.ld $(OBJS) $(TEST_OBJS) $(LIBAGBSYSCALL) | tools check-tools
 	@echo "cd $(OBJ_DIR) && $(LD) -T ld_script_test.ld -o ../../$@ <objects> <test-objects> <lib>"
 	@cd $(OBJ_DIR) && $(LD) $(TESTLDFLAGS) -T ld_script_test.ld -o ../../$@ $(OBJS_REL) $(TEST_OBJS_REL) $(LIB)
 	$(FIX) $@ -t"$(TITLE)" -c$(GAME_CODE) -m$(MAKER_CODE) -r$(REVISION) -d0 --silent
-	$(PATCHELF) $(TESTELF) gTestRunnerArgv "$(TESTS:%*=%)\0"
 
 ifeq ($(GITHUB_REPOSITORY_OWNER),rh-hideout)
 TEST_SKIP_IS_FAIL := \x01
@@ -361,7 +362,7 @@ endif
 
 check: $(TESTELF)
 	@cp $< $(HEADLESSELF)
-	$(PATCHELF) $(HEADLESSELF) gTestRunnerHeadless '\x01' gTestRunnerSkipIsFail "$(TEST_SKIP_IS_FAIL)"
+	$(PATCHELF) $(HEADLESSELF) gTestRunnerArgv "$(TESTS:%*=%)\0" gTestRunnerHeadless '\x01' gTestRunnerSkipIsFail "$(TEST_SKIP_IS_FAIL)"
 	$(ROMTESTHYDRA) $(ROMTEST) $(OBJCOPY) $(HEADLESSELF)
 
 # Other rules
@@ -564,21 +565,24 @@ LD_SCRIPT := ld_script_modern.ld
 
 # Final rules
 
-libagbsyscall:
+libagbsyscall: $(LIBAGBSYSCALL)
+	@:
+
+$(LIBAGBSYSCALL): $(LIBAGBSYSCALL_SRCS)
 	@$(MAKE) -C libagbsyscall TOOLCHAIN=$(TOOLCHAIN) MODERN=1
 
 # Enable LTO LDFLAGS if set
 ifneq ($(LTO),0)
 LDFLAGS := -march=armv4t -mabi=apcs-gnu -mcpu=arm7tdmi -Xlinker -Map=../../$(MAP) -Xlinker --print-memory-usage -Xassembler -meabi=5 -Xassembler -march=armv4t -Xassembler -mcpu=arm7tdmi -Xlinker --gc-sections
 LDFLAGS += -Xlinker -flto=auto
-$(ELF): $(LD_SCRIPT) $(OBJS) libagbsyscall
+$(ELF): $(LD_SCRIPT) $(OBJS) $(LIBAGBSYSCALL)
 	@echo "cd $(OBJ_DIR) && $(ARMCC) $(LDFLAGS) -T ../../$< -o ../../$@ <objs> <libs>"
 	+@cd $(OBJ_DIR) && $(ARMCC) $(LDFLAGS) -T ../../$< -o ../../$@ $(OBJS_REL) $(LIB)
 	$(FIX) $@ -t"$(TITLE)" -c$(GAME_CODE) -m$(MAKER_CODE) -r$(REVISION) --silent
 else
 # Output .map file, memory usage readout and gc sections to clean-up unused data
 LDFLAGS = -Map ../../$(MAP) --print-memory-usage --gc-sections
-$(ELF): $(LD_SCRIPT) $(OBJS) libagbsyscall
+$(ELF): $(LD_SCRIPT) $(OBJS) $(LIBAGBSYSCALL)
 	@cd $(OBJ_DIR) && $(LD) $(LDFLAGS) -T ../../$<  -o ../../$@ $(OBJS_REL) $(LIB) | cat
 	@echo "cd $(OBJ_DIR) && $(LD) $(LDFLAGS) -T ../../$< -o ../../$@ <objs> <libs> | cat"
 	$(FIX) $@ -t"$(TITLE)" -c$(GAME_CODE) -m$(MAKER_CODE) -r$(REVISION) --silent

--- a/Makefile
+++ b/Makefile
@@ -270,7 +270,7 @@ MAKEFLAGS += --no-print-directory
 # Delete files that weren't built properly
 .DELETE_ON_ERROR:
 
-RULES_NO_SCAN += libagbsyscall clean clean-assets tidy tidymodern tidycheck tidyrelease generated clean-generated clean-teachables clean-teachables_intermediates
+RULES_NO_SCAN += clean clean-assets tidy tidymodern tidycheck tidyrelease generated clean-generated clean-teachables clean-teachables_intermediates
 .PHONY: all rom agbcc modern compare check debug release $(TESTELF)
 .PHONY: FORCE_LIBAGBSYSCALL
 .PHONY: $(RULES_NO_SCAN)
@@ -570,9 +570,8 @@ LD_SCRIPT := ld_script_modern.ld
 
 # Final rules
 
-libagbsyscall: $(LIBAGBSYSCALL)
-	@:
-
+# Always let the nested Makefile check its own dependencies. The archive is only
+# updated when one of its inputs changes, so unchanged builds do not relink.
 $(LIBAGBSYSCALL): FORCE_LIBAGBSYSCALL
 	@$(MAKE) -C libagbsyscall TOOLCHAIN=$(TOOLCHAIN) MODERN=1
 

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ ASSETS_DIR_NAME := $(BUILD_DIR)/assets
 ELF_NAME := $(ROM_NAME:.gba=.elf)
 MAP_NAME := $(ROM_NAME:.gba=.map)
 TESTELF := $(ROM_NAME:.gba=-test.elf)
+TESTELF_BASE := $(ROM_NAME:.gba=-test-base.elf)
 HEADLESSELF := $(ROM_NAME:.gba=-test-headless.elf)
 
 # Pick our active variables
@@ -271,7 +272,7 @@ MAKEFLAGS += --no-print-directory
 .DELETE_ON_ERROR:
 
 RULES_NO_SCAN += libagbsyscall clean clean-assets tidy tidymodern tidycheck tidyrelease generated clean-generated clean-teachables clean-teachables_intermediates
-.PHONY: all rom agbcc modern compare check debug release
+.PHONY: all rom agbcc modern compare check debug release $(TESTELF)
 .PHONY: $(RULES_NO_SCAN)
 
 infoshell = $(foreach line, $(shell $1 | sed "s/ /__SPACE__/g"), $(info $(subst __SPACE__, ,$(line))))
@@ -349,10 +350,14 @@ LD_SCRIPT_TEST := ld_script_test.ld
 $(OBJ_DIR)/ld_script_test.ld: $(LD_SCRIPT_TEST)
 	cd $(OBJ_DIR) && sed "s#tools/#../../tools/#g" ../../$(LD_SCRIPT_TEST) > ld_script_test.ld
 
-$(TESTELF): $(OBJ_DIR)/ld_script_test.ld $(OBJS) $(TEST_OBJS) $(LIBAGBSYSCALL) | tools check-tools
+$(TESTELF_BASE): $(OBJ_DIR)/ld_script_test.ld $(OBJS) $(TEST_OBJS) $(LIBAGBSYSCALL) | tools check-tools
 	@echo "cd $(OBJ_DIR) && $(LD) -T ld_script_test.ld -o ../../$@ <objects> <test-objects> <lib>"
 	@cd $(OBJ_DIR) && $(LD) $(TESTLDFLAGS) -T ld_script_test.ld -o ../../$@ $(OBJS_REL) $(TEST_OBJS_REL) $(LIB)
 	$(FIX) $@ -t"$(TITLE)" -c$(GAME_CODE) -m$(MAKER_CODE) -r$(REVISION) -d0 --silent
+
+$(TESTELF): $(TESTELF_BASE)
+	@cp $< $@
+	$(PATCHELF) $@ gTestRunnerArgv "$(TESTS:%*=%)\0"
 
 ifeq ($(GITHUB_REPOSITORY_OWNER),rh-hideout)
 TEST_SKIP_IS_FAIL := \x01
@@ -362,7 +367,7 @@ endif
 
 check: $(TESTELF)
 	@cp $< $(HEADLESSELF)
-	$(PATCHELF) $(HEADLESSELF) gTestRunnerArgv "$(TESTS:%*=%)\0" gTestRunnerHeadless '\x01' gTestRunnerSkipIsFail "$(TEST_SKIP_IS_FAIL)"
+	$(PATCHELF) $(HEADLESSELF) gTestRunnerHeadless '\x01' gTestRunnerSkipIsFail "$(TEST_SKIP_IS_FAIL)"
 	$(ROMTESTHYDRA) $(ROMTEST) $(OBJCOPY) $(HEADLESSELF)
 
 # Other rules
@@ -393,7 +398,7 @@ tidymodern:
 	rm -rf $(OBJ_DIR_NAME)
 
 tidycheck:
-	rm -f $(TESTELF) $(HEADLESSELF)
+	rm -f $(TESTELF_BASE) $(TESTELF) $(HEADLESSELF)
 	rm -rf $(OBJ_DIR_NAME_TEST)
 
 tidydebug:


### PR DESCRIPTION
## Description

Small Makefile changes to improve incremental builds:

- Linker outputs now depend on the actual `libagbsyscall.a` archive. The archive recipe delegates its freshness check to the nested Makefile, so unchanged builds do not relink while syscall source changes propagate immediately.
- Test builds keep an internal unfiltered base ELF. Each invocation recreates the public `poke*-test.elf` from that base and applies `TESTS`, preserving the documented debugger workflow without repeating the expensive link.
- `check` copies the filtered public ELF and adds only the headless runner flags.
- Tool setup remains order-only, so the required tools are ready without their phony setup targets making the ELF stale.

The reusable syscall dependency change has also been prepared separately against `pret/pokeemerald:master`; the test-runner changes remain expansion-specific.

## Validation

- Clean Emerald, FireRed, and LeafGreen builds, followed by unchanged second builds with identical hashes and timestamps.
- Two sequential FireRed filters passed through mGBA without relinking the internal base test ELF.
- The public test ELF changed with each `TESTS` value and each filter selected the expected test.
- Changing `libagbsyscall.s` rebuilt both the archive and game ELF; an unchanged follow-up build touched neither.
- `git diff --check`.

### Large Language Models (AI)

AI was primarily responsible for implementation and validation, and I reviewed the design.

I reviewed and approved the final diff.

## Discord contact info

.stealthyturtle
