### PR TITLE
Fix heap corruption in shiny wild battle tests

### DIFF
--- a/test/test_runner.c
+++ b/test/test_runner.c
@@ -197,6 +197,8 @@ static void ClearSaveBlocks(void)
     ClearSav1();
     ClearSav2();
     ClearSav3();
+    // Game strings use EOS, so a zeroed player name is not terminated.
+    gSaveBlock2Ptr->playerName[0] = EOS;
 }
 
 void CB2_TestRunner(void)

--- a/test/test_test_runner.c
+++ b/test/test_test_runner.c
@@ -2,6 +2,29 @@
 #include "test/battle.h"
 #include "test/test.h"
 #include "test/battle.h"
+#include "constants/characters.h"
+
+TEST("Tests initialize a terminated player name")
+{
+    EXPECT(memchr(gSaveBlock2Ptr->playerName, EOS, sizeof(gSaveBlock2Ptr->playerName)) != NULL);
+}
+
+WILD_BATTLE_TEST("Shiny wild battle tests preserve adjacent TV shows")
+{
+    GIVEN {
+        gSaveBlock1Ptr->tvShows[NUM_NORMAL_TVSHOW_SLOTS + 1].common.kind = TVSHOW_FISHING_ADVICE;
+        gSaveBlock1Ptr->tvShows[NUM_NORMAL_TVSHOW_SLOTS + 1].common.active = TRUE;
+        PLAYER(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { Shiny(TRUE); }
+    } WHEN {
+        TURN { }
+    } THEN {
+        EXPECT_EQ(gSaveBlock1Ptr->tvShows[NUM_NORMAL_TVSHOW_SLOTS].common.kind, TVSHOW_BREAKING_NEWS);
+        EXPECT_EQ(gSaveBlock1Ptr->tvShows[NUM_NORMAL_TVSHOW_SLOTS].breakingNews.playerName[0], gSaveBlock2Ptr->playerName[0]);
+        EXPECT_EQ(gSaveBlock1Ptr->tvShows[NUM_NORMAL_TVSHOW_SLOTS + 1].common.kind, TVSHOW_FISHING_ADVICE);
+        EXPECT_EQ(gSaveBlock1Ptr->tvShows[NUM_NORMAL_TVSHOW_SLOTS + 1].common.active, TRUE);
+    }
+}
 
 TEST("Tests resume after CRASH")
 {


### PR DESCRIPTION
## Description

The test runner clears the saved player name to zero bytes without adding the game's `EOS` terminator. After a shiny wild battle, `TryPutBreakingNewsOnAir` copies that unterminated name into a TV record and overwrites adjacent save data. With both `FREE_MYSTERY_EVENT_BUFFERS` and `FREE_MYSTERY_GIFT` enabled, the overwrite reaches the heap and stalls `Front anims work`.

### Validation

- Reproduced the original stall and `src/malloc.c:97` assertion with both settings enabled
- With the fix and both settings enabled, all 98 front-animation cases completed, and the test-runner tests passed
- With default settings restored, `make -j16 check` completed successfully with no unexpected failures

### Large Language Models (AI)

No AI was used.

## Issue(s) that this PR fixes

Fixes #10761.

## Discord contact info

viridian.
