### PR TITLE
Fix asymmetrical follower turning when used as object events

### DIFF
--- a/src/data/object_events/object_event_anims.h
+++ b/src/data/object_events/object_event_anims.h
@@ -1618,6 +1618,10 @@ static const struct StepAnimTable sStepAnimTables[] = {
         .animPos = {1, 3, 0, 2},
     },
     {
+        .anims = sAnimTable_Following_Asym,
+        .animPos = {1, 3, 0, 2},
+    },
+    {
         .anims = sAnimTable_BrendanMayNormal,
         .animPos = {1, 3, 0, 2},
     },


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
Currently, when follower graphics are used as an object event through the `OBJ_EVENT_GFX_SPECIES()` macro, if the follower graphics use the `sAnimTable_Following_Asym` animation table, any facing movement (MOVEMENT_TYPE_LOOK_AROUND, faceplayer script macro) fails to turn the object properly. This is due to `sStepAnimTables` missing an entry for the animation table, which the game uses to determine if the object has step anims.

### Large Language Models (AI)
No AI used.

## Media
<!--- Add relevant images, GIFs, or videos to help reviewers understand the changes. Remove this section if not applicable. --->
Before fix:
https://github.com/user-attachments/assets/3e08a5e4-05a2-4056-b608-43ddfc0b4988

After fix:
https://github.com/user-attachments/assets/1b79e278-fe5b-4a9e-b7f9-5673adf1ddb3


## Discord contact info
kaseni
