### PR TITLE
Implement Champions Sheer Force exceptions for Berserk and Pickpocket

### DIFF
--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -4921,7 +4921,12 @@ static enum MoveEndResult MoveEndMoveBlockRecoil(struct BattleCalcValues *cv)
 static enum MoveEndResult MoveEndSheerForce(struct BattleCalcValues *cv)
 {
     if (IsSheerForceAffected(cv->move, cv->abilities[cv->battlerAtk]))
-        gBattleScripting.moveendState = MOVEEND_ITEMS_EFFECTS_ALL;
+    {
+        if (GetConfig(B_SHEER_FORCE_AGAINST_ABILITIES) >= GEN_CHAMPIONS)
+            gBattleScripting.moveendState = MOVEEND_COLOR_CHANGE;
+        else
+            gBattleScripting.moveendState = MOVEEND_ITEMS_EFFECTS_ALL;
+    }
     else
         gBattleScripting.moveendState++;
 
@@ -5264,18 +5269,25 @@ static enum MoveEndResult MoveEndShellTrap(struct BattleCalcValues *cv)
 
 static enum MoveEndResult MoveEndColorChange(struct BattleCalcValues *cv)
 {
+    bool32 sheerForceAffected = IsSheerForceAffected(cv->move, cv->abilities[cv->battlerAtk]);
+
     while (gBattleStruct->eventState.moveEndBattler < gBattlersCount)
     {
         enum BattlerId battler = (enum BattlerId)gBattleStruct->eventState.moveEndBattler++;
 
         if (battler == cv->battlerAtk)
             continue;
+        if (sheerForceAffected && cv->abilities[battler] != ABILITY_BERSERK)
+            continue;
         if (AbilityBattleEffects(ABILITYEFFECT_COLOR_CHANGE, battler, cv->abilities[battler], 0, TRUE))
             return MOVEEND_RESULT_RUN_SCRIPT;
     }
 
     gBattleStruct->eventState.moveEndBattler = 0;
-    gBattleScripting.moveendState++;
+    if (sheerForceAffected)
+        gBattleScripting.moveendState = MOVEEND_PICKPOCKET;
+    else
+        gBattleScripting.moveendState++;
     return MOVEEND_RESULT_CONTINUE;
 }
 

--- a/test/battle/ability/anger_shell.c
+++ b/test/battle/ability/anger_shell.c
@@ -95,7 +95,7 @@ SINGLE_BATTLE_TEST("Anger Shell does not activate if move is boosted by Sheer Fo
 {
     u16 maxHp = 500;
     GIVEN {
-        // WITH_CONFIG(B_SHEER_FORCE_AGAINST_ABILITIES, GEN_9);
+        WITH_CONFIG(B_SHEER_FORCE_AGAINST_ABILITIES, GEN_9);
         PLAYER(SPECIES_KLAWF) { Ability(ABILITY_ANGER_SHELL); MaxHP(maxHp); HP(maxHp / 2 + 1); }
         OPPONENT(SPECIES_NIDOKING) { Ability(ABILITY_SHEER_FORCE); }
     } WHEN {
@@ -112,24 +112,4 @@ SINGLE_BATTLE_TEST("Anger Shell does not activate if move is boosted by Sheer Fo
     }
 }
 
-SINGLE_BATTLE_TEST("Anger Shell does activate if move is boosted by Sheer Force (Champions)")
-{
-    KNOWN_FAILING;
-    u16 maxHp = 500;
-    GIVEN {
-        // WITH_CONFIG(B_SHEER_FORCE_AGAINST_ABILITIES, GEN_CHAMPIONS);
-        PLAYER(SPECIES_KLAWF) { Ability(ABILITY_ANGER_SHELL); MaxHP(maxHp); HP(maxHp / 2 + 1); }
-        OPPONENT(SPECIES_NIDOKING) { Ability(ABILITY_SHEER_FORCE); }
-    } WHEN {
-        TURN { MOVE(opponent, MOVE_EMBER); }
-    } SCENE {
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_EMBER, opponent);
-        ABILITY_POPUP(player, ABILITY_ANGER_SHELL);
-    } THEN {
-        EXPECT_EQ(player->statStages[STAT_DEF], DEFAULT_STAT_STAGE + 1);
-        EXPECT_EQ(player->statStages[STAT_SPDEF], DEFAULT_STAT_STAGE + 1);
-        EXPECT_EQ(player->statStages[STAT_ATK], DEFAULT_STAT_STAGE + 1);
-        EXPECT_EQ(player->statStages[STAT_SPATK], DEFAULT_STAT_STAGE + 1);
-        EXPECT_EQ(player->statStages[STAT_SPEED], DEFAULT_STAT_STAGE + 1);
-    }
-}
+TO_DO_BATTLE_TEST("Anger Shell interaction with Sheer Force in Champions needs confirmation");

--- a/test/battle/ability/berserk.c
+++ b/test/battle/ability/berserk.c
@@ -74,46 +74,36 @@ SINGLE_BATTLE_TEST("Berserk activates after all hits from a multi-hit move")
     }
 }
 
