### PR TITLE
Fix Sheer Force suppressing King's Rock and Razor Fang flinches

### DIFF
--- a/include/battle_set_effect.h
+++ b/include/battle_set_effect.h
@@ -14,6 +14,7 @@ struct SetEffect
     u16 primary:1;
     u16 certain:1;
     u16 onSide:1;
+    u16 bypassSheerForce:1;
 };
 
 void SetMoveEffect(struct BattleCalcValues *cv, struct SetEffect *se);

--- a/include/constants/battle_set_effect.h
+++ b/include/constants/battle_set_effect.h
@@ -133,6 +133,7 @@ enum SetMoveEffectFlags
     EFFECT_PRIMARY    = (1 << 0),
     EFFECT_CERTAIN    = (1 << 1),
     EFFECT_ON_SIDE    = (1 << 2),
+    EFFECT_BYPASS_SHEER_FORCE = (1 << 3),
 };
 
 #endif // GUARD_CONSTANTS_BATTLE_SET_EFFECT_H

--- a/src/battle_hold_effects.c
+++ b/src/battle_hold_effects.c
@@ -173,7 +173,8 @@ static enum ItemEffect TryKingsRock(enum BattlerId battlerAtk, enum BattlerId ba
         holdEffectParam *= 2;
     if (ability != ABILITY_STENCH && RandomPercentage(RNG_HOLD_EFFECT_FLINCH, holdEffectParam))
     {
-        SetMoveEffectHelper(battlerAtk, battlerDef, MOVE_EFFECT_FLINCH, gBattlescriptCurrInstr, NO_FLAGS);
+        // This item effect is independent of Sheer Force; moves that natively flinch were rejected above.
+        SetMoveEffectHelper(battlerAtk, battlerDef, MOVE_EFFECT_FLINCH, gBattlescriptCurrInstr, EFFECT_BYPASS_SHEER_FORCE);
         effect = ITEM_EFFECT_OTHER;
     }
 

--- a/src/battle_set_effect.c
+++ b/src/battle_set_effect.c
@@ -1426,6 +1426,7 @@ void SetMoveEffect(struct BattleCalcValues *cv, struct SetEffect *se)
     if (!se->primary && !affectsUser && IsMoveEffectBlockedByTarget(cv->abilities[se->effectBattler]))
         se->moveEffect = MOVE_EFFECT_NONE;
     else if (!se->primary
+          && !se->bypassSheerForce
           && IsSheerForceAffected(cv->move, cv->abilities[cv->battlerAtk])
           && !(se->moveEffect == MOVE_EFFECT_ORDER_UP && gBattleStruct->battlerState[cv->battlerAtk].commanderSpecies != SPECIES_NONE))
         se->moveEffect = MOVE_EFFECT_NONE;
@@ -1456,8 +1457,9 @@ void SetMoveEffectHelper(enum BattlerId battlerAtk, enum BattlerId effectBattler
     se.moveEffect = moveEffect;
     se.script = battleScript;
     se.effectBattler = effectBattler;
-    se.primary = effectFlags & EFFECT_PRIMARY;
-    se.certain = effectFlags & EFFECT_CERTAIN;
+    se.primary = (effectFlags & EFFECT_PRIMARY) != 0;
+    se.certain = (effectFlags & EFFECT_CERTAIN) != 0;
+    se.bypassSheerForce = (effectFlags & EFFECT_BYPASS_SHEER_FORCE) != 0;
 
     SetMoveEffect(&cv, &se);
 }
@@ -1539,4 +1541,3 @@ static bool32 IsFinalStrikeEffect(enum MoveEffect moveEffect)
         return FALSE;
     }
 }
-

