### PR TITLE
Allow onSide to be used by any additional effect

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -740,7 +740,8 @@ struct BattleStruct
     u32 dancerSavedTarget:3;
     u32 statChangeBattler:3;
     u32 overworldWeatherPresent:1;
-    u32 padding5:4;
+    u32 setEffectOnAlly:1;
+    u32 padding5:3;
     enum BattlerId statusedBattler:4; // For Synchronize/Poison Puppeteer
     enum BattlerId statusInflicterBattler:4; // For Synchronize/Poison Puppeteer
     enum MoveEffect synchronizeStatus;

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -2681,18 +2681,16 @@ static enum CancelerResult CancelerPreAttackMoveEffect(struct BattleCalcValues *
         while (gBattleStruct->additionalEffectsCounter < numAdditionalEffects)
         {
             const struct AdditionalEffect *additionalEffect = GetMoveAdditionalEffectById(cv->move, gBattleStruct->additionalEffectsCounter);
-            gBattleStruct->additionalEffectsCounter++;
-
-            if (!additionalEffect->preAttackEffect)
-                continue;
 
             bool32 isSelf = gEffectBattler == cv->battlerAtk;
 
-            if (isSelf != additionalEffect->self)
+            if (!additionalEffect->preAttackEffect
+             || isSelf != additionalEffect->self
+             || (!isSelf && ShouldSkipFailureCheckOnBattler(cv->battlerAtk, gEffectBattler)))
+            {
+                gBattleStruct->additionalEffectsCounter++;
                 continue;
-
-            if (!isSelf && ShouldSkipFailureCheckOnBattler(cv->battlerAtk, gEffectBattler))
-                continue;
+            }
 
             TryTriggerAdditionalEffect(cv, additionalEffect, gEffectBattler);
 
@@ -3373,13 +3371,15 @@ static enum MoveEndResult MoveEndSubstituteBlock(struct BattleCalcValues *cv)
                  && battlerDef != cv->battlerAtk)
                 {
                     const struct AdditionalEffect *additionalEffect = GetMoveAdditionalEffectById(gCurrentMove, gBattleStruct->additionalEffectsCounter);
-                    gBattleStruct->additionalEffectsCounter++;
 
                     // Various checks for if this move effect can be applied this turn
                     if (!CanApplyAdditionalEffect(cv->battlerAtk, battlerDef, additionalEffect)
                      || !ShouldApplyAfterHitEffects(cv->battlerAtk, battlerDef)
                      || additionalEffect->self) // handled in MoveEndAdditionalEffects
+                    {
+                        gBattleStruct->additionalEffectsCounter++;
                         continue;
+                    }
 
                     TryTriggerAdditionalEffect(cv, additionalEffect, battlerDef);
 
@@ -3861,9 +3861,12 @@ static void TryTriggerAdditionalEffect(struct BattleCalcValues *cv, const struct
 
     bool32 percentChance = CalcSecondaryEffectChance(cv->battlerAtk, cv->abilities[cv->battlerAtk], additionalEffect);
     bool32 isPrimary = percentChance == 0;
+    bool32 failedToTrigger = TRUE;
 
-    // RNG tag is RNG_SECONDARY_EFFECT + gBattleStruct->additionalEffectsCounter - 1 because it's incremented before this function is called
-    if (isPrimary || RandomPercentage(RNG_SECONDARY_EFFECT + gBattleStruct->additionalEffectsCounter - 1, percentChance))
+    // By default, onSide effects apply if they applied on the original target/user
+    if (isPrimary
+     || gBattleStruct->setEffectOnAlly
+     || RandomPercentage(RNG_SECONDARY_EFFECT + gBattleStruct->additionalEffectsCounter, percentChance))
     {
         if (!additionalEffect->self)
             cv->battlerDef = effectBattler; // For SetMoveEffect, will be restored to previous value when run again
@@ -3873,8 +3876,21 @@ static void TryTriggerAdditionalEffect(struct BattleCalcValues *cv, const struct
         se.effectBattler = effectBattler;
         se.primary = isPrimary;
         se.certain = percentChance >= 100;
-        se.onSide = additionalEffect->onSide;
+        failedToTrigger = FALSE;
+
+        if (gBattleStruct->setEffectOnAlly)
+            se.effectBattler = GetPartnerBattler(se.effectBattler);
+        else if (additionalEffect->onSide)
+            gBattleStruct->setEffectOnAlly = TRUE;
+
         SetMoveEffect(cv, &se);
+    }
+
+    // If applying an onSide effect on partner or if unsuccessful, jump to next effect
+    if (se.effectBattler != effectBattler || !additionalEffect->onSide || failedToTrigger)
+    {
+        gBattleStruct->additionalEffectsCounter++;
+        gBattleStruct->setEffectOnAlly = FALSE;
     }
 }
 
@@ -3902,14 +3918,16 @@ static enum MoveEndResult MoveEndAdditionalEffects(struct BattleCalcValues *cv)
          && (!ShouldSkipBattlerForMoveEndSubstitute(effectBattler, cv) || effectBattler == cv->battlerAtk))
         {
             const struct AdditionalEffect *additionalEffect = GetMoveAdditionalEffectById(gCurrentMove, gBattleStruct->additionalEffectsCounter);
-            gBattleStruct->additionalEffectsCounter++;
 
             // Various checks for if this move effect can be applied this turn
             if (!CanApplyAdditionalEffect(cv->battlerAtk, effectBattler, additionalEffect)
              || !ShouldApplyAfterHitEffects(cv->battlerAtk, effectBattler)
              || (additionalEffect->moveEffect == MOVE_EFFECT_STAT_MINUS && additionalEffect->self)
              || (effectBattler == cv->battlerAtk) != additionalEffect->self)
+            {
+                gBattleStruct->additionalEffectsCounter++;
                 continue;
+            }
 
             TryTriggerAdditionalEffect(cv, additionalEffect, effectBattler);
 
@@ -3939,13 +3957,15 @@ static enum MoveEndResult MoveEndAdditionalEffectsLowerStatsAttacker(struct Batt
     if (numAdditionalEffects > gBattleStruct->additionalEffectsCounter)
     {
         const struct AdditionalEffect *additionalEffect = GetMoveAdditionalEffectById(gCurrentMove, gBattleStruct->additionalEffectsCounter);
-        gBattleStruct->additionalEffectsCounter++;
 
         // Various checks for if this move effect can be applied this turn
         if (!CanApplyAdditionalEffect(cv->battlerAtk, cv->battlerAtk, additionalEffect)
          || !ShouldApplyAfterHitEffects(cv->battlerAtk, cv->battlerAtk)
          || !(additionalEffect->moveEffect == MOVE_EFFECT_STAT_MINUS && additionalEffect->self))
+        {
+            gBattleStruct->additionalEffectsCounter++;
             return MOVEEND_RESULT_BREAK; // recall the same state
+        }
 
         TryTriggerAdditionalEffect(cv, additionalEffect, cv->battlerAtk);
 

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -3883,6 +3883,10 @@ static void TryTriggerAdditionalEffect(struct BattleCalcValues *cv, const struct
         else if (additionalEffect->onSide)
             gBattleStruct->setEffectOnAlly = TRUE;
 
+    // Reminders for myself:
+    // - Change secondary effect chance function so it can be used by G-Max Replenish.
+    // - G-Max Meltdown should only apply Torment for 3 turns unlike Torment itself.
+
         SetMoveEffect(cv, &se);
     }
 

--- a/src/battle_set_effect.c
+++ b/src/battle_set_effect.c
@@ -119,7 +119,7 @@ static void HandleSetEffectAbsorb(struct BattleCalcValues *cv, struct SetEffect 
         gBattlerAbility = gBattleScripting.battler = cv->battlerDef;
 
         if (cv->abilities[cv->battlerDef] == ABILITY_LIQUID_OOZE
-         && (GetMoveEffect(cv->move)!= EFFECT_DREAM_EATER || GetConfig(B_DREAM_EATER_LIQUID_OOZE) >= GEN_5))
+         && (GetMoveEffect(cv->move) != EFFECT_DREAM_EATER || GetConfig(B_DREAM_EATER_LIQUID_OOZE) >= GEN_5))
         {
             SetPassiveDamageAmount(cv->battlerAtk, healAmount);
             gBattleCommunication[MULTISTRING_CHOOSER] = B_MSG_ABSORB_OOZE;
@@ -228,8 +228,6 @@ static void HandleSetEffectStatChange(struct BattleCalcValues *cv, struct SetEff
             stage = -1 * stage;
 
         SetStatChange(se->effectBattler, stat, stage);
-        if (se->additionalEffect->onSide)
-            SetStatChange(GetPartnerBattler(se->effectBattler), stat, stage);
     }
 
     BattleScriptPush(se->script);

--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -23198,7 +23198,9 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
         .category = DAMAGE_CATEGORY_PHYSICAL,
         .battleAnimScript = gBattleAnimMove_GMaxBefuddle,
         .additionalEffects = ADDITIONAL_EFFECTS({
-            .moveEffect = MOVE_EFFECT_EFFECT_SPORE_SIDE,
+            .moveEffect = MOVE_EFFECT_RANDOM_FROM_LIST,
+            .argument.randomMoveEffects = { MOVE_EFFECT_SLEEP, MOVE_EFFECT_PARALYSIS, MOVE_EFFECT_POISON },
+            .onSide = TRUE,
         }),
     },
 
@@ -23218,7 +23220,8 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
         .category = DAMAGE_CATEGORY_PHYSICAL,
         .battleAnimScript = gBattleAnimMove_GMaxVoltCrash,
         .additionalEffects = ADDITIONAL_EFFECTS({
-            .moveEffect = MOVE_EFFECT_PARALYZE_SIDE,
+            .moveEffect = MOVE_EFFECT_PARALYSIS,
+            .onSide = TRUE,
         }),
     },
 
@@ -23238,7 +23241,11 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
         .category = DAMAGE_CATEGORY_PHYSICAL,
         .battleAnimScript = gBattleAnimMove_GMaxGoldRush,
         .additionalEffects = ADDITIONAL_EFFECTS({
-            .moveEffect = MOVE_EFFECT_CONFUSE_PAY_DAY_SIDE,
+            .moveEffect = MOVE_EFFECT_CONFUSION,
+            .onSide = TRUE,
+        },
+        {
+            .moveEffect = MOVE_EFFECT_PAYDAY,
         }),
     },
 
@@ -23383,7 +23390,8 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
         .category = DAMAGE_CATEGORY_PHYSICAL,
         .battleAnimScript = gBattleAnimMove_GMaxMalodor,
         .additionalEffects = ADDITIONAL_EFFECTS({
-            .moveEffect = MOVE_EFFECT_POISON_SIDE,
+            .moveEffect = MOVE_EFFECT_POISON,
+            .onSide = TRUE,
         }),
     },
 
@@ -23630,7 +23638,9 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
         .category = DAMAGE_CATEGORY_PHYSICAL,
         .battleAnimScript = gBattleAnimMove_GMaxStunShock,
         .additionalEffects = ADDITIONAL_EFFECTS({
-            .moveEffect = MOVE_EFFECT_POISON_PARALYZE_SIDE,
+            .moveEffect = MOVE_EFFECT_RANDOM_FROM_LIST,
+            .argument.randomMoveEffects = { MOVE_EFFECT_PARALYSIS, MOVE_EFFECT_POISON, MOVE_EFFECT_NONE },
+            .onSide = TRUE,
         }),
     },
 
@@ -23670,7 +23680,8 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
         .category = DAMAGE_CATEGORY_PHYSICAL,
         .battleAnimScript = gBattleAnimMove_GMaxSmite,
         .additionalEffects = ADDITIONAL_EFFECTS({
-            .moveEffect = MOVE_EFFECT_CONFUSE_SIDE,
+            .moveEffect = MOVE_EFFECT_CONFUSION,
+            .onSide = TRUE,
         }),
     },
 