-SINGLE_BATTLE_TEST("Berserk does not activate if move is boosted by Sheer Force (Gen9)")
+SINGLE_BATTLE_TEST("Berserk ignores Sheer Force suppression only in Champions")
 {
-    u16 maxHp = 500;
-    GIVEN {
-        // WITH_CONFIG(B_SHEER_FORCE_AGAINST_ABILITIES, GEN_9);
-        PLAYER(SPECIES_DRAMPA) { Ability(ABILITY_BERSERK); MaxHP(maxHp); HP(maxHp / 2 + 1); }
-        OPPONENT(SPECIES_NIDOKING) { Ability(ABILITY_SHEER_FORCE); }
-    } WHEN {
-        TURN { MOVE(opponent, MOVE_EMBER); }
-    } SCENE {
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_EMBER, opponent);
-        NOT ABILITY_POPUP(player, ABILITY_BERSERK);
-    } THEN {
-        EXPECT_EQ(player->statStages[STAT_DEF], DEFAULT_STAT_STAGE);
-        EXPECT_EQ(player->statStages[STAT_SPDEF], DEFAULT_STAT_STAGE);
-        EXPECT_EQ(player->statStages[STAT_ATK], DEFAULT_STAT_STAGE);
-        EXPECT_EQ(player->statStages[STAT_SPATK], DEFAULT_STAT_STAGE);
-        EXPECT_EQ(player->statStages[STAT_SPEED], DEFAULT_STAT_STAGE);
-    }
-}
+    u32 gen;
+    enum Move move;
+    bool32 activates;
 
-SINGLE_BATTLE_TEST("Berserk does activate if move is boosted by Sheer Force (Champions)")
-{
-    KNOWN_FAILING;
-    u16 maxHp = 500;
+    PARAMETRIZE { gen = GEN_9; move = MOVE_EMBER; activates = FALSE; }
+    PARAMETRIZE { gen = GEN_CHAMPIONS; move = MOVE_EMBER; activates = TRUE; }
+    PARAMETRIZE { gen = GEN_9; move = MOVE_SCRATCH; activates = TRUE; }
+    PARAMETRIZE { gen = GEN_CHAMPIONS; move = MOVE_SCRATCH; activates = TRUE; }
+
     GIVEN {
-        // WITH_CONFIG(B_SHEER_FORCE_AGAINST_ABILITIES, GEN_CHAMPIONS);
-        PLAYER(SPECIES_DRAMPA) { Ability(ABILITY_BERSERK); MaxHP(maxHp); HP(maxHp / 2 + 1); }
+        WITH_CONFIG(B_SHEER_FORCE_AGAINST_ABILITIES, gen);
+        ASSUME(MoveIsAffectedBySheerForce(MOVE_EMBER));
+        ASSUME(!MoveIsAffectedBySheerForce(MOVE_SCRATCH));
+        PLAYER(SPECIES_DRAMPA) { Ability(ABILITY_BERSERK); MaxHP(500); HP(251); }
         OPPONENT(SPECIES_NIDOKING) { Ability(ABILITY_SHEER_FORCE); }
     } WHEN {
-        TURN { MOVE(opponent, MOVE_EMBER); }
+        TURN { MOVE(opponent, move); }
     } SCENE {
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_EMBER, opponent);
-        NOT ABILITY_POPUP(player, ABILITY_BERSERK);
+        ANIMATION(ANIM_TYPE_MOVE, move, opponent);
+        HP_BAR(player);
+        if (activates)
+            ABILITY_POPUP(player, ABILITY_BERSERK);
+        else
+            NOT ABILITY_POPUP(player, ABILITY_BERSERK);
     } THEN {
-        EXPECT_EQ(player->statStages[STAT_DEF], DEFAULT_STAT_STAGE);
-        EXPECT_EQ(player->statStages[STAT_SPDEF], DEFAULT_STAT_STAGE);
-        EXPECT_EQ(player->statStages[STAT_ATK], DEFAULT_STAT_STAGE + 1);
-        EXPECT_EQ(player->statStages[STAT_SPATK], DEFAULT_STAT_STAGE);
-        EXPECT_EQ(player->statStages[STAT_SPEED], DEFAULT_STAT_STAGE);
+        EXPECT_GT(player->hp, 0);
+        EXPECT_LE(player->hp, 250);
+        EXPECT_EQ(player->statStages[STAT_SPATK], DEFAULT_STAT_STAGE + activates);
     }
 }
 