--- a/test/battle/hold_effect/flinch.c
+++ b/test/battle/hold_effect/flinch.c
@@ -53,6 +53,7 @@ SINGLE_BATTLE_TEST("Kings Rock can flinch with a non-flinching move boosted by S
 
 SINGLE_BATTLE_TEST("Kings Rock cannot flinch with a flinching move boosted by Sheer Force")
 {
+    PASSES_RANDOMLY(0, 100, RNG_HOLD_EFFECT_FLINCH);
     GIVEN {
         ASSUME(MoveIsAffectedBySheerForce(MOVE_BITE));
         ASSUME(MoveHasAdditionalEffect(MOVE_BITE, MOVE_EFFECT_FLINCH));
@@ -60,13 +61,12 @@ SINGLE_BATTLE_TEST("Kings Rock cannot flinch with a flinching move boosted by Sh
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
         TURN {
-            MOVE(player, MOVE_BITE, secondaryEffect: TRUE, WITH_RNG(RNG_HOLD_EFFECT_FLINCH, TRUE));
+            MOVE(player, MOVE_BITE, secondaryEffect: TRUE);
             MOVE(opponent, MOVE_SCRATCH);
         }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_BITE, player);
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
-        NOT MESSAGE("The opposing Wobbuffet flinched and couldn't move!");
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
     }
 }
 

--- a/test/battle/hold_effect/flinch.c
+++ b/test/battle/hold_effect/flinch.c
@@ -35,6 +35,41 @@ SINGLE_BATTLE_TEST("Kings Rock does not increase flinch chance of a move that ha
     }
 }
 
+SINGLE_BATTLE_TEST("Kings Rock can flinch with a non-flinching move boosted by Sheer Force")
+{
+    PASSES_RANDOMLY(10, 100, RNG_HOLD_EFFECT_FLINCH);
+    GIVEN {
+        ASSUME(MoveIsAffectedBySheerForce(MOVE_FLARE_BLITZ));
+        ASSUME(MoveHasAdditionalEffect(MOVE_FLARE_BLITZ, MOVE_EFFECT_FLINCH) == FALSE);
+        PLAYER(SPECIES_NIDOKING) { Ability(ABILITY_SHEER_FORCE); Item(ITEM_KINGS_ROCK); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_FLARE_BLITZ); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FLARE_BLITZ, player);
+        MESSAGE("The opposing Wobbuffet flinched and couldn't move!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Kings Rock cannot flinch with a flinching move boosted by Sheer Force")
+{
+    GIVEN {
+        ASSUME(MoveIsAffectedBySheerForce(MOVE_BITE));
+        ASSUME(MoveHasAdditionalEffect(MOVE_BITE, MOVE_EFFECT_FLINCH));
+        PLAYER(SPECIES_NIDOKING) { Ability(ABILITY_SHEER_FORCE); Item(ITEM_KINGS_ROCK); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN {
+            MOVE(player, MOVE_BITE, secondaryEffect: TRUE, WITH_RNG(RNG_HOLD_EFFECT_FLINCH, TRUE));
+            MOVE(opponent, MOVE_SCRATCH);
+        }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BITE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
+        NOT MESSAGE("The opposing Wobbuffet flinched and couldn't move!");
+    }
+}
+
 DOUBLE_BATTLE_TEST("Kings Rock flinch chance boosted by Serene Grace does not stack with rainbow")
 {
     PASSES_RANDOMLY(20, 100, RNG_HOLD_EFFECT_FLINCH);


### PR DESCRIPTION
I found out while looking for an answer to a question on Discors that King's Rock and Razor Fang flinches were incorrectly treated as move-generated secondary effects, causing Sheer Force to suppress them whenever it boosted the move.

Sources:
https://wiki.xn--rckteqa2e.com/wiki/かみつく
https://www.smogon.com/forums/threads/sword-shield-battle-mechanics-research.3655528/post-8905424

Cartridge can give King's Rock flinching to a Sheer Force-boosted move with no native flinch effect, such as Flare Blitz. Expansion's current generic Sheer Force suppression appears to block that King's Rock effect too. This change allows item-generated flinches to bypass Sheer Force suppression while preserving the existing restriction for moves with a native flinch effect. As a result:
- Flare Blitz with Sheer Force retains the item's 10% flinch chance.
- Bite with Sheer Force has a 0% flinch chance.

Shield Dust, Covert Cloak, Substitute, and Inner Focus interactions remain unchanged. I implemented regression tests to cover both the eligible Flare Blitz case and the ineligible Bite case. I also made a fix to convert assignments to explicit boolean normalization, they previously worked by coincidence because its mask equals 1. EFFECT_CERTAIN could truncate 2 to 0 when assigned to a one-bit field.

### Large Language Models (AI)

No AI has been used.

## Discord contact info

syreldar