--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -23199,7 +23199,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
         .battleAnimScript = gBattleAnimMove_GMaxBefuddle,
         .additionalEffects = ADDITIONAL_EFFECTS({
             .moveEffect = MOVE_EFFECT_RANDOM_FROM_LIST,
-            .argument.randomMoveEffects = { MOVE_EFFECT_SLEEP, MOVE_EFFECT_PARALYSIS, MOVE_EFFECT_POISON },
+            .argument.randomMoveEffects = { MOVE_EFFECT_PARALYSIS, MOVE_EFFECT_POISON, MOVE_EFFECT_SLEEP },
             .onSide = TRUE,
         }),
     },

--- a/test/battle/gimmick/dynamax.c
+++ b/test/battle/gimmick/dynamax.c
@@ -988,7 +988,7 @@ SINGLE_BATTLE_TEST("Dynamax: G-Max Hydrosnipe has fixed power and ignores abilit
 DOUBLE_BATTLE_TEST("Dynamax: G-Max Volt Crash paralyzes both opponents")
 {
     GIVEN {
-        ASSUME(MoveHasAdditionalEffect(MOVE_G_MAX_VOLT_CRASH, MOVE_EFFECT_PARALYZE_SIDE));
+        ASSUME(MoveHasAdditionalEffect(MOVE_G_MAX_VOLT_CRASH, MOVE_EFFECT_PARALYSIS));
         PLAYER(SPECIES_PIKACHU) { GigantamaxFactor(TRUE); }
         PLAYER(SPECIES_PICHU);
         OPPONENT(SPECIES_WOBBUFFET);
@@ -1013,17 +1013,17 @@ DOUBLE_BATTLE_TEST("Dynamax: G-Max Stun Shock paralyzes or poisons both opponent
 {
     u8 statusAnim;
     u32 rng;
-    PARAMETRIZE { statusAnim = B_ANIM_STATUS_PRZ; rng = STATUS1_PARALYSIS; }
-    PARAMETRIZE { statusAnim = B_ANIM_STATUS_PSN; rng = STATUS1_POISON; }
+    PARAMETRIZE { statusAnim = B_ANIM_STATUS_PRZ; rng = 0; }
+    PARAMETRIZE { statusAnim = B_ANIM_STATUS_PSN; rng = 1; }
     GIVEN {
-        ASSUME(MoveHasAdditionalEffect(MOVE_G_MAX_STUN_SHOCK, MOVE_EFFECT_POISON_PARALYZE_SIDE));
+        ASSUME(MoveHasAdditionalEffect(MOVE_G_MAX_STUN_SHOCK, MOVE_EFFECT_RANDOM_FROM_LIST));
         PLAYER(SPECIES_TOXTRICITY) { GigantamaxFactor(TRUE); }
         PLAYER(SPECIES_TOXEL);
         OPPONENT(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WYNAUT);
     } WHEN {
         TURN { MOVE(playerLeft, MOVE_THUNDERBOLT, target: opponentLeft, gimmick: GIMMICK_DYNAMAX, \
-               WITH_RNG(RNG_G_MAX_STUN_SHOCK, rng)); }
+               WITH_RNG(RNG_RANDOM_FROM_LIST, rng)); }
     } SCENE {
         MESSAGE("Toxtricity used G-Max Stun Shock!");
         // opponent left
@@ -1053,14 +1053,14 @@ DOUBLE_BATTLE_TEST("Dynamax: G-Max Stun Shock paralyzes or poisons both opponent
 DOUBLE_BATTLE_TEST("Dynamax: G-Max Stun Shock chooses statuses before considering immunities")
 {
     GIVEN {
-        ASSUME(MoveHasAdditionalEffect(MOVE_G_MAX_STUN_SHOCK, MOVE_EFFECT_POISON_PARALYZE_SIDE));
+        ASSUME(MoveHasAdditionalEffect(MOVE_G_MAX_STUN_SHOCK, MOVE_EFFECT_RANDOM_FROM_LIST));
         PLAYER(SPECIES_TOXTRICITY) { GigantamaxFactor(TRUE); }
         PLAYER(SPECIES_TOXEL);
         OPPONENT(SPECIES_GARBODOR);
         OPPONENT(SPECIES_TRUBBISH);
     } WHEN {
         TURN { MOVE(playerLeft, MOVE_NUZZLE, target: opponentLeft, gimmick: GIMMICK_DYNAMAX, \
-               WITH_RNG(RNG_G_MAX_STUN_SHOCK, STATUS1_POISON)); }
+               WITH_RNG(RNG_RANDOM_FROM_LIST, 1)); }
     } SCENE {
         MESSAGE("Toxtricity used G-Max Stun Shock!");
         NONE_OF {
@@ -1082,18 +1082,18 @@ DOUBLE_BATTLE_TEST("Dynamax: G-Max Befuddle paralyzes, poisons, or sleeps both o
 {
     u8 statusAnim;
     u32 rng;
-    PARAMETRIZE { statusAnim = B_ANIM_STATUS_PRZ; rng = STATUS1_PARALYSIS; }
-    PARAMETRIZE { statusAnim = B_ANIM_STATUS_PSN; rng = STATUS1_POISON; }
-    PARAMETRIZE { statusAnim = B_ANIM_STATUS_SLP; rng = STATUS1_SLEEP; }
+    PARAMETRIZE { statusAnim = B_ANIM_STATUS_PRZ; rng = 0; }
+    PARAMETRIZE { statusAnim = B_ANIM_STATUS_PSN; rng = 1; }
+    PARAMETRIZE { statusAnim = B_ANIM_STATUS_SLP; rng = 2; }
     GIVEN {
-        ASSUME(MoveHasAdditionalEffect(MOVE_G_MAX_BEFUDDLE, MOVE_EFFECT_EFFECT_SPORE_SIDE));
+        ASSUME(MoveHasAdditionalEffect(MOVE_G_MAX_BEFUDDLE, MOVE_EFFECT_RANDOM_FROM_LIST));
         PLAYER(SPECIES_BUTTERFREE) { GigantamaxFactor(TRUE); }
         PLAYER(SPECIES_CATERPIE);
         OPPONENT(SPECIES_WOBBUFFET);
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
         TURN { MOVE(playerLeft, MOVE_BUG_BITE, target: opponentLeft, gimmick: GIMMICK_DYNAMAX,
-               WITH_RNG(RNG_G_MAX_BEFUDDLE, rng)); }
+               WITH_RNG(RNG_RANDOM_FROM_LIST, rng)); }
     } SCENE {
         MESSAGE("Butterfree used G-Max Befuddle!");
         // opponent left
@@ -1130,7 +1130,8 @@ DOUBLE_BATTLE_TEST("Dynamax: G-Max Befuddle paralyzes, poisons, or sleeps both o
 DOUBLE_BATTLE_TEST("Dynamax: G-Max Gold Rush confuses both opponents and generates money")
 {
     GIVEN {
-        ASSUME(MoveHasAdditionalEffect(MOVE_G_MAX_GOLD_RUSH, MOVE_EFFECT_CONFUSE_PAY_DAY_SIDE));
+        ASSUME(MoveHasAdditionalEffect(MOVE_G_MAX_GOLD_RUSH, MOVE_EFFECT_CONFUSION));
+        ASSUME(MoveHasAdditionalEffect(MOVE_G_MAX_GOLD_RUSH, MOVE_EFFECT_PAYDAY));
         PLAYER(SPECIES_MEOWTH) { GigantamaxFactor(TRUE); }
         PLAYER(SPECIES_PERSIAN);
         OPPONENT(SPECIES_WOBBUFFET);
@@ -1150,7 +1151,7 @@ DOUBLE_BATTLE_TEST("Dynamax: G-Max Gold Rush confuses both opponents and generat
 DOUBLE_BATTLE_TEST("Dynamax: G-Max Smite confuses both opponents")
 {
     GIVEN {
-        ASSUME(MoveHasAdditionalEffect(MOVE_G_MAX_SMITE, MOVE_EFFECT_CONFUSE_SIDE));
+        ASSUME(MoveHasAdditionalEffect(MOVE_G_MAX_SMITE, MOVE_EFFECT_CONFUSION));
         PLAYER(SPECIES_HATTERENE) { GigantamaxFactor(TRUE); }
         PLAYER(SPECIES_HATENNA);
         OPPONENT(SPECIES_WOBBUFFET);
@@ -1784,7 +1785,7 @@ DOUBLE_BATTLE_TEST("Dynamax: G-Max Replenish recycles allies' berries 50\% of th
 DOUBLE_BATTLE_TEST("Dynamax: G-Max Volt Crash paralyzes other opponent even if its target faints")
 {
     GIVEN {
-        ASSUME(MoveHasAdditionalEffect(MOVE_G_MAX_VOLT_CRASH, MOVE_EFFECT_PARALYZE_SIDE));
+        ASSUME(MoveHasAdditionalEffect(MOVE_G_MAX_VOLT_CRASH, MOVE_EFFECT_PARALYSIS));
         PLAYER(SPECIES_PIKACHU) { GigantamaxFactor(TRUE); }
         PLAYER(SPECIES_PICHU);
         OPPONENT(SPECIES_WOBBUFFET) { HP(1); }

--- a/test/battle/sleep_clause.c
+++ b/test/battle/sleep_clause.c
@@ -541,7 +541,7 @@ DOUBLE_BATTLE_TEST("Sleep Clause: G-Max Befuddle can only sleep one opposing mon
 {
     GIVEN {
         FLAG_SET(B_FLAG_SLEEP_CLAUSE);
-        ASSUME(MoveHasAdditionalEffect(MOVE_G_MAX_BEFUDDLE, MOVE_EFFECT_EFFECT_SPORE_SIDE));
+        ASSUME(MoveHasAdditionalEffect(MOVE_G_MAX_BEFUDDLE, MOVE_EFFECT_RANDOM_FROM_LIST));
         PLAYER(SPECIES_BUTTERFREE) { GigantamaxFactor(TRUE); }
         PLAYER(SPECIES_CATERPIE);
         OPPONENT(SPECIES_WOBBUFFET);


### PR DESCRIPTION
Changed how `onSide` works so it can be used by any additional effects.

This should clear some of the Max Move additional effects and allow for greater additional effect customizability.

This should be merged after #10637, as some effects introduced in that PR will be used to simplify Max Moves' effects.

### Large Language Models (AI)
No.

## Things to note in the release changelog:
- `onSide` now properly can be used with any additional effect to allow for additional effects to apply to all battlers on one side. Passing the effect chance check once allows for all battlers to benefit from the effect, as that is how G-Max Replenish works.

## Discord contact info
PhallenTree