--- a/test/battle/ability/color_change.c
+++ b/test/battle/ability/color_change.c
@@ -188,17 +188,4 @@ SINGLE_BATTLE_TEST("Color Change does not activate if move is boosted by Sheer F
     }
 }
 
-SINGLE_BATTLE_TEST("Color Change does activate if move is boosted by Sheer Force (Champions)")
-{
-    KNOWN_FAILING;
-    GIVEN {
-        WITH_CONFIG(B_SHEER_FORCE_AGAINST_ABILITIES, GEN_CHAMPIONS);
-        PLAYER(SPECIES_KECLEON) { Ability(ABILITY_COLOR_CHANGE); }
-        OPPONENT(SPECIES_NIDOKING) { Ability(ABILITY_SHEER_FORCE); }
-    } WHEN {
-        TURN { MOVE(opponent, MOVE_EMBER); }
-    } SCENE {
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_EMBER, opponent);
-        ABILITY_POPUP(player, ABILITY_COLOR_CHANGE);
-    }
-}
+TO_DO_BATTLE_TEST("Color Change interaction with Sheer Force in Champions needs confirmation");

--- a/test/battle/ability/pickpocket.c
+++ b/test/battle/ability/pickpocket.c
@@ -445,47 +445,35 @@ SINGLE_BATTLE_TEST("Pickpocket does not activate if its user switches out with E
     }
 }
 
-SINGLE_BATTLE_TEST("Pickpocket cannot steal an item if hit by a contact move that's boosted by Sheer Force (Gen9-)")
+SINGLE_BATTLE_TEST("Pickpocket ignores Sheer Force suppression only in Champions")
 {
-    GIVEN {
-        // GIVEN(B_SHEER_FORCE_AGAINST_ABILITIES, GEN_9);
-        ASSUME(gMovesInfo[MOVE_CRUNCH].additionalEffects->moveEffect == MOVE_EFFECT_STAT_MINUS);
-        ASSUME(gItemsInfo[ITEM_LIFE_ORB].holdEffect == HOLD_EFFECT_LIFE_ORB);
-        PLAYER(SPECIES_LANDORUS) { Item(ITEM_LIFE_ORB); Ability(ABILITY_SHEER_FORCE); }
-        OPPONENT(SPECIES_SNEASEL) { Ability(ABILITY_PICKPOCKET); }
-    } WHEN {
-        TURN { MOVE(player, MOVE_CRUNCH); }
-    } SCENE {
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_CRUNCH, player);
-        HP_BAR(opponent);
-        NONE_OF {
-            ABILITY_POPUP(opponent, ABILITY_PICKPOCKET);
-            MESSAGE("The opposing Sneasel stole Landorus's Life Orb!");
-        }
-    } THEN {
-        EXPECT(opponent->item == ITEM_NONE);
-        EXPECT(player->item == ITEM_LIFE_ORB);
-    }
-}
+    u32 gen;
+    enum Move move;
+    bool32 activates;
 
