### PR TITLE
Fix Truant volatile usage

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -3195,7 +3195,7 @@ static bool32 ShouldAvoidRedundantTarget(enum BattlerId battlerAtk, enum Battler
      || gBattleMons[partner].volatiles.rechargeTimer
      || gBattleMons[partner].volatiles.semiInvulnerable == STATE_SKY_DROP_TARGET
      || gBattleStruct->battlerState[partner].commandingDondozo
-     || (aiData->abilities[partner] == ABILITY_TRUANT && gBattleMons[partner].volatiles.truantCounter)
+     || (aiData->abilities[partner] == ABILITY_TRUANT && gBattleMons[partner].volatiles.truantToggle)
      || (GetMoveEffect(partnerMove) == EFFECT_SEMI_INVULNERABLE
       && !IsSemiInvulnerable(partner, CHECK_ALL)
       && aiData->holdEffects[partner] != HOLD_EFFECT_POWER_HERB)


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
#10751 which is using `volatiles.truantCounter` was merged after #10719 which changed the member to `volatiles.truantToggle`.

### Large Language Models (AI)
<!-- Does your pull request contain code or assets generated by a large language model (AI)? If so, where? -->
<!-- ⚠️ WARNING ⚠️ -->
<!-- There is an expectation that you have fully reviewed your code to ensure it meets all merge criteria (detailed above). -->
<!-- If the maintainers believe that a pull request was generated by AI with no or little to no human oversight, the pull request will be closed without further discussion. -->
<!-- Pull requests that have non-code (comments, descriptions, etc) content written by AI or have commits co-authored by AI are liable to be closed with extreme predjuice. -->
<!-- Please write your own commits, comments, and descriptions. -->
No

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara