### PR TITLE
Fix custom multi-battle return and party detection

### DIFF
--- a/include/battle_special.h
+++ b/include/battle_special.h
@@ -2,6 +2,7 @@
 #define GUARD_BATTLE_SPECIAL_H
 
 void DoSpecialTrainerBattle(void); 
+void CB2_EndSpecialTrainerBattle(void);
 void SetEReaderTrainerGfxId(void);
 u8 GetEreaderTrainerFrontSpriteId(void);
 enum TrainerClassID GetEreaderTrainerClassId(void);

--- a/src/battle_setup.c
+++ b/src/battle_setup.c
@@ -6,6 +6,7 @@
 #include "battle_pike.h"
 #include "battle_pyramid.h"
 #include "battle_setup.h"
+#include "battle_special.h"
 #include "battle_partner.h"
 #include "battle_tower.h"
 #include "battle_transition.h"
@@ -350,6 +351,9 @@ void BattleSetup_StartDoubleWildBattle(void)
 
 void BattleSetup_StartMultiBattle(void)
 {
+    gBattleScripting.specialTrainerBattleType = SPECIAL_BATTLE_MULTI;
+    gMain.savedCallback = CB2_EndSpecialTrainerBattle;
+
     if (gSpecialVar_0x8005 & MULTI_BATTLE_2_VS_WILD) // Player + AI against wild mon
     {
         gBattleTypeFlags = BATTLE_TYPE_DOUBLE | BATTLE_TYPE_MULTI | BATTLE_TYPE_INGAME_PARTNER;

--- a/src/battle_special.c
+++ b/src/battle_special.c
@@ -18,7 +18,6 @@
 #include "constants/battle_frontier.h"
 #include "constants/battle_special.h"
 
-static void HandleSpecialTrainerBattleEnd(void);
 static void Task_StartBattleAfterTransition(u8 taskId);
 static void UNUSED FillEReaderTrainerWithPlayerData(void);
 static void CopyEReaderTrainerFarewellMessage(void);
@@ -27,7 +26,7 @@ static void CopyEReaderTrainerFarewellMessage(void);
 static void SetEReaderTrainerChecksum(struct BattleTowerEReaderTrainer *ereaderTrainer);
 #endif //FREE_BATTLE_TOWER_E_READER
 
-static void HandleSpecialTrainerBattleEnd(void)
+void CB2_EndSpecialTrainerBattle(void)
 {
     s32 i;
 
@@ -63,7 +62,7 @@ static void Task_StartBattleAfterTransition(u8 taskId)
 {
     if (IsBattleTransitionDone() == TRUE)
     {
-        gMain.savedCallback = HandleSpecialTrainerBattleEnd;
+        gMain.savedCallback = CB2_EndSpecialTrainerBattle;
         SetMainCallback2(CB2_InitBattle);
         DestroyTask(taskId);
     }

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -9947,11 +9947,17 @@ bool32 AreMultiPartiesFullTeams(void)
     enum DifficultyLevel difficulty = GetCurrentDifficultyLevel();
 
     if (B_MULTI_HALF_TEAMS)
-		return FALSE;
+    {
+        gSpecialVar_Result = FALSE;
+        return FALSE;
+    }
 
-	if (!(gBattleTypeFlags & BATTLE_TYPE_TRAINER))
-		return TRUE;
-		
+    if (!(gBattleTypeFlags & BATTLE_TYPE_TRAINER))
+    {
+        gSpecialVar_Result = TRUE;
+        return TRUE;
+    }
+
     if (TRAINER_BATTLE_PARAM.opponentA == TRAINER_LINK_OPPONENT
      || gBattleTypeFlags & BATTLE_TYPE_TOWER_LINK_MULTI
      || (gTrainers[difficulty][TRAINER_BATTLE_PARAM.opponentA].multiTeamSize == MULTI_TEAM_SIZE_HALF)


### PR DESCRIPTION
Restored the special battle end callback in `BattleSetup_StartMultiBattle`, including the existing battle outcome recording and fixed half-party cleanup before returning to the field script.

Also ensured every `AreMultiPartiesFullTeams` return path writes its result to `VAR_RESULT`.
This prevents `multi_2_vs_2` from using a stale result and reducing an unselected party to an empty party.

### Large Language Models (AI)

No AI has been used.

## Discord contact info

syreldar