-SINGLE_BATTLE_TEST("Pickpocket can steal an item even if hit by a contact move that's boosted by Sheer Force (Champions)")
-{
-    KNOWN_FAILING;
+    PARAMETRIZE { gen = GEN_9; move = MOVE_CRUNCH; activates = FALSE; }
+    PARAMETRIZE { gen = GEN_CHAMPIONS; move = MOVE_CRUNCH; activates = TRUE; }
+    PARAMETRIZE { gen = GEN_9; move = MOVE_SCRATCH; activates = TRUE; }
+    PARAMETRIZE { gen = GEN_CHAMPIONS; move = MOVE_SCRATCH; activates = TRUE; }
+
     GIVEN {
-        // GIVEN(B_SHEER_FORCE_AGAINST_ABILITIES, GEN_CHAMPIONS);
-        ASSUME(gMovesInfo[MOVE_CRUNCH].additionalEffects->moveEffect == MOVE_EFFECT_STAT_MINUS);
-        ASSUME(gItemsInfo[ITEM_LIFE_ORB].holdEffect == HOLD_EFFECT_LIFE_ORB);
+        WITH_CONFIG(B_SHEER_FORCE_AGAINST_ABILITIES, gen);
+        ASSUME(MoveIsAffectedBySheerForce(MOVE_CRUNCH));
+        ASSUME(!MoveIsAffectedBySheerForce(MOVE_SCRATCH));
+        ASSUME(MoveMakesContact(move));
         PLAYER(SPECIES_LANDORUS) { Item(ITEM_LIFE_ORB); Ability(ABILITY_SHEER_FORCE); }
         OPPONENT(SPECIES_SNEASEL) { Ability(ABILITY_PICKPOCKET); }
     } WHEN {
-        TURN { MOVE(player, MOVE_CRUNCH); }
+        TURN { MOVE(player, move); }
     } SCENE {
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_CRUNCH, player);
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
         HP_BAR(opponent);
-        ABILITY_POPUP(opponent, ABILITY_PICKPOCKET);
-        MESSAGE("The opposing Sneasel stole Landorus's Life Orb!");
+        if (activates)
+            ABILITY_POPUP(opponent, ABILITY_PICKPOCKET);
+        else
+            NOT ABILITY_POPUP(opponent, ABILITY_PICKPOCKET);
     } THEN {
-        EXPECT(opponent->item == ITEM_LIFE_ORB);
-        EXPECT(player->item == ITEM_NONE);
+        EXPECT_EQ(opponent->item, activates ? ITEM_LIFE_ORB : ITEM_NONE);
+        EXPECT_EQ(player->item, activates ? ITEM_NONE : ITEM_LIFE_ORB);
     }
 }

--- a/test/battle/ability/sheer_force.c
+++ b/test/battle/ability/sheer_force.c
@@ -1448,16 +1448,29 @@ AI_SINGLE_BATTLE_TEST("AI sees Sheer Force skips additional effects")
     }
 }
 
-SINGLE_BATTLE_TEST("Sheer Force doesn't activate Shell Bell")
+SINGLE_BATTLE_TEST("Sheer Force suppresses Shell Bell recovery and Life Orb recoil")
 {
+    u32 gen;
+    enum Item item;
+
+    PARAMETRIZE { gen = GEN_9; item = ITEM_SHELL_BELL; }
+    PARAMETRIZE { gen = GEN_CHAMPIONS; item = ITEM_SHELL_BELL; }
+    PARAMETRIZE { gen = GEN_9; item = ITEM_LIFE_ORB; }
+    PARAMETRIZE { gen = GEN_CHAMPIONS; item = ITEM_LIFE_ORB; }
+
     GIVEN {
-        PLAYER(SPECIES_TAUROS) { Ability(ABILITY_SHEER_FORCE); Item(ITEM_SHELL_BELL); HP(1); }
+        WITH_CONFIG(B_SHEER_FORCE_AGAINST_ABILITIES, gen);
+        ASSUME(MoveIsAffectedBySheerForce(MOVE_EARTH_POWER));
+        PLAYER(SPECIES_TAUROS) { Ability(ABILITY_SHEER_FORCE); Item(item); MaxHP(500); HP(250); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
         TURN { MOVE(player, MOVE_EARTH_POWER); }
     } SCENE {
-        NONE_OF {
-            HP_BAR(player);
-        }
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EARTH_POWER, player);
+        HP_BAR(opponent);
+        NOT HP_BAR(player);
+    } THEN {
+        EXPECT_EQ(player->hp, 250);
+        EXPECT_EQ(player->item, item);
     }
 }


### PR DESCRIPTION
Wired `B_SHEER_FORCE_AGAINST_ABILITIES` into move resolution so Berserk and Pickpocket activate through Sheer Force in Champions. Also preserved Gen 9 behavior and suppression of Shell Bell recovery and Life Orb recoil.

I've updated the regression coverage and replaced the unconfirmed Color Change and Anger Shell cases with TODOs.
I will update this when more interactions are confirmed.

### Large Language Models (AI)

No AI has been used.

## Issue(s) that this PR fixes

Addresses #10240.

## Discord contact info

syreldar