### PR TITLE
BXPY: Fixed an issue related to empty trainer parties resulting from non-default difficulty modes

### DIFF
--- a/src/bxpy.c
+++ b/src/bxpy.c
@@ -313,10 +313,10 @@ static void BXPY_InitTrainerBattleParams(u32 trainerA, const u8 *loseTextA, u32 
 static void BXPY_PrepareEnemyParty(u32 bringSize, u32 battleFlags)
 {
     ZeroEnemyPartyMons();
-    CreateNPCTrainerPartyFromTrainer(&gParties[B_TRAINER_OPPONENT_A][0], &gTrainers[GetCurrentDifficultyLevel()][TRAINER_BATTLE_PARAM.opponentA]);
+    CreateNPCTrainerPartyFromTrainer(&gParties[B_TRAINER_OPPONENT_A][0], &gTrainers[GetTrainerDifficultyLevel(TRAINER_BATTLE_PARAM.opponentA)][TRAINER_BATTLE_PARAM.opponentA]);
 
     if (BXPY_BattleGreaterThanTwoTrainers())
-        CreateNPCTrainerPartyFromTrainer(&gParties[B_TRAINER_OPPONENT_B][0], &gTrainers[GetCurrentDifficultyLevel()][TRAINER_BATTLE_PARAM.opponentB]);
+        CreateNPCTrainerPartyFromTrainer(&gParties[B_TRAINER_OPPONENT_B][0], &gTrainers[GetTrainerDifficultyLevel(TRAINER_BATTLE_PARAM.opponentB)][TRAINER_BATTLE_PARAM.opponentB]);
 }
 
 void BXPY_GetEnemyEnterMons(enum BattlerId battler, u8* enteredMons, u32 pickSize)


### PR DESCRIPTION
Title. Targets upcoming due to BXPY only being present in upcoming at the time of opening this PR.

## Description
This fixes a bug in BXPY (Bring X Pick Y) where if the player is on a different difficulty mode than `DIFFICULTY_NORMAL`, the function BXPY uses to pull trainer party data does not properly check for difficulty.

This PR emulates the trainer party generation in `GetTrainerStructFromId` by using `GetTrainerDifficultyLevel` in BXPY_PrepareEnemyParty instead of `GetCurrentDifficultyLevel`.

### Large Language Models (AI)
None

## Issue(s) that this PR fixes
Fixes #10736

## Discord contact info
linathan
