### PR TITLE
Fix overworld encounter flee sound playing every step in towns

### DIFF
--- a/src/wild_encounter_ow.c
+++ b/src/wild_encounter_ow.c
@@ -1122,9 +1122,6 @@ void TryDespawnOWEsCrossingMapConnection(void)
     if (gMapHeader.mapType != MAP_TYPE_CITY && gMapHeader.mapType != MAP_TYPE_TOWN)
         return;
 
-    if (WE_OWE_DESPAWN_SOUND)
-        PlaySE(SE_FLEE);
-        
     DespawnAllOverworldWildEncounters(OWE_GENERATED, 0);
 }
 


### PR DESCRIPTION
Fixes `SE_FLEE` playing every step in towns and cities when `WE_OWE_DESPAWN_SOUND` is enabled, including when `WE_OW_ENCOUNTERS` is disabled.

`TryDespawnOWEsCrossingMapConnection()` runs on camera tile updates and played the sound without checking whether any encounters were removed. I'll remove this redundant call, since actual encounter removal already handles despawn sounds through `DoOWEDespawnAnim()`.

`WE_OWE_FLEE_DESPAWN` was unrelated to the cause.

### Large Language Models (AI)

No AI has been used.

## Issue(s) that this PR fixes

Fixes #10750 

## Discord contact info

syreldar