### PR TITLE
Fix Hydra output buffering and summary memory safety

### DIFF
--- a/tools/mgba-rom-test-hydra/main.c
+++ b/tools/mgba-rom-test-hydra/main.c
@@ -73,6 +73,7 @@ void *memrchr(const void *s_, int c, size_t n)
 
 #define MAX_PROCESSES             32 // See also test/test.h
 #define MAX_SUMMARY_TESTS_TO_LIST 50
+#define MAX_OUTPUT_BUFFER_SIZE (1024 * 1024)
 
 #define ARRAY_COUNT(arr) (sizeof((arr)) / sizeof((arr)[0]))
 
@@ -104,6 +105,7 @@ struct Runner
     size_t output_buffer_size;
     size_t output_buffer_capacity;
     char *output_buffer;
+    bool output_truncated;
     int passes;
     int expected_fails;
     int expected_fails_passing;
@@ -125,6 +127,10 @@ void push_summary_result(struct SummaryResults *summaries, const struct Runner *
 
         memcpy(result->filename_line, runner->filename_line, sizeof(result->filename_line));
 
+        result->output_line[0] = '\0';
+        if (runner->output_buffer_size == 0)
+            return;
+
         // Extract the last line of the output buffer.
         // NOTE: '- 1' because 'output_buffer' ends with a '\n'.
         const char *nl = memrchr(runner->output_buffer, '\n', runner->output_buffer_size - 1);
@@ -139,18 +145,15 @@ void push_summary_result(struct SummaryResults *summaries, const struct Runner *
         if (colon)
         {
             colon++;
-            n = nl + nl_n - colon;
+            n = min(nl + nl_n - colon, sizeof(result->output_line) - 1);
             memcpy(result->output_line, colon, n);
         }
         else
         {
-            n = nl_n;
+            n = min(nl_n, sizeof(result->output_line) - 1);
             memcpy(result->output_line, nl, n);
         }
-        if (n < sizeof(result->output_line))
-            result->output_line[n] = '\0';
-        else
-            result->output_line[sizeof(result->output_line) - 1] = '\0';
+        result->output_line[n] = '\0';
     }
 }
 
@@ -330,8 +333,11 @@ add_to_results:
                     fprintf(stdout, "[%0*d] %s: ", runners_digits, i, runner->test_name);
                     fwrite(soc, 1, eol - soc, stdout);
                     fprint_buffer(stdout, runner->output_buffer, runner->output_buffer_size);
+                    if (runner->output_truncated)
+                        fprintf(stdout, "[Further test output was truncated.]\n");
                     strcpy(runner->test_name, "WAITING...");
                     runner->output_buffer_size = 0;
+                    runner->output_truncated = false;
                     break;
 
                 default:
@@ -341,9 +347,23 @@ add_to_results:
             else
             {
 buffer_output:
+                // Keep complete lines and continue parsing result commands even
+                // when a broken emulator floods its diagnostic output.
+                if ((size_t)(eol - soc) > MAX_OUTPUT_BUFFER_SIZE - runner->output_buffer_size)
+                {
+                    if (!runner->output_truncated)
+                    {
+                        fprintf(stderr, "[%0*d] %s (%s): test output exceeded %u bytes; further output is truncated. The worker may be stuck.\n",
+                                runners_digits, i, runner->test_name, runner->filename_line,
+                                (unsigned)MAX_OUTPUT_BUFFER_SIZE);
+                        runner->output_truncated = true;
+                    }
+                }
+                if (runner->output_truncated)
+                    goto next_line;
                 if (runner->output_buffer_size + eol - soc >= runner->output_buffer_capacity)
                 {
-                    runner->output_buffer_capacity *= 2;
+                    runner->output_buffer_capacity = min(runner->output_buffer_capacity * 2, MAX_OUTPUT_BUFFER_SIZE);
                     if (runner->output_buffer_capacity < runner->output_buffer_size + eol - soc)
                         runner->output_buffer_capacity = runner->output_buffer_size + eol - soc;
                     runner->output_buffer = realloc(runner->output_buffer, runner->output_buffer_capacity);
@@ -361,12 +381,13 @@ buffer_output:
         {
             fwrite(sol, 1, eol - sol, stdout);
         }
+next_line:
         sol += n;
         consumed += n;
         remaining -= n;
     }
 
-    memcpy(runner->input_buffer, sol, remaining);
+    memmove(runner->input_buffer, sol, remaining);
     runner->input_buffer_size -= consumed;
 
     if (runner->input_buffer_size == runner->input_buffer_capacity)


### PR DESCRIPTION
@miriamlefae brought up some bugs regarding tests, so I analyzed the runner for a bit and found out Hydra buffers test diagnostics until a result arrives. If an emulator repeatedly emits errors without completing the test, that buffer can grow indefinitely.

This change:
1. Caps buffered test output at 1 MiB per worker, retaining complete lines.
2. Reports truncation with the worker ID, test name, and source location while continuing to parse result commands.
3. Bounds diagnostic copies into the 256-byte summary field.
4. Handles empty summary output before subtracting from its size.
5. Uses `memmove` when compacting potentially overlapping input-buffer regions.

### Large Language Models (AI)

No AI has been used.

## Feature(s) this PR does NOT handle:

- The underlying battle hangs, ROM heap assertions, and timeout recovery.
- The output cap does not terminate stuck workers or bound input lines without a newline.

## Discord contact info

syreldar