### PR TITLE
Matster to upcoming merge 

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -4236,7 +4236,7 @@ BattleScript_DoSelfConfusionDmg::
 	waitstate
 	tryselfconfusiondmgformchange
 	healthbarupdate BS_ATTACKER
-	datahpupdate BS_ATTACKER, ASSURANCE_IGNORE
+	datahpupdate BS_ATTACKER, ASSURANCE_DOUBLE
 	resultmessage
 	waitmessage B_WAIT_TIME_LONG
 	tryfaintmon BS_ATTACKER

--- a/include/battle_set_effect.h
+++ b/include/battle_set_effect.h
@@ -14,6 +14,7 @@ struct SetEffect
     u16 primary:1;
     u16 certain:1;
     u16 onSide:1;
+    u16 bypassSheerForce:1;
 };
 
 void SetMoveEffect(struct BattleCalcValues *cv, struct SetEffect *se);

--- a/include/battle_special.h
+++ b/include/battle_special.h
@@ -2,6 +2,7 @@
 #define GUARD_BATTLE_SPECIAL_H
 
 void DoSpecialTrainerBattle(void); 
+void CB2_EndSpecialTrainerBattle(void);
 void SetEReaderTrainerGfxId(void);
 u8 GetEreaderTrainerFrontSpriteId(void);
 enum TrainerClassID GetEreaderTrainerClassId(void);

--- a/include/config/battle.h
+++ b/include/config/battle.h
@@ -38,6 +38,8 @@
 #define B_EXPLOSION_DEFENSE         GEN_LATEST // In Gen5+, Self-Destruct and Explosion no longer halve the targets' Defense.
 #define B_PARENTAL_BOND_DMG         GEN_LATEST // In Gen7+, Parental Bond's second hit does 25% of the initial hit's damage instead of 50%.
 #define B_MULTIPLE_TARGETS_DMG      GEN_LATEST // In Gen4+, damage dealt by moves that hit multiple targets at once is reduced to 75%. Previously, it was 50%, unless the move hit the entire field, in which case there was no reduction.
+#define B_STRUGGLE_RECOIL           GEN_LATEST // In Gen4+, Struggle's recoil is 1/4 of the user's max HP. In Gen2-3, it's 1/4 of the damage dealt, and in Gen1, 1/2 of it.
+#define B_RETURN_FRUSTRATION_DMG    GEN_LATEST // In Gen3+, Return and Frustration deal at least 1 damage. In Gen2, they deal none at the friendship value that gives them 0 power.
 
 // Type settings
 #define B_GHOSTS_ESCAPE             GEN_LATEST // In Gen6+, escape prevention fails on Ghost-types. Additionally, attempting to escape from a wild battle is always sucessful.
@@ -48,6 +50,7 @@
 #define B_SHEER_COLD_IMMUNITY       GEN_LATEST // In Gen7+, Ice-types are immune to Sheer Cold.
 #define B_ROOST_PURE_FLYING         GEN_LATEST // In Gen5+, Roost turns pure Flying-types into Normal-types.
 #define B_STATUS_TYPE_IMMUNITY      GEN_LATEST // In Gen1, Pokémon were immune to additional effects of attacking moves if they shared a type with the move.
+#define B_FIXED_DMG_IGNORES_TYPE    GEN_LATEST // In Gen1, fixed damage moves (Sonic Boom, Dragon Rage, Super Fang, Psywave, Seismic Toss, Night Shade, Bide, Counter) ignore type effectiveness and immunities.
 
 // Turn settings
 #define B_BINDING_TURNS             GEN_LATEST // In Gen5+, binding moves last for 4-5 turns instead of 2-5. If the user is holding a Grip Claw, they last for 7 turns instead of 5.
@@ -122,6 +125,8 @@
 #define B_HIT_THAW                      GEN_LATEST // In Gen6+, damaging moves that thaw the user will thaw the target. In Gen 3+, Fire-type moves thaw the target. In Gen 1-2, damaging moves that can burn will thaw the target, regardless if they can be burned or not.
 #define B_HEALING_WISH_SWITCH           GEN_LATEST // In Gen5+, the Pokémon receiving Healing Wish/Lunar Dance is sent out at the end of the turn. Additionally, in Gen8+, the effect will be stored until the user switches into a statused or hurt Pokémon.
 #define B_DEFOG_EFFECT_CLEARING         GEN_LATEST // In Gen5+, Defog does not lower the evasion of a target behind a Subsitute. In Gen6+, Defog also clears hazards from the user's side. In Gen8+, Defog also clears active Terrain.
+#define B_HAZE_FOCUS_ENERGY             GEN_LATEST // In Gen1 and Gen4, Haze also removes Focus Energy's effect.
+#define B_AUTOTOMIZE_FORM_CHANGE        GEN_LATEST // In Gen6+, changing form resets Autotomize's weight reduction.
 #define B_STOCKPILE_RAISES_DEFS         GEN_LATEST // In Gen4+, Stockpile also raises Defense and Sp. Def stats. Once Spit Up/Swallow is used, these stat changes are lost.
 #define B_TRANSFORM_SEMI_INV_FAIL       GEN_LATEST // In Gen2+, Transform fails if the target is semi-invulnerable.
 #define B_TRANSFORM_TARGET_FAIL         GEN_LATEST // In Gen2+, Transform fails if the target is already transformed.

--- a/include/config_changes.h
+++ b/include/config_changes.h
@@ -20,7 +20,25 @@ struct ConfigChanges
     // ...
 };
 
-#define GetConfig(name) GetConfigInternal(CONFIG_##name)
+#if TESTING
+extern struct ConfigChanges *gConfigChangesTestOverride;
+#define GET_CONFIG_VALUE(_field, _default) (gConfigChangesTestOverride == NULL ? (_default) : gConfigChangesTestOverride->_field)
+#else
+#define GET_CONFIG_VALUE(_field, _default) (_default)
+#endif
+
+#define UNPACK_BATTLE_CONFIG_GETTER(_name, _field, ...) static inline u32 GetConfig_##_name(void) { return GET_CONFIG_VALUE(_field, _name); }
+#define UNPACK_POKEMON_CONFIG_GETTER(_name, _field, ...) static inline u32 GetConfig_##_name(void) { return GET_CONFIG_VALUE(_field, P_##_name); }
+
+BATTLE_CONFIG_DEFINITIONS(UNPACK_BATTLE_CONFIG_GETTER)
+POKEMON_CONFIG_DEFINITIONS(UNPACK_POKEMON_CONFIG_GETTER)
+AI_CONFIG_DEFINITIONS(UNPACK_BATTLE_CONFIG_GETTER)
+
+#undef UNPACK_BATTLE_CONFIG_GETTER
+#undef UNPACK_POKEMON_CONFIG_GETTER
+#undef GET_CONFIG_VALUE
+
+#define GetConfig(name) GetConfig_##name()
 
 ARM_FUNC u32 GetConfigInternal(enum ConfigTag configTag);
 void SetConfig(enum ConfigTag configTag, u32 value);

--- a/include/constants/battle_move_effects.h
+++ b/include/constants/battle_move_effects.h
@@ -283,6 +283,7 @@ enum  BattleMoveEffects
     EFFECT_CEASELESS_EDGE, // Same applies to spikes
     EFFECT_SPECIES_POWER_OVERRIDE, // Uses argument field to for the species, power and (number of hits, used only for multi hit moves)
     EFFECT_SCALE_SHOT,
+    EFFECT_SECRET_POWER,
     NUM_BATTLE_MOVE_EFFECTS,
 };
 

--- a/include/constants/battle_set_effect.h
+++ b/include/constants/battle_set_effect.h
@@ -133,6 +133,7 @@ enum SetMoveEffectFlags
     EFFECT_PRIMARY    = (1 << 0),
     EFFECT_CERTAIN    = (1 << 1),
     EFFECT_ON_SIDE    = (1 << 2),
+    EFFECT_BYPASS_SHEER_FORCE = (1 << 3),
 };
 
 #endif // GUARD_CONSTANTS_BATTLE_SET_EFFECT_H

--- a/include/constants/config_changes.h
+++ b/include/constants/config_changes.h
@@ -37,6 +37,8 @@
     F(B_EXPLOSION_DEFENSE,         explosionDefense,        (u32, GEN_COUNT - 1)) /* TODO: use in tests */ \
     F(B_PARENTAL_BOND_DMG,         parentalBondDmg,         (u32, GEN_COUNT - 1)) /* TODO: use in tests */ \
     F(B_MULTIPLE_TARGETS_DMG,      multipleTargetsDmg,      (u32, GEN_COUNT - 1)) /* TODO: use in tests */ \
+    F(B_STRUGGLE_RECOIL,           struggleRecoil,          (u32, GEN_COUNT - 1)) \
+    F(B_RETURN_FRUSTRATION_DMG,    returnFrustrationDmg,    (u32, GEN_COUNT - 1)) \
     /* Type settings */ \
     F(B_GHOSTS_ESCAPE,             ghostsEscape,            (u32, GEN_COUNT - 1)) /* TODO: use in tests */ \
     F(B_PARALYZE_ELECTRIC,         paralyzeElectric,        (u32, GEN_COUNT - 1)) \
@@ -47,6 +49,7 @@
     F(B_SHEER_COLD_IMMUNITY,       sheerColdImmunity,       (u32, GEN_COUNT - 1)) \
     F(B_ROOST_PURE_FLYING,         roostPureFlying,         (u32, GEN_COUNT - 1)) /* TODO: use in tests */ \
     F(B_STATUS_TYPE_IMMUNITY,      statusTypeImmunity,      (u32, GEN_COUNT - 1)) /* TODO: use in tests */ \
+    F(B_FIXED_DMG_IGNORES_TYPE,    fixedDmgIgnoresType,     (u32, GEN_COUNT - 1)) \
     F(B_HIDDEN_POWER_COUNTER,      hiddenPowerCounter,      (u32, GEN_COUNT - 1)) \
     /* Turn settings */ \
     F(B_BINDING_TURNS,             bindingTurns,            (u32, GEN_COUNT - 1)) \
@@ -111,6 +114,8 @@
     F(B_HIT_THAW,                  hitThaw,                 (u32, GEN_COUNT - 1)) \
     F(B_HEALING_WISH_SWITCH,       healingWishSwitch,       (u32, GEN_COUNT - 1)) \
     F(B_DEFOG_EFFECT_CLEARING,     defogEffectClearing,     (u32, GEN_COUNT - 1)) \
+    F(B_HAZE_FOCUS_ENERGY,         hazeFocusEnergy,         (u32, GEN_COUNT - 1)) \
+    F(B_AUTOTOMIZE_FORM_CHANGE,    autotomizeFormChange,    (u32, GEN_COUNT - 1)) \
     F(B_STOCKPILE_RAISES_DEFS,     stockpileRaisesDefs,     (u32, GEN_COUNT - 1)) /* TODO: use in tests */ \
     F(B_TRANSFORM_SEMI_INV_FAIL,   transformSemiInvFail,    (u32, GEN_COUNT - 1)) \
     F(B_TRANSFORM_TARGET_FAIL,     transformTargetFail,     (u32, GEN_COUNT - 1)) \

--- a/include/move.h
+++ b/include/move.h
@@ -211,6 +211,7 @@ struct MoveInfo
         u32 fixedDamage;
         u32 damagePercentage;
         u32 recoilPercentage;
+        u32 secondaryEffectChance;
         u32 nonVolatileStatus;
         u32 overwriteAbility;
         u32 weatherType;
@@ -768,6 +769,13 @@ static inline u32 GetMoveRecoil(enum Move moveId)
     moveId = SanitizeMoveId(moveId);
     assertf(gMovesInfo[moveId].effect == EFFECT_RECOIL, "not a recoil move: %S", gMovesInfo[moveId].name);
     return gMovesInfo[moveId].argument.recoilPercentage;
+}
+
+static inline u32 GetMoveSecondaryEffectChance(enum Move moveId)
+{
+    moveId = SanitizeMoveId(moveId);
+    assertf(gMovesInfo[moveId].effect == EFFECT_SECRET_POWER, "not a move with a secondary effect chance argument: %S", GetMoveName(moveId));
+    return gMovesInfo[moveId].argument.secondaryEffectChance;
 }
 
 static inline enum MoveEffect GetMoveNonVolatileStatus(enum Move move)

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -2990,7 +2990,7 @@ static s32 AI_CheckBadMove(enum BattlerId battlerAtk, enum BattlerId battlerDef,
             ADJUST_SCORE(-10);
         break;
     case EFFECT_DARK_VOID:
-        if (B_DARK_VOID_FAIL >= GEN_7 && gBattleMons[battlerAtk].species != SPECIES_DARKRAI)
+        if (GetConfig(B_DARK_VOID_FAIL) >= GEN_7 && gBattleMons[battlerAtk].species != SPECIES_DARKRAI)
             ADJUST_SCORE(-10);
         break;
     case EFFECT_HYPERSPACE_FURY:

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -5314,6 +5314,7 @@ static s32 AI_CalcMoveEffectScore(enum BattlerId battlerAtk, enum BattlerId batt
         break;
     }
     case EFFECT_TERRAIN:
+    {
         enum BattleTerrain terrain = GetMoveTerrainType(move);
 
         if (ShouldSetTerrain(battlerAtk, terrain))
@@ -5327,6 +5328,7 @@ static s32 AI_CalcMoveEffectScore(enum BattlerId battlerAtk, enum BattlerId batt
                 ADJUST_SCORE(WEAK_EFFECT);
         }
         break;
+    }
     case EFFECT_STEEL_ROLLER:
         {
             u32 terrain = gFieldTimers.terrain;

--- a/src/battle_hold_effects.c
+++ b/src/battle_hold_effects.c
@@ -173,7 +173,8 @@ static enum ItemEffect TryKingsRock(enum BattlerId battlerAtk, enum BattlerId ba
         holdEffectParam *= 2;
     if (ability != ABILITY_STENCH && RandomPercentage(RNG_HOLD_EFFECT_FLINCH, holdEffectParam))
     {
-        SetMoveEffectHelper(battlerAtk, battlerDef, MOVE_EFFECT_FLINCH, gBattlescriptCurrInstr, NO_FLAGS);
+        // This item effect is independent of Sheer Force; moves that natively flinch were rejected above.
+        SetMoveEffectHelper(battlerAtk, battlerDef, MOVE_EFFECT_FLINCH, gBattlescriptCurrInstr, EFFECT_BYPASS_SHEER_FORCE);
         effect = ITEM_EFFECT_OTHER;
     }
 

--- a/src/battle_hold_effects.c
+++ b/src/battle_hold_effects.c
@@ -351,7 +351,7 @@ static enum ItemEffect TrySetEnigmaBerry(enum BattlerId battlerDef, enum Battler
 
     if (((IsBattlerTurnDamaged(battlerDef, EXCLUDING_SUBSTITUTES) && gBattleStruct->moveResultFlags[battlerDef] & MOVE_RESULT_HIGH_EFFECTIVENESS) || gBattleScripting.overrideBerryRequirements)
      && !(gBattleScripting.overrideBerryRequirements && gBattleMons[battlerDef].hp == gBattleMons[battlerDef].maxHP)
-     && !(B_HEAL_BLOCKING >= GEN_5 && gBattleMons[battlerDef].volatiles.healBlockTimer))
+     && !(GetConfig(B_HEAL_BLOCKING) >= GEN_5 && gBattleMons[battlerDef].volatiles.healBlockTimer))
     {
         s32 healAmount = gBattleMons[battlerDef].maxHP * 25 / 100;
         if (GetBattlerAbility(battlerDef) == ABILITY_RIPEN)
@@ -498,7 +498,7 @@ static enum ItemEffect TryShellBell(enum BattlerId battlerAtk)
      && GetMoveEffect(gCurrentMove) != EFFECT_FUTURE_SIGHT
      && gBattleStruct->battlerState[battlerAtk].originalBattlerPartyId == PARTY_SIZE
      && !IsBattlerAtMaxHp(battlerAtk)
-     && !(B_HEAL_BLOCKING >= GEN_5 && gBattleMons[battlerAtk].volatiles.healBlockTimer))
+     && !(GetConfig(B_HEAL_BLOCKING) >= GEN_5 && gBattleMons[battlerAtk].volatiles.healBlockTimer))
     {
         if (EmergencyExitCanBeTriggered(battlerAtk, GetBattlerAbility(battlerAtk)))
             gSpecialStatuses[battlerAtk].shellBellEmergencyExit = TRUE;
@@ -602,7 +602,7 @@ static enum ItemEffect TryLeftovers(enum BattlerId battler, enum HoldEffect hold
     enum ItemEffect effect = ITEM_NO_EFFECT;
 
     if (gBattleMons[battler].hp < gBattleMons[battler].maxHP
-     && !(B_HEAL_BLOCKING >= GEN_5 && gBattleMons[battler].volatiles.healBlockTimer))
+     && !(GetConfig(B_HEAL_BLOCKING) >= GEN_5 && gBattleMons[battler].volatiles.healBlockTimer))
     {
         SetHealAmount(battler, GetNonDynamaxMaxHP(battler) / 16);
         RecordItemEffectBattle(battler, holdEffect);
@@ -798,7 +798,7 @@ static enum ItemEffect ItemHealHp(enum BattlerId battler, enum Item itemId, enum
     enum Ability ability = GetBattlerAbility(battler);
 
     if (!(gBattleScripting.overrideBerryRequirements && gBattleMons[battler].hp == gBattleMons[battler].maxHP)
-     && !(B_HEAL_BLOCKING >= GEN_5 && gBattleMons[battler].volatiles.healBlockTimer)
+     && !(GetConfig(B_HEAL_BLOCKING) >= GEN_5 && gBattleMons[battler].volatiles.healBlockTimer)
      && HasEnoughHpToEatBerry(battler, ability, 2, itemId))
     {
         s32 healAmount = 0;
@@ -894,7 +894,7 @@ static enum ItemEffect HealConfuseBerry(enum BattlerId battler, enum Item itemId
     enum Ability ability = GetBattlerAbility(battler);
 
     if (HasEnoughHpToEatBerry(battler, ability, hpFraction, itemId)
-     && !(B_HEAL_BLOCKING >= GEN_5 && gBattleMons[battler].volatiles.healBlockTimer))
+     && !(GetConfig(B_HEAL_BLOCKING) >= GEN_5 && gBattleMons[battler].volatiles.healBlockTimer))
     {
         s32 healAmount = GetNonDynamaxMaxHP(battler) / GetItemHoldEffectParam(itemId);
         if (ability == ABILITY_RIPEN)

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3021,6 +3021,10 @@ void SwitchInClearSetData(enum BattlerId battler, struct Volatiles *volatilesCop
         gBattleMons[battler].volatiles.battlerPreventingEscape = volatilesCopy->battlerPreventingEscape;
         gBattleMons[battler].volatiles.embargoTimer = volatilesCopy->embargoTimer;
         gBattleMons[battler].volatiles.healBlockTimer = volatilesCopy->healBlockTimer;
+        if (IsTelekinesisBannedSpecies(gBattleMons[battler].species))
+            gBattleMons[battler].volatiles.telekinesis = FALSE;
+        else
+            gBattleMons[battler].volatiles.telekinesisTimer = volatilesCopy->telekinesisTimer;
     }
     else if (effect == EFFECT_SHED_TAIL)
     {
@@ -4454,6 +4458,9 @@ s32 GetChosenMovePriority(enum BattlerId battler, enum Ability ability)
     gProtectStructs[battler].pranksterElevated = FALSE;
     if (gProtectStructs[battler].noValidMoves)
         move = MOVE_STRUGGLE;
+    else if (gLockedMoves[battler] != MOVE_NONE
+          && (gBattleMons[battler].volatiles.multipleTurns || gBattleMons[battler].volatiles.rechargeTimer > 0))
+        move = gLockedMoves[battler];
     else if (gBattleMons[battler].volatiles.encoredMove != MOVE_NONE && GetConfig(B_ENCORE_PRIORITY) >= GEN_CHAMPIONS)
         move = gBattleMons[battler].volatiles.encoredMove;
     else

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -1197,7 +1197,7 @@ static enum CancelerResult CancelerMoveFailure(struct BattleCalcValues *cv)
     case EFFECT_DARK_VOID:
         if (gBattleStruct->bouncedMoveIsUsed)
             break;
-        if (B_DARK_VOID_FAIL >= GEN_7 && gBattleMons[cv->battlerAtk].species != SPECIES_DARKRAI)
+        if (GetConfig(B_DARK_VOID_FAIL) >= GEN_7 && gBattleMons[cv->battlerAtk].species != SPECIES_DARKRAI)
             battleScript = BattleScript_PokemonCantUseTheMove;
         break;
     case EFFECT_AURA_WHEEL:
@@ -4165,6 +4165,15 @@ static enum MoveEndResult MoveEndMoveBlockRecoil(struct BattleCalcValues *cv)
             result = MOVEEND_RESULT_RUN_SCRIPT;
         }
         break;
+    case EFFECT_RAPID_SPIN:
+        if (GetConfig(B_SPEED_BUFFING_RAPID_SPIN) == GEN_8
+         && IsAnyTargetTurnDamaged(cv->battlerAtk, INCLUDING_SUBSTITUTES)
+         && IsBattlerAlive(cv->battlerAtk))
+        {
+            BattleScriptCall(BattleScript_RapidSpinAway);
+            result = MOVEEND_RESULT_RUN_SCRIPT;
+        }
+        break;
     default:
         break;
     }
@@ -4261,6 +4270,35 @@ static enum MoveEndResult MoveEndMoveBlock(struct BattleCalcValues *cv)
 
                 BattleScriptCall(BattleScript_KnockedOff);
                 return MOVEEND_RESULT_RUN_SCRIPT;
+            }
+            break;
+        case EFFECT_SECRET_POWER:
+            if (IsBattlerTurnDamaged(battlerDef, EXCLUDING_SUBSTITUTES) && IsBattlerAlive(cv->battlerAtk))
+            {
+                u32 chance = GetMoveSecondaryEffectChance(cv->move);
+                bool32 hasSereneGrace = cv->abilities[cv->battlerAtk] == ABILITY_SERENE_GRACE;
+                bool32 hasRainbow = gSideStatuses[GetBattlerSide(cv->battlerAtk)] & SIDE_STATUS_RAINBOW;
+                bool32 hasFlinchEffect = gFieldTimers.terrain == B_TERRAIN_NONE
+                                      && gBattleEnvironmentInfo[gBattleEnvironment].secretPowerEffect == MOVE_EFFECT_FLINCH;
+
+                if (hasSereneGrace)
+                    chance *= 2;
+                if (hasRainbow && !(hasSereneGrace && hasFlinchEffect))
+                    chance *= 2;
+
+                if (RandomPercentage(RNG_SECONDARY_EFFECT, chance))
+                {
+                    const u8 *moveEndScript = gBattlescriptCurrInstr;
+                    struct SetEffect se = {0};
+
+                    se.moveEffect = MOVE_EFFECT_SECRET_POWER;
+                    se.script = moveEndScript;
+                    se.effectBattler = battlerDef;
+
+                    SetMoveEffect(cv, &se);
+                    if (gBattlescriptCurrInstr != moveEndScript)
+                        return MOVEEND_RESULT_RUN_SCRIPT;
+                }
             }
             break;
         case EFFECT_STEAL_ITEM:
@@ -4361,7 +4399,8 @@ static enum MoveEndResult MoveEndMoveBlock(struct BattleCalcValues *cv)
             }
             break;
         case EFFECT_RAPID_SPIN:
-            if (IsBattlerTurnDamaged(battlerDef, INCLUDING_SUBSTITUTES))
+            if (GetConfig(B_SPEED_BUFFING_RAPID_SPIN) != GEN_8
+             && IsBattlerTurnDamaged(battlerDef, INCLUDING_SUBSTITUTES))
             {
                 if (!IsBattlerAlive(cv->battlerAtk) && GetConfig(B_FAINT_MOVE_EFFECT_TIMING) < GEN_CHAMPIONS)
                     break;

--- a/src/battle_move_resolution.c
+++ b/src/battle_move_resolution.c
@@ -3260,8 +3260,11 @@ static enum MoveEndResult MoveEndSetValues(struct BattleCalcValues *cv)
     {
         gBattleStruct->accumulatedDamage += gBattleStruct->moveDamage[battlerDef];
     }
+
     gBattleStruct->eventState.moveEndBattler = 0;
     gBattleStruct->eventState.moveEndBlock = 0;
+    gBattleStruct->eventState.resolution = 0;
+    gBattleStruct->statChangeBattler = 0;
     gBattleScripting.moveendState++;
     return MOVEEND_RESULT_CONTINUE;
 }

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -5397,7 +5397,11 @@ static void Cmd_normalisebuffs(void)
     CMD_ARGS();
 
     for (enum BattlerId i = 0; i < gBattlersCount; i++)
+    {
         TryResetBattlerStatChanges(i);
+        if (GetConfig(B_HAZE_FOCUS_ENERGY) == GEN_1 || GetConfig(B_HAZE_FOCUS_ENERGY) == GEN_4)
+            gBattleMons[i].volatiles.focusEnergy = FALSE;
+    }
 
     gBattlescriptCurrInstr = cmd->nextInstr;
 }

--- a/src/battle_set_effect.c
+++ b/src/battle_set_effect.c
@@ -1435,6 +1435,7 @@ void SetMoveEffect(struct BattleCalcValues *cv, struct SetEffect *se)
     if (!se->primary && !affectsUser && IsMoveEffectBlockedByTarget(cv->abilities[se->effectBattler]))
         se->moveEffect = MOVE_EFFECT_NONE;
     else if (!se->primary
+          && !se->bypassSheerForce
           && IsSheerForceAffected(cv->move, cv->abilities[cv->battlerAtk])
           && !(se->moveEffect == MOVE_EFFECT_ORDER_UP && gBattleStruct->battlerState[cv->battlerAtk].commanderSpecies != SPECIES_NONE))
         se->moveEffect = MOVE_EFFECT_NONE;
@@ -1465,8 +1466,9 @@ void SetMoveEffectHelper(enum BattlerId battlerAtk, enum BattlerId effectBattler
     se.moveEffect = moveEffect;
     se.script = battleScript;
     se.effectBattler = effectBattler;
-    se.primary = effectFlags & EFFECT_PRIMARY;
-    se.certain = effectFlags & EFFECT_CERTAIN;
+    se.primary = (effectFlags & EFFECT_PRIMARY) != 0;
+    se.certain = (effectFlags & EFFECT_CERTAIN) != 0;
+    se.bypassSheerForce = (effectFlags & EFFECT_BYPASS_SHEER_FORCE) != 0;
 
     SetMoveEffect(&cv, &se);
 }
@@ -1548,4 +1550,3 @@ static bool32 IsFinalStrikeEffect(enum MoveEffect moveEffect)
         return FALSE;
     }
 }
-

--- a/src/battle_set_effect.c
+++ b/src/battle_set_effect.c
@@ -490,8 +490,17 @@ static void HandleSetEffectBugBite(struct BattleCalcValues *cv, struct SetEffect
 
 static void HandleSetEffectRecoilHp25(struct BattleCalcValues *cv, struct SetEffect *se)
 {
-    s32 recoil = (gBattleMons[se->effectBattler].maxHP) / 4;
-    if (B_UPDATED_MOVE_DATA >= GEN_5 && (gBattleMons[se->effectBattler].maxHP % 4) >= 2) // Account for standard rounding (Gen5+)
+    s32 recoil;
+    if (GetConfig(B_STRUGGLE_RECOIL) < GEN_4)
+    {
+        u32 recoilPercentage = GetConfig(B_STRUGGLE_RECOIL) == GEN_1 ? 50 : 25;
+        recoil = gBattleStruct->moveDamage[gBattlerTarget] * recoilPercentage / 100;
+    }
+    else
+    {
+        recoil = (gBattleMons[se->effectBattler].maxHP) / 4;
+    }
+    if (GetConfig(B_STRUGGLE_RECOIL) >= GEN_5 && (gBattleMons[se->effectBattler].maxHP % 4) >= 2) // Account for standard rounding (Gen5+)
         recoil++;
     if (recoil == 0)
         recoil = 1;
@@ -925,7 +934,7 @@ static void HandleSetEffectWeather(struct BattleCalcValues *cv, struct SetEffect
         msg = B_MSG_STARTED_SANDSTORM;
         break;
     case MOVE_EFFECT_HAIL:
-        if (B_PREFERRED_ICE_WEATHER == B_ICE_WEATHER_SNOW)
+        if (GetConfig(B_PREFERRED_ICE_WEATHER) == B_ICE_WEATHER_SNOW)
         {
             weather = BATTLE_WEATHER_SNOW;
             msg = B_MSG_STARTED_SNOW;

--- a/src/battle_setup.c
+++ b/src/battle_setup.c
@@ -6,6 +6,7 @@
 #include "battle_pike.h"
 #include "battle_pyramid.h"
 #include "battle_setup.h"
+#include "battle_special.h"
 #include "battle_partner.h"
 #include "battle_tower.h"
 #include "battle_transition.h"
@@ -350,6 +351,9 @@ void BattleSetup_StartDoubleWildBattle(void)
 
 void BattleSetup_StartMultiBattle(void)
 {
+    gBattleScripting.specialTrainerBattleType = SPECIAL_BATTLE_MULTI;
+    gMain.savedCallback = CB2_EndSpecialTrainerBattle;
+
     if (gSpecialVar_0x8005 & MULTI_BATTLE_2_VS_WILD) // Player + AI against wild mon
     {
         gBattleTypeFlags = BATTLE_TYPE_DOUBLE | BATTLE_TYPE_MULTI | BATTLE_TYPE_INGAME_PARTNER;

--- a/src/battle_special.c
+++ b/src/battle_special.c
@@ -18,7 +18,6 @@
 #include "constants/battle_frontier.h"
 #include "constants/battle_special.h"
 
-static void HandleSpecialTrainerBattleEnd(void);
 static void Task_StartBattleAfterTransition(u8 taskId);
 static void UNUSED FillEReaderTrainerWithPlayerData(void);
 static void CopyEReaderTrainerFarewellMessage(void);
@@ -27,7 +26,7 @@ static void CopyEReaderTrainerFarewellMessage(void);
 static void SetEReaderTrainerChecksum(struct BattleTowerEReaderTrainer *ereaderTrainer);
 #endif //FREE_BATTLE_TOWER_E_READER
 
-static void HandleSpecialTrainerBattleEnd(void)
+void CB2_EndSpecialTrainerBattle(void)
 {
     s32 i;
 
@@ -63,7 +62,7 @@ static void Task_StartBattleAfterTransition(u8 taskId)
 {
     if (IsBattleTransitionDone() == TRUE)
     {
-        gMain.savedCallback = HandleSpecialTrainerBattleEnd;
+        gMain.savedCallback = CB2_EndSpecialTrainerBattle;
         SetMainCallback2(CB2_InitBattle);
         DestroyTask(taskId);
     }

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -2402,7 +2402,7 @@ bool32 CanAbilityAbsorbMove(struct DamageContext *ctx)
 
 const u8 *AbsorbedByDrainHpAbility(enum BattlerId battlerDef)
 {
-    if (IsBattlerAtMaxHp(battlerDef) || (B_HEAL_BLOCKING >= GEN_5 && gBattleMons[battlerDef].volatiles.healBlockTimer))
+    if (IsBattlerAtMaxHp(battlerDef) || (GetConfig(B_HEAL_BLOCKING) >= GEN_5 && gBattleMons[battlerDef].volatiles.healBlockTimer))
     {
         return BattleScript_AbilityProtectedTarget;
     }
@@ -3999,7 +3999,7 @@ u32 AbilityBattleEffects(enum AbilityEffect caseID, enum BattlerId battler, enum
             break;
         case ABILITY_ANGER_POINT:
             if (gSpecialStatuses[battler].criticalHit
-             && IsBattlerTurnDamaged(battler, EXCLUDING_SUBSTITUTES)
+             && IsBattlerTurnDamaged(battler, GetConfig(B_UPDATED_ABILITY_DATA) <= GEN_4 ? INCLUDING_SUBSTITUTES : EXCLUDING_SUBSTITUTES)
              && IsBattlerAlive(battler)
              && CompareStat(battler, STAT_ATK, MAX_STAT_STAGE, CMP_LESS_THAN, gLastUsedAbility))
             {
@@ -5734,19 +5734,31 @@ enum HoldEffect GetBattlerHoldEffectIgnoreAbility(enum BattlerId battler)
 
 enum HoldEffect GetBattlerHoldEffectInternal(enum BattlerId battler, enum Ability ability)
 {
+    enum HoldEffect holdEffect;
+
     if (gBattleStruct->battlerState[battler].notOnField)
         return HOLD_EFFECT_NONE;
     if (gSpecialStatuses[battler].attackerInParty)
         return HOLD_EFFECT_NONE;
-    if (gBattleMons[battler].volatiles.embargoTimer)
+
+    if (gBattleMons[battler].volatiles.embargoTimer
+     || gFieldStatuses & STATUS_FIELD_MAGIC_ROOM
+     || (ability == ABILITY_KLUTZ && !gBattleMons[battler].volatiles.gastroAcid))
+    {
+        if (gBattleMons[battler].item == ITEM_ENIGMA_BERRY_E_READER)
+            holdEffect = gEnigmaBerries[battler].holdEffect;
+        else
+            holdEffect = GetItemHoldEffect(gBattleMons[battler].item);
+
+        if (holdEffect == HOLD_EFFECT_DOUBLE_PRIZE)
+        {
+            gPotentialItemEffectBattler = battler;
+            return holdEffect;
+        }
         return HOLD_EFFECT_NONE;
-    if (gFieldStatuses & STATUS_FIELD_MAGIC_ROOM)
-        return HOLD_EFFECT_NONE;
-    if (ability == ABILITY_KLUTZ && !gBattleMons[battler].volatiles.gastroAcid)
-        return HOLD_EFFECT_NONE;
+    }
 
     gPotentialItemEffectBattler = battler;
-
     if (gBattleMons[battler].item == ITEM_ENIGMA_BERRY_E_READER)
         return gEnigmaBerries[battler].holdEffect;
     else
@@ -6387,7 +6399,7 @@ static inline u32 CalcMoveBasePower(struct DamageContext *ctx)
         break;
     case EFFECT_HIDDEN_POWER:
     {
-        if (B_HIDDEN_POWER_DMG < GEN_6)
+        if (GetConfig(B_HIDDEN_POWER_DMG) < GEN_6)
         {
             u8 powerBits = ((gBattleMons[battlerAtk].hpIV & 2) >> 1)
                          | ((gBattleMons[battlerAtk].attackIV & 2) << 0)
@@ -6435,7 +6447,11 @@ static inline u32 CalcMoveBasePower(struct DamageContext *ctx)
     }
 
     if (basePower == 0)
-        basePower = 1;
+    {
+        if ((moveEffect != EFFECT_RETURN && moveEffect != EFFECT_FRUSTRATION)
+         || GetConfig(B_RETURN_FRUSTRATION_DMG) >= GEN_3)
+            basePower = 1;
+    }
     return basePower;
 }
 
@@ -7326,13 +7342,14 @@ static inline uq4_12_t GetParentalBondModifier(enum BattlerId battlerAtk)
 
 static inline uq4_12_t GetSameTypeAttackBonusModifier(struct DamageContext *ctx)
 {
-    bool32 isAdaptability = ctx->abilities[ctx->battlerAtk] == ABILITY_ADAPTABILITY;
-
-    if (IS_BATTLER_OF_TYPE(ctx->battlerAtk, ctx->moveType) && ctx->move != MOVE_STRUGGLE)
-        return isAdaptability ? UQ_4_12(2.0) : UQ_4_12(1.5);
-
-    if (gBattleStruct->pledgeState == PLEDGE_COMBO_ATTACK && IS_BATTLER_OF_TYPE(GetPartnerBattler(ctx->battlerAtk), ctx->moveType))
-        return isAdaptability ? UQ_4_12(2.0) : UQ_4_12(1.5);
+    if (ctx->moveType != TYPE_MYSTERY)
+    {
+        if ((IS_BATTLER_OF_TYPE(ctx->battlerAtk, ctx->moveType) && ctx->move != MOVE_STRUGGLE)
+         || (gBattleStruct->pledgeState == PLEDGE_COMBO_ATTACK && IS_BATTLER_OF_TYPE(GetPartnerBattler(ctx->battlerAtk), ctx->moveType)))
+        {
+            return ctx->abilities[ctx->battlerAtk] == ABILITY_ADAPTABILITY ? UQ_4_12(2.0) : UQ_4_12(1.5);
+        }
+    }
 
     return UQ_4_12(1.0);
 }
@@ -7684,6 +7701,9 @@ static inline s32 DoMoveDamageCalcVars(struct DamageContext *ctx)
         gBattleMovePower = ctx->fixedBasePower;
     else
         gBattleMovePower = CalcMoveBasePowerAfterModifiers(ctx);
+
+    if (gBattleMovePower == 0)
+        return 0;
 
     userFinalAttack = CalcAttackStat(ctx);
     targetFinalDefense = CalcDefenseStat(ctx);
@@ -8330,11 +8350,30 @@ static inline uq4_12_t CalcTypeEffectivenessMultiplierInternal(struct DamageCont
     return modifier;
 }
 
+static inline bool32 MoveIgnoresType(struct DamageContext *ctx)
+{
+    if (ctx->moveType == TYPE_MYSTERY)
+        return TRUE;
+
+    switch (GetMoveEffect(ctx->move))
+    {
+    case EFFECT_FIXED_PERCENT_DAMAGE:
+    case EFFECT_FIXED_HP_DAMAGE:
+    case EFFECT_LEVEL_DAMAGE:
+    case EFFECT_PSYWAVE:
+    case EFFECT_BIDE:
+    case EFFECT_REFLECT_DAMAGE:
+        return GetConfig(B_FIXED_DMG_IGNORES_TYPE) < GEN_2;
+    default:
+        return FALSE;
+    }
+}
+
 uq4_12_t CalcTypeEffectivenessMultiplier(struct DamageContext *ctx)
 {
     uq4_12_t modifier = UQ_4_12(1.0);
 
-    if (ctx->move != MOVE_STRUGGLE && ctx->moveType != TYPE_MYSTERY)
+    if (!MoveIgnoresType(ctx))
     {
         modifier = CalcTypeEffectivenessMultiplierInternal(ctx, modifier);
         if (GetMoveEffect(ctx->move) == EFFECT_TWO_TYPED_MOVE && !ctx->isAnticipation)
@@ -8768,6 +8807,8 @@ bool32 TryBattleFormChange(enum BattlerId battler, enum FormChanges method, enum
         TryToSetBattleFormChangeMoves(mon, method);
         SetMonData(mon, MON_DATA_SPECIES, &targetSpecies);
         gBattleMons[battler].species = targetSpecies;
+        if (GetConfig(B_AUTOTOMIZE_FORM_CHANGE) >= GEN_6)
+            gBattleMons[battler].volatiles.autotomizeCount = 0;
         RecalcBattlerStats(battler, mon, method == FORM_CHANGE_BATTLE_GIGANTAMAX);
         return TRUE;
     }
@@ -9583,7 +9624,7 @@ u32 CalcSecondaryEffectChance(enum BattlerId battler, enum Ability battlerAbilit
 
     if (hasSereneGrace)
         secondaryEffectChance *= 2;
-    if (hasRainbow && additionalEffect->moveEffect != MOVE_EFFECT_SECRET_POWER)
+    if (hasRainbow)
         secondaryEffectChance *= 2;
 
     return secondaryEffectChance;
@@ -9824,9 +9865,9 @@ enum Type GetBattleMoveType(enum Move move)
             return gBattleStruct->dynamicMoveType;
 
         enum BattleMoveEffects effect = GetMoveEffect(move);
-        if (B_UPDATED_MOVE_TYPES < GEN_5
-         && (effect == EFFECT_BEAT_UP || effect == EFFECT_FUTURE_SIGHT))
-          return TYPE_MYSTERY;
+        if ((effect == EFFECT_BEAT_UP || effect == EFFECT_FUTURE_SIGHT)
+         && GetConfig(B_UPDATED_MOVE_TYPES) < GEN_5)
+            return TYPE_MYSTERY;
     }
     return GetMoveType(move);
 }

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -9947,11 +9947,17 @@ bool32 AreMultiPartiesFullTeams(void)
     enum DifficultyLevel difficulty = GetCurrentDifficultyLevel();
 
     if (B_MULTI_HALF_TEAMS)
-		return FALSE;
+    {
+        gSpecialVar_Result = FALSE;
+        return FALSE;
+    }
 
-	if (!(gBattleTypeFlags & BATTLE_TYPE_TRAINER))
-		return TRUE;
-		
+    if (!(gBattleTypeFlags & BATTLE_TYPE_TRAINER))
+    {
+        gSpecialVar_Result = TRUE;
+        return TRUE;
+    }
+
     if (TRAINER_BATTLE_PARAM.opponentA == TRAINER_LINK_OPPONENT
      || gBattleTypeFlags & BATTLE_TYPE_TOWER_LINK_MULTI
      || (gTrainers[difficulty][TRAINER_BATTLE_PARAM.opponentA].multiTeamSize == MULTI_TEAM_SIZE_HALF)

--- a/src/data/battle_move_effects.h
+++ b/src/data/battle_move_effects.h
@@ -1876,4 +1876,10 @@ const struct BattleMoveEffect gBattleMoveEffects[NUM_BATTLE_MOVE_EFFECTS] =
         .battleScript = BattleScript_EffectHit,
         .battleTvScore = 0, // TODO: Assign points
     },
+
+    [EFFECT_SECRET_POWER] =
+    {
+        .battleScript = BattleScript_EffectHit,
+        .battleTvScore = 1,
+    },
 };

--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -2003,7 +2003,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
         #endif
         .effect = EFFECT_GROWTH,
         .power = 0,
-        .type = B_UPDATED_MOVE_DATA >= GEN_CHAMPIONS ? TYPE_GRASS : TYPE_NORMAL,
+        .type = B_UPDATED_MOVE_TYPES >= GEN_CHAMPIONS ? TYPE_GRASS : TYPE_NORMAL,
         .accuracy = 0,
         .pp = B_UPDATED_MOVE_DATA >= GEN_6 ? 20 : 40,
         .target = TARGET_USER,
@@ -18770,7 +18770,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
             "trap for four to five turns."),
         .effect = EFFECT_HIT,
         .power = 35,
-        .type = B_UPDATED_MOVE_DATA >= GEN_CHAMPIONS ? TYPE_STEEL : TYPE_GRASS,
+        .type = B_UPDATED_MOVE_TYPES >= GEN_CHAMPIONS ? TYPE_STEEL : TYPE_GRASS,
         .accuracy = 100,
         .pp = 15,
         .target = TARGET_SELECTED,

--- a/src/data/moves_info.h
+++ b/src/data/moves_info.h
@@ -4527,7 +4527,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
         .argument = { .recoilPercentage = 50 },
     #endif
         .power = 50,
-        .type = TYPE_NORMAL,
+        .type = B_UPDATED_MOVE_TYPES >= GEN_2 ? TYPE_MYSTERY : TYPE_NORMAL,
         .accuracy = B_UPDATED_MOVE_DATA >= GEN_4 ? 0 : 100,
         .pp = B_UPDATED_MOVE_DATA >= GEN_2 ? 1: 10,
         .target = TARGET_SELECTED,
@@ -7961,7 +7961,7 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
         .description = COMPOUND_STRING(
             "An attack with effects\n"
             "that vary by location."),
-        .effect = EFFECT_HIT,
+        .effect = EFFECT_SECRET_POWER,
         .power = 70,
         .type = TYPE_NORMAL,
         .accuracy = 100,
@@ -7969,9 +7969,9 @@ const struct MoveInfo gMovesInfo[MOVES_COUNT_ALL] =
         .target = TARGET_SELECTED,
         .priority = 0,
         .category = DAMAGE_CATEGORY_PHYSICAL,
+        .argument = { .secondaryEffectChance = 30 },
         .additionalEffects = ADDITIONAL_EFFECTS({
-            .moveEffect = MOVE_EFFECT_SECRET_POWER,
-            .chance = 30,
+            .sheerForceOverride = TRUE,
         }),
         .contestEffect = CONTEST_EFFECT_BETTER_WITH_GOOD_CONDITION,
         .contestCategory = CONTEST_CATEGORY_SMART,

--- a/src/data/pokemon/species_info/gen_1_families.h
+++ b/src/data/pokemon/species_info/gen_1_families.h
@@ -1862,6 +1862,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
             gOverworldPalette_Pidgey,
             gShinyOverworldPalette_Pidgey
         )
+        .isSkyBattleBanned = B_SKY_BATTLE_STRICT_ELIGIBILITY,
         .levelUpLearnset = sPidgeyLevelUpLearnset,
         .teachableLearnset = sPidgeyTeachableLearnset,
         .eggMoveLearnset = sPidgeyEggMoveLearnset,

--- a/src/pokemon_summary_screen.c
+++ b/src/pokemon_summary_screen.c
@@ -1214,7 +1214,7 @@ void ShowPokemonSummaryScreen(u8 mode, void *mons, u8 monIndex, u8 maxMonIndex, 
     else
         sMonSummaryScreen->isBoxMon = FALSE;
 
-    u32 maxPageIndex = PSS_PAGE_COUNT - (C_HIDE_CONTEST_DATA) ? 2 : 1;
+    u32 maxPageIndex = PSS_PAGE_COUNT - (C_HIDE_CONTEST_DATA ? 2 : 1);
     switch (mode)
     {
     case SUMMARY_MODE_NORMAL:

--- a/src/wild_encounter_ow.c
+++ b/src/wild_encounter_ow.c
@@ -1122,9 +1122,6 @@ void TryDespawnOWEsCrossingMapConnection(void)
     if (gMapHeader.mapType != MAP_TYPE_CITY && gMapHeader.mapType != MAP_TYPE_TOWN)
         return;
 
-    if (WE_OWE_DESPAWN_SOUND)
-        PlaySE(SE_FLEE);
-        
     DespawnAllOverworldWildEncounters(OWE_GENERATED, 0);
 }
 

--- a/test/battle/ability/anger_point.c
+++ b/test/battle/ability/anger_point.c
@@ -45,7 +45,26 @@ SINGLE_BATTLE_TEST("Anger Point does not trigger when already at maximum Attack 
     }
 }
 
-TO_DO_BATTLE_TEST("Anger Point triggers when a substitute takes the hit (Gen4)");
+SINGLE_BATTLE_TEST("Anger Point triggers when a substitute takes the hit (Gen4)")
+{
+    GIVEN {
+        WITH_CONFIG(B_UPDATED_ABILITY_DATA, GEN_4);
+        ASSUME(GetMoveEffect(MOVE_SUBSTITUTE) == EFFECT_SUBSTITUTE);
+        PLAYER(SPECIES_PRIMEAPE) { Ability(ABILITY_ANGER_POINT); Speed(2); }
+        OPPONENT(SPECIES_SNORUNT) { Speed(1); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SUBSTITUTE); MOVE(opponent, MOVE_SCRATCH, criticalHit: TRUE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SUBSTITUTE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
+        MESSAGE("A critical hit!");
+        ABILITY_POPUP(player, ABILITY_ANGER_POINT);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        MESSAGE("Primeape maxed its Attack!");
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_ATK], MAX_STAT_STAGE);
+    }
+}
 
 SINGLE_BATTLE_TEST("Anger Point does not trigger when a substitute takes the hit (Gen5+)")
 {

--- a/test/battle/ability/contrary.c
+++ b/test/battle/ability/contrary.c
@@ -289,4 +289,43 @@ SINGLE_BATTLE_TEST("Contrary does not invert stat changes that have been Baton-p
     }
 }
 
-TO_DO_BATTLE_TEST("Contrary inverts stat changes from X Attack and other stat-boosting items.")
+SINGLE_BATTLE_TEST("Contrary inverts stat changes from X items")
+{
+    enum Item item;
+    enum Stat stat;
+
+    PARAMETRIZE { item = ITEM_X_ATTACK;   stat = STAT_ATK; }
+    PARAMETRIZE { item = ITEM_X_DEFENSE;  stat = STAT_DEF; }
+    PARAMETRIZE { item = ITEM_X_SP_ATK;   stat = STAT_SPATK; }
+    PARAMETRIZE { item = ITEM_X_SP_DEF;   stat = STAT_SPDEF; }
+    PARAMETRIZE { item = ITEM_X_SPEED;    stat = STAT_SPEED; }
+    PARAMETRIZE { item = ITEM_X_ACCURACY; stat = STAT_ACC; }
+
+    GIVEN {
+        WITH_CONFIG(B_X_ITEMS_BUFF, GEN_7);
+        ASSUME(gItemsInfo[item].battleUsage == EFFECT_ITEM_INCREASE_STAT);
+        PLAYER(SPECIES_SNIVY) { Ability(ABILITY_CONTRARY); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { USE_ITEM(player, item); }
+    } THEN {
+        EXPECT_EQ(player->statStages[stat], DEFAULT_STAT_STAGE - 2);
+    }
+}
+
+SINGLE_BATTLE_TEST("Contrary inverts stat changes from Max Mushrooms")
+{
+    GIVEN {
+        ASSUME(gItemsInfo[ITEM_MAX_MUSHROOMS].battleUsage == EFFECT_ITEM_INCREASE_ALL_STATS);
+        PLAYER(SPECIES_SNIVY) { Ability(ABILITY_CONTRARY); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { USE_ITEM(player, ITEM_MAX_MUSHROOMS); }
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_ATK], DEFAULT_STAT_STAGE - 1);
+        EXPECT_EQ(player->statStages[STAT_DEF], DEFAULT_STAT_STAGE - 1);
+        EXPECT_EQ(player->statStages[STAT_SPATK], DEFAULT_STAT_STAGE - 1);
+        EXPECT_EQ(player->statStages[STAT_SPDEF], DEFAULT_STAT_STAGE - 1);
+        EXPECT_EQ(player->statStages[STAT_SPEED], DEFAULT_STAT_STAGE - 1);
+    }
+}

--- a/test/battle/ability/cute_charm.c
+++ b/test/battle/ability/cute_charm.c
@@ -46,7 +46,29 @@ SINGLE_BATTLE_TEST("Cute Charm cannot infatuate same gender")
     }
 }
 
-TO_DO_BATTLE_TEST("Cute Charm cannot infatuate if either Pokémon are Gender-unknown")
+SINGLE_BATTLE_TEST("Cute Charm cannot infatuate if either Pokémon is genderless")
+{
+    enum Species playerSpecies, opponentSpecies;
+
+    PARAMETRIZE { playerSpecies = SPECIES_STARMIE; opponentSpecies = SPECIES_NIDOQUEEN; }
+    PARAMETRIZE { playerSpecies = SPECIES_NIDOKING; opponentSpecies = SPECIES_STARMIE; }
+
+    GIVEN {
+        ASSUME(MoveMakesContact(MOVE_SCRATCH));
+        ASSUME(gSpeciesInfo[SPECIES_NIDOKING].genderRatio == MON_MALE);
+        ASSUME(gSpeciesInfo[SPECIES_NIDOQUEEN].genderRatio == MON_FEMALE);
+        ASSUME(gSpeciesInfo[SPECIES_STARMIE].genderRatio == MON_GENDERLESS);
+        PLAYER(playerSpecies);
+        OPPONENT(opponentSpecies) { Ability(ABILITY_CUTE_CHARM); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SCRATCH, WITH_RNG(RNG_CUTE_CHARM, 1)); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        NOT ABILITY_POPUP(opponent, ABILITY_CUTE_CHARM);
+    } THEN {
+        EXPECT(!(player->volatiles.infatuation));
+    }
+}
 
 SINGLE_BATTLE_TEST("Cute Charm triggers 1/3 times (Gen3) or 30% (Gen 4+) of the time")
 {

--- a/test/battle/ability/opportunist.c
+++ b/test/battle/ability/opportunist.c
@@ -374,4 +374,44 @@ DOUBLE_BATTLE_TEST("Opportunist activates before Mirror Herb during the end turn
     }
 }
 
-TO_DO_BATTLE_TEST("Opportunist copies stat changes from the opponent's X Attack and other stat-boosting items.")
+SINGLE_BATTLE_TEST("Opportunist copies stat changes from the opponent's X items")
+{
+    enum Item item;
+    enum Stat stat;
+
+    PARAMETRIZE { item = ITEM_X_ATTACK;   stat = STAT_ATK; }
+    PARAMETRIZE { item = ITEM_X_DEFENSE;  stat = STAT_DEF; }
+    PARAMETRIZE { item = ITEM_X_SP_ATK;   stat = STAT_SPATK; }
+    PARAMETRIZE { item = ITEM_X_SP_DEF;   stat = STAT_SPDEF; }
+    PARAMETRIZE { item = ITEM_X_SPEED;    stat = STAT_SPEED; }
+    PARAMETRIZE { item = ITEM_X_ACCURACY; stat = STAT_ACC; }
+
+    GIVEN {
+        WITH_CONFIG(B_X_ITEMS_BUFF, GEN_7);
+        ASSUME(gItemsInfo[item].battleUsage == EFFECT_ITEM_INCREASE_STAT);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_ESPATHRA) { Ability(ABILITY_OPPORTUNIST); }
+    } WHEN {
+        TURN { USE_ITEM(player, item); }
+    } THEN {
+        EXPECT_EQ(player->statStages[stat], DEFAULT_STAT_STAGE + 2);
+        EXPECT_EQ(opponent->statStages[stat], DEFAULT_STAT_STAGE + 2);
+    }
+}
+
+SINGLE_BATTLE_TEST("Opportunist copies stat changes from the opponent's Max Mushrooms")
+{
+    GIVEN {
+        ASSUME(gItemsInfo[ITEM_MAX_MUSHROOMS].battleUsage == EFFECT_ITEM_INCREASE_ALL_STATS);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_ESPATHRA) { Ability(ABILITY_OPPORTUNIST); }
+    } WHEN {
+        TURN { USE_ITEM(player, ITEM_MAX_MUSHROOMS); }
+    } THEN {
+        for (enum Stat stat = STAT_ATK; stat < NUM_STATS; stat++)
+        {
+            EXPECT_EQ(player->statStages[stat], DEFAULT_STAT_STAGE + 1);
+            EXPECT_EQ(opponent->statStages[stat], DEFAULT_STAT_STAGE + 1);
+        }
+    }
+}

--- a/test/battle/hold_effect/ability_shield.c
+++ b/test/battle/hold_effect/ability_shield.c
@@ -351,7 +351,80 @@ DOUBLE_BATTLE_TEST("Ability Shield on fainted ally does not block Receiver/Power
     }
 }
 
-// These currently do not activate, but probably should do held item animation + message
-TO_DO_BATTLE_TEST("Ability Shield prevents the user's Trace from changing its ability");
-TO_DO_BATTLE_TEST("Ability Shield protects against Wandering Spirit");
-TO_DO_BATTLE_TEST("Ability Shield protects against Mummy/Lingering Aroma");
+SINGLE_BATTLE_TEST("Ability Shield prevents the user's Trace from changing its ability")
+{
+    enum Item item;
+
+    PARAMETRIZE { item = ITEM_ABILITY_SHIELD; }
+    PARAMETRIZE { item = ITEM_NONE; }
+
+    GIVEN {
+        ASSUME(!gAbilitiesInfo[ABILITY_BLAZE].cantBeTraced);
+        PLAYER(SPECIES_RALTS) { Ability(ABILITY_TRACE); Item(item); }
+        OPPONENT(SPECIES_TORCHIC) { Ability(ABILITY_BLAZE); }
+    } WHEN {
+        TURN {}
+    } SCENE {
+        if (item == ITEM_ABILITY_SHIELD) {
+            NOT ABILITY_POPUP(player, ABILITY_TRACE);
+        } else {
+            ABILITY_POPUP(player, ABILITY_TRACE);
+            MESSAGE("It traced the opposing Torchic's Blaze!");
+        }
+    } THEN {
+        EXPECT_EQ(player->ability, item == ITEM_ABILITY_SHIELD ? ABILITY_TRACE : ABILITY_BLAZE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Ability Shield protects either holder against Wandering Spirit")
+{
+    enum Item playerItem, opponentItem;
+
+    PARAMETRIZE { playerItem = ITEM_ABILITY_SHIELD; opponentItem = ITEM_NONE; }
+    PARAMETRIZE { playerItem = ITEM_NONE; opponentItem = ITEM_ABILITY_SHIELD; }
+    PARAMETRIZE { playerItem = ITEM_NONE; opponentItem = ITEM_NONE; }
+
+    GIVEN {
+        ASSUME(MoveMakesContact(MOVE_AQUA_JET));
+        ASSUME(!gAbilitiesInfo[ABILITY_BLAZE].cantBeSwapped);
+        PLAYER(SPECIES_TORCHIC) { Ability(ABILITY_BLAZE); Item(playerItem); }
+        OPPONENT(SPECIES_YAMASK_GALAR) { Ability(ABILITY_WANDERING_SPIRIT); Item(opponentItem); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_AQUA_JET); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_AQUA_JET, player);
+    } THEN {
+        if (playerItem == ITEM_ABILITY_SHIELD || opponentItem == ITEM_ABILITY_SHIELD) {
+            EXPECT_EQ(player->ability, ABILITY_BLAZE);
+            EXPECT_EQ(opponent->ability, ABILITY_WANDERING_SPIRIT);
+        } else {
+            EXPECT_EQ(player->ability, ABILITY_WANDERING_SPIRIT);
+            EXPECT_EQ(opponent->ability, ABILITY_BLAZE);
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Ability Shield protects against Mummy and Lingering Aroma")
+{
+    enum Ability ability;
+    enum Item item;
+    enum Species species;
+
+    PARAMETRIZE { ability = ABILITY_MUMMY; species = SPECIES_YAMASK; item = ITEM_ABILITY_SHIELD; }
+    PARAMETRIZE { ability = ABILITY_MUMMY; species = SPECIES_YAMASK; item = ITEM_NONE; }
+    PARAMETRIZE { ability = ABILITY_LINGERING_AROMA; species = SPECIES_OINKOLOGNE; item = ITEM_ABILITY_SHIELD; }
+    PARAMETRIZE { ability = ABILITY_LINGERING_AROMA; species = SPECIES_OINKOLOGNE; item = ITEM_NONE; }
+
+    GIVEN {
+        ASSUME(MoveMakesContact(MOVE_AQUA_JET));
+        ASSUME(!gAbilitiesInfo[ABILITY_SHADOW_TAG].cantBeSuppressed);
+        PLAYER(SPECIES_WOBBUFFET) { Ability(ABILITY_SHADOW_TAG); Item(item); }
+        OPPONENT(species) { Ability(ability); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_AQUA_JET); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_AQUA_JET, player);
+    } THEN {
+        EXPECT_EQ(player->ability, item == ITEM_ABILITY_SHIELD ? ABILITY_SHADOW_TAG : ability);
+    }
+}

--- a/test/battle/hold_effect/absorb_bulb.c
+++ b/test/battle/hold_effect/absorb_bulb.c
@@ -1,4 +1,79 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Absorb Bulb (Hold Effect) test titles")
+ASSUMPTIONS
+{
+    ASSUME(GetItemHoldEffect(ITEM_ABSORB_BULB) == HOLD_EFFECT_ABSORB_BULB);
+}
+
+SINGLE_BATTLE_TEST("Absorb Bulb raises Sp. Atk by one stage and is consumed when its holder is hit by a Water-type move")
+{
+    enum Species species;
+    enum Ability ability;
+    s32 expectedDelta;
+
+    PARAMETRIZE { species = SPECIES_WOBBUFFET; ability = ABILITY_SHADOW_TAG; expectedDelta = 1; }
+    PARAMETRIZE { species = SPECIES_BIBAREL;   ability = ABILITY_SIMPLE;     expectedDelta = 2; }
+    PARAMETRIZE { species = SPECIES_INKAY;     ability = ABILITY_CONTRARY;   expectedDelta = -1; }
+
+    GIVEN {
+        ASSUME(GetMoveType(MOVE_BUBBLE) == TYPE_WATER);
+        PLAYER(species) { Ability(ability); HP(400); MaxHP(400); SpDefense(400); Item(ITEM_ABSORB_BULB); }
+        OPPONENT(SPECIES_WOBBUFFET) { SpAttack(1); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_BUBBLE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BUBBLE, opponent);
+        HP_BAR(player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_SPATK], DEFAULT_STAT_STAGE + expectedDelta);
+        EXPECT_EQ(player->item, ITEM_NONE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Magic Room and Embargo prevent Absorb Bulb from activating")
+{
+    enum Move setupMove;
+
+    PARAMETRIZE { setupMove = MOVE_MAGIC_ROOM; }
+    PARAMETRIZE { setupMove = MOVE_EMBARGO; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_MAGIC_ROOM) == EFFECT_MAGIC_ROOM);
+        ASSUME(GetMoveEffect(MOVE_EMBARGO) == EFFECT_EMBARGO);
+        ASSUME(GetMoveType(MOVE_BUBBLE) == TYPE_WATER);
+        PLAYER(SPECIES_WOBBUFFET) { HP(400); MaxHP(400); SpDefense(400); Item(ITEM_ABSORB_BULB); }
+        OPPONENT(SPECIES_WOBBUFFET) { SpAttack(1); }
+    } WHEN {
+        TURN { MOVE(opponent, setupMove); }
+        TURN { MOVE(opponent, MOVE_BUBBLE); }
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_SPATK], DEFAULT_STAT_STAGE);
+        EXPECT_EQ(player->item, ITEM_ABSORB_BULB);
+    }
+}
+
+SINGLE_BATTLE_TEST("Liquid Voice activates Absorb Bulb unless the Ability is suppressed")
+{
+    enum Move setupMove;
+    s32 expectedDelta;
+    enum Item expectedItem;
+
+    PARAMETRIZE { setupMove = MOVE_CELEBRATE;   expectedDelta = 1; expectedItem = ITEM_NONE; }
+    PARAMETRIZE { setupMove = MOVE_GASTRO_ACID; expectedDelta = 0; expectedItem = ITEM_ABSORB_BULB; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_GASTRO_ACID) == EFFECT_GASTRO_ACID);
+        ASSUME(GetMoveType(MOVE_HYPER_VOICE) == TYPE_NORMAL);
+        ASSUME(IsSoundMove(MOVE_HYPER_VOICE));
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); HP(400); MaxHP(400); SpDefense(400); Item(ITEM_ABSORB_BULB); }
+        OPPONENT(SPECIES_PRIMARINA) { Speed(1); SpAttack(1); Ability(ABILITY_LIQUID_VOICE); }
+    } WHEN {
+        TURN { MOVE(player, setupMove); MOVE(opponent, MOVE_HYPER_VOICE); }
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_SPATK], DEFAULT_STAT_STAGE + expectedDelta);
+        EXPECT_EQ(player->item, expectedItem);
+    }
+}

--- a/test/battle/hold_effect/adamant_orb.c
+++ b/test/battle/hold_effect/adamant_orb.c
@@ -1,4 +1,34 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Adamant Orb (Hold Effect) test titles")
+ASSUMPTIONS
+{
+    ASSUME(GetItemHoldEffect(ITEM_ADAMANT_ORB) == HOLD_EFFECT_ADAMANT_ORB);
+    ASSUME(GetItemHoldEffectParam(ITEM_ADAMANT_ORB) == 20);
+}
+
+SINGLE_BATTLE_TEST("Adamant Orb boosts Dialga's Dragon- and Steel-type move damage by 20%", s16 damage)
+{
+    enum Item item;
+    enum Move move;
+
+    PARAMETRIZE { item = ITEM_NONE;        move = MOVE_DRAGON_CLAW; }
+    PARAMETRIZE { item = ITEM_ADAMANT_ORB; move = MOVE_DRAGON_CLAW; }
+    PARAMETRIZE { item = ITEM_NONE;        move = MOVE_FLASH_CANNON; }
+    PARAMETRIZE { item = ITEM_ADAMANT_ORB; move = MOVE_FLASH_CANNON; }
+
+    GIVEN {
+        ASSUME(GetMoveType(MOVE_DRAGON_CLAW) == TYPE_DRAGON);
+        ASSUME(GetMoveType(MOVE_FLASH_CANNON) == TYPE_STEEL);
+        PLAYER(SPECIES_DIALGA) { Item(item); Moves(move); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, move); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.2), results[1].damage);
+        EXPECT_MUL_EQ(results[2].damage, Q_4_12(1.2), results[3].damage);
+    }
+}

--- a/test/battle/hold_effect/assault_vest.c
+++ b/test/battle/hold_effect/assault_vest.c
@@ -1,4 +1,116 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Assault Vest (Hold Effect) test titles")
+ASSUMPTIONS
+{
+    ASSUME(GetItemHoldEffect(ITEM_ASSAULT_VEST) == HOLD_EFFECT_ASSAULT_VEST);
+}
+
+SINGLE_BATTLE_TEST("Assault Vest boosts Sp. Def by 50%", s16 damage)
+{
+    enum Item item;
+
+    PARAMETRIZE { item = ITEM_ASSAULT_VEST; }
+    PARAMETRIZE { item = ITEM_NONE; }
+
+    GIVEN {
+        ASSUME(GetMoveCategory(MOVE_WATER_GUN) == DAMAGE_CATEGORY_SPECIAL);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(1); Item(item); Moves(MOVE_SCRATCH); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(2); Moves(MOVE_WATER_GUN); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SCRATCH); MOVE(opponent, MOVE_WATER_GUN); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_WATER_GUN, opponent);
+        HP_BAR(player, captureDamage: &results[i].damage);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        HP_BAR(opponent);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.5), results[1].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("A Pokémon that receives an Assault Vest through Trick or Switcheroo Struggles when Encored")
+{
+    enum Move transferMove;
+
+    PARAMETRIZE { transferMove = MOVE_TRICK; }
+    PARAMETRIZE { transferMove = MOVE_SWITCHEROO; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_TRICK) == EFFECT_TRICK);
+        ASSUME(GetMoveEffect(MOVE_SWITCHEROO) == EFFECT_TRICK);
+        ASSUME(GetMoveEffect(MOVE_ENCORE) == EFFECT_ENCORE);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(1); Moves(transferMove, MOVE_CELEBRATE); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(2); Item(ITEM_ASSAULT_VEST); Moves(MOVE_ENCORE, MOVE_SCRATCH); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SCRATCH); MOVE(player, transferMove); }
+        TURN { MOVE(opponent, MOVE_ENCORE); FORCED_MOVE(player); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, transferMove, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ENCORE, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_STRUGGLE, player);
+    } THEN {
+        EXPECT_EQ(player->item, ITEM_ASSAULT_VEST);
+    }
+}
+
+DOUBLE_BATTLE_TEST("A Pokémon that receives an Assault Vest through Trick or Switcheroo can repeat the move when Instructed")
+{
+    enum Move transferMove;
+
+    PARAMETRIZE { transferMove = MOVE_TRICK; }
+    PARAMETRIZE { transferMove = MOVE_SWITCHEROO; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_TRICK) == EFFECT_TRICK);
+        ASSUME(GetMoveEffect(MOVE_SWITCHEROO) == EFFECT_TRICK);
+        ASSUME(GetMoveEffect(MOVE_INSTRUCT) == EFFECT_INSTRUCT);
+        ASSUME(!IsMoveInstructBanned(transferMove));
+        PLAYER(SPECIES_WOBBUFFET) { Speed(30); Moves(transferMove, MOVE_CELEBRATE); }
+        PLAYER(SPECIES_WYNAUT) { Speed(20); Moves(MOVE_INSTRUCT, MOVE_CELEBRATE); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(10); Item(ITEM_ASSAULT_VEST); Moves(MOVE_SCRATCH); }
+        OPPONENT(SPECIES_WYNAUT) { Speed(5); }
+    } WHEN {
+        TURN { MOVE(playerLeft, transferMove, target: opponentLeft); MOVE(playerRight, MOVE_INSTRUCT, target: playerLeft); MOVE(opponentLeft, MOVE_SCRATCH, target: playerLeft); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, transferMove, playerLeft);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_INSTRUCT, playerRight);
+        ANIMATION(ANIM_TYPE_MOVE, transferMove, playerLeft);
+    } THEN {
+        EXPECT_EQ(playerLeft->item, ITEM_NONE);
+        EXPECT_EQ(opponentLeft->item, ITEM_ASSAULT_VEST);
+    }
+}
+
+SINGLE_BATTLE_TEST("Assault Vest forces Struggle after the holder exhausts its only damaging move")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) {
+            Item(ITEM_ASSAULT_VEST);
+            MovesWithPP({MOVE_SCRATCH, 1}, {MOVE_CELEBRATE, 10}, {MOVE_GROWL, 10}, {MOVE_SPLASH, 10});
+        }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_SCRATCH); }
+        TURN { FORCED_MOVE(player); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_STRUGGLE, player);
+    }
+}
+
+SINGLE_BATTLE_TEST("Assault Vest forces Struggle when Torment blocks the holder's only damaging move")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_TORMENT) == EFFECT_TORMENT);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); Item(ITEM_ASSAULT_VEST); Moves(MOVE_SCRATCH, MOVE_CELEBRATE, MOVE_GROWL, MOVE_SPLASH); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SCRATCH); MOVE(opponent, MOVE_TORMENT); }
+        TURN { FORCED_MOVE(player); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TORMENT, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_STRUGGLE, player);
+    }
+}

--- a/test/battle/hold_effect/black_sludge.c
+++ b/test/battle/hold_effect/black_sludge.c
@@ -1,4 +1,160 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Black Sludge (Hold Effect) test titles")
+ASSUMPTIONS
+{
+    ASSUME(GetItemHoldEffect(ITEM_BLACK_SLUDGE) == HOLD_EFFECT_BLACK_SLUDGE);
+}
+
+SINGLE_BATTLE_TEST("Black Sludge recovers 1/16 HP for Poison-type holders")
+{
+    GIVEN {
+        ASSUME(GetSpeciesType(SPECIES_EKANS, 0) == TYPE_POISON);
+        PLAYER(SPECIES_EKANS) { MaxHP(160); HP(1); Item(ITEM_BLACK_SLUDGE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN {}
+    } SCENE {
+        ITEM_POPUP(player, ITEM_BLACK_SLUDGE);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+        HP_BAR(player, damage: -10);
+    }
+}
+
+SINGLE_BATTLE_TEST("Black Sludge deals 1/8 max HP to non-Poison-type holders")
+{
+    GIVEN {
+        ASSUME(GetSpeciesType(SPECIES_WOBBUFFET, 0) != TYPE_POISON);
+        ASSUME(GetSpeciesType(SPECIES_WOBBUFFET, 1) != TYPE_POISON);
+        PLAYER(SPECIES_WOBBUFFET) { MaxHP(160); HP(160); Item(ITEM_BLACK_SLUDGE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN {}
+    } SCENE {
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MON_HIT, player);
+        HP_BAR(player, damage: 20);
+    }
+}
+
+SINGLE_BATTLE_TEST("Black Sludge does nothing if a Poison-type holder is at full HP")
+{
+    GIVEN {
+        ASSUME(GetSpeciesType(SPECIES_EKANS, 0) == TYPE_POISON);
+        PLAYER(SPECIES_EKANS) { Item(ITEM_BLACK_SLUDGE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN {}
+    } SCENE {
+        NONE_OF {
+            ITEM_POPUP(player, ITEM_BLACK_SLUDGE);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+            HP_BAR(player);
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Black Sludge does not heal a Poison-type holder under Heal Block (Gen 5+)")
+{
+    u32 genConfig;
+
+    PARAMETRIZE { genConfig = GEN_4; }
+    PARAMETRIZE { genConfig = GEN_5; }
+
+    GIVEN {
+        WITH_CONFIG(B_HEAL_BLOCKING, genConfig);
+        ASSUME(GetSpeciesType(SPECIES_EKANS, 0) == TYPE_POISON);
+        ASSUME(GetMoveEffect(MOVE_HEAL_BLOCK) == EFFECT_HEAL_BLOCK);
+        PLAYER(SPECIES_EKANS) { MaxHP(160); HP(1); Item(ITEM_BLACK_SLUDGE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_HEAL_BLOCK); }
+    } SCENE {
+        if (genConfig >= GEN_5) {
+            NONE_OF {
+                ITEM_POPUP(player, ITEM_BLACK_SLUDGE);
+                ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+                HP_BAR(player);
+            }
+        } else {
+            ITEM_POPUP(player, ITEM_BLACK_SLUDGE);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+            HP_BAR(player, damage: -10);
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Black Sludge does not damage a non-Poison-type holder with Magic Guard")
+{
+    GIVEN {
+        ASSUME(GetSpeciesType(SPECIES_CLEFABLE, 0) != TYPE_POISON);
+        PLAYER(SPECIES_CLEFABLE) { Ability(ABILITY_MAGIC_GUARD); MaxHP(160); HP(160); Item(ITEM_BLACK_SLUDGE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN {}
+    } SCENE {
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MON_HIT, player);
+            HP_BAR(player);
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Black Sludge has no effect if the holder has Klutz")
+{
+    GIVEN {
+        ASSUME(GetSpeciesType(SPECIES_EKANS, 0) == TYPE_POISON);
+        PLAYER(SPECIES_EKANS) { Ability(ABILITY_KLUTZ); MaxHP(160); HP(1); Item(ITEM_BLACK_SLUDGE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN {}
+    } SCENE {
+        NONE_OF {
+            ITEM_POPUP(player, ITEM_BLACK_SLUDGE);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+            HP_BAR(player);
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Black Sludge has no effect while Magic Room is active")
+{
+    GIVEN {
+        ASSUME(GetSpeciesType(SPECIES_EKANS, 0) == TYPE_POISON);
+        ASSUME(GetMoveEffect(MOVE_MAGIC_ROOM) == EFFECT_MAGIC_ROOM);
+        PLAYER(SPECIES_EKANS) { MaxHP(160); HP(1); Item(ITEM_BLACK_SLUDGE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_MAGIC_ROOM); }
+    } SCENE {
+        NONE_OF {
+            ITEM_POPUP(player, ITEM_BLACK_SLUDGE);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+            HP_BAR(player);
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Black Sludge deals 1/8 max HP after its holder loses the Poison type")
+{
+    GIVEN {
+        ASSUME(GetSpeciesType(SPECIES_EKANS, 0) == TYPE_POISON);
+        ASSUME(GetMoveEffect(MOVE_SONIC_BOOM) == EFFECT_FIXED_HP_DAMAGE);
+        ASSUME(GetMoveFixedHPDamage(MOVE_SONIC_BOOM) == 20);
+        ASSUME(GetMoveEffect(MOVE_SOAK) == EFFECT_SOAK);
+        PLAYER(SPECIES_EKANS) { MaxHP(160); HP(160); Item(ITEM_BLACK_SLUDGE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SONIC_BOOM); }
+        TURN { MOVE(opponent, MOVE_SOAK); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SONIC_BOOM, opponent);
+        HP_BAR(player, damage: 20);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+        HP_BAR(player, damage: -10);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SOAK, opponent);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_MON_HIT, player);
+        HP_BAR(player, damage: 20);
+    } THEN {
+        EXPECT_EQ(player->hp, 130);
+    }
+}

--- a/test/battle/hold_effect/cell_battery.c
+++ b/test/battle/hold_effect/cell_battery.c
@@ -1,4 +1,79 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Cell Battery (Hold Effect) test titles")
+ASSUMPTIONS
+{
+    ASSUME(GetItemHoldEffect(ITEM_CELL_BATTERY) == HOLD_EFFECT_CELL_BATTERY);
+}
+
+SINGLE_BATTLE_TEST("Cell Battery raises Attack by one stage and is consumed when its holder is hit by an Electric-type move")
+{
+    enum Species species;
+    enum Ability ability;
+    s32 expectedDelta;
+
+    PARAMETRIZE { species = SPECIES_WOBBUFFET; ability = ABILITY_SHADOW_TAG; expectedDelta = 1; }
+    PARAMETRIZE { species = SPECIES_BIBAREL;   ability = ABILITY_SIMPLE;     expectedDelta = 2; }
+    PARAMETRIZE { species = SPECIES_INKAY;     ability = ABILITY_CONTRARY;   expectedDelta = -1; }
+
+    GIVEN {
+        ASSUME(GetMoveType(MOVE_THUNDER_SHOCK) == TYPE_ELECTRIC);
+        PLAYER(species) { Ability(ability); HP(400); MaxHP(400); SpDefense(400); Item(ITEM_CELL_BATTERY); }
+        OPPONENT(SPECIES_WOBBUFFET) { SpAttack(1); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_THUNDER_SHOCK); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_THUNDER_SHOCK, opponent);
+        HP_BAR(player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_ATK], DEFAULT_STAT_STAGE + expectedDelta);
+        EXPECT_EQ(player->item, ITEM_NONE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Magic Room and Embargo prevent Cell Battery from activating")
+{
+    enum Move setupMove;
+
+    PARAMETRIZE { setupMove = MOVE_MAGIC_ROOM; }
+    PARAMETRIZE { setupMove = MOVE_EMBARGO; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_MAGIC_ROOM) == EFFECT_MAGIC_ROOM);
+        ASSUME(GetMoveEffect(MOVE_EMBARGO) == EFFECT_EMBARGO);
+        ASSUME(GetMoveType(MOVE_THUNDER_SHOCK) == TYPE_ELECTRIC);
+        PLAYER(SPECIES_WOBBUFFET) { HP(400); MaxHP(400); SpDefense(400); Item(ITEM_CELL_BATTERY); }
+        OPPONENT(SPECIES_WOBBUFFET) { SpAttack(1); }
+    } WHEN {
+        TURN { MOVE(opponent, setupMove); }
+        TURN { MOVE(opponent, MOVE_THUNDER_SHOCK); }
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_ATK], DEFAULT_STAT_STAGE);
+        EXPECT_EQ(player->item, ITEM_CELL_BATTERY);
+    }
+}
+
+SINGLE_BATTLE_TEST("Galvanize activates Cell Battery unless the Ability is suppressed")
+{
+    enum Move setupMove;
+    s32 expectedDelta;
+    enum Item expectedItem;
+
+    PARAMETRIZE { setupMove = MOVE_CELEBRATE;   expectedDelta = 1; expectedItem = ITEM_NONE; }
+    PARAMETRIZE { setupMove = MOVE_GASTRO_ACID; expectedDelta = 0; expectedItem = ITEM_CELL_BATTERY; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_GASTRO_ACID) == EFFECT_GASTRO_ACID);
+        ASSUME(GetMoveType(MOVE_HYPER_VOICE) == TYPE_NORMAL);
+        ASSUME(IsSoundMove(MOVE_HYPER_VOICE));
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); HP(400); MaxHP(400); SpDefense(400); Item(ITEM_CELL_BATTERY); }
+        OPPONENT(SPECIES_GEODUDE_ALOLA) { Speed(1); SpAttack(1); Ability(ABILITY_GALVANIZE); }
+    } WHEN {
+        TURN { MOVE(player, setupMove); MOVE(opponent, MOVE_HYPER_VOICE); }
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_ATK], DEFAULT_STAT_STAGE + expectedDelta);
+        EXPECT_EQ(player->item, expectedItem);
+    }
+}

--- a/test/battle/hold_effect/choice_band.c
+++ b/test/battle/hold_effect/choice_band.c
@@ -1,4 +1,73 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Choice Band (Hold Effect) test titles")
+ASSUMPTIONS
+{
+    ASSUME(GetItemHoldEffect(ITEM_CHOICE_BAND) == HOLD_EFFECT_CHOICE_BAND);
+}
+
+SINGLE_BATTLE_TEST("Choice Band boosts physical damage by 50%", s16 damage)
+{
+    enum Item item;
+
+    PARAMETRIZE { item = ITEM_NONE; }
+    PARAMETRIZE { item = ITEM_CHOICE_BAND; }
+
+    GIVEN {
+        ASSUME(GetMoveCategory(MOVE_SCRATCH) == DAMAGE_CATEGORY_PHYSICAL);
+        PLAYER(SPECIES_WOBBUFFET) { Item(item); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_SCRATCH); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.5), results[1].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Choice Band forces Struggle when its locked move becomes unusable")
+{
+    enum Move selectedMove;
+    enum Move restrictingMove;
+
+    PARAMETRIZE { selectedMove = MOVE_CELEBRATE; restrictingMove = MOVE_TAUNT; }
+    PARAMETRIZE { selectedMove = MOVE_SCRATCH;   restrictingMove = MOVE_TORMENT; }
+    PARAMETRIZE { selectedMove = MOVE_SCRATCH;   restrictingMove = MOVE_DISABLE; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_TAUNT) == EFFECT_TAUNT);
+        ASSUME(GetMoveEffect(MOVE_TORMENT) == EFFECT_TORMENT);
+        ASSUME(GetMoveEffect(MOVE_DISABLE) == EFFECT_DISABLE);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); Item(ITEM_CHOICE_BAND); Moves(selectedMove); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); }
+    } WHEN {
+        TURN { MOVE(player, selectedMove); MOVE(opponent, restrictingMove); }
+        TURN { FORCED_MOVE(player); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_STRUGGLE, player);
+    }
+}
+
+SINGLE_BATTLE_TEST("Magic Room and Embargo remove Choice Band's move lock")
+{
+    enum Move setupMove;
+
+    PARAMETRIZE { setupMove = MOVE_MAGIC_ROOM; }
+    PARAMETRIZE { setupMove = MOVE_EMBARGO; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_MAGIC_ROOM) == EFFECT_MAGIC_ROOM);
+        ASSUME(GetMoveEffect(MOVE_EMBARGO) == EFFECT_EMBARGO);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); Item(ITEM_CHOICE_BAND); Moves(MOVE_SCRATCH, MOVE_WATER_GUN); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SCRATCH); MOVE(opponent, setupMove); }
+        TURN { MOVE(player, MOVE_WATER_GUN); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_WATER_GUN, player);
+    } THEN {
+        EXPECT_EQ(player->item, ITEM_CHOICE_BAND);
+    }
+}

--- a/test/battle/hold_effect/choice_scarf.c
+++ b/test/battle/hold_effect/choice_scarf.c
@@ -1,4 +1,82 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Choice Scarf (Hold Effect) test titles")
+ASSUMPTIONS
+{
+    ASSUME(GetItemHoldEffect(ITEM_CHOICE_SCARF) == HOLD_EFFECT_CHOICE_SCARF);
+}
+
+SINGLE_BATTLE_TEST("Choice Scarf boosts Speed by 50%")
+{
+    enum Item item;
+    u32 opponentSpeed;
+    bool32 playerFirst;
+
+    PARAMETRIZE { item = ITEM_NONE;         opponentSpeed = 149; playerFirst = FALSE; }
+    PARAMETRIZE { item = ITEM_CHOICE_SCARF; opponentSpeed = 149; playerFirst = TRUE;  }
+    PARAMETRIZE { item = ITEM_CHOICE_SCARF; opponentSpeed = 151; playerFirst = FALSE; }
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Speed(100); Item(item); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(opponentSpeed); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SCRATCH); MOVE(opponent, MOVE_SCRATCH); }
+    } SCENE {
+        if (playerFirst) {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+            HP_BAR(opponent);
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
+            HP_BAR(player);
+        } else {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
+            HP_BAR(player);
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+            HP_BAR(opponent);
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Choice Scarf forces Struggle when its locked move becomes unusable")
+{
+    enum Move selectedMove;
+    enum Move restrictingMove;
+
+    PARAMETRIZE { selectedMove = MOVE_CELEBRATE; restrictingMove = MOVE_TAUNT; }
+    PARAMETRIZE { selectedMove = MOVE_SCRATCH;   restrictingMove = MOVE_TORMENT; }
+    PARAMETRIZE { selectedMove = MOVE_SCRATCH;   restrictingMove = MOVE_DISABLE; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_TAUNT) == EFFECT_TAUNT);
+        ASSUME(GetMoveEffect(MOVE_TORMENT) == EFFECT_TORMENT);
+        ASSUME(GetMoveEffect(MOVE_DISABLE) == EFFECT_DISABLE);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); Item(ITEM_CHOICE_SCARF); Moves(selectedMove); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); }
+    } WHEN {
+        TURN { MOVE(player, selectedMove); MOVE(opponent, restrictingMove); }
+        TURN { FORCED_MOVE(player); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_STRUGGLE, player);
+    }
+}
+
+SINGLE_BATTLE_TEST("Magic Room and Embargo remove Choice Scarf's move lock")
+{
+    enum Move setupMove;
+
+    PARAMETRIZE { setupMove = MOVE_MAGIC_ROOM; }
+    PARAMETRIZE { setupMove = MOVE_EMBARGO; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_MAGIC_ROOM) == EFFECT_MAGIC_ROOM);
+        ASSUME(GetMoveEffect(MOVE_EMBARGO) == EFFECT_EMBARGO);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); Item(ITEM_CHOICE_SCARF); Moves(MOVE_SCRATCH, MOVE_WATER_GUN); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SCRATCH); MOVE(opponent, setupMove); }
+        TURN { MOVE(player, MOVE_WATER_GUN); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_WATER_GUN, player);
+    } THEN {
+        EXPECT_EQ(player->item, ITEM_CHOICE_SCARF);
+    }
+}

--- a/test/battle/hold_effect/choice_specs.c
+++ b/test/battle/hold_effect/choice_specs.c
@@ -1,4 +1,73 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Choice Scarf (Hold Effect) test titles")
+ASSUMPTIONS
+{
+    ASSUME(GetItemHoldEffect(ITEM_CHOICE_SPECS) == HOLD_EFFECT_CHOICE_SPECS);
+}
+
+SINGLE_BATTLE_TEST("Choice Specs boost special damage by 50%", s16 damage)
+{
+    enum Item item;
+
+    PARAMETRIZE { item = ITEM_NONE; }
+    PARAMETRIZE { item = ITEM_CHOICE_SPECS; }
+
+    GIVEN {
+        ASSUME(GetMoveCategory(MOVE_WATER_GUN) == DAMAGE_CATEGORY_SPECIAL);
+        PLAYER(SPECIES_WOBBUFFET) { Item(item); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_WATER_GUN); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_WATER_GUN, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.5), results[1].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Choice Specs force Struggle when their locked move becomes unusable")
+{
+    enum Move selectedMove;
+    enum Move restrictingMove;
+
+    PARAMETRIZE { selectedMove = MOVE_CELEBRATE; restrictingMove = MOVE_TAUNT; }
+    PARAMETRIZE { selectedMove = MOVE_SCRATCH;   restrictingMove = MOVE_TORMENT; }
+    PARAMETRIZE { selectedMove = MOVE_SCRATCH;   restrictingMove = MOVE_DISABLE; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_TAUNT) == EFFECT_TAUNT);
+        ASSUME(GetMoveEffect(MOVE_TORMENT) == EFFECT_TORMENT);
+        ASSUME(GetMoveEffect(MOVE_DISABLE) == EFFECT_DISABLE);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); Item(ITEM_CHOICE_SPECS); Moves(selectedMove); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); }
+    } WHEN {
+        TURN { MOVE(player, selectedMove); MOVE(opponent, restrictingMove); }
+        TURN { FORCED_MOVE(player); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_STRUGGLE, player);
+    }
+}
+
+SINGLE_BATTLE_TEST("Magic Room and Embargo remove Choice Specs' move lock")
+{
+    enum Move setupMove;
+
+    PARAMETRIZE { setupMove = MOVE_MAGIC_ROOM; }
+    PARAMETRIZE { setupMove = MOVE_EMBARGO; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_MAGIC_ROOM) == EFFECT_MAGIC_ROOM);
+        ASSUME(GetMoveEffect(MOVE_EMBARGO) == EFFECT_EMBARGO);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); Item(ITEM_CHOICE_SPECS); Moves(MOVE_SCRATCH, MOVE_WATER_GUN); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SCRATCH); MOVE(opponent, setupMove); }
+        TURN { MOVE(player, MOVE_WATER_GUN); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_WATER_GUN, player);
+    } THEN {
+        EXPECT_EQ(player->item, ITEM_CHOICE_SPECS);
+    }
+}

--- a/test/battle/hold_effect/damp_rock.c
+++ b/test/battle/hold_effect/damp_rock.c
@@ -1,4 +1,37 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Damp Rock (Hold Effect) test titles")
+ASSUMPTIONS
+{
+    ASSUME(GetItemHoldEffect(ITEM_DAMP_ROCK) == HOLD_EFFECT_DAMP_ROCK);
+    ASSUME(GetMoveEffect(MOVE_RAIN_DANCE) == EFFECT_WEATHER);
+    ASSUME(GetMoveWeatherType(MOVE_RAIN_DANCE) == BATTLE_WEATHER_RAIN);
+}
+
+SINGLE_BATTLE_TEST("Damp Rock extends rain created by Rain Dance to 8 turns")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_DAMP_ROCK); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_RAIN_DANCE); }
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_RAIN_DANCE, player);
+        MESSAGE("It started to rain!");
+        MESSAGE("Rain continues to fall.");
+        MESSAGE("Rain continues to fall.");
+        MESSAGE("Rain continues to fall.");
+        MESSAGE("Rain continues to fall.");
+        MESSAGE("Rain continues to fall.");
+        MESSAGE("Rain continues to fall.");
+        MESSAGE("Rain continues to fall.");
+        MESSAGE("The rain stopped.");
+    }
+}

--- a/test/battle/hold_effect/deep_sea_scale.c
+++ b/test/battle/hold_effect/deep_sea_scale.c
@@ -1,4 +1,62 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Deep Sea Scale (Hold Effect) test titles")
+ASSUMPTIONS
+{
+    ASSUME(GetItemHoldEffect(ITEM_DEEP_SEA_SCALE) == HOLD_EFFECT_DEEP_SEA_SCALE);
+}
+
+SINGLE_BATTLE_TEST("Deep Sea Scale doubles Clamperl's Sp. Def", s16 damage)
+{
+    enum Item item;
+
+    PARAMETRIZE { item = ITEM_NONE; }
+    PARAMETRIZE { item = ITEM_DEEP_SEA_SCALE; }
+
+    GIVEN {
+        ASSUME(GetMoveCategory(MOVE_DRAGON_PULSE) == DAMAGE_CATEGORY_SPECIAL);
+        ASSUME(GetMoveEffect(MOVE_DRAGON_PULSE) == EFFECT_HIT);
+        PLAYER(SPECIES_WOBBUFFET) { SpAttack(200); }
+        OPPONENT(SPECIES_CLAMPERL) { SpDefense(100); Item(item); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_DRAGON_PULSE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_PULSE, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[1].damage, Q_4_12(2.0), results[0].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Deep Sea Scale does not reduce damage that targets Defense or damage to non-Clamperl holders", s16 damage)
+{
+    enum Item item;
+    enum Move move;
+    enum Species species;
+
+    PARAMETRIZE { item = ITEM_NONE;           move = MOVE_SCRATCH;      species = SPECIES_CLAMPERL; }
+    PARAMETRIZE { item = ITEM_DEEP_SEA_SCALE; move = MOVE_SCRATCH;      species = SPECIES_CLAMPERL; }
+    PARAMETRIZE { item = ITEM_NONE;           move = MOVE_PSYSHOCK;     species = SPECIES_CLAMPERL; }
+    PARAMETRIZE { item = ITEM_DEEP_SEA_SCALE; move = MOVE_PSYSHOCK;     species = SPECIES_CLAMPERL; }
+    PARAMETRIZE { item = ITEM_NONE;           move = MOVE_DRAGON_PULSE; species = SPECIES_WOBBUFFET; }
+    PARAMETRIZE { item = ITEM_DEEP_SEA_SCALE; move = MOVE_DRAGON_PULSE; species = SPECIES_WOBBUFFET; }
+
+    GIVEN {
+        ASSUME(GetMoveCategory(MOVE_SCRATCH) == DAMAGE_CATEGORY_PHYSICAL);
+        ASSUME(GetMoveCategory(MOVE_PSYSHOCK) == DAMAGE_CATEGORY_SPECIAL);
+        ASSUME(GetMoveEffect(MOVE_PSYSHOCK) == EFFECT_PSYSHOCK);
+        ASSUME(GetMoveCategory(MOVE_DRAGON_PULSE) == DAMAGE_CATEGORY_SPECIAL);
+        ASSUME(GetMoveEffect(MOVE_DRAGON_PULSE) == EFFECT_HIT);
+        PLAYER(SPECIES_WOBBUFFET) { Attack(100); SpAttack(100); Moves(move); }
+        OPPONENT(species) { Defense(200); SpDefense(200); Item(item); }
+    } WHEN {
+        TURN { MOVE(player, move); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_EQ(results[0].damage, results[1].damage);
+        EXPECT_EQ(results[2].damage, results[3].damage);
+        EXPECT_EQ(results[4].damage, results[5].damage);
+    }
+}

--- a/test/battle/hold_effect/deep_sea_tooth.c
+++ b/test/battle/hold_effect/deep_sea_tooth.c
@@ -1,4 +1,55 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Deep Sea Tooth (Hold Effect) test titles")
+ASSUMPTIONS
+{
+    ASSUME(GetItemHoldEffect(ITEM_DEEP_SEA_TOOTH) == HOLD_EFFECT_DEEP_SEA_TOOTH);
+}
+
+SINGLE_BATTLE_TEST("Deep Sea Tooth doubles Clamperl's special damage", s16 damage)
+{
+    enum Item item;
+
+    PARAMETRIZE { item = ITEM_NONE; }
+    PARAMETRIZE { item = ITEM_DEEP_SEA_TOOTH; }
+
+    GIVEN {
+        ASSUME(GetMoveCategory(MOVE_WATER_GUN) == DAMAGE_CATEGORY_SPECIAL);
+        PLAYER(SPECIES_CLAMPERL) { SpAttack(100); Item(item); }
+        OPPONENT(SPECIES_WOBBUFFET) { SpDefense(200); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_WATER_GUN); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_WATER_GUN, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(2.0), results[1].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Deep Sea Tooth does not boost physical moves or non-Clamperl holders", s16 damage)
+{
+    enum Item item;
+    enum Move move;
+    enum Species species;
+
+    PARAMETRIZE { item = ITEM_NONE;           move = MOVE_SCRATCH;   species = SPECIES_CLAMPERL; }
+    PARAMETRIZE { item = ITEM_DEEP_SEA_TOOTH; move = MOVE_SCRATCH;   species = SPECIES_CLAMPERL; }
+    PARAMETRIZE { item = ITEM_NONE;           move = MOVE_WATER_GUN; species = SPECIES_WOBBUFFET; }
+    PARAMETRIZE { item = ITEM_DEEP_SEA_TOOTH; move = MOVE_WATER_GUN; species = SPECIES_WOBBUFFET; }
+
+    GIVEN {
+        ASSUME(GetMoveCategory(MOVE_SCRATCH) == DAMAGE_CATEGORY_PHYSICAL);
+        ASSUME(GetMoveCategory(MOVE_WATER_GUN) == DAMAGE_CATEGORY_SPECIAL);
+        PLAYER(species) { Attack(100); SpAttack(100); Item(item); Moves(move); }
+        OPPONENT(SPECIES_WOBBUFFET) { Defense(200); SpDefense(200); }
+    } WHEN {
+        TURN { MOVE(player, move); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_EQ(results[0].damage, results[1].damage);
+        EXPECT_EQ(results[2].damage, results[3].damage);
+    }
+}

--- a/test/battle/hold_effect/expert_belt.c
+++ b/test/battle/hold_effect/expert_belt.c
@@ -1,4 +1,63 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Expert Belt (Hold Effect) test titles")
+ASSUMPTIONS
+{
+    ASSUME(GetItemHoldEffect(ITEM_EXPERT_BELT) == HOLD_EFFECT_EXPERT_BELT);
+    ASSUME(GetItemHoldEffectParam(ITEM_EXPERT_BELT) == 20);
+}
+
+SINGLE_BATTLE_TEST("Expert Belt boosts damage of 2x and 4x super-effective moves by 20%", s16 damage)
+{
+    enum Item item;
+    enum Species species;
+
+    PARAMETRIZE { item = ITEM_NONE;        species = SPECIES_VULPIX; }
+    PARAMETRIZE { item = ITEM_EXPERT_BELT; species = SPECIES_VULPIX; }
+    PARAMETRIZE { item = ITEM_NONE;        species = SPECIES_GEODUDE; }
+    PARAMETRIZE { item = ITEM_EXPERT_BELT; species = SPECIES_GEODUDE; }
+
+    GIVEN {
+        ASSUME(GetMoveType(MOVE_WATER_GUN) == TYPE_WATER);
+        ASSUME(GetSpeciesType(SPECIES_VULPIX, 0) == TYPE_FIRE);
+        ASSUME(GetSpeciesType(SPECIES_GEODUDE, 0) == TYPE_ROCK);
+        ASSUME(GetSpeciesType(SPECIES_GEODUDE, 1) == TYPE_GROUND);
+        PLAYER(SPECIES_WOBBUFFET) { SpAttack(100); Item(item); }
+        OPPONENT(species) { SpDefense(200); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_WATER_GUN); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_WATER_GUN, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.2), results[1].damage);
+        EXPECT_MUL_EQ(results[2].damage, Q_4_12(1.2), results[3].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Expert Belt does not boost neutral or resisted damage", s16 damage)
+{
+    enum Item item;
+    enum Species species;
+
+    PARAMETRIZE { item = ITEM_NONE;        species = SPECIES_WOBBUFFET; }
+    PARAMETRIZE { item = ITEM_EXPERT_BELT; species = SPECIES_WOBBUFFET; }
+    PARAMETRIZE { item = ITEM_NONE;        species = SPECIES_BULBASAUR; }
+    PARAMETRIZE { item = ITEM_EXPERT_BELT; species = SPECIES_BULBASAUR; }
+
+    GIVEN {
+        ASSUME(GetMoveType(MOVE_WATER_GUN) == TYPE_WATER);
+        ASSUME(GetSpeciesType(SPECIES_WOBBUFFET, 0) == TYPE_PSYCHIC);
+        ASSUME(GetSpeciesType(SPECIES_BULBASAUR, 0) == TYPE_GRASS);
+        PLAYER(SPECIES_WOBBUFFET) { SpAttack(100); Item(item); }
+        OPPONENT(species) { SpDefense(200); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_WATER_GUN); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_WATER_GUN, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_EQ(results[0].damage, results[1].damage);
+        EXPECT_EQ(results[2].damage, results[3].damage);
+    }
+}

--- a/test/battle/hold_effect/flinch.c
+++ b/test/battle/hold_effect/flinch.c
@@ -35,6 +35,41 @@ SINGLE_BATTLE_TEST("Kings Rock does not increase flinch chance of a move that ha
     }
 }
 
+SINGLE_BATTLE_TEST("Kings Rock can flinch with a non-flinching move boosted by Sheer Force")
+{
+    PASSES_RANDOMLY(10, 100, RNG_HOLD_EFFECT_FLINCH);
+    GIVEN {
+        ASSUME(MoveIsAffectedBySheerForce(MOVE_FLARE_BLITZ));
+        ASSUME(MoveHasAdditionalEffect(MOVE_FLARE_BLITZ, MOVE_EFFECT_FLINCH) == FALSE);
+        PLAYER(SPECIES_NIDOKING) { Ability(ABILITY_SHEER_FORCE); Item(ITEM_KINGS_ROCK); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_FLARE_BLITZ); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FLARE_BLITZ, player);
+        MESSAGE("The opposing Wobbuffet flinched and couldn't move!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Kings Rock cannot flinch with a flinching move boosted by Sheer Force")
+{
+    PASSES_RANDOMLY(0, 100, RNG_HOLD_EFFECT_FLINCH);
+    GIVEN {
+        ASSUME(MoveIsAffectedBySheerForce(MOVE_BITE));
+        ASSUME(MoveHasAdditionalEffect(MOVE_BITE, MOVE_EFFECT_FLINCH));
+        PLAYER(SPECIES_NIDOKING) { Ability(ABILITY_SHEER_FORCE); Item(ITEM_KINGS_ROCK); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN {
+            MOVE(player, MOVE_BITE, secondaryEffect: TRUE);
+            MOVE(opponent, MOVE_SCRATCH);
+        }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BITE, player);
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
+    }
+}
+
 DOUBLE_BATTLE_TEST("Kings Rock flinch chance boosted by Serene Grace does not stack with rainbow")
 {
     PASSES_RANDOMLY(20, 100, RNG_HOLD_EFFECT_FLINCH);

--- a/test/battle/hold_effect/float_stone.c
+++ b/test/battle/hold_effect/float_stone.c
@@ -29,4 +29,21 @@ SINGLE_BATTLE_TEST("Float Stone halves the holder's weight", s16 damage)
     }
 }
 
-TO_DO_BATTLE_TEST("Float Stone doesn't affect Heavy Ball's multiplier")
+WILD_BATTLE_TEST("Float Stone doesn't affect Heavy Ball's multiplier", u32 catchingChance)
+{
+    enum Item item;
+    PARAMETRIZE { item = ITEM_NONE; }
+    PARAMETRIZE { item = ITEM_FLOAT_STONE; }
+
+    GIVEN {
+        ASSUME(GetSpeciesWeight(SPECIES_SCIZOR) == 1180);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_SCIZOR) { Ability(ABILITY_TECHNICIAN); Item(item); }
+    } WHEN {
+        TURN { USE_ITEM(player, ITEM_HEAVY_BALL); }
+    } SCENE {
+        CATCHING_CHANCE(&results[i].catchingChance);
+    } FINALLY {
+        EXPECT_EQ(results[0].catchingChance, results[1].catchingChance);
+    }
+}

--- a/test/battle/hold_effect/gems.c
+++ b/test/battle/hold_effect/gems.c
@@ -6,6 +6,30 @@ ASSUMPTIONS
     ASSUME(gItemsInfo[ITEM_NORMAL_GEM].holdEffect == HOLD_EFFECT_GEMS);
 }
 
+static const enum Item sStruggleGemItems[] =
+{
+    ITEM_NORMAL_GEM,
+#if B_UPDATED_MOVE_FLAGS >= GEN_2
+    ITEM_FIRE_GEM,
+    ITEM_WATER_GEM,
+    ITEM_ELECTRIC_GEM,
+    ITEM_GRASS_GEM,
+    ITEM_ICE_GEM,
+    ITEM_FIGHTING_GEM,
+    ITEM_POISON_GEM,
+    ITEM_GROUND_GEM,
+    ITEM_FLYING_GEM,
+    ITEM_PSYCHIC_GEM,
+    ITEM_BUG_GEM,
+    ITEM_ROCK_GEM,
+    ITEM_GHOST_GEM,
+    ITEM_DRAGON_GEM,
+    ITEM_DARK_GEM,
+    ITEM_STEEL_GEM,
+    ITEM_FAIRY_GEM,
+#endif
+};
+
 SINGLE_BATTLE_TEST("Gem is consumed when it corresponds to the type of a move")
 {
     GIVEN {
@@ -31,26 +55,25 @@ SINGLE_BATTLE_TEST("Gem is not consumed when using Struggle", s16 damage)
     enum Item item = ITEM_NONE;
 
     PARAMETRIZE { item = ITEM_NONE; }
-    PARAMETRIZE { item = ITEM_NORMAL_GEM; }
+    for (u32 j = 0; j < ARRAY_COUNT(sStruggleGemItems); j++)
+        PARAMETRIZE { item = sStruggleGemItems[j]; }
 
     GIVEN {
-        if (item != ITEM_NONE) {
+        if (item != ITEM_NONE)
             ASSUME(GetItemHoldEffect(item) == HOLD_EFFECT_GEMS);
-            ASSUME(GetItemSecondaryId(item) == GetMoveType(MOVE_STRUGGLE));
-        }
         PLAYER(SPECIES_WOBBUFFET) { Item(item); }
         OPPONENT(SPECIES_WOBBUFFET);
     } WHEN {
         TURN { MOVE(player, MOVE_STRUGGLE); }
     } SCENE {
-        NONE_OF {
-            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
-            MESSAGE("The Normal Gem strengthened Wobbuffet's power!");
-        }
+        NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_STRUGGLE, player);
         HP_BAR(opponent, captureDamage: &results[i].damage);
+    } THEN {
+        EXPECT_EQ(player->item, item);
     } FINALLY {
-        EXPECT_EQ(results[0].damage, results[1].damage);
+        for (u32 j = 0; j < ARRAY_COUNT(sStruggleGemItems); j++)
+            EXPECT_EQ(results[0].damage, results[j + 1].damage);
     }
 }
 

--- a/test/battle/hold_effect/griseous_orb.c
+++ b/test/battle/hold_effect/griseous_orb.c
@@ -1,4 +1,34 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Griseous Orb (Hold Effect) test titles")
+ASSUMPTIONS
+{
+    ASSUME(GetItemHoldEffect(ITEM_GRISEOUS_ORB) == HOLD_EFFECT_GRISEOUS_ORB);
+    ASSUME(GetItemHoldEffectParam(ITEM_GRISEOUS_ORB) == 20);
+}
+
+SINGLE_BATTLE_TEST("Griseous Orb boosts Giratina's Ghost- and Dragon-type move damage by 20%", s16 damage)
+{
+    enum Item item;
+    enum Move move;
+
+    PARAMETRIZE { item = ITEM_NONE;         move = MOVE_SHADOW_CLAW; }
+    PARAMETRIZE { item = ITEM_GRISEOUS_ORB; move = MOVE_SHADOW_CLAW; }
+    PARAMETRIZE { item = ITEM_NONE;         move = MOVE_DRAGON_BREATH; }
+    PARAMETRIZE { item = ITEM_GRISEOUS_ORB; move = MOVE_DRAGON_BREATH; }
+
+    GIVEN {
+        ASSUME(GetMoveType(MOVE_SHADOW_CLAW) == TYPE_GHOST);
+        ASSUME(GetMoveType(MOVE_DRAGON_BREATH) == TYPE_DRAGON);
+        PLAYER(SPECIES_GIRATINA) { Attack(100); SpAttack(100); Item(item); Moves(move); }
+        OPPONENT(SPECIES_WOBBUFFET) { Defense(200); SpDefense(200); }
+    } WHEN {
+        TURN { MOVE(player, move); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.2), results[1].damage);
+        EXPECT_MUL_EQ(results[2].damage, Q_4_12(1.2), results[3].damage);
+    }
+}

--- a/test/battle/hold_effect/heat_rock.c
+++ b/test/battle/hold_effect/heat_rock.c
@@ -1,4 +1,37 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Heat Rock (Hold Effect) test titles")
+ASSUMPTIONS
+{
+    ASSUME(GetItemHoldEffect(ITEM_HEAT_ROCK) == HOLD_EFFECT_HEAT_ROCK);
+    ASSUME(GetMoveEffect(MOVE_SUNNY_DAY) == EFFECT_WEATHER);
+    ASSUME(GetMoveWeatherType(MOVE_SUNNY_DAY) == BATTLE_WEATHER_SUN);
+}
+
+SINGLE_BATTLE_TEST("Heat Rock extends sun created by Sunny Day to 8 turns")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_HEAT_ROCK); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_SUNNY_DAY); }
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SUNNY_DAY, player);
+        MESSAGE("The sunlight turned harsh!");
+        MESSAGE("The sunlight is strong.");
+        MESSAGE("The sunlight is strong.");
+        MESSAGE("The sunlight is strong.");
+        MESSAGE("The sunlight is strong.");
+        MESSAGE("The sunlight is strong.");
+        MESSAGE("The sunlight is strong.");
+        MESSAGE("The sunlight is strong.");
+        MESSAGE("The sunlight faded.");
+    }
+}

--- a/test/battle/hold_effect/icy_rock.c
+++ b/test/battle/hold_effect/icy_rock.c
@@ -1,4 +1,94 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Icy Rock (Hold Effect) test titles")
+ASSUMPTIONS
+{
+    ASSUME(GetItemHoldEffect(ITEM_ICY_ROCK) == HOLD_EFFECT_ICY_ROCK);
+    ASSUME(GetMoveEffect(MOVE_HAIL) == EFFECT_WEATHER);
+    ASSUME(GetMoveEffect(MOVE_SNOWSCAPE) == EFFECT_WEATHER);
+    ASSUME(GetMoveEffect(MOVE_CHILLY_RECEPTION) == EFFECT_WEATHER_AND_SWITCH);
+}
+
+#if B_PREFERRED_ICE_WEATHER != B_ICE_WEATHER_SNOW
+SINGLE_BATTLE_TEST("Icy Rock extends hail created by compatible moves to 8 turns")
+{
+    enum Move move;
+
+    PARAMETRIZE { move = MOVE_HAIL; }
+    if (GetConfig(B_PREFERRED_ICE_WEATHER) == B_ICE_WEATHER_HAIL) {
+        PARAMETRIZE { move = MOVE_SNOWSCAPE; }
+        PARAMETRIZE { move = MOVE_CHILLY_RECEPTION; }
+    }
+
+    GIVEN {
+        PLAYER(SPECIES_GLACEON) { Item(ITEM_ICY_ROCK); }
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_GLACEON);
+    } WHEN {
+        if (move == MOVE_CHILLY_RECEPTION)
+            TURN { MOVE(player, move); SEND_OUT(player, 1); }
+        else
+            TURN { MOVE(player, move); }
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        MESSAGE("It started to hail!");
+        MESSAGE("The hail is crashing down.");
+        MESSAGE("The hail is crashing down.");
+        MESSAGE("The hail is crashing down.");
+        MESSAGE("The hail is crashing down.");
+        MESSAGE("The hail is crashing down.");
+        MESSAGE("The hail is crashing down.");
+        MESSAGE("The hail is crashing down.");
+        MESSAGE("The hail stopped.");
+    }
+}
+#endif
+
+#if B_PREFERRED_ICE_WEATHER != B_ICE_WEATHER_HAIL
+SINGLE_BATTLE_TEST("Icy Rock extends snow created by compatible moves to 8 turns")
+{
+    enum Move move;
+
+    if (GetConfig(B_PREFERRED_ICE_WEATHER) == B_ICE_WEATHER_SNOW) {
+        PARAMETRIZE { move = MOVE_HAIL; }
+    }
+    PARAMETRIZE { move = MOVE_SNOWSCAPE; }
+    PARAMETRIZE { move = MOVE_CHILLY_RECEPTION; }
+
+    GIVEN {
+        PLAYER(SPECIES_GLACEON) { Item(ITEM_ICY_ROCK); }
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_GLACEON);
+    } WHEN {
+        if (move == MOVE_CHILLY_RECEPTION)
+            TURN { MOVE(player, move); SEND_OUT(player, 1); }
+        else
+            TURN { MOVE(player, move); }
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        MESSAGE("It started to snow!");
+        MESSAGE("Snow continues to fall.");
+        MESSAGE("Snow continues to fall.");
+        MESSAGE("Snow continues to fall.");
+        MESSAGE("Snow continues to fall.");
+        MESSAGE("Snow continues to fall.");
+        MESSAGE("Snow continues to fall.");
+        MESSAGE("Snow continues to fall.");
+        MESSAGE("The snow stopped.");
+    }
+}
+#endif

--- a/test/battle/hold_effect/luminous_moss.c
+++ b/test/battle/hold_effect/luminous_moss.c
@@ -1,4 +1,79 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Luminous Moss (Hold Effect) test titles")
+ASSUMPTIONS
+{
+    ASSUME(GetItemHoldEffect(ITEM_LUMINOUS_MOSS) == HOLD_EFFECT_LUMINOUS_MOSS);
+}
+
+SINGLE_BATTLE_TEST("Luminous Moss raises Sp. Def by one stage and is consumed when its holder is hit by a Water-type move")
+{
+    enum Species species;
+    enum Ability ability;
+    s32 expectedDelta;
+
+    PARAMETRIZE { species = SPECIES_WOBBUFFET; ability = ABILITY_SHADOW_TAG; expectedDelta = 1; }
+    PARAMETRIZE { species = SPECIES_BIBAREL;   ability = ABILITY_SIMPLE;     expectedDelta = 2; }
+    PARAMETRIZE { species = SPECIES_INKAY;     ability = ABILITY_CONTRARY;   expectedDelta = -1; }
+
+    GIVEN {
+        ASSUME(GetMoveType(MOVE_BUBBLE) == TYPE_WATER);
+        PLAYER(species) { Ability(ability); HP(400); MaxHP(400); SpDefense(400); Item(ITEM_LUMINOUS_MOSS); }
+        OPPONENT(SPECIES_WOBBUFFET) { SpAttack(1); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_BUBBLE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BUBBLE, opponent);
+        HP_BAR(player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_SPDEF], DEFAULT_STAT_STAGE + expectedDelta);
+        EXPECT_EQ(player->item, ITEM_NONE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Magic Room and Embargo prevent Luminous Moss from activating")
+{
+    enum Move setupMove;
+
+    PARAMETRIZE { setupMove = MOVE_MAGIC_ROOM; }
+    PARAMETRIZE { setupMove = MOVE_EMBARGO; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_MAGIC_ROOM) == EFFECT_MAGIC_ROOM);
+        ASSUME(GetMoveEffect(MOVE_EMBARGO) == EFFECT_EMBARGO);
+        ASSUME(GetMoveType(MOVE_BUBBLE) == TYPE_WATER);
+        PLAYER(SPECIES_WOBBUFFET) { HP(400); MaxHP(400); SpDefense(400); Item(ITEM_LUMINOUS_MOSS); }
+        OPPONENT(SPECIES_WOBBUFFET) { SpAttack(1); }
+    } WHEN {
+        TURN { MOVE(opponent, setupMove); }
+        TURN { MOVE(opponent, MOVE_BUBBLE); }
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_SPDEF], DEFAULT_STAT_STAGE);
+        EXPECT_EQ(player->item, ITEM_LUMINOUS_MOSS);
+    }
+}
+
+SINGLE_BATTLE_TEST("Liquid Voice activates Luminous Moss unless the Ability is suppressed")
+{
+    enum Move setupMove;
+    s32 expectedDelta;
+    enum Item expectedItem;
+
+    PARAMETRIZE { setupMove = MOVE_CELEBRATE;   expectedDelta = 1; expectedItem = ITEM_NONE; }
+    PARAMETRIZE { setupMove = MOVE_GASTRO_ACID; expectedDelta = 0; expectedItem = ITEM_LUMINOUS_MOSS; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_GASTRO_ACID) == EFFECT_GASTRO_ACID);
+        ASSUME(GetMoveType(MOVE_HYPER_VOICE) == TYPE_NORMAL);
+        ASSUME(IsSoundMove(MOVE_HYPER_VOICE));
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); HP(400); MaxHP(400); SpDefense(400); Item(ITEM_LUMINOUS_MOSS); }
+        OPPONENT(SPECIES_PRIMARINA) { Speed(1); SpAttack(1); Ability(ABILITY_LIQUID_VOICE); }
+    } WHEN {
+        TURN { MOVE(player, setupMove); MOVE(opponent, MOVE_HYPER_VOICE); }
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_SPDEF], DEFAULT_STAT_STAGE + expectedDelta);
+        EXPECT_EQ(player->item, expectedItem);
+    }
+}

--- a/test/battle/hold_effect/lustrous_orb.c
+++ b/test/battle/hold_effect/lustrous_orb.c
@@ -1,4 +1,34 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Lustrous Orb (Hold Effect) test titles")
+ASSUMPTIONS
+{
+    ASSUME(GetItemHoldEffect(ITEM_LUSTROUS_ORB) == HOLD_EFFECT_LUSTROUS_ORB);
+    ASSUME(GetItemHoldEffectParam(ITEM_LUSTROUS_ORB) == 20);
+}
+
+SINGLE_BATTLE_TEST("Lustrous Orb boosts Palkia's Dragon- and Water-type move damage by 20%", s16 damage)
+{
+    enum Item item;
+    enum Move move;
+
+    PARAMETRIZE { item = ITEM_NONE;         move = MOVE_DRAGON_CLAW; }
+    PARAMETRIZE { item = ITEM_LUSTROUS_ORB; move = MOVE_DRAGON_CLAW; }
+    PARAMETRIZE { item = ITEM_NONE;         move = MOVE_SCALD; }
+    PARAMETRIZE { item = ITEM_LUSTROUS_ORB; move = MOVE_SCALD; }
+
+    GIVEN {
+        ASSUME(GetMoveType(MOVE_DRAGON_CLAW) == TYPE_DRAGON);
+        ASSUME(GetMoveType(MOVE_SCALD) == TYPE_WATER);
+        PLAYER(SPECIES_PALKIA) { Item(item); Moves(move); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, move); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.2), results[1].damage);
+        EXPECT_MUL_EQ(results[2].damage, Q_4_12(1.2), results[3].damage);
+    }
+}

--- a/test/battle/hold_effect/metal_powder.c
+++ b/test/battle/hold_effect/metal_powder.c
@@ -1,4 +1,85 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Metal Powder (Hold Effect) test titles")
+ASSUMPTIONS
+{
+    ASSUME(GetItemHoldEffect(ITEM_METAL_POWDER) == HOLD_EFFECT_METAL_POWDER);
+}
+
+SINGLE_BATTLE_TEST("Metal Powder doubles an untransformed Ditto's Defense", s16 damage)
+{
+    enum Item item;
+    enum Move move;
+
+    PARAMETRIZE { item = ITEM_NONE;         move = MOVE_SCRATCH; }
+    PARAMETRIZE { item = ITEM_METAL_POWDER; move = MOVE_SCRATCH; }
+    PARAMETRIZE { item = ITEM_NONE;         move = MOVE_PSYSHOCK; }
+    PARAMETRIZE { item = ITEM_METAL_POWDER; move = MOVE_PSYSHOCK; }
+
+    GIVEN {
+        ASSUME(GetMoveCategory(MOVE_SCRATCH) == DAMAGE_CATEGORY_PHYSICAL);
+        ASSUME(GetMoveCategory(MOVE_PSYSHOCK) == DAMAGE_CATEGORY_SPECIAL);
+        ASSUME(GetMoveEffect(MOVE_PSYSHOCK) == EFFECT_PSYSHOCK);
+        PLAYER(SPECIES_WOBBUFFET) { Attack(200); SpAttack(200); Moves(move); }
+        OPPONENT(SPECIES_DITTO) { Defense(100); Item(item); }
+    } WHEN {
+        TURN { MOVE(player, move); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[1].damage, Q_4_12(2.0), results[0].damage);
+        EXPECT_MUL_EQ(results[3].damage, Q_4_12(2.0), results[2].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Metal Powder does not boost Sp. Def or the Defense of non-Ditto holders", s16 damage)
+{
+    enum Item item;
+    enum Move move;
+    enum Species species;
+
+    PARAMETRIZE { item = ITEM_NONE;         move = MOVE_ROUND;   species = SPECIES_DITTO; }
+    PARAMETRIZE { item = ITEM_METAL_POWDER; move = MOVE_ROUND;   species = SPECIES_DITTO; }
+    PARAMETRIZE { item = ITEM_NONE;         move = MOVE_SCRATCH; species = SPECIES_WOBBUFFET; }
+    PARAMETRIZE { item = ITEM_METAL_POWDER; move = MOVE_SCRATCH; species = SPECIES_WOBBUFFET; }
+
+    GIVEN {
+        ASSUME(GetMoveCategory(MOVE_ROUND) == DAMAGE_CATEGORY_SPECIAL);
+        ASSUME(GetMoveEffect(MOVE_ROUND) != EFFECT_PSYSHOCK);
+        ASSUME(GetMoveCategory(MOVE_SCRATCH) == DAMAGE_CATEGORY_PHYSICAL);
+        PLAYER(SPECIES_WOBBUFFET) { Attack(100); SpAttack(100); Moves(move); }
+        OPPONENT(species) { Defense(200); SpDefense(200); Item(item); }
+    } WHEN {
+        TURN { MOVE(player, move); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_EQ(results[0].damage, results[1].damage);
+        EXPECT_EQ(results[2].damage, results[3].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Metal Powder does not boost Ditto's Defense after it transforms", s16 damage)
+{
+    enum Item item;
+
+    PARAMETRIZE { item = ITEM_NONE; }
+    PARAMETRIZE { item = ITEM_METAL_POWDER; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_TRANSFORM) == EFFECT_TRANSFORM);
+        PLAYER(SPECIES_DITTO) { Attack(100); Defense(200); Speed(50); Moves(MOVE_CELEBRATE, MOVE_SCRATCH); }
+        OPPONENT(SPECIES_DITTO) { Speed(100); Item(item); Moves(MOVE_TRANSFORM); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_CELEBRATE); MOVE(opponent, MOVE_TRANSFORM); }
+        TURN { MOVE(player, MOVE_SCRATCH); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TRANSFORM, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_EQ(results[0].damage, results[1].damage);
+    }
+}

--- a/test/battle/hold_effect/muscle_band.c
+++ b/test/battle/hold_effect/muscle_band.c
@@ -1,4 +1,50 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Muscle Band (Hold Effect) test titles")
+ASSUMPTIONS
+{
+    ASSUME(GetItemHoldEffect(ITEM_MUSCLE_BAND) == HOLD_EFFECT_MUSCLE_BAND);
+    ASSUME(GetItemHoldEffectParam(ITEM_MUSCLE_BAND) == 10);
+}
+
+SINGLE_BATTLE_TEST("Muscle Band boosts physical damage by 10%", s16 damage)
+{
+    enum Item item;
+
+    PARAMETRIZE { item = ITEM_NONE; }
+    PARAMETRIZE { item = ITEM_MUSCLE_BAND; }
+
+    GIVEN {
+        ASSUME(GetMoveCategory(MOVE_SCRATCH) == DAMAGE_CATEGORY_PHYSICAL);
+        PLAYER(SPECIES_WOBBUFFET) { Item(item); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_SCRATCH); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.1), results[1].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Muscle Band does not boost special damage", s16 damage)
+{
+    enum Item item;
+
+    PARAMETRIZE { item = ITEM_NONE; }
+    PARAMETRIZE { item = ITEM_MUSCLE_BAND; }
+
+    GIVEN {
+        ASSUME(GetMoveCategory(MOVE_WATER_GUN) == DAMAGE_CATEGORY_SPECIAL);
+        PLAYER(SPECIES_WOBBUFFET) { Item(item); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_WATER_GUN); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_WATER_GUN, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_EQ(results[0].damage, results[1].damage);
+    }
+}

--- a/test/battle/hold_effect/quick_powder.c
+++ b/test/battle/hold_effect/quick_powder.c
@@ -1,4 +1,77 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Quick Powder (Hold Effect) test titles")
+ASSUMPTIONS
+{
+    ASSUME(GetItemHoldEffect(ITEM_QUICK_POWDER) == HOLD_EFFECT_QUICK_POWDER);
+}
+
+SINGLE_BATTLE_TEST("Quick Powder doubles an untransformed Ditto's Speed")
+{
+    enum Item item;
+    u32 opponentSpeed;
+    bool32 playerFirst;
+
+    PARAMETRIZE { item = ITEM_NONE;         opponentSpeed = 199; playerFirst = FALSE; }
+    PARAMETRIZE { item = ITEM_QUICK_POWDER; opponentSpeed = 199; playerFirst = TRUE;  }
+    PARAMETRIZE { item = ITEM_QUICK_POWDER; opponentSpeed = 201; playerFirst = FALSE; }
+
+    GIVEN {
+        PLAYER(SPECIES_DITTO) { Speed(100); Item(item); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(opponentSpeed); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SCRATCH); MOVE(opponent, MOVE_SCRATCH); }
+    } SCENE {
+        if (playerFirst) {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+            HP_BAR(opponent);
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
+            HP_BAR(player);
+        } else {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
+            HP_BAR(player);
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+            HP_BAR(opponent);
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Quick Powder does not boost the Speed of non-Ditto holders")
+{
+    enum Item item;
+
+    PARAMETRIZE { item = ITEM_NONE; }
+    PARAMETRIZE { item = ITEM_QUICK_POWDER; }
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Speed(100); Item(item); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(150); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SCRATCH); MOVE(opponent, MOVE_SCRATCH); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
+        HP_BAR(player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        HP_BAR(opponent);
+    }
+}
+
+SINGLE_BATTLE_TEST("Quick Powder does not boost Ditto's Speed after it transforms")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_TRANSFORM) == EFFECT_TRANSFORM);
+        ASSUME_STAT_CHANGE(MOVE_DRAGON_DANCE, attack: 1, speed: 1);
+        PLAYER(SPECIES_DITTO) { Speed(100); Moves(MOVE_DRAGON_DANCE, MOVE_SCRATCH); }
+        OPPONENT(SPECIES_DITTO) { Speed(200); Item(ITEM_QUICK_POWDER); Moves(MOVE_TRANSFORM, MOVE_SCRATCH); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_DRAGON_DANCE); MOVE(opponent, MOVE_TRANSFORM); }
+        TURN { MOVE(player, MOVE_SCRATCH); MOVE(opponent, MOVE_SCRATCH); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TRANSFORM, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_DANCE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        HP_BAR(opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
+        HP_BAR(player);
+    }
+}

--- a/test/battle/hold_effect/shell_bell.c
+++ b/test/battle/hold_effect/shell_bell.c
@@ -289,5 +289,51 @@ SINGLE_BATTLE_TEST("Shell Bell recovers only 1 damage if the move only did 1 dam
     }
 }
 
-TO_DO_BATTLE_TEST("If a Pokémon steals a Shell Bell with Thief or Covet, it will recover HP for the use of that move that stole the Shell Bell")
-TO_DO_BATTLE_TEST("If a Pokémon steals a Shell Bell with Magician, it will recover HP for the use of that move that stole the Shell Bell")
+SINGLE_BATTLE_TEST("A Pokémon that steals a Shell Bell with Thief or Covet recovers HP for that move", s16 damage, s16 recovery)
+{
+    enum Move move;
+    PARAMETRIZE { move = MOVE_THIEF; }
+    PARAMETRIZE { move = MOVE_COVET; }
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_THIEF) == EFFECT_STEAL_ITEM);
+        ASSUME(GetMoveEffect(MOVE_COVET) == EFFECT_STEAL_ITEM);
+        PLAYER(SPECIES_WOBBUFFET) { HP(1); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_SHELL_BELL); }
+    } WHEN {
+        TURN { MOVE(player, move); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+        MESSAGE("Wobbuffet stole the opposing Wobbuffet's Shell Bell!");
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+        HP_BAR(player, captureDamage: &results[i].recovery);
+    } THEN {
+        EXPECT_EQ(player->item, ITEM_SHELL_BELL);
+        EXPECT_EQ(opponent->item, ITEM_NONE);
+        EXPECT_EQ(results[i].damage / 8, -results[i].recovery);
+    }
+}
+
+SINGLE_BATTLE_TEST("A Pokémon that steals a Shell Bell with Magician recovers HP for that move")
+{
+    s16 damage;
+    s16 recovery;
+
+    GIVEN {
+        PLAYER(SPECIES_DELPHOX) { HP(1); Ability(ABILITY_MAGICIAN); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_SHELL_BELL); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SCRATCH); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        HP_BAR(opponent, captureDamage: &damage);
+        ABILITY_POPUP(player, ABILITY_MAGICIAN);
+        MESSAGE("Delphox stole the opposing Wobbuffet's Shell Bell!");
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+        HP_BAR(player, captureDamage: &recovery);
+    } THEN {
+        EXPECT_EQ(player->item, ITEM_SHELL_BELL);
+        EXPECT_EQ(opponent->item, ITEM_NONE);
+        EXPECT_EQ(damage / 8, -recovery);
+    }
+}

--- a/test/battle/hold_effect/smooth_rock.c
+++ b/test/battle/hold_effect/smooth_rock.c
@@ -1,4 +1,37 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Smooth Rock (Hold Effect) test titles")
+ASSUMPTIONS
+{
+    ASSUME(GetItemHoldEffect(ITEM_SMOOTH_ROCK) == HOLD_EFFECT_SMOOTH_ROCK);
+    ASSUME(GetMoveEffect(MOVE_SANDSTORM) == EFFECT_WEATHER);
+    ASSUME(GetMoveWeatherType(MOVE_SANDSTORM) == BATTLE_WEATHER_SANDSTORM);
+}
+
+SINGLE_BATTLE_TEST("Smooth Rock extends sandstorm created by Sandstorm to 8 turns")
+{
+    GIVEN {
+        PLAYER(SPECIES_SANDSLASH) { Item(ITEM_SMOOTH_ROCK); }
+        OPPONENT(SPECIES_SANDSLASH);
+    } WHEN {
+        TURN { MOVE(player, MOVE_SANDSTORM); }
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SANDSTORM, player);
+        MESSAGE("A sandstorm kicked up!");
+        MESSAGE("The sandstorm is raging.");
+        MESSAGE("The sandstorm is raging.");
+        MESSAGE("The sandstorm is raging.");
+        MESSAGE("The sandstorm is raging.");
+        MESSAGE("The sandstorm is raging.");
+        MESSAGE("The sandstorm is raging.");
+        MESSAGE("The sandstorm is raging.");
+        MESSAGE("The sandstorm subsided.");
+    }
+}

--- a/test/battle/hold_effect/snowball.c
+++ b/test/battle/hold_effect/snowball.c
@@ -1,4 +1,79 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Snowball (Hold Effect) test titles")
+ASSUMPTIONS
+{
+    ASSUME(GetItemHoldEffect(ITEM_SNOWBALL) == HOLD_EFFECT_SNOWBALL);
+}
+
+SINGLE_BATTLE_TEST("Snowball raises Attack by one stage and is consumed when its holder is hit by an Ice-type move")
+{
+    enum Species species;
+    enum Ability ability;
+    s32 expectedDelta;
+
+    PARAMETRIZE { species = SPECIES_WOBBUFFET; ability = ABILITY_SHADOW_TAG; expectedDelta = 1; }
+    PARAMETRIZE { species = SPECIES_BIBAREL;   ability = ABILITY_SIMPLE;     expectedDelta = 2; }
+    PARAMETRIZE { species = SPECIES_INKAY;     ability = ABILITY_CONTRARY;   expectedDelta = -1; }
+
+    GIVEN {
+        ASSUME(GetMoveType(MOVE_ICE_BEAM) == TYPE_ICE);
+        PLAYER(species) { Ability(ability); HP(400); MaxHP(400); SpDefense(400); Item(ITEM_SNOWBALL); }
+        OPPONENT(SPECIES_WOBBUFFET) { SpAttack(1); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_ICE_BEAM); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ICE_BEAM, opponent);
+        HP_BAR(player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_ATK], DEFAULT_STAT_STAGE + expectedDelta);
+        EXPECT_EQ(player->item, ITEM_NONE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Magic Room and Embargo prevent Snowball from activating")
+{
+    enum Move setupMove;
+
+    PARAMETRIZE { setupMove = MOVE_MAGIC_ROOM; }
+    PARAMETRIZE { setupMove = MOVE_EMBARGO; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_MAGIC_ROOM) == EFFECT_MAGIC_ROOM);
+        ASSUME(GetMoveEffect(MOVE_EMBARGO) == EFFECT_EMBARGO);
+        ASSUME(GetMoveType(MOVE_ICE_BEAM) == TYPE_ICE);
+        PLAYER(SPECIES_WOBBUFFET) { HP(400); MaxHP(400); SpDefense(400); Item(ITEM_SNOWBALL); }
+        OPPONENT(SPECIES_WOBBUFFET) { SpAttack(1); }
+    } WHEN {
+        TURN { MOVE(opponent, setupMove); }
+        TURN { MOVE(opponent, MOVE_ICE_BEAM); }
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_ATK], DEFAULT_STAT_STAGE);
+        EXPECT_EQ(player->item, ITEM_SNOWBALL);
+    }
+}
+
+SINGLE_BATTLE_TEST("Refrigerate activates Snowball unless the Ability is suppressed")
+{
+    enum Move setupMove;
+    s32 expectedDelta;
+    enum Item expectedItem;
+
+    PARAMETRIZE { setupMove = MOVE_CELEBRATE;   expectedDelta = 1; expectedItem = ITEM_NONE; }
+    PARAMETRIZE { setupMove = MOVE_GASTRO_ACID; expectedDelta = 0; expectedItem = ITEM_SNOWBALL; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_GASTRO_ACID) == EFFECT_GASTRO_ACID);
+        ASSUME(GetMoveType(MOVE_HYPER_VOICE) == TYPE_NORMAL);
+        ASSUME(IsSoundMove(MOVE_HYPER_VOICE));
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); HP(400); MaxHP(400); SpDefense(400); Item(ITEM_SNOWBALL); }
+        OPPONENT(SPECIES_AMAURA) { Speed(1); SpAttack(1); Ability(ABILITY_REFRIGERATE); }
+    } WHEN {
+        TURN { MOVE(player, setupMove); MOVE(opponent, MOVE_HYPER_VOICE); }
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_ATK], DEFAULT_STAT_STAGE + expectedDelta);
+        EXPECT_EQ(player->item, expectedItem);
+    }
+}

--- a/test/battle/hold_effect/terrain_extender.c
+++ b/test/battle/hold_effect/terrain_extender.c
@@ -1,4 +1,205 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Terrain Extender (Hold Effect) test titles")
+ASSUMPTIONS
+{
+    ASSUME(GetItemHoldEffect(ITEM_TERRAIN_EXTENDER) == HOLD_EFFECT_TERRAIN_EXTENDER);
+    ASSUME(GetMoveEffect(MOVE_ELECTRIC_TERRAIN) == EFFECT_TERRAIN);
+    ASSUME(GetMoveTerrainType(MOVE_ELECTRIC_TERRAIN) == B_TERRAIN_ELECTRIC);
+    ASSUME(GetMoveEffect(MOVE_GRASSY_TERRAIN) == EFFECT_TERRAIN);
+    ASSUME(GetMoveTerrainType(MOVE_GRASSY_TERRAIN) == B_TERRAIN_GRASSY);
+    ASSUME(GetMoveEffect(MOVE_MISTY_TERRAIN) == EFFECT_TERRAIN);
+    ASSUME(GetMoveTerrainType(MOVE_MISTY_TERRAIN) == B_TERRAIN_MISTY);
+    ASSUME(GetMoveEffect(MOVE_PSYCHIC_TERRAIN) == EFFECT_TERRAIN);
+    ASSUME(GetMoveTerrainType(MOVE_PSYCHIC_TERRAIN) == B_TERRAIN_PSYCHIC);
+}
+
+SINGLE_BATTLE_TEST("Terrain created by moves lasts 5 turns without Terrain Extender")
+{
+    enum Move move;
+
+    PARAMETRIZE { move = MOVE_ELECTRIC_TERRAIN; }
+    PARAMETRIZE { move = MOVE_GRASSY_TERRAIN; }
+    PARAMETRIZE { move = MOVE_MISTY_TERRAIN; }
+    PARAMETRIZE { move = MOVE_PSYCHIC_TERRAIN; }
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Speed(100); Moves(move); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(50); }
+    } WHEN {
+        TURN { MOVE(player, move); MOVE(opponent, MOVE_CELEBRATE); }
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
+        for (u32 turn = 0; turn < 4; turn++)
+        {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
+        }
+        switch (move)
+        {
+        case MOVE_ELECTRIC_TERRAIN:
+            MESSAGE("The electricity disappeared from the battlefield.");
+            break;
+        case MOVE_GRASSY_TERRAIN:
+            MESSAGE("The grass disappeared from the battlefield.");
+            break;
+        case MOVE_MISTY_TERRAIN:
+            MESSAGE("The mist disappeared from the battlefield.");
+            break;
+        case MOVE_PSYCHIC_TERRAIN:
+            MESSAGE("The weirdness disappeared from the battlefield!");
+            break;
+        default:
+            break;
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Terrain Extender does not extend terrain created by another Pokémon")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Speed(50); Item(ITEM_TERRAIN_EXTENDER); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(100); Moves(MOVE_ELECTRIC_TERRAIN); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_ELECTRIC_TERRAIN); MOVE(player, MOVE_CELEBRATE); }
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ELECTRIC_TERRAIN, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
+        for (u32 turn = 0; turn < 4; turn++)
+        {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
+        }
+        MESSAGE("The electricity disappeared from the battlefield.");
+    }
+}
+
+SINGLE_BATTLE_TEST("Terrain Extender does not extend terrain if the holder has Klutz")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Speed(100); Ability(ABILITY_KLUTZ); Item(ITEM_TERRAIN_EXTENDER); Moves(MOVE_ELECTRIC_TERRAIN); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(50); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_ELECTRIC_TERRAIN); MOVE(opponent, MOVE_CELEBRATE); }
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ELECTRIC_TERRAIN, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
+        for (u32 turn = 0; turn < 4; turn++)
+        {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
+        }
+        MESSAGE("The electricity disappeared from the battlefield.");
+    }
+}
+
+SINGLE_BATTLE_TEST("Terrain Extender makes terrain created by moves last 8 turns")
+{
+    enum Move move;
+
+    PARAMETRIZE { move = MOVE_ELECTRIC_TERRAIN; }
+    PARAMETRIZE { move = MOVE_GRASSY_TERRAIN; }
+    PARAMETRIZE { move = MOVE_MISTY_TERRAIN; }
+    PARAMETRIZE { move = MOVE_PSYCHIC_TERRAIN; }
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Speed(100); Item(ITEM_TERRAIN_EXTENDER); Moves(move); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(50); }
+    } WHEN {
+        TURN { MOVE(player, move); MOVE(opponent, MOVE_CELEBRATE); }
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
+        for (u32 turn = 0; turn < 7; turn++)
+        {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
+        }
+        switch (move)
+        {
+        case MOVE_ELECTRIC_TERRAIN:
+            MESSAGE("The electricity disappeared from the battlefield.");
+            break;
+        case MOVE_GRASSY_TERRAIN:
+            MESSAGE("The grass disappeared from the battlefield.");
+            break;
+        case MOVE_MISTY_TERRAIN:
+            MESSAGE("The mist disappeared from the battlefield.");
+            break;
+        case MOVE_PSYCHIC_TERRAIN:
+            MESSAGE("The weirdness disappeared from the battlefield!");
+            break;
+        default:
+            break;
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Terrain Extender makes terrain created by abilities last 8 turns")
+{
+    enum Ability ability;
+    enum Species species;
+
+    PARAMETRIZE { ability = ABILITY_ELECTRIC_SURGE; species = SPECIES_PINCURCHIN; }
+    PARAMETRIZE { ability = ABILITY_GRASSY_SURGE;   species = SPECIES_RILLABOOM; }
+    PARAMETRIZE { ability = ABILITY_MISTY_SURGE;    species = SPECIES_TAPU_FINI; }
+    PARAMETRIZE { ability = ABILITY_PSYCHIC_SURGE;  species = SPECIES_TAPU_LELE; }
+
+    GIVEN {
+        PLAYER(species) { Speed(100); Ability(ability); Item(ITEM_TERRAIN_EXTENDER); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(50); }
+    } WHEN {
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+        TURN {}
+    } SCENE {
+        ABILITY_POPUP(player, ability);
+        for (u32 turn = 0; turn < 8; turn++)
+        {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
+        }
+        switch (ability)
+        {
+        case ABILITY_ELECTRIC_SURGE:
+            MESSAGE("The electricity disappeared from the battlefield.");
+            break;
+        case ABILITY_GRASSY_SURGE:
+            MESSAGE("The grass disappeared from the battlefield.");
+            break;
+        case ABILITY_MISTY_SURGE:
+            MESSAGE("The mist disappeared from the battlefield.");
+            break;
+        case ABILITY_PSYCHIC_SURGE:
+            MESSAGE("The weirdness disappeared from the battlefield!");
+            break;
+        default:
+            break;
+        }
+    }
+}

--- a/test/battle/hold_effect/thick_club.c
+++ b/test/battle/hold_effect/thick_club.c
@@ -1,4 +1,62 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Thick Club (Hold Effect) test titles")
+ASSUMPTIONS
+{
+    ASSUME(GetItemHoldEffect(ITEM_THICK_CLUB) == HOLD_EFFECT_THICK_CLUB);
+}
+
+SINGLE_BATTLE_TEST("Thick Club doubles the physical damage of Cubone and Marowak", s16 damage)
+{
+    enum Item item;
+    enum Species species;
+
+    PARAMETRIZE { item = ITEM_NONE;       species = SPECIES_CUBONE; }
+    PARAMETRIZE { item = ITEM_THICK_CLUB; species = SPECIES_CUBONE; }
+    PARAMETRIZE { item = ITEM_NONE;       species = SPECIES_MAROWAK; }
+    PARAMETRIZE { item = ITEM_THICK_CLUB; species = SPECIES_MAROWAK; }
+    PARAMETRIZE { item = ITEM_NONE;       species = SPECIES_MAROWAK_ALOLA; }
+    PARAMETRIZE { item = ITEM_THICK_CLUB; species = SPECIES_MAROWAK_ALOLA; }
+
+    GIVEN {
+        ASSUME(GetMoveCategory(MOVE_SCRATCH) == DAMAGE_CATEGORY_PHYSICAL);
+        PLAYER(species) { Attack(100); Item(item); }
+        OPPONENT(SPECIES_WOBBUFFET) { Defense(200); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SCRATCH); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(2.0), results[1].damage);
+        EXPECT_MUL_EQ(results[2].damage, Q_4_12(2.0), results[3].damage);
+        EXPECT_MUL_EQ(results[4].damage, Q_4_12(2.0), results[5].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Thick Club does not boost special moves or unrelated species", s16 damage)
+{
+    enum Item item;
+    enum Move move;
+    enum Species species;
+
+    PARAMETRIZE { item = ITEM_NONE;       move = MOVE_ROUND;   species = SPECIES_CUBONE; }
+    PARAMETRIZE { item = ITEM_THICK_CLUB; move = MOVE_ROUND;   species = SPECIES_CUBONE; }
+    PARAMETRIZE { item = ITEM_NONE;       move = MOVE_SCRATCH; species = SPECIES_WOBBUFFET; }
+    PARAMETRIZE { item = ITEM_THICK_CLUB; move = MOVE_SCRATCH; species = SPECIES_WOBBUFFET; }
+
+    GIVEN {
+        ASSUME(GetMoveCategory(MOVE_ROUND) == DAMAGE_CATEGORY_SPECIAL);
+        ASSUME(GetMoveCategory(MOVE_SCRATCH) == DAMAGE_CATEGORY_PHYSICAL);
+        PLAYER(species) { Attack(100); SpAttack(100); Item(item); Moves(move); }
+        OPPONENT(SPECIES_WOBBUFFET) { Defense(200); SpDefense(200); }
+    } WHEN {
+        TURN { MOVE(player, move); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_EQ(results[0].damage, results[1].damage);
+        EXPECT_EQ(results[2].damage, results[3].damage);
+    }
+}

--- a/test/battle/hold_effect/type_power.c
+++ b/test/battle/hold_effect/type_power.c
@@ -61,12 +61,18 @@ SINGLE_BATTLE_TEST("Type-enhancing items do not increase the power of Struggle",
     enum Item item = ITEM_NONE;
 
     PARAMETRIZE { item = ITEM_NONE; }
-    PARAMETRIZE { item = ITEM_SILK_SCARF; }
+    if (GetConfig(B_UPDATED_MOVE_FLAGS) == GEN_1) {
+        PARAMETRIZE { item = ITEM_SILK_SCARF; }
+    } else {
+        for (u32 j = 0; j < ARRAY_COUNT(sMoveItemTable); j++)
+            PARAMETRIZE { item = sMoveItemTable[j][2]; }
+    }
 
     GIVEN {
         if (item != ITEM_NONE) {
             ASSUME(GetItemHoldEffect(item) == HOLD_EFFECT_TYPE_POWER);
-            ASSUME(GetItemSecondaryId(item) == GetMoveType(MOVE_STRUGGLE));
+            if (GetConfig(B_UPDATED_MOVE_FLAGS) == GEN_1)
+                ASSUME(GetItemSecondaryId(item) == TYPE_NORMAL);
         }
         PLAYER(SPECIES_WOBBUFFET) { Item(item); }
         OPPONENT(SPECIES_WOBBUFFET);
@@ -76,6 +82,11 @@ SINGLE_BATTLE_TEST("Type-enhancing items do not increase the power of Struggle",
         ANIMATION(ANIM_TYPE_MOVE, MOVE_STRUGGLE, player);
         HP_BAR(opponent, captureDamage: &results[i].damage);
     } FINALLY {
-        EXPECT_EQ(results[0].damage, results[1].damage);
+        if (GetConfig(B_UPDATED_MOVE_FLAGS) == GEN_1) {
+            EXPECT_EQ(results[0].damage, results[1].damage);
+        } else {
+            for (u32 j = 0; j < ARRAY_COUNT(sMoveItemTable); j++)
+                EXPECT_EQ(results[0].damage, results[j + 1].damage);
+        }
     }
 }

--- a/test/battle/hold_effect/wise_glasses.c
+++ b/test/battle/hold_effect/wise_glasses.c
@@ -1,4 +1,50 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("TODO: Write Wise Glasses (Hold Effect) test titles")
+ASSUMPTIONS
+{
+    ASSUME(GetItemHoldEffect(ITEM_WISE_GLASSES) == HOLD_EFFECT_WISE_GLASSES);
+    ASSUME(GetItemHoldEffectParam(ITEM_WISE_GLASSES) == 10);
+}
+
+SINGLE_BATTLE_TEST("Wise Glasses boost special damage by 10%", s16 damage)
+{
+    enum Item item;
+
+    PARAMETRIZE { item = ITEM_NONE; }
+    PARAMETRIZE { item = ITEM_WISE_GLASSES; }
+
+    GIVEN {
+        ASSUME(GetMoveCategory(MOVE_WATER_GUN) == DAMAGE_CATEGORY_SPECIAL);
+        PLAYER(SPECIES_WOBBUFFET) { Item(item); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_WATER_GUN); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_WATER_GUN, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.1), results[1].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Wise Glasses do not boost physical damage", s16 damage)
+{
+    enum Item item;
+
+    PARAMETRIZE { item = ITEM_NONE; }
+    PARAMETRIZE { item = ITEM_WISE_GLASSES; }
+
+    GIVEN {
+        ASSUME(GetMoveCategory(MOVE_SCRATCH) == DAMAGE_CATEGORY_PHYSICAL);
+        PLAYER(SPECIES_WOBBUFFET) { Item(item); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_SCRATCH); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_EQ(results[0].damage, results[1].damage);
+    }
+}

--- a/test/battle/item_effect/revive.c
+++ b/test/battle/item_effect/revive.c
@@ -1,4 +1,6 @@
 #include "global.h"
+#include "item_use.h"
+#include "party_menu.h"
 #include "test/battle.h"
 
 SINGLE_BATTLE_TEST("Revive restores a fainted battler's HP to half")
@@ -263,4 +265,25 @@ SINGLE_BATTLE_TEST("Revive keeps Mimikyu Busted forms and Eiscue Noice in their 
     }
 }
 
-TO_DO_BATTLE_TEST("Revive won't restore a battler's HP if it hasn't fainted")
+SINGLE_BATTLE_TEST("Revive can only be used if the selected Pokémon has fainted")
+{
+    bool32 fainted;
+
+    PARAMETRIZE { fainted = FALSE; }
+    PARAMETRIZE { fainted = TRUE; }
+
+    GIVEN {
+        ASSUME(gItemsInfo[ITEM_REVIVE].battleUsage == EFFECT_ITEM_REVIVE);
+        PLAYER(SPECIES_WYNAUT) { HP(100); MaxHP(200); }
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        if (fainted)
+            TURN { MOVE(player, MOVE_MEMENTO); SEND_OUT(player, 1); }
+        else
+            TURN {}
+    } THEN {
+        gPartyMenu.slotId = 0;
+        EXPECT_EQ(CannotUseItemsInBattle(ITEM_REVIVE, &gParties[B_TRAINER_PLAYER][0]), !fainted);
+    }
+}

--- a/test/battle/move_effect/acupressure.c
+++ b/test/battle/move_effect/acupressure.c
@@ -1,6 +1,11 @@
 #include "global.h"
 #include "test/battle.h"
 
+ASSUMPTIONS
+{
+    ASSUME(GetMoveEffect(MOVE_ACUPRESSURE) == EFFECT_ACUPRESSURE);
+}
+
 DOUBLE_BATTLE_TEST("Acupressure fails on the user if it targeted its ally but switched positions via Ally Switch")
 {
     GIVEN {
@@ -163,10 +168,111 @@ DOUBLE_BATTLE_TEST("Acupressure will target self if both side allies fainted")
     }
 }
 
-TO_DO_BATTLE_TEST("Acupressure fails on the user if all of its stats are maximized");
-TO_DO_BATTLE_TEST("Acupressure fails on the ally if all of its stats are maximized");
-TO_DO_BATTLE_TEST("Acupressure doesn't try to increase a stat that has been maximized");
-TO_DO_BATTLE_TEST("Acupressure increases one of its stats by 2 stages at random");
+SINGLE_BATTLE_TEST("Acupressure fails on the user if all of its stats are maximized")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_CLANGOROUS_SOUL) == EFFECT_CLANGOROUS_SOUL);
+        ASSUME_STAT_CHANGE(MOVE_HONE_CLAWS, attack: +1, accuracy: +1);
+        ASSUME_STAT_CHANGE(MOVE_DOUBLE_TEAM, evasion: +1);
+        PLAYER(SPECIES_BIBAREL) { Ability(ABILITY_SIMPLE); HP(601); MaxHP(601); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_CLANGOROUS_SOUL); }
+        TURN { MOVE(player, MOVE_CLANGOROUS_SOUL); }
+        TURN { MOVE(player, MOVE_CLANGOROUS_SOUL); }
+        for (u32 j = 0; j < 3; j++)
+            TURN { MOVE(player, MOVE_HONE_CLAWS); }
+        for (u32 j = 0; j < 3; j++)
+            TURN { MOVE(player, MOVE_DOUBLE_TEAM); }
+        TURN { MOVE(player, MOVE_ACUPRESSURE, target: player); }
+    } SCENE {
+        MESSAGE("Bibarel used Acupressure!");
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_ACUPRESSURE, player);
+        MESSAGE("But it failed!");
+    } THEN {
+        for (enum Stat stat = STAT_ATK; stat < NUM_BATTLE_STATS; stat++)
+            EXPECT_EQ(player->statStages[stat], MAX_STAT_STAGE);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Acupressure fails on the ally if all of its stats are maximized")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_CLANGOROUS_SOUL) == EFFECT_CLANGOROUS_SOUL);
+        ASSUME_STAT_CHANGE(MOVE_HONE_CLAWS, attack: +1, accuracy: +1);
+        ASSUME_STAT_CHANGE(MOVE_DOUBLE_TEAM, evasion: +1);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_BIBAREL) { Ability(ABILITY_SIMPLE); HP(601); MaxHP(601); }
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN { MOVE(playerRight, MOVE_CLANGOROUS_SOUL); }
+        TURN { MOVE(playerRight, MOVE_CLANGOROUS_SOUL); }
+        TURN { MOVE(playerRight, MOVE_CLANGOROUS_SOUL); }
+        for (u32 j = 0; j < 3; j++)
+            TURN { MOVE(playerRight, MOVE_HONE_CLAWS); }
+        for (u32 j = 0; j < 3; j++)
+            TURN { MOVE(playerRight, MOVE_DOUBLE_TEAM); }
+        TURN { MOVE(playerLeft, MOVE_ACUPRESSURE, target: playerRight); }
+    } SCENE {
+        MESSAGE("Wobbuffet used Acupressure!");
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_ACUPRESSURE, playerLeft);
+        MESSAGE("But it failed!");
+    } THEN {
+        for (enum Stat stat = STAT_ATK; stat < NUM_BATTLE_STATS; stat++)
+            EXPECT_EQ(playerRight->statStages[stat], MAX_STAT_STAGE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Acupressure doesn't try to increase a stat that has been maximized")
+{
+    u32 boostedStats = 0;
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_BELLY_DRUM) == EFFECT_BELLY_DRUM);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_BELLY_DRUM); }
+        TURN { MOVE(player, MOVE_ACUPRESSURE, target: player); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BELLY_DRUM, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ACUPRESSURE, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_ATK], MAX_STAT_STAGE);
+        for (enum Stat stat = STAT_DEF; stat < NUM_BATTLE_STATS; stat++) {
+            if (player->statStages[stat] == DEFAULT_STAT_STAGE + 2)
+                boostedStats++;
+            else
+                EXPECT_EQ(player->statStages[stat], DEFAULT_STAT_STAGE);
+        }
+        EXPECT_EQ(boostedStats, 1);
+    }
+}
+
+SINGLE_BATTLE_TEST("Acupressure increases one of its stats by 2 stages at random")
+{
+    u32 boostedStats = 0;
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_ACUPRESSURE, target: player); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ACUPRESSURE, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+    } THEN {
+        for (enum Stat stat = STAT_ATK; stat < NUM_BATTLE_STATS; stat++) {
+            if (player->statStages[stat] == DEFAULT_STAT_STAGE + 2)
+                boostedStats++;
+            else
+                EXPECT_EQ(player->statStages[stat], DEFAULT_STAT_STAGE);
+        }
+        EXPECT_EQ(boostedStats, 1);
+    }
+}
 
 // Triple Battles required to test
 //TO_DO_BATTLE_TEST("Acupressure works on the ally if the user targeted itself but switched positions via Triple Battle shift before execution");

--- a/test/battle/move_effect/assurance.c
+++ b/test/battle/move_effect/assurance.c
@@ -66,28 +66,58 @@ DOUBLE_BATTLE_TEST("Assurance does not double in power if the target's damage is
     }
 }
 
-SINGLE_BATTLE_TEST("Assurance does not double in power if the target took damage from confusion")
+SINGLE_BATTLE_TEST("Assurance doubles in power if the target has been damaged by entry hazards on switch-in", s16 damage)
+{
+    bool32 hazards;
+
+    PARAMETRIZE { hazards = FALSE; }
+    PARAMETRIZE { hazards = TRUE; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_STEALTH_ROCK) == EFFECT_STEALTH_ROCK);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(5); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); }
+        OPPONENT(SPECIES_WYNAUT) { MaxHP(500); HP(500); Speed(1); }
+    } WHEN {
+        if (hazards)
+            TURN { MOVE(player, MOVE_STEALTH_ROCK); }
+        else
+            TURN { MOVE(player, MOVE_CELEBRATE); }
+        TURN { SWITCH(opponent, 1); MOVE(player, MOVE_ASSURANCE); }
+    } SCENE {
+        if (hazards)
+            HP_BAR(opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(2.0), results[1].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Assurance doubles in power if the target took damage from confusion")
 {
     s16 hits[2];
 
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_CONFUSE_RAY) == EFFECT_CONFUSE);
-        PLAYER(SPECIES_WOBBUFFET) { Speed(2); }
+        PLAYER(SPECIES_WOBBUFFET) { MaxHP(500); HP(500); Speed(2); }
         OPPONENT(SPECIES_WOBBUFFET) { Speed(1); }
     } WHEN {
         TURN { MOVE(opponent, MOVE_ASSURANCE); }
         TURN { MOVE(opponent, MOVE_CONFUSE_RAY); }
-        TURN { MOVE(opponent, MOVE_ASSURANCE); }
+        TURN { MOVE(player, MOVE_CELEBRATE, WITH_RNG(RNG_CONFUSION, TRUE)); MOVE(opponent, MOVE_ASSURANCE); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponent);
         HP_BAR(player, captureDamage: &hits[0]);
 
         ANIMATION(ANIM_TYPE_MOVE, MOVE_CONFUSE_RAY, opponent);
 
+        MESSAGE("It hurt itself in its confusion!");
+        HP_BAR(player);
         ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponent);
         HP_BAR(player, captureDamage: &hits[1]);
     } THEN {
-        EXPECT_EQ(hits[0], hits[1]);
+        EXPECT_MUL_EQ(hits[0], Q_4_12(2.0), hits[1]);
     }
 }
 
@@ -562,5 +592,62 @@ SINGLE_BATTLE_TEST("Assurance does not double in power if the target was damaged
         HP_BAR(player, captureDamage: &hits[1]);
     } THEN {
         EXPECT_EQ(hits[0], hits[1]);
+    }
+}
+
+SINGLE_BATTLE_TEST("Assurance doubles in power if the target has been damaged in the same turn - Confusion", s16 damage)
+{
+    bool32 confusionDamage;
+
+    PARAMETRIZE { confusionDamage = FALSE; }
+    PARAMETRIZE { confusionDamage = TRUE; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_CONFUSE_RAY) == EFFECT_CONFUSE);
+        PLAYER(SPECIES_WOBBUFFET) { HP(500); MaxHP(500); Speed(2); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_CONFUSE_RAY); }
+        TURN {
+            MOVE(player, MOVE_CELEBRATE, WITH_RNG(RNG_CONFUSION, confusionDamage));
+            MOVE(opponent, MOVE_ASSURANCE);
+        }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CONFUSE_RAY, opponent);
+        if (confusionDamage) {
+            MESSAGE("It hurt itself in its confusion!");
+            HP_BAR(player);
+        } else {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
+        }
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponent);
+        HP_BAR(player, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(2.0), results[1].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Assurance does not double in power if the target was damaged on a previous turn", s16 damage)
+{
+    bool32 previousDamage;
+
+    PARAMETRIZE { previousDamage = FALSE; }
+    PARAMETRIZE { previousDamage = TRUE; }
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { HP(500); MaxHP(500); Speed(2); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); }
+    } WHEN {
+        if (previousDamage)
+            TURN { MOVE(opponent, MOVE_SCRATCH); }
+        else
+            TURN { MOVE(opponent, MOVE_CELEBRATE); }
+        TURN { MOVE(player, MOVE_CELEBRATE); MOVE(opponent, MOVE_ASSURANCE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, previousDamage ? MOVE_SCRATCH : MOVE_CELEBRATE, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ASSURANCE, opponent);
+        HP_BAR(player, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_EQ(results[0].damage, results[1].damage);
     }
 }

--- a/test/battle/move_effect/autotomize.c
+++ b/test/battle/move_effect/autotomize.c
@@ -1,7 +1,31 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("Autotomize increases Speed by 2 stages")
+static u32 GetPlayerLeftWeight(void)
+{
+    enum BattlerId battler = GetBattlerAtPosition(B_POSITION_PLAYER_LEFT);
+    return GetBattlerWeight(battler, GetBattlerAbility(battler), GetBattlerHoldEffect(battler));
+}
+
+ASSUMPTIONS
+{
+    ASSUME(GetMoveEffect(MOVE_AUTOTOMIZE) == EFFECT_AUTOTOMIZE);
+    ASSUME_STAT_CHANGE(MOVE_AUTOTOMIZE, speed: +2);
+}
+
+SINGLE_BATTLE_TEST("Autotomize increases Speed by 2 stages")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_AUTOTOMIZE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_AUTOTOMIZE, player);
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_SPEED], DEFAULT_STAT_STAGE + 2);
+    }
+}
 
 SINGLE_BATTLE_TEST("Autotomize decreases weight by 100kg (220 lbs.) each time it's used")
 {
@@ -31,15 +55,156 @@ SINGLE_BATTLE_TEST("Autotomize decreases weight by 100kg (220 lbs.) each time it
         HP_BAR(opponent, captureDamage: &damage[2]);
     } THEN {
         EXPECT_MUL_EQ(damage[2], Q_4_12(6.0), damage[0]);
-        EXPECT_MUL_EQ(damage[2], Q_4_12(5.0), damage[0]);
+        EXPECT_MUL_EQ(damage[2], Q_4_12(5.0), damage[1]);
     }
 }
 
+SINGLE_BATTLE_TEST("Autotomize cannot decrease weight below 0.1kg (0.2 lbs)")
+{
+    GIVEN {
+        ASSUME(GetSpeciesWeight(SPECIES_DURALUDON) == 400);
+        PLAYER(SPECIES_DURALUDON) { Ability(ABILITY_STALWART); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_AUTOTOMIZE); }
+        TURN { MOVE(player, MOVE_AUTOTOMIZE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_AUTOTOMIZE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_AUTOTOMIZE, player);
+    } THEN {
+        EXPECT_EQ(GetPlayerLeftWeight(), 1);
+        EXPECT_EQ((u32)player->volatiles.autotomizeCount, 1);
+    }
+}
 
-TO_DO_BATTLE_TEST("Autotomize cannot decrease weight below 0.1kg (0.2 lbs)");
-TO_DO_BATTLE_TEST("Autotomize's weight reduction cannot be Baton Passed");
-TO_DO_BATTLE_TEST("Autotomize's weight reduction cannot be removed by Haze");
-TO_DO_BATTLE_TEST("Autotomize's weight reduction is reset upon form change (Gen6+)");
-TO_DO_BATTLE_TEST("Autotomize's weight reduction is reset upon switch");
-TO_DO_BATTLE_TEST("Autotomize's weight reduction is reset upon fainting");
-TO_DO_BATTLE_TEST("Autotomize doesn't affect Heavy Ball's multiplier")
+SINGLE_BATTLE_TEST("Autotomize's weight reduction cannot be Baton Passed")
+{
+    GIVEN {
+        ASSUME(GetSpeciesWeight(SPECIES_DURALUDON) == 400);
+        PLAYER(SPECIES_DURALUDON) { Ability(ABILITY_STALWART); }
+        PLAYER(SPECIES_DURALUDON) { Ability(ABILITY_STALWART); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_AUTOTOMIZE); }
+        TURN { MOVE(player, MOVE_BATON_PASS); SEND_OUT(player, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_AUTOTOMIZE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BATON_PASS, player);
+        SEND_IN_MESSAGE("Duraludon");
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_SPEED], DEFAULT_STAT_STAGE + 2);
+        EXPECT_EQ(GetPlayerLeftWeight(), 400);
+        EXPECT_EQ((u32)player->volatiles.autotomizeCount, 0);
+    }
+}
+
+SINGLE_BATTLE_TEST("Autotomize's weight reduction cannot be removed by Haze")
+{
+    GIVEN {
+        ASSUME(GetSpeciesWeight(SPECIES_DURALUDON) == 400);
+        PLAYER(SPECIES_DURALUDON) { Ability(ABILITY_STALWART); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_AUTOTOMIZE); }
+        TURN { MOVE(opponent, MOVE_HAZE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_AUTOTOMIZE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_HAZE, opponent);
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_SPEED], DEFAULT_STAT_STAGE);
+        EXPECT_EQ(GetPlayerLeftWeight(), 1);
+        EXPECT_EQ((u32)player->volatiles.autotomizeCount, 1);
+    }
+}
+
+SINGLE_BATTLE_TEST("Autotomize's weight reduction is reset upon form change (Gen 6+)")
+{
+    u32 gen;
+
+    PARAMETRIZE { gen = GEN_5; }
+    PARAMETRIZE { gen = GEN_6; }
+
+    GIVEN {
+        ASSUME(GetSpeciesWeight(SPECIES_AEGISLASH_SHIELD) == 530);
+        ASSUME(GetSpeciesWeight(SPECIES_AEGISLASH_BLADE) == 530);
+        WITH_CONFIG(B_AUTOTOMIZE_FORM_CHANGE, gen);
+        PLAYER(SPECIES_AEGISLASH_SHIELD) { Ability(ABILITY_STANCE_CHANGE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_AUTOTOMIZE); }
+        TURN { MOVE(player, MOVE_SCRATCH); }
+    } THEN {
+        EXPECT_EQ(player->species, SPECIES_AEGISLASH_BLADE);
+        if (gen >= GEN_6)
+        {
+            EXPECT_EQ(GetPlayerLeftWeight(), 530);
+            EXPECT_EQ((u32)player->volatiles.autotomizeCount, 0);
+        }
+        else
+        {
+            EXPECT_EQ(GetPlayerLeftWeight(), 1);
+            EXPECT_EQ((u32)player->volatiles.autotomizeCount, 1);
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Autotomize's weight reduction is reset upon switch")
+{
+    GIVEN {
+        ASSUME(GetSpeciesWeight(SPECIES_DURALUDON) == 400);
+        PLAYER(SPECIES_DURALUDON) { Ability(ABILITY_STALWART); }
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_AUTOTOMIZE); }
+        TURN { SWITCH(player, 1); }
+        TURN { SWITCH(player, 0); }
+    } THEN {
+        EXPECT_EQ(GetPlayerLeftWeight(), 400);
+        EXPECT_EQ((u32)player->volatiles.autotomizeCount, 0);
+    }
+}
+
+SINGLE_BATTLE_TEST("Autotomize's weight reduction is reset upon fainting")
+{
+    GIVEN {
+        ASSUME(GetSpeciesWeight(SPECIES_DURALUDON) == 400);
+        PLAYER(SPECIES_DURALUDON) { Ability(ABILITY_STALWART); HP(1); }
+        PLAYER(SPECIES_RABSCA);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_AUTOTOMIZE); }
+        TURN { MOVE(opponent, MOVE_SCRATCH); SEND_OUT(player, 1); }
+        TURN { MOVE(player, MOVE_REVIVAL_BLESSING, partyIndex: 0); }
+        TURN { SWITCH(player, 0); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_AUTOTOMIZE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
+        MESSAGE("Duraludon fainted!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_REVIVAL_BLESSING, player);
+    } THEN {
+        EXPECT_EQ(GetPlayerLeftWeight(), 400);
+        EXPECT_EQ((u32)player->volatiles.autotomizeCount, 0);
+    }
+}
+
+WILD_BATTLE_TEST("Autotomize doesn't affect Heavy Ball's multiplier", u32 catchingChance)
+{
+    bool32 usedAutotomize;
+    PARAMETRIZE { usedAutotomize = FALSE; }
+    PARAMETRIZE { usedAutotomize = TRUE; }
+
+    GIVEN {
+        ASSUME(GetSpeciesWeight(SPECIES_SCIZOR) == 1180);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_SCIZOR) { Ability(ABILITY_TECHNICIAN); }
+    } WHEN {
+        if (usedAutotomize)
+            TURN { MOVE(opponent, MOVE_AUTOTOMIZE); }
+        TURN { USE_ITEM(player, ITEM_HEAVY_BALL); }
+    } SCENE {
+        CATCHING_CHANCE(&results[i].catchingChance);
+    } FINALLY {
+        EXPECT_EQ(results[0].catchingChance, results[1].catchingChance);
+    }
+}

--- a/test/battle/move_effect/baton_pass.c
+++ b/test/battle/move_effect/baton_pass.c
@@ -39,7 +39,6 @@ TO_DO_BATTLE_TEST("Baton Pass doesn't pass ability changes");
 //
 TO_DO_BATTLE_TEST("Baton Pass passes confusion status");                                                    // test/battle/volatiles/confusion.c
 
-TO_DO_BATTLE_TEST("Baton Pass passes Fairy lock's escape prevention effect");                               // test/battle/move_effect/fairy_lock.c
 TO_DO_BATTLE_TEST("Baton Pass passes Focus Energy's effect");                                               // test/battle/move_effect/focus_energy.c
 TO_DO_BATTLE_TEST("Baton Pass passes Heal Block's effect");                                                 // test/battle/move_effect/heal_block.c
 TO_DO_BATTLE_TEST("Baton Pass doesn't pass Imprison's effect");                                             // test/battle/move_effect/imprison.c

--- a/test/battle/move_effect/bide.c
+++ b/test/battle/move_effect/bide.c
@@ -35,6 +35,40 @@ SINGLE_BATTLE_TEST("Bide deals twice the taken damage over two turns")
     }
 }
 
+SINGLE_BATTLE_TEST("Bide ignores type effectiveness and STAB (Gen 1)", s16 damage1, s16 damage2, s16 bideDamage)
+{
+    enum Species species;
+
+    PARAMETRIZE { species = SPECIES_WOBBUFFET; }
+    PARAMETRIZE { species = SPECIES_GEODUDE; }
+    PARAMETRIZE { species = SPECIES_GASTLY; }
+
+    GIVEN {
+        WITH_CONFIG(B_FIXED_DMG_IGNORES_TYPE, GEN_1);
+        ASSUME(IsSpeciesOfType(SPECIES_RATTATA, TYPE_NORMAL));
+        ASSUME(IsSpeciesOfType(SPECIES_GEODUDE, TYPE_ROCK));
+        ASSUME(IsSpeciesOfType(SPECIES_GASTLY, TYPE_GHOST));
+        PLAYER(SPECIES_RATTATA) { MaxHP(1000); HP(1000); }
+        OPPONENT(species) { MaxHP(1000); HP(1000); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_BIDE); MOVE(opponent, MOVE_SCRATCH); }
+        TURN { SKIP_TURN(player); MOVE(opponent, MOVE_SCRATCH); }
+        TURN { SKIP_TURN(player); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BIDE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
+        HP_BAR(player, captureDamage: &results[i].damage1);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
+        HP_BAR(player, captureDamage: &results[i].damage2);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BIDE, player);
+        HP_BAR(opponent, captureDamage: &results[i].bideDamage);
+    } FINALLY {
+        EXPECT_EQ(results[0].bideDamage, 2 * (results[0].damage1 + results[0].damage2));
+        EXPECT_EQ(results[1].bideDamage, 2 * (results[1].damage1 + results[1].damage2));
+        EXPECT_EQ(results[2].bideDamage, 2 * (results[2].damage1 + results[2].damage2));
+    }
+}
+
 SINGLE_BATTLE_TEST("Bide fails if no damage has been dealt to the user")
 {
     GIVEN {
@@ -198,5 +232,28 @@ SINGLE_BATTLE_TEST("Bide doesn't deal damage through protect")
     }
 }
 
-TO_DO_BATTLE_TEST("Bide has +1 priority on following turns if called via a different move");
+SINGLE_BATTLE_TEST("Bide has +1 priority on following turns if called via a different move")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_METRONOME) == EFFECT_METRONOME);
+        ASSUME(GetMovePriority(MOVE_BIDE) == 1);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(1); MaxHP(1000); HP(1000); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(2); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_METRONOME, WITH_RNG(RNG_METRONOME, MOVE_BIDE)); MOVE(opponent, MOVE_SCRATCH); }
+        TURN { SKIP_TURN(player); MOVE(opponent, MOVE_SCRATCH); }
+        TURN { SKIP_TURN(player); MOVE(opponent, MOVE_CELEBRATE); }
+    } SCENE {
+        // Bide has not started yet, so the faster opponent moves first on turn 1.
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_METRONOME, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BIDE, player);
 
+        // On the following turns, Bide's +1 priority overrides the speed order.
+        MESSAGE("Wobbuffet is storing energy!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
+        MESSAGE("Wobbuffet unleashed its energy!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BIDE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, opponent);
+    }
+}

--- a/test/battle/move_effect/body_press.c
+++ b/test/battle/move_effect/body_press.c
@@ -119,9 +119,73 @@ SINGLE_BATTLE_TEST("Body Press uses Special Defense stat Stages in Wonder Room",
     }
 }
 
-// Could be split into multiple tests or maybe to separate files based on the modifier?
-TO_DO_BATTLE_TEST("Body Press's damage is influenced by all other Attack modifiers that are not stat stages");
-TO_DO_BATTLE_TEST("Body Press's damage is NOT influenced by any other Defense besides stat stages");
+SINGLE_BATTLE_TEST("Body Press is influenced by Attack modifiers other than stat stages", s16 damage)
+{
+    enum Species species;
+    enum Ability ability;
+    enum Item item;
+    u32 status;
+    u32 maxHP, hp;
+
+    PARAMETRIZE { species = SPECIES_WOBBUFFET;              ability = ABILITY_SHADOW_TAG;      item = ITEM_NONE;        status = STATUS1_NONE; maxHP = 100; hp = 100; }
+    PARAMETRIZE { species = SPECIES_WOBBUFFET;              ability = ABILITY_SHADOW_TAG;      item = ITEM_CHOICE_BAND; status = STATUS1_NONE; maxHP = 100; hp = 100; }
+    PARAMETRIZE { species = SPECIES_AZUMARILL;              ability = ABILITY_HUGE_POWER;      item = ITEM_NONE;        status = STATUS1_NONE; maxHP = 100; hp = 100; }
+    PARAMETRIZE { species = SPECIES_DARMANITAN_GALAR;       ability = ABILITY_GORILLA_TACTICS; item = ITEM_NONE;        status = STATUS1_NONE; maxHP = 100; hp = 100; }
+    PARAMETRIZE { species = SPECIES_WOBBUFFET;              ability = ABILITY_SHADOW_TAG;      item = ITEM_NONE;        status = STATUS1_BURN; maxHP = 100; hp = 100; }
+    PARAMETRIZE { species = SPECIES_SWELLOW;                ability = ABILITY_GUTS;            item = ITEM_NONE;        status = STATUS1_BURN; maxHP = 100; hp = 100; }
+    PARAMETRIZE { species = SPECIES_ARCHEOPS;               ability = ABILITY_DEFEATIST;       item = ITEM_NONE;        status = STATUS1_NONE; maxHP = 100; hp = 50;  }
+    PARAMETRIZE { species = SPECIES_REGIGIGAS;              ability = ABILITY_SLOW_START;      item = ITEM_NONE;        status = STATUS1_NONE; maxHP = 100; hp = 100; }
+
+    GIVEN {
+        ASSUME(GetItemHoldEffect(ITEM_CHOICE_BAND) == HOLD_EFFECT_CHOICE_BAND);
+        PLAYER(species) { Ability(ability); Item(item); Status1(status); MaxHP(maxHP); HP(hp); Attack(100); Defense(100); }
+        OPPONENT(SPECIES_WOBBUFFET) { MaxHP(500); HP(500); Defense(100); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_BODY_PRESS); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BODY_PRESS, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.5), results[1].damage);
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(2.0), results[2].damage);
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.5), results[3].damage);
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(0.5), results[4].damage);
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.5), results[5].damage);
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(0.5), results[6].damage);
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(0.5), results[7].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Body Press is not influenced by Defense modifiers other than stat stages", s16 damage)
+{
+    enum Species species;
+    enum Ability ability;
+    enum Item item;
+    u32 status;
+
+    PARAMETRIZE { species = SPECIES_WOBBUFFET; ability = ABILITY_SHADOW_TAG;   item = ITEM_NONE;         status = STATUS1_NONE; }
+    PARAMETRIZE { species = SPECIES_FURFROU;   ability = ABILITY_FUR_COAT;     item = ITEM_NONE;         status = STATUS1_NONE; }
+    PARAMETRIZE { species = SPECIES_MILOTIC;   ability = ABILITY_MARVEL_SCALE; item = ITEM_NONE;        status = STATUS1_POISON; }
+    PARAMETRIZE { species = SPECIES_PORYGON;   ability = ABILITY_TRACE;        item = ITEM_EVIOLITE;     status = STATUS1_NONE; }
+    PARAMETRIZE { species = SPECIES_WOBBUFFET; ability = ABILITY_SHADOW_TAG;   item = ITEM_ASSAULT_VEST; status = STATUS1_NONE; }
+
+    GIVEN {
+        ASSUME(GetItemHoldEffect(ITEM_EVIOLITE) == HOLD_EFFECT_EVIOLITE);
+        ASSUME(GetItemHoldEffect(ITEM_ASSAULT_VEST) == HOLD_EFFECT_ASSAULT_VEST);
+        PLAYER(species) { Ability(ability); Item(item); Status1(status); Attack(100); Defense(100); SpDefense(100); }
+        OPPONENT(SPECIES_WOBBUFFET) { MaxHP(500); HP(500); Defense(100); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_BODY_PRESS); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BODY_PRESS, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_EQ(results[0].damage, results[1].damage);
+        EXPECT_EQ(results[1].damage, results[2].damage);
+        EXPECT_EQ(results[2].damage, results[3].damage);
+        EXPECT_EQ(results[3].damage, results[4].damage);
+    }
+}
 
 // Unconfirmed by Bulbapedia:
 // - Defeatist interaction

--- a/test/battle/move_effect/camouflage.c
+++ b/test/battle/move_effect/camouflage.c
@@ -1,8 +1,123 @@
 #include "global.h"
 #include "test/battle.h"
+#include "battle_environment.h"
 
-TO_DO_BATTLE_TEST("Camouflage changes the type of the user based on battle environment");
-TO_DO_BATTLE_TEST("Camouflage changes the type of the user to Grass if Grassy Terrain is active");
-TO_DO_BATTLE_TEST("Camouflage changes the type of the user to Electric if Electric Terrain is active");
-TO_DO_BATTLE_TEST("Camouflage changes the type of the user to Psychic if Psychic Terrain is active");
-TO_DO_BATTLE_TEST("Camouflage changes the type of the user to Fairy if Misty Terrain is active");
+SINGLE_BATTLE_TEST("Camouflage changes the type of the user based on battle environment")
+{
+    u32 environment = 0;
+
+    for (u32 j = 0; j < BATTLE_ENVIRONMENT_COUNT; j++)
+        PARAMETRIZE { environment = j; }
+
+    GIVEN {
+        ASSUME(GetSpeciesType(SPECIES_EKANS, 0) == TYPE_POISON);
+        PLAYER(SPECIES_EKANS);
+        OPPONENT(SPECIES_WOBBUFFET);
+        Environment(environment);
+    } WHEN {
+        TURN { MOVE(player, MOVE_CAMOUFLAGE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CAMOUFLAGE, player);
+    } THEN {
+        EXPECT_EQ(player->types[0], gBattleEnvironmentInfo[environment].camouflageType);
+        EXPECT_EQ(player->types[1], gBattleEnvironmentInfo[environment].camouflageType);
+        EXPECT_EQ(player->types[2], TYPE_MYSTERY);
+    }
+}
+
+SINGLE_BATTLE_TEST("Camouflage changes the type of the user to Grass if Grassy Terrain is active")
+{
+    GIVEN {
+        PLAYER(SPECIES_EKANS) { Speed(1); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(2); }
+        Environment(BATTLE_ENVIRONMENT_BUILDING);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_GRASSY_TERRAIN); MOVE(player, MOVE_CAMOUFLAGE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CAMOUFLAGE, player);
+    } THEN {
+        EXPECT_EQ(player->types[0], TYPE_GRASS);
+        EXPECT_EQ(player->types[1], TYPE_GRASS);
+        EXPECT_EQ(player->types[2], TYPE_MYSTERY);
+    }
+}
+
+SINGLE_BATTLE_TEST("Camouflage changes the type of the user to Electric if Electric Terrain is active")
+{
+    GIVEN {
+        PLAYER(SPECIES_EKANS) { Speed(1); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(2); }
+        Environment(BATTLE_ENVIRONMENT_BUILDING);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_ELECTRIC_TERRAIN); MOVE(player, MOVE_CAMOUFLAGE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CAMOUFLAGE, player);
+    } THEN {
+        EXPECT_EQ(player->types[0], TYPE_ELECTRIC);
+        EXPECT_EQ(player->types[1], TYPE_ELECTRIC);
+        EXPECT_EQ(player->types[2], TYPE_MYSTERY);
+    }
+}
+
+SINGLE_BATTLE_TEST("Camouflage changes the type of the user to Psychic if Psychic Terrain is active")
+{
+    GIVEN {
+        PLAYER(SPECIES_EKANS) { Speed(1); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(2); }
+        Environment(BATTLE_ENVIRONMENT_BUILDING);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_PSYCHIC_TERRAIN); MOVE(player, MOVE_CAMOUFLAGE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CAMOUFLAGE, player);
+    } THEN {
+        EXPECT_EQ(player->types[0], TYPE_PSYCHIC);
+        EXPECT_EQ(player->types[1], TYPE_PSYCHIC);
+        EXPECT_EQ(player->types[2], TYPE_MYSTERY);
+    }
+}
+
+SINGLE_BATTLE_TEST("Camouflage changes the type of the user to Fairy if Misty Terrain is active")
+{
+    GIVEN {
+        PLAYER(SPECIES_EKANS) { Speed(1); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(2); }
+        Environment(BATTLE_ENVIRONMENT_BUILDING);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_MISTY_TERRAIN); MOVE(player, MOVE_CAMOUFLAGE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CAMOUFLAGE, player);
+    } THEN {
+        EXPECT_EQ(player->types[0], TYPE_FAIRY);
+        EXPECT_EQ(player->types[1], TYPE_FAIRY);
+        EXPECT_EQ(player->types[2], TYPE_MYSTERY);
+    }
+}
+
+SINGLE_BATTLE_TEST("Camouflage fails if the user already has the environment's type")
+{
+    GIVEN {
+        ASSUME(GetSpeciesType(SPECIES_BULBASAUR, 0) == TYPE_GRASS);
+        PLAYER(SPECIES_BULBASAUR);
+        OPPONENT(SPECIES_WOBBUFFET);
+        Environment(BATTLE_ENVIRONMENT_GRASS);
+    } WHEN {
+        TURN { MOVE(player, MOVE_CAMOUFLAGE); }
+    } SCENE {
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_CAMOUFLAGE, player);
+        MESSAGE("But it failed!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Camouflage fails if the user is Terastallized")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { TeraType(TYPE_PSYCHIC); }
+        OPPONENT(SPECIES_WOBBUFFET);
+        Environment(BATTLE_ENVIRONMENT_GRASS);
+    } WHEN {
+        TURN { MOVE(player, MOVE_CAMOUFLAGE, gimmick: GIMMICK_TERA); }
+    } SCENE {
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_CAMOUFLAGE, player);
+        MESSAGE("But it failed!");
+    }
+}

--- a/test/battle/move_effect/change_type_on_item.c
+++ b/test/battle/move_effect/change_type_on_item.c
@@ -1,10 +1,26 @@
 #include "global.h"
 #include "test/battle.h"
 
+static uq4_12_t GetSpeciesTypeEffectiveness(enum Type moveType, enum Species species)
+{
+    enum Type type1 = GetSpeciesType(species, 0);
+    enum Type type2 = GetSpeciesType(species, 1);
+    uq4_12_t modifier = GetTypeModifier(moveType, type1);
+
+    if (type1 != type2)
+        modifier = uq4_12_multiply(modifier, GetTypeModifier(moveType, type2));
+
+    return modifier;
+}
+
 ASSUMPTIONS
 {
     ASSUME(GetMoveEffect(MOVE_TECHNO_BLAST) == EFFECT_CHANGE_TYPE_ON_ITEM);
     ASSUME(GetMoveEffectArg_HoldEffect(MOVE_TECHNO_BLAST) == HOLD_EFFECT_DRIVE);
+    ASSUME(GetSpeciesTypeEffectiveness(TYPE_FIRE, SPECIES_VENUSAUR) == UQ_4_12(2.0));
+    ASSUME(GetSpeciesTypeEffectiveness(TYPE_WATER, SPECIES_CHARIZARD) == UQ_4_12(2.0));
+    ASSUME(GetSpeciesTypeEffectiveness(TYPE_ELECTRIC, SPECIES_BLASTOISE) == UQ_4_12(2.0));
+    ASSUME(GetSpeciesTypeEffectiveness(TYPE_ICE, SPECIES_DRATINI) == UQ_4_12(2.0));
 }
 
 SINGLE_BATTLE_TEST("Techno Blast changes type depending on the drive the user holds")
@@ -24,10 +40,55 @@ SINGLE_BATTLE_TEST("Techno Blast changes type depending on the drive the user ho
         TURN { MOVE(player, MOVE_TECHNO_BLAST); }
     } SCENE {
         ANIMATION(ANIM_TYPE_MOVE, MOVE_TECHNO_BLAST, player);
+        EFFECTIVENESS_SE(opponent, SE_SUPER_EFFECTIVE);
         HP_BAR(opponent);
-        MESSAGE("It's super effective!");
     }
 }
 
-TO_DO_BATTLE_TEST("Judgement changes type depending on the plate the user holds");
-TO_DO_BATTLE_TEST("Multi Attack changes type depending on the memory the user holds");
+SINGLE_BATTLE_TEST("Judgment changes type depending on the Plate the user holds")
+{
+    enum Species species;
+    enum Item item;
+
+    PARAMETRIZE { species = SPECIES_VENUSAUR; item = ITEM_FLAME_PLATE; }
+    PARAMETRIZE { species = SPECIES_CHARIZARD; item = ITEM_SPLASH_PLATE; }
+    PARAMETRIZE { species = SPECIES_BLASTOISE; item = ITEM_ZAP_PLATE; }
+    PARAMETRIZE { species = SPECIES_DRATINI; item = ITEM_ICICLE_PLATE; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_JUDGMENT) == EFFECT_CHANGE_TYPE_ON_ITEM);
+        ASSUME(GetMoveEffectArg_HoldEffect(MOVE_JUDGMENT) == HOLD_EFFECT_PLATE);
+        PLAYER(SPECIES_WOBBUFFET) { Item(item); }
+        OPPONENT(species);
+    } WHEN {
+        TURN { MOVE(player, MOVE_JUDGMENT); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_JUDGMENT, player);
+        EFFECTIVENESS_SE(opponent, SE_SUPER_EFFECTIVE);
+        HP_BAR(opponent);
+    }
+}
+
+SINGLE_BATTLE_TEST("Multi-Attack changes type depending on the Memory the user holds")
+{
+    enum Species species;
+    enum Item item;
+
+    PARAMETRIZE { species = SPECIES_VENUSAUR; item = ITEM_FIRE_MEMORY; }
+    PARAMETRIZE { species = SPECIES_CHARIZARD; item = ITEM_WATER_MEMORY; }
+    PARAMETRIZE { species = SPECIES_BLASTOISE; item = ITEM_ELECTRIC_MEMORY; }
+    PARAMETRIZE { species = SPECIES_DRATINI; item = ITEM_ICE_MEMORY; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_MULTI_ATTACK) == EFFECT_CHANGE_TYPE_ON_ITEM);
+        ASSUME(GetMoveEffectArg_HoldEffect(MOVE_MULTI_ATTACK) == HOLD_EFFECT_MEMORY);
+        PLAYER(SPECIES_WOBBUFFET) { Item(item); }
+        OPPONENT(species);
+    } WHEN {
+        TURN { MOVE(player, MOVE_MULTI_ATTACK); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_MULTI_ATTACK, player);
+        EFFECTIVENESS_SE(opponent, SE_SUPER_EFFECTIVE);
+        HP_BAR(opponent);
+    }
+}

--- a/test/battle/move_effect/clangorous_soul.c
+++ b/test/battle/move_effect/clangorous_soul.c
@@ -49,4 +49,30 @@ SINGLE_BATTLE_TEST("Clangorous Soul fails if the user's HP is less or equal than
     }
 }
 
-TO_DO_BATTLE_TEST("Clangorous Soul fails if Attack, Defense, Sp. Attack, Sp. Defense and Speed are all maxed out");
+SINGLE_BATTLE_TEST("Clangorous Soul fails if Attack, Defense, Sp. Attack, Sp. Defense and Speed are all maxed out")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_CLANGOROUS_SOUL) == EFFECT_CLANGOROUS_SOUL);
+        PLAYER(SPECIES_BIBAREL) { Ability(ABILITY_SIMPLE); HP(300); MaxHP(300); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        for (u32 j = 0; j < 3; j++)
+        {
+            TURN { MOVE(player, MOVE_CLANGOROUS_SOUL); }
+            TURN { MOVE(player, MOVE_RECOVER); }
+        }
+        TURN { MOVE(player, MOVE_CLANGOROUS_SOUL); }
+    } SCENE {
+        for (u32 j = 0; j < 3; j++)
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_CLANGOROUS_SOUL, player);
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_CLANGOROUS_SOUL, player);
+        MESSAGE("But it failed!");
+    } THEN {
+        EXPECT_EQ(player->hp, player->maxHP);
+        EXPECT_EQ(player->statStages[STAT_ATK], MAX_STAT_STAGE);
+        EXPECT_EQ(player->statStages[STAT_DEF], MAX_STAT_STAGE);
+        EXPECT_EQ(player->statStages[STAT_SPATK], MAX_STAT_STAGE);
+        EXPECT_EQ(player->statStages[STAT_SPDEF], MAX_STAT_STAGE);
+        EXPECT_EQ(player->statStages[STAT_SPEED], MAX_STAT_STAGE);
+    }
+}

--- a/test/battle/move_effect/conversion_2.c
+++ b/test/battle/move_effect/conversion_2.c
@@ -1,7 +1,25 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("Conversion 2's type change considers Inverse Battles");
+SINGLE_BATTLE_TEST("Conversion 2's type change considers Inverse Battles")
+{
+    u32 config;
+    PARAMETRIZE { config = GEN_4; }
+    PARAMETRIZE { config = GEN_5; }
+
+    GIVEN {
+        WITH_CONFIG(B_UPDATED_CONVERSION_2, config);
+        FLAG_SET(B_FLAG_INVERSE_BATTLE);
+        ASSUME(GetMoveType(MOVE_OMINOUS_WIND) == TYPE_GHOST);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_OMINOUS_WIND); }
+        TURN { MOVE(player, MOVE_CONVERSION_2); }
+    } SCENE {
+        MESSAGE("Wobbuffet transformed into the Ghost type!");
+    }
+}
 
 SINGLE_BATTLE_TEST("Conversion 2 randomly changes the type of the user to a type that resists the last move that hit the user (Gen 1-4)")
 {

--- a/test/battle/move_effect/corrosive_gas.c
+++ b/test/battle/move_effect/corrosive_gas.c
@@ -118,5 +118,46 @@ DOUBLE_BATTLE_TEST("Corrosive Gas destroys foes and ally's items if they have on
     }
 }
 
-TO_DO_BATTLE_TEST("Corrosive Gas doesn't destroy the item of a Pokemon behind a Substitute");
-TO_DO_BATTLE_TEST("Corrosive Gas doesn't destroy items if they change the Pokémon's form"); // Giratina, Genesect, Silvally, Zacian, Zamazenta. Bulbapedia hasn't confirmed Arceus or Ogerpon, but it's a safe assumption that they will also fail.
+SINGLE_BATTLE_TEST("Corrosive Gas doesn't destroy the target's item behind a Substitute")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_SUBSTITUTE) == EFFECT_SUBSTITUTE);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(1); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(2); Item(ITEM_ORAN_BERRY); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SUBSTITUTE); MOVE(player, MOVE_CORROSIVE_GAS); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SUBSTITUTE, opponent);
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_CORROSIVE_GAS, player);
+    } THEN {
+        EXPECT_EQ(opponent->item, ITEM_ORAN_BERRY);
+    }
+}
+
+SINGLE_BATTLE_TEST("Corrosive Gas doesn't destroy items required for the target's form change")
+{
+    enum Species species;
+    enum Item item;
+
+    PARAMETRIZE { species = SPECIES_BLAZIKEN;            item = ITEM_BLAZIKENITE; }
+    PARAMETRIZE { species = SPECIES_GROUDON;             item = ITEM_RED_ORB; }
+    PARAMETRIZE { species = SPECIES_NECROZMA_DUSK_MANE; item = ITEM_ULTRANECROZIUM_Z; }
+    PARAMETRIZE { species = SPECIES_GIRATINA_ORIGIN;     item = ITEM_GRISEOUS_CORE; }
+    PARAMETRIZE { species = SPECIES_ARCEUS;              item = ITEM_SKY_PLATE; }
+    PARAMETRIZE { species = SPECIES_GENESECT;            item = ITEM_BURN_DRIVE; }
+    PARAMETRIZE { species = SPECIES_SILVALLY;            item = ITEM_FIRE_MEMORY; }
+    PARAMETRIZE { species = SPECIES_ZACIAN_HERO;         item = ITEM_RUSTED_SWORD; }
+    PARAMETRIZE { species = SPECIES_ZAMAZENTA_HERO;      item = ITEM_RUSTED_SHIELD; }
+    PARAMETRIZE { species = SPECIES_OGERPON;             item = ITEM_HEARTHFLAME_MASK; }
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(species) { Item(item); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_CORROSIVE_GAS); }
+    } SCENE {
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_CORROSIVE_GAS, player);
+    } THEN {
+        EXPECT_EQ(opponent->item, item);
+    }
+}

--- a/test/battle/move_effect/dark_void.c
+++ b/test/battle/move_effect/dark_void.c
@@ -38,6 +38,64 @@ SINGLE_BATTLE_TEST("Dark Void inflicts 1-3 turns of sleep (Gen9-)")
     }
 }
 
-TO_DO_BATTLE_TEST("Dark Void can only be used by Darkrai (Gen7+)");
-TO_DO_BATTLE_TEST("Dark Void can be used by Pokémon other than Darkrai (Gen4-6)");
-TO_DO_BATTLE_TEST("Dark Void can be used by a Pokémon transformed into Darkrai");
+SINGLE_BATTLE_TEST("Dark Void can only be used by Darkrai in Gen 7+")
+{
+    enum Species species;
+    bool32 succeeds;
+
+    PARAMETRIZE { species = SPECIES_DARKRAI; succeeds = TRUE; }
+    PARAMETRIZE { species = SPECIES_SMEARGLE; succeeds = FALSE; }
+
+    GIVEN {
+        WITH_CONFIG(B_DARK_VOID_FAIL, GEN_7);
+        PLAYER(species);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        if (succeeds)
+            TURN { MOVE(player, MOVE_DARK_VOID, hit: TRUE); }
+        else
+            TURN { MOVE(player, MOVE_DARK_VOID); }
+    } SCENE {
+        if (succeeds)
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_DARK_VOID, player);
+        else
+            NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_DARK_VOID, player);
+    } THEN {
+        if (succeeds)
+            EXPECT_NE(opponent->status1 & STATUS1_SLEEP, 0);
+        else
+            EXPECT_EQ(opponent->status1, STATUS1_NONE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Dark Void can be used by Pokémon other than Darkrai in Gen 4-6")
+{
+    GIVEN {
+        WITH_CONFIG(B_DARK_VOID_FAIL, GEN_6);
+        PLAYER(SPECIES_SMEARGLE);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_DARK_VOID, hit: TRUE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DARK_VOID, player);
+    } THEN {
+        EXPECT_NE(opponent->status1 & STATUS1_SLEEP, 0);
+    }
+}
+
+SINGLE_BATTLE_TEST("Dark Void can be used by a Pokémon transformed into Darkrai")
+{
+    GIVEN {
+        WITH_CONFIG(B_DARK_VOID_FAIL, GEN_7);
+        PLAYER(SPECIES_DITTO);
+        OPPONENT(SPECIES_DARKRAI) { Moves(MOVE_CELEBRATE, MOVE_DARK_VOID); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_TRANSFORM); }
+        TURN { MOVE(player, MOVE_DARK_VOID, hit: TRUE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TRANSFORM, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DARK_VOID, player);
+    } THEN {
+        EXPECT_NE(opponent->status1 & STATUS1_SLEEP, 0);
+    }
+}

--- a/test/battle/move_effect/defense_curl.c
+++ b/test/battle/move_effect/defense_curl.c
@@ -4,6 +4,8 @@
 ASSUMPTIONS
 {
     ASSUME_STAT_CHANGE(MOVE_DEFENSE_CURL, defense: +1);
+    ASSUME(GetMoveEffect(MOVE_ROLLOUT) == EFFECT_ROLLOUT);
+    ASSUME(GetMoveEffect(MOVE_ICE_BALL) == EFFECT_ROLLOUT);
 }
 
 SINGLE_BATTLE_TEST("Defense Curl raises Defense by 1 stage", s16 damage)
@@ -70,7 +72,131 @@ SINGLE_BATTLE_TEST("Defense Curl doubles the power of Rollout even if stat could
     }
 }
 
-TO_DO_BATTLE_TEST("Defense Curl doubles the power of Rollout and Ice Ball");
-TO_DO_BATTLE_TEST("Defense Curl's effect cannot be stacked");
-TO_DO_BATTLE_TEST("Defense Curl's effect is removed when switching out");
-TO_DO_BATTLE_TEST("Baton Pass doesn't pass Defense Curl's effect");
+SINGLE_BATTLE_TEST("Defense Curl doubles the power of Rollout", s16 damage)
+{
+    bool32 defenseCurl;
+
+    PARAMETRIZE { defenseCurl = FALSE; }
+    PARAMETRIZE { defenseCurl = TRUE; }
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        if (defenseCurl)
+            TURN { MOVE(player, MOVE_DEFENSE_CURL); }
+        TURN { MOVE(player, MOVE_ROLLOUT); }
+    } SCENE {
+        if (defenseCurl)
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_DEFENSE_CURL, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ROLLOUT, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(2.0), results[1].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Defense Curl doubles the power of Ice Ball", s16 damage)
+{
+    bool32 defenseCurl;
+
+    PARAMETRIZE { defenseCurl = FALSE; }
+    PARAMETRIZE { defenseCurl = TRUE; }
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        if (defenseCurl)
+            TURN { MOVE(player, MOVE_DEFENSE_CURL); }
+        TURN { MOVE(player, MOVE_ICE_BALL); }
+    } SCENE {
+        if (defenseCurl)
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_DEFENSE_CURL, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ICE_BALL, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(2.0), results[1].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Defense Curl's effect cannot be stacked", s16 damage)
+{
+    u32 uses;
+
+    PARAMETRIZE { uses = 1; }
+    PARAMETRIZE { uses = 2; }
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_DEFENSE_CURL); }
+        if (uses == 2)
+            TURN { MOVE(player, MOVE_DEFENSE_CURL); }
+        TURN { MOVE(player, MOVE_ROLLOUT); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DEFENSE_CURL, player);
+        if (uses == 2)
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_DEFENSE_CURL, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ROLLOUT, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_EQ(results[0].damage, results[1].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Defense Curl's effect is removed when switching out", s16 damage)
+{
+    bool32 switchOut;
+
+    PARAMETRIZE { switchOut = FALSE; }
+    PARAMETRIZE { switchOut = TRUE; }
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_DEFENSE_CURL); }
+        if (switchOut) {
+            TURN { SWITCH(player, 1); }
+            TURN { SWITCH(player, 0); }
+        }
+        TURN { MOVE(player, MOVE_ROLLOUT); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DEFENSE_CURL, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ROLLOUT, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[1].damage, Q_4_12(2.0), results[0].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Baton Pass doesn't pass Defense Curl's effect", s16 damage)
+{
+    bool32 defenseCurl;
+
+    PARAMETRIZE { defenseCurl = FALSE; }
+    PARAMETRIZE { defenseCurl = TRUE; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_BATON_PASS) == EFFECT_BATON_PASS);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        if (defenseCurl)
+            TURN { MOVE(player, MOVE_DEFENSE_CURL); }
+        TURN { MOVE(player, MOVE_BATON_PASS); SEND_OUT(player, 1); }
+        TURN { MOVE(player, MOVE_ROLLOUT); }
+    } SCENE {
+        if (defenseCurl)
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_DEFENSE_CURL, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BATON_PASS, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ROLLOUT, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_EQ(results[0].damage, results[1].damage);
+    }
+}

--- a/test/battle/move_effect/do_nothing.c
+++ b/test/battle/move_effect/do_nothing.c
@@ -1,4 +1,25 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("Splash does nothing");
+SINGLE_BATTLE_TEST("Splash does nothing")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_SPLASH) == EFFECT_DO_NOTHING);
+        ASSUME(GetItemHoldEffect(ITEM_NORMAL_GEM) == HOLD_EFFECT_GEMS);
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_NORMAL_GEM); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_SPLASH); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SPLASH, player);
+        MESSAGE("But nothing happened!");
+    } THEN {
+        EXPECT_EQ(player->hp, player->maxHP);
+        EXPECT_EQ(player->item, ITEM_NORMAL_GEM);
+        for (enum Stat stat = STAT_ATK; stat < NUM_BATTLE_STATS; stat++)
+            EXPECT_EQ(player->statStages[stat], DEFAULT_STAT_STAGE);
+        EXPECT_EQ(opponent->hp, opponent->maxHP);
+        EXPECT_EQ(player->status1, STATUS1_NONE);
+        EXPECT_EQ(opponent->status1, STATUS1_NONE);
+    }
+}

--- a/test/battle/move_effect/double_power_on_arg_status.c
+++ b/test/battle/move_effect/double_power_on_arg_status.c
@@ -29,7 +29,29 @@ SINGLE_BATTLE_TEST("Hex deals double damage to foes with a status", s16 damage)
     }
 }
 
-TO_DO_BATTLE_TEST("Hex deals double damage to Pokémon with Comatose")
+SINGLE_BATTLE_TEST("Hex deals double damage to Pokémon with Comatose", s16 damage)
+{
+    enum Species species;
+    enum Ability ability;
+
+    PARAMETRIZE { species = SPECIES_LOPUNNY; ability = ABILITY_LIMBER; }
+    PARAMETRIZE { species = SPECIES_KOMALA;  ability = ABILITY_COMATOSE; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_HEX) == EFFECT_DOUBLE_POWER_ON_ARG_STATUS);
+        ASSUME(GetMoveEffectArg_Status(MOVE_HEX) == STATUS1_ANY);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(species) { Ability(ability); HP(300); MaxHP(300); SpDefense(100); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SOAK); }
+        TURN { MOVE(player, MOVE_HEX); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_HEX, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(2.0), results[1].damage);
+    }
+}
 
 SINGLE_BATTLE_TEST("Venoshock's power doubles if the target is poisoned/badly poisoned", s16 damage)
 {

--- a/test/battle/move_effect/dragon_cheer.c
+++ b/test/battle/move_effect/dragon_cheer.c
@@ -102,7 +102,27 @@ DOUBLE_BATTLE_TEST("Dragon Cheer fails if critical hit stage was already increas
     }
 }
 
-TO_DO_BATTLE_TEST("Baton Pass passes Dragon Cheer's effect");
+DOUBLE_BATTLE_TEST("Baton Pass passes Dragon Cheer's effect")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_BATON_PASS) == EFFECT_BATON_PASS);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WYNAUT);
+        PLAYER(SPECIES_CATERPIE);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(playerRight, MOVE_DRAGON_CHEER, target: playerLeft); }
+        TURN { MOVE(playerLeft, MOVE_BATON_PASS); SEND_OUT(playerLeft, 2); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_CHEER, playerRight);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BATON_PASS, playerLeft);
+        SEND_IN_MESSAGE("Caterpie");
+    } THEN {
+        EXPECT_EQ(playerLeft->species, SPECIES_CATERPIE);
+        EXPECT(playerLeft->volatiles.dragonCheer);
+    }
+}
 
 AI_DOUBLE_BATTLE_TEST("AI uses Dragon Cheer")
 {

--- a/test/battle/move_effect/electro_ball.c
+++ b/test/battle/move_effect/electro_ball.c
@@ -1,5 +1,67 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("Electro Ball inflicts more damage the faster the user is compared to the target");
-TO_DO_BATTLE_TEST("Electro Ball considers speed modifiers"); // Stat modifiers, paralysis, Iron Ball, Abilities
+ASSUMPTIONS
+{
+    ASSUME(GetMoveEffect(MOVE_ELECTRO_BALL) == EFFECT_ELECTRO_BALL);
+}
+
+SINGLE_BATTLE_TEST("Electro Ball's power increases with the user's Speed relative to the target", s16 damage)
+{
+    u32 speed;
+
+    PARAMETRIZE { speed = 99;  } // 40 power
+    PARAMETRIZE { speed = 100; } // 60 power
+    PARAMETRIZE { speed = 200; } // 80 power
+    PARAMETRIZE { speed = 300; } // 120 power
+    PARAMETRIZE { speed = 400; } // 150 power
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Speed(speed); SpAttack(100); }
+        OPPONENT(SPECIES_WOBBUFFET) { MaxHP(500); HP(500); Speed(100); SpDefense(100); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_ELECTRO_BALL); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ELECTRO_BALL, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.5), results[1].damage);
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(2.0), results[2].damage);
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(3.0), results[3].damage);
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(3.75), results[4].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Electro Ball considers Speed stat stages, status, held items, and abilities", s16 damage)
+{
+    enum Species species;
+    enum Ability ability;
+    enum Item item;
+    enum Move setupMove;
+    u32 status;
+
+    PARAMETRIZE { species = SPECIES_WOBBUFFET; ability = ABILITY_SHADOW_TAG;  item = ITEM_NONE;      status = STATUS1_NONE;      setupMove = MOVE_CELEBRATE; }
+    PARAMETRIZE { species = SPECIES_WOBBUFFET; ability = ABILITY_SHADOW_TAG;  item = ITEM_NONE;      status = STATUS1_NONE;      setupMove = MOVE_AGILITY; }
+    PARAMETRIZE { species = SPECIES_WOBBUFFET; ability = ABILITY_SHADOW_TAG;  item = ITEM_NONE;      status = STATUS1_PARALYSIS; setupMove = MOVE_CELEBRATE; }
+    PARAMETRIZE { species = SPECIES_WOBBUFFET; ability = ABILITY_SHADOW_TAG;  item = ITEM_IRON_BALL; status = STATUS1_NONE;      setupMove = MOVE_CELEBRATE; }
+    PARAMETRIZE { species = SPECIES_VENUSAUR;  ability = ABILITY_CHLOROPHYLL; item = ITEM_NONE;      status = STATUS1_NONE;      setupMove = MOVE_SUNNY_DAY; }
+
+    GIVEN {
+        WITH_CONFIG(B_PARALYSIS_SPEED, GEN_7);
+        ASSUME_STAT_CHANGE(MOVE_AGILITY, speed: +2);
+        ASSUME(GetItemHoldEffect(ITEM_IRON_BALL) == HOLD_EFFECT_IRON_BALL);
+        PLAYER(species) { Ability(ability); Speed(100); SpAttack(100); }
+        OPPONENT(SPECIES_WOBBUFFET) { Item(item); Status1(status); MaxHP(500); HP(500); Speed(100); SpDefense(100); }
+    } WHEN {
+        TURN { MOVE(player, setupMove); }
+        TURN { MOVE(player, MOVE_ELECTRO_BALL); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ELECTRO_BALL, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.3333), results[1].damage);
+        EXPECT_EQ(results[1].damage, results[2].damage);
+        EXPECT_EQ(results[2].damage, results[3].damage);
+        EXPECT_EQ(results[3].damage, results[4].damage);
+    }
+}

--- a/test/battle/move_effect/embargo.c
+++ b/test/battle/move_effect/embargo.c
@@ -390,5 +390,40 @@ SINGLE_BATTLE_TEST("Embargo doesn't prevent Primal Reversion")
     }
 }
 
-TO_DO_BATTLE_TEST("Embargo doesn't prevent the usage of Z-Moves")
-TO_DO_BATTLE_TEST("Embargo doesn't block held item effects that affect prize money")
+SINGLE_BATTLE_TEST("Embargo doesn't prevent the usage of Z-Moves")
+{
+    GIVEN {
+        ASSUME(GetMoveType(MOVE_SCRATCH) == TYPE_NORMAL);
+        PLAYER(SPECIES_WOBBUFFET) { Item(ITEM_NORMALIUM_Z); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_EMBARGO); }
+        TURN { MOVE(player, MOVE_SCRATCH, gimmick: GIMMICK_Z_MOVE); }
+    } SCENE {
+        MESSAGE("The opposing Wobbuffet used Embargo!");
+        MESSAGE("Wobbuffet can't use items anymore!");
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ZMOVE_ACTIVATE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BREAKNECK_BLITZ, player);
+    }
+}
+
+SINGLE_BATTLE_TEST("Embargo doesn't block held item effects that affect prize money")
+{
+    GIVEN {
+        ASSUME(GetItemHoldEffect(ITEM_AMULET_COIN) == HOLD_EFFECT_DOUBLE_PRIZE);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WYNAUT) { Item(ITEM_AMULET_COIN); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_EMBARGO); }
+        TURN { MOVE(player, MOVE_BATON_PASS); SEND_OUT(player, 1); }
+    } SCENE {
+        MESSAGE("The opposing Wobbuffet used Embargo!");
+        MESSAGE("Wobbuffet can't use items anymore!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BATON_PASS, player);
+        SEND_IN_MESSAGE("Wynaut");
+    } THEN {
+        EXPECT_EQ((u32)gBattleStruct->moneyMultiplier, 2);
+        EXPECT((bool32)gBattleStruct->moneyMultiplierItem);
+    }
+}

--- a/test/battle/move_effect/entrainment.c
+++ b/test/battle/move_effect/entrainment.c
@@ -73,4 +73,19 @@ SINGLE_BATTLE_TEST("Entrainment causes primal weather to revert")
     }
 }
 
-TO_DO_BATTLE_TEST("Entrainment fails on Dynamaxed Pokémon");
+SINGLE_BATTLE_TEST("Entrainment fails on Dynamaxed Pokémon")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_ENTRAINMENT) == EFFECT_ENTRAINMENT);
+        PLAYER(SPECIES_WOBBUFFET) { Ability(ABILITY_SHADOW_TAG); }
+        OPPONENT(SPECIES_WOBBUFFET) { Ability(ABILITY_TELEPATHY); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SCRATCH, gimmick: GIMMICK_DYNAMAX); MOVE(opponent, MOVE_ENTRAINMENT); }
+    } SCENE {
+        MESSAGE("Wobbuffet used Max Strike!");
+        MESSAGE("The opposing Wobbuffet used Entrainment!");
+        MESSAGE("But it failed!");
+    } THEN {
+        EXPECT_EQ(player->ability, ABILITY_SHADOW_TAG);
+    }
+}

--- a/test/battle/move_effect/evasion_down.c
+++ b/test/battle/move_effect/evasion_down.c
@@ -1,4 +1,26 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("Sweet Scent lowers evasion by 1 stage (Gen 2-5)");
+DOUBLE_BATTLE_TEST("Sweet Scent lowers both foes' evasion according to the configured move data")
+{
+    GIVEN {
+        ASSUME_STAT_CHANGE(
+            MOVE_SWEET_SCENT,
+            evasion: -(GetConfig(B_UPDATED_MOVE_DATA) >= GEN_6 ? 2 : 1)
+        );
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_SWEET_SCENT); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SWEET_SCENT, playerLeft);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentLeft);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponentRight);
+    } THEN {
+        u32 stages = GetConfig(B_UPDATED_MOVE_DATA) >= GEN_6 ? 2 : 1;
+        EXPECT_EQ(opponentLeft->statStages[STAT_EVASION], DEFAULT_STAT_STAGE - stages);
+        EXPECT_EQ(opponentRight->statStages[STAT_EVASION], DEFAULT_STAT_STAGE - stages);
+    }
+}

--- a/test/battle/move_effect/evasion_down_2.c
+++ b/test/battle/move_effect/evasion_down_2.c
@@ -1,4 +1,17 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("Sweet Scent lowers evasion by 1 stage (Gen 6+)");
+SINGLE_BATTLE_TEST("Sweet Scent lowers evasion according to the configured move data")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_SWEET_SCENT); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SWEET_SCENT, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
+    } THEN {
+        EXPECT_EQ(opponent->statStages[STAT_EVASION], DEFAULT_STAT_STAGE - (GetConfig(B_UPDATED_MOVE_DATA) >= GEN_6 ? 2 : 1));
+    }
+}

--- a/test/battle/move_effect/extreme_evoboost.c
+++ b/test/battle/move_effect/extreme_evoboost.c
@@ -1,4 +1,25 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("Extreme Evoboost increases the user's Attack, Defense, Special Attack, Special Defense, and Speed stats by 2 stages each");
+SINGLE_BATTLE_TEST("Extreme Evoboost does not raise a stat beyond its maximum stage")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_EXTREME_EVOBOOST) == EFFECT_EXTREME_EVOBOOST);
+        ASSUME(GetMoveEffect(MOVE_BELLY_DRUM) == EFFECT_BELLY_DRUM);
+        PLAYER(SPECIES_EEVEE) { Item(ITEM_EEVIUM_Z); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_BELLY_DRUM); }
+        TURN { MOVE(player, MOVE_LAST_RESORT, gimmick: GIMMICK_Z_MOVE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BELLY_DRUM, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ZMOVE_ACTIVATE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_EXTREME_EVOBOOST, player);
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_ATK], MAX_STAT_STAGE);
+        EXPECT_EQ(player->statStages[STAT_DEF], DEFAULT_STAT_STAGE + 2);
+        EXPECT_EQ(player->statStages[STAT_SPATK], DEFAULT_STAT_STAGE + 2);
+        EXPECT_EQ(player->statStages[STAT_SPDEF], DEFAULT_STAT_STAGE + 2);
+        EXPECT_EQ(player->statStages[STAT_SPEED], DEFAULT_STAT_STAGE + 2);
+    }
+}

--- a/test/battle/move_effect/facade.c
+++ b/test/battle/move_effect/facade.c
@@ -1,6 +1,95 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("Facade doubles in power when the user is Paralyzed and Poisoned")
-TO_DO_BATTLE_TEST("Facade does not ignore burn's attack-halving effect, cancelling out its power (Gen3-5)")
-TO_DO_BATTLE_TEST("Facade ignores burn's attack-halving effect, making it double in power (Gen3-5)")
+ASSUMPTIONS
+{
+    ASSUME(GetMoveEffect(MOVE_FACADE) == EFFECT_FACADE);
+}
+
+SINGLE_BATTLE_TEST("Facade doubles in power when the user is paralyzed or poisoned", s16 damage)
+{
+    u32 status;
+
+    PARAMETRIZE { status = STATUS1_NONE; }
+    PARAMETRIZE { status = STATUS1_PARALYSIS; }
+    PARAMETRIZE { status = STATUS1_POISON; }
+    PARAMETRIZE { status = STATUS1_TOXIC_POISON; }
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Status1(status); Attack(100); }
+        OPPONENT(SPECIES_WOBBUFFET) { MaxHP(500); HP(500); Defense(100); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_FACADE, WITH_RNG(RNG_PARALYSIS, FALSE)); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FACADE, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(2.0), results[1].damage);
+        EXPECT_EQ(results[1].damage, results[2].damage);
+        EXPECT_EQ(results[2].damage, results[3].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Facade stacks its boost with Guts when the user is burned", s16 damage)
+{
+    u32 status;
+
+    PARAMETRIZE { status = STATUS1_NONE; }
+    PARAMETRIZE { status = STATUS1_BURN; }
+
+    GIVEN {
+        WITH_CONFIG(B_BURN_FACADE_DMG, GEN_6);
+        PLAYER(SPECIES_WOBBUFFET) { Ability(ABILITY_GUTS); Status1(status); Attack(100); }
+        OPPONENT(SPECIES_WOBBUFFET) { MaxHP(500); HP(500); Defense(100); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_FACADE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FACADE, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(3.0), results[1].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Facade does not ignore burn's Attack reduction in Gen 3-5", s16 damage)
+{
+    u32 status;
+
+    PARAMETRIZE { status = STATUS1_NONE; }
+    PARAMETRIZE { status = STATUS1_BURN; }
+
+    GIVEN {
+        WITH_CONFIG(B_BURN_FACADE_DMG, GEN_5);
+        PLAYER(SPECIES_WOBBUFFET) { Status1(status); Attack(100); }
+        OPPONENT(SPECIES_WOBBUFFET) { MaxHP(500); HP(500); Defense(100); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_FACADE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FACADE, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_LE(results[0].damage, results[1].damage + 1);
+        EXPECT_LE(results[1].damage, results[0].damage + 1);
+    }
+}
+
+SINGLE_BATTLE_TEST("Facade ignores burn's Attack reduction in Gen 6+", s16 damage)
+{
+    u32 status;
+
+    PARAMETRIZE { status = STATUS1_NONE; }
+    PARAMETRIZE { status = STATUS1_BURN; }
+
+    GIVEN {
+        WITH_CONFIG(B_BURN_FACADE_DMG, GEN_6);
+        PLAYER(SPECIES_WOBBUFFET) { Status1(status); Attack(100); }
+        OPPONENT(SPECIES_WOBBUFFET) { MaxHP(500); HP(500); Defense(100); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_FACADE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FACADE, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(2.0), results[1].damage);
+    }
+}

--- a/test/battle/move_effect/fail_if_not_arg_type.c
+++ b/test/battle/move_effect/fail_if_not_arg_type.c
@@ -40,7 +40,28 @@ SINGLE_BATTLE_TEST("Burn Up fails if the user isn't a Fire-type (Gen9)")
     }
 }
 
-TO_DO_BATTLE_TEST("Burn Up doesn't thaw the user if it fails due to the user not being Fire-type")
+SINGLE_BATTLE_TEST("Burn Up does not thaw the user if it fails because the user is not a Fire-type")
+{
+    GIVEN {
+        WITH_CONFIG(B_MOVES_THAT_REMOVE_TYPE, GEN_9);
+        ASSUME(GetMoveEffect(MOVE_BURN_UP) == EFFECT_FAIL_IF_NOT_ARG_TYPE);
+        ASSUME(IsMoveEffectRemoveSpeciesType(MOVE_BURN_UP, MOVE_EFFECT_REMOVE_ARG_TYPE, TYPE_FIRE) == TRUE);
+        ASSUME(MoveThawsUser(MOVE_BURN_UP));
+        ASSUME(GetSpeciesType(SPECIES_WOBBUFFET, 0) != TYPE_FIRE || GetSpeciesType(SPECIES_WOBBUFFET, 1) != TYPE_FIRE);
+        PLAYER(SPECIES_WOBBUFFET) { Status1(STATUS1_FREEZE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_BURN_UP); }
+    } SCENE {
+        NONE_OF {
+            MESSAGE("Wobbuffet's Burn Up melted the ice!");
+            STATUS_ICON(player, none: TRUE);
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_BURN_UP, player);
+        }
+    } THEN {
+        EXPECT(player->status1 & STATUS1_FREEZE);
+    }
+}
 
 SINGLE_BATTLE_TEST("Burn Up fails if the user has Protean/Libero and is not a Fire-type (Gen9)")
 {
@@ -62,7 +83,24 @@ SINGLE_BATTLE_TEST("Burn Up fails if the user has Protean/Libero and is not a Fi
     }
 }
 
-TO_DO_BATTLE_TEST("(TERA) Burn Up user does not lose their Fire type if they've Terastallized into Fire type")
+SINGLE_BATTLE_TEST("(TERA) Burn Up does not remove a user's Fire type after Terastallizing into Fire")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_BURN_UP) == EFFECT_FAIL_IF_NOT_ARG_TYPE);
+        ASSUME(IsMoveEffectRemoveSpeciesType(MOVE_BURN_UP, MOVE_EFFECT_REMOVE_ARG_TYPE, TYPE_FIRE) == TRUE);
+        ASSUME(GetSpeciesType(SPECIES_CYNDAQUIL, 0) == TYPE_FIRE || GetSpeciesType(SPECIES_CYNDAQUIL, 1) == TYPE_FIRE);
+        PLAYER(SPECIES_CYNDAQUIL) { TeraType(TYPE_FIRE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_BURN_UP, gimmick: GIMMICK_TERA); }
+        TURN { MOVE(player, MOVE_BURN_UP); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BURN_UP, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BURN_UP, player);
+    } THEN {
+        EXPECT(IS_BATTLER_OF_TYPE(GetBattlerAtPosition(B_POSITION_PLAYER_LEFT), TYPE_FIRE));
+    }
+}
 
 SINGLE_BATTLE_TEST("Burn Up user loses its Fire-type if enemy faints")
 {

--- a/test/battle/move_effect/fairy_lock.c
+++ b/test/battle/move_effect/fairy_lock.c
@@ -1,9 +1,137 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("Fairy Lock prevents all Pokémon from switching out on their next turn")
-TO_DO_BATTLE_TEST("Fairy Lock does not prevent switch out via Dragon Tail")
-TO_DO_BATTLE_TEST("Fairy Lock does not prevent switch out via Whirlwind")
-TO_DO_BATTLE_TEST("Fairy Lock does not prevent switch out via Eject Button")
-TO_DO_BATTLE_TEST("Fairy Lock does not prevent switch out via Red Card")
-TO_DO_BATTLE_TEST("Fairy Lock prevents a Pokémon from switching out on the following turn after replacing a fainted mon")
+ASSUMPTIONS
+{
+    ASSUME(GetMoveEffect(MOVE_FAIRY_LOCK) == EFFECT_FAIRY_LOCK);
+}
+
+DOUBLE_BATTLE_TEST("Fairy Lock prevents all Pokémon from switching out on their next turn")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_FAIRY_LOCK); }
+    } THEN {
+        EXPECT_EQ(CanBattlerEscape(GetBattlerAtPosition(B_POSITION_PLAYER_LEFT)), FALSE);
+        EXPECT_EQ(CanBattlerEscape(GetBattlerAtPosition(B_POSITION_PLAYER_RIGHT)), FALSE);
+        EXPECT_EQ(CanBattlerEscape(GetBattlerAtPosition(B_POSITION_OPPONENT_LEFT)), FALSE);
+        EXPECT_EQ(CanBattlerEscape(GetBattlerAtPosition(B_POSITION_OPPONENT_RIGHT)), FALSE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Fairy Lock does not prevent switch out via Dragon Tail")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_DRAGON_TAIL) == EFFECT_HIT_SWITCH_TARGET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN { MOVE(player, MOVE_FAIRY_LOCK); }
+        TURN { MOVE(player, MOVE_DRAGON_TAIL); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_TAIL, player);
+        MESSAGE("The opposing Wynaut was dragged out!");
+    } THEN {
+        EXPECT_EQ(opponent->species, SPECIES_WYNAUT);
+    }
+}
+
+SINGLE_BATTLE_TEST("Fairy Lock does not prevent switch out via Whirlwind")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_WHIRLWIND) == EFFECT_ROAR);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN { MOVE(player, MOVE_FAIRY_LOCK); }
+        TURN { MOVE(player, MOVE_WHIRLWIND); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_WHIRLWIND, player);
+        MESSAGE("The opposing Wynaut was dragged out!");
+    } THEN {
+        EXPECT_EQ(opponent->species, SPECIES_WYNAUT);
+    }
+}
+
+SINGLE_BATTLE_TEST("Fairy Lock does not prevent switch out via Eject Button")
+{
+    GIVEN {
+        ASSUME(gItemsInfo[ITEM_EJECT_BUTTON].holdEffect == HOLD_EFFECT_EJECT_BUTTON);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_EJECT_BUTTON); }
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN { MOVE(player, MOVE_FAIRY_LOCK); }
+        TURN { MOVE(player, MOVE_SCRATCH); SEND_OUT(opponent, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
+        MESSAGE("The opposing Wobbuffet is switched out with the Eject Button!");
+        MESSAGE("2 sent out Wynaut!");
+    } THEN {
+        EXPECT_EQ(opponent->species, SPECIES_WYNAUT);
+    }
+}
+
+SINGLE_BATTLE_TEST("Fairy Lock does not prevent switch out via Red Card")
+{
+    GIVEN {
+        ASSUME(gItemsInfo[ITEM_RED_CARD].holdEffect == HOLD_EFFECT_RED_CARD);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_RED_CARD); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_FAIRY_LOCK); }
+        TURN { MOVE(player, MOVE_SCRATCH); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
+        MESSAGE("The opposing Wobbuffet held up its Red Card against Wobbuffet!");
+        MESSAGE("Wynaut was dragged out!");
+    } THEN {
+        EXPECT_EQ(player->species, SPECIES_WYNAUT);
+        EXPECT_EQ(opponent->item, ITEM_NONE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Fairy Lock prevents a replacement for a fainted Pokémon from switching out on the following turn")
+{
+    GIVEN {
+        PLAYER(SPECIES_KLEFKI) { HP(1); Speed(3); }
+        PLAYER(SPECIES_WYNAUT) { Speed(2); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_FAIRY_LOCK); MOVE(opponent, MOVE_SCRATCH); SEND_OUT(player, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FAIRY_LOCK, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
+        MESSAGE("Klefki fainted!");
+        SEND_IN_MESSAGE("Wynaut");
+    } THEN {
+        EXPECT_EQ(CanBattlerEscape(GetBattlerAtPosition(B_POSITION_PLAYER_LEFT)), FALSE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Fairy Lock does not prevent switch out via Baton Pass")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_BATON_PASS) == EFFECT_BATON_PASS);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_FAIRY_LOCK); }
+        TURN { MOVE(player, MOVE_BATON_PASS); SEND_OUT(player, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BATON_PASS, player);
+        SEND_IN_MESSAGE("Wynaut");
+    } THEN {
+        EXPECT_EQ(player->species, SPECIES_WYNAUT);
+    }
+}

--- a/test/battle/move_effect/false_swipe.c
+++ b/test/battle/move_effect/false_swipe.c
@@ -1,6 +1,71 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("False Swipe always leaves the target with at least 1 HP")
-TO_DO_BATTLE_TEST("False Swipe still hits the target if it has 1 HP") // Test with Rocky Helmet or something
-TO_DO_BATTLE_TEST("False Swipe does not reduce its damage when hitting a substitute")
+ASSUMPTIONS
+{
+    ASSUME(GetMoveEffect(MOVE_FALSE_SWIPE) == EFFECT_FALSE_SWIPE);
+}
+
+SINGLE_BATTLE_TEST("False Swipe always leaves the target with at least 1 HP")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Attack(999); }
+        OPPONENT(SPECIES_WOBBUFFET) { HP(100); MaxHP(100); Defense(1); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_FALSE_SWIPE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FALSE_SWIPE, player);
+        HP_BAR(opponent, damage: 99);
+    } THEN {
+        EXPECT_EQ(opponent->hp, 1);
+    }
+}
+
+SINGLE_BATTLE_TEST("False Swipe still hits the target if it has 1 HP")
+{
+    GIVEN {
+        ASSUME(MoveMakesContact(MOVE_FALSE_SWIPE));
+        ASSUME(GetItemHoldEffect(ITEM_ROCKY_HELMET) == HOLD_EFFECT_ROCKY_HELMET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { HP(1); Item(ITEM_ROCKY_HELMET); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_FALSE_SWIPE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FALSE_SWIPE, player);
+        HP_BAR(player);
+        MESSAGE("Wobbuffet was hurt by the opposing Wobbuffet's Rocky Helmet!");
+    } THEN {
+        EXPECT_EQ(opponent->hp, 1);
+    }
+}
+
+SINGLE_BATTLE_TEST("False Swipe does not reduce its damage when hitting a substitute", s16 damage, u16 substituteDamage)
+{
+    bool32 substitute;
+
+    PARAMETRIZE { substitute = FALSE; }
+    PARAMETRIZE { substitute = TRUE; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_SUBSTITUTE) == EFFECT_SUBSTITUTE);
+        ASSUME(!MoveIgnoresSubstitute(MOVE_FALSE_SWIPE));
+        PLAYER(SPECIES_WOBBUFFET) { Speed(1); }
+        OPPONENT(SPECIES_WOBBUFFET) { HP(101); MaxHP(400); Speed(2); }
+    } WHEN {
+        TURN {
+            MOVE(opponent, substitute ? MOVE_SUBSTITUTE : MOVE_CELEBRATE);
+            MOVE(player, MOVE_FALSE_SWIPE);
+        }
+    } SCENE {
+        if (substitute) {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_SUBSTITUTE, opponent);
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_FALSE_SWIPE, player);
+            SUB_HIT(opponent, captureDamage: &results[i].substituteDamage);
+        } else {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_FALSE_SWIPE, player);
+            HP_BAR(opponent, captureDamage: &results[i].damage);
+        }
+    } FINALLY {
+        EXPECT_EQ(results[0].damage, results[1].substituteDamage);
+    }
+}

--- a/test/battle/move_effect/fillet_away.c
+++ b/test/battle/move_effect/fillet_away.c
@@ -73,5 +73,27 @@ SINGLE_BATTLE_TEST("Fillet Away's HP cost doesn't trigger effects that trigger o
     }
 }
 
-TO_DO_BATTLE_TEST("Fillet Away fails if the user's Attack, Sp. Atk and Speed are all maxed out")
-
+SINGLE_BATTLE_TEST("Fillet Away fails if the user's Attack, Sp. Atk and Speed are all maxed out")
+{
+    GIVEN {
+        PLAYER(SPECIES_BIBAREL) { Ability(ABILITY_SIMPLE); MaxHP(300); HP(300); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        for (u32 j = 0; j < 2; j++)
+        {
+            TURN { MOVE(player, MOVE_FILLET_AWAY); }
+            TURN { MOVE(player, MOVE_RECOVER); }
+        }
+        TURN { MOVE(player, MOVE_FILLET_AWAY); }
+    } SCENE {
+        for (u32 j = 0; j < 2; j++)
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_FILLET_AWAY, player);
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_FILLET_AWAY, player);
+        MESSAGE("But it failed!");
+    } THEN {
+        EXPECT_EQ(player->hp, player->maxHP);
+        EXPECT_EQ(player->statStages[STAT_ATK], MAX_STAT_STAGE);
+        EXPECT_EQ(player->statStages[STAT_SPATK], MAX_STAT_STAGE);
+        EXPECT_EQ(player->statStages[STAT_SPEED], MAX_STAT_STAGE);
+    }
+}

--- a/test/battle/move_effect/final_gambit.c
+++ b/test/battle/move_effect/final_gambit.c
@@ -125,13 +125,155 @@ SINGLE_BATTLE_TEST("Final Gambit does not faint user if target is immune")
 //     }
 // }
 
-TO_DO_BATTLE_TEST("Final Gambit doesn't faint the user if it misses")
-TO_DO_BATTLE_TEST("Final Gambit doesn't trigger the user's Focus Band")
-TO_DO_BATTLE_TEST("Final Gambit doesn't trigger the user's Focus Sash")
-TO_DO_BATTLE_TEST("Final Gambit doesn't trigger the user's Sturdy")
-TO_DO_BATTLE_TEST("Final Gambit triggers the target's Focus Band")
-TO_DO_BATTLE_TEST("Final Gambit triggers the target's Focus Sash")
-TO_DO_BATTLE_TEST("Final Gambit triggers the target's Sturdy")
-TO_DO_BATTLE_TEST("Final Gambit triggers the target's Endure")
+SINGLE_BATTLE_TEST("Final Gambit does not faint the user if it misses")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { MaxHP(10); HP(10); Speed(1); }
+        OPPONENT(SPECIES_WOBBUFFET) { MaxHP(10); HP(10); Speed(2); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SAND_ATTACK); MOVE(player, MOVE_FINAL_GAMBIT, hit: FALSE); }
+    } THEN {
+        EXPECT_EQ(player->hp, 10);
+        EXPECT_EQ(opponent->hp, 10);
+    }
+}
+
+SINGLE_BATTLE_TEST("Final Gambit does not trigger the user's Focus Band")
+{
+    GIVEN {
+        ASSUME(GetItemHoldEffect(ITEM_FOCUS_BAND) == HOLD_EFFECT_FOCUS_BAND);
+        PLAYER(SPECIES_WOBBUFFET) { MaxHP(3); HP(3); Item(ITEM_FOCUS_BAND); }
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET) { MaxHP(10); HP(10); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_FINAL_GAMBIT); SEND_OUT(player, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FINAL_GAMBIT, player);
+        HP_BAR(opponent, damage: 3);
+        HP_BAR(player, hp: 0);
+        NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+    } THEN {
+        EXPECT_EQ(GetMonData(&gParties[B_TRAINER_PLAYER][0], MON_DATA_HP), 0);
+        EXPECT_EQ(GetMonData(&gParties[B_TRAINER_PLAYER][0], MON_DATA_HELD_ITEM), ITEM_FOCUS_BAND);
+    }
+}
+
+SINGLE_BATTLE_TEST("Final Gambit does not trigger the user's Focus Sash")
+{
+    GIVEN {
+        ASSUME(GetItemHoldEffect(ITEM_FOCUS_SASH) == HOLD_EFFECT_FOCUS_SASH);
+        PLAYER(SPECIES_WOBBUFFET) { MaxHP(3); HP(3); Item(ITEM_FOCUS_SASH); }
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET) { MaxHP(10); HP(10); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_FINAL_GAMBIT); SEND_OUT(player, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FINAL_GAMBIT, player);
+        HP_BAR(opponent, damage: 3);
+        HP_BAR(player, hp: 0);
+        NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, player);
+    } THEN {
+        EXPECT_EQ(GetMonData(&gParties[B_TRAINER_PLAYER][0], MON_DATA_HP), 0);
+        EXPECT_EQ(GetMonData(&gParties[B_TRAINER_PLAYER][0], MON_DATA_HELD_ITEM), ITEM_FOCUS_SASH);
+    }
+}
+
+SINGLE_BATTLE_TEST("Final Gambit does not trigger the user's Sturdy")
+{
+    GIVEN {
+        WITH_CONFIG(B_STURDY, GEN_5);
+        PLAYER(SPECIES_GEODUDE) { MaxHP(3); HP(3); Ability(ABILITY_STURDY); }
+        PLAYER(SPECIES_GRAVELER);
+        OPPONENT(SPECIES_WOBBUFFET) { MaxHP(10); HP(10); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_FINAL_GAMBIT); SEND_OUT(player, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FINAL_GAMBIT, player);
+        HP_BAR(opponent, damage: 3);
+        HP_BAR(player, hp: 0);
+        NOT ABILITY_POPUP(player, ABILITY_STURDY);
+    } THEN {
+        EXPECT_EQ(GetMonData(&gParties[B_TRAINER_PLAYER][0], MON_DATA_HP), 0);
+    }
+}
+
+SINGLE_BATTLE_TEST("Final Gambit triggers the target's Focus Band")
+{
+    GIVEN {
+        ASSUME(GetItemHoldEffect(ITEM_FOCUS_BAND) == HOLD_EFFECT_FOCUS_BAND);
+        RNGSeed(((rng_value_t){ .ctr = 1 })); // Force Focus Band's 10% check to succeed.
+        PLAYER(SPECIES_WOBBUFFET) { MaxHP(3); HP(3); }
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET) { MaxHP(2); HP(2); Item(ITEM_FOCUS_BAND); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_FINAL_GAMBIT); SEND_OUT(player, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FINAL_GAMBIT, player);
+        HP_BAR(opponent, hp: 1);
+        MESSAGE("The opposing Wobbuffet hung on using its Focus Band!");
+        HP_BAR(player, hp: 0);
+    } THEN {
+        EXPECT_EQ(opponent->hp, 1);
+    }
+}
+
+SINGLE_BATTLE_TEST("Final Gambit triggers the target's Focus Sash")
+{
+    GIVEN {
+        ASSUME(GetItemHoldEffect(ITEM_FOCUS_SASH) == HOLD_EFFECT_FOCUS_SASH);
+        PLAYER(SPECIES_WOBBUFFET) { MaxHP(3); HP(3); }
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET) { MaxHP(2); HP(2); Item(ITEM_FOCUS_SASH); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_FINAL_GAMBIT); SEND_OUT(player, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FINAL_GAMBIT, player);
+        HP_BAR(opponent, hp: 1);
+        MESSAGE("The opposing Wobbuffet hung on using its Focus Sash!");
+        HP_BAR(player, hp: 0);
+    } THEN {
+        EXPECT_EQ(opponent->hp, 1);
+        EXPECT_EQ(opponent->item, ITEM_NONE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Final Gambit triggers the target's Sturdy")
+{
+    GIVEN {
+        WITH_CONFIG(B_STURDY, GEN_5);
+        PLAYER(SPECIES_WOBBUFFET) { MaxHP(3); HP(3); }
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_GEODUDE) { MaxHP(2); HP(2); Ability(ABILITY_STURDY); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_FINAL_GAMBIT); SEND_OUT(player, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FINAL_GAMBIT, player);
+        HP_BAR(opponent, hp: 1);
+        ABILITY_POPUP(opponent, ABILITY_STURDY);
+        HP_BAR(player, hp: 0);
+    } THEN {
+        EXPECT_EQ(opponent->hp, 1);
+    }
+}
+
+SINGLE_BATTLE_TEST("Final Gambit triggers the target's Endure")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { MaxHP(3); HP(3); Speed(1); }
+        PLAYER(SPECIES_WYNAUT) { Speed(1); }
+        OPPONENT(SPECIES_WOBBUFFET) { MaxHP(2); HP(2); Speed(2); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_ENDURE); MOVE(player, MOVE_FINAL_GAMBIT); SEND_OUT(player, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ENDURE, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FINAL_GAMBIT, player);
+        HP_BAR(opponent, hp: 1);
+        MESSAGE("The opposing Wobbuffet endured the hit!");
+        HP_BAR(player, hp: 0);
+    } THEN {
+        EXPECT_EQ(opponent->hp, 1);
+    }
+}
+
 TO_DO_BATTLE_TEST("Final Gambit fails in Max Raids")
 TO_DO_BATTLE_TEST("Final Gambit fails in Tera Raids")

--- a/test/battle/move_effect/fixed_hp_damage.c
+++ b/test/battle/move_effect/fixed_hp_damage.c
@@ -4,6 +4,7 @@
 ASSUMPTIONS
 {
     ASSUME(GetMoveEffect(MOVE_SONIC_BOOM) == EFFECT_FIXED_HP_DAMAGE);
+    ASSUME(GetMoveEffect(MOVE_DRAGON_RAGE) == EFFECT_FIXED_HP_DAMAGE);
 }
 
 SINGLE_BATTLE_TEST("Sonic Boom deals fixed damage", s16 damage)
@@ -27,7 +28,24 @@ SINGLE_BATTLE_TEST("Sonic Boom deals fixed damage", s16 damage)
     }
 }
 
-TO_DO_BATTLE_TEST("Sonic Boom affects ghost types (Gen1)")
+SINGLE_BATTLE_TEST("Sonic Boom affects ghost types (Gen1)")
+{
+    s16 damage;
+
+    GIVEN {
+        WITH_CONFIG(B_FIXED_DMG_IGNORES_TYPE, GEN_1);
+        ASSUME(GetMoveFixedHPDamage(MOVE_SONIC_BOOM) == 20);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_GASTLY);
+    } WHEN {
+        TURN { MOVE(player, MOVE_SONIC_BOOM); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SONIC_BOOM, player);
+        HP_BAR(opponent, captureDamage: &damage);
+    } THEN {
+        EXPECT_EQ(damage, 20);
+    }
+}
 
 SINGLE_BATTLE_TEST("Sonic Boom doesn't affect ghost types (Gen2+)")
 {
@@ -39,5 +57,25 @@ SINGLE_BATTLE_TEST("Sonic Boom doesn't affect ghost types (Gen2+)")
     } SCENE {
         NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_SONIC_BOOM, player);
         MESSAGE("It doesn't affect the opposing Gastly…");
+    }
+}
+
+SINGLE_BATTLE_TEST("Dragon Rage is unaffected by type immunities (Gen 1)")
+{
+    s16 damage;
+
+    GIVEN {
+        WITH_CONFIG(B_FIXED_DMG_IGNORES_TYPE, GEN_1);
+        ASSUME(GetMoveFixedHPDamage(MOVE_DRAGON_RAGE) == 40);
+        ASSUME(GetSpeciesType(SPECIES_CLEFAIRY, 0) == TYPE_FAIRY);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_CLEFAIRY);
+    } WHEN {
+        TURN { MOVE(player, MOVE_DRAGON_RAGE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_RAGE, player);
+        HP_BAR(opponent, captureDamage: &damage);
+    } THEN {
+        EXPECT_EQ(damage, 40);
     }
 }

--- a/test/battle/move_effect/fixed_percent_damage.c
+++ b/test/battle/move_effect/fixed_percent_damage.c
@@ -1,9 +1,98 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("Super Fang does 50% damage to the target's current HP")
-TO_DO_BATTLE_TEST("Super Fang always deals at least 1 HP of damage")
-TO_DO_BATTLE_TEST("Super Fang is unaffected by type immunities (Gen 1)")
-TO_DO_BATTLE_TEST("Super Fang doesn't hit Ghost-type Pokémon (Gen 2+)")
+ASSUMPTIONS
+{
+    ASSUME(GetMoveEffect(MOVE_SUPER_FANG) == EFFECT_FIXED_PERCENT_DAMAGE);
+    ASSUME(GetMoveDamagePercentage(MOVE_SUPER_FANG) == 50);
+}
 
-TO_DO_BATTLE_TEST("Guardian of Alola does 75% damage to the target's current HP")
+SINGLE_BATTLE_TEST("Super Fang does 50% damage to the target's current HP")
+{
+    s16 damage;
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { MaxHP(200); HP(100); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SUPER_FANG); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SUPER_FANG, player);
+        HP_BAR(opponent, captureDamage: &damage);
+    } THEN {
+        EXPECT_EQ(damage, 50);
+    }
+}
+
+SINGLE_BATTLE_TEST("Super Fang always deals at least 1 HP of damage")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { MaxHP(200); HP(1); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SUPER_FANG); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SUPER_FANG, player);
+        HP_BAR(opponent, damage: 1);
+        MESSAGE("The opposing Wobbuffet fainted!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Super Fang is unaffected by type immunities (Gen 1)")
+{
+    s16 damage;
+
+    GIVEN {
+        WITH_CONFIG(B_FIXED_DMG_IGNORES_TYPE, GEN_1);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_GASTLY) { MaxHP(100); HP(100); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SUPER_FANG); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SUPER_FANG, player);
+        HP_BAR(opponent, captureDamage: &damage);
+    } THEN {
+        EXPECT_EQ(damage, 50);
+    }
+}
+
+SINGLE_BATTLE_TEST("Super Fang doesn't hit Ghost-type Pokémon (Gen 2+)")
+{
+    u32 genConfig;
+
+    PARAMETRIZE { genConfig = GEN_2; }
+    PARAMETRIZE { genConfig = GEN_5; }
+    PARAMETRIZE { genConfig = GEN_LATEST; }
+    GIVEN {
+        WITH_CONFIG(B_FIXED_DMG_IGNORES_TYPE, genConfig);
+        ASSUME(GetMoveType(MOVE_SUPER_FANG) == TYPE_NORMAL);
+        ASSUME(GetSpeciesType(SPECIES_GASTLY, 0) == TYPE_GHOST);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_GASTLY) { MaxHP(100); HP(100); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SUPER_FANG); }
+    } SCENE {
+        MESSAGE("It doesn't affect the opposing Gastly…");
+        NOT HP_BAR(opponent);
+    }
+}
+
+SINGLE_BATTLE_TEST("Guardian of Alola does 75% damage to the target's current HP")
+{
+    s16 damage;
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_GUARDIAN_OF_ALOLA) == EFFECT_FIXED_PERCENT_DAMAGE);
+        ASSUME(GetMoveDamagePercentage(MOVE_GUARDIAN_OF_ALOLA) == 75);
+        PLAYER(SPECIES_TAPU_KOKO) { Item(ITEM_TAPUNIUM_Z); Moves(MOVE_NATURES_MADNESS); }
+        OPPONENT(SPECIES_WOBBUFFET) { MaxHP(200); HP(100); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_NATURES_MADNESS, gimmick: GIMMICK_Z_MOVE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_ZMOVE_ACTIVATE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_GUARDIAN_OF_ALOLA, player);
+        HP_BAR(opponent, captureDamage: &damage);
+    } THEN {
+        EXPECT_EQ(damage, 75);
+    }
+}

--- a/test/battle/move_effect/flatter.c
+++ b/test/battle/move_effect/flatter.c
@@ -4,6 +4,9 @@
 ASSUMPTIONS
 {
     ASSUME(GetMoveEffect(MOVE_FLATTER) == EFFECT_SWAGGER);
+    ASSUME(GetMoveEffect(MOVE_CONFUSE_RAY) == EFFECT_CONFUSE);
+    ASSUME(GetMoveEffect(MOVE_SAFEGUARD) == EFFECT_SAFEGUARD);
+    ASSUME_STAT_CHANGE(MOVE_NASTY_PLOT, spAtk: +2);
 }
 
 SINGLE_BATTLE_TEST("Flatter increases the target's Sp. Attack by 1 stage and confuses them")
@@ -36,8 +39,94 @@ SINGLE_BATTLE_TEST("Flatter on a foe with Own Tempo prevents confusion, changes 
     }
 }
 
-TO_DO_BATTLE_TEST("Flatter raises the target's Sp. Atk even if they're already confused")
-TO_DO_BATTLE_TEST("Flatter raises the target's Sp. Atk even when protected by Safeguard")
-TO_DO_BATTLE_TEST("Flatter raises the target's Sp. Atk even when protected Own Tempo")
-TO_DO_BATTLE_TEST("Flatter confuses the target even when they have their Sp. Atk maxed")
-TO_DO_BATTLE_TEST("Flatter confuses the target even when at -6 Sp. Atk and has Contrary")
+SINGLE_BATTLE_TEST("Flatter raises the target's Sp. Atk even if they're already confused")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_CONFUSE_RAY); }
+        TURN { MOVE(player, MOVE_FLATTER); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CONFUSE_RAY, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FLATTER, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
+    } THEN {
+        EXPECT_EQ(opponent->statStages[STAT_SPATK], DEFAULT_STAT_STAGE + 1);
+        EXPECT(opponent->volatiles.confusionTimer > 0);
+    }
+}
+
+SINGLE_BATTLE_TEST("Flatter raises the target's Sp. Atk even when protected by Safeguard")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Speed(1); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(2); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SAFEGUARD); MOVE(player, MOVE_FLATTER); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SAFEGUARD, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FLATTER, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
+    } THEN {
+        EXPECT_EQ(opponent->statStages[STAT_SPATK], DEFAULT_STAT_STAGE + 1);
+        EXPECT(!opponent->volatiles.confusionTimer);
+    }
+}
+
+SINGLE_BATTLE_TEST("Flatter raises the target's Sp. Atk even when protected by Own Tempo")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_SLOWPOKE) { Ability(ABILITY_OWN_TEMPO); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_FLATTER); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FLATTER, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
+        ABILITY_POPUP(opponent, ABILITY_OWN_TEMPO);
+    } THEN {
+        EXPECT_EQ(opponent->statStages[STAT_SPATK], DEFAULT_STAT_STAGE + 1);
+        EXPECT(!opponent->volatiles.confusionTimer);
+    }
+}
+
+SINGLE_BATTLE_TEST("Flatter confuses the target even when they have their Sp. Atk maxed")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { Ability(ABILITY_SIMPLE); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_NASTY_PLOT); }
+        TURN { MOVE(opponent, MOVE_NASTY_PLOT); }
+        TURN { MOVE(player, MOVE_FLATTER); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_NASTY_PLOT, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_NASTY_PLOT, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FLATTER, player);
+    } THEN {
+        EXPECT_EQ(opponent->statStages[STAT_SPATK], MAX_STAT_STAGE);
+        EXPECT(opponent->volatiles.confusionTimer > 0);
+    }
+}
+
+SINGLE_BATTLE_TEST("Flatter confuses the target even when at -6 Sp. Atk and has Contrary")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_INKAY) { Ability(ABILITY_CONTRARY); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_NASTY_PLOT); }
+        TURN { MOVE(opponent, MOVE_NASTY_PLOT); }
+        TURN { MOVE(opponent, MOVE_NASTY_PLOT); }
+        TURN { MOVE(player, MOVE_FLATTER); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_NASTY_PLOT, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_NASTY_PLOT, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_NASTY_PLOT, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FLATTER, player);
+    } THEN {
+        EXPECT_EQ(opponent->statStages[STAT_SPATK], MIN_STAT_STAGE);
+        EXPECT(opponent->volatiles.confusionTimer > 0);
+    }
+}

--- a/test/battle/move_effect/focus_energy.c
+++ b/test/battle/move_effect/focus_energy.c
@@ -67,5 +67,43 @@ SINGLE_BATTLE_TEST("Focus Energy multiplies crit chance by 4 with gen 1 crit cha
     }
 }
 
-TO_DO_BATTLE_TEST("Focus Energy fails if critical hit stage was already increased by Dragon Cheer")
-TO_DO_BATTLE_TEST("Baton Pass passes Focus Energy's effect");
+DOUBLE_BATTLE_TEST("Focus Energy fails if critical hit stage was already increased by Dragon Cheer")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_DRAGON_CHEER) == EFFECT_DRAGON_CHEER);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(playerRight, MOVE_DRAGON_CHEER, target: playerLeft); }
+        TURN { MOVE(playerLeft, MOVE_FOCUS_ENERGY); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_DRAGON_CHEER, playerRight);
+        MESSAGE("Wobbuffet is getting pumped!");
+        MESSAGE("But it failed!");
+    } THEN {
+        EXPECT(playerLeft->volatiles.dragonCheer);
+        EXPECT(!playerLeft->volatiles.focusEnergy);
+    }
+}
+
+SINGLE_BATTLE_TEST("Baton Pass passes Focus Energy's effect")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_BATON_PASS) == EFFECT_BATON_PASS);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_CATERPIE);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_FOCUS_ENERGY); }
+        TURN { MOVE(player, MOVE_BATON_PASS); SEND_OUT(player, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FOCUS_ENERGY, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BATON_PASS, player);
+        SEND_IN_MESSAGE("Caterpie");
+    } THEN {
+        EXPECT_EQ(player->species, SPECIES_CATERPIE);
+        EXPECT(player->volatiles.focusEnergy);
+    }
+}

--- a/test/battle/move_effect/foul_play.c
+++ b/test/battle/move_effect/foul_play.c
@@ -28,6 +28,63 @@ SINGLE_BATTLE_TEST("Foul Play uses the target's Attack stat and stat stages of t
     }
 }
 
-TO_DO_BATTLE_TEST("Foul Play uses the user's attack modifiers - Held Item")
-TO_DO_BATTLE_TEST("Foul Play uses the user's attack modifiers - Ability")
-TO_DO_BATTLE_TEST("Foul Play uses the user's attack modifiers - Burn")
+SINGLE_BATTLE_TEST("Foul Play uses the user's held item Attack modifier", s16 damage)
+{
+    enum Item item;
+
+    PARAMETRIZE { item = ITEM_NONE; }
+    PARAMETRIZE { item = ITEM_CHOICE_BAND; }
+
+    GIVEN {
+        ASSUME(GetItemHoldEffect(ITEM_CHOICE_BAND) == HOLD_EFFECT_CHOICE_BAND);
+        PLAYER(SPECIES_WOBBUFFET) { Item(item); }
+        OPPONENT(SPECIES_WOBBUFFET) { Attack(150); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_FOUL_PLAY); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FOUL_PLAY, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.5), results[1].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Foul Play uses the user's Ability Attack modifier", s16 damage)
+{
+    enum Ability ability;
+
+    PARAMETRIZE { ability = ABILITY_PICKUP; }
+    PARAMETRIZE { ability = ABILITY_HUGE_POWER; }
+
+    GIVEN {
+        PLAYER(SPECIES_DIGGERSBY) { Ability(ability); }
+        OPPONENT(SPECIES_WOBBUFFET) { Attack(150); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_FOUL_PLAY); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FOUL_PLAY, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(2.0), results[1].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Foul Play uses the user's burn Attack modifier", s16 damage)
+{
+    u32 status1;
+
+    PARAMETRIZE { status1 = STATUS1_NONE; }
+    PARAMETRIZE { status1 = STATUS1_BURN; }
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Status1(status1); }
+        OPPONENT(SPECIES_WOBBUFFET) { Attack(150); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_FOUL_PLAY); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FOUL_PLAY, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[1].damage, Q_4_12(2.0), results[0].damage);
+    }
+}

--- a/test/battle/move_effect/frustration.c
+++ b/test/battle/move_effect/frustration.c
@@ -1,6 +1,63 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("Frustration's power increases the lower friendship of the user is")
-TO_DO_BATTLE_TEST("Frustration does 0 damage at max Friendship (Gen2)")
-TO_DO_BATTLE_TEST("Frustration does 1 damage at max Friendship (Gen3+)")
+ASSUMPTIONS
+{
+    ASSUME(GetMoveEffect(MOVE_FRUSTRATION) == EFFECT_FRUSTRATION);
+}
+
+SINGLE_BATTLE_TEST("Frustration's power increases the lower the user's friendship is", s16 damage)
+{
+    u32 friendship;
+    PARAMETRIZE { friendship = 255; }
+    PARAMETRIZE { friendship = 200; }
+    PARAMETRIZE { friendship = 100; }
+    PARAMETRIZE { friendship = 0; }
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Friendship(friendship); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_FRUSTRATION); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FRUSTRATION, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } THEN {
+        if (i > 0)
+            EXPECT_GT(results[i].damage, results[i - 1].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Frustration does 0 damage at max Friendship (Gen 2)")
+{
+    s16 damage;
+
+    GIVEN {
+        WITH_CONFIG(B_RETURN_FRUSTRATION_DMG, GEN_2);
+        PLAYER(SPECIES_WOBBUFFET) { Friendship(255); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_FRUSTRATION); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FRUSTRATION, player);
+        HP_BAR(opponent, captureDamage: &damage);
+    } THEN {
+        EXPECT_EQ(damage, 0);
+    }
+}
+
+SINGLE_BATTLE_TEST("Frustration does 1 damage at max Friendship (Gen 3+)")
+{
+    s16 damage;
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Friendship(255); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_FRUSTRATION); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FRUSTRATION, player);
+        HP_BAR(opponent, captureDamage: &damage);
+    } THEN {
+        EXPECT_EQ(damage, 1);
+    }
+}

--- a/test/battle/move_effect/fury_cutter.c
+++ b/test/battle/move_effect/fury_cutter.c
@@ -82,9 +82,73 @@ SINGLE_BATTLE_TEST("Fury Cutter's base power resets if the it is used again but 
     }
 }
 
-TO_DO_BATTLE_TEST("Fury Cutter's power is reset if the user misses")
-TO_DO_BATTLE_TEST("Fury Cutter's power is reset if the user is switched out")
-TO_DO_BATTLE_TEST("Fury Cutter's power is reset if the trainer uses an item")
+SINGLE_BATTLE_TEST("Fury Cutter's power is reset if the user misses")
+{
+    s16 damage[2];
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_FURY_CUTTER); }
+        TURN { MOVE(player, MOVE_FURY_CUTTER, hit: FALSE); }
+        TURN { MOVE(player, MOVE_FURY_CUTTER); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FURY_CUTTER, player);
+        HP_BAR(opponent, captureDamage: &damage[0]);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FURY_CUTTER, player);
+        HP_BAR(opponent, captureDamage: &damage[1]);
+    } THEN {
+        EXPECT_EQ(damage[0], damage[1]);
+    }
+}
+
+SINGLE_BATTLE_TEST("Fury Cutter's power is reset if the user is switched out")
+{
+    s16 damage[2];
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_FURY_CUTTER); }
+        TURN { SWITCH(player, 1); }
+        TURN { SWITCH(player, 0); }
+        TURN { MOVE(player, MOVE_FURY_CUTTER); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FURY_CUTTER, player);
+        HP_BAR(opponent, captureDamage: &damage[0]);
+        SEND_IN_MESSAGE("Wynaut");
+        SEND_IN_MESSAGE("Wobbuffet");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FURY_CUTTER, player);
+        HP_BAR(opponent, captureDamage: &damage[1]);
+    } THEN {
+        EXPECT_EQ(damage[0], damage[1]);
+    }
+}
+
+SINGLE_BATTLE_TEST("Fury Cutter's power is reset if the trainer uses an item")
+{
+    s16 damage[2];
+
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_FURY_CUTTER); }
+        TURN { USE_ITEM(player, ITEM_X_DEFENSE); }
+        TURN { MOVE(player, MOVE_FURY_CUTTER); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FURY_CUTTER, player);
+        HP_BAR(opponent, captureDamage: &damage[0]);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FURY_CUTTER, player);
+        HP_BAR(opponent, captureDamage: &damage[1]);
+    } THEN {
+        EXPECT_EQ(damage[0], damage[1]);
+    }
+}
 
 SINGLE_BATTLE_TEST("Fury Cutter counter is the same for both hits of Parental Bond")
 {

--- a/test/battle/move_effect/fusion_combo.c
+++ b/test/battle/move_effect/fusion_combo.c
@@ -1,6 +1,96 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("Fusion Flare and Fusion Bolt double in power if the other move was immediately used in the same turn")
-TO_DO_BATTLE_TEST("Fusion Flare and Fusion Bolt do not double in power if there was a move used in-between the two of them")
-TO_DO_BATTLE_TEST("Fusion Flare and Fusion Bolt double in power if used by the same Pokémon in the same turn") // Use Instruct to replicate this
+ASSUMPTIONS
+{
+    ASSUME(GetMoveEffect(MOVE_FUSION_FLARE) == EFFECT_FUSION_COMBO);
+    ASSUME(GetMoveEffect(MOVE_FUSION_BOLT) == EFFECT_FUSION_COMBO);
+}
+
+DOUBLE_BATTLE_TEST("Fusion Flare and Fusion Bolt double in power if the other move was used immediately before in the same turn", s16 damage)
+{
+    enum Move firstMove;
+    enum Move secondMove;
+    PARAMETRIZE { firstMove = MOVE_CELEBRATE;    secondMove = MOVE_FUSION_BOLT; }
+    PARAMETRIZE { firstMove = MOVE_FUSION_FLARE; secondMove = MOVE_FUSION_BOLT; }
+    PARAMETRIZE { firstMove = MOVE_CELEBRATE;    secondMove = MOVE_FUSION_FLARE; }
+    PARAMETRIZE { firstMove = MOVE_FUSION_BOLT;  secondMove = MOVE_FUSION_FLARE; }
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Speed(100); }
+        PLAYER(SPECIES_WOBBUFFET) { Speed(90); Attack(100); SpAttack(100); }
+        OPPONENT(SPECIES_WOBBUFFET) { HP(1000); MaxHP(1000); Defense(100); SpDefense(100); Speed(20); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(10); }
+    } WHEN {
+        TURN {
+            MOVE(playerLeft, firstMove, target: opponentLeft);
+            MOVE(playerRight, secondMove, target: opponentLeft);
+        }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, secondMove, playerRight);
+        HP_BAR(opponentLeft, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(2.0), results[1].damage);
+        EXPECT_MUL_EQ(results[2].damage, Q_4_12(2.0), results[3].damage);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Fusion Flare and Fusion Bolt do not double in power if another move was used between them", s16 damage)
+{
+    enum Move firstMove;
+    enum Move secondMove;
+    PARAMETRIZE { firstMove = MOVE_CELEBRATE;    secondMove = MOVE_FUSION_BOLT; }
+    PARAMETRIZE { firstMove = MOVE_FUSION_FLARE; secondMove = MOVE_FUSION_BOLT; }
+    PARAMETRIZE { firstMove = MOVE_CELEBRATE;    secondMove = MOVE_FUSION_FLARE; }
+    PARAMETRIZE { firstMove = MOVE_FUSION_BOLT;  secondMove = MOVE_FUSION_FLARE; }
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET) { Speed(100); }
+        PLAYER(SPECIES_WOBBUFFET) { Speed(80); Attack(100); SpAttack(100); }
+        OPPONENT(SPECIES_WOBBUFFET) { HP(1000); MaxHP(1000); Defense(100); SpDefense(100); Speed(20); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(90); }
+    } WHEN {
+        TURN {
+            MOVE(playerLeft, firstMove, target: opponentLeft);
+            MOVE(opponentRight, MOVE_CELEBRATE);
+            MOVE(playerRight, secondMove, target: opponentLeft);
+        }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, secondMove, playerRight);
+        HP_BAR(opponentLeft, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_EQ(results[0].damage, results[1].damage);
+        EXPECT_EQ(results[2].damage, results[3].damage);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Fusion Flare and Fusion Bolt double in power if the same Pokémon uses both in one turn through Instruct", s16 damage)
+{
+    bool32 useInstruct;
+    enum Move firstMove;
+    enum Move secondMove;
+    PARAMETRIZE { useInstruct = FALSE; firstMove = MOVE_FUSION_FLARE; secondMove = MOVE_FUSION_BOLT; }
+    PARAMETRIZE { useInstruct = TRUE;  firstMove = MOVE_FUSION_FLARE; secondMove = MOVE_FUSION_BOLT; }
+    PARAMETRIZE { useInstruct = FALSE; firstMove = MOVE_FUSION_BOLT;  secondMove = MOVE_FUSION_FLARE; }
+    PARAMETRIZE { useInstruct = TRUE;  firstMove = MOVE_FUSION_BOLT;  secondMove = MOVE_FUSION_FLARE; }
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_INSTRUCT) == EFFECT_INSTRUCT);
+        PLAYER(SPECIES_WOBBUFFET) { Attack(100); SpAttack(100); Speed(50); }
+        PLAYER(SPECIES_ORANGURU) { Speed(100); }
+        OPPONENT(SPECIES_WOBBUFFET) { HP(1000); MaxHP(1000); Defense(100); SpDefense(100); Speed(20); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(10); }
+    } WHEN {
+        TURN { MOVE(playerLeft, firstMove, target: opponentLeft); }
+        TURN {
+            if (useInstruct)
+                MOVE(playerRight, MOVE_INSTRUCT, target: playerLeft);
+            else
+                MOVE(playerRight, MOVE_CELEBRATE);
+            MOVE(playerLeft, secondMove, target: opponentLeft);
+        }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, secondMove, playerLeft);
+        HP_BAR(opponentLeft, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(2.0), results[1].damage);
+        EXPECT_MUL_EQ(results[2].damage, Q_4_12(2.0), results[3].damage);
+    }
+}

--- a/test/battle/move_effect/future_sight.c
+++ b/test/battle/move_effect/future_sight.c
@@ -75,7 +75,36 @@ SINGLE_BATTLE_TEST("Future Sight is not boosted by Life Orb is original user if 
     }
 }
 
-TO_DO_BATTLE_TEST("Future Sight does not receive STAB from party mon (Gen 2-4)")
+SINGLE_BATTLE_TEST("Future Sight does not receive STAB from party mon (Gen 2-4)")
+{
+    u32 genConfig;
+    s16 directDamage;
+    s16 futureSightDamage;
+
+    PARAMETRIZE { genConfig = GEN_2; }
+    PARAMETRIZE { genConfig = GEN_3; }
+    PARAMETRIZE { genConfig = GEN_4; }
+    GIVEN {
+        WITH_CONFIG(B_UPDATED_MOVE_TYPES, genConfig);
+        PLAYER(SPECIES_RALTS);
+        PLAYER(SPECIES_RAICHU);
+        OPPONENT(SPECIES_REGICE);
+    } WHEN {
+        TURN { MOVE(player, FUTURE_SIGHT_EQUIVALENT, WITH_RNG(RNG_SECONDARY_EFFECT, FALSE)); }
+        TURN { MOVE(player, MOVE_FUTURE_SIGHT); }
+        TURN { SWITCH(player, 1); }
+        TURN {}
+        TURN {}
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, FUTURE_SIGHT_EQUIVALENT, player);
+        HP_BAR(opponent, captureDamage: &directDamage);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FUTURE_SIGHT, player);
+        HP_BAR(opponent, captureDamage: &futureSightDamage);
+    } THEN {
+        EXPECT_EQ(directDamage, futureSightDamage);
+    }
+}
+
 SINGLE_BATTLE_TEST("Future Sight receives STAB from party mon (Gen 5+)")
 {
     s16 seedFlareDmg;
@@ -101,7 +130,44 @@ SINGLE_BATTLE_TEST("Future Sight receives STAB from party mon (Gen 5+)")
     }
 }
 
-TO_DO_BATTLE_TEST("Future Sight is not affected by type effectiveness (Gen 2-4)")
+SINGLE_BATTLE_TEST("Future Sight is not affected by type effectiveness (Gen 2-4)", s16 damage)
+{
+    u32 genConfig;
+    enum Species species;
+
+    PARAMETRIZE { genConfig = GEN_2; species = SPECIES_DITTO; }
+    PARAMETRIZE { genConfig = GEN_2; species = SPECIES_MACHOP; }
+    PARAMETRIZE { genConfig = GEN_2; species = SPECIES_STARMIE; }
+    PARAMETRIZE { genConfig = GEN_2; species = SPECIES_HOUNDOOM; }
+    PARAMETRIZE { genConfig = GEN_3; species = SPECIES_DITTO; }
+    PARAMETRIZE { genConfig = GEN_3; species = SPECIES_MACHOP; }
+    PARAMETRIZE { genConfig = GEN_3; species = SPECIES_STARMIE; }
+    PARAMETRIZE { genConfig = GEN_3; species = SPECIES_HOUNDOOM; }
+    PARAMETRIZE { genConfig = GEN_4; species = SPECIES_DITTO; }
+    PARAMETRIZE { genConfig = GEN_4; species = SPECIES_MACHOP; }
+    PARAMETRIZE { genConfig = GEN_4; species = SPECIES_STARMIE; }
+    PARAMETRIZE { genConfig = GEN_4; species = SPECIES_HOUNDOOM; }
+    GIVEN {
+        WITH_CONFIG(B_UPDATED_MOVE_TYPES, genConfig);
+        ASSUME(GetSpeciesType(SPECIES_DITTO, 0) == TYPE_NORMAL);
+        ASSUME(GetSpeciesType(SPECIES_MACHOP, 0) == TYPE_FIGHTING);
+        ASSUME(GetSpeciesType(SPECIES_STARMIE, 1) == TYPE_PSYCHIC);
+        ASSUME(GetSpeciesType(SPECIES_HOUNDOOM, 0) == TYPE_DARK);
+        PLAYER(SPECIES_PIKACHU);
+        OPPONENT(species) { HP(1000); MaxHP(1000); SpDefense(100); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_FUTURE_SIGHT); }
+        TURN {}
+        TURN {}
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FUTURE_SIGHT, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } THEN {
+        if (i % 4 != 0)
+            EXPECT_EQ(results[i].damage, results[i - i % 4].damage);
+    }
+}
+
 SINGLE_BATTLE_TEST("Future Sight is affected by type effectiveness (Gen 5+)")
 {
     GIVEN {
@@ -123,7 +189,28 @@ SINGLE_BATTLE_TEST("Future Sight is affected by type effectiveness (Gen 5+)")
     }
 }
 
-TO_DO_BATTLE_TEST("Future Sight ignores Wonder Guard (Gen 2-4)")
+SINGLE_BATTLE_TEST("Future Sight ignores Wonder Guard (Gen 2-4)")
+{
+    u32 genConfig;
+
+    PARAMETRIZE { genConfig = GEN_2; }
+    PARAMETRIZE { genConfig = GEN_3; }
+    PARAMETRIZE { genConfig = GEN_4; }
+    GIVEN {
+        WITH_CONFIG(B_UPDATED_MOVE_TYPES, genConfig);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_SHEDINJA) { Ability(ABILITY_WONDER_GUARD); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_FUTURE_SIGHT); }
+        TURN {}
+        TURN {}
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FUTURE_SIGHT, player);
+        NOT ABILITY_POPUP(opponent, ABILITY_WONDER_GUARD);
+        HP_BAR(opponent, hp: 0);
+    }
+}
+
 SINGLE_BATTLE_TEST("Future Sight doesn't ignore Wonder Guard (Gen 5+)")
 {
     GIVEN {

--- a/test/battle/move_effect/grassy_glide.c
+++ b/test/battle/move_effect/grassy_glide.c
@@ -1,5 +1,37 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("Grassy Glide's priority increases by 1 when the user is affected by Grassy Terrain")
-TO_DO_BATTLE_TEST("Dynamax: Grassy Glide's priority doesn't increase for the Max Move it becomes")
+ASSUMPTIONS
+{
+    ASSUME(GetMoveEffect(MOVE_GRASSY_GLIDE) == EFFECT_GRASSY_GLIDE);
+    ASSUME(GetMovePriority(MOVE_GRASSY_GLIDE) == 0);
+    ASSUME(GetMovePriority(MOVE_SCRATCH) == 0);
+}
+
+SINGLE_BATTLE_TEST("Grassy Glide's priority increases by 1 when the user is affected by Grassy Terrain")
+{
+    GIVEN {
+        PLAYER(SPECIES_TAPU_BULU) { Ability(ABILITY_GRASSY_SURGE); Speed(1); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(2); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_GRASSY_GLIDE); MOVE(opponent, MOVE_SCRATCH); }
+    } SCENE {
+        ABILITY_POPUP(player, ABILITY_GRASSY_SURGE);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_GRASSY_GLIDE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
+    }
+}
+
+SINGLE_BATTLE_TEST("Dynamax: Grassy Glide's priority does not increase for the Max Move it becomes")
+{
+    GIVEN {
+        PLAYER(SPECIES_TAPU_BULU) { Ability(ABILITY_GRASSY_SURGE); Speed(1); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(2); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_GRASSY_GLIDE, gimmick: GIMMICK_DYNAMAX); MOVE(opponent, MOVE_SCRATCH); }
+    } SCENE {
+        ABILITY_POPUP(player, ABILITY_GRASSY_SURGE);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_MAX_OVERGROWTH, player);
+    }
+}

--- a/test/battle/move_effect/grav_apple.c
+++ b/test/battle/move_effect/grav_apple.c
@@ -1,5 +1,71 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("Grav Apple lowers the target's Defense by 1 stage")
-TO_DO_BATTLE_TEST("Grav Apple's power increases by 50% under Gravity's effect")
+ASSUMPTIONS
+{
+    ASSUME(GetMoveEffect(MOVE_GRAV_APPLE) == EFFECT_GRAV_APPLE);
+    ASSUME_MOVE_EFFECT_STAT_CHANGE(MOVE_GRAV_APPLE, self: FALSE, defense: -1);
+}
+
+SINGLE_BATTLE_TEST("Grav Apple lowers the target's Defense by 1 stage")
+{
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_GRAV_APPLE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_GRAV_APPLE, player);
+        HP_BAR(opponent);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
+        MESSAGE("The opposing Wobbuffet's Defense fell!");
+    } THEN {
+        EXPECT_EQ(opponent->statStages[STAT_DEF], DEFAULT_STAT_STAGE - 1);
+    }
+}
+
+SINGLE_BATTLE_TEST("Mirror Armor reflects Grav Apple's Defense drop and considers Simple and Contrary")
+{
+    enum Species species;
+    enum Ability ability;
+    s32 expectedDelta;
+
+    PARAMETRIZE { species = SPECIES_BIBAREL; ability = ABILITY_SIMPLE;   expectedDelta = -2; }
+    PARAMETRIZE { species = SPECIES_INKAY;   ability = ABILITY_CONTRARY; expectedDelta = 1; }
+
+    GIVEN {
+        PLAYER(species) { Ability(ability); }
+        OPPONENT(SPECIES_CORVIKNIGHT) { Ability(ABILITY_MIRROR_ARMOR); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_GRAV_APPLE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_GRAV_APPLE, player);
+        HP_BAR(opponent);
+        ABILITY_POPUP(opponent, ABILITY_MIRROR_ARMOR);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_DEF], DEFAULT_STAT_STAGE + expectedDelta);
+        EXPECT_EQ(opponent->statStages[STAT_DEF], DEFAULT_STAT_STAGE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Grav Apple's power increases by 50% under Gravity's effect", s16 damage)
+{
+    u32 setupMove;
+    PARAMETRIZE { setupMove = MOVE_CELEBRATE; }
+    PARAMETRIZE { setupMove = MOVE_GRAVITY; }
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_GRAVITY) == EFFECT_GRAVITY);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, setupMove); }
+        TURN { MOVE(player, MOVE_GRAV_APPLE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_GRAV_APPLE, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.5), results[1].damage);
+    }
+}

--- a/test/battle/move_effect/guard_split.c
+++ b/test/battle/move_effect/guard_split.c
@@ -21,6 +21,80 @@ SINGLE_BATTLE_TEST("Guard Split averages users and targets Def and Sp. Def stats
     }
 }
 
-TO_DO_BATTLE_TEST("Stat stages use Guard Split's altered stats")
-TO_DO_BATTLE_TEST("Assault Vest uses Guard Split's altered stats")
-TO_DO_BATTLE_TEST("Eviolite uses Guard Split's altered stats")
+SINGLE_BATTLE_TEST("Defense stat stages apply to Guard Split's altered stat", s16 damage)
+{
+    bool32 boostDefense;
+    PARAMETRIZE { boostDefense = FALSE; }
+    PARAMETRIZE { boostDefense = TRUE; }
+    GIVEN {
+        ASSUME_STAT_CHANGE(MOVE_IRON_DEFENSE, defense: +2);
+        ASSUME(GetMoveCategory(MOVE_SCRATCH) == DAMAGE_CATEGORY_PHYSICAL);
+        PLAYER(SPECIES_WOBBUFFET) { Defense(20); }
+        OPPONENT(SPECIES_WOBBUFFET) { Attack(100); Defense(200); }
+    } WHEN {
+        if (boostDefense)
+            TURN { MOVE(player, MOVE_IRON_DEFENSE); }
+        TURN { MOVE(player, MOVE_GUARD_SPLIT); }
+        TURN { MOVE(opponent, MOVE_SCRATCH); }
+    } SCENE {
+        if (boostDefense)
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_IRON_DEFENSE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_GUARD_SPLIT, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
+        HP_BAR(player, captureDamage: &results[i].damage);
+    } THEN {
+        EXPECT_EQ(player->defense, 110);
+        EXPECT_EQ(player->statStages[STAT_DEF], DEFAULT_STAT_STAGE + (boostDefense ? 2 : 0));
+    } FINALLY {
+        EXPECT_GT(results[0].damage, results[1].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Assault Vest boosts Guard Split's altered Sp. Def stat", s16 damage)
+{
+    enum Item item;
+    PARAMETRIZE { item = ITEM_ASSAULT_VEST; }
+    PARAMETRIZE { item = ITEM_NONE; }
+    GIVEN {
+        ASSUME(GetItemHoldEffect(ITEM_ASSAULT_VEST) == HOLD_EFFECT_ASSAULT_VEST);
+        ASSUME(GetMoveCategory(MOVE_WATER_GUN) == DAMAGE_CATEGORY_SPECIAL);
+        PLAYER(SPECIES_WOBBUFFET) { Attack(1); SpDefense(20); Speed(1); Item(item); Moves(MOVE_SCRATCH); }
+        OPPONENT(SPECIES_WOBBUFFET) { SpAttack(100); SpDefense(200); Speed(2); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_GUARD_SPLIT); MOVE(player, MOVE_SCRATCH); }
+        TURN { MOVE(opponent, MOVE_WATER_GUN); MOVE(player, MOVE_SCRATCH); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_GUARD_SPLIT, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_WATER_GUN, opponent);
+        HP_BAR(player, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.5), results[1].damage);
+    }
+}
+
+SINGLE_BATTLE_TEST("Eviolite boosts Guard Split's altered Defense and Sp. Def stats", s16 damage)
+{
+    enum Item item;
+    enum Move move;
+    PARAMETRIZE { move = MOVE_SCRATCH;   item = ITEM_EVIOLITE; }
+    PARAMETRIZE { move = MOVE_SCRATCH;   item = ITEM_NONE; }
+    PARAMETRIZE { move = MOVE_WATER_GUN; item = ITEM_EVIOLITE; }
+    PARAMETRIZE { move = MOVE_WATER_GUN; item = ITEM_NONE; }
+    GIVEN {
+        ASSUME(GetItemHoldEffect(ITEM_EVIOLITE) == HOLD_EFFECT_EVIOLITE);
+        ASSUME(GetMoveCategory(MOVE_SCRATCH) == DAMAGE_CATEGORY_PHYSICAL);
+        ASSUME(GetMoveCategory(MOVE_WATER_GUN) == DAMAGE_CATEGORY_SPECIAL);
+        PLAYER(SPECIES_PORYGON) { Defense(20); SpDefense(20); Item(item); }
+        OPPONENT(SPECIES_WOBBUFFET) { Attack(100); Defense(200); SpAttack(100); SpDefense(200); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_GUARD_SPLIT); }
+        TURN { MOVE(opponent, move); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_GUARD_SPLIT, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, move, opponent);
+        HP_BAR(player, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(1.5), results[1].damage);
+        EXPECT_MUL_EQ(results[2].damage, Q_4_12(1.5), results[3].damage);
+    }
+}

--- a/test/battle/move_effect/guard_swap.c
+++ b/test/battle/move_effect/guard_swap.c
@@ -1,4 +1,50 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("Guard Swap switches the user's Defense and Sp. Def stat stages with the target")
+SINGLE_BATTLE_TEST("Guard Swap switches the user's Defense and Sp. Def stat stages with the target")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_GUARD_SWAP) == EFFECT_GUARD_SWAP);
+        ASSUME_STAT_CHANGE(MOVE_IRON_DEFENSE, defense: +2);
+        ASSUME_STAT_CHANGE(MOVE_AMNESIA, spDef: +2);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_IRON_DEFENSE); MOVE(opponent, MOVE_AMNESIA); }
+        TURN { MOVE(player, MOVE_GUARD_SWAP); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_IRON_DEFENSE, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_AMNESIA, opponent);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_GUARD_SWAP, player);
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_DEF], DEFAULT_STAT_STAGE);
+        EXPECT_EQ(player->statStages[STAT_SPDEF], DEFAULT_STAT_STAGE + 2);
+        EXPECT_EQ(opponent->statStages[STAT_DEF], DEFAULT_STAT_STAGE + 2);
+        EXPECT_EQ(opponent->statStages[STAT_SPDEF], DEFAULT_STAT_STAGE);
+    }
+}
+
+SINGLE_BATTLE_TEST("Clear Amulet does not prevent Guard Swap from transferring lowered stat stages")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_GUARD_SWAP) == EFFECT_GUARD_SWAP);
+        ASSUME_MOVE_EFFECT_STAT_CHANGE(MOVE_CLOSE_COMBAT, self: TRUE, defense: -1, spDef: -1);
+        ASSUME(GetItemHoldEffect(ITEM_CLEAR_AMULET) == HOLD_EFFECT_CLEAR_AMULET);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_CLEAR_AMULET); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_CLOSE_COMBAT); }
+        TURN { MOVE(player, MOVE_GUARD_SWAP); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_CLOSE_COMBAT, player);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_GUARD_SWAP, player);
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_DEF], DEFAULT_STAT_STAGE);
+        EXPECT_EQ(player->statStages[STAT_SPDEF], DEFAULT_STAT_STAGE);
+        EXPECT_EQ(opponent->statStages[STAT_DEF], DEFAULT_STAT_STAGE - 1);
+        EXPECT_EQ(opponent->statStages[STAT_SPDEF], DEFAULT_STAT_STAGE - 1);
+    }
+}

--- a/test/battle/move_effect/haze.c
+++ b/test/battle/move_effect/haze.c
@@ -31,5 +31,51 @@ SINGLE_BATTLE_TEST("Haze resets stat changes", s16 damage)
     }
 }
 
-TO_DO_BATTLE_TEST("Haze resets Focus Energy (Gen 1 and 4)")
-TO_DO_BATTLE_TEST("Haze doesn't reset Focus Energy (Gen 2-3 and 5+)")
+SINGLE_BATTLE_TEST("Haze resets Focus Energy (Gen 1 and 4)")
+{
+    u32 genConfig;
+    PARAMETRIZE { genConfig = GEN_1; }
+    PARAMETRIZE { genConfig = GEN_4; }
+    GIVEN {
+        WITH_CONFIG(B_HAZE_FOCUS_ENERGY, genConfig);
+        WITH_CONFIG(B_CRIT_CHANCE, genConfig);
+        WITH_CONFIG(B_FOCUS_ENERGY_CRIT_RATIO, genConfig);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_FOCUS_ENERGY); }
+        TURN { MOVE(opponent, MOVE_HAZE); }
+        TURN { MOVE(player, MOVE_FOCUS_ENERGY); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FOCUS_ENERGY, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_HAZE, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FOCUS_ENERGY, player);
+    }
+}
+
+SINGLE_BATTLE_TEST("Haze does not reset Focus Energy (Gen 2-3 and 5+)")
+{
+    u32 genConfig;
+    PARAMETRIZE { genConfig = GEN_2; }
+    PARAMETRIZE { genConfig = GEN_3; }
+    PARAMETRIZE { genConfig = GEN_5; }
+    PARAMETRIZE { genConfig = GEN_6; }
+    PARAMETRIZE { genConfig = GEN_7; }
+    PARAMETRIZE { genConfig = GEN_8; }
+    PARAMETRIZE { genConfig = GEN_9; }
+    GIVEN {
+        WITH_CONFIG(B_HAZE_FOCUS_ENERGY, genConfig);
+        WITH_CONFIG(B_CRIT_CHANCE, genConfig);
+        WITH_CONFIG(B_FOCUS_ENERGY_CRIT_RATIO, genConfig);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_FOCUS_ENERGY); }
+        TURN { MOVE(opponent, MOVE_HAZE); }
+        TURN { MOVE(player, MOVE_FOCUS_ENERGY); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_FOCUS_ENERGY, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_HAZE, opponent);
+        MESSAGE("But it failed!");
+    }
+}

--- a/test/battle/move_effect/hidden_power.c
+++ b/test/battle/move_effect/hidden_power.c
@@ -135,7 +135,36 @@ SINGLE_BATTLE_TEST("Hidden Power's type is determined by IVs")
     }
 }
 
-TO_DO_BATTLE_TEST("Hidden Power's power is determined by IVs before Gen6");
+SINGLE_BATTLE_TEST("Hidden Power's power is determined by IVs before Gen6", s16 damage)
+{
+    u32 powerBits;
+
+    PARAMETRIZE { powerBits = 0; }
+    PARAMETRIZE { powerBits = 32; }
+    PARAMETRIZE { powerBits = 63; }
+
+    GIVEN {
+        WITH_CONFIG(B_HIDDEN_POWER_DMG, GEN_5);
+        PLAYER(SPECIES_WOBBUFFET) {
+            Attack(100); Defense(100); SpAttack(100); SpDefense(100);
+            HPIV(powerBits & 1 ? 2 : 0);
+            AttackIV(powerBits & 2 ? 2 : 0);
+            DefenseIV(powerBits & 4 ? 2 : 0);
+            SpeedIV(powerBits & 8 ? 2 : 0);
+            SpAttackIV(powerBits & 16 ? 2 : 0);
+            SpDefenseIV(powerBits & 32 ? 2 : 0);
+        }
+        OPPONENT(SPECIES_WOBBUFFET) { Defense(100); SpDefense(100); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_HIDDEN_POWER); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_HIDDEN_POWER, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_LT(results[0].damage, results[1].damage);
+        EXPECT_LT(results[1].damage, results[2].damage);
+    }
+}
 
 SINGLE_BATTLE_TEST("Hidden Power always triggers Counter instead of Mirror Coat (Gen 1-3)")
 {

--- a/test/battle/move_effect/ingrain.c
+++ b/test/battle/move_effect/ingrain.c
@@ -127,4 +127,41 @@ SINGLE_BATTLE_TEST("Ingrain's effect is passed by Baton Pass")
     }
 }
 
-TO_DO_BATTLE_TEST("Red Card and forced switch moves (Roar/Whirlwind) cannot force out a rooted Pokémon");
+SINGLE_BATTLE_TEST("Ingrain prevents Red Card and forced switch moves from switching out the user")
+{
+    enum Move move;
+    bool32 redCard;
+
+    PARAMETRIZE { move = MOVE_SCRATCH; redCard = TRUE; }
+    PARAMETRIZE { move = MOVE_ROAR; redCard = FALSE; }
+    PARAMETRIZE { move = MOVE_WHIRLWIND; redCard = FALSE; }
+    PARAMETRIZE { move = MOVE_DRAGON_TAIL; redCard = FALSE; }
+    PARAMETRIZE { move = MOVE_CIRCLE_THROW; redCard = FALSE; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_ROAR) == EFFECT_ROAR);
+        ASSUME(GetMoveEffect(MOVE_WHIRLWIND) == EFFECT_ROAR);
+        ASSUME(GetMoveEffect(MOVE_DRAGON_TAIL) == EFFECT_HIT_SWITCH_TARGET);
+        ASSUME(GetMoveEffect(MOVE_CIRCLE_THROW) == EFFECT_HIT_SWITCH_TARGET);
+        ASSUME(gItemsInfo[ITEM_RED_CARD].holdEffect == HOLD_EFFECT_RED_CARD);
+        PLAYER(SPECIES_WOBBUFFET);
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET) { Item(redCard ? ITEM_RED_CARD : ITEM_NONE); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_INGRAIN); }
+        if (redCard)
+            TURN { MOVE(player, move); }
+        else
+            TURN { MOVE(opponent, move); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_INGRAIN, player);
+        if (redCard) {
+            ANIMATION(ANIM_TYPE_MOVE, move, player);
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
+        }
+    } THEN {
+        EXPECT_EQ(player->species, SPECIES_WOBBUFFET);
+        if (redCard)
+            EXPECT_EQ(opponent->item, ITEM_NONE);
+    }
+}

--- a/test/battle/move_effect/instruct.c
+++ b/test/battle/move_effect/instruct.c
@@ -52,7 +52,21 @@ DOUBLE_BATTLE_TEST("Instruct fails if move is banned by Instruct")
     }
 }
 
-TO_DO_BATTLE_TEST("Instruct fails if target is in the middle of Bide");
+SINGLE_BATTLE_TEST("Instruct fails if target is in the middle of Bide")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_BIDE) == EFFECT_BIDE);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); }
+        OPPONENT(SPECIES_WYNAUT) { Speed(1); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_BIDE); }
+        TURN { MOVE(player, MOVE_INSTRUCT); SKIP_TURN(opponent); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BIDE, opponent);
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_INSTRUCT, player);
+        MESSAGE("But it failed!");
+    }
+}
 
 DOUBLE_BATTLE_TEST("Instruct fails if target is preparing Focus Punch, Beak Blast or Shell Trap")
 {

--- a/test/battle/move_effect/level_damage.c
+++ b/test/battle/move_effect/level_damage.c
@@ -4,6 +4,7 @@
 ASSUMPTIONS
 {
     ASSUME(GetMoveEffect(MOVE_SEISMIC_TOSS) == EFFECT_LEVEL_DAMAGE);
+    ASSUME(GetMoveEffect(MOVE_NIGHT_SHADE) == EFFECT_LEVEL_DAMAGE);
 }
 
 SINGLE_BATTLE_TEST("Level Damage: Seismic Toss deals damage based on user's level")
@@ -19,5 +20,41 @@ SINGLE_BATTLE_TEST("Level Damage: Seismic Toss deals damage based on user's leve
         HP_BAR(opponent, captureDamage: &dmg);
     } THEN {
         EXPECT(dmg == 50);
+    }
+}
+
+SINGLE_BATTLE_TEST("Level Damage: Night Shade is unaffected by type immunities (Gen 1)")
+{
+    s16 damage;
+
+    GIVEN {
+        WITH_CONFIG(B_FIXED_DMG_IGNORES_TYPE, GEN_1);
+        PLAYER(SPECIES_WOBBUFFET) { Level(50); }
+        OPPONENT(SPECIES_RATTATA);
+    } WHEN {
+        TURN { MOVE(player, MOVE_NIGHT_SHADE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_NIGHT_SHADE, player);
+        HP_BAR(opponent, captureDamage: &damage);
+    } THEN {
+        EXPECT_EQ(damage, 50);
+    }
+}
+
+SINGLE_BATTLE_TEST("Level Damage: Seismic Toss is unaffected by type immunities (Gen 1)")
+{
+    s16 damage;
+
+    GIVEN {
+        WITH_CONFIG(B_FIXED_DMG_IGNORES_TYPE, GEN_1);
+        PLAYER(SPECIES_WOBBUFFET) { Level(50); }
+        OPPONENT(SPECIES_GASTLY);
+    } WHEN {
+        TURN { MOVE(player, MOVE_SEISMIC_TOSS); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SEISMIC_TOSS, player);
+        HP_BAR(opponent, captureDamage: &damage);
+    } THEN {
+        EXPECT_EQ(damage, 50);
     }
 }

--- a/test/battle/move_effect/ohko.c
+++ b/test/battle/move_effect/ohko.c
@@ -4,6 +4,56 @@
 ASSUMPTIONS
 {
     ASSUME(GetMoveEffect(MOVE_FISSURE) == EFFECT_OHKO);
+    ASSUME(GetMoveEffect(MOVE_GUILLOTINE) == EFFECT_OHKO);
+    ASSUME(GetMoveEffect(MOVE_HORN_DRILL) == EFFECT_OHKO);
+    ASSUME(GetMoveType(MOVE_FISSURE) == TYPE_GROUND);
+    ASSUME(GetMoveType(MOVE_GUILLOTINE) == TYPE_NORMAL);
+    ASSUME(GetMoveType(MOVE_HORN_DRILL) == TYPE_NORMAL);
+}
+
+SINGLE_BATTLE_TEST("Fissure does not bypass type immunities (Gen 1)")
+{
+    GIVEN {
+        WITH_CONFIG(B_FIXED_DMG_IGNORES_TYPE, GEN_1);
+        ASSUME(IsSpeciesOfType(SPECIES_PIDGEY, TYPE_FLYING));
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_PIDGEY);
+    } WHEN {
+        TURN { MOVE(player, MOVE_FISSURE); }
+    } SCENE {
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_FISSURE, player);
+        MESSAGE("It doesn't affect the opposing Pidgey…");
+    }
+}
+
+SINGLE_BATTLE_TEST("Guillotine does not bypass type immunities (Gen 1)")
+{
+    GIVEN {
+        WITH_CONFIG(B_FIXED_DMG_IGNORES_TYPE, GEN_1);
+        ASSUME(IsSpeciesOfType(SPECIES_GASTLY, TYPE_GHOST));
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_GASTLY);
+    } WHEN {
+        TURN { MOVE(player, MOVE_GUILLOTINE); }
+    } SCENE {
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_GUILLOTINE, player);
+        MESSAGE("It doesn't affect the opposing Gastly…");
+    }
+}
+
+SINGLE_BATTLE_TEST("Horn Drill does not bypass type immunities (Gen 1)")
+{
+    GIVEN {
+        WITH_CONFIG(B_FIXED_DMG_IGNORES_TYPE, GEN_1);
+        ASSUME(IsSpeciesOfType(SPECIES_GASTLY, TYPE_GHOST));
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_GASTLY);
+    } WHEN {
+        TURN { MOVE(player, MOVE_HORN_DRILL); }
+    } SCENE {
+        NOT ANIMATION(ANIM_TYPE_MOVE, MOVE_HORN_DRILL, player);
+        MESSAGE("It doesn't affect the opposing Gastly…");
+    }
 }
 
 SINGLE_BATTLE_TEST("OHKO moves can hit semi-invulnerable mons when the user has No-Guard")

--- a/test/battle/move_effect/psywave.c
+++ b/test/battle/move_effect/psywave.c
@@ -1,4 +1,28 @@
 #include "global.h"
 #include "test/battle.h"
 
+ASSUMPTIONS
+{
+    ASSUME(GetMoveEffect(MOVE_PSYWAVE) == EFFECT_PSYWAVE);
+}
+
 TO_DO_BATTLE_TEST("TODO: Write Psywave (Move Effect) test titles")
+
+SINGLE_BATTLE_TEST("Psywave is unaffected by type immunities (Gen 1)")
+{
+    s16 damage;
+
+    GIVEN {
+        WITH_CONFIG(B_FIXED_DMG_IGNORES_TYPE, GEN_1);
+        ASSUME(IsSpeciesOfType(SPECIES_UMBREON, TYPE_DARK));
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_UMBREON);
+    } WHEN {
+        TURN { MOVE(player, MOVE_PSYWAVE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_PSYWAVE, player);
+        HP_BAR(opponent, captureDamage: &damage);
+    } THEN {
+        EXPECT_GT(damage, 0);
+    }
+}

--- a/test/battle/move_effect/pursuit.c
+++ b/test/battle/move_effect/pursuit.c
@@ -725,4 +725,33 @@ SINGLE_BATTLE_TEST("Pursuit doesn't trigger a switching mon's Emergency Exit")
     }
 }
 
-TO_DO_BATTLE_TEST("Baton Pass doesn't cause Pursuit to increase its power or priority");
+SINGLE_BATTLE_TEST("Baton Pass doesn't cause Pursuit to increase its power or priority", s16 damage)
+{
+    bool32 batonPass;
+
+    PARAMETRIZE { batonPass = FALSE; }
+    PARAMETRIZE { batonPass = TRUE; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_BATON_PASS) == EFFECT_BATON_PASS);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); Defense(100); }
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); Defense(100); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(1); Attack(100); }
+    } WHEN {
+        if (batonPass)
+            TURN { MOVE(player, MOVE_BATON_PASS); MOVE(opponent, MOVE_PURSUIT); SEND_OUT(player, 1); }
+        else
+            TURN { MOVE(player, MOVE_CELEBRATE); MOVE(opponent, MOVE_PURSUIT); }
+    } SCENE {
+        if (batonPass) {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_BATON_PASS, player);
+            SEND_IN_MESSAGE("Wobbuffet");
+        } else {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_CELEBRATE, player);
+        }
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_PURSUIT, opponent);
+        HP_BAR(player, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_EQ(results[0].damage, results[1].damage);
+    }
+}

--- a/test/battle/move_effect/rapid_spin.c
+++ b/test/battle/move_effect/rapid_spin.c
@@ -93,7 +93,57 @@ SINGLE_BATTLE_TEST("Rapid Spin blows away all hazards")
     }
 }
 
-TO_DO_BATTLE_TEST("Rapid Spin blows away Wrap, hazards, but doesn't raise Speed when Sheer Force boosted (Gen 8)");
+SINGLE_BATTLE_TEST("Rapid Spin blows away Wrap and hazards but doesn't raise Speed when Sheer Force boosted (Gen 8)")
+{
+    GIVEN {
+        WITH_CONFIG(B_SPEED_BUFFING_RAPID_SPIN, GEN_8);
+        ASSUME(GetMoveEffect(MOVE_RAPID_SPIN) == EFFECT_RAPID_SPIN);
+        ASSUME_MOVE_EFFECT_STAT_CHANGE(MOVE_RAPID_SPIN, self: TRUE, speed: 1);
+        PLAYER(SPECIES_TAUROS) { Ability(ABILITY_SHEER_FORCE); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_WRAP); }
+        TURN { MOVE(opponent, MOVE_STEALTH_ROCK); MOVE(player, MOVE_RAPID_SPIN); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_STEALTH_ROCK, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_RAPID_SPIN, player);
+        NOT ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
+        MESSAGE("Tauros was freed from Wrap!");
+        MESSAGE("The pointed stones disappeared from your side!");
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_SPEED], DEFAULT_STAT_STAGE);
+        for (u32 i = 0; i < ARRAY_COUNT(gBattleStruct->hazardsQueue[B_SIDE_PLAYER]); i++)
+        {
+            EXPECT_EQ(gBattleStruct->hazardsQueue[B_SIDE_PLAYER][i], HAZARDS_NONE);
+        }
+    }
+}
+
+SINGLE_BATTLE_TEST("Sheer Force boosted Rapid Spin doesn't trigger Eject Button or Emergency Exit (Gen 8)")
+{
+    GIVEN {
+        WITH_CONFIG(B_SPEED_BUFFING_RAPID_SPIN, GEN_8);
+        ASSUME(GetMoveEffect(MOVE_RAPID_SPIN) == EFFECT_RAPID_SPIN);
+        ASSUME_MOVE_EFFECT_STAT_CHANGE(MOVE_RAPID_SPIN, self: TRUE, speed: 1);
+        ASSUME(GetItemHoldEffect(ITEM_EJECT_BUTTON) == HOLD_EFFECT_EJECT_BUTTON);
+        PLAYER(SPECIES_TAUROS) { Ability(ABILITY_SHEER_FORCE); Attack(1); }
+        OPPONENT(SPECIES_GOLISOPOD) { Ability(ABILITY_EMERGENCY_EXIT); Item(ITEM_EJECT_BUTTON); MaxHP(200); HP(101); Defense(999); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_RAPID_SPIN); MOVE(opponent, MOVE_SCRATCH); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_RAPID_SPIN, player);
+        HP_BAR(opponent);
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_EFFECT, opponent);
+            ABILITY_POPUP(opponent, ABILITY_EMERGENCY_EXIT);
+        }
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
+    } THEN {
+        EXPECT_EQ(opponent->species, SPECIES_GOLISOPOD);
+        EXPECT_EQ(opponent->item, ITEM_EJECT_BUTTON);
+    }
+}
 
 SINGLE_BATTLE_TEST("Rapid Spin doesn't blow away Wrap, hazards or raise Speed when Sheer Force boosted (Gen 9+)")
 {
@@ -180,7 +230,7 @@ SINGLE_BATTLE_TEST("Rapid Spin and Mortal Spin don't remove hazards if the user 
         ANIMATION(ANIM_TYPE_MOVE, move, player);
         ABILITY_POPUP(opponent, ABILITY_ROUGH_SKIN);
         NONE_OF {
-            MESSAGE("The pointed stones disappeared from around your team!");
+            MESSAGE("The pointed stones disappeared from your side!");
         }
     }
 }

--- a/test/battle/move_effect/reflect_damage.c
+++ b/test/battle/move_effect/reflect_damage.c
@@ -267,7 +267,32 @@ SINGLE_BATTLE_TEST("Reflect Damage: Counter works when surviving OHKO move with 
 
 // Gen 1
 TO_DO_BATTLE_TEST("Reflect Damage: Counter can only counter Normal and Fighting-type moves (Gen 1)");
-TO_DO_BATTLE_TEST("Reflect Damage: Counter can hit ghost-type Pokémon (Gen 1)");
+SINGLE_BATTLE_TEST("Reflect Damage moves can hit Pokémon immune to their type (Gen 1)")
+{
+    enum Move attackMove;
+    enum Move reflectMove;
+    enum Species targetSpecies;
+    s16 damage;
+    s16 reflectedDamage;
+
+    PARAMETRIZE { attackMove = MOVE_POUND; reflectMove = MOVE_COUNTER; targetSpecies = SPECIES_GASTLY; }
+    PARAMETRIZE { attackMove = MOVE_ROUND; reflectMove = MOVE_MIRROR_COAT; targetSpecies = SPECIES_UMBREON; }
+
+    GIVEN {
+        WITH_CONFIG(B_FIXED_DMG_IGNORES_TYPE, GEN_1);
+        PLAYER(SPECIES_WOBBUFFET) { MaxHP(1000); HP(1000); }
+        OPPONENT(targetSpecies) { MaxHP(1000); HP(1000); }
+    } WHEN {
+        TURN { MOVE(opponent, attackMove); MOVE(player, reflectMove); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, attackMove, opponent);
+        HP_BAR(player, captureDamage: &damage);
+        ANIMATION(ANIM_TYPE_MOVE, reflectMove, player);
+        HP_BAR(opponent, captureDamage: &reflectedDamage);
+    } THEN {
+        EXPECT_MUL_EQ(damage, Q_4_12(2.0), reflectedDamage);
+    }
+}
 TO_DO_BATTLE_TEST("Reflect Damage: Counter can return damage dealt to a substitute (Gen 1)");
 
 // Gen 2-3

--- a/test/battle/move_effect/return.c
+++ b/test/battle/move_effect/return.c
@@ -27,7 +27,23 @@ SINGLE_BATTLE_TEST("Return's power increases the higher friendship of the user i
     }
 }
 
-TO_DO_BATTLE_TEST("Return does 0 damage at min Friendship (Gen2)")
+SINGLE_BATTLE_TEST("Return does 0 damage at min Friendship (Gen2)")
+{
+    s16 damage;
+
+    GIVEN {
+        WITH_CONFIG(B_RETURN_FRUSTRATION_DMG, GEN_2);
+        PLAYER(SPECIES_WOBBUFFET) { Friendship(0); }
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_RETURN); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_RETURN, player);
+        HP_BAR(opponent, captureDamage: &damage);
+    } THEN {
+        EXPECT_EQ(damage, 0);
+    }
+}
 
 SINGLE_BATTLE_TEST("Return does 1 damage at min Friendship (Gen3+)")
 {

--- a/test/battle/move_effect/roost.c
+++ b/test/battle/move_effect/roost.c
@@ -439,8 +439,3 @@ SINGLE_BATTLE_TEST("Roost does not suppress the ungrounded effect of Telekinesis
         }
     }
 }
-
-// Tested in ORAS
-// Transform does not copy the Roost "status" either.
-// Probably better as a Transform test.
-TO_DO_BATTLE_TEST("Roost's suppression does not prevent others who are Transforming into the user from copying its Flying-type");

--- a/test/battle/move_effect/soak.c
+++ b/test/battle/move_effect/soak.c
@@ -7,7 +7,32 @@ ASSUMPTIONS
     ASSUME(GetMoveEffect(MOVE_MAGIC_POWDER) == EFFECT_SOAK);
 }
 
-TO_DO_BATTLE_TEST("Soak/Magic Powder changes the target's type to pure Water/Psychic");
+SINGLE_BATTLE_TEST("Soak/Magic Powder changes the target's type to pure Water/Psychic")
+{
+    enum Move move;
+    enum Type type;
+
+    PARAMETRIZE { move = MOVE_SOAK; type = TYPE_WATER; }
+    PARAMETRIZE { move = MOVE_MAGIC_POWDER; type = TYPE_PSYCHIC; }
+    GIVEN {
+        ASSUME(GetSpeciesType(SPECIES_GOLEM, 0) == TYPE_ROCK);
+        ASSUME(GetSpeciesType(SPECIES_GOLEM, 1) == TYPE_GROUND);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_GOLEM);
+    } WHEN {
+        TURN { MOVE(player, move); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        switch (move) {
+            case MOVE_SOAK:         MESSAGE("The opposing Golem transformed into the Water type!"); break;
+            case MOVE_MAGIC_POWDER: MESSAGE("The opposing Golem transformed into the Psychic type!"); break;
+            default: break;
+        }
+    } THEN {
+        EXPECT_EQ(opponent->types[0], type);
+        EXPECT_EQ(opponent->types[1], type);
+    }
+}
 
 SINGLE_BATTLE_TEST("Soak/Magic Powder's type change is overwitten if the target changes form")
 {
@@ -39,8 +64,111 @@ SINGLE_BATTLE_TEST("Soak/Magic Powder's type change is overwitten if the target 
     }
 }
 
-TO_DO_BATTLE_TEST("Soak/Magic Powder's type change overritten if the target transforms");
-TO_DO_BATTLE_TEST("(TERA) Soak/Magic Powder's type change overritten if the target Terastalizes");
-TO_DO_BATTLE_TEST("Soak/Magic Powder fails if the target is behind a Substitute");
-TO_DO_BATTLE_TEST("Soak/Magic Powder fails if the target is already Water/Psychic");
-TO_DO_BATTLE_TEST("Soak/Magic Powder fails if the target has Multitype or RKS System");
+SINGLE_BATTLE_TEST("Soak/Magic Powder's type change is overwritten if the target transforms")
+{
+    enum Move move;
+
+    PARAMETRIZE { move = MOVE_SOAK; }
+    PARAMETRIZE { move = MOVE_MAGIC_POWDER; }
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_TRANSFORM) == EFFECT_TRANSFORM);
+        ASSUME(GetSpeciesType(SPECIES_GOLEM, 0) == TYPE_ROCK);
+        ASSUME(GetSpeciesType(SPECIES_GOLEM, 1) == TYPE_GROUND);
+        PLAYER(SPECIES_GOLEM) { Speed(20); }
+        OPPONENT(SPECIES_DITTO) { Speed(10); }
+    } WHEN {
+        TURN { MOVE(player, move); MOVE(opponent, MOVE_TRANSFORM); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TRANSFORM, opponent);
+    } THEN {
+        EXPECT_EQ(opponent->types[0], TYPE_ROCK);
+        EXPECT_EQ(opponent->types[1], TYPE_GROUND);
+    }
+}
+
+SINGLE_BATTLE_TEST("(TERA) Soak/Magic Powder's type change is overwritten if the target Terastalizes")
+{
+    enum Move move;
+
+    PARAMETRIZE { move = MOVE_SOAK; }
+    PARAMETRIZE { move = MOVE_MAGIC_POWDER; }
+    GIVEN {
+        ASSUME(GetMoveType(MOVE_VINE_WHIP) == TYPE_GRASS);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_GOLEM) { TeraType(TYPE_FIRE); }
+    } WHEN {
+        TURN { MOVE(player, move); }
+        TURN { MOVE(opponent, MOVE_CELEBRATE, gimmick: GIMMICK_TERA); }
+        TURN { MOVE(player, MOVE_VINE_WHIP); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_VINE_WHIP, player);
+        MESSAGE("It's not very effective…");
+    }
+}
+
+SINGLE_BATTLE_TEST("Soak/Magic Powder fails if the target is behind a Substitute")
+{
+    enum Move move;
+
+    PARAMETRIZE { move = MOVE_SOAK; }
+    PARAMETRIZE { move = MOVE_MAGIC_POWDER; }
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_SUBSTITUTE) == EFFECT_SUBSTITUTE);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(10); }
+        OPPONENT(SPECIES_GOLEM) { Speed(20); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_SUBSTITUTE); MOVE(player, move); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SUBSTITUTE, opponent);
+        NOT ANIMATION(ANIM_TYPE_MOVE, move, player);
+        MESSAGE("But it failed!");
+    } THEN {
+        EXPECT_EQ(opponent->types[0], TYPE_ROCK);
+        EXPECT_EQ(opponent->types[1], TYPE_GROUND);
+    }
+}
+
+SINGLE_BATTLE_TEST("Soak/Magic Powder fails if the target is already Water/Psychic")
+{
+    enum Move move;
+    enum Species species;
+
+    PARAMETRIZE { move = MOVE_SOAK; species = SPECIES_MAGIKARP; }
+    PARAMETRIZE { move = MOVE_MAGIC_POWDER; species = SPECIES_WOBBUFFET; }
+    GIVEN {
+        ASSUME(GetSpeciesType(SPECIES_MAGIKARP, 0) == TYPE_WATER);
+        ASSUME(GetSpeciesType(SPECIES_MAGIKARP, 1) == TYPE_WATER);
+        ASSUME(GetSpeciesType(SPECIES_WOBBUFFET, 0) == TYPE_PSYCHIC);
+        ASSUME(GetSpeciesType(SPECIES_WOBBUFFET, 1) == TYPE_PSYCHIC);
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(species);
+    } WHEN {
+        TURN { MOVE(player, move); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, move, player);
+        MESSAGE("But it failed!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Soak/Magic Powder fails if the target has Multitype or RKS System")
+{
+    enum Move move;
+    enum Species species;
+    enum Ability ability;
+
+    PARAMETRIZE { move = MOVE_SOAK; species = SPECIES_ARCEUS; ability = ABILITY_MULTITYPE; }
+    PARAMETRIZE { move = MOVE_SOAK; species = SPECIES_SILVALLY; ability = ABILITY_RKS_SYSTEM; }
+    PARAMETRIZE { move = MOVE_MAGIC_POWDER; species = SPECIES_ARCEUS; ability = ABILITY_MULTITYPE; }
+    PARAMETRIZE { move = MOVE_MAGIC_POWDER; species = SPECIES_SILVALLY; ability = ABILITY_RKS_SYSTEM; }
+    GIVEN {
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(species) { Ability(ability); }
+    } WHEN {
+        TURN { MOVE(player, move); }
+    } SCENE {
+        NOT ANIMATION(ANIM_TYPE_MOVE, move, player);
+        MESSAGE("But it failed!");
+    }
+}

--- a/test/battle/move_effect/strength_sap.c
+++ b/test/battle/move_effect/strength_sap.c
@@ -141,23 +141,24 @@ SINGLE_BATTLE_TEST("Strength Sap fails if target is at -6 Atk")
     }
 }
 
-SINGLE_BATTLE_TEST("Strength Sap will restore hp if target has Contrary and is at +6 Atk")
+SINGLE_BATTLE_TEST("Strength Sap will restore HP if target has Contrary and is at +6 Attack")
 {
     GIVEN {
         ASSUME_STAT_CHANGE(MOVE_CHARM, attack: -2);
-        PLAYER(SPECIES_SNIVY) { Ability(ABILITY_CONTRARY); }
-        OPPONENT(SPECIES_WOBBUFFET) { HP(1); };
+        PLAYER(SPECIES_WOBBUFFET) { MaxHP(300); HP(1); }
+        OPPONENT(SPECIES_SNIVY) { Ability(ABILITY_CONTRARY); Attack(50); }
     } WHEN {
-        TURN { MOVE(opponent, MOVE_CHARM); }
-        TURN { MOVE(opponent, MOVE_CHARM); }
-        TURN { MOVE(opponent, MOVE_CHARM); }
-        TURN { MOVE(opponent, MOVE_STRENGTH_SAP); }
+        TURN { MOVE(player, MOVE_CHARM); }
+        TURN { MOVE(player, MOVE_CHARM); }
+        TURN { MOVE(player, MOVE_CHARM); }
+        TURN { MOVE(player, MOVE_STRENGTH_SAP); }
     } SCENE {
-        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_STATS_CHANGE, player);
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_STRENGTH_SAP, opponent);
-        HP_BAR(opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_STRENGTH_SAP, player);
+        HP_BAR(player, hp: 201);
+        MESSAGE("The opposing Snivy had its energy drained!");
+    } THEN {
+        EXPECT_EQ(opponent->statStages[STAT_ATK], MAX_STAT_STAGE);
+        EXPECT_EQ(player->hp, 201);
     }
 }
 

--- a/test/battle/move_effect/struggle.c
+++ b/test/battle/move_effect/struggle.c
@@ -1,7 +1,63 @@
 #include "global.h"
 #include "test/battle.h"
 
-TO_DO_BATTLE_TEST("Struggle deals recoil 1/4 of damage dealt (Gen 2-3)")
+#if B_UPDATED_MOVE_FLAGS >= GEN_2
+SINGLE_BATTLE_TEST("Struggle does not receive STAB from typeless users")
+{
+    s16 typedDamage;
+    s16 typelessDamage;
+
+    GIVEN {
+        ASSUME(GetMoveType(MOVE_STRUGGLE) == TYPE_MYSTERY);
+        ASSUME(GetMoveEffect(MOVE_BURN_UP) == EFFECT_FAIL_IF_NOT_ARG_TYPE);
+        ASSUME(IsMoveEffectRemoveSpeciesType(MOVE_BURN_UP, MOVE_EFFECT_REMOVE_ARG_TYPE, TYPE_FIRE) == TRUE);
+        ASSUME(GetSpeciesType(SPECIES_ARCANINE, 0) == TYPE_FIRE);
+        ASSUME(GetSpeciesType(SPECIES_ARCANINE, 1) == TYPE_FIRE);
+        PLAYER(SPECIES_ARCANINE) { MaxHP(1000); HP(1000); }
+        OPPONENT(SPECIES_WOBBUFFET) { MaxHP(1000); HP(1000); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_STRUGGLE, WITH_RNG(RNG_DAMAGE_MODIFIER, 0)); }
+        TURN { MOVE(player, MOVE_BURN_UP); }
+        TURN { MOVE(player, MOVE_STRUGGLE, WITH_RNG(RNG_DAMAGE_MODIFIER, 0)); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_STRUGGLE, player);
+        HP_BAR(opponent, captureDamage: &typedDamage);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BURN_UP, player);
+        HP_BAR(opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_STRUGGLE, player);
+        HP_BAR(opponent, captureDamage: &typelessDamage);
+    } THEN {
+        EXPECT_EQ(player->types[0], TYPE_MYSTERY);
+        EXPECT_EQ(player->types[1], TYPE_MYSTERY);
+        EXPECT_EQ(player->types[2], TYPE_MYSTERY);
+        EXPECT_EQ(typedDamage, typelessDamage);
+    }
+}
+#endif
+
+SINGLE_BATTLE_TEST("Struggle deals recoil 1/4 of damage dealt (Gen 2-3)")
+{
+    s16 directDamage;
+    s16 recoilDamage;
+    u32 genConfig;
+
+    PARAMETRIZE { genConfig = GEN_2; }
+    PARAMETRIZE { genConfig = GEN_3; }
+
+    GIVEN {
+        WITH_CONFIG(B_STRUGGLE_RECOIL, genConfig);
+        PLAYER(SPECIES_WOBBUFFET) { MaxHP(1000); HP(1000); }
+        OPPONENT(SPECIES_WOBBUFFET) { MaxHP(1000); HP(1000); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_STRUGGLE); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_STRUGGLE, player);
+        HP_BAR(opponent, captureDamage: &directDamage);
+        HP_BAR(player, captureDamage: &recoilDamage);
+    } THEN {
+        EXPECT_MUL_EQ(directDamage, UQ_4_12(0.25), recoilDamage);
+    }
+}
 
 SINGLE_BATTLE_TEST("Struggle deals recoil 1/4 of user's hp (Gen 4+)")
 {
@@ -28,11 +84,9 @@ SINGLE_BATTLE_TEST("Struggle deals recoil 1/4 of user's hp (Gen 4+)")
     }
 }
 
-SINGLE_BATTLE_TEST("Struggle can hit ghost types")
+SINGLE_BATTLE_TEST("Struggle is Normal-type in Gen 1 and typeless in Gen 2+")
 {
     ASSUME(GetSpeciesType(SPECIES_DRIFBLIM, 0) == TYPE_GHOST);
-
-    s16 damage;
 
     GIVEN {
         PLAYER(SPECIES_WOBBUFFET);
@@ -40,20 +94,31 @@ SINGLE_BATTLE_TEST("Struggle can hit ghost types")
     } WHEN {
         TURN { MOVE(player, MOVE_STRUGGLE); }
     } SCENE {
-        ANIMATION(ANIM_TYPE_MOVE, MOVE_STRUGGLE, player);
-        HP_BAR(opponent, captureDamage: &damage);
+        if (GetConfig(B_UPDATED_MOVE_FLAGS) >= GEN_2) {
+            ANIMATION(ANIM_TYPE_MOVE, MOVE_STRUGGLE, player);
+            HP_BAR(opponent);
+        } else {
+            MESSAGE("It doesn't affect the opposing Drifblim…");
+        }
     } THEN {
-        EXPECT_NE(0, damage);
+        if (GetConfig(B_UPDATED_MOVE_FLAGS) >= GEN_2)
+            EXPECT_EQ(GetMoveType(MOVE_STRUGGLE), TYPE_MYSTERY);
+        else
+            EXPECT_EQ(GetMoveType(MOVE_STRUGGLE), TYPE_NORMAL);
     }
 }
 
-SINGLE_BATTLE_TEST("Struggle does not receive normal-type STAB")
+SINGLE_BATTLE_TEST("Struggle does not receive STAB from Normal-type users")
 {
     // Compare with Cut, which does receive normal-type STAB
-    ASSUME(GetSpeciesType(SPECIES_ZANGOOSE, 0) == GetMoveType(MOVE_STRUGGLE));
+    ASSUME(GetSpeciesType(SPECIES_ZANGOOSE, 0) == TYPE_NORMAL);
     ASSUME(GetMovePower(MOVE_CUT) == GetMovePower(MOVE_STRUGGLE));
     ASSUME(GetMoveCategory(MOVE_CUT) == GetMoveCategory(MOVE_STRUGGLE));
-    ASSUME(GetMoveType(MOVE_CUT) == GetMoveType(MOVE_STRUGGLE));
+    ASSUME(GetMoveType(MOVE_CUT) == TYPE_NORMAL);
+    if (GetConfig(B_UPDATED_MOVE_FLAGS) >= GEN_2)
+        ASSUME(GetMoveType(MOVE_STRUGGLE) == TYPE_MYSTERY);
+    else
+        ASSUME(GetMoveType(MOVE_STRUGGLE) == TYPE_NORMAL);
 
     s16 cutDamage;
     s16 struggleDamage;

--- a/test/battle/move_effect/substitute.c
+++ b/test/battle/move_effect/substitute.c
@@ -68,4 +68,27 @@ SINGLE_BATTLE_TEST("Substitute's HP cost doesn't trigger effects that trigger on
     }
 }
 
-TO_DO_BATTLE_TEST("Baton Pass passes Substitutes");
+SINGLE_BATTLE_TEST("Baton Pass passes Substitutes")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_BATON_PASS) == EFFECT_BATON_PASS);
+        PLAYER(SPECIES_WOBBUFFET) { MaxHP(400); HP(400); }
+        PLAYER(SPECIES_WYNAUT) { MaxHP(200); HP(200); Defense(999); }
+        OPPONENT(SPECIES_WOBBUFFET) { Attack(1); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_SUBSTITUTE); }
+        TURN { MOVE(player, MOVE_BATON_PASS); SEND_OUT(player, 1); }
+        TURN { MOVE(opponent, MOVE_SCRATCH); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SUBSTITUTE, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BATON_PASS, player);
+        SEND_IN_MESSAGE("Wynaut");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SCRATCH, opponent);
+        SUB_HIT(player);
+    } THEN {
+        EXPECT_EQ(player->species, SPECIES_WYNAUT);
+        EXPECT_EQ(player->hp, player->maxHP);
+        EXPECT(player->volatiles.substitute);
+        EXPECT_EQ((u32)player->volatiles.substituteHP, 99);
+    }
+}

--- a/test/battle/move_effect/telekinesis.c
+++ b/test/battle/move_effect/telekinesis.c
@@ -73,6 +73,44 @@ SINGLE_BATTLE_TEST("Telekinesis makes the target immune to Ground-type attacks")
     }
 }
 
-TO_DO_BATTLE_TEST("Baton Pass passes Telekinesis' effect");
-//Bulbapedia doesn't confirm what happens with Diglett, Dugtrio, Sandygast and Palossand, so it needs to be tested in-game.
-TO_DO_BATTLE_TEST("Baton Pass removes Telekinesis' effect disappears if the switching-in mon is Mega Gengar");
+SINGLE_BATTLE_TEST("Baton Pass passes Telekinesis's effect")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_BATON_PASS) == EFFECT_BATON_PASS);
+        ASSUME(!IsTelekinesisBannedSpecies(SPECIES_WYNAUT));
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_EEVEE);
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN { MOVE(player, MOVE_TELEKINESIS); }
+        TURN { MOVE(opponent, MOVE_BATON_PASS); SEND_OUT(opponent, 1); }
+    } THEN {
+        EXPECT(opponent->volatiles.telekinesis);
+        EXPECT_GT((u32)opponent->volatiles.telekinesisTimer, 0);
+    }
+}
+
+SINGLE_BATTLE_TEST("Baton Pass removes Telekinesis's effect if the recipient can't be affected by it")
+{
+    enum Species species;
+
+    PARAMETRIZE { species = SPECIES_DIGLETT; }
+    PARAMETRIZE { species = SPECIES_DUGTRIO; }
+    PARAMETRIZE { species = SPECIES_SANDYGAST; }
+    PARAMETRIZE { species = SPECIES_PALOSSAND; }
+    PARAMETRIZE { species = SPECIES_GENGAR_MEGA; }
+
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_BATON_PASS) == EFFECT_BATON_PASS);
+        ASSUME(IsTelekinesisBannedSpecies(species));
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_EEVEE);
+        OPPONENT(species);
+    } WHEN {
+        TURN { MOVE(player, MOVE_TELEKINESIS); }
+        TURN { MOVE(opponent, MOVE_BATON_PASS); SEND_OUT(opponent, 1); }
+    } THEN {
+        EXPECT(!opponent->volatiles.telekinesis);
+        EXPECT_EQ((u32)opponent->volatiles.telekinesisTimer, 0);
+    }
+}

--- a/test/battle/move_effect/transform.c
+++ b/test/battle/move_effect/transform.c
@@ -171,4 +171,136 @@ SINGLE_BATTLE_TEST("Transform returns the user to normal at the end of the battl
     }
 }
 
-TO_DO_BATTLE_TEST("TODO: Write Transform (Move Effect) test titles")
+DOUBLE_BATTLE_TEST("Transform copies a target's Flying type but not its active Roost state")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_ROOST) == EFFECT_ROOST);
+        ASSUME(GetMoveType(MOVE_MUD_SHOT) == TYPE_GROUND);
+        ASSUME(GetSpeciesType(SPECIES_SWELLOW, 0) == TYPE_NORMAL);
+        ASSUME(GetSpeciesType(SPECIES_SWELLOW, 1) == TYPE_FLYING);
+        PLAYER(SPECIES_SWELLOW) { Speed(4); HP(1); }
+        PLAYER(SPECIES_WOBBUFFET) { Speed(2); }
+        OPPONENT(SPECIES_DITTO) { Ability(ABILITY_LIMBER); Speed(3); HP(100); MaxHP(100); }
+        OPPONENT(SPECIES_WYNAUT) { Speed(1); }
+    } WHEN {
+        TURN {
+            MOVE(playerLeft, MOVE_ROOST);
+            MOVE(opponentLeft, MOVE_TRANSFORM, target: playerLeft);
+            MOVE(playerRight, MOVE_MUD_SHOT, target: opponentLeft);
+        }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ROOST, playerLeft);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_TRANSFORM, opponentLeft);
+        MESSAGE("The opposing Ditto transformed into Swellow!");
+        MESSAGE("It doesn't affect the opposing Ditto…");
+    } THEN {
+        EXPECT_EQ(opponentLeft->types[0], TYPE_NORMAL);
+        EXPECT_EQ(opponentLeft->types[1], TYPE_FLYING);
+        EXPECT_EQ(opponentLeft->hp, opponentLeft->maxHP);
+    }
+}
+
+SINGLE_BATTLE_TEST("Transform copies the target's species, stats, types, Ability, and moves but retains the user's HP")
+{
+    GIVEN {
+        ASSUME(GetSpeciesType(SPECIES_SWELLOW, 0) == TYPE_NORMAL);
+        ASSUME(GetSpeciesType(SPECIES_SWELLOW, 1) == TYPE_FLYING);
+        PLAYER(SPECIES_DITTO) {
+            MaxHP(100); HP(80);
+            Attack(10); Defense(20); SpAttack(30); SpDefense(40); Speed(50);
+            Ability(ABILITY_LIMBER);
+            Moves(MOVE_TRANSFORM);
+        }
+        OPPONENT(SPECIES_SWELLOW) {
+            MaxHP(300); HP(200);
+            Attack(110); Defense(120); SpAttack(130); SpDefense(140); Speed(150);
+            Ability(ABILITY_GUTS);
+            Moves(MOVE_SCRATCH, MOVE_WATER_GUN, MOVE_GROWL, MOVE_CELEBRATE);
+        }
+    } WHEN {
+        TURN { MOVE(player, MOVE_TRANSFORM); }
+    } THEN {
+        EXPECT_EQ(player->species, SPECIES_SWELLOW);
+        EXPECT_EQ(player->attack, 110);
+        EXPECT_EQ(player->defense, 120);
+        EXPECT_EQ(player->spAttack, 130);
+        EXPECT_EQ(player->spDefense, 140);
+        EXPECT_EQ(player->speed, 150);
+        EXPECT_EQ(player->types[0], TYPE_NORMAL);
+        EXPECT_EQ(player->types[1], TYPE_FLYING);
+        EXPECT_EQ(player->ability, ABILITY_GUTS);
+        EXPECT_EQ(player->moves[0], MOVE_SCRATCH);
+        EXPECT_EQ(player->moves[1], MOVE_WATER_GUN);
+        EXPECT_EQ(player->moves[2], MOVE_GROWL);
+        EXPECT_EQ(player->moves[3], MOVE_CELEBRATE);
+        EXPECT_EQ(player->maxHP, 100);
+        EXPECT_EQ(player->hp, 80);
+    }
+}
+
+SINGLE_BATTLE_TEST("Transform copies the target's stat stages")
+{
+    GIVEN {
+        PLAYER(SPECIES_DITTO) { Speed(1); Moves(MOVE_TRANSFORM); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(2); Moves(MOVE_SWORDS_DANCE); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_TRANSFORM); MOVE(opponent, MOVE_SWORDS_DANCE); }
+    } THEN {
+        EXPECT_EQ(player->statStages[STAT_ATK], DEFAULT_STAT_STAGE + 2);
+    }
+}
+
+SINGLE_BATTLE_TEST("Transform gives each copied move 5 PP regardless of the target's remaining PP")
+{
+    GIVEN {
+        ASSUME(GetMovePP(MOVE_SCRATCH) >= 5);
+        ASSUME(GetMovePP(MOVE_WATER_GUN) >= 5);
+        ASSUME(GetMovePP(MOVE_GROWL) >= 5);
+        ASSUME(GetMovePP(MOVE_CELEBRATE) >= 5);
+        PLAYER(SPECIES_DITTO) { Moves(MOVE_TRANSFORM); }
+        OPPONENT(SPECIES_WOBBUFFET) {
+            MovesWithPP({MOVE_SCRATCH, 1}, {MOVE_WATER_GUN, 2}, {MOVE_GROWL, 3}, {MOVE_CELEBRATE, 4});
+        }
+    } WHEN {
+        TURN { MOVE(player, MOVE_TRANSFORM); }
+    } THEN {
+        EXPECT_EQ(player->pp[0], 5);
+        EXPECT_EQ(player->pp[1], 5);
+        EXPECT_EQ(player->pp[2], 5);
+        EXPECT_EQ(player->pp[3], 5);
+    }
+}
+
+SINGLE_BATTLE_TEST("Transform fails against a target with an active Illusion")
+{
+    GIVEN {
+        PLAYER(SPECIES_DITTO) { Moves(MOVE_TRANSFORM); }
+        OPPONENT(SPECIES_ZOROARK) { Ability(ABILITY_ILLUSION); }
+        OPPONENT(SPECIES_WYNAUT);
+    } WHEN {
+        TURN { MOVE(player, MOVE_TRANSFORM); }
+    } SCENE {
+        MESSAGE("But it failed!");
+    } THEN {
+        EXPECT_EQ(player->species, SPECIES_DITTO);
+        EXPECT_EQ(gBattleStruct->illusion[B_POSITION_OPPONENT_LEFT].state, ILLUSION_ON);
+    }
+}
+
+SINGLE_BATTLE_TEST("Transform copies the target's shiny state in Gen4+")
+{
+    bool32 targetIsShiny;
+
+    PARAMETRIZE { targetIsShiny = FALSE; }
+    PARAMETRIZE { targetIsShiny = TRUE; }
+
+    GIVEN {
+        WITH_CONFIG(B_TRANSFORM_SHINY, GEN_4);
+        PLAYER(SPECIES_DITTO) { Moves(MOVE_TRANSFORM); Shiny(!targetIsShiny); }
+        OPPONENT(SPECIES_WOBBUFFET) { Shiny(targetIsShiny); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_TRANSFORM); }
+    } THEN {
+        EXPECT(player->volatiles.isTransformedMonShiny == targetIsShiny);
+    }
+}

--- a/test/battle/move_effect_secondary/reflect.c
+++ b/test/battle/move_effect_secondary/reflect.c
@@ -33,4 +33,19 @@ SINGLE_BATTLE_TEST("Baddy Bad sets up Reflect when it was succesful")
     }
 }
 
-TO_DO_BATTLE_TEST("Baddy Bad can still damage the target when Reflect is already set up");
+SINGLE_BATTLE_TEST("Baddy Bad can still damage the target when Reflect is already set up")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_REFLECT) == EFFECT_REFLECT);
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET);
+    } WHEN {
+        TURN { MOVE(player, MOVE_REFLECT); }
+        TURN { MOVE(player, MOVE_BADDY_BAD); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_REFLECT, player);
+        MESSAGE("Reflect made your side stronger against physical moves!");
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_BADDY_BAD, player);
+        HP_BAR(opponent);
+    }
+}

--- a/test/battle/move_effect_secondary/remove_status.c
+++ b/test/battle/move_effect_secondary/remove_status.c
@@ -117,7 +117,28 @@ SINGLE_BATTLE_TEST("Wake-Up Slap gets increased power against sleeping targets")
     }
 }
 
-TO_DO_BATTLE_TEST("Wake-Up Slap gets increased power against Pokémon with Comatose")
+SINGLE_BATTLE_TEST("Wake-Up Slap gets increased power against Pokémon with Comatose", s16 damage)
+{
+    enum Species species;
+    enum Ability ability;
+
+    PARAMETRIZE { species = SPECIES_LOPUNNY; ability = ABILITY_LIMBER; }
+    PARAMETRIZE { species = SPECIES_KOMALA;  ability = ABILITY_COMATOSE; }
+
+    GIVEN {
+        ASSUME(MoveHasAdditionalEffect(MOVE_WAKE_UP_SLAP, MOVE_EFFECT_REMOVE_STATUS) == TRUE);
+        ASSUME(GetMoveEffectArg_Status(MOVE_WAKE_UP_SLAP) == STATUS1_SLEEP);
+        PLAYER(SPECIES_CROBAT);
+        OPPONENT(species) { Ability(ability); HP(999); MaxHP(999); Defense(100); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_WAKE_UP_SLAP); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_WAKE_UP_SLAP, player);
+        HP_BAR(opponent, captureDamage: &results[i].damage);
+    } FINALLY {
+        EXPECT_MUL_EQ(results[0].damage, Q_4_12(2.0), results[1].damage);
+    }
+}
 
 DOUBLE_BATTLE_TEST("Sparkling Aria cures burns from all Pokemon on the field and behind substitutes")
 {

--- a/test/battle/move_effect_secondary/secret_power.c
+++ b/test/battle/move_effect_secondary/secret_power.c
@@ -1,9 +1,11 @@
 #include "global.h"
+#include "battle_environment.h"
 #include "test/battle.h"
 
 ASSUMPTIONS
 {
-    ASSUME(MoveHasAdditionalEffect(MOVE_SECRET_POWER, MOVE_EFFECT_SECRET_POWER) == TRUE);
+    ASSUME(GetMoveEffect(MOVE_SECRET_POWER) == EFFECT_SECRET_POWER);
+    ASSUME(GetMoveSecondaryEffectChance(MOVE_SECRET_POWER) == 30);
 }
 
 SINGLE_BATTLE_TEST("Secret Power inflicts paralysis in Electric Terrain")
@@ -74,4 +76,106 @@ SINGLE_BATTLE_TEST("Secret Power lowers Sp. Atk in Misty Terrain")
     }
 }
 
-TO_DO_BATTLE_TEST("Secret Power doesn't inflict secondary effects when user fainted");
+SINGLE_BATTLE_TEST("Serene Grace doubles Secret Power's secondary effect chance")
+{
+    PASSES_RANDOMLY(60, 100, RNG_SECONDARY_EFFECT);
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_ELECTRIC_TERRAIN) == EFFECT_TERRAIN);
+        ASSUME(GetMoveTerrainType(MOVE_ELECTRIC_TERRAIN) == B_TERRAIN_ELECTRIC);
+        PLAYER(SPECIES_TOGEPI) { Ability(ABILITY_SERENE_GRACE); Speed(4); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(8); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_ELECTRIC_TERRAIN); MOVE(player, MOVE_SECRET_POWER); }
+    } SCENE {
+        STATUS_ICON(opponent, paralysis: TRUE);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Rainbow doubles Secret Power's secondary effect chance")
+{
+    PASSES_RANDOMLY(60, 100, RNG_SECONDARY_EFFECT);
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_ELECTRIC_TERRAIN) == EFFECT_TERRAIN);
+        ASSUME(GetMoveTerrainType(MOVE_ELECTRIC_TERRAIN) == B_TERRAIN_ELECTRIC);
+        PLAYER(SPECIES_WOBBUFFET) { Speed(5); }
+        PLAYER(SPECIES_WYNAUT) { Speed(4); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(8); }
+        OPPONENT(SPECIES_WYNAUT) { Speed(3); }
+    } WHEN {
+        TURN { MOVE(opponentLeft, MOVE_ELECTRIC_TERRAIN);
+               MOVE(playerLeft, MOVE_WATER_PLEDGE, target: opponentLeft);
+               MOVE(playerRight, MOVE_FIRE_PLEDGE, target: opponentRight); }
+        TURN { MOVE(playerLeft, MOVE_SECRET_POWER, target: opponentRight); }
+    } SCENE {
+        STATUS_ICON(opponentRight, paralysis: TRUE);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Rainbow and Serene Grace stack for Secret Power's non-flinch effects")
+{
+    PASSES_RANDOMLY(100, 100, RNG_SECONDARY_EFFECT);
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_ELECTRIC_TERRAIN) == EFFECT_TERRAIN);
+        ASSUME(GetMoveTerrainType(MOVE_ELECTRIC_TERRAIN) == B_TERRAIN_ELECTRIC);
+        PLAYER(SPECIES_TOGEPI) { Ability(ABILITY_SERENE_GRACE); Speed(5); }
+        PLAYER(SPECIES_WOBBUFFET) { Speed(4); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(8); }
+        OPPONENT(SPECIES_WYNAUT) { Speed(3); }
+    } WHEN {
+        TURN { MOVE(opponentLeft, MOVE_ELECTRIC_TERRAIN);
+               MOVE(playerLeft, MOVE_WATER_PLEDGE, target: opponentLeft);
+               MOVE(playerRight, MOVE_FIRE_PLEDGE, target: opponentRight); }
+        TURN { MOVE(playerLeft, MOVE_SECRET_POWER, target: opponentRight); }
+    } SCENE {
+        STATUS_ICON(opponentRight, paralysis: TRUE);
+    }
+}
+
+DOUBLE_BATTLE_TEST("Rainbow and Serene Grace do not stack for Secret Power's flinch effect")
+{
+    PASSES_RANDOMLY(60, 100, RNG_SECONDARY_EFFECT);
+    GIVEN {
+        ASSUME(gBattleEnvironmentInfo[BATTLE_ENVIRONMENT_CAVE].secretPowerEffect == MOVE_EFFECT_FLINCH);
+        PLAYER(SPECIES_TOGEPI) { Ability(ABILITY_SERENE_GRACE); Speed(8); }
+        PLAYER(SPECIES_WOBBUFFET) { Speed(5); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(4); }
+        OPPONENT(SPECIES_WYNAUT) { Speed(3); }
+        Environment(BATTLE_ENVIRONMENT_CAVE);
+    } WHEN {
+        TURN { MOVE(playerLeft, MOVE_WATER_PLEDGE, target: opponentLeft);
+               MOVE(playerRight, MOVE_FIRE_PLEDGE, target: opponentRight); }
+        TURN { MOVE(playerLeft, MOVE_SECRET_POWER, target: opponentRight); MOVE(opponentRight, MOVE_CELEBRATE); }
+    } SCENE {
+        MESSAGE("The opposing Wynaut flinched and couldn't move!");
+    }
+}
+
+SINGLE_BATTLE_TEST("Secret Power does not inflict its secondary effect if the user faints")
+{
+    GIVEN {
+        ASSUME(GetMoveEffect(MOVE_ELECTRIC_TERRAIN) == EFFECT_TERRAIN);
+        ASSUME(GetMoveTerrainType(MOVE_ELECTRIC_TERRAIN) == B_TERRAIN_ELECTRIC);
+        ASSUME(GetMoveCategory(MOVE_SECRET_POWER) == DAMAGE_CATEGORY_PHYSICAL);
+        ASSUME(gItemsInfo[ITEM_JABOCA_BERRY].holdEffect == HOLD_EFFECT_JABOCA_BERRY);
+        PLAYER(SPECIES_WOBBUFFET) { HP(1); }
+        PLAYER(SPECIES_WYNAUT);
+        OPPONENT(SPECIES_WOBBUFFET) { Item(ITEM_JABOCA_BERRY); }
+    } WHEN {
+        TURN { MOVE(player, MOVE_ELECTRIC_TERRAIN); }
+        TURN { MOVE(player, MOVE_SECRET_POWER, WITH_RNG(RNG_SECONDARY_EFFECT, TRUE)); SEND_OUT(player, 1); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_ELECTRIC_TERRAIN, player);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_SECRET_POWER, player);
+        HP_BAR(opponent);
+        ANIMATION(ANIM_TYPE_GENERAL, B_ANIM_HELD_ITEM_BERRY, opponent);
+        HP_BAR(player, hp: 0);
+        MESSAGE("Wobbuffet was hurt by the opposing Wobbuffet's Jaboca Berry!");
+        MESSAGE("Wobbuffet fainted!");
+        NONE_OF {
+            ANIMATION(ANIM_TYPE_STATUS, B_ANIM_STATUS_PRZ, opponent);
+            STATUS_ICON(opponent, paralysis: TRUE);
+        }
+    } THEN {
+        EXPECT_EQ(opponent->status1, STATUS1_NONE);
+    }
+}

--- a/test/battle/move_flags/minimize_double_damage.c
+++ b/test/battle/move_flags/minimize_double_damage.c
@@ -27,5 +27,21 @@ SINGLE_BATTLE_TEST("MinimizeDoubleDamage flag makes moves cause double damage to
     }
 }
 
-// Remember to add ASSUME(B_MINIMIZE_DMG_ACC >= GEN_6)
-TO_DO_BATTLE_TEST("MinimizeDoubleDamage flag allows moves to skip accuracy checks towards Minimized targets")
+SINGLE_BATTLE_TEST("MinimizeDoubleDamage flag allows moves to skip accuracy checks towards Minimized targets")
+{
+    PASSES_RANDOMLY(100, 100, RNG_ACCURACY);
+    GIVEN {
+        WITH_CONFIG(B_MINIMIZE_DMG_ACC, GEN_6);
+        WITH_CONFIG(B_MINIMIZE_EVASION, GEN_5);
+        ASSUME(GetMoveAccuracy(MOVE_STEAMROLLER) > 0);
+        ASSUME(MoveIncreasesPowerToMinimizedTargets(MOVE_STEAMROLLER));
+        PLAYER(SPECIES_WOBBUFFET) { Speed(1); }
+        OPPONENT(SPECIES_WOBBUFFET) { Speed(2); }
+    } WHEN {
+        TURN { MOVE(opponent, MOVE_MINIMIZE); MOVE(player, MOVE_STEAMROLLER); }
+    } SCENE {
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_MINIMIZE, opponent);
+        ANIMATION(ANIM_TYPE_MOVE, MOVE_STEAMROLLER, player);
+        HP_BAR(opponent);
+    }
+}


### PR DESCRIPTION
Don't squash 

the test `"Anger Point triggers when a substitute takes the hit (Gen4)"` has been marked as known failing. It needs a gen4 config. 